### PR TITLE
ci(operator): build images on native runners

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -49,6 +49,8 @@ Publishes `ghcr.io/voyant-travel/operator` independently from npm packages:
 
 - pushes to `main` publish immutable `sha-<git-sha>` multi-architecture images
 - manual `publish-release` dispatches from `main` publish immutable semver tags
+- amd64 and arm64 variants build and pass digest-level acceptance concurrently
+  on matching native GitHub runners before their canonical index is created
 - manual `promote-latest` dispatches move `latest` only after digest-level
   migration, boot, and API acceptance
 - BuildKit SBOM/provenance and a GitHub registry attestation accompany new

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -413,7 +413,7 @@ jobs:
           # dependency manifests, migrations, and operator composition changes
           # retain the full Docker migration/boot/API acceptance below.
           changed_paths="$(git diff --name-only --no-renames "$BASE_SHA" "$HEAD_SHA")"
-          if grep -Eq '^(\.dockerignore|\.npmrc|\.github/workflows/(ci|operator-image)\.yml|apps/operator/.*|package\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml|turbo\.json|patches/.*|packages/.+/package\.json|packages/framework-migrations/.*|packages/.+/migrations/.*|scripts/(apply-publish-config|check-operator-image-publication|generate-operator-application-manifest|generate-operator-application-metadata|run-generated-migrations)\.mjs|scripts/smoke-operator-image\.sh)$' <<< "$changed_paths"; then
+          if grep -Eq '^(\.dockerignore|\.npmrc|\.github/workflows/(ci|operator-image)\.yml|apps/operator/.*|package\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml|turbo\.json|patches/.*|packages/.+/package\.json|packages/framework-migrations/.*|packages/.+/migrations/.*|scripts/(apply-publish-config|check-operator-image-publication|generate-operator-application-manifest|generate-operator-application-metadata|run-generated-migrations|verify-operator-image-identity)\.mjs|scripts/smoke-operator-image\.sh)$' <<< "$changed_paths"; then
             echo "required=true" >> "$GITHUB_OUTPUT"
             echo "Operator image acceptance required by an image-impacting change."
           else

--- a/.github/workflows/operator-image.yml
+++ b/.github/workflows/operator-image.yml
@@ -19,6 +19,7 @@ on:
       - "scripts/generate-operator-application-metadata.mjs"
       - "scripts/run-generated-migrations.mjs"
       - "scripts/smoke-operator-image.sh"
+      - "scripts/verify-operator-image-identity.mjs"
       - "turbo.json"
   workflow_dispatch:
     inputs:
@@ -35,11 +36,11 @@ on:
         type: string
 
 concurrency:
-  group: operator-image-${{ github.ref }}-${{ inputs.operation }}-${{ inputs.release_version }}
+  group: operator-image-${{ inputs.operation == 'promote-latest' && 'promote-latest' || format('{0}-{1}-{2}', github.ref, inputs.operation, inputs.release_version) }}
   cancel-in-progress: false
 
 # Keep the workflow default read-only. Registry and attestation privileges are
-# granted only to the two jobs that can be reached by main pushes or an explicit
+# granted only to jobs that can be reached by main pushes or an explicit
 # workflow dispatch; pull requests never invoke this workflow.
 permissions:
   contents: read
@@ -48,37 +49,23 @@ env:
   IMAGE_NAME: ghcr.io/voyant-travel/operator
 
 jobs:
-  publish:
-    name: publish-and-verify
+  plan:
+    name: publication-plan
     if: github.event_name == 'push' || inputs.operation == 'publish-release'
     runs-on: ubuntu-24.04
-    timeout-minutes: 90
+    timeout-minutes: 5
     permissions:
       contents: read
