### PR TITLE
fix(notifications): deliver storefront verification through durable delivery

### DIFF
--- a/.changeset/storefront-verification-durable-delivery.md
+++ b/.changeset/storefront-verification-durable-delivery.md
@@ -1,0 +1,23 @@
+---
+"@voyant-travel/notifications": patch
+---
+
+Fix storefront contact verification failing with `provider.send is not a
+function`. The `storefront.verification.runtime` contribution handed the app's
+configured `NotificationProvider` set straight to Storefront, whose provider
+contract expects a bare `send(payload)` — the two shapes agree on `name` and
+`channels` (enough for channel routing to succeed) but a `NotificationProvider`
+only delivers through `durableDelivery`, so every
+`POST /v1/public/storefront-verification/{email,sms}/start` returned 400 and
+guest booking stayed blocked behind `401 verification_required`.
+
+`resolveProviders` now adapts each provider, delivering through
+`durableDelivery` under a payload-derived idempotency key, so an identical
+challenge replays instead of re-sending while a freshly minted code always
+sends. A provider without a durable capability now fails closed naming itself
+rather than throwing a bare `TypeError`.
+
+The two contracts are also pinned against each other at compile time: the
+config primitive's untyped read is narrowed to `NotificationProvider` once, and
+the payload/result shapes are asserted assignable, so drift in either package
+breaks the build instead of a shopper's checkout.

--- a/packages/notifications/src/runtime-contributor.ts
+++ b/packages/notifications/src/runtime-contributor.ts
@@ -19,6 +19,8 @@ import { createQuotesNotificationsRuntime } from "./quotes-runtime.js"
 import { notificationsReminderJobRuntimePort } from "./reminder-job-runtime-port.js"
 import { createNotificationsRuntime } from "./runtime.js"
 import { notificationsRuntimePort } from "./runtime-port.js"
+import { toStorefrontVerificationNotificationProviders } from "./storefront-verification-runtime.js"
+import type { NotificationProvider } from "./types.js"
 
 export interface NotificationsRuntimeContributorHost {
   primitives: VoyantRuntimeHostPrimitives
@@ -33,8 +35,9 @@ export function createNotificationsRuntimePortContribution(
   const runtime = createNotificationsRuntime(host.primitives)
   const verification = {
     resolveProviders(bindings: Record<string, unknown>) {
-      const resolver = host.primitives.config.read(bindings, "notificationProviders")
-      return typeof resolver === "function" ? resolver(host.primitives.env(bindings)) : []
+      return toStorefrontVerificationNotificationProviders(
+        configuredNotificationProviders(host, bindings),
+      )
     },
     email: { subject: "Your verification code" },
   } satisfies StorefrontVerificationRoutesOptions
@@ -55,4 +58,20 @@ export function createNotificationsRuntimePortContribution(
     )
   }
   return contribution
+}
+
+/**
+ * Read the app's configured provider set. The host config primitive is untyped,
+ * so the narrowing happens here once and callers work against
+ * `NotificationProvider` instead of `any` — the `any` is what let a durable
+ * provider reach Storefront's `send`-shaped contract unchallenged (voyant#3923).
+ */
+function configuredNotificationProviders(
+  host: NotificationsRuntimeContributorHost,
+  bindings: Record<string, unknown>,
+): ReadonlyArray<NotificationProvider> {
+  const resolver = host.primitives.config.read(bindings, "notificationProviders")
+  return typeof resolver === "function"
+    ? (resolver(host.primitives.env(bindings)) as ReadonlyArray<NotificationProvider>)
+    : []
 }

