### PR TITLE
test(mcp): agent journey eval harness — and the discovery cost it exposes

### DIFF
--- a/packages/mcp/tests/agent-journey-eval.test.ts
+++ b/packages/mcp/tests/agent-journey-eval.test.ts
@@ -1,0 +1,445 @@
+/**
+ * Agent journey eval — scored scenarios over a seeded MCP deployment (voyant#3936).
+ *
+ * This is the executable half of the eval loop the #3921 plan calls for. The
+ * ratchets in `starters/operator/tests/selected-graph-mcp-tool-surface.test.ts`
+ * measure how BIG the surface is; this measures whether an agent can DO a job
+ * against it — completion, call count, token cost, and error codes per journey.
+ *
+ * The deployment is seeded in-process: a registry of read tools carrying the
+ * REAL tool names the surface actually serves (`list_products`, `get_product`,
+ * `get_product_content`, `list_bookings` — each verified against its owning
+ * package's `defineTool` in packages/inventory and packages/bookings) backed by
+ * a small in-memory fixture. Real names, deterministic backend: the scenarios
+ * exercise the meta-tool / guide indirection exactly as a live agent would,
+ * without a database or a model API key. Discovery of those same names on the
+ * REAL selected graph is grounded separately in the operator starter test.
+ *
+ * The scores are recorded below as named baseline constants with docblocks that
+ * say what they mean and when to move them — the ratchet precedent — and the run
+ * prints a legible per-scenario report so a regression is visible in CI output,
+ * not just a boolean. The token estimate is response-bytes ÷ 4 (see the harness
+ * docblock); it is a floor and a relative signal, not an exact token bill.
+ */
+import {
+  createToolRegistry,
+  defineTool,
+  READ_ONLY_RISK,
+  type ToolContext,
+  ToolError,
+} from "@voyant-travel/tools"
+import { Hono } from "hono"
+import { beforeAll, describe, expect, it } from "vitest"
+import { z } from "zod"
+
+import { createMcpApiRoutes } from "../src/index.js"
+import {
+  formatJourneyReport,
+  honoTransport,
+  type JourneyScenario,
+  type JourneyScore,
+  type JourneyStepResult,
+  runJourney,
+} from "./support/journey-harness.js"
+
+// --- Seeded fixture: a tiny catalog and booking set the read tools serve. ------
+
+const SEED_PRODUCTS = [
+  {
+    id: "prod_seed_1",
+    slug: "kyoto-cherry-blossom",
+    name: "Kyoto Cherry Blossom Tour",
+    status: "active",
+    bookingMode: "date",
+  },
+  {
+    id: "prod_seed_2",
+    slug: "andes-high-trek",
+    name: "Andes High Trek",
+    status: "active",
+    bookingMode: "itinerary",
+  },
+  {
+    id: "prod_seed_3",
+    slug: "nile-luxury-cruise",
+    name: "Nile Luxury Cruise",
+    status: "draft",
+    bookingMode: "date_time",
+  },
+] as const
+
+const SEED_CONTENT: Record<string, { id: string; name: string; itinerary: string[] }> = {
+  prod_seed_1: {
+    id: "prod_seed_1",
+    name: "Kyoto Cherry Blossom Tour",
+    itinerary: ["Arrive Kyoto", "Philosopher's Path", "Arashiyama bamboo grove"],
+  },
+}
+
+const SEED_BOOKINGS = [
+  { id: "bk_1", status: "confirmed", productId: "prod_seed_1" },
+  { id: "bk_2", status: "held", productId: "prod_seed_2" },
+  { id: "bk_3", status: "confirmed", productId: "prod_seed_1" },
+] as const
+
+const productSchema = z.object({
+  id: z.string(),
+  slug: z.string(),
+  name: z.string(),
+  status: z.string(),
+  bookingMode: z.string(),
+})
+
+const OWNER = "@voyant-travel/inventory"
+const BOOKINGS_OWNER = "@voyant-travel/bookings"
+
+// Read tools mirror the real surface's names, scopes, and read-only risk. The
+// handlers read the seeded fixture instead of a provider so the journey is
+// deterministic and needs no database.
+const listProductsTool = defineTool({
+  capabilityId: `${OWNER}#tool.list-products`,
+  owner: OWNER,
+  capabilityVersion: "v1",
+  name: "list_products",
+  description:
+    "List products with optional filters (status) and pagination. Returns " +
+    "{ data, total, limit, offset }. Read-only.",
+  inputSchema: z.object({
+    status: z.string().optional(),
+    limit: z.number().int().min(1).max(100).optional(),
+    offset: z.number().int().min(0).optional(),
+  }),
+  outputSchema: z.object({
+    data: z.array(productSchema),
+    total: z.number(),
+    limit: z.number(),
+    offset: z.number(),
+  }),
+  requiredScopes: ["products:read"],
+  tier: "read",
+  riskPolicy: READ_ONLY_RISK,
+  annotations: { idempotentHint: true },
+  async handler({ status, limit = 25, offset = 0 }) {
+    const filtered = SEED_PRODUCTS.filter((p) => (status ? p.status === status : true))
+    return {
+      data: filtered.slice(offset, offset + limit).map((p) => ({ ...p })),
+      total: filtered.length,
+      limit,
+      offset,
+    }
+  },
+})
+
+const getProductTool = defineTool({
+  capabilityId: `${OWNER}#tool.get-product`,
+  owner: OWNER,
+  capabilityVersion: "v1",
+  name: "get_product",
+  description: "Read a single product by id or by its catalog slug. Returns null when not found.",
+  inputSchema: z.object({ id: z.string().min(1).optional(), slug: z.string().min(1).optional() }),
+  outputSchema: z.object({ product: productSchema.nullable() }),
+  requiredScopes: ["products:read"],
+  tier: "read",
+  riskPolicy: READ_ONLY_RISK,
+  async handler({ id, slug }) {
+    if (!id && !slug) throw new ToolError("Provide either id or slug.", "INVALID_INPUT")
+    const product = SEED_PRODUCTS.find((p) => (id ? p.id === id : p.slug === slug)) ?? null
+    return { product: product ? { ...product } : null }
+  },
+})
+
+const getProductContentTool = defineTool({
+  capabilityId: `${OWNER}#content-extension.tool.get-product-content`,
+  owner: OWNER,
+  capabilityVersion: "v1",
+  name: "get_product_content",
+  description: "Resolve composed product content (options, itinerary, media, policies). Read-only.",
+  inputSchema: z.object({ id: z.string().min(1) }),
+  outputSchema: z
+    .object({ id: z.string(), name: z.string(), itinerary: z.array(z.string()) })
+    .nullable(),
+  requiredScopes: ["products:read"],
+  tier: "read",
+  riskPolicy: READ_ONLY_RISK,
+  async handler({ id }) {
+    return SEED_CONTENT[id] ?? null
+  },
+})
+
+const listBookingsTool = defineTool({
+  capabilityId: `${BOOKINGS_OWNER}#tool.list-bookings`,
+  owner: BOOKINGS_OWNER,
+  capabilityVersion: "v1",
+  name: "list_bookings",
+  description: "List bookings with an optional status filter. Returns { data, total }. Read-only.",
+  inputSchema: z.object({ status: z.string().optional() }),
+  outputSchema: z.object({
+    data: z.array(z.object({ id: z.string(), status: z.string(), productId: z.string() })),
+    total: z.number(),
+  }),
+  requiredScopes: ["bookings:read"],
+  tier: "read",
+  riskPolicy: READ_ONLY_RISK,
+  annotations: { idempotentHint: true },
+  async handler({ status }) {
+    const filtered = SEED_BOOKINGS.filter((b) => (status ? b.status === status : true))
+    return { data: filtered.map((b) => ({ ...b })), total: filtered.length }
+  },
+})
+
+const accessCatalog = {
+  resources: [
+    {
+      id: "products",
+      unitId: OWNER,
+      resource: "products",
+      label: "Products",
+      description: "Catalog products",
+      wildcard: "allow" as const,
+      actions: [{ action: "read", label: "Read", description: "Read products" }],
+    },
+    {
+      id: "bookings",
+      unitId: BOOKINGS_OWNER,
+      resource: "bookings",
+      label: "Bookings",
+      description: "Bookings",
+      wildcard: "allow" as const,
+      actions: [{ action: "read", label: "Read", description: "Read bookings" }],
+    },
+  ],
+  presets: [],
+}
+
+function buildContext(): ToolContext {
+  return {
+    db: {},
+    actor: "staff",
+    audience: "staff",
+    tenantId: "t1",
+    resolverScope: { locale: "en-GB", audience: "staff", market: "default", actor: "staff" },
+  }
+}
+
+/** Mount the seeded MCP surface behind a read-scoped staff key. */
+function seededMcpApp(): Hono {
+  const registry = createToolRegistry()
+  registry.register(listProductsTool)
+  registry.register(getProductTool)
+  registry.register(getProductContentTool)
+  registry.register(listBookingsTool)
+  const mcp = createMcpApiRoutes({ accessCatalog, registry, buildContext })
+  const outer = new Hono()
+  outer.use("*", async (c, next) => {
+    c.set("scopes", ["products:read", "bookings:read"])
+    await next()
+  })
+  outer.route("/", mcp)
+  return outer
+}
+
+// --- Structured-content readers the scripted drivers chain through. ------------
+
+interface ProductRow {
+  id: string
+  slug: string
+  name: string
+  status: string
+}
+
+function productList(step: JourneyStepResult | undefined): ProductRow[] {
+  const data = (step?.structured as { data?: ProductRow[] } | undefined)?.data
+  return Array.isArray(data) ? data : []
+}
+
+function bookingList(step: JourneyStepResult | undefined): Array<{ id: string; status: string }> {
+  const data = (step?.structured as { data?: Array<{ id: string; status: string }> } | undefined)
+    ?.data
+  return Array.isArray(data) ? data : []
+}
+
+function describedName(step: JourneyStepResult | undefined): string | undefined {
+  return (step?.structured as { name?: string } | undefined)?.name
+}
+
+function searchHit(step: JourneyStepResult | undefined, name: string): boolean {
+  const tools = (step?.structured as { tools?: Array<{ name: string }> } | undefined)?.tools
+  return Array.isArray(tools) && tools.some((t) => t.name === name)
+}
+
+// --- The fixed scenario set. ---------------------------------------------------
+
+const SCENARIOS: JourneyScenario[] = [
+  {
+    // discover → describe → read: the canonical progressive-disclosure path.
+    id: "discover-then-read-products",
+    title: "search_tools → describe_tool → list_products",
+    drive(prior) {
+      if (prior.length === 0) return { tool: "search_tools", args: { query: "product" } }
+      if (prior.length === 1) return { tool: "describe_tool", args: { name: "list_products" } }
+      if (prior.length === 2) return { tool: "list_products", args: {} }
+      return null
+    },
+    completed: (prior) =>
+      searchHit(prior[0], "list_products") &&
+      describedName(prior[1]) === "list_products" &&
+      productList(prior[2]).length > 0,
+  },
+  {
+    // Find a product, then read its composed content by the id just discovered.
+    id: "find-product-read-content",
+    title: "search_tools → list_products → get_product_content(id)",
+    drive(prior) {
+      if (prior.length === 0) return { tool: "search_tools", args: { query: "product content" } }
+      if (prior.length === 1) return { tool: "list_products", args: { status: "active" } }
+      if (prior.length === 2) {
+        const id = productList(prior[1])[0]?.id
+        return id ? { tool: "get_product_content", args: { id } } : null
+      }
+      return null
+    },
+    completed(prior) {
+      const id = productList(prior[1])[0]?.id
+      // A nullable output schema is envelope-wrapped under `result` by the MCP
+      // output contract, so the content id lands at structured.result.id.
+      const wrapped = prior[2]?.structured as { result?: { id?: string } } | undefined
+      return Boolean(id && !prior[2]?.isError && wrapped?.result?.id === id)
+    },
+  },
+  {
+    // List bookings with a filter, dispatched through the call_tool meta-tool.
+    id: "list-bookings-with-filter",
+    title: "search_tools → describe_tool → call_tool(list_bookings, confirmed)",
+    drive(prior) {
+      if (prior.length === 0) return { tool: "search_tools", args: { query: "booking" } }
+      if (prior.length === 1) return { tool: "describe_tool", args: { name: "list_bookings" } }
+      if (prior.length === 2)
+        return { tool: "list_bookings", args: { status: "confirmed" }, via: "meta" }
+      return null
+    },
+    completed(prior) {
+      const rows = bookingList(prior[2])
+      return rows.length > 0 && rows.every((b) => b.status === "confirmed")
+    },
+  },
+  {
+    // Guide-first: read the discovery guide, then discover and read a product.
+    id: "guide-then-act",
+    title: "voyant_guide(discovery) → search_tools → get_product(id)",
+    drive(prior) {
+      if (prior.length === 0) return { tool: "voyant_guide", args: { topic: "discovery" } }
+      if (prior.length === 1) return { tool: "search_tools", args: { query: "product" } }
+      if (prior.length === 2) return { tool: "get_product", args: { id: "prod_seed_1" } }
+      return null
+    },
+    completed(prior) {
+      const guided = (prior[0]?.text ?? "").length > 0 && !prior[0]?.isError
+      const product = (prior[2]?.structured as { product?: unknown } | undefined)?.product
+      return guided && searchHit(prior[1], "get_product") && product != null
+    },
+  },
+  {
+    // An agent that fumbles input (no id/slug), reads the actionable error, and
+    // recovers. Exercises the error-code breakdown while still completing.
+    id: "recover-from-bad-input",
+    title: "get_product() [INVALID_INPUT] → list_products → get_product(id)",
+    drive(prior) {
+      if (prior.length === 0) return { tool: "get_product", args: {} }
+      if (prior.length === 1) return { tool: "list_products", args: {} }
+      if (prior.length === 2) {
+        const id = productList(prior[1])[0]?.id
+        return id ? { tool: "get_product", args: { id } } : null
+      }
+      return null
+    },
+    completed(prior) {
+      const recovered = (prior[2]?.structured as { product?: unknown } | undefined)?.product
+      return prior[0]?.code === "INVALID_INPUT" && recovered != null
+    },
+  },
+]
+
+/**
+ * Recorded baselines — the point of the harness (voyant#3936 acceptance). Each
+ * scenario's transcript is fully scripted, so `calls` is EXACT and asserted as
+ * an equality: a change here means the number of round-trips a journey takes
+ * changed, which is exactly the regression worth reviewing.
+ *
+ * `maxTokens` is a NON-BLOCKING ceiling with headroom, not an equality: response
+ * sizes drift with tool-description and guide wording, and the brief wants a
+ * slowdown to be *legible*, not a merge blocker, until the numbers are trusted.
+ * The ceiling is ~1.5× the measured estimate so routine wording edits pass while
+ * a gross regression (a tool's schema ballooning, an unbounded list) trips it.
+ * When you intentionally change the surface, re-run, read the printed report,
+ * and move the measured baseline in the comment plus the ceiling if needed.
+ *
+ * Measured estimates at authoring (response bytes ÷ 4). The describe_tool step
+ * dominates the discovery journeys — it pays a tool's full input schema once,
+ * which is exactly the per-tool cost the aggregate ratchet in the operator
+ * starter bounds. The guide journey pays the `voyant_guide` prose instead.
+ *   discover-then-read-products   calls=3  ~tokens≈1789
+ *   find-product-read-content     calls=3  ~tokens≈425
+ *   list-bookings-with-filter     calls=3  ~tokens≈1092
+ *   guide-then-act                calls=3  ~tokens≈872
+ *   recover-from-bad-input        calls=3  ~tokens≈422
+ */
+const BASELINES: Record<string, { calls: number; maxTokens: number }> = {
+  "discover-then-read-products": { calls: 3, maxTokens: 2_700 },
+  "find-product-read-content": { calls: 3, maxTokens: 650 },
+  "list-bookings-with-filter": { calls: 3, maxTokens: 1_650 },
+  "guide-then-act": { calls: 3, maxTokens: 1_300 },
+  "recover-from-bad-input": { calls: 3, maxTokens: 650 },
+}
+
+describe("agent journey eval harness", () => {
+  let scores: JourneyScore[] = []
+
+  beforeAll(async () => {
+    const transport = honoTransport(seededMcpApp())
+    scores = []
+    for (const scenario of SCENARIOS) scores.push(await runJourney(transport, scenario))
+    // Non-blocking report written straight to stdout so the numbers are legible
+    // in CI on every run — vitest suppresses console.* on a passing file, which
+    // would hide a token/call drift that stayed under the ceiling (voyant#3936).
+    process.stdout.write(`\n${formatJourneyReport(scores)}\n\n`)
+  })
+
+  it("reaches the terminal state of every journey", () => {
+    const incomplete = scores.filter((s) => !s.completed).map((s) => s.id)
+    expect(incomplete, `incomplete journeys: ${incomplete.join(", ") || "none"}`).toEqual([])
+  })
+
+  it("takes exactly the recorded number of tool calls per journey", () => {
+    for (const score of scores) {
+      const baseline = BASELINES[score.id]
+      expect(baseline, `no baseline recorded for ${score.id}`).toBeDefined()
+      expect(score.calls, `${score.id} call count changed`).toBe(baseline?.calls)
+    }
+  })
+
+  it("stays under the non-blocking token ceiling per journey", () => {
+    for (const score of scores) {
+      const ceiling = BASELINES[score.id]?.maxTokens ?? Number.POSITIVE_INFINITY
+      expect(
+        score.tokenEstimate,
+        `${score.id} token estimate ${score.tokenEstimate} exceeded ceiling ${ceiling} — ` +
+          "read the printed report; raise the baseline only with a recorded reason.",
+      ).toBeLessThanOrEqual(ceiling)
+    }
+  })
+
+  it("records tool errors broken down by ToolError code", () => {
+    const byId = new Map(scores.map((s) => [s.id, s]))
+    // The happy-path journeys hit no errors...
+    for (const id of [
+      "discover-then-read-products",
+      "find-product-read-content",
+      "list-bookings-with-filter",
+      "guide-then-act",
+    ]) {
+      expect(byId.get(id)?.errorsByCode, `${id} unexpectedly errored`).toEqual({})
+    }
+    // ...and the recovery journey records exactly one INVALID_INPUT and no more.
+    expect(byId.get("recover-from-bad-input")?.errorsByCode).toEqual({ INVALID_INPUT: 1 })
+  })
+})

