### PR TITLE
refactor(framework): gate the auth-integration rule on the adminAuth binding

### DIFF
--- a/.changeset/adminauth-binding-gate.md
+++ b/.changeset/adminauth-binding-gate.md
@@ -1,0 +1,13 @@
+---
+"@voyant-travel/framework": patch
+---
+
+Gate the injected-auth-integration requirement on the `adminAuth` provider
+binding rather than on `deployment.mode`.
+
+A deployment binding `adminAuth: "voyant-cloud"` needs the integration injected
+wherever it runs, not only under `mode: "managed-cloud"`. `better-auth` is
+self-contained and requires nothing.
+
+The two Redis rules are unchanged and remain context-gated — they encode
+"shared, untrusted infrastructure", which no provider value expresses.

--- a/packages/framework/src/node-runtime.test.ts
+++ b/packages/framework/src/node-runtime.test.ts
@@ -159,7 +159,9 @@ const BASE_PROVIDERS = {
   search: "none",
   email: "none",
   sms: "none",
-  adminAuth: "voyant-cloud",
+  // better-auth is self-contained. voyant-cloud admin auth requires an injected
+  // integration, which is orthogonal to what most of these tests exercise.
+  adminAuth: "better-auth",
   customerAuth: "disabled",
   realtime: "none",
   scheduledJobs: "none",
@@ -619,6 +621,26 @@ describe("loadVoyantNodeRuntime Redis URL validation", () => {
       deployment: { mode: "managed-cloud" },
       env: { REDIS_NAMESPACE: "region-eu-1" },
     })
+  })
+
+  it("requires an injected auth integration when adminAuth binds voyant-cloud", async () => {
+    // Gated on the binding rather than the deployment mode: the voyant-cloud
+    // provider is externally supplied, so the integration must be injected
+    // wherever it is bound. better-auth is self-contained and needs nothing.
+    const providers = {
+      ...BASE_PROVIDERS,
+      adminAuth: "voyant-cloud",
+    } satisfies VoyantDeploymentProviders
+
+    await expect(
+      loadVoyantNodeRuntime({
+        graphRuntime: emptyGraphRuntime(providers),
+        jobs: [],
+        deployment: { mode: "self-hosted", providers },
+        deploymentRequirements: { resources: [] },
+        env: { ORIGIN_TRUST_SECRET: "secret" },
+      }),
+    ).rejects.toThrow(/voyant-cloud admin-auth provider requires an injected auth integration/)
   })
 
   it("allows self-hosted Redis providers to use plaintext TCP without a namespace", async () => {

--- a/packages/framework/src/node-runtime.ts
+++ b/packages/framework/src/node-runtime.ts
@@ -335,6 +335,7 @@ export async function loadVoyantNodeRuntime(
   )
   assertVoyantNodeRuntimeSupport({
     mode: options.deployment.mode,
+    providers: options.deployment.providers,
     providerPlan,
     requirements,
     env,
@@ -688,39 +689,67 @@ function isPostgresConnectionUrl(value: string): boolean {
   }
 }
 
+/**
+ * Whether any binding in this plan resolves to Redis.
+ *
+ * Deliberately NOT "the cache/sharedState/rateLimit group" — those roles are
+ * bound independently. Managed binds `cache: redis`, `rateLimit: redis` and
+ * `sharedState: postgres`, so a group-wide test over-applies, and a test keyed
+ * on `sharedState` alone would never fire there. Legacy stored snapshots also
+ * carry `sharedState: redis` from an old backfill, so that role is the least
+ * reliable signal of the three.
+ */
+function bindsRedis(plan: VoyantNodeProviderPlan): boolean {
+  return plan.cache === "redis" || plan.sharedState === "redis" || plan.rateLimit === "redis"
+}
+
 function assertVoyantNodeRuntimeSupport(options: {
   mode: VoyantDeploymentMode
+  providers: Readonly<Record<string, string>>
   providerPlan: VoyantNodeProviderPlan
   requirements: VoyantGraphDeploymentRequirements
   env: VoyantNodeRuntimeEnv
   hasAuthIntegration: boolean
 }) {
   const issues = nodeRuntimeEnvIssues(options.requirements, options.env)
-  if (options.mode === "managed-cloud" && !options.hasAuthIntegration) {
-    issues.push("managed-cloud applications require an injected auth integration")
+
+  // Gated on the binding that implies it, not on the deployment mode: the
+  // voyant-cloud admin-auth provider is externally supplied, so the integration
+  // has to be injected. `better-auth` is self-contained and needs nothing.
+  if (options.providers.adminAuth === "voyant-cloud" && !options.hasAuthIntegration) {
+    issues.push("the voyant-cloud admin-auth provider requires an injected auth integration")
   }
-  if (
-    options.mode === "managed-cloud" &&
-    (options.providerPlan.cache === "redis" ||
-      options.providerPlan.sharedState === "redis" ||
-      options.providerPlan.rateLimit === "redis") &&
-    !options.env.REDIS_NAMESPACE?.trim()
-  ) {
-    issues.push(
-      "managed-cloud Redis cache, shared-state, and rate-limit providers require REDIS_NAMESPACE",
-    )
+
+  // Both Redis rules stay gated on the deployment context, and that is correct
+  // rather than provisional. They encode "this Redis instance is shared between
+  // tenants and reachable over an untrusted network" — which no provider value
+  // carries. `cache: "redis"` is equally true of a managed Upstash instance and
+  // of a self-hoster's Redis on a private network, and the two have opposite
+  // requirements. `allows self-hosted Redis providers to use plaintext TCP
+  // without a namespace` in node-runtime.test.ts is the specification for that.
+  //
+  // REDIS_NAMESPACE additionally cannot be declared unconditionally: the
+  // platform injects it only for images advertising `regionalRedisNamespaceV1`,
+  // an explicit allowlist rather than a version range, so a blanket requirement
+  // would hard-fail boot on managed images outside it (platform#1622).
+  //
+  // What IS wrong here is the name of the axis. This is not managed-versus-
+  // self-hosted; it is shared-untrusted infrastructure versus dedicated. A
+  // self-hoster on shared infrastructure would want both of these rules, which
+  // the current name makes unthinkable. See voyant#3976 item 1.
+  if (options.mode === "managed-cloud" && bindsRedis(options.providerPlan)) {
+    if (!options.env.REDIS_NAMESPACE?.trim()) {
+      issues.push(
+        "managed-cloud Redis cache, shared-state, and rate-limit providers require REDIS_NAMESPACE",
+      )
+    }
+    if (!isSecureRedisUrl(options.env.REDIS_URL)) {
+      issues.push(
+        "managed-cloud Redis providers require rediss:// for Redis TCP or an HTTPS Redis REST URL with a token",
+      )
+    }
   }
-  if (
-    options.mode === "managed-cloud" &&
-    (options.providerPlan.cache === "redis" ||
-      options.providerPlan.sharedState === "redis" ||
-      options.providerPlan.rateLimit === "redis") &&
-    !isManagedRedisUrl(options.env.REDIS_URL)
-  ) {
-    issues.push(
-      "managed-cloud Redis providers require rediss:// for Redis TCP or an HTTPS Redis REST URL with a token",
-    )
-  }
+
   if (issues.length > 0) {
     throw new Error(`Voyant Node runtime is not ready to start:\n${formatIssues(issues)}`)
   }
@@ -798,7 +827,7 @@ function isRedisUrl(value: unknown): value is string {
   }
 }
 
-function isManagedRedisUrl(value: unknown): value is string {
+function isSecureRedisUrl(value: unknown): value is string {
   if (typeof value !== "string" || value.trim().length === 0) return false
   try {
     const protocol = redisUrlProtocol(value)


### PR DESCRIPTION
Part of #3976 (item 1).

## Problem

`assertNodeRuntimeReady` rejected a deployment whenever `mode === "managed-cloud"`, regardless of which providers the deployment actually bound. The mode flag and the provider bindings are independent axes, so a deployment could be refused for a provider it never uses.

## What changed

The auth-integration rule is now gated on the binding rather than the mode:

```ts
if (options.providers.adminAuth === "voyant-cloud" && !options.hasAuthIntegration) {
  issues.push("the voyant-cloud admin-auth provider requires an injected auth integration")
}
```

This is strictly more correct in both directions. A self-hosted deployment that binds the hosted admin-auth provider now gets the same error it would have gotten hosted, and a hosted deployment that binds `better-auth` is no longer asked for an integration it does not need.

Supporting changes:

- `bindsRedis(plan)` replaces the repeated three-role condition (`cache`, `sharedState`, `rateLimit`).
- `isManagedRedisUrl` renamed to `isSecureRedisUrl` — it tests the URL scheme, not the operator.
- `BASE_PROVIDERS.adminAuth` in the test file moved from `voyant-cloud` to `better-auth`, so the existing cases exercise the default path.

## What deliberately did not change

The namespace and TLS rules stay gated on `mode === "managed-cloud"`.

The first attempt generalised them to every Redis binding and broke `allows self-hosted Redis providers to use plaintext TCP without a namespace`. That test is the specification: a self-hoster running Redis on a private network is entitled to plaintext TCP and a whole keyspace. The real axis is shared-untrusted versus dedicated infrastructure, and `mode` is the only signal currently carrying it — under a name that describes the operator instead of the trust boundary.

Reconciling that needs the namespace floor to move upstream, which is tracked separately. A comment at the call site records the reasoning so the next reader does not repeat the attempt.

## Verification

- 374 framework tests pass, including a new case pinning the binding-gated rule.
- `typecheck` clean for `framework`, `runtime`, and `operator-standard`.
- `biome check` clean.