### PR TITLE
refactor(admin-app)!: stop re-exporting admin/app from the root

### DIFF
--- a/.changeset/admin-app-root-owns-content.md
+++ b/.changeset/admin-app-root-owns-content.md
@@ -1,0 +1,17 @@
+---
+"@voyant-travel/admin-app": minor
+---
+
+`@voyant-travel/admin-app` no longer re-exports `@voyant-travel/admin/app` from
+its root.
+
+The root export was half alias, half content: `export * from
+"@voyant-travel/admin/app"` alongside its own core-extension surface. That gave
+importers two specifiers for one API with nothing to indicate which was
+canonical, and no code used the aliased half — the root specifier had no
+importer anywhere in this repo, the operator starter, or the sibling
+repositories.
+
+The root now exports only what this package owns. Anything wanting the admin app
+shell types imports `@voyant-travel/admin/app` directly, which is where they are
+defined.

--- a/packages/admin-app/src/index.ts
+++ b/packages/admin-app/src/index.ts
@@ -1,2 +1,7 @@
-export * from "@voyant-travel/admin/app"
+/**
+ * The core admin extension. Route and workspace types live in
+ * `@voyant-travel/admin/app`, which this package no longer re-exports — it
+ * aliased that surface without adding to it, so importers had two specifiers
+ * for one API and no way to tell which was canonical.
+ */
 export * from "./core-extension/index.js"


### PR DESCRIPTION
Completes the façade removal started in #3964.

## What the root export was

```ts
// packages/admin-app/src/index.ts
export * from "@voyant-travel/admin/app"      // ← alias
export * from "./core-extension/index.js"     // ← this package's own content
```

Half alias, half content. That gave importers **two specifiers for one API** with nothing marking either canonical — and nothing used the aliased half.

## Evidence it is unused

The root specifier `"@voyant-travel/admin-app"` has no importer in this repo, the operator starter (including generated `.voyant` output), or any sibling repository. Real consumers reach only the two subpaths carrying code:

| Subpath | Consumers |
|---|---|
| `./core-extension` | `admin-host`, `operator-settings-react` |
| `./runtime` | `operator-standard` |

The package's own test imports `../src/index.js` for `createAdminCoreExtension` — that comes from the **content** half and is unaffected.

## After

```ts
export * from "./core-extension/index.js"
```

The root exports only what `admin-app` owns. Callers wanting the admin app shell types import `@voyant-travel/admin/app`, where they are defined.

`admin-app` is now a package with three exports and no aliasing: `.`, `./core-extension`, `./runtime` — down from seven exports, five of which were one-line re-exports, before #3964.

## Verification

| Check | Result |
|---|---|
| `pnpm verify:architecture` | **exit 0** (full chain) |
| `-F admin-app typecheck` | pass |
| typecheck `admin-host`, `operator-settings-react`, `operator-standard` | pass |
| `-F admin-app test` | 22 passed |
| `-F admin-app build` | pass |
| `biome check packages/admin-app` | clean |

Marked `minor` per 0.x convention — removing re-exports from a root is breaking in principle, though provably unused in practice.

## Note

The `admin-app` package name remains in `scripts/generate-standard-product-distribution.mjs` and `check-retail-spine-closure.mjs`. That is unchanged and correct: the package still exists and still ships real code. This PR only stops its root pretending to be `@voyant-travel/admin/app`.
