### PR TITLE
ci: skip operator image work for unrelated changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,8 +376,55 @@ jobs:
       - name: Enforce all database lanes
         run: test "${{ needs.db-lanes.result }}" = "success"
 
+  operator-image-impact:
+    name: operator-image-impact
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    outputs:
+      required: ${{ steps.impact.outputs.required }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          filter: blob:none
+
+      - name: Verify operator image publication contract
+        run: node scripts/check-operator-image-publication.mjs
+
+      - name: Determine whether operator image acceptance is required
+        id: impact
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+
+          # workflow_dispatch has no comparison SHA and is explicitly asking for
+          # CI, so retain the complete image acceptance lane for that event.
+          if [[ -z "${BASE_SHA:-}" || "$BASE_SHA" =~ ^0+$ ]]; then
+            echo "required=true" >> "$GITHUB_OUTPUT"
+            echo "Operator image acceptance required: no comparison SHA is available."
+            exit 0
+          fi
+
+          # Source-only package changes are intentionally handled by the build
+          # graph and packaged operator acceptance. Container-specific inputs,
+          # dependency manifests, migrations, and operator composition changes
+          # retain the full Docker migration/boot/API acceptance below.
+          changed_paths="$(git diff --name-only --no-renames "$BASE_SHA" "$HEAD_SHA")"
+          if grep -Eq '^(\.dockerignore|\.npmrc|\.github/workflows/(ci|operator-image)\.yml|apps/operator/.*|package\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml|turbo\.json|patches/.*|packages/.+/package\.json|packages/framework-migrations/.*|packages/.+/migrations/.*|scripts/(apply-publish-config|check-operator-image-publication|generate-operator-application-manifest|generate-operator-application-metadata|run-generated-migrations)\.mjs|scripts/smoke-operator-image\.sh)$' <<< "$changed_paths"; then
+            echo "required=true" >> "$GITHUB_OUTPUT"
+            echo "Operator image acceptance required by an image-impacting change."
+          else
+            echo "required=false" >> "$GITHUB_OUTPUT"
+            echo "Operator image acceptance skipped: packaged acceptance covers these changes."
+          fi
+
   operator-image-smoke:
     name: operator-image-smoke
+    needs: operator-image-impact
+    if: needs.operator-image-impact.outputs.required == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     services:
@@ -399,9 +446,6 @@ jobs:
         with:
           fetch-depth: 0
           filter: blob:none
-
-      - name: Verify operator image publication contract
-        run: node scripts/check-operator-image-publication.mjs
 
       - name: Build production operator image
         run: docker build -f apps/operator/Dockerfile -t voyant-operator:ci .

--- a/.github/workflows/operator-image.yml
+++ b/.github/workflows/operator-image.yml
@@ -4,6 +4,22 @@ on:
   push:
     branches:
       - main
+    paths:
+      - ".dockerignore"
+      - ".npmrc"
+      - ".github/workflows/operator-image.yml"
+      - "apps/operator/**"
+      - "package.json"
+      - "packages/**"
+      - "patches/**"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "scripts/apply-publish-config.mjs"
+      - "scripts/generate-operator-application-manifest.mjs"
+      - "scripts/generate-operator-application-metadata.mjs"
+      - "scripts/run-generated-migrations.mjs"
+      - "scripts/smoke-operator-image.sh"
+      - "turbo.json"
   workflow_dispatch:
     inputs:
       operation:

--- a/scripts/check-operator-image-publication.mjs
+++ b/scripts/check-operator-image-publication.mjs
@@ -37,6 +37,13 @@ if (/^\s*pull_request\s*:/m.test(workflow)) {
 
 requireFragments(WORKFLOW, workflow, [
   ["ghcr.io/voyant-travel/operator", "workflow must publish the canonical GHCR image"],
+  ["paths:", "automatic main publication must be limited to image-impacting changes"],
+  ['"apps/operator/**"', "automatic main publication must include operator changes"],
+  ['"packages/**"', "automatic main publication must include workspace package changes"],
+  [
+    '      - "scripts/smoke-operator-image.sh"',
+    "automatic main publication must verify changes to its smoke harness",
+  ],
   ["platforms: linux/amd64,linux/arm64", "workflow must publish amd64 and arm64"],
   ["provenance: mode=max", "workflow must emit maximum BuildKit provenance"],
   ["sbom: true", "workflow must emit an SBOM"],
@@ -52,6 +59,22 @@ requireFragments(WORKFLOW, workflow, [
 ])
 
 requireFragments(CI_WORKFLOW, ci, [
+  [
+    "operator-image-impact:",
+    "branch CI must cheaply detect whether operator image acceptance is required",
+  ],
+  [
+    "if: needs.operator-image-impact.outputs.required == 'true'",
+    "branch CI must not run operator image acceptance for unrelated changes",
+  ],
+  [
+    "git diff --name-only --no-renames",
+    "branch CI must classify both sides of image-impacting renames and deletions",
+  ],
+  [
+    "generate-operator-application-manifest|generate-operator-application-metadata",
+    "branch CI must accept changes to operator composition generators",
+  ],
   [
     "scripts/smoke-operator-image.sh voyant-operator:ci",
     "branch CI must retain shared migration/boot/API image acceptance",


### PR DESCRIPTION
## Summary

- add a cheap `operator-image-impact` job that compares the PR/push range
- schedule Docker/Postgres image acceptance only for container-specific inputs, dependency manifests, migrations, and operator composition changes
- retain the existing `operator-image-smoke` check name for branch protection
- path-filter automatic multi-architecture publication on `main`
- run the cheap publication contract on every CI invocation and enforce both gates there
- classify both sides of renames/deletions with `--no-renames`

## Why

The image smoke currently runs on every PR and takes roughly 15–20 minutes. The publication workflow also runs after every merge, including docs-only changes. That is a material development blocker.

Source-only workspace package changes intentionally do **not** run the PR Docker smoke: the build graph plus packaged operator production acceptance already cover their build/deploy behavior. They remain in the automatic publication path because they can change the final operator image. Container wiring, manifests, migrations, composition generators, and operator app changes retain the full PR image acceptance.

## Expected behavior

- unrelated PR: cheap contract + `operator-image-impact`; `operator-image-smoke` skipped before runner/service allocation
- source-only package PR: affected graph + packaged operator acceptance; Docker smoke skipped
- image-infrastructure/operator/migration PR: full image build plus migration/boot/API acceptance
- unrelated `main` push: no multi-architecture publication workflow
- image-impacting `main` push: publish and accept the immutable multi-architecture image

## Verification

- `git diff --check`
- Ruby YAML parse for both workflows
- `node scripts/check-operator-image-publication.mjs`
- CI exercises the heavy PR path because this PR changes both image workflows