### PR TITLE
feat(mcp): instrument the MCP transport boundary

### DIFF
--- a/.changeset/mcp-dispatch-observability.md
+++ b/.changeset/mcp-dispatch-observability.md
@@ -1,0 +1,19 @@
+---
+"@voyant-travel/mcp": minor
+---
+
+Instrument the MCP transport so agent behaviour is observable. A new
+`observability.ts` hangs off the shipped vendor-neutral Reporter seam
+(`@voyant-travel/hono/observability`, RFC #1553) — no new logging framework, no
+vendor SDK, no `console.log`. The `POST /` handler now emits one structured
+event per `tools/call` carrying the tool name, caller identity, granted scopes,
+duration, outcome, and — on failure — the error code. Unknown-tool and
+argument-validation failures are captured as distinct outcomes (`unknown_tool`,
+`validation_error`) rather than blurring into a successful call, and both
+`tools/list` and `GET /manifest` emit the served payload size.
+
+Telemetry carries shapes, names, and codes only — never argument or result
+payloads (`docs/architecture/booking-pii.md`), covered by a test. Instrumentation
+is best-effort and can never break a `tools/call`. `createMcpApiRoutes` and
+`createGraphMcpApiRoutes` accept an optional `reporter` and `appName`, defaulting
+to the no-op reporter so the behaviour is opt-in.

--- a/packages/mcp/src/observability.ts
+++ b/packages/mcp/src/observability.ts
@@ -1,0 +1,207 @@
+/**
+ * MCP transport instrumentation — one reviewable unit for what agents actually
+ * do at the `tools/call` boundary.
+ *
+ * This hangs off the shipped vendor-neutral observability seam
+ * (`@voyant-travel/hono/observability`, RFC #1553): the deployment registers one
+ * {@link Reporter} and this module forwards normalized events to it. No new
+ * logging framework, no vendor SDK, no `console.log`. `server.ts` calls in here;
+ * the `requestId` correlation id is read from the ambient async-context store so
+ * every event joins the same trace as the request's `X-Request-Id`.
+ *
+ * ## Why the HTTP boundary, not the dispatch funnel
+ *
+ * `dispatchToResult` only runs for a tool that exists, is authorized, and whose
+ * arguments already passed the MCP SDK's input-schema check. The two
+ * highest-signal events — a call to a tool NAME that does not exist, and an
+ * argument-validation failure — are rejected by the SDK *before* the dispatch
+ * handler is invoked, so dispatch never sees them. The per-request POST handler
+ * in `server.ts` is the single place that observes all four outcomes, so the
+ * instrumentation lives there and consumes the error CODE that dispatch already
+ * writes into the result `_meta`.
+ *
+ * ## PII
+ *
+ * Per `docs/architecture/booking-pii.md`, telemetry carries shapes, names, and
+ * codes — NEVER argument or result payloads. This module never reads tool
+ * arguments or results: an event carries the tool NAME, the caller's identity
+ * ids and granted scopes, a duration, an outcome, and an error CODE. The signal
+ * string stamped on the event is derived only from the event kind, outcome, and
+ * code, so it is safe to log verbatim.
+ */
+import {
+  type ErrorEvent,
+  getRequestId,
+  noopReporter,
+  type Reporter,
+  safeCaptureException,
+} from "@voyant-travel/hono/observability"
+import type { ToolContext } from "@voyant-travel/tools"
+
+/**
+ * Marker key stamped on every emitted event's `context` so a deployment's
+ * Reporter can route MCP telemetry apart from genuine exceptions.
+ */
+export const MCP_TELEMETRY_CONTEXT_KEY = "voyant.mcp" as const
+
+/**
+ * The four outcomes of a `tools/call`, kept distinct so `unknown_tool` and
+ * `validation_error` — the naming and schema mismatches an agent hits — never
+ * blur into a successful call.
+ */
+export type McpCallOutcome = "ok" | "tool_error" | "unknown_tool" | "validation_error"
+
+/** Caller identity ids and granted scopes — never booking/traveller payloads. */
+export interface McpCaller {
+  actor?: string
+  audience?: string
+  tenantId?: string
+  organizationId?: string
+  scopes?: readonly string[]
+}
+
+export interface McpToolCallEvent {
+  /** Invocation name the caller asked for — a NAME, never an argument value. */
+  tool: string
+  outcome: McpCallOutcome
+  durationMs: number
+  /** Whether the tool mutates state; lets a backend find sessions with no write. */
+  write: boolean
+  /** ToolError / provider code when the outcome is an error; omitted on success. */
+  code?: string
+  caller: McpCaller
+}
+
+export interface McpToolsListEvent {
+  /** Byte length of the serialized manifest payload. */
+  payloadBytes: number
+  /** Number of tools the caller was authorized to see. */
+  toolCount: number
+  caller: McpCaller
+}
+
+/**
+ * Non-fault signal carried in an {@link ErrorEvent.error} slot so MCP telemetry
+ * rides the exception-shaped Reporter seam. Its message is derived only from the
+ * event kind, outcome, and code — never from arguments or results — so it is
+ * safe for a Reporter to log verbatim.
+ */
+export class McpTelemetrySignal extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "McpTelemetrySignal"
+  }
+}
+
+export interface McpObserver {
+  /** Emit one event per `tools/call`, including unknown-tool and validation misses. */
+  toolCall(event: McpToolCallEvent): void
+  /** Emit the size of a served `tools/list` / manifest payload. */
+  toolsList(event: McpToolsListEvent): void
+}
+
+export interface McpObserverOptions {
+  /** Observability sink; defaults to the no-op reporter so telemetry is opt-in. */
+  reporter?: Reporter
+  /** Logical app name stamped on emitted events. Defaults to `"voyant"`. */
+  appName?: string
+  /** Runtime hook to flush async reporters without blocking the response. */
+  waitUntil?: (promise: Promise<unknown>) => void
+}
+
+/**
+ * Build a per-request observer bound to the deployment's reporter. Capture is
+ * best-effort: {@link safeCaptureException} never throws and never blocks the
+ * response, so instrumentation can never break a `tools/call`.
+ */
+export function createMcpObserver(options: McpObserverOptions = {}): McpObserver {
+  const reporter = options.reporter ?? noopReporter
+  const app = options.appName ?? "voyant"
+  const emit = (signal: string, context: Record<string, unknown>): void => {
+    const event: ErrorEvent = {
+      requestId: getRequestId() ?? "unknown",
+      app,
+      error: new McpTelemetrySignal(signal),
+      context: { [MCP_TELEMETRY_CONTEXT_KEY]: context },
+    }
+    safeCaptureException(reporter, event, options.waitUntil)
+  }
+  return {
+    toolCall(e) {
+      emit(`mcp.tool_call ${e.outcome}${e.code ? ` ${e.code}` : ""}`, {
+        event: "tool_call",
+        tool: e.tool,
+        outcome: e.outcome,
+        durationMs: e.durationMs,
+        write: e.write,
+        ...(e.code ? { code: e.code } : {}),
+        caller: e.caller,
+      })
+    },
+    toolsList(e) {
+      emit("mcp.tools_list", {
+        event: "tools_list",
+        payloadBytes: e.payloadBytes,
+        toolCount: e.toolCount,
+        caller: e.caller,
+      })
+    },
+  }
+}
+
+/** Project the request context down to non-payload caller identity for telemetry. */
+export function callerFromContext(
+  ctx: Pick<ToolContext, "actor" | "audience" | "tenantId" | "organizationId" | "scopes">,
+): McpCaller {
+  return {
+    ...(ctx.actor ? { actor: ctx.actor } : {}),
+    ...(ctx.audience ? { audience: ctx.audience } : {}),
+    ...(ctx.tenantId ? { tenantId: ctx.tenantId } : {}),
+    ...(ctx.organizationId ? { organizationId: ctx.organizationId } : {}),
+    ...(ctx.scopes ? { scopes: [...ctx.scopes] } : {}),
+  }
+}
+
+/** UTF-8 byte length of a value's JSON serialization — the payload's wire size. */
+export function jsonByteLength(value: unknown): number {
+  return new TextEncoder().encode(JSON.stringify(value) ?? "").length
+}
+
+/** `_meta` key under which `dispatchToResult` records a domain ToolError code. */
+const DISPATCH_ERROR_META_KEY = "voyant.travel/error"
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : undefined
+}
+
+/**
+ * Classify a `tools/call` JSON-RPC response into an {@link McpCallOutcome} and,
+ * when it is an error, the domain error CODE — reading only shape and code, never
+ * a payload value.
+ *
+ * The MCP SDK converts a call to an unknown tool or an argument-validation
+ * failure into an `isError` result with no Voyant error `_meta`; a domain
+ * failure surfaces the same `isError` shape but carries the code
+ * `dispatchToResult` wrote into `_meta`. That distinction is what separates a
+ * validation miss from a genuine tool error.
+ */
+export function classifyToolCallResult(
+  response: unknown,
+  known: boolean,
+): { outcome: McpCallOutcome; code?: string } {
+  if (!known) return { outcome: "unknown_tool" }
+  const envelope = asRecord(response)
+  const rpcError = asRecord(envelope?.error)
+  if (rpcError) {
+    const code = rpcError.code
+    return { outcome: "tool_error", code: code === undefined ? undefined : String(code) }
+  }
+  const result = asRecord(envelope?.result)
+  if (result?.isError !== true) return { outcome: "ok" }
+  const dispatchError = asRecord(asRecord(result._meta)?.[DISPATCH_ERROR_META_KEY])
+  const code = dispatchError?.code
+  if (typeof code === "string" && code.length > 0) return { outcome: "tool_error", code }
+  return { outcome: "validation_error" }
+}

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -26,9 +26,12 @@ import {
   createToolRegistry,
   TOOL_CONTEXT_CONTRIBUTION_EXPORT,
   TOOL_CONTRACT_VERSION,
+  type ToolContext,
   type ToolContextContribution,
+  type ToolManifestEntry,
   type ToolRegistry,
 } from "@voyant-travel/tools"
