### PR TITLE
feat(mcp): response budgets, response_format, guided truncation

### DIFF
--- a/.changeset/mcp-response-budgets.md
+++ b/.changeset/mcp-response-budgets.md
@@ -1,0 +1,36 @@
+---
+"@voyant-travel/mcp": minor
+"@voyant-travel/types": patch
+---
+
+Response budgets, `response_format`, and guided truncation for the MCP tool
+surface (voyant#3928, RFC voyant#3921 Finding 7). Tool responses used to be
+uncapped — a single `list_bookings` at the maximum page size could put more into
+an agent's context than the entire tool catalog, and unlike the catalog that cost
+is charged on every call.
+
+- **Transport-level response budget.** `dispatchToResult` now enforces a
+  serialized byte ceiling on every tool result, so the cap covers every tool
+  uniformly instead of relying on each domain. Configurable through
+  `McpApiRoutesOptions.responseBudgetBytes` / `GraphMcpApiRoutesOptions`;
+  defaults to `DEFAULT_RESPONSE_BUDGET_BYTES` (~24 KB).
+
+- **Guided truncation, never silent.** An over-budget list result has whole rows
+  dropped until it fits, and the result states how many of the total it is
+  showing and which of the tool's own input filters would narrow it (e.g.
+  "narrow with `status`, `dateFrom`"). The `content` text and `structuredContent`
+  are trimmed to the same row set, `structuredContent` stays valid against the
+  untouched output schema, `_meta["voyant.travel/truncation"]` records what was
+  withheld, and the call remains a success.
+
+- **`response_format: "concise" | "detailed"`** is advertised on list-shaped
+  tools and defaults to `concise`, which renders the text content as compact rows
+  projected to their populated scalar fields; `detailed` renders the full nested
+  records. `structuredContent` always carries the full-field rows. Measured on a
+  booking-shaped list: detailed ~255 tokens/row vs concise ~109 tokens/row — 57%
+  smaller — on the `content` block agents read.
+
+Also documents in `@voyant-travel/types` `paginationSchema` that a row count is
+not a payload budget (200 bookings and 200 contact points are not the same
+bytes): `limit` stays a page-size ergonomic while the MCP byte budget is the real
+ceiling on what a response costs an agent's context.

--- a/packages/mcp/src/dispatch.ts
+++ b/packages/mcp/src/dispatch.ts
@@ -19,6 +19,13 @@ import {
 } from "@voyant-travel/tools"
 
 import { isRecord } from "./guards.js"
+import {
+  isListShapedOutput,
+  listFilterFieldsFromInput,
+  RESPONSE_FORMAT_FIELD,
+  type ResponseFormat,
+  shapeResponse,
+} from "./response-budget.js"
 import { actionInvocationSchemaFor, reviveDateInputs } from "./schema-projection.js"
 
 /** Dispatch through the registry (validates in + out) and wrap pure data in an MCP envelope. */
