### PR TITLE
Booking v1: commit payment-required Sessions

### DIFF
--- a/.changeset/booking-v1-payment-required-commit.md
+++ b/.changeset/booking-v1-payment-required-commit.md
@@ -1,0 +1,15 @@
+---
+"@voyant-travel/catalog-contracts": minor
+"@voyant-travel/catalog": minor
+"@voyant-travel/finance-contracts": minor
+"@voyant-travel/finance": minor
+"@voyant-travel/inventory": patch
+"@voyant-travel/distribution": patch
+"@voyant-travel/storefront-sdk": minor
+"@voyant-travel/storefront-react": patch
+---
+
+Continue owned Product Booking Session Commit through an idempotent pre-Booking
+Finance payment session, selected payment adapter, and atomic transfer to the
+created Booking. Expose typed payment-required continuation and recovery through
+the shared route contract, Storefront SDK, and React hooks.

--- a/docs/adr/0019-booking-v1-commitment-point-policies.md
+++ b/docs/adr/0019-booking-v1-commitment-point-policies.md
@@ -137,8 +137,9 @@ tracers.
 
 ## Consequences
 
-- Booking Session is pre-commitment state. Abandonment must not leak Booking or
-  Finance records.
+- Booking Session is pre-commitment state. Abandonment must not leak a Booking;
+  pending Finance attempts are terminalized, while captured pre-Booking money
+  remains explicitly targeted at the terminal Session for reconciliation.
 - Quote is immutable and exact-revision scoped. Re-quoting after a material
   change supersedes prior pricing rather than mutating it.
 - Hold is inventory state, not a Booking. Owned Commit converts Hold to

--- a/docs/architecture/catalog-booking-engine.md
+++ b/docs/architecture/catalog-booking-engine.md
@@ -140,7 +140,9 @@ The canonical persistence shape is:
   `(session_id, idempotency_key)` replay record.
 
 Creating or abandoning a Booking Session does not create a Booking, booking
-number, Booking Item, Allocation, Finance record, or reporting row. Updating
+number, Booking Item, Allocation, or reporting row. A Commit that requires
+payment may create a Finance Payment Session targeted at the Booking Session;
+that pre-Booking payment attempt is not a Booking or a draft Booking. Updating
 price-relevant state increments the Session revision and supersedes active
 Quotes. Commit rejects stale revisions, expired/superseded Quotes, expired or
 mismatched Holds, and different server-recomputed prices. Stable idempotency
@@ -156,6 +158,30 @@ reference SDK and React hook are exported from `@voyant-travel/storefront-sdk`
 and `@voyant-travel/storefront-react`; they hide the route sequence while
 preserving returned revision, capability, Quote, Hold, and stable idempotency
 semantics.
+
+#### Payment-required Commit continuation
+
+The owned Product tracer resolves the effective customer payment policy from
+server-owned listing, category, supplier, and operator settings. When money is
+due at Commit, Finance creates or reuses an idempotent Payment Session targeted
+at the Booking Session and Catalog returns `payment_required`. The Session,
+Quote, and Hold remain live only until their existing expiries; initiating a
+payment does not silently extend spend authority.
+
+Provider redirects, delayed callbacks, duplicate callbacks, failures, and
+customer retries update the Finance Payment Session through the selected
+payment adapter. Storefront and authenticated callers resume by invoking the
+same typed Commit operation again. While payment remains pending, Commit
+creates no Booking. Once the Payment Session is `authorized` or `paid`, Commit
+creates the Booking exactly once and retargets the Payment Session—and its
+authorization—to that Booking inside the root PostgreSQL transaction. If the
+transaction rolls back, both the Booking graph and payment transfer roll back.
+
+Session expiry or abandonment releases the Hold and expires pending payment
+attempts. An already captured payment is retained against the terminal Booking
+Session for explicit reconciliation; it is never rewritten as unpaid or used
+to fabricate a Booking after spend authority expires. Booking lifecycle status
+continues to describe the travel commitment, never the payment state.
 
 ### 3.3. `cancelEntity`
 

