### PR TITLE
fix(mcp): ship the connector consent screen in every auth mode

### DIFF
--- a/.changeset/mcp-consent-own-presentation.md
+++ b/.changeset/mcp-consent-own-presentation.md
@@ -1,0 +1,28 @@
+---
+"@voyant-travel/operator-standard": minor
+"@voyant-travel/auth-react": minor
+"@voyant-travel/mcp": minor
+---
+
+Ship the MCP connector consent screen in every admin auth mode.
+
+`/mcp-consent` was contributed as part of the local-auth presentation, alongside
+`sign-in`, `sign-up`, and the password-reset pages. A deployment running
+`VOYANT_ADMIN_AUTH_MODE=voyant-cloud` deliberately does not select that
+contribution, so it shipped no consent page: an MCP connector registered and
+authorized successfully, then landed on a 404 at the last step before the grant.
+
+That was a miscategorisation. The consent screen is not a local-auth page — it
+is an OAuth authorization decision point, and the authorization server issuing
+connector grants is local to the deployment in every auth mode, which is why
+`/auth/oauth2/consent` and `/auth/oauth2/get-client` are already reachable in
+cloud mode.
+
+The screen now has its own presentation, `@voyant-travel/mcp#presentation.consent`,
+declared by the MCP module and mounted from a new
+`@voyant-travel/auth-react/mcp-consent-routes` export. It ships whenever the MCP
+transport ships, and a broker-authenticated Operator gets it without also
+getting a local sign-in and sign-up page. `createLocalAuthRouteContribution` no
+longer returns an `mcpConsent` route, and the generated route host moved from
+`(auth)/mcp-consent.tsx` to `(mcp)/mcp-consent.tsx`; the public path
+`/mcp-consent` is unchanged.

--- a/packages/accommodations/tsconfig.build.json
+++ b/packages/accommodations/tsconfig.build.json
@@ -172,6 +172,9 @@
       "@voyant-travel/auth-react/i18n/en": ["../auth-react/dist/i18n/en.d.ts"],
       "@voyant-travel/auth-react/i18n/ro": ["../auth-react/dist/i18n/ro.d.ts"],
       "@voyant-travel/auth-react/local-auth-routes": ["../auth-react/dist/local-auth-routes.d.ts"],
+      "@voyant-travel/auth-react/mcp-consent-routes": [
+        "../auth-react/dist/mcp-consent-routes.d.ts"
+      ],
       "@voyant-travel/auth-react/organization-members": [
         "../auth-react/dist/components/organization-members-page.d.ts"
       ],

--- a/packages/accommodations/tsconfig.typecheck.json
+++ b/packages/accommodations/tsconfig.typecheck.json
@@ -173,6 +173,9 @@
       "@voyant-travel/auth-react/i18n/en": ["../auth-react/dist/i18n/en.d.ts"],
       "@voyant-travel/auth-react/i18n/ro": ["../auth-react/dist/i18n/ro.d.ts"],
       "@voyant-travel/auth-react/local-auth-routes": ["../auth-react/dist/local-auth-routes.d.ts"],
+      "@voyant-travel/auth-react/mcp-consent-routes": [
+        "../auth-react/dist/mcp-consent-routes.d.ts"
+      ],
       "@voyant-travel/auth-react/organization-members": [
         "../auth-react/dist/components/organization-members-page.d.ts"
       ],

--- a/packages/auth-react/package.json
+++ b/packages/auth-react/package.json
@@ -17,6 +17,7 @@
     "./query-keys": "./src/query-keys.ts",
     "./ui": "./src/ui.ts",
     "./local-auth-routes": "./src/local-auth-routes.tsx",
+    "./mcp-consent-routes": "./src/mcp-consent-routes.tsx",
     "./admin": "./src/admin.tsx",
     "./account": "./src/components/account-page.tsx",
     "./organization-members": "./src/components/organization-members-page.tsx",
@@ -122,6 +123,11 @@
         "types": "./dist/local-auth-routes.d.ts",
         "import": "./dist/local-auth-routes.js",
         "default": "./dist/local-auth-routes.js"
