### PR TITLE
fix(finance): settle a self-service booking create under its admitted action

### DIFF
--- a/.changeset/self-service-booking-create-lease.md
+++ b/.changeset/self-service-booking-create-lease.md
@@ -1,0 +1,17 @@
+---
+"@voyant-travel/finance": patch
+---
+
+Settle a self-service booking create under the action it was admitted with.
+
+The action-ledger mints the created-target mutation lease under the action that
+was admitted, and domain settlement re-checks that name by identity. The
+self-service entrypoint admits
+`bookings-create-extension.action.create-booking-self-service` but left the
+settle expectation at its default, which names the staff
+`action.create-booking` — so every verified-guest booking failed closed with
+`invalid_mutation_lease` at the last step of the create, after the shopper had
+verified a contact, chosen a room and been quoted.
+
+The staff entrypoint matches the default and `book_product` was fixed in
+voyant#3992; this entrypoint was missed, so nothing surfaced it.

--- a/packages/finance/src/booking-create-command.ts
+++ b/packages/finance/src/booking-create-command.ts
@@ -15,6 +15,7 @@ import {
   FINANCE_BOOK_PRODUCT_HANDLER_POLICY,
   FINANCE_BOOKING_CREATE_HANDLER_POLICY,
   FINANCE_BOOKING_CREATE_POLICY,
+  FINANCE_BOOKING_CREATE_SELF_SERVICE_ACTION,
   FINANCE_BOOKING_CREATE_SELF_SERVICE_HANDLER_POLICY,
 } from "./booking-create-policy.js"
 import type { FinanceServiceRuntime } from "./service.js"
@@ -95,7 +96,18 @@ export async function executeFinanceSelfServiceBookingCreateCommand(
   input: FinanceSelfServiceBookingCreateCommandInput,
 ) {
   assertAdmittedActionPolicy(input.admitted, FINANCE_BOOKING_CREATE_SELF_SERVICE_HANDLER_POLICY)
-  return executeBookingCreateCommand(input, input.fallbackPrincipalId, input.consumeSources)
+  // The ledger mints the lease under the action it admitted, which for this
+  // entrypoint is the self-service action -- so settlement has to expect that
+  // one. Leaving it to the default named the staff action and failed every
+  // guest booking closed with `invalid_mutation_lease`, after the shopper had
+  // verified a contact, chosen a room and been quoted. Same defect voyant#3992
+  // fixed for `book_product`; this entrypoint was missed.
+  return executeBookingCreateCommand(
+    input,
+    input.fallbackPrincipalId,
+    input.consumeSources,
+    FINANCE_BOOKING_CREATE_SELF_SERVICE_ACTION,
+  )
 }
 
 /**

--- a/packages/finance/tests/unit/booking-create-lease-action.test.ts
+++ b/packages/finance/tests/unit/booking-create-lease-action.test.ts
@@ -1,0 +1,102 @@
+import { createToolRegistry, type ToolHandlerActionPolicyContext } from "@voyant-travel/tools"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+/** What each entrypoint asks the domain to settle under. */
+const settleCalls: { actionName?: string }[] = []
+/** The identity the action-ledger would mint the lease with. */
+const mintedWith: { actionName?: string }[] = []
+
+/**
+ * Drive `handlers.create` directly instead of executing the durable command.
+ * The real executor needs a live transaction and ledger tables; the thing under
+ * test is only which action name the entrypoint hands to settlement, and
+ * whether it matches the admitted policy the lease is minted from.
+ */
+vi.mock("@voyant-travel/action-ledger", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    async executeAdmittedCreatedTargetCommand(
+      input: { admitted: { actionPolicy: { id: string } } },
+      handlers: { create: (tx: unknown, lease: unknown) => Promise<unknown> },
+    ) {
+      mintedWith.push({ actionName: input.admitted.actionPolicy.id })
+      // Everything after the settle — outbox, consumeSources — needs a real
+      // database. The action name has already been captured by then, so let the
+      // rest fall away rather than stubbing the whole booking graph.
+      await handlers.create({}, {}).catch(() => undefined)
+      return { replayed: false, value: { bookingId: "bkg_1" }, result: {} }
+    },
+  }
+})
+
+vi.mock("../../src/service-booking-create.js", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    createBookingMutation: async (
+      _tx: unknown,
+      _input: unknown,
+      options: { actionName?: string },
+    ) => {
+      settleCalls.push({ actionName: options.actionName })
+      return { status: "ok", result: { booking: { id: "bkg_1" } } }
+    },
+  }
+})
+
+const { executeFinanceSelfServiceBookingCreateCommand } = await import(
+  "../../src/booking-create-command.js"
+)
+const {
+  FINANCE_BOOKING_CREATE_ACTION,
+  FINANCE_BOOKING_CREATE_SELF_SERVICE_ACTION,
+  FINANCE_BOOKING_CREATE_SELF_SERVICE_ROUTE_ACTION,
+} = await import("../../src/booking-create-policy.js")
+
+/**
+ * Every entrypoint composes the same durable command but admits a DIFFERENT
+ * action, and settlement re-checks that name by identity. An entrypoint that
+ * leaves it to the default settles against the staff action and fails closed
+ * with `invalid_mutation_lease` — at the very last step of the create, after
+ * the shopper has verified a contact, chosen a room and been quoted. The staff
+ * path matches the default, so nothing surfaces it.
+ *
+ * voyant#3992 fixed exactly this for `book_product`. The self-service
+ * entrypoint was missed, and every guest booking on protravel.ro failed.
+ */
+describe("booking-create lease action identity", () => {
+  beforeEach(() => {
+    settleCalls.length = 0
+    mintedWith.length = 0
+  })
+
+  it("settles self-service under the action it admitted, not the staff default", async () => {
+    await executeFinanceSelfServiceBookingCreateCommand({
+      db: {} as never,
+      context: { actor: "customer", callerType: "session" },
+      commandInput: {} as never,
+      admitted: selfServiceAdmission(),
+      fallbackPrincipalId: "storefront-verification:svch_1",
+    } as never)
+
+    expect(settleCalls).toHaveLength(1)
+    expect(settleCalls[0]?.actionName).toBe(FINANCE_BOOKING_CREATE_SELF_SERVICE_ACTION)
+    expect(settleCalls[0]?.actionName).not.toBe(FINANCE_BOOKING_CREATE_ACTION)
+    // The invariant, stated directly: settlement expects the action the ledger
+    // minted the lease with. Any entrypoint that breaks this fails closed.
+    expect(settleCalls[0]?.actionName).toBe(mintedWith[0]?.actionName)
+  })
+})
+
+function selfServiceAdmission(): ToolHandlerActionPolicyContext {
+  const registry = createToolRegistry()
+  registry.registerRouteAction(FINANCE_BOOKING_CREATE_SELF_SERVICE_ROUTE_ACTION)
+  return registry.admitRouteAction(
+    FINANCE_BOOKING_CREATE_SELF_SERVICE_ROUTE_ACTION.actionPolicy.id,
+    {
+      actor: "customer",
+      invocation: { idempotencyKey: "req_1" },
+    },
+  )
+}


