### PR TITLE
ci(operator): establish the public GHCR base

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -47,6 +47,8 @@ Handles package releases:
 
 Publishes `ghcr.io/voyant-travel/operator` independently from npm packages:
 
+- GHCR is the sole public registry for the OSS operator base; no mirror is
+  published
 - pushes to `main` publish immutable `sha-<git-sha>` multi-architecture images
 - manual `publish-release` dispatches from `main` publish immutable semver tags
 - amd64 and arm64 variants build and pass digest-level acceptance concurrently
@@ -55,6 +57,8 @@ Publishes `ghcr.io/voyant-travel/operator` independently from npm packages:
   migration, boot, and API acceptance
 - BuildKit SBOM/provenance and a GitHub registry attestation accompany new
   artifacts
+- canonical publication finishes by resolving the exact digest without registry
+  credentials, so a private package cannot pass as the public base
 
 Pull requests do not trigger this workflow. Platform deployments consume a
 digest, never `latest`; see

--- a/.github/workflows/operator-image.yml
+++ b/.github/workflows/operator-image.yml
@@ -354,6 +354,12 @@ jobs:
       - name: Migrate, boot, and API-smoke the canonical digest
         run: scripts/smoke-operator-image.sh "${{ steps.image.outputs.ref }}"
 
+      - name: Verify anonymous access to the public base digest
+        run: |
+          set -euo pipefail
+          docker logout ghcr.io
+          docker buildx imagetools inspect "${{ steps.image.outputs.ref }}" --raw >/dev/null
+
   promote-latest:
     name: promote-latest-and-verify
     if: github.event_name == 'workflow_dispatch' && inputs.operation == 'promote-latest'

--- a/apps/operator/README.md
+++ b/apps/operator/README.md
@@ -144,11 +144,8 @@ so the composed graph stays resident. Env/secrets come from the platform (no
 `.env` in the image).
 
 ```bash
-# Build + push, from the repo root (custom Dockerfile path, so build locally and
-# push — or run the same `docker build` inside a Cloud Build `--config` step):
-IMAGE=REGION-docker.pkg.dev/PROJECT/voyant/operator
-docker build -f apps/operator/Dockerfile -t "$IMAGE" .
-docker push "$IMAGE"
+# Pin the public OSS image by the exact accepted multi-platform digest.
+IMAGE=ghcr.io/voyant-travel/operator@sha256:<digest>
 
 # Deploy (secrets via Secret Manager; DATABASE_URL_DIRECT = the pooled Node lane):
 gcloud run deploy operator \
@@ -157,6 +154,11 @@ gcloud run deploy operator \
   --set-env-vars="APP_URL=https://operator.example/api,DASH_BASE_URL=https://operator.example" \
   --set-secrets="DATABASE_URL_DIRECT=operator-db-direct:latest,BETTER_AUTH_ADMIN_SECRET=operator-admin-auth:latest,BETTER_AUTH_CUSTOMER_SECRET=operator-customer-auth:latest,SESSION_CLAIMS_ADMIN_SECRET=operator-admin-claims:latest,SESSION_CLAIMS_CUSTOMER_SECRET=operator-customer-claims:latest,VOYANT_CHECKOUT_CAPABILITY_SECRET=operator-checkout-capability:latest,INTERNAL_API_KEY=operator-internal-key:latest,ORIGIN_TRUST_SECRET=operator-origin-trust:latest"
 ```
+
+The GHCR package is the sole public operator image. Cloud Run can pull a public
+GHCR image directly, so this path does not require copying or retagging the base
+into another registry. Resolve a release tag to its accepted digest before
+deployment; never place `latest` in a service specification.
 
 The image uses the providers compiled from `voyant.config.ts` by default. To
 boot that same image with different infrastructure, set

--- a/docs/architecture/deployment-targets.md
+++ b/docs/architecture/deployment-targets.md
@@ -87,8 +87,11 @@ workload class well. On Node none of it is necessary.
   `node run-generated-migrations.mjs` as an explicit pre-rollout command and
   boots `dist/server/server.js`, which validates graph artifacts and required
   graph resource env before serving traffic. Startup does not own migrations.
