### PR TITLE
refactor(operator-standard): drive standard operator routes from presentation declarations

### DIFF
--- a/.changeset/presentation-driven-operator-routes.md
+++ b/.changeset/presentation-driven-operator-routes.md
@@ -1,0 +1,28 @@
+---
+"@voyant-travel/core": minor
+"@voyant-travel/framework": minor
+"@voyant-travel/operator-standard": minor
+"@voyant-travel/auth": minor
+"@voyant-travel/storefront": minor
+"@voyant-travel/finance": minor
+"@voyant-travel/quotes": minor
+"@voyant-travel/mcp": minor
+---
+
+Make `createStandardOperatorRouteFiles` a pure function of resolved
+deployment-graph data (voyant#3976 item 10.1).
+
+The standard operator route generator previously hardcoded the presentation
+IDs and route tables for auth, storefront, finance, quotes, and MCP consent, so
+a package could not get admin routes emitted without editing
+`@voyant-travel/operator-standard`. Each presentation now declares its own
+route contribution on its `presentations` graph entry via `contribution` and
+`routes`, and the generator emits from those declarations.
+
+`VoyantGraphPresentationDeclaration` gains optional `contribution` and `routes`
+fields (`VoyantGraphPresentationRouteDeclaration`), validated in the deployment
+graph: when `routes` is non-empty, `contribution` must be a non-empty string,
+each `route` must start with `/`, and each `member` must be a non-empty string.
+The product BOM now carries the full presentation declarations rather than just
+their IDs. This is a behaviour-preserving refactor — the emitted route-file set
+is byte-identical to before.

--- a/packages/auth/src/voyant.ts
+++ b/packages/auth/src/voyant.ts
@@ -124,6 +124,18 @@ export const authInvitationsVoyantModule = defineModule({
         entry: "@voyant-travel/auth-react/local-auth-routes",
         export: "createLocalAuthRouteContribution",
       },
+      contribution: "localAuth",
+      routes: [
+        { route: "/(auth)", member: "layout" },
+        { route: "/(auth)/accept-invitation", member: "acceptInvitation" },
+        { route: "/(auth)/accept-invite", member: "acceptInvite" },
+        { route: "/(auth)/forgot-password", member: "forgotPassword" },
+        { route: "/(auth)/onboarding", member: "onboarding" },
+        { route: "/(auth)/reset-password", member: "resetPassword" },
+        { route: "/(auth)/sign-in", member: "signIn" },
+        { route: "/(auth)/sign-up", member: "signUp" },
+        { route: "/(auth)/verify-email", member: "verifyEmail" },
+      ],
     },
   ],
   meta: {

--- a/packages/core/src/project-facets.ts
+++ b/packages/core/src/project-facets.ts
@@ -147,9 +147,22 @@ export interface VoyantGraphAdminDeclaration {
   setupSteps?: readonly VoyantGraphAdminSetupStep[]
 }
 
+export interface VoyantGraphPresentationRouteDeclaration {
+  /** Router path as passed to `createFileRoute`, e.g. "/(auth)/sign-in". */
+  route: string
+  /** Member on the presentation's frontend route contribution, e.g. "signIn". */
+  member: string
+}
+
 /** A package-owned frontend presentation selected through the deployment graph. */
 export interface VoyantGraphPresentationDeclaration extends VoyantGraphFacetEntity {
   runtime: VoyantGraphRuntimeReference
+  /**
+   * Key on `operatorFrontend.routes` carrying this presentation's route
+   * contribution. Required when `routes` is present.
+   */
+  contribution?: string
+  routes?: readonly VoyantGraphPresentationRouteDeclaration[]
 }
 
 export interface VoyantGraphReportingGridSize {

--- a/packages/finance/src/voyant.ts
+++ b/packages/finance/src/voyant.ts
@@ -514,6 +514,12 @@ export const financeVoyantModule = defineModule({
         entry: "@voyant-travel/finance-react/public-routes",
         export: "createFinancePublicRouteContribution",
       },
+      contribution: "finance",
+      routes: [
+        { route: "/accountant/$token", member: "accountant" },
+        { route: "/pay", member: "pay" },
+        { route: "/pay_/$sessionId", member: "paymentLink" },
+      ],
     },
   ],
   lifecycle: {

--- a/packages/framework/src/deployment-graph.test.ts
+++ b/packages/framework/src/deployment-graph.test.ts
@@ -310,6 +310,25 @@ describe("deployment graph v1", () => {
       ]),
     )
 
+    expect(
+      validateGraphUnitManifest({
+        ...module,
+        presentations: [
+          {
+            id: "@acme/storefront#presentation.customer",
+            runtime: { entry: "./customer", export: "createCustomerPresentation" },
+            routes: [{ route: "shop", member: "" }],
+          },
+        ],
+      }),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ facet: "presentations[0].contribution" }),
+        expect.objectContaining({ facet: "presentations[0].routes[0].route" }),
+        expect.objectContaining({ facet: "presentations[0].routes[0].member" }),
+      ]),
+    )
+
     const graph = await resolveDeploymentGraph({ project: defineProject({ modules: [module] }) })
     expect(graph.modules[0]?.presentations?.map(({ id }) => id)).toEqual([
       "@acme/storefront#presentation.customer",

--- a/packages/framework/src/deployment-graph.ts
+++ b/packages/framework/src/deployment-graph.ts
@@ -2319,6 +2319,34 @@ function validatePromotedFacets(
         "Presentation runtime references require a named factory export.",
       )
     }
+    if (entry.routes !== undefined) {
+      if (!Array.isArray(entry.routes)) {
+        invalidFacet(
+          `${facet}.routes`,
+          source,
+          diagnostics,
+          "Presentation routes must be an array.",
+        )
+      } else if (entry.routes.length > 0) {
+        requireNonEmptyString(entry.contribution, `${facet}.contribution`, source, diagnostics)
+        entry.routes.forEach((route, index) => {
+          const routeFacet = `${facet}.routes[${index}]`
+          if (!isRecord(route)) {
+            invalidFacet(routeFacet, source, diagnostics, "Presentation route must be an object.")
+            return
+          }
+          if (typeof route.route !== "string" || !route.route.startsWith("/")) {
+            invalidFacet(
+              `${routeFacet}.route`,
+              source,
+              diagnostics,
+              'Presentation route paths must start with "/".',
+            )
+          }
+          requireNonEmptyString(route.member, `${routeFacet}.member`, source, diagnostics)
+        })
+      }
+    }
   })
   validateReportingFacet(input.reporting, source, diagnostics)
   if (input.lifecycle !== undefined) {

--- a/packages/framework/src/project-resolver.ts
+++ b/packages/framework/src/project-resolver.ts
@@ -351,8 +351,7 @@ function buildProductBomExpansionArtifact(graph: ResolvedVoyantProjectGraph): st
         providers: graph.providers.map(({ id }) => id),
         presentations: allResolvedGraphUnits(graph)
           .flatMap((unit) => unit.presentations ?? [])
-          .map(({ id }) => id)
-          .sort(),
+          .sort((left, right) => left.id.localeCompare(right.id)),
       },
     },
     null,

