### PR TITLE
fix(catalog): wire the billing-person resolver regardless of contributor order

### DIFF
--- a/.changeset/billing-person-contributor-order.md
+++ b/.changeset/billing-person-contributor-order.md
@@ -1,0 +1,21 @@
+---
+"@voyant-travel/catalog": patch
+---
+
+Wire `resolveBillingPerson` regardless of runtime-contributor load order.
+
+Contributors load in alphabetical order by package name, and the check for
+`bookings.relationships.runtime` ran while this contributor was being built.
+That port is provided by `@voyant-travel/relationships`, which sorts after
+`@voyant-travel/catalog` and therefore cannot ever have run yet — so the port
+always read as absent and `resolveBillingPerson` was dropped from the
+self-service booking source on every runtime.
+
+`resolveBilling` then returned null and every guest self-service booking was
+refused with `incomplete_draft`, after the shopper had verified a contact.
+Authenticated customers resolve their own billing party and were unaffected,
+which is why it stayed invisible.
+
+The capability check now happens on call, where every contributor has run. A
+deployment that genuinely ships no relationships runtime still returns null, so
+only authenticated customers can book there.

--- a/packages/catalog/src/runtime-contributor.test.ts
+++ b/packages/catalog/src/runtime-contributor.test.ts
@@ -1,3 +1,4 @@
+import { bookingsRelationshipsRuntimePort } from "@voyant-travel/bookings/runtime-port"
 import { catalogSearchRuntimePort } from "@voyant-travel/catalog/api-runtime-ports"
 import { createFieldPolicyRegistry } from "@voyant-travel/catalog/contract"
 import { catalogIndexerProviderPort } from "@voyant-travel/catalog/indexer/provider"
@@ -16,6 +17,29 @@ import { financeOperatorSettingsRuntimePort } from "@voyant-travel/finance/runti
 import { describe, expect, it, vi } from "vitest"
 
 import { createCatalogRuntimePortContribution } from "./runtime-contributor.js"
