### PR TITLE
refactor(contracts): move MemoizeOptions into cruises/charters contracts

### DIFF
--- a/.changeset/memoize-options-in-contracts.md
+++ b/.changeset/memoize-options-in-contracts.md
@@ -1,0 +1,15 @@
+---
+"@voyant-travel/cruises-contracts": patch
+"@voyant-travel/charters-contracts": patch
+"@voyant-travel/cruises": patch
+"@voyant-travel/charters": patch
+---
+
+Move the pure `MemoizeOptions` type into `@voyant-travel/cruises-contracts` and
+`@voyant-travel/charters-contracts` so external consumers can reference the
+adapter cache option shape without taking a runtime dependency on the cruises
+or charters modules (ADR-0002).
+
+The `@voyant-travel/cruises` and `@voyant-travel/charters` runtimes re-export
+`MemoizeOptions` from their contracts package, so existing importers keep
+working — no breaking change.

--- a/packages/charters-contracts/src/index.ts
+++ b/packages/charters-contracts/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./content-shape.js"
+export * from "./memoize-options.js"

--- a/packages/charters-contracts/src/memoize-options.ts
+++ b/packages/charters-contracts/src/memoize-options.ts
@@ -1,0 +1,18 @@
+/**
+ * Options for the in-memory TTL cache decorator that wraps charter adapters.
+ *
+ * This is a pure options contract with no runtime dependency — the
+ * `memoizeCharterAdapter` implementation that consumes it lives in the
+ * `@voyant-travel/charters` runtime package. It is placed here so external
+ * consumers (e.g. Voyant Connect) can reference the option shape without
+ * taking a runtime dependency on the charters module (ADR-0002).
+ */
+export type MemoizeOptions = {
+  /** Cache TTL in milliseconds. Default 60_000 (60 seconds). */
+  ttlMs?: number
+  /**
+   * Maximum cache entries before LRU eviction kicks in. Default 1000.
+   * Set to 0 to disable size cap (only TTL evicts).
+   */
+  maxEntries?: number
+}

--- a/packages/charters/src/adapters/memoize.ts
+++ b/packages/charters/src/adapters/memoize.ts
@@ -15,6 +15,8 @@
  * own caching (it sits closer to the source replica) over wrapping at this layer.
  */
 
