### PR TITLE
feat(apps): add installed page navigation metadata

### DIFF
--- a/.changeset/quiet-app-pages-navigate.md
+++ b/.changeset/quiet-app-pages-navigate.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/apps": minor
+"@voyant-travel/admin": minor
+---
+
+Allow installed app pages to declare deterministic navigation order, structural groups, and host-item anchors, and resolve those contributions through the admin shell without changing existing flat appended pages.

--- a/docs/architecture/remote-app-platform-rfc.md
+++ b/docs/architecture/remote-app-platform-rfc.md
@@ -377,6 +377,16 @@ App assets never execute in the admin origin. The host passes only declared,
 validated context. Full entity payloads and installation credentials are not
 sent through iframe initialization messages.
 
+Each `admin.pages[]` declaration may also provide declarative navigation
+placement. `order` is an integer (default `0`; lower values render first),
+`insertAfter` names an existing host navigation item after which the page is
+anchored, and `group` is an installation-local key. Pages with the same `group`
+render beneath one non-navigable structural entry whose label is resolved from
+the app's localized `navigation` messages using the group key. All pages in a
+group must declare the same `insertAfter`; equal-order ties preserve the
+resolved descriptor list order. When these fields are omitted, pages retain the
+original flat, appended navigation behavior and order.
+
 The host issues short-lived, audience-bound session tokens for an extension.
 The host-authenticated viewer scope set is captured inside the signed token at
 issuance. At exchange, an app may only narrow that set; app-supplied scope names

