### PR TITLE
fix(tools): do not crash constructing a ToolError with an unknown code

### DIFF
--- a/.changeset/tool-error-unknown-code.md
+++ b/.changeset/tool-error-unknown-code.md
@@ -1,0 +1,10 @@
+---
+"@voyant-travel/tools": patch
+---
+
+Fix `ToolError` throwing a `TypeError` when constructed with a code outside
+`ToolErrorCode`. Domain handlers may raise their own codes, which the MCP
+transport forwards verbatim; looking up per-code defaults without a fallback
+turned any such throw into an unrelated construction failure and masked the real
+error as a generic `PROVIDER_ERROR`. Unknown codes now fall back to the
+conservative terminal defaults and keep their code.

--- a/packages/tools/src/errors.ts
+++ b/packages/tools/src/errors.ts
@@ -135,7 +135,11 @@ export class ToolError extends Error {
   ) {
     super(message, options)
     this.name = "ToolError"
-    const defaults = TOOL_ERROR_DEFAULTS[code]
+    // A domain may throw a code outside the union (the transport forwards it
+    // verbatim). Never crash while CONSTRUCTING an error — that replaces the real
+    // failure with a TypeError and loses the original cause. Fall back to the
+    // conservative terminal defaults instead.
+    const defaults = TOOL_ERROR_DEFAULTS[code] ?? TOOL_ERROR_DEFAULTS.PROVIDER_ERROR
     this.retryable = details?.retryable ?? defaults.retryable
     this.nextSteps =
       details?.nextSteps && details.nextSteps.length > 0 ? details.nextSteps : defaults.nextSteps

--- a/packages/tools/tests/errors.test.ts
+++ b/packages/tools/tests/errors.test.ts
@@ -50,3 +50,16 @@ describe("ToolError actionable fields", () => {
     expect(error.nextSteps).toEqual(["Use trip_1."])
   })
 })
+
+describe("ToolError with a code outside the union", () => {
+  it("does not throw while constructing, so the real failure is not masked", () => {
+    // A domain may raise its own code; the transport forwards it verbatim.
+    // Constructing must never crash — a TypeError here would replace the real
+    // failure with an unrelated one and lose the cause.
+    const error = new ToolError("record is locked", "RECORD_LOCKED" as ToolErrorCode)
+
+    expect(error.code).toBe("RECORD_LOCKED")
+    expect(error.retryable).toBe(false)
+    expect(error.nextSteps.length).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
**main is currently red for `@voyant-travel/mcp`. This fixes it.**

## The defect

`ToolError`'s constructor (added in #3947) does:

```ts
const defaults = TOOL_ERROR_DEFAULTS[code]
this.retryable = details?.retryable ?? defaults.retryable
```

For any code outside the `ToolErrorCode` union that lookup is `undefined`, so reading `.retryable` **throws a `TypeError` while the error is being constructed**. Domain handlers do raise their own codes — the transport forwards them verbatim — so a domain error became an unrelated construction failure, and the catch in `dispatchToResult` then reported the masked result as a generic `PROVIDER_ERROR`. **The original cause was lost.**

This is not just a failing assertion. Crashing while building an error object is the worst place to crash: it destroys exactly the diagnostic the caller needed, and it converts a specific, actionable domain error into a generic terminal one — the precise failure mode #3930 set out to eliminate.

## Why CI did not catch it

A semantic conflict between two PRs that were each green on their own branch:

- **#3944** added `tests/observability.test.ts`, whose handler throws `new ToolError(msg, "RECORD_LOCKED")` and asserts the domain code survives to the telemetry event.
- **#3947** added the unguarded lookup.

Neither branch contained the other's code, so neither run could fail. The conflict only existed once both had landed. Green-on-branch is not green-after-merge.

## The fix

Fall back to the conservative terminal defaults and preserve the code:

```ts
const defaults = TOOL_ERROR_DEFAULTS[code] ?? TOOL_ERROR_DEFAULTS.PROVIDER_ERROR
```

Plus a regression test in `packages/tools/tests/errors.test.ts` asserting that constructing with an out-of-union code does not throw, keeps its code, and still yields usable `retryable`/`nextSteps`.

## Verification

```
pnpm -F @voyant-travel/mcp test      Test Files 7 passed   Tests 44 passed   (was 1 failed | 43 passed)
pnpm -F @voyant-travel/tools test    Test Files 6 passed   Tests 57 passed   (was 56)
pnpm -F @voyant-travel/tools typecheck   exit 0
npx biome check packages/tools           Checked 21 files. No fixes applied.
```

Reproduced on `origin/main` at `fae0f36b90` before fixing, so this is confirmed as the cause rather than inferred.

**Note for reviewers:** run `pnpm -F @voyant-travel/tools build` first — a stale `dist/errors.d.ts` produces phantom `TS2339` errors on the new fields.