### PR TITLE
fix(mcp): three contract and payload bugs found by a real client

### DIFF
--- a/.changeset/mcp-live-client-fixes.md
+++ b/.changeset/mcp-live-client-fixes.md
@@ -1,0 +1,21 @@
+---
+"@voyant-travel/tools": minor
+"@voyant-travel/mcp": minor
+"@voyant-travel/finance": patch
+---
+
+Three fixes found by driving the MCP surface as a real client rather than a
+scripted one.
+
+`ToolDefinition` gains `resolvesIdempotencyKeyServerSide`. A handler-enforced
+ledgered `execute` previously advertised `idempotencyKey` as caller-required
+unconditionally, so `book_product` — whose purpose is that no token crosses
+calls — told agents to supply the very thing it resolves for them.
+
+A `<domain>_query` result now applies the concise projection to
+`structuredContent`, not only the text block. Query tools advertise a permissive
+output schema, so trimming cannot fail validation; a client reading structured
+content previously saw none of the concise saving. Measured 52% smaller.
+
+Server instructions distinguish a key that authorizes nothing from a read-only
+one, instead of claiming reads work when every query returns empty.

--- a/packages/finance/src/tools.ts
+++ b/packages/finance/src/tools.ts
@@ -293,6 +293,7 @@ export const bookProductTool = defineTool({
   outputSchema: bookProductToolOutputSchema,
   requiredScopes: ["bookings:write", "finance:write"],
   audience: { source: "grant", allowed: ["staff"] },
+  resolvesIdempotencyKeyServerSide: true,
   tier: "destructive",
   riskPolicy: {
     destructive: true,

--- a/packages/mcp/src/dispatch.ts
+++ b/packages/mcp/src/dispatch.ts
@@ -38,6 +38,7 @@ export async function dispatchToResult(
   requireActionPolicy: boolean,
   envelopeResult: boolean,
   budgetBytes: number,
+  conciseStructuredContent = false,
 ): Promise<CallToolResult> {
   try {
     // `response_format` is a transport-only control, never a domain input — strip
@@ -93,6 +94,7 @@ export async function dispatchToResult(
     const shaped = shapeResponse(data, {
       format: format ?? (listShaped ? "concise" : undefined),
       budgetBytes,
+      conciseStructuredContent,
       filterFields: def ? listFilterFieldsFromInput(def.inputSchema) : [],
       toWire: (value) => toStructuredContent(value, envelopeResult),
     })

--- a/packages/mcp/src/guide.ts
+++ b/packages/mcp/src/guide.ts
@@ -27,6 +27,14 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 export interface GuideScope {
   /** Whether the caller can reach any state-mutating Tool with its granted key. */
   writeEnabled: boolean
+  /**
+   * Whether the caller can reach ANY Tool at all. A key with no granted
+   * permissions authorizes nothing — not even reads — and must be told so.
+   * Without this the read-only branch below claims the key "can list and read"
+   * when every `search_tools` query will come back empty, which is worse than
+   * silence: the agent trusts the orientation and blames its own queries.
+   */
+  anyToolReachable: boolean
 }
 
 /** Names of the guide Tools registered on every MCP server, for instrumentation. */
@@ -49,9 +57,11 @@ type GuideTopic = (typeof GUIDE_TOPICS)[number]
  * agent and points at the guide Tools for depth, rather than reproducing them.
  */
 export function buildServerInstructions(scope: GuideScope): string {
-  const access = scope.writeEnabled
-    ? "This key can read catalog and booking data and invoke state-changing Tools (subject to per-Tool scopes and the confirmation protocol below)."
-    : "This key is READ-ONLY: it can list and read, but the create/update/publish/book Tools below are not reachable with it. Ignore write instructions."
+  const access = !scope.anyToolReachable
+    ? "This key currently authorizes NO Tools — not reads either. `search_tools` will return nothing and the guide below describes capabilities you cannot reach. This is a permissions problem, not a query problem: ask the operator to grant scopes on the API key before retrying."
+    : scope.writeEnabled
+      ? "This key can read catalog and booking data and invoke state-changing Tools (subject to per-Tool scopes and the confirmation protocol below)."
+      : "This key is READ-ONLY: it can list and read, but the create/update/publish/book Tools below are not reachable with it. Ignore write instructions."
   return [
     "This MCP server is the admin surface of a Voyant deployment — an online travel agency, tour-operator, and destination-management platform. Through it you can discover and operate the operator's catalog (Products, Options, and dated departures/Slots), the sales pipeline (Quotes and Quote Versions), Bookings and their Travelers, and downstream Invoices and Payments.",
     "",

--- a/packages/mcp/src/read-projection.ts
+++ b/packages/mcp/src/read-projection.ts
@@ -251,6 +251,11 @@ export async function dispatchQueryTool(
     requireActionPolicy,
     output.envelopeResult,
     budgetBytes,
+    // A query tool advertises QUERY_OUTPUT_SCHEMA (permissive
+    // `additionalProperties`), so trimming null/nested fields from the structured
+    // result cannot fail validation — and without this a client reading
+    // `structuredContent` sees none of the concise saving.
+    true,
   )
   return { result, member }
 }

--- a/packages/mcp/src/response-budget.ts
+++ b/packages/mcp/src/response-budget.ts
@@ -124,6 +124,18 @@ export interface ShapeResponseOptions {
   filterFields: readonly string[]
   /** Wrap pure data in the same MCP structured-content envelope dispatch uses. */
   toWire: (data: unknown) => Record<string, unknown>
+  /**
+   * Apply the concise projection to `structuredContent` too, not only the text
+   * block.
+   *
+   * Off by default: a tool advertises its real output schema, and dropping fields
+   * would make the structured result fail the SDK's validation. It is safe — and
+   * necessary — for a `<domain>_query` tool, which advertises a permissive
+   * `additionalProperties` output. Without it a client that reads
+   * `structuredContent` (the modern MCP path) receives every null field on every
+   * row and sees none of the concise saving.
+   */
+  conciseStructuredContent?: boolean
 }
 
 export interface ShapedResponse {
@@ -153,8 +165,13 @@ export function shapeResponse(data: unknown, options: ShapeResponseOptions): Sha
 
   const render = (count: number) => {
     const truncated = count < n
-    const nextData = rebuild(rows.slice(0, count))
-    const wire = options.toWire(nextData)
+    const kept = rows.slice(0, count)
+    const nextData = rebuild(kept)
+    const wire = options.toWire(
+      format === "concise" && options.conciseStructuredContent
+        ? rebuild(kept.map((row) => conciseRow(row)))
+        : nextData,
+    )
     const notice = truncated
       ? buildTruncationNotice({ shown: count, total, filterFields: options.filterFields })
       : undefined

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -184,6 +184,7 @@ export function createMcpApiRoutes(options: McpApiRoutesOptions): OpenAPIHono {
       writeEnabled: [...surface.values()].some(
         ({ entry }) => entry.annotations.readOnlyHint !== true,
       ),
+      anyToolReachable: surface.size > 0,
     }
     const server = new McpServer(serverInfo, {
       instructions: buildServerInstructions(guideScope),

--- a/packages/mcp/tests/guide.test.ts
+++ b/packages/mcp/tests/guide.test.ts
@@ -164,6 +164,20 @@ describe("MCP guide layer", () => {
     expect(writeInstructions).not.toMatch(/READ-ONLY/i)
   })
 
+  it("tells a key that authorizes nothing that it is a permissions problem", async () => {
+    // A key with no granted scopes reaches NO Tool — not even a read. Before this
+    // it was told "READ-ONLY: it can list and read", which is worse than silence:
+    // every `search_tools` query comes back empty and the agent, trusting the
+    // orientation, blames its own queries instead of reporting a grant problem.
+    const none = await readRpc(await app([]).request("/", rpc("initialize", INITIALIZE_PARAMS)))
+    const instructions = (none.result as { instructions?: string }).instructions ?? ""
+
+    expect(instructions).toMatch(/authorizes NO Tools/i)
+    expect(instructions).toMatch(/permissions problem/i)
+    // It must NOT claim reads work.
+    expect(instructions).not.toMatch(/can list and read/i)
+  })
+
   it("puts the guide Tools in the resident tier, not the lazy long tail", async () => {
     const listed = await readRpc(await app(["catalog:read"]).request("/", rpc("tools/list", {})))
     const names =

--- a/packages/tools/src/define-tool.ts
+++ b/packages/tools/src/define-tool.ts
@@ -62,6 +62,17 @@ export interface ToolDefinition<In, Out, Ctx extends ToolContext = ToolContext> 
   /** Use only when the handler already enforces the selected action-ledger policy itself. */
   actionPolicyEnforcement?: ToolActionPolicyEnforcement
   /**
+   * Set when the handler mints its own idempotency key (via
+   * `withServerResolvedIdempotencyKey`) instead of accepting one from the caller.
+   *
+   * Without it a handler-enforced ledgered `execute` advertises `idempotencyKey`
+   * as a REQUIRED invocation field, which is exactly backwards for an
+   * intent-level Tool whose purpose is that the caller carries no token across
+   * calls. An agent reading the manifest would believe it must supply a key it
+   * must not supply.
+   */
+  resolvesIdempotencyKeyServerSide?: boolean
+  /**
    * Resolve the durable action target from validated domain input.
    *
    * Use this for targets that cannot be selected by the graph action's

--- a/packages/tools/src/registered-tool.ts
+++ b/packages/tools/src/registered-tool.ts
@@ -158,7 +158,13 @@ function deriveActionPolicy(
       }
     }
   } else {
-    if (action.kind === "execute" && action.ledger === "required") {
+    // A handler that mints its own key must not advertise one as caller-required:
+    // the whole point of an intent-level Tool is that no token crosses calls.
+    if (
+      action.kind === "execute" &&
+      action.ledger === "required" &&
+      !tool.resolvesIdempotencyKeyServerSide
+    ) {
       requiredFields.push("idempotencyKey")
     }
     if (action.approval === "required") {

--- a/packages/tools/tests/registered-tool.test.ts
+++ b/packages/tools/tests/registered-tool.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest"
+import { z } from "zod"
+
+import { createToolRegistry, defineTool } from "../src/index.js"
+
+describe("server-resolved idempotency keys", () => {
+  it("does not advertise idempotencyKey as caller-required when the handler mints it", () => {
+    // book_product exists so the caller carries no token across calls. Advertising
+    // idempotencyKey as required told an agent to supply the very thing the Tool
+    // resolves for it — the manifest contradicting the description.
+    const registry = createToolRegistry()
+    registry.register(
+      defineTool({
+        capabilityId: "@test#tool.intent",
+        owner: "@test",
+        name: "intent_tool",
+        description: "Intent-level tool that mints its own key.",
+        inputSchema: z.object({ productId: z.string() }),
+        outputSchema: z.object({ id: z.string() }),
+        requiredScopes: [],
+        tier: "destructive",
+        riskPolicy: {
+          destructive: true,
+          reversible: false,
+          dryRunSupported: false,
+          confirmationRequired: true,
+          sideEffects: ["data-write"],
+        },
+        actionPolicyEnforcement: "handler",
+        resolvesIdempotencyKeyServerSide: true,
+        async handler() {
+          return { id: "x" }
+        },
+      }),
+      {
+        actionPolicy: {
+          id: "@test#action.intent",
+          capabilityId: "@test#action.intent",
+          version: "v1",
+          kind: "execute",
+          targetType: "thing",
+          targetLifecycle: "created",
+          risk: "high",
+          ledger: "required",
+          approval: "never",
+          reversible: false,
+          createdTarget: {
+            commandTargetType: "thing_create_command",
+            resultReferenceType: "thing",
+            durability: "handler-command-claim-v1",
+          },
+        },
+      },
+    )
+
+    const entry = registry.list().find(({ name }) => name === "intent_tool")
+    const required = entry?.actionPolicy?.invocation.requiredFields ?? []
+
+    expect(required).toContain("confirmed")
+    expect(required).not.toContain("idempotencyKey")
+  })
+})


### PR DESCRIPTION
Follow-up to #3921. Found by connecting a real MCP client to a running deployment and driving it as an agent — reading the instructions, discovering tools, and attempting a booking.

**All three live between layers that no single test asserts against the other**, which is why the scripted eval harness (#3975) could not catch them.

## 1. An intent-level Tool advertised a field it forbids

`registered-tool.ts` pushed `idempotencyKey` into `requiredFields` for *any* handler-enforced ledgered `execute`. That is right for `create_booking` and exactly backwards for `book_product`, whose entire purpose (#3933) is that **no token crosses calls**.

So the description said *"the platform resolves the idempotency key server-side, so nothing has to be carried across calls"* while the metadata said `requiredFields: ["confirmed", "idempotencyKey"]`. An agent reading the manifest would supply the very thing the Tool exists to resolve. Nothing compared prose to metadata — they are different layers.

`ToolDefinition` now carries `resolvesIdempotencyKeyServerSide`; the derivation honours it. **Verified live:** `requiredFields` is now `["confirmed"]`.

## 2. The concise projection never reached clients — 52% wasted

`shapeResponse` trimmed only the **text** block. `structuredContent` stayed full, deliberately, because dropping fields would fail the SDK's output-schema validation.

Correct in general — but a `<domain>_query` tool advertises `QUERY_OUTPUT_SCHEMA` with `additionalProperties: true`, so trimming there **cannot** fail validation. And `structuredContent` is what a modern MCP client actually reads: my own client received every null field on every row and saw none of #3970's measured saving.

Now opt-in, and only the query path opts in. **Measured on the live server:**

```
structuredContent concise :  1183 bytes  ~296 tokens
structuredContent detailed:  2473 bytes  ~618 tokens
saving: 52%
```

Three rows. On a 50-row page it is thousands of tokens per call, on every call.

## 3. A key that authorizes nothing was told it could read

With no granted scopes the instructions said *"This key is READ-ONLY: it can list and read"*. It could read nothing — every `search_tools` query returned empty while the orientation insisted the capability was there.

That is worse than silence: an agent trusts the orientation and blames its own queries instead of reporting a permissions problem. `GuideScope` gains `anyToolReachable` and the state is now named explicitly, pointing at the actual cause.

## Verification

```
pnpm -F @voyant-travel/mcp test       12 files / 78 tests passed
pnpm -F @voyant-travel/tools test      7 files / 60 tests passed  (+1 regression test)
pnpm -F @voyant-travel/finance test   61 files / 494 tests passed
npx biome check .                     repo-wide, 0 errors
```

Fixes 1 and 2 were additionally confirmed against the running server, not only in tests.

## Not included

`describe_tool("book_product")` returns roughly 8–10k tokens, nearly all output schema — a single describe of one write tool costs an order of magnitude more than the entire tier-0 surface. Unlike the query case there is no permissive-schema escape hatch, so it needs a design decision (summarise the schema / omit it / return on request) rather than a patch. Left for a separate issue.