### PR TITLE
Safely adopt partially materialized migrations

### DIFF
--- a/.changeset/clean-migration-adoption.md
+++ b/.changeset/clean-migration-adoption.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework-migrations": patch
+---
+
+Allow a deployment to verify and adopt selected materialized table DDL while executing the remainder of the migration atomically under its original content hash.

--- a/docs/architecture/migration-collector-d2.md
+++ b/docs/architecture/migration-collector-d2.md
@@ -174,6 +174,20 @@ pending allowlisted identity before a normal migration can commit:
 - an exact footprint is recorded with the current immutable SQL content hash and
   reported through both `adopted` and the existing `baselined` result/hook.
 
+An allowlist entry may instead name an exact `tables` subset when only part of a
+migration was materialized. The verifier selects the `CREATE TABLE`, owned
+`ALTER TABLE` constraint, and owned `CREATE INDEX` statements for those tables
+and proves that selected footprint against the PostgreSQL catalogs with the same
+strict comparison used for whole-migration adoption. It then skips only those
+verified statements and executes every remaining migration statement inside the
+normal migration transaction. After that transaction succeeds, the collector
+records the migration's original, complete immutable SQL content hash. The
+migration therefore appears in both `executed` (because its remaining SQL ran)
+and `adopted` (because selected DDL was already present); it is not reported as
+`baselined`. An empty `tables` list, an unknown table name, a table without a
+supported `CREATE TABLE` statement, or any unsupported or mismatched selected
+DDL fails closed before execution or a ledger write.
+
 Fresh databases always execute from scratch. Migrations not named in the
 allowlist are never considered for materialized adoption. The verifier supports
 only DDL forms it can prove from PostgreSQL catalogs and fails closed for an

--- a/packages/framework-migrations/src/collector.ts
+++ b/packages/framework-migrations/src/collector.ts
@@ -83,6 +83,11 @@ export interface ApplyMigrationsOptions {
   onBaselined?: (id: string) => void
 }
 
