### PR TITLE
refactor(scripts): move Trips and Relationships port facts onto the graph

### DIFF
--- a/scripts/check-relationships-runtime-authority.mjs
+++ b/scripts/check-relationships-runtime-authority.mjs
@@ -40,13 +40,10 @@ if (existsSync(retiredAdapterPath)) {
   violations.push("starters/operator/src/api/runtime/runtime-adapter.ts must stay deleted")
 }
 
-if (
-  !manifest.includes("requirePort(customFieldsRuntimePort)") ||
-  !manifest.includes("requirePort(relationshipsRouteRuntimePort)") ||
-  !manifest.includes('export: "createRelationshipsVoyantRuntime"') ||
-  !manifest.includes("relationshipsMiceRuntimePort")
-) {
-  violations.push("Relationships manifest must own and publish its route runtime dependency")
+// Ports and the runtime-dependency references are asserted against the resolved
+// graph by verify:graph-conformance, not by matching manifest source text.
+if (!manifest.includes('export: "createRelationshipsVoyantRuntime"')) {
+  violations.push("Relationships manifest must name its package-owned graph factory")
 }
 if (
   !runtimePort.includes("definePort<RelationshipsRouteRuntimeOptions>") ||

--- a/scripts/check-trips-runtime-authority.mjs
+++ b/scripts/check-trips-runtime-authority.mjs
@@ -41,22 +41,10 @@ if (existsSync(retiredAdapterPath)) {
   violations.push("starters/operator/src/api/runtime/runtime-adapter.ts must stay deleted")
 }
 
-if (
-  !manifest.includes("requirePort(tripsRoutesRuntimePort)") ||
-  !manifest.includes("requirePort(tripsDatabaseRuntimePort)") ||
-  !manifest.includes('catalogRuntimeServicesPortReference = { id: "catalog.runtime-services" }') ||
-  !manifest.includes(
-    'catalogCheckoutApiRuntimePortReference = { id: "commerce.checkout-api-options" }',
-  ) ||
-  !manifest.includes('flightsRuntimePortReference = { id: "flights.runtime" }') ||
-  !manifest.includes("catalogRuntimeServicesPortReference,") ||
-  !manifest.includes("catalogCheckoutApiRuntimePortReference,") ||
-  !manifest.includes("flightsRuntimePortReference,") ||
-  !manifest.includes('export: "createTripsVoyantRuntime"')
-) {
-  violations.push(
-    "Trips manifest must own its local ports, neutral runtime dependencies, and graph factory",
-  )
+// Ports and the runtime-dependency references are asserted against the resolved
+// graph by verify:graph-conformance, not by matching manifest source text.
+if (!manifest.includes('export: "createTripsVoyantRuntime"')) {
+  violations.push("Trips manifest must name its package-owned graph factory")
 }
 if (
   !runtimePort.includes("definePort<TripsRoutesOptionsProvider>") ||

--- a/scripts/checks/graph/graph-conformance.json
+++ b/scripts/checks/graph/graph-conformance.json
@@ -11,6 +11,26 @@
       "requiredCapabilities": ["finance.payment-sessions"],
       "portIds": ["flights.runtime", "flights.durable-action-runtime"],
       "runtimeExport": "createFlightsRuntimePortContribution"
+    },
+    "@voyant-travel/trips": {
+      "requiresSchemas": ["@voyant-travel/db"],
+      "portIds": [
+        "trips.routes-runtime",
+        "trips.database-runtime",
+        "catalog.runtime-services",
+        "commerce.checkout-api-options",
+        "flights.runtime"
+      ],
+      "runtimeExport": "createTripsRuntimePortContribution"
+    },
+    "@voyant-travel/relationships": {
+      "requiresSchemas": ["@voyant-travel/db", "@voyant-travel/identity"],
+      "portIds": [
+        "relationships.route-runtime",
+        "relationships.mice.runtime",
+        "custom-fields.runtime"
+      ],
+      "runtimeExport": "createRelationshipsRuntimePortContribution"
     }
   }
 }

--- a/scripts/checks/graph/query.ts
+++ b/scripts/checks/graph/query.ts
@@ -47,5 +47,7 @@ export function requiredCapabilities(graph: GraphLike, packageName: string): rea
 export function declaredPortIds(graph: GraphLike, packageName: string): string[] {
   const unit = unitForPackage(graph, packageName)
   const ports = [...(unit?.provides?.ports ?? []), ...(unit?.runtimePorts ?? [])]
-  return ports.map((port) => (typeof port === "string" ? port : port.id)).filter(Boolean)
+  return [
+    ...new Set(ports.map((port) => (typeof port === "string" ? port : port.id)).filter(Boolean)),
+  ]
 }


### PR DESCRIPTION
Second and third packages through the conformance spec from #3937 — run specifically to get a real cost curve rather than extrapolating from the first.

## What moved

**Trips** pinned five port facts as manifest substrings: two `requirePort(...)` calls plus three port references written as literal object initialisers —

```js
!manifest.includes('catalogRuntimeServicesPortReference = { id: "catalog.runtime-services" }')
!manifest.includes('catalogCheckoutApiRuntimePortReference = { id: "commerce.checkout-api-options" }')
!manifest.includes('flightsRuntimePortReference = { id: "flights.runtime" }')
```

The resolved graph records all five, including the *referenced* ports, so they are now declared in `graph-conformance.json`. **Relationships** is the same shape with three ports.

Also fixed: `declaredPortIds` concatenates `provides.ports` and `runtimePorts`, which overlap — Trips was reporting four ids twice. It now dedupes.

## The cost curve

| Package | `.includes()` before → after | Converted |
|---|---|---|
| `flights` | 16 → 12 | 4 |
| `trips` | 34 → 26 | 8 |
| `relationships` | 27 → 24 | 3 |
| **total** | **77 → 62** | **15** |

Plus 4 more from the flights work in #3937 that were counted there. **~19 substring pins retired across three packages, against a corpus of 339.**

That is roughly **20% per package**, and the three were picked as favourable candidates. The honest read is that graph conformance addresses a fifth of the problem, not most of it.

## What is deliberately left

The pins that survive assert **implementation shape**, not graph facts:

```js
runtimePort.includes("definePort<TripsRoutesOptionsProvider>")
packageIndex.includes("async ({ api, getPort })")
composition.includes("options.createRuntimePorts({ primitives })")
runtimeContributor.includes("resolveVisibleValues")
```

These pin call signatures and internal call shapes. They are not derivable from the graph because the graph does not record how a factory is written — which is also why they break on refactors. They need a different treatment (AST-based reference containment, as `check-booking-create-authority` already does), not this one.

## Verification

| Check | Result |
|---|---|
| `pnpm verify:architecture` | **exit 0** (full chain) |
| `pnpm verify:graph-conformance` | 3 packages conform |
| conformance unit tests | 6 passed (still green after the dedupe change) |
| `check-trips-runtime-authority` + companion tests | pass, 2 tests |
| `check-relationships-runtime-authority` + companion tests | pass, 5 tests |
| `biome check .` | clean |

No published package changes, so no changeset.
