### PR TITLE
fix(finance-contracts): drop the drizzle-orm dependency

### DIFF
--- a/.changeset/finance-contracts-drop-drizzle.md
+++ b/.changeset/finance-contracts-drop-drizzle.md
@@ -1,0 +1,18 @@
+---
+"@voyant-travel/finance-contracts": minor
+"@voyant-travel/finance": patch
+"@voyant-travel/apps": patch
+---
+
+Remove the `drizzle-orm` dependency from `@voyant-travel/finance-contracts`.
+
+`FinanceAppApiRuntime` took a concrete `PostgresJsDatabase` for a handle it only
+ever passes through — it never calls a method on it — which forced a Drizzle
+dependency into a package ADR-0002 requires to stay dependency-light. The handle
+is now a type parameter, `FinanceAppApiRuntime<TDatabase = unknown>`, and the
+implementing runtimes instantiate it as
+`FinanceAppApiRuntime<PostgresJsDatabase>`.
+
+Consumers that write the bare `FinanceAppApiRuntime` still compile; the handle
+resolves to `unknown` for them, so an implementer relying on the previous
+implicit `PostgresJsDatabase` should instantiate the parameter explicitly.

--- a/packages/apps/src/app-api-service.ts
+++ b/packages/apps/src/app-api-service.ts
@@ -49,7 +49,7 @@ export interface AppApiEntityReader {
   list(db: PostgresJsDatabase, query: AppApiEntityReadQuery): Promise<unknown>
 }
 
