### PR TITLE
fix(catalog): stamp the draft when a hold is placed

### DIFF
--- a/.changeset/stamp-draft-hold-on-place.md
+++ b/.changeset/stamp-draft-hold-on-place.md
@@ -1,0 +1,14 @@
+---
+"@voyant-travel/catalog": patch
+---
+
+Stamp `hold_expires_at` on the draft when `POST /catalog/holds/place` succeeds.
+
+`hold_expires_at` is the only evidence of a hold that anything downstream reads:
+the public self-service create refuses a draft without it (`hold_required`) for
+precisely the verticals that implement `placeHold`, and the reaper releases by
+it. Nothing on the public path wrote the column — `updateBookingDraft` is its
+only writer and no route called it with `holdExpiresAt` — so placing a hold took
+the inventory and still guaranteed the create would be refused. Public
+self-service booking against a holds-implementing vertical could not succeed at
+all.

--- a/packages/catalog/src/booking-engine/routes.test.ts
+++ b/packages/catalog/src/booking-engine/routes.test.ts
@@ -458,4 +458,32 @@ describe("createCatalogBookingRoutes", () => {
       "hold_1",
     )
   })
+
+  /**
+   * `hold_expires_at` is the only evidence of a hold that anything downstream
+   * reads. The public self-service create refuses a draft without it
+   * (`hold_required`) for precisely the verticals that implement holds, so
+   * placing a hold without stamping it took the inventory and then guaranteed
+   * the booking would be refused — unsatisfiable through the public API.
+   */
+  it("stamps the hold expiry on the draft it was placed for", async () => {
+    const expiresAt = new Date("2026-05-05T10:30:00.000Z")
+    const handler: OwnedBookingHandler = {
+      entityModule: "products",
+      computeQuote: async () => ({ available: true }),
+      placeHold: async () => ({ holdToken: "hold_1", expiresAt }),
+      releaseHold: async () => undefined,
+    }
+    const { app, ownedHandlers } = createTestApp()
+    ownedHandlers.register(handler)
+
+    const response = await app.request("/v1/public/catalog/holds/place", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ entityModule: "products", entityId: "prod_1", draftId: "draft_1" }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(updateBookingDraft).toHaveBeenCalledWith(db, "draft_1", { holdExpiresAt: expiresAt })
+  })
 })

--- a/packages/catalog/src/booking-engine/routes.ts
+++ b/packages/catalog/src/booking-engine/routes.ts
@@ -697,6 +697,16 @@ async function handleHoldPlace(
         parameters: body.parameters,
       },
     )
+    // Record the hold on the draft that now carries it.
+    //
+    // `hold_expires_at` is the only evidence a hold exists that anything
+    // downstream reads: the public self-service create refuses a draft without
+    // it (`hold_required`) for exactly the verticals that implement holds, and
+    // the reaper releases by it. Placing the hold without stamping left that
+    // column permanently null for every public caller, so the create could
+    // never be satisfied — the hold was taken, inventory was decremented, and
+    // the booking was refused anyway.
+    await updateBookingDraft(db, body.draftId, { holdExpiresAt: result.expiresAt })
     return c.json({ holdToken: result.holdToken, expiresAt: result.expiresAt.toISOString() })
   } catch (err) {
     return bookingEngineErrorResponse(c, err)


### PR DESCRIPTION
Public self-service booking against a holds-implementing vertical could not succeed at all.

## The gap

`POST /catalog/holds/place` places the hold, decrements inventory and returns a token — but never records the hold on the draft it was placed for. The public self-service create then reads exactly that column:

```js
// self-service-source.ts
if (handler.placeHold && !draft.hold_expires_at) return reject("hold_required")
```

`updateBookingDraft({ holdExpiresAt })` is the only writer of `catalog_booking_drafts.hold_expires_at`, and no route called it. So for any vertical implementing `placeHold` — `products` does — the hold was taken and the booking it was taken for was then guaranteed to be refused. The reaper also releases by this column, so an unstamped hold is invisible to cleanup as well.

## Verified against production first

Against the live pro-travel runtime (`@voyant-travel/catalog` 0.221.0), on a real draft:

```
PUT  /v1/public/catalog/drafts/{id}       -> draft created
POST /v1/public/catalog/holds/place       -> {"holdToken":"...","expiresAt":"2026-07-31T10:36:16.833Z"}
GET  /v1/public/catalog/drafts/{id}       -> hold_expires_at = null
```

(The probe hold was released afterwards.)

## Change

`handleHoldPlace` stamps `holdExpiresAt` from the value the handler returned, so the draft carries the hold the caller was just granted.

## Tests

New case in `routes.test.ts` asserting the stamp. Confirmed it fails without the source change and passes with it. Full `src/booking-engine` suite: 106 passed.

Local typecheck OOMs on this machine, so CI is the check for that.