### PR TITLE
fix(release): accept any published peer range the provider version satisfies

### DIFF
--- a/scripts/tests/release-plan.test.mjs
+++ b/scripts/tests/release-plan.test.mjs
@@ -67,6 +67,53 @@ test("accepts a compatible published union of caret peers", () => {
   )
 })
 
+test("accepts a compatible published comparator span", () => {
+  // A wide span is what keeps changesets from rewriting the peer range on every
+  // provider bump when onlyUpdatePeerDependentsWhenOutOfRange is set.
+  assert.deepEqual(
+    collectWorkspaceRangeProblems(
+      createPackages({
+        "@fixture/consumer": {
+          version: "1.1.0",
+          peerDependencies: { "@fixture/provider": ">=0.64.0 <2.0.0" },
+        },
+        "@fixture/provider": { version: "0.65.0" },
+      }),
+    ),
+    [],
+  )
+})
+
+test("rejects a published peer range the current provider version falls outside", () => {
+  assert.notDeepEqual(
+    collectWorkspaceRangeProblems(
+      createPackages({
+        "@fixture/consumer": {
+          version: "1.1.0",
+          peerDependencies: { "@fixture/provider": ">=0.64.0 <0.65.0" },
+        },
+        "@fixture/provider": { version: "0.66.0" },
+      }),
+    ),
+    [],
+  )
+})
+
+test("rejects a peer range that is not valid semver", () => {
+  assert.notDeepEqual(
+    collectWorkspaceRangeProblems(
+      createPackages({
+        "@fixture/consumer": {
+          version: "1.1.0",
+          peerDependencies: { "@fixture/provider": "not-a-range" },
+        },
+        "@fixture/provider": { version: "0.66.0" },
+      }),
+    ),
+    [],
+  )
+})
+
 test("rejects a future internal peer range when either package is absent from the release plan", () => {
   const packages = createPackages({
     "@fixture/consumer": {

--- a/scripts/verify-release-config.cjs
+++ b/scripts/verify-release-config.cjs
@@ -77,8 +77,17 @@ const DEPENDENCY_FIELDS = [
   "optionalDependencies",
 ]
 const REQUIRED_WORKSPACE_RANGE = "workspace:^"
-const COMPATIBLE_PUBLISHED_CARET_RANGE =
-  /^\^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\s*\|\|\s*\^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)*$/
+// A peer may state a published range instead of `workspace:^` as long as the
+// range is a real semver range that admits the version currently in the
+// workspace. This deliberately accepts comparator spans such as
+// `>=0.65.0 <2.0.0` and not only caret unions: with
+// `onlyUpdatePeerDependentsWhenOutOfRange` set in .changeset/config.json, a wide
+// span is what stops changesets rewriting the range on every provider bump, so
+// requiring caret shape here forced exactly the churn that setting prevents.
+const isPublishedRange = (version) =>
+  typeof version === "string" &&
+  !version.startsWith("workspace:") &&
+  semver.validRange(version) !== null
 
 // The standard product distribution pins its runtime modules to the EXACT current version
 // (`workspace:*` → `X.Y.Z` on publish) so the published set is deterministic and
@@ -119,7 +128,7 @@ function collectWorkspaceRangeProblems(packages, projectedVersions = new Map()) 
         const currentProviderVersion = workspacePackageVersions.get(name)
         const isCompatiblePublishedPeerRange =
           field === "peerDependencies" &&
-          COMPATIBLE_PUBLISHED_CARET_RANGE.test(version) &&
+          isPublishedRange(version) &&
           semver.satisfies(currentProviderVersion, version)
         const isExactStagedPeerRange =
           field === "peerDependencies" &&


### PR DESCRIPTION
**The Release workflow is still failing on `main`** — verified by running the gate against `1b72f013c9` (current tip, after #3907 and #3908):

```
Release configuration verification failed:
- packages/mcp/package.json: peerDependencies.@voyant-travel/framework
  uses >=0.65.0 <2.0.0; expected workspace:^
```

Framework 0.66.0 and the rest of that release cohort are still unpublished as a result.

## The bug is in the checker, not in mcp

`scripts/verify-release-config.cjs` exempts an internal peer from `workspace:^` only when **both** hold:

1. the range matches `COMPATIBLE_PUBLISHED_CARET_RANGE` — a union of carets
2. the current provider version satisfies it

`>=0.65.0 <2.0.0` is a comparator span, not a caret union, so condition 1 rejects it however compatible it is.

**The caret shape was never the property that mattered.** Condition 2 already does the real work — it is what guarantees the range admits what is in the workspace.

## Requiring caret shape fought our own config

`.changeset/config.json` sets `onlyUpdatePeerDependentsWhenOutOfRange`. A wide comparator span is exactly what stops changesets rewriting the peer range on every provider bump. A caret union *must* be rewritten the moment the provider leaves it — which is how the range drifted out of sync with `voyant.compatibleWith` in the first place, since release tooling does not manage that mirror field.

So the previous attempts were each half right: #3908's wide span is the correct range and should stay; it just could not pass a gate that demanded the opposite shape.

I had originally proposed narrowing mcp to `^0.66.0 || ^1.0.0` to satisfy the regex. That was the weaker fix — it would have been rewritten on the next framework bump and restarted the same cycle. **This PR changes nothing in `packages/mcp`.**

## Change

The gate now accepts any value that is a valid semver range, is not the `workspace:` protocol, and is satisfied by the current provider version.

Two files, no published package touched, so no changeset.

## Verification

| Check | Result |
|---|---|
| `pnpm verify:release-config` | pass — *"Verified 15 release cohorts and compatible @voyant-travel workspace ranges"* (fails on current main) |
| `node --test scripts/tests/release-plan.test.mjs` | 11 passed |
| `pnpm -F @voyant-travel/mcp test` | 34 passed |

New coverage: a compatible comparator span is accepted; a range the provider version falls **outside** is still rejected; a value that is not valid semver is still rejected.