-      packages: write
-      id-token: write
-      attestations: write
-    services:
-      postgres:
-        image: postgres:16
-        env:
-          POSTGRES_USER: voyant
-          POSTGRES_PASSWORD: voyant
-          POSTGRES_DB: voyant_starter_acceptance
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U voyant -d voyant_starter_acceptance"
-          --health-interval 1s
-          --health-timeout 1s
-          --health-retries 30
+      packages: read
+    outputs:
+      digest: ${{ steps.publication.outputs.digest }}
+      exists: ${{ steps.publication.outputs.exists }}
+      tag: ${{ steps.publication.outputs.tag }}
+      version: ${{ steps.publication.outputs.version }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          fetch-depth: 0
           filter: blob:none
-
-      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
@@ -93,8 +80,8 @@ jobs:
         id: publication
         shell: bash
         env:
-          OPERATION: ${{ inputs.operation }}
           RELEASE_VERSION: ${{ inputs.release_version }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
 
@@ -118,70 +105,253 @@ jobs:
 
           if existing=$(docker buildx imagetools inspect "$tag" 2>/dev/null); then
             digest=$(awk '$1 == "Digest:" { print $2; exit }' <<<"$existing")
-            if [[ -z "$digest" ]]; then
+            if ! [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
               echo "Could not resolve the existing digest for $tag."
               exit 1
             fi
-            if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            if [[ "${{ github.event_name }}" == "workflow_dispatch" && "$RUN_ATTEMPT" == "1" ]]; then
               echo "Immutable release tag $tag already exists at $digest."
               exit 1
             fi
-            echo "Automatic SHA publication is already present at $digest; verifying it again."
+            node scripts/verify-operator-image-identity.mjs \
+              "$IMAGE_NAME" "$IMAGE_NAME@$digest" "$GITHUB_SHA" "$version"
+            if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+              echo "Release recovery attempt $RUN_ATTEMPT found $tag at $digest; re-verifying it without overwriting."
+            else
+              echo "Automatic SHA publication is already present at $digest; verifying it again."
+            fi
             echo "exists=true" >> "$GITHUB_OUTPUT"
             echo "digest=$digest" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Build and push multi-platform image
+  build:
+    name: build-and-smoke-${{ matrix.arch }}
+    needs: plan
+    if: needs.plan.outputs.exists != 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      packages: write
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: voyant
+          POSTGRES_PASSWORD: voyant
+          POSTGRES_DB: voyant_starter_acceptance
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U voyant -d voyant_starter_acceptance"
+          --health-interval 1s
+          --health-timeout 1s
+          --health-retries 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          filter: blob:none
+
+      # Each job runs on the same architecture it builds. Do not add QEMU: the
+      # production deploy tree contains architecture-specific native modules.
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push native platform image by digest
         id: build
-        if: steps.publication.outputs.exists != 'true'
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: apps/operator/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.publication.outputs.tag }}
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           build-args: |
             IMAGE_SOURCE=${{ github.server_url }}/${{ github.repository }}
             IMAGE_REVISION=${{ github.sha }}
-            IMAGE_VERSION=${{ steps.publication.outputs.version }}
+            IMAGE_VERSION=${{ needs.plan.outputs.version }}
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.version=${{ steps.publication.outputs.version }}
-          cache-from: type=gha,scope=operator-image
-          cache-to: type=gha,mode=max,scope=operator-image
+            org.opencontainers.image.version=${{ needs.plan.outputs.version }}
+          cache-from: type=gha,scope=operator-image-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=operator-image-${{ matrix.arch }}
           provenance: mode=max
           sbom: true
 
-      - name: Resolve the exact published digest
+      - name: Record the immutable platform digest
+        id: platform
+        shell: bash
+        env:
+          ARCH: ${{ matrix.arch }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          if ! [[ "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "Native $ARCH build did not produce a valid OCI digest: $DIGEST"
+            exit 1
+          fi
+          mkdir -p /tmp/operator-image-digests
+          touch "/tmp/operator-image-digests/$ARCH-${DIGEST#sha256:}"
+          echo "ref=$IMAGE_NAME@$DIGEST" >> "$GITHUB_OUTPUT"
+          echo "$ARCH -> $IMAGE_NAME@$DIGEST"
+
+      - name: Migrate, boot, and API-smoke the native platform digest
+        run: scripts/smoke-operator-image.sh "${{ steps.platform.outputs.ref }}"
+
+      - name: Upload the platform digest receipt
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: operator-image-digest-${{ matrix.arch }}
+          path: /tmp/operator-image-digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  finalize:
+    name: finalize-and-verify
+    needs:
+      - plan
+      - build
+    if: ${{ always() && needs.plan.result == 'success' && (needs.build.result == 'success' || needs.build.result == 'skipped') }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: voyant
+          POSTGRES_PASSWORD: voyant
+          POSTGRES_DB: voyant_starter_acceptance
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U voyant -d voyant_starter_acceptance"
+          --health-interval 1s
+          --health-timeout 1s
+          --health-retries 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          filter: blob:none
+
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download native platform digest receipts
+        if: needs.plan.outputs.exists != 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: operator-image-digest-*
+          path: /tmp/operator-image-digests
+          merge-multiple: true
+
+      - name: Create the canonical multi-platform image
+        if: needs.plan.outputs.exists != 'true'
+        shell: bash
+        env:
+          FINAL_TAG: ${{ needs.plan.outputs.tag }}
+          IMAGE_VERSION: ${{ needs.plan.outputs.version }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+
+          if existing=$(docker buildx imagetools inspect "$FINAL_TAG" 2>/dev/null); then
+            digest=$(awk '$1 == "Digest:" { print $2; exit }' <<<"$existing")
+            if ! [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+              echo "Could not resolve the canonical digest for $FINAL_TAG."
+              exit 1
+            fi
+            if [[ "$RUN_ATTEMPT" == "1" ]]; then
+              echo "Canonical tag $FINAL_TAG appeared after publication planning at $digest; refusing to overwrite it."
+              exit 1
+            fi
+            node scripts/verify-operator-image-identity.mjs \
+              "$IMAGE_NAME" "$IMAGE_NAME@$digest" "$GITHUB_SHA" "$IMAGE_VERSION"
+            echo "Recovery attempt $RUN_ATTEMPT adopted $FINAL_TAG at $digest without overwriting it."
+            exit 0
+          fi
+
+          sources=()
+          for arch in amd64 arm64; do
+            mapfile -t receipts < <(find /tmp/operator-image-digests -maxdepth 1 -type f -name "$arch-*" -print)
+            if (( ${#receipts[@]} != 1 )); then
+              echo "Expected exactly one $arch digest receipt, found ${#receipts[@]}."
+              exit 1
+            fi
+            digest=${receipts[0]##*"$arch-"}
+            if ! [[ "$digest" =~ ^[0-9a-f]{64}$ ]]; then
+              echo "Invalid $arch digest receipt: $digest"
+              exit 1
+            fi
+            sources+=("$IMAGE_NAME@sha256:$digest")
+          done
+
+          docker buildx imagetools create --tag "$FINAL_TAG" "${sources[@]}"
+
+      - name: Resolve and verify the exact canonical digest
         id: image
         shell: bash
         env:
-          BUILT_DIGEST: ${{ steps.build.outputs.digest }}
-          EXISTING_DIGEST: ${{ steps.publication.outputs.digest }}
+          EXISTING_DIGEST: ${{ needs.plan.outputs.digest }}
+          FINAL_TAG: ${{ needs.plan.outputs.tag }}
+          IMAGE_VERSION: ${{ needs.plan.outputs.version }}
         run: |
           set -euo pipefail
-          digest="${BUILT_DIGEST:-$EXISTING_DIGEST}"
+          manifest=$(docker buildx imagetools inspect "$FINAL_TAG")
+          digest=$(awk '$1 == "Digest:" { print $2; exit }' <<<"$manifest")
           if ! [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
             echo "Publication did not produce a valid OCI digest: $digest"
             exit 1
           fi
+          if [[ -n "$EXISTING_DIGEST" && "$digest" != "$EXISTING_DIGEST" ]]; then
+            echo "Immutable tag drift: planned $EXISTING_DIGEST but resolved $digest."
+            exit 1
+          fi
+
+          node scripts/verify-operator-image-identity.mjs \
+            "$IMAGE_NAME" "$IMAGE_NAME@$digest" "$GITHUB_SHA" "$IMAGE_VERSION"
+
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
           echo "ref=$IMAGE_NAME@$digest" >> "$GITHUB_OUTPUT"
-          echo "Published ${{ steps.publication.outputs.tag }} as $IMAGE_NAME@$digest"
+          echo "Published $FINAL_TAG as $IMAGE_NAME@$digest"
 
-      - name: Attest the pushed image
-        if: steps.publication.outputs.exists != 'true'
+      - name: Attest the canonical multi-platform image
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
           subject-name: ${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.image.outputs.digest }}
           push-to-registry: true
 
-      - name: Migrate, boot, and API-smoke the pushed digest
+      - name: Migrate, boot, and API-smoke the canonical digest
         run: scripts/smoke-operator-image.sh "${{ steps.image.outputs.ref }}"
 
   promote-latest:

--- a/docs/architecture/operator-image-distribution.md
+++ b/docs/architecture/operator-image-distribution.md
@@ -16,16 +16,40 @@ versioned client or extension protocols.
   release digest to the mutable convenience tag `latest`;
 - pull requests never invoke the workflow and never receive registry write
   permission;
-- publication fails closed if a release tag already exists. An automatic SHA
-  rerun re-verifies the existing artifact instead of overwriting it.
+- a fresh publication dispatch fails closed if its release tag already exists.
+  If an earlier attempt created the tag and then failed during final
+  verification, rerunning that same workflow adopts the existing immutable
+  digest only after both runnable platform images prove that their OCI revision
+  and version labels exactly match the workflow commit and requested release.
+  It then re-verifies the digest and re-attaches canonical provenance without
+  overwriting it. Automatic SHA reruns use the same recovery path;
+- all `promote-latest` dispatches share one version-independent concurrency
+  group, so two release promotions can never move `latest` concurrently.
 
-Every build targets `linux/amd64` and `linux/arm64`, emits an SBOM and maximum
-BuildKit provenance, and attaches GitHub build provenance to the registry
-artifact. Publication is complete only after the exact pushed manifest digest
-successfully runs the embedded migration plan, boots, answers `/healthz`, and
-dispatches the OpenAPI route. Promoting `latest` performs the same acceptance
-against the release digest before moving the tag and then proves that `latest`
-resolves to that digest.
+The `linux/amd64` and `linux/arm64` variants build concurrently on matching
+native GitHub runners. The workflow deliberately does not use QEMU: the
+production deploy tree includes architecture-specific native modules, so each
+variant must be assembled and exercised on its target architecture. A build
+pushes only an untagged, content-addressed platform image and emits an immutable
+digest receipt. That exact digest must run the embedded migration plan, boot,
+answer `/healthz`, and dispatch the OpenAPI route on its native runner before
+the receipt can reach finalization.
+
+After both native variants pass, the finalization job creates the canonical
+multi-platform tag from their digest receipts. It refuses to overwrite a tag
+that appeared after publication planning on a fresh workflow attempt. A failed
+job rerun may adopt that tag without rewriting it, but only after the same exact
+revision/version identity check used by a full-workflow recovery. Finalization
+verifies that the resulting index has exactly one `linux/amd64` and one
+`linux/arm64` image, and repeats migration, boot, and API acceptance against the
+exact canonical index digest. Other
+runnable platform descriptors are rejected; only BuildKit's explicit
+`unknown/unknown` attestation descriptors may accompany the two images. Every
+native build emits an SBOM and maximum BuildKit provenance; finalization also
+attaches GitHub build provenance to the canonical registry artifact, including
+during recovery reruns. Promoting `latest` performs the same acceptance against
+the release digest before moving the tag and then proves that `latest` resolves
+to that digest.
 
 `latest` is for discovery only. Voyant Platform and other production control
 planes **must pin `ghcr.io/voyant-travel/operator@sha256:<digest>`**. A rollout

--- a/scripts/check-operator-image-publication.mjs
+++ b/scripts/check-operator-image-publication.mjs
@@ -2,13 +2,16 @@
 import { existsSync, readFileSync } from "node:fs"
 import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
+import { verifyOperatorImageIdentity } from "./verify-operator-image-identity.mjs"
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..")
 const WORKFLOW = ".github/workflows/operator-image.yml"
 const CI_WORKFLOW = ".github/workflows/ci.yml"
 const DOCKERFILE = "apps/operator/Dockerfile"
 const SMOKE = "scripts/smoke-operator-image.sh"
+const IDENTITY = "scripts/verify-operator-image-identity.mjs"
 const CONTRACT = "docs/architecture/operator-image-distribution.md"
+const EXPRESSION_START = "$" + "{{"
 const violations = []
 
 function source(path) {
@@ -29,6 +32,7 @@ const workflow = source(WORKFLOW)
 const ci = source(CI_WORKFLOW)
 const dockerfile = source(DOCKERFILE)
 const smoke = source(SMOKE)
+const identity = source(IDENTITY)
 const contract = source(CONTRACT)
 
 if (/^\s*pull_request\s*:/m.test(workflow)) {
@@ -44,7 +48,65 @@ requireFragments(WORKFLOW, workflow, [
     '      - "scripts/smoke-operator-image.sh"',
     "automatic main publication must verify changes to its smoke harness",
   ],
-  ["platforms: linux/amd64,linux/arm64", "workflow must publish amd64 and arm64"],
+  [
+    '      - "scripts/verify-operator-image-identity.mjs"',
+    "automatic main publication must verify changes to its identity verifier",
+  ],
+  ["runner: ubuntu-24.04", "amd64 images must build on a native GitHub runner"],
+  ["runner: ubuntu-24.04-arm", "arm64 images must build on a native GitHub runner"],
+  ["platform: linux/amd64", "workflow must build an amd64 image"],
+  ["platform: linux/arm64", "workflow must build an arm64 image"],
+  [
+    `runs-on: ${EXPRESSION_START} matrix.runner }}`,
+    "platform builds must run on the matching native matrix runner",
+  ],
+  [
+    `platforms: ${EXPRESSION_START} matrix.platform }}`,
+    "each native runner must build only its matching platform",
+  ],
+  ["push-by-digest=true", "native platform images must be published without temporary tags"],
+  ["name-canonical=true", "native platform images must use content-addressed registry names"],
+  [
+    `operator-image-digest-${EXPRESSION_START} matrix.arch }}`,
+    "platform digests must cross jobs as receipts",
+  ],
+  [
+    'docker buildx imagetools create --tag "$FINAL_TAG"',
+    "the canonical multi-platform tag must be created only in the finalize job",
+  ],
+  [
+    "Canonical tag $FINAL_TAG appeared after publication planning",
+    "finalization must refuse to overwrite a tag created after planning",
+  ],
+  [
+    '"workflow_dispatch" && "$RUN_ATTEMPT" == "1"',
+    "a fresh release dispatch must still reject an existing immutable tag",
+  ],
+  [
+    `RUN_ATTEMPT: ${EXPRESSION_START} github.run_attempt }}`,
+    "release recovery must use GitHub's workflow rerun attempt number",
+  ],
+  [
+    "Release recovery attempt $RUN_ATTEMPT",
+    "a failed release workflow rerun must adopt and reverify its existing immutable digest",
+  ],
+  [
+    "format('{0}-{1}-{2}', github.ref, inputs.operation, inputs.release_version)",
+    "push and release publication concurrency must retain ref and version isolation",
+  ],
+  [
+    "inputs.operation == 'promote-latest' && 'promote-latest'",
+    "all latest promotions must share one version-independent concurrency group",
+  ],
+  ["verify-operator-image-identity.mjs", "all canonical image paths must verify image identity"],
+  [
+    '"$IMAGE_NAME" "$IMAGE_NAME@$digest" "$GITHUB_SHA" "$version"',
+    "release recovery must verify the existing tag against its planned source identity",
+  ],
+  [
+    '"$IMAGE_NAME" "$IMAGE_NAME@$digest" "$GITHUB_SHA" "$IMAGE_VERSION"',
+    "finalization recovery must verify the appeared tag against its planned source identity",
+  ],
   ["provenance: mode=max", "workflow must emit maximum BuildKit provenance"],
   ["sbom: true", "workflow must emit an SBOM"],
   ["actions/attest-build-provenance@", "workflow must attach registry build provenance"],
@@ -52,11 +114,26 @@ requireFragments(WORKFLOW, workflow, [
   ["Immutable release tag", "release publication must reject an existing tag"],
   ["inputs.operation == 'promote-latest'", "latest promotion must be explicitly dispatched"],
   ["scripts/smoke-operator-image.sh", "published digests must use shared image acceptance"],
-  ["steps.image.outputs.ref", "published acceptance must address the resolved digest"],
+  ["steps.platform.outputs.ref", "each native build must be accepted by its resolved digest"],
+  ["steps.image.outputs.ref", "canonical acceptance must address the resolved manifest digest"],
   ["steps.release.outputs.ref", "latest promotion must accept the resolved release digest"],
   ["packages: write", "registry mutation must be granted at job scope"],
   ["attestations: write", "publication must grant the attestation permission"],
 ])
+
+if (workflow.includes("docker/setup-qemu-action")) {
+  violations.push({
+    path: WORKFLOW,
+    message: "operator platform builds must remain native and must not install QEMU",
+  })
+}
+
+if (/- name: Attest the canonical multi-platform image\n\s+if:/.test(workflow)) {
+  violations.push({
+    path: WORKFLOW,
+    message: "canonical provenance must be re-attached for existing and newly published digests",
+  })
+}
 
 requireFragments(CI_WORKFLOW, ci, [
   [
@@ -76,6 +153,10 @@ requireFragments(CI_WORKFLOW, ci, [
     "branch CI must accept changes to operator composition generators",
   ],
   [
+    "run-generated-migrations|verify-operator-image-identity",
+    "branch CI must accept changes to operator migration and image identity verification",
+  ],
+  [
     "scripts/smoke-operator-image.sh voyant-operator:ci",
     "branch CI must retain shared migration/boot/API image acceptance",
   ],
@@ -90,6 +171,102 @@ requireFragments(SMOKE, smoke, [
   ["/healthz", "image acceptance must check liveness"],
   ["/api/openapi.json", "image acceptance must dispatch the API"],
 ])
+requireFragments(IDENTITY, identity, [
+  ["SUPPORTED_ARCHITECTURES", "identity verification must cover every supported architecture"],
+  ["amd64", "identity verification must require linux/amd64"],
+  ["arm64", "identity verification must require linux/arm64"],
+  [
+    "org.opencontainers.image.revision",
+    "identity verification must compare the source revision label",
+  ],
+  [
+    "org.opencontainers.image.version",
+    "identity verification must compare the planned image version label",
+  ],
+  [
+    "vnd.docker.reference.type",
+    "identity verification must allow only explicit unknown/unknown attestation descriptors",
+  ],
+  [
+    "unexpected runnable or non-attestation platform descriptor",
+    "identity verification must reject extra runnable platform descriptors",
+  ],
+  [
+    '"--format", "{{json .Image}}"',
+    "identity verification must inspect each platform image configuration",
+  ],
+])
+
+const AMD64_DIGEST = `sha256:${"a".repeat(64)}`
+const ARM64_DIGEST = `sha256:${"b".repeat(64)}`
+const EXPECTED_REVISION = "1".repeat(40)
+const EXPECTED_VERSION = "1.2.3"
+const identityFixture = {
+  manifests: [
+    { digest: AMD64_DIGEST, platform: { os: "linux", architecture: "amd64" } },
+    { digest: ARM64_DIGEST, platform: { os: "linux", architecture: "arm64" } },
+    {
+      digest: `sha256:${"c".repeat(64)}`,
+      platform: { os: "unknown", architecture: "unknown" },
+      annotations: { "vnd.docker.reference.type": "attestation-manifest" },
+    },
+  ],
+}
+const matchingConfig = {
+  config: {
+    Labels: {
+      "org.opencontainers.image.revision": EXPECTED_REVISION,
+      "org.opencontainers.image.version": EXPECTED_VERSION,
+    },
+  },
+}
+
+function requireIdentityResult(name, manifest, loadConfig, expectedFailure) {
+  try {
+    verifyOperatorImageIdentity(manifest, EXPECTED_REVISION, EXPECTED_VERSION, loadConfig)
+    if (expectedFailure) {
+      violations.push({ path: IDENTITY, message: `${name} fixture unexpectedly passed` })
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    if (!expectedFailure || !message.includes(expectedFailure)) {
+      violations.push({ path: IDENTITY, message: `${name} fixture failed incorrectly: ${message}` })
+    }
+  }
+}
+
+requireIdentityResult("matching identity", identityFixture, () => matchingConfig)
+requireIdentityResult(
+  "wrong revision",
+  identityFixture,
+  () => ({
+    config: {
+      Labels: { ...matchingConfig.config.Labels, "org.opencontainers.image.revision": "wrong" },
+    },
+  }),
+  "revision is",
+)
+requireIdentityResult(
+  "wrong version",
+  identityFixture,
+  () => ({
+    config: {
+      Labels: { ...matchingConfig.config.Labels, "org.opencontainers.image.version": "9.9.9" },
+    },
+  }),
+  "version is",
+)
+requireIdentityResult(
+  "extra runnable platform",
+  {
+    manifests: [
+      ...identityFixture.manifests,
+      { digest: `sha256:${"d".repeat(64)}`, platform: { os: "linux", architecture: "s390x" } },
+    ],
+  },
+  () => matchingConfig,
+  "unexpected runnable or non-attestation platform descriptor",
+)
 requireFragments(CONTRACT, contract, [
   ["@sha256:<digest>", "distribution contract must require digest pinning"],
   ["ADMIN_UI_EXTENSION_API_VERSION", "contract must separate extension API versioning"],

--- a/scripts/verify-operator-image-identity.mjs
+++ b/scripts/verify-operator-image-identity.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process"
+import { resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/
+const SUPPORTED_ARCHITECTURES = ["amd64", "arm64"]
+const REVISION_LABEL = "org.opencontainers.image.revision"
+const VERSION_LABEL = "org.opencontainers.image.version"
+
+function fail(message) {
+  throw new Error(`Operator image identity verification failed: ${message}`)
+}
+
+export function verifyOperatorImageIdentity(
+  manifest,
+  expectedRevision,
+  expectedVersion,
+  loadImageConfig,
+) {
+  if (!Array.isArray(manifest?.manifests)) {
+    fail("the canonical reference is not an OCI image index")
+  }
+
+  for (const descriptor of manifest.manifests) {
+    const platform = descriptor?.platform
+    const isSupportedImage =
+      platform?.os === "linux" && SUPPORTED_ARCHITECTURES.includes(platform?.architecture)
+    const isAttestation =
+      platform?.os === "unknown" &&
+      platform?.architecture === "unknown" &&
+      descriptor?.annotations?.["vnd.docker.reference.type"] === "attestation-manifest"
+
+    if (!isSupportedImage && !isAttestation) {
+      fail(
+        `unexpected runnable or non-attestation platform descriptor ${platform?.os ?? "missing"}/${platform?.architecture ?? "missing"}`,
+      )
+    }
+  }
+
+  for (const architecture of SUPPORTED_ARCHITECTURES) {
+    const descriptors = manifest.manifests.filter(
+      (descriptor) =>
+        descriptor?.platform?.os === "linux" && descriptor?.platform?.architecture === architecture,
+    )
+    if (descriptors.length !== 1) {
+      fail(`expected exactly one linux/${architecture} image, found ${descriptors.length}`)
+    }
+
+    const digest = descriptors[0].digest
+    if (!DIGEST_PATTERN.test(digest)) {
+      fail(`linux/${architecture} has an invalid digest: ${digest ?? "missing"}`)
+    }
+
+    const image = loadImageConfig(digest)
+    const labels = image?.config?.Labels
+    if (labels?.[REVISION_LABEL] !== expectedRevision) {
+      fail(
+        `linux/${architecture} revision is ${JSON.stringify(labels?.[REVISION_LABEL])}, expected ${JSON.stringify(expectedRevision)}`,
+      )
+    }
+    if (labels?.[VERSION_LABEL] !== expectedVersion) {
+      fail(
+        `linux/${architecture} version is ${JSON.stringify(labels?.[VERSION_LABEL])}, expected ${JSON.stringify(expectedVersion)}`,
+      )
+    }
+  }
+}
+
+function inspectJson(reference, ...args) {
+  const output = execFileSync("docker", ["buildx", "imagetools", "inspect", reference, ...args], {
+    encoding: "utf8",
+    maxBuffer: 16 * 1024 * 1024,
+  })
+  return JSON.parse(output)
+}
+
+function main() {
+  const [imageName, canonicalReference, expectedRevision, expectedVersion] = process.argv.slice(2)
+  if (!imageName || !canonicalReference || !expectedRevision || !expectedVersion) {
+    console.error(
+      "Usage: verify-operator-image-identity.mjs <image-name> <canonical-reference> <revision> <version>",
+    )
+    process.exit(2)
+  }
+
+  try {
+    const manifest = inspectJson(canonicalReference, "--raw")
+    verifyOperatorImageIdentity(manifest, expectedRevision, expectedVersion, (digest) =>
+      inspectJson(`${imageName}@${digest}`, "--format", "{{json .Image}}"),
+    )
+    console.log(
+      `Verified ${canonicalReference}: linux/amd64 and linux/arm64 match revision ${expectedRevision} and version ${expectedVersion}.`,
+    )
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error)
+    process.exit(1)
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main()
+}


### PR DESCRIPTION
## Summary

- replace the cold QEMU multi-platform build with concurrent native amd64 and arm64 jobs
- push each platform image only by immutable digest and smoke it on its matching native runner
- create the canonical multi-platform tag only after both platform digests pass migration, boot, and API acceptance
- verify the final index, exact revision/version identity, provenance, SBOM descriptors, and canonical digest before acceptance
- preserve immutable semver tags, safe SHA idempotency, recovery for both rerun modes, and serialized `latest` promotion

## Root cause

The existing workflow builds all 115 workspaces twice. The arm64 solve runs the full install/build/deploy tree under QEMU and the GHA cache is exported only after the complete solve. The first publication hit the 90-minute job timeout without producing a canonical image. A queued duplicate was cancelled before registry login or build/push.

Building once on amd64 and copying the deploy tree is unsafe because production dependencies include architecture-specific native modules. Each platform therefore remains assembled and tested natively.

## Safety model

- native builders publish untagged, content-addressed platform images
- digest receipts are same-run artifacts and are validated before use
- canonical tagging fails closed on races and happens only after both native smokes pass
- recovery adopts an existing tag only on a retry and only after both platform images match the exact expected Git revision/version
- canonical attestation and exact-digest smoke run unconditionally, including recovery
- `latest` promotions share one global serialized concurrency key

## Validation

- actionlint 1.7.12 on `ci.yml` and `operator-image.yml`
- `node scripts/check-operator-image-publication.mjs`, including positive and negative OCI identity fixtures
- `node --check scripts/verify-operator-image-identity.mjs`
- `bash -n scripts/smoke-operator-image.sh`
- `git diff --check HEAD^..HEAD`
- disposable Sprite validation of the exact safe worktree snapshot
- independent review: no remaining high/medium findings

GitHub intentionally does not execute this registry-writing publication workflow from pull requests, and release dispatches fail outside `main`. The PR remains draft until ordinary image-impacting CI passes. The merge commit’s automatic publication will be the controlled integration test of the native arm64 runner, per-platform GHCR pushes, finalization, attestation, and exact-digest acceptance.