### PR TITLE
Preserve generic Node runtime boundary

### DIFF
--- a/.changeset/warm-neon-outbox.md
+++ b/.changeset/warm-neon-outbox.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/framework": patch
+"@voyant-travel/runtime": patch
+---
+
+Bind durable event delivery to the composed internal subscriber bus without
+making the generic Node host depend on a product package.

--- a/packages/framework/src/node-runtime.test.ts
+++ b/packages/framework/src/node-runtime.test.ts
@@ -1,4 +1,5 @@
-import { eventOutboxJobRuntimePort } from "@voyant-travel/db/outbox-job"
+import type { EventEnvelope } from "@voyant-travel/core"
+import { definePort } from "@voyant-travel/core/project"
 import type { LazyRedisClient } from "@voyant-travel/utils/redis-client"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import type { VoyantDeploymentProviders } from "./deployment-types.js"
@@ -185,6 +186,16 @@ function emptyGraphRuntime(providers: VoyantDeploymentProviders) {
 }
 
 const OUTBOX_JOB_ID = "infrastructure.event-outbox-drain"
+const outboxRuntimePort = definePort<{
+  deliver(event: EventEnvelope): Promise<unknown>
+}>({
+  id: "infrastructure.event-outbox-delivery",
+  test(runtime) {
+    if (!runtime || typeof runtime.deliver !== "function") {
+      throw new TypeError("test event-delivery port must implement deliver().")
+    }
+  },
+})
 
 function outboxJobRuntime(
   providers: VoyantDeploymentProviders,
@@ -200,7 +211,7 @@ function outboxJobRuntime(
         kind: "module",
         packageName: unitId,
         order: 0,
-        runtimePorts: [eventOutboxJobRuntimePort.id],
+        runtimePorts: [outboxRuntimePort.id],
         references: [
           {
             id: "event-outbox-job",
@@ -383,8 +394,12 @@ describe("createVoyantNodeEnv Redis namespace", () => {
 
 describe("loadVoyantNodeRuntime Redis URL validation", () => {
   it("delivers outbox events through the composed internal subscriber bus", async () => {
-    const originalDeliver = vi.fn(async () => ({ attempted: 0, failed: 0, errors: [] }))
-    const event = {
+    const originalDeliver = vi.fn(async (_envelope: EventEnvelope) => ({
+      attempted: 0,
+      failed: 0,
+      errors: [],
+    }))
+    const event: EventEnvelope = {
       name: "person.changed",
       data: { personId: "pers_1" },
       metadata: { eventId: "evt_1" },
@@ -396,12 +411,13 @@ describe("loadVoyantNodeRuntime Redis URL validation", () => {
     })
     const handler: VoyantGraphRuntimeJobHandler = async ({ getPort }) => {
       try {
-        const outbox = await getPort(eventOutboxJobRuntimePort)
+        const outbox = await getPort(outboxRuntimePort)
         await outbox.deliver(event)
       } finally {
         markJobFinished()
       }
     }
+    let deliverEvent: (envelope: EventEnvelope) => Promise<unknown> = originalDeliver
     const runtime = await loadVoyantNodeRuntime({
       graphRuntime: outboxJobRuntime(BASE_PROVIDERS, handler),
       jobs: [
@@ -415,10 +431,15 @@ describe("loadVoyantNodeRuntime Redis URL validation", () => {
       deployment: { mode: "self-hosted", providers: BASE_PROVIDERS },
       deploymentRequirements: { resources: [] },
       runtimePorts: {
-        [eventOutboxJobRuntimePort.id]: {
+        [outboxRuntimePort.id]: {
           withDb: vi.fn(),
-          deliver: originalDeliver,
+          deliver: (envelope: EventEnvelope) => deliverEvent(envelope),
           warn: vi.fn(),
+        },
+      },
+      eventDelivery: {
+        bind(deliver) {
+          deliverEvent = deliver
         },
       },
     })

--- a/packages/framework/src/node-runtime.ts
+++ b/packages/framework/src/node-runtime.ts
@@ -4,7 +4,6 @@
 
 import type { ActionLedgerCapabilityRegistry } from "@voyant-travel/action-ledger/capability"
 import type { EventEnvelope, VoyantRuntimeHostPrimitives } from "@voyant-travel/core"
-import { type EventOutboxJobRuntime, eventOutboxJobRuntimePort } from "@voyant-travel/db/outbox-job"
 import {
   createPostgresFixedWindowRateLimitStore,
   createPostgresKvStore,
@@ -204,6 +203,14 @@ export interface VoyantNodeRuntimeOptions {
   deployment: VoyantNodeRuntimeDeployment
   deploymentRequirements: VoyantGraphDeploymentRequirements
   runtimePorts?: import("./runtime-composition.js").VoyantGraphRuntimePorts
+  /**
+   * Binds graph-contributed durable event delivery to the composed application
+   * bus after boot. The caller owns the concrete runtime port; the generic Node
+   * host owns only the event-delivery lifecycle.
+   */
+  eventDelivery?: {
+    bind(deliver: (event: EventEnvelope) => Promise<unknown>): void
+  }
   /** Node-owned durable boundary for graph-selected outbound webhook events. */
   outboundWebhooks?: {
     enqueue: (event: EventEnvelope, bindings: unknown) => Promise<unknown>
@@ -371,20 +378,11 @@ export async function loadVoyantNodeRuntime(
     ),
   })
 
-  const configuredOutboxRuntime = (await runtimePorts?.[eventOutboxJobRuntimePort.id]) as
-    | EventOutboxJobRuntime
-    | undefined
-  if (runtimePorts && configuredOutboxRuntime) {
-    runtimePorts[eventOutboxJobRuntimePort.id] = {
-      ...configuredOutboxRuntime,
-      deliver: async (envelope: EventEnvelope) => {
-        await app.ready(env)
-        if (app.eventBus.deliver) return app.eventBus.deliver(envelope)
-        await app.eventBus.emit(envelope.name, envelope.data, envelope.metadata)
-        return { attempted: 0, failed: 0, errors: [] }
-      },
-    } satisfies EventOutboxJobRuntime
-  }
+  options.eventDelivery?.bind(async (envelope) => {
+    await app.ready(env)
+    if (app.eventBus.deliver) return app.eventBus.deliver(envelope)
+    await app.eventBus.emit(envelope.name, envelope.data, envelope.metadata)
+  })
 
   const fetch = async (
     request: Request,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -281,6 +281,11 @@ export async function loadVoyantProject(
     createRuntimePorts: generated.createRuntimePorts,
     outboundWebhooks,
   })
+  const eventDelivery = {
+    bind(deliver: (event: EventEnvelope) => Promise<unknown>) {
+      deploymentResources.primitives.events.deliver = (event) => deliver(event as EventEnvelope)
+    },
+  }
   const customerBusinessAccountOnboarding = deploymentResources.ports[
     customerBusinessAccountOnboardingRuntimePort.id
   ] as CustomerBusinessAccountOnboardingRuntimeProvider | undefined
@@ -313,6 +318,7 @@ export async function loadVoyantProject(
     },
     deploymentRequirements: graph.requirements,
     runtimePorts: deploymentResources.ports,
+    eventDelivery,
     resources: deploymentResources.capabilities,
     outboundWebhooks: deploymentResources.outboundWebhooks,
     appWebhooks,

--- a/packages/trips/tests/integration/durable-sourcing.test.ts
+++ b/packages/trips/tests/integration/durable-sourcing.test.ts
@@ -49,7 +49,10 @@ describe.skipIf(!DB_AVAILABLE)("Trips durable requirement sourcing", () => {
       timeouts: { statementMs: false, queryMs: false, connectMs: false },
     }) as ClosableTestDb
   })
-  beforeEach(() => cleanupTestDb(db))
+  // This suite runs late in the shared integration lane. Truncating the full
+  // package-union schema can exceed Vitest's 10-second hook default once the
+  // preceding suites have populated it.
+  beforeEach(() => cleanupTestDb(db), 30_000)
   afterAll(async () => {
     await db.$client.end({ timeout: 0 })
   })

--- a/scripts/check-node-runtime-product-authority.mjs
+++ b/scripts/check-node-runtime-product-authority.mjs
@@ -207,10 +207,6 @@ const allowedInfrastructureImports = new Map([
     "lowers graph action declarations into the generic runtime capability registry",
   ],
   ["@voyant-travel/core", "types the domain-neutral runtime host primitive contract"],
-  [
-    "@voyant-travel/db/outbox-job",
-    "provides the generic durable event-outbox job port used by the resident runtime",
-  ],
   ["@voyant-travel/db/runtime", "constructs the Node database and database-backed stores"],
   ["@voyant-travel/hono", "provides the generic HTTP, auth, database, and rate-limit contracts"],
   ["@voyant-travel/hono/composition", "types deployment-local graph factories"],


### PR DESCRIPTION
## What changed

- replace the DB-specific framework import from #3891 with a generic event-delivery binding owned by the Node host
- bind graph-contributed durable delivery to the composed internal subscriber bus in the package runtime
- include `@voyant-travel/runtime` in the patch release because it owns the concrete binding

## Why

PR #3891 fixed durable redelivery behavior but its first implementation made the generic framework Node host import a DB product entrypoint. The architecture check correctly rejected that dependency direction.

This follow-up preserves the behavior while restoring the zero-product-import framework boundary. The OSS runtime remains provider-neutral.

## Validation

- `check-node-runtime-product-authority`: pass, zero framework product imports
- focused internal outbox delivery test: pass
- Biome on changed files: pass
- framework typecheck: pass
- runtime typecheck started remotely but its retained Sprite connection closed before status collection; CI is the remaining authoritative runtime typecheck