+import type { MemoizeOptions } from "@voyant-travel/charters-contracts"
+
 import type {
   CharterAdapter,
   ExternalCharterProduct,
@@ -25,15 +27,11 @@ import type {
   SourceRef,
 } from "./index.js"
 
-export type MemoizeOptions = {
-  /** Cache TTL in milliseconds. Default 60_000 (60 seconds). */
-  ttlMs?: number
-  /**
-   * Maximum cache entries before LRU eviction kicks in. Default 1000.
-   * Set to 0 to disable size cap (only TTL evicts).
-   */
-  maxEntries?: number
-}
+// `MemoizeOptions` is a pure options contract and lives in
+// `@voyant-travel/charters-contracts` so external consumers can reference it
+// without a runtime dependency on this module (ADR-0002). Re-exported here so
+// existing `@voyant-travel/charters` importers keep working.
+export type { MemoizeOptions }
 
 type CacheEntry<T> = { value: T; expiresAt: number }
 

--- a/packages/cruises-contracts/src/index.ts
+++ b/packages/cruises-contracts/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./cabin-features.js"
 export * from "./content-shape.js"
+export * from "./memoize-options.js"

--- a/packages/cruises-contracts/src/memoize-options.ts
+++ b/packages/cruises-contracts/src/memoize-options.ts
@@ -1,0 +1,18 @@
+/**
+ * Options for the in-memory TTL cache decorator that wraps cruise adapters.
+ *
+ * This is a pure options contract with no runtime dependency — the
+ * `memoizeCruiseAdapter` implementation that consumes it lives in the
+ * `@voyant-travel/cruises` runtime package. It is placed here so external
+ * consumers (e.g. Voyant Connect) can reference the option shape without
+ * taking a runtime dependency on the cruises module (ADR-0002).
+ */
+export type MemoizeOptions = {
+  /** Cache TTL in milliseconds. Default 60_000 (60 seconds). */
+  ttlMs?: number
+  /**
+   * Maximum cache entries before LRU eviction kicks in. Default 1000.
+   * Set to 0 to disable size cap (only TTL evicts).
+   */
+  maxEntries?: number
+}

--- a/packages/cruises/src/adapters/memoize.ts
+++ b/packages/cruises/src/adapters/memoize.ts
@@ -15,6 +15,8 @@
  * own caching (it sits closer to the source replica) over wrapping at this layer.
  */
 
+import type { MemoizeOptions } from "@voyant-travel/cruises-contracts"
+
 import type {
   CruiseAdapter,
   ExternalCruise,
@@ -25,15 +27,11 @@ import type {
   SourceRef,
 } from "./index.js"
 
-export type MemoizeOptions = {
-  /** Cache TTL in milliseconds. Default 60_000 (60 seconds). */
-  ttlMs?: number
-  /**
-   * Maximum cache entries before LRU eviction kicks in. Default 1000.
-   * Set to 0 to disable size cap (only TTL evicts).
-   */
-  maxEntries?: number
-}
+// `MemoizeOptions` is a pure options contract and lives in
+// `@voyant-travel/cruises-contracts` so external consumers can reference it
+// without a runtime dependency on this module (ADR-0002). Re-exported here so
+// existing `@voyant-travel/cruises` importers keep working.
+export type { MemoizeOptions }
 
 type CacheEntry<T> = { value: T; expiresAt: number }
 


### PR DESCRIPTION
Unblocks the ADR-0002 conformance work tracked as W3 of #3898.

## Why

`../connect-sdk` currently peer-depends on the full `@voyant-travel/cruises` runtime for a
single **type-only** import — `packages/plugin-voyant-connect/src/sources.ts:9` does
`import type { MemoizeOptions } from "@voyant-travel/cruises"`. ADR-0002 says pure contracts
live in dependency-light `*-contracts` packages so external consumers can reference them
without pulling Drizzle, Hono, or the framework DB.

`SourceAdapter` and `CatalogProjection` were already correctly placed in `catalog-contracts`,
so `MemoizeOptions` was the last type stranded in a runtime package.

## What changed

The pure type (`ttlMs?`, `maxEntries?`) moves to `cruises-contracts` and `charters-contracts`.
The memoize **implementation** stays in the runtime packages. Both runtimes re-export the type,
so existing importers keep working — **not a breaking change**.

This is the same façade pattern the codebase already uses elsewhere: `bookings/validation` →
`bookings-contracts`, `legal/contracts/validation` → `legal-contracts`,
`flights/contract/types` → `flights-contracts`.

Charters was included because the type was identical in shape.

## Verification

Rebased onto `main` and re-verified locally — the original branch was cut from a feature branch.

| Check | Result |
|---|---|
| `-F cruises-contracts... typecheck` | pass |
| `-F cruises... -F charters... typecheck` | pass |
| `-F catalog typecheck` | pass, 0 TS errors |
| `-F cruises... test` | 262 passed, 7 skipped |

Contracts packages gained no runtime dependencies — `cruises-contracts` is `catalog-contracts`
+ `zod`; `charters-contracts` is `zod` only.

The four-edit subpath checklist does not apply: the type was added to the existing `index.ts`
barrel, not a new subpath export, so there is no `publishConfig.exports` gap for CI
packaged-acceptance to catch.

Note for reviewers: `catalog` typecheck aborts with SIGABRT under the default heap on a local
machine — that is OOM, not a type error. It passes with the `--max-old-space-size=8192` the root
`typecheck` script already sets.

## Follow-up

The connect-sdk side of W3 is a separate change in that repo and needs these packages published
first.