+
+type SelfServiceDeps = {
+  resolveBillingPerson?: (
+    contact: Record<string, unknown>,
+    provenance: { source: string; sourceRef: string },
+  ) => Promise<string | null>
+}
+
+/** Deps handed to the provider, in call order; the last one is the newest. */
+const capturedSelfServiceDeps: SelfServiceDeps[] = []
+
+vi.mock("@voyant-travel/catalog/booking-engine", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    createSelfServiceBookingSourceProvider: (deps: SelfServiceDeps) => {
+      capturedSelfServiceDeps.push(deps)
+      return (actual.createSelfServiceBookingSourceProvider as (d: SelfServiceDeps) => unknown)(
+        deps,
+      )
+    },
+  }
+})
 
 describe("createCatalogRuntimePortContribution", () => {
   it.each([
@@ -167,5 +191,75 @@ describe("createCatalogRuntimePortContribution", () => {
       expect.objectContaining({ id: "product_1" }),
     ])
     expect(transaction).toHaveBeenCalled()
+  })
+
+  /**
+   * Contributors load in alphabetical order by package name, and
+   * `bookings.relationships.runtime` comes from @voyant-travel/relationships —
+   * which sorts AFTER @voyant-travel/catalog and so cannot ever have run by the
+   * time this contributor is built. Deciding then read the port as permanently
+   * absent and dropped `resolveBillingPerson` from the deps entirely, which made
+   * `resolveBilling` return null and refused every guest self-service booking
+   * with `incomplete_draft`. Authenticated customers were unaffected, so it
+   * stayed invisible.
+   *
+   * `resolveBillingPerson` lives in the provider's closure, so the deps object
+   * handed to `createSelfServiceBookingSourceProvider` is the only place the
+   * wiring is observable.
+   */
+  it("wires a billing-person resolver even when the relationships port arrives later", async () => {
+    const upsertPersonFromContact = vi.fn(async () => ({ id: "person_1" }))
+    let relationshipsPortPresent = false
+    const contribution = createCatalogRuntimePortContribution({
+      primitives: { env: () => ({}), database: { resolve: () => ({}) } } as never,
+      hasRuntimePort: (port) =>
+        port.id === bookingsRelationshipsRuntimePort.id ? relationshipsPortPresent : false,
+      getRuntimePort: ((port: { id: string }) =>
+        port.id === bookingsRelationshipsRuntimePort.id
+          ? { upsertPersonFromContact }
+          : {}) as never,
+    })
+    // The port lands after every contributor has run, before any request.
+    relationshipsPortPresent = true
+
+    const deps = capturedSelfServiceDeps.at(-1)
+    expect(deps?.resolveBillingPerson).toBeTypeOf("function")
+    await expect(
+      deps?.resolveBillingPerson?.(
+        { firstName: "Mihai", lastName: "Ungureanu", email: "buyer@example.com", phone: null },
+        { source: "storefront-self-service", sourceRef: "bdrf_1" },
+      ),
+    ).resolves.toBe("person_1")
+    expect(upsertPersonFromContact).toHaveBeenCalledOnce()
+
+    await Promise.allSettled(
+      Object.values(contribution).filter(
+        (value): value is Promise<unknown> => value instanceof Promise,
+      ),
+    )
+  })
+
+  it("refuses a guest booking when the relationships port is genuinely absent", async () => {
+    const contribution = createCatalogRuntimePortContribution({
+      primitives: { env: () => ({}), database: { resolve: () => ({}) } } as never,
+      hasRuntimePort: () => false,
+      getRuntimePort: vi.fn() as never,
+    })
+
+    const deps = capturedSelfServiceDeps.at(-1)
+    // Null, not a throw: only authenticated customers can book on a deployment
+    // that ships no relationships runtime.
+    await expect(
+      deps?.resolveBillingPerson?.(
+        { firstName: "Mihai", lastName: "Ungureanu", email: "buyer@example.com", phone: null },
+        { source: "storefront-self-service", sourceRef: "bdrf_1" },
+      ),
+    ).resolves.toBeNull()
+
+    await Promise.allSettled(
+      Object.values(contribution).filter(
+        (value): value is Promise<unknown> => value instanceof Promise,
+      ),
+    )
   })
 })

