### PR TITLE
chore(mcp): upgrade the MCP SDK to 1.30.0 and track the 2026-07-28 spec

### DIFF
--- a/.changeset/mcp-sdk-1-30-spec-tracking.md
+++ b/.changeset/mcp-sdk-1-30-spec-tracking.md
@@ -1,0 +1,18 @@
+---
+"@voyant-travel/mcp": patch
+---
+
+Upgrade `@modelcontextprotocol/sdk` to `^1.30.0` (from `^1.29.0`) and add a
+protocol-version negotiation test.
+
+1.30.0 is the latest published SDK; it negotiates protocol `2025-11-25` over our
+stateless transport. It shipped one day before the 2026-07-28 spec revision, so
+none of that revision's features (cacheable list results, MRTR
+`input_required`, the tasks extension, `Mcp-Method`/`Mcp-Name` header routing)
+are implemented yet. `tests/protocol-version.test.ts` pins the negotiated
+version so a future SDK bump that advances it is visible rather than silent, and
+`docs/architecture/mcp-2026-07-28-spec-adoption.md` tracks the features to adopt
+as the SDK ships them — including the constraint that Sampling, Roots, and
+Logging are now deprecated and must not be built on.
+
+No behaviour change.

--- a/docs/architecture/mcp-2026-07-28-spec-adoption.md
+++ b/docs/architecture/mcp-2026-07-28-spec-adoption.md
@@ -1,0 +1,112 @@
+# MCP 2026-07-28 Spec Adoption Tracking
+
+- **Status:** Tracking (opened for [#3934](https://github.com/voyant-travel/voyant/issues/3934), MCP W10)
+- **Umbrella:** [#3921](https://github.com/voyant-travel/voyant/issues/3921) — redesign the MCP tool surface around intents
+- **Relates to:** [ADR-0011](../adr/0011-agent-tool-library-and-mcp.md) (transport-neutral tool library + in-deployment, stateless MCP server)
+
+## Purpose
+
+A new MCP specification revision landed **2026-07-28** with several features that
+would let us delete workarounds currently carried in `packages/mcp` and
+`packages/hono`. This document tracks those features and what each one buys us.
+
+It is a **checklist, not an implementation**. None of the features below are
+implemented here yet, because the TypeScript SDK does not support them yet.
+
+## SDK reality (verified 2026-07-31)
+
+- `packages/mcp` now depends on `@modelcontextprotocol/sdk@^1.30.0`
+  (was `^1.29.0`; lockfile updated). 1.30.0 is the latest published release.
+- **1.30.0 was published 2026-07-27 — one day *before* the spec revision
+  landed** — so none of the 2026-07-28 features are implemented in the TS SDK.
+- The SDK's `LATEST_PROTOCOL_VERSION` is `2025-11-25`. Its
+  `SUPPORTED_PROTOCOL_VERSIONS` do **not** include `2026-07-28`.
+- Our stateless Streamable-HTTP transport negotiates `2025-11-25` when a client
+  requests it, and falls back to `2025-11-25` for an unsupported
+  `2026-07-28` request.
+- This is asserted by `tests/protocol-version.test.ts` so a future SDK bump that
+  advances the negotiated wire protocol — and unlocks the features below — is
+  visible in a diff rather than silent.
+
+**Adopt each feature as the SDK ships it.** Re-verify SDK support with:
+
+```sh
+npm view @modelcontextprotocol/sdk version
+node -e "import('@modelcontextprotocol/sdk/types.js').then(m => console.log(m.SUPPORTED_PROTOCOL_VERSIONS))"
+```
+
+## ⚠️ Deprecation constraint — do not build on these
+
+**Sampling, Roots, and Logging are DEPRECATED in the 2026-07-28 revision, with a
+12-month offramp.** Do not build new capabilities on them, and migrate off them
+where already used:
+
+- The **guide layer** (#3931) and any future **elicitation** work must not depend
+  on Sampling, Roots, or Logging.
+- Prefer the MRTR `input_required` path (feature 2 below) over Sampling-based
+  round-trips for server-initiated input.
+
+## Note — the spec validates ADR-0011
+
+The spec core went **stateless**: protocol version is per-request, and client
+identity plus capabilities travel in `_meta` rather than in a negotiated
+session. This independently validates
+[ADR-0011](../adr/0011-agent-tool-library-and-mcp.md)'s decision to run a
+stateless MCP server (fresh server + transport per request, **no session store,
+no Durable Object**). It closes the statefulness tension raised during #3921:
+the spec is now moving in the direction we already committed to, so there is no
+pressure to introduce a session store or a separate MCP service.
+
+## Feature checklist (value order)
+
+### 1. Cacheable list results — `ttlMs`, `cacheScope`, deterministic ordering
+
+- [ ] Adopt when SDK supports it.
+- **What it buys us:** clients can cache the tool catalog, and upstream prompt
+  caches stay stable across reconnects. Compounds with the progressive
+  disclosure already merged (#3927): the residual tier-0 payload becomes
+  near-free on reconnect. Lets us stop worrying that every reconnect re-pays the
+  `tools/list` token cost.
+
+### 2. MRTR `resultType: "input_required"` — server-initiated elicitation
+
+- [ ] Adopt when SDK supports it.
+- **What it buys us:** a tool can request missing input via `inputRequests` plus
+  an opaque `requestState` the client echoes back, **without a session** — so it
+  fits our stateless transport directly. This is the eventual fix for
+  orchestration prose currently embedded in tool descriptions: a workflow tool
+  missing (e.g.) a billing party can *ask* for one instead of failing or relying
+  on description text. Pairs with W9. Must avoid Sampling (see deprecation note).
+
+### 3. Tasks extension — `io.modelcontextprotocol/tasks`, poll-based `tasks/get`
+
+- [ ] Adopt when SDK supports it.
+- **What it buys us:** long-running work no longer has to finish inside one HTTP
+  request. Lets us delete the "must complete within one request" constraint on
+  `search_flights`, `source_trip_requirement_candidates`, and document
+  generation, replacing it with a poll-based task lifecycle.
+
+### 4. `Mcp-Method` / `Mcp-Name` header routing
+
+- [ ] Adopt when SDK supports it.
+- **What it buys us:** authorization and rate limiting can route on headers
+  without parsing the JSON-RPC body. Lets us delete the path special-case in
+  `packages/hono/src/middleware/auth.ts` (around line 415) and stop the rate
+  limiter from parsing the request body to classify calls.
+
+### 5. Authorization hardening — RFC 9207 issuer validation; CIMD
+
+- [ ] Adopt when SDK supports it.
+- **What it buys us:** RFC 9207 issuer validation on the authorization response,
+  and Client ID Metadata Documents (CIMD) replacing the deprecated Dynamic
+  Client Registration (DCR). Lets us retire DCR-based client onboarding.
+
+## Acceptance for #3934 (this change)
+
+- [x] SDK on the latest published version (1.30.0), lockfile updated.
+- [x] A test asserts the negotiated protocol version
+      (`tests/protocol-version.test.ts`).
+- [x] This tracking checklist exists for features 1–5, including the
+      Sampling/Roots/Logging deprecation warning.
+- [x] Existing `packages/mcp` tests still pass — this is an upgrade, not a
+      behaviour change.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@hono/mcp": "^0.3.0",
     "@hono/zod-openapi": "catalog:",
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "@voyant-travel/core": "workspace:^",
     "@voyant-travel/hono": "workspace:^",
     "@voyant-travel/tools": "workspace:^",

--- a/packages/mcp/tests/protocol-version.test.ts
+++ b/packages/mcp/tests/protocol-version.test.ts
@@ -1,0 +1,108 @@
+import {
+  LATEST_PROTOCOL_VERSION,
+  SUPPORTED_PROTOCOL_VERSIONS,
+} from "@modelcontextprotocol/sdk/types.js"
+import { createToolRegistry, type ToolContext } from "@voyant-travel/tools"
+import { Hono } from "hono"
+import { describe, expect, it } from "vitest"
+
+import { createMcpApiRoutes } from "../src/index.js"
+
+/**
+ * Protocol-version guard for the MCP SDK upgrade (voyant#3934, MCP W10).
+ *
+ * The 2026-07-28 spec revision adds cacheable list results, MRTR
+ * `input_required`, the tasks extension, and `Mcp-Method`/`Mcp-Name` header
+ * routing — none of which the TypeScript SDK implements yet (1.30.0 shipped one
+ * day *before* the spec landed). The tracking checklist lives in
+ * `docs/architecture/mcp-2026-07-28-spec-adoption.md`.
+ *
+ * This test pins the version the SDK actually negotiates over our stateless
+ * transport, so a future SDK bump that advances the wire protocol — and, with
+ * it, the features we can finally delete workarounds for — is visible in a diff
+ * rather than silent.
+ */
+
+const MCP_HEADERS = {
+  "content-type": "application/json",
+  accept: "application/json, text/event-stream",
+}
+
+const accessCatalog = { resources: [], presets: [] }
+
+function buildContext(): ToolContext {
+  return {
+    db: {},
+    actor: "staff",
+    audience: "staff",
+    tenantId: "t1",
+    resolverScope: { locale: "en-GB", audience: "staff", market: "default", actor: "staff" },
+  }
+}
+
+function app(): Hono {
+  const mcp = createMcpApiRoutes({
+    accessCatalog,
+    registry: createToolRegistry(),
+    buildContext,
+  })
+  const outer = new Hono()
+  outer.use("*", async (c, next) => {
+    c.set("scopes", [])
+    await next()
+  })
+  outer.route("/", mcp)
+  return outer
+}
+
+async function readRpc(res: Response): Promise<Record<string, unknown>> {
+  const text = await res.text()
+  if ((res.headers.get("content-type") ?? "").includes("text/event-stream")) {
+    const line = text.split("\n").find((l) => l.startsWith("data:"))
+    return JSON.parse(line?.slice("data:".length).trim() ?? "{}")
+  }
+  return JSON.parse(text)
+}
+
+async function initialize(protocolVersion: string): Promise<Record<string, unknown>> {
+  const res = await app().request("/", {
+    method: "POST",
+    headers: MCP_HEADERS,
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion,
+        capabilities: {},
+        clientInfo: { name: "voyant-protocol-test", version: "0.0.0" },
+      },
+    }),
+  })
+  const body = await readRpc(res)
+  return (body.result as Record<string, unknown>) ?? {}
+}
+
+describe("MCP protocol negotiation (SDK @modelcontextprotocol/sdk)", () => {
+  it("negotiates the SDK's latest protocol version when the client requests it", async () => {
+    // Guards the SDK upgrade in voyant#3934: 1.30.0 tops out at 2025-11-25 and
+    // does NOT yet carry the 2026-07-28 spec features. When a later SDK advances
+    // this, the assertion fails and points at the tracking checklist.
+    expect(LATEST_PROTOCOL_VERSION).toBe("2025-11-25")
+
+    const result = await initialize(LATEST_PROTOCOL_VERSION)
+    expect(result.protocolVersion).toBe("2025-11-25")
+    expect(result.protocolVersion).toBe(LATEST_PROTOCOL_VERSION)
+  })
+
+  it("does not negotiate the unshipped 2026-07-28 spec revision", async () => {
+    // If a future SDK begins negotiating 2026-07-28, this deliberately fails so
+    // the checklist features can be picked up rather than silently skipped.
+    expect(SUPPORTED_PROTOCOL_VERSIONS).not.toContain("2026-07-28")
+
+    const result = await initialize("2026-07-28")
+    // An unsupported request falls back to the SDK's latest supported version.
+    expect(result.protocolVersion).toBe(LATEST_PROTOCOL_VERSION)
+    expect(result.protocolVersion).not.toBe("2026-07-28")
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1235,7 +1235,7 @@ importers:
         version: link:../hono
       '@voyant-travel/plugin-voyant-connect':
         specifier: ^0.3.2
-        version: 0.3.2(@voyant-travel/catalog@0.219.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)
+        version: 0.3.2(@voyant-travel/catalog@0.222.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.223.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/cruises@0.223.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)
       '@voyant-travel/tools':
         specifier: workspace:^
         version: link:../tools
@@ -2470,7 +2470,7 @@ importers:
         version: link:../operator-standard
       '@voyant-travel/plugin-voyant-connect':
         specifier: ^0.3.2
-        version: 0.3.2(@voyant-travel/catalog@0.219.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)
+        version: 0.3.2(@voyant-travel/catalog@0.222.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)
       '@voyant-travel/runtime-core':
         specifier: workspace:^
         version: link:../runtime-core
@@ -3093,19 +3093,19 @@ importers:
     dependencies:
       '@hono/mcp':
         specifier: ^0.3.0
-        version: 0.3.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(hono-rate-limiter@0.5.3(hono@4.12.25))(hono@4.12.25)(zod@4.4.3)
+        version: 0.3.0(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(hono-rate-limiter@0.5.3(hono@4.12.25))(hono@4.12.25)(zod@4.4.3)
       '@hono/zod-openapi':
         specifier: 'catalog:'
         version: 1.4.0(hono@4.12.25)(zod@4.4.3)
       '@modelcontextprotocol/sdk':
-        specifier: ^1.29.0
-        version: 1.29.0(zod@4.4.3)
+        specifier: ^1.30.0
+        version: 1.30.0(zod@4.4.3)
       '@voyant-travel/core':
         specifier: workspace:^
         version: link:../core
       '@voyant-travel/framework':
         specifier: '>=0.65.0 <2.0.0'
-        version: 0.66.0(5e5393ff8964cb84d9b6afaaab0441cb)
+        version: 0.66.0(891e036f95d9643f9522bb733cf07765)
       '@voyant-travel/hono':
         specifier: workspace:^
         version: link:../hono
@@ -6991,8 +6991,8 @@ packages:
   '@marijn/find-cluster-break@1.0.3':
     resolution: {integrity: sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==}
 
-  '@modelcontextprotocol/sdk@1.29.0':
-    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+  '@modelcontextprotocol/sdk@1.30.0':
+    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -8576,6 +8576,9 @@ packages:
   '@voyant-travel/action-ledger@0.115.5':
     resolution: {integrity: sha512-zHpZSKtcy8nJSOALFdWDXQI3UYQKLKERAg9ID4U8Pj7iiXPkuvEDuEk5+idFdEQo3ITamm9cpXt0vnwaPMR01w==}
 
+  '@voyant-travel/action-ledger@0.115.8':
+    resolution: {integrity: sha512-qcBJWvR8/n0Fjvpj71TjJv6lJrNemYc2TnFf08fDPMU7j4FBfkY34vddL4+HO0gpbltGt8zUeYUMRmmcD5VvCQ==}
+
   '@voyant-travel/admin-app@0.113.0':
     resolution: {integrity: sha512-oZnvpwzJzdxQXLydqo40uw61ng2dupAC45aHCyHA2O+Ow2xss4c9i2yhqMwMBqzYTByUUd+RP1PWXFhRmilk3Q==}
     peerDependencies:
@@ -8769,6 +8772,9 @@ packages:
   '@voyant-travel/bookings@0.221.0':
     resolution: {integrity: sha512-IJqkDYUYfBy96D1voViq97oiiw2EdLItqnfaRY+9AevmMjwQnk0wamE6JPmf4Wpno9DA6XJoNt+NogRv3woRmw==}
 
+  '@voyant-travel/bookings@0.224.0':
+    resolution: {integrity: sha512-BFuiPTvTi/2tMeQa4t0b4XRxiWm2uOybEnGQZ4VuM1Qh56wpEpvjEWtB1NbYa8md7GDvDYh+rw3OdIFFtS3Ddg==}
+
   '@voyant-travel/catalog-authoring@0.107.33':
     resolution: {integrity: sha512-x+gdo+BHOo48SQPZb2Ye4a/mUCBMyifxsV6Nj6u2vGBz7Xu9NzgTQkCzQAptZySmT+BBZ8zDoNLES9s7XZ+Fqw==}
 
@@ -8810,6 +8816,9 @@ packages:
 
   '@voyant-travel/catalog@0.219.0':
     resolution: {integrity: sha512-Qi8CHc6XZarRE4mvJLklzhR+t6RMRnxWmzsCfufB6b8r9T1UzPehUfsnu60u4FQiFbruWW0/8lXrAm/D+bReoQ==}
+
+  '@voyant-travel/catalog@0.222.0':
+    resolution: {integrity: sha512-qOoP0kkMyxS97lb0hhKv6LdxWI/lq5dMvKRLGlDYPbFN36G4pNj4IhgkhiPgpc3NZqn6W9oGcNtLZPrgOMze4w==}
 
   '@voyant-travel/charters-contracts@0.104.3':
     resolution: {integrity: sha512-fUDp/oNtg/w2NyoovIQFTSXp+OeikkHQXixdc5LKcys4tJp0Shw1LBMLFSMTttv4flE0VKNOeBNAxFMLY0qxKw==}
@@ -8923,6 +8932,9 @@ packages:
   '@voyant-travel/cruises@0.220.1':
     resolution: {integrity: sha512-yPyRatbBNnV3igERAIMyJBAhoUH+9uOfxyl6To7OPMDn3t1rra+5b7Lj1V44/9p2Cj6u8wm2FT8j+PUliUgldw==}
 
+  '@voyant-travel/cruises@0.223.0':
+    resolution: {integrity: sha512-JSVFfQe4IpzCUlOcbxZTDvfInUlc3pbz03OF7mBSs/C+Hm/Yt1RDk5T8O0zJEhjyxljIqWFRAhfswlhOSC2FOw==}
+
   '@voyant-travel/custom-fields-react@0.7.1':
     resolution: {integrity: sha512-YwaWIZzxaOuFlYJ3Q+JCLXnPt05ARqzfKopAP2lmltmPCsEKCO1qbWysGFiNoR7qpN5r9l8k7+p1tVzcxIKPAw==}
     peerDependencies:
@@ -9002,6 +9014,9 @@ packages:
   '@voyant-travel/finance-contracts@0.107.3':
     resolution: {integrity: sha512-U3/4G1menmYNzZbJ+cw7wpD7dFfb6X3mAB8bK+ZgLI10veXFWE7dI8AGWuMBzwMId6wqyAmN48iDQNUpBx4O+w==}
 
+  '@voyant-travel/finance-contracts@0.108.0':
+    resolution: {integrity: sha512-M5nALcezB03AQzM0fJKnm24xSkVotHz085Lv2l+5mi1ndrXThL8My/XflycoD7OhFo7DBFvqkLf2pb17d9PK3g==}
+
   '@voyant-travel/finance-react@0.221.0':
     resolution: {integrity: sha512-e5zHH2t72SStx/X2dxcqR5IR0QX+IM+ByQf9FmviEUOvG7d/3L9MigLkbs+0aX7Ac2XHyInx63Nrk58TWNYSKQ==}
     peerDependencies:
@@ -9045,6 +9060,9 @@ packages:
 
   '@voyant-travel/finance@0.221.0':
     resolution: {integrity: sha512-pQJqKBBrzePNRd9qAXxD8g//ObHiEsB0NNl3mndtQNiUwW7EhO83e0Up1HadakrsQL7LZyZOaG/n5hJDM8fU2Q==}
+
+  '@voyant-travel/finance@0.224.0':
+    resolution: {integrity: sha512-ilePRALSXkCpJl+xjf9iZf+USekHXCSbXHQRIdhAjqeRlLnpWD//Vm+D2jdQD9aeBOTuvqA2dEx9MctrcGalzg==}
 
   '@voyant-travel/flights-contracts@0.104.11':
     resolution: {integrity: sha512-kZyhwiMEXAik7lmbizDTha36T8Q8XvNu6NKs/7R2ebZbvub/wKPvb92c0NYZAaxW5KTYVMo0XqzffWOk8Vd0iA==}
@@ -9090,6 +9108,9 @@ packages:
 
   '@voyant-travel/hono@0.136.1':
     resolution: {integrity: sha512-g7avFFnhV3OjSEnK0DbPHtkRHoFFtW8BFJ7hfViUemtrunqsS3bq821XFIFv74K0Z6izhm/U4dTzTxr39XA50A==}
+
+  '@voyant-travel/hono@0.138.0':
+    resolution: {integrity: sha512-CX6K6zeAruh5GOB65tXD1meHYeS/dip8azEUg4yZgiJTcQiNagb2VZBx283KzGsCwplrj69juxaAmJpwnTsAdg==}
 
   '@voyant-travel/i18n@0.119.0':
     resolution: {integrity: sha512-HvIq/MdKsTu1ZoxC5E88RpnorIJwSbsKFjUchmp1ZxBWpgF0kb4RKhIN2H4fRSBRL9P4+B5mpA9iTG4rg5/73Q==}
@@ -9564,6 +9585,11 @@ packages:
 
   '@voyant-travel/tools@0.8.0':
     resolution: {integrity: sha512-BscpUoB4MZmNH6PcyDVp+LRhFpFx1wd76e2pvAS5wsBrQVjg8vlW1vPB5jOLVet/se23Gt0QxZZkPdDMhrilYQ==}
+    peerDependencies:
+      zod: ^4.4.3
+
+  '@voyant-travel/tools@0.9.1':
+    resolution: {integrity: sha512-USn/eJqNd9ssT0/f0vyz4oCkoCBHmCEpZUa6xXoPLh6FAOnejp+7/B6lyp+fx/TQNwOJ5fHNFxf0QWru/pZ+2A==}
     peerDependencies:
       zod: ^4.4.3
 
@@ -13992,28 +14018,28 @@ snapshots:
       '@cloudflare/workers-types': 4.20260702.1
       '@opentelemetry/api': 1.9.0
 
-  '@better-auth/drizzle-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9))':
+  '@better-auth/drizzle-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9))':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0)
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
 
-  '@better-auth/kysely-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)':
+  '@better-auth/kysely-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0)
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       kysely: 0.29.2
 
-  '@better-auth/memory-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/memory-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0)
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/mongo-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(mongodb@7.1.0(socks@2.8.7))':
+  '@better-auth/mongo-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(mongodb@7.1.0(socks@2.8.7))':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0)
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       mongodb: 7.1.0(socks@2.8.7)
@@ -14028,14 +14054,14 @@ snapshots:
       jose: 6.2.4
       zod: 4.4.3
 
-  '@better-auth/prisma-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/prisma-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0)
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/telemetry@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
+  '@better-auth/telemetry@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0)
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
 
@@ -14656,9 +14682,9 @@ snapshots:
       '@tanstack/vue-virtual': 3.13.31(vue@3.5.39(typescript@6.0.3))
       vue: 3.5.39(typescript@6.0.3)
 
-  '@hono/mcp@0.3.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(hono-rate-limiter@0.5.3(hono@4.12.25))(hono@4.12.25)(zod@4.4.3)':
+  '@hono/mcp@0.3.0(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(hono-rate-limiter@0.5.3(hono@4.12.25))(hono@4.12.25)(zod@4.4.3)':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.30.0(zod@4.4.3)
       hono: 4.12.25
       hono-rate-limiter: 0.5.3(hono@4.12.25)
       pkce-challenge: 5.0.1
@@ -14826,7 +14852,7 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.3': {}
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+  '@modelcontextprotocol/sdk@1.30.0(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 2.0.6(hono@4.12.25)
       ajv: 8.20.0
@@ -16634,7 +16660,7 @@ snapshots:
       - sqlite3
       - typesense
 
-  '@voyant-travel/action-ledger-react@0.110.0(ebb281d4321a7fe53e117ef462716269)':
+  '@voyant-travel/action-ledger-react@0.110.0(12b8a4856bd3c21ce51fefbf5c44aa14)':
     dependencies:
       '@tanstack/react-query': 5.101.2(react@19.2.7)
       '@voyant-travel/action-ledger': 0.115.5(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
@@ -16644,11 +16670,11 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
-      '@voyant-travel/bookings-react': 0.221.0(0c785601167be93c5cca8a23bc8c3568)
-      '@voyant-travel/inventory-react': 0.103.0(3f7e032a5669051f320c6d3d91f2fc63)
-      '@voyant-travel/relationships-react': 0.221.0(e47d6302e1332aaa92b73d1818e0f5f0)
-      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/bookings-react': 0.221.0(c938444c4122508a78df56ad5b346211)
+      '@voyant-travel/inventory-react': 0.103.0(ff0377a474b625e0f4a2919b2ce4742c)
+      '@voyant-travel/relationships-react': 0.221.0(eb7835b6d8b004093c7e3973c522d93e)
+      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
 
   '@voyant-travel/action-ledger@0.115.5(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)':
     dependencies:
@@ -16691,24 +16717,65 @@ snapshots:
       - sql.js
       - sqlite3
 
-  '@voyant-travel/admin-app@0.113.0(1de63da28db14b9ecfb7d8902fed2e27)':
+  '@voyant-travel/action-ledger@0.115.8(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)':
+    dependencies:
+      '@hono/zod-openapi': 1.4.0(hono@4.12.25)(zod@4.4.3)
+      '@voyant-travel/core': 0.136.1
+      '@voyant-travel/db': 0.119.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)
+      '@voyant-travel/hono': 0.138.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
+      '@voyant-travel/tools': 0.9.1(zod@4.4.3)
+      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
+      hono: 4.12.25
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@aws-sdk/client-rds-data'
+      - '@cloudflare/workers-types'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@libsql/client-wasm'
+      - '@neondatabase/serverless'
+      - '@op-engineering/op-sqlite'
+      - '@opentelemetry/api'
+      - '@planetscale/database'
+      - '@prisma/client'
+      - '@tidbcloud/serverless'
+      - '@types/better-sqlite3'
+      - '@types/pg'
+      - '@types/sql.js'
+      - '@upstash/redis'
+      - '@vercel/postgres'
+      - '@xata.io/client'
+      - better-sqlite3
+      - bun-types
+      - expo-sqlite
+      - gel
+      - knex
+      - kysely
+      - mysql2
+      - pg
+      - postgres
+      - prisma
+      - sql.js
+      - sqlite3
+
+  '@voyant-travel/admin-app@0.113.0(d592f62ec89a3d309086c38d8b40f4c7)':
     dependencies:
       '@tanstack/react-query': 5.101.2(react@19.2.7)
       '@tanstack/react-router': 1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/react-start': 1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.3)(rollup@4.60.2)(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3))
-      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
       '@voyant-travel/react': 0.104.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@voyant-travel/types': link:packages/types
-      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
       lucide-react: 1.23.0(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@voyant-travel/auth-react': 0.146.1(c5b48837e1cd9aeeb1b01daad828a612)
-      '@voyant-travel/commerce-react': 0.103.0(282ec5418785f3e4854a832e7fa5c439)
-      '@voyant-travel/distribution-react': 0.211.0(97023016a7cb6431b92bfd79d2b52f25)
-      '@voyant-travel/finance-react': 0.221.0(71d8be1af97797345e64a924c18b51c4)
-      '@voyant-travel/inventory-react': 0.103.0(3f7e032a5669051f320c6d3d91f2fc63)
+      '@voyant-travel/auth-react': 0.146.1(69e45fb72f5c0df2a76f66a6f882a4e8)
+      '@voyant-travel/commerce-react': 0.103.0(cf11d98a6b8faa37935bbb668c5bd96e)
+      '@voyant-travel/distribution-react': 0.211.0(66a41da1ed37b3544388201438a75e84)
+      '@voyant-travel/finance-react': 0.221.0(46b0d7939898ca887119ebaba6b1bf00)
+      '@voyant-travel/inventory-react': 0.103.0(ff0377a474b625e0f4a2919b2ce4742c)
 
   '@voyant-travel/admin-client@0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)':
     dependencies:
@@ -16786,13 +16853,13 @@ snapshots:
 
   '@voyant-travel/admin-extension-sdk@0.2.0': {}
 
-  '@voyant-travel/admin-host@0.71.0(c3d637c445dd94a0800a92d30b8afe2e)':
+  '@voyant-travel/admin-host@0.71.0(91d4aa63b6d0b4e6f9de2dd1ca73c961)':
     dependencies:
       '@hono/node-server': 2.0.6(hono@4.12.25)
       '@tanstack/react-router': 1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/react-start': 1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.3)(rollup@4.60.2)(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3))
-      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
-      '@voyant-travel/admin-app': 0.113.0(1de63da28db14b9ecfb7d8902fed2e27)
+      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/admin-app': 0.113.0(d592f62ec89a3d309086c38d8b40f4c7)
       '@voyant-travel/admin-react': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(react@19.2.7)
       '@voyant-travel/hono': 0.136.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
       '@voyant-travel/runtime-core': 0.6.7(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(hono@4.12.25)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
@@ -16867,7 +16934,7 @@ snapshots:
       - sql.js
       - sqlite3
 
-  '@voyant-travel/admin@0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))':
+  '@voyant-travel/admin@0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))':
     dependencies:
       '@tanstack/react-query': 5.101.2(react@19.2.7)
       '@tanstack/react-router': 1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -16875,7 +16942,7 @@ snapshots:
       '@voyant-travel/i18n': 0.119.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@voyant-travel/react': 0.104.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@voyant-travel/types': 0.109.10(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)
-      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
       lucide-react: 1.23.0(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -16911,7 +16978,7 @@ snapshots:
 
   '@voyant-travel/allotments@0.2.1': {}
 
-  '@voyant-travel/apps-react@0.7.1(b2996a85124729d86eac97b2f37a1b97)':
+  '@voyant-travel/apps-react@0.7.1(8e5fb3356eee509af65eadde29bccbb3)':
     dependencies:
       '@tanstack/react-query': 5.101.2(react@19.2.7)
       '@voyant-travel/i18n': 0.119.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -16922,8 +16989,8 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       zod: 4.4.3
     optionalDependencies:
-      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
-      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
       - '@cloudflare/workers-types'
@@ -16953,10 +17020,10 @@ snapshots:
       - sql.js
       - sqlite3
 
-  '@voyant-travel/apps@0.12.15(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(postgres@3.4.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))':
+  '@voyant-travel/apps@0.12.15(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(postgres@3.4.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))':
     dependencies:
       '@hono/zod-openapi': 1.4.0(hono@4.12.25)(zod@4.4.3)
-      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
       '@voyant-travel/admin-extension-sdk': 0.2.0
       '@voyant-travel/core': 0.136.1
       '@voyant-travel/custom-fields': 0.2.19(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
@@ -17006,7 +17073,7 @@ snapshots:
       - sql.js
       - sqlite3
 
-  '@voyant-travel/auth-react@0.146.1(c5b48837e1cd9aeeb1b01daad828a612)':
+  '@voyant-travel/auth-react@0.146.1(69e45fb72f5c0df2a76f66a6f882a4e8)':
     dependencies:
       '@tanstack/react-query': 5.101.2(react@19.2.7)
       '@tanstack/react-router': 1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -17018,8 +17085,8 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       zod: 4.4.3
     optionalDependencies:
-      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
-      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
       lucide-react: 1.23.0(react@19.2.7)
 
   '@voyant-travel/auth@0.146.1(e0704632a9c58ad18b35d3ef6c8c05af)':
@@ -17126,7 +17193,7 @@ snapshots:
       '@voyant-travel/schema-kit': 0.115.0
       zod: 4.4.3
 
-  '@voyant-travel/bookings-react@0.221.0(0c785601167be93c5cca8a23bc8c3568)':
+  '@voyant-travel/bookings-react@0.221.0(c938444c4122508a78df56ad5b346211)':
     dependencies:
       '@tanstack/react-query': 5.101.2(react@19.2.7)
       '@voyant-travel/bookings': 0.221.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
@@ -17141,22 +17208,22 @@ snapshots:
     optionalDependencies:
       '@tanstack/react-table': 8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@voyant-travel/accommodations': 0.181.0(d682f9081bcd532728f4e4fa5b242145)
-      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
-      '@voyant-travel/catalog': 0.219.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
-      '@voyant-travel/catalog-react': 0.219.0(05fb669ba8f726d7b2d4c6a70ffb191e)
-      '@voyant-travel/commerce-react': 0.103.0(282ec5418785f3e4854a832e7fa5c439)
+      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/catalog': 0.222.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
+      '@voyant-travel/catalog-react': 0.219.0(fb4ec808eef22f5a0ff25b0680f364e1)
+      '@voyant-travel/commerce-react': 0.103.0(cf11d98a6b8faa37935bbb668c5bd96e)
       '@voyant-travel/cruises': 0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
-      '@voyant-travel/distribution-react': 0.211.0(97023016a7cb6431b92bfd79d2b52f25)
+      '@voyant-travel/distribution-react': 0.211.0(66a41da1ed37b3544388201438a75e84)
       '@voyant-travel/finance': 0.221.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
-      '@voyant-travel/finance-react': 0.221.0(71d8be1af97797345e64a924c18b51c4)
-      '@voyant-travel/identity-react': 0.221.0(ef66ce9cd9d949fda50ddd38198d2277)
+      '@voyant-travel/finance-react': 0.221.0(46b0d7939898ca887119ebaba6b1bf00)
+      '@voyant-travel/identity-react': 0.221.0(3f6ccbe45b3bc30ee6fa8da6f6c5cd89)
       '@voyant-travel/inventory': 0.24.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(@voyant-travel/relationships@0.132.17(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9))(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
-      '@voyant-travel/inventory-react': 0.103.0(3f7e032a5669051f320c6d3d91f2fc63)
-      '@voyant-travel/legal-react': 0.221.0(9e2312aae534a7c4c81c69226255182a)
-      '@voyant-travel/operations-react': 0.102.0(6b06bf63cd4fd219b364f4f4baa85db8)
-      '@voyant-travel/relationships-react': 0.221.0(e47d6302e1332aaa92b73d1818e0f5f0)
-      '@voyant-travel/storefront-react': 0.223.0(976a8607c08daac463958afe7c37815e)
-      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/inventory-react': 0.103.0(ff0377a474b625e0f4a2919b2ce4742c)
+      '@voyant-travel/legal-react': 0.221.0(dadaeb1178b4fa7a046c1672c806304a)
+      '@voyant-travel/operations-react': 0.102.0(7b5e2d5a09ad0764ae607975b916e053)
+      '@voyant-travel/relationships-react': 0.221.0(eb7835b6d8b004093c7e3973c522d93e)
+      '@voyant-travel/storefront-react': 0.223.0(ff5a4a1dc91f112ccc39637d04f76a94)
+      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
       lucide-react: 1.23.0(react@19.2.7)
       react-hook-form: 7.80.0(react@19.2.7)
     transitivePeerDependencies:
@@ -17198,6 +17265,52 @@ snapshots:
       '@voyant-travel/hono': 0.136.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
       '@voyant-travel/reporting-contracts': 0.3.6
       '@voyant-travel/tools': 0.8.0(zod@4.4.3)
+      '@voyant-travel/types': 0.109.10(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)
+      '@voyant-travel/utils': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
+      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
+      hono: 4.12.25
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@aws-sdk/client-rds-data'
+      - '@cloudflare/workers-types'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@libsql/client-wasm'
+      - '@neondatabase/serverless'
+      - '@op-engineering/op-sqlite'
+      - '@opentelemetry/api'
+      - '@planetscale/database'
+      - '@prisma/client'
+      - '@tidbcloud/serverless'
+      - '@types/better-sqlite3'
+      - '@types/pg'
+      - '@types/sql.js'
+      - '@upstash/redis'
+      - '@vercel/postgres'
+      - '@xata.io/client'
+      - better-sqlite3
+      - bun-types
+      - expo-sqlite
+      - gel
+      - knex
+      - kysely
+      - mysql2
+      - pg
+      - postgres
+      - prisma
+      - sql.js
+      - sqlite3
+
+  '@voyant-travel/bookings@0.224.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)':
+    dependencies:
+      '@hono/zod-openapi': 1.4.0(hono@4.12.25)(zod@4.4.3)
+      '@voyant-travel/action-ledger': 0.115.8(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
+      '@voyant-travel/bookings-contracts': 0.111.0
+      '@voyant-travel/core': 0.136.1
+      '@voyant-travel/db': 0.119.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)
+      '@voyant-travel/hono': 0.138.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
+      '@voyant-travel/reporting-contracts': 0.3.6
+      '@voyant-travel/tools': 0.9.1(zod@4.4.3)
       '@voyant-travel/types': 0.109.10(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)
       '@voyant-travel/utils': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
       drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
@@ -17281,7 +17394,7 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  '@voyant-travel/catalog-react@0.219.0(05fb669ba8f726d7b2d4c6a70ffb191e)':
+  '@voyant-travel/catalog-react@0.219.0(fb4ec808eef22f5a0ff25b0680f364e1)':
     dependencies:
       '@tanstack/react-query': 5.101.2(react@19.2.7)
       '@voyant-travel/catalog-contracts': 0.112.2
@@ -17292,11 +17405,11 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       '@tanstack/react-table': 8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
-      '@voyant-travel/commerce-react': 0.103.0(282ec5418785f3e4854a832e7fa5c439)
-      '@voyant-travel/distribution-react': 0.211.0(97023016a7cb6431b92bfd79d2b52f25)
-      '@voyant-travel/inventory-react': 0.103.0(3f7e032a5669051f320c6d3d91f2fc63)
-      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/commerce-react': 0.103.0(cf11d98a6b8faa37935bbb668c5bd96e)
+      '@voyant-travel/distribution-react': 0.211.0(66a41da1ed37b3544388201438a75e84)
+      '@voyant-travel/inventory-react': 0.103.0(ff0377a474b625e0f4a2919b2ce4742c)
+      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
       sonner: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
   '@voyant-travel/catalog@0.219.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))':
@@ -17348,18 +17461,116 @@ snapshots:
       - sqlite3
       - typesense
 
-  '@voyant-travel/catalog@0.219.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))':
+  '@voyant-travel/catalog@0.222.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))':
     dependencies:
       '@hono/zod-openapi': 1.4.0(hono@4.12.25)(zod@4.4.3)
-      '@voyant-travel/bookings': 0.221.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
+      '@voyant-travel/bookings': 0.224.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
       '@voyant-travel/catalog-contracts': 0.112.2
       '@voyant-travel/connect-sdk': 0.9.1
       '@voyant-travel/core': 0.136.1
       '@voyant-travel/db': 0.119.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)
-      '@voyant-travel/finance': 0.221.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
-      '@voyant-travel/hono': 0.136.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
-      '@voyant-travel/plugin-voyant-connect': 0.3.2(@voyant-travel/catalog@0.219.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)
-      '@voyant-travel/tools': 0.8.0(zod@4.4.3)
+      '@voyant-travel/finance': 0.224.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
+      '@voyant-travel/hono': 0.138.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
+      '@voyant-travel/plugin-voyant-connect': 0.3.2(@voyant-travel/catalog@0.222.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)
+      '@voyant-travel/tools': 0.9.1(zod@4.4.3)
+      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
+      hono: 4.12.25
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@aws-sdk/client-rds-data'
+      - '@cloudflare/workers-types'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@libsql/client-wasm'
+      - '@neondatabase/serverless'
+      - '@op-engineering/op-sqlite'
+      - '@opentelemetry/api'
+      - '@planetscale/database'
+      - '@prisma/client'
+      - '@tidbcloud/serverless'
+      - '@types/better-sqlite3'
+      - '@types/pg'
+      - '@types/sql.js'
+      - '@upstash/redis'
+      - '@vercel/postgres'
+      - '@voyant-travel/cruises'
+      - '@voyant-travel/data-sdk'
+      - '@xata.io/client'
+      - better-sqlite3
+      - bun-types
+      - expo-sqlite
+      - gel
+      - knex
+      - kysely
+      - mysql2
+      - pg
+      - postgres
+      - prisma
+      - sql.js
+      - sqlite3
+      - typesense
+
+  '@voyant-travel/catalog@0.222.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.223.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))':
+    dependencies:
+      '@hono/zod-openapi': 1.4.0(hono@4.12.25)(zod@4.4.3)
+      '@voyant-travel/bookings': 0.224.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
+      '@voyant-travel/catalog-contracts': 0.112.2
+      '@voyant-travel/connect-sdk': 0.9.1
+      '@voyant-travel/core': 0.136.1
+      '@voyant-travel/db': 0.119.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)
+      '@voyant-travel/finance': 0.224.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
+      '@voyant-travel/hono': 0.138.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
+      '@voyant-travel/plugin-voyant-connect': 0.3.2(@voyant-travel/catalog@0.222.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.223.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/cruises@0.223.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)
+      '@voyant-travel/tools': 0.9.1(zod@4.4.3)
+      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
+      hono: 4.12.25
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@aws-sdk/client-rds-data'
+      - '@cloudflare/workers-types'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@libsql/client-wasm'
+      - '@neondatabase/serverless'
+      - '@op-engineering/op-sqlite'
+      - '@opentelemetry/api'
+      - '@planetscale/database'
+      - '@prisma/client'
+      - '@tidbcloud/serverless'
+      - '@types/better-sqlite3'
+      - '@types/pg'
+      - '@types/sql.js'
+      - '@upstash/redis'
+      - '@vercel/postgres'
+      - '@voyant-travel/cruises'
+      - '@voyant-travel/data-sdk'
+      - '@xata.io/client'
+      - better-sqlite3
+      - bun-types
+      - expo-sqlite
+      - gel
+      - knex
+      - kysely
+      - mysql2
+      - pg
+      - postgres
+      - prisma
+      - sql.js
+      - sqlite3
+      - typesense
+
+  '@voyant-travel/catalog@0.222.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))':
+    dependencies:
+      '@hono/zod-openapi': 1.4.0(hono@4.12.25)(zod@4.4.3)
+      '@voyant-travel/bookings': 0.224.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
+      '@voyant-travel/catalog-contracts': 0.112.2
+      '@voyant-travel/connect-sdk': 0.9.1
+      '@voyant-travel/core': 0.136.1
+      '@voyant-travel/db': 0.119.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)
+      '@voyant-travel/finance': 0.224.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
+      '@voyant-travel/hono': 0.138.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
+      '@voyant-travel/plugin-voyant-connect': 0.3.2(@voyant-travel/catalog@0.222.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)
+      '@voyant-travel/tools': 0.9.1(zod@4.4.3)
       drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
       hono: 4.12.25
       zod: 4.4.3
@@ -17501,7 +17712,7 @@ snapshots:
     optionalDependencies:
       typesense: 3.0.6(@babel/runtime@7.29.7)
 
-  '@voyant-travel/commerce-react@0.103.0(282ec5418785f3e4854a832e7fa5c439)':
+  '@voyant-travel/commerce-react@0.103.0(cf11d98a6b8faa37935bbb668c5bd96e)':
     dependencies:
       '@tanstack/react-query': 5.101.2(react@19.2.7)
       '@voyant-travel/commerce': 0.45.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
@@ -17514,10 +17725,10 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       zod: 4.4.3
     optionalDependencies:
-      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
-      '@voyant-travel/distribution-react': 0.211.0(97023016a7cb6431b92bfd79d2b52f25)
-      '@voyant-travel/inventory-react': 0.103.0(3f7e032a5669051f320c6d3d91f2fc63)
-      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/distribution-react': 0.211.0(66a41da1ed37b3544388201438a75e84)
+      '@voyant-travel/inventory-react': 0.103.0(ff0377a474b625e0f4a2919b2ce4742c)
+      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
       react-hook-form: 7.80.0(react@19.2.7)
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
@@ -17608,9 +17819,19 @@ snapshots:
       '@voyant-travel/catalog': 0.219.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
       '@voyant-travel/connect-sdk': 0.9.1
 
-  '@voyant-travel/connect-adapter@0.4.0(@voyant-travel/catalog@0.219.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))':
+  '@voyant-travel/connect-adapter@0.4.0(@voyant-travel/catalog@0.222.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))':
     dependencies:
-      '@voyant-travel/catalog': 0.219.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
+      '@voyant-travel/catalog': 0.222.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
+      '@voyant-travel/connect-sdk': 0.9.1
+
+  '@voyant-travel/connect-adapter@0.4.0(@voyant-travel/catalog@0.222.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.223.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))':
+    dependencies:
+      '@voyant-travel/catalog': 0.222.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.223.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
+      '@voyant-travel/connect-sdk': 0.9.1
+
+  '@voyant-travel/connect-adapter@0.4.0(@voyant-travel/catalog@0.222.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))':
+    dependencies:
+      '@voyant-travel/catalog': 0.222.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
       '@voyant-travel/connect-sdk': 0.9.1
 
   '@voyant-travel/connect-adapter@0.4.0(@voyant-travel/catalog@packages+catalog)':
@@ -17623,6 +17844,12 @@ snapshots:
       '@voyant-travel/connect-sdk': 0.9.1
     optionalDependencies:
       '@voyant-travel/cruises': 0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
+
+  '@voyant-travel/connect-cruises@0.6.1(@voyant-travel/cruises@0.223.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))':
+    dependencies:
+      '@voyant-travel/connect-sdk': 0.9.1
+    optionalDependencies:
+      '@voyant-travel/cruises': 0.223.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
 
   '@voyant-travel/connect-cruises@0.6.1(@voyant-travel/cruises@packages+cruises)':
     dependencies:
@@ -17641,7 +17868,7 @@ snapshots:
       '@voyant-travel/catalog-contracts': 0.112.2
       zod: 4.4.3
 
-  '@voyant-travel/cruises-react@0.220.1(@tanstack/react-query@5.101.2(react@19.2.7))(@voyant-travel/catalog-contracts@0.112.2)(@voyant-travel/catalog-react@0.219.0)(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/storefront-react@0.223.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)':
+  '@voyant-travel/cruises-react@0.220.1(@tanstack/react-query@5.101.2(react@19.2.7))(@voyant-travel/catalog-contracts@0.112.2)(@voyant-travel/catalog-react@0.219.0)(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/storefront-react@0.223.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)':
     dependencies:
       '@tanstack/react-query': 5.101.2(react@19.2.7)
       '@voyant-travel/cruises': 0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
@@ -17652,9 +17879,9 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       '@voyant-travel/catalog-contracts': 0.112.2
-      '@voyant-travel/catalog-react': 0.219.0(05fb669ba8f726d7b2d4c6a70ffb191e)
-      '@voyant-travel/storefront-react': 0.223.0(976a8607c08daac463958afe7c37815e)
-      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/catalog-react': 0.219.0(fb4ec808eef22f5a0ff25b0680f364e1)
+      '@voyant-travel/storefront-react': 0.223.0(ff5a4a1dc91f112ccc39637d04f76a94)
+      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
 
   '@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))':
     dependencies:
@@ -17704,7 +17931,55 @@ snapshots:
       - sqlite3
       - typesense
 
-  '@voyant-travel/custom-fields-react@0.7.1(857242392515eba839720df421846d5a)':
+  '@voyant-travel/cruises@0.223.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))':
+    dependencies:
+      '@hono/zod-openapi': 1.4.0(hono@4.12.25)(zod@4.4.3)
+      '@voyant-travel/action-ledger': 0.115.8(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
+      '@voyant-travel/catalog': 0.222.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.223.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
+      '@voyant-travel/core': 0.136.1
+      '@voyant-travel/cruises-contracts': 0.105.10
+      '@voyant-travel/db': 0.119.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)
+      '@voyant-travel/finance': 0.224.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
+      '@voyant-travel/hono': 0.138.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
+      '@voyant-travel/tools': 0.9.1(zod@4.4.3)
+      '@voyant-travel/types': 0.109.10(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)
+      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
+      hono: 4.12.25
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@aws-sdk/client-rds-data'
+      - '@cloudflare/workers-types'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@libsql/client-wasm'
+      - '@neondatabase/serverless'
+      - '@op-engineering/op-sqlite'
+      - '@opentelemetry/api'
+      - '@planetscale/database'
+      - '@prisma/client'
+      - '@tidbcloud/serverless'
+      - '@types/better-sqlite3'
+      - '@types/pg'
+      - '@types/sql.js'
+      - '@upstash/redis'
+      - '@vercel/postgres'
+      - '@voyant-travel/data-sdk'
+      - '@xata.io/client'
+      - better-sqlite3
+      - bun-types
+      - expo-sqlite
+      - gel
+      - knex
+      - kysely
+      - mysql2
+      - pg
+      - postgres
+      - prisma
+      - sql.js
+      - sqlite3
+      - typesense
+
+  '@voyant-travel/custom-fields-react@0.7.1(9ada2420b5a218cec9afb076c4ba8840)':
     dependencies:
       '@tanstack/react-query': 5.101.2(react@19.2.7)
       '@voyant-travel/custom-fields': 0.2.19(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
@@ -17716,8 +17991,8 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       zod: 4.4.3
     optionalDependencies:
-      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
-      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
       - '@cloudflare/workers-types'
@@ -17829,7 +18104,7 @@ snapshots:
       - sql.js
       - sqlite3
 
-  '@voyant-travel/distribution-react@0.211.0(97023016a7cb6431b92bfd79d2b52f25)':
+  '@voyant-travel/distribution-react@0.211.0(66a41da1ed37b3544388201438a75e84)':
     dependencies:
       '@tanstack/react-query': 5.101.2(react@19.2.7)
       '@voyant-travel/distribution': 0.211.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
@@ -17840,11 +18115,11 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       '@tanstack/react-table': 8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
-      '@voyant-travel/bookings-react': 0.221.0(0c785601167be93c5cca8a23bc8c3568)
-      '@voyant-travel/inventory-react': 0.103.0(3f7e032a5669051f320c6d3d91f2fc63)
-      '@voyant-travel/relationships-react': 0.221.0(e47d6302e1332aaa92b73d1818e0f5f0)
-      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/bookings-react': 0.221.0(c938444c4122508a78df56ad5b346211)
+      '@voyant-travel/inventory-react': 0.103.0(ff0377a474b625e0f4a2919b2ce4742c)
+      '@voyant-travel/relationships-react': 0.221.0(eb7835b6d8b004093c7e3973c522d93e)
+      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
       react-hook-form: 7.80.0(react@19.2.7)
 
   '@voyant-travel/distribution@0.211.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))':
@@ -17899,9 +18174,9 @@ snapshots:
       - sqlite3
       - typesense
 
-  '@voyant-travel/event-catalog-react@0.21.1(8137040f4d261bd2feef1fe07fdd17db)':
+  '@voyant-travel/event-catalog-react@0.21.1(45000690ff698c294f21ffd8b337261d)':
     dependencies:
-      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
       '@voyant-travel/core': 0.136.1
       '@voyant-travel/i18n': 0.119.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@voyant-travel/react': 0.104.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -17987,7 +18262,12 @@ snapshots:
       - sql.js
       - sqlite3
 
-  '@voyant-travel/finance-react@0.221.0(71d8be1af97797345e64a924c18b51c4)':
+  '@voyant-travel/finance-contracts@0.108.0':
+    dependencies:
+      '@voyant-travel/schema-kit': 0.115.0
+      zod: 4.4.3
+
+  '@voyant-travel/finance-react@0.221.0(46b0d7939898ca887119ebaba6b1bf00)':
     dependencies:
       '@tanstack/react-query': 5.101.2(react@19.2.7)
       '@tanstack/react-router': 1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -17999,12 +18279,12 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       '@tanstack/react-table': 8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
-      '@voyant-travel/bookings-react': 0.221.0(0c785601167be93c5cca8a23bc8c3568)
-      '@voyant-travel/distribution-react': 0.211.0(97023016a7cb6431b92bfd79d2b52f25)
-      '@voyant-travel/inventory-react': 0.103.0(3f7e032a5669051f320c6d3d91f2fc63)
-      '@voyant-travel/operations-react': 0.102.0(6b06bf63cd4fd219b364f4f4baa85db8)
-      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/bookings-react': 0.221.0(c938444c4122508a78df56ad5b346211)
+      '@voyant-travel/distribution-react': 0.211.0(66a41da1ed37b3544388201438a75e84)
+      '@voyant-travel/inventory-react': 0.103.0(ff0377a474b625e0f4a2919b2ce4742c)
+      '@voyant-travel/operations-react': 0.102.0(7b5e2d5a09ad0764ae607975b916e053)
+      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
       react-hook-form: 7.80.0(react@19.2.7)
       recharts: 3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)
       sonner: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -18063,12 +18343,66 @@ snapshots:
       - sqlite3
       - typesense
 
+  '@voyant-travel/finance@0.224.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))':
+    dependencies:
+      '@hono/zod-openapi': 1.4.0(hono@4.12.25)(zod@4.4.3)
+      '@voyant-travel/action-ledger': 0.115.8(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
+      '@voyant-travel/bookings': 0.224.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
+      '@voyant-travel/core': 0.136.1
+      '@voyant-travel/data-sdk': 0.7.1
+      '@voyant-travel/db': 0.119.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)
+      '@voyant-travel/finance-contracts': 0.108.0
+      '@voyant-travel/hono': 0.138.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
+      '@voyant-travel/payments': 0.8.0
+      '@voyant-travel/public-document-delivery': 0.4.18(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))(zod@4.4.3)
+      '@voyant-travel/reporting-contracts': 0.3.6
+      '@voyant-travel/storage': 0.115.0(hono@4.12.25)(typesense@3.0.6(@babel/runtime@7.29.7))(zod@4.4.3)
+      '@voyant-travel/tools': 0.9.1(zod@4.4.3)
+      '@voyant-travel/types': 0.109.10(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)
+      '@voyant-travel/utils': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
+      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
+      fflate: 0.8.3
+      hono: 4.12.25
+      rrule: 2.8.1
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@aws-sdk/client-rds-data'
+      - '@cloudflare/workers-types'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@libsql/client-wasm'
+      - '@neondatabase/serverless'
+      - '@op-engineering/op-sqlite'
+      - '@opentelemetry/api'
+      - '@planetscale/database'
+      - '@prisma/client'
+      - '@tidbcloud/serverless'
+      - '@types/better-sqlite3'
+      - '@types/pg'
+      - '@types/sql.js'
+      - '@upstash/redis'
+      - '@vercel/postgres'
+      - '@xata.io/client'
+      - better-sqlite3
+      - bun-types
+      - expo-sqlite
+      - gel
+      - knex
+      - kysely
+      - mysql2
+      - pg
+      - postgres
+      - prisma
+      - sql.js
+      - sqlite3
+      - typesense
+
   '@voyant-travel/flights-contracts@0.104.11':
     dependencies:
       '@voyant-travel/catalog-contracts': 0.112.2
       zod: 4.4.3
 
-  '@voyant-travel/flights-react@0.221.0(131591d62ada4d49a861bcffb2782840)':
+  '@voyant-travel/flights-react@0.221.0(28ce33a29bc3cd1caeb788ae4b506269)':
     dependencies:
       '@tanstack/react-query': 5.101.2(react@19.2.7)
       '@voyant-travel/finance': 0.221.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
@@ -18080,10 +18414,10 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       '@tanstack/react-table': 8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
-      '@voyant-travel/finance-react': 0.221.0(71d8be1af97797345e64a924c18b51c4)
-      '@voyant-travel/relationships-react': 0.221.0(e47d6302e1332aaa92b73d1818e0f5f0)
-      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/finance-react': 0.221.0(46b0d7939898ca887119ebaba6b1bf00)
+      '@voyant-travel/relationships-react': 0.221.0(eb7835b6d8b004093c7e3973c522d93e)
+      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
 
   '@voyant-travel/flights@0.221.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))':
     dependencies:
@@ -18136,7 +18470,7 @@ snapshots:
 
   '@voyant-travel/framework-migrations@0.10.8': {}
 
-  '@voyant-travel/framework@0.66.0(5e5393ff8964cb84d9b6afaaab0441cb)':
+  '@voyant-travel/framework@0.66.0(891e036f95d9643f9522bb733cf07765)':
     dependencies:
       '@hono/zod-openapi': 1.4.0(hono@4.12.25)(zod@4.4.3)
       '@voyant-travel/action-ledger': 0.115.5(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
@@ -18147,8 +18481,8 @@ snapshots:
       '@voyant-travel/db': 0.119.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)
       '@voyant-travel/framework-migrations': 0.10.8
       '@voyant-travel/hono': link:packages/hono
-      '@voyant-travel/operator-standard': 0.16.3(4eca76b58bf44a967a342f3f4da6f98b)
-      '@voyant-travel/plugin-voyant-connect': 0.3.2(@voyant-travel/catalog@0.219.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)
+      '@voyant-travel/operator-standard': 0.16.3(ef5ddf0f892670f40bd20bd70afa0934)
+      '@voyant-travel/plugin-voyant-connect': 0.3.2(@voyant-travel/catalog@0.222.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)
       '@voyant-travel/runtime-core': 0.6.7(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(hono@4.12.25)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
       '@voyant-travel/storage': 0.115.0(hono@4.12.25)(typesense@3.0.6(@babel/runtime@7.29.7))(zod@4.4.3)
       '@voyant-travel/tools': 0.8.0(zod@4.4.3)
@@ -18296,6 +18630,47 @@ snapshots:
       - sql.js
       - sqlite3
 
+  '@voyant-travel/hono@0.138.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)':
+    dependencies:
+      '@hono/zod-openapi': 1.4.0(hono@4.12.25)(zod@4.4.3)
+      '@voyant-travel/core': 0.136.1
+      '@voyant-travel/db': 0.119.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)
+      '@voyant-travel/types': 0.109.10(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)
+      '@voyant-travel/utils': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
+      drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
+      hono: 4.12.25
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@aws-sdk/client-rds-data'
+      - '@cloudflare/workers-types'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@libsql/client-wasm'
+      - '@neondatabase/serverless'
+      - '@op-engineering/op-sqlite'
+      - '@opentelemetry/api'
+      - '@planetscale/database'
+      - '@prisma/client'
+      - '@tidbcloud/serverless'
+      - '@types/better-sqlite3'
+      - '@types/pg'
+      - '@types/sql.js'
+      - '@upstash/redis'
+      - '@vercel/postgres'
+      - '@xata.io/client'
+      - better-sqlite3
+      - bun-types
+      - expo-sqlite
+      - gel
+      - knex
+      - kysely
+      - mysql2
+      - pg
+      - postgres
+      - prisma
+      - sql.js
+      - sqlite3
+
   '@voyant-travel/i18n@0.119.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       intl-messageformat: 11.2.12
@@ -18307,7 +18682,7 @@ snapshots:
       '@voyant-travel/schema-kit': 0.115.0
       zod: 4.4.3
 
-  '@voyant-travel/identity-react@0.221.0(ef66ce9cd9d949fda50ddd38198d2277)':
+  '@voyant-travel/identity-react@0.221.0(3f6ccbe45b3bc30ee6fa8da6f6c5cd89)':
     dependencies:
       '@tanstack/react-query': 5.101.2(react@19.2.7)
       '@voyant-travel/i18n': 0.119.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -18318,11 +18693,11 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       '@tanstack/react-table': 8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@voyant-travel/bookings-react': 0.221.0(0c785601167be93c5cca8a23bc8c3568)
-      '@voyant-travel/distribution-react': 0.211.0(97023016a7cb6431b92bfd79d2b52f25)
-      '@voyant-travel/inventory-react': 0.103.0(3f7e032a5669051f320c6d3d91f2fc63)
-      '@voyant-travel/relationships-react': 0.221.0(e47d6302e1332aaa92b73d1818e0f5f0)
-      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/bookings-react': 0.221.0(c938444c4122508a78df56ad5b346211)
+      '@voyant-travel/distribution-react': 0.211.0(66a41da1ed37b3544388201438a75e84)
+      '@voyant-travel/inventory-react': 0.103.0(ff0377a474b625e0f4a2919b2ce4742c)
+      '@voyant-travel/relationships-react': 0.221.0(eb7835b6d8b004093c7e3973c522d93e)
+      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
       react-hook-form: 7.80.0(react@19.2.7)
 
   '@voyant-travel/identity@0.221.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)':
@@ -18369,7 +18744,7 @@ snapshots:
       - sql.js
       - sqlite3
 
-  '@voyant-travel/inventory-react@0.103.0(3f7e032a5669051f320c6d3d91f2fc63)':
+  '@voyant-travel/inventory-react@0.103.0(ff0377a474b625e0f4a2919b2ce4742c)':
     dependencies:
       '@tanstack/react-query': 5.101.2(react@19.2.7)
       '@voyant-travel/finance': 0.221.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
@@ -18387,13 +18762,13 @@ snapshots:
       sonner: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       zod: 4.4.3
     optionalDependencies:
-      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
       '@voyant-travel/catalog-contracts': 0.112.2
-      '@voyant-travel/catalog-react': 0.219.0(05fb669ba8f726d7b2d4c6a70ffb191e)
-      '@voyant-travel/finance-react': 0.221.0(71d8be1af97797345e64a924c18b51c4)
-      '@voyant-travel/media-react': 0.7.2(71499598e4c92212fe9152722b34d2c2)
-      '@voyant-travel/storefront-react': 0.223.0(976a8607c08daac463958afe7c37815e)
-      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/catalog-react': 0.219.0(fb4ec808eef22f5a0ff25b0680f364e1)
+      '@voyant-travel/finance-react': 0.221.0(46b0d7939898ca887119ebaba6b1bf00)
+      '@voyant-travel/media-react': 0.7.2(c3409fba5278537a2f4c5b4f24844a10)
+      '@voyant-travel/storefront-react': 0.223.0(ff5a4a1dc91f112ccc39637d04f76a94)
+      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
       react-hook-form: 7.80.0(react@19.2.7)
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
@@ -18491,7 +18866,7 @@ snapshots:
       '@voyant-travel/templating': 0.104.2
       zod: 4.4.3
 
-  '@voyant-travel/legal-react@0.221.0(9e2312aae534a7c4c81c69226255182a)':
+  '@voyant-travel/legal-react@0.221.0(dadaeb1178b4fa7a046c1672c806304a)':
     dependencies:
       '@tanstack/react-query': 5.101.2(react@19.2.7)
       '@voyant-travel/i18n': 0.119.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -18503,13 +18878,13 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       zod: 4.4.3
     optionalDependencies:
-      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
-      '@voyant-travel/bookings-react': 0.221.0(0c785601167be93c5cca8a23bc8c3568)
-      '@voyant-travel/commerce-react': 0.103.0(282ec5418785f3e4854a832e7fa5c439)
-      '@voyant-travel/distribution-react': 0.211.0(97023016a7cb6431b92bfd79d2b52f25)
-      '@voyant-travel/inventory-react': 0.103.0(3f7e032a5669051f320c6d3d91f2fc63)
-      '@voyant-travel/relationships-react': 0.221.0(e47d6302e1332aaa92b73d1818e0f5f0)
-      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/bookings-react': 0.221.0(c938444c4122508a78df56ad5b346211)
+      '@voyant-travel/commerce-react': 0.103.0(cf11d98a6b8faa37935bbb668c5bd96e)
+      '@voyant-travel/distribution-react': 0.211.0(66a41da1ed37b3544388201438a75e84)
+      '@voyant-travel/inventory-react': 0.103.0(ff0377a474b625e0f4a2919b2ce4742c)
+      '@voyant-travel/relationships-react': 0.221.0(eb7835b6d8b004093c7e3973c522d93e)
+      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
       react-hook-form: 7.80.0(react@19.2.7)
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
@@ -18598,13 +18973,13 @@ snapshots:
       - sqlite3
       - typesense
 
-  '@voyant-travel/mcp@0.10.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/framework@0.66.0(5e5393ff8964cb84d9b6afaaab0441cb))(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)':
+  '@voyant-travel/mcp@0.10.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/framework@0.66.0(891e036f95d9643f9522bb733cf07765))(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)':
     dependencies:
-      '@hono/mcp': 0.3.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(hono-rate-limiter@0.5.3(hono@4.12.25))(hono@4.12.25)(zod@4.4.3)
+      '@hono/mcp': 0.3.0(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(hono-rate-limiter@0.5.3(hono@4.12.25))(hono@4.12.25)(zod@4.4.3)
       '@hono/zod-openapi': 1.4.0(hono@4.12.25)(zod@4.4.3)
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.30.0(zod@4.4.3)
       '@voyant-travel/core': 0.136.1
-      '@voyant-travel/framework': 0.66.0(5e5393ff8964cb84d9b6afaaab0441cb)
+      '@voyant-travel/framework': 0.66.0(891e036f95d9643f9522bb733cf07765)
       '@voyant-travel/hono': 0.136.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
       '@voyant-travel/tools': 0.8.0(zod@4.4.3)
       '@voyant-travel/types': 0.109.10(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)
@@ -18645,7 +19020,7 @@ snapshots:
       - supports-color
       - unstorage
 
-  '@voyant-travel/media-react@0.7.2(71499598e4c92212fe9152722b34d2c2)':
+  '@voyant-travel/media-react@0.7.2(c3409fba5278537a2f4c5b4f24844a10)':
     dependencies:
       '@tanstack/react-query': 5.101.2(react@19.2.7)
       '@voyant-travel/i18n': 0.119.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -18657,8 +19032,8 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       zod: 4.4.3
     optionalDependencies:
-      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
-      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
       - '@cloudflare/workers-types'
@@ -18734,13 +19109,13 @@ snapshots:
       - sqlite3
       - typesense
 
-  '@voyant-travel/mice-react@0.89.0(9b5458278f6178cf1004a4b2278bbd3d)':
+  '@voyant-travel/mice-react@0.89.0(c290db36aa878e3fba8da71d402b6db2)':
     dependencies:
       '@tanstack/react-query': 5.101.2(react@19.2.7)
       '@voyant-travel/i18n': 0.119.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@voyant-travel/mice': 0.77.0(8b075d290d5a4362282dccc0dc4085d1)
       '@voyant-travel/react': 0.104.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@voyant-travel/relationships-react': 0.221.0(e47d6302e1332aaa92b73d1818e0f5f0)
+      '@voyant-travel/relationships-react': 0.221.0(eb7835b6d8b004093c7e3973c522d93e)
       '@voyant-travel/types': 0.109.10(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)
       '@voyant-travel/utils': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
       lucide-react: 1.23.0(react@19.2.7)
@@ -18748,8 +19123,8 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       zod: 4.4.3
     optionalDependencies:
-      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
-      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
       - '@cloudflare/workers-types'
@@ -18832,15 +19207,15 @@ snapshots:
       - sqlite3
       - typesense
 
-  '@voyant-travel/navigation-preferences-react@0.20.1(7e70f9c62e9a32a8283f10b0336d5696)':
+  '@voyant-travel/navigation-preferences-react@0.20.1(e4fa5628a0602f0beee1114848313387)':
     dependencies:
       '@tanstack/react-query': 5.101.2(react@19.2.7)
-      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
-      '@voyant-travel/auth-react': 0.146.1(c5b48837e1cd9aeeb1b01daad828a612)
+      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/auth-react': 0.146.1(69e45fb72f5c0df2a76f66a6f882a4e8)
       '@voyant-travel/i18n': 0.119.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@voyant-travel/navigation-preferences': 0.20.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
       '@voyant-travel/react': 0.104.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
       lucide-react: 1.23.0(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -18888,7 +19263,7 @@ snapshots:
       - sql.js
       - sqlite3
 
-  '@voyant-travel/notifications-react@0.142.9(dc8bb0c5544e8b3b37bd5ba506189926)':
+  '@voyant-travel/notifications-react@0.142.9(bf95140fe4041137d5ddfb050a7d69fb)':
     dependencies:
       '@tanstack/react-query': 5.101.2(react@19.2.7)
       '@voyant-travel/i18n': 0.119.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -18900,8 +19275,8 @@ snapshots:
       sonner: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       zod: 4.4.3
     optionalDependencies:
-      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
-      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
       lucide-react: 1.23.0(react@19.2.7)
       react-hook-form: 7.80.0(react@19.2.7)
     transitivePeerDependencies:
@@ -19006,7 +19381,7 @@ snapshots:
       - vitest
       - vue
 
-  '@voyant-travel/operations-react@0.102.0(6b06bf63cd4fd219b364f4f4baa85db8)':
+  '@voyant-travel/operations-react@0.102.0(7b5e2d5a09ad0764ae607975b916e053)':
     dependencies:
       '@tanstack/react-query': 5.101.2(react@19.2.7)
       '@voyant-travel/i18n': 0.119.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -19017,10 +19392,10 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       '@tanstack/react-table': 8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
-      '@voyant-travel/bookings-react': 0.221.0(0c785601167be93c5cca8a23bc8c3568)
-      '@voyant-travel/inventory-react': 0.103.0(3f7e032a5669051f320c6d3d91f2fc63)
-      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/bookings-react': 0.221.0(c938444c4122508a78df56ad5b346211)
+      '@voyant-travel/inventory-react': 0.103.0(ff0377a474b625e0f4a2919b2ce4742c)
+      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
       lucide-react: 1.23.0(react@19.2.7)
       react-hook-form: 7.80.0(react@19.2.7)
       sonner: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -19075,17 +19450,17 @@ snapshots:
       - sqlite3
       - typesense
 
-  '@voyant-travel/operator-settings-react@0.76.0(8e7b1b7ddd10854c57508278c782a3f2)':
+  '@voyant-travel/operator-settings-react@0.76.0(56dd9a47bcae898e8360a8b4e96ccdf2)':
     dependencies:
       '@stripe/connect-js': 3.4.6
       '@stripe/react-connect-js': 3.4.4(@stripe/connect-js@3.4.6)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/react-query': 5.101.2(react@19.2.7)
-      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
-      '@voyant-travel/admin-app': 0.113.0(1de63da28db14b9ecfb7d8902fed2e27)
+      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/admin-app': 0.113.0(d592f62ec89a3d309086c38d8b40f4c7)
       '@voyant-travel/finance': 0.221.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
-      '@voyant-travel/finance-react': 0.221.0(71d8be1af97797345e64a924c18b51c4)
+      '@voyant-travel/finance-react': 0.221.0(46b0d7939898ca887119ebaba6b1bf00)
       '@voyant-travel/react': 0.104.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
       lucide-react: 1.23.0(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -19138,7 +19513,7 @@ snapshots:
       - sqlite3
       - typesense
 
-  '@voyant-travel/operator-standard@0.16.3(4eca76b58bf44a967a342f3f4da6f98b)':
+  '@voyant-travel/operator-standard@0.16.3(ef5ddf0f892670f40bd20bd70afa0934)':
     dependencies:
       '@better-auth/api-key': 1.6.23(1ac6a98f3eafa8cc5361cfcd8d9e497a)
       '@fontsource-variable/inter-tight': 5.2.7
@@ -19151,86 +19526,86 @@ snapshots:
       '@vitejs/plugin-react': 6.0.3(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3))
       '@voyant-travel/accommodations': 0.181.0(d682f9081bcd532728f4e4fa5b242145)
       '@voyant-travel/action-ledger': 0.115.5(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
-      '@voyant-travel/action-ledger-react': 0.110.0(ebb281d4321a7fe53e117ef462716269)
-      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
-      '@voyant-travel/admin-app': 0.113.0(1de63da28db14b9ecfb7d8902fed2e27)
-      '@voyant-travel/admin-host': 0.71.0(c3d637c445dd94a0800a92d30b8afe2e)
+      '@voyant-travel/action-ledger-react': 0.110.0(12b8a4856bd3c21ce51fefbf5c44aa14)
+      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/admin-app': 0.113.0(d592f62ec89a3d309086c38d8b40f4c7)
+      '@voyant-travel/admin-host': 0.71.0(91d4aa63b6d0b4e6f9de2dd1ca73c961)
       '@voyant-travel/admin-react': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(react@19.2.7)
-      '@voyant-travel/apps': 0.12.15(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(postgres@3.4.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
-      '@voyant-travel/apps-react': 0.7.1(b2996a85124729d86eac97b2f37a1b97)
+      '@voyant-travel/apps': 0.12.15(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(postgres@3.4.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/apps-react': 0.7.1(8e5fb3356eee509af65eadde29bccbb3)
       '@voyant-travel/auth': 0.146.1(e0704632a9c58ad18b35d3ef6c8c05af)
-      '@voyant-travel/auth-react': 0.146.1(c5b48837e1cd9aeeb1b01daad828a612)
+      '@voyant-travel/auth-react': 0.146.1(69e45fb72f5c0df2a76f66a6f882a4e8)
       '@voyant-travel/availability': 0.2.28(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
       '@voyant-travel/bookings': 0.221.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
-      '@voyant-travel/bookings-react': 0.221.0(0c785601167be93c5cca8a23bc8c3568)
+      '@voyant-travel/bookings-react': 0.221.0(c938444c4122508a78df56ad5b346211)
       '@voyant-travel/catalog': 0.219.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
       '@voyant-travel/catalog-authoring': 0.107.33(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(@voyant-travel/relationships@0.132.17(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9))(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
-      '@voyant-travel/catalog-react': 0.219.0(05fb669ba8f726d7b2d4c6a70ffb191e)
+      '@voyant-travel/catalog-react': 0.219.0(fb4ec808eef22f5a0ff25b0680f364e1)
       '@voyant-travel/charters': 0.219.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
       '@voyant-travel/cloud-sdk': 0.11.0(typesense@3.0.6(@babel/runtime@7.29.7))
       '@voyant-travel/commerce': 0.45.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
-      '@voyant-travel/commerce-react': 0.103.0(282ec5418785f3e4854a832e7fa5c439)
+      '@voyant-travel/commerce-react': 0.103.0(cf11d98a6b8faa37935bbb668c5bd96e)
       '@voyant-travel/connect-sdk': 0.9.1
       '@voyant-travel/core': 0.136.1
       '@voyant-travel/cruises': 0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
-      '@voyant-travel/cruises-react': 0.220.1(@tanstack/react-query@5.101.2(react@19.2.7))(@voyant-travel/catalog-contracts@0.112.2)(@voyant-travel/catalog-react@0.219.0)(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/storefront-react@0.223.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+      '@voyant-travel/cruises-react': 0.220.1(@tanstack/react-query@5.101.2(react@19.2.7))(@voyant-travel/catalog-contracts@0.112.2)(@voyant-travel/catalog-react@0.219.0)(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/storefront-react@0.223.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       '@voyant-travel/custom-fields': 0.2.19(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
-      '@voyant-travel/custom-fields-react': 0.7.1(857242392515eba839720df421846d5a)
+      '@voyant-travel/custom-fields-react': 0.7.1(9ada2420b5a218cec9afb076c4ba8840)
       '@voyant-travel/db': 0.119.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)
       '@voyant-travel/distribution': 0.211.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
-      '@voyant-travel/distribution-react': 0.211.0(97023016a7cb6431b92bfd79d2b52f25)
+      '@voyant-travel/distribution-react': 0.211.0(66a41da1ed37b3544388201438a75e84)
       '@voyant-travel/event-catalog': 0.2.19(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
-      '@voyant-travel/event-catalog-react': 0.21.1(8137040f4d261bd2feef1fe07fdd17db)
+      '@voyant-travel/event-catalog-react': 0.21.1(45000690ff698c294f21ffd8b337261d)
       '@voyant-travel/finance': 0.221.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
       '@voyant-travel/finance-contracts': 0.107.3(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
-      '@voyant-travel/finance-react': 0.221.0(71d8be1af97797345e64a924c18b51c4)
+      '@voyant-travel/finance-react': 0.221.0(46b0d7939898ca887119ebaba6b1bf00)
       '@voyant-travel/flights': 0.221.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
-      '@voyant-travel/flights-react': 0.221.0(131591d62ada4d49a861bcffb2782840)
+      '@voyant-travel/flights-react': 0.221.0(28ce33a29bc3cd1caeb788ae4b506269)
       '@voyant-travel/framework-migrations': 0.10.8
       '@voyant-travel/i18n': 0.119.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@voyant-travel/identity': 0.221.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
-      '@voyant-travel/identity-react': 0.221.0(ef66ce9cd9d949fda50ddd38198d2277)
+      '@voyant-travel/identity-react': 0.221.0(3f6ccbe45b3bc30ee6fa8da6f6c5cd89)
       '@voyant-travel/inventory': 0.24.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(@voyant-travel/relationships@0.132.17(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9))(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
-      '@voyant-travel/inventory-react': 0.103.0(3f7e032a5669051f320c6d3d91f2fc63)
+      '@voyant-travel/inventory-react': 0.103.0(ff0377a474b625e0f4a2919b2ce4742c)
       '@voyant-travel/legal': 0.221.0(06ee32ec3f0d8ebd3d78e83e9b2f9158)
-      '@voyant-travel/legal-react': 0.221.0(9e2312aae534a7c4c81c69226255182a)
-      '@voyant-travel/mcp': 0.10.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/framework@0.66.0(5e5393ff8964cb84d9b6afaaab0441cb))(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
+      '@voyant-travel/legal-react': 0.221.0(dadaeb1178b4fa7a046c1672c806304a)
+      '@voyant-travel/mcp': 0.10.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/framework@0.66.0(891e036f95d9643f9522bb733cf07765))(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
       '@voyant-travel/media': 0.6.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
-      '@voyant-travel/media-react': 0.7.2(71499598e4c92212fe9152722b34d2c2)
+      '@voyant-travel/media-react': 0.7.2(c3409fba5278537a2f4c5b4f24844a10)
       '@voyant-travel/mice': 0.77.0(8b075d290d5a4362282dccc0dc4085d1)
-      '@voyant-travel/mice-react': 0.89.0(9b5458278f6178cf1004a4b2278bbd3d)
+      '@voyant-travel/mice-react': 0.89.0(c290db36aa878e3fba8da71d402b6db2)
       '@voyant-travel/navigation-preferences': 0.20.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
-      '@voyant-travel/navigation-preferences-react': 0.20.1(7e70f9c62e9a32a8283f10b0336d5696)
+      '@voyant-travel/navigation-preferences-react': 0.20.1(e4fa5628a0602f0beee1114848313387)
       '@voyant-travel/notifications': 0.142.9(b270cdd822b665123f26438140ebe050)
-      '@voyant-travel/notifications-react': 0.142.9(dc8bb0c5544e8b3b37bd5ba506189926)
+      '@voyant-travel/notifications-react': 0.142.9(bf95140fe4041137d5ddfb050a7d69fb)
       '@voyant-travel/operations': 0.11.4(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
-      '@voyant-travel/operations-react': 0.102.0(6b06bf63cd4fd219b364f4f4baa85db8)
+      '@voyant-travel/operations-react': 0.102.0(7b5e2d5a09ad0764ae607975b916e053)
       '@voyant-travel/operator-settings': 0.16.6(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
-      '@voyant-travel/operator-settings-react': 0.76.0(8e7b1b7ddd10854c57508278c782a3f2)
+      '@voyant-travel/operator-settings-react': 0.76.0(56dd9a47bcae898e8360a8b4e96ccdf2)
       '@voyant-travel/payments': 0.8.0
       '@voyant-travel/plugin-voyant-connect': 0.3.2(@voyant-travel/catalog@0.219.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)
       '@voyant-travel/public-document-delivery': 0.4.18(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))(zod@4.4.3)
       '@voyant-travel/quotes': 0.135.13(defc09abefea765c498eb5c73014c896)
       '@voyant-travel/quotes-contracts': 0.108.3
-      '@voyant-travel/quotes-react': 0.219.0(f45fc65952894a2aa076ba5f9caf5e1c)
+      '@voyant-travel/quotes-react': 0.219.0(70e60a8ec8c9086751e031c3505d96dd)
       '@voyant-travel/realtime': 0.7.3(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))(zod@4.4.3)
       '@voyant-travel/realtime-react': 0.2.2(@tanstack/react-query@5.101.2(react@19.2.7))(react@19.2.7)
       '@voyant-travel/relationships': 0.132.17(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
-      '@voyant-travel/relationships-react': 0.221.0(e47d6302e1332aaa92b73d1818e0f5f0)
+      '@voyant-travel/relationships-react': 0.221.0(eb7835b6d8b004093c7e3973c522d93e)
       '@voyant-travel/reporting': 0.3.10(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
       '@voyant-travel/reporting-contracts': 0.3.6
-      '@voyant-travel/reporting-react': 0.7.0(ed8c9e2ac5b97e6ca9eae1f2e4c33911)
+      '@voyant-travel/reporting-react': 0.7.0(ee806624ba7a23e14e6e39fd2a3e1f8c)
       '@voyant-travel/runtime-core': 0.6.7(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(hono@4.12.25)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
       '@voyant-travel/setup': 0.7.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
-      '@voyant-travel/setup-react': 0.13.0(c19cebe5db410f2fbf05ae860d619996)
+      '@voyant-travel/setup-react': 0.13.0(354a3ff3bc5d7787bc002695575c9687)
       '@voyant-travel/storage': 0.115.0(hono@4.12.25)(typesense@3.0.6(@babel/runtime@7.29.7))(zod@4.4.3)
       '@voyant-travel/storefront': 0.223.0(f218f77f523702a384756067fe51f8e5)
-      '@voyant-travel/storefront-react': 0.223.0(976a8607c08daac463958afe7c37815e)
+      '@voyant-travel/storefront-react': 0.223.0(ff5a4a1dc91f112ccc39637d04f76a94)
       '@voyant-travel/tools': 0.8.0(zod@4.4.3)
       '@voyant-travel/trips': 0.214.0(198186e6c6b64cfd88cdcbf17ac0ced2)
-      '@voyant-travel/trips-react': 0.214.0(22ad227335ebe76ded07b3222aadcc00)
+      '@voyant-travel/trips-react': 0.214.0(4ca548596988fba53b3cfd92f86d16a7)
       '@voyant-travel/types': 0.109.10(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)
-      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
       '@voyant-travel/utils': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
       '@voyant-travel/vite-config': 0.4.0(rollup-plugin-visualizer@7.0.1(rolldown@1.1.3)(rollup@4.60.2))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3))
       '@voyant-travel/webhook-delivery': 0.5.7(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
@@ -19353,15 +19728,35 @@ snapshots:
     optionalDependencies:
       '@voyant-travel/catalog': 0.219.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
 
-  '@voyant-travel/plugin-voyant-connect@0.3.2(@voyant-travel/catalog@0.219.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)':
+  '@voyant-travel/plugin-voyant-connect@0.3.2(@voyant-travel/catalog@0.222.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)':
     dependencies:
-      '@voyant-travel/connect-adapter': 0.4.0(@voyant-travel/catalog@0.219.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))
+      '@voyant-travel/connect-adapter': 0.4.0(@voyant-travel/catalog@0.222.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))
+      '@voyant-travel/connect-cruises': 0.6.1(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))
+      '@voyant-travel/connect-sdk': 0.9.1
+      '@voyant-travel/cruises': 0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
+      '@voyant-travel/data-sdk': 0.7.1
+    optionalDependencies:
+      '@voyant-travel/catalog': 0.222.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
+
+  '@voyant-travel/plugin-voyant-connect@0.3.2(@voyant-travel/catalog@0.222.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.223.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/cruises@0.223.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)':
+    dependencies:
+      '@voyant-travel/connect-adapter': 0.4.0(@voyant-travel/catalog@0.222.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.223.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))
+      '@voyant-travel/connect-cruises': 0.6.1(@voyant-travel/cruises@0.223.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))
+      '@voyant-travel/connect-sdk': 0.9.1
+      '@voyant-travel/cruises': 0.223.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
+      '@voyant-travel/data-sdk': 0.7.1
+    optionalDependencies:
+      '@voyant-travel/catalog': 0.222.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.223.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
+
+  '@voyant-travel/plugin-voyant-connect@0.3.2(@voyant-travel/catalog@0.222.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)':
+    dependencies:
+      '@voyant-travel/connect-adapter': 0.4.0(@voyant-travel/catalog@0.222.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))
       '@voyant-travel/connect-cruises': 0.6.1(@voyant-travel/cruises@packages+cruises)
       '@voyant-travel/connect-sdk': 0.9.1
       '@voyant-travel/cruises': link:packages/cruises
       '@voyant-travel/data-sdk': 0.7.1
     optionalDependencies:
-      '@voyant-travel/catalog': 0.219.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
+      '@voyant-travel/catalog': 0.222.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
 
   '@voyant-travel/plugin-voyant-connect@0.3.2(@voyant-travel/catalog@packages+catalog)(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)':
     dependencies:
@@ -19424,7 +19819,7 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  '@voyant-travel/quotes-react@0.219.0(f45fc65952894a2aa076ba5f9caf5e1c)':
+  '@voyant-travel/quotes-react@0.219.0(70e60a8ec8c9086751e031c3505d96dd)':
     dependencies:
       '@tanstack/react-query': 5.101.2(react@19.2.7)
       '@tanstack/react-router': 1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -19438,10 +19833,10 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       zod: 4.4.3
     optionalDependencies:
-      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
-      '@voyant-travel/auth-react': 0.146.1(c5b48837e1cd9aeeb1b01daad828a612)
-      '@voyant-travel/relationships-react': 0.221.0(e47d6302e1332aaa92b73d1818e0f5f0)
-      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/auth-react': 0.146.1(69e45fb72f5c0df2a76f66a6f882a4e8)
+      '@voyant-travel/relationships-react': 0.221.0(eb7835b6d8b004093c7e3973c522d93e)
+      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
       - '@cloudflare/workers-types'
@@ -19597,7 +19992,7 @@ snapshots:
       '@voyant-travel/schema-kit': 0.115.0
       zod: 4.4.3
 
-  '@voyant-travel/relationships-react@0.221.0(e47d6302e1332aaa92b73d1818e0f5f0)':
+  '@voyant-travel/relationships-react@0.221.0(eb7835b6d8b004093c7e3973c522d93e)':
     dependencies:
       '@tanstack/react-query': 5.101.2(react@19.2.7)
       '@voyant-travel/i18n': 0.119.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -19609,9 +20004,9 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       zod: 4.4.3
     optionalDependencies:
-      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
-      '@voyant-travel/identity-react': 0.221.0(ef66ce9cd9d949fda50ddd38198d2277)
-      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/identity-react': 0.221.0(3f6ccbe45b3bc30ee6fa8da6f6c5cd89)
+      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
       - '@cloudflare/workers-types'
@@ -19696,7 +20091,7 @@ snapshots:
       '@voyant-travel/core': 0.136.1
       zod: 4.4.3
 
-  '@voyant-travel/reporting-react@0.7.0(ed8c9e2ac5b97e6ca9eae1f2e4c33911)':
+  '@voyant-travel/reporting-react@0.7.0(ee806624ba7a23e14e6e39fd2a3e1f8c)':
     dependencies:
       '@codemirror/commands': 6.10.4
       '@codemirror/language': 6.12.4
@@ -19714,8 +20109,8 @@ snapshots:
       react-resizable-panels: 3.0.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     optionalDependencies:
       '@tanstack/react-query': 5.101.2(react@19.2.7)
-      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
-      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
       lucide-react: 1.23.0(react@19.2.7)
       recharts: 3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)
     transitivePeerDependencies:
@@ -19805,13 +20200,13 @@ snapshots:
       typeid-js: 1.2.0
       zod: 4.4.3
 
-  '@voyant-travel/setup-react@0.13.0(c19cebe5db410f2fbf05ae860d619996)':
+  '@voyant-travel/setup-react@0.13.0(354a3ff3bc5d7787bc002695575c9687)':
     dependencies:
       '@tanstack/react-query': 5.101.2(react@19.2.7)
-      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
       '@voyant-travel/react': 0.104.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@voyant-travel/setup': 0.7.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
-      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
       lucide-react: 1.23.0(react@19.2.7)
       react: 19.2.7
 
@@ -19869,7 +20264,7 @@ snapshots:
     transitivePeerDependencies:
       - typesense
 
-  '@voyant-travel/storefront-react@0.223.0(976a8607c08daac463958afe7c37815e)':
+  '@voyant-travel/storefront-react@0.223.0(ff5a4a1dc91f112ccc39637d04f76a94)':
     dependencies:
       '@tanstack/react-query': 5.101.2(react@19.2.7)
       '@tanstack/react-router': 1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -19881,11 +20276,11 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       '@voyant-travel/accommodations': 0.181.0(d682f9081bcd532728f4e4fa5b242145)
-      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
-      '@voyant-travel/auth-react': 0.146.1(c5b48837e1cd9aeeb1b01daad828a612)
+      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/auth-react': 0.146.1(69e45fb72f5c0df2a76f66a6f882a4e8)
       '@voyant-travel/catalog-contracts': 0.112.2
-      '@voyant-travel/catalog-react': 0.219.0(05fb669ba8f726d7b2d4c6a70ffb191e)
-      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/catalog-react': 0.219.0(fb4ec808eef22f5a0ff25b0680f364e1)
+      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
       lucide-react: 1.23.0(react@19.2.7)
 
   '@voyant-travel/storefront@0.223.0(f218f77f523702a384756067fe51f8e5)':
@@ -19973,7 +20368,11 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  '@voyant-travel/trips-react@0.214.0(22ad227335ebe76ded07b3222aadcc00)':
+  '@voyant-travel/tools@0.9.1(zod@4.4.3)':
+    dependencies:
+      zod: 4.4.3
+
+  '@voyant-travel/trips-react@0.214.0(4ca548596988fba53b3cfd92f86d16a7)':
     dependencies:
       '@tanstack/react-query': 5.101.2(react@19.2.7)
       '@voyant-travel/i18n': 0.119.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -19984,15 +20383,15 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       zod: 4.4.3
     optionalDependencies:
-      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
-      '@voyant-travel/bookings-react': 0.221.0(0c785601167be93c5cca8a23bc8c3568)
+      '@voyant-travel/admin': 0.131.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)))(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/bookings-react': 0.221.0(c938444c4122508a78df56ad5b346211)
       '@voyant-travel/catalog': 0.219.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
-      '@voyant-travel/catalog-react': 0.219.0(05fb669ba8f726d7b2d4c6a70ffb191e)
+      '@voyant-travel/catalog-react': 0.219.0(fb4ec808eef22f5a0ff25b0680f364e1)
       '@voyant-travel/finance': 0.221.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
       '@voyant-travel/flights': 0.221.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.220.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
-      '@voyant-travel/flights-react': 0.221.0(131591d62ada4d49a861bcffb2782840)
-      '@voyant-travel/relationships-react': 0.221.0(e47d6302e1332aaa92b73d1818e0f5f0)
-      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
+      '@voyant-travel/flights-react': 0.221.0(28ce33a29bc3cd1caeb788ae4b506269)
+      '@voyant-travel/relationships-react': 0.221.0(eb7835b6d8b004093c7e3973c522d93e)
+      '@voyant-travel/ui': 0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))
 
   '@voyant-travel/trips@0.214.0(198186e6c6b64cfd88cdcbf17ac0ced2)':
     dependencies:
@@ -20103,7 +20502,7 @@ snapshots:
       - sql.js
       - sqlite3
 
-  '@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@floating-ui/dom@1.7.6)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))':
+  '@voyant-travel/ui@0.110.1(@cloudflare/workers-types@4.20260702.1)(@date-fns/tz@1.4.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1))':
     dependencies:
       '@base-ui/react': 1.6.0(@date-fns/tz@1.4.1)(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/react-table': 8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -20600,12 +20999,12 @@ snapshots:
   better-auth@1.6.23(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.3)(rollup@4.60.2)(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9))(mongodb@7.1.0(socks@2.8.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.11)(vitest@4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)))(vue@3.5.39(typescript@6.0.3)):
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
-      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9))
-      '@better-auth/kysely-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)
-      '@better-auth/memory-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
-      '@better-auth/mongo-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(mongodb@7.1.0(socks@2.8.7))
-      '@better-auth/prisma-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
-      '@better-auth/telemetry': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9))
+      '@better-auth/kysely-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)
+      '@better-auth/memory-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(mongodb@7.1.0(socks@2.8.7))
+      '@better-auth/prisma-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
+      '@better-auth/telemetry': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@noble/ciphers': 2.2.0


### PR DESCRIPTION
Addresses #3934. Wave 2 of #3921.

## The upgrade does not bring the spec

`@modelcontextprotocol/sdk` **1.29.0 → 1.30.0**. Verified rather than assumed:

```
npm view @modelcontextprotocol/sdk version   →  1.30.0
LATEST_PROTOCOL_VERSION                      →  2025-11-25
```

1.30.0 was published **2026-07-27, one day before** the 2026-07-28 spec landed, so none of the spec's features are in the TypeScript SDK yet. The bump is worth taking on its own; the features are not available.

## The test is better than an assertion of the current version

Besides pinning the negotiated protocol version, it asserts `SUPPORTED_PROTOCOL_VERSIONS` does **not** contain `2026-07-28` — so the SDK gaining spec support **fails loudly** rather than passing silently and going unnoticed for months. That inverts the usual staleness problem with version pins.

## Tracking doc

`docs/architecture/mcp-2026-07-28-spec-adoption.md` records the five relevant features in value order, each with what it would let us **delete**:

| Feature | What it buys |
|---|---|
| Cacheable list results (`ttlMs`, `cacheScope`) | compounds with the progressive disclosure in #3961 |
| MRTR `resultType: "input_required"` | stateless server-initiated elicitation — the eventual fix for orchestration prose embedded in tool descriptions |
| Tasks extension | long-running search / document generation, today forced into one HTTP request |
| `Mcp-Method` / `Mcp-Name` headers | deletes the path special-case at `packages/hono/src/middleware/auth.ts:415` and lets the rate limiter classify without parsing the body |
| Auth hardening (RFC 9207, CIMD over DCR) | — |

**Sampling, Roots and Logging are deprecated** with a 12-month offramp; the doc carries that as a prominent callout so nothing new is built on them.

The spec core also went **stateless** (per-request identity in `_meta`), which independently validates ADR-0011's no-Durable-Object decision — worth recording because it closes a tension raised during #3921.

## The lockfile churn — investigated, not waved through

865 insertions / 234 deletions is far larger than an SDK bump warrants. **It is not caused by the SDK.**

Peer-hash strings in the lockfile embed workspace package versions, and the `chore: release packages` commits moved `@voyant-travel/catalog` 0.219.0 → 0.222.0 and `@voyant-travel/cruises` 0.220.1 → 0.223.0. `main` tolerates that drift under `--frozen-lockfile` (verified: passes in 3.5s), but **any** install materializes it.

I checked whether it could be split out by resetting the lockfile to main's and regenerating with only the SDK range changed — the result is an **identical** 632/233 diff. It cannot be separated; this PR is simply the first install since the release.

**No declared dependency is downgraded.** `packages/auth` declares `jose: ^6.2.4` and still resolves to `6.2.4`. The `6.2.3` references are transitive peer-hash strings inside better-auth's subgraph.

## Verification

```
pnpm -F @voyant-travel/mcp test        Test Files 10 passed   Tests 66 passed
pnpm -F @voyant-travel/mcp typecheck   exit 0
npx biome check .                      repo-wide, 0 errors
node scripts/check-agent-code-quality.mjs | grep packages/mcp/src   # no matches
```

Tests run against 1.30.0 after a real install, not `--lockfile-only`.