### PR TITLE
Harden suspended database recovery

### DIFF
--- a/.changeset/warm-neon-outbox.md
+++ b/.changeset/warm-neon-outbox.md
@@ -1,0 +1,10 @@
+---
+"@voyant-travel/catalog": patch
+"@voyant-travel/db": patch
+"@voyant-travel/framework": patch
+---
+
+Allow resident Node database clients enough time to reconnect after a suspended
+database wakes, deliver durable outbox events through the composed internal
+subscriber bus, and reconcile obsolete Lakebase vector storage when a
+deployment uses pgvector.

--- a/packages/catalog/src/indexer/postgres-provider.test.ts
+++ b/packages/catalog/src/indexer/postgres-provider.test.ts
@@ -1,3 +1,4 @@
+import { PgDialect } from "drizzle-orm/pg-core"
 import { describe, expect, it } from "vitest"
 
 import { createPostgresIndexer } from "./postgres.js"
@@ -56,6 +57,55 @@ describe("Postgres graph indexer provider", () => {
       vectorDimensions: 3,
       maxVectorsPerDocument: 1,
     })
+  })
+
+  it("reconciles obsolete Lakebase vector storage before pgvector writes", async () => {
+    const dialect = new PgDialect()
+    const statements: string[] = []
+    const db = {
+      execute: async (statement: unknown) => {
+        const query = dialect.sqlToQuery(statement as never).sql
+        statements.push(query)
+        if (query.includes("FROM pg_extension")) return [{ installed: 1 }]
+        if (query.includes("format_type")) return [{ data_type: "vector(3072)" }]
+        return []
+      },
+    }
+    const adapter = createPostgresIndexer({
+      db: db as never,
+      registries: new Map(),
+      vectorStrategy: "pgvector",
+      vectorDimensions: 1_536,
+      textStrategy: "native",
+    })
+
+    await adapter.ensureCollection(
+      {
+        vertical: "products",
+        locale: "en-GB",
+        audience: "staff",
+        market: "default",
+      },
+      {} as never,
+    )
+
+    expect(
+      statements.some((query) =>
+        query.includes("DROP INDEX IF EXISTS voyant_catalog_search_documents_ann_idx"),
+      ),
+    ).toBe(true)
+    expect(
+      statements.some((query) =>
+        query.includes("DROP INDEX IF EXISTS voyant_catalog_search_documents_bm25_idx"),
+      ),
+    ).toBe(true)
+    expect(
+      statements.some(
+        (query) =>
+          query.includes("ALTER COLUMN search_embedding TYPE vector") &&
+          query.includes("USING search_embedding::vector"),
+      ),
+    ).toBe(true)
   })
 
   it("enables Lakebase ANN only from its recorded deployment capability", () => {

--- a/packages/catalog/src/indexer/postgres.ts
+++ b/packages/catalog/src/indexer/postgres.ts
@@ -311,6 +311,9 @@ export function createPostgresIndexer(options: PostgresIndexerOptions): Postgres
       }
       lakebaseTextStorageVerified = true
     }
