### PR TITLE
fix(admin-extension-sdk): publish the extension slot vocabulary from one place

### DIFF
--- a/.changeset/single-slot-registry.md
+++ b/.changeset/single-slot-registry.md
@@ -1,0 +1,22 @@
+---
+"@voyant-travel/admin-extension-sdk": minor
+"@voyant-travel/admin": minor
+"@voyant-travel/apps": minor
+---
+
+Publish the admin UI extension slot vocabulary from the contract package.
+
+`ADMIN_UI_EXTENSION_SLOTS` and `AdminUiExtensionSlot` now live in
+`@voyant-travel/admin-extension-sdk`, which is the dependency-free package an
+extension author already installs. `@voyant-travel/admin` and
+`@voyant-travel/apps` derive from it instead of restating it.
+
+The list was previously maintained twice — once in
+`packages/admin/src/ui-extensions/registry.ts` for the shell that renders the
+slots, and once in `packages/apps/src/contracts.ts` as the enum the manifest
+schema validates against. They agreed only by discipline, and a slot added to
+one would have been rejected by the schema or left unrendered by the shell.
+
+`@voyant-travel/admin` keeps exporting `ADMIN_UI_EXTENSION_SLOTS`,
+`AdminUiExtensionSlot`, and `isAdminUiExtensionSlot`, and `@voyant-travel/apps`
+keeps exporting `APP_ADMIN_EXTENSION_SLOTS`, so no consumer import changes.