-  The production artifact is published as `ghcr.io/voyant-travel/operator`;
-  production control planes pin its immutable digest. See
+  The public OSS artifact is published only as
+  `ghcr.io/voyant-travel/operator`; production control planes pin its immutable
+  digest. Self-hosters deploy that digest directly. A private downstream product
+  may use it as a digest-pinned base and publish its resulting derivative under
+  separate private provenance and release authority. See
   [Operator Image Distribution Contract](./operator-image-distribution.md) for
   tag promotion, OCI identity, provenance, digest acceptance, and provider
   binding compatibility rules.

--- a/docs/architecture/operator-image-distribution.md
+++ b/docs/architecture/operator-image-distribution.md
@@ -9,6 +9,8 @@ versioned client or extension protocols.
 
 `.github/workflows/operator-image.yml` is the only image publication authority:
 
+- GHCR is the sole public OCI distribution point for the OSS operator. The
+  workflow publishes `ghcr.io/voyant-travel/operator` and no registry mirror;
 - every push to `main` publishes an immutable `sha-<git-sha>` tag;
 - an explicit workflow dispatch from `main` publishes an immutable bare-semver
   release tag such as `0.225.0`;
@@ -49,19 +51,53 @@ native build emits an SBOM and maximum BuildKit provenance; finalization also
 attaches GitHub build provenance to the canonical registry artifact, including
 during recovery reruns. Promoting `latest` performs the same acceptance against
 the release digest before moving the tag and then proves that `latest` resolves
-to that digest.
+to that digest. Publication succeeds only if the canonical digest remains
+resolvable after the workflow logs out of GHCR, proving anonymous access to the
+public base.
 
-`latest` is for discovery only. Voyant Platform and other production control
-planes **must pin `ghcr.io/voyant-travel/operator@sha256:<digest>`**. A rollout
-records that digest and uses the same digest for its pre-rollout
-`node run-generated-migrations.mjs` invocation and all serving replicas.
+`latest` is for discovery only. Self-hosted and other direct consumers **must
+pin `ghcr.io/voyant-travel/operator@sha256:<digest>`** and use that same digest
+for the pre-rollout `node run-generated-migrations.mjs` invocation and all
+serving replicas. A downstream Platform build pins that public digest as its
+base input, records the relationship in provenance, and deploys the resulting
+private derivative by its own immutable digest.
 
 GitHub creates a new container package as private by default unless the
 organization has configured another default. The `voyant-travel` organization
-owner must make `operator` public if unauthenticated Platform pulls are a
-requirement, or provision a read-only GHCR credential to Platform. The workflow
-deliberately does not change package visibility. Visibility is an organization
-policy decision, not a source-controlled build side effect.
+owner must make `operator` public. The workflow deliberately does not mutate
+package visibility; instead, its final anonymous digest check fails closed until
+that one-time repository setting is correct.
+
+## Public base and private derivatives
+
+This supersedes #3976's original “Platform and self-hosters run the same final
+image” premise. The shared artifact is the public OSS product and base:
+self-hosters run it directly, while Platform builds a private downstream
+derivative from its exact digest. Both retain the same graph-native runtime and
+provider-binding contract, but the final public and private image digests are
+intentionally distinct and carry separate provenance.
+
+The published artifact is both a directly deployable OSS operator and the
+canonical base for downstream private products. A downstream build must consume
+the public base directly from GHCR by immutable digest:
+
+```dockerfile
+ARG VOYANT_OPERATOR_BASE
+FROM ${VOYANT_OPERATOR_BASE}
+
+# Add only downstream-owned private material and metadata.
+```
+
+For example, the downstream build supplies
+`--build-arg VOYANT_OPERATOR_BASE=ghcr.io/voyant-travel/operator@sha256:<digest>`.
+
+The downstream pipeline must reject tag-only base references, record the exact
+base name and digest in its own provenance, and run migration, boot, and API
+acceptance against the resulting derivative digest. The derivative has its own
+identity, SBOM, provenance, visibility, and release policy; it does not replace,
+retag, or mirror the public OSS artifact. Self-hosters deploy the public digest
+directly, while a private Platform derivative preserves that digest as its
+auditable source foundation.
 
 ## OCI identity
 

--- a/scripts/check-operator-image-publication.mjs
+++ b/scripts/check-operator-image-publication.mjs
@@ -8,6 +8,7 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..")
 const WORKFLOW = ".github/workflows/operator-image.yml"
 const CI_WORKFLOW = ".github/workflows/ci.yml"
 const DOCKERFILE = "apps/operator/Dockerfile"