+      },
+      "./mcp-consent-routes": {
+        "types": "./dist/mcp-consent-routes.d.ts",
+        "import": "./dist/mcp-consent-routes.js",
+        "default": "./dist/mcp-consent-routes.js"
       },
       "./admin": {
         "types": "./dist/admin.d.ts",

--- a/packages/auth-react/src/local-auth-routes.test.tsx
+++ b/packages/auth-react/src/local-auth-routes.test.tsx
@@ -22,7 +22,6 @@ describe("local auth presentation", () => {
       "acceptInvitation",
       "acceptInvite",
       "forgotPassword",
-      "mcpConsent",
       "onboarding",
       "resetPassword",
       "signIn",

--- a/packages/auth-react/src/local-auth-routes.tsx
+++ b/packages/auth-react/src/local-auth-routes.tsx
@@ -2,12 +2,10 @@ import { useMutation, useQuery } from "@tanstack/react-query"
 import { Outlet, redirect, useNavigate, useSearch } from "@tanstack/react-router"
 import { formatMessage } from "@voyant-travel/admin/lib/i18n"
 import type { AdminAuthMessages } from "@voyant-travel/i18n"
-import { useVoyantReactContext } from "@voyant-travel/react"
 import type { ReactNode } from "react"
 import { z } from "zod"
 import { AcceptInvitationPage } from "./components/accept-invitation-page.js"
 import { AuthLayout } from "./components/auth-layout.js"
-import { McpConsentPage } from "./components/mcp-consent-page.js"
 import {
   ForgotPasswordPage,
   type ForgotPasswordPageMessages,
@@ -57,7 +55,6 @@ export interface LocalAuthRouteContribution {
     readonly acceptInvitation: LocalAuthRouteOptions
     readonly acceptInvite: LocalAuthRouteOptions
     readonly forgotPassword: LocalAuthRouteOptions
-    readonly mcpConsent: LocalAuthRouteOptions
     readonly onboarding: LocalAuthRouteOptions
     readonly resetPassword: LocalAuthRouteOptions
     readonly signIn: LocalAuthRouteOptions
@@ -315,44 +312,6 @@ export function createLocalAuthRouteContribution<TUser>(
     )
   }
 
-  function McpConsentRoute() {
-    const { client_id, scope } = useSearch({ strict: false }) as {
-      client_id?: string
-      scope?: string
-    }
-    const { baseUrl, fetcher } = useVoyantReactContext()
-    // The authorization server signs the whole query and expects it back
-    // verbatim, so read it from the address bar rather than reserializing the
-    // parsed params (which would reorder them and break the signature).
-    const oauthQuery =
-      typeof window === "undefined" ? "" : window.location.search.replace(/^\?/, "")
-
-    // The redirect carries `client_id` but no display name; look it up so the
-    // operator sees "Claude", not an opaque identifier.
-    const client = useQuery({
-      queryKey: ["mcp-consent-client", client_id],
-      enabled: Boolean(client_id),
-      queryFn: async () => {
-        const response = await fetcher(
-          `${baseUrl}/auth/admin/oauth2/public-client?client_id=${encodeURIComponent(client_id ?? "")}`,
-          { credentials: "include" },
-        )
-        if (!response.ok) return null
-        return (await response.json()) as { name?: string | null; client_name?: string | null }
-      },
-    })
-
-    return (
-      <McpConsentPage
-        clientName={client.data?.name ?? client.data?.client_name ?? null}
-        scope={scope ?? null}
-        oauthQuery={oauthQuery}
-        baseUrl={baseUrl}
-        fetcher={fetcher}
-      />
-    )
-  }
-
   return {
     id: "@voyant-travel/auth#presentation.local-auth",
     routes: {
@@ -369,16 +328,6 @@ export function createLocalAuthRouteContribution<TUser>(
       forgotPassword: {
         loader: localAuthLoader("forgot-password"),
         component: ForgotPasswordRoute,
-      },
-      mcpConsent: {
-        // No `localAuthLoader`: the authorization server sends the operator
-        // through sign-in first, so reaching this route already implies a
-        // session. Guarding again here would bounce a mid-flight consent.
-        // Permissive: the authorization server forwards its entire signed
-        // query (including `sig`, `exp`, and repeated `ba_param` entries), and
-        // a strict schema would reject the redirect outright.
-        validateSearch: z.object({}).passthrough(),
-        component: McpConsentRoute,
       },
       onboarding: {
         loader: async ({ location }) => {

--- a/packages/auth-react/src/mcp-consent-routes.test.tsx
+++ b/packages/auth-react/src/mcp-consent-routes.test.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest"
+import { createLocalAuthRouteContribution } from "./local-auth-routes.js"
+import { createMcpConsentRouteContribution } from "./mcp-consent-routes.js"
+
+describe("mcp consent presentation", () => {
+  it("matches the package-owned presentation declaration", () => {
+    const contribution = createMcpConsentRouteContribution()
+
+    expect(contribution.id).toBe("@voyant-travel/mcp#presentation.consent")
+    expect(Object.keys(contribution.routes)).toEqual(["layout", "consent"])
+  })
+
+  it("mounts without a local-auth host runtime", () => {
+    // A broker-authenticated deployment has no local sign-in runtime to hand
+    // over, so the factory must take no arguments at all.
+    expect(createMcpConsentRouteContribution.length).toBe(0)
+  })
+
+  it("is not reachable through the local-auth contribution", () => {
+    const localAuth = createLocalAuthRouteContribution({
+      getCurrentUser: vi.fn(async () => null),
+      getBootstrapStatus: vi.fn(async () => ({ hasUsers: true, authMode: "local" as const })),
+      cloudAuthStartHref: vi.fn(() => "/api/auth/admin/cloud/start"),
+      useMessages: vi.fn(),
+      getInvitation: vi.fn(),
+      redeemInvitation: vi.fn(),
+      signInWithEmail: vi.fn(),
+      signInWithSocial: vi.fn(),
+      sendVerificationOtp: vi.fn(),
+      refreshAuthStatus: vi.fn(),
+    } as never)
+
+    expect(Object.keys(localAuth.routes)).not.toContain("mcpConsent")
+  })
+})

--- a/packages/auth-react/src/mcp-consent-routes.tsx
+++ b/packages/auth-react/src/mcp-consent-routes.tsx
@@ -1,0 +1,95 @@
+import { useQuery } from "@tanstack/react-query"
+import { Outlet, useSearch } from "@tanstack/react-router"
+import { useVoyantReactContext } from "@voyant-travel/react"
+import type { ReactNode } from "react"
+import { z } from "zod"
+import { AuthLayout } from "./components/auth-layout.js"
+import { McpConsentPage } from "./components/mcp-consent-page.js"
+
+/**
+ * The OAuth consent screen an MCP connector sends the operator to.
+ *
+ * It is deliberately not part of the local-auth contribution. The authorization
+ * server issuing connector grants is local to the deployment in *every* admin
+ * auth mode, so a broker-authenticated deployment — one that ships no sign-in,
+ * sign-up, or password-reset page — still has to answer this route or the
+ * connector handshake dies on its last step. Keeping it in its own presentation
+ * lets a cloud-auth Operator mount consent without mounting local sign-in.
+ */
+export interface McpConsentRouteContribution {
+  readonly id: "@voyant-travel/mcp#presentation.consent"
+  readonly routes: {
+    readonly layout: McpConsentRouteOptions
+    readonly consent: McpConsentRouteOptions
+  }
+}
+
+export interface McpConsentRouteOptions {
+  readonly component: () => ReactNode
+  readonly validateSearch?: z.ZodType
+}
+
+export function createMcpConsentRouteContribution(): McpConsentRouteContribution {
+  return {
+    id: "@voyant-travel/mcp#presentation.consent",
+    routes: {
+      layout: { component: McpConsentLayout },
+      consent: {
+        // No auth guard: the authorization server sends the operator through
+        // sign-in (local mode) or the broker (cloud mode) before redirecting
+        // here, so reaching this route already implies a session. Guarding
+        // again would bounce a mid-flight consent.
+        // Permissive: the authorization server forwards its entire signed query
+        // (including `sig`, `exp`, and repeated `ba_param` entries), and a
+        // strict schema would reject the redirect outright.
+        validateSearch: z.object({}).passthrough(),
+        component: McpConsentRoute,
+      },
+    },
+  }
+}
+
+function McpConsentLayout() {
+  return (
+    <AuthLayout>
+      <Outlet />
+    </AuthLayout>
+  )
+}
+
+function McpConsentRoute() {
+  const { client_id, scope } = useSearch({ strict: false }) as {
+    client_id?: string
+    scope?: string
+  }
+  const { baseUrl, fetcher } = useVoyantReactContext()
+  // The authorization server signs the whole query and expects it back
+  // verbatim, so read it from the address bar rather than reserializing the
+  // parsed params (which would reorder them and break the signature).
+  const oauthQuery = typeof window === "undefined" ? "" : window.location.search.replace(/^\?/, "")
+
+  // The redirect carries `client_id` but no display name; look it up so the
+  // operator sees "Claude", not an opaque identifier.
+  const client = useQuery({
+    queryKey: ["mcp-consent-client", client_id],
+    enabled: Boolean(client_id),
+    queryFn: async () => {
+      const response = await fetcher(
+        `${baseUrl}/auth/admin/oauth2/public-client?client_id=${encodeURIComponent(client_id ?? "")}`,
+        { credentials: "include" },
+      )
+      if (!response.ok) return null
+      return (await response.json()) as { name?: string | null; client_name?: string | null }
+    },
+  })
+
+  return (
+    <McpConsentPage
+      clientName={client.data?.name ?? client.data?.client_name ?? null}
+      scope={scope ?? null}
+      oauthQuery={oauthQuery}
+      baseUrl={baseUrl}
+      fetcher={fetcher}
+    />
+  )
+}

--- a/packages/catalog/tsconfig.build.json
+++ b/packages/catalog/tsconfig.build.json
@@ -225,6 +225,9 @@
       "@voyant-travel/auth-react/i18n/en": ["../auth-react/dist/i18n/en.d.ts"],
       "@voyant-travel/auth-react/i18n/ro": ["../auth-react/dist/i18n/ro.d.ts"],
       "@voyant-travel/auth-react/local-auth-routes": ["../auth-react/dist/local-auth-routes.d.ts"],
+      "@voyant-travel/auth-react/mcp-consent-routes": [
+        "../auth-react/dist/mcp-consent-routes.d.ts"
+      ],
       "@voyant-travel/auth-react/organization-members": [
         "../auth-react/dist/components/organization-members-page.d.ts"
       ],

--- a/packages/catalog/tsconfig.typecheck.json
+++ b/packages/catalog/tsconfig.typecheck.json
@@ -226,6 +226,9 @@
       "@voyant-travel/auth-react/i18n/en": ["../auth-react/dist/i18n/en.d.ts"],
       "@voyant-travel/auth-react/i18n/ro": ["../auth-react/dist/i18n/ro.d.ts"],
       "@voyant-travel/auth-react/local-auth-routes": ["../auth-react/dist/local-auth-routes.d.ts"],
+      "@voyant-travel/auth-react/mcp-consent-routes": [
+        "../auth-react/dist/mcp-consent-routes.d.ts"
+      ],
       "@voyant-travel/auth-react/organization-members": [
         "../auth-react/dist/components/organization-members-page.d.ts"
       ],

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -232,6 +232,9 @@
       "@voyant-travel/auth-react/i18n/en": ["../auth-react/dist/i18n/en.d.ts"],
       "@voyant-travel/auth-react/i18n/ro": ["../auth-react/dist/i18n/ro.d.ts"],
       "@voyant-travel/auth-react/local-auth-routes": ["../auth-react/dist/local-auth-routes.d.ts"],
+      "@voyant-travel/auth-react/mcp-consent-routes": [
+        "../auth-react/dist/mcp-consent-routes.d.ts"
+      ],
       "@voyant-travel/auth-react/organization-members": [
         "../auth-react/dist/components/organization-members-page.d.ts"
       ],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -226,6 +226,9 @@
       "@voyant-travel/auth-react/i18n/en": ["../auth-react/dist/i18n/en.d.ts"],
       "@voyant-travel/auth-react/i18n/ro": ["../auth-react/dist/i18n/ro.d.ts"],
       "@voyant-travel/auth-react/local-auth-routes": ["../auth-react/dist/local-auth-routes.d.ts"],
+      "@voyant-travel/auth-react/mcp-consent-routes": [
+        "../auth-react/dist/mcp-consent-routes.d.ts"
+      ],
       "@voyant-travel/auth-react/organization-members": [
         "../auth-react/dist/components/organization-members-page.d.ts"
       ],

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -225,6 +225,9 @@
       "@voyant-travel/auth-react/i18n/en": ["../auth-react/dist/i18n/en.d.ts"],
       "@voyant-travel/auth-react/i18n/ro": ["../auth-react/dist/i18n/ro.d.ts"],
       "@voyant-travel/auth-react/local-auth-routes": ["../auth-react/dist/local-auth-routes.d.ts"],
+      "@voyant-travel/auth-react/mcp-consent-routes": [
+        "../auth-react/dist/mcp-consent-routes.d.ts"
+      ],
       "@voyant-travel/auth-react/organization-members": [
         "../auth-react/dist/components/organization-members-page.d.ts"
       ],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -226,6 +226,9 @@
       "@voyant-travel/auth-react/i18n/en": ["../auth-react/dist/i18n/en.d.ts"],
       "@voyant-travel/auth-react/i18n/ro": ["../auth-react/dist/i18n/ro.d.ts"],
       "@voyant-travel/auth-react/local-auth-routes": ["../auth-react/dist/local-auth-routes.d.ts"],
+      "@voyant-travel/auth-react/mcp-consent-routes": [
+        "../auth-react/dist/mcp-consent-routes.d.ts"
+      ],
       "@voyant-travel/auth-react/organization-members": [
         "../auth-react/dist/components/organization-members-page.d.ts"
       ],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -225,6 +225,9 @@
       "@voyant-travel/auth-react/i18n/en": ["../auth-react/dist/i18n/en.d.ts"],
       "@voyant-travel/auth-react/i18n/ro": ["../auth-react/dist/i18n/ro.d.ts"],
       "@voyant-travel/auth-react/local-auth-routes": ["../auth-react/dist/local-auth-routes.d.ts"],
+      "@voyant-travel/auth-react/mcp-consent-routes": [
+        "../auth-react/dist/mcp-consent-routes.d.ts"
+      ],
       "@voyant-travel/auth-react/organization-members": [
         "../auth-react/dist/components/organization-members-page.d.ts"
       ],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -226,6 +226,9 @@
       "@voyant-travel/auth-react/i18n/en": ["../auth-react/dist/i18n/en.d.ts"],
       "@voyant-travel/auth-react/i18n/ro": ["../auth-react/dist/i18n/ro.d.ts"],
       "@voyant-travel/auth-react/local-auth-routes": ["../auth-react/dist/local-auth-routes.d.ts"],
+      "@voyant-travel/auth-react/mcp-consent-routes": [
+        "../auth-react/dist/mcp-consent-routes.d.ts"
+      ],
       "@voyant-travel/auth-react/organization-members": [
         "../auth-react/dist/components/organization-members-page.d.ts"
       ],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -231,6 +231,9 @@
       "@voyant-travel/auth-react/i18n/en": ["../auth-react/dist/i18n/en.d.ts"],
       "@voyant-travel/auth-react/i18n/ro": ["../auth-react/dist/i18n/ro.d.ts"],
       "@voyant-travel/auth-react/local-auth-routes": ["../auth-react/dist/local-auth-routes.d.ts"],
+      "@voyant-travel/auth-react/mcp-consent-routes": [
+        "../auth-react/dist/mcp-consent-routes.d.ts"
+      ],
       "@voyant-travel/auth-react/organization-members": [
         "../auth-react/dist/components/organization-members-page.d.ts"
       ],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -226,6 +226,9 @@
       "@voyant-travel/auth-react/i18n/en": ["../auth-react/dist/i18n/en.d.ts"],
       "@voyant-travel/auth-react/i18n/ro": ["../auth-react/dist/i18n/ro.d.ts"],
       "@voyant-travel/auth-react/local-auth-routes": ["../auth-react/dist/local-auth-routes.d.ts"],
+      "@voyant-travel/auth-react/mcp-consent-routes": [
+        "../auth-react/dist/mcp-consent-routes.d.ts"
+      ],
       "@voyant-travel/auth-react/organization-members": [
         "../auth-react/dist/components/organization-members-page.d.ts"
       ],

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -225,6 +225,9 @@
       "@voyant-travel/auth-react/i18n/en": ["../auth-react/dist/i18n/en.d.ts"],
       "@voyant-travel/auth-react/i18n/ro": ["../auth-react/dist/i18n/ro.d.ts"],
       "@voyant-travel/auth-react/local-auth-routes": ["../auth-react/dist/local-auth-routes.d.ts"],
+      "@voyant-travel/auth-react/mcp-consent-routes": [
+        "../auth-react/dist/mcp-consent-routes.d.ts"
+      ],
       "@voyant-travel/auth-react/organization-members": [
         "../auth-react/dist/components/organization-members-page.d.ts"
       ],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -226,6 +226,9 @@
       "@voyant-travel/auth-react/i18n/en": ["../auth-react/dist/i18n/en.d.ts"],
       "@voyant-travel/auth-react/i18n/ro": ["../auth-react/dist/i18n/ro.d.ts"],
       "@voyant-travel/auth-react/local-auth-routes": ["../auth-react/dist/local-auth-routes.d.ts"],
+      "@voyant-travel/auth-react/mcp-consent-routes": [
+        "../auth-react/dist/mcp-consent-routes.d.ts"
+      ],
       "@voyant-travel/auth-react/organization-members": [
         "../auth-react/dist/components/organization-members-page.d.ts"
       ],

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -231,6 +231,9 @@
       "@voyant-travel/auth-react/i18n/en": ["../auth-react/dist/i18n/en.d.ts"],
       "@voyant-travel/auth-react/i18n/ro": ["../auth-react/dist/i18n/ro.d.ts"],
       "@voyant-travel/auth-react/local-auth-routes": ["../auth-react/dist/local-auth-routes.d.ts"],
+      "@voyant-travel/auth-react/mcp-consent-routes": [
+        "../auth-react/dist/mcp-consent-routes.d.ts"
+      ],
       "@voyant-travel/auth-react/organization-members": [
         "../auth-react/dist/components/organization-members-page.d.ts"
       ],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -226,6 +226,9 @@
       "@voyant-travel/auth-react/i18n/en": ["../auth-react/dist/i18n/en.d.ts"],
       "@voyant-travel/auth-react/i18n/ro": ["../auth-react/dist/i18n/ro.d.ts"],
       "@voyant-travel/auth-react/local-auth-routes": ["../auth-react/dist/local-auth-routes.d.ts"],
+      "@voyant-travel/auth-react/mcp-consent-routes": [
+        "../auth-react/dist/mcp-consent-routes.d.ts"
+      ],
       "@voyant-travel/auth-react/organization-members": [
         "../auth-react/dist/components/organization-members-page.d.ts"
       ],

--- a/packages/inventory/tsconfig.build.json
+++ b/packages/inventory/tsconfig.build.json
@@ -225,6 +225,9 @@
       "@voyant-travel/auth-react/i18n/en": ["../auth-react/dist/i18n/en.d.ts"],
       "@voyant-travel/auth-react/i18n/ro": ["../auth-react/dist/i18n/ro.d.ts"],
       "@voyant-travel/auth-react/local-auth-routes": ["../auth-react/dist/local-auth-routes.d.ts"],
+      "@voyant-travel/auth-react/mcp-consent-routes": [
+        "../auth-react/dist/mcp-consent-routes.d.ts"
+      ],
       "@voyant-travel/auth-react/organization-members": [
         "../auth-react/dist/components/organization-members-page.d.ts"
       ],

--- a/packages/inventory/tsconfig.typecheck.json
+++ b/packages/inventory/tsconfig.typecheck.json
@@ -226,6 +226,9 @@
       "@voyant-travel/auth-react/i18n/en": ["../auth-react/dist/i18n/en.d.ts"],
       "@voyant-travel/auth-react/i18n/ro": ["../auth-react/dist/i18n/ro.d.ts"],
       "@voyant-travel/auth-react/local-auth-routes": ["../auth-react/dist/local-auth-routes.d.ts"],
+      "@voyant-travel/auth-react/mcp-consent-routes": [
+        "../auth-react/dist/mcp-consent-routes.d.ts"
+      ],
       "@voyant-travel/auth-react/organization-members": [
         "../auth-react/dist/components/organization-members-page.d.ts"
       ],

--- a/packages/mcp/src/voyant.ts
+++ b/packages/mcp/src/voyant.ts
@@ -18,6 +18,19 @@ export const mcpVoyantModule = defineModule({
       },
     },
   ],
+  presentations: [
+    // The OAuth grant screen for this transport. It belongs to MCP rather than
+    // to local auth: the authorization server issuing connector grants is local
+    // to the deployment in every admin auth mode, so a broker-authenticated
+    // deployment that ships no sign-in page must still answer /mcp-consent.
+    {
+      id: "@voyant-travel/mcp#presentation.consent",
+      runtime: {
+        entry: "@voyant-travel/auth-react/mcp-consent-routes",
+        export: "createMcpConsentRouteContribution",
+      },
+    },
+  ],
   access: {
     resources: [
       {

--- a/packages/mcp/tests/voyant-manifest.test.ts
+++ b/packages/mcp/tests/voyant-manifest.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest"
+
+import { mcpVoyantModule } from "../src/voyant.js"
+
+describe("@voyant-travel/mcp manifest", () => {
+  it("owns the connector consent screen so every auth mode ships it", () => {
+    // The consent page used to ride along with the local-auth presentation,
+    // which a broker-authenticated deployment deliberately does not select —
+    // so the connector handshake 404ed on its last step.
+    expect(mcpVoyantModule.presentations).toHaveLength(1)
+    expect(mcpVoyantModule.presentations?.[0]).toMatchObject({
+      id: "@voyant-travel/mcp#presentation.consent",
+      runtime: {
+        entry: "@voyant-travel/auth-react/mcp-consent-routes",
+        export: "createMcpConsentRouteContribution",
+      },
+    })
+  })
+})

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -231,6 +231,9 @@
       "@voyant-travel/auth-react/i18n/en": ["../auth-react/dist/i18n/en.d.ts"],
       "@voyant-travel/auth-react/i18n/ro": ["../auth-react/dist/i18n/ro.d.ts"],
       "@voyant-travel/auth-react/local-auth-routes": ["../auth-react/dist/local-auth-routes.d.ts"],
+      "@voyant-travel/auth-react/mcp-consent-routes": [
+        "../auth-react/dist/mcp-consent-routes.d.ts"
+      ],
       "@voyant-travel/auth-react/organization-members": [
         "../auth-react/dist/components/organization-members-page.d.ts"
       ],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -226,6 +226,9 @@
       "@voyant-travel/auth-react/i18n/en": ["../auth-react/dist/i18n/en.d.ts"],
       "@voyant-travel/auth-react/i18n/ro": ["../auth-react/dist/i18n/ro.d.ts"],
       "@voyant-travel/auth-react/local-auth-routes": ["../auth-react/dist/local-auth-routes.d.ts"],
+      "@voyant-travel/auth-react/mcp-consent-routes": [
+        "../auth-react/dist/mcp-consent-routes.d.ts"
+      ],
       "@voyant-travel/auth-react/organization-members": [
         "../auth-react/dist/components/organization-members-page.d.ts"
       ],

--- a/packages/operator-standard/src/standard-frontend.tsx
+++ b/packages/operator-standard/src/standard-frontend.tsx
@@ -29,6 +29,7 @@ import type {
   LocalAuthPresentationRuntime,
   LocalAuthRouteContribution,
 } from "@voyant-travel/auth-react/local-auth-routes"
+import type { McpConsentRouteContribution } from "@voyant-travel/auth-react/mcp-consent-routes"
 import type { RedeemInvitationStatus } from "@voyant-travel/auth-react/ui"
 import { RealtimeChannel } from "@voyant-travel/cloud-sdk"
 import type { VoyantGraphJsonValue } from "@voyant-travel/core/project"
@@ -101,6 +102,7 @@ export interface StandardOperatorFrontend {
     docs: ReturnType<typeof createApiDocsRouteOptions>
     finance?: ReturnType<typeof createFinancePublicRouteContribution>["routes"]
     localAuth?: LocalAuthRouteContribution["routes"]
+    mcpConsent?: McpConsentRouteContribution["routes"]
     quotes?: ReturnType<typeof createQuotesPublicRouteContribution>["routes"]
     storefront?: StorefrontPresentationContribution["routes"]
   }
@@ -224,6 +226,11 @@ function createPresentationRuntime(
   const localAuthFactory = presentationFactories["@voyant-travel/auth#presentation.local-auth"] as
     | LocalAuthPresentationFactory
     | undefined
+  // The consent screen needs no host runtime: it reads the signed query from the
+  // address bar and posts it back through the shared React context.
+  const mcpConsentFactory = presentationFactories["@voyant-travel/mcp#presentation.consent"] as
+    | (() => McpConsentRouteContribution)
+    | undefined
   const financeFactory = presentationFactories["@voyant-travel/finance#presentation.public"] as
     | FinancePublicPresentationFactory
     | undefined
@@ -321,7 +328,8 @@ function createPresentationRuntime(
       useSession: authClient.useSession,
     },
   })
-  return { finance, localAuth, quotes, storefront, workspace }
+  const mcpConsent = mcpConsentFactory?.()
+  return { finance, localAuth, mcpConsent, quotes, storefront, workspace }
 }
 
 export function createStandardOperatorFrontend(
@@ -369,6 +377,7 @@ export function createStandardOperatorFrontend(
       docs: createApiDocsRouteOptions(options.openApiSpecs ?? {}),
       ...(runtime.finance ? { finance: runtime.finance.routes } : {}),
       ...(runtime.localAuth ? { localAuth: runtime.localAuth.routes } : {}),
+      ...(runtime.mcpConsent ? { mcpConsent: runtime.mcpConsent.routes } : {}),
       ...(runtime.quotes ? { quotes: runtime.quotes.routes } : {}),
       ...(runtime.storefront ? { storefront: runtime.storefront.routes } : {}),
     },

--- a/packages/operator-standard/src/standard-route-files.ts
+++ b/packages/operator-standard/src/standard-route-files.ts
@@ -7,7 +7,7 @@ const standardFrontendImport = "@voyant-travel/operator-standard/standard-fronte
 const contributionRoute = (
   path: string,
   routeId: string,
-  contribution: "localAuth" | "storefront",
+  contribution: "localAuth" | "mcpConsent" | "storefront",
   member: string,
 ): VoyantGeneratedRouteFile => ({
   path,
@@ -36,6 +36,7 @@ export const Route = createFileRoute(${JSON.stringify(routeId)})(operatorFronten
 
 const STOREFRONT_PRESENTATION_ID = "@voyant-travel/storefront#presentation.customer"
 const AUTH_PRESENTATION_ID = "@voyant-travel/auth#presentation.local-auth"
+const MCP_CONSENT_PRESENTATION_ID = "@voyant-travel/mcp#presentation.consent"
 const FINANCE_PRESENTATION_ID = "@voyant-travel/finance#presentation.public"
 const QUOTES_PRESENTATION_ID = "@voyant-travel/quotes#presentation.public"
 
@@ -141,10 +142,6 @@ const authRouteFiles: readonly VoyantGeneratedRouteFile[] = [
     "localAuth",
     "forgotPassword",
   ),
-  // The OAuth consent screen an MCP connector sends the operator to. It lives
-  // in the chrome-less auth group because it is a decision point handed over
-  // from an external client, not a page inside the workspace.
-  contributionRoute("(auth)/mcp-consent.tsx", "/(auth)/mcp-consent", "localAuth", "mcpConsent"),
   contributionRoute("(auth)/onboarding.tsx", "/(auth)/onboarding", "localAuth", "onboarding"),
   contributionRoute(
     "(auth)/reset-password.tsx",
@@ -155,6 +152,16 @@ const authRouteFiles: readonly VoyantGeneratedRouteFile[] = [
   contributionRoute("(auth)/sign-in.tsx", "/(auth)/sign-in", "localAuth", "signIn"),
   contributionRoute("(auth)/sign-up.tsx", "/(auth)/sign-up", "localAuth", "signUp"),
   contributionRoute("(auth)/verify-email.tsx", "/(auth)/verify-email", "localAuth", "verifyEmail"),
+]
+
+// The OAuth consent screen an MCP connector sends the operator to. It gets its
+// own chrome-less group rather than riding along with local auth: the
+// authorization server issuing connector grants is local to the deployment in
+// every admin auth mode, so a broker-authenticated deployment — which ships no
+// sign-in or sign-up page — must still answer /mcp-consent.
+const mcpConsentRouteFiles: readonly VoyantGeneratedRouteFile[] = [
+  contributionRoute("(mcp)/route.tsx", "/(mcp)", "mcpConsent", "layout"),
+  contributionRoute("(mcp)/mcp-consent.tsx", "/(mcp)/mcp-consent", "mcpConsent", "consent"),
 ]
 
 const workspaceRouteFiles: readonly VoyantGeneratedRouteFile[] = [
@@ -238,6 +245,7 @@ export function createStandardOperatorRouteFiles(
     ...standardOperatorRouteFiles,
     ...(selected.has(AUTH_PRESENTATION_ID) ? authRouteFiles : []),
     ...(selected.has(FINANCE_PRESENTATION_ID) ? financeRouteFiles : []),
+    ...(selected.has(MCP_CONSENT_PRESENTATION_ID) ? mcpConsentRouteFiles : []),
     ...(selected.has(QUOTES_PRESENTATION_ID) ? quotesRouteFiles : []),
     ...(selected.has(STOREFRONT_PRESENTATION_ID) ? storefrontRouteFiles : []),
     ...workspaceRouteFiles,

--- a/packages/operator-standard/tests/standard-route-files.test.ts
+++ b/packages/operator-standard/tests/standard-route-files.test.ts
@@ -8,6 +8,7 @@ describe("createStandardOperatorRouteFiles", () => {
       presentationIds: [
         "@voyant-travel/auth#presentation.local-auth",
         "@voyant-travel/finance#presentation.public",
+        "@voyant-travel/mcp#presentation.consent",
         "@voyant-travel/quotes#presentation.public",
         "@voyant-travel/storefront#presentation.customer",
       ],
@@ -34,6 +35,7 @@ describe("createStandardOperatorRouteFiles", () => {
     const cases = [
       ["@voyant-travel/auth#presentation.local-auth", "(auth)/"],
       ["@voyant-travel/finance#presentation.public", "pay.tsx"],
+      ["@voyant-travel/mcp#presentation.consent", "(mcp)/"],
       ["@voyant-travel/quotes#presentation.public", "proposal.$quoteVersionId.tsx"],
     ] as const
 
@@ -43,6 +45,18 @@ describe("createStandardOperatorRouteFiles", () => {
       expect(selected.some(({ path }) => path.startsWith(expectedPath))).toBe(true)
       expect(absent.some(({ path }) => path.startsWith(expectedPath))).toBe(false)
     }
+  })
+
+  it("emits the MCP consent screen without the local-auth pages", () => {
+    // A broker-authenticated deployment ships no sign-in, sign-up, or
+    // password-reset page, but the authorization server issuing connector
+    // grants is still local to it — so consent has to be reachable anyway.
+    const cloudAuth = createStandardOperatorRouteFiles({
+      presentationIds: ["@voyant-travel/mcp#presentation.consent"],
+    })
+
+    expect(cloudAuth.map(({ path }) => path)).toContain("(mcp)/mcp-consent.tsx")
+    expect(cloudAuth.some(({ path }) => path.startsWith("(auth)/"))).toBe(false)
   })
 
   it("emits Storefront routes only when its presentation is selected", () => {

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -224,6 +224,9 @@
       "@voyant-travel/auth-react/i18n/en": ["../auth-react/dist/i18n/en.d.ts"],
       "@voyant-travel/auth-react/i18n/ro": ["../auth-react/dist/i18n/ro.d.ts"],
       "@voyant-travel/auth-react/local-auth-routes": ["../auth-react/dist/local-auth-routes.d.ts"],
+      "@voyant-travel/auth-react/mcp-consent-routes": [
+        "../auth-react/dist/mcp-consent-routes.d.ts"
+      ],
       "@voyant-travel/auth-react/organization-members": [
         "../auth-react/dist/components/organization-members-page.d.ts"
       ],

--- a/scripts/check-operator-frontend-shell-authority.mjs
+++ b/scripts/check-operator-frontend-shell-authority.mjs
@@ -56,8 +56,9 @@ const routeRegistry = readFileSync(
 for (const token of [
   "createStandardOperatorFrontend",
   "operatorFrontend.routes.docs",
-  'contribution: "localAuth" | "storefront"',
+  'contribution: "localAuth" | "mcpConsent" | "storefront"',
   'contribution: "finance" | "quotes"',
+  "MCP_CONSENT_PRESENTATION_ID",
   "operatorFrontend.workspace",
   "createStandardOperatorRouteFiles",
   "STOREFRONT_PRESENTATION_ID",


### PR DESCRIPTION
Closes #3920.

## The bug

`/mcp-consent` was contributed as part of the `localAuth` route group, next to
`sign-in`, `sign-up`, `forgot-password`, `reset-password`, `verify-email`, and
`onboarding`. A deployment running `VOYANT_ADMIN_AUTH_MODE=voyant-cloud`
deliberately does not select that contribution, so it shipped no consent page:
an MCP connector registered and authorized successfully, then landed on a 404 at
the last step before the grant.

That was a miscategorisation. The consent screen is not a local-auth page — it
is an OAuth authorization decision point, and the authorization server issuing
connector grants is local to the deployment in *every* auth mode. That is
already the stated reason `/auth/oauth2/consent` and `/auth/oauth2/get-client`
are allowlisted for cloud mode in `packages/auth/src/node-runtime.ts`. Only the
page that calls them was left behind the gate.

## The fix

The consent screen gets its own presentation, `@voyant-travel/mcp#presentation.consent`,
declared by the MCP module and mounted from a new
`@voyant-travel/auth-react/mcp-consent-routes` export.

- **Owner is the MCP module.** The page exists only to grant an MCP connector,
  so it ships exactly when the MCP transport ships — independent of admin auth
  mode. The runtime entry points at `auth-react` (where the component and its
  i18n already live), the same cross-package UI reference
  `@voyant-travel/webhook-delivery` already makes into `operator-settings-react`.
- **Its own export boundary.** A cloud-auth admin can mount consent without
  pulling in `createLocalAuthRouteContribution` and the sign-in/sign-up pages.
- **Its own chrome-less route group.** The generated host moves from
  `(auth)/mcp-consent.tsx` to `(mcp)/mcp-consent.tsx`, with a `(mcp)` layout that
  renders the same `AuthLayout`. `(auth)` no longer has to exist for consent to
  be reachable. The public path `/mcp-consent` is unchanged, so the
  `consentPage` default in `mcp-oauth.ts` and the redirect the authorization
  server issues both stay as they are.
- `createLocalAuthRouteContribution` no longer returns an `mcpConsent` route.

Opting a cloud-auth deployment into the whole `localAuth` contribution was not
an option — it would ship a local sign-in and sign-up page into a deployment
that authenticates through the broker.

## Verification

- `pnpm verify:deployment-graph` — green. The resolved operator BOM now lists
  `@voyant-travel/mcp#presentation.consent`, the generated
  `selected-graph-presentations.generated.js` imports
  `createMcpConsentRouteContribution`, and `.voyant/routes/(mcp)/` emits both
  hosts while `(auth)/` no longer carries `mcp-consent.tsx`.
- `pnpm verify:architecture` — green.
- `pnpm verify:operator-auth-presentation-authority`, `verify:dep-paths`,
  `verify:dist-configs` — green.
- Tests: `@voyant-travel/auth-react`, `@voyant-travel/mcp`,
  `@voyant-travel/operator-standard` — green, including a new
  `standard-route-files` case asserting the consent host ships when *no*
  local-auth routes do.
- Typecheck: those three packages — green.
- `pnpm test` (full): only `@voyant-travel/media` failed, on two pglite
  assertions that time out at ~10.5s under parallel load and pass on a rerun in
  isolation. Unrelated to this change.

## Note on an unrelated pre-existing failure

`scripts/check-operator-frontend-shell-authority.mjs` already fails on `main`:
its expected starter-src list still names `jobs/README.md` and
`workflows/README.md`, which `f2c9404040` ("Retire the workflow product
surface") deleted. The checker is not wired into any CI aggregate, which is why
it went unnoticed. This PR updates its route-registry token assertions to match
the new contribution union but leaves that stale file list alone — it wants its
own fix.
