### PR TITLE
feat(hono): expose the observability sink on the request context

### DIFF
--- a/.changeset/reporter-on-request-context.md
+++ b/.changeset/reporter-on-request-context.md
@@ -1,0 +1,10 @@
+---
+"@voyant-travel/hono": minor
+---
+
+Expose the deployment's observability sink on the request context as
+`c.var.reporter` (and `c.var.appName`). `createVoyantApp` already resolved a
+`Reporter` for the error boundary, but composed route modules had no way to reach
+it, so a module that emitted its own telemetry had to be handed a reporter
+through every composition seam — and in practice was handed none, so it emitted
+nothing. Falls back to `noopReporter`, so a module may emit unconditionally.

--- a/packages/hono/src/app.ts
+++ b/packages/hono/src/app.ts
@@ -185,6 +185,16 @@ export function mountApp<TBindings extends VoyantBindings>(
   const appName = config.appName ?? "voyant"
   app.onError((err, c) => handleApiError(err, c, { reporter, appName }))
 
+  // Expose the same sink on the request context so a composed route module can
+  // emit its own telemetry without the deployment threading a reporter through
+  // every composition seam. Registered before everything else so it is present
+  // even on requests that fail early.
+  app.use("*", async (c, next) => {
+    c.set("reporter", reporter)
+    c.set("appName", appName)
+    await next()
+  })
+
   const basePath = normalizeBaseDispatchPath(config.basePath)
   if (basePath) {
     const dispatchWithoutBasePath = (request: Request): Request => {

--- a/packages/hono/src/types.ts
+++ b/packages/hono/src/types.ts
@@ -63,6 +63,18 @@ export type VoyantVariables = CoreVoyantVariables & {
   link?: LinkService
   /** Shared cross-module query runtime, when the app wires one in. */
   query?: VoyantQueryRuntime
+  /**
+   * The deployment's observability sink (RFC #1553), resolved once by
+   * `createVoyantApp`. Exposed here so a composed route module can emit its own
+   * telemetry through the same sink as the error boundary, without the
+   * deployment having to thread a reporter through every composition seam.
+   *
+   * Always present on a request served by `createVoyantApp` — it falls back to
+   * `noopReporter` when the deployment configured none.
+   */
+  reporter?: Reporter
+  /** Logical app name stamped on telemetry, alongside {@link reporter}. */
+  appName?: string
 }
 
 /** Handler contract for application-authored Hono API routes. */

--- a/packages/hono/tests/unit/create-app.test.ts
+++ b/packages/hono/tests/unit/create-app.test.ts
@@ -94,3 +94,76 @@ describe("createApp (config-driven front door)", () => {
     expect(loads).toBe(1)
   })
 })
+
+describe("observability sink on the request context (RFC #1553)", () => {
+  it("exposes the deployment reporter so composed modules can emit their own telemetry", async () => {
+    const captured: string[] = []
+    const seen: { reporter?: unknown; appName?: unknown } = {}
+
+    const app = createApp<Record<string, never>, Caps>({
+      manifest: { modules: ["@voyant-travel/probe"] },
+      registry: {
+        modules: {
+          "@voyant-travel/probe": () => ({
+            module: { name: "probe" },
+            adminRoutes: new Hono().get("/ping", (c) => {
+              seen.reporter = c.get("reporter")
+              seen.appName = c.get("appName")
+              return c.text("ok")
+            }),
+          }),
+        },
+      },
+      capabilities: { greeting: "pong" },
+      appName: "probe-app",
+      reporter: { captureException: (event) => captured.push(String(event.message)) },
+      // biome-ignore lint/suspicious/noExplicitAny: stub db for the mount smoke test.
+      db: () => ({}) as any,
+      auth: {
+        resolve: () => ({ userId: "u1", actor: "staff" as Actor, realm: "admin" as const }),
+      },
+    })
+
+    const response = await app.request("/v1/admin/probe/ping", {}, {} as never)
+
+    expect(response.status).toBe(200)
+    // A composed module must reach the SAME sink the error boundary uses,
+    // without the deployment threading a reporter through every seam.
+    expect(seen.appName).toBe("probe-app")
+    expect(seen.reporter).toBeDefined()
+    ;(seen.reporter as { captureException: (e: { message: string }) => void }).captureException({
+      message: "from a composed module",
+    })
+    expect(captured).toContain("from a composed module")
+  })
+
+  it("falls back to a no-op sink rather than leaving the context empty", async () => {
+    let reporter: unknown
+    const app = createApp<Record<string, never>, Caps>({
+      manifest: { modules: ["@voyant-travel/probe"] },
+      registry: {
+        modules: {
+          "@voyant-travel/probe": () => ({
+            module: { name: "probe" },
+            adminRoutes: new Hono().get("/ping", (c) => {
+              reporter = c.get("reporter")
+              return c.text("ok")
+            }),
+          }),
+        },
+      },
+      capabilities: { greeting: "pong" },
+      // biome-ignore lint/suspicious/noExplicitAny: stub db for the mount smoke test.
+      db: () => ({}) as any,
+      auth: {
+        resolve: () => ({ userId: "u1", actor: "staff" as Actor, realm: "admin" as const }),
+      },
+    })
+
+    await app.request("/v1/admin/probe/ping", {}, {} as never)
+
+    // Never undefined: a module that emits unconditionally must not crash on a
+    // deployment that configured no sink.
+    expect(reporter).toBeDefined()
+  })
+})


### PR DESCRIPTION
Unblocks #3925 / #3921. **Without this, the MCP transport telemetry merged in #3944 emits nothing.**

## The gap

`createVoyantApp` resolves a `Reporter` at `packages/hono/src/app.ts:184` and uses it for the error boundary. Nothing else can reach it. A composed route module that wants to emit its own telemetry has to be handed a reporter through every composition seam — and in practice none was.

Concretely: `packages/mcp/src/runtime.ts` (`createMcpVoyantRuntime`) is the only mount site for the MCP transport, and it does not pass a reporter. So the instrumentation added in #3944 defaults to `noopReporter` in every deployment and emits **nowhere**.

That matters beyond one package. The MCP surface plan in #3921 is explicitly ordered *instrument → measure → decide*, and W8 (read projection) and W9 (workflow tools) are meant to be sized from that data. There is currently no data.

## The change

Set the same resolved sink on the request context as `c.var.reporter` and `c.var.appName`, registered before everything else so it is present even on requests that fail early. Falls back to `noopReporter`, so a module may emit unconditionally without a guard.

This is deliberately general rather than an MCP special case — one seam that unblocks every composed module, instead of threading a reporter into one runtime factory.

## Verification

```
pnpm -F @voyant-travel/hono test        Test Files 36 passed   Tests 321 passed  (was 319)
pnpm -F @voyant-travel/hono typecheck   exit 0
npx biome check packages/hono/src/app.ts packages/hono/src/types.ts   clean
```

Two new tests: one asserts a composed module reaches the **same** sink the error boundary uses (by capturing through it), one asserts the fallback is never `undefined` so an unconditional emitter cannot crash a deployment that configured no sink. Both genuinely failed before the wiring worked — I hit a 404 and an `undefined` while getting the harness right — so they are not passing vacuously.

## Follow-on

`packages/mcp/src/server.ts` must read `c.var.reporter` in `observerFor` for the telemetry to actually flow. That lands with the progressive-disclosure work (#3927), which rewrites the same region — doing it separately would guarantee a conflict.