### PR TITLE
fix(mcp): unblock the release by making the framework peer range resolvable

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -27,5 +27,8 @@
   "ignore": ["@voyant-travel/voyant-test-utils", "@voyant-travel/voyant-typescript-config"],
   "access": "public",
   "baseBranch": "main",
-  "updateInternalDependencies": "patch"
+  "updateInternalDependencies": "patch",
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -14,7 +14,7 @@
     "kind": "module",
     "manifest": "./voyant",
     "compatibleWith": {
-      "framework": "^0.65.0 || ^1.0.0",
+      "framework": ">=0.65.0 <2.0.0",
       "targets": [
         "node"
       ],
@@ -78,7 +78,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@voyant-travel/framework": "^0.66.0"
+    "@voyant-travel/framework": ">=0.65.0 <2.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/mcp/tests/package-contract.test.ts
+++ b/packages/mcp/tests/package-contract.test.ts
@@ -19,7 +19,14 @@ describe("@voyant-travel/mcp package contract", () => {
     ) as McpPackageJson
     const frameworkRange = packageJson.peerDependencies?.["@voyant-travel/framework"]
 
-    expect(frameworkRange).toBe("^0.65.0 || ^1.0.0")
+    // Spans the published 0.65 line, the 0.66 a release publishes, and the
+    // projected 1.x. The span matters at release time: changesets rewrites this
+    // peer range when the bumped framework version falls outside it, and a bare
+    // caret on an as-yet-unpublished version makes `pnpm install
+    // --frozen-lockfile` unresolvable before the publish step runs. Keeping the
+    // bumped version inside the range is what lets
+    // `onlyUpdatePeerDependentsWhenOutOfRange` leave it alone.
+    expect(frameworkRange).toBe(">=0.65.0 <2.0.0")
     expect(packageJson.voyant?.compatibleWith?.framework).toBe(frameworkRange)
     expect(packageJson.dependencies?.["@voyant-travel/framework"]).toBeUndefined()
     expect(packageJson.peerDependenciesMeta?.["@voyant-travel/framework"]).toBeUndefined()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3123,7 +3123,7 @@ importers:
         specifier: workspace:^
         version: link:../core
       '@voyant-travel/framework':
-        specifier: ^0.65.0 || ^1.0.0
+        specifier: '>=0.65.0 <2.0.0'
         version: link:../framework
       '@voyant-travel/hono':
         specifier: workspace:^


### PR DESCRIPTION
## Why

The Release workflow has been failing before it publishes anything, so `@voyant-travel/framework` 0.66.0 and everything versioned alongside it in #3906 is committed but unpublished.

```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because
pnpm-lock.yaml is not up to date with <ROOT>/packages/mcp/package.json
  specifiers in the lockfile don't match specifiers in package.json:
  - @voyant-travel/framework (lockfile: ^0.65.0 || ^1.0.0, manifest: ^0.66.0)
```

Regenerating the lockfile does not fix it, it fails harder, because the rewritten range points at a version that only exists after the publish step this install gates:

```
ERR_PNPM_NO_MATCHING_VERSION  No matching version found for
@voyant-travel/framework@^0.66.0
The latest release of @voyant-travel/framework is "0.65.1".
```

## What this adds

The preceding commit widens the peer range and `voyant.compatibleWith.framework` to `>=0.65.0 <2.0.0` and syncs the lockfile. It left `packages/mcp/tests/package-contract.test.ts` asserting the old `^0.65.0 || ^1.0.0` literal, so the suite failed on the very commit that unblocks the release. This aligns the literal and records why the span matters.

The equality assertion between the peer range and `compatibleWith` is the real invariant and is unchanged. The literal is safe now that `onlyUpdatePeerDependentsWhenOutOfRange` keeps changesets from rewriting the range on each release, which is what turned this into a release-time landmine rather than a one-off.

## Verification

Both run locally against this branch:

- `pnpm install --frozen-lockfile` — passes, 14s. This is the step that was failing.
- `pnpm vitest run tests/package-contract.test.ts` in `packages/mcp` — 1 passed.

## Impact

This is on the critical path for a customer-facing outage. #3747 removed `POST /v1/public/bookings/sessions`, the route the Pro Travel storefront calls to create a booking. The replacement, `POST /v1/public/bookings` from #3903, is merged and versioned but unpublished because this release cannot run. So the deployed runtime currently has no public booking-creation route at all: protravel.ro checkout has returned 404 since 2026-07-25, with zero bookings in the five days since against a prior baseline of 6-47/day.

Publishing this release is the prerequisite for restoring that, followed by rolling the Pro Travel managed runtime.
