### PR TITLE
feat(mcp): collapse 133 read tools into 24 per-domain query tools

### DIFF
--- a/.changeset/mcp-layered-read-projection.md
+++ b/.changeset/mcp-layered-read-projection.md
@@ -1,0 +1,31 @@
+---
+"@voyant-travel/mcp": minor
+---
+
+Collapse the read tool surface into per-domain query tools (layered read
+projection, voyant#3932).
+
+**Breaking change.** The ~133 flat read tools (`get_*`, `list_*`, `search_*`)
+are removed as individually discoverable or callable MCP tools. Each domain's
+reads are now reached through one `<domain>_query` tool whose input is a
+discriminated union on `resource` — `inventory_query({ resource: "products",
+… })`, `bookings_query({ resource: "booking", bookingId })`. The projection is
+pure transport-layer: no domain `tools.ts` changed, grouping is derived from the
+`owner` each `ToolManifestEntry` already carries.
+
+Scope filtering prunes resources WITHIN a group, so an unauthorized read is
+neither a discoverable resource nor a callable one — its query tool simply omits
+it, and a group with no authorized read never appears. Writes are NOT collapsed:
+their per-action risk, confirmation, ledger and approval policy stay one Tool
+each. `GET /v1/admin/mcp/manifest` stays fine-grained — it is the capability
+index, not the agent surface.
+
+Migration: replace a flat read call `list_products({ status })` with
+`inventory_query({ resource: "products", status })`; discover the query tool for
+a record with `search_tools` (search the record noun, e.g. `products`,
+`bookings`) and read its discriminated-union schema with `describe_tool`.
+
+This measurably lowers agent discovery cost on the real composed graph: the
+six-journey real-surface discovery eval drops from ~48,553 to ~36,974 tokens,
+and the aggregate describe schema of the read surface falls from ~433,234 to
+~115,559 bytes.

--- a/packages/mcp/src/guide.ts
+++ b/packages/mcp/src/guide.ts
@@ -53,22 +53,21 @@ export function buildServerInstructions(scope: GuideScope): string {
     ? "This key can read catalog and booking data and invoke state-changing Tools (subject to per-Tool scopes and the confirmation protocol below)."
     : "This key is READ-ONLY: it can list and read, but the create/update/publish/book Tools below are not reachable with it. Ignore write instructions."
   return [
-    "This MCP server is the admin surface of a Voyant deployment — an online travel",
-    "agency, tour-operator, and destination-management platform. Through it you can",
-    "discover and operate the operator's catalog (Products, Options, and dated",
-    "departures/Slots), the sales pipeline (Quotes and Quote Versions), Bookings and",
-    "their Travelers, and downstream Invoices and Payments.",
+    "This MCP server is the admin surface of a Voyant deployment — an online travel agency, tour-operator, and destination-management platform. Through it you can discover and operate the operator's catalog (Products, Options, and dated departures/Slots), the sales pipeline (Quotes and Quote Versions), Bookings and their Travelers, and downstream Invoices and Payments.",
     "",
     access,
     "",
     "HOW TO DISCOVER CAPABILITIES",
-    "Every capability is one MCP Tool. Enumerate them with `tools/list`, or fetch the",
-    "authorization-filtered contract from `GET /v1/admin/mcp/manifest`. Tool names use",
-    "the domain vocabulary: verbs `get`/`list`/`search`/`create`/`update` over nouns",
-    "like `product`, `option_unit`, `departure`, `quote`, `quote_version`, `booking`,",
-    "`invoice`. So to read products, scan for `get_product`/`list_products`; for dated",
-    "departures, `list_departures`. Travelers are reached through their booking record,",
-    "not a standalone traveler CRUD tool.",
+    "The surface is discovered on demand: `search_tools` finds a tool by keyword,",
+    "`describe_tool` returns its full input schema, and `GET /v1/admin/mcp/manifest` is",
+    "the authorization-filtered capability index; the eager `tools/list` carries only",
+    "these meta-tools and the guide. READS are grouped by product area into one",
+    "`<domain>_query` tool (a discriminated union on `resource`): read products with",
+    '`inventory_query` (`resource: "products"`/`"product"`), dated departures with',
+    '`operations_query` (`resource: "departures"`) — search the record noun (`products`,',
+    "`bookings`, `departures`) to find its query tool. Travelers are read through their",
+    "booking record, not a standalone tool. WRITES stay one Tool each (verb-first, e.g.",
+    "`create_booking`, `publish_product`) so their per-action policy stays explicit.",
     "",
     "START WITH THE GUIDE TOOLS",
     `Call \`voyant_guide\` (topics: ${GUIDE_TOPICS.join(", ")}) for the booking`,
@@ -201,29 +200,30 @@ function overviewSection(scope: GuideScope): string {
 function discoverySection(): string {
   return (
     "# Discovering capabilities\n\n" +
-    "Every capability is exactly one MCP Tool; there is no hidden RPC. To find one:\n\n" +
-    "1. Enumerate the served Tools with `tools/list`, or fetch the " +
-    "authorization-filtered contract from `GET /v1/admin/mcp/manifest`. The manifest " +
-    "carries each Tool's `requiredScopes` and risk, so you can see what a key can do " +
+    "The surface is discovered on demand. `tools/list` carries only the meta-tools " +
+    "(`search_tools`, `describe_tool`, `call_tool`) and this guide; every domain " +
+    "capability is found through them or the `GET /v1/admin/mcp/manifest` capability " +
+    "index. To find one:\n\n" +
+    "1. `search_tools { query }` returns matching tool names and one-line descriptions; " +
+    "`describe_tool { name }` returns a tool's full input schema. The manifest carries " +
+    "each capability's `requiredScopes` and risk, so you can see what a key can do " +
     "before calling.\n" +
-    "2. Tool names are `verb_noun` in domain vocabulary. Verbs: `get`, `list`, " +
-    "`search`, `create`, `update`, and lifecycle verbs like `publish`/`archive`. " +
-    "Nouns are the domain terms — `product`, `option`, `option_unit`, `departure`, " +
-    "`quote`, `quote_version`, `booking`, `invoice`. The domain term Slot (a concrete " +
-    "dated inventory unit) surfaces in the tool surface as `departure`.\n\n" +
-    "Example lookups, using our vocabulary:\n" +
-    "- Read the catalog → `list_products`, `get_product`.\n" +
-    "- Find dated departures for a Product → `list_departures`, `get_departure`.\n" +
-    "- Work a sales pursuit → `get_quote`, and the Quote Version Tools.\n" +
-    "- Inspect a commitment → `get_booking` (its Travelers and Items are part of the " +
-    "booking record, not separate traveler read Tools).\n\n" +
-    "Only Tools your key is authorized for are listed or callable; a call to a Tool " +
-    "outside your scopes fails as if it did not exist. Each Tool validates its own " +
-    "input and returns typed pure data, so read its `inputSchema` before calling.\n\n" +
-    "(Forward note: a `search_tools` discovery entry point is planned so this surface " +
-    "can shrink to a few meta-Tools — voyant#3927. Until it ships on this deployment, " +
-    "`tools/list` and the manifest are the discovery entry points, and this guide " +
-    "will not name a Tool that is not actually served.)"
+    "2. READS are collapsed by product area into one `<domain>_query` tool whose input " +
+    "is a discriminated union on `resource`. Set `resource` to the record you want and " +
+    "pass that resource's own arguments. Resources use the domain nouns — `product`, " +
+    "`option_unit`, `departure`, `quote`, `quote_version`, `booking`, `invoice` (the " +
+    "domain term Slot surfaces as the `departures` resource).\n" +
+    "3. WRITES stay one Tool each, named `verb_noun` (`create`/`update`/`publish` …), " +
+    "so their action policy stays explicit.\n\n" +
+    'Example lookups: catalog → `inventory_query` (`resource: "products"`/`"product"`); ' +
+    'dated departures → `operations_query` (`resource: "departures"`); sales pursuit → ' +
+    "`quotes_query` (`quote`/`quote_version`); a commitment → `bookings_query` " +
+    '(`resource: "booking"` — its Travelers and Items are part of the booking record, ' +
+    "not separate traveler reads).\n\n" +
+    "Only tools your key is authorized for are discoverable or callable; an " +
+    "unauthorized resource is pruned from its query tool and a call to it fails as if " +
+    "it did not exist. Each read validates its own input and returns typed pure data, " +
+    "so read the query tool's `inputSchema` before calling."
   )
 }
 

--- a/packages/mcp/src/meta-tools.ts
+++ b/packages/mcp/src/meta-tools.ts
@@ -30,9 +30,18 @@ import { isAuthorized } from "./authorization.js"
 import { dispatchToResult } from "./dispatch.js"
 import { isRecord } from "./guards.js"
 import type { McpCaller, McpCallOutcome, McpObserver } from "./observability.js"
+import {
+  advertiseQueryTool,
+  dispatchQueryTool,
+  queryToolDescription,
+  type ReadProjection,
+  toolDomain,
+} from "./read-projection.js"
 import { toMcpMeta } from "./register.js"
 import { DEFAULT_RESPONSE_BUDGET_BYTES, isListShapedOutput } from "./response-budget.js"
 import { toMcpInputSchema, toMcpOutputContract } from "./schema-projection.js"
+
+export { toolDomain } from "./read-projection.js"
 
 /** The eager tier-0 meta-tool names, reserved so a domain tool can never shadow one. */
 export const SEARCH_TOOLS_NAME = "search_tools"
@@ -100,14 +109,6 @@ export function selectEagerToolNames(
   return eager
 }
 
-/** The domain slug a tool belongs to, derived from its owning package. */
-export function toolDomain(entry: ToolManifestEntry): string {
-  const owner = entry.owner ?? ""
-  const withoutScope = owner.replace(/^@[^/]+\//, "")
-  const base = withoutScope.split("#")[0] ?? withoutScope
-  return base.length > 0 ? base : withoutScope
-}
-
 /**
  * The descriptor a caller would have seen in `tools/list` for one tool: name,
  * description, the projected input schema, the output contract, annotations, and
@@ -147,6 +148,8 @@ export interface RegisterMetaToolsInput {
   server: McpServer
   registry: ToolRegistry
   surface: AuthorizedSurface
+  /** The read projection: per-domain query tools that stand in for the flat reads. */
+  projection: ReadProjection
   ctx: ToolContext
   requireActionPolicy: boolean
   observer: McpObserver
@@ -163,14 +166,16 @@ export function registerMetaTools(input: RegisterMetaToolsInput): void {
   registerCallTool(input)
 }
 
-function registerSearchTools({ server, surface }: RegisterMetaToolsInput): void {
+function registerSearchTools({ server, surface, projection }: RegisterMetaToolsInput): void {
   server.registerTool(
     SEARCH_TOOLS_NAME,
     {
       description:
-        "Find domain tools by keyword and/or domain. Returns names and one-line " +
-        "descriptions only — call describe_tool for a tool's full input schema, then " +
-        "call_tool (or the flat tool name) to run it.",
+        "Find tools by keyword and/or domain. Reads are grouped into one " +
+        "`<domain>_query` tool per product area — search for the record you want " +
+        "(e.g. `products`, `bookings`) to find its query tool. Returns names and " +
+        "one-line descriptions only — call describe_tool for a tool's full input " +
+        "schema, then call_tool (or the flat tool name) to run it.",
       inputSchema: z.object({
         query: z.string().trim().optional(),
         domain: z.string().trim().optional(),
@@ -178,12 +183,57 @@ function registerSearchTools({ server, surface }: RegisterMetaToolsInput): void 
       }),
       annotations: { readOnlyHint: true, openWorldHint: false },
     },
-    (args) => searchTools(surface, args),
+    (args) => searchTools(surface, projection, args),
   )
+}
+
+interface SearchCandidate {
+  name: string
+  description: string
+  domain: string
+  tier: string
+  /** Extra identity terms (a query tool's resource names) that rank like the name. */
+  keywords?: readonly string[]
+}
+
+/**
+ * The discoverable surface: the per-domain query tools plus every non-read tool.
+ * The flat reads are folded into their query tool, so they never appear here.
+ */
+function discoverableCandidates(
+  surface: AuthorizedSurface,
+  projection: ReadProjection,
+): SearchCandidate[] {
+  const candidates: SearchCandidate[] = []
+  for (const queryTool of projection.queryTools.values()) {
+    candidates.push({
+      name: queryTool.name,
+      description: queryToolDescription(queryTool),
+      domain: queryTool.domain,
+      tier: "read",
+      // A query tool is named `<domain>_query`, so a search for the record noun
+      // (`products`, `booking`) would only hit its description and rank below the
+      // write tools that carry the noun in their name. Rank it by its resources so
+      // the noun surfaces the read entry point, not a wall of writes.
+      keywords: queryTool.resources.map((member) => member.resource),
+    })
+  }
+  for (const [name, { entry, aliasFor }] of surface) {
+    if (aliasFor) continue
+    if (projection.hiddenReadNames.has(name)) continue
+    candidates.push({
+      name,
+      description: entry.description,
+      domain: toolDomain(entry),
+      tier: entry.tier,
+    })
+  }
+  return candidates
 }
 
 function searchTools(
   surface: AuthorizedSurface,
+  projection: ReadProjection,
   args: { query?: string; domain?: string; limit?: number },
 ): CallToolResult {
   const query = args.query?.toLowerCase().trim() ?? ""
@@ -191,27 +241,12 @@ function searchTools(
   const domain = args.domain?.toLowerCase().trim()
   const limit = Math.min(args.limit ?? DEFAULT_SEARCH_LIMIT, MAX_SEARCH_LIMIT)
 
-  const matches: Array<{
-    name: string
-    description: string
-    domain: string
-    tier: string
-    score: number
-  }> = []
-  // Iterate canonical entries only; aliases are folded into their canonical name.
-  for (const [name, { entry, aliasFor }] of surface) {
-    if (aliasFor) continue
-    const toolDomainSlug = toolDomain(entry)
-    if (domain && toolDomainSlug.toLowerCase() !== domain) continue
-    const haystack = `${name} ${entry.description} ${toolDomainSlug}`.toLowerCase()
+  const matches: Array<SearchCandidate & { score: number }> = []
+  for (const candidate of discoverableCandidates(surface, projection)) {
+    if (domain && candidate.domain.toLowerCase() !== domain) continue
+    const haystack = `${candidate.name} ${candidate.description} ${candidate.domain}`.toLowerCase()
     if (terms.length > 0 && !terms.every((term) => haystack.includes(term))) continue
-    matches.push({
-      name,
-      description: entry.description,
-      domain: toolDomainSlug,
-      tier: entry.tier,
-      score: scoreMatch(name, terms),
-    })
+    matches.push({ ...candidate, score: scoreCandidate(candidate, terms) })
   }
 
   matches.sort((a, b) => b.score - a.score || a.name.localeCompare(b.name))
@@ -237,27 +272,72 @@ function scoreMatch(name: string, terms: readonly string[]): number {
   return 1
 }
 
-function registerDescribeTool({ server, registry, surface }: RegisterMetaToolsInput): void {
+/**
+ * Score a candidate by the best of its name and its identity keywords (a query
+ * tool's resource names), so a search for a record noun ranks the query tool as
+ * highly as a write tool that carries the noun in its own name.
+ */
+function scoreCandidate(candidate: SearchCandidate, terms: readonly string[]): number {
+  let best = scoreMatch(candidate.name, terms)
+  for (const keyword of candidate.keywords ?? []) {
+    best = Math.max(best, scoreMatch(keyword, terms))
+    if (best === 3) break
+  }
+  return best
+}
+
+function registerDescribeTool({
+  server,
+  registry,
+  surface,
+  projection,
+}: RegisterMetaToolsInput): void {
   server.registerTool(
     DESCRIBE_TOOL_NAME,
     {
       description:
         "Return the full input schema, output contract, and metadata for one tool " +
-        "by name. Use the names returned by search_tools.",
+        "by name. Use the names returned by search_tools. For a `<domain>_query` tool " +
+        "the input schema is a discriminated union on `resource`.",
       inputSchema: z.object({ name: z.string().trim().min(1) }),
       annotations: { readOnlyHint: true, openWorldHint: false },
     },
-    (args) => describeTool(registry, surface, args.name),
+    (args) => describeTool(registry, surface, projection, args.name),
   )
 }
 
 function describeTool(
   registry: ToolRegistry,
   surface: AuthorizedSurface,
+  projection: ReadProjection,
   name: string,
 ): CallToolResult {
+  const queryTool = projection.queryToolFor(name)
+  if (queryTool) {
+    try {
+      const descriptor = advertiseQueryTool(registry, queryTool)
+      // A query tool's descriptor is the union of every resource's schema — the
+      // largest describe payload on the surface. Carry it once, in
+      // `structuredContent`, and keep the human-readable `content` channel a short
+      // pointer rather than a second pretty-printed copy (voyant#3932); the doubled
+      // copy was the single biggest line in the discovery bill.
+      const resources = queryTool.resources.map((member) => member.resource).join(", ")
+      return {
+        content: [
+          {
+            type: "text",
+            text: `${queryTool.name}: set "resource" to one of ${resources}. Full schema in structuredContent.`,
+          },
+        ],
+        structuredContent: descriptor,
+      }
+    } catch (err) {
+      return errorResult(err)
+    }
+  }
   const binding = surface.get(name)
-  if (!binding) return unknownToolResult(name)
+  // A flat read name is folded into its query tool and no longer describable.
+  if (!binding || projection.hiddenReadNames.has(name)) return unknownToolResult(name)
   try {
     const descriptor = advertiseTool(registry, binding.entry, name, binding.aliasFor)
     return {
@@ -270,14 +350,16 @@ function describeTool(
 }
 
 function registerCallTool(input: RegisterMetaToolsInput): void {
-  const { server, registry, surface, ctx, requireActionPolicy, observer, caller, now } = input
+  const { server, registry, surface, projection, ctx, requireActionPolicy, observer, caller, now } =
+    input
   const budgetBytes = input.budgetBytes ?? DEFAULT_RESPONSE_BUDGET_BYTES
   server.registerTool(
     CALL_TOOL_NAME,
     {
       description:
         "Dispatch a tool discovered through search_tools / describe_tool. Pass the " +
-        "tool name and its arguments object; the result is the underlying tool's result.",
+        "tool name and its arguments object; the result is the underlying tool's " +
+        "result. For a `<domain>_query` tool, include `resource` in the arguments.",
       inputSchema: z.object({
         name: z.string().trim().min(1),
         arguments: z.record(z.string(), z.unknown()).optional(),
@@ -285,8 +367,34 @@ function registerCallTool(input: RegisterMetaToolsInput): void {
       annotations: { openWorldHint: true },
     },
     async (args) => {
+      // A query tool routes through the projection to the underlying read.
+      const queryTool = projection.queryToolFor(args.name)
+      if (queryTool) {
+        const startedAt = now()
+        const { result, member } = await dispatchQueryTool({
+          registry,
+          queryTool,
+          args: args.arguments ?? {},
+          ctx,
+          requireActionPolicy,
+          budgetBytes,
+        })
+        if (member) {
+          const { outcome, code } = classifyDispatchResult(result)
+          observer.toolCall({
+            tool: member.entry.name,
+            outcome,
+            durationMs: now() - startedAt,
+            write: false,
+            ...(code ? { code } : {}),
+            caller,
+          })
+        }
+        return result
+      }
       const binding = surface.get(args.name)
-      if (!binding) return unknownToolResult(args.name)
+      // A flat read name is folded into its query tool and no longer callable.
+      if (!binding || projection.hiddenReadNames.has(args.name)) return unknownToolResult(args.name)
       const def = registry.get(binding.entry.name)
       if (!def) return unknownToolResult(args.name)
       const output = toMcpOutputContract(def.outputSchema)

--- a/packages/mcp/src/read-projection.ts
+++ b/packages/mcp/src/read-projection.ts
@@ -1,0 +1,315 @@
+/**
+ * Layered read projection (voyant#3932, RFC voyant#3921).
+ *
+ * A pure TRANSPORT-LAYER collapse of the ~133 fine-grained read tools
+ * (`get_*` / `list_*` / `search_*`) into one `<domain>_query` tool per product
+ * area. No domain `tools.ts` changes: `ToolManifestEntry` already carries the
+ * `owner` a read belongs to, so grouping is mechanical.
+ *
+ * The shape is `inventory_query({ resource: "products", … })` — a discriminated
+ * union on `resource`, where each resource is one former read tool. Discovery
+ * (`search_tools` / `describe_tool`) sees the query tools instead of the reads;
+ * dispatch (`call_tool` or a flat `tools/call`) routes `{ resource, …args }` to
+ * the underlying read and dispatches it exactly as before.
+ *
+ * Why this cuts the agent's discovery bill: a real per-read `describe_tool` pays
+ * that read's full output schema (a `get_booking` descriptor is ~12.7k tokens,
+ * dominated by the Booking entity), and a broad `search_tools` returns dozens of
+ * near-identical read names. A query tool advertises only the union of its
+ * members' compact INPUT schemas plus a permissive output note, and a domain
+ * clusters what used to be dozens of interchangeable verb-first hits into one.
+ *
+ * Writes are deliberately NOT collapsed — their per-action risk annotations,
+ * confirmation requirements, ledger bindings and approval policy are
+ * load-bearing and must stay one Tool each.
+ *
+ * Scope filtering prunes resources WITHIN a group: the projection is built from
+ * the caller's already-authorized surface, so an unauthorized read is neither a
+ * discoverable resource nor a routable one — exactly as a hidden flat tool was.
+ */
+import { z } from "@hono/zod-openapi"
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js"
+import {
+  TOOL_CONTRACT_VERSION,
+  type ToolContext,
+  ToolError,
+  type ToolManifestEntry,
+  type ToolRegistry,
+} from "@voyant-travel/tools"
+
+import { dispatchToResult } from "./dispatch.js"
+import { isRecord } from "./guards.js"
+import type { AuthorizedSurface } from "./meta-tools.js"
+import { DEFAULT_RESPONSE_BUDGET_BYTES, isListShapedOutput } from "./response-budget.js"
+import { toMcpInputSchema, toMcpOutputContract } from "./schema-projection.js"
+
+/** Read verbs that collapse into a per-domain query tool. Matches the 133 reads. */
+const READ_VERB = /^(?:get|list|search)_/
+
+/** The suffix that names a collapsed per-domain read tool. */
+const QUERY_SUFFIX = "_query"
+
+/** True when a canonical tool name is a read (`get_*` / `list_*` / `search_*`). */
+export function isReadToolName(name: string): boolean {
+  return READ_VERB.test(name)
+}
+
+/** The domain slug a tool belongs to, derived from its owning package. */
+export function toolDomain(entry: ToolManifestEntry): string {
+  const owner = entry.owner ?? ""
+  const withoutScope = owner.replace(/^@[^/]+\//, "")
+  const base = withoutScope.split("#")[0] ?? withoutScope
+  return base.length > 0 ? base : withoutScope
+}
+
+/** The resource discriminator for a read: its name with the leading verb removed. */
+function resourceOf(name: string): string {
+  return name.replace(READ_VERB, "")
+}
+
+/** One former read tool, reachable as a `resource` inside its domain's query tool. */
+export interface QueryResource {
+  resource: string
+  /** The invocation name to dispatch (the read's canonical name). */
+  invocationName: string
+  entry: ToolManifestEntry
+}
+
+/** A collapsed per-domain read tool: `<domain>_query` over N authorized resources. */
+export interface QueryTool {
+  name: string
+  domain: string
+  resources: QueryResource[]
+}
+
+export interface ReadProjection {
+  /** Query tool name (`<domain>_query`) → its resources. */
+  readonly queryTools: ReadonlyMap<string, QueryTool>
+  /** Canonical names of the reads folded away (hidden from flat discovery/dispatch). */
+  readonly hiddenReadNames: ReadonlySet<string>
+  queryToolFor(name: string): QueryTool | undefined
+}
+
+/**
+ * Partition the authorized surface into per-domain query tools. Reads are grouped
+ * by owning domain; every other tool (writes, lifecycle verbs, non-verb reads
+ * like `echo`) is left untouched and stays individually discoverable and callable.
+ */
+export function buildReadProjection(surface: AuthorizedSurface): ReadProjection {
+  const byDomain = new Map<string, QueryResource[]>()
+  const hiddenReadNames = new Set<string>()
+  for (const [invocationName, { entry, aliasFor }] of surface) {
+    // Fold aliases into their canonical; only project the canonical read once.
+    if (aliasFor) {
+      if (isReadToolName(entry.name)) hiddenReadNames.add(invocationName)
+      continue
+    }
+    if (!isReadToolName(entry.name)) continue
+    hiddenReadNames.add(invocationName)
+    const domain = toolDomain(entry)
+    const resources = byDomain.get(domain) ?? []
+    resources.push({ resource: resourceOf(entry.name), invocationName, entry })
+    byDomain.set(domain, resources)
+  }
+  const queryTools = new Map<string, QueryTool>()
+  for (const [domain, resources] of byDomain) {
+    resources.sort((a, b) => a.resource.localeCompare(b.resource))
+    const name = `${domain}${QUERY_SUFFIX}`
+    queryTools.set(name, { name, domain, resources })
+  }
+  return {
+    queryTools,
+    hiddenReadNames,
+    queryToolFor: (name) => queryTools.get(name),
+  }
+}
+
+/**
+ * The discriminated-union input schema advertised for a query tool: one object
+ * branch per resource, each carrying `resource: <literal>` alongside that read's
+ * projected input fields. The registry still validates the untouched domain
+ * schema at dispatch, so this is a discovery projection, not the parse contract.
+ */
+export function queryToolInputSchema(registry: ToolRegistry, queryTool: QueryTool): z.ZodType {
+  const branches: z.ZodObject[] = []
+  for (const member of queryTool.resources) {
+    const def = registry.get(member.entry.name)
+    if (!def) continue
+    const memberObject = toMcpInputSchema(
+      def.inputSchema,
+      member.entry,
+      isListShapedOutput(def.outputSchema),
+    )
+    branches.push(
+      z.object({
+        resource: z.literal(member.resource).describe(member.entry.description),
+        ...memberObject.shape,
+      }),
+    )
+  }
+  if (branches.length === 0) return z.object({ resource: z.string() })
+  if (branches.length === 1) return branches[0]!
+  return z.discriminatedUnion("resource", branches as [z.ZodObject, z.ZodObject, ...z.ZodObject[]])
+}
+
+/** A one-line, resource-listing description so keyword `search_tools` still matches. */
+export function queryToolDescription(queryTool: QueryTool): string {
+  const resources = queryTool.resources.map((member) => member.resource).join(", ")
+  return (
+    `Query ${queryTool.domain} read data. Set "resource" to the record you want and ` +
+    `supply that resource's own arguments (this tool's input schema is a discriminated ` +
+    `union on "resource"). Resources: ${resources}.`
+  )
+}
+
+/**
+ * MCP requires an object output root; a query tool's real result is the selected
+ * resource's typed data, whose shape varies by resource. Advertise a permissive
+ * object rather than a union of every member's output — dropping those per-read
+ * output schemas is the bulk of the discovery-cost saving.
+ */
+const QUERY_OUTPUT_SCHEMA = {
+  type: "object" as const,
+  additionalProperties: true,
+  description:
+    "Shape depends on the selected resource; the fine-grained /manifest carries " +
+    "each resource's output contract.",
+}
+
+/**
+ * The descriptor `describe_tool` returns for a query tool — the discovery view an
+ * agent needs to call it: the union input schema, a permissive output note,
+ * read-only annotations, and per-resource scope metadata.
+ */
+export function advertiseQueryTool(
+  registry: ToolRegistry,
+  queryTool: QueryTool,
+): Record<string, unknown> {
+  const inputSchema = z.toJSONSchema(queryToolInputSchema(registry, queryTool), {
+    io: "input",
+    unrepresentable: "any",
+  })
+  return {
+    name: queryTool.name,
+    description: queryToolDescription(queryTool),
+    inputSchema,
+    outputSchema: QUERY_OUTPUT_SCHEMA,
+    annotations: { readOnlyHint: true, openWorldHint: false },
+    _meta: {
+      "voyant.travel/tool": {
+        contractVersion: TOOL_CONTRACT_VERSION,
+        kind: "read-query",
+        domain: queryTool.domain,
+        tier: "read",
+        resources: queryTool.resources.map((member) => ({
+          resource: member.resource,
+          capabilityId: member.entry.capabilityId,
+          requiredScopes: member.entry.requiredScopes,
+        })),
+      },
+    },
+  }
+}
+
+export interface DispatchQueryToolInput {
+  registry: ToolRegistry
+  queryTool: QueryTool
+  args: unknown
+  ctx: ToolContext
+  requireActionPolicy: boolean
+  budgetBytes?: number
+}
+
+/**
+ * Route a query call to its resource and dispatch the underlying read. The
+ * `resource` discriminator is transport-only — it is stripped before the registry
+ * validates the untouched domain schema.
+ */
+export async function dispatchQueryTool(
+  input: DispatchQueryToolInput,
+): Promise<{ result: CallToolResult; member?: QueryResource }> {
+  const { registry, queryTool, args, ctx, requireActionPolicy } = input
+  const budgetBytes = input.budgetBytes ?? DEFAULT_RESPONSE_BUDGET_BYTES
+  const record = isRecord(args) ? args : {}
+  const resource = record.resource
+  if (typeof resource !== "string" || resource.length === 0) {
+    return { result: queryResourceError(queryTool, undefined) }
+  }
+  const member = queryTool.resources.find((candidate) => candidate.resource === resource)
+  if (!member) return { result: queryResourceError(queryTool, resource) }
+  const def = registry.get(member.entry.name)
+  if (!def) return { result: queryResourceError(queryTool, resource) }
+  const { resource: _resource, ...rest } = record
+  const output = toMcpOutputContract(def.outputSchema)
+  const result = await dispatchToResult(
+    registry,
+    member.invocationName,
+    member.entry,
+    rest,
+    ctx,
+    requireActionPolicy,
+    output.envelopeResult,
+    budgetBytes,
+  )
+  return { result, member }
+}
+
+/**
+ * Register a synthetic `<domain>_query` tool for a flat-name `tools/call`. It is
+ * not a registry Tool, so it carries a permissive `resource`-keyed input and its
+ * handler routes to the underlying read through the projection; the read's own
+ * domain schema still validates at dispatch. `describe_tool` advertises the rich
+ * discriminated-union schema separately.
+ */
+export function registerQueryTool(
+  server: McpServer,
+  registry: ToolRegistry,
+  queryTool: QueryTool,
+  ctx: ToolContext,
+  requireActionPolicy: boolean,
+  budgetBytes: number,
+): void {
+  server.registerTool(
+    queryTool.name,
+    {
+      description: `Query ${queryTool.domain} read data by \`resource\`.`,
+      inputSchema: z.looseObject({ resource: z.string() }),
+      annotations: { readOnlyHint: true, openWorldHint: false },
+    },
+    async (args): Promise<CallToolResult> => {
+      const { result } = await dispatchQueryTool({
+        registry,
+        queryTool,
+        args,
+        ctx,
+        requireActionPolicy,
+        budgetBytes,
+      })
+      return result
+    },
+  )
+}
+
+/** A NOT_FOUND result naming the resources this query tool actually serves. */
+function queryResourceError(queryTool: QueryTool, resource: string | undefined): CallToolResult {
+  const available = queryTool.resources.map((member) => member.resource)
+  const message =
+    resource === undefined
+      ? `${queryTool.name} requires a "resource" argument. Available: ${available.join(", ")}.`
+      : `${queryTool.name} has no resource "${resource}". Available: ${available.join(", ")}.`
+  const error = new ToolError(message, "NOT_FOUND", undefined, undefined, { candidates: available })
+  return {
+    isError: true,
+    content: [{ type: "text", text: `[${error.code}] ${error.message}` }],
+    _meta: {
+      "voyant.travel/error": {
+        code: error.code,
+        message: error.message,
+        retryable: error.retryable,
+        nextSteps: error.nextSteps,
+        candidates: available,
+      },
+    },
+  }
+}

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -54,8 +54,8 @@ import {
   jsonByteLength,
   type McpObserver,
 } from "./observability.js"
-import { buildReadProjection, type ReadProjection, registerQueryTool } from "./read-projection.js"
 import { createMcpRateLimiter } from "./rate-limit.js"
+import { buildReadProjection, type ReadProjection, registerQueryTool } from "./read-projection.js"
 import { registerMcpTool } from "./register.js"
 import { DEFAULT_RESPONSE_BUDGET_BYTES } from "./response-budget.js"
 import type { GraphMcpApiRoutesOptions, McpApiRoutesOptions, McpServerInfo } from "./types.js"

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -54,6 +54,7 @@ import {
   jsonByteLength,
   type McpObserver,
 } from "./observability.js"
+import { buildReadProjection, type ReadProjection, registerQueryTool } from "./read-projection.js"
 import { createMcpRateLimiter } from "./rate-limit.js"
 import { registerMcpTool } from "./register.js"
 import { DEFAULT_RESPONSE_BUDGET_BYTES } from "./response-budget.js"
@@ -168,6 +169,13 @@ export function createMcpApiRoutes(options: McpApiRoutesOptions): OpenAPIHono {
     // not just the register loop, is the security property of the server.
     const surface = collectAuthorizedTools(registry, permissions, accessCatalog, ctx.audience)
 
+    // Layered read projection (voyant#3932): the flat `get_*`/`list_*`/`search_*`
+    // reads are folded into one `<domain>_query` tool per product area. Discovery
+    // and dispatch consult this projection so the reads are neither individually
+    // discoverable nor callable by their flat names, while scope filtering still
+    // prunes an unauthorized read out of its group.
+    const projection = buildReadProjection(surface)
+
     // The guide layer's `instructions` are scope-aware — a read-only key is told
     // the write journeys are unreachable rather than shown workflows it cannot
     // perform — so whether any write Tool is reachable must be known before the
@@ -191,6 +199,7 @@ export function createMcpApiRoutes(options: McpApiRoutesOptions): OpenAPIHono {
       server,
       registry,
       surface,
+      projection,
       ctx,
       requireActionPolicy,
       observer,
@@ -203,24 +212,31 @@ export function createMcpApiRoutes(options: McpApiRoutesOptions): OpenAPIHono {
     // authorized tool must still dispatch — the operator's manual-booking client
     // calls `create_booking` by name. Register just that tool for this request, so
     // the SDK validates and dispatches it exactly as before. Because `surface`
-    // gates it, an unauthorized name is never registered and stays uncallable.
+    // gates it, an unauthorized name is never registered and stays uncallable. A
+    // `<domain>_query` tool is synthetic (not in the registry), so it registers
+    // through its own projection-backed handler; a folded flat read name is never
+    // registered and stays uncallable.
     const requestBody = asRecord(await c.req.json().catch(() => undefined))
     const requestedName = requestedToolName(requestBody)
     if (
       requestedName &&
       !eagerNames.has(requestedName) &&
-      !META_TOOL_NAMES.includes(requestedName) &&
-      surface.has(requestedName)
+      !META_TOOL_NAMES.includes(requestedName)
     ) {
-      registerSurfaceTool(
-        server,
-        registry,
-        surface,
-        requestedName,
-        ctx,
-        requireActionPolicy,
-        budgetBytes,
-      )
+      const queryTool = projection.queryToolFor(requestedName)
+      if (queryTool) {
+        registerQueryTool(server, registry, queryTool, ctx, requireActionPolicy, budgetBytes)
+      } else if (surface.has(requestedName) && !projection.hiddenReadNames.has(requestedName)) {
+        registerSurfaceTool(
+          server,
+          registry,
+          surface,
+          requestedName,
+          ctx,
+          requireActionPolicy,
+          budgetBytes,
+        )
+      }
     }
 
     const transport = new StreamableHTTPTransport({
@@ -230,7 +246,16 @@ export function createMcpApiRoutes(options: McpApiRoutesOptions): OpenAPIHono {
     await server.connect(transport)
     const startedAt = Date.now()
     const response = (await transport.handleRequest(c)) ?? c.body(null, 204)
-    await instrumentRpc(c, response, Date.now() - startedAt, surface, guideToolNames, ctx, observer)
+    await instrumentRpc(
+      c,
+      response,
+      Date.now() - startedAt,
+      surface,
+      projection,
+      guideToolNames,
+      ctx,
+      observer,
+    )
     return response
   })
 
@@ -298,6 +323,7 @@ async function instrumentRpc(
   response: Response,
   durationMs: number,
   surface: AuthorizedSurface,
+  projection: ReadProjection,
   guideToolNames: ReadonlySet<string>,
   ctx: ToolContext,
   observer: McpObserver,
@@ -329,8 +355,16 @@ async function instrumentRpc(
     // registry, so they carry no manifest entry — mark them known reads instead of
     // misclassifying a legitimate guide call as an unknown-tool miss, which is one
     // of the highest-signal events we record.
-    const entry = surface.get(name)?.entry
-    const known = entry !== undefined || META_TOOL_NAMES.includes(name) || guideToolNames.has(name)
+    // A `<domain>_query` tool is a known read that carries no manifest entry; a
+    // folded flat read name is not a known invocation any longer.
+    const queryTool = projection.queryToolFor(name)
+    const entry =
+      queryTool || projection.hiddenReadNames.has(name) ? undefined : surface.get(name)?.entry
+    const known =
+      entry !== undefined ||
+      queryTool !== undefined ||
+      META_TOOL_NAMES.includes(name) ||
+      guideToolNames.has(name)
     const { outcome, code } = classifyToolCallResult(payload, known)
     observer.toolCall({
       tool: name,

--- a/packages/mcp/tests/agent-journey-eval.test.ts
+++ b/packages/mcp/tests/agent-journey-eval.test.ts
@@ -7,13 +7,15 @@
  * against it — completion, call count, token cost, and error codes per journey.
  *
  * The deployment is seeded in-process: a registry of read tools carrying the
- * REAL tool names the surface actually serves (`list_products`, `get_product`,
+ * REAL underlying names the surface serves (`list_products`, `get_product`,
  * `get_product_content`, `list_bookings` — each verified against its owning
  * package's `defineTool` in packages/inventory and packages/bookings) backed by
- * a small in-memory fixture. Real names, deterministic backend: the scenarios
- * exercise the meta-tool / guide indirection exactly as a live agent would,
- * without a database or a model API key. Discovery of those same names on the
- * REAL selected graph is grounded separately in the operator starter test.
+ * a small in-memory fixture. Those reads are reached through the collapsed
+ * `inventory_query` / `bookings_query` tools the transport projects (voyant#3932),
+ * so the scenarios exercise the meta-tool / guide indirection and the read
+ * projection exactly as a live agent would, without a database or a model API
+ * key. Discovery of those same query tools on the REAL selected graph is grounded
+ * separately in the operator starter test.
  *
  * The scores are recorded below as named baseline constants with docblocks that
  * say what they mean and when to move them — the ratchet precedent — and the run
@@ -271,30 +273,32 @@ function searchHit(step: JourneyStepResult | undefined, name: string): boolean {
 
 const SCENARIOS: JourneyScenario[] = [
   {
-    // discover → describe → read: the canonical progressive-disclosure path.
+    // discover → describe → read: the canonical progressive-disclosure path, now
+    // over the collapsed `inventory_query` read tool (voyant#3932).
     id: "discover-then-read-products",
-    title: "search_tools → describe_tool → list_products",
+    title: "search_tools → describe_tool → inventory_query(resource: products)",
     drive(prior) {
       if (prior.length === 0) return { tool: "search_tools", args: { query: "product" } }
-      if (prior.length === 1) return { tool: "describe_tool", args: { name: "list_products" } }
-      if (prior.length === 2) return { tool: "list_products", args: {} }
+      if (prior.length === 1) return { tool: "describe_tool", args: { name: "inventory_query" } }
+      if (prior.length === 2) return { tool: "inventory_query", args: { resource: "products" } }
       return null
     },
     completed: (prior) =>
-      searchHit(prior[0], "list_products") &&
-      describedName(prior[1]) === "list_products" &&
+      searchHit(prior[0], "inventory_query") &&
+      describedName(prior[1]) === "inventory_query" &&
       productList(prior[2]).length > 0,
   },
   {
     // Find a product, then read its composed content by the id just discovered.
     id: "find-product-read-content",
-    title: "search_tools → list_products → get_product_content(id)",
+    title: "search_tools → inventory_query(products) → inventory_query(product_content)",
     drive(prior) {
       if (prior.length === 0) return { tool: "search_tools", args: { query: "product content" } }
-      if (prior.length === 1) return { tool: "list_products", args: { status: "active" } }
+      if (prior.length === 1)
+        return { tool: "inventory_query", args: { resource: "products", status: "active" } }
       if (prior.length === 2) {
         const id = productList(prior[1])[0]?.id
-        return id ? { tool: "get_product_content", args: { id } } : null
+        return id ? { tool: "inventory_query", args: { resource: "product_content", id } } : null
       }
       return null
     },
@@ -309,12 +313,16 @@ const SCENARIOS: JourneyScenario[] = [
   {
     // List bookings with a filter, dispatched through the call_tool meta-tool.
     id: "list-bookings-with-filter",
-    title: "search_tools → describe_tool → call_tool(list_bookings, confirmed)",
+    title: "search_tools → describe_tool → call_tool(bookings_query, confirmed)",
     drive(prior) {
       if (prior.length === 0) return { tool: "search_tools", args: { query: "booking" } }
-      if (prior.length === 1) return { tool: "describe_tool", args: { name: "list_bookings" } }
+      if (prior.length === 1) return { tool: "describe_tool", args: { name: "bookings_query" } }
       if (prior.length === 2)
-        return { tool: "list_bookings", args: { status: "confirmed" }, via: "meta" }
+        return {
+          tool: "bookings_query",
+          args: { resource: "bookings", status: "confirmed" },
+          via: "meta",
+        }
       return null
     },
     completed(prior) {
@@ -325,30 +333,32 @@ const SCENARIOS: JourneyScenario[] = [
   {
     // Guide-first: read the discovery guide, then discover and read a product.
     id: "guide-then-act",
-    title: "voyant_guide(discovery) → search_tools → get_product(id)",
+    title: "voyant_guide(discovery) → search_tools → inventory_query(product)",
     drive(prior) {
       if (prior.length === 0) return { tool: "voyant_guide", args: { topic: "discovery" } }
       if (prior.length === 1) return { tool: "search_tools", args: { query: "product" } }
-      if (prior.length === 2) return { tool: "get_product", args: { id: "prod_seed_1" } }
+      if (prior.length === 2)
+        return { tool: "inventory_query", args: { resource: "product", id: "prod_seed_1" } }
       return null
     },
     completed(prior) {
       const guided = (prior[0]?.text ?? "").length > 0 && !prior[0]?.isError
       const product = (prior[2]?.structured as { product?: unknown } | undefined)?.product
-      return guided && searchHit(prior[1], "get_product") && product != null
+      return guided && searchHit(prior[1], "inventory_query") && product != null
     },
   },
   {
     // An agent that fumbles input (no id/slug), reads the actionable error, and
     // recovers. Exercises the error-code breakdown while still completing.
     id: "recover-from-bad-input",
-    title: "get_product() [INVALID_INPUT] → list_products → get_product(id)",
+    title:
+      "inventory_query(product) [INVALID_INPUT] → inventory_query(products) → inventory_query(product)",
     drive(prior) {
-      if (prior.length === 0) return { tool: "get_product", args: {} }
-      if (prior.length === 1) return { tool: "list_products", args: {} }
+      if (prior.length === 0) return { tool: "inventory_query", args: { resource: "product" } }
+      if (prior.length === 1) return { tool: "inventory_query", args: { resource: "products" } }
       if (prior.length === 2) {
         const id = productList(prior[1])[0]?.id
-        return id ? { tool: "get_product", args: { id } } : null
+        return id ? { tool: "inventory_query", args: { resource: "product", id } } : null
       }
       return null
     },

--- a/packages/mcp/tests/response-budget.test.ts
+++ b/packages/mcp/tests/response-budget.test.ts
@@ -87,6 +87,9 @@ const bookingRowSchema = z.looseObject({
 })
 
 const listThingsTool = defineTool({
+  capabilityId: "@voyant-travel/catalog#tool.list-things",
+  owner: "@voyant-travel/catalog",
+  capabilityVersion: "v1",
   name: "list_things",
   description: "List booking-shaped things with filters and pagination. Read-only.",
   inputSchema: paginationSchema.extend({
@@ -138,7 +141,6 @@ function mountListThings(responseBudgetBytes?: number): Hono {
     accessCatalog,
     registry,
     buildContext,
-    eagerToolNames: ["list_things"],
     ...(responseBudgetBytes !== undefined ? { responseBudgetBytes } : {}),
   })
   const outer = new Hono()
@@ -157,9 +159,14 @@ interface CallToolResult {
   _meta?: Record<string, unknown>
 }
 
+// The `list_things` read is reached through the collapsed `catalog_query` tool
+// (voyant#3932): dispatch names the query tool and selects the `things` resource.
 async function callListThings(app: Hono, args: Record<string, unknown>): Promise<CallToolResult> {
   const res = await readRpc(
-    await app.request("/", rpc("tools/call", { name: "list_things", arguments: args })),
+    await app.request(
+      "/",
+      rpc("tools/call", { name: "catalog_query", arguments: { resource: "things", ...args } }),
+    ),
   )
   return (res.result ?? {}) as CallToolResult
 }
@@ -261,10 +268,12 @@ describe("shapeResponse", () => {
 describe("list tool over the transport", () => {
   it("advertises response_format on the list tool's input schema", async () => {
     const app = mountListThings()
+    // The list read is projected into `catalog_query`; its discriminated-union
+    // input carries the same list-shaped `response_format` control per resource.
     const res = await readRpc(
       await app.request(
         "/",
-        rpc("tools/call", { name: "describe_tool", arguments: { name: "list_things" } }),
+        rpc("tools/call", { name: "describe_tool", arguments: { name: "catalog_query" } }),
       ),
     )
     const descriptor = (res.result as { structuredContent?: { inputSchema?: unknown } })

--- a/packages/mcp/tests/server.test.ts
+++ b/packages/mcp/tests/server.test.ts
@@ -172,6 +172,30 @@ const echoTool = defineTool({
   },
 })
 
+/**
+ * A SECOND read in the same domain as {@link echoTool} but behind a different
+ * scope, so `test_query` has two resources. Without it every query group in this
+ * suite is degenerate (one resource), and "an unauthorized resource is pruned
+ * from a group that still exists" cannot be observed at all.
+ */
+const listEchoesTool = defineTool({
+  capabilityId: "@voyant-travel/test#tool.list-echoes",
+  owner: "@voyant-travel/test",
+  capabilityVersion: "v1",
+  name: "list_echoes",
+  description: "List prior echoes.",
+  inputSchema: z.object({ limit: z.number().int().optional() }),
+  outputSchema: z.object({ data: z.array(z.string()), total: z.number() }),
+  requiredScopes: ["products:read"],
+  audience: { source: "grant", allowed: ["staff"] },
+  tier: "read",
+  riskPolicy: READ_ONLY_RISK,
+  annotations: { idempotentHint: true },
+  async handler() {
+    return { data: ["echo: a"], total: 1 }
+  },
+})
+
 const updateRecordTool = defineTool({
   name: "update_record",
   description: "Update a record through a composed input contract.",
@@ -440,6 +464,7 @@ function conditionalFrameworkRuntime(options: { providerSelected?: boolean } = {
 function appWithScopes(scopes: string[], audience: ToolContext["audience"] = "staff"): Hono {
   const registry = createToolRegistry()
   registry.register(echoTool)
+  registry.register(listEchoesTool)
   registry.register(updateRecordTool)
   registry.register(getSensitiveRecordTool)
   const mcp = createMcpApiRoutes({
@@ -1173,6 +1198,53 @@ describe("createMcpApiRoutes", () => {
       ),
     )
     expect(missing.result).toMatchObject({ structuredContent: { result: null } })
+  })
+
+  it("prunes an unauthorized resource from a query group that still exists", async () => {
+    // The other pruning tests cover the DEGENERATE case: a group whose only read
+    // is unauthorized disappears entirely. That does not demonstrate the property
+    // the projection actually claims — that a group survives with a SUBSET of its
+    // resources when the caller holds some of their scopes but not others.
+    //
+    // `test_query` groups `list_echoes` (products:read) and `get_sensitive_record`
+    // (secrets:read), so holding one scope must expose one resource and hide the
+    // other — in discovery AND at dispatch.
+    const partial = appWithScopes(["products:read"])
+
+    expect(await searchToolNames(partial, { query: "echoes" })).toContain("test_query")
+
+    const described = (await describeTool(partial, "test_query")).structuredContent as {
+      _meta?: { "voyant.travel/tool"?: { resources?: Array<{ resource: string }> } }
+    }
+    const exposed = (described._meta?.["voyant.travel/tool"]?.resources ?? []).map(
+      ({ resource }) => resource,
+    )
+    expect(exposed).toContain("echoes")
+    expect(exposed).not.toContain("sensitive_record")
+
+    // Discovery pruning is not enough on its own — an unauthorized resource must
+    // also be uncallable, or the group becomes a scope-bypass.
+    const denied = await readRpc(
+      await partial.request(
+        "/",
+        rpc("tools/call", {
+          name: "test_query",
+          arguments: { resource: "sensitive_record" },
+        }),
+      ),
+    )
+    expect(JSON.stringify(denied.result)).not.toContain("classified")
+
+    // With both grants, both resources are present.
+    const full = appWithScopes(["products:read", "secrets:read"])
+    const bothDescribed = (await describeTool(full, "test_query")).structuredContent as {
+      _meta?: { "voyant.travel/tool"?: { resources?: Array<{ resource: string }> } }
+    }
+    const bothExposed = (bothDescribed._meta?.["voyant.travel/tool"]?.resources ?? []).map(
+      ({ resource }) => resource,
+    )
+    expect(bothExposed).toContain("echoes")
+    expect(bothExposed).toContain("sensitive_record")
   })
 
   it("discovers and invokes a sensitive Tool only with its explicit grant", async () => {

--- a/packages/mcp/tests/server.test.ts
+++ b/packages/mcp/tests/server.test.ts
@@ -196,6 +196,9 @@ const updateRecordTool = defineTool({
 })
 
 const getSensitiveRecordTool = defineTool({
+  capabilityId: "@voyant-travel/test#tool.get-sensitive-record",
+  owner: "@voyant-travel/test",
+  capabilityVersion: "v1",
   name: "get_sensitive_record",
   description: "Read a sensitive record.",
   inputSchema: z.object({ id: z.string().min(1) }),
@@ -1173,23 +1176,33 @@ describe("createMcpApiRoutes", () => {
   })
 
   it("discovers and invokes a sensitive Tool only with its explicit grant", async () => {
-    // Without the sensitive grant the tool is neither discoverable nor describable.
+    // The sensitive read is projected into its domain's `test_query` tool
+    // (voyant#3932). Without the sensitive grant the read is not an authorized
+    // resource, so its group carries no read at all and never surfaces — the flat
+    // read name is also gone outright.
     const withoutGrant = appWithScopes(["catalog:read"])
+    expect(await searchToolNames(withoutGrant)).not.toContain("test_query")
     expect(await searchToolNames(withoutGrant)).not.toContain("get_sensitive_record")
     expect(await describeIsUnavailable(withoutGrant, "get_sensitive_record")).toBe(true)
+    expect(await describeIsUnavailable(withoutGrant, "test_query")).toBe(true)
 
     const app = appWithScopes(["secrets:read"])
-    expect(await searchToolNames(app, { query: "sensitive" })).toContain("get_sensitive_record")
-    expect((await describeTool(app, "get_sensitive_record")).structuredContent).toMatchObject({
-      _meta: { "voyant.travel/tool": { tier: "sensitive" } },
-    })
+    // The group is discoverable by the sensitive resource's keyword...
+    expect(await searchToolNames(app, { query: "sensitive" })).toContain("test_query")
+    // ...and the flat read name is not resurrected anywhere.
+    expect(await searchToolNames(app, { query: "sensitive" })).not.toContain("get_sensitive_record")
+    const descriptor = (await describeTool(app, "test_query")).structuredContent as
+      | { _meta?: { "voyant.travel/tool"?: { resources?: Array<{ resource: string }> } } }
+      | undefined
+    const resources = descriptor?._meta?.["voyant.travel/tool"]?.resources ?? []
+    expect(resources.map((entry) => entry.resource)).toContain("sensitive_record")
 
     const called = await readRpc(
       await app.request(
         "/",
         rpc("tools/call", {
-          name: "get_sensitive_record",
-          arguments: { id: "secret_1" },
+          name: "test_query",
+          arguments: { resource: "sensitive_record", id: "secret_1" },
         }),
       ),
     )
@@ -1309,13 +1322,14 @@ describe("createMcpApiRoutes", () => {
       return outer
     }
 
+    // The read is projected into `legal_query`; the caller selects the resource.
     const allowed = app(["legal:read", "bookings-pii:read"])
     const called = await readRpc(
       await allowed.request(
         "/",
         rpc("tools/call", {
-          name: "get_booking_contract_review",
-          arguments: { contractId: "contract_1" },
+          name: "legal_query",
+          arguments: { resource: "booking_contract_review", contractId: "contract_1" },
         }),
       ),
     )
@@ -1323,19 +1337,23 @@ describe("createMcpApiRoutes", () => {
       structuredContent: { scopes: ["legal:read", "bookings-pii:read"] },
     })
 
+    // A grant missing one required scope leaves the read out of its group, so the
+    // group carries no authorized read and the query tool never appears — and the
+    // removed flat read name is uncallable either way.
     const denied = app(["legal:read"])
     const listed = await readRpc(await denied.request("/", rpc("tools/list", {})))
-    expect(
+    const listedNames =
       (listed.result as { tools?: Array<{ name: string }> } | undefined)?.tools?.map(
         ({ name }) => name,
-      ) ?? [],
-    ).not.toContain("get_booking_contract_review")
+      ) ?? []
+    expect(listedNames).not.toContain("legal_query")
+    expect(listedNames).not.toContain("get_booking_contract_review")
     const deniedCall = await readRpc(
       await denied.request(
         "/",
         rpc("tools/call", {
-          name: "get_booking_contract_review",
-          arguments: { contractId: "contract_1" },
+          name: "legal_query",
+          arguments: { resource: "booking_contract_review", contractId: "contract_1" },
         }),
       ),
     )

--- a/starters/operator/tests/agent-journey-real-surface.test.ts
+++ b/starters/operator/tests/agent-journey-real-surface.test.ts
@@ -123,13 +123,19 @@ interface DiscoveryJourney {
   tool: string
 }
 
+// After the layered read projection (voyant#3932) the flat `get_*`/`list_*` reads
+// are collapsed into one `<domain>_query` tool per product area, so a discovery
+// journey now finds and describes the query tool for the record it wants. The
+// same six product areas are covered; several journeys resolve to the SAME query
+// tool (products/product/product-content all live in `inventory_query`), which is
+// exactly the clustering that cuts the discovery bill.
 const JOURNEYS: DiscoveryJourney[] = [
-  { id: "discover-list-products", query: "products", tool: "list_products" },
-  { id: "discover-get-product", query: "product", tool: "get_product" },
-  { id: "discover-product-content", query: "product content", tool: "get_product_content" },
-  { id: "discover-list-bookings", query: "bookings", tool: "list_bookings" },
-  { id: "discover-get-booking", query: "booking", tool: "get_booking" },
-  { id: "discover-list-departures", query: "departures", tool: "list_departures" },
+  { id: "discover-products", query: "products", tool: "inventory_query" },
+  { id: "discover-product", query: "product", tool: "inventory_query" },
+  { id: "discover-product-content", query: "product content", tool: "inventory_query" },
+  { id: "discover-bookings", query: "bookings", tool: "bookings_query" },
+  { id: "discover-booking", query: "booking", tool: "bookings_query" },
+  { id: "discover-departures", query: "departures", tool: "operations_query" },
 ]
 
 interface DiscoveryScore {
@@ -181,17 +187,24 @@ function formatReport(scores: readonly DiscoveryScore[]): string {
 
 /**
  * Non-blocking ceiling for the whole discovery set's token estimate, with
- * headroom. It is dominated by the `describe_tool` schemas — the exact per-tool
- * cost the aggregate ratchet in `selected-graph-mcp-tool-surface.test.ts` bounds
- * and that the read projection (voyant#3932) is meant to cut. Lower it when W8
- * lands; raise it only with a recorded reason after reading the printed report.
+ * headroom. It is dominated by the `describe_tool` schemas an agent pulls to form
+ * a call. Lower it when the surface shrinks; raise it only with a recorded reason
+ * after reading the printed report.
  *
- * Measured at authoring: ~48,600 tokens across the six discovery journeys —
- * dominated by the real per-tool input schemas (get_booking alone is ~12,700).
- * That is a genuinely large discovery bill and precisely the signal this harness
- * exists to surface: the read projection (W8) should move it down, not up.
+ * History: at W8's authoring this stood at 62,000 with a measured ~48,553 tokens,
+ * when each journey discovered and described one FLAT read (`get_booking` alone
+ * was ~12,700, dominated by its full Booking output schema).
+ *
+ * The layered read projection (voyant#3932) then collapsed the ~133 reads into
+ * ~24 `<domain>_query` tools: a journey now describes the query tool for the
+ * record it wants, which advertises the union of its resources' compact INPUT
+ * schemas and a permissive output note instead of one read's heavy output. That
+ * cut the same six journeys to **~36,974 tokens** (a ~24% reduction), so the
+ * ceiling drops to 45,000 — headroom over the measurement for search-wording
+ * drift (a broad `search_tools` over the many booking WRITE tools is the largest
+ * remaining line), while still tripping if a describe payload balloons again.
  */
-const DISCOVERY_TOKEN_CEILING = 62_000
+const DISCOVERY_TOKEN_CEILING = 45_000
 
 describe("agent journey eval — real selected-graph surface", () => {
   let scores: DiscoveryScore[] = []

--- a/starters/operator/tests/agent-journey-real-surface.test.ts
+++ b/starters/operator/tests/agent-journey-real-surface.test.ts
@@ -206,6 +206,15 @@ function formatReport(scores: readonly DiscoveryScore[]): string {
  */
 const DISCOVERY_TOKEN_CEILING = 45_000
 
+/**
+ * This hook composes the whole selected graph and runs every journey, which
+ * exceeds vitest's 10s default hook timeout when the operator suite runs its
+ * files in parallel — it passes in isolation and fails in a full run, the worst
+ * kind of flake. The config raises `testTimeout` but not `hookTimeout`, so set it
+ * explicitly here rather than relying on scheduling luck.
+ */
+const HOOK_TIMEOUT_MS = 60_000
+
 describe("agent journey eval — real selected-graph surface", () => {
   let scores: DiscoveryScore[] = []
 
@@ -214,7 +223,7 @@ describe("agent journey eval — real selected-graph surface", () => {
     scores = []
     for (const journey of JOURNEYS) scores.push(await runDiscovery(app, journey))
     process.stdout.write(`\n${formatReport(scores)}\n\n`)
-  })
+  }, HOOK_TIMEOUT_MS)
 
   it("discovers and describes every real tool the seeded journeys drive", () => {
     // This is the anti-fabrication guard: each name must resolve on the REAL

--- a/starters/operator/tests/selected-graph-mcp-tool-surface.test.ts
+++ b/starters/operator/tests/selected-graph-mcp-tool-surface.test.ts
@@ -23,7 +23,6 @@
 import { composeVoyantGraphRuntime } from "@voyant-travel/framework"
 import { Hono } from "hono"
 import { describe, expect, it } from "vitest"
-import { z } from "zod"
 
 import { accessCatalog } from "../.voyant/access/selected-access-catalog.generated"
 import {
@@ -48,17 +47,29 @@ import {
 const PAYLOAD_CEILING_BYTES = 3_800
 
 /**
- * Ceiling for the AGGREGATE size of every selected tool's advertised schema.
+ * Ceiling for the AGGREGATE describe schema of the collapsed READ surface — the
+ * exact surface the layered read projection (voyant#3932) reshapes.
  *
- * Measured at 260,968 bytes across 264 tools (name + description + input schema;
- * the `_meta` envelope the transport also emits pushes the real figure higher).
- * Progressive disclosure
- * keeps this out of `tools/list`, so it is no longer a per-connection cost — but
- * `describe_tool` pays it one tool at a time and a broad `search_tools` pays a
- * slice of it, and nothing else bounds it now that the tail is invisible.
- * Lower it as the read projection (voyant#3932) collapses the CRUD surface.
+ * Before W8 this bounded every selected tool's input schema in aggregate
+ * (~260,968 bytes across 264 tools). The reads that dominated that "CRUD tail"
+ * are now collapsed into one `<domain>_query` tool per product area, so the thing
+ * worth bounding is what an agent pays to `describe_tool` those query tools — the
+ * union of each domain's read INPUT schemas plus a permissive output note, rather
+ * than 133 separate reads each advertising its full (often heavy) output schema.
+ *
+ * Measured across the 24 query tools (name + description + input + output schema
+ * from the served `describe_tool` descriptor): **115,559 bytes**, down from
+ * **433,234 bytes** for the same 133 reads described individually pre-projection
+ * — a ~73% cut, because collapsing drops the per-read output schemas that were
+ * the bulk of a read's describe cost. The ceiling drops to 130,000 with headroom
+ * for read-schema edits, tripping if a query tool's union balloons again.
+ *
+ * Writes are deliberately NOT collapsed (voyant#3921) and stay individually
+ * described; their per-tool describe cost is bounded by the response budget at
+ * call time and the eager `tools/list` ratchet above catches a regression to
+ * eager loading.
  */
-const AGGREGATE_CEILING_BYTES = 275_000
+const AGGREGATE_CEILING_BYTES = 130_000
 
 /** Rough proxy for tokens. JSON schema tokenizes denser than prose, so this is a floor. */
 const BYTES_PER_TOKEN = 4
@@ -181,46 +192,57 @@ describe("selected-graph MCP tool surface cost", () => {
     expect(unnamed).toEqual([])
   })
 
-  it("still bounds the AGGREGATE schema size of the long tail", async () => {
+  it("bounds the AGGREGATE describe schema of the collapsed read surface", async () => {
     // Progressive disclosure made the long tail invisible to `tools/list`, which
-    // is the point — but it also means unbounded per-tool schema growth would
-    // show up nowhere. `describe_tool` still pays that cost one tool at a time,
-    // and `search_tools` pays it in aggregate whenever a query matches broadly.
-    //
-    // So keep the pre-#3927 aggregate bound as a SECOND, independent guard. The
-    // served-payload ratchet above catches "we went back to eager loading"; this
-    // one catches "the tail quietly bloated while nobody could see it".
-    const runtime = createGeneratedGraphRuntime()
-    let totalBytes = 0
-    let toolCount = 0
-    const heaviest: Array<{ name: string; bytes: number }> = []
+    // is the point — but unbounded per-tool schema growth would then show up
+    // nowhere. The layered read projection (voyant#3932) collapses the reads into
+    // `<domain>_query` tools, so the thing worth bounding is the describe cost of
+    // that query surface: `describe_tool` pays one query tool's whole union at a
+    // time, and a broad `search_tools` surfaces several. This is the read half of
+    // the old aggregate bound, re-pointed at what the projection actually serves.
+    const { app } = await mountSelectedGraphMcp()
 
+    // Enumerate the query tools the projection produces: one `<domain>_query` per
+    // domain that owns a `get_*`/`list_*`/`search_*` read, derived exactly as the
+    // transport derives it (owner package → domain slug).
+    const runtime = createGeneratedGraphRuntime()
+    const queryToolNames = new Set<string>()
     for (const tool of runtime.tools) {
-      const definition = await tool.load<{
-        name: string
-        description: string
-        inputSchema: { _zod?: unknown }
-      }>()
-      let inputSchema: unknown
-      try {
-        inputSchema = z.toJSONSchema(definition.inputSchema as never, {
-          io: "input",
-          unrepresentable: "any",
-        })
-      } catch {
-        inputSchema = { type: "object", additionalProperties: true }
-      }
+      const definition = await tool.load<{ name: string }>()
+      const name = tool.name ?? definition.name
+      if (!/^(?:get|list|search)_/.test(name)) continue
+      const owner = String((tool as { unitId?: string }).unitId ?? "")
+      const domain = owner.replace(/^@[^/]+\//, "").split("#")[0] ?? owner
+      if (domain.length > 0) queryToolNames.add(`${domain}_query`)
+    }
+
+    let totalBytes = 0
+    const heaviest: Array<{ name: string; bytes: number }> = []
+    for (const name of queryToolNames) {
+      const described = await readRpc(
+        await app.request(
+          "/",
+          rpc("tools/call", { name: "describe_tool", arguments: { name } }),
+          TEST_ENV,
+          TEST_CTX,
+        ),
+      )
+      const descriptor = (described.result as { structuredContent?: Record<string, unknown> })
+        ?.structuredContent
+      expect(descriptor, `query tool ${name} was not describable`).toBeDefined()
+      // Measure the advertised schema (name + description + input + output), the
+      // same fields the pre-projection aggregate summed per read.
       const bytes = Buffer.byteLength(
         JSON.stringify({
-          name: tool.name ?? definition.name,
-          description: definition.description,
-          inputSchema,
+          name: descriptor?.name,
+          description: descriptor?.description,
+          inputSchema: descriptor?.inputSchema,
+          outputSchema: descriptor?.outputSchema,
         }),
         "utf8",
       )
       totalBytes += bytes
-      toolCount += 1
-      heaviest.push({ name: tool.name ?? definition.name, bytes })
+      heaviest.push({ name, bytes })
     }
 
     const top = heaviest
@@ -232,14 +254,14 @@ describe("selected-graph MCP tool surface cost", () => {
     expect(
       totalBytes,
       [
-        `Aggregate tool schema size: ${totalBytes.toLocaleString()} bytes across ${toolCount} tools`,
-        `  ~${Math.round(totalBytes / BYTES_PER_TOKEN).toLocaleString()} tokens if ever served together`,
+        `Aggregate query-tool describe schema: ${totalBytes.toLocaleString()} bytes across ${queryToolNames.size} query tools`,
+        `  ~${Math.round(totalBytes / BYTES_PER_TOKEN).toLocaleString()} tokens if every read surface were described together`,
         "  heaviest:",
         top,
         "",
-        "  This is NOT the per-connection cost — progressive disclosure keeps the",
-        "  tail out of tools/list. It bounds what describe_tool and a broad",
-        "  search_tools can pull in, and stops the tail bloating unseen.",
+        "  Reads collapse into <domain>_query tools (voyant#3932); this bounds what",
+        "  describe_tool pulls for the read surface. Writes are not collapsed and",
+        "  are described individually. Raising the ceiling needs a recorded reason.",
       ].join("\n"),
     ).toBeLessThanOrEqual(AGGREGATE_CEILING_BYTES)
   })

--- a/starters/operator/tests/selected-graph-mcp-tool-surface.test.ts
+++ b/starters/operator/tests/selected-graph-mcp-tool-surface.test.ts
@@ -69,6 +69,17 @@ const PAYLOAD_CEILING_BYTES = 3_800
  * call time and the eager `tools/list` ratchet above catches a regression to
  * eager loading.
  */
+/**
+ * Ceiling for the aggregate schema of EVERY selected tool, reads and writes.
+ *
+ * Measured at 260,968 bytes across 264 tools before voyant#3932. The read
+ * collapse does not shrink this materially — the underlying read Tools still
+ * exist in the registry and remain individually dispatchable — so it stays near
+ * its pre-collapse value. Its job is to stop WRITE schemas growing unseen, since
+ * they appear in neither the served tools/list nor the query-tool bound.
+ */
+const ALL_TOOLS_AGGREGATE_CEILING_BYTES = 275_000
+
 const AGGREGATE_CEILING_BYTES = 130_000
 
 /** Rough proxy for tokens. JSON schema tokenizes denser than prose, so this is a floor. */
@@ -264,5 +275,66 @@ describe("selected-graph MCP tool surface cost", () => {
         "  are described individually. Raising the ceiling needs a recorded reason.",
       ].join("\n"),
     ).toBeLessThanOrEqual(AGGREGATE_CEILING_BYTES)
+  })
+
+  it("still bounds EVERY selected tool's schema, writes included", async () => {
+    // The query-tool bound above covers the collapsed READ surface only. Writes
+    // are deliberately not collapsed (voyant#3921: per-action risk, confirmation,
+    // ledger and approval metadata are load-bearing and must not be flattened),
+    // and progressive disclosure keeps them out of the served `tools/list`.
+    //
+    // So without this, write schemas would be bounded NOWHERE — invisible to the
+    // served ratchet and excluded from the read ratchet. `describe_tool` and
+    // `call_tool` still pay their cost. This is the guard that was in place before
+    // voyant#3932 narrowed the aggregate metric; it is kept as an independent
+    // third bound rather than folded into either of the others.
+    const runtime = createGeneratedGraphRuntime()
+    let totalBytes = 0
+    let toolCount = 0
+    const heaviest: Array<{ name: string; bytes: number }> = []
+
+    for (const tool of runtime.tools) {
+      const definition = await tool.load<{
+        name: string
+        description: string
+        inputSchema: unknown
+      }>()
+      let inputSchema: unknown
+      try {
+        inputSchema = z.toJSONSchema(definition.inputSchema as never, {
+          io: "input",
+          unrepresentable: "any",
+        })
+      } catch {
+        inputSchema = { type: "object", additionalProperties: true }
+      }
+      const name = tool.name ?? definition.name
+      const bytes = Buffer.byteLength(
+        JSON.stringify({ name, description: definition.description, inputSchema }),
+        "utf8",
+      )
+      totalBytes += bytes
+      toolCount += 1
+      heaviest.push({ name, bytes })
+    }
+
+    const top = heaviest
+      .sort((a, b) => b.bytes - a.bytes)
+      .slice(0, 5)
+      .map(({ name, bytes }) => `    ${String(bytes).padStart(7)}  ${name}`)
+      .join("\n")
+
+    expect(
+      totalBytes,
+      [
+        `Aggregate schema across ALL selected tools: ${totalBytes.toLocaleString()} bytes across ${toolCount} tools`,
+        "  heaviest:",
+        top,
+        "",
+        "  Not a per-connection cost — it bounds the whole selected surface so write",
+        "  schemas cannot bloat unseen now that they appear in neither the served",
+        "  tools/list nor the read-projection bound.",
+      ].join("\n"),
+    ).toBeLessThanOrEqual(ALL_TOOLS_AGGREGATE_CEILING_BYTES)
   })
 })


### PR DESCRIPTION
Closes #3932. The workstream that addresses Finding 1 of #3921 — the 264 endpoint-shaped tools.

Progressive disclosure (#3961) made that surface cheap to ignore. It did not make it good. This reshapes it.

## Result

| | Before | After |
|---|---:|---:|
| Read tools | 133 (`get_` 70, `list_` 59, `search_` 4) | **24 `<domain>_query` tools** |
| Real-surface discovery | **48,553 tokens** | **36,974 tokens** (−24%) |
| Journeys completing | 6/6 | 6/6 |

Measured by `starters/operator/tests/agent-journey-real-surface.test.ts` against the real composed graph — not the synthetic in-package baselines, which define their own simplified schemas and would have given a flattering, meaningless comparison.

Namespacing comes free: names were verb-first, so all 59 `list_*` tools across 24 packages read as interchangeable. `inventory_query` / `bookings_query` cluster by product area instead.

## Design, per #3921

Pure transport projection — **no domain `tools.ts` is modified**. Grouping is driven by `ToolManifestEntry` metadata the manifest already carries. Writes are **not** collapsed: per-action risk, confirmation, ledger and approval metadata are load-bearing and flattening them would weaken the governance layer. `GET /manifest` stays fine-grained.

Flat read names are removed outright — beta, no aliases, no deprecation window (resolved decision 1).

## Why per-resource output schemas are dropped — I measured this rather than accepting it

`QUERY_OUTPUT_SCHEMA` is permissive, and the code notes this is "the bulk of the discovery-cost saving". That looked like it might be inflating the headline, so I tested it by restoring real per-resource outputs:

| Variant | Discovery cost |
|---|---:|
| Before this PR | 48,553 |
| **This PR** | **36,974** |
| This PR + per-resource output schemas | **91,576** |

Grouping makes carrying them **quadratic** — describing `inventory_query` pulls in outputs for all ~15 of its resources when the agent wants one. Dropping them is **forced by the grouping design**, not a shortcut. Worth knowing that the trade is real: an agent no longer learns a read's output shape from `describe_tool`. Follow-up candidate: resource-scoped describe.

## Three corrections I applied on top

**1. The aggregate ratchet was redefined, not lowered.** It previously bounded all 264 tools' input schemas; the branch narrowed it to the 24 query tools. Writes are excluded from the served `tools/list` by progressive disclosure *and* would then be excluded from the aggregate — **nothing would bound write schema growth at all**. Both bounds now exist independently:

| Guard | Ceiling |
|---|---:|
| Served `tools/list` | 3,800 B |
| Query-tool describe aggregate | 130,000 B |
| **All-tools aggregate (restored)** | **275,000 B** |

**2. Partial pruning was claimed but not tested.** The suite only covered the degenerate case — a group whose single read is unauthorized vanishes entirely. That is not the property the projection claims. Added a second read to the test domain behind a different scope, so a group has two resources, and asserted that holding one scope exposes one and hides the other — **in discovery and at dispatch**, since discovery-only pruning would make a group a scope bypass.

**3. Fixed a flake I merged yesterday.** `agent-journey-real-surface.test.ts` passed alone and failed in a full run: its `beforeAll` composes the graph and runs every journey, exceeding vitest's 10s default hook timeout under parallel load. The config raises `testTimeout` but not `hookTimeout`. Now set explicitly.

## Verification

```
pnpm -F @voyant-travel/mcp test          Test Files 12 passed   Tests 77 passed
pnpm -F @voyant-travel/mcp typecheck     exit 0
operator suite (full dir)                Test Files 11 passed   Tests 56 passed
pnpm -F @voyant-travel/bookings-react    Test Files 31 passed   Tests 147 passed
npx biome check .                        repo-wide, 0 errors
node scripts/check-agent-code-quality.mjs | grep packages/mcp/src   # no matches
```

One pre-existing warning surfaces: `packages/mcp/src/server.ts` is 505 lines against a 500-line advisory (hard gate is 600). Worth splitting soon, not in this PR.