--- a/packages/notifications/src/storefront-verification-runtime.ts
+++ b/packages/notifications/src/storefront-verification-runtime.ts
@@ -1,0 +1,88 @@
+import type {
+  StorefrontVerificationNotificationPayload,
+  StorefrontVerificationNotificationProvider,
+  StorefrontVerificationNotificationResult,
+} from "@voyant-travel/storefront/verification"
+
+import type { NotificationPayload, NotificationProvider, NotificationResult } from "./types.js"
+
+/**
+ * Storefront's verification provider contract and this package's provider
+ * contract agree on `name`/`channels` but not on delivery: Storefront calls a
+ * bare `send(payload)`, while a `NotificationProvider` only delivers through
+ * `durableDelivery`. The two used to meet as `unknown` across the options port,
+ * so a `NotificationProvider` handed straight to Storefront type-checked and
+ * then failed at request time with `provider.send is not a function`
+ * (voyant#3923). Every crossing now goes through the adapter below, and the
+ * assignability of the payload/result shapes is asserted at compile time so a
+ * drift in either package breaks the build instead of a shopper's checkout.
+ */
+type AssertAssignableTo<TTarget, TSource extends TTarget> = TSource
+
+type _VerificationPayloadIsANotificationPayload = AssertAssignableTo<
+  NotificationPayload,
+  StorefrontVerificationNotificationPayload
+>
+type _NotificationResultIsAVerificationResult = AssertAssignableTo<
+  StorefrontVerificationNotificationResult,
+  NotificationResult
+>
+
+/**
+ * Scoped, payload-derived idempotency keys. Verification codes are minted per
+ * challenge, so an identical payload is genuinely the same delivery and must
+ * replay rather than re-send; a fresh code produces a fresh key. Deriving the
+ * key from the payload also makes provider-side drift rejection unreachable.
+ */
+const IDEMPOTENCY_KEY_PREFIX = "voyant:storefront-verification"
+
+async function verificationIdempotencyKey(
+  payload: StorefrontVerificationNotificationPayload,
+): Promise<string> {
+  const canonical = JSON.stringify([
+    payload.channel,
+    payload.to,
+    payload.template,
+    payload.provider ?? null,
+    payload.subject ?? null,
+    payload.text ?? null,
+    payload.data ?? null,
+  ])
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(canonical))
+  const hex = Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join(
+    "",
+  )
+  return `${IDEMPOTENCY_KEY_PREFIX}:${hex}`
+}
+
+/** Adapt one durable Notifications provider to Storefront's verification sender. */
+export function toStorefrontVerificationNotificationProvider(
+  provider: NotificationProvider,
+): StorefrontVerificationNotificationProvider {
+  return {
+    name: provider.name,
+    channels: provider.channels,
+    async send(payload) {
+      const capability = provider.durableDelivery
+      if (
+        capability?.protocol !== "notification-provider-idempotency-v1" ||
+        typeof capability.send !== "function"
+      ) {
+        throw new Error(
+          `Notification provider "${provider.name}" does not expose durable delivery, so storefront verification cannot deliver over "${payload.channel}".`,
+        )
+      }
+      const result = await capability.send(payload, {
+        idempotencyKey: await verificationIdempotencyKey(payload),
+      })
+      return { id: result.id, provider: result.provider }
+    },
+  }
+}
+
+/** Adapt the configured Notifications provider set for storefront verification. */
+export function toStorefrontVerificationNotificationProviders(
+  providers: ReadonlyArray<NotificationProvider>,
+): ReadonlyArray<StorefrontVerificationNotificationProvider> {
+  return providers.map(toStorefrontVerificationNotificationProvider)
+}

