### PR TITLE
fix(mcp): make the framework peer range resolvable across a release

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -27,5 +27,8 @@
   "ignore": ["@voyant-travel/voyant-test-utils", "@voyant-travel/voyant-typescript-config"],
   "access": "public",
   "baseBranch": "main",
-  "updateInternalDependencies": "patch"
+  "updateInternalDependencies": "patch",
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -14,7 +14,7 @@
     "kind": "module",
     "manifest": "./voyant",
     "compatibleWith": {
-      "framework": "^0.65.0 || ^1.0.0",
+      "framework": ">=0.65.0 <2.0.0",
       "targets": [
         "node"
       ],
@@ -78,7 +78,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@voyant-travel/framework": "^0.66.0"
+    "@voyant-travel/framework": ">=0.65.0 <2.0.0"
   },
   "repository": {
     "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3123,7 +3123,7 @@ importers:
         specifier: workspace:^
         version: link:../core
       '@voyant-travel/framework':
-        specifier: ^0.65.0 || ^1.0.0
+        specifier: '>=0.65.0 <2.0.0'
         version: link:../framework
       '@voyant-travel/hono':
         specifier: workspace:^


### PR DESCRIPTION
The release published nothing: `pnpm install --frozen-lockfile` failed in [run 30529603947](https://github.com/voyant-travel/voyant/actions/runs/30529603947/job/90828532041).

## What happened

Changesets bumped `@voyant-travel/framework` to 0.66.0 and rewrote MCP's peer range to a bare `^0.66.0`. **That version does not exist on npm** — this release is what publishes it — so the lockfile could not be satisfied and the publish step never ran.

The bare caret caused two further problems:

- It dropped the `|| ^1.0.0` allowance that 59a1e408 ("Preserve MCP framework compatibility") added deliberately.
- It left `peerDependencies` contradicting `voyant.compatibleWith.framework`, which changesets does not touch and which still read `^0.65.0 || ^1.0.0`.

## Fix

Both fields become `>=0.65.0 <2.0.0` — spanning the published 0.65 line, the 0.66 this release publishes, and the projected 1.x.

Setting `onlyUpdatePeerDependentsWhenOutOfRange` means changesets leaves the range alone while the bumped version falls inside it. Without that, every future release would rewrite it to a bare caret on an unpublished version and break the publish again — this was a recurring landmine, not a one-off.

Verified with `pnpm install --frozen-lockfile`, the exact command that failed.