--- a/packages/admin/src/components/operator-admin-sidebar.tsx
+++ b/packages/admin/src/components/operator-admin-sidebar.tsx
@@ -17,7 +17,11 @@ import {
 import { Settings as DefaultSettingsIcon } from "lucide-react"
 import type * as React from "react"
 
-import type { AdminExtension } from "../extensions.js"
+import {
+  type AdminExtension,
+  type AdminNavigationContribution,
+  resolveAdminNavigation,
+} from "../extensions.js"
 import {
   createOperatorAdminNavigation,
   type OperatorAdminNavigationIcons,
@@ -40,24 +44,40 @@ import { VoyantWordmark } from "./brand/voyant-wordmark.js"
 import { OperatorAdminUserMenu } from "./operator-admin-user-menu.js"
 
 /**
- * Merge each extension's OPTIONAL runtime navigation hook into a flat list, in
- * stable extension order. Runtime nav (e.g. installed apps' admin pages fetched
- * at render time) is appended after static navigation as its own sections.
+ * Collect each extension's optional runtime navigation hooks in stable extension
+ * order. Declarative contributions retain standard order/anchor behavior; the
+ * legacy flat hook remains the fallback for extensions without the richer hook.
  *
  * Rules-of-hooks: the extension registry is a stable, append-only list, so
- * calling each extension's `useRuntimeNavItems` once per render in a fixed order
- * keeps hook call order stable across renders.
+ * calling each runtime hook once per render in a fixed order keeps hook call
+ * order stable across renders.
  */
-function useRuntimeExtensionNavItems(
+function useRuntimeExtensionNavigation(
   extensions: ReadonlyArray<AdminExtension> | undefined,
-): NavItem[] {
-  const runtimeItems: NavItem[] = []
+): AdminNavigationContribution[] {
+  const contributions: AdminNavigationContribution[] = []
   for (const extension of extensions ?? []) {
-    // biome-ignore lint/correctness/useHookAtTopLevel: owner: admin; intentional -- the extension registry is a stable, append-only list, so calling each extension's runtime nav hook once per render in a fixed order keeps hook call order stable across renders.
-    const items = extension.useRuntimeNavItems?.() ?? []
-    runtimeItems.push(...items)
+    if (extension.useRuntimeNavigation) {
+      // biome-ignore lint/correctness/useHookAtTopLevel: owner: admin; intentional -- the extension registry and hook shape are stable, so calling each extension's preferred runtime nav hook once per render keeps hook order stable.
+      contributions.push(...extension.useRuntimeNavigation())
+      continue
+    }
+    // biome-ignore lint/correctness/useHookAtTopLevel: owner: admin; same stable extension-registry contract as above; this is the backwards-compatible fallback.
+    const legacyItems = extension.useRuntimeNavItems?.() ?? []
+    if (legacyItems.length) contributions.push({ items: legacyItems })
   }
-  return runtimeItems
+  return contributions
+}
+
+function mergeRuntimeExtensionNavigation(
+  staticItems: ReadonlyArray<NavItem>,
+  contributions: ReadonlyArray<AdminNavigationContribution>,
+): NavItem[] {
+  if (!contributions.length) return [...staticItems]
+  return resolveAdminNavigation({
+    baseItems: staticItems,
+    extensions: [{ id: "voyant-runtime-navigation", navigation: contributions }],
+  })
 }
 
 export interface OperatorAdminSidebarProps
@@ -128,8 +148,8 @@ export function OperatorAdminSidebar({
     extensions,
     preferences: navigationPreferences,
   })
-  const runtimeItems = useRuntimeExtensionNavItems(extensions)
-  const resolvedItems = runtimeItems.length ? [...staticItems, ...runtimeItems] : staticItems
+  const runtimeNavigation = useRuntimeExtensionNavigation(extensions)
+  const resolvedItems = mergeRuntimeExtensionNavigation(staticItems, runtimeNavigation)
   const resolvedBrand = brand ?? <DefaultOperatorAdminBrand linkComponent={linkComponent} />
   const LinkComponent = linkComponent ?? DefaultAdminNavLink
   const SettingsIcon = icons?.settings ?? DefaultSettingsIcon
@@ -293,8 +313,8 @@ export function OperatorAdminWorkspaceLayout({
   // Merge runtime nav here (not just in the sidebar) so app-page entries are
   // resolved for both the sidebar tree and the page-title/breadcrumb lookup;
   // the nested sidebar is handed the merged list with `extensions={undefined}`.
-  const runtimeItems = useRuntimeExtensionNavItems(activeExtensions)
-  const resolvedItems = runtimeItems.length ? [...staticItems, ...runtimeItems] : staticItems
+  const runtimeNavigation = useRuntimeExtensionNavigation(activeExtensions)
+  const resolvedItems = mergeRuntimeExtensionNavigation(staticItems, runtimeNavigation)
   const resolvedSide = sidebarSide ?? side
   let pageTitle: string | null = null
   if (pageHead !== false) {

--- a/packages/admin/src/extensions.ts
+++ b/packages/admin/src/extensions.ts
@@ -364,6 +364,13 @@ export interface AdminExtension {
    * on a fetch error return `[]` rather than throwing.
    */
   useRuntimeNavItems?: () => ReadonlyArray<NavItem>
+  /**
+   * Runtime counterpart of {@link navigation}. This preserves declarative
+   * ordering and anchoring for contributions discovered after installation.
+   * It is a React hook and follows the same stability/fail-soft requirements as
+   * {@link useRuntimeNavItems}. The older flat hook remains supported.
+   */
+  useRuntimeNavigation?: () => ReadonlyArray<AdminNavigationContribution>
   /** Final navigation-visibility source, evaluated after selected contributions merge. */
   navigationPreferences?: AdminNavigationPreferencesContribution
   routes?: ReadonlyArray<AdminUiRouteContribution>

--- a/packages/admin/src/ui-extensions/app-pages.tsx
+++ b/packages/admin/src/ui-extensions/app-pages.tsx
@@ -64,6 +64,14 @@ export interface AppPageNavEntry {
   label: string
   /** App-declared nav icon URL (HTTPS). Absent → host renders a generic icon. */
   icon?: string
+  /** Lower values appear first; omitted values resolve as `0`. */
+  order?: number
+  /** Installation-local structural navigation group key. */
+  group?: string
+  /** Host-localized label for {@link group}. */
+  groupLabel?: string
+  /** Existing host navigation item id after which this page/group is inserted. */
+  insertAfter?: string
 }
 
 /**
@@ -96,6 +104,10 @@ export function useAppPageNavEntries(client: UiExtensionsClient): AppPageNavEntr
       path: page.path,
       label: page.navLabel,
       ...(page.icon ? { icon: page.icon } : {}),
+      ...(page.order !== undefined ? { order: page.order } : {}),
+      ...(page.group ? { group: page.group } : {}),
+      ...(page.groupLabel ? { groupLabel: page.groupLabel } : {}),
+      ...(page.insertAfter ? { insertAfter: page.insertAfter } : {}),
     }
   })
 }

--- a/packages/admin/src/ui-extensions/ui-extensions-extension.tsx
+++ b/packages/admin/src/ui-extensions/ui-extensions-extension.tsx
@@ -14,6 +14,7 @@ import { createContext, useContext } from "react"
 
 import {
   type AdminExtension,
+  type AdminNavigationContribution,
   type AdminRoutePageProps,
   defineAdminExtension,
 } from "../extensions.js"
@@ -21,7 +22,7 @@ import { createRemoteNavIcon } from "../navigation/remote-nav-icon.js"
 import { useLocale } from "../providers/locale.js"
 import { useOperatorAdminMessages } from "../providers/operator-admin-messages.js"
 import { useTheme } from "../providers/theme.js"
-import type { NavItem } from "../types.js"
+import type { NavItem, NavSubItem } from "../types.js"
 import { AppExtensionPage, useAppPageNavEntries, useInstalledAppPages } from "./app-pages.js"
 import { ADMIN_UI_EXTENSION_SLOTS } from "./registry.js"
 import { UiExtensionHost, type UiExtensionSessionTokenGrant } from "./ui-extension-host.js"
@@ -62,6 +63,14 @@ export interface AppPageDescriptor {
   navLabel: string
   /** App-declared nav icon URL (HTTPS). Absent → host renders a generic icon. */
   icon?: string
+  /** Deterministic navigation order; lower values appear first. */
+  order?: number
+  /** Installation-local structural navigation group key. */
+  group?: string
+  /** Locale-resolved label for {@link group}. */
+  groupLabel?: string
+  /** Existing host navigation item id after which this page or group is inserted. */
+  insertAfter?: string
   appLocale?: string
   direction?: UiExtensionTextDirection
 }
@@ -231,8 +240,8 @@ export interface CreateUiExtensionsAdminExtensionOptions {
  * Route id + path pattern for the single param route that renders ANY installed
  * app page. Installations can repeat a manifest page key, so the route is keyed
  * on both `installationId` and `pageKey`; the component resolves the matching
- * descriptor at render time. Nav urls built by {@link useAppPageRuntimeNavItems}
- * match this pattern.
+ * descriptor at render time. Nav urls built by
+ * {@link createAppPageNavigationContributions} match this pattern.
  */
 export const APP_PAGE_ROUTE_ID = "voyant-ui-extensions:app-page"
 export const APP_PAGE_ROUTE_PATH = "apps/$installationId/$pageKey"
@@ -269,18 +278,87 @@ function createAppPageRouteComponent(client: UiExtensionsClient) {
 }
 
 /**
- * Runtime nav items for installed app pages: one entry per active page, titled
- * with the resolved nav label, routed to {@link APP_PAGE_ROUTE_PATH}, and iconed
- * from the app-declared remote URL (generic fallback when absent/invalid). List
- * failures resolve to `[]` (fail-soft) through {@link useInstalledAppPages}.
+ * Runtime navigation contributions for installed app pages. Ungrouped pages
+ * become top-level entries; pages sharing an installation-local `group` become
+ * children of one structural entry. Contributions retain manifest `order` and
+ * `insertAfter` metadata for the shell's standard navigation resolver.
  */
-function useAppPageRuntimeNavItems(client: UiExtensionsClient): NavItem[] {
-  return useAppPageNavEntries(client).map((entry) => ({
+export function createAppPageNavigationContributions(
+  entries: ReadonlyArray<ReturnType<typeof useAppPageNavEntries>[number]>,
+): AdminNavigationContribution[] {
+  const ordered = entries
+    .map((entry, index) => ({ entry, index }))
+    .sort(
+      (left, right) =>
+        (left.entry.order ?? 0) - (right.entry.order ?? 0) || left.index - right.index,
+    )
+    .map(({ entry }) => entry)
+  const contributions: AdminNavigationContribution[] = []
+  const groups = new Map<string, typeof ordered>()
+
+  for (const entry of ordered) {
+    if (!entry.group) continue
+    const bucketKey = `${entry.installationId}\u0000${entry.group}\u0000${entry.insertAfter ?? ""}`
+    const bucket = groups.get(bucketKey) ?? []
+    bucket.push(entry)
+    groups.set(bucketKey, bucket)
+  }
+
+  const emittedGroups = new Set<string>()
+  for (const entry of ordered) {
+    if (!entry.group) {
+      contributions.push({
+        order: entry.order ?? 0,
+        ...(entry.insertAfter ? { insertAfter: entry.insertAfter } : {}),
+        items: [toAppPageNavItem(entry)],
+      })
+      continue
+    }
+    const bucketKey = `${entry.installationId}\u0000${entry.group}\u0000${entry.insertAfter ?? ""}`
+    if (emittedGroups.has(bucketKey)) continue
+    emittedGroups.add(bucketKey)
+    const pages = groups.get(bucketKey) ?? []
+    const items: NavSubItem[] = pages.map((entry) => ({
+      id: `${APP_PAGE_ROUTE_ID}:${entry.key}`,
+      title: entry.label,
+      url: appPageNavUrl(entry.installationId, entry.pageKey),
+      icon: createRemoteNavIcon(entry.icon),
+    }))
+    contributions.push({
+      order: entry.order ?? 0,
+      ...(entry.insertAfter ? { insertAfter: entry.insertAfter } : {}),
+      items: [
+        {
+          id: `${APP_PAGE_ROUTE_ID}:group:${entry.installationId}:${entry.group}`,
+          title: entry.groupLabel ?? entry.group,
+          url: items[0]?.url ?? "/apps",
+          icon: createRemoteNavIcon(entry.icon),
+          items,
+          structural: true,
+        },
+      ],
+    })
+  }
+
+  return contributions
+}
+
+function toAppPageNavItem(entry: ReturnType<typeof useAppPageNavEntries>[number]): NavItem {
+  return {
     id: `${APP_PAGE_ROUTE_ID}:${entry.key}`,
     title: entry.label,
     url: appPageNavUrl(entry.installationId, entry.pageKey),
     icon: createRemoteNavIcon(entry.icon),
-  }))
+  }
+}
+
+function useAppPageRuntimeNavigation(client: UiExtensionsClient): AdminNavigationContribution[] {
+  return createAppPageNavigationContributions(useAppPageNavEntries(client))
+}
+
+/** Legacy flat projection retained for hosts that predate runtime contributions. */
+function useAppPageRuntimeNavItems(client: UiExtensionsClient): NavItem[] {
+  return useAppPageNavEntries(client).map(toAppPageNavItem)
 }
 
 /**
@@ -290,8 +368,8 @@ function useAppPageRuntimeNavItems(client: UiExtensionsClient): NavItem[] {
  * descriptor that targets the slot. List failures render nothing (fail-soft).
  *
  * It also surfaces installed full-page app extensions as first-class navigation:
- * {@link AdminExtension.useRuntimeNavItems} contributes one sidebar entry per
- * active page (icon + label), and a single param route renders the page through
+ * {@link AdminExtension.useRuntimeNavigation} contributes sidebar entries for
+ * active pages (icon + label), and a single param route renders the page through
  * {@link AppExtensionPage}. Pausing/uninstalling an app drops the page from the
  * resolver, so both the nav entry and the route target vanish on the next query.
  */
@@ -318,6 +396,9 @@ export function createUiExtensionsAdminExtension({
         page: async () => ({ default: AppPageRoute }),
       },
     ],
+    useRuntimeNavigation: function useRuntimeNavigation() {
+      return useAppPageRuntimeNavigation(client)
+    },
     useRuntimeNavItems: function useRuntimeNavItems() {
       return useAppPageRuntimeNavItems(client)
     },

--- a/packages/admin/tests/unit/app-page-nav-entries.test.tsx
+++ b/packages/admin/tests/unit/app-page-nav-entries.test.tsx
@@ -5,11 +5,11 @@ import { describe, expect, it } from "vitest"
 
 import { resolveAdminNavigation } from "../../src/extensions.js"
 import { useAppPageNavEntries } from "../../src/ui-extensions/app-pages.js"
-import { createAppPageNavigationContributions } from "../../src/ui-extensions/ui-extensions-extension.js"
 import type {
   AppPageDescriptor,
   UiExtensionsClient,
 } from "../../src/ui-extensions/ui-extensions-extension.js"
+import { createAppPageNavigationContributions } from "../../src/ui-extensions/ui-extensions-extension.js"
 
 function page(overrides: Partial<AppPageDescriptor> = {}): AppPageDescriptor {
   return {
@@ -135,10 +135,7 @@ describe("useAppPageNavEntries", () => {
       },
     ])
 
-    expect(contributions[0]?.items[0]?.items?.map((item) => item.title)).toEqual([
-      "Zeta",
-      "Alpha",
-    ])
+    expect(contributions[0]?.items[0]?.items?.map((item) => item.title)).toEqual(["Zeta", "Alpha"])
   })
 
   it("keeps legacy pages flat, appended, and in descriptor input order", () => {

--- a/packages/admin/tests/unit/app-page-nav-entries.test.tsx
+++ b/packages/admin/tests/unit/app-page-nav-entries.test.tsx
@@ -3,7 +3,9 @@ import { renderHook, waitFor } from "@testing-library/react"
 import type { ReactNode } from "react"
 import { describe, expect, it } from "vitest"
 
+import { resolveAdminNavigation } from "../../src/extensions.js"
 import { useAppPageNavEntries } from "../../src/ui-extensions/app-pages.js"
+import { createAppPageNavigationContributions } from "../../src/ui-extensions/ui-extensions-extension.js"
 import type {
   AppPageDescriptor,
   UiExtensionsClient,
@@ -52,5 +54,144 @@ describe("useAppPageNavEntries", () => {
 
     await waitFor(() => expect(result.current).toHaveLength(1))
     expect(result.current[0]?.icon).toBeUndefined()
+  })
+
+  it("threads page ordering, grouping, and anchoring metadata", async () => {
+    const { result } = renderHook(
+      () =>
+        useAppPageNavEntries(
+          clientWith([
+            page({ order: -10, group: "tools", groupLabel: "Tools", insertAfter: "bookings" }),
+          ]),
+        ),
+      { wrapper },
+    )
+
+    await waitFor(() => expect(result.current).toHaveLength(1))
+    expect(result.current[0]).toMatchObject({
+      order: -10,
+      group: "tools",
+      groupLabel: "Tools",
+      insertAfter: "bookings",
+    })
+  })
+
+  it("groups pages per installation and sorts grouped children deterministically", () => {
+    const contributions = createAppPageNavigationContributions([
+      {
+        key: "apin_1:reports",
+        installationId: "apin_1",
+        pageKey: "reports",
+        path: "/reports",
+        label: "Reports",
+        group: "tools",
+        groupLabel: "Tools",
+        order: 20,
+        insertAfter: "bookings",
+      },
+      {
+        key: "apin_1:settings",
+        installationId: "apin_1",
+        pageKey: "settings",
+        path: "/settings",
+        label: "Settings",
+        group: "tools",
+        groupLabel: "Tools",
+        order: 10,
+        insertAfter: "bookings",
+      },
+    ])
+
+    expect(contributions).toHaveLength(1)
+    expect(contributions[0]?.order).toBe(10)
+    expect(contributions[0]?.insertAfter).toBe("bookings")
+    expect(contributions[0]?.items[0]).toMatchObject({
+      structural: true,
+      title: "Tools",
+    })
+    expect(contributions[0]?.items[0]?.items?.map((item) => item.title)).toEqual([
+      "Settings",
+      "Reports",
+    ])
+  })
+
+  it("preserves descriptor input order for grouped children with equal order", () => {
+    const contributions = createAppPageNavigationContributions([
+      {
+        key: "apin_1:zeta",
+        installationId: "apin_1",
+        pageKey: "zeta",
+        path: "/zeta",
+        label: "Zeta",
+        group: "tools",
+      },
+      {
+        key: "apin_1:alpha",
+        installationId: "apin_1",
+        pageKey: "alpha",
+        path: "/alpha",
+        label: "Alpha",
+        group: "tools",
+      },
+    ])
+
+    expect(contributions[0]?.items[0]?.items?.map((item) => item.title)).toEqual([
+      "Zeta",
+      "Alpha",
+    ])
+  })
+
+  it("keeps legacy pages flat, appended, and in descriptor input order", () => {
+    const contributions = createAppPageNavigationContributions([
+      {
+        key: "apin_1:zeta",
+        installationId: "apin_1",
+        pageKey: "zeta",
+        path: "/zeta",
+        label: "Zeta",
+      },
+      {
+        key: "apin_1:alpha",
+        installationId: "apin_1",
+        pageKey: "alpha",
+        path: "/alpha",
+        label: "Alpha",
+      },
+    ])
+    expect(contributions.map((item) => item.items[0]?.title)).toEqual(["Zeta", "Alpha"])
+
+    const resolved = resolveAdminNavigation({
+      baseItems: [{ id: "dashboard", title: "Dashboard", url: "/" }],
+      extensions: [{ id: "installed-apps", navigation: contributions }],
+    })
+    expect(resolved.map((item) => item.title)).toEqual(["Dashboard", "Zeta", "Alpha"])
+  })
+
+  it("uses the standard shell resolver for host-item anchors", () => {
+    const contributions = createAppPageNavigationContributions([
+      {
+        key: "apin_1:settings",
+        installationId: "apin_1",
+        pageKey: "settings",
+        path: "/settings",
+        label: "Settings",
+        insertAfter: "bookings",
+      },
+    ])
+    const resolved = resolveAdminNavigation({
+      baseItems: [
+        { id: "dashboard", title: "Dashboard", url: "/" },
+        { id: "bookings", title: "Bookings", url: "/bookings" },
+        { id: "finance", title: "Finance", url: "/finance" },
+      ],
+      extensions: [{ id: "installed-apps", navigation: contributions }],
+    })
+
+    expect(resolved.map((item) => item.title)).toEqual([
+      "Dashboard",
+      "Bookings",
+      "Settings",
+      "Finance",
+    ])
   })
 })

--- a/packages/admin/tests/unit/ui-extensions-extension.test.tsx
+++ b/packages/admin/tests/unit/ui-extensions-extension.test.tsx
@@ -100,6 +100,7 @@ describe("createUiExtensionsAdminExtension", () => {
     expect(extension.routes).toHaveLength(1)
     expect(extension.routes?.[0]?.path).toBe("apps/$installationId/$pageKey")
     expect(extension.routes?.[0]?.page).toBeTypeOf("function")
+    expect(extension.useRuntimeNavigation).toBeTypeOf("function")
     expect(extension.useRuntimeNavItems).toBeTypeOf("function")
   })
 

--- a/packages/apps/src/compiler.test.ts
+++ b/packages/apps/src/compiler.test.ts
@@ -202,6 +202,47 @@ describe("app manifest compiler", () => {
     expect(normalized.adminPages[0]?.icon).toBeUndefined()
   })
 
+  it("preserves declarative page navigation placement and rejects conflicting group anchors", () => {
+    const normalized = compileAppManifest({
+      ...validManifest,
+      admin: {
+        ...validManifest.admin,
+        pages: [
+          {
+            ...validManifest.admin.pages[0],
+            order: -10,
+            group: "app-tools",
+            insertAfter: "bookings",
+          },
+        ],
+      },
+    }).normalizedRelease
+    expect(normalized.adminPages[0]).toMatchObject({
+      order: -10,
+      group: "app-tools",
+      insertAfter: "bookings",
+    })
+
+    expect(() =>
+      compileAppManifest({
+        ...validManifest,
+        admin: {
+          ...validManifest.admin,
+          pages: [
+            { ...validManifest.admin.pages[0], group: "app-tools", insertAfter: "bookings" },
+            {
+              ...validManifest.admin.pages[0],
+              key: "reports",
+              path: "/reports",
+              group: "app-tools",
+              insertAfter: "finance",
+            },
+          ],
+        },
+      }),
+    ).toThrow(/same insertAfter/)
+  })
+
   it("rejects webhook endpoints that target local infrastructure", () => {
     expect(() =>
       compileAppManifest({

--- a/packages/apps/src/contracts.ts
+++ b/packages/apps/src/contracts.ts
@@ -104,6 +104,16 @@ const adminPageSchema = z
      * fallback when a page omits its own. Absent/invalid → generic app icon.
      */
     icon: httpsUrlSchema.optional(),
+    /** Lower values appear first. Omitted pages use the deterministic default `0`. */
+    order: z.number().int().min(-10_000).max(10_000).optional(),
+    /**
+     * Installation-local navigation group key. Pages with the same key render
+     * beneath one structural nav item; its label is resolved from the
+     * manifest's localized `navigation` messages using this key.
+     */
+    group: z.string().trim().min(1).max(80).optional(),
+    /** Existing host navigation item id after which this page or group is inserted. */
+    insertAfter: z.string().trim().min(1).max(120).optional(),
   })
   .strict()
 
@@ -204,6 +214,21 @@ export const appManifestSchema = manifestDisallowedKeySchema.pipe(
           path: ["locales", "host", manifest.locales.default],
           message: "Host-rendered metadata is required for the default locale.",
         })
+      }
+      const groupAnchors = new Map<string, string | undefined>()
+      for (const [index, page] of manifest.admin.pages.entries()) {
+        if (!page.group) continue
+        if (!groupAnchors.has(page.group)) {
+          groupAnchors.set(page.group, page.insertAfter)
+          continue
+        }
+        if (groupAnchors.get(page.group) !== page.insertAfter) {
+          context.addIssue({
+            code: "custom",
+            path: ["admin", "pages", index, "insertAfter"],
+            message: `All pages in navigation group '${page.group}' must use the same insertAfter value.`,
+          })
+        }
       }
     }),
 )

--- a/packages/apps/src/extension-resolution.test.ts
+++ b/packages/apps/src/extension-resolution.test.ts
@@ -93,6 +93,39 @@ describe("assembleInstalledExtensions", () => {
     expect(result.pages[0]?.icon).toBeUndefined()
   })
 
+  it("resolves page ordering, anchoring, and a localized navigation group", () => {
+    const grouped = pageRow({
+      descriptor: {
+        key: "settings",
+        titleKey: "settings.title",
+        path: "/settings",
+        entryUrl: "https://app.example.com/settings",
+        order: -10,
+        group: "app-tools",
+        insertAfter: "bookings",
+      },
+    })
+    const labels = new Map(localizations)
+    labels.set("aprl_1", [
+      ...(labels.get("aprl_1") ?? []),
+      { locale: "en", surface: "navigation", messageKey: "app-tools", text: "App tools" },
+    ])
+    const result = assembleInstalledExtensions([grouped], labels, { activeLocale: "en" })
+    expect(result.pages[0]).toMatchObject({
+      order: -10,
+      group: "app-tools",
+      groupLabel: "App tools",
+      insertAfter: "bookings",
+    })
+  })
+
+  it("uses deterministic page navigation defaults", () => {
+    const result = assembleInstalledExtensions([pageRow()], localizations, { activeLocale: "en" })
+    expect(result.pages[0]?.order).toBe(0)
+    expect(result.pages[0]?.group).toBeUndefined()
+    expect(result.pages[0]?.insertAfter).toBeUndefined()
+  })
+
   it("filters out extensionApi-incompatible slot extensions", () => {
     const incompatible = slotRow({
       descriptor: {

--- a/packages/apps/src/extension-resolution.ts
+++ b/packages/apps/src/extension-resolution.ts
@@ -60,6 +60,14 @@ export interface ResolvedAppPage {
    * nor the app declared one (the host falls back to a generic app icon).
    */
   icon?: string
+  /** Deterministic navigation order; omitted manifest values resolve to `0`. */
+  order: number
+  /** Installation-local structural group key, when the page is grouped. */
+  group?: string
+  /** Locale-resolved label for {@link group}. */
+  groupLabel?: string
+  /** Existing host navigation item id after which this page or group is inserted. */
+  insertAfter?: string
   appLocale: string
   direction: AppTextDirection
 }
@@ -161,6 +169,9 @@ export function assembleInstalledExtensions(
       if (!page) continue
       const title = labels.resolve(page.titleKey, ["extension", "navigation"]) ?? page.key
       const navLabel = labels.resolve(page.titleKey, ["navigation", "extension"]) ?? title
+      const groupLabel = page.group
+        ? (labels.resolve(page.group, ["navigation", "extension"]) ?? page.group)
+        : undefined
       pages.push({
         key: `${row.installationId}:${page.key}`,
         installationId: row.installationId,
@@ -170,6 +181,9 @@ export function assembleInstalledExtensions(
         title,
         navLabel,
         ...(page.icon ? { icon: page.icon } : {}),
+        order: page.order ?? 0,
+        ...(page.group ? { group: page.group, groupLabel: groupLabel ?? page.group } : {}),
+        ...(page.insertAfter ? { insertAfter: page.insertAfter } : {}),
         appLocale: locale.appLocale,
         direction: locale.direction,
       })
@@ -240,6 +254,9 @@ interface ParsedPageDescriptor {
   path: string
   entryUrl: string
   icon?: string
+  order?: number
+  group?: string
+  insertAfter?: string
 }
 
 function parsePageDescriptor(value: Record<string, unknown>): ParsedPageDescriptor | null {
@@ -249,7 +266,25 @@ function parsePageDescriptor(value: Record<string, unknown>): ParsedPageDescript
   const entryUrl = stringField(value.entryUrl)
   if (!key || !titleKey || !path || !entryUrl) return null
   const icon = stringField(value.icon)
-  return icon ? { key, titleKey, path, entryUrl, icon } : { key, titleKey, path, entryUrl }
+  const order =
+    typeof value.order === "number" &&
+    Number.isInteger(value.order) &&
+    value.order >= -10_000 &&
+    value.order <= 10_000
+      ? value.order
+      : undefined
+  const group = stringField(value.group) ?? undefined
+  const insertAfter = stringField(value.insertAfter) ?? undefined
+  return {
+    key,
+    titleKey,
+    path,
+    entryUrl,
+    ...(icon ? { icon } : {}),
+    ...(order !== undefined ? { order } : {}),
+    ...(group ? { group } : {}),
+    ...(insertAfter ? { insertAfter } : {}),
+  }
 }
 
 interface ParsedSlotDescriptor {


### PR DESCRIPTION
## What changed

- carry optional page order, group, and insert-after metadata through installed app manifests
- preserve existing flat/input ordering when metadata is absent
- keep grouping local to each installation and retain the legacy hook
- add tests, documentation, and a changeset

## Why

This closes the declaration-driven navigation ordering gap identified while auditing #3976.

## Validation

- Apps lint/typecheck and 132 tests passed remotely
- Admin lint/typecheck and 166 tests passed remotely
- `git diff --check`