### PR TITLE
docs(agents): make checker conversion opportunistic rather than a campaign

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,50 @@ and promote repeated review feedback into scripts or docs.
 Update the relevant doc when changing an architectural rule. Add or update a
 checker when a rule is mechanical enough to enforce.
 
+- Module boundaries and what the package split is for:
+  `docs/adr/0016-modules-as-components-of-one-deployable.md`
+
+## Architecture Checkers
+
+`verify:architecture` runs a chain of checks. Four are declarative and take new
+rules as data rather than code:
+
+| Check | Enforces | Where rules live |
+|---|---|---|
+| `verify:boundary` | browser packages must not reach Drizzle or Hono through value imports | `.dependency-cruiser.cjs` |
+| `verify:graph-conformance` | what a package contributes to the resolved graph | `scripts/checks/graph/graph-conformance.json` |
+| `verify:symbol-policy` | where a symbol may and may not appear | `scripts/checks/symbols/symbol-policy.json` |
+| `verify:retired-surfaces` | deleted paths stay deleted | `scripts/checks/regression/retired-paths.json` |
+
+Two run as ratchets, holding a line rather than demanding it be clean today:
+`verify:table-privacy` (cross-module table reach-ins) and
+`verify:package-descriptions`. **Their baselines may only shrink.** Regenerate
+one only when tightening it; never to make a failure go away.
+
+### Converting an authority script you are already editing
+
+The per-module `scripts/check-*authority*.mjs` scripts assert architecture by
+matching **substrings of source text** — `manifest.includes("requirePort(x)")`.
+That breaks on reformatting and passes when a module is subtly wrong, which is
+why a feature change sometimes has to edit a checker to proceed.
+
+**If one of them fights you, convert those assertions instead of patching the
+substring.** You already have the context loaded; converting cold costs far more.
+
+- a fact about the graph — ports, capabilities, `requiresSchemas`, the runtime
+  contributor export — becomes an entry in `graph-conformance.json`
+- a rule about where a symbol may appear becomes an entry in `symbol-policy.json`
+- an assertion that a deleted file stays deleted becomes a path in
+  `retired-paths.json`
+
+Some assertions are none of these — they pin a call shape or a signature inside a
+factory. Leave those alone rather than forcing a fit, and say so in the PR.
+
+There is deliberately **no campaign** to convert the rest. The corpus shrinks as
+a side effect of normal work, which is cheaper than a sweep and puts each
+conversion in the hands of someone who knows what the module does. See
+[#3898](https://github.com/voyant-travel/voyant/issues/3898).
+
 ## Local Verification Lanes
 
 Use the smallest lane that matches the risk of the change:


### PR DESCRIPTION
Makes the authority-script corpus shrink as a side effect of normal work, instead of via a campaign nobody has time to run.

## The measurement behind it

Over the last 90 days, **51 commits touched a `check-*authority*.mjs` script** — 1.6% of 3,233. Reading them, roughly half are product changes that had to edit a checker to proceed:

```
feat(bookings): public self-service booking creation
feat(flights): activate durable supplier ticket and cancel actions
fix(finance): restore durable booking creation
feat(legal)!: add durable document operations
```

So the friction is roughly **one product commit every three or four days**. Enough to be worth removing; **not** enough to justify a dedicated sweep across the 44 remaining modules.

## Why opportunistic beats a campaign

- **A cold conversion pays a full context load per module** — read the script, work out what it pins, find the graph equivalent, verify. Converting while already in that module for a feature is nearly free.
- **The tooling is now the cheap part.** Three techniques exist, each self-tested, each taking rules as JSON. Adding a rule is editing a config file, not building infrastructure.
- **It routes each conversion to someone who knows what the module does**, which matters because deciding whether an assertion is a graph fact or an implementation detail is a judgement call.

## What the doc now says

A table of the four declarative checkers and where their rules live, the two ratchets and the rule that **their baselines may only shrink — never regenerate one to clear a failure**, and the conversion guidance:

> If an authority script fights you, convert its assertions rather than patching the substring.
>
> - a graph fact — ports, capabilities, `requiresSchemas`, contributor export → `graph-conformance.json`
> - where a symbol may appear → `symbol-policy.json`
> - a deleted path staying deleted → `retired-paths.json`
>
> Some assertions are none of these — they pin a call shape or signature inside a factory. Leave those alone rather than forcing a fit, and say so in the PR.

And explicitly: **there is deliberately no campaign** to convert the rest.

## Verification

Every path and script name referenced in the new sections was checked to exist:

```
ok  .dependency-cruiser.cjs
ok  scripts/checks/graph/graph-conformance.json
ok  scripts/checks/symbols/symbol-policy.json
ok  scripts/checks/regression/retired-paths.json
ok  docs/adr/0016-modules-as-components-of-one-deployable.md
ok  verify:boundary · graph-conformance · symbol-policy · retired-surfaces · table-privacy · package-descriptions
```

Docs only. The per-tool importer at the repo root re-exports `AGENTS.md`, so this reaches every agent without a second edit.
