### PR TITLE
refactor(scripts): collapse the mechanically-safe retired-path pins

### DIFF
--- a/scripts/check-booking-create-authority.mjs
+++ b/scripts/check-booking-create-authority.mjs
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync } from "node:fs"
+import { readdirSync, readFileSync } from "node:fs"
 import { extname, join, relative, sep } from "node:path"
 import ts from "typescript"
 
@@ -7,19 +7,6 @@ const SOURCE_EXTENSIONS = new Set([".ts", ".tsx", ".mts", ".cts", ".js", ".jsx",
 const failures = []
 const files = sourceFiles("packages").filter(isProductionSource)
 const sources = new Map(files.map((file) => [file, parse(file)]))
-
-for (const file of [
-  "packages/charters/src/service-bookings.ts",
-  "packages/charters/src/service-bookings-local.ts",
-  "packages/cruises/src/service-bookings.ts",
-  "packages/bookings-react/src/hooks/use-booking-convert-mutation.ts",
-  "packages/catalog/src/booking-engine/book.ts",
-  "packages/catalog/src/booking-engine/snapshot-content.ts",
-  "packages/catalog-react/src/booking-engine/use-booking-commit.ts",
-  "packages/bookings-react/src/storefront/storefront-checkout-bodies.ts",
-]) {
-  if (existsSync(file)) fail(file, "retired raw booking-create module still exists")
-}
 
 for (const [file, routePath] of [
   ["packages/bookings/src/routes-admin.ts", "/reserve"],

--- a/scripts/check-bookings-runtime-authority.mjs
+++ b/scripts/check-bookings-runtime-authority.mjs
@@ -29,9 +29,6 @@ const violations = inspectBookingsRuntimeAuthority({
   manifests: readWorkspaceManifests(root),
   policy,
 })
-if (existsSync(path.join(root, "starters/operator/src/api/runtime/runtime-adapter.ts"))) {
-  violations.push("starters/operator/src/api/runtime/runtime-adapter.ts must stay deleted")
-}
 
 if (violations.length > 0) {
   throw new Error(`check-bookings-runtime-authority:\n- ${violations.join("\n- ")}`)

--- a/scripts/check-catalog-runtime-authority.mjs
+++ b/scripts/check-catalog-runtime-authority.mjs
@@ -39,9 +39,6 @@ const cyclicPackages = [
   "@voyant-travel/operations",
 ]
 
-if (existsSync(path.join(root, "packages/catalog-node"))) {
-  violations.push("the retired Catalog target package still exists")
-}
 if (
   catalog.voyant?.runtime?.entry !== "./runtime-contributor" ||
   catalog.voyant?.runtime?.export !== "createCatalogRuntimePortContribution"
@@ -161,9 +158,6 @@ const operatorResources = [
   read("packages/runtime/src/deployment-resources.ts"),
 ].join("\n")
 const runtimeHost = read("packages/core/src/runtime-host.ts")
-if (existsSync(path.join(root, "starters/operator/src/api/runtime/runtime-adapter.ts"))) {
-  violations.push("starters/operator/src/api/runtime/runtime-adapter.ts must stay deleted")
-}
 if (
   /\bmodules\s*:|modules\.import|primitives\.modules/.test(`${runtimeHost}\n${operatorResources}`)
 ) {

--- a/scripts/check-catalog-subscriber-authority.mjs
+++ b/scripts/check-catalog-subscriber-authority.mjs
@@ -1,4 +1,3 @@
-import { existsSync } from "node:fs"
 import { access, readFile } from "node:fs/promises"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
@@ -65,9 +64,6 @@ requireMatch(
   /bookingSnapshot:\s*RuntimePortValue<CatalogBookingSnapshotRuntimeProvider>/,
   "Catalog snapshot contribution must satisfy its package-owned type",
 )
-if (existsSync(path.join(repoRoot, "starters/operator/src/api/app.ts"))) {
-  failures.push("starters/operator/src/api/app.ts must stay deleted")
-}
 
 for (const legacyPath of [
   "starters/operator/src/api/subscribers/catalog-bridge.ts",

--- a/scripts/check-generated-runtime-contributor-authority.mjs
+++ b/scripts/check-generated-runtime-contributor-authority.mjs
@@ -56,9 +56,6 @@ const [
 ])
 
 const violations = []
-if (existsSync(path.join(root, "starters/operator/src/api/runtime/runtime-adapter.ts"))) {
-  violations.push("starters/operator/src/api/runtime/runtime-adapter.ts must stay deleted")
-}
 for (const retiredPath of [
   "release.runtime-packages.generated.json",
   "packages/framework/src/runtime-packages.generated.ts",

--- a/scripts/check-legal-subscriber-authority.mjs
+++ b/scripts/check-legal-subscriber-authority.mjs
@@ -1,4 +1,3 @@
-import { existsSync } from "node:fs"
 import { readFile } from "node:fs/promises"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
@@ -26,9 +25,6 @@ const sources = Object.fromEntries(
 )
 
 const failures = []
-if (existsSync(path.join(repoRoot, "starters/operator/src/api/runtime/runtime-adapter.ts"))) {
-  failures.push("starters/operator/src/api/runtime/runtime-adapter.ts must stay deleted")
-}
 const requireMatch = (source, pattern, message) => {
   if (!pattern.test(source)) failures.push(message)
 }

--- a/scripts/check-node-runtime-authority.mjs
+++ b/scripts/check-node-runtime-authority.mjs
@@ -12,9 +12,6 @@ const runtimePackage = JSON.parse(await read("packages/runtime/package.json"))
 const runtimeCorePackage = JSON.parse(await read("packages/runtime-core/package.json"))
 const violations = []
 
-if (existsSync(path.join(root, "packages/operator-runtime"))) {
-  violations.push("the retired packages/operator-runtime directory must stay deleted")
-}
 if (runtimePackage.name !== "@voyant-travel/runtime") {
   violations.push("packages/runtime must be the public @voyant-travel/runtime host")
 }

--- a/scripts/check-operator-booking-finance-runtime-authority.mjs
+++ b/scripts/check-operator-booking-finance-runtime-authority.mjs
@@ -1,4 +1,3 @@
-import { existsSync } from "node:fs"
 import { readFile } from "node:fs/promises"
 import path from "node:path"
 
@@ -29,9 +28,6 @@ const contributors = {
 }
 
 const violations = []
-if (existsSync(path.join(root, "starters/operator/src/api/runtime/runtime-adapter.ts"))) {
-  violations.push("starters/operator/src/api/runtime/runtime-adapter.ts must stay deleted")
-}
 for (const [packageName, ports] of Object.entries(packagePorts)) {
   for (const port of ports) {
     if (deploymentResources.includes(port)) {

--- a/scripts/check-operator-catalog-commerce-runtime-authority.mjs
+++ b/scripts/check-operator-catalog-commerce-runtime-authority.mjs
@@ -1,4 +1,3 @@
-import { existsSync } from "node:fs"
 import { access, readFile } from "node:fs/promises"
 import path from "node:path"
 
@@ -40,9 +39,6 @@ const commercePorts = [
 ]
 
 const violations = []
-if (existsSync(path.join(root, "starters/operator/src/api/runtime/runtime-adapter.ts"))) {
-  violations.push("starters/operator/src/api/runtime/runtime-adapter.ts must stay deleted")
-}
 for (const port of [...catalogPorts, ...commercePorts]) {
   if (deploymentResources.includes(port)) {
     violations.push(`deployment-resources.ts must not register or import ${port}`)

--- a/scripts/check-operator-final-runtime-authority.mjs
+++ b/scripts/check-operator-final-runtime-authority.mjs
@@ -1,4 +1,3 @@
-import { existsSync } from "node:fs"
 import { readFile } from "node:fs/promises"
 import path from "node:path"
 
@@ -47,9 +46,6 @@ const [deploymentResources, smartbillAdapter, ...contributors] = await Promise.a
 ])
 
 const violations = []
-if (existsSync(path.join(root, "starters/operator/src/api/runtime/runtime-adapter.ts"))) {
-  violations.push("starters/operator/src/api/runtime/runtime-adapter.ts must stay deleted")
-}
 const directRegistrations = deploymentResources.match(/\[[A-Za-z][A-Za-z0-9]*Port\.id\]/g) ?? []
 if (directRegistrations.length > 0) {
   violations.push(

--- a/scripts/check-operator-storefront-legal-inventory-runtime-authority.mjs
+++ b/scripts/check-operator-storefront-legal-inventory-runtime-authority.mjs
@@ -1,4 +1,3 @@
-import { existsSync } from "node:fs"
 import { readFile } from "node:fs/promises"
 import path from "node:path"
 
@@ -45,9 +44,6 @@ const contributors = {
 }
 
 const violations = []
-if (existsSync(path.join(root, "starters/operator/src/api/runtime/runtime-adapter.ts"))) {
-  violations.push("starters/operator/src/api/runtime/runtime-adapter.ts must stay deleted")
-}
 for (const [packageName, ports] of Object.entries(packagePorts)) {
   for (const port of ports) {
     if (deploymentResources.includes(port)) {

--- a/scripts/check-starter-executable-surface-authority.mjs
+++ b/scripts/check-starter-executable-surface-authority.mjs
@@ -55,10 +55,6 @@ for (const [relativePath, tokens] of requiredSourceTokens) {
   }
 }
 
-if (existsSync(join(root, "packages/framework/src/managed-jobs.ts"))) {
-  violations.push("packages/framework/src/managed-jobs.ts must remain deleted")
-}
-
 if (violations.length > 0) {
   console.error("Starter executable-surface authority check failed.\n")
   for (const violation of violations) console.error(`  - ${violation}`)

--- a/scripts/check-storage-media-runtime-authority.mjs
+++ b/scripts/check-storage-media-runtime-authority.mjs
@@ -18,10 +18,6 @@ const storagePackage = JSON.parse(read("packages/storage/package.json"))
 const inventoryPackage = JSON.parse(read("packages/inventory/package.json"))
 const policy = JSON.parse(read("scripts/fixtures/storage-media-runtime-policy.json"))
 
-if (existsSync(path.join(root, "starters/operator/src/api/runtime/runtime-adapter.ts"))) {
-  failures.push("starters/operator/src/api/runtime/runtime-adapter.ts must stay deleted")
-}
-
 for (const relativePath of policy.forbiddenStarterPaths) {
   if (existsSync(path.join(root, relativePath))) {
     failures.push(`${relativePath} must stay deleted`)

--- a/scripts/check-trips-subscriber-authority.mjs
+++ b/scripts/check-trips-subscriber-authority.mjs
@@ -31,9 +31,6 @@ for (const retiredPath of [
   if (existsSync(path.join(repoRoot, retiredPath)))
     failures.push(`${retiredPath} must stay deleted`)
 }
-if (existsSync(path.join(repoRoot, "starters/operator/src/api/runtime/trips-runtime.ts"))) {
-  failures.push("Operator Trips runtime must stay deleted")
-}
 const requireMatch = (source, pattern, message) => {
   if (!pattern.test(source)) failures.push(message)
 }

--- a/scripts/tests/check-catalog-subscriber-authority.test.mjs
+++ b/scripts/tests/check-catalog-subscriber-authority.test.mjs
@@ -68,15 +68,9 @@ describe("Catalog subscriber authority checker", () => {
     assert.match(result.stdout, /Catalog subscriber authority: OK/)
   })
 
-  it("rejects a restored starter app", async () => {
-    const root = await createFixture({
-      "starters/operator/src/api/app.ts": "plugins: [catalogBridgeBundle]\n",
-    })
-    await assert.rejects(
-      runChecker(root),
-      /starters\/operator\/src\/api\/app\.ts must stay deleted/,
-    )
-  })
+  // The "restored starter app" case moved: that path is declared in
+  // scripts/checks/regression/retired-paths.json and asserted by
+  // verify:retired-surfaces, which covers every retired path in one place.
 
   it("rejects a retained legacy bridge file", async () => {
     const root = await createFixture({

--- a/scripts/tests/check-trips-subscriber-authority.test.mjs
+++ b/scripts/tests/check-trips-subscriber-authority.test.mjs
@@ -53,14 +53,9 @@ describe("Trips subscriber authority checker", () => {
     )
   })
 
-  it("rejects a restored Operator Trips runtime", async () => {
-    const root = await createFixture({
-      "starters/operator/src/api/runtime/trips-runtime.ts": `
-export const restored = true
-`,
-    })
-    await assert.rejects(runChecker(root), /Operator Trips runtime must stay deleted/)
-  })
+  // The "restored Operator Trips runtime" case moved: that path is declared in
+  // scripts/checks/regression/retired-paths.json and asserted by
+  // verify:retired-surfaces, which covers every retired path in one place.
 
   it("rejects manual descriptor registration in composition", async () => {
     const root = await createFixture({


### PR DESCRIPTION
Follow-up to #3918. That PR added the retired-surface engine; this one removes what it replaced.

## What was removed

**15 removals across 14 scripts, covering 22 declared paths** — 14 single `if (existsSync(...))` guards, plus one whole array loop of 8 paths in `check-booking-create-authority`.

Every removal was gated on two conditions:

1. the path already appears in `retired-paths.json`, and
2. the guard body does nothing but record a violation

So no assertion is lost — each one is relocated to `verify:retired-surfaces`, which asserts all 83 retired paths at once.

## The honest scope

**This is not the wholesale collapse the plan implied.** Of the 91 `existsSync` guards across the 47 scripts, only 22 paths were mechanically safe to move. The rest were skipped, each with a reason:

| Reason skipped | Example |
|---|---|
| path is relative to a **variable root**, not repo-relative | `check-distribution-channel-push-runtime-authority` pins `src/api/runtime/runtime-adapter.ts` |
| path is a **bare fragment** from a loop variable | `check-node-runtime-authority` pins `packages/runtime/src` |
| guard body does **more than record a violation** | `check-operator-product-ui-authority`, `check-storefront-presentation-authority` |
| guard is a **negated presence assertion** (`!existsSync`) | must not be touched — asserts a file *exists* |

Collapsing those means reconstructing paths from surrounding code by hand. I would rather report the real number than commit a guessed path into a checked-in list.

## Companion tests

Two unit tests asserted the removed pins directly and started failing, which is the system working:

- `check-catalog-subscriber-authority.test.mjs` → "rejects a restored starter app"
- `check-trips-subscriber-authority.test.mjs` → "rejects a restored Operator Trips runtime"

Both cases are removed with a comment pointing at where the coverage now lives. Both paths remain declared in `retired-paths.json` — verified explicitly, and the drift test in `scripts/tests/retired-surfaces.test.mjs` keeps it that way.

## Verification

| Check | Result |
|---|---|
| `pnpm verify:architecture` | **exit 0** (the full ~60-link chain) |
| `pnpm verify:retired-surfaces` | 83 retired paths still absent |
| `pnpm verify:boundary` | 47 packages, no violations |
| companion tests for both edited scripts | 3 passed each, 0 failed |
| `biome check .` | clean |

Each modified checker was also run individually. Note `check-operator-final-runtime-authority` has no `verify:` script of its own — it is invoked inside `verify:runtime-ports`, which passes.

No published package changes, so no changeset.