--- a/packages/notifications/tests/unit/storefront-verification-runtime.test.ts
+++ b/packages/notifications/tests/unit/storefront-verification-runtime.test.ts
@@ -1,0 +1,159 @@
+import { storefrontVerificationRuntimePort } from "@voyant-travel/storefront/runtime-port"
+import {
+  buildStorefrontVerificationSenders,
+  type StorefrontVerificationRoutesOptions,
+} from "@voyant-travel/storefront/verification"
+import { describe, expect, it, vi } from "vitest"
+
+import { createNotificationsRuntimePortContribution } from "../../src/runtime-contributor.js"
+import { toStorefrontVerificationNotificationProvider } from "../../src/storefront-verification-runtime.js"
+import type { NotificationProvider } from "../../src/types.js"
+
+function durableProvider(
+  name: string,
+  channels: ReadonlyArray<string>,
+  send = vi.fn(async () => ({ id: `ntf_${name}`, provider: name })),
+): NotificationProvider {
+  return {
+    name,
+    channels,
+    durableDelivery: { protocol: "notification-provider-idempotency-v1", send },
+  }
+}
+
+function contributionOptions(
+  providers: ReadonlyArray<NotificationProvider>,
+): StorefrontVerificationRoutesOptions {
+  const contribution = createNotificationsRuntimePortContribution({
+    primitives: {
+      env: (bindings: unknown) => (bindings as Record<string, unknown> | undefined) ?? {},
+      database: { resolve: vi.fn(), fromContext: vi.fn(), transaction: vi.fn() },
+      storage: { resolve: vi.fn(), read: vi.fn(), downloadUrl: vi.fn() },
+      events: { deliver: vi.fn() },
+      config: {
+        read: (_bindings: unknown, key: string) =>
+          key === "notificationProviders" ? () => providers : undefined,
+      },
+    },
+    hasRuntimePort: () => false,
+    getRuntimePort: async () => {
+      throw new Error("unselected port must not be read")
+    },
+  } as never)
+  return contribution[storefrontVerificationRuntimePort.id] as StorefrontVerificationRoutesOptions
+}
+
+describe("storefront verification notification providers", () => {
+  it("delivers an email challenge through durable delivery (voyant#3923)", async () => {
+    const send = vi.fn(async () => ({ id: "ntf_1", provider: "voyant-cloud" }))
+    const senders = buildStorefrontVerificationSenders(
+      {},
+      contributionOptions([durableProvider("voyant-cloud", ["email"], send)]),
+    )
+
+    const result = await senders.sendEmailChallenge?.({
+      email: "shopper@example.com",
+      code: "123456",
+      purpose: "booking.create",
+      locale: "en",
+      expiresAt: new Date("2026-01-01T00:10:00.000Z"),
+    })
+
+    expect(result).toEqual({ id: "ntf_1", provider: "voyant-cloud" })
+    expect(send).toHaveBeenCalledOnce()
+    const [payload, context] = send.mock.calls[0] as unknown as [
+      Record<string, unknown>,
+      { idempotencyKey: string },
+    ]
+    expect(payload).toMatchObject({
+      to: "shopper@example.com",
+      channel: "email",
+      template: "storefront-verification-email",
+      subject: "Your verification code",
+      data: expect.objectContaining({ code: "123456", purpose: "booking.create" }),
+    })
+    expect(context.idempotencyKey).toMatch(/^voyant:storefront-verification:[0-9a-f]{64}$/)
+  })
+
+  it("delivers an SMS challenge through the sms-capable provider", async () => {
+    const email = vi.fn(async () => ({ id: "ntf_email", provider: "email-provider" }))
+    const sms = vi.fn(async () => ({ id: "ntf_sms", provider: "sms-provider" }))
+    const senders = buildStorefrontVerificationSenders(
+      {},
+      contributionOptions([
+        durableProvider("email-provider", ["email"], email),
+        durableProvider("sms-provider", ["sms"], sms),
+      ]),
+    )
+
+    const result = await senders.sendSmsChallenge?.({
+      phone: "+40700000000",
+      code: "654321",
+      purpose: "booking.create",
+      expiresAt: new Date("2026-01-01T00:10:00.000Z"),
+    })
+
+    expect(result).toEqual({ id: "ntf_sms", provider: "sms-provider" })
+    expect(email).not.toHaveBeenCalled()
+    expect(sms).toHaveBeenCalledOnce()
+  })
+
+  it("keys deliveries by payload so a replay dedupes and a fresh code does not", async () => {
+    const send = vi.fn(async () => ({ id: "ntf_1", provider: "voyant-cloud" }))
+    const provider = toStorefrontVerificationNotificationProvider(
+      durableProvider("voyant-cloud", ["email"], send),
+    )
+    const payload = {
+      to: "shopper@example.com",
+      channel: "email" as const,
+      template: "storefront-verification-email",
+      data: { code: "123456" },
+    }
+
+    await provider.send(payload)
+    await provider.send(payload)
+    await provider.send({ ...payload, data: { code: "999999" } })
+
+    const keys = send.mock.calls.map(
+      ([, context]) => (context as unknown as { idempotencyKey: string }).idempotencyKey,
+    )
+    expect(keys[0]).toBe(keys[1])
+    expect(keys[2]).not.toBe(keys[0])
+  })
+
+  it("fails closed with a named provider when durable delivery is missing", async () => {
+    const provider = toStorefrontVerificationNotificationProvider({
+      name: "legacy",
+      channels: ["email"],
+    } as unknown as NotificationProvider)
+
+    await expect(
+      provider.send({
+        to: "shopper@example.com",
+        channel: "email",
+        template: "storefront-verification-email",
+      }),
+    ).rejects.toThrow(/"legacy" does not expose durable delivery/)
+  })
+
+  it("resolves no providers when the app configures no resolver", () => {
+    const contribution = createNotificationsRuntimePortContribution({
+      primitives: {
+        env: () => ({}),
+        database: { resolve: vi.fn(), fromContext: vi.fn(), transaction: vi.fn() },
+        storage: { resolve: vi.fn(), read: vi.fn(), downloadUrl: vi.fn() },
+        events: { deliver: vi.fn() },
+        config: { read: () => undefined },
+      },
+      hasRuntimePort: () => false,
+      getRuntimePort: async () => {
+        throw new Error("unselected port must not be read")
+      },
+    } as never)
+    const options = contribution[
+      storefrontVerificationRuntimePort.id
+    ] as StorefrontVerificationRoutesOptions
+
+    expect(options.resolveProviders?.({})).toEqual([])
+  })
+})


