### PR TITLE
feat(mcp): per-key rate limiting on /v1/admin/mcp

### DIFF
--- a/.changeset/mcp-rate-limiting.md
+++ b/.changeset/mcp-rate-limiting.md
@@ -1,0 +1,18 @@
+---
+"@voyant-travel/mcp": minor
+---
+
+Rate-limit the MCP JSON-RPC endpoint (`/v1/admin/mcp`) per caller. Every request
+is sorted into a `read` bucket (discovery and read-only `tools/call`) or a
+tighter `write` bucket (`tools/call` on a non-`read` tier, a `destructive` risk
+policy, or an action-ledgered capability), keyed independently so a read burst
+never starves writes. Classification reads only existing manifest metadata
+(`tier` / `riskPolicy` / `actionPolicy`).
+
+Limits, the window, the per-caller key derivation, and the backing store are
+deployment-configurable via the new `rateLimit` option on `createMcpApiRoutes`
+and `createGraphMcpApiRoutes` (pass `false` to disable); they default to safe
+values (120 reads and 20 writes per key per minute). Exposes
+`createMcpRateLimiter`, `isRestrictedTool`, `DEFAULT_MCP_RATE_LIMIT`, and the
+`McpRateLimitOptions` / `McpRateLimitBucket` types. This wires the previously
+unused `hono-rate-limiter` dependency.

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,4 +1,11 @@
 export {
+  createMcpRateLimiter,
+  DEFAULT_MCP_RATE_LIMIT,
+  isRestrictedTool,
+  type McpRateLimitBucket,
+  type McpRateLimitOptions,
+} from "./rate-limit.js"
+export {
   DEFAULT_RESPONSE_BUDGET_BYTES,
   isListShapedOutput,
   RESPONSE_FORMAT_FIELD,

--- a/packages/mcp/src/rate-limit.ts
+++ b/packages/mcp/src/rate-limit.ts
@@ -1,0 +1,139 @@
+/**
+ * Per-key rate limiting for the MCP JSON-RPC endpoint (voyant#3935).
+ *
+ * `/v1/admin/mcp` exposes the whole selected tool surface — including
+ * destructive and action-ledgered tools — to autonomous agent clients that
+ * retry automatically on failure. Without a throttle, a stuck agent can hammer
+ * an irreversible, externally-committing tool as fast as the transport allows.
+ *
+ * The throttle is intentionally risk-aware. Every request is sorted into one of
+ * two buckets, keyed independently so they never share a counter:
+ * - `read` — discovery (`initialize`, `tools/list`) and `tools/call` on a
+ *   read-only tool. Loose limit.
+ * - `write` — `tools/call` on a tool that is anything other than a pure read:
+ *   a non-`read` {@link ToolManifestEntry.tier}, a `destructive` risk policy, or
+ *   an action-ledgered capability (`actionPolicy`). Tight limit.
+ *
+ * The classification reads only manifest metadata already carried by the
+ * registry (`tier` / `riskPolicy` / `actionPolicy`) — it invents no new
+ * taxonomy. Limits and the window are deployment-configurable with safe
+ * defaults; the deployment can also swap the key derivation or the backing
+ * store (e.g. a shared `RedisStore` across instances).
+ */
+
+import type { ToolManifestEntry, ToolRegistry } from "@voyant-travel/tools"
+import type { Context, MiddlewareHandler } from "hono"
+import { MemoryStore, rateLimiter, type Store } from "hono-rate-limiter"
+
+/** The two throttle buckets, keyed apart so a read burst never starves writes. */
+export type McpRateLimitBucket = "read" | "write"
+
+/** Deployment-tunable limits for the MCP endpoint. All fields are optional. */
+export interface McpRateLimitOptions {
+  /** Sliding window length in milliseconds. Defaults to 60_000 (one minute). */
+  windowMs?: number
+  /** Max discovery / read `tools/call` requests per key per window. Defaults to 120. */
+  readLimit?: number
+  /** Max write / destructive / ledgered `tools/call` requests per key per window. Defaults to 20. */
+  writeLimit?: number
+  /**
+   * Derive the per-caller identity a limit applies to. Defaults to the
+   * authenticated API key / token id, falling back to the actor and then to a
+   * single shared bucket for unidentified callers.
+   */
+  keyGenerator?: (c: Context) => string
+  /** Backing hit-count store. Defaults to an in-process {@link MemoryStore}. */
+  store?: Store
+}
+
+/** Safe defaults applied when a deployment does not override a field. */
+export const DEFAULT_MCP_RATE_LIMIT = {
+  windowMs: 60_000,
+  readLimit: 120,
+  writeLimit: 20,
+} as const
+
+/**
+ * A tool is throttled on the tight `write` bucket when it is anything other than
+ * a pure read: a non-`read` tier, a destructive risk policy, or an
+ * action-ledgered capability. Reads fall through to the loose bucket.
+ */
+export function isRestrictedTool(entry: ToolManifestEntry): boolean {
+  return (
+    entry.tier !== "read" ||
+    entry.riskPolicy.destructive === true ||
+    entry.actionPolicy !== undefined
+  )
+}
+
+/** Default caller identity: the API key/token id, then the actor, then a shared key. */
+function defaultKeyGenerator(c: Context): string {
+  const vars = c.var as {
+    apiKeyId?: unknown
+    apiTokenId?: unknown
+    actor?: unknown
+  }
+  for (const candidate of [vars.apiKeyId, vars.apiTokenId, vars.actor]) {
+    if (typeof candidate === "string" && candidate.length > 0) return candidate
+  }
+  return "anonymous"
+}
+
+/**
+ * Build the set of invocation names (including aliases) that must be throttled
+ * on the write bucket. Classification is caller-independent, so it is computed
+ * once when the middleware is created.
+ */
+function restrictedNames(registry: ToolRegistry): ReadonlySet<string> {
+  const names = new Set<string>()
+  for (const entry of registry.list()) {
+    if (!isRestrictedTool(entry)) continue
+    names.add(entry.name)
+    for (const alias of entry.aliases) names.add(alias)
+  }
+  return names
+}
+
+/** Classify the JSON-RPC request into a bucket, reading only the cached body. */
+async function bucketFor(c: Context, restricted: ReadonlySet<string>): Promise<McpRateLimitBucket> {
+  try {
+    const body = (await c.req.json()) as {
+      method?: unknown
+      params?: { name?: unknown }
+    }
+    if (body?.method === "tools/call") {
+      const name = body.params?.name
+      if (typeof name === "string" && restricted.has(name)) return "write"
+    }
+  } catch {
+    // A malformed body is rejected downstream by the route validator; treat it
+    // as a read for throttling so a parse slip cannot bypass the tighter bucket.
+  }
+  return "read"
+}
+
+/**
+ * Middleware that rate-limits the MCP JSON-RPC endpoint per caller, with a
+ * tighter bucket for write/destructive/ledgered tool calls than for reads. A
+ * single limiter instance backs both buckets — the bucket is folded into the
+ * key so their counters stay separate — and the per-request limit is chosen
+ * from the classified bucket.
+ */
+export function createMcpRateLimiter(
+  registry: ToolRegistry,
+  options: McpRateLimitOptions = {},
+): MiddlewareHandler {
+  const windowMs = options.windowMs ?? DEFAULT_MCP_RATE_LIMIT.windowMs
+  const readLimit = options.readLimit ?? DEFAULT_MCP_RATE_LIMIT.readLimit
+  const writeLimit = options.writeLimit ?? DEFAULT_MCP_RATE_LIMIT.writeLimit
+  const identify = options.keyGenerator ?? defaultKeyGenerator
+  const restricted = restrictedNames(registry)
+
+  return rateLimiter({
+    windowMs,
+    store: options.store ?? new MemoryStore(),
+    standardHeaders: "draft-6",
+    keyGenerator: async (c) => `${await bucketFor(c, restricted)}:${identify(c)}`,
+    limit: async (c) => ((await bucketFor(c, restricted)) === "write" ? writeLimit : readLimit),
+  })
+}

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -54,6 +54,7 @@ import {
   jsonByteLength,
   type McpObserver,
 } from "./observability.js"
+import { createMcpRateLimiter } from "./rate-limit.js"
 import { registerMcpTool } from "./register.js"
 import { DEFAULT_RESPONSE_BUDGET_BYTES } from "./response-budget.js"
 import type { GraphMcpApiRoutesOptions, McpApiRoutesOptions, McpServerInfo } from "./types.js"
@@ -110,6 +111,12 @@ export function createMcpApiRoutes(options: McpApiRoutesOptions): OpenAPIHono {
   const { accessCatalog, registry, buildContext } = options
   const serverInfo = options.serverInfo ?? DEFAULT_SERVER_INFO
   const app = new OpenAPIHono()
+
+  // Throttle the JSON-RPC endpoint per caller before it can reach dispatch, with
+  // a tighter bucket for write/destructive/ledgered calls than for reads.
+  if (options.rateLimit !== false) {
+    app.use(callMcpRoute.path, createMcpRateLimiter(registry, options.rateLimit ?? {}))
+  }
 
   /**
    * Resolve the telemetry sink, preferring an explicitly configured reporter and
@@ -457,6 +464,7 @@ export async function createGraphMcpApiRoutes(
     ...(options.responseBudgetBytes !== undefined
       ? { responseBudgetBytes: options.responseBudgetBytes }
       : {}),
+    ...(options.rateLimit !== undefined ? { rateLimit: options.rateLimit } : {}),
     buildContext: (c) => buildContributedContext(c, options, contributions.values()),
   })
 }

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -9,6 +9,8 @@ import type { ToolContext, ToolRegistry } from "@voyant-travel/tools"
 import type { AccessCatalog } from "@voyant-travel/types/api-keys"
 import type { Context } from "hono"
 
+import type { McpRateLimitOptions } from "./rate-limit.js"
+
 export interface McpServerInfo {
   name: string
   version: string
@@ -42,6 +44,12 @@ export interface McpApiRoutesOptions {
    * defaults to `DEFAULT_RESPONSE_BUDGET_BYTES` (~24 KB).
    */
   responseBudgetBytes?: number
+  /**
+   * Per-key rate limiting for the JSON-RPC endpoint. Enabled with safe defaults
+   * (see {@link McpRateLimitOptions}); pass `false` to disable, or an object to
+   * tune the window, limits, key derivation, or backing store.
+   */
+  rateLimit?: McpRateLimitOptions | false
 }
 
 export interface GraphMcpApiRoutesOptions {
@@ -59,6 +67,8 @@ export interface GraphMcpApiRoutesOptions {
   appName?: string
   /** Serialized byte ceiling for a single tool response (voyant#3928). */
   responseBudgetBytes?: number
+  /** Per-key rate limiting for the JSON-RPC endpoint. See {@link McpApiRoutesOptions.rateLimit}. */
+  rateLimit?: McpRateLimitOptions | false
 }
 
 export type GraphMcpRuntime = VoyantGraphRuntime

--- a/packages/mcp/tests/rate-limit.test.ts
+++ b/packages/mcp/tests/rate-limit.test.ts
@@ -1,0 +1,190 @@
+import {
+  createToolRegistry,
+  defineTool,
+  READ_ONLY_RISK,
+  type ToolContext,
+} from "@voyant-travel/tools"
+import { Hono } from "hono"
+import { describe, expect, it } from "vitest"
+import { z } from "zod"
+
+import { createMcpApiRoutes } from "../src/index.js"
+import { isRestrictedTool } from "../src/rate-limit.js"
+
+const accessCatalog = {
+  resources: [
+    {
+      id: "catalog",
+      unitId: "@voyant-travel/catalog",
+      resource: "catalog",
+      label: "Catalog",
+      description: "Catalog",
+      wildcard: "allow" as const,
+      actions: [{ action: "read", label: "Read", description: "Read" }],
+    },
+    {
+      id: "records",
+      unitId: "@voyant-travel/test",
+      resource: "records",
+      label: "Records",
+      description: "Test records",
+      wildcard: "allow" as const,
+      actions: [
+        { action: "read", label: "Read", description: "Read records" },
+        { action: "write", label: "Write", description: "Write records" },
+      ],
+    },
+  ],
+  presets: [],
+}
+
+const MCP_HEADERS = {
+  "content-type": "application/json",
+  accept: "application/json, text/event-stream",
+}
+
+function rpc(method: string, params: unknown, id: number | string = 1) {
+  return {
+    method: "POST",
+    headers: MCP_HEADERS,
+    body: JSON.stringify({ jsonrpc: "2.0", id, method, params }),
+  }
+}
+
+const echoTool = defineTool({
+  capabilityId: "@voyant-travel/test#tool.echo",
+  owner: "@voyant-travel/test",
+  capabilityVersion: "v2",
+  name: "echo",
+  description: "Echo the text back.",
+  inputSchema: z.object({ text: z.string() }),
+  outputSchema: z.object({ text: z.string() }),
+  requiredScopes: ["catalog:read"],
+  audience: { source: "grant", allowed: ["staff"] },
+  tier: "read",
+  riskPolicy: READ_ONLY_RISK,
+  async handler({ text }) {
+    return { text: `echo: ${text}` }
+  },
+})
+
+const deleteRecordTool = defineTool({
+  name: "delete_record",
+  description: "Irreversibly delete a record.",
+  inputSchema: z.object({ id: z.string().min(1) }),
+  outputSchema: z.object({ id: z.string() }),
+  requiredScopes: ["records:write"],
+  audience: { source: "grant", allowed: ["staff"] },
+  tier: "destructive",
+  riskPolicy: {
+    destructive: true,
+    reversible: false,
+    dryRunSupported: false,
+    sideEffects: ["data-delete"],
+  },
+  async handler({ id }) {
+    return { id }
+  },
+})
+
+function buildContext(): ToolContext {
+  return {
+    db: {},
+    actor: "staff",
+    audience: "staff",
+    tenantId: "t1",
+    resolverScope: { locale: "en-GB", audience: "staff", market: "default", actor: "staff" },
+  }
+}
+
+/** Mount the MCP app, seeding granted scopes and a stable per-caller key. */
+function app(options: {
+  readLimit?: number
+  writeLimit?: number
+  rateLimit?: false
+  apiKeyId?: string
+}): Hono {
+  const registry = createToolRegistry()
+  registry.register(echoTool)
+  registry.register(deleteRecordTool)
+  const mcp = createMcpApiRoutes({
+    accessCatalog,
+    registry,
+    buildContext,
+    ...(options.rateLimit === false
+      ? { rateLimit: false as const }
+      : {
+          rateLimit: {
+            ...(options.readLimit !== undefined ? { readLimit: options.readLimit } : {}),
+            ...(options.writeLimit !== undefined ? { writeLimit: options.writeLimit } : {}),
+          },
+        }),
+  })
+
+  const outer = new Hono()
+  outer.use("*", async (c, next) => {
+    c.set("scopes", ["catalog:read", "records:write"])
+    c.set("apiKeyId", options.apiKeyId ?? "key-a")
+    await next()
+  })
+  outer.route("/", mcp)
+  return outer
+}
+
+const echoCall = rpc("tools/call", { name: "echo", arguments: { text: "hi" } })
+const deleteCall = rpc("tools/call", { name: "delete_record", arguments: { id: "r1" } })
+
+describe("isRestrictedTool", () => {
+  it("treats reads as unrestricted and non-reads as restricted", () => {
+    const registry = createToolRegistry()
+    registry.register(echoTool)
+    registry.register(deleteRecordTool)
+    const byName = new Map(registry.list().map((entry) => [entry.name, entry]))
+    expect(isRestrictedTool(byName.get("echo")!)).toBe(false)
+    expect(isRestrictedTool(byName.get("delete_record")!)).toBe(true)
+  })
+})
+
+describe("createMcpRateLimiter middleware", () => {
+  it("throttles read calls after the read limit and returns 429", async () => {
+    const server = app({ readLimit: 2, writeLimit: 10 })
+    expect((await server.request("/", echoCall)).status).toBe(200)
+    expect((await server.request("/", echoCall)).status).toBe(200)
+    const limited = await server.request("/", echoCall)
+    expect(limited.status).toBe(429)
+  })
+
+  it("throttles destructive/ledgered calls tighter than reads", async () => {
+    const server = app({ readLimit: 100, writeLimit: 1 })
+    expect((await server.request("/", deleteCall)).status).toBe(200)
+    const limited = await server.request("/", deleteCall)
+    expect(limited.status).toBe(429)
+    // The read bucket is independent and still has plenty of budget.
+    expect((await server.request("/", echoCall)).status).toBe(200)
+  })
+
+  it("keeps read and write buckets on separate counters", async () => {
+    const server = app({ readLimit: 1, writeLimit: 1 })
+    expect((await server.request("/", echoCall)).status).toBe(200)
+    // A read at its limit must not consume the write budget.
+    expect((await server.request("/", deleteCall)).status).toBe(200)
+    expect((await server.request("/", echoCall)).status).toBe(429)
+    expect((await server.request("/", deleteCall)).status).toBe(429)
+  })
+
+  it("limits each caller key independently", async () => {
+    const first = app({ readLimit: 1, apiKeyId: "key-a" })
+    const second = app({ readLimit: 1, apiKeyId: "key-b" })
+    expect((await first.request("/", echoCall)).status).toBe(200)
+    expect((await first.request("/", echoCall)).status).toBe(429)
+    // A different key starts with a fresh budget.
+    expect((await second.request("/", echoCall)).status).toBe(200)
+  })
+
+  it("does not throttle when rate limiting is disabled", async () => {
+    const server = app({ rateLimit: false })
+    for (let i = 0; i < 10; i++) {
+      expect((await server.request("/", echoCall)).status).toBe(200)
+    }
+  })
+})


### PR DESCRIPTION
Closes #3935. The last unlanded piece of Wave 1.

`hono-rate-limiter` was a **declared dependency of `packages/mcp` that nothing imported**:

```sh
grep -rn "rate-limiter\|rateLimit" packages/mcp/src packages/mcp/tests   # no matches
```

So the JSON-RPC endpoint exposed the entire tool surface — including destructive, ledgered tools — with **no throttle**, to a caller class that retries automatically on failure.

## Design

Two buckets **keyed apart**, so a read burst cannot starve writes.

Classification reuses metadata the manifest already carries rather than inventing a taxonomy:

```ts
export function isRestrictedTool(entry: ToolManifestEntry): boolean {
  return (
    entry.tier !== "read" ||
    entry.riskPolicy.destructive === true ||
    entry.actionPolicy !== undefined
  )
}
```

Aliases fold into the same bucket as their canonical name. Window, limits, key derivation, and store are deployment-configurable — the store hook lets a multi-instance deployment supply a shared one rather than rate limiting per process. Defaults: **120 reads / 20 writes per key per minute**.

The middleware sits **ahead of dispatch**, so it throttles before the meta-tools resolve a name.

## Rebase

This branch was authored before progressive disclosure (#3961), the guide layer (#3967), and response budgets (#3970) landed, and conflicted with all three in `server.ts`, `types.ts`, and `index.ts`. All conflicts were additive — both sides adding distinct options — and were resolved by hand rather than by a merge tool, then re-verified.

## Known cost, worth a look

`bucketFor` calls `c.req.json()` in middleware to classify the call. Hono caches the parse so nothing downstream re-reads it, but it does mean **the JSON-RPC body is parsed before the limit decision** — an unauthenticated flood still pays parsing cost before being rejected.

The clean fix is the `Mcp-Method` / `Mcp-Name` headers from the 2026-07-28 spec, which let the limiter classify without touching the body. That is recorded as feature 4 in `docs/architecture/mcp-2026-07-28-spec-adoption.md` (#3973), pending SDK support.

## Verification

```
pnpm -F @voyant-travel/mcp test        Test Files 11 passed   Tests 72 passed
pnpm -F @voyant-travel/mcp typecheck   exit 0
npx biome check .                      repo-wide, 0 errors
node scripts/check-agent-code-quality.mjs | grep packages/mcp/src   # no matches
```

All verified after the rebase, not before. No unused dependency remains in `packages/mcp/package.json`.