+const OPERATOR_README = "apps/operator/README.md"
 const SMOKE = "scripts/smoke-operator-image.sh"
 const IDENTITY = "scripts/verify-operator-image-identity.mjs"
 const CONTRACT = "docs/architecture/operator-image-distribution.md"
@@ -31,12 +32,19 @@ function requireFragments(path, text, fragments) {
 const workflow = source(WORKFLOW)
 const ci = source(CI_WORKFLOW)
 const dockerfile = source(DOCKERFILE)
+const operatorReadme = source(OPERATOR_README)
 const smoke = source(SMOKE)
 const identity = source(IDENTITY)
 const contract = source(CONTRACT)
 
 if (/^\s*pull_request\s*:/m.test(workflow)) {
   violations.push({ path: WORKFLOW, message: "pull requests must never trigger image publication" })
+}
+
+for (const match of workflow.matchAll(/^\s+registry:\s*(\S+)\s*$/gm)) {
+  if (match[1] !== "ghcr.io") {
+    violations.push({ path: WORKFLOW, message: "GHCR must remain the sole publication registry" })
+  }
 }
 
 requireFragments(WORKFLOW, workflow, [
@@ -119,6 +127,11 @@ requireFragments(WORKFLOW, workflow, [
   ["steps.release.outputs.ref", "latest promotion must accept the resolved release digest"],
   ["packages: write", "registry mutation must be granted at job scope"],
   ["attestations: write", "publication must grant the attestation permission"],
+  ["docker logout ghcr.io", "publication must remove registry credentials before its public check"],
+  [
+    `imagetools inspect "${EXPRESSION_START} steps.image.outputs.ref }}" --raw`,
+    "publication must prove anonymous access to the exact canonical digest",
+  ],
 ])
 
 if (workflow.includes("docker/setup-qemu-action")) {
@@ -165,6 +178,13 @@ requireFragments(DOCKERFILE, dockerfile, [
   ["org.opencontainers.image.source", "runtime image must label its source"],
   ["org.opencontainers.image.revision", "runtime image must label its revision"],
   ["org.opencontainers.image.version", "runtime image must label its version"],
+])
+requireFragments(OPERATOR_README, operatorReadme, [
+  [
+    "IMAGE=ghcr.io/voyant-travel/operator@sha256:<digest>",
+    "operator deployment guidance must pin the sole public GHCR image by digest",
+  ],
+  ["sole public operator image", "operator deployment guidance must identify one public image"],
 ])
 requireFragments(SMOKE, smoke, [
   ["node run-generated-migrations.mjs", "image acceptance must run embedded migrations"],
@@ -268,6 +288,15 @@ requireIdentityResult(
   "unexpected runnable or non-attestation platform descriptor",
 )
 requireFragments(CONTRACT, contract, [
+  [
+    "sole public OCI distribution point",
+    "distribution contract must name a single public registry",
+  ],
+  [
+    "supersedes #3976's original",
+    "distribution contract must replace the same-final-image premise with a public base",
+  ],
+  ["canonical base for downstream private products", "contract must define private derivatives"],
   ["@sha256:<digest>", "distribution contract must require digest pinning"],
   ["ADMIN_UI_EXTENSION_API_VERSION", "contract must separate extension API versioning"],
   ["APP_API_VERSION", "contract must separate Apps API versioning"],


### PR DESCRIPTION
## What changed

- make GHCR the sole public registry for the OSS operator image
- verify the final canonical digest remains anonymously pullable after registry logout
- document the public OSS image as both the self-hosted product and the digest-pinned base for private downstream derivatives
- replace the former same-final-image premise from #3976 without adding a GAR mirror

## Why

Platform contains proprietary pages, extensions, providers, and capabilities, so it cannot share the OSS image's final identity. The stable boundary is a public OSS image on GHCR and a separately built private Platform derivative with independent provenance.

## Validation

- actionlint 1.7.12
- operator publication architecture checker
- Biome on a disposable Sprite
- `git diff --check`

## Rollout

The `voyant-travel/operator` package still returns `401` to anonymous pulls. An organization/package owner must make it public before this workflow can pass on `main`; the workflow intentionally fails closed until then.

Relates to #3976.
