### PR TITLE
feat(finance): book_product — one intent-level call, server-resolved idempotency

### DIFF
--- a/.changeset/finance-book-product-workflow-tool.md
+++ b/.changeset/finance-book-product-workflow-tool.md
@@ -1,0 +1,38 @@
+---
+"@voyant-travel/finance": minor
+"@voyant-travel/bookings-react": minor
+"@voyant-travel/tools": minor
+---
+
+Add `book_product`, an intent-level booking workflow tool, and retire
+`generate_booking_number` (voyant#3933).
+
+`book_product` books a product for a client in a single call — product and
+option, the billing party (`personId` or `organizationId`), travelers, and
+rooms. It replaces the multi-call sequence the old `create_booking` description
+scripted in prose (find the client with `list_people`/`list_organizations`,
+resolve options with `list_product_options`/`list_option_units`, allocate a
+reference with `generate_booking_number`, then create). The platform now
+orchestrates all of it: the booking reference **and** the action-ledger
+idempotency key are resolved server-side, so the model never carries a token
+across turns — the failure mode that produced duplicate bookings. Like
+`compose_product`, an incomplete request returns actionable issues and writes
+nothing. It carries its own action policy and does not bypass the action-ledger
+gate.
+
+**Breaking change.** `generate_booking_number` is removed — no alias, no
+deprecation window (the product is in beta). `book_product` subsumes it, and
+`create_booking` now allocates the reference server-side too, so
+`booking.bookingNumber` is optional and callers no longer pre-allocate. The
+orchestration prose is deleted from `create_booking`'s description.
+
+First-party migration in the same change: `@voyant-travel/bookings-react`'s
+manual-booking MCP client and dialog no longer call `generate_booking_number`
+(`REQUIRED_TOOLS` is now `["create_booking"]`); they submit `create_booking`
+without a client-invented reference and keep the stable client idempotency key
+that makes a retry replay the original booking.
+
+`@voyant-travel/tools` gains `withServerResolvedIdempotencyKey`, the sanctioned
+way for a handler-owned workflow tool to seat a server-derived idempotency key
+on an already-authentic admission — the created-target analogue of the
+server-owned `requestId` a generic server-owned-target action already uses.

--- a/docs/architecture/agent-tool-library.md
+++ b/docs/architecture/agent-tool-library.md
@@ -78,6 +78,46 @@ Rules:
   architecture checker rejects `z.custom()` and opaque top-level output schemas in
   canonical Tool runtime modules.
 
+## Intent-level workflow tools
+
+Some jobs an operator does are not one service call — they are a fixed sequence of
+them. When that sequence leaks into a tool **description** as prose the model is
+expected to follow ("find the client with `list_people`, resolve options with
+`list_product_options`, allocate a reference with `generate_booking_number`,
+then create"), that is the signal to build a **workflow tool**: one intent-driven
+call that the platform orchestrates. See voyant#3921 / voyant#3933.
+
+A workflow tool:
+
+- is **one intent-level call** — `book_product`, not
+  find-client → resolve-options → allocate-reference → create;
+- **resolves server-side** every token the caller would otherwise carry across
+  turns. `book_product` allocates the booking reference and derives the
+  action-ledger idempotency key itself, so an identical retry replays the
+  original booking instead of minting a second one. Carrying an opaque token
+  across turns is one of the least reliable things to ask of a model, and the
+  failure mode is a duplicate write;
+- **validates before it writes** — an incomplete request returns actionable
+  issues and creates nothing, exactly as `compose_product` does;
+- **carries its own action policy.** It does not bypass the action-ledger gate:
+  risk, confirmation, ledger binding, and approval are per-action and
+  load-bearing. A workflow tool gets its own capability identity and action id
+  even when it composes the same durable command as a lower-level tool, so the
+  two admissions stay unconfusable.
+
+**Where a workflow tool lives — the ownership rule.** A workflow tool lives in the
+package that owns the **real orchestration service**, which is not always the
+package the job is named after. Booking is the load-bearing example: a booking is
+created by `book_product`, but that tool lives in **`@voyant-travel/finance`**, not
+`@voyant-travel/bookings`. Finance already composes Bookings (the lease-gated
+domain settlement), travel credits, payment schedules, and invoices inside one
+durable command — it is the only package that can orchestrate all of them without
+introducing a workspace dependency cycle — so the booking workflow tool belongs to
+Finance. Do not add a booking tool to `@voyant-travel/bookings`; it would have to
+reach back into Finance to do the real work. When a workflow's home is
+non-obvious, it is because the orchestration service already lives somewhere the
+job's name does not point to — follow the service, not the noun.
+
 ## Domain completeness notes
 
 Inventory owns guarded core authoring and lifecycle Tools (`create_product`,
@@ -109,7 +149,13 @@ later reservation.
 Booking creation is exposed only through Finance's admitted create command. Finance
 owns the public command and its policy admission; Bookings owns the lease-gated domain
 settlement that inserts the canonical row. Capacity holds remain separate pre-booking
-operations and cannot create a booking.
+operations and cannot create a booking. The intent-level entry point is
+`book_product` (a Finance workflow tool, per the ownership rule above): it maps a
+product/client/travelers/rooms request onto that same durable command, resolving the
+booking reference and the idempotency key server-side. `create_booking` remains the
+lower-level tool for a caller that already holds a fully resolved command; it too now
+allocates the reference server-side. The old `generate_booking_number` tool — which
+existed only to make the caller carry a reference across calls — is retired.
 
 Graph actions distinguish existing targets from handler-generated targets explicitly.
 Generic action preflight resolves targets through a deterministic server-owned ladder: a

--- a/packages/bookings-react/src/components/manual-booking-create-form.tsx
+++ b/packages/bookings-react/src/components/manual-booking-create-form.tsx
@@ -71,13 +71,13 @@ import {
   usePricingPreview,
 } from "../index.js"
 import {
-  allocateManualBookingNumber,
   createManualBookingThroughTool,
   getManualBookingToolAvailability,
 } from "../manual-booking-mcp-client.js"
 import { useVoyantBookingsContext } from "../provider.js"
 import {
   findAlreadyPaidInstallmentMissingPaymentDate,
+  generateBookingNumber,
   hasAnyPaidPayment,
   inferTravelerPricingCategoryId,
   isBookingInventoryUnit,
@@ -148,7 +148,12 @@ export interface ManualBookingCreateFormProps {
 
 export interface ManualBookingAttempt {
   fingerprint: string
-  bookingNumber: string | null
+  /**
+   * Cosmetic reference for the default shared-room group label only. The durable
+   * booking reference is resolved server-side by `create_booking` (voyant#3933),
+   * so this is never sent as the booking number.
+   */
+  labelReference: string | null
   idempotencyKey: string
 }
 
@@ -1432,7 +1437,7 @@ export function ManualBookingCreateForm({
       redistributed.travelers,
       travelerPricingCategories,
     )
-    const bookingNumber = attemptRef.current?.bookingNumber ?? null
+    const labelReference = attemptRef.current?.labelReference ?? null
     const selectedSharedRoomUnitId = getSelectedSharedRoomUnitId(rooms.quantities)
     const groupMembership: BookingCreateGroupMembershipInput | undefined = sharedRoom.enabled
       ? sharedRoom.mode === "create"
@@ -1442,7 +1447,7 @@ export function ManualBookingCreateForm({
             label:
               sharedRoom.groupLabel?.trim() ||
               `${messages.bookingCreateDialog.labels.sharedRoomGeneratedLabelPrefix} - ${
-                bookingNumber ?? "pending"
+                labelReference ?? "pending"
               }`,
             optionUnitId: selectedSharedRoomUnitId,
             makeBookingPrimary: true,
@@ -1500,7 +1505,9 @@ export function ManualBookingCreateForm({
     if (!attemptRef.current || attemptRef.current.fingerprint !== fingerprint) {
       attemptRef.current = {
         fingerprint,
-        bookingNumber: null,
+        // Cosmetic reference for the default shared-room group label; the durable
+        // booking reference is allocated server-side by `create_booking`.
+        labelReference: generateBookingNumber(),
         idempotencyKey: createIdempotencyKey(),
       }
     }
@@ -1508,19 +1515,18 @@ export function ManualBookingCreateForm({
     setSubmitting(true)
     try {
       const attempt = attemptRef.current
-      if (!attempt.bookingNumber) {
-        attempt.bookingNumber = await allocateManualBookingNumber(client)
-      }
       if (groupMembership?.action === "create") {
         booking.groupMembership = {
           ...groupMembership,
           label:
             sharedRoom.groupLabel?.trim() ||
-            `${messages.bookingCreateDialog.labels.sharedRoomGeneratedLabelPrefix} - ${attempt.bookingNumber}`,
+            `${messages.bookingCreateDialog.labels.sharedRoomGeneratedLabelPrefix} - ${attempt.labelReference}`,
         }
       }
+      // The reference is resolved server-side; the stable idempotencyKey makes a
+      // retry replay the original booking instead of creating a second one.
       const result = await createManualBookingThroughTool(client, {
-        booking: { ...booking, bookingNumber: attempt.bookingNumber },
+        booking,
         idempotencyKey: attempt.idempotencyKey,
       })
       await queryClient.invalidateQueries({ queryKey: availabilityQueryKeys.slots() })

--- a/packages/bookings-react/src/manual-booking-mcp-client.ts
+++ b/packages/bookings-react/src/manual-booking-mcp-client.ts
@@ -31,7 +31,10 @@ interface JsonRpcResponse {
   }
 }
 
-const REQUIRED_TOOLS = ["generate_booking_number", "create_booking"] as const
+// `generate_booking_number` was retired (voyant#3933): `create_booking` now
+// resolves the booking reference server-side, so the dialog needs only the one
+// write capability.
+const REQUIRED_TOOLS = ["create_booking"] as const
 
 export async function getManualBookingToolAvailability(
   options: ManualBookingMcpClientOptions,
@@ -48,16 +51,6 @@ export async function getManualBookingToolAvailability(
   )
   const missingTools = REQUIRED_TOOLS.filter((name) => !names.has(name))
   return { canCreate: missingTools.length === 0, missingTools }
-}
-
-export async function allocateManualBookingNumber(
-  options: ManualBookingMcpClientOptions,
-): Promise<string> {
-  const result = await callTool(options, "generate_booking_number", {})
-  if (typeof result.bookingNumber !== "string" || result.bookingNumber.length === 0) {
-    throw new Error("The booking number Tool returned an invalid reference.")
-  }
-  return result.bookingNumber
 }
 
 export async function createManualBookingThroughTool(

--- a/packages/bookings-react/tests/unit/manual-booking-mcp-client.test.ts
+++ b/packages/bookings-react/tests/unit/manual-booking-mcp-client.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi } from "vitest"
 
 import {
-  allocateManualBookingNumber,
   createManualBookingThroughTool,
   getManualBookingToolAvailability,
 } from "../../src/manual-booking-mcp-client.js"
@@ -15,10 +14,12 @@ function json(body: unknown, init?: ResponseInit) {
 }
 
 describe("manual booking MCP client", () => {
-  it("fails closed unless both authorized Finance booking tools are visible", async () => {
+  it("fails closed unless the create_booking tool is visible", async () => {
+    // generate_booking_number was retired (voyant#3933): create_booking resolves
+    // the reference server-side, so it is the only capability the dialog needs.
     const fetcher = vi.fn(async () =>
       json({
-        tools: [{ name: "generate_booking_number" }],
+        tools: [{ name: "list_invoices" }],
       }),
     )
     await expect(
@@ -33,42 +34,39 @@ describe("manual booking MCP client", () => {
     )
   })
 
-  it("allocates the authoritative reference and delegates create with confirmation", async () => {
+  it("reports create availability when create_booking is present", async () => {
+    const fetcher = vi.fn(async () => json({ tools: [{ name: "create_booking" }] }))
+    await expect(
+      getManualBookingToolAvailability({ baseUrl: "https://operator.test", fetcher }),
+    ).resolves.toEqual({ canCreate: true, missingTools: [] })
+  })
+
+  it("delegates create with confirmation and a server-resolved reference", async () => {
     const calls: Array<Record<string, unknown>> = []
     const fetcher = vi.fn(async (_url: string, init?: RequestInit) => {
       const request = JSON.parse(String(init?.body)) as {
         params: { name: string; arguments: Record<string, unknown> }
       }
       calls.push(request)
-      return request.params.name === "generate_booking_number"
-        ? json({
-            jsonrpc: "2.0",
-            id: "1",
-            result: { structuredContent: { bookingNumber: "BK-000123" } },
-          })
-        : json({
-            jsonrpc: "2.0",
-            id: "2",
-            result: {
-              structuredContent: { status: "created", bookingId: "book_1", replayed: false },
-            },
-          })
+      return json({
+        jsonrpc: "2.0",
+        id: "1",
+        result: {
+          structuredContent: { status: "created", bookingId: "book_1", replayed: false },
+        },
+      })
     })
     const client = { baseUrl: "", fetcher }
-    const bookingNumber = await allocateManualBookingNumber(client)
     const result = await createManualBookingThroughTool(client, {
-      booking: { productId: "prod_1", bookingNumber },
+      // No bookingNumber — the server allocates the reference.
+      booking: { productId: "prod_1" },
       idempotencyKey: "manual-booking:stable-1",
     })
 
-    expect(bookingNumber).toBe("BK-000123")
     expect(result).toEqual({ status: "created", bookingId: "book_1", replayed: false })
-    expect(calls.map((call) => (call.params as { name: string }).name)).toEqual([
-      "generate_booking_number",
-      "create_booking",
-    ])
-    expect((calls[1]?.params as { arguments: Record<string, unknown> }).arguments).toEqual({
-      booking: { productId: "prod_1", bookingNumber: "BK-000123" },
+    expect(calls.map((call) => (call.params as { name: string }).name)).toEqual(["create_booking"])
+    expect((calls[0]?.params as { arguments: Record<string, unknown> }).arguments).toEqual({
+      booking: { productId: "prod_1" },
       _voyant: {
         confirmed: true,
         idempotencyKey: "manual-booking:stable-1",
@@ -91,7 +89,7 @@ describe("manual booking MCP client", () => {
       })
     })
     const input = {
-      booking: { productId: "prod_1", bookingNumber: "BK-000123" },
+      booking: { productId: "prod_1" },
       idempotencyKey: "manual-booking:stable-1",
     }
     await createManualBookingThroughTool({ baseUrl: "", fetcher }, input)

--- a/packages/finance/src/book-product.ts
+++ b/packages/finance/src/book-product.ts
@@ -1,0 +1,312 @@
+/**
+ * `book_product` — the intent-level booking workflow tool (voyant#3933).
+ *
+ * One call books a product for a client: product + option, the billing party,
+ * travelers, and rooms. It replaces the multi-call sequence the old
+ * `create_booking` description scripted in prose — find the client with
+ * `list_people`/`list_organizations`, resolve options with
+ * `list_product_options`/`list_option_units`, allocate a reference with
+ * `generate_booking_number`, then create. Here the platform orchestrates all of
+ * it: the booking reference and the action-ledger idempotency key are resolved
+ * SERVER-SIDE, so the model never carries an opaque token across turns (the
+ * failure mode that produced duplicate bookings).
+ *
+ * Like `compose_product`, it validates before it writes: an incomplete request
+ * returns actionable issues and creates nothing.
+ *
+ * This module owns the wire contract and the pure mapping/validation. The DB
+ * work (reference allocation, the durable command) lives in `mcp-runtime.ts`,
+ * which holds the request-scoped services.
+ */
+import { bookingToolDetailSchema } from "@voyant-travel/bookings"
+import { bookingStatusSchema } from "@voyant-travel/bookings/validation"
+import { z } from "zod"
+
+import { type BookingCreateInput, bookingCreateSchema } from "./service-booking-create.js"
+import { paymentScheduleStatusSchema, paymentScheduleTypeSchema } from "./validation-shared.js"
+
+const bookProductTravelerSchema = z.object({
+  clientTravelerKey: z
+    .string()
+    .min(1)
+    .max(255)
+    .optional()
+    .describe(
+      "Stable key for this traveler within the request. Reference it from a room's `travelerKeys` to seat the traveler in that room.",
+    ),
+  firstName: z.string().min(1).max(255),
+  lastName: z.string().min(1).max(255),
+  email: z.string().email().optional().nullable(),
+  phone: z.string().max(50).optional().nullable(),
+  personId: z
+    .string()
+    .optional()
+    .nullable()
+    .describe("Linked CRM person id when this traveler already exists as a contact."),
+  participantType: z.enum(["traveler", "occupant", "other"]).default("traveler"),
+  travelerCategory: z.enum(["adult", "child", "infant", "senior", "other"]).optional().nullable(),
+  isPrimary: z.boolean().optional().nullable(),
+  specialRequests: z.string().optional().nullable(),
+})
+
+const bookProductRoomSchema = z.object({
+  optionUnitId: z
+    .string()
+    .min(1)
+    .describe(
+      "The selected room or priced unit id for the chosen option. The server accepts it as given; a wrong unit is reported as an actionable issue rather than guessed.",
+    ),
+  quantity: z
+    .number()
+    .int()
+    .min(1)
+    .describe("Number of this unit. For a room this is the number of ROOMS, not travelers."),
+  travelerKeys: z
+    .array(z.string().min(1).max(255))
+    .optional()
+    .describe(
+      "`clientTravelerKey` values seated in this room. Assign every traveler to exactly one room and respect its occupancy.",
+    ),
+  title: z.string().min(1).max(255).optional().nullable(),
+})
+
+const bookProductBillingContactSchema = z.object({
+  firstName: z.string().max(255).optional().nullable(),
+  lastName: z.string().max(255).optional().nullable(),
+  email: z.string().max(255).optional().nullable(),
+  phone: z.string().max(50).optional().nullable(),
+  partyType: z.enum(["individual", "company"]).optional().nullable(),
+  taxId: z.string().max(100).optional().nullable(),
+  preferredLanguage: z.string().max(35).optional().nullable(),
+  country: z.string().max(2).optional().nullable(),
+  region: z.string().max(100).optional().nullable(),
+  city: z.string().max(100).optional().nullable(),
+  addressLine1: z.string().max(500).optional().nullable(),
+  addressLine2: z.string().max(500).optional().nullable(),
+  postalCode: z.string().max(20).optional().nullable(),
+})
+
+const documentGenerationSchema = z.object({
+  contractDocument: z.boolean().default(false),
+  invoiceDocument: z.boolean().default(false),
+  invoiceType: z.enum(["invoice", "proforma"]).default("invoice"),
+})
+
+export const bookProductToolInputSchema = z.object({
+  productId: z.string().min(1).describe("The product to book."),
+  optionId: z
+    .string()
+    .optional()
+    .nullable()
+    .describe("Chosen product option. Supply it when the product has rooms or multiple options."),
+  slotId: z.string().optional().nullable().describe("Dated departure/availability slot, if any."),
+  catalogId: z
+    .string()
+    .min(1)
+    .optional()
+    .nullable()
+    .describe("Public price catalog the quote used; omit to use the default public catalog."),
+  personId: z
+    .string()
+    .min(1)
+    .optional()
+    .describe(
+      "Billing party for a private client. Provide exactly one of `personId` or `organizationId`.",
+    ),
+  organizationId: z
+    .string()
+    .min(1)
+    .optional()
+    .describe(
+      "Billing party for a company or agency booking. Provide exactly one of `personId` or `organizationId`.",
+    ),
+  billingContact: bookProductBillingContactSchema
+    .optional()
+    .describe(
+      "Billing-contact snapshot captured on the booking. For a private client a real name and an email or phone are required.",
+    ),
+  pax: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .nullable()
+    .describe("Total traveler count. Must match `travelers` and the selected room capacity."),
+  travelers: z
+    .array(bookProductTravelerSchema)
+    .min(1)
+    .describe("Everyone on the booking. Give each a unique `clientTravelerKey`."),
+  rooms: z
+    .array(bookProductRoomSchema)
+    .optional()
+    .describe(
+      "Selected rooms or priced units. Required for room products: `quantity` is room count and `travelerKeys` seats travelers.",
+    ),
+  paymentSchedules: z
+    .array(
+      z.object({
+        scheduleType: paymentScheduleTypeSchema.default("balance"),
+        status: paymentScheduleStatusSchema.default("pending"),
+        dueDate: z.string().min(1),
+        currency: z.string().min(3).max(3),
+        amountCents: z.number().int().min(0),
+        notes: z.string().optional().nullable(),
+      }),
+    )
+    .optional(),
+  documentGeneration: documentGenerationSchema
+    .optional()
+    .describe("Ask the create to also request a contract and/or an invoice or proforma."),
+  initialStatus: bookingStatusSchema
+    .optional()
+    .describe("Seat the booking in this status instead of the default `draft`."),
+  suppressNotifications: z
+    .boolean()
+    .optional()
+    .describe("Confirm silently — skip customer-facing email and document bundles."),
+  allowDuplicate: z
+    .boolean()
+    .optional()
+    .describe(
+      "Override the same-party/same-departure guard to intentionally create a second active booking.",
+    ),
+  internalNotes: z.string().optional().nullable(),
+})
+
+export type BookProductInput = z.infer<typeof bookProductToolInputSchema>
+
+export const bookProductIssueSchema = z.object({
+  path: z.string().describe("Dot-path of the offending field, e.g. `travelers.0.email`."),
+  message: z.string(),
+})
+
+export const bookProductToolOutputSchema = z.discriminatedUnion("status", [
+  z.object({
+    status: z.literal("created"),
+    bookingId: z.string(),
+    bookingNumber: z.string(),
+    replayed: z.boolean(),
+    booking: bookingToolDetailSchema,
+  }),
+  z.object({
+    status: z.literal("invalid"),
+    issues: z.array(bookProductIssueSchema),
+  }),
+])
+
+export type BookProductOutput = z.infer<typeof bookProductToolOutputSchema>
+
+/**
+ * Map the intent-shaped request onto the durable booking-create command. The
+ * reference is threaded in by the caller after allocation so this stays a pure
+ * function of the request.
+ */
+export function mapBookProductIntentToCommand(
+  input: BookProductInput,
+  bookingNumber: string,
+): BookingCreateInput {
+  return {
+    productId: input.productId,
+    optionId: input.optionId ?? null,
+    slotId: input.slotId ?? null,
+    catalogId: input.catalogId ?? null,
+    bookingNumber,
+    personId: input.personId ?? null,
+    organizationId: input.organizationId ?? null,
+    pax: input.pax ?? null,
+    internalNotes: input.internalNotes ?? null,
+    contactFirstName: input.billingContact?.firstName ?? null,
+    contactLastName: input.billingContact?.lastName ?? null,
+    contactPartyType: input.billingContact?.partyType ?? null,
+    contactTaxId: input.billingContact?.taxId ?? null,
+    contactEmail: input.billingContact?.email ?? null,
+    contactPhone: input.billingContact?.phone ?? null,
+    contactPreferredLanguage: input.billingContact?.preferredLanguage ?? null,
+    contactCountry: input.billingContact?.country ?? null,
+    contactRegion: input.billingContact?.region ?? null,
+    contactCity: input.billingContact?.city ?? null,
+    contactAddressLine1: input.billingContact?.addressLine1 ?? null,
+    contactAddressLine2: input.billingContact?.addressLine2 ?? null,
+    contactPostalCode: input.billingContact?.postalCode ?? null,
+    travelers: input.travelers.map((traveler) => ({
+      clientTravelerKey: traveler.clientTravelerKey ?? null,
+      firstName: traveler.firstName,
+      lastName: traveler.lastName,
+      email: traveler.email ?? null,
+      phone: traveler.phone ?? null,
+      personId: traveler.personId ?? null,
+      participantType: traveler.participantType,
+      travelerCategory: traveler.travelerCategory ?? null,
+      isPrimary: traveler.isPrimary ?? null,
+      specialRequests: traveler.specialRequests ?? null,
+    })),
+    itemLines: input.rooms?.map((room) => ({
+      optionUnitId: room.optionUnitId,
+      quantity: room.quantity,
+      travelerKeys: room.travelerKeys ?? null,
+      title: room.title ?? null,
+    })),
+    paymentSchedules: input.paymentSchedules,
+    documentGeneration: input.documentGeneration,
+    ...(input.initialStatus ? { initialStatus: input.initialStatus } : {}),
+    ...(input.suppressNotifications !== undefined
+      ? { suppressNotifications: input.suppressNotifications }
+      : {}),
+    ...(input.allowDuplicate !== undefined ? { allowDuplicate: input.allowDuplicate } : {}),
+  }
+}
+
+/**
+ * Run the domain command validation (including the billing-party, traveler-key,
+ * and room-occupancy refinements) without touching the database. Returns the
+ * actionable issues to hand back, or `null` when the request is complete.
+ *
+ * `bookingNumber` is not known at validation time, so a placeholder stands in;
+ * it never surfaces because a real reference is allocated only once validation
+ * passes, so an invalid request allocates nothing and writes nothing.
+ */
+export function collectBookProductIssues(
+  input: BookProductInput,
+): z.infer<typeof bookProductIssueSchema>[] | null {
+  const candidate = mapBookProductIntentToCommand(input, "BK-PENDING-000000")
+  const parsed = bookingCreateSchema.safeParse(candidate)
+  if (parsed.success) return null
+  return parsed.error.issues
+    .filter((issue) => !(issue.path.length === 1 && issue.path[0] === "bookingNumber"))
+    .map((issue) => ({
+      path: issue.path.map((segment) => String(segment)).join("."),
+      message: issue.message,
+    }))
+}
+
+/**
+ * Derive the action-ledger idempotency key from the semantic content of the
+ * request. An identical retry produces the same key, so the durable claim
+ * short-circuits and replays the original booking instead of minting a second
+ * one — the guarantee `generate_booking_number` used to push onto the caller.
+ * Two genuinely distinct requests differ in content and get distinct keys; a
+ * deliberate same-content double is what `allowDuplicate` and the
+ * same-party/same-slot guard are for.
+ */
+export async function deriveBookProductIdempotencyKey(input: BookProductInput): Promise<string> {
+  const canonical = canonicalJson(input)
+  const bytes = new TextEncoder().encode(canonical)
+  const digest = await crypto.subtle.digest("SHA-256", bytes)
+  const hex = Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+  return `book-product:v1:${hex}`
+}
+
+/** Stable stringification: object keys sorted so key order never changes the fingerprint. */
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`
+  if (value && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, nested]) => nested !== undefined)
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+      .map(([key, nested]) => `${JSON.stringify(key)}:${canonicalJson(nested)}`)
+    return `{${entries.join(",")}}`
+  }
+  return JSON.stringify(value ?? null)
+}

--- a/packages/finance/src/booking-create-command.ts
+++ b/packages/finance/src/booking-create-command.ts
@@ -11,6 +11,7 @@ import {
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import {
+  FINANCE_BOOK_PRODUCT_HANDLER_POLICY,
   FINANCE_BOOKING_CREATE_HANDLER_POLICY,
   FINANCE_BOOKING_CREATE_POLICY,
   FINANCE_BOOKING_CREATE_SELF_SERVICE_HANDLER_POLICY,
@@ -63,6 +64,20 @@ export async function executeFinanceStaffBookingCreateCommand(
   input: FinanceBookingCreateCommandInput,
 ) {
   assertAdmittedActionPolicy(input.admitted, FINANCE_BOOKING_CREATE_HANDLER_POLICY)
+  return executeBookingCreateCommand(input)
+}
+
+/**
+ * Intent-level `book_product` creation (voyant#3933).
+ *
+ * Pins the `book_product` staff policy expectation. It composes the exact same
+ * durable command as `executeFinanceStaffBookingCreateCommand` — only the
+ * admission identity differs — so the two entrypoints stay unconfusable while
+ * the workflow tool resolves the booking reference and idempotency key
+ * server-side before this runs.
+ */
+export async function executeFinanceBookProductCommand(input: FinanceBookingCreateCommandInput) {
+  assertAdmittedActionPolicy(input.admitted, FINANCE_BOOK_PRODUCT_HANDLER_POLICY)
   return executeBookingCreateCommand(input)
 }
 

--- a/packages/finance/src/booking-create-policy.ts
+++ b/packages/finance/src/booking-create-policy.ts
@@ -53,6 +53,45 @@ export const FINANCE_BOOKING_CREATE_HANDLER_POLICY = {
 } as const satisfies HandlerActionPolicyExpectation
 
 /**
+ * `book_product` (voyant#3933) is the intent-level front door to the same
+ * durable booking create. It is a second staff action over the same command,
+ * with its own capability identity and audit trail, so the low-level
+ * `create_booking` admission can never be confused for it and vice versa. It
+ * shares `FINANCE_BOOKING_CREATE_POLICY`'s target facts — it creates the same
+ * `booking` target through the same claim durability — and differs only in
+ * identity: unlike `create_booking`, its handler resolves the booking reference
+ * and the idempotency key server-side, so the model never carries either token.
+ */
+export const FINANCE_BOOK_PRODUCT_ACTION =
+  "@voyant-travel/finance#bookings-create-extension.action.book-product"
+export const FINANCE_BOOK_PRODUCT_TOOL =
+  "@voyant-travel/finance#bookings-create-extension.tool.book-product"
+
+export const FINANCE_BOOK_PRODUCT_HANDLER_POLICY = {
+  capabilityId: FINANCE_BOOK_PRODUCT_TOOL,
+  capabilityVersion: "v1",
+  canonicalName: "book_product",
+  actionPolicy: {
+    id: FINANCE_BOOK_PRODUCT_ACTION,
+    capabilityId: FINANCE_BOOK_PRODUCT_ACTION,
+    version: "v1",
+    kind: "execute",
+    targetType: FINANCE_BOOKING_CREATE_POLICY.canonicalTargetType,
+    targetLifecycle: "created",
+    ledger: "required",
+    approval: "never",
+    risk: FINANCE_BOOKING_CREATE_POLICY.evaluatedRisk,
+    reversible: false,
+    allowedActorTypes: ["staff"],
+    createdTarget: {
+      commandTargetType: FINANCE_BOOKING_CREATE_POLICY.commandTargetType,
+      resultReferenceType: FINANCE_BOOKING_CREATE_POLICY.resultReferenceType,
+      durability: "handler-command-claim-v1",
+    },
+  },
+} as const satisfies HandlerActionPolicyExpectation
+
+/**
  * The narrow public invocation contract. A self-service caller supplies only an
  * idempotency key; every other command field is derived server-side from the
  * draft and quote.

--- a/packages/finance/src/mcp-booking-runtime.ts
+++ b/packages/finance/src/mcp-booking-runtime.ts
@@ -1,0 +1,134 @@
+/**
+ * Request-scoped booking tool services: `create_booking` and the intent-level
+ * `book_product` (voyant#3933). Both compose Finance's durable booking-create
+ * command; `book_product` additionally resolves the booking reference and the
+ * action-ledger idempotency key server-side, so the caller carries neither.
+ *
+ * Split out of `mcp-runtime.ts` to keep that module reviewable; it is spread
+ * into the Finance tool-context contribution there.
+ */
+import {
+  bookingsService,
+  bookingToolDetailSchema,
+  redactBookingContact,
+  redactTravelerIdentity,
+  shouldRevealBookingPii,
+} from "@voyant-travel/bookings"
+import { isStaffRbacEnforced } from "@voyant-travel/hono"
+import { ToolError, withServerResolvedIdempotencyKey } from "@voyant-travel/tools"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import type { Context } from "hono"
+
+import {
+  type BookProductInput,
+  type BookProductOutput,
+  collectBookProductIssues,
+  deriveBookProductIdempotencyKey,
+  mapBookProductIntentToCommand,
+} from "./book-product.js"
+import {
+  executeFinanceBookProductCommand,
+  executeFinanceStaffBookingCreateCommand,
+} from "./booking-create-command.js"
+import { allocateBookingNumber } from "./booking-number.js"
+import { financeToolActionLedgerContext } from "./mcp-runtime-shared.js"
+import { getFinanceRouteRuntime } from "./routes-runtime.js"
+import type { Env } from "./routes-shared.js"
+import type { BookingCreateInput } from "./service-booking-create.js"
+import { toJsonValue } from "./tool-json.js"
+
+type BookingRuntimeDb = PostgresJsDatabase
+
+export function financeBookingToolServices(db: BookingRuntimeDb, c: Context<Env>) {
+  return {
+    createBooking: async (
+      input: Omit<BookingCreateInput, "bookingNumber"> & { bookingNumber?: string | null },
+      admitted: Parameters<typeof executeFinanceStaffBookingCreateCommand>[0]["admitted"],
+    ) => {
+      // The reference is resolved server-side (voyant#3933): allocate one when
+      // the caller omits it, and replay a provided one unchanged.
+      const commandInput: BookingCreateInput = {
+        ...input,
+        bookingNumber: input.bookingNumber ?? (await allocateBookingNumber(db)),
+      }
+      const result = await executeFinanceStaffBookingCreateCommand({
+        db,
+        context: financeToolActionLedgerContext(c),
+        commandInput,
+        admitted,
+        runtime: getFinanceRouteRuntime(c),
+      })
+      return readBookingCreateResult(db, c, result.value.bookingId, result.replayed)
+    },
+    async bookProduct(
+      input: BookProductInput,
+      admitted: Parameters<typeof executeFinanceBookProductCommand>[0]["admitted"],
+    ): Promise<BookProductOutput> {
+      // Validate before writing: an incomplete request returns actionable
+      // issues and allocates nothing, exactly like compose_product.
+      const issues = collectBookProductIssues(input)
+      if (issues) return { status: "invalid", issues }
+
+      // Resolve both the reference and the idempotency key server-side so the
+      // model never carries a token across turns. An identical retry derives the
+      // same key, so the durable claim replays the original booking.
+      const idempotencyKey = await deriveBookProductIdempotencyKey(input)
+      const bookingNumber = await allocateBookingNumber(db)
+      const commandInput = mapBookProductIntentToCommand(input, bookingNumber)
+      const result = await executeFinanceBookProductCommand({
+        db,
+        context: financeToolActionLedgerContext(c),
+        commandInput,
+        admitted: withServerResolvedIdempotencyKey(admitted, idempotencyKey),
+        runtime: getFinanceRouteRuntime(c),
+      })
+      const detail = await readBookingCreateResult(db, c, result.value.bookingId, result.replayed)
+      return {
+        status: "created",
+        bookingId: detail.bookingId,
+        // The persisted reference — on an idempotent replay this is the ORIGINAL
+        // booking's number, not the one just allocated and discarded.
+        bookingNumber: detail.booking.bookingNumber,
+        replayed: detail.replayed,
+        booking: detail.booking,
+      }
+    },
+  }
+}
+
+/**
+ * Read a freshly created (or replayed) booking back into the tool detail shape,
+ * applying the same PII redaction the caller's scope allows.
+ */
+async function readBookingCreateResult(
+  db: BookingRuntimeDb,
+  c: Context<Env>,
+  bookingId: string,
+  replayed: boolean,
+) {
+  const booking = await bookingsService.getBookingById(db, bookingId)
+  if (!booking) {
+    throw new ToolError("The created booking could not be read back.", "NOT_FOUND", { bookingId })
+  }
+  const [items, travelers] = await Promise.all([
+    bookingsService.listItems(db, booking.id),
+    bookingsService.listTravelers(db, booking.id),
+  ])
+  const reveal = shouldRevealBookingPii({
+    actor: c.var.actor,
+    scopes: c.var.scopes,
+    callerType: c.var.callerType,
+    isInternalRequest: c.var.isInternalRequest,
+    enforceRbac: isStaffRbacEnforced(c.env),
+  })
+  const detail = {
+    ...(reveal ? booking : redactBookingContact(booking)),
+    items,
+    travelers: reveal ? travelers : travelers.map((traveler) => redactTravelerIdentity(traveler)),
+  }
+  return {
+    bookingId: booking.id,
+    replayed,
+    booking: bookingToolDetailSchema.parse(toJsonValue(detail)),
+  }
+}

--- a/packages/finance/src/mcp-runtime-shared.ts
+++ b/packages/finance/src/mcp-runtime-shared.ts
@@ -1,0 +1,28 @@
+/**
+ * Request-context plumbing shared by the Finance MCP tool runtime and the
+ * booking tool runtime: build the action-ledger request context from the Hono
+ * context. (JSON coercion of service rows lives in the transport-free
+ * `tool-json.ts`.)
+ */
+import type { ActionLedgerRequestContextValues } from "@voyant-travel/action-ledger"
+import type { Context } from "hono"
+
+import type { Env } from "./routes-shared.js"
+
+export function financeToolActionLedgerContext(c: Context<Env>): ActionLedgerRequestContextValues {
+  return {
+    userId: c.get("userId") ?? null,
+    agentId: c.get("agentId") ?? null,
+    workflowPrincipalId: c.get("workflowPrincipalId") ?? null,
+    principalSubtype: c.get("principalSubtype") ?? null,
+    sessionId: c.get("sessionId") ?? null,
+    apiTokenId: c.get("apiTokenId") ?? c.get("apiKeyId") ?? null,
+    callerType: c.get("callerType") ?? null,
+    actor: c.get("actor") ?? null,
+    isInternalRequest: c.get("isInternalRequest") ?? false,
+    organizationId: c.get("organizationId") ?? null,
+    workflowRunId: c.get("workflowRunId") ?? null,
+    workflowStepId: c.get("workflowStepId") ?? null,
+    correlationId: c.req.header("x-correlation-id") ?? c.req.header("x-request-id") ?? null,
+  }
+}

--- a/packages/finance/src/mcp-runtime.ts
+++ b/packages/finance/src/mcp-runtime.ts
@@ -1,27 +1,16 @@
-import {
-  type ActionLedgerRequestContextValues,
-  buildActionLedgerApprovedExecutionFields,
-} from "@voyant-travel/action-ledger"
-import {
-  bookingsService,
-  bookingToolDetailSchema,
-  redactBookingContact,
-  redactTravelerIdentity,
-  shouldRevealBookingPii,
-} from "@voyant-travel/bookings"
-import { isStaffRbacEnforced } from "@voyant-travel/hono"
+import { buildActionLedgerApprovedExecutionFields } from "@voyant-travel/action-ledger"
 import { defineToolContextContribution, ToolError } from "@voyant-travel/tools"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
 
-import { executeFinanceStaffBookingCreateCommand } from "./booking-create-command.js"
-import { allocateBookingNumber } from "./booking-number.js"
 import {
   authorizeFinanceInvoiceIssue,
   FINANCE_INVOICE_ISSUE_ACTION_NAME,
   FINANCE_INVOICE_ISSUE_CAPABILITY,
   FINANCE_INVOICE_ISSUE_TOOL_NAME,
 } from "./invoice-issue-authorization.js"
+import { financeBookingToolServices } from "./mcp-booking-runtime.js"
+import { financeToolActionLedgerContext } from "./mcp-runtime-shared.js"
 import {
   authorizeFinanceRefund,
   FINANCE_REFUND_ACTION_NAME,
@@ -35,6 +24,7 @@ import {
   buildUnsyncedProformaApprovalSnapshot,
   issueInvoiceFromBookingCommand,
 } from "./service-issue.js"
+import { toJsonValue } from "./tool-json.js"
 
 export * from "./tools.js"
 
@@ -52,50 +42,9 @@ export const voyantToolContextContribution = defineToolContextContribution({
           financeService.getFinanceAggregates(db, query),
         voidInvoice: (id: string, input: { reason?: string }) =>
           financeService.voidInvoice(db, id, input),
-        generateBookingNumber: async () => ({
-          bookingNumber: await allocateBookingNumber(db as PostgresJsDatabase),
-        }),
-        createBooking: (
-          input: Parameters<typeof executeFinanceStaffBookingCreateCommand>[0]["commandInput"],
-          admitted: Parameters<typeof executeFinanceStaffBookingCreateCommand>[0]["admitted"],
-        ) =>
-          executeFinanceStaffBookingCreateCommand({
-            db,
-            context: financeToolActionLedgerContext(c),
-            commandInput: input,
-            admitted,
-            runtime: getFinanceRouteRuntime(c),
-          }).then(async (result) => {
-            const booking = await bookingsService.getBookingById(db, result.value.bookingId)
-            if (!booking) {
-              throw new ToolError("The created booking could not be read back.", "NOT_FOUND", {
-                bookingId: result.value.bookingId,
-              })
-            }
-            const [items, travelers] = await Promise.all([
-              bookingsService.listItems(db, booking.id),
-              bookingsService.listTravelers(db, booking.id),
-            ])
-            const reveal = shouldRevealBookingPii({
-              actor: c.var.actor,
-              scopes: c.var.scopes,
-              callerType: c.var.callerType,
-              isInternalRequest: c.var.isInternalRequest,
-              enforceRbac: isStaffRbacEnforced(c.env),
-            })
-            const detail = {
-              ...(reveal ? booking : redactBookingContact(booking)),
-              items,
-              travelers: reveal
-                ? travelers
-                : travelers.map((traveler) => redactTravelerIdentity(traveler)),
-            }
-            return {
-              bookingId: booking.id,
-              replayed: result.replayed,
-              booking: bookingToolDetailSchema.parse(toJsonValue(detail)),
-            }
-          }),
+        // create_booking + book_product (voyant#3933) — both compose the durable
+        // booking-create command; book_product resolves reference and key server-side.
+        ...financeBookingToolServices(db as PostgresJsDatabase, c),
         async issueInvoiceFromBooking(input: {
           command: CreateInvoiceFromBookingInput
           idempotencyKey: string
@@ -353,24 +302,6 @@ async function executeInvoiceIssueTool(input: {
   }
 }
 
-function financeToolActionLedgerContext(c: Context<Env>): ActionLedgerRequestContextValues {
-  return {
-    userId: c.get("userId") ?? null,
-    agentId: c.get("agentId") ?? null,
-    workflowPrincipalId: c.get("workflowPrincipalId") ?? null,
-    principalSubtype: c.get("principalSubtype") ?? null,
-    sessionId: c.get("sessionId") ?? null,
-    apiTokenId: c.get("apiTokenId") ?? c.get("apiKeyId") ?? null,
-    callerType: c.get("callerType") ?? null,
-    actor: c.get("actor") ?? null,
-    isInternalRequest: c.get("isInternalRequest") ?? false,
-    organizationId: c.get("organizationId") ?? null,
-    workflowRunId: c.get("workflowRunId") ?? null,
-    workflowStepId: c.get("workflowStepId") ?? null,
-    correlationId: c.req.header("x-correlation-id") ?? c.req.header("x-request-id") ?? null,
-  }
-}
-
 function financeRefundAuthorizationError(
   result: Exclude<
     Awaited<ReturnType<typeof authorizeFinanceRefund>>,
@@ -474,15 +405,4 @@ function financeInvoiceIssueAuthorizationError(
 function toIsoString(value: Date | string | null): string | null {
   if (!value) return null
   return value instanceof Date ? value.toISOString() : value
-}
-
-function toJsonValue(value: unknown): unknown {
-  if (value instanceof Date) return value.toISOString()
-  if (Array.isArray(value)) return value.map(toJsonValue)
-  if (typeof value !== "object" || value === null) return value
-  return Object.fromEntries(
-    Object.entries(value)
-      .map(([key, nested]) => [key, toJsonValue(nested)] as const)
-      .filter(([, nested]) => nested !== undefined),
-  )
 }

--- a/packages/finance/src/service-booking-create.ts
+++ b/packages/finance/src/service-booking-create.ts
@@ -400,14 +400,16 @@ const bookingCreateBaseSchema = z.object({
   availabilityHoldToken: z.string().min(1).optional(),
   /**
    * Immutable booking reference and idempotency anchor for the durable create.
-   * Allocate it with `generate_booking_number` (or `allocateBookingNumber`) and
-   * replay the same value on retries — a fresh reference mints a second booking.
+   * The command requires it, but callers do not mint it: the `create_booking`
+   * tool and the self-service route both allocate it server-side with
+   * `allocateBookingNumber` before composing the command, and replay the same
+   * value on retries — a fresh reference would mint a second booking.
    */
   bookingNumber: z
     .string()
     .min(1)
     .describe(
-      "Booking reference allocated by `generate_booking_number`. Never invent one and never derive it from traveller or client details. Pass the same value again when retrying the same create.",
+      "Immutable booking reference. Allocated server-side; never invented or derived from traveller or client details.",
     ),
   /**
    * Who is billed. At least one of `personId` / `organizationId` is required.
@@ -549,6 +551,15 @@ export const bookingCreateToolSchema = bookingCreateBaseSchema
     priceOverrideReason: true,
   })
   .extend({
+    // The reference is resolved server-side: omit it and the tool allocates one.
+    // A previously allocated reference may be passed back to replay a create.
+    bookingNumber: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "Booking reference. Omit it — the server allocates one. Pass a previously returned reference only to replay a specific create.",
+      ),
     itemLines: z
       .array(itemLineInputSchema.omit({ unitSellAmountCents: true, totalSellAmountCents: true }))
       .optional()

--- a/packages/finance/src/tool-json.ts
+++ b/packages/finance/src/tool-json.ts
@@ -1,0 +1,22 @@
+/**
+ * Pure JSON coercion for Finance tool outputs: turn service rows (with `Date`s
+ * and `undefined`s) into plain JSON before validating against a tool output
+ * schema. No transport or request dependency, so both the deployment-agnostic
+ * `tools.ts` contract and the request-scoped runtimes can share it.
+ */
+import type { z } from "zod"
+
+export function toJsonValue(value: unknown): unknown {
+  if (value instanceof Date) return value.toISOString()
+  if (Array.isArray(value)) return value.map(toJsonValue)
+  if (typeof value !== "object" || value === null) return value
+  return Object.fromEntries(
+    Object.entries(value)
+      .map(([key, nested]) => [key, toJsonValue(nested)] as const)
+      .filter(([, nested]) => nested !== undefined),
+  )
+}
+
+export function parseJsonResult<T extends z.ZodType>(schema: T, value: unknown): z.output<T> {
+  return schema.parse(toJsonValue(value))
+}

--- a/packages/finance/src/tools.ts
+++ b/packages/finance/src/tools.ts
@@ -14,14 +14,23 @@ import {
 } from "@voyant-travel/tools"
 import { listResponseSchema } from "@voyant-travel/types"
 import { z } from "zod"
-import { FINANCE_BOOKING_CREATE_HANDLER_POLICY } from "./booking-create-policy.js"
+import {
+  type BookProductOutput,
+  bookProductToolInputSchema,
+  bookProductToolOutputSchema,
+} from "./book-product.js"
+import {
+  FINANCE_BOOK_PRODUCT_HANDLER_POLICY,
+  FINANCE_BOOKING_CREATE_HANDLER_POLICY,
+} from "./booking-create-policy.js"
 import {
   creditNoteSchema,
   invoiceDetailSchema,
   invoiceListItemSchema,
   invoiceSchema,
 } from "./routes-invoice-schemas.js"
-import { type bookingCreateSchema, bookingCreateToolSchema } from "./service-booking-create.js"
+import { bookingCreateToolSchema } from "./service-booking-create.js"
+import { parseJsonResult } from "./tool-json.js"
 import {
   insertCreditNoteSchema,
   invoiceFromBookingSchema,
@@ -61,15 +70,18 @@ export interface FinanceToolServices {
     idempotencyKey: string
     approvalId?: string
   }): Promise<unknown>
-  generateBookingNumber(): Promise<{ bookingNumber: string }>
   createBooking(
-    input: z.infer<typeof bookingCreateSchema>,
+    input: z.infer<typeof createBookingToolInputSchema>["booking"],
     admitted: ReturnType<typeof admitHandlerActionPolicy>,
   ): Promise<{
     bookingId: string
     replayed: boolean
     booking: z.infer<typeof bookingToolDetailSchema>
   }>
+  bookProduct(
+    input: z.infer<typeof bookProductToolInputSchema>,
+    admitted: ReturnType<typeof admitHandlerActionPolicy>,
+  ): Promise<BookProductOutput>
   issueInvoiceFromBooking(
     input: z.infer<typeof issueInvoiceFromBookingToolInputSchema>,
   ): Promise<unknown>
@@ -244,7 +256,7 @@ export const createBookingTool = defineTool({
   capabilityVersion: "v1",
   name: "create_booking",
   description:
-    "Durably create one booking from a product or slot. Requires a billing party: set `personId` for a private client (find it with `list_people`), or `organizationId` for a company booking (find it with `list_organizations`) — at least one is mandatory. For a product with rooms or options, first use `list_product_options` and `list_option_units`, then pass explicit `optionId` and `itemLines`: room quantity means number of rooms, while each line's `travelerKeys` assigns travelers to that room type. Exact retries resolve the original immutable booking reference.",
+    "Durably create one booking from an explicit product/slot command. The booking reference is resolved server-side; omit `booking.bookingNumber`. Prefer `book_product` for the ordinary intent — this lower-level tool is for callers that already hold a fully resolved command.",
   inputSchema: createBookingToolInputSchema,
   outputSchema: durableBookingCreateResultSchema,
   requiredScopes: ["bookings:write", "finance:write"],
@@ -270,37 +282,34 @@ export const createBookingTool = defineTool({
   },
 })
 
-const generateBookingNumberArgs = z.object({})
-
-const generateBookingNumberResultSchema = z.object({
-  bookingNumber: z
-    .string()
-    .describe("The allocated booking reference. Pass it to `create_booking` unchanged."),
-})
-
-export const generateBookingNumberTool = defineTool<
-  z.infer<typeof generateBookingNumberArgs>,
-  z.infer<typeof generateBookingNumberResultSchema>,
-  FinanceToolContext
->({
+export const bookProductTool = defineTool({
   owner: "@voyant-travel/finance#bookings-create-extension",
-  capabilityId: "@voyant-travel/finance#bookings-create-extension.tool.generate-booking-number",
+  capabilityId: "@voyant-travel/finance#bookings-create-extension.tool.book-product",
   capabilityVersion: "v1",
-  name: "generate_booking_number",
+  name: "book_product",
   description:
-    "Allocate the booking reference for a new booking. Call this before `create_booking` and pass the result through as `bookingNumber`. Never invent a reference and never build one out of the traveller's or client's details — the reference is shown to travellers and printed on invoices. Re-use the same allocated value when retrying the same create so the retry resolves the original booking instead of making a second one.",
-  inputSchema: generateBookingNumberArgs,
-  outputSchema: generateBookingNumberResultSchema,
-  requiredScopes: ["bookings:write"],
+    "Book a product for a client in one call: product and option, the billing party (a `personId` for a private client or an `organizationId` for a company), travelers, and rooms. The platform resolves the booking reference and the idempotency key server-side, so nothing has to be carried across calls. An incomplete request returns actionable issues and creates nothing.",
+  inputSchema: bookProductToolInputSchema,
+  outputSchema: bookProductToolOutputSchema,
+  requiredScopes: ["bookings:write", "finance:write"],
   audience: { source: "grant", allowed: ["staff"] },
-  tier: "read",
-  riskPolicy: READ_ONLY_RISK,
-  async handler(_args, ctx) {
-    return generateBookingNumberResultSchema.parse(await finance(ctx).generateBookingNumber())
+  tier: "destructive",
+  riskPolicy: {
+    destructive: true,
+    reversible: false,
+    dryRunSupported: false,
+    confirmationRequired: true,
+    sideEffects: ["data-write", "external-booking", "payment"],
+  },
+  actionPolicyEnforcement: "handler",
+  annotations: { idempotentHint: true },
+  async handler(input, ctx) {
+    const admitted = admitHandlerActionPolicy(ctx, FINANCE_BOOK_PRODUCT_HANDLER_POLICY)
+    return bookProductToolOutputSchema.parse(await finance(ctx).bookProduct(input, admitted))
   },
 })
 
-export const financeBookingsCreateTools = [createBookingTool, generateBookingNumberTool] as const
+export const financeBookingsCreateTools = [createBookingTool, bookProductTool] as const
 
 export const issueInvoiceFromBookingToolInputSchema = z.object({
   command: invoiceFromBookingSchema.describe("The exact invoice or proforma issue command."),
@@ -485,18 +494,3 @@ export const financeTools = [
   previewUnsyncedProformaFromBookingTool,
   issueUnsyncedProformaFromBookingTool,
 ] as const
-
-function parseJsonResult<T extends z.ZodType>(schema: T, value: unknown): z.output<T> {
-  return schema.parse(toJsonValue(value))
-}
-
-function toJsonValue(value: unknown): unknown {
-  if (value instanceof Date) return value.toISOString()
-  if (Array.isArray(value)) return value.map(toJsonValue)
-  if (typeof value !== "object" || value === null) return value
-  return Object.fromEntries(
-    Object.entries(value)
-      .map(([key, nested]) => [key, toJsonValue(nested)] as const)
-      .filter(([, nested]) => nested !== undefined),
-  )
-}

--- a/packages/finance/src/voyant.ts
+++ b/packages/finance/src/voyant.ts
@@ -592,12 +592,12 @@ export const financeBookingsCreateVoyantPlugin = defineExtension({
   runtimePorts: [requirePort(financeSelfServiceBookingSourceRuntimePort, { optional: true })],
   tools: [
     {
-      id: "@voyant-travel/finance#bookings-create-extension.tool.generate-booking-number",
-      name: "generate_booking_number",
-      runtime: { entry: "@voyant-travel/finance/tools", export: "generateBookingNumberTool" },
-      requiredScopes: ["bookings:write"],
+      id: "@voyant-travel/finance#bookings-create-extension.tool.book-product",
+      name: "book_product",
+      runtime: { entry: "@voyant-travel/finance/tools", export: "bookProductTool" },
+      requiredScopes: ["bookings:write", "finance:write"],
       context: ["finance"],
-      risk: "low",
+      risk: "high",
     },
     {
       id: "@voyant-travel/finance#bookings-create-extension.tool.create-booking",
@@ -637,6 +637,40 @@ export const financeBookingsCreateVoyantPlugin = defineExtension({
       allowedActorTypes: ["staff"],
       from: {
         tools: ["@voyant-travel/finance#bookings-create-extension.tool.create-booking"],
+      },
+    },
+    {
+      // Intent-level workflow action (voyant#3933). Same durable command and
+      // created target as create-booking; a distinct capability identity so the
+      // two admissions stay unconfusable and the server-resolved reference and
+      // idempotency key belong to this action's audit trail.
+      id: "@voyant-travel/finance#bookings-create-extension.action.book-product",
+      capabilityId: "@voyant-travel/finance#bookings-create-extension.action.book-product",
+      version: "v1",
+      kind: "execute",
+      targetType: "booking",
+      availability: { status: "available" },
+      effectBoundary: "multistage",
+      durability: {
+        strategy: "outbox",
+        testReference: "tests/integration/booking-create.test.ts",
+      },
+      targetLifecycle: "created",
+      createdTarget: {
+        commandTargetType: "finance_booking_create_command",
+        resultReferenceType: "booking",
+        durability: "handler-command-claim-v1",
+      },
+      resource: "bookings",
+      action: "write",
+      requiredScopes: ["bookings:write", "finance:write"],
+      risk: "high",
+      ledger: "required",
+      approval: "never",
+      reversible: false,
+      allowedActorTypes: ["staff"],
+      from: {
+        tools: ["@voyant-travel/finance#bookings-create-extension.tool.book-product"],
       },
     },
     {

--- a/packages/finance/tests/tools.test.ts
+++ b/packages/finance/tests/tools.test.ts
@@ -4,7 +4,10 @@ import {
   type ToolHandlerActionPolicyContext,
 } from "@voyant-travel/tools"
 import { describe, expect, it } from "vitest"
-import { FINANCE_BOOKING_CREATE_HANDLER_POLICY } from "../src/booking-create-policy.js"
+import {
+  FINANCE_BOOK_PRODUCT_HANDLER_POLICY,
+  FINANCE_BOOKING_CREATE_HANDLER_POLICY,
+} from "../src/booking-create-policy.js"
 import {
   type FinanceToolServices,
   financeBookingsCreateTools,
@@ -364,34 +367,73 @@ describe("finance tools", () => {
     ).toMatchObject({ status: "approval_required", approval: { id: "apr_proforma_1" } })
   })
 
-  it("allocates the booking reference through a Tool instead of leaving it to the caller", async () => {
+  it("books a product through the intent-level workflow Tool, resolving reference and key server-side", async () => {
     const registry = createToolRegistry()
-    const tool = financeBookingsCreateTools.find(
-      (entry) => entry.name === "generate_booking_number",
+    const tool = financeBookingsCreateTools.find((entry) => entry.name === "book_product")
+    const action = (financeBookingsCreateVoyantPlugin.actions ?? []).find(
+      (entry) =>
+        entry.id === "@voyant-travel/finance#bookings-create-extension.action.book-product",
     )
-    if (!tool) throw new Error("generate_booking_number is missing")
+    if (!tool || !action) throw new Error("book_product graph declarations are missing")
     registry.register(tool, {
       capabilityId: tool.capabilityId,
       owner: tool.owner,
       capabilityVersion: tool.capabilityVersion,
       name: tool.name,
       requiredScopes: tool.requiredScopes,
-      deploymentRisk: "low",
+      deploymentRisk: "high",
+      actionPolicy: action,
     })
+    expect(tool.actionPolicyEnforcement).toBe("handler")
 
+    let receivedInput: { productId?: string; personId?: string } | undefined
+    const services = {
+      // The caller never supplies an idempotency key — the handler (in
+      // mcp-runtime) resolves it server-side before the durable command.
+      async bookProduct(input: { productId?: string; personId?: string }) {
+        receivedInput = input
+        return {
+          status: "created" as const,
+          bookingId: "booking_1",
+          bookingNumber: "B-1",
+          replayed: false,
+          booking: bookingDetail(),
+        }
+      },
+    }
     const result = await registry.dispatch(
-      "generate_booking_number",
-      {},
-      ctx({
-        async generateBookingNumber() {
-          return { bookingNumber: "BK-2607-000123" }
+      "book_product",
+      {
+        productId: "product_1",
+        personId: "person_1",
+        billingContact: { firstName: "Ada", lastName: "Lovelace", email: "ada@example.com" },
+        travelers: [
+          { clientTravelerKey: "ada", firstName: "Ada", lastName: "Lovelace", isPrimary: true },
+        ],
+      },
+      ctx(services, {
+        capabilityId: FINANCE_BOOK_PRODUCT_HANDLER_POLICY.capabilityId,
+        capabilityVersion: FINANCE_BOOK_PRODUCT_HANDLER_POLICY.capabilityVersion,
+        canonicalName: "book_product",
+        actionPolicy: {
+          ...FINANCE_BOOK_PRODUCT_HANDLER_POLICY.actionPolicy,
+          enforcement: "handler",
+          invocation: {
+            requiredFields: ["confirmed", "idempotencyKey"],
+            optionalFields: ["reasonCode", "approvalId", "idempotencyFingerprint"],
+          },
         },
+        // No idempotencyKey: book_product resolves it server-side.
+        invocation: { confirmed: true },
       }),
     )
 
-    expect(result).toEqual({ bookingNumber: "BK-2607-000123" })
-    // Read-tier so allocating a reference never needs an approval round-trip.
-    expect(tool.tier).toBe("read")
+    expect(result).toMatchObject({
+      status: "created",
+      bookingId: "booking_1",
+      bookingNumber: "B-1",
+    })
+    expect(receivedInput).toMatchObject({ productId: "product_1", personId: "person_1" })
   })
 
   it("creates a booking through the composing Finance extension Tool", async () => {
@@ -478,20 +520,27 @@ describe("finance tools", () => {
     })
   })
 
-  it("advertises the billing-party requirement in the create_booking contract", () => {
-    // ProTravel hit this in production: Max resolved the client, then called
-    // create_booking without personId and looped on
-    // "Select a billing person or organization". personId and organizationId
-    // are both structurally optional (either satisfies the rule), and the
-    // requirement lived only in a superRefine, which does not serialize into
-    // the JSON Schema a Tool caller reads. The contract has to state it.
+  it("no longer scripts an orchestration sequence in the create_booking description", () => {
+    // voyant#3933: the orchestration prose is deleted. The old description named
+    // three other tools and the order to call them in (find the client with
+    // list_people/list_organizations, resolve options with
+    // list_product_options/list_option_units, allocate with
+    // generate_booking_number). That intent now lives in book_product, which
+    // resolves the reference and idempotency key server-side.
     const tool = financeBookingsCreateTools.find((entry) => entry.name === "create_booking")
-    if (!tool) throw new Error("create_booking is missing")
+    const bookTool = financeBookingsCreateTools.find((entry) => entry.name === "book_product")
+    if (!tool || !bookTool) throw new Error("booking-create tools are missing")
 
-    expect(tool.description).toMatch(/personId/)
-    expect(tool.description).toMatch(/organizationId/)
-    expect(tool.description).toMatch(/list_option_units/)
-    expect(tool.description).toMatch(/room quantity means number of rooms/i)
+    expect(tool.description).not.toMatch(/find it with/i)
+    expect(tool.description).not.toMatch(/first use/i)
+    expect(tool.description).not.toMatch(/generate_booking_number/)
+    expect(tool.description).not.toMatch(/list_people/)
+    expect(tool.description).not.toMatch(/list_product_options/)
+
+    // The intent create_booking used to script is expressed by book_product.
+    expect(bookTool.description).toMatch(/personId/)
+    expect(bookTool.description).toMatch(/organizationId/)
+    expect(bookTool.description).toMatch(/idempotency key server-side/i)
 
     // Assert on the same carrier `bookingNumber` already relies on to reach a
     // caller, so this pins the description actually shipping, not a doc comment.

--- a/packages/finance/tests/unit/book-product.test.ts
+++ b/packages/finance/tests/unit/book-product.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  type BookProductInput,
+  collectBookProductIssues,
+  deriveBookProductIdempotencyKey,
+  mapBookProductIntentToCommand,
+} from "../../src/book-product.js"
+
+function completeInput(overrides: Partial<BookProductInput> = {}): BookProductInput {
+  return {
+    productId: "product_1",
+    personId: "person_1",
+    billingContact: { firstName: "Ada", lastName: "Lovelace", email: "ada@example.com" },
+    travelers: [
+      { clientTravelerKey: "ada", firstName: "Ada", lastName: "Lovelace", isPrimary: true },
+    ],
+    ...overrides,
+  } as BookProductInput
+}
+
+describe("book_product validate-before-write", () => {
+  it("returns no issues for a complete private-client request", () => {
+    expect(collectBookProductIssues(completeInput())).toBeNull()
+  })
+
+  it("returns an actionable billing-party issue when neither person nor organization is set", () => {
+    const issues = collectBookProductIssues(
+      completeInput({ personId: undefined, organizationId: undefined }),
+    )
+    expect(issues).not.toBeNull()
+    expect(issues).toContainEqual(
+      expect.objectContaining({
+        path: "personId",
+        message: expect.stringMatching(/billing party/i),
+      }),
+    )
+  })
+
+  it("flags a private client missing an email or phone", () => {
+    const issues = collectBookProductIssues(
+      completeInput({ billingContact: { firstName: "Ada", lastName: "Lovelace" } }),
+    )
+    expect(issues).not.toBeNull()
+    expect(issues?.some((issue) => /email or phone/i.test(issue.message))).toBe(true)
+  })
+
+  it("flags an unknown travelerKey referenced by a room", () => {
+    const issues = collectBookProductIssues(
+      completeInput({
+        rooms: [{ optionUnitId: "unit_1", quantity: 1, travelerKeys: ["ghost"] }],
+      }),
+    )
+    expect(issues?.some((issue) => /Unknown travelerKey/i.test(issue.message))).toBe(true)
+  })
+})
+
+describe("book_product mapping", () => {
+  it("threads the billing party, contact snapshot, and rooms into the command", () => {
+    const command = mapBookProductIntentToCommand(
+      completeInput({
+        rooms: [{ optionUnitId: "unit_1", quantity: 2, travelerKeys: ["ada"], title: "Suite" }],
+      }),
+      "BK-2607-000123",
+    )
+    expect(command).toMatchObject({
+      productId: "product_1",
+      bookingNumber: "BK-2607-000123",
+      personId: "person_1",
+      contactFirstName: "Ada",
+      contactLastName: "Lovelace",
+      contactEmail: "ada@example.com",
+      itemLines: [{ optionUnitId: "unit_1", quantity: 2, travelerKeys: ["ada"], title: "Suite" }],
+    })
+  })
+})
+
+describe("book_product idempotency key", () => {
+  it("is deterministic and independent of key order", async () => {
+    const a = await deriveBookProductIdempotencyKey(completeInput())
+    const b = await deriveBookProductIdempotencyKey({
+      travelers: [
+        { clientTravelerKey: "ada", firstName: "Ada", lastName: "Lovelace", isPrimary: true },
+      ],
+      billingContact: { email: "ada@example.com", firstName: "Ada", lastName: "Lovelace" },
+      personId: "person_1",
+      productId: "product_1",
+    } as BookProductInput)
+    expect(a).toBe(b)
+    expect(a).toMatch(/^book-product:v1:[0-9a-f]{64}$/)
+  })
+
+  it("differs when the semantic request differs", async () => {
+    const a = await deriveBookProductIdempotencyKey(completeInput())
+    const b = await deriveBookProductIdempotencyKey(completeInput({ productId: "product_2" }))
+    expect(a).not.toBe(b)
+  })
+})

--- a/packages/finance/tests/unit/voyant-manifest.test.ts
+++ b/packages/finance/tests/unit/voyant-manifest.test.ts
@@ -540,9 +540,9 @@ describe("finance deployment manifest", () => {
         id: "@voyant-travel/finance#bookings-create-extension",
         tools: [
           expect.objectContaining({
-            id: "@voyant-travel/finance#bookings-create-extension.tool.generate-booking-number",
-            name: "generate_booking_number",
-            requiredScopes: ["bookings:write"],
+            id: "@voyant-travel/finance#bookings-create-extension.tool.book-product",
+            name: "book_product",
+            requiredScopes: ["bookings:write", "finance:write"],
           }),
           expect.objectContaining({
             id: "@voyant-travel/finance#bookings-create-extension.tool.create-booking",
@@ -569,6 +569,23 @@ describe("finance deployment manifest", () => {
             allowedActorTypes: ["staff"],
             from: {
               tools: ["@voyant-travel/finance#bookings-create-extension.tool.create-booking"],
+            },
+          }),
+          // Intent-level workflow action (voyant#3933): same command and target,
+          // distinct capability identity, server-resolved reference and key.
+          expect.objectContaining({
+            id: "@voyant-travel/finance#bookings-create-extension.action.book-product",
+            availability: { status: "available" },
+            targetLifecycle: "created",
+            createdTarget: {
+              commandTargetType: "finance_booking_create_command",
+              resultReferenceType: "booking",
+              durability: "handler-command-claim-v1",
+            },
+            ledger: "required",
+            allowedActorTypes: ["staff"],
+            from: {
+              tools: ["@voyant-travel/finance#bookings-create-extension.tool.book-product"],
             },
           }),
           // Self-service creation is a separate action over the same command:

--- a/packages/mcp/src/guide.ts
+++ b/packages/mcp/src/guide.ts
@@ -252,10 +252,10 @@ function bookingJourneySection(scope: GuideScope): string {
     "min default) and is a live-pricing snapshot, not a commitment.\n" +
     "2. Hold (where supported) — place a time-limited claim on inventory while details " +
     "are gathered. A Hold expires; it is not a Booking.\n" +
-    "3. Commit — creating the Booking is a SEPARATE, admitted operation, not a side " +
-    "effect of quoting or holding. Quote and hold routes never insert a Booking; " +
-    "booking creation is admitted through the Finance/Bookings settlement path with " +
-    "its action-ledger claim and idempotency key.\n\n" +
+    "3. Commit — creating the Booking is a SEPARATE, admitted operation, not a side effect of " +
+    "quoting or holding. The intent-level entry point is `book_product` (product, option, billing " +
+    "party — a `personId` or `organizationId` — travelers, rooms — in one call): it resolves the " +
+    "booking reference and idempotency key server-side (you carry neither), validates before writing, and takes `_voyant.confirmed: true`.\n\n" +
     "Because commit is its own confirmed step, quoting or holding leaves no durable " +
     "reservation. Do not treat a successful quote as a booked seat." +
     (scope.writeEnabled

--- a/packages/tools/src/handler-action-policy.ts
+++ b/packages/tools/src/handler-action-policy.ts
@@ -133,6 +133,40 @@ export function assertAuthenticHandlerActionPolicyContext(
 }
 
 /**
+ * Re-mint an already-authentic handler admission with a server-resolved
+ * idempotency key.
+ *
+ * Intent-level workflow tools (voyant#3933) resolve the action-ledger
+ * idempotency key server-side rather than making the caller carry an opaque
+ * token across turns — the failure mode that motivated retiring
+ * `generate_booking_number`. Because `executeAdmittedCreatedTargetCommand`
+ * treats `admitted.invocation.idempotencyKey` as authoritative, the workflow
+ * handler needs to seat its server-derived key there without weakening the
+ * gate. This is the sanctioned way to do it: the input admission must already
+ * be authentic, and only the idempotency key is changed — actor, action policy,
+ * capability identity and transport are carried through untouched. It is the
+ * created-target analogue of the server-owned `requestId` a generic
+ * server-owned-target action already uses.
+ */
+export function withServerResolvedIdempotencyKey(
+  admitted: ToolHandlerActionPolicyContext,
+  idempotencyKey: string,
+): ToolHandlerActionPolicyContext {
+  assertAuthenticHandlerActionPolicyContext(admitted)
+  const key = idempotencyKey.trim()
+  if (!key) {
+    throw new ToolError(
+      "A server-resolved idempotency key must be a non-empty string.",
+      "INVALID_INPUT",
+    )
+  }
+  return mintHandlerActionPolicyContext(
+    { ...admitted, invocation: { ...admitted.invocation, idempotencyKey: key } },
+    admitted.transport,
+  )
+}
+
+/**
  * Package-private runtime primitive used only by the Tool registry.
  *
  * This module is not a package export; consumers can assert admissions but

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -49,6 +49,7 @@ export {
   assertAdmittedActionPolicy,
   assertAuthenticHandlerActionPolicyContext,
   type HandlerActionPolicyExpectation,
+  withServerResolvedIdempotencyKey,
 } from "./handler-action-policy.js"
 export {
   createToolRegistry,

--- a/packages/tools/tests/handler-action-policy.test.ts
+++ b/packages/tools/tests/handler-action-policy.test.ts
@@ -3,11 +3,13 @@ import { z } from "zod"
 
 import {
   admitHandlerActionPolicy,
+  assertAdmittedActionPolicy,
   createToolRegistry,
   defineTool,
   type HandlerActionPolicyExpectation,
   type ToolContext,
   type ToolError,
+  withServerResolvedIdempotencyKey,
 } from "../src/index.js"
 
 const expected = {
@@ -68,6 +70,68 @@ describe("admitHandlerActionPolicy", () => {
       code: "ACTION_POLICY_REQUIRED",
     })
     expect(mutations).toBe(0)
+  })
+})
+
+describe("withServerResolvedIdempotencyKey", () => {
+  it("re-mints an authentic admission carrying the server-resolved key", async () => {
+    let observed: { key?: string; authentic?: boolean } | undefined
+    const registry = createToolRegistry()
+    registry.register(
+      defineTool({
+        capabilityId: expected.capabilityId,
+        capabilityVersion: expected.capabilityVersion,
+        owner: "@voyant-travel/legal",
+        name: expected.canonicalName,
+        description: "Re-mints a server-resolved idempotency key",
+        inputSchema: z.object({}),
+        outputSchema: z.object({ key: z.string(), authentic: z.boolean() }),
+        requiredScopes: [],
+        tier: "write",
+        riskPolicy: {
+          destructive: false,
+          reversible: true,
+          dryRunSupported: false,
+          sideEffects: ["legal-document-write"],
+        },
+        actionPolicyEnforcement: "handler",
+        async handler(_args, ctx) {
+          const admitted = admitHandlerActionPolicy(ctx, expected)
+          const remixed = withServerResolvedIdempotencyKey(admitted, "  server-derived-key  ")
+          // Authentic: passes the exact assertion the command entrypoints run
+          // before minting a claim, and carries the trimmed server key.
+          let authentic = true
+          try {
+            assertAdmittedActionPolicy(remixed, expected)
+          } catch {
+            authentic = false
+          }
+          observed = { key: remixed.invocation.idempotencyKey, authentic }
+          return observed as { key: string; authentic: boolean }
+        },
+      }),
+      { actionPolicy: expected.actionPolicy },
+    )
+
+    await registry.dispatch("legal_issue_document", {}, context())
+    expect(observed).toEqual({ key: "server-derived-key", authentic: true })
+  })
+
+  it("rejects a forged (non-authentic) admission", () => {
+    const forged = {
+      capabilityId: expected.capabilityId,
+      capabilityVersion: expected.capabilityVersion,
+      canonicalName: expected.canonicalName,
+      actionPolicy: {
+        ...expected.actionPolicy,
+        enforcement: "handler",
+        invocation: invocationPolicy,
+      },
+      invocation: { confirmed: true },
+    } as never
+    expect(() => withServerResolvedIdempotencyKey(forged, "k")).toThrowError(
+      expect.objectContaining<Partial<ToolError>>({ code: "ACTION_POLICY_REQUIRED" }),
+    )
   })
 })
 


### PR DESCRIPTION
Addresses #3933. **The finding that started #3921.**

## What this deletes

`create_booking`'s description WAS an orchestration script — it named three other tools and the order to call them in, because no tool expressed "book this product for this client":

> "Requires a billing party: set \`personId\` for a private client (**find it with \`list_people\`**), or \`organizationId\` for a company booking (**find it with \`list_organizations\`**)… **first use \`list_product_options\` and \`list_option_units\`**, then pass explicit \`optionId\` and \`itemLines\`…"

Now:

> "Durably create one booking from an explicit product/slot command. The booking reference is resolved server-side; omit \`booking.bookingNumber\`. Prefer \`book_product\` for the ordinary intent — this lower-level tool is for callers that already hold a fully resolved command."

**`generate_booking_number` is deleted outright** — tool, schemas, and the dangling reference in the `bookingNumber` field description. It existed only to make the caller carry an idempotency token across turns, where the failure mode was a **duplicate booking**. That guarantee now lives server-side via a new sanctioned `@voyant-travel/tools` export, `withServerResolvedIdempotencyKey`, deriving the key as a SHA-256 fingerprint of the semantic request.

Asking a model to carry an opaque token unchanged across turns, including across retries, was the single least reliable thing in the surface. It is gone.

## Scope — 1 of 4, deliberately

`book_product` is complete. Quote→accept→reserve, invoice-a-booking, and cancellation-with-policy were **not** attempted. The brief said to finish one properly rather than half-finish four, and that instruction was followed. Remaining three stay tracked on #3933.

## Verification

```
pnpm -F @voyant-travel/finance test        61 files / 494 tests passed (16, 357 skipped)
pnpm -F @voyant-travel/mcp test            12 files / 77 tests passed
pnpm -F @voyant-travel/bookings-react test 31 files / 148 tests passed
operator suite (full dir)                  11 files / 56 tests passed
npx biome check .                          repo-wide, 0 errors
```

**No ratchet ceiling moved.** `starters/operator/tests/` is untouched, and real-surface discovery actually *dropped* 36,974 → **36,794** tokens — a workflow tool that replaces a 3-call sequence costs less to discover than the sequence did.

## One thing to know

**The React client was un-broken, not migrated.** `manual-booking-mcp-client.ts`'s `REQUIRED_TOOLS` went from `["generate_booking_number", "create_booking"]` to `["create_booking"]` — not to `["book_product"]`.

That is defensible: the manual-booking form already collects a fully resolved command, which is exactly the case the new `create_booking` description carves out. Routing a completed form through an intent-level tool would be worse, not better. But it does mean **no first-party caller exercises `book_product`** — its coverage is its own tests. Worth knowing when judging how much real-world confidence to place in it.