### PR TITLE
docs(adr): renumber composable-reporting to 0017 to resolve the duplicate 0015

### DIFF
--- a/docs/adr/0017-composable-reporting.md
+++ b/docs/adr/0017-composable-reporting.md
@@ -1,4 +1,4 @@
-# ADR-0015: Reporting is composed from semantic datasets and grid widgets
+# ADR-0017: Reporting is composed from semantic datasets and grid widgets
 
 - **Status:** Accepted (2026-07-18)
 - **Relates to:** [ADR-0002](./0002-contract-packages.md),


### PR DESCRIPTION
Resolves the duplicate ADR number flagged in #3902 item 6. Docs-only, one file.

`docs/adr/` contained two `0015-` files: `0015-composable-reporting.md` and
`0015-payment-adapter-transports-and-managed-connect.md`.

Renumbering was done by inbound-reference count rather than by date, so no existing link breaks:

| ADR | Inbound references |
|---|---|
| `0015-composable-reporting.md` | **0** (only its own title line) |
| `0015-payment-adapter-transports-and-managed-connect.md` | **9** — `docs/architecture/payment-adapter-boundary.md` ×2, `packages/operator-settings` ×3, `packages/operator-settings-react` ×1, `packages/payments` ×3 |

The zero-reference one moves to **0017**. 0016 is claimed by open PR #3900.

`git mv` plus the title line `# ADR-0015:` → `# ADR-0017:`. No source, `package.json`, export, or
script changes, so no changeset is required and no published package is affected.

## Two sibling cleanups from #3902 item 6 were investigated and correctly rejected

Recording here so they are not re-attempted.

**Inlining `packages/framework/src/operator-distribution.ts` — do not do this.** It is a
one-line re-export, but `./operator-distribution` is a published subpath in **both** `exports`
(`packages/framework/package.json:14`) and `publishConfig.exports` (lines 116-118), so removing
it is a breaking change for external consumers. It is also load-bearing for a checker:
`scripts/check-lockstep-membership.mjs:26` throws
`"operator-distribution.ts: standard distribution policy boundary not found"` if the marker
goes missing. #3902 item 6 should be corrected — the recommendation there was wrong.

**Deleting `starters/federated-operator` — not a repo change.** `git ls-files
starters/federated-operator` returns **zero tracked files**; the directory exists only as local
`dist/` + `node_modules/` build artifacts. There is nothing for a branch to delete. It is a
local `rm -rf` on each machine that has one.

That directory does leave one stale reference: `.fallowrc.jsonc:19` lists
`starters/federated-operator/voyant.config.ts`, a file that no longer exists. Deliberately not
fixed here — checking the rest of that file showed **several other entries are also untracked**,
so it needs its own pass rather than a drive-by edit inside a docs PR.