### PR DESCRIPTION
**Every verified-guest booking has always failed.** This is the last blocker on Pro Travel's booking engine.

## Cause

The action-ledger mints the created-target mutation lease under the action that was **admitted**, and domain settlement re-checks that name by identity (`consumeCreatedTargetMutationLease`). Finance admits a different action per entrypoint:

| entrypoint | admits | passes to settle | |
|---|---|---|---|
| staff Tool | `action.create-booking` | *(default)* `action.create-booking` | ✅ |
| `book_product` | `action.book-product` | `FINANCE_BOOK_PRODUCT_ACTION` | ✅ (voyant#3992) |
| **self-service** | `action.create-booking-self-service` | *(default)* `action.create-booking` | ❌ |

So the check compared `…create-booking-self-service` against `…create-booking` and failed closed:

```
ActionLedgerCreatedCommandProtocolError:
  Created-target command protocol failed closed: invalid_mutation_lease
```

The staff path matches the default, so nothing ever surfaced it. voyant#3992 fixed precisely this for `book_product`; this entrypoint was missed.

## Where it lands

At the **very last step** of the create — after the draft, quote, hold, contact verification, traveller and room-capacity checks have all passed. The shopper has verified a contact, entered travellers, chosen a room and been quoted before it fails, and it surfaces as a bare 500.

Observed on protravel.ro production (runtime 0.69.1), deterministic across retries.

## Change

One argument: the self-service entrypoint now passes `FINANCE_BOOKING_CREATE_SELF_SERVICE_ACTION`, matching what it admitted.

## Tests

`booking-create-lease-action.test.ts` drives `handlers.create` directly (the real executor needs a live transaction and ledger tables) and asserts the invariant stated plainly: **settlement expects the action the ledger minted the lease with**. Confirmed failing without the source change:

```
× settles self-service under the action it admitted, not the staff default
  AssertionError: expected undefined to be '@voyant-travel/finance#bookings-creat…'
```

`packages/finance` unit suite: **488 passed**.

Local typecheck OOMs on this machine, so CI is the check for that.

## Note for reviewers

This is now the second time an entrypoint has been added without threading its action name through to settlement, and the failure mode is silent until someone exercises that exact path in production. Worth considering whether `settleBookingCreateDomain` should take the admitted policy rather than a bare string, so the two cannot drift.