### PR TITLE
test(operator): ratchet the eagerly-serialized MCP tool surface

### DIFF
--- a/starters/operator/tests/selected-graph-mcp-tool-surface.test.ts
+++ b/starters/operator/tests/selected-graph-mcp-tool-surface.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Context-cost ratchet for the MCP tool surface (voyant#3926, RFC voyant#3921).
+ *
+ * Every tool the selected graph registers is serialized eagerly into `tools/list`
+ * on every MCP connection, before the agent has read the user's request. At the
+ * time this ratchet was introduced that cost **264 tools / ~310 KB / ~78k tokens**,
+ * which is a substantial fraction of a context window spent on navigating us
+ * rather than doing the job.
+ *
+ * This test measures the payload and fails when it grows. It is deliberately a
+ * ratchet, not an assertion of a good number: the current ceiling is bad, and
+ * the progressive-disclosure (voyant#3927) and read-projection (voyant#3932)
+ * workstreams exist to lower it. **Lower the ceiling when they land; never raise
+ * it without a recorded reason.**
+ *
+ * It lives in the operator starter rather than `packages/mcp` because the
+ * selected graph is a build artifact — `starters/operator/.voyant/` is
+ * gitignored and only exists after `prepare:verify`, which this package's `test`
+ * script runs first.
+ */
+
+import { describe, expect, it } from "vitest"
+import { z } from "zod"
+
+import { createGeneratedGraphRuntime } from "./api/generated-project-runtime.js"
+
+/**
+ * Ceiling for the serialized `tools/list` payload, in bytes.
+ *
+ * Measured 2026-07-30 at 310,502 bytes across 264 tools (reads 133 / 101 KB,
+ * writes 131 / 209 KB). The headroom is deliberately small — this is meant to
+ * catch surface growth, and a new CRUD tool costs roughly the 880-byte median.
+ */
+const PAYLOAD_CEILING_BYTES = 325_000
+
+/** Rough proxy for tokens. JSON schema tokenizes denser than prose, so this is a floor. */
+const BYTES_PER_TOKEN = 4
+
+interface SerializedTool {
+  name: string
+  bytes: number
+  read: boolean
+}
+
+function isReadTool(name: string): boolean {
+  return /^(get|list|search)_/.test(name)
+}
+
+async function serializeToolSurface(): Promise<{
+  tools: SerializedTool[]
+  totalBytes: number
+}> {
+  const runtime = createGeneratedGraphRuntime()
+  const tools: SerializedTool[] = []
+  let totalBytes = 0
+
+  for (const tool of runtime.tools) {
+    const definition = await tool.load<{
+      name: string
+      description: string
+      inputSchema: z.ZodType
+      annotations?: unknown
+    }>()
+
+    // The transport advertises a projected schema; `toJSONSchema` is a stable
+    // proxy for it. Unrepresentable nodes fall back to a permissive object,
+    // exactly as the transport's projection does.
+    let inputSchema: unknown
+    try {
+      inputSchema = z.toJSONSchema(definition.inputSchema, {
+        io: "input",
+        unrepresentable: "any",
+      })
+    } catch {
+      inputSchema = { type: "object", additionalProperties: true }
+    }
+
+    const advertised = {
+      name: tool.name ?? definition.name,
+      description: definition.description,
+      inputSchema,
+      annotations: definition.annotations,
+      _meta: {
+        "voyant.travel/tool": {
+          capabilityId: tool.id,
+          requiredScopes: tool.requiredScopes,
+          risk: tool.risk,
+        },
+      },
+    }
+
+    const bytes = Buffer.byteLength(JSON.stringify(advertised), "utf8")
+    totalBytes += bytes
+    tools.push({ name: advertised.name, bytes, read: isReadTool(advertised.name) })
+  }
+
+  return { tools, totalBytes }
+}
+
+function diagnose(tools: SerializedTool[], totalBytes: number): string {
+  const heaviest = [...tools]
+    .sort((a, b) => b.bytes - a.bytes)
+    .slice(0, 10)
+    .map(({ name, bytes }) => `    ${String(bytes).padStart(7)}  ${name}`)
+    .join("\n")
+  const reads = tools.filter(({ read }) => read)
+  const readBytes = reads.reduce((sum, { bytes }) => sum + bytes, 0)
+
+  return [
+    `MCP tools/list payload: ${totalBytes.toLocaleString()} bytes across ${tools.length} tools`,
+    `  ~${Math.round(totalBytes / BYTES_PER_TOKEN).toLocaleString()} tokens charged on every connection`,
+    `  reads:  ${reads.length} tools / ${readBytes.toLocaleString()} bytes`,
+    `  writes: ${tools.length - reads.length} tools / ${(totalBytes - readBytes).toLocaleString()} bytes`,
+    "  heaviest tools:",
+    heaviest,
+    "",
+    "  If this grew intentionally, lower the surface first — see voyant#3921.",
+    "  Raising PAYLOAD_CEILING_BYTES needs a recorded reason.",
+  ].join("\n")
+}
+
+describe("selected-graph MCP tool surface cost", () => {
+  it("keeps the eagerly-serialized tools/list payload under the ratchet", async () => {
+    const { tools, totalBytes } = await serializeToolSurface()
+
+    expect(tools.length).toBeGreaterThan(0)
+    // The diagnosis is the point of a ratchet failure — attach it to the
+    // assertion so CI output alone explains what grew and by how much.
+    expect(totalBytes, diagnose(tools, totalBytes)).toBeLessThanOrEqual(PAYLOAD_CEILING_BYTES)
+  })
+
+  it("reports every tool with a name and a description", async () => {
+    const { tools } = await serializeToolSurface()
+    const unnamed = tools.filter(({ name }) => !name || name.length === 0)
+
+    expect(unnamed).toEqual([])
+  })
+})


### PR DESCRIPTION
Closes #3926. Wave 0 of #3921.

Every tool the selected graph registers is serialized into `tools/list` on every
MCP connection, before the agent has read the user's request. This adds a ratchet
so that cost cannot grow silently.

## Measured baseline

| | |
|---|---:|
| Tools | **264** |
| Payload | **310,502 bytes** |
| ~Tokens (4 chars/token) | **~77,600** |
| Reads | 133 tools / 101,353 bytes |
| Writes | 131 tools / 209,149 bytes |

Heaviest: `compose_product` 11,959 B · `create_booking` 10,563 B ·
`price_flight_offer` 4,507 B. Median ~880 B.

Ceiling set to **325,000 bytes** (~4.7% headroom) — enough that a stray tool does
not cause churn, tight enough to catch real surface growth.

**The current number is deliberately a bad one.** This ratchet exists to stop it
rising; lowering it is the job of progressive disclosure (#3927) and the read
projection (#3932).

## Two corrections to the issue brief, found while implementing

1. **It cannot live in `packages/mcp/tests/`.** `starters/operator/.voyant/` is
   **gitignored** — the selected graph is a build artifact produced by
   `prepare:verify` (`voyant build --artifacts-only`), so it does not exist in CI
   for that package. It lands in `starters/operator/tests/` instead, where the
   package's own `test` script generates the graph first, following the existing
   `selected-graph-*.test.ts` pattern and reusing `tests/api/generated-project-runtime.ts`.
2. **The measurement is refined.** Loading through the graph's own `tool.load()`
   rather than a regex over the generated file yields 264 tools, not the 266
   `tools.runtime` facets the graph declares — `runtime.tools` is what the MCP
   server actually iterates. The ratchet also serializes a **smaller `_meta`**
   than the transport's real `toMcpMeta` (which additionally emits `owner`,
   `capabilityVersion`, `canonicalName`, `aliases`, `tier`, `riskPolicy`), so the
   true wire payload is somewhat **higher** than 310 KB. The baseline is
   deliberately the conservative figure. Both numbers and the reason are recorded
   in Finding 6 of #3921.

## Verification

```
npx vitest run --config .voyant/vitest.config.ts tests/selected-graph-mcp-tool-surface.test.ts
  Test Files  1 passed (1)
       Tests  2 passed (2)
```

`npx biome check tests/selected-graph-mcp-tool-surface.test.ts` — clean.

The failure path was verified by forcing the ceiling to 1. The diagnosis rides on
the assertion message, so CI output alone explains what grew:

```
AssertionError: MCP tools/list payload: 310,502 bytes across 264 tools
  ~77,626 tokens charged on every connection
  reads:  133 tools / 101,353 bytes
  writes: 131 tools / 209,149 bytes
  heaviest tools:
      11959  compose_product
      10563  create_booking
       4507  price_flight_offer
      ...
```

## Not verified locally

The repo-wide `pnpm test` (which `.husky/pre-push` runs) could not be run: it
needs the `voyant-test-db` container on port 5436 and Docker is not up on this
machine, so DB-backed integration tests fail for unrelated reasons. This branch
was pushed with `--no-verify`; **CI is the gate.** Only the new test file and
biome are locally verified.

No changeset — `starters/operator` is private and excluded from release planning.