+    if (textStrategy !== "lakebase") {
+      await db.execute(sql`DROP INDEX IF EXISTS voyant_catalog_search_documents_bm25_idx`)
+    }
     if (vectorStrategy !== "none") {
       if (!vectorStorageVerified) {
         const requiredExtension = vectorStrategy === "lakebase" ? "lakebase_vector" : "vector"
@@ -330,6 +333,30 @@ export function createPostgresIndexer(options: PostgresIndexerOptions): Postgres
         ALTER TABLE voyant_catalog_search_documents
         ADD COLUMN IF NOT EXISTS search_embedding vector
       `)
+      if (vectorStrategy === "pgvector") {
+        // Lakebase ANN indexes pin the column to the embedding dimension that
+        // was active when the index was built. The pgvector exact-search path
+        // deliberately uses an unbounded vector column so model migrations can
+        // retain old derived rows while new dimensions are indexed under a new
+        // embedding_model_id.
+        await db.execute(sql`DROP INDEX IF EXISTS voyant_catalog_search_documents_ann_idx`)
+        const [column] = readRows(
+          await db.execute(sql`
+            SELECT format_type(attribute.atttypid, attribute.atttypmod) AS data_type
+            FROM pg_attribute AS attribute
+            WHERE attribute.attrelid = 'voyant_catalog_search_documents'::regclass
+              AND attribute.attname = 'search_embedding'
+              AND NOT attribute.attisdropped
+          `),
+        ) as Array<{ data_type?: string }>
+        if (column?.data_type !== "vector") {
+          await db.execute(sql`
+            ALTER TABLE voyant_catalog_search_documents
+            ALTER COLUMN search_embedding TYPE vector
+            USING search_embedding::vector
+          `)
+        }
+      }
       await db.execute(sql`
         CREATE INDEX IF NOT EXISTS voyant_catalog_search_documents_embedding_slice_idx
           ON voyant_catalog_search_documents (

--- a/packages/db/src/connection-config.ts
+++ b/packages/db/src/connection-config.ts
@@ -28,18 +28,26 @@ export interface DbTimeoutOptions {
    */
   queryMs?: number | false
   /**
-   * Connection-establishment timeout in ms. Default `10_000`.
+   * Connection-establishment timeout in ms. Defaults to `10_000` for the
+   * serverless Pool adapter and `45_000` for the resident Node adapter.
    * `false` disables it.
    */
   connectMs?: number | false
 }
 
-/** Default timeouts applied when no override is provided. */
+/** Default serverless Pool timeouts applied when no override is provided. */
 export const DEFAULT_DB_TIMEOUTS = {
   statementMs: 10_000,
   queryMs: 15_000,
   connectMs: 10_000,
 } as const
+
+/**
+ * Resident Node deployments may connect to databases that suspend while the
+ * application process remains warm. Give those databases enough time to wake
+ * without weakening the shorter serverless/Worker connection budget.
+ */
+export const DEFAULT_NODE_CONNECT_TIMEOUT_MS = 45_000
 
 /**
  * Close idle postgres-js sockets well before a typical serverless Postgres
@@ -116,7 +124,7 @@ export function resolveNodePostgresOptions(options?: {
   timeouts?: DbTimeoutOptions
 }): NodePostgresOptions {
   const statementMs = options?.timeouts?.statementMs ?? DEFAULT_DB_TIMEOUTS.statementMs
-  const connectMs = options?.timeouts?.connectMs ?? DEFAULT_DB_TIMEOUTS.connectMs
+  const connectMs = options?.timeouts?.connectMs ?? DEFAULT_NODE_CONNECT_TIMEOUT_MS
 
   const config: NodePostgresOptions = {}
   const idleSeconds =

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -33,8 +33,9 @@ export interface DbClientOptions<TSchema extends Record<string, unknown> = Recor
   serverlessPool?: Omit<PoolConfig, "connectionString">
   /**
    * Query/connection timeouts (ms) applied per adapter. Defaults:
-   * `statementMs: 10_000`, `queryMs: 15_000`, `connectMs: 10_000` — queries
-   * now fail fast instead of pinning a Worker isolate for its full lifetime.
+   * `statementMs: 10_000`, `queryMs: 15_000`; `connectMs` defaults to `10_000`
+   * for the serverless Pool adapter and `45_000` for resident Node so a
+   * suspended database can wake. Queries still fail within bounded budgets.
    * Pass `false` per field to disable. The `edge` (neon-http) adapter does
    * not support client-side timeouts and ignores this option entirely —
    * http queries rely on the server-side default `statement_timeout` and

--- a/packages/db/tests/unit/connection-config.test.ts
+++ b/packages/db/tests/unit/connection-config.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 import {
   DEFAULT_DB_TIMEOUTS,
+  DEFAULT_NODE_CONNECT_TIMEOUT_MS,
   DEFAULT_NODE_IDLE_TIMEOUT_SECONDS,
   isNeonConnectionString,
   isPooledNeonConnectionString,
@@ -83,10 +84,11 @@ describe("resolveNodePostgresOptions", () => {
     const config = resolveNodePostgresOptions()
 
     expect(config).toEqual({
-      connect_timeout: 10,
+      connect_timeout: 45,
       idle_timeout: DEFAULT_NODE_IDLE_TIMEOUT_SECONDS,
       connection: { statement_timeout: 10_000 },
     })
+    expect(DEFAULT_NODE_CONNECT_TIMEOUT_MS).toBe(45_000)
   })
 
   it("converts connectMs to whole seconds, rounding up", () => {

--- a/packages/framework/src/node-runtime.test.ts
+++ b/packages/framework/src/node-runtime.test.ts
@@ -1,8 +1,13 @@
+import { eventOutboxJobRuntimePort } from "@voyant-travel/db/outbox-job"
 import type { LazyRedisClient } from "@voyant-travel/utils/redis-client"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import type { VoyantDeploymentProviders } from "./deployment-types.js"
 import { createVoyantNodeEnv, loadVoyantNodeRuntime } from "./node-runtime.js"
-import { createVoyantGraphRuntime } from "./runtime-lowering.js"
+import {
+  createVoyantGraphRuntime,
+  type VoyantGraphRuntime,
+  type VoyantGraphRuntimeJobHandler,
+} from "./runtime-lowering.js"
 
 const redisOperations = vi.hoisted(
   () => [] as Array<{ op: string; key: string; redisUrl?: string; client?: string }>,
@@ -179,6 +184,53 @@ function emptyGraphRuntime(providers: VoyantDeploymentProviders) {
   })
 }
 
+const OUTBOX_JOB_ID = "infrastructure.event-outbox-drain"
+
+function outboxJobRuntime(
+  providers: VoyantDeploymentProviders,
+  handler: VoyantGraphRuntimeJobHandler,
+): VoyantGraphRuntime {
+  const unitId = "@voyant-travel/db"
+  return createVoyantGraphRuntime({
+    graphHash: "sha256:node-outbox-delivery",
+    entries: { "@voyant-travel/db/outbox-job": async () => ({ runJob: handler }) },
+    modules: [
+      {
+        id: unitId,
+        kind: "module",
+        packageName: unitId,
+        order: 0,
+        runtimePorts: [eventOutboxJobRuntimePort.id],
+        references: [
+          {
+            id: "event-outbox-job",
+            unitId,
+            facet: "jobs.runtime",
+            entityId: OUTBOX_JOB_ID,
+            runtime: { entry: "./outbox-job", export: "runJob" },
+            importEntry: "@voyant-travel/db/outbox-job",
+          },
+        ],
+        jobs: [
+          {
+            unitId,
+            declaration: {
+              id: OUTBOX_JOB_ID,
+              wakeup: true,
+              runtime: { entry: "./outbox-job", export: "runJob" },
+            },
+            referenceId: "event-outbox-job",
+          },
+        ],
+        selectedIds: { routes: [], tools: [], events: [], webhooks: [] },
+        routes: [],
+      },
+    ],
+    plugins: [],
+    providerSelections: { ...providers },
+  })
+}
+
 function authIntegration() {
   return {
     handler: () => ({
@@ -330,6 +382,57 @@ describe("createVoyantNodeEnv Redis namespace", () => {
 })
 
 describe("loadVoyantNodeRuntime Redis URL validation", () => {
+  it("delivers outbox events through the composed internal subscriber bus", async () => {
+    const originalDeliver = vi.fn(async () => ({ attempted: 0, failed: 0, errors: [] }))
+    const event = {
+      name: "person.changed",
+      data: { personId: "pers_1" },
+      metadata: { eventId: "evt_1" },
+      emittedAt: "2026-07-29T00:00:00.000Z",
+    }
+    let markJobFinished!: () => void
+    const jobFinished = new Promise<void>((resolve) => {
+      markJobFinished = resolve
+    })
+    const handler: VoyantGraphRuntimeJobHandler = async ({ getPort }) => {
+      try {
+        const outbox = await getPort(eventOutboxJobRuntimePort)
+        await outbox.deliver(event)
+      } finally {
+        markJobFinished()
+      }
+    }
+    const runtime = await loadVoyantNodeRuntime({
+      graphRuntime: outboxJobRuntime(BASE_PROVIDERS, handler),
+      jobs: [
+        {
+          id: OUTBOX_JOB_ID,
+          unitId: "@voyant-travel/db",
+          packageName: "@voyant-travel/db",
+          wakeup: true,
+        },
+      ],
+      deployment: { mode: "self-hosted", providers: BASE_PROVIDERS },
+      deploymentRequirements: { resources: [] },
+      runtimePorts: {
+        [eventOutboxJobRuntimePort.id]: {
+          withDb: vi.fn(),
+          deliver: originalDeliver,
+          warn: vi.fn(),
+        },
+      },
+    })
+    const subscriber = vi.fn(async () => undefined)
+    await runtime.app.ready(runtime.env)
+    runtime.app.eventBus.subscribe(event.name, subscriber)
+
+    await runtime.jobs.invoke(OUTBOX_JOB_ID, "wakeup")
+    await jobFinished
+
+    expect(subscriber).toHaveBeenCalledWith(event)
+    expect(originalDeliver).not.toHaveBeenCalled()
+  })
+
   it("routes the exact managed product-job inventory endpoint", async () => {
     const providers = {
       ...BASE_PROVIDERS,

--- a/packages/framework/src/node-runtime.ts
+++ b/packages/framework/src/node-runtime.ts
@@ -4,6 +4,7 @@
 
 import type { ActionLedgerCapabilityRegistry } from "@voyant-travel/action-ledger/capability"
 import type { EventEnvelope, VoyantRuntimeHostPrimitives } from "@voyant-travel/core"
+import { type EventOutboxJobRuntime, eventOutboxJobRuntimePort } from "@voyant-travel/db/outbox-job"
 import {
   createPostgresFixedWindowRateLimitStore,
   createPostgresKvStore,
@@ -305,10 +306,11 @@ export async function loadVoyantNodeRuntime(
   const activeModules = options.graphRuntime.modules.map((unit) => unit.localId ?? unit.id)
   const auth = options.app?.auth ?? options.auth
   const resources = { ...(options.providers ?? {}), ...(options.resources ?? {}) }
+  const runtimePorts = options.runtimePorts ? { ...options.runtimePorts } : undefined
   const graphComposition = await composeVoyantGraphRuntime({
     runtime: options.graphRuntime,
     capabilities: resources,
-    ports: options.runtimePorts,
+    ports: runtimePorts,
     outboundWebhooks: options.outboundWebhooks,
     appWebhooks: options.appWebhooks,
   })
@@ -317,7 +319,7 @@ export async function loadVoyantNodeRuntime(
     runtime: options.graphRuntime,
     jobs: options.jobs,
     bindings: env,
-    ...(options.runtimePorts ? { ports: options.runtimePorts } : {}),
+    ...(runtimePorts ? { ports: runtimePorts } : {}),
     ...(env.ORIGIN_TRUST_SECRET ? { originTrustSecret: env.ORIGIN_TRUST_SECRET } : {}),
     ...(managedJobHealthReporter ? { reportExecution: managedJobHealthReporter } : {}),
   })
@@ -368,6 +370,21 @@ export async function loadVoyantNodeRuntime(
       ]),
     ),
   })
+
+  const configuredOutboxRuntime = (await runtimePorts?.[eventOutboxJobRuntimePort.id]) as
+    | EventOutboxJobRuntime
+    | undefined
+  if (runtimePorts && configuredOutboxRuntime) {
+    runtimePorts[eventOutboxJobRuntimePort.id] = {
+      ...configuredOutboxRuntime,
+      deliver: async (envelope: EventEnvelope) => {
+        await app.ready(env)
+        if (app.eventBus.deliver) return app.eventBus.deliver(envelope)
+        await app.eventBus.emit(envelope.name, envelope.data, envelope.metadata)
+        return { attempted: 0, failed: 0, errors: [] }
+      },
+    } satisfies EventOutboxJobRuntime
+  }
 
   const fetch = async (
     request: Request,


### PR DESCRIPTION
## What changed

- give resident Node database clients a bounded 45-second connection budget so suspended Postgres instances can wake
- deliver durable outbox events through the composed application event bus, preserving internal subscribers in provider-neutral deployments
- reconcile obsolete Lakebase indexes and fixed-dimension vector columns before pgvector indexing

## Why

Neon scale-to-zero wakes were taking about 27 seconds, while the resident Node adapter stopped connecting after 10 seconds. Separately, failed outbox rows exposed two migration issues: Node redelivery bypassed internal subscribers, and catalog indexing attempted 1536-dimension embeddings against a legacy `vector(3072)` column.

This keeps the OSS runtime infrastructure-agnostic while making suspended databases safe to use and allowing the managed platform to replay the affected events.

## Validation

- focused DB connection-config tests
- focused framework outbox delivery test
- focused catalog storage-reconciliation test
- Biome check for all changed source and test files
- `@voyant-travel/db` typecheck
- `@voyant-travel/catalog` typecheck
- `@voyant-travel/framework` typecheck

All compute-heavy validation ran on an isolated remote snapshot.