--- a/packages/mcp/src/voyant.ts
+++ b/packages/mcp/src/voyant.ts
@@ -29,6 +29,17 @@ export const mcpVoyantModule = defineModule({
         entry: "@voyant-travel/auth-react/mcp-consent-routes",
         export: "createMcpConsentRouteContribution",
       },
+      contribution: "mcpConsent",
+      routes: [
+        { route: "/(mcp)", member: "layout" },
+        // The OAuth consent screen an MCP connector sends the operator to. It
+        // gets its own chrome-less group rather than riding along with local
+        // auth: the authorization server issuing connector grants is local to
+        // the deployment in every admin auth mode, so a broker-authenticated
+        // deployment — which ships no sign-in or sign-up page — must still
+        // answer /mcp-consent.
+        { route: "/(mcp)/mcp-consent", member: "consent" },
+      ],
     },
   ],
   access: {

--- a/packages/operator-standard/src/standard-route-files.ts
+++ b/packages/operator-standard/src/standard-route-files.ts
@@ -1,47 +1,44 @@
+import type { VoyantGraphPresentationDeclaration } from "@voyant-travel/core/project"
 import type { VoyantGeneratedRouteFile } from "@voyant-travel/vite-config"
 
 const runtimeImport = (path: string) =>
   path.includes("/") ? "../_lib/operator-frontend.js" : "./_lib/operator-frontend.js"
 const standardFrontendImport = "@voyant-travel/operator-standard/standard-frontend"
 
-const contributionRoute = (
-  path: string,
-  routeId: string,
-  contribution: "localAuth" | "mcpConsent" | "storefront",
+/**
+ * Derive a route file path from a router path. The mapping is mechanical:
+ * strip the leading `/`, keep a leading group segment `(x)` as a directory,
+ * turn the remaining `/` into `.`, and emit `route.tsx` for a bare group path.
+ */
+const routeFilePath = (route: string): string => {
+  const withoutLeadingSlash = route.slice(1)
+  const groupMatch = /^(\([^)]+\))(?:\/(.*))?$/.exec(withoutLeadingSlash)
+  if (groupMatch) {
+    const [, group, rest] = groupMatch
+    return rest === undefined ? `${group}/route.tsx` : `${group}/${rest.replaceAll("/", ".")}.tsx`
+  }
+  return `${withoutLeadingSlash.replaceAll("/", ".")}.tsx`
+}
+
+const presentationRoute = (
+  route: string,
+  contribution: string,
   member: string,
-): VoyantGeneratedRouteFile => ({
-  path,
-  source: `
+): VoyantGeneratedRouteFile => {
+  const path = routeFilePath(route)
+  return {
+    path,
+    source: `
 import { createFileRoute } from "@tanstack/react-router"
 import { operatorFrontend } from ${JSON.stringify(runtimeImport(path))}
 
-export const Route = createFileRoute(${JSON.stringify(routeId)})(operatorFrontend.routes.${contribution}!.${member})
+export const Route = createFileRoute(${JSON.stringify(route)})(operatorFrontend.routes.${contribution}!.${member})
 `,
-})
-
-const contributedPublicRoute = (
-  path: string,
-  routeId: string,
-  contribution: "finance" | "quotes",
-  member: string,
-): VoyantGeneratedRouteFile => ({
-  path,
-  source: `
-import { createFileRoute } from "@tanstack/react-router"
-import { operatorFrontend } from ${JSON.stringify(runtimeImport(path))}
-
-export const Route = createFileRoute(${JSON.stringify(routeId)})(operatorFrontend.routes.${contribution}!.${member})
-`,
-})
-
-const STOREFRONT_PRESENTATION_ID = "@voyant-travel/storefront#presentation.customer"
-const AUTH_PRESENTATION_ID = "@voyant-travel/auth#presentation.local-auth"
-const MCP_CONSENT_PRESENTATION_ID = "@voyant-travel/mcp#presentation.consent"
-const FINANCE_PRESENTATION_ID = "@voyant-travel/finance#presentation.public"
-const QUOTES_PRESENTATION_ID = "@voyant-travel/quotes#presentation.public"
+  }
+}
 
 export interface CreateStandardOperatorRouteFilesOptions {
-  presentationIds: readonly string[]
+  presentations: readonly VoyantGraphPresentationDeclaration[]
 }
 
 const standardOperatorRouteFiles: readonly VoyantGeneratedRouteFile[] = [
@@ -107,63 +104,6 @@ export const Route = createFileRoute("/docs")(operatorFrontend.routes.docs)
   },
 ]
 
-const financeRouteFiles: readonly VoyantGeneratedRouteFile[] = [
-  contributedPublicRoute("accountant.$token.tsx", "/accountant/$token", "finance", "accountant"),
-  contributedPublicRoute("pay.tsx", "/pay", "finance", "pay"),
-  contributedPublicRoute("pay_.$sessionId.tsx", "/pay_/$sessionId", "finance", "paymentLink"),
-]
-
-const quotesRouteFiles: readonly VoyantGeneratedRouteFile[] = [
-  contributedPublicRoute(
-    "proposal.$quoteVersionId.tsx",
-    "/proposal/$quoteVersionId",
-    "quotes",
-    "proposal",
-  ),
-]
-
-const authRouteFiles: readonly VoyantGeneratedRouteFile[] = [
-  contributionRoute("(auth)/route.tsx", "/(auth)", "localAuth", "layout"),
-  contributionRoute(
-    "(auth)/accept-invitation.tsx",
-    "/(auth)/accept-invitation",
-    "localAuth",
-    "acceptInvitation",
-  ),
-  contributionRoute(
-    "(auth)/accept-invite.tsx",
-    "/(auth)/accept-invite",
-    "localAuth",
-    "acceptInvite",
-  ),
-  contributionRoute(
-    "(auth)/forgot-password.tsx",
-    "/(auth)/forgot-password",
-    "localAuth",
-    "forgotPassword",
-  ),
-  contributionRoute("(auth)/onboarding.tsx", "/(auth)/onboarding", "localAuth", "onboarding"),
-  contributionRoute(
-    "(auth)/reset-password.tsx",
-    "/(auth)/reset-password",
-    "localAuth",
-    "resetPassword",
-  ),
-  contributionRoute("(auth)/sign-in.tsx", "/(auth)/sign-in", "localAuth", "signIn"),
-  contributionRoute("(auth)/sign-up.tsx", "/(auth)/sign-up", "localAuth", "signUp"),
-  contributionRoute("(auth)/verify-email.tsx", "/(auth)/verify-email", "localAuth", "verifyEmail"),
-]
-
-// The OAuth consent screen an MCP connector sends the operator to. It gets its
-// own chrome-less group rather than riding along with local auth: the
-// authorization server issuing connector grants is local to the deployment in
-// every admin auth mode, so a broker-authenticated deployment — which ships no
-// sign-in or sign-up page — must still answer /mcp-consent.
-const mcpConsentRouteFiles: readonly VoyantGeneratedRouteFile[] = [
-  contributionRoute("(mcp)/route.tsx", "/(mcp)", "mcpConsent", "layout"),
-  contributionRoute("(mcp)/mcp-consent.tsx", "/(mcp)/mcp-consent", "mcpConsent", "consent"),
-]
-
 const workspaceRouteFiles: readonly VoyantGeneratedRouteFile[] = [
   {
     path: "_workspace/route.tsx",
@@ -189,65 +129,26 @@ function WorkspaceLayout() {
   },
 ]
 
-const storefrontRouteFiles: readonly VoyantGeneratedRouteFile[] = [
-  contributionRoute("(storefront)/route.tsx", "/(storefront)", "storefront", "layout"),
-  contributionRoute("(storefront)/shop.tsx", "/(storefront)/shop", "storefront", "shop"),
-  contributionRoute(
-    "(storefront)/shop_.account.tsx",
-    "/(storefront)/shop_/account",
-    "storefront",
-    "account",
-  ),
-  contributionRoute(
-    "(storefront)/shop_.account.sign-in.tsx",
-    "/(storefront)/shop_/account/sign-in",
-    "storefront",
-    "accountSignIn",
-  ),
-  contributionRoute(
-    "(storefront)/shop_.account.sign-up.tsx",
-    "/(storefront)/shop_/account/sign-up",
-    "storefront",
-    "accountSignUp",
-  ),
-  contributionRoute(
-    "(storefront)/shop_.account.verify-email.tsx",
-    "/(storefront)/shop_/account/verify-email",
-    "storefront",
-    "accountVerifyEmail",
-  ),
-  contributionRoute(
-    "(storefront)/shop_.composer.tsx",
-    "/(storefront)/shop_/composer",
-    "storefront",
-    "composer",
-  ),
-  contributionRoute(
-    "(storefront)/shop_.confirmation.$bookingId.tsx",
-    "/(storefront)/shop_/confirmation/$bookingId",
-    "storefront",
-    "confirmation",
-  ),
-  contributionRoute(
-    "(storefront)/shop_.products.$entityModule.$entityId.tsx",
-    "/(storefront)/shop_/products/$entityModule/$entityId",
-    "storefront",
-    "productDetail",
-  ),
-]
+/**
+ * Emit the route files a selected presentation contributes, in declared order.
+ * A presentation without a `contribution`/`routes` table contributes nothing.
+ */
+const presentationRouteFiles = (
+  presentation: VoyantGraphPresentationDeclaration,
+): readonly VoyantGeneratedRouteFile[] => {
+  if (!presentation.contribution || !presentation.routes?.length) return []
+  const contribution = presentation.contribution
+  return presentation.routes.map((route) =>
+    presentationRoute(route.route, contribution, route.member),
+  )
+}
 
 /** Standard package-owned route registrations emitted into `.voyant/routes`. */
 export function createStandardOperatorRouteFiles(
   options: CreateStandardOperatorRouteFilesOptions,
 ): readonly VoyantGeneratedRouteFile[] {
-  const selected = new Set(options.presentationIds)
-  return [
-    ...standardOperatorRouteFiles,
-    ...(selected.has(AUTH_PRESENTATION_ID) ? authRouteFiles : []),
-    ...(selected.has(FINANCE_PRESENTATION_ID) ? financeRouteFiles : []),
-    ...(selected.has(MCP_CONSENT_PRESENTATION_ID) ? mcpConsentRouteFiles : []),
-    ...(selected.has(QUOTES_PRESENTATION_ID) ? quotesRouteFiles : []),
-    ...(selected.has(STOREFRONT_PRESENTATION_ID) ? storefrontRouteFiles : []),
-    ...workspaceRouteFiles,
-  ]
+  const presentationFamilies = [...options.presentations]
+    .sort((left, right) => left.id.localeCompare(right.id))
+    .flatMap(presentationRouteFiles)
+  return [...standardOperatorRouteFiles, ...presentationFamilies, ...workspaceRouteFiles]
 }

--- a/packages/operator-standard/tests/standard-package-manifests.test.ts
+++ b/packages/operator-standard/tests/standard-package-manifests.test.ts
@@ -84,6 +84,21 @@ describe("standard package manifests", () => {
           entry: "@voyant-travel/storefront-react/storefront",
           export: "createStorefrontPresentationContribution",
         },
+        contribution: "storefront",
+        routes: [
+          { route: "/(storefront)", member: "layout" },
+          { route: "/(storefront)/shop", member: "shop" },
+          { route: "/(storefront)/shop_/account", member: "account" },
+          { route: "/(storefront)/shop_/account/sign-in", member: "accountSignIn" },
+          { route: "/(storefront)/shop_/account/sign-up", member: "accountSignUp" },
+          { route: "/(storefront)/shop_/account/verify-email", member: "accountVerifyEmail" },
+          { route: "/(storefront)/shop_/composer", member: "composer" },
+          { route: "/(storefront)/shop_/confirmation/$bookingId", member: "confirmation" },
+          {
+            route: "/(storefront)/shop_/products/$entityModule/$entityId",
+            member: "productDetail",
+          },
+        ],
       },
     ])
   })

--- a/packages/operator-standard/tests/standard-route-files.test.ts
+++ b/packages/operator-standard/tests/standard-route-files.test.ts
@@ -1,17 +1,68 @@
+import type { VoyantGraphPresentationDeclaration } from "@voyant-travel/core/project"
 import { describe, expect, it } from "vitest"
 
 import { createStandardOperatorRouteFiles } from "../src/standard-route-files"
 
+const presentation = (
+  id: string,
+  contribution: string,
+  routes: readonly { route: string; member: string }[],
+): VoyantGraphPresentationDeclaration => ({
+  id,
+  runtime: { entry: "@voyant-travel/example-react/routes", export: "createRouteContribution" },
+  contribution,
+  routes,
+})
+
+const localAuth = presentation("@voyant-travel/auth#presentation.local-auth", "localAuth", [
+  { route: "/(auth)", member: "layout" },
+  { route: "/(auth)/accept-invitation", member: "acceptInvitation" },
+  { route: "/(auth)/accept-invite", member: "acceptInvite" },
+  { route: "/(auth)/forgot-password", member: "forgotPassword" },
+  { route: "/(auth)/onboarding", member: "onboarding" },
+  { route: "/(auth)/reset-password", member: "resetPassword" },
+  { route: "/(auth)/sign-in", member: "signIn" },
+  { route: "/(auth)/sign-up", member: "signUp" },
+  { route: "/(auth)/verify-email", member: "verifyEmail" },
+])
+
+const financePublic = presentation("@voyant-travel/finance#presentation.public", "finance", [
+  { route: "/accountant/$token", member: "accountant" },
+  { route: "/pay", member: "pay" },
+  { route: "/pay_/$sessionId", member: "paymentLink" },
+])
+
+const mcpConsent = presentation("@voyant-travel/mcp#presentation.consent", "mcpConsent", [
+  { route: "/(mcp)", member: "layout" },
+  { route: "/(mcp)/mcp-consent", member: "consent" },
+])
+
+const quotesPublic = presentation("@voyant-travel/quotes#presentation.public", "quotes", [
+  { route: "/proposal/$quoteVersionId", member: "proposal" },
+])
+
+const storefrontCustomer = presentation(
+  "@voyant-travel/storefront#presentation.customer",
+  "storefront",
+  [
+    { route: "/(storefront)", member: "layout" },
+    { route: "/(storefront)/shop", member: "shop" },
+    { route: "/(storefront)/shop_/account", member: "account" },
+    { route: "/(storefront)/shop_/account/sign-in", member: "accountSignIn" },
+    { route: "/(storefront)/shop_/account/sign-up", member: "accountSignUp" },
+    { route: "/(storefront)/shop_/account/verify-email", member: "accountVerifyEmail" },
+    { route: "/(storefront)/shop_/composer", member: "composer" },
+    { route: "/(storefront)/shop_/confirmation/$bookingId", member: "confirmation" },
+    { route: "/(storefront)/shop_/products/$entityModule/$entityId", member: "productDetail" },
+  ],
+)
+
+const allPresentations = [localAuth, financePublic, mcpConsent, quotesPublic, storefrontCustomer]
+
 describe("createStandardOperatorRouteFiles", () => {
   it("routes every standard frontend surface through the package runtime", () => {
     const standardOperatorRouteFiles = createStandardOperatorRouteFiles({
-      presentationIds: [
-        "@voyant-travel/auth#presentation.local-auth",
-        "@voyant-travel/finance#presentation.public",
-        "@voyant-travel/mcp#presentation.consent",
-        "@voyant-travel/quotes#presentation.public",
-        "@voyant-travel/storefront#presentation.customer",
-      ],
+      presentations: allPresentations,
     })
     const runtime = standardOperatorRouteFiles.find(
       (file) => file.path === "_lib/operator-frontend.tsx",
@@ -33,15 +84,15 @@ describe("createStandardOperatorRouteFiles", () => {
 
   it("emits each package route family only when its presentation is selected", () => {
     const cases = [
-      ["@voyant-travel/auth#presentation.local-auth", "(auth)/"],
-      ["@voyant-travel/finance#presentation.public", "pay.tsx"],
-      ["@voyant-travel/mcp#presentation.consent", "(mcp)/"],
-      ["@voyant-travel/quotes#presentation.public", "proposal.$quoteVersionId.tsx"],
+      [localAuth, "(auth)/"],
+      [financePublic, "pay.tsx"],
+      [mcpConsent, "(mcp)/"],
+      [quotesPublic, "proposal.$quoteVersionId.tsx"],
     ] as const
 
-    for (const [presentationId, expectedPath] of cases) {
-      const selected = createStandardOperatorRouteFiles({ presentationIds: [presentationId] })
-      const absent = createStandardOperatorRouteFiles({ presentationIds: [] })
+    for (const [declaration, expectedPath] of cases) {
+      const selected = createStandardOperatorRouteFiles({ presentations: [declaration] })
+      const absent = createStandardOperatorRouteFiles({ presentations: [] })
       expect(selected.some(({ path }) => path.startsWith(expectedPath))).toBe(true)
       expect(absent.some(({ path }) => path.startsWith(expectedPath))).toBe(false)
     }
@@ -52,7 +103,7 @@ describe("createStandardOperatorRouteFiles", () => {
     // password-reset page, but the authorization server issuing connector
     // grants is still local to it — so consent has to be reachable anyway.
     const cloudAuth = createStandardOperatorRouteFiles({
-      presentationIds: ["@voyant-travel/mcp#presentation.consent"],
+      presentations: [mcpConsent],
     })
 
     expect(cloudAuth.map(({ path }) => path)).toContain("(mcp)/mcp-consent.tsx")
@@ -61,14 +112,79 @@ describe("createStandardOperatorRouteFiles", () => {
 
   it("emits Storefront routes only when its presentation is selected", () => {
     const selected = createStandardOperatorRouteFiles({
-      presentationIds: ["@voyant-travel/storefront#presentation.customer"],
+      presentations: [storefrontCustomer],
     })
-    const absent = createStandardOperatorRouteFiles({ presentationIds: [] })
+    const absent = createStandardOperatorRouteFiles({ presentations: [] })
 
     expect(selected.filter((file) => file.path.startsWith("(storefront)/"))).toHaveLength(9)
     expect(absent.some((file) => file.path.startsWith("(storefront)/"))).toBe(false)
     expect(absent.map(({ path }) => path)).toEqual(
       selected.filter((file) => !file.path.startsWith("(storefront)/")).map(({ path }) => path),
     )
+  })
+
+  it("emits routes for a presentation declared entirely outside operator-standard", () => {
+    // The whole point of the refactor: a package that declares a presentation
+    // with a contribution + routes gets admin route files emitted without any
+    // edit to operator-standard.
+    const loyalty = presentation("@acme/loyalty#presentation.portal", "loyalty", [
+      { route: "/(loyalty)", member: "layout" },
+      { route: "/loyalty/$memberId", member: "member" },
+    ])
+
+    const files = createStandardOperatorRouteFiles({ presentations: [loyalty] })
+    const byPath = new Map(files.map((file) => [file.path, file.source]))
+
+    expect(byPath.has("(loyalty)/route.tsx")).toBe(true)
+    expect(byPath.get("(loyalty)/route.tsx")).toContain(
+      'createFileRoute("/(loyalty)")(operatorFrontend.routes.loyalty!.layout)',
+    )
+    expect(byPath.has("loyalty.$memberId.tsx")).toBe(true)
+    expect(byPath.get("loyalty.$memberId.tsx")).toContain(
+      'createFileRoute("/loyalty/$memberId")(operatorFrontend.routes.loyalty!.member)',
+    )
+  })
+
+  it("orders presentation families by presentation id", () => {
+    const files = createStandardOperatorRouteFiles({
+      // Deliberately shuffled to prove the generator sorts by presentation id.
+      presentations: [storefrontCustomer, localAuth, quotesPublic, financePublic, mcpConsent],
+    })
+    const familyPaths = files
+      .map(({ path }) => path)
+      .filter(
+        (path) =>
+          path !== "_lib/operator-frontend.tsx" &&
+          path !== "__root.tsx" &&
+          path !== "docs.tsx" &&
+          path !== "_workspace/route.tsx",
+      )
+
+    expect(familyPaths).toEqual([
+      "(auth)/route.tsx",
+      "(auth)/accept-invitation.tsx",
+      "(auth)/accept-invite.tsx",
+      "(auth)/forgot-password.tsx",
+      "(auth)/onboarding.tsx",
+      "(auth)/reset-password.tsx",
+      "(auth)/sign-in.tsx",
+      "(auth)/sign-up.tsx",
+      "(auth)/verify-email.tsx",
+      "accountant.$token.tsx",
+      "pay.tsx",
+      "pay_.$sessionId.tsx",
+      "(mcp)/route.tsx",
+      "(mcp)/mcp-consent.tsx",
+      "proposal.$quoteVersionId.tsx",
+      "(storefront)/route.tsx",
+      "(storefront)/shop.tsx",
+      "(storefront)/shop_.account.tsx",
+      "(storefront)/shop_.account.sign-in.tsx",
+      "(storefront)/shop_.account.sign-up.tsx",
+      "(storefront)/shop_.account.verify-email.tsx",
+      "(storefront)/shop_.composer.tsx",
+      "(storefront)/shop_.confirmation.$bookingId.tsx",
+      "(storefront)/shop_.products.$entityModule.$entityId.tsx",
+    ])
   })
 })

--- a/packages/quotes/src/voyant.ts
+++ b/packages/quotes/src/voyant.ts
@@ -568,6 +568,8 @@ export const quotesProposalVoyantPlugin = defineExtension({
         entry: "@voyant-travel/quotes-react/public-routes",
         export: "createQuotesPublicRouteContribution",
       },
+      contribution: "quotes",
+      routes: [{ route: "/proposal/$quoteVersionId", member: "proposal" }],
     },
   ],
   meta: {

--- a/packages/runtime/src/tooling-internal.ts
+++ b/packages/runtime/src/tooling-internal.ts
@@ -10,6 +10,7 @@ import { devtools } from "@tanstack/devtools-vite"
 import { tanstackStart } from "@tanstack/react-start/plugin/vite"
 import { Generator, getConfig } from "@tanstack/router-generator"
 import viteReact from "@vitejs/plugin-react"
+import type { VoyantGraphPresentationDeclaration } from "@voyant-travel/core/project"
 import {
   createAnalyzePlugin,
   VOYANT_ROUTE_FILE_IGNORE_PATTERN,
@@ -615,7 +616,7 @@ async function generateRouteTree(options: ProjectRouteGenerationOptions): Promis
 export async function loadStandardRouteFiles(
   projectRoot: string,
 ): Promise<readonly VoyantGeneratedRouteFile[]> {
-  const { productBomId, presentationIds } = await loadProductBomSelection(projectRoot)
+  const { productBomId, presentations } = await loadProductBomSelection(projectRoot)
   const routeFilesExport = `${productBomId}/${PRODUCT_ROUTE_FILES_EXPORT}`
   const resolveFromProject = createRequire(path.join(projectRoot, "package.json"))
   let resolved: string
@@ -637,7 +638,7 @@ export async function loadStandardRouteFiles(
       `${routeFilesExport} must export createStandardOperatorRouteFiles as a function`,
     )
   }
-  const files = module.createStandardOperatorRouteFiles({ presentationIds })
+  const files = module.createStandardOperatorRouteFiles({ presentations })
   if (!isGeneratedRouteFileArray(files)) {
     throw new TypeError(`${routeFilesExport} createStandardOperatorRouteFiles must return an array`)
   }
@@ -648,9 +649,10 @@ export async function loadProductBomId(projectRoot: string): Promise<string> {
   return (await loadProductBomSelection(projectRoot)).productBomId
 }
 
-async function loadProductBomSelection(
-  projectRoot: string,
-): Promise<{ productBomId: string; presentationIds: readonly string[] }> {
+async function loadProductBomSelection(projectRoot: string): Promise<{
+  productBomId: string
+  presentations: readonly VoyantGraphPresentationDeclaration[]
+}> {
   const artifactPath = path.join(projectRoot, PRODUCT_BOM_ARTIFACT)
   let source: string
   try {
@@ -682,13 +684,21 @@ async function loadProductBomSelection(
       `Voyant product BOM artifact at ${artifactPath} must declare productBom.id as a canonical package name.`,
     )
   }
-  const presentationIds = (artifact as { graph?: { presentations?: unknown } }).graph?.presentations
-  if (!Array.isArray(presentationIds) || presentationIds.some((id) => typeof id !== "string")) {
+  const presentations = (artifact as { graph?: { presentations?: unknown } }).graph?.presentations
+  if (
+    !Array.isArray(presentations) ||
+    presentations.some(
+      (entry) => typeof entry !== "object" || entry === null || typeof entry.id !== "string",
+    )
+  ) {
     throw new TypeError(
-      `Voyant product BOM artifact at ${artifactPath} must declare graph.presentations as a string array.`,
+      `Voyant product BOM artifact at ${artifactPath} must declare graph.presentations as an array of presentation declarations.`,
     )
   }
-  return { productBomId, presentationIds }
+  return {
+    productBomId,
+    presentations: presentations as readonly VoyantGraphPresentationDeclaration[],
+  }
 }
 
 async function pathExists(file: string): Promise<boolean> {

--- a/packages/runtime/src/tooling.test.ts
+++ b/packages/runtime/src/tooling.test.ts
@@ -442,7 +442,7 @@ describe("Voyant project tooling", () => {
   it("loads selected presentation routes from the product BOM package", async () => {
     const projectRoot = await createTemporaryDirectory()
     await writeProductBom(projectRoot, "@voyant-travel/operator-standard", [
-      "@voyant-travel/storefront#presentation.customer",
+      { id: "@voyant-travel/storefront#presentation.customer" },
     ])
     const packageRoot = path.join(projectRoot, "node_modules/@voyant-travel/operator-standard")
     await mkdir(packageRoot, { recursive: true })
@@ -457,8 +457,8 @@ describe("Voyant project tooling", () => {
     await writeFile(
       path.join(packageRoot, "standard-route-files.ts"),
       `interface RouteFile { readonly path: string; readonly source: string }
-export function createStandardOperatorRouteFiles(options: { presentationIds: readonly string[] }): readonly RouteFile[] {
-  return [{ path: "project.tsx", source: options.presentationIds.join(",") }]
+export function createStandardOperatorRouteFiles(options: { presentations: readonly { id: string }[] }): readonly RouteFile[] {
+  return [{ path: "project.tsx", source: options.presentations.map((entry) => entry.id).join(",") }]
 }
 `,
     )
@@ -737,7 +737,7 @@ async function createTemporaryDirectory(): Promise<string> {
 async function writeProductBom(
   projectRoot: string,
   id: string,
-  presentationIds: readonly string[] = [],
+  presentations: readonly { id: string }[] = [],
 ): Promise<void> {
   const artifactDirectory = path.join(projectRoot, ".voyant")
   await mkdir(artifactDirectory, { recursive: true })
@@ -750,7 +750,7 @@ async function writeProductBom(
         id,
         version: "1",
       },
-      graph: { presentations: presentationIds },
+      graph: { presentations },
     }),
   )
 }

--- a/packages/storefront/src/voyant.ts
+++ b/packages/storefront/src/voyant.ts
@@ -130,6 +130,18 @@ export const storefrontVoyantModule = defineModule({
         entry: "@voyant-travel/storefront-react/storefront",
         export: "createStorefrontPresentationContribution",
       },
+      contribution: "storefront",
+      routes: [
+        { route: "/(storefront)", member: "layout" },
+        { route: "/(storefront)/shop", member: "shop" },
+        { route: "/(storefront)/shop_/account", member: "account" },
+        { route: "/(storefront)/shop_/account/sign-in", member: "accountSignIn" },
+        { route: "/(storefront)/shop_/account/sign-up", member: "accountSignUp" },
+        { route: "/(storefront)/shop_/account/verify-email", member: "accountVerifyEmail" },
+        { route: "/(storefront)/shop_/composer", member: "composer" },
+        { route: "/(storefront)/shop_/confirmation/$bookingId", member: "confirmation" },
+        { route: "/(storefront)/shop_/products/$entityModule/$entityId", member: "productDetail" },
+      ],
     },
   ],
   meta: {

--- a/scripts/check-admin-composition-drift.mjs
+++ b/scripts/check-admin-composition-drift.mjs
@@ -336,6 +336,10 @@ for (const name of presentationImports) {
       "@voyant-travel/operator-standard/standard-frontend",
       "@voyant-travel/ui/components",
       "@voyant-travel/vite-config",
+      // Type-only: the route generator is driven by the resolved graph's
+      // presentation declarations, so it consumes their shape from core. This
+      // carries no package admin authority — it is the graph schema itself.
+      "@voyant-travel/core/project",
     ].includes(name)
   )
     continue

--- a/scripts/check-operator-auth-presentation-authority.mjs
+++ b/scripts/check-operator-auth-presentation-authority.mjs
@@ -7,17 +7,49 @@ import {
 } from "./lib/operator-auth-presentation-authority.mjs"
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..")
+
+// The auth route files are no longer hardcoded in operator-standard. The
+// local-auth presentation declares its route table in @voyant-travel/auth, and
+// the operator-standard generator turns each declaration into a generated host
+// binding `operatorFrontend.routes.localAuth!.<member>`. Reconstruct the host
+// map from those two sources so this check still asserts package authority over
+// the generated auth route files.
 const routeRegistry = readFileSync(
   join(root, "packages/operator-standard/src/standard-route-files.ts"),
   "utf8",
 )
+const authModule = readFileSync(join(root, "packages/auth/src/voyant.ts"), "utf8")
+
+// Derive a route file path from a router path exactly as the generator does.
+const routeFilePath = (route) => {
+  const withoutLeadingSlash = route.slice(1)
+  const groupMatch = /^(\([^)]+\))(?:\/(.*))?$/.exec(withoutLeadingSlash)
+  if (groupMatch) {
+    const [, group, rest] = groupMatch
+    return rest === undefined ? `${group}/route.tsx` : `${group}/${rest.replaceAll("/", ".")}.tsx`
+  }
+  return `${withoutLeadingSlash.replaceAll("/", ".")}.tsx`
+}
+
+// The generator must still emit the generic package-owned host binding; without
+// it the declarations would not be routed through the operator frontend.
+const emitsPackagedHost =
+  routeRegistry.includes("createFileRoute") &&
+  // biome-ignore lint/suspicious/noTemplateCurlyInString: matches the generator's literal source template.
+  routeRegistry.includes("operatorFrontend.routes.${contribution}!.${member}")
+
 const routeHosts = Object.fromEntries(
-  Object.keys(AUTH_ROUTE_HOSTS).map((file) => [
-    file,
-    routeRegistry.includes(`"(auth)/${file}"`)
-      ? `createFileRoute operatorFrontend routes.localAuth.${AUTH_ROUTE_HOSTS[file]}`
-      : undefined,
-  ]),
+  Object.entries(AUTH_ROUTE_HOSTS).map(([file, routeKey]) => {
+    const declared = new RegExp(`route:\\s*"(/\\(auth\\)[^"]*)",\\s*member:\\s*"${routeKey}"`).exec(
+      authModule,
+    )
+    const hosted =
+      emitsPackagedHost && declared !== null && routeFilePath(declared[1]) === `(auth)/${file}`
+    return [
+      file,
+      hosted ? `createFileRoute operatorFrontend routes.localAuth!.${routeKey}` : undefined,
+    ]
+  }),
 )
 const result = checkOperatorAuthPresentationAuthority({
   routeHosts,

--- a/scripts/generate-operator-starter-metadata.mjs
+++ b/scripts/generate-operator-starter-metadata.mjs
@@ -199,7 +199,7 @@ import productBom from "./product-bom.generated.json" with { type: "json" }
 const appRoot = fileURLToPath(new URL("..", import.meta.url))
 const generatedRoutes = voyantGeneratedRoutes({
   appRootUrl: new URL("../generated-config-anchor.ts", import.meta.url).href,
-  files: createStandardOperatorRouteFiles({ presentationIds: productBom.graph.presentations }),
+  files: createStandardOperatorRouteFiles({ presentations: productBom.graph.presentations }),
 })
 const config = getConfig(
   {
@@ -234,7 +234,7 @@ import productBom from "./product-bom.generated.json" with { type: "json" }
 const appRootUrl = new URL("../generated-config-anchor.ts", import.meta.url).href
 const generatedRoutes = voyantGeneratedRoutes({
   appRootUrl,
-  files: createStandardOperatorRouteFiles({ presentationIds: productBom.graph.presentations }),
+  files: createStandardOperatorRouteFiles({ presentations: productBom.graph.presentations }),
 })
 
 export default defineConfig(


### PR DESCRIPTION
Part of #3976 (item 10.1).

## Problem

`createStandardOperatorRouteFiles` hardcoded five presentation IDs and their route tables. A package that declared a presentation could not get admin routes emitted without editing `@voyant-travel/operator-standard`, which is why platform hand-composes its admin surface instead of using the generated one.

## What changed

`VoyantGraphPresentationDeclaration` gains optional `contribution` and `routes`:

```ts
{
  id: "@voyant-travel/auth#presentation.local-auth",
  runtime: { entry: "@voyant-travel/auth-react/local-auth-routes", export: "createLocalAuthRouteContribution" },
  contribution: "localAuth",
  routes: [{ route: "/(auth)/sign-in", member: "signIn" }, /* … */],
}
```

Each of the five route tables moved into the package that owns the presentation. The generator now emits from the declarations, and the route *file* path is derived from the router path rather than declared twice:

```
/(auth)                                               -> (auth)/route.tsx
/(auth)/sign-in                                       -> (auth)/sign-in.tsx
/(storefront)/shop_/products/$entityModule/$entityId  -> (storefront)/shop_.products.$entityModule.$entityId.tsx
/pay                                                  -> pay.tsx
/proposal/$quoteVersionId                             -> proposal.$quoteVersionId.tsx
```

That rule reproduces all 24 existing routes with no special cases, so the mapping is one-directional data rather than a parallel table that can drift.

`contributionRoute` and `contributedPublicRoute` emitted byte-identical source and differed only in the union type of one parameter; they are now one helper. The product BOM carries the full declarations rather than only IDs, and graph validation rejects a non-empty `routes` without a `contribution`, a `route` that does not start with `/`, or an empty `member`.

## Verification

This is behaviour-preserving, so the oracle is the emitted output itself. Both generators were loaded side by side and run over the same presentation set:

```
[all five presentations]        before=28 after=28   byte-identical, order identical
[operator BOM subset, no mcp]   before=26 after=26   byte-identical, order identical
```

Compared on file path, file order, and full `source` string.

Also:

- full repository test suite passes (the pre-push gate)
- `core`, `framework`, `operator-standard`, `runtime`, `auth`, `mcp` unit tests pass — 374 in `framework`, 18 in `operator-standard`
- typecheck passes for `core`, `mcp`, `auth`, `finance`, `quotes`; the remaining packages exhaust the heap on the machine this ran on rather than reporting type errors, so CI is the authority for those
- `biome check .` exits clean

New test coverage: a presentation declared entirely outside `operator-standard` (`@acme/loyalty#presentation.portal`) gets its routes emitted with no edit to the generator. That is the point of the change, so it is pinned rather than assumed.

## Note on `check-operator-auth-presentation-authority`

That checker asserted package authority by string-matching the hardcoded route table. With the table gone it now reconstructs the host map from the auth manifest plus the generator's template, applying the same path derivation. It still fails if a route stops being routed through `operatorFrontend`.