-export interface AppApiFinanceRuntime extends Partial<FinanceAppApiRuntime> {
+export interface AppApiFinanceRuntime extends Partial<FinanceAppApiRuntime<PostgresJsDatabase>> {
   listDocuments?(db: PostgresJsDatabase, query: AppApiFinanceDocumentQuery): Promise<unknown>
   executeAction?(db: PostgresJsDatabase, input: AppApiFinanceActionInput): Promise<unknown>
 }

--- a/packages/finance-contracts/package.json
+++ b/packages/finance-contracts/package.json
@@ -55,7 +55,6 @@
   },
   "dependencies": {
     "@voyant-travel/schema-kit": "workspace:^",
-    "drizzle-orm": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/finance-contracts/src/app-api.ts
+++ b/packages/finance-contracts/src/app-api.ts
@@ -1,4 +1,3 @@
-import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { financeAppApiRuntimePort as importCheapFinanceAppApiRuntimePort } from "./runtime-port.js"
 
 export interface FinanceAppApiIssuanceDocument {
@@ -236,43 +235,52 @@ export class FinanceAppApiNumberConflictError extends Error {
   }
 }
 
-export interface FinanceAppApiRuntime {
+/**
+ * Database handle supplied by the implementing runtime.
+ *
+ * `finance-contracts` is dependency-light per ADR-0002 and must not depend on
+ * Drizzle, so the handle is a type parameter rather than a concrete
+ * `PostgresJsDatabase`. The interface only ever passes it through - it never
+ * calls a method on it - so the contract loses nothing by leaving it opaque.
+ * Implementers instantiate it, e.g. `FinanceAppApiRuntime<PostgresJsDatabase>`.
+ */
+export interface FinanceAppApiRuntime<TDatabase = unknown> {
   getIssuanceDocument(
-    db: PostgresJsDatabase,
+    db: TDatabase,
     documentId: string,
   ): Promise<FinanceAppApiIssuanceDocument | null>
   getExternalReference(
-    db: PostgresJsDatabase,
+    db: TDatabase,
     documentId: string,
     provider: string,
   ): Promise<FinanceAppApiExternalReference | null>
   upsertExternalReference(
-    db: PostgresJsDatabase,
+    db: TDatabase,
     documentId: string,
     provider: string,
     input: FinanceAppApiExternalReferenceUpsertInput,
   ): Promise<FinanceAppApiReferenceMutationResult>
   attachPdfArtifact(
-    db: PostgresJsDatabase,
+    db: TDatabase,
     environment: unknown,
     documentId: string,
     provider: string,
     input: FinanceAppApiPdfArtifactInput,
   ): Promise<FinanceAppApiPdfArtifactMutationResult>
   updateExternalSyncState(
-    db: PostgresJsDatabase,
+    db: TDatabase,
     documentId: string,
     provider: string,
     input: FinanceAppApiExternalSyncStateInput,
   ): Promise<FinanceAppApiExternalSyncMutationResult>
   updateExternalLifecycleState(
-    db: PostgresJsDatabase,
+    db: TDatabase,
     documentId: string,
     provider: string,
     input: FinanceAppApiExternalLifecycleStateInput,
   ): Promise<FinanceAppApiExternalLifecycleMutationResult>
   recordSettlementObservation(
-    db: PostgresJsDatabase,
+    db: TDatabase,
     documentId: string,
     provider: string,
     input: FinanceAppApiSettlementObservationInput,

--- a/packages/finance/src/app-api-runtime.ts
+++ b/packages/finance/src/app-api-runtime.ts
@@ -1,3 +1,4 @@
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { bookings } from "@voyant-travel/bookings/schema"
 import type { VoyantRuntimeHostPrimitives } from "@voyant-travel/core"
 import type {
@@ -41,7 +42,7 @@ type ArtifactRuntimePrimitives = Pick<VoyantRuntimeHostPrimitives, "storage">
 
 export function createFinanceAppApiRuntime(
   primitives?: ArtifactRuntimePrimitives,
-): FinanceAppApiRuntime {
+): FinanceAppApiRuntime<PostgresJsDatabase> {
   return {
     async getIssuanceDocument(db, documentId) {
       const [invoice] = await db.select().from(invoices).where(eq(invoices.id, documentId)).limit(1)
@@ -616,7 +617,7 @@ export function createFinanceAppApiRuntime(
 }
 
 async function validateNativeLifecycleState(
-  db: Parameters<FinanceAppApiRuntime["updateExternalLifecycleState"]>[0],
+  db: Parameters<FinanceAppApiRuntime<PostgresJsDatabase>["updateExternalLifecycleState"]>[0],
   document: { invoice_type: string; status: string },
   documentId: string,
   input: FinanceAppApiExternalLifecycleStateInput,
@@ -847,7 +848,7 @@ function isExternalSyncStatus(
 }
 
 async function findAppArtifact(
-  db: Parameters<FinanceAppApiRuntime["attachPdfArtifact"]>[0],
+  db: Parameters<FinanceAppApiRuntime<PostgresJsDatabase>["attachPdfArtifact"]>[0],
   documentId: string,
   provider: string,
   idempotencyDigest: string,

--- a/packages/finance/src/app-api-runtime.ts
+++ b/packages/finance/src/app-api-runtime.ts
@@ -1,4 +1,3 @@
-import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { bookings } from "@voyant-travel/bookings/schema"
 import type { VoyantRuntimeHostPrimitives } from "@voyant-travel/core"
 import type {
@@ -22,6 +21,7 @@ import type {
 import { FinanceAppApiNumberConflictError } from "@voyant-travel/finance-contracts/app-api"
 import type { StorageProvider } from "@voyant-travel/storage"
 import { and, asc, desc, eq, inArray, sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import {
   invoiceExternalLifecycleOperations,
   invoiceExternalPaymentIdentifiers,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2227,9 +2227,6 @@ importers:
       '@voyant-travel/schema-kit':
         specifier: workspace:^
         version: link:../schema-kit
-      drizzle-orm:
-        specifier: 'catalog:'
-        version: 0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
       zod:
         specifier: 'catalog:'
         version: 4.4.3


### PR DESCRIPTION
Closes the ADR-0002 conformance defect recorded in ADR-0016 (#3900). Step 2 of its Sequencing.

## The defect

`finance-contracts` was the **only** contracts package declaring `drizzle-orm` as a runtime dependency — so installing it pulled Drizzle, exactly what ADR-0002 exists to prevent:

> External consumers increasingly need [pure contracts] without [runtime] … It must not pull Drizzle, Hono, or framework DB modules into its own runtime.

The dependency existed for a **single type-only import**:

```ts
import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
```

## Why the fix is safe

`PostgresJsDatabase` was used purely as an **opaque handle**. `FinanceAppApiRuntime` takes it in all seven methods and passes it straight through to the implementation — it never calls a method on it, never narrows it, never inspects it. The contract was therefore paying a dependency for a type it did not use.

The handle becomes a type parameter:

```ts
export interface FinanceAppApiRuntime<TDatabase = unknown> {
  getIssuanceDocument(db: TDatabase, documentId: string): Promise<…>
  …
}
```

and the two implementing sites instantiate it concretely — `packages/finance/src/app-api-runtime.ts` and `packages/apps/src/app-api-service.ts` both already import `PostgresJsDatabase` independently, so no dependency moves, it only stops being in the contracts package.

Note `packages/finance/src/app-api-runtime.ts` derives its own parameter types from the contract via `Parameters<FinanceAppApiRuntime[…]>[0]`; instantiating the generic keeps those derivations resolving to `PostgresJsDatabase`.

## Compatibility

Consumers writing the bare `FinanceAppApiRuntime` still compile — the handle resolves to `unknown`. An implementer that relied on the previous implicit `PostgresJsDatabase` should instantiate the parameter. Marked `minor` on `finance-contracts` for that reason; no external repo references the interface.

`finance-contracts` runtime dependencies are now `@voyant-travel/schema-kit` + `zod`.

## Verification

| Check | Result |
|---|---|
| `-F finance-contracts typecheck` | pass |
| `-F finance typecheck` | pass |
| `-F apps typecheck` | pass |
| `-F finance test` | 487 passed, 357 skipped |
| `-F apps test` | 128 passed, 15 skipped |
| `pnpm verify:release-config` | pass |
| `pnpm install --frozen-lockfile` | pass |

`verify:package-exports` was not run locally — it requires a prior full build and fails on an unrelated `storefront` dist path without one. CI builds first.