--- a/packages/mcp/tests/support/journey-harness.ts
+++ b/packages/mcp/tests/support/journey-harness.ts
@@ -1,0 +1,222 @@
+/**
+ * Agent journey eval harness (voyant#3936, RFC voyant#3921).
+ *
+ * The #3921 plan is ordered instrument → measure → decide: the observability
+ * seam (W1) and the size ratchets (W2) tell us how big the surface is, but
+ * nothing yet measures whether an *agent* can actually get work done against it.
+ * This harness closes that loop. It runs a fixed set of realistic journeys —
+ * each an explicit, scripted sequence of MCP calls standing in for what an agent
+ * would do — and scores the MECHANICS of each: did it reach its terminal state,
+ * how many tool calls it took, roughly how many tokens the responses cost, and
+ * which {@link ToolError} codes it hit.
+ *
+ * It is deliberately model-free. A journey that needs a live LLM to drive it
+ * gets disabled the first week a CI key rotates and is then worse than nothing,
+ * so every scenario here is a deterministic scripted driver: given the results
+ * so far it returns the next MCP call, or `null` to stop. The same transcript
+ * runs identically on every commit, which is what makes a recorded baseline a
+ * meaningful before/after.
+ *
+ * TOKEN ESTIMATE. We report bytes-of-response ÷ 4 as a token proxy — and only
+ * the RESPONSE payloads (the `describe_tool` schemas and tool outputs an agent
+ * actually pulls into its context), not the tiny request arguments. JSON schema
+ * tokenizes denser than prose, so bytes/4 is a floor, not a ceiling; treat it as
+ * a stable relative signal for regressions, not an exact token bill.
+ */
+import { Buffer } from "node:buffer"
+
+/** Token proxy divisor. Response-bytes ÷ 4; see the file docblock — this is a floor. */
+export const BYTES_PER_TOKEN = 4
+
+const MCP_HEADERS = {
+  "content-type": "application/json",
+  accept: "application/json, text/event-stream",
+}
+
+const DISPATCH_ERROR_META_KEY = "voyant.travel/error"
+
+/** A minimal MCP JSON-RPC transport: issue one method and return the parsed body. */
+export type McpTransport = (method: string, params: unknown) => Promise<RpcBody>
+
+interface RpcBody {
+  result?: {
+    isError?: boolean
+    structuredContent?: unknown
+    content?: Array<{ type?: string; text?: string }>
+    _meta?: Record<string, unknown>
+  }
+  error?: { code?: number; message?: string }
+}
+
+interface HonoLike {
+  request(path: string, init: unknown, env?: unknown, ctx?: unknown): Promise<Response>
+}
+
+let rpcSequence = 0
+
+function rpcInit(method: string, params: unknown) {
+  rpcSequence += 1
+  return {
+    method: "POST",
+    headers: MCP_HEADERS,
+    body: JSON.stringify({ jsonrpc: "2.0", id: rpcSequence, method, params }),
+  }
+}
+
+async function readRpc(res: Response): Promise<RpcBody> {
+  const text = await res.text()
+  if ((res.headers.get("content-type") ?? "").includes("text/event-stream")) {
+    const line = text.split("\n").find((l) => l.startsWith("data:"))
+    return JSON.parse(line?.slice("data:".length).trim() ?? "{}") as RpcBody
+  }
+  return JSON.parse(text) as RpcBody
+}
+
+/** A transport bound to a mounted Hono MCP app, optionally with a test env/ctx. */
+export function honoTransport(app: HonoLike, env?: unknown, ctx?: unknown): McpTransport {
+  return async (method, params) =>
+    readRpc(await app.request("/", rpcInit(method, params), env, ctx))
+}
+
+/**
+ * One step an agent would take: invoke `tool` with `args`. `via` chooses the
+ * dispatch path — a flat-name `tools/call` (the default) or routing through the
+ * `call_tool` meta-tool — so a scenario can measure either indirection.
+ */
+export interface JourneyCall {
+  tool: string
+  args?: Record<string, unknown>
+  via?: "flat" | "meta"
+}
+
+/** The observed outcome of one journey step. */
+export interface JourneyStepResult {
+  call: JourneyCall
+  /** Response payload bytes (result, else error) — the token-proxy input. */
+  bytes: number
+  isError: boolean
+  /** The ToolError code when the step failed with a structured domain error. */
+  code?: string
+  structured?: unknown
+  text?: string
+}
+
+/** Given the steps so far, return the next call to make, or `null` to stop. */
+export type JourneyDriver = (prior: readonly JourneyStepResult[]) => JourneyCall | null
+
+export interface JourneyScenario {
+  id: string
+  title: string
+  /** Scripted driver: the fixed sequence of MCP calls this journey performs. */
+  drive: JourneyDriver
+  /** Terminal-state predicate evaluated over the full transcript. */
+  completed: (prior: readonly JourneyStepResult[]) => boolean
+  /** Safety bound so a mis-scripted driver cannot loop forever. */
+  maxCalls?: number
+}
+
+/** The four scores the brief asks for, per journey. */
+export interface JourneyScore {
+  id: string
+  title: string
+  completed: boolean
+  calls: number
+  bytes: number
+  tokenEstimate: number
+  errorsByCode: Record<string, number>
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+/** Pull the structured domain error code off a failed `tools/call` result. */
+function errorCodeOf(body: RpcBody): string | undefined {
+  const meta = isRecord(body.result?._meta)
+    ? body.result?._meta[DISPATCH_ERROR_META_KEY]
+    : undefined
+  const code = isRecord(meta) ? meta.code : undefined
+  if (typeof code === "string" && code.length > 0) return code
+  // A JSON-RPC transport error (unregistered/unauthorized flat name) has no
+  // domain code; label it so it is still counted, not silently dropped.
+  if (body.error) return "RPC_ERROR"
+  return body.result?.isError === true ? "UNKNOWN" : undefined
+}
+
+async function issueCall(transport: McpTransport, call: JourneyCall): Promise<JourneyStepResult> {
+  const params =
+    call.via === "meta"
+      ? { name: "call_tool", arguments: { name: call.tool, arguments: call.args ?? {} } }
+      : { name: call.tool, arguments: call.args ?? {} }
+  const body = await transport("tools/call", params)
+  const payload = body.result ?? body.error ?? {}
+  return {
+    call,
+    bytes: Buffer.byteLength(JSON.stringify(payload), "utf8"),
+    isError: body.result?.isError === true || body.error != null,
+    ...(errorCodeOf(body) ? { code: errorCodeOf(body) } : {}),
+    structured: body.result?.structuredContent,
+    text: body.result?.content?.find((part) => part.type === "text")?.text,
+  }
+}
+
+/** Drive one scenario to its terminal state and score all four metrics. */
+export async function runJourney(
+  transport: McpTransport,
+  scenario: JourneyScenario,
+): Promise<JourneyScore> {
+  const prior: JourneyStepResult[] = []
+  const errorsByCode: Record<string, number> = {}
+  let bytes = 0
+  const max = scenario.maxCalls ?? 12
+  while (prior.length < max) {
+    const call = scenario.drive(prior)
+    if (!call) break
+    const step = await issueCall(transport, call)
+    prior.push(step)
+    bytes += step.bytes
+    if (step.isError) {
+      const code = step.code ?? "UNKNOWN"
+      errorsByCode[code] = (errorsByCode[code] ?? 0) + 1
+    }
+  }
+  return {
+    id: scenario.id,
+    title: scenario.title,
+    completed: scenario.completed(prior),
+    calls: prior.length,
+    bytes,
+    tokenEstimate: Math.round(bytes / BYTES_PER_TOKEN),
+    errorsByCode,
+  }
+}
+
+/**
+ * A legible, non-blocking report of a scenario run. This is the point of wiring
+ * the harness into CI as a report first (voyant#3936 acceptance): a journey that
+ * gets slower or starts erroring should be readable in the CI log, not buried in
+ * a boolean pass/fail. Print it whether or not the assertions pass.
+ */
+export function formatJourneyReport(scores: readonly JourneyScore[]): string {
+  const lines = [
+    "agent journey eval — per-scenario scores (voyant#3936)",
+    "  columns: completed | calls | ~tokens (resp bytes/4) | errors",
+  ]
+  for (const score of scores) {
+    const errors = Object.entries(score.errorsByCode)
+    const errorText = errors.length === 0 ? "none" : errors.map(([c, n]) => `${c}×${n}`).join(", ")
+    lines.push(
+      `  ${score.completed ? "✓" : "✗"} ${score.id.padEnd(26)} ` +
+        `calls=${String(score.calls).padStart(2)} ` +
+        `~tokens=${String(score.tokenEstimate).padStart(5)} ` +
+        `errors=${errorText}`,
+    )
+  }
+  const totalTokens = scores.reduce((sum, s) => sum + s.tokenEstimate, 0)
+  const totalCalls = scores.reduce((sum, s) => sum + s.calls, 0)
+  lines.push(
+    `  TOTAL calls=${totalCalls} ~tokens=${totalTokens} ` +
+      `completed=${scores.filter((s) => s.completed).length}/${scores.length}`,
+  )
+  return lines.join("\n")
+}

--- a/starters/operator/tests/agent-journey-real-surface.test.ts
+++ b/starters/operator/tests/agent-journey-real-surface.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Agent journey eval — real-surface grounding (voyant#3936, RFC voyant#3921).
+ *
+ * The scored, act-to-completion journeys live in the mcp package
+ * (`packages/mcp/tests/agent-journey-eval.test.ts`) over a seeded in-memory
+ * backend, so completion is deterministic without a database or a model key.
+ * This companion pins the OTHER half the brief insists on: that the tool names
+ * those journeys drive are the names the REAL selected graph actually serves,
+ * and it records what the discovery half of a journey costs against that real
+ * surface. A previous eval fabricated tool names; this test fails loudly if any
+ * of ours drift out of the registry.
+ *
+ * It measures only the model-free, database-free mechanics — `search_tools`
+ * discovery and `describe_tool` schema fetch — because those are the steps that
+ * pay the real per-tool token cost the #3921 read-projection work (W8) will be
+ * sized to cut. Dispatch to a read handler needs a seeded DB and is covered by
+ * the seeded mcp harness instead. Token estimate is response-bytes ÷ 4 (a floor;
+ * JSON schema tokenizes denser than prose); see the mcp harness docblock.
+ *
+ * Baselines are recorded as named constants with headroom, and the report is
+ * printed to stdout on every run — a discovery journey getting more expensive
+ * should be legible in CI output, non-blocking, until the numbers are trusted
+ * (the ratchet precedent in `selected-graph-mcp-tool-surface.test.ts`).
+ */
+
+import { Buffer } from "node:buffer"
+import { composeVoyantGraphRuntime } from "@voyant-travel/framework"
+import { Hono } from "hono"
+import { beforeAll, describe, expect, it } from "vitest"
+
+import { accessCatalog } from "../.voyant/access/selected-access-catalog.generated"
+import {
+  createGeneratedGraphRuntime,
+  createGeneratedTestDeploymentResources,
+} from "./api/generated-project-runtime.js"
+
+const MCP_HEADERS = {
+  "content-type": "application/json",
+  accept: "application/json, text/event-stream",
+}
+const TEST_ENV = { DATABASE_URL: "postgres://test", VOYANT_API_KEY: "test" } as never
+const TEST_CTX = { waitUntil() {}, passThroughOnException() {} } as never
+
+/** Response-bytes ÷ 4 token proxy — a floor; see the mcp harness docblock. */
+const BYTES_PER_TOKEN = 4
+
+let rpcSequence = 0
+function rpc(method: string, params: unknown) {
+  rpcSequence += 1
+  return {
+    method: "POST",
+    headers: MCP_HEADERS,
+    body: JSON.stringify({ jsonrpc: "2.0", id: rpcSequence, method, params }),
+  }
+}
+
+async function readRpc(res: Response): Promise<Record<string, unknown>> {
+  const text = await res.text()
+  if ((res.headers.get("content-type") ?? "").includes("text/event-stream")) {
+    const line = text.split("\n").find((l) => l.startsWith("data:"))
+    return JSON.parse(line?.slice("data:".length).trim() ?? "{}")
+  }
+  return JSON.parse(text)
+}
+
+/** Mount the selected-graph MCP admin routes behind a full-scope staff key. */
+async function mountSelectedGraphMcp(): Promise<Hono> {
+  const selected = await createGeneratedTestDeploymentResources(createGeneratedGraphRuntime())
+  const composed = await composeVoyantGraphRuntime({
+    runtime: selected.runtime,
+    capabilities: selected.capabilities,
+    ports: selected.ports,
+  })
+  const mcp = composed.modules.find((module) => module.module.name === "mcp")
+  const routes = await mcp?.lazyAdminRoutes?.()
+  if (!routes) throw new Error("selected graph did not expose MCP admin routes")
+
+  const scopes = accessCatalog.resources.flatMap((resource) =>
+    resource.actions.map((action) => `${resource.resource}:${action.action}`),
+  )
+  const app = new Hono()
+  app.use("*", async (c, next) => {
+    c.set("scopes", scopes)
+    c.set("actor", "staff")
+    c.set("audience", "staff")
+    c.set("db", {})
+    await next()
+  })
+  app.route("/", routes)
+  return app
+}
+
+async function callTool(
+  app: Hono,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<{ bytes: number; result: Record<string, unknown> | undefined }> {
+  const body = await readRpc(
+    await app.request("/", rpc("tools/call", { name, arguments: args }), TEST_ENV, TEST_CTX),
+  )
+  const payload = body.result ?? body.error ?? {}
+  return {
+    bytes: Buffer.byteLength(JSON.stringify(payload), "utf8"),
+    result: body.result as Record<string, unknown> | undefined,
+  }
+}
+
+function searchNames(result: Record<string, unknown> | undefined): string[] {
+  const structured = (result as { structuredContent?: { tools?: Array<{ name: string }> } })
+    ?.structuredContent
+  return (structured?.tools ?? []).map(({ name }) => name)
+}
+
+/**
+ * A discovery journey against the real surface: search for a capability by
+ * keyword, then fetch the tool's full descriptor. It completes when the tool the
+ * agent was looking for is both discoverable and describable — the two steps a
+ * real agent takes before it can call anything under progressive disclosure.
+ */
+interface DiscoveryJourney {
+  id: string
+  query: string
+  tool: string
+}
+
+const JOURNEYS: DiscoveryJourney[] = [
+  { id: "discover-list-products", query: "products", tool: "list_products" },
+  { id: "discover-get-product", query: "product", tool: "get_product" },
+  { id: "discover-product-content", query: "product content", tool: "get_product_content" },
+  { id: "discover-list-bookings", query: "bookings", tool: "list_bookings" },
+  { id: "discover-get-booking", query: "booking", tool: "get_booking" },
+  { id: "discover-list-departures", query: "departures", tool: "list_departures" },
+]
+
+interface DiscoveryScore {
+  id: string
+  tool: string
+  completed: boolean
+  found: boolean
+  described: boolean
+  calls: number
+  tokenEstimate: number
+}
+
+async function runDiscovery(app: Hono, journey: DiscoveryJourney): Promise<DiscoveryScore> {
+  const search = await callTool(app, "search_tools", { query: journey.query })
+  const found = searchNames(search.result).includes(journey.tool)
+  const describe = await callTool(app, "describe_tool", { name: journey.tool })
+  const descriptor = (describe.result as { structuredContent?: { inputSchema?: unknown } })
+    ?.structuredContent
+  const described = describe.result?.isError !== true && descriptor?.inputSchema != null
+  return {
+    id: journey.id,
+    tool: journey.tool,
+    completed: found && described,
+    found,
+    described,
+    calls: 2,
+    tokenEstimate: Math.round((search.bytes + describe.bytes) / BYTES_PER_TOKEN),
+  }
+}
+
+function formatReport(scores: readonly DiscoveryScore[]): string {
+  const lines = [
+    "agent journey eval — real-surface discovery (voyant#3936)",
+    "  columns: completed | tool | calls | ~tokens (search + describe, resp bytes/4)",
+  ]
+  for (const s of scores) {
+    lines.push(
+      `  ${s.completed ? "✓" : "✗"} ${s.tool.padEnd(22)} ` +
+        `calls=${s.calls} ~tokens=${String(s.tokenEstimate).padStart(5)}` +
+        (s.completed ? "" : ` [found=${s.found} described=${s.described}]`),
+    )
+  }
+  const total = scores.reduce((sum, s) => sum + s.tokenEstimate, 0)
+  lines.push(
+    `  TOTAL discovery ~tokens=${total} completed=${scores.filter((s) => s.completed).length}/${scores.length}`,
+  )
+  return lines.join("\n")
+}
+
+/**
+ * Non-blocking ceiling for the whole discovery set's token estimate, with
+ * headroom. It is dominated by the `describe_tool` schemas — the exact per-tool
+ * cost the aggregate ratchet in `selected-graph-mcp-tool-surface.test.ts` bounds
+ * and that the read projection (voyant#3932) is meant to cut. Lower it when W8
+ * lands; raise it only with a recorded reason after reading the printed report.
+ *
+ * Measured at authoring: ~48,600 tokens across the six discovery journeys —
+ * dominated by the real per-tool input schemas (get_booking alone is ~12,700).
+ * That is a genuinely large discovery bill and precisely the signal this harness
+ * exists to surface: the read projection (W8) should move it down, not up.
+ */
+const DISCOVERY_TOKEN_CEILING = 62_000
+
+describe("agent journey eval — real selected-graph surface", () => {
+  let scores: DiscoveryScore[] = []
+
+  beforeAll(async () => {
+    const app = await mountSelectedGraphMcp()
+    scores = []
+    for (const journey of JOURNEYS) scores.push(await runDiscovery(app, journey))
+    process.stdout.write(`\n${formatReport(scores)}\n\n`)
+  })
+
+  it("discovers and describes every real tool the seeded journeys drive", () => {
+    // This is the anti-fabrication guard: each name must resolve on the REAL
+    // selected graph, or the seeded mcp harness is testing tools nobody serves.
+    const broken = scores.filter((s) => !s.completed).map((s) => `${s.tool}(${s.id})`)
+    expect(
+      broken,
+      `not discoverable/describable on the real surface: ${broken.join(", ")}`,
+    ).toEqual([])
+  })
+
+  it("keeps discovery token cost under the non-blocking ceiling", () => {
+    const total = scores.reduce((sum, s) => sum + s.tokenEstimate, 0)
+    expect(
+      total,
+      `real-surface discovery cost ${total} tokens exceeded ceiling ${DISCOVERY_TOKEN_CEILING} — ` +
+        "read the printed report; this is what the read projection (W8) should cut.",
+    ).toBeLessThanOrEqual(DISCOVERY_TOKEN_CEILING)
+  })
+})


### PR DESCRIPTION
Closes #3936. Wave 3 of #3921.

Everything else in #3921 changed the MCP surface. Nothing measured whether an agent actually completes work against it. This closes that loop — and immediately produced a finding that **qualifies the headline result**.

## The finding

Progressive disclosure (#3961) cut `tools/list` from ~78,000 tokens to ~735. But it did not delete that cost — it **moved** it from a fixed per-connection charge to a variable per-journey discovery charge.

Measured on the real composed surface:

```
agent journey eval — real-surface discovery
  TOTAL discovery ~tokens=48553 completed=6/6      (~8,000 per journey)
```

So the honest accounting is:

| Session shape | Before #3961 | After #3961 |
|---|---:|---:|
| 1 journey | ~78,700 | **~8,700** |
| 5 journeys | ~78,000 | **~41,000** |
| 10 journeys | ~78,000 | ~80,700 |

A large win for narrow work, shrinking as a session touches more distinct tools, with a crossover around 9-10 journeys. That does not undo the change — most sessions are narrow, and the agent no longer pays for 264 tools it will never call — but *"~210x reduction"* is only true of the connection, not of the work.

**This is exactly what the harness was built to catch**, and it strengthens the case for the two held workstreams: #3932 (read projection) makes discovery cheaper by having fewer, better tools, and residency decisions kill discovery cost entirely for whatever earns a slot.

## What landed

Test-only, no `src` changes.

- `packages/mcp/tests/support/journey-harness.ts` — scoring engine. Scripted `JourneyDriver` returns the next MCP call or `null`; terminal-state predicate; per-`ToolError`-code tally.
- `packages/mcp/tests/agent-journey-eval.test.ts` — 5 scored journeys over an in-process seeded deployment.
- `starters/operator/tests/agent-journey-real-surface.test.ts` — anti-fabrication guard + the real-surface discovery measurement above.

**Model-free by design.** No API key, no database. A test that needs a model key gets disabled within a week and is worse than nothing.

**Non-blocking as specified**: `calls` asserts exact equality, token cost only against a ~1.5x ceiling. The report is written via `process.stdout.write` because vitest suppresses `console.*` on passing files — so the numbers land in CI output rather than only in an assertion nobody reads.

Errors come from `_meta["voyant.travel/error"].code`; JSON-RPC transport errors are labelled `RPC_ERROR` rather than silently dropped.

## Baselines

```
  ✓ discover-then-read-products calls= 3 ~tokens= 1789 errors=none
  ✓ find-product-read-content   calls= 3 ~tokens=  413 errors=none
  ✓ list-bookings-with-filter   calls= 3 ~tokens= 1092 errors=none
  ✓ guide-then-act              calls= 3 ~tokens=  872 errors=none
  ✓ recover-from-bad-input      calls= 3 ~tokens=  422 errors=INVALID_INPUT×1
  TOTAL calls=15 ~tokens=4588 completed=5/5
```

## Which number to watch — this matters

**The 4,588 figure is synthetic.** `agent-journey-eval.test.ts` defines its own tools mirroring the real *names* but with hand-written simplified schemas, so it will **not** move if a real tool's schema balloons. It tracks harness mechanics — call counts, error classification, completion.

**The number to watch for #3932's before/after is 48,553**, from the operator test, which runs against the real composed selected graph.

## Anti-fabrication guard

The operator test asserts each of the 6 tool names is both discoverable via `search_tools` and describable via `describe_tool` on the real graph, failing with the broken names listed. That directly addresses the earlier failure where an agent invented tool names inside an `instructions` string — a scenario suite referencing tools that do not exist would be worse than no suite.

## Verification

```
pnpm -F @voyant-travel/mcp test        Test Files 11 passed   Tests 70 passed
pnpm -F @voyant-travel/mcp typecheck   exit 0
operator real-surface test             Test Files 1 passed    Tests 2 passed
npx biome check .                      repo-wide, 0 errors
node scripts/check-agent-code-quality.mjs | grep packages/mcp/src   # no matches
```

Rebased onto current main (which had moved 3 commits ahead, including the SDK 1.30.0 bump) and re-verified after the rebase, not before.