### PR TITLE
fix(hono): derive the MCP challenge from the configured public address

### DIFF
--- a/.changeset/mcp-challenge-public-origin.md
+++ b/.changeset/mcp-challenge-public-origin.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/hono": patch
+---
+
+Build the MCP RFC 9728 challenge from the configured public address instead of the request origin. Behind an edge that terminates TLS and rewrites `Host` to the upstream service, the request carries the internal origin, so the `WWW-Authenticate` header advertised a `resource_metadata` URL the client could not reach and the connector handshake died at its first hop. The challenge now reads `API_BASE_URL`, then `APP_URL`, `DASH_BASE_URL`, and the first `CORS_ALLOWLIST` entry — the same configuration the issuer and the protected-resource document derive from — and falls back to the request origin only when none is configured.

--- a/packages/hono/src/middleware/auth.ts
+++ b/packages/hono/src/middleware/auth.ts
@@ -552,7 +552,7 @@ export function requireAuth<TBindings extends VoyantBindings>(
     // nowhere to go, so the whole flow is unreachable.
     if (isMcpApi) {
       return c.json({ error: "Unauthorized" }, 401, {
-        "WWW-Authenticate": `Bearer resource_metadata="${mcpResourceMetadataUrl(c.req.url)}"`,
+        "WWW-Authenticate": `Bearer resource_metadata="${mcpResourceMetadataUrl(c.env, c.req.url)}"`,
       })
     }
 
@@ -563,16 +563,56 @@ export function requireAuth<TBindings extends VoyantBindings>(
 /**
  * Absolute URL of the protected-resource document named in the challenge.
  *
- * Built from the request's own origin rather than a configured base URL: the
- * client fetches exactly this URL, and the origin is the one piece of the
- * deployment's public address the middleware can always observe. The root form
- * is used because the API base path is already stripped by the time this
- * middleware runs, so a path-derived form would omit that prefix.
+ * Derived from the deployment's configured public address, not from the
+ * request: behind an edge that terminates TLS and re-points `Host` at the
+ * upstream service — how managed deployments are fronted — the runtime
+ * observes the internal origin, so a request-derived challenge advertises an
+ * address the client cannot reach. The configured address is the same source
+ * the issuer and the protected-resource document itself derive from, so the
+ * challenge and the document it names agree under any proxy topology.
+ *
+ * The request origin remains the fallback for deployments that configure no
+ * public address at all (local development), where it is the only signal there
+ * is. The root form is used because OAuth discovery answers at the origin root,
+ * ahead of the API layer, so a path-derived form would point at nothing.
  */
-function mcpResourceMetadataUrl(requestUrl: string): string {
+function mcpResourceMetadataUrl(env: VoyantBindings, requestUrl: string): string {
+  const origin = configuredPublicOrigin(env) ?? httpOrigin(requestUrl)
+  return origin
+    ? `${origin}/.well-known/oauth-protected-resource`
+    : "/.well-known/oauth-protected-resource"
+}
+
+/**
+ * Public origin of this deployment, read from configuration in the same
+ * precedence order the auth runtime's `getPublicApiBaseUrl`/`getAuthBaseUrl`
+ * use, so every document in the connector handshake names one address.
+ */
+function configuredPublicOrigin(env: VoyantBindings): string | null {
+  const candidates = [
+    env.API_BASE_URL,
+    env.APP_URL,
+    env.DASH_BASE_URL,
+    env.CORS_ALLOWLIST?.split(",")[0],
+  ]
+  for (const candidate of candidates) {
+    const origin = httpOrigin(candidate)
+    // A malformed or relative value says nothing about the public address;
+    // keep reading the lower-precedence candidates rather than giving up.
+    if (origin) return origin
+  }
+  return null
+}
+
+/** Origin of an absolute http(s) URL, or `null` for anything else. */
+function httpOrigin(url: string | undefined): string | null {
+  const value = url?.trim()
+  if (!value) return null
   try {
-    return `${new URL(requestUrl).origin}/.well-known/oauth-protected-resource`
+    const parsed = new URL(value)
+    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return null
+    return parsed.origin
   } catch {
-    return "/.well-known/oauth-protected-resource"
+    return null
   }
 }

--- a/packages/hono/tests/unit/mcp-challenge.test.ts
+++ b/packages/hono/tests/unit/mcp-challenge.test.ts
@@ -6,6 +6,10 @@ import type { VoyantBindings } from "../../src/types.js"
 
 const TEST_ENV = { DATABASE_URL: "postgres://localhost/test" } as VoyantBindings
 
+function envWith(overrides: Partial<VoyantBindings>): VoyantBindings {
+  return { ...TEST_ENV, ...overrides }
+}
+
 function mockExecutionCtx() {
   return { waitUntil: () => {}, passThroughOnException: () => {} }
 }
@@ -19,24 +23,84 @@ function appWithAuth() {
   return app
 }
 
+async function challenge(request: Request, env: VoyantBindings): Promise<string | null> {
+  const app = appWithAuth()
+  app.all("/v1/admin/mcp", (c) => c.json({ ok: true }))
+  const response = await app.fetch(request, env, mockExecutionCtx())
+  expect(response.status).toBe(401)
+  return response.headers.get("WWW-Authenticate")
+}
+
 describe("MCP connector challenge", () => {
   it("answers an anonymous MCP request with the resource-metadata challenge", async () => {
-    const app = appWithAuth()
-    app.post("/v1/admin/mcp", (c) => c.json({ ok: true }))
-
-    const response = await app.fetch(
-      new Request("https://ops.example.com/v1/admin/mcp", { method: "POST" }),
-      TEST_ENV,
-      mockExecutionCtx(),
-    )
-
     // This header IS the discovery entry point: a chat assistant dials the
     // pasted URL with no credential and follows `resource_metadata` from here
     // to the authorization server. Without it the handshake cannot start.
-    expect(response.status).toBe(401)
-    expect(response.headers.get("WWW-Authenticate")).toBe(
+    expect(
+      await challenge(
+        new Request("https://ops.example.com/v1/admin/mcp", { method: "POST" }),
+        envWith({ API_BASE_URL: "https://ops.example.com/api" }),
+      ),
+    ).toBe(
       'Bearer resource_metadata="https://ops.example.com/.well-known/oauth-protected-resource"',
     )
+  })
+
+  it("names the configured public origin, not the origin a proxy rewrote Host to", async () => {
+    // Managed deployments sit behind an edge that terminates TLS and re-points
+    // `Host` at the upstream service. A request-derived challenge would send the
+    // client to the internal address, where it cannot reach discovery at all.
+    expect(
+      await challenge(
+        new Request("http://operator-abc123-europe-west1.a.run.app/v1/admin/mcp", {
+          method: "POST",
+        }),
+        envWith({ API_BASE_URL: "https://ops.example.com/api" }),
+      ),
+    ).toBe(
+      'Bearer resource_metadata="https://ops.example.com/.well-known/oauth-protected-resource"',
+    )
+  })
+
+  it("falls back through APP_URL, DASH_BASE_URL and the CORS allowlist", async () => {
+    const internal = () =>
+      new Request("http://operator-abc123.internal/v1/admin/mcp", { method: "POST" })
+    const expected = (origin: string) =>
+      `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource"`
+
+    expect(await challenge(internal(), envWith({ APP_URL: "https://app.example.com" }))).toBe(
+      expected("https://app.example.com"),
+    )
+    expect(
+      await challenge(internal(), envWith({ DASH_BASE_URL: "https://dash.example.com" })),
+    ).toBe(expected("https://dash.example.com"))
+    expect(
+      await challenge(
+        internal(),
+        envWith({ CORS_ALLOWLIST: "https://first.example.com,https://second.example.com" }),
+      ),
+    ).toBe(expected("https://first.example.com"))
+  })
+
+  it("skips malformed configuration in favour of the next candidate", async () => {
+    expect(
+      await challenge(
+        new Request("http://operator-abc123.internal/v1/admin/mcp", { method: "POST" }),
+        envWith({ API_BASE_URL: "not-a-url", APP_URL: "https://app.example.com" }),
+      ),
+    ).toBe(
+      'Bearer resource_metadata="https://app.example.com/.well-known/oauth-protected-resource"',
+    )
+  })
+
+  it("falls back to the request origin when no public address is configured", async () => {
+    // Local development configures nothing; the request is then the only signal.
+    expect(
+      await challenge(
+        new Request("http://localhost:5173/v1/admin/mcp", { method: "POST" }),
+        TEST_ENV,
+      ),
+    ).toBe('Bearer resource_metadata="http://localhost:5173/.well-known/oauth-protected-resource"')
   })
 
   it("challenges nested MCP paths such as the discovery manifest", async () => {


### PR DESCRIPTION
Closes #3901.

## Problem

The RFC 9728 challenge on `/v1/admin/mcp` built its `resource_metadata` URL from `c.req.url`. Behind an edge that terminates TLS and re-points `Host` at the upstream service — how managed deployments are fronted — the runtime observes the internal origin, so an unauthenticated MCP client got:

```
HTTP/2 401
www-authenticate: Bearer resource_metadata="http://<service>-<hash>-<region>.a.run.app/.well-known/oauth-protected-resource"
```

Wrong scheme, wrong host, and following it reaches an origin that rejects callers arriving without the edge's trust header. The connector handshake died at its very first hop — this header is the only thing that tells a chat assistant where the authorization server lives.

## Fix

`mcpResourceMetadataUrl` now takes `env` and reads the public origin from configuration, in the same precedence order the auth runtime's `getPublicApiBaseUrl` / `getAuthBaseUrl` already use:

`API_BASE_URL` → `APP_URL` → `DASH_BASE_URL` → first `CORS_ALLOWLIST` entry → request origin.

Each candidate must parse as an absolute `http(s)` URL; a malformed or relative value is skipped rather than treated as an answer. Only the origin is taken, because OAuth discovery answers at the origin root ahead of the `/api` layer (`packages/runtime/src/index.ts`), not behind it.

The request origin survives as the last fallback — local development configures no public address, and there the request is the only signal there is.

This makes the challenge agree with the document it points at: `resolveOAuthDiscoveryRequest` in `packages/auth/src/node-runtime.ts` already builds the protected-resource document from `getPublicApiBaseUrl(env)`. Only the challenge header disagreed.

## Verification

- `pnpm --filter @voyant-travel/hono test` — 324 passed
- `pnpm --filter @voyant-travel/auth test` — 251 passed, 18 skipped
- `pnpm --filter @voyant-travel/hono typecheck` / `lint` — clean

New cases in `packages/hono/tests/unit/mcp-challenge.test.ts` cover the proxy topology (internal `http://…a.run.app` request + configured `https://ops.example.com`), each fallback rung, a malformed higher-precedence value, and the unconfigured local-development path.

## Follow-up

Voyant Cloud's managed router carries a local correction that rewrites the header's origin. That workaround can be removed once this ships.