### PR TITLE
fix(tools): keep the domain code when a ToolError has an unknown code

### DIFF
--- a/.changeset/tool-error-unknown-code.md
+++ b/.changeset/tool-error-unknown-code.md
@@ -1,0 +1,12 @@
+---
+"@voyant-travel/tools": patch
+---
+
+Stop `ToolError` throwing when constructed with an unrecognised code.
+
+The per-code defaults lookup added alongside `retryable`/`nextSteps` assumed the
+code was always present in `TOOL_ERROR_DEFAULTS`. An unknown code made the
+lookup `undefined`, so the constructor threw a `TypeError` on the failure path
+and MCP dispatch normalised it to a generic `PROVIDER_ERROR` — discarding the
+domain code the caller needed. Unknown codes now fall back to the terminal
+`PROVIDER_ERROR` defaults while keeping the code itself intact.

--- a/packages/mcp/tests/observability.test.ts
+++ b/packages/mcp/tests/observability.test.ts
@@ -112,7 +112,7 @@ const saveNoteTool = defineTool({
     sideEffects: ["data-write"],
   },
   async handler({ note }) {
-    throw new ToolError(`refusing to persist ${note}`, "RECORD_LOCKED")
+    throw new ToolError(`refusing to persist ${note}`, "NOT_FOUND")
   },
 })
 
@@ -243,7 +243,7 @@ describe("MCP dispatch instrumentation", () => {
     const h = harness()
     await call(h.app, "save_note", { note: "keep" })
     const event = h.telemetry().find((e) => e.event === "tool_call")
-    expect(event).toMatchObject({ tool: "save_note", outcome: "tool_error", code: "RECORD_LOCKED" })
+    expect(event).toMatchObject({ tool: "save_note", outcome: "tool_error", code: "NOT_FOUND" })
   })
 
   it("emits the tools/list payload size", async () => {

--- a/packages/tools/src/errors.ts
+++ b/packages/tools/src/errors.ts
@@ -135,7 +135,13 @@ export class ToolError extends Error {
   ) {
     super(message, options)
     this.name = "ToolError"
-    const defaults = TOOL_ERROR_DEFAULTS[code]
+    // Constructing an error must never throw. TypeScript keeps `code` inside
+    // ToolErrorCode, but this runs on the failure path where a value can arrive
+    // from an untyped boundary or a stale build; an unknown code then made
+    // `defaults` undefined and turned the domain failure into a TypeError, which
+    // dispatch reported as a generic PROVIDER_ERROR — losing the very code the
+    // caller needed. Fall back to the terminal default instead.
+    const defaults = TOOL_ERROR_DEFAULTS[code] ?? TOOL_ERROR_DEFAULTS.PROVIDER_ERROR
     this.retryable = details?.retryable ?? defaults.retryable
     this.nextSteps =
       details?.nextSteps && details.nextSteps.length > 0 ? details.nextSteps : defaults.nextSteps

--- a/packages/tools/tests/errors.test.ts
+++ b/packages/tools/tests/errors.test.ts
@@ -49,4 +49,15 @@ describe("ToolError actionable fields", () => {
     expect(error.didYouMean).toBe("trip_1")
     expect(error.nextSteps).toEqual(["Use trip_1."])
   })
+
+  it("does not throw when constructed with an unrecognised code", () => {
+    // The failure path must not itself fail. An unknown code previously made the
+    // per-code defaults lookup undefined, so the constructor threw a TypeError
+    // and callers saw a generic PROVIDER_ERROR instead of the domain code.
+    const error = new ToolError("boom", "NOT_A_REAL_CODE" as ToolErrorCode)
+    expect(error).toBeInstanceOf(ToolError)
+    expect(error.code).toBe("NOT_A_REAL_CODE")
+    expect(error.retryable).toBe(false)
+    expect(error.nextSteps.length).toBeGreaterThan(0)
+  })
 })


### PR DESCRIPTION
**CI has been failing on `main` since #3947.** Two defects, one in each of the commits involved.

## Symptom

`packages/mcp/tests/observability.test.ts` asserts that a domain error code reaches dispatch telemetry:

```
- Expected            + Received
-   "code": "RECORD_LOCKED",
+   "code": "PROVIDER_ERROR",
    "outcome": "tool_error",
    "tool": "save_note",
```

## Defect 1 — the constructor throws on the failure path (#3947)

`ToolError`'s constructor gained a per-code defaults lookup and dereferenced it unguarded:

```ts
const defaults = TOOL_ERROR_DEFAULTS[code]
this.retryable = details?.retryable ?? defaults.retryable
```

An unrecognised code makes `defaults` `undefined`, so reading `.retryable` throws a **`TypeError` while constructing the error**. Dispatch then catches that TypeError, sees something that is not a `ToolError`, and normalises it to `PROVIDER_ERROR` — discarding the domain code the caller needed.

The normalisation in `dispatch.ts` is correct; it was fed a TypeError.

**Constructing an error must never throw, least of all on the failure path.** An unknown code now falls back to the terminal `PROVIDER_ERROR` defaults while keeping `code` itself intact, so the domain code still reaches telemetry.

## Defect 2 — the fixture used a code that does not exist (#3944)

The test threw `RECORD_LOCKED`, which is not a member of `ToolErrorCode` and never has been:

```ts
export type ToolErrorCode =
  | "MISSING_SERVICE" | "AUTHORIZATION_DENIED" | "ACTION_POLICY_REQUIRED"
  | "APPROVAL_REQUIRED" | "CONFIRMATION_REQUIRED" | "NOT_FOUND"
  | "INVALID_INPUT" | "INVALID_OUTPUT" | "PROVIDER_ERROR" | "PROVIDER_UNAVAILABLE"
```

Before the defaults lookup existed the constructor ignored the code entirely, so the invented value went unnoticed for two commits. The fixture now throws `NOT_FOUND` — the test's point is that *a domain code survives to telemetry*, and any real code demonstrates that.

## Regression test

`packages/tools/tests/errors.test.ts` now asserts that constructing with an unrecognised code yields a `ToolError`, preserves the code, and supplies usable `retryable`/`nextSteps` defaults. Without it, the next invented code silently degrades to `PROVIDER_ERROR` again.

## Verification

| Check | Result |
|---|---|
| `-F @voyant-travel/mcp test` | 44 passed (was 1 failed / 43 passed) |
| `-F @voyant-travel/tools test` | 57 passed |
| `-F @voyant-travel/tools... -F @voyant-travel/mcp typecheck` | pass |
| `biome check packages/tools packages/mcp` | clean |

Changeset included — `@voyant-travel/tools` patch.

## Note

This is #3921 territory, which I had been staying clear of. Picked it up because it is blocking `main`, and the fix is confined to the error-construction contract rather than the tool-surface design. The `ToolError` shape from #3947 is otherwise untouched.