+import type { Context } from "hono"
 
 import { buildAuthenticatedContext, callerPermissions, isAuthorized } from "./authorization.js"
 import {
@@ -36,6 +39,13 @@ import {
   buildContributedContext,
   indexActionsByTool,
 } from "./graph-composition.js"
+import {
+  callerFromContext,
+  classifyToolCallResult,
+  createMcpObserver,
+  jsonByteLength,
+  type McpObserver,
+} from "./observability.js"
 import { registerMcpTool } from "./register.js"
 import type { GraphMcpApiRoutesOptions, McpApiRoutesOptions, McpServerInfo } from "./types.js"
 
@@ -92,24 +102,42 @@ export function createMcpApiRoutes(options: McpApiRoutesOptions): OpenAPIHono {
   const serverInfo = options.serverInfo ?? DEFAULT_SERVER_INFO
   const app = new OpenAPIHono()
 
+  const observerFor = (ctx: ToolContext): McpObserver =>
+    createMcpObserver({
+      ...(options.reporter ? { reporter: options.reporter } : {}),
+      ...(options.appName ? { appName: options.appName } : {}),
+      ...(ctx.waitUntil ? { waitUntil: ctx.waitUntil } : {}),
+    })
+
   app.openapi(getManifestRoute, async (c) => {
     const permissions = callerPermissions(c)
     const ctx = await buildAuthenticatedContext(c, buildContext)
     const tools = registry
       .list()
       .filter((tool) => isAuthorized(tool, permissions, accessCatalog, ctx.audience))
+    observerFor(ctx).toolsList({
+      payloadBytes: jsonByteLength(tools),
+      toolCount: tools.length,
+      caller: callerFromContext(ctx),
+    })
     return c.json({ version: TOOL_CONTRACT_VERSION, serverInfo, tools })
   })
 
   app.openapi(callMcpRoute, async (c) => {
     const permissions = callerPermissions(c)
     const ctx = await buildAuthenticatedContext(c, buildContext)
+    const observer = observerFor(ctx)
     const server = new McpServer(serverInfo)
 
+    // The invocation names the caller could actually reach, so an unknown-tool
+    // event is a name that was never registered *or* was filtered by scope —
+    // both of which reveal what the model expected but could not call.
+    const authorizedTools = new Map<string, ToolManifestEntry>()
     for (const entry of registry.list()) {
       if (!isAuthorized(entry, permissions, accessCatalog, ctx.audience)) continue
       const def = registry.get(entry.name)
       if (!def) continue
+      authorizedTools.set(entry.name, entry)
       registerMcpTool(
         server,
         registry,
@@ -121,6 +149,7 @@ export function createMcpApiRoutes(options: McpApiRoutesOptions): OpenAPIHono {
         options.requireActionPolicies,
       )
       for (const alias of entry.aliases) {
+        authorizedTools.set(alias, entry)
         registerMcpTool(
           server,
           registry,
@@ -139,10 +168,78 @@ export function createMcpApiRoutes(options: McpApiRoutesOptions): OpenAPIHono {
       enableJsonResponse: true,
     })
     await server.connect(transport)
-    return (await transport.handleRequest(c)) ?? c.body(null, 204)
+    const startedAt = Date.now()
+    const response = (await transport.handleRequest(c)) ?? c.body(null, 204)
+    await instrumentRpc(c, response, Date.now() - startedAt, authorizedTools, ctx, observer)
+    return response
   })
 
   return app
+}
+
+/**
+ * Emit the boundary telemetry for the request that just completed. Best-effort:
+ * a parsing slip here must never change the response the caller receives, so the
+ * whole body is defensive and swallows its own failures.
+ */
+async function instrumentRpc(
+  c: Context,
+  response: Response,
+  durationMs: number,
+  authorizedTools: Map<string, ToolManifestEntry>,
+  ctx: ToolContext,
+  observer: McpObserver,
+): Promise<void> {
+  try {
+    // Hono caches the parsed body, so this reuses the parse the transport read.
+    const request = asRecord(await c.req.json())
+    const method = request?.method
+    if (method !== "tools/call" && method !== "tools/list") return
+    const caller = callerFromContext(ctx)
+    const payload = await readJsonRpcResponse(response)
+    if (method === "tools/list") {
+      const tools = asRecord(payload?.result)?.tools
+      const list = Array.isArray(tools) ? tools : []
+      observer.toolsList({
+        payloadBytes: jsonByteLength(list),
+        toolCount: list.length,
+        caller,
+      })
+      return
+    }
+    const name = asRecord(request?.params)?.name
+    if (typeof name !== "string") return
+    const entry = authorizedTools.get(name)
+    const { outcome, code } = classifyToolCallResult(payload, entry !== undefined)
+    observer.toolCall({
+      tool: name,
+      outcome,
+      durationMs,
+      write: entry ? entry.annotations.readOnlyHint !== true : false,
+      ...(code ? { code } : {}),
+      caller,
+    })
+  } catch {
+    // Instrumentation is best-effort and must never break a tools/call.
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : undefined
+}
+
+/** Read a JSON-RPC response body without consuming the response returned to the caller. */
+async function readJsonRpcResponse(
+  response: Response,
+): Promise<Record<string, unknown> | undefined> {
+  if (!response.body && response.status === 204) return undefined
+  try {
+    return asRecord(await response.clone().json())
+  } catch {
+    return undefined
+  }
 }
 
 /** Compose selected tools and their package-owned context contributors from one graph. */
@@ -241,6 +338,8 @@ export async function createGraphMcpApiRoutes(
     registry,
     requireActionPolicies: true,
     ...(options.serverInfo ? { serverInfo: options.serverInfo } : {}),
+    ...(options.reporter ? { reporter: options.reporter } : {}),
+    ...(options.appName ? { appName: options.appName } : {}),
     buildContext: (c) => buildContributedContext(c, options, contributions.values()),
   })
 }

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -4,6 +4,7 @@
  * them without importing the route factories back.
  */
 import type { VoyantGraphRuntime } from "@voyant-travel/framework/runtime-attestation"
+import type { Reporter } from "@voyant-travel/hono/observability"
 import type { ToolContext, ToolRegistry } from "@voyant-travel/tools"
 import type { AccessCatalog } from "@voyant-travel/types/api-keys"
 import type { Context } from "hono"
@@ -24,6 +25,10 @@ export interface McpApiRoutesOptions {
   serverInfo?: McpServerInfo
   /** Graph-composed hosts fail closed when a selected Tool has no selected action policy. */
   requireActionPolicies?: boolean
+  /** Observability sink for MCP transport telemetry (RFC #1553). Defaults to no-op. */
+  reporter?: Reporter
+  /** Logical app name stamped on emitted telemetry events. Defaults to `"voyant"`. */
+  appName?: string
 }
 
 export interface GraphMcpApiRoutesOptions {
@@ -35,6 +40,10 @@ export interface GraphMcpApiRoutesOptions {
   /** Context keys supplied by the deployment while packages migrate to contributions. */
   providedContext?: readonly string[]
   serverInfo?: McpServerInfo
+  /** Observability sink for MCP transport telemetry (RFC #1553). Defaults to no-op. */
+  reporter?: Reporter
+  /** Logical app name stamped on emitted telemetry events. Defaults to `"voyant"`. */
+  appName?: string
 }
 
 export type GraphMcpRuntime = VoyantGraphRuntime

--- a/packages/mcp/tests/observability.test.ts
+++ b/packages/mcp/tests/observability.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Instrumentation at the MCP dispatch boundary (voyant#3925). Proves that every
+ * `tools/call` emits one structured event through the shipped Reporter seam,
+ * that unknown-tool and validation-failure events stay distinct from a
+ * successful call, and — the hard rule from `docs/architecture/booking-pii.md` —
+ * that no argument or result payload value ever reaches an emitted event.
+ */
+import type { ErrorEvent, Reporter } from "@voyant-travel/hono/observability"
+import {
+  createToolRegistry,
+  defineTool,
+  READ_ONLY_RISK,
+  type ToolContext,
+  ToolError,
+} from "@voyant-travel/tools"
+import { Hono } from "hono"
+import { describe, expect, it } from "vitest"
+import { z } from "zod"
+
+import { createMcpApiRoutes } from "../src/index.js"
+import { MCP_TELEMETRY_CONTEXT_KEY } from "../src/observability.js"
+
+const accessCatalog = {
+  resources: [
+    {
+      id: "catalog",
+      unitId: "@voyant-travel/catalog",
+      resource: "catalog",
+      label: "Catalog",
+      description: "Catalog",
+      wildcard: "allow" as const,
+      actions: [{ action: "read", label: "Read", description: "Read" }],
+    },
+    {
+      id: "records",
+      unitId: "@voyant-travel/test",
+      resource: "records",
+      label: "Records",
+      description: "Records",
+      wildcard: "allow" as const,
+      actions: [
+        { action: "read", label: "Read", description: "Read records" },
+        { action: "write", label: "Write", description: "Write records" },
+      ],
+    },
+  ],
+  presets: [],
+}
+
+// A sentinel that stands in for encrypted booking/traveller PII. If any of these
+// strings surfaces in an emitted event, the payload leaked.
+const PII = {
+  email: "traveller.secret@pii.example",
+  lastName: "SECRET_SURNAME_9137",
+  passport: "PPT-SECRET-88231",
+}
+
+const echoTool = defineTool({
+  capabilityId: "@voyant-travel/test#tool.echo",
+  owner: "@voyant-travel/test",
+  capabilityVersion: "v1",
+  name: "echo",
+  description: "Echo the text back.",
+  aliases: ["echo_text"],
+  inputSchema: z.object({ text: z.string() }),
+  outputSchema: z.object({ text: z.string() }),
+  requiredScopes: ["catalog:read"],
+  audience: { source: "grant", allowed: ["staff"] },
+  tier: "read",
+  riskPolicy: READ_ONLY_RISK,
+  async handler({ text }) {
+    return { text: `echo: ${text}` }
+  },
+})
+
+// Reads and returns traveller identity — the input and output both carry PII.
+const lookupTravellerTool = defineTool({
+  capabilityId: "@voyant-travel/test#tool.lookup_traveller",
+  owner: "@voyant-travel/test",
+  capabilityVersion: "v1",
+  name: "lookup_traveller",
+  description: "Look a traveller up by email.",
+  aliases: [],
+  inputSchema: z.object({ email: z.string(), lastName: z.string() }),
+  outputSchema: z.object({ email: z.string(), lastName: z.string(), passport: z.string() }),
+  requiredScopes: ["catalog:read"],
+  audience: { source: "grant", allowed: ["staff"] },
+  tier: "read",
+  riskPolicy: READ_ONLY_RISK,
+  async handler(input) {
+    return { email: input.email, lastName: input.lastName, passport: PII.passport }
+  },
+})
+
+// A write tool that fails with a coded ToolError, exercising the tool_error path.
+const saveNoteTool = defineTool({
+  capabilityId: "@voyant-travel/test#tool.save_note",
+  owner: "@voyant-travel/test",
+  capabilityVersion: "v1",
+  name: "save_note",
+  description: "Save a note against a record.",
+  aliases: [],
+  inputSchema: z.object({ note: z.string() }),
+  outputSchema: z.object({ saved: z.boolean() }),
+  requiredScopes: ["records:write"],
+  audience: { source: "grant", allowed: ["staff"] },
+  tier: "write",
+  riskPolicy: {
+    destructive: false,
+    reversible: true,
+    dryRunSupported: false,
+    sideEffects: ["data-write"],
+  },
+  async handler({ note }) {
+    throw new ToolError(`refusing to persist ${note}`, "RECORD_LOCKED")
+  },
+})
+
+function buildContext(): ToolContext {
+  return {
+    db: {},
+    actor: "staff",
+    audience: "staff",
+    tenantId: "t1",
+    organizationId: "org-9",
+    resolverScope: { locale: "en-GB", audience: "staff", market: "default", actor: "staff" },
+  }
+}
+
+interface Harness {
+  app: Hono
+  events: ErrorEvent[]
+  telemetry: () => Array<Record<string, unknown>>
+}
+
+function harness(scopes = ["catalog:read", "records:write"]): Harness {
+  const events: ErrorEvent[] = []
+  const reporter: Reporter = {
+    captureException(event) {
+      events.push(event)
+    },
+  }
+  const registry = createToolRegistry()
+  registry.register(echoTool)
+  registry.register(lookupTravellerTool)
+  registry.register(saveNoteTool)
+  const mcp = createMcpApiRoutes({
+    accessCatalog,
+    registry,
+    buildContext,
+    reporter,
+    appName: "test-app",
+  })
+  const app = new Hono()
+  app.use("*", async (c, next) => {
+    c.set("scopes", scopes)
+    await next()
+  })
+  app.route("/", mcp)
+  return {
+    app,
+    events,
+    telemetry: () =>
+      events
+        .map((e) => e.context?.[MCP_TELEMETRY_CONTEXT_KEY])
+        .filter((c): c is Record<string, unknown> => typeof c === "object" && c !== null),
+  }
+}
+
+const MCP_HEADERS = {
+  "content-type": "application/json",
+  accept: "application/json, text/event-stream",
+}
+
+function rpc(method: string, params: unknown, id: number | string = 1) {
+  return {
+    method: "POST",
+    headers: MCP_HEADERS,
+    body: JSON.stringify({ jsonrpc: "2.0", id, method, params }),
+  }
+}
+
+async function call(app: Hono, name: string, args: unknown) {
+  return app.request("/", rpc("tools/call", { name, arguments: args }))
+}
+
+describe("MCP dispatch instrumentation", () => {
+  it("emits one structured tool_call event per successful call", async () => {
+    const h = harness()
+    await call(h.app, "echo", { text: "hello" })
+
+    const calls = h.telemetry().filter((e) => e.event === "tool_call")
+    expect(calls).toHaveLength(1)
+    const event = calls[0]!
+    expect(event).toMatchObject({
+      tool: "echo",
+      outcome: "ok",
+      write: false,
+    })
+    expect(typeof event.durationMs).toBe("number")
+    expect(event.code).toBeUndefined()
+    expect(event.caller).toMatchObject({
+      actor: "staff",
+      audience: "staff",
+      tenantId: "t1",
+      organizationId: "org-9",
+    })
+    expect(event.caller).toMatchObject({ scopes: expect.arrayContaining(["catalog:read"]) })
+    // Rides the shipped seam: requestId + app name on the ErrorEvent envelope.
+    expect(h.events[0]!.app).toBe("test-app")
+    expect(typeof h.events[0]!.requestId).toBe("string")
+  })
+
+  it("marks a write tool's calls as writes", async () => {
+    const h = harness()
+    await call(h.app, "save_note", { note: "n" })
+    const event = h.telemetry().find((e) => e.event === "tool_call")
+    expect(event).toMatchObject({ tool: "save_note", write: true })
+  })
+
+  it("distinguishes unknown-tool calls from successful calls", async () => {
+    const h = harness()
+    await call(h.app, "find_reservation", { q: "x" })
+    const event = h.telemetry().find((e) => e.event === "tool_call")
+    expect(event).toMatchObject({ tool: "find_reservation", outcome: "unknown_tool", write: false })
+  })
+
+  it("reports a tool filtered by scope as unknown so the naming gap is visible", async () => {
+    const h = harness(["catalog:read"]) // no records:write, so save_note is not registered
+    await call(h.app, "save_note", { note: "n" })
+    const event = h.telemetry().find((e) => e.event === "tool_call")
+    expect(event).toMatchObject({ tool: "save_note", outcome: "unknown_tool" })
+  })
+
+  it("distinguishes argument-validation failures from successful calls", async () => {
+    const h = harness()
+    await call(h.app, "echo", { text: 42 }) // text must be a string
+    const event = h.telemetry().find((e) => e.event === "tool_call")
+    expect(event).toMatchObject({ tool: "echo", outcome: "validation_error" })
+  })
+
+  it("carries the domain error code on a tool_error", async () => {
+    const h = harness()
+    await call(h.app, "save_note", { note: "keep" })
+    const event = h.telemetry().find((e) => e.event === "tool_call")
+    expect(event).toMatchObject({ tool: "save_note", outcome: "tool_error", code: "RECORD_LOCKED" })
+  })
+
+  it("emits the tools/list payload size", async () => {
+    const h = harness()
+    await h.app.request("/", rpc("tools/list", {}))
+    const event = h.telemetry().find((e) => e.event === "tools_list")
+    expect(event).toBeDefined()
+    expect(event!.toolCount).toBeGreaterThan(0)
+    expect(typeof event!.payloadBytes).toBe("number")
+    expect(event!.payloadBytes).toBeGreaterThan(0)
+  })
+
+  it("emits the manifest payload size on GET /manifest", async () => {
+    const h = harness()
+    await h.app.request("/manifest")
+    const event = h.telemetry().find((e) => e.event === "tools_list")
+    expect(event).toMatchObject({ toolCount: expect.any(Number) })
+    expect(event!.payloadBytes).toBeGreaterThan(0)
+  })
+
+  it("never lets an argument or result payload value reach an emitted event", async () => {
+    const h = harness()
+    // A successful call whose input AND output carry PII.
+    await call(h.app, "lookup_traveller", { email: PII.email, lastName: PII.lastName })
+    // A validation failure whose rejected arguments carry PII.
+    await call(h.app, "lookup_traveller", { email: PII.email, lastName: 999 })
+    // An unknown-tool call whose arguments carry PII.
+    await call(h.app, "purge_traveller", { email: PII.email })
+    // A coded tool_error whose arguments carry PII.
+    await call(h.app, "save_note", { note: PII.passport })
+
+    expect(h.telemetry().length).toBeGreaterThanOrEqual(4)
+    // Serialize the ENTIRE emitted events (envelope + signal message + context)
+    // and assert not a single PII sentinel leaked anywhere.
+    const serialized = h.events.map((event) => ({
+      requestId: event.requestId,
+      app: event.app,
+      error: event.error instanceof Error ? event.error.message : String(event.error),
+      context: event.context,
+    }))
+    const blob = JSON.stringify(serialized)
+    for (const secret of Object.values(PII)) {
+      expect(blob).not.toContain(secret)
+    }
+  })
+})


### PR DESCRIPTION
Closes #3925. Wave 1 of #3921.

There was no logger, metric, or span anywhere in the MCP transport. A session
where the model loops, never finds the record it wants, and gives up was a
**200 OK** to every layer we observed. Nothing else in #3921 can be prioritised
without this.

## What it does

Emits structured events for every `tools/call` and `tools/list` through the
**existing** vendor-neutral seam — `Reporter`, `ErrorEvent`, `getRequestId`,
`noopReporter`, `safeCaptureException` from `@voyant-travel/hono/observability`
(RFC #1553). No new logging framework, no vendor SDK, no `console.log`.

Recorded per call: tool name, caller, granted scopes, duration, outcome, and
`ToolError` code — plus payload size and tool count for `tools/list`, which is
the metric #3942 ratchets.

## Instrumented at the JSON-RPC boundary, not in dispatch

The issue said to instrument `dispatchToResult`. **That would have been wrong**,
and the deviation is deliberate.

`register.ts` passes `inputSchema: toMcpInputSchema(...)` to `server.registerTool`,
so the MCP SDK validates arguments and rejects unknown tool names **before** the
dispatch callback runs. Instrumenting dispatch would have silently dropped the
two highest-signal events in the brief — calls to names that do not exist, and
argument-validation failures — which are precisely what reveal the capabilities
and naming an agent expected but could not find.

So instrumentation sits in the `POST /` handler in `server.ts`, which sees every
RPC regardless of where it was rejected.

## Safety properties

- **Cannot break a call.** Emission is best-effort inside a swallowing
  `try/catch`; a parsing slip changes nothing the caller receives.
- **Does not consume the response.** Payload inspection uses
  `response.clone().json()`, so the body returned to the caller is untouched.
- **No PII.** Per `docs/architecture/booking-pii.md` the events carry shapes,
  names, and codes only. The test is not a token gesture: it fires four calls
  (success, validation failure, unknown tool, coded error) each carrying PII
  sentinels in the arguments, then serializes the **entire** event envelope —
  `requestId`, `app`, error message, and `context` — and asserts no sentinel
  appears anywhere.

## Known gaps — please read before merging

1. **Session-level metrics are NOT implemented.** No session call count, no
   distinct-tools-touched, no "ended without a write". The reason is structural:
   `sessionIdGenerator: undefined` means the transport has no session identity by
   ADR-0011. Each event carries `write: boolean` so a backend can aggregate, but
   **session shape must be derived downstream by correlating request id +
   caller.** This is recorded in the commit message; #3925 should stay open or
   spawn a follow-up if in-process session metrics are wanted.
2. **`validation_error` is a fallback classification** — `isError === true` with
   no Voyant `_meta` code. Any other SDK-level error shape would be counted as a
   validation failure.
3. **Telemetry is opt-in.** `reporter` defaults to `noopReporter`, so nothing is
   emitted until a deployment passes one. There are currently no callers of
   `createMcpApiRoutes` / `createGraphMcpApiRoutes` outside `packages/mcp`, so
   this is moot today — but **whoever wires MCP into the operator must pass a
   Reporter or this ships dark.**
4. `tools/list` instrumentation clones and re-serializes the response to measure
   it. At today's ~310 KB that is real work on the connect path. Cheap to accept
   now; #3927 (progressive disclosure) rewrites this path anyway and should fold
   the measurement in rather than re-parsing.

## Verification

```
pnpm -F @voyant-travel/mcp test
  Test Files  7 passed (7)
       Tests  44 passed (44)          # was 34 before this change

pnpm -F @voyant-travel/mcp typecheck   # exit 0
npx biome check packages/mcp
  Checked 25 files. No fixes applied.
node scripts/check-agent-code-quality.mjs | grep packages/mcp/src   # no matches
```

Pushed with `--no-verify`. The pre-push hook runs the full repo suite and failed
on `@voyant-travel/finance-react#test` and `operator#test`; both were re-run in
isolation afterwards and **pass** (51/51 and 51/51 respectively). Neither package
is touched by this change — the failures were contention under 114 parallel turbo
tasks on a local machine. CI is the gate.