### PR DESCRIPTION
Closes #3923.

## The bug

The `storefront.verification.runtime` contribution handed the app's configured
`NotificationProvider` set straight to Storefront. The two provider contracts
agree on `name` and `channels` — enough for Storefront's channel routing in
`createStorefrontVerificationSendersFromProviders` to resolve a provider — but
disagree on the one member that delivers: Storefront calls a bare
`send(payload)`, while a `NotificationProvider` only delivers through
`durableDelivery`.

Nothing caught it, because `host.primitives.config.read` returns `unknown`, so
the resolver call produced `any` and the mismatch survived the
`satisfies StorefrontVerificationRoutesOptions`. It surfaced only when a shopper
asked for a code:

```
POST /v1/public/storefront-verification/email/start
400 {"error":"provider.send is not a function"}
```

which left guest booking blocked behind `401 verification_required` with no way
to satisfy it. Observed on `voyant-operator-runtime:0.66.0`.

## The fix

`resolveProviders` now adapts every provider through
`toStorefrontVerificationNotificationProviders`, delivering via
`durableDelivery.send(payload, { idempotencyKey })`.

The key is `voyant:storefront-verification:<sha256 of the payload>`. Deriving it
from the payload matches how verification actually works: a code is minted per
challenge, so an identical payload is genuinely the same delivery and replays
rather than re-sending, while a freshly minted code always produces a new key
and sends. It also makes provider-side drift rejection unreachable by
construction.

A provider that declares no durable capability now fails closed naming itself,
instead of throwing a bare `TypeError`.

## Keeping it from recurring

Per the issue, the two contracts are pinned against each other at compile time
rather than meeting as `unknown` across the port:

- the untyped `config.read` result is narrowed to `ReadonlyArray<NotificationProvider>`
  once, in `configuredNotificationProviders`, so callers work against the real
  type instead of `any`;
- the adapter asserts `StorefrontVerificationNotificationPayload` is assignable
  to `NotificationPayload` and `NotificationResult` to
  `StorefrontVerificationNotificationResult`, so a drift in either package
  breaks the build.

The MCP verification tools (`createVerificationToolServices`) build senders from
the same options object, so they are fixed by the same change.

## Tests

`packages/notifications/tests/unit/storefront-verification-runtime.test.ts` — 5
tests driving the real seam through storefront's
`buildStorefrontVerificationSenders`, so they exercise the exact path that
failed in production:

- an email challenge delivers through `durableDelivery` with a well-formed
  idempotency key and the expected payload (fails without this change with
  `provider.send is not a function`)
- an SMS challenge routes to the sms-capable provider and leaves the email
  provider untouched
- an identical payload reuses its key while a fresh code does not
- a provider without durable delivery fails closed naming itself
- an app with no configured resolver yields no providers

## Verification

- `vitest run tests/unit/storefront-verification-runtime.test.ts` — 5 passed
- `biome check` — clean on all changed files

`pnpm --filter @voyant-travel/notifications typecheck` was **not** completed
locally: the package lane needs more heap than the machines available to me
here (CI sets `--max-old-space-size=12288`; three disposable 8 GB runners OOM'd
and the local run was still going at 85 minutes under contention). CI is the
gate for that lane on this PR.

## Out of scope, but worth filing

`packages/auth/src/runtime-contributor.ts` has the identical defect:
`sendInvitationEmail` casts the same `notificationProviders` config result to a
local `send`-shaped interface and calls `provider.send(...)`. It is wrapped in
`try`/`catch` returning `false`, so invitation emails fail silently rather than
returning 400. `@voyant-travel/auth` does not depend on
`@voyant-travel/notifications`, so it needs a separate fix.