@@ -30,11 +37,16 @@ export async function dispatchToResult(
   ctx: ToolContext,
   requireActionPolicy: boolean,
   envelopeResult: boolean,
+  budgetBytes: number,
 ): Promise<CallToolResult> {
   try {
+    // `response_format` is a transport-only control, never a domain input — strip
+    // it before the registry re-validates against the untouched domain schema,
+    // which would otherwise reject an unexpected key.
+    const { format, rest } = extractResponseFormat(args)
     const { commandInput, invocation } = entry.actionPolicy
-      ? splitInvocation(args, entry)
-      : { commandInput: args, invocation: {} }
+      ? splitInvocation(rest, entry)
+      : { commandInput: rest, invocation: {} }
     if (requireActionPolicy && !entry.actionPolicy && entry.deploymentRisk !== "low") {
       throw new ToolError(
         `Tool "${entry.name}" has no selected graph action policy.`,
@@ -76,9 +88,18 @@ export async function dispatchToResult(
               ? handlerDispatchContext(baseDispatchContext, entry, invocation)
               : baseDispatchContext,
           )
+    const def = registry.get(name)
+    const listShaped = def ? isListShapedOutput(def.outputSchema) : false
+    const shaped = shapeResponse(data, {
+      format: format ?? (listShaped ? "concise" : undefined),
+      budgetBytes,
+      filterFields: def ? listFilterFieldsFromInput(def.inputSchema) : [],
+      toWire: (value) => toStructuredContent(value, envelopeResult),
+    })
     return {
-      content: [{ type: "text", text: safeStringify(data) }],
-      structuredContent: toStructuredContent(data, envelopeResult),
+      content: [{ type: "text", text: shaped.text }],
+      structuredContent: shaped.structuredContent,
+      ...(shaped.meta ? { _meta: shaped.meta } : {}),
     }
   } catch (err) {
     // Normalize any thrown value into a ToolError so the envelope always carries
@@ -249,10 +270,10 @@ function requireActionGate(ctx: ToolContext) {
   return ctx.toolActionPolicy
 }
 
-function safeStringify(data: unknown): string {
-  try {
-    return JSON.stringify(data, null, 2)
-  } catch {
-    return String(data)
-  }
+/** Peel the transport-only `response_format` control off the caller's arguments. */
+function extractResponseFormat(args: unknown): { format?: ResponseFormat; rest: unknown } {
+  if (!isRecord(args) || !(RESPONSE_FORMAT_FIELD in args)) return { rest: args }
+  const { [RESPONSE_FORMAT_FIELD]: raw, ...rest } = args
+  const format = raw === "detailed" ? "detailed" : raw === "concise" ? "concise" : undefined
+  return { ...(format ? { format } : {}), rest }
 }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,4 +1,12 @@
 export {
+  DEFAULT_RESPONSE_BUDGET_BYTES,
+  isListShapedOutput,
+  RESPONSE_FORMAT_FIELD,
+  RESPONSE_TRUNCATION_META_KEY,
+  type ResponseFormat,
+  shapeResponse,
+} from "./response-budget.js"
+export {
   createGraphMcpApiRoutes,
   createMcpApiRoutes,
   type GraphMcpApiRoutesOptions,

--- a/packages/mcp/src/meta-tools.ts
+++ b/packages/mcp/src/meta-tools.ts
@@ -31,6 +31,7 @@ import { dispatchToResult } from "./dispatch.js"
 import { isRecord } from "./guards.js"
 import type { McpCaller, McpCallOutcome, McpObserver } from "./observability.js"
 import { toMcpMeta } from "./register.js"
+import { DEFAULT_RESPONSE_BUDGET_BYTES, isListShapedOutput } from "./response-budget.js"
 import { toMcpInputSchema, toMcpOutputContract } from "./schema-projection.js"
 
 /** The eager tier-0 meta-tool names, reserved so a domain tool can never shadow one. */
@@ -123,10 +124,13 @@ export function advertiseTool(
   if (!def) {
     throw new ToolError(`Tool "${invocationName}" is not registered.`, "NOT_FOUND")
   }
-  const inputSchema = z.toJSONSchema(toMcpInputSchema(def.inputSchema, entry), {
-    io: "input",
-    unrepresentable: "any",
-  })
+  const inputSchema = z.toJSONSchema(
+    toMcpInputSchema(def.inputSchema, entry, isListShapedOutput(def.outputSchema)),
+    {
+      io: "input",
+      unrepresentable: "any",
+    },
+  )
   const output = toMcpOutputContract(def.outputSchema)
   const outputSchema = z.toJSONSchema(output.schema, { unrepresentable: "any" })
   return {
@@ -148,6 +152,8 @@ export interface RegisterMetaToolsInput {
   observer: McpObserver
   caller: McpCaller
   now: () => number
+  /** Serialized response byte budget applied to every dispatched tool result. */
+  budgetBytes?: number
 }
 
 /** Register the three tier-0 meta-tools on the per-request server. */
@@ -265,6 +271,7 @@ function describeTool(
 
 function registerCallTool(input: RegisterMetaToolsInput): void {
   const { server, registry, surface, ctx, requireActionPolicy, observer, caller, now } = input
+  const budgetBytes = input.budgetBytes ?? DEFAULT_RESPONSE_BUDGET_BYTES
   server.registerTool(
     CALL_TOOL_NAME,
     {
@@ -292,6 +299,7 @@ function registerCallTool(input: RegisterMetaToolsInput): void {
         ctx,
         requireActionPolicy,
         output.envelopeResult,
+        budgetBytes,
       )
       // Emit telemetry for the DISPATCHED tool, not the call_tool wrapper, so a
       // write routed through call_tool is as observable as a flat-name write.

--- a/packages/mcp/src/register.ts
+++ b/packages/mcp/src/register.ts
@@ -12,6 +12,7 @@ import {
 } from "@voyant-travel/tools"
 
 import { dispatchToResult } from "./dispatch.js"
+import { DEFAULT_RESPONSE_BUDGET_BYTES, isListShapedOutput } from "./response-budget.js"
 import { toMcpInputSchema, toMcpOutputContract } from "./schema-projection.js"
 
 export function registerMcpTool(
@@ -23,13 +24,14 @@ export function registerMcpTool(
   ctx: ToolContext,
   aliasFor?: string,
   requireActionPolicy = false,
+  budgetBytes: number = DEFAULT_RESPONSE_BUDGET_BYTES,
 ): void {
   const output = toMcpOutputContract(def.outputSchema)
   server.registerTool(
     invocationName,
     {
       description: entry.description,
-      inputSchema: toMcpInputSchema(def.inputSchema, entry),
+      inputSchema: toMcpInputSchema(def.inputSchema, entry, isListShapedOutput(def.outputSchema)),
       outputSchema: output.schema,
       annotations: entry.annotations,
       _meta: toMcpMeta(entry, aliasFor),
@@ -43,6 +45,7 @@ export function registerMcpTool(
         ctx,
         requireActionPolicy,
         output.envelopeResult,
+        budgetBytes,
       ),
   )
 }

--- a/packages/mcp/src/response-budget.ts
+++ b/packages/mcp/src/response-budget.ts
@@ -1,0 +1,282 @@
+/**
+ * Transport-level response budget, `response_format`, and guided truncation
+ * (voyant#3928, RFC voyant#3921 Finding 7).
+ *
+ * Tool responses used to be uncapped: a single `list_bookings` at the maximum
+ * page size could put more into an agent's context than the entire tool catalog,
+ * and — unlike the catalog — that cost is charged on EVERY call. This module caps
+ * the serialized size of a result and shapes list-shaped payloads, and it is
+ * applied in `dispatch.ts` where the MCP envelope is built, so every tool is
+ * covered uniformly rather than relying on each domain to remember.
+ *
+ * Two levers:
+ *
+ * - **Budget.** {@link shapeResponse} trims whole rows from a list result until
+ *   the serialized envelope (structured content + text) fits the configured byte
+ *   budget. Truncation is **guided, never silent**: a trimmed result states how
+ *   many rows it is showing of the total and which of the tool's own input
+ *   filters would narrow it. A silently clipped array makes a model conclude it
+ *   has seen everything, which is worse than an error — so the guidance rides in
+ *   the text content and in `_meta`, and the call stays a success.
+ *
+ * - **`response_format`.** `concise` (the default for list tools) renders the
+ *   text content as compact rows projected to their POPULATED scalar fields —
+ *   null and nested fields, which carry little selection signal, are omitted;
+ *   `detailed` renders the full nested records. Only the TEXT content is
+ *   projected — the `structuredContent` always carries the full-field rows
+ *   (row-truncated), so it stays valid against the tool's untouched output schema
+ *   and a caller that needs every field still has it. Whole rows are dropped
+ *   identically from both, so the two never describe different result sets.
+ *
+ * ## PII
+ *
+ * Per `docs/architecture/booking-pii.md` this module measures byte lengths and
+ * copies field values while shaping, but never logs or echoes a payload: nothing
+ * here writes to a logger or telemetry sink. The domain has already applied its
+ * redaction before the value reaches dispatch.
+ */
+import { z } from "@hono/zod-openapi"
+import { TOOL_ACTION_INVOCATION_FIELD } from "@voyant-travel/tools"
+
+import { isRecord } from "./guards.js"
+
+/**
+ * Default ceiling for a serialized tool response, in bytes. ~24 KB is roughly
+ * 6k tokens at 4 bytes/token — an order of magnitude below the old ~339 KB tool
+ * catalog, while still comfortably fitting a default page of typical rows.
+ * Deployment-configurable through `McpApiRoutesOptions.responseBudgetBytes`.
+ */
+export const DEFAULT_RESPONSE_BUDGET_BYTES = 24_000
+
+/** The input field a caller sets to choose a response verbosity. */
+export const RESPONSE_FORMAT_FIELD = "response_format"
+
+/** `_meta` key under which {@link shapeResponse} records what it truncated. */
+export const RESPONSE_TRUNCATION_META_KEY = "voyant.travel/truncation"
+
+export type ResponseFormat = "concise" | "detailed"
+
+/**
+ * The `response_format` input schema added to list-shaped tools. Defaulting to
+ * `concise` is the point: published guidance measures the same result at ~72
+ * tokens concise vs ~206 detailed, and we used to always send detailed.
+ */
+export const responseFormatSchema = z
+  .enum(["concise", "detailed"])
+  .describe(
+    "Response verbosity. concise (default) returns compact rows with scalar " +
+      "fields only; detailed returns the full nested records.",
+  )
+  .default("concise")
+
+/**
+ * Does this tool's output schema match the canonical `ListResponse` envelope
+ * (`{ data: T[], total, limit, offset }`)? That is the shape whose row count the
+ * budget trims and the only shape `response_format` is advertised on.
+ */
+export function isListShapedOutput(schema: z.ZodType): boolean {
+  try {
+    const json = z.toJSONSchema(schema, { unrepresentable: "any" }) as {
+      type?: string
+      properties?: Record<string, { type?: string }>
+    }
+    if (json.type !== "object" || !json.properties) return false
+    const p = json.properties
+    return (
+      p.data?.type === "array" &&
+      p.total !== undefined &&
+      p.limit !== undefined &&
+      p.offset !== undefined
+    )
+  } catch {
+    return false
+  }
+}
+
+/**
+ * The candidate narrowing filters to name in a truncation notice: every
+ * top-level input field that is not pagination, the reserved action-metadata
+ * field, or `response_format`. Named filters ("narrow with `status`") beat
+ * generic advice because they are the tool's real inputs.
+ */
+export function listFilterFieldsFromInput(schema: z.ZodType): string[] {
+  let properties: Record<string, unknown> | undefined
+  try {
+    properties = (
+      z.toJSONSchema(schema, { io: "input", unrepresentable: "any" }) as {
+        properties?: Record<string, unknown>
+      }
+    ).properties
+  } catch {
+    return []
+  }
+  if (!properties || typeof properties !== "object") return []
+  const excluded = new Set(["limit", "offset", RESPONSE_FORMAT_FIELD, TOOL_ACTION_INVOCATION_FIELD])
+  return Object.keys(properties).filter((key) => !excluded.has(key))
+}
+
+export interface ShapeResponseOptions {
+  /** Chosen verbosity; a list tool defaults to `concise`, non-list stays detailed. */
+  format: ResponseFormat | undefined
+  /** Serialized byte ceiling for the whole result. */
+  budgetBytes: number
+  /** The tool's own input filter names, for guided truncation. */
+  filterFields: readonly string[]
+  /** Wrap pure data in the same MCP structured-content envelope dispatch uses. */
+  toWire: (data: unknown) => Record<string, unknown>
+}
+
+export interface ShapedResponse {
+  /** The text content block. */
+  text: string
+  /** The structured-content envelope, schema-valid and row-truncated to budget. */
+  structuredContent: Record<string, unknown>
+  /** Present only when rows were dropped: what was withheld and how to narrow. */
+  meta?: Record<string, unknown>
+}
+
+/**
+ * Shape a dispatched domain value into the text + structured content the envelope
+ * carries, enforcing the byte budget and `response_format`. A non-list value is
+ * returned unchanged (its schema forbids dropping fields, and it is not the
+ * payload Finding 7 is about) so behavior for every existing tool is preserved.
+ */
+export function shapeResponse(data: unknown, options: ShapeResponseOptions): ShapedResponse {
+  const located = locatePrimaryArray(data)
+  if (!located) {
+    return { text: safeStringify(data), structuredContent: options.toWire(data) }
+  }
+
+  const { rows, total, rebuild } = located
+  const format: ResponseFormat = options.format ?? "detailed"
+  const n = rows.length
+
+  const render = (count: number) => {
+    const truncated = count < n
+    const nextData = rebuild(rows.slice(0, count))
+    const wire = options.toWire(nextData)
+    const notice = truncated
+      ? buildTruncationNotice({ shown: count, total, filterFields: options.filterFields })
+      : undefined
+    const text = renderText(nextData, format) + (notice ? `\n\n${notice}` : "")
+    const bytes = byteLength(JSON.stringify(wire)) + byteLength(text)
+    return { wire, text, bytes }
+  }
+
+  const full = render(n)
+  if (full.bytes <= options.budgetBytes) {
+    return { text: full.text, structuredContent: full.wire }
+  }
+
+  // Largest prefix of rows whose serialized envelope fits the budget. render(0)
+  // is a near-empty array, so a fit always exists and truncation never errors.
+  let low = 0
+  let high = n
+  let best = 0
+  while (low <= high) {
+    const mid = (low + high) >> 1
+    if (render(mid).bytes <= options.budgetBytes) {
+      best = mid
+      low = mid + 1
+    } else {
+      high = mid - 1
+    }
+  }
+  const chosen = render(best)
+  return {
+    text: chosen.text,
+    structuredContent: chosen.wire,
+    meta: {
+      [RESPONSE_TRUNCATION_META_KEY]: {
+        returned: best,
+        total,
+        withheld: n - best,
+        reason: "response_budget",
+        guidance: narrowingGuidance(options.filterFields),
+      },
+    },
+  }
+}
+
+interface LocatedArray {
+  rows: unknown[]
+  total: number
+  rebuild: (rows: unknown[]) => unknown
+}
+
+/** Find the trimmable row array: a bare array result, or a `ListResponse.data`. */
+function locatePrimaryArray(data: unknown): LocatedArray | undefined {
+  if (Array.isArray(data)) {
+    return { rows: data, total: data.length, rebuild: (rows) => rows }
+  }
+  if (isRecord(data) && Array.isArray(data.data)) {
+    const total = typeof data.total === "number" ? data.total : data.data.length
+    return { rows: data.data, total, rebuild: (rows) => ({ ...data, data: rows }) }
+  }
+  return undefined
+}
+
+function renderText(data: unknown, format: ResponseFormat): string {
+  if (format === "concise") return JSON.stringify(conciseView(data))
+  return safeStringify(data)
+}
+
+/** Project list rows to their populated scalar top-level fields for concise text. */
+function conciseView(data: unknown): unknown {
+  if (Array.isArray(data)) return data.map(conciseRow)
+  if (isRecord(data) && Array.isArray(data.data)) {
+    return { ...data, data: data.data.map(conciseRow) }
+  }
+  return data
+}
+
+function conciseRow(row: unknown): unknown {
+  if (!isRecord(row)) return row
+  const out: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(row)) {
+    // Keep populated scalars; drop null and nested (object/array) fields, which
+    // dominate the byte cost and carry little tool-selection signal.
+    if (isScalar(value)) out[key] = value
+  }
+  return out
+}
+
+function isScalar(value: unknown): boolean {
+  const t = typeof value
+  return t === "string" || t === "number" || t === "boolean"
+}
+
+function buildTruncationNotice(input: {
+  shown: number
+  total: number
+  filterFields: readonly string[]
+}): string {
+  return (
+    `⚠ Response truncated to fit the response budget: showing ${input.shown} of ` +
+    `${input.total} result(s). To retrieve the rest, ${narrowingGuidance(input.filterFields)}.`
+  )
+}
+
+/** Human guidance naming real input filters where they exist, else generic advice. */
+function narrowingGuidance(filterFields: readonly string[]): string {
+  const priority = /status|state|date|from|to|type|category|kind|query|search|filter|q$/i
+  const ranked = [...filterFields].sort(
+    (a, b) => (priority.test(b) ? 1 : 0) - (priority.test(a) ? 1 : 0),
+  )
+  const picks = ranked.slice(0, 3)
+  if (picks.length === 0) return "narrow your query or page with `offset`"
+  return `narrow with ${picks.map((field) => `\`${field}\``).join(", ")} (or page with \`offset\`)`
+}
+
+/** UTF-8 byte length of a string — the payload's wire size, no payload logged. */
+function byteLength(text: string): number {
+  return new TextEncoder().encode(text).length
+}
+
+function safeStringify(data: unknown): string {
+  try {
+    return JSON.stringify(data, null, 2)
+  } catch {
+    return String(data)
+  }
+}

--- a/packages/mcp/src/schema-projection.ts
+++ b/packages/mcp/src/schema-projection.ts
@@ -12,6 +12,7 @@ import { z } from "@hono/zod-openapi"
 import { TOOL_ACTION_INVOCATION_FIELD, type ToolManifestEntry } from "@voyant-travel/tools"
 
 import { isRecord } from "./guards.js"
+import { RESPONSE_FORMAT_FIELD, responseFormatSchema } from "./response-budget.js"
 
 export interface McpOutputContract {
   schema: z.ZodType
@@ -57,12 +58,16 @@ type ZodDiscoveryDef = ZodCompositionDef & {
  * Wire clients send ISO strings; before registry dispatch those strings are
  * revived to `Date` wherever the domain schema expects a date node.
  */
-export function toMcpInputSchema(schema: z.ZodType, entry: ToolManifestEntry): z.ZodObject {
+export function toMcpInputSchema(
+  schema: z.ZodType,
+  entry: ToolManifestEntry,
+  listShaped = false,
+): z.ZodObject {
   const shape =
     schema instanceof z.ZodObject
       ? schema.shape
       : Object.assign({}, ...collectInputObjectShapes(schema))
-  const projectedShape = projectShapeForMcpDiscovery(shape)
+  const projectedShape = withResponseFormat(projectShapeForMcpDiscovery(shape), listShaped)
   if (!entry.actionPolicy) {
     return z.looseObject(projectedShape)
   }
@@ -75,6 +80,16 @@ export function toMcpInputSchema(schema: z.ZodType, entry: ToolManifestEntry): z
     ...projectedShape,
     [TOOL_ACTION_INVOCATION_FIELD]: actionInvocationSchemaFor(entry).optional(),
   })
+}
+
+/**
+ * Advertise `response_format` on a list-shaped tool so callers can pick concise
+ * (the default) or detailed. A domain schema that already owns the field is left
+ * untouched — the domain's own meaning wins over the transport control.
+ */
+function withResponseFormat(shape: z.ZodRawShape, listShaped: boolean): z.ZodRawShape {
+  if (!listShaped || RESPONSE_FORMAT_FIELD in shape) return shape
+  return { ...shape, [RESPONSE_FORMAT_FIELD]: responseFormatSchema }
 }
 
 const mcpDateTimeSchema = z.iso.datetime({ offset: true })

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -55,6 +55,7 @@ import {
   type McpObserver,
 } from "./observability.js"
 import { registerMcpTool } from "./register.js"
+import { DEFAULT_RESPONSE_BUDGET_BYTES } from "./response-budget.js"
 import type { GraphMcpApiRoutesOptions, McpApiRoutesOptions, McpServerInfo } from "./types.js"
 
 export type {
@@ -151,6 +152,7 @@ export function createMcpApiRoutes(options: McpApiRoutesOptions): OpenAPIHono {
     const ctx = await buildAuthenticatedContext(c, buildContext)
     const observer = observerFor(c, ctx)
     const requireActionPolicy = options.requireActionPolicies ?? false
+    const budgetBytes = options.responseBudgetBytes ?? DEFAULT_RESPONSE_BUDGET_BYTES
 
     // The caller's full authorized surface (canonical + alias names). Progressive
     // disclosure means only tier 0 is *registered* — but search / describe / call
@@ -176,7 +178,7 @@ export function createMcpApiRoutes(options: McpApiRoutesOptions): OpenAPIHono {
     // Register only the tier-0 domain tools eagerly; the long tail stays lazy.
     const eagerNames = selectEagerToolNames(surface, options.eagerToolNames)
     for (const name of eagerNames)
-      registerSurfaceTool(server, registry, surface, name, ctx, requireActionPolicy)
+      registerSurfaceTool(server, registry, surface, name, ctx, requireActionPolicy, budgetBytes)
 
     registerMetaTools({
       server,
@@ -187,6 +189,7 @@ export function createMcpApiRoutes(options: McpApiRoutesOptions): OpenAPIHono {
       observer,
       caller: callerFromContext(ctx),
       now: () => Date.now(),
+      budgetBytes,
     })
 
     // Backwards compatibility: a flat-name `tools/call` for a lazy (non-eager)
@@ -202,7 +205,15 @@ export function createMcpApiRoutes(options: McpApiRoutesOptions): OpenAPIHono {
       !META_TOOL_NAMES.includes(requestedName) &&
       surface.has(requestedName)
     ) {
-      registerSurfaceTool(server, registry, surface, requestedName, ctx, requireActionPolicy)
+      registerSurfaceTool(
+        server,
+        registry,
+        surface,
+        requestedName,
+        ctx,
+        requireActionPolicy,
+        budgetBytes,
+      )
     }
 
     const transport = new StreamableHTTPTransport({
@@ -227,6 +238,7 @@ function registerSurfaceTool(
   invocationName: string,
   ctx: ToolContext,
   requireActionPolicy: boolean,
+  budgetBytes: number,
 ): void {
   const binding = surface.get(invocationName)
   if (!binding) return
@@ -241,6 +253,7 @@ function registerSurfaceTool(
     ctx,
     binding.aliasFor,
     requireActionPolicy,
+    budgetBytes,
   )
   // A canonical eager tool also advertises its deprecated aliases, matching the
   // pre-disclosure behavior for the tools that remain resident.
@@ -255,6 +268,7 @@ function registerSurfaceTool(
         ctx,
         binding.entry.name,
         requireActionPolicy,
+        budgetBytes,
       )
     }
   }
@@ -440,6 +454,9 @@ export async function createGraphMcpApiRoutes(
     ...(options.serverInfo ? { serverInfo: options.serverInfo } : {}),
     ...(options.reporter ? { reporter: options.reporter } : {}),
     ...(options.appName ? { appName: options.appName } : {}),
+    ...(options.responseBudgetBytes !== undefined
+      ? { responseBudgetBytes: options.responseBudgetBytes }
+      : {}),
     buildContext: (c) => buildContributedContext(c, options, contributions.values()),
   })
 }

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -36,6 +36,12 @@ export interface McpApiRoutesOptions {
   reporter?: Reporter
   /** Logical app name stamped on emitted telemetry events. Defaults to `"voyant"`. */
   appName?: string
+  /**
+   * Serialized byte ceiling for a single tool response (voyant#3928). A
+   * list-shaped result over this budget is row-truncated with guidance;
+   * defaults to `DEFAULT_RESPONSE_BUDGET_BYTES` (~24 KB).
+   */
+  responseBudgetBytes?: number
 }
 
 export interface GraphMcpApiRoutesOptions {
@@ -51,6 +57,8 @@ export interface GraphMcpApiRoutesOptions {
   reporter?: Reporter
   /** Logical app name stamped on emitted telemetry events. Defaults to `"voyant"`. */
   appName?: string
+  /** Serialized byte ceiling for a single tool response (voyant#3928). */
+  responseBudgetBytes?: number
 }
 
 export type GraphMcpRuntime = VoyantGraphRuntime

--- a/packages/mcp/tests/response-budget.test.ts
+++ b/packages/mcp/tests/response-budget.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Response budget, `response_format`, and guided truncation (voyant#3928).
+ *
+ * Unit coverage for {@link shapeResponse} / {@link isListShapedOutput} plus an
+ * end-to-end pass through the real transport, and a measured concise-vs-detailed
+ * token delta on a booking-shaped list — the heaviest read tool in the tree.
+ */
+import {
+  createToolRegistry,
+  defineTool,
+  READ_ONLY_RISK,
+  type ToolContext,
+} from "@voyant-travel/tools"
+import { listResponseSchema, paginationSchema } from "@voyant-travel/types"
+import { Hono } from "hono"
+import { describe, expect, it } from "vitest"
+import { z } from "zod"
+
+import { createMcpApiRoutes } from "../src/index.js"
+import {
+  isListShapedOutput,
+  RESPONSE_TRUNCATION_META_KEY,
+  shapeResponse,
+} from "../src/response-budget.js"
+
+const MCP_HEADERS = {
+  "content-type": "application/json",
+  accept: "application/json, text/event-stream",
+}
+
+function rpc(method: string, params: unknown, id: number | string = 1) {
+  return {
+    method: "POST",
+    headers: MCP_HEADERS,
+    body: JSON.stringify({ jsonrpc: "2.0", id, method, params }),
+  }
+}
+
+async function readRpc(res: Response): Promise<Record<string, unknown>> {
+  const text = await res.text()
+  if ((res.headers.get("content-type") ?? "").includes("text/event-stream")) {
+    const line = text.split("\n").find((l) => l.startsWith("data:"))
+    return JSON.parse(line?.slice("data:".length).trim() ?? "{}")
+  }
+  return JSON.parse(text)
+}
+
+/** A booking-shaped list row: many flat fields, several null, a couple nested. */
+function bookingRow(index: number): Record<string, unknown> {
+  return {
+    id: `book_${index.toString().padStart(6, "0")}`,
+    bookingNumber: `B-${1000 + index}`,
+    status: index % 2 === 0 ? "confirmed" : "hold",
+    personId: `per_${index}`,
+    organizationId: null,
+    sourceType: "direct",
+    externalBookingRef: null,
+    communicationLanguage: "en-GB",
+    contactFirstName: null,
+    contactLastName: null,
+    contactEmail: null,
+    contactPhone: null,
+    contactCountry: "GB",
+    sellCurrency: "GBP",
+    baseCurrency: null,
+    sellAmountCents: 125_000 + index,
+    costAmountCents: 90_000 + index,
+    marginPercent: 28,
+    startDate: "2026-09-14",
+    endDate: "2026-09-21",
+    pax: 2,
+    internalNotes: null,
+    notificationsSuppressed: false,
+    priceOverride: null,
+    customFields: { "voyant.loyalty": { tier: "gold", points: 4200 } },
+    holdExpiresAt: null,
+    confirmedAt: index % 2 === 0 ? "2026-07-01T10:00:00.000Z" : null,
+    createdAt: "2026-06-30T09:00:00.000Z",
+    updatedAt: "2026-07-01T10:00:00.000Z",
+  }
+}
+
+const bookingRowSchema = z.looseObject({
+  id: z.string(),
+  bookingNumber: z.string(),
+  status: z.string(),
+})
+
+const listThingsTool = defineTool({
+  name: "list_things",
+  description: "List booking-shaped things with filters and pagination. Read-only.",
+  inputSchema: paginationSchema.extend({
+    status: z.string().optional().describe("Filter by status."),
+    dateFrom: z.string().optional().describe("Only things on or after this date."),
+    count: z.coerce.number().int().min(0).max(500).default(0),
+  }),
+  outputSchema: listResponseSchema(bookingRowSchema),
+  requiredScopes: ["catalog:read"],
+  audience: { source: "grant", allowed: ["staff"] },
+  tier: "read",
+  riskPolicy: READ_ONLY_RISK,
+  annotations: { readOnlyHint: true },
+  async handler(query) {
+    const rows = Array.from({ length: query.count }, (_, i) => bookingRow(i))
+    return { data: rows, total: rows.length, limit: query.limit, offset: query.offset }
+  },
+})
+
+const accessCatalog = {
+  resources: [
+    {
+      id: "catalog",
+      unitId: "@voyant-travel/catalog",
+      resource: "catalog",
+      label: "Catalog",
+      description: "Catalog",
+      wildcard: "allow" as const,
+      actions: [{ action: "read", label: "Read", description: "Read" }],
+    },
+  ],
+  presets: [],
+}
+
+function buildContext(): ToolContext {
+  return {
+    db: {},
+    actor: "staff",
+    audience: "staff",
+    tenantId: "t1",
+    resolverScope: { locale: "en-GB", audience: "staff", market: "default", actor: "staff" },
+  }
+}
+
+function mountListThings(responseBudgetBytes?: number): Hono {
+  const registry = createToolRegistry()
+  registry.register(listThingsTool)
+  const mcp = createMcpApiRoutes({
+    accessCatalog,
+    registry,
+    buildContext,
+    eagerToolNames: ["list_things"],
+    ...(responseBudgetBytes !== undefined ? { responseBudgetBytes } : {}),
+  })
+  const outer = new Hono()
+  outer.use("*", async (c, next) => {
+    c.set("scopes", ["catalog:read"])
+    await next()
+  })
+  outer.route("/", mcp)
+  return outer
+}
+
+interface CallToolResult {
+  isError?: boolean
+  content?: Array<{ type: string; text: string }>
+  structuredContent?: { data?: unknown[]; total?: number }
+  _meta?: Record<string, unknown>
+}
+
+async function callListThings(app: Hono, args: Record<string, unknown>): Promise<CallToolResult> {
+  const res = await readRpc(
+    await app.request("/", rpc("tools/call", { name: "list_things", arguments: args })),
+  )
+  return (res.result ?? {}) as CallToolResult
+}
+
+describe("isListShapedOutput", () => {
+  it("recognizes the ListResponse envelope and rejects a plain object", () => {
+    expect(isListShapedOutput(listResponseSchema(bookingRowSchema))).toBe(true)
+    expect(isListShapedOutput(z.object({ id: z.string(), name: z.string() }))).toBe(false)
+    expect(isListShapedOutput(z.array(bookingRowSchema))).toBe(false)
+  })
+})
+
+describe("shapeResponse", () => {
+  const toWire = (data: unknown) => data as Record<string, unknown>
+
+  it("leaves a within-budget list untouched", () => {
+    const data = { data: [bookingRow(0)], total: 1, limit: 50, offset: 0 }
+    const shaped = shapeResponse(data, {
+      format: "detailed",
+      budgetBytes: 1_000_000,
+      filterFields: ["status", "dateFrom"],
+      toWire,
+    })
+    expect(shaped.meta).toBeUndefined()
+    expect((shaped.structuredContent as { data: unknown[] }).data).toHaveLength(1)
+  })
+
+  it("row-truncates over budget, stays a success, and names real filters", () => {
+    const rows = Array.from({ length: 200 }, (_, i) => bookingRow(i))
+    const data = { data: rows, total: 200, limit: 200, offset: 0 }
+    const shaped = shapeResponse(data, {
+      format: "concise",
+      budgetBytes: 4_000,
+      filterFields: ["status", "dateFrom"],
+      toWire,
+    })
+    const returned = (shaped.structuredContent as { data: unknown[] }).data
+    expect(returned.length).toBeGreaterThan(0)
+    expect(returned.length).toBeLessThan(200)
+    // Whole rows only — each returned row is the full record, so it still
+    // validates against the untouched output schema.
+    expect(returned[0]).toMatchObject({ id: "book_000000", createdAt: expect.any(String) })
+    const text = shaped.text
+    expect(text).toContain("truncated")
+    expect(text).toContain("`status`")
+    expect(text).toContain(`of 200`)
+    const truncation = shaped.meta?.[RESPONSE_TRUNCATION_META_KEY] as {
+      returned: number
+      total: number
+      withheld: number
+    }
+    expect(truncation.total).toBe(200)
+    expect(truncation.returned + truncation.withheld).toBe(200)
+    // The whole serialized envelope respects the budget.
+    const bytes = new TextEncoder().encode(JSON.stringify(shaped.structuredContent) + text).length
+    expect(bytes).toBeLessThanOrEqual(4_000)
+  })
+
+  it("concise omits null and nested fields from the text; detailed keeps them", () => {
+    const data = { data: [bookingRow(0)], total: 1, limit: 50, offset: 0 }
+    const concise = shapeResponse(data, {
+      format: "concise",
+      budgetBytes: 1_000_000,
+      filterFields: [],
+      toWire,
+    }).text
+    const detailed = shapeResponse(data, {
+      format: "detailed",
+      budgetBytes: 1_000_000,
+      filterFields: [],
+      toWire,
+    }).text
+    expect(concise).not.toContain("organizationId") // null → dropped
+    expect(concise).not.toContain("customFields") // nested → dropped
+    expect(concise).toContain("bookingNumber")
+    expect(detailed).toContain("organizationId")
+    expect(detailed).toContain("customFields")
+    // structuredContent is unaffected by format — full fields survive for clients.
+    const full = shapeResponse(data, {
+      format: "concise",
+      budgetBytes: 1_000_000,
+      filterFields: [],
+      toWire,
+    }).structuredContent as { data: Array<Record<string, unknown>> }
+    expect(full.data[0]).toHaveProperty("organizationId")
+    expect(full.data[0]).toHaveProperty("customFields")
+  })
+
+  it("passes a non-list value straight through", () => {
+    const shaped = shapeResponse(
+      { id: "x", name: "y" },
+      { format: undefined, budgetBytes: 10, filterFields: [], toWire },
+    )
+    expect(shaped.meta).toBeUndefined()
+    expect(shaped.structuredContent).toEqual({ id: "x", name: "y" })
+  })
+})
+
+describe("list tool over the transport", () => {
+  it("advertises response_format on the list tool's input schema", async () => {
+    const app = mountListThings()
+    const res = await readRpc(
+      await app.request(
+        "/",
+        rpc("tools/call", { name: "describe_tool", arguments: { name: "list_things" } }),
+      ),
+    )
+    const descriptor = (res.result as { structuredContent?: { inputSchema?: unknown } })
+      ?.structuredContent
+    expect(JSON.stringify(descriptor?.inputSchema)).toContain("response_format")
+  })
+
+  it("defaults to concise and truncates a large result with guidance, not an error", async () => {
+    const app = mountListThings(6_000)
+    const result = await callListThings(app, { count: 200, limit: 200 })
+    expect(result.isError).not.toBe(true)
+    const returned = result.structuredContent?.data ?? []
+    expect(returned.length).toBeGreaterThan(0)
+    expect(returned.length).toBeLessThan(200)
+    const text = result.content?.[0]?.text ?? ""
+    expect(text).toContain("truncated")
+    expect(text).toContain("`status`")
+    // Default (no response_format arg) is concise: null/nested fields absent from text.
+    expect(text).not.toContain("customFields")
+    expect(result._meta?.[RESPONSE_TRUNCATION_META_KEY]).toBeDefined()
+  })
+
+  it("honors response_format:detailed", async () => {
+    const app = mountListThings(1_000_000)
+    const detailed = await callListThings(app, {
+      count: 3,
+      limit: 50,
+      response_format: "detailed",
+    })
+    expect(detailed.content?.[0]?.text ?? "").toContain("customFields")
+    const concise = await callListThings(app, { count: 3, limit: 50 })
+    expect(concise.content?.[0]?.text ?? "").not.toContain("customFields")
+  })
+
+  it("reports the concise-vs-detailed token delta on a booking-shaped list", async () => {
+    const app = mountListThings(1_000_000)
+    const rowsWanted = 30
+    const detailed = await callListThings(app, {
+      count: rowsWanted,
+      limit: 50,
+      response_format: "detailed",
+    })
+    const concise = await callListThings(app, {
+      count: rowsWanted,
+      limit: 50,
+      response_format: "concise",
+    })
+    const detailedText = detailed.content?.[0]?.text ?? ""
+    const conciseText = concise.content?.[0]?.text ?? ""
+    const toTokens = (t: string) => Math.round(new TextEncoder().encode(t).length / 4)
+    const detailedTokens = toTokens(detailedText)
+    const conciseTokens = toTokens(conciseText)
+    const perRow = (n: number) => Math.round(n / rowsWanted)
+    // eslint-disable-next-line no-console
+    console.log(
+      `[voyant#3928] list_things content tokens over ${rowsWanted} booking-shaped rows — ` +
+        `detailed ${detailedTokens} (${perRow(detailedTokens)}/row), ` +
+        `concise ${conciseTokens} (${perRow(conciseTokens)}/row), ` +
+        `delta ${detailedTokens - conciseTokens} tokens ` +
+        `(${Math.round((1 - conciseTokens / detailedTokens) * 100)}% smaller).`,
+    )
+    expect(conciseTokens).toBeLessThan(detailedTokens)
+  })
+})

--- a/packages/mcp/tests/response-budget.test.ts
+++ b/packages/mcp/tests/response-budget.test.ts
@@ -318,7 +318,9 @@ describe("list tool over the transport", () => {
     const detailedTokens = toTokens(detailedText)
     const conciseTokens = toTokens(conciseText)
     const perRow = (n: number) => Math.round(n / rowsWanted)
-    // eslint-disable-next-line no-console
+    // biome-ignore lint/suspicious/noConsole: intentional — this test's purpose is to
+    // report the measured concise-vs-detailed delta, so the number lands in CI output
+    // rather than only in an assertion nobody reads.
     console.log(
       `[voyant#3928] list_things content tokens over ${rowsWanted} booking-shaped rows — ` +
         `detailed ${detailedTokens} (${perRow(detailedTokens)}/row), ` +

--- a/packages/types/src/list-response.ts
+++ b/packages/types/src/list-response.ts
@@ -39,6 +39,18 @@ export function listResponse<T>(
  * `limit` coerces to an int in `[1, 200]` (default 50); `offset` coerces to a
  * non-negative int (default 0). Domain list-query schemas should extend this
  * rather than re-declaring `limit`/`offset` privately.
+ *
+ * ## Row count is not a payload budget (voyant#3928)
+ *
+ * A row count is the wrong lever for bounding what a response costs an agent's
+ * context: 200 bookings and 200 contact points are not remotely the same number
+ * of bytes, so a single cap of 200 cannot mean the same thing for both. The real
+ * ceiling on a tool response is therefore enforced at the MCP transport as a
+ * **byte budget** — see `shapeResponse` / `DEFAULT_RESPONSE_BUDGET_BYTES` in
+ * `@voyant-travel/mcp`, which row-truncates an over-budget list result with
+ * guidance rather than clipping it silently. This `limit` stays a page-size
+ * ergonomic (kept at 50/200 so REST callers and their tests are undisturbed);
+ * the byte budget is what actually bounds the payload on the agent surface.
  */
 export const paginationSchema = z.object({
   limit: z.coerce.number().int().min(1).max(200).default(50),


### PR DESCRIPTION
Addresses #3928. Wave 2 of #3921.

Tool **responses** were uncapped — no truncation, byte cap, or token cap anywhere in `packages/tools/src`, `packages/mcp/src`, or any domain `tools.ts`.

## Why this is now the dominant cost

Progressive disclosure (#3961) and the guide layer (#3967) cut `tools/list` from ~78,000 tokens to ~735. **The catalog is no longer the problem.** An uncapped list response is now the largest thing an agent puts in its context — and unlike the catalog, it is charged on *every call* rather than once per connection.

## What landed

- **Byte budget**, default 24,000, overridable per deployment. Applied as a transport projection inside `dispatchToResult`, so flat-name dispatch and `call_tool` both go through it and no domain has to remember.
- **Guided truncation, never silent.** Binary-searches the largest fitting row prefix, drops whole rows from `content` and `structuredContent` **identically** so the two never describe different result sets, keeps the true `total`, names the tool's own input filters to narrow with, records `_meta["voyant.travel/truncation"]`, and **stays a success result**. A silently clipped array makes a model conclude it has seen everything — worse than an error.
- **`response_format: concise | detailed`**, default concise, injected only at the MCP projection layer and only on tools whose output matches the `ListResponse` envelope. Only the *text* block is projected; `structuredContent` always carries full-field rows, so SDK output-schema validation is unaffected.

**Measured delta** (30 booking-shaped rows): detailed **7,660** tokens → concise **3,278** tokens — **57% smaller**, 255/row → 109/row.

## Security boundary

The action-policy gate is untouched. The single change on that path is that `response_format` is stripped from args *before* `splitInvocation`, so the domain schema never sees an unexpected key and the invocation metadata is unaffected. I verified this in the diff rather than trusting the summary.

## Caveats — read before merging

1. **Non-list results are not capped.** `shapeResponse` passes any non-array, non-`ListResponse` value through unchanged, because fields cannot be dropped without breaking the tool's output schema. So *"no tool response can exceed the budget"* holds for **list-shaped results only** — narrower than #3928's acceptance criterion as written. Documented in the module header; follow-up filed.
2. **Task 4 was answered, not implemented.** `limit` stays 50/200. The reasoning — a row count is the wrong lever, the byte budget is the real ceiling, and changing it would break ~66 test files and every REST caller — is recorded in `packages/types/src/list-response.ts`. **This is a decision worth ratifying rather than a silent skip.**
3. **The token delta is measured on a synthetic fixture** modeled on `bookingToolSchema`, not the real `list_bookings`, and tokens are estimated as bytes/4 rather than by a tokenizer. Directionally sound, not exact.
4. **Concise drops all nested/array fields** from the text block, not only verbose ones — an agent reading only `content` loses e.g. line items until it asks for `detailed`. Structured content still carries them.

## Verification

```
pnpm -F @voyant-travel/mcp test        Test Files 9 passed   Tests 64 passed
pnpm -F @voyant-travel/mcp typecheck   exit 0
pnpm -F @voyant-travel/types test      Test Files 3 passed   Tests 37 passed
npx biome check .                      repo-wide, 0 errors
operator ratchets                      53 passed — both hold
node scripts/check-agent-code-quality.mjs | grep packages/mcp/src   # no matches
```

**The aggregate ratchet did not need raising**, and the reason was confirmed in code rather than assumed: `response_format` is added in `toMcpInputSchema` (transport projection), never in the domain `inputSchema` the ratchet measures.

One cleanup on top of the original branch: an `eslint-disable` comment in the test suppressed nothing (this repo lints with Biome) and was replaced with a real `biome-ignore` explaining why the measurement log is deliberate.