--- a/packages/admin-extension-sdk/src/index.ts
+++ b/packages/admin-extension-sdk/src/index.ts
@@ -62,6 +62,7 @@ export {
   uiExtensionMessageTypes,
 } from "./protocol.js"
 export type {
+  AdminUiExtensionSlot,
   UiExtensionContext,
   UiExtensionDescriptor,
   UiExtensionEntity,
@@ -71,4 +72,5 @@ export type {
   UiExtensionToastIntent,
   UiExtensionViewer,
 } from "./types.js"
+export { ADMIN_UI_EXTENSION_SLOTS } from "./types.js"
 export { ADMIN_UI_EXTENSION_API_VERSION } from "./version.js"

--- a/packages/admin-extension-sdk/src/types.ts
+++ b/packages/admin-extension-sdk/src/types.ts
@@ -55,6 +55,34 @@ export interface UiExtensionContext {
 }
 
 /**
+ * The slots an admin UI extension may target.
+ *
+ * This is the canonical list. It lives here, in the dependency-free contract
+ * package an extension author already installs, because it is part of the
+ * public extension surface rather than an internal detail of the shell: the
+ * host renders these, the manifest schema validates against them, and an
+ * author needs to know them to target one.
+ *
+ * `@voyant-travel/admin` and `@voyant-travel/apps` both derive from this
+ * rather than restating it. Adding a slot is a contract change — it widens
+ * what a published manifest may declare, so it belongs to this package's
+ * version.
+ */
+export const ADMIN_UI_EXTENSION_SLOTS = [
+  "dashboard.header",
+  "dashboard.after-kpis",
+  "dashboard.footer",
+  "booking.details.header",
+  "booking.details.after-summary",
+  "invoice.details.header",
+  "invoice.details.after-summary",
+  "workspace.header.actions",
+] as const
+
+/** A slot id from the public UI-extension registry. */
+export type AdminUiExtensionSlot = (typeof ADMIN_UI_EXTENSION_SLOTS)[number]
+
+/**
  * A manifest resolved into the shape the host consumes. The cloud platform
  * resolves and validates extension manifests into this; the framework host
  * never parses raw manifests.

--- a/packages/admin/src/ui-extensions/registry.ts
+++ b/packages/admin/src/ui-extensions/registry.ts
@@ -5,22 +5,25 @@
  * UI extension is contributed through the same {@link AdminWidgetSlot}
  * mechanism as any first-party widget. Adding a slot is a MINOR change (a new
  * capability extensions can opt into); renaming or removing one is MAJOR.
+ *
+ * The list itself lives in `@voyant-travel/admin-extension-sdk`, which is the
+ * versioned contract an extension author installs. This module adapts it to
+ * the shell's widget vocabulary.
  */
+import {
+  type AdminUiExtensionSlot,
+  ADMIN_UI_EXTENSION_SLOTS as CONTRACT_SLOTS,
+} from "@voyant-travel/admin-extension-sdk/types"
 import type { AdminWidgetSlot } from "../extensions.js"
 
-export const ADMIN_UI_EXTENSION_SLOTS = [
-  "dashboard.header",
-  "dashboard.after-kpis",
-  "dashboard.footer",
-  "booking.details.header",
-  "booking.details.after-summary",
-  "invoice.details.header",
-  "invoice.details.after-summary",
-  "workspace.header.actions",
-] as const satisfies readonly AdminWidgetSlot[]
+/**
+ * Re-exported from the contract package so the shell and the manifest schema
+ * cannot drift apart. The `satisfies` keeps the host's own guarantee: every
+ * contract slot must still be a usable {@link AdminWidgetSlot}.
+ */
+export const ADMIN_UI_EXTENSION_SLOTS = CONTRACT_SLOTS satisfies readonly AdminWidgetSlot[]
 
-/** A slot id from the public UI-extension registry. */
-export type AdminUiExtensionSlot = (typeof ADMIN_UI_EXTENSION_SLOTS)[number]
+export type { AdminUiExtensionSlot }
 
 /** Whether `slot` is one of the public UI-extension slots. */
 export function isAdminUiExtensionSlot(slot: string): slot is AdminUiExtensionSlot {

--- a/packages/apps/src/compiler.test.ts
+++ b/packages/apps/src/compiler.test.ts
@@ -1,6 +1,7 @@
+import { ADMIN_UI_EXTENSION_SLOTS } from "@voyant-travel/admin-extension-sdk/types"
 import { describe, expect, it } from "vitest"
 import { compileAppManifest } from "./compiler.js"
-import { appManifestSchema } from "./contracts.js"
+import { APP_ADMIN_EXTENSION_SLOTS, appManifestSchema } from "./contracts.js"
 import { validManifest } from "./test-fixtures.js"
 
 describe("app manifest compiler", () => {
@@ -69,6 +70,26 @@ describe("app manifest compiler", () => {
       )
       expect(result.error.issues.map((issue) => issue.message).join("\n")).toContain("forbidden")
     }
+  })
+
+  it("accepts every slot the shell contract publishes", () => {
+    // The manifest schema and the admin shell used to keep separate hand-written
+    // copies of this list. They agreed only by discipline, and a slot added to
+    // one would have been rejected or unrendered by the other. Both now derive
+    // from the contract package; this fails if either restates it.
+    for (const slot of ADMIN_UI_EXTENSION_SLOTS) {
+      expect(() =>
+        compileAppManifest({
+          ...validManifest,
+          admin: {
+            ...validManifest.admin,
+            slotExtensions: [{ ...validManifest.admin.slotExtensions[0], slots: [slot] }],
+          },
+        }),
+      ).not.toThrow()
+    }
+
+    expect(APP_ADMIN_EXTENSION_SLOTS).toBe(ADMIN_UI_EXTENSION_SLOTS)
   })
 
   it("validates slot ids and external webhook event versions", () => {

--- a/packages/apps/src/contracts.ts
+++ b/packages/apps/src/contracts.ts
@@ -1,18 +1,16 @@
+import { ADMIN_UI_EXTENSION_SLOTS } from "@voyant-travel/admin-extension-sdk/types"
 import { customFieldDefinitionInputSchema } from "@voyant-travel/custom-fields/contracts"
 import { assertOutboundWebhookEndpointUrl } from "@voyant-travel/webhook-delivery"
 import { z } from "zod"
 
 export const APP_MANIFEST_SCHEMA_VERSION = "voyant.app-manifest.v1" as const
-export const APP_ADMIN_EXTENSION_SLOTS = [
-  "dashboard.header",
-  "dashboard.after-kpis",
-  "dashboard.footer",
-  "booking.details.header",
-  "booking.details.after-summary",
-  "invoice.details.header",
-  "invoice.details.after-summary",
-  "workspace.header.actions",
-] as const
+
+/**
+ * What a published manifest may target, taken from the contract package rather
+ * than restated here. A manifest that validates must be renderable by the
+ * shell, so the schema and the host have to read one list.
+ */
+export const APP_ADMIN_EXTENSION_SLOTS = ADMIN_UI_EXTENSION_SLOTS
 
 const disallowedManifestKeys = {
   schemas: "Database schemas are deployment-package authority and cannot appear in app manifests.",


### PR DESCRIPTION
Part of #3976 (item 10.2, first of the two concrete gaps).

## The duplication

The eight admin UI extension slot identifiers were maintained in two places:

| File | Role |
|---|---|
| `packages/admin/src/ui-extensions/registry.ts` | the shell renders a widget per slot |
| `packages/apps/src/contracts.ts` | `z.enum(...)` the manifest schema validates against |

Byte-identical lists, agreeing only by discipline, with nothing checking. A slot added to the shell would be **rejected** by the manifest schema; a slot added to the schema would be **accepted and never rendered**. `apps` already depends on `admin`, so there was no structural reason for the copy.

## Where it goes

`@voyant-travel/admin-extension-sdk` — which is:

- dependency-free, so no weight is added anywhere
- already a dependency of both `admin` and `apps`
- what a third-party extension author actually installs

That last point is the argument. An author has to know which slots exist in order to target one, so the vocabulary is part of the public extension contract, not an internal detail of the shell. It now sits next to `UI_EXTENSION_PROTOCOL_VERSION` and `ADMIN_UI_EXTENSION_API_VERSION`, and widening it is versioned with the contract it widens.

`admin` keeps the `satisfies readonly AdminWidgetSlot[]` check, so the host's own guarantee — every contract slot is a usable widget slot — is still enforced at compile time.

## Compatibility

No consumer import changes. `@voyant-travel/admin` still exports `ADMIN_UI_EXTENSION_SLOTS`, `AdminUiExtensionSlot`, and `isAdminUiExtensionSlot`; `@voyant-travel/apps` still exports `APP_ADMIN_EXTENSION_SLOTS`. Both are now re-exports.

## Verification

- `admin-extension-sdk` 19 tests, `admin` 161 tests, `apps` 129 tests — all pass
- typecheck passes for all three
- `pnpm verify:architecture` exits 0, including `verify:boundary` (47 packages, no violations) — relevant here because the SDK is a browser package and this adds a runtime value to it
- `biome check .` exits 0

New test: every slot in the contract list compiles in a manifest. The existing `admin` test already asserts the shell renders a widget for every slot in the registry, so the two together now pin both directions of the invariant the duplication used to break.

## Not included

The other gap identified in the [item 10.2 comment](https://github.com/voyant-travel/voyant/issues/3976) — manifest admin pages carrying no `order`/`group`, where `AdminNavigationContribution` has `order` and `insertAfter` — is left out deliberately. Adding schema fields nothing reads would be speculative surface on a published contract; it needs the nav renderer to honour them in the same change.