--- a/packages/catalog/src/runtime-contributor.ts
+++ b/packages/catalog/src/runtime-contributor.ts
@@ -90,7 +90,6 @@ export function createCatalogRuntimePortContribution(
   host: CatalogRuntimeContributorHost,
 ): Readonly<Record<string, unknown>> {
   const hasIndexerPort = host.hasRuntimePort?.(catalogIndexerProviderPort) === true
-  const hasRelationshipsPort = host.hasRuntimePort?.(bookingsRelationshipsRuntimePort) === true
   const dependencies = Promise.resolve().then(() =>
     Promise.all([
       host.getRuntimePort<CatalogAccommodationsRuntimeExtension>(
@@ -171,21 +170,28 @@ export function createCatalogRuntimePortContribution(
       // matches on email then phone, so a retry reuses the same person rather
       // than creating another. Absent the port, only authenticated customers
       // can book — they already are the billing party.
-      ...(hasRelationshipsPort
-        ? {
-            async resolveBillingPerson(contact, provenance) {
-              const relationships = await host.getRuntimePort<BookingsRelationshipsRuntime>(
-                bookingsRelationshipsRuntimePort,
-              )
-              const person = await relationships.upsertPersonFromContact(
-                host.primitives.database.resolve(undefined) as never,
-                { ...contact, preferredLanguage: null },
-                { source: provenance.source, sourceRef: provenance.sourceRef },
-              )
-              return person?.id ?? null
-            },
-          }
-        : {}),
+      //
+      // The port check happens HERE, on call, not while this contributor is
+      // being built. Contributors load in alphabetical order by package name,
+      // and `bookings.relationships.runtime` is provided by
+      // @voyant-travel/relationships — which sorts after @voyant-travel/catalog
+      // and therefore cannot ever have run yet. Deciding at build time read the
+      // port as permanently absent and dropped this method from every runtime,
+      // so `resolveBilling` returned null and every guest self-service booking
+      // was refused with `incomplete_draft`. By the time a request calls this,
+      // every contributor has run.
+      async resolveBillingPerson(contact, provenance) {
+        if (host.hasRuntimePort?.(bookingsRelationshipsRuntimePort) !== true) return null
+        const relationships = await host.getRuntimePort<BookingsRelationshipsRuntime>(
+          bookingsRelationshipsRuntimePort,
+        )
+        const person = await relationships.upsertPersonFromContact(
+          host.primitives.database.resolve(undefined) as never,
+          { ...contact, preferredLanguage: null },
+          { source: provenance.source, sourceRef: provenance.sourceRef },
+        )
+        return person?.id ?? null
+      },
     }),
     [catalogDraftReaperJobRuntimePort.id]: {
       async withDb<T>(operation: (db: AnyDrizzleDb) => Promise<T>) {


### PR DESCRIPTION
Guest self-service booking has never worked on a composed runtime. This is why.

## Cause

Runtime contributors are loaded in **alphabetical order by package name**:

```js
// "contributors may read ports earlier contributors provided, so the order is contract."
.sort((left, right) => left.packageName.localeCompare(right.packageName))
```

Catalog's contributor decided, at build time, whether to wire `resolveBillingPerson`:

```js
const hasRelationshipsPort = host.hasRuntimePort?.(bookingsRelationshipsRuntimePort) === true
...(hasRelationshipsPort ? { async resolveBillingPerson(...) {...} } : {})
```

`bookings.relationships.runtime` is provided by `@voyant-travel/relationships`, which sorts **after** `@voyant-travel/catalog` — `c` < `r`. The port it needs comes from a package that can never have run yet, so the check always read `false` and the method was silently dropped.

`resolveBilling` then hits:

```js
if (!deps.resolveBillingPerson) return null
```

and the create refuses with `incomplete_draft`. An authenticated customer is their own billing party and never enters this branch, which is why nothing surfaced it.

## Evidence from production

On pro-travel (runtime 0.68.1), after `email/start` 201 and `email/confirm` 200:

```
POST /v1/public/bookings -> 422 {"error":"incomplete_draft"}
```

with a draft that round-trips correctly, checked directly against the live API:

```
keys:      ['billing', 'configure', 'travelers']
travelers: [{"band":"adult","email":"…","lastName":"Ungureanu","firstName":"Mihai"}]
billing:   {"contact":{"email":"…","lastName":"Ungureanu","firstName":"Mihai"}}
```

So `hasName`, `hasContactPoint` and `hasTravelers` in `resolveBilling` were all satisfied. The only remaining branch is the missing resolver.

## Change

The capability check moves inside the method, where every contributor has run by the time any request arrives. The body already resolved the port lazily — only the gate was early.

A deployment that genuinely ships no relationships runtime still gets `null`, so only authenticated customers can book there. That is what the original gate meant to express; it just asked at a moment when the answer could only ever be "no".

## Tests

Two cases in `runtime-contributor.test.ts`, both confirmed failing without the source change and passing with it:

- the port arriving **after** the contributor is built still yields a working resolver
- a genuinely absent port still yields `null` rather than throwing

`resolveBillingPerson` lives in the provider's closure, so the deps object passed to `createSelfServiceBookingSourceProvider` is the only observable surface — the test captures it through a module mock.

`packages/catalog` `runtime-contributor` + `booking-engine` suites: **116 passed**. Local typecheck OOMs on this machine, so CI is the check for that.

## Note for reviewers

The alphabetical-order contract is fine in general, but it makes any *build-time* `hasRuntimePort` check in a package unreliable against providers that sort later. Worth a sweep for other instances; this PR fixes only the one that is breaking bookings.