--- a/packages/catalog-contracts/src/booking-engine/lifecycle-conformance.test.ts
+++ b/packages/catalog-contracts/src/booking-engine/lifecycle-conformance.test.ts
@@ -424,6 +424,14 @@ function outcomeForScenario(
         nextAction: "establish_payment_guarantee",
         paymentTarget: "booking_session",
         allowedGuarantees: ["deposit", "pre_auth", "card_on_file"],
+        paymentSession: {
+          id: "pays_conformance",
+          status: "requires_redirect",
+          amountCents: 10_000,
+          currency: "EUR",
+          redirectUrl: "https://pay.example.test/session",
+          expiresAt: "2026-08-01T13:00:00.000Z",
+        },
       }
     case "supplier_pending":
       return {

--- a/packages/catalog-contracts/src/booking-engine/lifecycle-conformance.ts
+++ b/packages/catalog-contracts/src/booking-engine/lifecycle-conformance.ts
@@ -250,6 +250,23 @@ const bookingLifecycleOriginalCommitOutcomeV1 = z.discriminatedUnion("kind", [
     nextAction: z.literal("establish_payment_guarantee"),
     paymentTarget: z.enum(["booking_session", "quote", "supplier_operation"]),
     allowedGuarantees: z.array(z.enum(["deposit", "pre_auth", "card_on_file", "agency_letter"])),
+    paymentSession: z.object({
+      id: z.string().min(1),
+      status: z.enum([
+        "pending",
+        "requires_redirect",
+        "processing",
+        "authorized",
+        "paid",
+        "failed",
+        "cancelled",
+        "expired",
+      ]),
+      amountCents: z.number().int().positive(),
+      currency: z.string().length(3),
+      redirectUrl: z.string().url().nullable(),
+      expiresAt: z.string().datetime().nullable(),
+    }),
   }),
   z.object({
     kind: z.literal("supplier_pending"),

--- a/packages/catalog-contracts/src/booking-engine/session-contracts.ts
+++ b/packages/catalog-contracts/src/booking-engine/session-contracts.ts
@@ -123,6 +123,12 @@ export const commitBookingSessionV1 = z.object({
   quoteId: z.string().min(1),
   holdId: z.string().min(1),
   idempotencyKey: z.string().min(8).max(128),
+  payment: z
+    .object({
+      returnUrl: z.string().url().optional(),
+      cancelUrl: z.string().url().optional(),
+    })
+    .optional(),
 })
 export type CommitBookingSessionV1 = z.input<typeof commitBookingSessionV1>
 

--- a/packages/catalog/src/booking-engine/index.ts
+++ b/packages/catalog/src/booking-engine/index.ts
@@ -228,6 +228,10 @@ export {
   type InMemoryOwnedInventoryPorts,
 } from "./sessions-memory.js"
 export {
+  createProductionBookingSessionPaymentPorts,
+  type ProductionBookingSessionPaymentDeps,
+} from "./sessions-payment-production.js"
+export {
   createProductionBookingSessionModule,
   type ProductionBookingSessionModuleDeps,
 } from "./sessions-production.js"

--- a/packages/catalog/src/booking-engine/sessions-payment-production.ts
+++ b/packages/catalog/src/booking-engine/sessions-payment-production.ts
@@ -1,0 +1,198 @@
+import type { PaymentAdapter, PaymentAdapterRuntimeContext } from "@voyant-travel/finance"
+import {
+  computePaymentSchedule,
+  createOrReuseBookingSessionPayment,
+  expirePendingBookingSessionPayments,
+  financeService,
+  findEstablishedBookingSessionPayment,
+  noDepositPolicy,
+  resolveEffectivePaymentPolicy,
+  resolvePaymentCallbackUrl,
+  startPaymentAdapterCardPayment,
+  transferBookingSessionPaymentToBooking,
+} from "@voyant-travel/finance"
+import type { FinanceOperatorSettingsRuntime } from "@voyant-travel/finance/runtime-port"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import type {
+  CatalogDistributionRuntimeExtension,
+  CatalogInventoryRuntimeExtension,
+} from "../runtime-contracts.js"
+import type { BookingSessionPaymentPorts } from "./sessions-service.js"
+
+export interface ProductionBookingSessionPaymentDeps {
+  db: PostgresJsDatabase
+  inventory: Pick<CatalogInventoryRuntimeExtension, "loadProductPaymentPolicyContext">
+  distribution: Pick<CatalogDistributionRuntimeExtension, "loadSupplierPaymentPolicy">
+  settings: Pick<FinanceOperatorSettingsRuntime, "resolveOperatorDefaultPaymentPolicy">
+  resolvePaymentAdapter?: () => PaymentAdapter | null | Promise<PaymentAdapter | null>
+  paymentAdapterContext?: PaymentAdapterRuntimeContext
+  financeRuntime?: Parameters<typeof createOrReuseBookingSessionPayment>[2]
+}
+
+export function createProductionBookingSessionPaymentPorts(
+  deps: ProductionBookingSessionPaymentDeps,
+): BookingSessionPaymentPorts {
+  return {
+    async prepare({ session, quote, hold, commit, now }) {
+      if (session.target.kind !== "product") return { kind: "not_required" }
+
+      const context = await deps.inventory.loadProductPaymentPolicyContext(
+        deps.db,
+        session.target.productId,
+      )
+      if (!context) throw new Error("booking_session_payment_product_not_found")
+      const [supplierPolicy, operatorDefault] = await Promise.all([
+        context.supplierId
+          ? deps.distribution.loadSupplierPaymentPolicy(deps.db, context.supplierId)
+          : Promise.resolve(null),
+        deps.settings.resolveOperatorDefaultPaymentPolicy(deps.db),
+      ])
+      const resolved = resolveEffectivePaymentPolicy({
+        listingPolicy: context.listingPolicy,
+        categoryPolicy: context.categoryPolicy,
+        supplierPolicy,
+        operatorDefault: operatorDefault ?? noDepositPolicy,
+      })
+      const dueNow = computePaymentSchedule(
+        {
+          totalCents: quote.pricing.total,
+          currency: quote.pricing.currency,
+          departureDate: context.departureDate,
+          today: now,
+        },
+        resolved.policy,
+      )[0]
+      if (!dueNow || dueNow.amountCents <= 0) return { kind: "not_required" }
+
+      const established = await findEstablishedBookingSessionPayment(deps.db, session.id, {
+        amountCents: dueNow.amountCents,
+        currency: dueNow.currency,
+      })
+      if (established) return { kind: "established", paymentSessionId: established.id }
+
+      const contact = paymentContact(session.statePayload)
+      let paymentSession = await createOrReuseBookingSessionPayment(
+        deps.db,
+        {
+          bookingSessionId: session.id,
+          commitIdempotencyKey: commit.idempotencyKey,
+          amountCents: dueNow.amountCents,
+          currency: dueNow.currency,
+          payerEmail: contact.email,
+          payerName: [contact.firstName, contact.lastName].filter(Boolean).join(" ") || null,
+          returnUrl: commit.payment?.returnUrl,
+          cancelUrl: commit.payment?.cancelUrl,
+          expiresAt: earliestDate(session.expiresAt, quote.expiresAt, hold.expiresAt),
+          metadata: {
+            paymentPolicySource: resolved.source,
+            paymentScheduleType: dueNow.scheduleType,
+            sessionActorKind: session.actorKind,
+            quoteId: quote.id,
+            holdId: hold.id,
+          },
+        },
+        deps.financeRuntime,
+      )
+      if (!paymentSession) throw new Error("booking_session_payment_creation_failed")
+
+      if (paymentSession.status === "authorized" || paymentSession.status === "paid") {
+        return { kind: "established", paymentSessionId: paymentSession.id }
+      }
+
+      const adapter = await deps.resolvePaymentAdapter?.()
+      if (adapter && paymentSession.status === "pending" && contact.email && contact.firstName) {
+        await startPaymentAdapterCardPayment(
+          adapter,
+          {
+            db: deps.db,
+            sessionId: paymentSession.id,
+            billing: {
+              email: contact.email,
+              firstName: contact.firstName,
+              ...(contact.lastName ? { lastName: contact.lastName } : {}),
+              ...(contact.phone ? { phone: contact.phone } : {}),
+              ...(contact.country ? { country: contact.country } : {}),
+            },
+            description: `Booking Session ${session.id}`,
+            returnUrl: commit.payment?.returnUrl,
+            cancelUrl: commit.payment?.cancelUrl,
+            metadata: { bookingSessionId: session.id, quoteId: quote.id, holdId: hold.id },
+          },
+          {
+            context: deps.paymentAdapterContext ?? { env: {} },
+            runtime: deps.financeRuntime,
+            notifyUrl: resolvePaymentCallbackUrl(deps.paymentAdapterContext?.env ?? {}),
+          },
+        )
+        const refreshed = await financeService.getPaymentSessionById(deps.db, paymentSession.id)
+        if (refreshed) paymentSession = refreshed
+      }
+
+      return {
+        kind: "required",
+        allowedGuarantees: ["deposit"],
+        paymentSession: projectPaymentSession(paymentSession),
+      }
+    },
+    async transferToBooking({ tx, ...input }) {
+      await transferBookingSessionPaymentToBooking(tx as PostgresJsDatabase, input)
+    },
+    async expirePending({ tx, bookingSessionId, at }) {
+      await expirePendingBookingSessionPayments(tx as PostgresJsDatabase, bookingSessionId, at)
+    },
+  }
+}
+
+function projectPaymentSession(session: {
+  id: string
+  status:
+    | "pending"
+    | "requires_redirect"
+    | "processing"
+    | "authorized"
+    | "paid"
+    | "failed"
+    | "cancelled"
+    | "expired"
+  amountCents: number
+  currency: string
+  redirectUrl: string | null
+  expiresAt: Date | null
+}) {
+  return {
+    id: session.id,
+    status: session.status,
+    amountCents: session.amountCents,
+    currency: session.currency,
+    redirectUrl: session.redirectUrl,
+    expiresAt: session.expiresAt?.toISOString() ?? null,
+  }
+}
+
+function earliestDate(...dates: Date[]): Date {
+  return new Date(Math.min(...dates.map((date) => date.getTime())))
+}
+
+function paymentContact(payload: Record<string, unknown>) {
+  const billing = record(payload.billing)
+  const contact = record(billing?.contact)
+  const address = record(billing?.address)
+  return {
+    firstName: stringValue(contact?.firstName),
+    lastName: stringValue(contact?.lastName),
+    email: stringValue(contact?.email),
+    phone: stringValue(contact?.phone),
+    country: stringValue(address?.country),
+  }
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null
+}

--- a/packages/catalog/src/booking-engine/sessions-production.ts
+++ b/packages/catalog/src/booking-engine/sessions-production.ts
@@ -8,12 +8,13 @@ import {
 import { createRouteActionRegistry } from "@voyant-travel/tools"
 import { eq } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
-
 import type { PricingBasis } from "../snapshot/schema.js"
 import { bookingAllocationsRef, bookingsRef } from "./bookings-ref.js"
 import { pricingBreakdownV1 } from "./contracts.js"
 import type { OwnedBookingHandlerRegistry, SelfServiceBillingParty } from "./owned-handler.js"
 import { engineParametersFromDraft } from "./routes.js"
+import type { ProductionBookingSessionPaymentDeps } from "./sessions-payment-production.js"
+import { createProductionBookingSessionPaymentPorts } from "./sessions-payment-production.js"
 import {
   BookingSessionCommitRejectedError,
   type BookingSessionModule,
@@ -29,11 +30,19 @@ export interface ProductionBookingSessionModuleDeps {
   resolveOwnedHandlers(): OwnedBookingHandlerRegistry | Promise<OwnedBookingHandlerRegistry>
   relationships?: BookingsRelationshipsRuntime
   financeRuntime?: FinanceServiceRuntime
+  payments?: Omit<ProductionBookingSessionPaymentDeps, "db" | "financeRuntime">
 }
 
 export function createProductionBookingSessionModule(
   deps: ProductionBookingSessionModuleDeps,
 ): BookingSessionModule {
+  const payments = deps.payments
+    ? createProductionBookingSessionPaymentPorts({
+        db: deps.db,
+        financeRuntime: deps.financeRuntime,
+        ...deps.payments,
+      })
+    : undefined
   return createBookingSessionModule({
     ports: {
       repository: deps.repository,
@@ -104,6 +113,7 @@ export function createProductionBookingSessionModule(
         )
       },
       commitOwnedBooking: (input) => commitOwnedBooking(deps, input),
+      payments,
     },
   })
 }

--- a/packages/catalog/src/booking-engine/sessions-service.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-service.test.ts
@@ -167,6 +167,30 @@ describe("Booking Session v1 owned tracer", () => {
     ])
   })
 
+  it("returns a typed conflict when a reused Commit key maps to a changed payment requirement", async () => {
+    const payment = createPaymentHarness()
+    payment.ports.prepare = async () => {
+      throw new Error("booking_session_payment_idempotency_conflict")
+    }
+    const harness = createHarness({}, payment.ports)
+    const { session, quote, hold } = await createQuoteAndHold(harness)
+
+    await expect(
+      harness.module.commitSession(
+        session.id,
+        {
+          expectedRevision: session.revision,
+          quoteId: quote.id,
+          holdId: hold.id,
+          idempotencyKey: "commit_changed_payment_requirement",
+        },
+        ANONYMOUS_ACCESS,
+      ),
+    ).resolves.toMatchObject({ kind: "rejected", error: { kind: "idempotency_conflict" } })
+    expect(harness.inventory.bookingIds).toEqual([])
+    expect(harness.repository.sessions.get(session.id)?.state).toBe("active")
+  })
+
   it("expires pending Session payments when the journey is abandoned", async () => {
     const payment = createPaymentHarness()
     const harness = createHarness({}, payment.ports)

--- a/packages/catalog/src/booking-engine/sessions-service.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-service.test.ts
@@ -8,7 +8,7 @@ import {
   createInMemoryBookingSessionRepository,
   createInMemoryOwnedInventoryPorts,
 } from "./sessions-memory.js"
-import { createBookingSessionModule } from "./sessions-service.js"
+import { type BookingSessionPaymentPorts, createBookingSessionModule } from "./sessions-service.js"
 
 const BASE_PRICING = {
   currency: "EUR",
@@ -33,6 +33,7 @@ function createHarness(
     maxRenewalExtensionMs?: number
     maxSessionLifetimeMs?: number
   } = {},
+  payments?: BookingSessionPaymentPorts,
 ) {
   let currentNow = new Date("2026-08-01T12:00:00.000Z")
   let price = BASE_PRICING
@@ -55,6 +56,7 @@ function createHarness(
       placeCapacityHold: inventory.placeCapacityHold,
       releaseCapacityHold: inventory.releaseCapacityHold,
       commitOwnedBooking: inventory.commitOwnedBooking,
+      payments,
     },
   })
   return {
@@ -108,6 +110,78 @@ async function createQuoteAndHold(harness = createHarness()) {
 }
 
 describe("Booking Session v1 owned tracer", () => {
+  it("returns a stable payment_required continuation without creating a Booking", async () => {
+    const payment = createPaymentHarness()
+    const harness = createHarness({}, payment.ports)
+    const { session, quote, hold } = await createQuoteAndHold(harness)
+    const input = {
+      expectedRevision: session.revision,
+      quoteId: quote.id,
+      holdId: hold.id,
+      idempotencyKey: "commit_payment_required",
+    }
+
+    const first = await harness.module.commitSession(session.id, input, ANONYMOUS_ACCESS)
+    const retry = await harness.module.commitSession(session.id, input, ANONYMOUS_ACCESS)
+
+    expect(first).toMatchObject({
+      kind: "commit_result",
+      outcome: {
+        kind: "payment_required",
+        paymentTarget: "booking_session",
+        paymentSession: { id: "payment_session_1", status: "requires_redirect" },
+      },
+    })
+    expect(retry).toEqual(first)
+    expect(payment.prepareCalls).toBe(2)
+    expect(harness.inventory.bookingIds).toEqual([])
+    expect(harness.repository.commits.size).toBe(0)
+    expect(harness.repository.sessions.get(session.id)?.state).toBe("active")
+    expect(harness.repository.quotes.get(quote.id)?.state).toBe("active")
+    expect(harness.repository.holds.get(hold.id)?.state).toBe("active")
+  })
+
+  it("transfers an established Session payment in the atomic Commit transaction", async () => {
+    const payment = createPaymentHarness()
+    const harness = createHarness({}, payment.ports)
+    const { session, quote, hold } = await createQuoteAndHold(harness)
+    const input = {
+      expectedRevision: session.revision,
+      quoteId: quote.id,
+      holdId: hold.id,
+      idempotencyKey: "commit_after_payment",
+    }
+
+    await harness.module.commitSession(session.id, input, ANONYMOUS_ACCESS)
+    payment.established = true
+    const committed = await harness.module.commitSession(session.id, input, ANONYMOUS_ACCESS)
+
+    expect(committed).toMatchObject({ kind: "commit_result", outcome: { kind: "committed" } })
+    expect(harness.inventory.bookingIds).toHaveLength(1)
+    expect(payment.transfers).toEqual([
+      expect.objectContaining({
+        paymentSessionId: "payment_session_1",
+        bookingSessionId: session.id,
+        bookingId: harness.inventory.bookingIds[0],
+      }),
+    ])
+  })
+
+  it("expires pending Session payments when the journey is abandoned", async () => {
+    const payment = createPaymentHarness()
+    const harness = createHarness({}, payment.ports)
+    const { session, hold } = await createQuoteAndHold(harness)
+
+    await harness.module.abandonSession(
+      session.id,
+      { expectedRevision: session.revision, idempotencyKey: "abandon_payment_pending" },
+      ANONYMOUS_ACCESS,
+    )
+
+    expect(payment.expirations).toEqual([expect.objectContaining({ bookingSessionId: session.id })])
+    expect(harness.repository.holds.get(hold.id)?.state).toBe("released")
+  })
+
   it("requires the caller-held anonymous Session capability before mutation", async () => {
     const harness = createHarness()
     const created = await harness.module.createSession(
@@ -928,6 +1002,50 @@ describe("Booking Session v1 owned tracer", () => {
     })
   })
 })
+
+function createPaymentHarness() {
+  const transfers: Array<{
+    tx: unknown
+    paymentSessionId: string
+    bookingSessionId: string
+    bookingId: string
+  }> = []
+  const expirations: Array<{ tx: unknown; bookingSessionId: string; at: Date }> = []
+  const harness = {
+    established: false,
+    prepareCalls: 0,
+    transfers,
+    expirations,
+    ports: undefined as unknown as BookingSessionPaymentPorts,
+  }
+  harness.ports = {
+    async prepare() {
+      harness.prepareCalls += 1
+      if (harness.established) {
+        return { kind: "established", paymentSessionId: "payment_session_1" }
+      }
+      return {
+        kind: "required",
+        allowedGuarantees: ["deposit"],
+        paymentSession: {
+          id: "payment_session_1",
+          status: "requires_redirect",
+          amountCents: 10_000,
+          currency: "EUR",
+          redirectUrl: "https://payments.example.test/session/1",
+          expiresAt: "2026-08-01T12:01:00.000Z",
+        },
+      }
+    },
+    async transferToBooking(input) {
+      transfers.push(input)
+    },
+    async expirePending(input) {
+      expirations.push(input)
+    },
+  }
+  return harness
+}
 
 function nextCreateKey(prefix: string): string {
   createCounter += 1

--- a/packages/catalog/src/booking-engine/sessions-service.ts
+++ b/packages/catalog/src/booking-engine/sessions-service.ts
@@ -212,7 +212,49 @@ export interface CommitOwnedBookingInput {
   requestFingerprint: string
   access: BookingSessionAccessContext
   now: Date
+  paymentSessionId?: string
   consumeSources(tx: unknown, bookingId: string, allocationIds: string[]): Promise<void>
+}
+
+export interface BookingSessionPaymentPorts {
+  prepare(input: {
+    session: BookingSessionInternalRecord
+    quote: BookingQuoteInternalRecord
+    hold: BookingHoldInternalRecord
+    commit: CommitBookingSessionV1
+    access: BookingSessionAccessContext
+    now: Date
+  }): Promise<
+    | { kind: "not_required" }
+    | { kind: "established"; paymentSessionId: string }
+    | {
+        kind: "required"
+        paymentSession: {
+          id: string
+          status:
+            | "pending"
+            | "requires_redirect"
+            | "processing"
+            | "authorized"
+            | "paid"
+            | "failed"
+            | "cancelled"
+            | "expired"
+          amountCents: number
+          currency: string
+          redirectUrl: string | null
+          expiresAt: string | null
+        }
+        allowedGuarantees: Array<"deposit" | "pre_auth" | "card_on_file" | "agency_letter">
+      }
+  >
+  transferToBooking(input: {
+    tx: unknown
+    paymentSessionId: string
+    bookingSessionId: string
+    bookingId: string
+  }): Promise<void>
+  expirePending(input: { tx: unknown; bookingSessionId: string; at: Date }): Promise<void>
 }
 
 export interface BookingSessionAccessContext {
@@ -255,6 +297,7 @@ export interface BookingSessionModulePorts {
     bookingId: string
     allocationIds: string[]
   }>
+  payments?: BookingSessionPaymentPorts
 }
 
 export interface BookingSessionModuleOptions {
@@ -803,6 +846,11 @@ export function createBookingSessionModule(
         session.revision += 1
         session.updatedAt = at
         await releaseLiveHolds(repository, options.ports, session, access, at, tx)
+        await options.ports.payments?.expirePending({
+          tx,
+          bookingSessionId: session.id,
+          at,
+        })
         for (const quote of await repository.listActiveQuotes(session.id)) {
           quote.state = "superseded"
           await repository.saveQuote(quote)
@@ -953,6 +1001,31 @@ export function createBookingSessionModule(
 
       const { session, quote, hold, at } = preflight
 
+      const preparedPayment = options.ports.payments
+        ? await options.ports.payments.prepare({
+            session,
+            quote,
+            hold,
+            commit: input,
+            access,
+            now: at,
+          })
+        : ({ kind: "not_required" } as const)
+      if (preparedPayment.kind === "required") {
+        return {
+          kind: "commit_result",
+          outcome: {
+            kind: "payment_required",
+            nextAction: "establish_payment_guarantee",
+            paymentTarget: "booking_session",
+            allowedGuarantees: preparedPayment.allowedGuarantees,
+            paymentSession: preparedPayment.paymentSession,
+          },
+        }
+      }
+      const paymentSessionId =
+        preparedPayment.kind === "established" ? preparedPayment.paymentSessionId : undefined
+
       const requestFingerprint = await commitRequestFingerprint(input)
       let committed: { bookingId: string; allocationIds: string[] }
       try {
@@ -964,6 +1037,7 @@ export function createBookingSessionModule(
           requestFingerprint,
           access,
           now: at,
+          paymentSessionId,
           async consumeSources(tx, bookingId, allocationIds) {
             const outcome: BookingLifecycleCommitOutcomeV1 = {
               kind: "committed",
@@ -1054,6 +1128,14 @@ export function createBookingSessionModule(
                 bookingId,
                 now: currentAt,
               })
+              if (paymentSessionId && options.ports.payments) {
+                await options.ports.payments.transferToBooking({
+                  tx,
+                  paymentSessionId,
+                  bookingSessionId: session.id,
+                  bookingId,
+                })
+              }
               await appendSessionAudit(repository, currentSession, "commit", access, currentAt, {
                 bookingId,
                 quoteId: currentQuote.id,
@@ -1300,6 +1382,7 @@ async function expireSession(
   tx: unknown,
 ): Promise<void> {
   await releaseLiveHolds(repository, ports, session, access, now, tx)
+  await ports.payments?.expirePending({ tx, bookingSessionId: session.id, at: now })
   for (const quote of await repository.listActiveQuotes(session.id)) {
     quote.state = "expired"
     await repository.saveQuote(quote)

--- a/packages/catalog/src/booking-engine/sessions-service.ts
+++ b/packages/catalog/src/booking-engine/sessions-service.ts
@@ -1001,16 +1001,22 @@ export function createBookingSessionModule(
 
       const { session, quote, hold, at } = preflight
 
-      const preparedPayment = options.ports.payments
-        ? await options.ports.payments.prepare({
-            session,
-            quote,
-            hold,
-            commit: input,
-            access,
-            now: at,
-          })
-        : ({ kind: "not_required" } as const)
+      let preparedPayment: Awaited<ReturnType<BookingSessionPaymentPorts["prepare"]>>
+      try {
+        preparedPayment = options.ports.payments
+          ? await options.ports.payments.prepare({
+              session,
+              quote,
+              hold,
+              commit: input,
+              access,
+              now: at,
+            })
+          : ({ kind: "not_required" } as const)
+      } catch (error) {
+        if (isIdempotencyConflictError(error)) return idempotencyConflict()
+        throw error
+      }
       if (preparedPayment.kind === "required") {
         return {
           kind: "commit_result",

--- a/packages/catalog/src/runtime-contracts.ts
+++ b/packages/catalog/src/runtime-contracts.ts
@@ -4,6 +4,7 @@ import type {
 } from "@voyant-travel/catalog-contracts/indexer/contract"
 import { definePort } from "@voyant-travel/core/project"
 import type { AnyDrizzleDb } from "@voyant-travel/db"
+import type { PaymentPolicy } from "@voyant-travel/finance"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { SourceAdapterContext } from "./adapter/contract.js"
 import type {
@@ -79,6 +80,7 @@ export interface CatalogDistributionRuntimeExtension {
     db: AnyDrizzleDb,
     supplierId: string,
   ): Promise<{ reservationTimeoutMinutes: number | null } | null>
+  loadSupplierPaymentPolicy(db: AnyDrizzleDb, supplierId: string): Promise<PaymentPolicy | null>
 }
 
 export interface CatalogCruisesRuntimeExtension extends CatalogPolicyRuntimeExtension {
@@ -156,6 +158,15 @@ export interface CatalogInventoryRuntimeExtension {
     db: AnyDrizzleDb,
     productId: string,
   ): Promise<{ supplierId: string | null; reservationTimeoutMinutes: number | null } | null>
+  loadProductPaymentPolicyContext(
+    db: AnyDrizzleDb,
+    productId: string,
+  ): Promise<{
+    listingPolicy: PaymentPolicy | null
+    categoryPolicy: PaymentPolicy | null
+    supplierId: string | null
+    departureDate: string | null
+  } | null>
   enrichProductQuoteShape: CatalogProductQuoteEnricher
   buildSnapshotInput(
     db: AnyDrizzleDb,

--- a/packages/catalog/src/runtime-contributor.ts
+++ b/packages/catalog/src/runtime-contributor.ts
@@ -33,6 +33,7 @@ import {
 import type { VoyantRuntimeHostPrimitives } from "@voyant-travel/core"
 import type { VoyantPort } from "@voyant-travel/core/project"
 import type { AnyDrizzleDb } from "@voyant-travel/db"
+import type { PaymentAdapter } from "@voyant-travel/finance"
 import {
   type FinanceOperatorSettingsRuntime,
   financeOperatorSettingsRuntimePort,
@@ -79,6 +80,7 @@ import {
 type RuntimePortValue<T> = T | Promise<T>
 // Importing Cruises here would create a Catalog <-> Cruises package cycle.
 const cruisesRoutesRuntimePortReference = { id: "cruises.routes-runtime" } as const
+const paymentAdapterRuntimePortReference = { id: "payments.adapter.runtime" } as const
 
 export interface CatalogRuntimePortContribution {
   search: RuntimePortValue<CatalogSearchRuntimeOptions>
@@ -158,6 +160,10 @@ export function createCatalogRuntimePortContribution(
             const eventBus = (context as { var?: { eventBus?: unknown } }).var?.eventBus
             return eventBus ? { eventBus: eventBus as never } : {}
           },
+          async resolvePaymentAdapter() {
+            if (host.hasRuntimePort?.(paymentAdapterRuntimePortReference) !== true) return null
+            return host.getRuntimePort<PaymentAdapter>(paymentAdapterRuntimePortReference)
+          },
         },
       )
     },
@@ -220,10 +226,23 @@ export function createCatalogRuntimePortContribution(
         const db = host.primitives.database.resolve(undefined) as PostgresJsDatabase
         const runtime = await contribution
         const services = await runtime.services
+        const [, , , distribution, , inventory, , settings] = await dependencies
         return createProductionBookingSessionModule({
           db,
           repository: createDrizzleBookingSessionRepository(db),
           resolveOwnedHandlers: () => services.getOwnedHandlers(host.primitives.env(undefined)),
+          payments: {
+            inventory,
+            distribution,
+            settings,
+            async resolvePaymentAdapter() {
+              if (host.hasRuntimePort?.(paymentAdapterRuntimePortReference) !== true) return null
+              return host.getRuntimePort<PaymentAdapter>(paymentAdapterRuntimePortReference)
+            },
+            paymentAdapterContext: {
+              env: host.primitives.env(undefined) as Readonly<Record<string, unknown>>,
+            },
+          },
         })
       },
       resolveRetentionMs: () => resolveBookingSessionRetentionMs(host.primitives.env(undefined)),

--- a/packages/catalog/src/runtime.ts
+++ b/packages/catalog/src/runtime.ts
@@ -5,7 +5,7 @@ import { CATALOG_PRESENTATION_SUBJECT_MODULES } from "@voyant-travel/catalog/pre
 import type { CatalogSearchRuntime } from "@voyant-travel/catalog/search/routes"
 import { createReferencedSubjectReindexFanout } from "@voyant-travel/catalog/services/indexer"
 import type { VoyantRuntimeHostPrimitives } from "@voyant-travel/core"
-import type { FinanceServiceRuntime } from "@voyant-travel/finance"
+import type { FinanceServiceRuntime, PaymentAdapter } from "@voyant-travel/finance"
 import type { FinanceOperatorSettingsRuntime } from "@voyant-travel/finance/runtime-port"
 import {
   ensureBookingEngineRegistry,
@@ -50,6 +50,7 @@ export function createCatalogRuntime(
     indexer?: CatalogIndexer
     resolveBookingsRelationshipsRuntime?: () => Promise<BookingsRelationshipsRuntime | null>
     resolveFinanceServiceRuntime?: (context: unknown) => FinanceServiceRuntime
+    resolvePaymentAdapter?: () => PaymentAdapter | null | Promise<PaymentAdapter | null>
   } = {},
 ): CatalogRuntimePortContribution {
   configureCatalogRuntimeHost(primitives, extensions)
@@ -148,8 +149,10 @@ export function createCatalogRuntime(
       resolveRuntime: (context) => createCatalogSearchRuntime(context, resolveIndexer),
     },
     booking: createOperatorCatalogBookingRouteModuleOptions({
+      settings,
       resolveBookingsRelationshipsRuntime: options.resolveBookingsRelationshipsRuntime,
       resolveFinanceServiceRuntime: options.resolveFinanceServiceRuntime,
+      resolvePaymentAdapter: options.resolvePaymentAdapter,
     }),
     offers: createOperatorCatalogOffersRouteModuleOptions(
       (context) => withoutCatalogScopeChannel(resolveCatalogDefaultScope(context)),

--- a/packages/catalog/src/runtime/booking-runtime.ts
+++ b/packages/catalog/src/runtime/booking-runtime.ts
@@ -13,7 +13,7 @@ import {
   resolveCatalogHoldTtlMs,
 } from "@voyant-travel/catalog/runtime-support"
 import type { AnyDrizzleDb } from "@voyant-travel/db"
-import type { FinanceServiceRuntime } from "@voyant-travel/finance"
+import type { FinanceServiceRuntime, PaymentAdapter } from "@voyant-travel/finance"
 import {
   computeBookingItemTaxLine,
   resolveBookingSellTaxRate,
@@ -72,13 +72,13 @@ function createOperatorCatalogBookingRoutesOptions(): CatalogBookingRoutesOption
   }
 }
 
-export function createOperatorCatalogBookingRouteModuleOptions(
-  options: {
-    resolveBookingsRelationshipsRuntime?: () => Promise<BookingsRelationshipsRuntime | null>
-    resolveFinanceServiceRuntime?: (context: Context) => FinanceServiceRuntime
-  } = {},
-): CatalogBookingRouteModuleOptions {
-  const { inventory, operations } = catalogRuntimeExtensions()
+export function createOperatorCatalogBookingRouteModuleOptions(options: {
+  resolveBookingsRelationshipsRuntime?: () => Promise<BookingsRelationshipsRuntime | null>
+  resolveFinanceServiceRuntime?: (context: Context) => FinanceServiceRuntime
+  settings: FinanceOperatorSettingsRuntime
+  resolvePaymentAdapter?: () => PaymentAdapter | null | Promise<PaymentAdapter | null>
+}): CatalogBookingRouteModuleOptions {
+  const { distribution, inventory, operations } = catalogRuntimeExtensions()
   return {
     booking: createOperatorCatalogBookingRoutesOptions(),
     bookingSessions: {
@@ -107,6 +107,13 @@ export function createOperatorCatalogBookingRouteModuleOptions(
             },
           },
           financeRuntime: options.resolveFinanceServiceRuntime?.(c),
+          payments: {
+            inventory,
+            distribution,
+            settings: options.settings,
+            resolvePaymentAdapter: options.resolvePaymentAdapter,
+            paymentAdapterContext: { env: c.env as Readonly<Record<string, unknown>> },
+          },
         })
       },
       resolveAccess(c, actorKind) {

--- a/packages/catalog/src/voyant.ts
+++ b/packages/catalog/src/voyant.ts
@@ -46,6 +46,7 @@ import {
 
 // Importing Cruises here would create a Catalog <-> Cruises package cycle.
 const cruisesRoutesRuntimePortReference = { id: "cruises.routes-runtime" } as const
+const paymentAdapterRuntimePortReference = { id: "payments.adapter.runtime" } as const
 
 const catalogAdminRuntime = {
   entry: "@voyant-travel/catalog-react/admin",
@@ -80,6 +81,7 @@ export const catalogVoyantModule = defineModule({
       requirePort(catalogInventoryRuntimeExtensionPort),
       requirePort(catalogOperationsRuntimeExtensionPort),
       requirePort(financeOperatorSettingsRuntimePort),
+      { ...paymentAdapterRuntimePortReference, optional: true },
     ],
   },
   provides: {

--- a/packages/catalog/tests/integration/booking-sessions-v1.test.ts
+++ b/packages/catalog/tests/integration/booking-sessions-v1.test.ts
@@ -1,6 +1,13 @@
 import { createDbClient } from "@voyant-travel/db"
 import { newId } from "@voyant-travel/db/lib/typeid"
-import { sql } from "drizzle-orm"
+import {
+  applyPaymentAdapterCallbackEvent,
+  createOrReuseBookingSessionPayment,
+  expirePendingBookingSessionPayments,
+  transferBookingSessionPaymentToBooking,
+} from "@voyant-travel/finance"
+import { paymentSessions } from "@voyant-travel/finance/schema"
+import { eq, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
 import {
@@ -18,6 +25,7 @@ import {
   bookingSessionsTable,
 } from "../../src/booking-engine/sessions-schema.js"
 import {
+  type BookingSessionPaymentPorts,
   type CommitOwnedBookingInput,
   createBookingSessionModule,
 } from "../../src/booking-engine/sessions-service.js"
@@ -187,6 +195,79 @@ describe.skipIf(!DB_AVAILABLE)("Booking Session v1 PostgreSQL invariants", () =>
     ])
   })
 
+  it("continues a paid Session into exactly one Booking under a concurrent Commit retry", async () => {
+    const repository = createDrizzleBookingSessionRepository(db)
+    const payments: BookingSessionPaymentPorts = {
+      async prepare({ session }) {
+        const [payment] = await db
+          .select()
+          .from(paymentSessions)
+          .where(eq(paymentSessions.targetId, session.id))
+          .limit(1)
+        if (!payment || (payment.status !== "authorized" && payment.status !== "paid")) {
+          throw new Error("Expected an established Session payment")
+        }
+        return { kind: "established", paymentSessionId: payment.id }
+      },
+      async transferToBooking({ tx, ...input }) {
+        await transferBookingSessionPaymentToBooking(tx as PostgresJsDatabase, input)
+      },
+      async expirePending({ tx, bookingSessionId, at }) {
+        await expirePendingBookingSessionPayments(tx as PostgresJsDatabase, bookingSessionId, at)
+      },
+    }
+    const module = createModule(
+      repository,
+      async (input) =>
+        db.transaction(async (tx) => {
+          const graph = await insertBookingGraph(tx as PostgresJsDatabase)
+          await input.consumeSources(tx, graph.bookingId, [graph.allocationId])
+          return { bookingId: graph.bookingId, allocationIds: [graph.allocationId] }
+        }),
+      payments,
+    )
+    const prepared = await createQuoteAndHold(module)
+    const payment = await createOrReuseBookingSessionPayment(db, {
+      bookingSessionId: prepared.session.id,
+      commitIdempotencyKey: "postgres_paid_continuation",
+      amountCents: PRICING.total,
+      currency: PRICING.currency,
+    })
+    if (!payment) throw new Error("Payment Session was not created")
+    await applyPaymentAdapterCallbackEvent(db, {
+      eventId: "evt_postgres_paid_continuation",
+      paymentSessionId: payment.id,
+      nextState: "paid",
+      occurredAt: "2026-08-01T12:00:00.000Z",
+      processorSessionId: "processor_postgres_paid_continuation",
+      processorPaymentId: "payment_postgres_paid_continuation",
+      idempotencyKey: "callback_postgres_paid_continuation",
+    })
+    const input = {
+      expectedRevision: prepared.session.revision,
+      quoteId: prepared.quote.id,
+      holdId: prepared.hold.id,
+      idempotencyKey: "postgres_paid_commit",
+    }
+
+    const outcomes = await Promise.all([
+      module.commitSession(prepared.session.id, input, ACCESS),
+      module.commitSession(prepared.session.id, input, ACCESS),
+    ])
+
+    expect(outcomes.filter(isCommitted)).toHaveLength(1)
+    expect(outcomes.filter(isReplay)).toHaveLength(1)
+    const [booking] = await db.select().from(bookings)
+    await expect(db.select().from(paymentSessions)).resolves.toEqual([
+      expect.objectContaining({
+        id: payment.id,
+        targetType: "booking",
+        targetId: booking?.id,
+        bookingId: booking?.id,
+      }),
+    ])
+  })
+
   it("serializes customer adoption, revokes the capability, and persists read audit", async () => {
     const repository = createDrizzleBookingSessionRepository(db)
     const module = createModule(repository, async () => {
@@ -249,6 +330,7 @@ function createModule(
     bookingId: string
     allocationIds: string[]
   }>,
+  payments?: BookingSessionPaymentPorts,
 ) {
   return createBookingSessionModule({
     ports: {
@@ -258,6 +340,7 @@ function createModule(
       placeCapacityHold: async () => "held",
       releaseCapacityHold: async () => {},
       commitOwnedBooking,
+      payments,
     },
   })
 }
@@ -325,6 +408,9 @@ async function resetTables(db: PostgresJsDatabase) {
       booking_session_holds,
       booking_session_quotes,
       booking_sessions,
+      payment_sessions,
+      payment_captures,
+      payment_authorizations,
       booking_allocations,
       booking_items,
       bookings

--- a/packages/catalog/tests/unit/voyant-manifest.test.ts
+++ b/packages/catalog/tests/unit/voyant-manifest.test.ts
@@ -43,6 +43,7 @@ describe("catalog deployment manifest", () => {
           { id: "catalog.extension.inventory" },
           { id: "catalog.extension.operations" },
           { id: "finance.operator-settings.runtime" },
+          { id: "payments.adapter.runtime", optional: true },
         ],
       },
       api: [

--- a/packages/distribution/src/catalog-runtime-extension.ts
+++ b/packages/distribution/src/catalog-runtime-extension.ts
@@ -1,4 +1,5 @@
 import type { CatalogDistributionRuntimeExtension } from "@voyant-travel/catalog/runtime-contracts"
+import type { PaymentPolicy } from "@voyant-travel/finance"
 import { and, asc, eq } from "drizzle-orm"
 
 import { channelProductMappings, channels, suppliers } from "./schema.js"
@@ -34,5 +35,13 @@ export const catalogDistributionRuntimeExtension = {
       .where(eq(suppliers.id, supplierId))
       .limit(1)
     return supplier ?? null
+  },
+  async loadSupplierPaymentPolicy(db, supplierId) {
+    const [supplier] = await db
+      .select({ policy: suppliers.customerPaymentPolicy })
+      .from(suppliers)
+      .where(eq(suppliers.id, supplierId))
+      .limit(1)
+    return (supplier?.policy as PaymentPolicy | null | undefined) ?? null
   },
 } satisfies CatalogDistributionRuntimeExtension

--- a/packages/finance-contracts/src/validation-payments.ts
+++ b/packages/finance-contracts/src/validation-payments.ts
@@ -56,6 +56,7 @@ export const paymentInstrumentListQuerySchema = paginationSchema.extend({
 })
 
 export const paymentTargetSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("booking_session"), bookingSessionId: z.string().min(1) }),
   z.object({ type: z.literal("booking"), bookingId: z.string().min(1) }),
   z.object({ type: z.literal("invoice"), invoiceId: z.string().min(1) }),
   z.object({

--- a/packages/finance-contracts/src/validation-public.ts
+++ b/packages/finance-contracts/src/validation-public.ts
@@ -133,6 +133,9 @@ function derivePublicPaymentTarget(value: {
     return { type: "booking_guarantee" as const, bookingGuaranteeId: value.bookingGuaranteeId }
   }
   if (value.invoiceId) return { type: "invoice" as const, invoiceId: value.invoiceId }
+  if (value.targetType === "booking_session" && value.targetId) {
+    return { type: "booking_session" as const, bookingSessionId: value.targetId }
+  }
   if (value.targetType === "flight_order" && value.targetId) {
     return { type: "flight_order" as const, flightOrderId: value.targetId }
   }

--- a/packages/finance-contracts/src/validation-shared.ts
+++ b/packages/finance-contracts/src/validation-shared.ts
@@ -32,6 +32,7 @@ export const paymentSessionStatusSchema = z.enum([
   "expired",
 ])
 export const paymentSessionTargetTypeSchema = z.enum([
+  "booking_session",
   "booking",
   "order",
   "invoice",

--- a/packages/finance-react/src/checkout-i18n/en.ts
+++ b/packages/finance-react/src/checkout-i18n/en.ts
@@ -54,6 +54,7 @@ export const checkoutUiEn: CheckoutUiMessages = {
     },
     descriptions: {
       booking: "Booking payment",
+      booking_session: "Booking session payment",
       booking_payment_schedule: "Booking deposit",
       booking_guarantee: "Booking guarantee",
       invoice: "Invoice payment",

--- a/packages/finance-react/src/checkout-i18n/ro.ts
+++ b/packages/finance-react/src/checkout-i18n/ro.ts
@@ -54,6 +54,7 @@ export const checkoutUiRo: CheckoutUiMessages = {
     },
     descriptions: {
       booking: "Plata rezervare",
+      booking_session: "Plata sesiune rezervare",
       booking_payment_schedule: "Avans rezervare",
       booking_guarantee: "Garantie rezervare",
       invoice: "Plata factura",

--- a/packages/finance/migrations/20260801164000_booking_session_payment_target_v1.sql
+++ b/packages/finance/migrations/20260801164000_booking_session_payment_target_v1.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."payment_session_target_type" ADD VALUE IF NOT EXISTS 'booking_session' BEFORE 'booking';

--- a/packages/finance/migrations/meta/_journal.json
+++ b/packages/finance/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1784698562480,
       "tag": "20260722053500_payment_session_provider_connection",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1785602400000,
+      "tag": "20260801164000_booking_session_payment_target_v1",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/finance/src/booking-session-payment.ts
+++ b/packages/finance/src/booking-session-payment.ts
@@ -1,0 +1,173 @@
+import { and, eq, inArray, sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { paymentAuthorizations } from "./schema/payment-processing.js"
+import { paymentSessions } from "./schema/payment-sessions.js"
+import { financePaymentSessionService } from "./service-payment-sessions.js"
+import type { FinanceServiceRuntime } from "./service-shared.js"
+
+export type BookingSessionPaymentState =
+  | "pending"
+  | "requires_redirect"
+  | "processing"
+  | "authorized"
+  | "paid"
+  | "failed"
+  | "cancelled"
+  | "expired"
+
+export interface CreateBookingSessionPaymentInput {
+  bookingSessionId: string
+  commitIdempotencyKey: string
+  amountCents: number
+  currency: string
+  payerPersonId?: string | null
+  payerOrganizationId?: string | null
+  payerEmail?: string | null
+  payerName?: string | null
+  returnUrl?: string | null
+  cancelUrl?: string | null
+  expiresAt?: Date | null
+  metadata?: Record<string, unknown>
+}
+
+export function bookingSessionPaymentIdempotencyKey(input: {
+  bookingSessionId: string
+  commitIdempotencyKey: string
+}): string {
+  return `booking-session:${input.bookingSessionId}:${input.commitIdempotencyKey}`
+}
+
+export async function createOrReuseBookingSessionPayment(
+  db: PostgresJsDatabase,
+  input: CreateBookingSessionPaymentInput,
+  runtime: FinanceServiceRuntime = {},
+) {
+  const [existing] = await db
+    .select()
+    .from(paymentSessions)
+    .where(
+      and(
+        eq(paymentSessions.targetType, "booking_session"),
+        eq(paymentSessions.targetId, input.bookingSessionId),
+        sql`${paymentSessions.metadata}->>'commitIdempotencyKey' = ${input.commitIdempotencyKey}`,
+      ),
+    )
+    .limit(1)
+  if (existing) return existing
+
+  return financePaymentSessionService.createPaymentSession(
+    db,
+    {
+      target: { type: "booking_session", bookingSessionId: input.bookingSessionId },
+      provenance: {
+        source: "storefront",
+        idempotencyKey: input.commitIdempotencyKey,
+      },
+      targetType: "booking_session",
+      targetId: input.bookingSessionId,
+      status: "pending",
+      currency: input.currency,
+      amountCents: input.amountCents,
+      paymentMethod: "credit_card",
+      payerPersonId: input.payerPersonId,
+      payerOrganizationId: input.payerOrganizationId,
+      payerEmail: input.payerEmail,
+      payerName: input.payerName,
+      returnUrl: input.returnUrl,
+      cancelUrl: input.cancelUrl,
+      expiresAt: input.expiresAt?.toISOString() ?? null,
+      idempotencyKey: bookingSessionPaymentIdempotencyKey(input),
+      clientReference: input.bookingSessionId,
+      metadata: {
+        ...(input.metadata ?? {}),
+        bookingSessionId: input.bookingSessionId,
+        commitIdempotencyKey: input.commitIdempotencyKey,
+      },
+    },
+    runtime,
+  )
+}
+
+export async function findEstablishedBookingSessionPayment(
+  db: PostgresJsDatabase,
+  bookingSessionId: string,
+  input: { amountCents: number; currency: string },
+) {
+  const [session] = await db
+    .select()
+    .from(paymentSessions)
+    .where(
+      and(
+        eq(paymentSessions.targetType, "booking_session"),
+        eq(paymentSessions.targetId, bookingSessionId),
+        eq(paymentSessions.amountCents, input.amountCents),
+        eq(paymentSessions.currency, input.currency),
+        inArray(paymentSessions.status, ["authorized", "paid"]),
+      ),
+    )
+    .orderBy(paymentSessions.createdAt)
+    .limit(1)
+  return session ?? null
+}
+
+/** Must run inside the root Booking transaction. */
+export async function transferBookingSessionPaymentToBooking(
+  tx: PostgresJsDatabase,
+  input: { paymentSessionId: string; bookingSessionId: string; bookingId: string },
+) {
+  const [session] = await tx
+    .select()
+    .from(paymentSessions)
+    .where(eq(paymentSessions.id, input.paymentSessionId))
+    .for("update")
+    .limit(1)
+  if (!session) throw new Error("booking_session_payment_not_found")
+  if (session.bookingId === input.bookingId && session.targetType === "booking") return session
+  if (
+    session.targetType !== "booking_session" ||
+    session.targetId !== input.bookingSessionId ||
+    (session.status !== "authorized" && session.status !== "paid")
+  ) {
+    throw new Error("booking_session_payment_not_transferable")
+  }
+  const [transferred] = await tx
+    .update(paymentSessions)
+    .set({
+      targetType: "booking",
+      targetId: input.bookingId,
+      bookingId: input.bookingId,
+      metadata: sql`coalesce(${paymentSessions.metadata}, '{}'::jsonb) || ${JSON.stringify({
+        originatingBookingSessionId: input.bookingSessionId,
+      })}::jsonb`,
+      updatedAt: new Date(),
+    })
+    .where(eq(paymentSessions.id, input.paymentSessionId))
+    .returning()
+  if (!transferred) throw new Error("booking_session_payment_transfer_failed")
+  if (transferred.paymentAuthorizationId) {
+    await tx
+      .update(paymentAuthorizations)
+      .set({ bookingId: input.bookingId, updatedAt: new Date() })
+      .where(eq(paymentAuthorizations.id, transferred.paymentAuthorizationId))
+  }
+  return transferred
+}
+
+export async function expirePendingBookingSessionPayments(
+  db: PostgresJsDatabase,
+  bookingSessionId: string,
+  at = new Date(),
+): Promise<number> {
+  const rows = await db
+    .update(paymentSessions)
+    .set({ status: "expired", expiredAt: at, expiresAt: at, updatedAt: at })
+    .where(
+      and(
+        eq(paymentSessions.targetType, "booking_session"),
+        eq(paymentSessions.targetId, bookingSessionId),
+        inArray(paymentSessions.status, ["pending", "requires_redirect", "processing"]),
+      ),
+    )
+    .returning({ id: paymentSessions.id })
+  return rows.length
+}

--- a/packages/finance/src/booking-session-payment.ts
+++ b/packages/finance/src/booking-session-payment.ts
@@ -30,6 +30,13 @@ export interface CreateBookingSessionPaymentInput {
   metadata?: Record<string, unknown>
 }
 
+export class BookingSessionPaymentIdempotencyConflictError extends Error {
+  constructor() {
+    super("booking_session_payment_idempotency_conflict")
+    this.name = "BookingSessionPaymentIdempotencyConflictError"
+  }
+}
+
 export function bookingSessionPaymentIdempotencyKey(input: {
   bookingSessionId: string
   commitIdempotencyKey: string
@@ -53,7 +60,12 @@ export async function createOrReuseBookingSessionPayment(
       ),
     )
     .limit(1)
-  if (existing) return existing
+  if (existing) {
+    if (existing.amountCents !== input.amountCents || existing.currency !== input.currency) {
+      throw new BookingSessionPaymentIdempotencyConflictError()
+    }
+    return existing
+  }
 
   return financePaymentSessionService.createPaymentSession(
     db,

--- a/packages/finance/src/card-payment.ts
+++ b/packages/finance/src/card-payment.ts
@@ -93,6 +93,29 @@ export interface PaymentAdapterCardPaymentExecution {
   idempotencyKey?: string
 }
 
+/** Resolve the deployment's canonical server-side payment callback URL. */
+export function resolvePaymentCallbackUrl(
+  env: Readonly<Record<string, unknown>>,
+): string | undefined {
+  const configured =
+    nonEmpty(env.PAYMENT_CALLBACK_BASE_URL) ??
+    nonEmpty(env.DASH_BASE_URL) ??
+    nonEmpty(env.APP_URL)?.replace(/\/api\/?$/, "")
+  if (!configured) return undefined
+  const url = new URL(configured)
+  if (
+    (url.protocol !== "http:" && url.protocol !== "https:") ||
+    url.username ||
+    url.password ||
+    url.pathname !== "/" ||
+    url.search ||
+    url.hash
+  ) {
+    throw new Error("Payment callback base must be an absolute HTTP(S) origin")
+  }
+  return `${url.origin}/api/v1/public/payment-link/callback`
+}
+
 /**
  * Start a payment through a selected adapter without requiring an HTTP
  * framework context. Package runtimes use this function; the Hono-oriented
@@ -216,4 +239,10 @@ export function createPaymentAdapterCardPaymentStarter(
       idempotencyKey: options.idempotencyKey?.(args.sessionId),
     })
   }
+}
+
+function nonEmpty(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined
+  const trimmed = value.trim()
+  return trimmed || undefined
 }

--- a/packages/finance/src/index.ts
+++ b/packages/finance/src/index.ts
@@ -39,6 +39,7 @@ import {
 
 export { FINANCE_BOOKING_CREATE_SELF_SERVICE_ROUTE_ACTION } from "./booking-create-policy.js"
 export {
+  BookingSessionPaymentIdempotencyConflictError,
   type BookingSessionPaymentState,
   bookingSessionPaymentIdempotencyKey,
   type CreateBookingSessionPaymentInput,

--- a/packages/finance/src/index.ts
+++ b/packages/finance/src/index.ts
@@ -38,6 +38,15 @@ import {
 } from "./runtime-port.js"
 
 export { FINANCE_BOOKING_CREATE_SELF_SERVICE_ROUTE_ACTION } from "./booking-create-policy.js"
+export {
+  type BookingSessionPaymentState,
+  bookingSessionPaymentIdempotencyKey,
+  type CreateBookingSessionPaymentInput,
+  createOrReuseBookingSessionPayment,
+  expirePendingBookingSessionPayments,
+  findEstablishedBookingSessionPayment,
+  transferBookingSessionPaymentToBooking,
+} from "./booking-session-payment.js"
 export type {
   CheckoutRouteRuntime,
   CheckoutRoutesOptions,
@@ -306,6 +315,7 @@ export type {
 } from "./card-payment.js"
 export {
   createPaymentAdapterCardPaymentStarter,
+  resolvePaymentCallbackUrl,
   startPaymentAdapterCardPayment,
 } from "./card-payment.js"
 export {

--- a/packages/finance/src/routes-invoice-schemas.ts
+++ b/packages/finance/src/routes-invoice-schemas.ts
@@ -69,6 +69,7 @@ const paymentSessionStatusValues = [
 ] as const
 
 const paymentSessionTargetTypeValues = [
+  "booking_session",
   "booking",
   "order",
   "invoice",

--- a/packages/finance/src/runtime.ts
+++ b/packages/finance/src/runtime.ts
@@ -2,7 +2,7 @@ import type { CustomFieldsRuntime } from "@voyant-travel/core/custom-fields"
 import type { AnyDrizzleDb } from "@voyant-travel/db"
 import type { PaymentAdapter } from "@voyant-travel/payments"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
-import { startPaymentAdapterCardPayment } from "./card-payment.js"
+import { resolvePaymentCallbackUrl, startPaymentAdapterCardPayment } from "./card-payment.js"
 import type { CheckoutPaymentStarter } from "./checkout-service.js"
 import type { FinanceApiModuleOptions } from "./index.js"
 import {
@@ -155,26 +155,6 @@ function recordValue(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : {}
-}
-
-function resolvePaymentCallbackUrl(env: Readonly<Record<string, unknown>>): string | undefined {
-  const configured =
-    nonEmpty(env.PAYMENT_CALLBACK_BASE_URL) ??
-    nonEmpty(env.DASH_BASE_URL) ??
-    nonEmpty(env.APP_URL)?.replace(/\/api\/?$/, "")
-  if (!configured) return undefined
-  const url = new URL(configured)
-  if (
-    (url.protocol !== "http:" && url.protocol !== "https:") ||
-    url.username ||
-    url.password ||
-    url.pathname !== "/" ||
-    url.search ||
-    url.hash
-  ) {
-    throw new Error("Payment callback base must be an absolute HTTP(S) origin")
-  }
-  return `${url.origin}/api/v1/public/payment-link/callback`
 }
 
 /** Compose Finance's payment schedule from statically selected domain providers. */

--- a/packages/finance/src/schema/enums.ts
+++ b/packages/finance/src/schema/enums.ts
@@ -41,6 +41,7 @@ export const paymentSessionStatusEnum = pgEnum("payment_session_status", [
 ])
 
 export const paymentSessionTargetTypeEnum = pgEnum("payment_session_target_type", [
+  "booking_session",
   "booking",
   "order",
   "invoice",

--- a/packages/finance/src/service-payment-sessions.ts
+++ b/packages/finance/src/service-payment-sessions.ts
@@ -59,6 +59,8 @@ function derivePaymentSessionTargetColumns(
   if (!explicitTarget) return {}
 
   switch (explicitTarget.type) {
+    case "booking_session":
+      return {}
     case "booking":
       return { bookingId: explicitTarget.bookingId }
     case "invoice":
@@ -167,11 +169,22 @@ export const financePaymentSessionService = {
           expiredAt: toTimestamp(data.expiredAt),
           expiresAt: toTimestamp(data.expiresAt),
         })
+        .onConflictDoNothing({ target: paymentSessions.idempotencyKey })
         .returning()
+
+    const loadIdempotentSession = async (writer: PostgresJsDatabase) => {
+      if (!data.idempotencyKey) return null
+      const [existing] = await writer
+        .select()
+        .from(paymentSessions)
+        .where(eq(paymentSessions.idempotencyKey, data.idempotencyKey))
+        .limit(1)
+      return existing ?? null
+    }
 
     const actionLedgerContext = runtime.actionLedgerContext
     if (actionLedgerContext) {
-      const [row] = await db.transaction(async (tx) => {
+      const row = await db.transaction(async (tx) => {
         const created = await createSession(tx)
 
         if (created[0]) {
@@ -186,15 +199,16 @@ export const financePaymentSessionService = {
           )
         }
 
-        return created
+        return created[0] ?? loadIdempotentSession(tx)
       })
 
-      return row ?? null
+      return row
     }
 
     const [row] = await createSession(db)
-    await touchPaymentSessionBooking(db, row)
-    return row ?? null
+    const resolved = row ?? (await loadIdempotentSession(db))
+    await touchPaymentSessionBooking(db, resolved ?? undefined)
+    return resolved
   },
 
   async updatePaymentSession(

--- a/packages/finance/src/service-public.ts
+++ b/packages/finance/src/service-public.ts
@@ -92,6 +92,9 @@ function toPublicPaymentTarget(
   if (session.invoiceId) {
     return { type: "invoice" as const, invoiceId: session.invoiceId }
   }
+  if (session.targetType === "booking_session" && session.targetId) {
+    return { type: "booking_session" as const, bookingSessionId: session.targetId }
+  }
   if (session.targetType === "flight_order" && session.targetId) {
     return { type: "flight_order" as const, flightOrderId: session.targetId }
   }

--- a/packages/finance/src/service-shared.ts
+++ b/packages/finance/src/service-shared.ts
@@ -909,6 +909,11 @@ export function derivePaymentSessionTarget(
   const explicitTarget = "target" in input ? input.target : undefined
   if (explicitTarget) {
     switch (explicitTarget.type) {
+      case "booking_session":
+        return {
+          targetType: "booking_session" as const,
+          targetId: explicitTarget.bookingSessionId,
+        }
       case "booking":
         return { targetType: "booking" as const, targetId: explicitTarget.bookingId }
       case "invoice":

--- a/packages/finance/src/voyant-event-schemas.ts
+++ b/packages/finance/src/voyant-event-schemas.ts
@@ -391,6 +391,7 @@ export const paymentCompletedPayloadSchema = {
     paymentSessionId: { type: "string" },
     targetType: {
       enum: [
+        "booking_session",
         "booking",
         "order",
         "invoice",

--- a/packages/finance/tests/integration/booking-session-payment.test.ts
+++ b/packages/finance/tests/integration/booking-session-payment.test.ts
@@ -4,6 +4,7 @@ import { eq } from "drizzle-orm"
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
 
 import {
+  BookingSessionPaymentIdempotencyConflictError,
   createOrReuseBookingSessionPayment,
   expirePendingBookingSessionPayments,
   transferBookingSessionPaymentToBooking,
@@ -45,6 +46,24 @@ describe.skipIf(!DB_AVAILABLE)("Booking Session payment continuity", () => {
     ])
 
     expect(first?.id).toBe(retry?.id)
+    await expect(db.select().from(paymentSessions)).resolves.toHaveLength(1)
+  })
+
+  it("rejects a reused Commit key when the required amount or currency changed", async () => {
+    const original = {
+      bookingSessionId: "bses_changed_payment_requirement",
+      commitIdempotencyKey: "commit_changed_payment_requirement",
+      amountCents: 5_000,
+      currency: "EUR",
+    }
+    await createOrReuseBookingSessionPayment(db, original)
+
+    await expect(
+      createOrReuseBookingSessionPayment(db, { ...original, amountCents: 7_500 }),
+    ).rejects.toBeInstanceOf(BookingSessionPaymentIdempotencyConflictError)
+    await expect(
+      createOrReuseBookingSessionPayment(db, { ...original, currency: "GBP" }),
+    ).rejects.toBeInstanceOf(BookingSessionPaymentIdempotencyConflictError)
     await expect(db.select().from(paymentSessions)).resolves.toHaveLength(1)
   })
 

--- a/packages/finance/tests/integration/booking-session-payment.test.ts
+++ b/packages/finance/tests/integration/booking-session-payment.test.ts
@@ -1,0 +1,226 @@
+import { bookings } from "@voyant-travel/bookings/schema"
+import { newId } from "@voyant-travel/db/lib/typeid"
+import { eq } from "drizzle-orm"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import {
+  createOrReuseBookingSessionPayment,
+  expirePendingBookingSessionPayments,
+  transferBookingSessionPaymentToBooking,
+} from "../../src/booking-session-payment.js"
+import { applyPaymentAdapterCallbackEvent } from "../../src/payment-adapter-events.js"
+import { paymentAuthorizations, paymentCaptures, paymentSessions } from "../../src/schema.js"
+
+const DB_AVAILABLE = Boolean(process.env.TEST_DATABASE_URL)
+
+describe.skipIf(!DB_AVAILABLE)("Booking Session payment continuity", () => {
+  let db: ReturnType<typeof import("@voyant-travel/db/test-utils").createTestDb>
+
+  beforeAll(async () => {
+    const { createTestDb } = await import("@voyant-travel/db/test-utils")
+    db = createTestDb()
+  })
+
+  beforeEach(async () => {
+    const { cleanupTestDb } = await import("@voyant-travel/db/test-utils")
+    await cleanupTestDb(db)
+  })
+
+  afterAll(async () => {
+    const { closeTestDb } = await import("@voyant-travel/db/test-utils")
+    await closeTestDb()
+  })
+
+  it("converges concurrent Commit retries on one pre-Booking payment session", async () => {
+    const input = {
+      bookingSessionId: "bses_concurrent_payment",
+      commitIdempotencyKey: "commit_concurrent_payment",
+      amountCents: 5_000,
+      currency: "EUR",
+    }
+
+    const [first, retry] = await Promise.all([
+      createOrReuseBookingSessionPayment(db, input),
+      createOrReuseBookingSessionPayment(db, input),
+    ])
+
+    expect(first?.id).toBe(retry?.id)
+    await expect(db.select().from(paymentSessions)).resolves.toHaveLength(1)
+  })
+
+  it("makes provider success versus Session expiry a terminal, duplicate-safe race", async () => {
+    const session = await createOrReuseBookingSessionPayment(db, {
+      bookingSessionId: "bses_expiry_race",
+      commitIdempotencyKey: "commit_expiry_race",
+      amountCents: 7_500,
+      currency: "EUR",
+    })
+    if (!session) throw new Error("Payment Session was not created")
+
+    await Promise.all([
+      expirePendingBookingSessionPayments(db, "bses_expiry_race"),
+      applyPaymentAdapterCallbackEvent(db, {
+        eventId: "evt_booking_session_expiry_race",
+        paymentSessionId: session.id,
+        nextState: "paid",
+        occurredAt: "2026-08-01T12:00:00.000Z",
+        processorSessionId: "processor_session_expiry_race",
+        processorPaymentId: "processor_payment_expiry_race",
+        idempotencyKey: "callback_expiry_race",
+      }),
+    ])
+    await applyPaymentAdapterCallbackEvent(db, {
+      eventId: "evt_booking_session_expiry_race_duplicate",
+      paymentSessionId: session.id,
+      nextState: "paid",
+      occurredAt: "2026-08-01T12:00:01.000Z",
+      processorSessionId: "processor_session_expiry_race",
+      processorPaymentId: "processor_payment_expiry_race",
+      idempotencyKey: "callback_expiry_race_duplicate",
+    })
+
+    const [resolved] = await db
+      .select()
+      .from(paymentSessions)
+      .where(eq(paymentSessions.id, session.id))
+    expect(["expired", "paid"]).toContain(resolved?.status)
+    const authorizations = await db.select().from(paymentAuthorizations)
+    const captures = await db.select().from(paymentCaptures)
+    expect(authorizations).toHaveLength(resolved?.status === "paid" ? 1 : 0)
+    expect(captures).toHaveLength(resolved?.status === "paid" ? 1 : 0)
+  })
+
+  it("keeps a declined attempt immutable and lets the customer start a new retry", async () => {
+    const declined = await createOrReuseBookingSessionPayment(db, {
+      bookingSessionId: "bses_declined_retry",
+      commitIdempotencyKey: "commit_declined_attempt",
+      amountCents: 8_000,
+      currency: "EUR",
+    })
+    if (!declined) throw new Error("Payment Session was not created")
+    await applyPaymentAdapterCallbackEvent(db, {
+      eventId: "evt_booking_session_declined",
+      paymentSessionId: declined.id,
+      nextState: "failed",
+      occurredAt: "2026-08-01T12:00:00.000Z",
+      processorSessionId: "processor_session_declined",
+      processorPaymentId: "processor_payment_declined",
+      idempotencyKey: "callback_declined",
+    })
+
+    const sameCommitRetry = await createOrReuseBookingSessionPayment(db, {
+      bookingSessionId: "bses_declined_retry",
+      commitIdempotencyKey: "commit_declined_attempt",
+      amountCents: 8_000,
+      currency: "EUR",
+    })
+
+    const retry = await createOrReuseBookingSessionPayment(db, {
+      bookingSessionId: "bses_declined_retry",
+      commitIdempotencyKey: "commit_customer_retry",
+      amountCents: 8_000,
+      currency: "EUR",
+    })
+
+    expect(sameCommitRetry?.id).toBe(declined.id)
+    expect(retry?.id).not.toBe(declined.id)
+    await expect(db.select().from(paymentSessions)).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: declined.id, status: "failed" }),
+        expect.objectContaining({ id: retry?.id, status: "pending" }),
+      ]),
+    )
+  })
+
+  it("transfers paid Session money and its authorization atomically to the Booking", async () => {
+    const session = await createOrReuseBookingSessionPayment(db, {
+      bookingSessionId: "bses_transfer_payment",
+      commitIdempotencyKey: "commit_transfer_payment",
+      amountCents: 9_000,
+      currency: "EUR",
+    })
+    if (!session) throw new Error("Payment Session was not created")
+    await applyPaymentAdapterCallbackEvent(db, {
+      eventId: "evt_booking_session_paid",
+      paymentSessionId: session.id,
+      nextState: "paid",
+      occurredAt: "2026-08-01T12:00:00.000Z",
+      processorSessionId: "processor_session_paid",
+      processorPaymentId: "processor_payment_paid",
+      idempotencyKey: "callback_paid",
+    })
+    const bookingId = newId("bookings")
+    await db.insert(bookings).values({
+      id: bookingId,
+      bookingNumber: `PAY-${bookingId}`,
+      status: "confirmed",
+      sellCurrency: "EUR",
+    })
+
+    await db.transaction((tx) =>
+      transferBookingSessionPaymentToBooking(tx, {
+        paymentSessionId: session.id,
+        bookingSessionId: "bses_transfer_payment",
+        bookingId,
+      }),
+    )
+
+    await expect(
+      db.select().from(paymentSessions).where(eq(paymentSessions.id, session.id)),
+    ).resolves.toEqual([
+      expect.objectContaining({ targetType: "booking", targetId: bookingId, bookingId }),
+    ])
+    await expect(db.select().from(paymentAuthorizations)).resolves.toEqual([
+      expect.objectContaining({ bookingId }),
+    ])
+  })
+
+  it("rolls the payment transfer back when Booking Commit fails", async () => {
+    const session = await createOrReuseBookingSessionPayment(db, {
+      bookingSessionId: "bses_transfer_rollback",
+      commitIdempotencyKey: "commit_transfer_rollback",
+      amountCents: 9_500,
+      currency: "EUR",
+    })
+    if (!session) throw new Error("Payment Session was not created")
+    await applyPaymentAdapterCallbackEvent(db, {
+      eventId: "evt_booking_session_authorized",
+      paymentSessionId: session.id,
+      nextState: "authorized",
+      occurredAt: "2026-08-01T12:00:00.000Z",
+      processorSessionId: "processor_session_authorized",
+      processorPaymentId: "processor_payment_authorized",
+      idempotencyKey: "callback_authorized",
+    })
+    const bookingId = newId("bookings")
+    await db.insert(bookings).values({
+      id: bookingId,
+      bookingNumber: `ROLLBACK-${bookingId}`,
+      status: "confirmed",
+      sellCurrency: "EUR",
+    })
+
+    await expect(
+      db.transaction(async (tx) => {
+        await transferBookingSessionPaymentToBooking(tx, {
+          paymentSessionId: session.id,
+          bookingSessionId: "bses_transfer_rollback",
+          bookingId,
+        })
+        throw new Error("injected_booking_commit_failure")
+      }),
+    ).rejects.toThrow("injected_booking_commit_failure")
+
+    await expect(
+      db.select().from(paymentSessions).where(eq(paymentSessions.id, session.id)),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        targetType: "booking_session",
+        targetId: "bses_transfer_rollback",
+      }),
+    ])
+    await expect(db.select().from(paymentAuthorizations)).resolves.toEqual([
+      expect.objectContaining({ bookingId: null }),
+    ])
+  })
+})

--- a/packages/finance/tests/unit/checkout-service.test.ts
+++ b/packages/finance/tests/unit/checkout-service.test.ts
@@ -694,14 +694,18 @@ function createCheckoutDb({
           if (table === paymentSessions) {
             insertedPaymentSessions.push(values)
             return {
-              returning() {
-                return Promise.resolve([
-                  {
-                    id: "ps_atomic_schedule",
-                    invoiceId: null,
-                    ...values,
+              onConflictDoNothing() {
+                return {
+                  returning() {
+                    return Promise.resolve([
+                      {
+                        id: "ps_atomic_schedule",
+                        invoiceId: null,
+                        ...values,
+                      },
+                    ])
                   },
-                ])
+                }
               },
             }
           }

--- a/packages/inventory/src/catalog-runtime-extension.ts
+++ b/packages/inventory/src/catalog-runtime-extension.ts
@@ -1,6 +1,7 @@
 import type { CatalogInventoryRuntimeExtension } from "@voyant-travel/catalog/runtime-contracts"
 import { createProductQuoteShapeEnricher } from "@voyant-travel/catalog/runtime-support"
-import { asc, eq, gt } from "drizzle-orm"
+import type { PaymentPolicy } from "@voyant-travel/finance"
+import { and, asc, eq, gt, isNotNull } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import { registerProductBookingHandler } from "./booking-engine/product-runtime.js"
@@ -12,7 +13,7 @@ import { productPromotionsCatalogPolicy } from "./catalog-policy-promotions.js"
 import { productTaxonomyCatalogPolicy } from "./catalog-policy-taxonomy.js"
 import { buildProductDraftShape } from "./draft-shape.js"
 import { extrasCatalogPolicy } from "./extras.js"
-import { products } from "./schema.js"
+import { productCategories, productCategoryProducts, products } from "./schema.js"
 import { productsService } from "./service.js"
 import {
   buildProductSnapshotInput,
@@ -97,6 +98,38 @@ export const catalogInventoryRuntimeExtension = {
       .where(eq(products.id, productId))
       .limit(1)
     return product ?? null
+  },
+  async loadProductPaymentPolicyContext(db, productId) {
+    const [[product], [category]] = await Promise.all([
+      db
+        .select({
+          listingPolicy: products.customerPaymentPolicy,
+          supplierId: products.supplierId,
+          departureDate: products.startDate,
+        })
+        .from(products)
+        .where(eq(products.id, productId))
+        .limit(1),
+      db
+        .select({ categoryPolicy: productCategories.customerPaymentPolicy })
+        .from(productCategoryProducts)
+        .innerJoin(productCategories, eq(productCategories.id, productCategoryProducts.categoryId))
+        .where(
+          and(
+            eq(productCategoryProducts.productId, productId),
+            isNotNull(productCategories.customerPaymentPolicy),
+          ),
+        )
+        .orderBy(asc(productCategoryProducts.sortOrder), asc(productCategoryProducts.createdAt))
+        .limit(1),
+    ])
+    if (!product) return null
+    return {
+      listingPolicy: (product.listingPolicy as PaymentPolicy | null | undefined) ?? null,
+      categoryPolicy: (category?.categoryPolicy as PaymentPolicy | null | undefined) ?? null,
+      supplierId: product.supplierId,
+      departureDate: product.departureDate,
+    }
   },
   enrichProductQuoteShape,
   buildSnapshotInput: (db, productId, options) => buildProductSnapshotInput(db, productId, options),

--- a/packages/storefront-react/src/hooks/use-booking-session-v1.ts
+++ b/packages/storefront-react/src/hooks/use-booking-session-v1.ts
@@ -6,6 +6,7 @@ import {
   type AdoptBookingSessionV1,
   type BookingSessionRequestOptions,
   type BookingSessionViewV1,
+  type CommitBookingSessionV1,
   type CreateBookingSessionV1,
   createBookingSessionCapabilityV1,
   createVoyantStorefrontClient,
@@ -93,6 +94,18 @@ export function useAbandonBookingSessionV1() {
       requestOptions: BookingSessionRequestOptions
     }) =>
       client.bookingSessionsV1.abandon(request.sessionId, request.input, request.requestOptions),
+  })
+}
+
+/** Retry Commit after a payment redirect/callback using the same Session authority. */
+export function useCommitBookingSessionV1() {
+  const client = useBookingSessionClient()
+  return useMutation({
+    mutationFn: (request: {
+      sessionId: string
+      input: CommitBookingSessionV1
+      requestOptions: BookingSessionRequestOptions
+    }) => client.bookingSessionsV1.commit(request.sessionId, request.input, request.requestOptions),
   })
 }
 

--- a/packages/storefront-sdk/src/booking-session-v1.ts
+++ b/packages/storefront-sdk/src/booking-session-v1.ts
@@ -17,6 +17,7 @@ export type {
   AbandonBookingSessionV1,
   AdoptBookingSessionV1,
   BookingSessionViewV1,
+  CommitBookingSessionV1,
   CreateBookingSessionV1,
   RenewBookingSessionV1,
   UpdateBookingSessionV1,
@@ -51,6 +52,7 @@ export interface OwnedProductBookingTracerInput {
   journeyKey: string
   state?: Record<string, unknown>
   quantity?: number
+  payment?: CommitBookingSessionV1["payment"]
   requestOptions?: BookingSessionRequestOptions
 }
 
@@ -61,6 +63,13 @@ export type OwnedProductBookingTracerResult =
       quoteOutcome: BookingSessionOutcomeV1
       holdOutcome: BookingSessionOutcomeV1
       commitOutcome: BookingSessionOutcomeV1
+    }
+  | {
+      kind: "payment_required"
+      session: BookingSessionRecordV1
+      quoteOutcome: BookingSessionOutcomeV1
+      holdOutcome: BookingSessionOutcomeV1
+      commitOutcome: Extract<BookingSessionOutcomeV1, { kind: "commit_result" }>
     }
   | {
       kind: "stopped"
@@ -299,11 +308,30 @@ export async function runOwnedProductBookingTracerV1(
       quoteId: quoteOutcome.quote.id,
       holdId: holdOutcome.hold.id,
       idempotencyKey: `${input.journeyKey}:commit`,
+      ...(input.payment ? { payment: input.payment } : {}),
     },
     sessionRequestOptions,
   )
 
   if (commitOutcome.kind !== "commit_result") {
+    return {
+      kind: "stopped",
+      stage: "commit",
+      outcome: commitOutcome,
+      session,
+      quoteOutcome,
+      holdOutcome,
+    }
+  }
+
+  if (commitOutcome.outcome.kind === "payment_required") {
+    return { kind: "payment_required", session, quoteOutcome, holdOutcome, commitOutcome }
+  }
+
+  if (
+    commitOutcome.outcome.kind !== "committed" &&
+    commitOutcome.outcome.kind !== "idempotent_replay"
+  ) {
     return {
       kind: "stopped",
       stage: "commit",

--- a/packages/storefront-sdk/tests/unit/booking-session-v1.test.ts
+++ b/packages/storefront-sdk/tests/unit/booking-session-v1.test.ts
@@ -3,6 +3,136 @@ import { describe, expect, it } from "vitest"
 import { createVoyantStorefrontClient } from "../../src/index.js"
 
 describe("Booking Session v1 SDK", () => {
+  it("returns a payment continuation and resumes Commit on the same typed route", async () => {
+    let commitAttempts = 0
+    const calls: Array<{ url: string; body: Record<string, unknown> | undefined }> = []
+    const fetcher = async (url: string, init?: RequestInit) => {
+      const body = init?.body
+        ? (JSON.parse(String(init.body)) as Record<string, unknown>)
+        : undefined
+      calls.push({ url, body })
+      if (url.endsWith("/v1/public/catalog/booking-sessions")) {
+        return json({ kind: "session_created", session: session(1) })
+      }
+      if (url.endsWith("/quote")) {
+        return json({
+          kind: "quote_created",
+          session: session(1),
+          quote: {
+            id: "bsqu_demo",
+            sessionId: "bses_demo",
+            sessionRevision: 1,
+            state: "active",
+            pricing: {
+              currency: "EUR",
+              lines: [],
+              taxes: [],
+              subtotal: 10000,
+              taxTotal: 0,
+              total: 10000,
+            },
+            quotedAt: "2026-08-01T12:00:00.000Z",
+            expiresAt: "2026-08-01T12:10:00.000Z",
+          },
+        })
+      }
+      if (url.endsWith("/hold")) {
+        return json({
+          kind: "hold_created",
+          session: session(1),
+          hold: {
+            id: "bshd_demo",
+            sessionId: "bses_demo",
+            quoteId: "bsqu_demo",
+            target: { kind: "product", productId: "prod_owned_1" },
+            quantity: 1,
+            state: "active",
+            expiresAt: "2026-08-01T12:15:00.000Z",
+            createdAt: "2026-08-01T12:00:00.000Z",
+          },
+        })
+      }
+      if (url.endsWith("/commit")) {
+        commitAttempts += 1
+        return commitAttempts === 1
+          ? json({
+              kind: "commit_result",
+              outcome: {
+                kind: "payment_required",
+                nextAction: "establish_payment_guarantee",
+                paymentTarget: "booking_session",
+                allowedGuarantees: ["deposit"],
+                paymentSession: {
+                  id: "pays_demo",
+                  status: "requires_redirect",
+                  amountCents: 10000,
+                  currency: "EUR",
+                  redirectUrl: "https://payments.example.test/checkout/pays_demo",
+                  expiresAt: "2026-08-01T12:15:00.000Z",
+                },
+              },
+            })
+          : json({
+              kind: "commit_result",
+              outcome: {
+                kind: "committed",
+                nextAction: "none",
+                booking: { id: "book_demo", status: "confirmed" },
+                allocationIds: ["bkac_demo"],
+                consumedSessionId: "bses_demo",
+                consumedQuoteId: "bsqu_demo",
+                convertedHoldId: "bshd_demo",
+              },
+            })
+      }
+      return new Response("not found", { status: 404 })
+    }
+    const client = createVoyantStorefrontClient({ baseUrl: "https://example.test", fetcher })
+    const requestOptions = { capability: "bcap_payment_continuation_1234567890" }
+
+    const pending = await client.bookingSessionsV1.runOwnedProductTracer({
+      target: { kind: "product", productId: "prod_owned_1" },
+      journeyKey: "payment-journey",
+      payment: {
+        returnUrl: "https://storefront.example.test/payment/return",
+        cancelUrl: "https://storefront.example.test/payment/cancel",
+      },
+      requestOptions,
+    })
+    expect(pending).toMatchObject({
+      kind: "payment_required",
+      commitOutcome: {
+        outcome: {
+          paymentSession: {
+            redirectUrl: "https://payments.example.test/checkout/pays_demo",
+          },
+        },
+      },
+    })
+
+    const resumed = await client.bookingSessionsV1.commit(
+      "bses_demo",
+      {
+        expectedRevision: 1,
+        quoteId: "bsqu_demo",
+        holdId: "bshd_demo",
+        idempotencyKey: "payment-journey:commit",
+      },
+      requestOptions,
+    )
+    expect(resumed).toMatchObject({
+      kind: "commit_result",
+      outcome: { kind: "committed", booking: { id: "book_demo" } },
+    })
+    expect(calls.filter((call) => call.url.endsWith("/commit"))).toHaveLength(2)
+    expect(calls.find((call) => call.url.endsWith("/commit"))?.body).toMatchObject({
+      payment: {
+        returnUrl: "https://storefront.example.test/payment/return",
+        cancelUrl: "https://storefront.example.test/payment/cancel",
+      },
+    })
+  })
+
   it("runs the owned Product journey through only v1 Session, Quote, Hold, and Commit routes", async () => {
     const calls: Array<{ url: string; body: unknown; capability: string | null }> = []
     const fetcher = async (url: string, init?: RequestInit) => {


### PR DESCRIPTION
Closes #4011

Builds on #4043.

## Summary

- Resolve the effective customer payment policy from server-owned listing, category, supplier, and operator settings.
- Create or reuse an idempotent Finance Payment Session targeted at the Booking Session and return a typed `payment_required` outcome without creating a Booking.
- Resume the same Commit after adapter callbacks; once payment is authorized or paid, create exactly one Booking and retarget the Payment Session and authorization inside the root PostgreSQL transaction.
- Expire pending payment attempts with Session abandonment/expiry while retaining captured pre-Booking money for explicit reconciliation.
- Expose the continuation through the shared contracts, Storefront SDK, and React hooks, with architecture documentation and a changeset.

## Guarantees

- Booking lifecycle status does not encode payment state.
- Session, Quote, and Hold expiry are never extended implicitly for payment.
- Duplicate Commit calls, duplicate/delayed callbacks, callback-versus-expiry races, and Booking transaction rollback remain idempotent and reconcilable.
- The authoritative runtime uses PostgreSQL transactions and row locks on Node/Docker; browser-facing packages remain portable.

## Validation

- Replayed all 31 operator migrations against PostgreSQL.
- Catalog PostgreSQL Booking Session invariants: 6 passed.
- Finance payment continuity/concurrency/rollback integration tests: 5 passed.
- Focused contracts, Catalog service/runtime, and Storefront SDK tests: 61 passed.
- Catalog and Finance package typechecks passed.
- The isolated Inventory typecheck exhausted the disposable runner's control-channel headroom without emitting a TypeScript diagnostic; the draft PR's normal CI is the final repository-sized gate.