+interface ApplyMigrationsInternalOptions extends ApplyMigrationsOptions {
+  /** Statement indexes proven materialized by the exact-footprint verifier. */
+  materializedStatementIndexes?: Readonly<Record<string, readonly number[]>>
+}
+
 /** Thrown when an already-applied `(source, tag)` arrives with changed SQL. */
 export class MigrationImmutabilityError extends Error {
   constructor(
@@ -287,10 +292,10 @@ async function ensureLedger(
  * migration. Returns the `"{source}/{tag}"` ids executed and import-baselined
  * this run, in apply order.
  */
-export async function applyMigrations(
+async function applyMigrationsInternal(
   client: MigrationClient,
   sources: MigrationSource[],
-  options?: ApplyMigrationsOptions,
+  options?: ApplyMigrationsInternalOptions,
 ): Promise<{ executed: string[]; baselined: string[] }> {
   const ledger = await ensureLedger(client, options)
   const existing = options?.existing ?? false
@@ -349,7 +354,9 @@ export async function applyMigrations(
       for (const statement of compatibilityPreflightStatementsForMigration(m)) {
         await client.query(statement)
       }
-      for (const statement of splitStatements(m.sql)) {
+      const materializedStatements = new Set(options?.materializedStatementIndexes?.[id] ?? [])
+      for (const [index, statement] of splitStatements(m.sql).entries()) {
+        if (materializedStatements.has(index)) continue
         await client.query(statement)
       }
       await client.query(
@@ -366,4 +373,25 @@ export async function applyMigrations(
   }
 
   return { executed, baselined }
+}
+
+export async function applyMigrations(
+  client: MigrationClient,
+  sources: MigrationSource[],
+  options?: ApplyMigrationsOptions,
+): Promise<{ executed: string[]; baselined: string[] }> {
+  return applyMigrationsInternal(client, sources, options)
+}
+
+/** @internal Deployment-runner path after exact statement-footprint verification. */
+export async function applyMigrationsWithMaterializedStatements(
+  client: MigrationClient,
+  sources: MigrationSource[],
+  materializedStatementIndexes: Readonly<Record<string, readonly number[]>>,
+  options?: ApplyMigrationsOptions,
+): Promise<{ executed: string[]; baselined: string[] }> {
+  return applyMigrationsInternal(client, sources, {
+    ...options,
+    materializedStatementIndexes,
+  })
 }

--- a/packages/framework-migrations/src/deployment-runner.test.ts
+++ b/packages/framework-migrations/src/deployment-runner.test.ts
@@ -600,6 +600,49 @@ CREATE INDEX "idx_product_itinerary_translations_itinerary" ON "product_itinerar
     expect(statements.some((sql) => sql.startsWith('CREATE TABLE "product_'))).toBe(false)
   })
 
+  it("adopts selected exact table DDL and executes the migration remainder", async () => {
+    const selectedTable = "product_day_service_translations"
+    const { client, ledgerRows, statements } = adoptionClient({
+      tables: [selectedTable],
+      columns: exactColumns.filter((row) => row.table_name === selectedTable),
+      constraints: exactConstraints.filter((row) => row.table_name === selectedTable),
+      indexes: exactIndexes.filter((row) => row.table_name === selectedTable),
+    })
+
+    const result = await runDeploymentMigrations(
+      client,
+      [materializedSource],
+      {},
+      {
+        materializedMigrationAdoptions: [
+          {
+            source: "inventory",
+            tag: "0001_inventory_baseline",
+            tables: [selectedTable],
+          },
+        ],
+      },
+    )
+
+    expect(result.adopted).toEqual(["inventory/0001_inventory_baseline"])
+    expect(result.baselined).toEqual([])
+    expect(result.executed).toEqual(["inventory/0001_inventory_baseline"])
+    expect(ledgerRows).toHaveLength(1)
+    expect(ledgerRows[0]?.content_hash).toMatch(/^[a-f0-9]{64}$/)
+    expect(
+      statements.some((sql) => sql.startsWith('CREATE TABLE "product_day_service_translations"')),
+    ).toBe(false)
+    expect(
+      statements.some((sql) => sql.startsWith('CREATE TABLE "product_itinerary_translations"')),
+    ).toBe(true)
+    expect(statements.some((sql) => sql.includes("uidx_product_day_service_translations"))).toBe(
+      false,
+    )
+    expect(
+      statements.some((sql) => sql.includes("idx_product_itinerary_translations_itinerary")),
+    ).toBe(true)
+  })
+
   it("leaves a wholly absent candidate on the normal execute path for an existing database", async () => {
     const { client, statements } = adoptionClient({ existing: true, tables: [] })
     const result = await runDeploymentMigrations(

--- a/packages/framework-migrations/src/deployment-runner.ts
+++ b/packages/framework-migrations/src/deployment-runner.ts
@@ -20,6 +20,7 @@
 import type { MigrationClient, MigrationSource } from "./collector.js"
 import {
   applyMigrations,
+  applyMigrationsWithMaterializedStatements,
   MigrationImmutabilityError,
   type PlannedMigration,
   planMigrations,
@@ -28,6 +29,7 @@ import {
 import type { Cutline } from "./cutline.js"
 import {
   classifyMaterializedMigration,
+  classifyMaterializedMigrationTables,
   type MaterializedMigrationAdoption,
 } from "./materialized-adoption.js"
 
@@ -49,7 +51,7 @@ export interface RunResult {
   executed: string[]
   /** `"{source}/{tag}"` ids import-baselined (recorded, not executed) this run. */
   baselined: string[]
-  /** Allowlisted materialized migrations included in `baselined`. */
+  /** Allowlisted migrations whose whole or selected exact footprint was adopted. */
   adopted: string[]
 }
 
@@ -81,6 +83,7 @@ async function recordedCollectorSources(client: MigrationClient): Promise<Set<st
 }
 
 interface AdoptionCandidate {
+  adoption: MaterializedMigrationAdoption
   migration: PlannedMigration
   source: MigrationSource
 }
@@ -89,24 +92,26 @@ function resolveAdoptionCandidates(
   sources: MigrationSource[],
   adoptions: readonly MaterializedMigrationAdoption[],
 ): AdoptionCandidate[] {
-  const requested = new Set<string>()
+  const requested = new Map<string, MaterializedMigrationAdoption>()
   for (const adoption of adoptions) {
     const id = `${adoption.source}/${adoption.tag}`
     if (requested.has(id)) throw new Error(`duplicate materialized migration adoption: ${id}`)
-    requested.add(id)
+    requested.set(id, adoption)
   }
   const sourceByName = new Map(sources.map((source) => [source.name, source]))
   const candidates: AdoptionCandidate[] = []
   for (const migration of planMigrations(sources)) {
     const id = `${migration.source}/${migration.tag}`
-    if (!requested.delete(id)) continue
+    const adoption = requested.get(id)
+    if (!adoption) continue
+    requested.delete(id)
     const source = sourceByName.get(migration.source)
     if (!source) throw new Error(`migration source disappeared while resolving ${id}`)
-    candidates.push({ migration, source })
+    candidates.push({ adoption, migration, source })
   }
   if (requested.size > 0) {
     throw new Error(
-      `unknown materialized migration adoption(s): ${[...requested].sort().join(", ")}. ` +
+      `unknown materialized migration adoption(s): ${[...requested.keys()].sort().join(", ")}. ` +
         "Every adoption must name an exact source/tag in the current migration plan.",
     )
   }
@@ -435,6 +440,29 @@ function cutlineCovered(sources: MigrationSource[], cutline: Cutline): Migration
     .filter((s) => s.migrations.length > 0)
 }
 
+function withoutMigrationIds(
+  sources: MigrationSource[],
+  excluded: ReadonlySet<string>,
+): MigrationSource[] {
+  return sources
+    .map((source) => ({
+      ...source,
+      migrations: source.migrations.filter(
+        (migration) => !excluded.has(`${source.name}/${migration.tag}`),
+      ),
+    }))
+    .filter((source) => source.migrations.length > 0)
+}
+
+function withoutCutlineMigrationIds(cutline: Cutline, excluded: ReadonlySet<string>): Cutline {
+  return Object.fromEntries(
+    Object.entries(cutline).map(([source, tags]) => [
+      source,
+      tags.filter((tag) => !excluded.has(`${source}/${tag}`)),
+    ]),
+  )
+}
+
 /**
  * Drop migrations already recorded in the ledger (under the source's stable OR
  * legacy names). The baseline parity gate must only assert the schema of
@@ -483,19 +511,41 @@ export async function runDeploymentMigrations(
     const existing = await detectExisting(client)
     let effectiveCutline = cutline
     const materialized: AdoptionCandidate[] = []
+    const partiallyAdopted: string[] = []
+    const materializedStatementIndexes: Record<string, readonly number[]> = {}
     if (existing) {
       // Classify every pending opt-in candidate before any ledger write or
       // normal migration transaction. A partial or definition mismatch aborts
       // the whole run without mutation; wholly absent candidates execute later.
       for (const candidate of await pendingAdoptionCandidates(client, adoptionCandidates)) {
+        const tables = candidate.adoption.tables
+        if (tables) {
+          const classification = await classifyMaterializedMigrationTables(
+            client,
+            candidate.migration,
+            tables,
+          )
+          if (classification.status === "materialized") {
+            const id = `${candidate.migration.source}/${candidate.migration.tag}`
+            partiallyAdopted.push(id)
+            materializedStatementIndexes[id] = classification.statementIndexes
+          }
+          continue
+        }
         const classification = await classifyMaterializedMigration(client, candidate.migration)
         if (classification.status === "materialized") materialized.push(candidate)
       }
 
+      const partiallyAdoptedIds = new Set(partiallyAdopted)
+      effectiveCutline = withoutCutlineMigrationIds(effectiveCutline, partiallyAdoptedIds)
+
       // Parity-gate only the cutline entries this run will import-baseline;
       // already-recorded entries' objects may have been legitimately reshaped by
       // applied post-cutline migrations.
-      const pending = await withoutRecordedMigrations(client, cutlineCovered(sources, cutline))
+      const pending = withoutMigrationIds(
+        await withoutRecordedMigrations(client, cutlineCovered(sources, cutline)),
+        partiallyAdoptedIds,
+      )
       if (pending.length > 0) {
         const [recordedSources, live] = await Promise.all([
           recordedCollectorSources(client),
@@ -519,7 +569,7 @@ export async function runDeploymentMigrations(
         }
         if (expandingSources.size > 0) {
           effectiveCutline = Object.fromEntries(
-            Object.entries(cutline).filter(([source]) => !expandingSources.has(source)),
+            Object.entries(effectiveCutline).filter(([source]) => !expandingSources.has(source)),
           )
         }
       }
@@ -528,7 +578,7 @@ export async function runDeploymentMigrations(
     // Record proven materialized migrations before normal migration commits.
     // Reusing the collector's baseline path guarantees the exact current SQL
     // hash, idempotent inserts, and the ordinary baseline hook semantics.
-    let adopted: string[] = []
+    let fullyAdopted: string[] = []
     if (materialized.length > 0) {
       const materializedSources = sourcesForAdoptions(materialized)
       const adoptionCutline = Object.fromEntries(
@@ -542,15 +592,29 @@ export async function runDeploymentMigrations(
         cutline: adoptionCutline,
         onBaselined: options?.onBaselined,
       })
-      adopted = adoptionResult.baselined
+      fullyAdopted = adoptionResult.baselined
     }
 
-    const { executed, baselined } = await applyMigrations(client, sources, {
+    const applyOptions = {
       cutline: effectiveCutline,
       existing,
       onApplied: options?.onApplied,
       onBaselined: options?.onBaselined,
-    })
-    return { existing, executed, baselined: [...adopted, ...baselined], adopted }
+    }
+    const { executed, baselined } =
+      partiallyAdopted.length > 0
+        ? await applyMigrationsWithMaterializedStatements(
+            client,
+            sources,
+            materializedStatementIndexes,
+            applyOptions,
+          )
+        : await applyMigrations(client, sources, applyOptions)
+    return {
+      existing,
+      executed,
+      baselined: [...fullyAdopted, ...baselined],
+      adopted: [...fullyAdopted, ...partiallyAdopted],
+    }
   })
 }

--- a/packages/framework-migrations/src/materialized-adoption.ts
+++ b/packages/framework-migrations/src/materialized-adoption.ts
@@ -5,6 +5,11 @@ import type { MigrationClient, PlannedMigration } from "./collector.js"
 export interface MaterializedMigrationAdoption {
   source: string
   tag: string
+  /**
+   * Exact tables whose DDL is already materialized while the remainder of the
+   * migration is still pending. Omit to adopt the migration's whole footprint.
+   */
+  tables?: readonly string[]
 }
 
 interface ExpectedColumn {
@@ -67,6 +72,10 @@ interface LiveFootprint {
 }
 
 export type MaterializedMigrationClassification = { status: "absent" } | { status: "materialized" }
+
+export type MaterializedMigrationTableClassification =
+  | { status: "absent" }
+  | { status: "materialized"; statementIndexes: number[] }
 
 const identifier = `"([^"]+)"`
 
@@ -535,6 +544,60 @@ function createdTables(migration: PlannedMigration): string[] {
   return tables
 }
 
+function migrationForTables(
+  migration: PlannedMigration,
+  requestedTables: readonly string[],
+): { migration: PlannedMigration; statementIndexes: number[] } {
+  const tables = [...new Set(requestedTables.map(postgresIdentifier))]
+  if (tables.length === 0) {
+    unsupported(migration, "a partial adoption must name at least one table")
+  }
+
+  const selected = new Set(tables)
+  const found = new Set<string>()
+  const statements = splitStatements(migration.sql)
+  const statementIndexes: number[] = []
+  const selectedStatements: string[] = []
+
+  for (const [index, statement] of statements.entries()) {
+    const create = statement.match(
+      new RegExp(`^CREATE\\s+TABLE\\s+(?:IF\\s+NOT\\s+EXISTS\\s+)?${identifier}\\s*\\(`, "i"),
+    )
+    const alter = statement.match(
+      new RegExp(`^ALTER\\s+TABLE\\s+${identifier}\\s+ADD\\s+CONSTRAINT\\s+`, "i"),
+    )
+    const indexTarget = statement.match(
+      new RegExp(
+        `^CREATE\\s+(?:UNIQUE\\s+)?INDEX\\s+(?:IF\\s+NOT\\s+EXISTS\\s+)?${identifier}\\s+ON\\s+${identifier}\\s+`,
+        "i",
+      ),
+    )
+    const table = create?.[1] ?? alter?.[1] ?? indexTarget?.[2]
+    if (!table) continue
+    const normalized = postgresIdentifier(table)
+    if (!selected.has(normalized)) continue
+    if (create) found.add(normalized)
+    statementIndexes.push(index)
+    selectedStatements.push(statement)
+  }
+
+  const unknown = tables.filter((table) => !found.has(table))
+  if (unknown.length > 0) {
+    unsupported(
+      migration,
+      `partial adoption names table(s) not created here: ${unknown.join(", ")}`,
+    )
+  }
+
+  return {
+    migration: {
+      ...migration,
+      sql: selectedStatements.join("\n--> statement-breakpoint\n"),
+    },
+    statementIndexes,
+  }
+}
+
 function strings(value: unknown): string[] {
   if (Array.isArray(value)) return value.map(String)
   if (typeof value !== "string") return []
@@ -744,4 +807,27 @@ export async function classifyMaterializedMigration(
   )
   compareFootprint(migration, expected, live)
   return { status: "materialized" }
+}
+
+/**
+ * Classify an explicitly allowlisted subset of one migration's table DDL.
+ * The selected CREATE TABLE statements and every constraint/index statement
+ * owned by those tables must already match exactly. The returned statement
+ * indexes are safe for the deployment runner to omit while it executes the
+ * migration's remaining immutable SQL and records the original content hash.
+ */
+export async function classifyMaterializedMigrationTables(
+  client: MigrationClient,
+  migration: PlannedMigration,
+  tables: readonly string[],
+): Promise<MaterializedMigrationTableClassification> {
+  const selected = migrationForTables(migration, tables)
+  const expected = parseExpectedFootprint(selected.migration)
+  const tableNames = expected.tables.map((table) => table.name)
+  const liveTables = await readLiveTables(client, tableNames)
+  if (liveTables.length === 0) return { status: "absent" }
+
+  const live = await readLiveFootprint(client, tableNames, liveTables)
+  compareFootprint(selected.migration, expected, live)
+  return { status: "materialized", statementIndexes: selected.statementIndexes }
 }


### PR DESCRIPTION
## What changed

- extend explicit materialized-migration adoptions with an optional exact table subset
- verify the selected tables, columns, constraints, and indexes against the immutable migration SQL
- omit only the verified statements while executing the migration remainder atomically
- record the original migration content hash after the remainder succeeds
- preserve whole-migration adoption and normal fresh/absent behavior
- add a patch changeset for `@voyant-travel/framework-migrations`

## Why

A managed database can contain one table that an auth runtime materialized before the matching package migration was introduced. Whole-migration adoption is correctly unsafe when sibling tables are absent, while ordinary execution fails on the existing relation. The collector needs a fail-closed middle path rather than a manual ledger edit or a destructive table replacement.

## Safety

The partial path is explicit and allowlisted by source, tag, and table name. It runs only on an existing database, verifies the selected DDL footprint exactly before any mutation, skips only statements owned by those tables, executes every remaining statement inside the normal migration transaction, and writes the original immutable hash only after success.

## Validation

Remote Sprite:

- `pnpm --filter @voyant-travel/framework-migrations lint`
- `pnpm --filter @voyant-travel/framework-migrations typecheck`
- `pnpm --filter @voyant-travel/framework-migrations test` — 66 passed, 12 PostgreSQL-only tests skipped without `TEST_DATABASE_URL`