### PR TITLE
Booking v1: commit sourced inventory with durable Supplier Operations

### DIFF
--- a/.changeset/sourced-booking-supplier-operations.md
+++ b/.changeset/sourced-booking-supplier-operations.md
@@ -1,0 +1,12 @@
+---
+"@voyant-travel/bookings": minor
+"@voyant-travel/catalog": minor
+"@voyant-travel/catalog-contracts": minor
+"@voyant-travel/cruises": minor
+"@voyant-travel/finance": patch
+"@voyant-travel/schema-kit": patch
+---
+
+Add Booking Platform v1 supplier-first Commit orchestration with durable
+Supplier Operations, typed pending and ambiguous outcomes, operator
+reconciliation and manual resolution, and a replay-safe sourced cruise tracer.

--- a/docs/architecture/catalog-booking-engine.md
+++ b/docs/architecture/catalog-booking-engine.md
@@ -165,9 +165,34 @@ scope. The established `bookings:write` plus `finance:write` authority also
 admits the staff write route and is required for `staffBooking`; the Catalog
 scope alone cannot submit Finance-owned operator details.
 
-Until a sourced target implements the Supplier Operation side of this same v1
-protocol, the admin form rejects sourced Commit rather than bypassing the
-commitment point through the legacy direct-create path.
+#### Sourced supplier-first v1 tracer
+
+Catalog Item Sessions resolve adapter identity exclusively from the durable
+`catalog_sourced_entries` row. A caller supplies the local Catalog Item and its
+bookable selection, but never an adapter kind, connection id, or upstream
+identity. Commit persists one Session-wide Supplier Operation before dispatch,
+including the exact Quote, request fingerprint, safe request payload, stable
+adapter idempotency key, attempts, and reconciliation evidence.
+
+The default `supplier_first` policy creates no Booking while the operation is
+queued, submitted, pending, in doubt, or awaiting manual review. Generic
+transport failures are treated as possibly dispatched and are never blindly
+retried. Only an adapter error that proves `not_sent` may return the operation
+to the dispatch queue. When a possibly dispatched call returns no upstream
+reference, capable adapters reconcile by the original stable idempotency key.
+A not-found observation remains in doubt until the supplier explicitly returns
+a terminal refusal, preventing eventual-consistency windows from authorizing a
+duplicate reservation. Optimistic Supplier Operation versions prevent stale or
+concurrent reconciliation from overwriting newer evidence or an operator's
+manual resolution. A secured result materializes one confirmed Booking,
+Booking Item, confirmed Allocation, provider-source Booking Origin, and
+immutable Catalog snapshot in a transaction that also consumes the Session and
+Quote. The sourced cruise adapter is the first complete vertical tracer.
+
+Authenticated operators can inspect Supplier Operations, request a supported
+point-read reconciliation, or record an admitted manual terminal resolution.
+Those actions retain supplier state separately from Booking state and append to
+the Booking Session audit log.
 The form likewise rejects promotion-code Commit until promotion evaluation is
 part of the immutable Booking Session Quote; a legacy preview cannot authorize
 the final Booking price.

--- a/docs/architecture/catalog-booking-engine.md
+++ b/docs/architecture/catalog-booking-engine.md
@@ -170,9 +170,12 @@ scope alone cannot submit Finance-owned operator details.
 Catalog Item Sessions resolve adapter identity exclusively from the durable
 `catalog_sourced_entries` row. A caller supplies the local Catalog Item and its
 bookable selection, but never an adapter kind, connection id, or upstream
-identity. Commit persists one Session-wide Supplier Operation before dispatch,
-including the exact Quote, request fingerprint, safe request payload, stable
-adapter idempotency key, attempts, and reconciliation evidence.
+identity. Commit persists one active Supplier Operation per Session before
+dispatch, including the exact Quote, request fingerprint, safe request payload,
+stable adapter idempotency key, attempts, and reconciliation evidence. A
+definitive refusal may be followed by a new operation for an updated selection;
+pending, ambiguous, secured, and manually secured operations continue to block
+competing dispatches.
 
 The default `supplier_first` policy creates no Booking while the operation is
 queued, submitted, pending, in doubt, or awaiting manual review. Generic

--- a/packages/accommodations/tsconfig.build.json
+++ b/packages/accommodations/tsconfig.build.json
@@ -326,6 +326,9 @@
       "@voyant-travel/bookings/runtime-contributor": ["../bookings/dist/runtime-contributor.d.ts"],
       "@voyant-travel/bookings/runtime-port": ["../bookings/dist/runtime-port.d.ts"],
       "@voyant-travel/bookings/schema": ["../bookings/dist/schema.d.ts"],
+      "@voyant-travel/bookings/service-sourced-commitment": [
+        "../bookings/dist/service-sourced-commitment.d.ts"
+      ],
       "@voyant-travel/bookings/stale-holds-job": ["../bookings/dist/stale-holds-job.d.ts"],
       "@voyant-travel/bookings/status": ["../bookings/dist/status.d.ts"],
       "@voyant-travel/bookings/status-dispatch": ["../bookings/dist/status-dispatch.d.ts"],
@@ -369,6 +372,9 @@
       ],
       "@voyant-travel/catalog-contracts/booking-engine/session-contracts": [
         "../catalog-contracts/dist/booking-engine/session-contracts.d.ts"
+      ],
+      "@voyant-travel/catalog-contracts/booking-engine/supplier-operations": [
+        "../catalog-contracts/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog-contracts/content": ["../catalog-contracts/dist/content.d.ts"],
       "@voyant-travel/catalog-contracts/contract": ["../catalog-contracts/dist/contract.d.ts"],
@@ -427,6 +433,9 @@
       ],
       "@voyant-travel/catalog/booking-engine/sessions-schema": [
         "../catalog/dist/booking-engine/sessions-schema.d.ts"
+      ],
+      "@voyant-travel/catalog/booking-engine/supplier-operations": [
+        "../catalog/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog/booking-session-maintenance-job": [
         "../catalog/dist/booking-session-maintenance-job.d.ts"

--- a/packages/accommodations/tsconfig.typecheck.json
+++ b/packages/accommodations/tsconfig.typecheck.json
@@ -327,6 +327,9 @@
       "@voyant-travel/bookings/runtime-contributor": ["../bookings/dist/runtime-contributor.d.ts"],
       "@voyant-travel/bookings/runtime-port": ["../bookings/dist/runtime-port.d.ts"],
       "@voyant-travel/bookings/schema": ["../bookings/dist/schema.d.ts"],
+      "@voyant-travel/bookings/service-sourced-commitment": [
+        "../bookings/dist/service-sourced-commitment.d.ts"
+      ],
       "@voyant-travel/bookings/stale-holds-job": ["../bookings/dist/stale-holds-job.d.ts"],
       "@voyant-travel/bookings/status": ["../bookings/dist/status.d.ts"],
       "@voyant-travel/bookings/status-dispatch": ["../bookings/dist/status-dispatch.d.ts"],
@@ -370,6 +373,9 @@
       ],
       "@voyant-travel/catalog-contracts/booking-engine/session-contracts": [
         "../catalog-contracts/dist/booking-engine/session-contracts.d.ts"
+      ],
+      "@voyant-travel/catalog-contracts/booking-engine/supplier-operations": [
+        "../catalog-contracts/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog-contracts/content": ["../catalog-contracts/dist/content.d.ts"],
       "@voyant-travel/catalog-contracts/contract": ["../catalog-contracts/dist/contract.d.ts"],
@@ -428,6 +434,9 @@
       ],
       "@voyant-travel/catalog/booking-engine/sessions-schema": [
         "../catalog/dist/booking-engine/sessions-schema.d.ts"
+      ],
+      "@voyant-travel/catalog/booking-engine/supplier-operations": [
+        "../catalog/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog/booking-session-maintenance-job": [
         "../catalog/dist/booking-session-maintenance-job.d.ts"

--- a/packages/bookings-react/src/storefront/resolve-contract-variables.ts
+++ b/packages/bookings-react/src/storefront/resolve-contract-variables.ts
@@ -39,7 +39,10 @@
  *     are populated only when `entitySummary` carries enough context.
  */
 
-import type { BookingDraftV1, PricingBreakdownV1 } from "@voyant-travel/catalog/booking-engine"
+import type {
+  BookingDraftV1,
+  PricingBreakdownV1,
+} from "@voyant-travel/catalog-contracts/booking-engine/contracts"
 import type {
   ComputedScheduleEntry,
   PaymentPolicySource,

--- a/packages/bookings/package.json
+++ b/packages/bookings/package.json
@@ -8,6 +8,7 @@
     "./linkables": "./src/linkables.ts",
     "./pii": "./src/pii.ts",
     "./schema": "./src/schema.ts",
+    "./service-sourced-commitment": "./src/service-sourced-commitment.ts",
     "./requirements": "./src/requirements/index.ts",
     "./requirements/schema": "./src/requirements/schema.ts",
     "./requirements/validation": "./src/requirements/validation.ts",
@@ -100,6 +101,11 @@
         "types": "./dist/schema.d.ts",
         "import": "./dist/schema.js",
         "default": "./dist/schema.js"
+      },
+      "./service-sourced-commitment": {
+        "types": "./dist/service-sourced-commitment.d.ts",
+        "import": "./dist/service-sourced-commitment.js",
+        "default": "./dist/service-sourced-commitment.js"
       },
       "./requirements": {
         "types": "./dist/requirements/index.d.ts",

--- a/packages/bookings/src/index.ts
+++ b/packages/bookings/src/index.ts
@@ -111,6 +111,12 @@ export {
   upsertBookingOrigin,
 } from "./service-origin.js"
 export {
+  type CreateSourcedBookingCommitmentInput,
+  type CreateSourcedBookingCommitmentResult,
+  createSourcedBookingCommitment,
+  type SourcedBookingTravelerInput,
+} from "./service-sourced-commitment.js"
+export {
   BOOKING_TRANSITIONS,
   type BookingStatus,
   type BookingStatusPatch,

--- a/packages/bookings/src/service-sourced-commitment.ts
+++ b/packages/bookings/src/service-sourced-commitment.ts
@@ -1,0 +1,180 @@
+import { newId } from "@voyant-travel/db/lib/typeid"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import { bookings, bookingTravelers } from "./schema-core.js"
+import { bookingAllocations, bookingItems, bookingItemTravelers } from "./schema-items.js"
+import { upsertBookingOrigin } from "./service-origin.js"
+
+export interface SourcedBookingTravelerInput {
+  firstName: string
+  lastName: string
+  email?: string | null
+  phone?: string | null
+  category?: "adult" | "child" | "infant" | "senior" | "other" | null
+  isPrimary?: boolean
+}
+
+export interface CreateSourcedBookingCommitmentInput {
+  bookingNumber: string
+  personId?: string | null
+  organizationId?: string | null
+  contactFirstName?: string | null
+  contactLastName?: string | null
+  contactEmail?: string | null
+  contactPhone?: string | null
+  sellCurrency: string
+  sellAmountCents: number
+  title: string
+  description?: string | null
+  quantity: number
+  serviceDate?: string | null
+  endDate?: string | null
+  startsAt?: Date | null
+  endsAt?: Date | null
+  travelers: SourcedBookingTravelerInput[]
+  entityModule: string
+  entityId: string
+  sourceKind: string
+  sourceProvider?: string | null
+  sourceConnectionId: string
+  sourceRef: string
+  upstreamRef: string
+  storefrontId?: string | null
+  channelId?: string | null
+  supplierOperationId: string
+  now: Date
+}
+
+export interface CreateSourcedBookingCommitmentResult {
+  bookingId: string
+  bookingItemId: string
+  allocationIds: string[]
+}
+
+/**
+ * Materialize a supplier-secured component as the first-party commercial
+ * commitment. The caller owns the surrounding transaction and must serialize
+ * on its Supplier Operation before invoking this service.
+ */
+export async function createSourcedBookingCommitment(
+  db: PostgresJsDatabase,
+  input: CreateSourcedBookingCommitmentInput,
+): Promise<CreateSourcedBookingCommitmentResult> {
+  const bookingId = newId("bookings")
+  const bookingItemId = newId("booking_items")
+  const allocationId = newId("booking_allocations")
+  const startDate = input.startsAt?.toISOString().slice(0, 10) ?? input.serviceDate ?? null
+  const endDate = input.endsAt?.toISOString().slice(0, 10) ?? input.endDate ?? null
+
+  await db.insert(bookings).values({
+    id: bookingId,
+    bookingNumber: input.bookingNumber,
+    status: "confirmed",
+    personId: input.personId ?? null,
+    organizationId: input.organizationId ?? null,
+    sourceType: "api_partner",
+    externalBookingRef: input.upstreamRef,
+    contactFirstName: input.contactFirstName ?? null,
+    contactLastName: input.contactLastName ?? null,
+    contactEmail: input.contactEmail ?? null,
+    contactPhone: input.contactPhone ?? null,
+    sellCurrency: input.sellCurrency,
+    sellAmountCents: input.sellAmountCents,
+    startDate,
+    endDate,
+    pax: input.travelers.length || input.quantity,
+    acceptedAt: input.now,
+    confirmedAt: input.now,
+    createdAt: input.now,
+    updatedAt: input.now,
+  })
+
+  await db.insert(bookingItems).values({
+    id: bookingItemId,
+    bookingId,
+    title: input.title,
+    description: input.description ?? null,
+    itemType: "service",
+    status: "confirmed",
+    serviceDate: input.serviceDate ?? null,
+    startsAt: input.startsAt ?? null,
+    endsAt: input.endsAt ?? null,
+    quantity: input.quantity,
+    sellCurrency: input.sellCurrency,
+    unitSellAmountCents: Math.round(input.sellAmountCents / input.quantity),
+    totalSellAmountCents: input.sellAmountCents,
+    productNameSnapshot: input.title,
+    sourceOfferId: input.sourceRef,
+    metadata: {
+      entityModule: input.entityModule,
+      entityId: input.entityId,
+      supplierOperationId: input.supplierOperationId,
+      upstreamRef: input.upstreamRef,
+    },
+    createdAt: input.now,
+    updatedAt: input.now,
+  })
+
+  await db.insert(bookingAllocations).values({
+    id: allocationId,
+    bookingId,
+    bookingItemId,
+    quantity: input.quantity,
+    allocationType: "unit",
+    status: "confirmed",
+    confirmedAt: input.now,
+    metadata: {
+      sourceKind: input.sourceKind,
+      sourceConnectionId: input.sourceConnectionId,
+      upstreamRef: input.upstreamRef,
+      supplierOperationId: input.supplierOperationId,
+    },
+    createdAt: input.now,
+    updatedAt: input.now,
+  })
+
+  const travelers = input.travelers.map((traveler) => ({
+    id: newId("booking_travelers"),
+    bookingId,
+    firstName: traveler.firstName,
+    lastName: traveler.lastName,
+    email: traveler.email ?? null,
+    phone: traveler.phone ?? null,
+    travelerCategory: traveler.category ?? null,
+    isPrimary: traveler.isPrimary ?? false,
+    createdAt: input.now,
+    updatedAt: input.now,
+  }))
+  if (travelers.length > 0) {
+    await db.insert(bookingTravelers).values(travelers)
+    await db.insert(bookingItemTravelers).values(
+      travelers.map((traveler) => ({
+        id: newId("booking_item_travelers"),
+        bookingItemId,
+        travelerId: traveler.id,
+        role: "traveler" as const,
+        isPrimary: traveler.isPrimary,
+        createdAt: input.now,
+      })),
+    )
+  }
+
+  await upsertBookingOrigin(db, {
+    bookingId,
+    originSource: "provider_source_order",
+    providerSourceKind: input.sourceKind,
+    providerSourceProvider: input.sourceProvider ?? null,
+    providerSourceConnectionId: input.sourceConnectionId,
+    providerSourceRef: input.sourceRef,
+    providerOrderRef: input.upstreamRef,
+    storefrontId: input.storefrontId ?? null,
+    channelId: input.channelId ?? null,
+    metadata: {
+      entityModule: input.entityModule,
+      entityId: input.entityId,
+      supplierOperationId: input.supplierOperationId,
+    },
+  })
+
+  return { bookingId, bookingItemId, allocationIds: [allocationId] }
+}

--- a/packages/catalog-contracts/package.json
+++ b/packages/catalog-contracts/package.json
@@ -20,6 +20,7 @@
     "./booking-engine/draft-shape": "./src/booking-engine/draft-shape.ts",
     "./booking-engine/lifecycle-conformance": "./src/booking-engine/lifecycle-conformance.ts",
     "./booking-engine/session-contracts": "./src/booking-engine/session-contracts.ts",
+    "./booking-engine/supplier-operations": "./src/booking-engine/supplier-operations.ts",
     "./booking-engine/promotions-contract": "./src/booking-engine/promotions-contract.ts",
     "./snapshot": "./src/snapshot.ts"
   },
@@ -116,6 +117,11 @@
         "types": "./dist/booking-engine/session-contracts.d.ts",
         "import": "./dist/booking-engine/session-contracts.js",
         "default": "./dist/booking-engine/session-contracts.js"
+      },
+      "./booking-engine/supplier-operations": {
+        "types": "./dist/booking-engine/supplier-operations.d.ts",
+        "import": "./dist/booking-engine/supplier-operations.js",
+        "default": "./dist/booking-engine/supplier-operations.js"
       },
       "./booking-engine/promotions-contract": {
         "types": "./dist/booking-engine/promotions-contract.d.ts",

--- a/packages/catalog-contracts/src/adapter/booking-forwarding.ts
+++ b/packages/catalog-contracts/src/adapter/booking-forwarding.ts
@@ -8,6 +8,8 @@ export interface SourceAdapterRequestScope {
 export interface ReserveRequest {
   entity_module: string
   entity_id: string
+  /** Durable upstream identity resolved from Catalog provenance by the server. */
+  source_ref?: string
   /**
    * Vertical-specific selection. Free-form, but adapters recognize well-known
    * keys such as departure/date/pax fields and, for sourced stays/packages,
@@ -29,9 +31,25 @@ export interface ReserveResult {
   /** Upstream order / booking identifier — used as `source_ref` in snapshots. */
   upstream_ref: string
   /** Status returned by the upstream system. */
-  status: "held" | "confirmed" | "ticketed" | "failed"
+  status: "pending" | "held" | "confirmed" | "ticketed" | "failed"
   /** Opaque per-vertical payload echoed back to the snapshot graph. */
   upstream_payload?: Record<string, unknown>
+}
+
+/**
+ * Adapter-declared dispatch certainty. Generic transport errors are always
+ * treated as possibly sent; adapters may use this error only when they can
+ * prove no upstream request left the process.
+ */
+export class ReservationDispatchError extends Error {
+  constructor(
+    message: string,
+    readonly certainty: "not_sent" | "possibly_sent",
+    readonly errorClass: string,
+  ) {
+    super(message)
+    this.name = "ReservationDispatchError"
+  }
 }
 
 export interface CancelRequest {

--- a/packages/catalog-contracts/src/adapter/contract-shared.ts
+++ b/packages/catalog-contracts/src/adapter/contract-shared.ts
@@ -15,6 +15,7 @@ export type {
   ReserveResult,
   SourceAdapterRequestScope,
 } from "./booking-forwarding.js"
+export { ReservationDispatchError } from "./booking-forwarding.js"
 export type {
   PushAvailabilityRequest,
   PushAvailabilityResult,
@@ -50,10 +51,17 @@ export type {
 // Reservation retrieval
 // ─────────────────────────────────────────────────────────────────────────────
 
-export interface GetReservationRequest {
-  upstream_ref: string
-  scope?: SourceAdapterRequestScope
-}
+export type GetReservationRequest =
+  | {
+      upstream_ref: string
+      idempotency_key?: never
+      scope?: SourceAdapterRequestScope
+    }
+  | {
+      upstream_ref?: never
+      idempotency_key: string
+      scope?: SourceAdapterRequestScope
+    }
 
 export type ReservationStatus = ReserveResult["status"] | CancelResult["status"] | "cancelling"
 
@@ -121,6 +129,8 @@ export interface AdapterCapabilities {
    * Gates `getReservation` and `listReservations`.
    */
   supportsReservationRetrieval?: boolean
+  /** Whether `getReservation` accepts the original stable write key. */
+  supportsReservationLookupByIdempotencyKey?: boolean
   /**
    * Whether `cancel` returns a terminal upstream status synchronously.
    * When false, the adapter may return `status: "pending"` and drive the
@@ -264,6 +274,8 @@ export interface DiscoveryPage {
  */
 export interface LiveResolveRequest {
   ids: string[]
+  /** Server-resolved durable upstream identity keyed by local entity id. */
+  source_refs?: Record<string, string>
   /** Variant scope for the request (mirrors the resolver's scope). */
   scope: SourceAdapterRequestScope
   /**

--- a/packages/catalog-contracts/src/adapter/schemas.ts
+++ b/packages/catalog-contracts/src/adapter/schemas.ts
@@ -189,6 +189,7 @@ export const adapterCapabilitiesSchema = z.object({
   supportsDriftDetection: z.boolean(),
   supportsBookingForwarding: z.boolean(),
   supportsReservationRetrieval: z.boolean().optional(),
+  supportsReservationLookupByIdempotencyKey: z.boolean().optional(),
   supportsSyncCancellation: z.boolean().optional(),
   postBookOperations: z.array(postBookOperationSchema).readonly(),
   cacheTtlSeconds: z.number().int().min(0).nullable().optional(),
@@ -300,7 +301,7 @@ export const reserveRequestSchema = z.object({
   idempotency_key: z.string().optional(),
 })
 
-export const reserveStatusSchema = z.enum(["held", "confirmed", "ticketed", "failed"])
+export const reserveStatusSchema = z.enum(["pending", "held", "confirmed", "ticketed", "failed"])
 
 export const reserveResultSchema = z.object({
   upstream_ref: z.string(),
@@ -335,10 +336,18 @@ export const reservationStatusSchema = z.enum([
   "cancelling",
 ])
 
-export const getReservationRequestSchema = z.object({
-  upstream_ref: z.string(),
-  scope: sourceAdapterRequestScopeSchema.optional(),
-})
+export const getReservationRequestSchema = z.union([
+  z.object({
+    upstream_ref: z.string(),
+    idempotency_key: z.never().optional(),
+    scope: sourceAdapterRequestScopeSchema.optional(),
+  }),
+  z.object({
+    upstream_ref: z.never().optional(),
+    idempotency_key: z.string(),
+    scope: sourceAdapterRequestScopeSchema.optional(),
+  }),
+])
 
 export const getReservationResultSchema = z.object({
   upstream_ref: z.string(),

--- a/packages/catalog-contracts/src/booking-engine/session-contracts.ts
+++ b/packages/catalog-contracts/src/booking-engine/session-contracts.ts
@@ -20,7 +20,13 @@ export const bookingSessionTargetV1 = z.discriminatedUnion("kind", [
 ])
 export type BookingSessionTargetV1 = z.infer<typeof bookingSessionTargetV1>
 
-export const bookingSessionStateV1 = z.enum(["active", "consumed", "expired", "abandoned"])
+export const bookingSessionStateV1 = z.enum([
+  "active",
+  "supplier_pending",
+  "consumed",
+  "expired",
+  "abandoned",
+])
 export type BookingSessionStateV1 = z.infer<typeof bookingSessionStateV1>
 
 export const bookingSessionCapabilityActionV1 = z.enum([
@@ -121,7 +127,8 @@ export type BookingHoldRecordV1 = z.infer<typeof bookingHoldRecordV1>
 export const commitBookingSessionV1 = z.object({
   expectedRevision: z.number().int().positive(),
   quoteId: z.string().min(1),
-  holdId: z.string().min(1),
+  /** Required for owned inventory; sourced targets may commit without a Hold. */
+  holdId: z.string().min(1).optional(),
   idempotencyKey: z.string().min(8).max(128),
   payment: z
     .object({
@@ -167,6 +174,10 @@ export const bookingSessionLifecycleErrorV1 = z.discriminatedUnion("kind", [
   }),
   z.object({ kind: z.literal("not_authorized") }),
   z.object({ kind: z.literal("idempotency_conflict") }),
+  z.object({
+    kind: z.literal("supplier_operation_active"),
+    nextAction: z.literal("reconcile_supplier_operation"),
+  }),
   z.object({
     kind: z.literal("quote_unavailable"),
     reason: z.enum([

--- a/packages/catalog-contracts/src/booking-engine/supplier-operations.ts
+++ b/packages/catalog-contracts/src/booking-engine/supplier-operations.ts
@@ -1,0 +1,71 @@
+import { z } from "zod"
+
+export const supplierOperationStateV1 = z.enum([
+  "queued",
+  "submitted",
+  "pending",
+  "succeeded",
+  "refused",
+  "cancelled",
+  "in_doubt",
+  "manual_review",
+  "manually_resolved",
+])
+export type SupplierOperationStateV1 = z.infer<typeof supplierOperationStateV1>
+
+export const supplierCommitmentPolicyV1 = z.enum(["supplier_first", "operator_backed"])
+export type SupplierCommitmentPolicyV1 = z.infer<typeof supplierCommitmentPolicyV1>
+
+export const supplierOperationRecordV1 = z.object({
+  id: z.string().min(1),
+  sessionId: z.string().min(1),
+  quoteId: z.string().min(1),
+  holdId: z.string().min(1).nullable(),
+  operationKind: z.literal("reserve"),
+  state: supplierOperationStateV1,
+  commitmentPolicy: supplierCommitmentPolicyV1,
+  entityModule: z.string().min(1),
+  entityId: z.string().min(1),
+  sourceKind: z.string().min(1),
+  sourceConnectionId: z.string().min(1),
+  sourceRef: z.string().min(1),
+  adapterKind: z.string().min(1),
+  requestFingerprint: z.string().min(1),
+  adapterIdempotencyKey: z.string().min(8),
+  attemptCount: z.number().int().nonnegative(),
+  upstreamRef: z.string().min(1).nullable(),
+  upstreamStatus: z.string().min(1).nullable(),
+  bookingId: z.string().min(1).nullable(),
+  lastErrorClass: z.string().min(1).nullable(),
+  safeEvidence: z.record(z.string(), z.unknown()),
+  submittedAt: z.string().datetime().nullable(),
+  lastCheckedAt: z.string().datetime().nullable(),
+  sourceUpdatedAt: z.string().datetime().nullable(),
+  nextReconcileAt: z.string().datetime().nullable(),
+  resolvedAt: z.string().datetime().nullable(),
+  resolvedBy: z.string().min(1).nullable(),
+  resolutionReason: z.string().min(1).nullable(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+})
+export type SupplierOperationRecordV1 = z.infer<typeof supplierOperationRecordV1>
+
+export const listSupplierOperationsQueryV1 = z.object({
+  state: supplierOperationStateV1.optional(),
+  sessionId: z.string().min(1).optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+})
+export type ListSupplierOperationsQueryV1 = z.input<typeof listSupplierOperationsQueryV1>
+
+export const reconcileSupplierOperationV1 = z.object({
+  idempotencyKey: z.string().min(8).max(128),
+})
+export type ReconcileSupplierOperationV1 = z.input<typeof reconcileSupplierOperationV1>
+
+export const resolveSupplierOperationV1 = z.object({
+  idempotencyKey: z.string().min(8).max(128),
+  resolution: z.enum(["succeeded", "refused", "cancelled"]),
+  reason: z.string().trim().min(1).max(2000),
+  upstreamRef: z.string().trim().min(1).optional(),
+})
+export type ResolveSupplierOperationV1 = z.input<typeof resolveSupplierOperationV1>

--- a/packages/catalog/migrations/20260802090000_supplier_operations_v1.sql
+++ b/packages/catalog/migrations/20260802090000_supplier_operations_v1.sql
@@ -1,0 +1,62 @@
+CREATE TABLE "supplier_operations" (
+  "id" text PRIMARY KEY NOT NULL,
+  "session_id" text NOT NULL,
+  "quote_id" text NOT NULL,
+  "hold_id" text,
+  "commit_idempotency_key" text NOT NULL,
+  "operation_kind" text NOT NULL,
+  "state" text NOT NULL,
+  "commitment_policy" text NOT NULL,
+  "entity_module" text NOT NULL,
+  "entity_id" text NOT NULL,
+  "source_kind" text NOT NULL,
+  "source_connection_id" text NOT NULL,
+  "source_ref" text NOT NULL,
+  "adapter_kind" text NOT NULL,
+  "request_fingerprint" text NOT NULL,
+  "adapter_idempotency_key" text NOT NULL,
+  "request_payload" jsonb NOT NULL,
+  "version" integer DEFAULT 0 NOT NULL,
+  "attempt_count" integer DEFAULT 0 NOT NULL,
+  "upstream_ref" text,
+  "upstream_status" text,
+  "booking_id" text,
+  "last_error_class" text,
+  "safe_evidence" jsonb DEFAULT '{}'::jsonb NOT NULL,
+  "submitted_at" timestamp with time zone,
+  "last_checked_at" timestamp with time zone,
+  "source_updated_at" timestamp with time zone,
+  "next_reconcile_at" timestamp with time zone,
+  "resolved_at" timestamp with time zone,
+  "resolved_by" text,
+  "resolution_reason" text,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "supplier_operations_session_id_booking_sessions_id_fk" FOREIGN KEY ("session_id") REFERENCES "public"."booking_sessions"("id") ON DELETE restrict ON UPDATE no action,
+  CONSTRAINT "supplier_operations_quote_id_booking_session_quotes_id_fk" FOREIGN KEY ("quote_id") REFERENCES "public"."booking_session_quotes"("id") ON DELETE restrict ON UPDATE no action,
+  CONSTRAINT "supplier_operations_hold_id_booking_session_holds_id_fk" FOREIGN KEY ("hold_id") REFERENCES "public"."booking_session_holds"("id") ON DELETE restrict ON UPDATE no action,
+  CONSTRAINT "supplier_operations_id_typeid" CHECK ("id" LIKE 'suop_%'),
+  CONSTRAINT "supplier_operations_kind" CHECK ("operation_kind" = 'reserve'),
+  CONSTRAINT "supplier_operations_state" CHECK ("state" IN ('queued','submitted','pending','succeeded','refused','cancelled','in_doubt','manual_review','manually_resolved')),
+  CONSTRAINT "supplier_operations_policy" CHECK ("commitment_policy" IN ('supplier_first','operator_backed')),
+  CONSTRAINT "supplier_operations_version" CHECK ("version" >= 0),
+  CONSTRAINT "supplier_operations_attempt_count" CHECK ("attempt_count" >= 0)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_supplier_operations_session_reserve" ON "supplier_operations" USING btree ("session_id","operation_kind");
+--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_supplier_operations_adapter_idem" ON "supplier_operations" USING btree ("source_connection_id","adapter_idempotency_key");
+--> statement-breakpoint
+CREATE INDEX "idx_supplier_operations_state_reconcile" ON "supplier_operations" USING btree ("state","next_reconcile_at");
+--> statement-breakpoint
+CREATE INDEX "idx_supplier_operations_session_created" ON "supplier_operations" USING btree ("session_id","created_at");
+--> statement-breakpoint
+CREATE INDEX "idx_supplier_operations_upstream" ON "supplier_operations" USING btree ("source_connection_id","upstream_ref");
+--> statement-breakpoint
+ALTER TABLE "booking_session_audit_events" DROP CONSTRAINT "booking_session_audit_events_action";
+--> statement-breakpoint
+ALTER TABLE "booking_session_audit_events" ADD CONSTRAINT "booking_session_audit_events_action" CHECK ("action" IN ('read', 'update', 'quote', 'hold', 'commit', 'adopt', 'renew', 'abandon', 'expire', 'purge', 'supplier_reconcile', 'supplier_manual_resolve'));
+--> statement-breakpoint
+ALTER TABLE "booking_sessions" DROP CONSTRAINT "booking_sessions_state";
+--> statement-breakpoint
+ALTER TABLE "booking_sessions" ADD CONSTRAINT "booking_sessions_state" CHECK ("state" IN ('active', 'supplier_pending', 'consumed', 'expired', 'abandoned'));

--- a/packages/catalog/migrations/20260802090000_supplier_operations_v1.sql
+++ b/packages/catalog/migrations/20260802090000_supplier_operations_v1.sql
@@ -43,7 +43,9 @@ CREATE TABLE "supplier_operations" (
   CONSTRAINT "supplier_operations_attempt_count" CHECK ("attempt_count" >= 0)
 );
 --> statement-breakpoint
-CREATE UNIQUE INDEX "uidx_supplier_operations_session_reserve" ON "supplier_operations" USING btree ("session_id","operation_kind");
+CREATE UNIQUE INDEX "uidx_supplier_operations_session_commit" ON "supplier_operations" USING btree ("session_id","commit_idempotency_key");
+--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_supplier_operations_session_reserve_guard" ON "supplier_operations" USING btree ("session_id","operation_kind") WHERE "state" IN ('queued','submitted','pending','succeeded','in_doubt','manual_review') OR ("state" = 'manually_resolved' AND "upstream_status" = 'succeeded');
 --> statement-breakpoint
 CREATE UNIQUE INDEX "uidx_supplier_operations_adapter_idem" ON "supplier_operations" USING btree ("source_connection_id","adapter_idempotency_key");
 --> statement-breakpoint

--- a/packages/catalog/migrations/meta/_journal.json
+++ b/packages/catalog/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1785614400000,
       "tag": "20260801200000_booking_session_storefront_origin",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1785650400000,
+      "tag": "20260802090000_supplier_operations_v1",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/catalog/package.json
+++ b/packages/catalog/package.json
@@ -45,6 +45,7 @@
     "./booking-engine/sessions-drizzle": "./src/booking-engine/sessions-drizzle.ts",
     "./booking-engine/sessions-routes": "./src/booking-engine/sessions-routes.ts",
     "./booking-engine/sessions-schema": "./src/booking-engine/sessions-schema.ts",
+    "./booking-engine/supplier-operations": "./src/booking-engine/supplier-operations.ts",
     "./booking-engine/draft-shape": "./src/booking-engine/draft-shape.ts",
     "./booking-engine/contracts": "./src/booking-engine/contracts.ts",
     "./booking-engine/drafts-schema": "./src/booking-engine/drafts-schema.ts",
@@ -318,6 +319,11 @@
         "types": "./dist/booking-engine/sessions-schema.d.ts",
         "import": "./dist/booking-engine/sessions-schema.js",
         "default": "./dist/booking-engine/sessions-schema.js"
+      },
+      "./booking-engine/supplier-operations": {
+        "types": "./dist/booking-engine/supplier-operations.d.ts",
+        "import": "./dist/booking-engine/supplier-operations.js",
+        "default": "./dist/booking-engine/supplier-operations.js"
       },
       "./booking-engine/draft-shape": {
         "types": "./dist/booking-engine/draft-shape.d.ts",

--- a/packages/catalog/src/adapter/contract.test.ts
+++ b/packages/catalog/src/adapter/contract.test.ts
@@ -338,6 +338,9 @@ describe("SourceAdapter — reservation retrieval capability gating", () => {
       scope: { locale: "en-GB", audience: "operator", market: "GB", currency: "GBP" },
     }
     expect(getReservationRequestSchema.parse(request)).toEqual(request)
+    expect(
+      getReservationRequestSchema.parse({ idempotency_key: "bses_1:commit_1:reserve" }),
+    ).toEqual({ idempotency_key: "bses_1:commit_1:reserve" })
     await expect(adapter.getReservation!({ connection_id: "conn_1" }, request)).resolves.toBeNull()
     await expect(
       adapter.getReservation!({ connection_id: "conn_1" }, { upstream_ref: "booking_abc" }),

--- a/packages/catalog/src/adapter/schemas.test.ts
+++ b/packages/catalog/src/adapter/schemas.test.ts
@@ -417,7 +417,7 @@ const invalidCases = [
     { ...getContentResult, content_schema_version: undefined },
   ],
   ["reserveRequestSchema", reserveRequestSchema, { ...reserveRequest, parameters: undefined }],
-  ["reserveResultSchema", reserveResultSchema, { ...reserveResult, status: "pending" }],
+  ["reserveResultSchema", reserveResultSchema, { ...reserveResult, status: "unknown" }],
   ["cancelRequestSchema", cancelRequestSchema, { reason: "customer_request" }],
   ["cancelResultSchema", cancelResultSchema, { ...cancelResult, refund_currency: "GB" }],
   ["reservationStatusSchema", reservationStatusSchema, "expired"],

--- a/packages/catalog/src/booking-engine/index.ts
+++ b/packages/catalog/src/booking-engine/index.ts
@@ -272,9 +272,34 @@ export {
   type BookingSessionModulePorts,
   type BookingSessionRepository,
   type CommitOwnedBookingInput,
+  type CommitSourcedBookingInput,
+  type CommitSourcedBookingResult,
   type ComposeBookingQuoteInput,
   createBookingSessionModule,
 } from "./sessions-service.js"
+export {
+  createSupplierOperationWorkflow,
+  type DispatchSupplierReservationInput,
+  type SupplierOperationWorkflow,
+  type SupplierOperationWorkflowOutcome,
+} from "./supplier-operation-workflow.js"
+export {
+  type CreateSupplierOperationResult,
+  createDrizzleSupplierOperationRepository,
+  createSupplierOperationRecord,
+  type SupplierOperationInternalRecord,
+  type SupplierOperationRepository,
+  serializeSupplierOperation,
+} from "./supplier-operations.js"
+export {
+  createSupplierOperationOperatorService,
+  type SupplierOperationOperatorService,
+} from "./supplier-operations-operator.js"
+export {
+  type InsertSupplierOperation,
+  type SelectSupplierOperation,
+  supplierOperationsTable,
+} from "./supplier-operations-schema.js"
 export {
   type SyncAdapterSummary,
   type SyncProgressEvent,

--- a/packages/catalog/src/booking-engine/routes.ts
+++ b/packages/catalog/src/booking-engine/routes.ts
@@ -925,6 +925,17 @@ export function engineParametersFromDraft(
     const value = stringValue(configure?.[key])
     if (value && next[key] == null) next[key] = value
   }
+  for (const key of [
+    "sailingId",
+    "cabinCategoryId",
+    "cabinCategoryRef",
+    "occupancy",
+    "passengerComposition",
+    "fareCode",
+    "fareVariant",
+  ] as const) {
+    if (configure?.[key] != null && next[key] == null) next[key] = configure[key]
+  }
   // Lift `draft.promotionCode` to the top-level so `quoteEntity`'s
   // promotion hook can read it without descending into the nested
   // draft. Same lifting pattern as `paxCount` above. Per

--- a/packages/catalog/src/booking-engine/sessions-drizzle.ts
+++ b/packages/catalog/src/booking-engine/sessions-drizzle.ts
@@ -1,6 +1,6 @@
 import { AsyncLocalStorage } from "node:async_hooks"
 import { newId } from "@voyant-travel/db/lib/typeid"
-import { and, eq, inArray, isNull, lte, sql } from "drizzle-orm"
+import { and, eq, inArray, isNull, lte, notExists, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import type { PricingBreakdownV1 } from "./contracts.js"
@@ -23,6 +23,7 @@ import type {
   BookingSessionInternalRecord,
   BookingSessionRepository,
 } from "./sessions-service.js"
+import { supplierOperationsTable } from "./supplier-operations-schema.js"
 
 export function createDrizzleBookingSessionRepository(
   db: PostgresJsDatabase,
@@ -129,6 +130,25 @@ export function createDrizzleBookingSessionRepository(
           and(
             eq(bookingSessionsTable.state, "active"),
             lte(bookingSessionsTable.expiresAt, input.at),
+            notExists(
+              resolveDb()
+                .select({ id: supplierOperationsTable.id })
+                .from(supplierOperationsTable)
+                .where(
+                  and(
+                    eq(supplierOperationsTable.sessionId, bookingSessionsTable.id),
+                    inArray(supplierOperationsTable.state, [
+                      "queued",
+                      "submitted",
+                      "pending",
+                      "in_doubt",
+                      "manual_review",
+                      "succeeded",
+                      "manually_resolved",
+                    ]),
+                  ),
+                ),
+            ),
           ),
         )
         .limit(input.limit)
@@ -323,7 +343,7 @@ export function createDrizzleBookingSessionRepository(
         .where(
           and(
             eq(bookingSessionsTable.id, input.sessionId),
-            eq(bookingSessionsTable.state, "active"),
+            inArray(bookingSessionsTable.state, ["active", "supplier_pending"]),
           ),
         )
         .returning()
@@ -340,18 +360,20 @@ export function createDrizzleBookingSessionRepository(
         )
         .returning()
       if (!quote) throw new Error("booking_session_commit_quote_consumed")
-      const [hold] = await resolveDb()
-        .update(bookingSessionHoldsTable)
-        .set({ state: "converted", convertedAt: at })
-        .where(
-          and(
-            eq(bookingSessionHoldsTable.id, input.holdId),
-            eq(bookingSessionHoldsTable.sessionId, input.sessionId),
-            eq(bookingSessionHoldsTable.state, "active"),
-          ),
-        )
-        .returning()
-      if (!hold) throw new Error("booking_session_commit_hold_consumed")
+      if (input.holdId) {
+        const [hold] = await resolveDb()
+          .update(bookingSessionHoldsTable)
+          .set({ state: "converted", convertedAt: at })
+          .where(
+            and(
+              eq(bookingSessionHoldsTable.id, input.holdId),
+              eq(bookingSessionHoldsTable.sessionId, input.sessionId),
+              eq(bookingSessionHoldsTable.state, "active"),
+            ),
+          )
+          .returning()
+        if (!hold) throw new Error("booking_session_commit_hold_consumed")
+      }
       await resolveDb()
         .insert(bookingSessionCommitsTable)
         .values({

--- a/packages/catalog/src/booking-engine/sessions-memory.ts
+++ b/packages/catalog/src/booking-engine/sessions-memory.ts
@@ -148,10 +148,14 @@ export function createInMemoryBookingSessionRepository(): InMemoryBookingSession
     async consumeCommit(input) {
       const session = repository.sessions.get(input.sessionId)
       const quote = repository.quotes.get(input.quoteId)
-      const hold = repository.holds.get(input.holdId)
-      if (session?.state !== "active") throw new Error("booking_session_commit_session_consumed")
+      const hold = input.holdId ? repository.holds.get(input.holdId) : undefined
+      if (session?.state !== "active" && session?.state !== "supplier_pending") {
+        throw new Error("booking_session_commit_session_consumed")
+      }
       if (quote?.state !== "active") throw new Error("booking_session_commit_quote_consumed")
-      if (hold?.state !== "active") throw new Error("booking_session_commit_hold_consumed")
+      if (input.holdId && hold?.state !== "active") {
+        throw new Error("booking_session_commit_hold_consumed")
+      }
       repository.sessions.set(input.sessionId, {
         ...cloneSession(session),
         state: "consumed",
@@ -159,7 +163,9 @@ export function createInMemoryBookingSessionRepository(): InMemoryBookingSession
         updatedAt: new Date(input.now),
       })
       repository.quotes.set(input.quoteId, { ...cloneQuote(quote), state: "consumed" })
-      repository.holds.set(input.holdId, { ...cloneHold(hold), state: "converted" })
+      if (input.holdId && hold) {
+        repository.holds.set(input.holdId, { ...cloneHold(hold), state: "converted" })
+      }
       const commitId = newId("booking_session_commits")
       repository.commits.set(commitId, {
         id: commitId,

--- a/packages/catalog/src/booking-engine/sessions-payment-production.ts
+++ b/packages/catalog/src/booking-engine/sessions-payment-production.ts
@@ -94,13 +94,17 @@ export function createProductionBookingSessionPaymentPorts(
           payerName: [contact.firstName, contact.lastName].filter(Boolean).join(" ") || null,
           returnUrl: commit.payment?.returnUrl,
           cancelUrl: commit.payment?.cancelUrl,
-          expiresAt: earliestDate(session.expiresAt, quote.expiresAt, hold.expiresAt),
+          expiresAt: earliestDate(
+            session.expiresAt,
+            quote.expiresAt,
+            hold?.expiresAt ?? quote.expiresAt,
+          ),
           metadata: {
             paymentPolicySource: resolved.source,
             paymentScheduleType: dueNow.scheduleType,
             sessionActorKind: session.actorKind,
             quoteId: quote.id,
-            holdId: hold.id,
+            ...(hold ? { holdId: hold.id } : {}),
           },
         },
         deps.financeRuntime,
@@ -128,7 +132,11 @@ export function createProductionBookingSessionPaymentPorts(
             description: `Booking Session ${session.id}`,
             returnUrl: commit.payment?.returnUrl,
             cancelUrl: commit.payment?.cancelUrl,
-            metadata: { bookingSessionId: session.id, quoteId: quote.id, holdId: hold.id },
+            metadata: {
+              bookingSessionId: session.id,
+              quoteId: quote.id,
+              ...(hold ? { holdId: hold.id } : {}),
+            },
           },
           {
             context: deps.paymentAdapterContext ?? { env: {} },

--- a/packages/catalog/src/booking-engine/sessions-production.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-production.test.ts
@@ -40,6 +40,7 @@ vi.mock("@voyant-travel/finance", async (importOriginal) => ({
 
 import type { OwnedBookingHandler } from "./owned-handler.js"
 import { createOwnedBookingHandlerRegistry } from "./owned-handler.js"
+import { createSourceAdapterRegistry } from "./registry.js"
 import { createInMemoryBookingSessionRepository } from "./sessions-memory.js"
 import {
   createProductionBookingSessionModule,
@@ -63,6 +64,7 @@ function createProductionHarness(handler: OwnedBookingHandler) {
     } as never,
     repository,
     resolveOwnedHandlers: () => handlers,
+    resolveSourceRegistry: () => createSourceAdapterRegistry(),
   })
   return { module, repository }
 }
@@ -705,6 +707,7 @@ function createCommittableProductionModule(command: Record<string, unknown> = {}
     } as never,
     repository,
     resolveOwnedHandlers: () => handlers,
+    resolveSourceRegistry: () => createSourceAdapterRegistry(),
     relationships: {
       upsertPersonFromContact: async () => ({ id: "per_buyer" }),
     } as never,

--- a/packages/catalog/src/booking-engine/sessions-production.ts
+++ b/packages/catalog/src/booking-engine/sessions-production.ts
@@ -1,6 +1,11 @@
 import type { BookingsRelationshipsRuntime } from "@voyant-travel/bookings/runtime-port"
+import {
+  createSourcedBookingCommitment,
+  type SourcedBookingTravelerInput,
+} from "@voyant-travel/bookings/service-sourced-commitment"
 import type { AnyDrizzleDb } from "@voyant-travel/db"
 import {
+  allocateBookingNumber,
   applyBookingSessionStaffSelectionV1,
   createSelfServiceCreateRuntime,
   FINANCE_BOOKING_CREATE_SELF_SERVICE_ROUTE_ACTION,
@@ -8,12 +13,15 @@ import {
   normalizeBookingSessionStaffSelectionV1,
 } from "@voyant-travel/finance"
 import { createRouteActionRegistry } from "@voyant-travel/tools"
-import { eq } from "drizzle-orm"
+import { and, eq } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { catalogSourcedEntriesTable } from "../schema-sourced-entries.js"
+import { captureSnapshot } from "../services/snapshot-service.js"
 import type { PricingBasis } from "../snapshot/schema.js"
 import { bookingAllocationsRef, bookingsRef } from "./bookings-ref.js"
 import { pricingBreakdownV1 } from "./contracts.js"
 import type { OwnedBookingHandlerRegistry, SelfServiceBillingParty } from "./owned-handler.js"
+import type { SourceAdapterRegistry } from "./registry.js"
 import { engineParametersFromDraft } from "./routes.js"
 import type { ProductionBookingSessionPaymentDeps } from "./sessions-payment-production.js"
 import { createProductionBookingSessionPaymentPorts } from "./sessions-payment-production.js"
@@ -22,14 +30,24 @@ import {
   type BookingSessionModule,
   type BookingSessionRepository,
   type CommitOwnedBookingInput,
+  type CommitSourcedBookingInput,
   createBookingSessionModule,
   InvalidBookingSessionSelectionError,
 } from "./sessions-service.js"
+import {
+  createSupplierOperationWorkflow,
+  safeSupplierRequestPayload,
+} from "./supplier-operation-workflow.js"
+import {
+  createDrizzleSupplierOperationRepository,
+  createSupplierOperationRecord,
+} from "./supplier-operations.js"
 
 export interface ProductionBookingSessionModuleDeps {
   db: PostgresJsDatabase
   repository: BookingSessionRepository
   resolveOwnedHandlers(): OwnedBookingHandlerRegistry | Promise<OwnedBookingHandlerRegistry>
+  resolveSourceRegistry(): SourceAdapterRegistry | Promise<SourceAdapterRegistry>
   relationships?: BookingsRelationshipsRuntime
   financeRuntime?: FinanceServiceRuntime
   payments?: Omit<ProductionBookingSessionPaymentDeps, "db" | "financeRuntime">
@@ -49,8 +67,11 @@ export function createProductionBookingSessionModule(
     ports: {
       repository: deps.repository,
       normalizeSelection: async ({ selection, target, access }) =>
-        normalizeProductSelection(target, selection, access),
+        normalizeBookingSelection(target, selection, access),
       composeQuote: async ({ session, tx }) => {
+        if (session.target.kind === "catalog_item") {
+          return composeSourcedQuote(deps, session, tx as PostgresJsDatabase)
+        }
         const handlers = await deps.resolveOwnedHandlers()
         const handler = handlers.resolve(entityModuleForSession(session.target))
         if (!handler) {
@@ -115,9 +136,286 @@ export function createProductionBookingSessionModule(
         )
       },
       commitOwnedBooking: (input) => commitOwnedBooking(deps, input),
+      commitSourcedBooking: (input) => commitSourcedBooking(deps, input),
+      hasActiveSupplierOperation: async ({ sessionId, tx }) => {
+        const operation = await createDrizzleSupplierOperationRepository(
+          tx as PostgresJsDatabase,
+        ).getBySession(sessionId)
+        return Boolean(
+          operation &&
+            operation.state !== "refused" &&
+            operation.state !== "cancelled" &&
+            !(operation.state === "manually_resolved" && operation.upstreamStatus !== "succeeded"),
+        )
+      },
       payments,
     },
   })
+}
+
+async function composeSourcedQuote(
+  deps: ProductionBookingSessionModuleDeps,
+  session: CommitSourcedBookingInput["session"],
+  tx: PostgresJsDatabase,
+) {
+  const sourced = await resolveSourcedTarget(tx, session)
+  if (!sourced) return unavailableQuoteResult("product_not_found")
+  const registry = await deps.resolveSourceRegistry()
+  const adapter = registry.resolveByConnection(sourced.sourceConnectionId)
+  if (!adapter?.capabilities.supportsLiveResolution || !adapter.liveResolve) {
+    return unavailableQuoteResult("no_sell_amount_configured")
+  }
+  const result = await adapter.liveResolve(
+    { connection_id: sourced.sourceConnectionId },
+    {
+      ids: [sourced.entityId],
+      source_refs: { [sourced.entityId]: sourced.sourceRef },
+      scope: { locale: "en", audience: "customer", market: "default" },
+      parameters: sourcedParameters(session.statePayload, sourced),
+    },
+  )
+  const liveValues = result.values[sourced.entityId]
+  if (result.failed?.[sourced.entityId] || !liveValues) {
+    return unavailableQuoteResult("selection_unavailable")
+  }
+  const pricing = pricingBreakdownFromLiveValues(liveValues)
+  return pricing
+    ? { status: "quoted" as const, pricing }
+    : unavailableQuoteResult("no_sell_amount_configured")
+}
+
+async function commitSourcedBooking(
+  deps: ProductionBookingSessionModuleDeps,
+  input: CommitSourcedBookingInput,
+) {
+  const sourced = await resolveSourcedTarget(deps.db, input.session)
+  if (!sourced) throw new BookingSessionCommitRejectedError("entity_not_bookable")
+  const registry = await deps.resolveSourceRegistry()
+  const workflow = createSupplierOperationWorkflow({
+    repository: createDrizzleSupplierOperationRepository(deps.db),
+    registry,
+  })
+  const parameters = sourcedParameters(input.session.statePayload, sourced)
+  const request = {
+    entity_module: sourced.entityModule,
+    entity_id: sourced.entityId,
+    source_ref: sourced.sourceRef,
+    parameters,
+    party: supplierParty(input.session.statePayload),
+    scope: { locale: "en", audience: "customer", market: "default" },
+  }
+  const adapter = registry.resolveByConnection(sourced.sourceConnectionId)
+  await deps.repository.withSessionTransaction(input.session.id, async (rawTx) => {
+    const currentSession = await deps.repository.getSession(input.session.id)
+    if (currentSession?.state !== "active" && currentSession?.state !== "supplier_pending") {
+      throw new BookingSessionCommitRejectedError("entity_not_bookable")
+    }
+    const claim = await createDrizzleSupplierOperationRepository(
+      rawTx as PostgresJsDatabase,
+    ).createOrReplay(
+      createSupplierOperationRecord({
+        sessionId: input.session.id,
+        quoteId: input.quote.id,
+        ...(input.hold ? { holdId: input.hold.id } : {}),
+        commitIdempotencyKey: input.idempotencyKey,
+        entityModule: sourced.entityModule,
+        entityId: sourced.entityId,
+        sourceKind: sourced.sourceKind,
+        sourceConnectionId: sourced.sourceConnectionId,
+        sourceRef: sourced.sourceRef,
+        adapterKind: adapter?.kind ?? sourced.sourceKind,
+        requestFingerprint: input.requestFingerprint,
+        adapterIdempotencyKey: `${input.session.id}:${input.idempotencyKey}:reserve`,
+        requestPayload: safeSupplierRequestPayload(request),
+        now: input.now,
+      }),
+    )
+    if (claim.status === "conflict") {
+      throw new Error("supplier_operation_idempotency_conflict")
+    }
+    if (currentSession.state === "active") {
+      currentSession.state = "supplier_pending"
+      currentSession.updatedAt = input.now
+      await deps.repository.saveSession(currentSession)
+    }
+  })
+  const result = await workflow.dispatch({
+    sessionId: input.session.id,
+    quoteId: input.quote.id,
+    ...(input.hold ? { holdId: input.hold.id } : {}),
+    commitIdempotencyKey: input.idempotencyKey,
+    requestFingerprint: input.requestFingerprint,
+    entityModule: sourced.entityModule,
+    entityId: sourced.entityId,
+    sourceKind: sourced.sourceKind,
+    sourceConnectionId: sourced.sourceConnectionId,
+    sourceRef: sourced.sourceRef,
+    request,
+    adapterContext: { connection_id: sourced.sourceConnectionId },
+    now: input.now,
+  })
+  if (result.kind === "idempotency_conflict") {
+    throw new BookingSessionCommitRejectedError("entity_not_bookable")
+  }
+  if (result.kind === "pending") {
+    return {
+      kind: "supplier_pending" as const,
+      nextAction: "await_supplier_operation" as const,
+      supplierOperationId: result.operation.id,
+      operatorBackedRiskAccepted: false,
+    }
+  }
+  if (result.kind === "in_doubt") {
+    return {
+      kind: "supplier_in_doubt" as const,
+      nextAction: "reconcile_supplier_operation" as const,
+      supplierOperationId: result.operation.id,
+      operatorBackedRiskAccepted: false,
+    }
+  }
+  if (result.kind === "failed") {
+    await reopenSessionAfterSupplierFailure(deps, result.operation.sessionId, input.now)
+    return {
+      kind: "supplier_failed" as const,
+      nextAction:
+        result.operation.state === "manual_review"
+          ? ("manual_review" as const)
+          : ("select_alternative_inventory" as const),
+      supplierOperationId: result.operation.id,
+      operatorBackedRiskAccepted: false,
+    }
+  }
+
+  return deps.db.transaction(async (tx) => {
+    const transaction = tx as PostgresJsDatabase
+    const operationRepository = createDrizzleSupplierOperationRepository(transaction)
+    const operation = await operationRepository.getForUpdate(result.operation.id)
+    if (operation?.state !== "succeeded") {
+      throw new Error("supplier_operation_not_secured")
+    }
+    if (operation.bookingId) {
+      const allocations = await transaction
+        .select({ id: bookingAllocationsRef.id })
+        .from(bookingAllocationsRef)
+        .where(eq(bookingAllocationsRef.bookingId, operation.bookingId))
+      return {
+        kind: "committed" as const,
+        bookingId: operation.bookingId,
+        allocationIds: allocations.map((row) => row.id),
+        supplierOperationId: operation.id,
+      }
+    }
+    const billing = await resolveBilling(deps, input, transaction)
+    if (!billing) throw new BookingSessionCommitRejectedError("incomplete_draft")
+    const bookingNumber = await allocateBookingNumber(transaction, { now: input.now })
+    const materialized = await createSourcedBookingCommitment(transaction, {
+      bookingNumber,
+      personId: billing.personId,
+      organizationId: billing.organizationId,
+      contactFirstName: billing.contactFirstName,
+      contactLastName: billing.contactLastName,
+      contactEmail: billing.contactEmail,
+      contactPhone: billing.contactPhone,
+      sellCurrency: input.quote.pricing.currency,
+      sellAmountCents: input.quote.pricing.total,
+      title: sourced.title,
+      quantity: supplierQuantity(input.session.statePayload),
+      serviceDate: supplierServiceDate(result.result.upstream_payload),
+      endDate: supplierEndDate(result.result.upstream_payload),
+      travelers: sourcedTravelers(input.session.statePayload),
+      entityModule: sourced.entityModule,
+      entityId: sourced.entityId,
+      sourceKind: sourced.sourceKind,
+      sourceProvider: sourced.sourceProvider,
+      sourceConnectionId: sourced.sourceConnectionId,
+      sourceRef: sourced.sourceRef,
+      upstreamRef: result.result.upstream_ref,
+      storefrontId: input.session.storefrontOrigin?.storefrontId,
+      channelId: input.session.storefrontOrigin?.channelId,
+      supplierOperationId: operation.id,
+      now: input.now,
+    })
+    await captureSnapshot(transaction, {
+      bookingId: materialized.bookingId,
+      entityModule: sourced.entityModule,
+      entityId: sourced.entityId,
+      sourceKind: sourced.sourceKind,
+      sourceProvider: sourced.sourceProvider ?? undefined,
+      sourceConnectionId: sourced.sourceConnectionId,
+      sourceRef: result.result.upstream_ref,
+      frozenPayload: {
+        projection: sourced.projection,
+        selection: safeSourcedSelection(input.session.statePayload),
+        supplierEvidence: operation.safeEvidence,
+        pricing: input.quote.pricing,
+      },
+      pricingBasis: pricingBasisFromBreakdown(input.quote.pricing),
+      idempotencyKey: operation.adapterIdempotencyKey,
+    })
+    operation.bookingId = materialized.bookingId
+    operation.updatedAt = input.now
+    await operationRepository.save(operation)
+    await input.consumeSources(
+      transaction,
+      materialized.bookingId,
+      materialized.allocationIds,
+      operation.id,
+    )
+    return {
+      kind: "committed" as const,
+      bookingId: materialized.bookingId,
+      allocationIds: materialized.allocationIds,
+      supplierOperationId: operation.id,
+    }
+  })
+}
+
+async function reopenSessionAfterSupplierFailure(
+  deps: ProductionBookingSessionModuleDeps,
+  sessionId: string,
+  at: Date,
+): Promise<void> {
+  await deps.repository.withSessionTransaction(sessionId, async () => {
+    const session = await deps.repository.getSession(sessionId)
+    if (session?.state !== "supplier_pending") return
+    session.state = "active"
+    session.updatedAt = at
+    await deps.repository.saveSession(session)
+  })
+}
+
+async function resolveSourcedTarget(
+  db: PostgresJsDatabase,
+  session: CommitSourcedBookingInput["session"],
+) {
+  if (session.target.kind !== "catalog_item") return null
+  const rows = await db
+    .select()
+    .from(catalogSourcedEntriesTable)
+    .where(
+      and(
+        eq(catalogSourcedEntriesTable.entity_id, session.target.catalogItemId),
+        eq(catalogSourcedEntriesTable.status, "active"),
+      ),
+    )
+    .limit(2)
+  if (rows.length !== 1) return null
+  const row = rows[0]
+  if (!row?.source_connection_id || !row.source_ref || row.source_kind === "owned") return null
+  const title =
+    stringValue(row.projection.name) ??
+    stringValue(row.projection.title) ??
+    `Sourced ${row.entity_module}`
+  return {
+    entityModule: row.entity_module,
+    entityId: row.entity_id,
+    sourceKind: row.source_kind,
+    sourceProvider: row.source_provider,
+    sourceConnectionId: row.source_connection_id,
+    sourceRef: row.source_ref,
+    projection: row.projection,
+    title,
+  }
 }
 
 async function commitOwnedBooking(
@@ -222,7 +520,7 @@ async function commitOwnedBookingInTransaction(
 
 async function resolveBilling(
   deps: ProductionBookingSessionModuleDeps,
-  input: CommitOwnedBookingInput,
+  input: Pick<CommitOwnedBookingInput, "session" | "access">,
   tx: PostgresJsDatabase,
 ): Promise<SelfServiceBillingParty | null> {
   const contact = billingContact(input.session.statePayload)
@@ -290,6 +588,55 @@ function pricingBreakdownFromBasis(pricing: PricingBasis) {
   }
 }
 
+function pricingBreakdownFromLiveValues(values: Record<string, unknown>) {
+  const priceCents = numberValue(values.priceCents) ?? numberValue(values.price)
+  const currency = stringValue(values.currency)
+  if (priceCents == null || !currency) return null
+  const taxes = numberValue(values.taxesCents) ?? 0
+  const fees = numberValue(values.feesCents) ?? 0
+  const surcharges = numberValue(values.surchargesCents) ?? 0
+  const total = priceCents + taxes + fees + surcharges
+  return {
+    currency,
+    lines: [
+      {
+        kind: "base" as const,
+        label: "Base",
+        quantity: 1,
+        unitAmount: priceCents,
+        totalAmount: priceCents,
+      },
+      ...(fees > 0
+        ? [
+            {
+              kind: "fee" as const,
+              label: "Fees",
+              quantity: 1,
+              unitAmount: fees,
+              totalAmount: fees,
+            },
+          ]
+        : []),
+      ...(surcharges > 0
+        ? [
+            {
+              kind: "fee" as const,
+              label: "Surcharges",
+              quantity: 1,
+              unitAmount: surcharges,
+              totalAmount: surcharges,
+            },
+          ]
+        : []),
+    ],
+    taxes:
+      taxes > 0 ? [{ code: "TAX", label: "Taxes", rate: 0, amount: taxes, base: priceCents }] : [],
+    subtotal: priceCents + fees + surcharges,
+    taxTotal: taxes,
+    total,
+  }
+}
+
 function unavailableQuoteResult(invalidReason: string | undefined) {
   if (invalidReason === "product_not_found") {
     return {
@@ -332,14 +679,11 @@ function pricingBasisFromBreakdown(
   }
 }
 
-export function normalizeProductSelection(
-  target: CommitOwnedBookingInput["session"]["target"],
+export function normalizeBookingSelection(
+  _target: CommitOwnedBookingInput["session"]["target"],
   selection: Record<string, unknown>,
   access?: CommitOwnedBookingInput["access"],
 ): Record<string, unknown> {
-  if (target.kind !== "product") {
-    throw new InvalidBookingSessionSelectionError("unsupported_target")
-  }
   const source = asRecord(selection) ?? {}
   const { staffBooking: rawStaffBooking, ...customerSelection } = source
   rejectForbiddenSelection(customerSelection)
@@ -364,6 +708,16 @@ export function normalizeProductSelection(
       optionSelections: arrayValue(configure?.optionSelections)
         ?.map(normalizeOptionSelection)
         .filter((value): value is Record<string, unknown> => value != null),
+      sailingId: stringValue(configure?.sailingId),
+      cabinCategoryId: stringValue(configure?.cabinCategoryId),
+      cabinCategoryRef: normalizeSourceRef(configure?.cabinCategoryRef),
+      occupancy: positiveInteger(configure?.occupancy),
+      passengerComposition: normalizeStringNumberMap(asRecord(configure?.passengerComposition)),
+      fareCode: stringValue(configure?.fareCode),
+      fareVariant:
+        configure?.fareVariant === "cruise_only" || configure?.fareVariant === "air_inclusive"
+          ? configure.fareVariant
+          : undefined,
     }),
     billing: pruneEmpty({
       buyerType:
@@ -391,6 +745,108 @@ export function normalizeProductSelection(
       ? { staffBooking: normalizeBookingSessionStaffSelectionV1(rawStaffBooking) }
       : {}),
   })
+}
+
+export const normalizeProductSelection = normalizeBookingSelection
+
+function sourcedParameters(
+  payload: Record<string, unknown>,
+  source: { entityModule: string; sourceKind: string; sourceProvider: string | null },
+): Record<string, unknown> {
+  const parameters = engineParametersFromDraft(undefined, payload, {
+    entityModule: source.entityModule,
+    sourceKind: source.sourceKind,
+    sourceProvider: source.sourceProvider ?? undefined,
+  })
+  delete parameters.draft
+  delete parameters.contact
+  delete parameters.passengers
+  return parameters
+}
+
+function safeSourcedSelection(payload: Record<string, unknown>): Record<string, unknown> {
+  return pruneEmpty({
+    configure: asRecord(payload.configure),
+    accommodation: asRecord(payload.accommodation),
+    addons: arrayValue(payload.addons),
+  })
+}
+
+function supplierParty(payload: Record<string, unknown>) {
+  const billing = asRecord(payload.billing)
+  const contact = asRecord(billing?.contact)
+  return {
+    contact: pruneEmpty({
+      firstName: stringValue(contact?.firstName),
+      lastName: stringValue(contact?.lastName),
+      email: stringValue(contact?.email),
+      phone: stringValue(contact?.phone),
+    }),
+    passengers: sourcedTravelers(payload).map((traveler) => ({
+      firstName: traveler.firstName,
+      lastName: traveler.lastName,
+      email: traveler.email,
+      phone: traveler.phone,
+      travelerCategory: traveler.category,
+      isPrimary: traveler.isPrimary,
+    })),
+  }
+}
+
+function sourcedTravelers(payload: Record<string, unknown>): SourcedBookingTravelerInput[] {
+  const travelers = arrayValue(payload.travelers) ?? []
+  return travelers.flatMap((value, index) => {
+    const traveler = asRecord(value)
+    const firstName = stringValue(traveler?.firstName)
+    const lastName = stringValue(traveler?.lastName)
+    if (!firstName || !lastName) return []
+    const rawCategory = stringValue(traveler?.travelerCategory) ?? stringValue(traveler?.band)
+    const category =
+      rawCategory === "adult" ||
+      rawCategory === "child" ||
+      rawCategory === "infant" ||
+      rawCategory === "senior" ||
+      rawCategory === "other"
+        ? rawCategory
+        : null
+    return [
+      {
+        firstName,
+        lastName,
+        email: stringValue(traveler?.email) ?? null,
+        phone: stringValue(traveler?.phone) ?? null,
+        category,
+        isPrimary: traveler?.isPrimary === true || index === 0,
+      },
+    ]
+  })
+}
+
+function supplierQuantity(payload: Record<string, unknown>): number {
+  const configure = asRecord(payload.configure)
+  return positiveInteger(configure?.occupancy) ?? (sourcedTravelers(payload).length || 1)
+}
+
+function supplierServiceDate(payload: Record<string, unknown> | undefined): string | null {
+  const evidence = asRecord(payload?.upstreamPayload) ?? payload
+  const sailing = asRecord(evidence?.sailing)
+  const value = stringValue(sailing?.departureDate)
+  return value && /^\d{4}-\d{2}-\d{2}$/.test(value) ? value : null
+}
+
+function supplierEndDate(payload: Record<string, unknown> | undefined): string | null {
+  const evidence = asRecord(payload?.upstreamPayload) ?? payload
+  const sailing = asRecord(evidence?.sailing)
+  const value = stringValue(sailing?.returnDate)
+  return value && /^\d{4}-\d{2}-\d{2}$/.test(value) ? value : null
+}
+
+function normalizeSourceRef(value: unknown): Record<string, unknown> | undefined {
+  const sourceRef = asRecord(value)
+  if (!sourceRef) return undefined
+  const externalId = stringValue(sourceRef.externalId)
+  if (!externalId) return undefined
+  return pruneEmpty({ externalId, connectionId: stringValue(sourceRef.connectionId) })
 }
 
 function applyStaffSelection(
@@ -454,6 +910,8 @@ function normalizeTraveler(value: unknown): Record<string, unknown> | null {
     email: stringValue(record.email),
     phone: stringValue(record.phone),
     band: stringValue(record.band),
+    travelerCategory: stringValue(record.travelerCategory),
+    isPrimary: record.isPrimary === true ? true : undefined,
   })
   return normalized.firstName || normalized.lastName ? normalized : null
 }
@@ -515,4 +973,11 @@ function stringValue(value: unknown): string | undefined {
 
 function positiveInteger(value: unknown): number | undefined {
   return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : undefined
+}
+
+function numberValue(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value
+  if (typeof value !== "string" || !value.trim()) return undefined
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : undefined
 }

--- a/packages/catalog/src/booking-engine/sessions-production.ts
+++ b/packages/catalog/src/booking-engine/sessions-production.ts
@@ -140,13 +140,8 @@ export function createProductionBookingSessionModule(
       hasActiveSupplierOperation: async ({ sessionId, tx }) => {
         const operation = await createDrizzleSupplierOperationRepository(
           tx as PostgresJsDatabase,
-        ).getBySession(sessionId)
-        return Boolean(
-          operation &&
-            operation.state !== "refused" &&
-            operation.state !== "cancelled" &&
-            !(operation.state === "manually_resolved" && operation.upstreamStatus !== "succeeded"),
-        )
+        ).getBlockingBySession(sessionId)
+        return Boolean(operation)
       },
       payments,
     },
@@ -290,7 +285,11 @@ async function commitSourcedBooking(
     const transaction = tx as PostgresJsDatabase
     const operationRepository = createDrizzleSupplierOperationRepository(transaction)
     const operation = await operationRepository.getForUpdate(result.operation.id)
-    if (operation?.state !== "succeeded") {
+    if (
+      !operation ||
+      (operation.state !== "succeeded" &&
+        !(operation.state === "manually_resolved" && operation.upstreamStatus === "succeeded"))
+    ) {
       throw new Error("supplier_operation_not_secured")
     }
     if (operation.bookingId) {

--- a/packages/catalog/src/booking-engine/sessions-routes.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-routes.test.ts
@@ -16,6 +16,38 @@ const ACTIVE_STOREFRONT = {
 
 const PUBLIC_CAPABILITY = `bcap_${"a".repeat(43)}`
 const WRONG_CAPABILITY = `bcap_${"b".repeat(43)}`
+const SUPPLIER_OPERATION = {
+  id: "suop_route_1",
+  sessionId: "bses_route_1",
+  quoteId: "bsqu_route_1",
+  holdId: null,
+  operationKind: "reserve" as const,
+  state: "manual_review" as const,
+  commitmentPolicy: "supplier_first" as const,
+  entityModule: "cruises",
+  entityId: "crus_route_1",
+  sourceKind: "cruise:test",
+  sourceConnectionId: "conn_route_1",
+  sourceRef: "source-route-1",
+  adapterKind: "cruise:test",
+  requestFingerprint: "request-fingerprint-route-1",
+  adapterIdempotencyKey: "bses_route_1:commit-route-1:reserve",
+  attemptCount: 1,
+  upstreamRef: null,
+  upstreamStatus: null,
+  bookingId: null,
+  lastErrorClass: "supplier_timeout",
+  safeEvidence: {},
+  submittedAt: "2026-08-01T12:00:00.000Z",
+  lastCheckedAt: null,
+  sourceUpdatedAt: null,
+  nextReconcileAt: null,
+  resolvedAt: null,
+  resolvedBy: null,
+  resolutionReason: null,
+  createdAt: "2026-08-01T12:00:00.000Z",
+  updatedAt: "2026-08-01T12:00:00.000Z",
+}
 
 function createApp(
   storefrontChannel: {
@@ -49,6 +81,12 @@ function createApp(
       commitOwnedBooking: inventory.commitOwnedBooking,
     },
   })
+  const supplierOperations = {
+    list: vi.fn(async () => [SUPPLIER_OPERATION]),
+    get: vi.fn(async () => SUPPLIER_OPERATION),
+    reconcile: vi.fn(async () => SUPPLIER_OPERATION),
+    resolve: vi.fn(async () => SUPPLIER_OPERATION),
+  }
   const app = new Hono()
   app.use("/v1/public/catalog/*", async (c, next) => {
     if (currentStorefrontChannel) {
@@ -70,12 +108,14 @@ function createApp(
         principalId: "staff_1",
         staffAuthority: { admitted: true, reason: "booking_support_case" },
       }),
+      resolveSupplierOperations: () => supplierOperations,
     }),
   )
   return {
     app,
     inventory,
     module,
+    supplierOperations,
     setStorefrontChannel(
       next: {
         storefrontId: string
@@ -235,6 +275,42 @@ describe("Booking Session v1 routes", () => {
     expect(publicResponse.status).toBe(404)
     expect(adminResponse.status).toBe(200)
     await expect(adminResponse.json()).resolves.toEqual({ expired: 0 })
+  })
+
+  it("mounts Supplier Operation inspection and resolution only on the staff surface", async () => {
+    const { app, supplierOperations } = createApp()
+    const publicResponse = await app.request("/v1/public/catalog/supplier-operations")
+    const adminResponse = await app.request("/v1/admin/catalog/supplier-operations")
+    const resolveResponse = await app.request(
+      `/v1/admin/catalog/supplier-operations/${SUPPLIER_OPERATION.id}/resolve`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          idempotencyKey: "route-resolution-key",
+          resolution: "refused",
+          reason: "Supplier confirmed no reservation exists",
+        }),
+      },
+    )
+
+    expect(publicResponse.status).toBe(404)
+    expect(adminResponse.status).toBe(200)
+    await expect(adminResponse.json()).resolves.toEqual({ operations: [SUPPLIER_OPERATION] })
+    expect(resolveResponse.status).toBe(200)
+    expect(supplierOperations.resolve).toHaveBeenCalledWith(
+      SUPPLIER_OPERATION.id,
+      {
+        idempotencyKey: "route-resolution-key",
+        resolution: "refused",
+        reason: "Supplier confirmed no reservation exists",
+      },
+      {
+        actorKind: "staff",
+        principalId: "staff_1",
+        staffAuthority: { admitted: true, reason: "booking_support_case" },
+      },
+    )
   })
 
   it("adapts public anonymous and admin staff transports to the same module outcomes", async () => {

--- a/packages/catalog/src/booking-engine/sessions-routes.ts
+++ b/packages/catalog/src/booking-engine/sessions-routes.ts
@@ -11,10 +11,17 @@ import {
   renewBookingSessionV1,
   updateBookingSessionV1,
 } from "@voyant-travel/catalog-contracts/booking-engine/session-contracts"
+import {
+  listSupplierOperationsQueryV1,
+  reconcileSupplierOperationV1,
+  resolveSupplierOperationV1,
+  supplierOperationRecordV1,
+} from "@voyant-travel/catalog-contracts/booking-engine/supplier-operations"
 import { openApiValidationHook } from "@voyant-travel/hono"
 import type { ApiModule } from "@voyant-travel/hono/module"
 import type { Context } from "hono"
 import type { BookingSessionAccessContext, BookingSessionModule } from "./sessions-service.js"
+import type { SupplierOperationOperatorService } from "./supplier-operations-operator.js"
 
 type Env = {
   Variables: Record<string, unknown> & {
@@ -30,6 +37,7 @@ export interface BookingSessionRoutesOptions {
   resolveModule(c: Context): BookingSessionModule
   actorKind: BookingSessionActorKindV1
   resolveAccess?(c: Context, actorKind: BookingSessionActorKindV1): BookingSessionAccessContext
+  resolveSupplierOperations?(c: Context): SupplierOperationOperatorService
 }
 
 const sessionParamSchema = z.object({ sessionId: z.string().min(1) })
@@ -264,6 +272,76 @@ const purgeSessionsRoute = createRoute({
   },
 })
 
+const supplierOperationParamSchema = z.object({ operationId: z.string().min(1) })
+
+const listSupplierOperationsRoute = createRoute({
+  method: "get",
+  path: "/supplier-operations",
+  request: { query: listSupplierOperationsQueryV1 },
+  responses: {
+    200: {
+      description: "Supplier Operations",
+      content: {
+        "application/json": {
+          schema: z.object({ operations: z.array(supplierOperationRecordV1) }),
+        },
+      },
+    },
+  },
+})
+
+const getSupplierOperationRoute = createRoute({
+  method: "get",
+  path: "/supplier-operations/{operationId}",
+  request: { params: supplierOperationParamSchema },
+  responses: {
+    200: {
+      description: "Supplier Operation",
+      content: { "application/json": { schema: supplierOperationRecordV1 } },
+    },
+    404: {
+      description: "Not found",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+const reconcileSupplierOperationRoute = createRoute({
+  method: "post",
+  path: "/supplier-operations/{operationId}/reconcile",
+  request: {
+    params: supplierOperationParamSchema,
+    body: {
+      required: true,
+      content: { "application/json": { schema: reconcileSupplierOperationV1 } },
+    },
+  },
+  responses: {
+    200: {
+      description: "Reconciled Supplier Operation",
+      content: { "application/json": { schema: supplierOperationRecordV1 } },
+    },
+  },
+})
+
+const resolveSupplierOperationRoute = createRoute({
+  method: "post",
+  path: "/supplier-operations/{operationId}/resolve",
+  request: {
+    params: supplierOperationParamSchema,
+    body: {
+      required: true,
+      content: { "application/json": { schema: resolveSupplierOperationV1 } },
+    },
+  },
+  responses: {
+    200: {
+      description: "Manually resolved Supplier Operation",
+      content: { "application/json": { schema: supplierOperationRecordV1 } },
+    },
+  },
+})
+
 export function createBookingSessionRoutes(options: BookingSessionRoutesOptions): OpenAPIHono<Env> {
   const routes = new OpenAPIHono<Env>({ defaultHook: openApiValidationHook })
   if (options.actorKind === "anonymous") {
@@ -397,7 +475,7 @@ export function createBookingSessionRoutes(options: BookingSessionRoutesOptions)
 
   if (options.actorKind !== "staff") return routes
 
-  return routes
+  const staffRoutes = routes
     .openapi(expireDueSessionsRoute, async (c) =>
       asRouteResponse(
         c.json(
@@ -420,6 +498,53 @@ export function createBookingSessionRoutes(options: BookingSessionRoutesOptions)
         ),
       )
     })
+
+  if (!options.resolveSupplierOperations) return staffRoutes
+  const resolveSupplierOperations = options.resolveSupplierOperations
+  return staffRoutes
+    .openapi(listSupplierOperationsRoute, async (c) =>
+      asRouteResponse(
+        c.json({
+          operations: await resolveSupplierOperations(c).list(
+            c.req.valid("query"),
+            resolveAccess(options, c),
+          ),
+        }),
+      ),
+    )
+    .openapi(getSupplierOperationRoute, async (c) => {
+      const operation = await resolveSupplierOperations(c).get(
+        c.req.valid("param").operationId,
+        resolveAccess(options, c),
+      )
+      return asRouteResponse(
+        operation
+          ? c.json(operation)
+          : c.json({ error: "Supplier Operation not found", code: "not_found" }, 404),
+      )
+    })
+    .openapi(reconcileSupplierOperationRoute, async (c) =>
+      asRouteResponse(
+        c.json(
+          await resolveSupplierOperations(c).reconcile(
+            c.req.valid("param").operationId,
+            c.req.valid("json"),
+            resolveAccess(options, c),
+          ),
+        ),
+      ),
+    )
+    .openapi(resolveSupplierOperationRoute, async (c) =>
+      asRouteResponse(
+        c.json(
+          await resolveSupplierOperations(c).resolve(
+            c.req.valid("param").operationId,
+            c.req.valid("json"),
+            resolveAccess(options, c),
+          ),
+        ),
+      ),
+    )
 }
 
 // biome-ignore lint/suspicious/noExplicitAny: bridges plain Hono responses to zod-openapi's inferred route union.

--- a/packages/catalog/src/booking-engine/sessions-schema.ts
+++ b/packages/catalog/src/booking-engine/sessions-schema.ts
@@ -50,7 +50,7 @@ export const bookingSessionsTable = pgTable(
     ),
     check(
       "booking_sessions_state",
-      sql`${table.state} IN ('active', 'consumed', 'expired', 'abandoned')`,
+      sql`${table.state} IN ('active', 'supplier_pending', 'consumed', 'expired', 'abandoned')`,
     ),
     check(
       "booking_sessions_storefront_origin",
@@ -208,7 +208,7 @@ export const bookingSessionAuditEventsTable = pgTable(
     check("booking_session_audit_events_id_typeid", sql`${table.id} LIKE 'bsae_%'`),
     check(
       "booking_session_audit_events_action",
-      sql`${table.action} IN ('read', 'update', 'quote', 'hold', 'commit', 'adopt', 'renew', 'abandon', 'expire', 'purge')`,
+      sql`${table.action} IN ('read', 'update', 'quote', 'hold', 'commit', 'adopt', 'renew', 'abandon', 'expire', 'purge', 'supplier_reconcile', 'supplier_manual_resolve')`,
     ),
     index("idx_booking_session_audit_events_session").on(table.sessionId, table.createdAt),
   ],

--- a/packages/catalog/src/booking-engine/sessions-service.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-service.test.ts
@@ -1165,6 +1165,93 @@ describe("Booking Session v1 owned tracer", () => {
   })
 })
 
+describe("Booking Session v1 sourced continuation", () => {
+  it("retains an admitted supplier-first Commit beyond Session and Quote expiry", async () => {
+    let currentNow = new Date("2026-08-02T10:00:00.000Z")
+    let commitCalls = 0
+    let supplierIntentActive = false
+    const repository = createInMemoryBookingSessionRepository()
+    const module = createBookingSessionModule({
+      now: () => currentNow,
+      sessionTtlMs: 1_000,
+      quoteTtlMs: 1_000,
+      ports: {
+        repository,
+        normalizeSelection: async ({ selection }) => selection,
+        composeQuote: async () => ({ status: "quoted", pricing: BASE_PRICING }),
+        placeCapacityHold: async () => "unavailable",
+        releaseCapacityHold: async () => {},
+        commitOwnedBooking: async () => {
+          throw new Error("owned commit must not run")
+        },
+        hasActiveSupplierOperation: async () => supplierIntentActive,
+        commitSourcedBooking: async (input) => {
+          commitCalls += 1
+          if (commitCalls === 1) {
+            supplierIntentActive = true
+            const persisted = await repository.getSession(input.session.id)
+            if (!persisted) throw new Error("session missing")
+            persisted.state = "supplier_pending"
+            persisted.updatedAt = input.now
+            await repository.saveSession(persisted)
+            return {
+              kind: "supplier_pending",
+              nextAction: "await_supplier_operation",
+              supplierOperationId: "suop_pending",
+              operatorBackedRiskAccepted: false,
+            }
+          }
+          await input.consumeSources({}, "book_sourced", [], "suop_pending")
+          return {
+            kind: "committed",
+            bookingId: "book_sourced",
+            allocationIds: [],
+            supplierOperationId: "suop_pending",
+          }
+        },
+      },
+    })
+    const created = await module.createSession(
+      {
+        idempotencyKey: nextCreateKey("create_sourced"),
+        target: { kind: "catalog_item", catalogItemId: "crus_sourced" },
+      },
+      ANONYMOUS_ACCESS,
+    )
+    if (created.kind !== "session_created") throw new Error("session not created")
+    const quoted = await module.quoteSession(
+      created.session.id,
+      { expectedRevision: created.session.revision, idempotencyKey: "quote_sourced" },
+      ANONYMOUS_ACCESS,
+    )
+    if (quoted.kind !== "quote_created") throw new Error("quote not created")
+    const commit = {
+      expectedRevision: created.session.revision,
+      quoteId: quoted.quote.id,
+      idempotencyKey: "commit_sourced",
+    }
+
+    await expect(
+      module.commitSession(created.session.id, commit, ANONYMOUS_ACCESS),
+    ).resolves.toMatchObject({
+      kind: "commit_result",
+      outcome: { kind: "supplier_pending", supplierOperationId: "suop_pending" },
+    })
+    currentNow = new Date("2026-08-02T10:10:00.000Z")
+    await expect(
+      module.commitSession(created.session.id, commit, ANONYMOUS_ACCESS),
+    ).resolves.toMatchObject({
+      kind: "commit_result",
+      outcome: {
+        kind: "committed",
+        booking: { id: "book_sourced" },
+        supplierOperationId: "suop_pending",
+      },
+    })
+    expect(commitCalls).toBe(2)
+  })
+})
+
 function createPaymentHarness() {
   const transfers: Array<{
     tx: unknown

--- a/packages/catalog/src/booking-engine/sessions-service.ts
+++ b/packages/catalog/src/booking-engine/sessions-service.ts
@@ -114,6 +114,8 @@ export interface BookingSessionAuditRecord {
     | "abandon"
     | "expire"
     | "purge"
+    | "supplier_reconcile"
+    | "supplier_manual_resolve"
   actorKind: BookingSessionActorKindV1 | "system"
   principalId?: string
   organizationId?: string
@@ -164,7 +166,7 @@ export interface BookingSessionRepository {
   consumeCommit(input: {
     sessionId: string
     quoteId: string
-    holdId: string
+    holdId?: string
     idempotencyKey: string
     requestFingerprint: string
     outcome: BookingCommitInternalRecord["outcome"]
@@ -218,11 +220,35 @@ export interface CommitOwnedBookingInput {
   consumeSources(tx: unknown, bookingId: string, allocationIds: string[]): Promise<void>
 }
 
+export interface CommitSourcedBookingInput {
+  session: BookingSessionInternalRecord
+  quote: BookingQuoteInternalRecord
+  hold?: BookingHoldInternalRecord
+  idempotencyKey: string
+  requestFingerprint: string
+  access: BookingSessionAccessContext
+  now: Date
+  paymentSessionId?: string
+  consumeSources(
+    tx: unknown,
+    bookingId: string,
+    allocationIds: string[],
+    supplierOperationId: string,
+  ): Promise<void>
+}
+
+export type CommitSourcedBookingResult =
+  | { kind: "committed"; bookingId: string; allocationIds: string[]; supplierOperationId: string }
+  | Extract<
+      BookingLifecycleCommitOutcomeV1,
+      { kind: "supplier_pending" | "supplier_in_doubt" | "supplier_failed" }
+    >
+
 export interface BookingSessionPaymentPorts {
   prepare(input: {
     session: BookingSessionInternalRecord
     quote: BookingQuoteInternalRecord
-    hold: BookingHoldInternalRecord
+    hold?: BookingHoldInternalRecord
     commit: CommitBookingSessionV1
     access: BookingSessionAccessContext
     now: Date
@@ -303,6 +329,8 @@ export interface BookingSessionModulePorts {
     bookingId: string
     allocationIds: string[]
   }>
+  commitSourcedBooking?(input: CommitSourcedBookingInput): Promise<CommitSourcedBookingResult>
+  hasActiveSupplierOperation?(input: { sessionId: string; tx: unknown }): Promise<boolean>
   payments?: BookingSessionPaymentPorts
 }
 
@@ -839,6 +867,20 @@ export function createBookingSessionModule(
         if (!session) return { kind: "rejected", error: { kind: "session_expired" } }
         const authorized = await authorizeSessionAccess(session, access, "abandon")
         if (authorized) return authorized
+        if (
+          await options.ports.hasActiveSupplierOperation?.({
+            sessionId: session.id,
+            tx,
+          })
+        ) {
+          return {
+            kind: "rejected" as const,
+            error: {
+              kind: "supplier_operation_active" as const,
+              nextAction: "reconcile_supplier_operation" as const,
+            },
+          }
+        }
         const at = now()
         if (session.state === "active" && session.expiresAt <= at) {
           await expireSession(repository, options.ports, session, access, at, tx)
@@ -904,10 +946,12 @@ export function createBookingSessionModule(
           return { status: "outcome" as const, outcome: lockedAuthorization }
         }
         const at = now()
-        if (session.state === "active" && session.expiresAt <= at) {
+        const sourcedContinuation =
+          session.target.kind === "catalog_item" && session.state === "supplier_pending"
+        if (!sourcedContinuation && session.state === "active" && session.expiresAt <= at) {
           await expireSession(repository, options.ports, session, access, at, tx)
         }
-        if (session.state !== "active") {
+        if (session.state !== "active" && !sourcedContinuation) {
           return {
             status: "outcome" as const,
             outcome:
@@ -925,7 +969,9 @@ export function createBookingSessionModule(
         const revisionRejected = rejectRevision(input.expectedRevision, session)
         if (revisionRejected) return { status: "outcome" as const, outcome: revisionRejected }
 
-        const quote = await loadUsableQuote(repository, input.quoteId, session, at)
+        const quote = sourcedContinuation
+          ? await loadPersistedSourcedQuote(repository, input.quoteId, session)
+          : await loadUsableQuote(repository, input.quoteId, session, at)
         if (quote === "expired" || quote === "superseded") {
           await releaseLiveHolds(repository, options.ports, session, access, at, tx)
           return {
@@ -968,8 +1014,12 @@ export function createBookingSessionModule(
           }
         }
 
-        const hold = await loadUsableHold(repository, input.holdId, session, quote, at)
-        if (hold === "expired" || !hold) {
+        const hold = input.holdId
+          ? sourcedContinuation
+            ? await loadPersistedSourcedHold(repository, input.holdId, session, quote)
+            : await loadUsableHold(repository, input.holdId, session, quote, at)
+          : null
+        if (hold === "expired" || (!hold && session.target.kind === "product")) {
           await releaseLiveHolds(repository, options.ports, session, access, at, tx)
           return {
             status: "outcome" as const,
@@ -982,6 +1032,10 @@ export function createBookingSessionModule(
               },
             } as const,
           }
+        }
+
+        if (sourcedContinuation) {
+          return { status: "ready" as const, session, quote, hold, at }
         }
 
         const freshQuote = await options.ports.composeQuote({ session, now: at, tx })
@@ -1019,7 +1073,7 @@ export function createBookingSessionModule(
           ? await options.ports.payments.prepare({
               session,
               quote,
-              hold,
+              ...(hold ? { hold } : {}),
               commit: input,
               access,
               now: at,
@@ -1045,123 +1099,79 @@ export function createBookingSessionModule(
         preparedPayment.kind === "established" ? preparedPayment.paymentSessionId : undefined
 
       const requestFingerprint = await commitRequestFingerprint(input)
-      let committed: { bookingId: string; allocationIds: string[] }
+      let committed: {
+        bookingId: string
+        allocationIds: string[]
+        supplierOperationId?: string
+      }
       try {
-        committed = await options.ports.commitOwnedBooking({
-          session,
-          quote,
-          hold,
-          idempotencyKey: input.idempotencyKey,
-          requestFingerprint,
-          access,
-          now: at,
-          paymentSessionId,
-          async consumeSources(tx, bookingId, allocationIds) {
-            const outcome: BookingLifecycleCommitOutcomeV1 = {
-              kind: "committed",
-              nextAction: "none",
-              booking: { id: bookingId, status: "confirmed" },
-              allocationIds,
-              consumedSessionId: session.id,
-              consumedQuoteId: quote.id,
-              convertedHoldId: hold.id,
-            }
-            await repository.withTransactionContext(tx, async () => {
-              const currentAt = now()
-              const currentSession = await loadSession(sessionId)
-              if (currentSession?.state !== "active") {
-                throw new CommitSessionStateError(
-                  currentSession?.state === "consumed" ? "consumed" : "expired",
-                )
-              }
-              if (currentSession.expiresAt <= currentAt) {
-                throw new CommitSessionStateError("expired")
-              }
-              const currentQuote = await loadUsableQuote(
+        if (session.target.kind === "catalog_item") {
+          const sourcedResult = await options.ports.commitSourcedBooking?.({
+            session,
+            quote,
+            ...(hold ? { hold } : {}),
+            idempotencyKey: input.idempotencyKey,
+            requestFingerprint,
+            access,
+            now: at,
+            paymentSessionId,
+            async consumeSources(tx, bookingId, allocationIds, supplierOperationId) {
+              await consumeCommittedSources({
                 repository,
-                quote.id,
-                currentSession,
-                currentAt,
-              )
-              if (currentQuote === "expired") {
-                throw new CommitOutcomeError({
-                  kind: "quote_failure",
-                  nextAction: "request_fresh_quote",
-                  reason: "expired",
-                })
-              }
-              if (currentQuote === "superseded" || !currentQuote) {
-                throw new CommitOutcomeError({
-                  kind: "quote_failure",
-                  nextAction: "request_fresh_quote",
-                  reason: currentQuote === "superseded" ? "superseded" : "mismatched_session",
-                })
-              }
-              const currentHold = await loadUsableHold(
-                repository,
-                hold.id,
-                currentSession,
-                currentQuote,
-                currentAt,
-              )
-              if (currentHold === "expired") {
-                throw new CommitOutcomeError({
-                  kind: "hold_failure",
-                  nextAction: "request_new_hold",
-                  reason: "expired",
-                })
-              }
-              if (!currentHold) {
-                throw new CommitOutcomeError({
-                  kind: "hold_failure",
-                  nextAction: "request_new_hold",
-                  reason: "missing",
-                })
-              }
-              const currentQuoteResult = await options.ports.composeQuote({
-                session: currentSession,
-                now: currentAt,
-                tx,
-              })
-              if (
-                currentQuoteResult.status === "unavailable" ||
-                (await stableFingerprint(currentQuoteResult.pricing)) !==
-                  currentQuote.priceFingerprint
-              ) {
-                currentQuote.state = "superseded"
-                await repository.saveQuote(currentQuote)
-                throw new CommitOutcomeError({
-                  kind: "quote_failure",
-                  nextAction: "request_fresh_quote",
-                  reason: "superseded",
-                })
-              }
-              await repository.consumeCommit({
-                sessionId,
-                quoteId: currentQuote.id,
-                holdId: currentHold.id,
-                idempotencyKey: input.idempotencyKey,
+                ports: options.ports,
+                session,
+                quote,
+                hold,
+                access,
+                paymentSessionId,
+                input,
                 requestFingerprint,
-                outcome,
                 bookingId,
-                now: currentAt,
+                allocationIds,
+                supplierOperationId,
+                recomposeQuote: false,
+                tx,
+                now,
               })
-              if (paymentSessionId && options.ports.payments) {
-                await options.ports.payments.transferToBooking({
-                  tx,
-                  paymentSessionId,
-                  bookingSessionId: session.id,
-                  bookingId,
-                })
-              }
-              await appendSessionAudit(repository, currentSession, "commit", access, currentAt, {
+            },
+          })
+          if (!sourcedResult) {
+            throw new BookingSessionCommitRejectedError("entity_not_bookable")
+          }
+          if (sourcedResult.kind !== "committed") {
+            return { kind: "commit_result", outcome: sourcedResult }
+          }
+          committed = sourcedResult
+        } else {
+          committed = await options.ports.commitOwnedBooking({
+            session,
+            quote,
+            hold: hold as BookingHoldInternalRecord,
+            idempotencyKey: input.idempotencyKey,
+            requestFingerprint,
+            access,
+            now: at,
+            paymentSessionId,
+            async consumeSources(tx, bookingId, allocationIds) {
+              await consumeCommittedSources({
+                repository,
+                ports: options.ports,
+                session,
+                quote,
+                hold,
+                access,
+                paymentSessionId,
+                input,
+                requestFingerprint,
                 bookingId,
-                quoteId: currentQuote.id,
-                holdId: currentHold.id,
+                allocationIds,
+                recomposeQuote: true,
+                tx,
+                now,
               })
-            })
-          },
-        })
+            },
+          })
+        }
       } catch (error) {
         if (isIdempotencyConflictError(error)) return idempotencyConflict()
         if (error instanceof BookingSessionCommitRejectedError) {
@@ -1253,7 +1263,10 @@ export function createBookingSessionModule(
         allocationIds: committed.allocationIds,
         consumedSessionId: session.id,
         consumedQuoteId: quote.id,
-        convertedHoldId: hold.id,
+        ...(hold ? { convertedHoldId: hold.id } : {}),
+        ...(committed.supplierOperationId
+          ? { supplierOperationId: committed.supplierOperationId }
+          : {}),
       }
       return { kind: "commit_result", outcome }
     },
@@ -1323,6 +1336,141 @@ export function createBookingSessionModule(
       return { purged }
     },
   }
+}
+
+async function consumeCommittedSources(input: {
+  repository: BookingSessionRepository
+  ports: BookingSessionModulePorts
+  session: BookingSessionInternalRecord
+  quote: BookingQuoteInternalRecord
+  hold: BookingHoldInternalRecord | null
+  access: BookingSessionAccessContext
+  paymentSessionId?: string
+  input: CommitBookingSessionV1
+  requestFingerprint: string
+  bookingId: string
+  allocationIds: string[]
+  supplierOperationId?: string
+  recomposeQuote: boolean
+  tx: unknown
+  now: () => Date
+}): Promise<void> {
+  const outcome: BookingLifecycleCommitOutcomeV1 = {
+    kind: "committed",
+    nextAction: "none",
+    booking: { id: input.bookingId, status: "confirmed" },
+    allocationIds: input.allocationIds,
+    consumedSessionId: input.session.id,
+    consumedQuoteId: input.quote.id,
+    ...(input.hold ? { convertedHoldId: input.hold.id } : {}),
+    ...(input.supplierOperationId ? { supplierOperationId: input.supplierOperationId } : {}),
+  }
+  await input.repository.withTransactionContext(input.tx, async () => {
+    const currentAt = input.now()
+    const currentSession = await input.repository.getSession(input.session.id)
+    const persistedSourcedCommit =
+      !input.recomposeQuote && currentSession?.state === "supplier_pending"
+    if (currentSession?.state !== "active" && !persistedSourcedCommit) {
+      throw new CommitSessionStateError(
+        currentSession?.state === "consumed" ? "consumed" : "expired",
+      )
+    }
+    if (!persistedSourcedCommit && currentSession.expiresAt <= currentAt) {
+      throw new CommitSessionStateError("expired")
+    }
+    const currentQuote = persistedSourcedCommit
+      ? await loadPersistedSourcedQuote(input.repository, input.quote.id, currentSession)
+      : await loadUsableQuote(input.repository, input.quote.id, currentSession, currentAt)
+    if (currentQuote === "expired") {
+      throw new CommitOutcomeError({
+        kind: "quote_failure",
+        nextAction: "request_fresh_quote",
+        reason: "expired",
+      })
+    }
+    if (currentQuote === "superseded" || !currentQuote) {
+      throw new CommitOutcomeError({
+        kind: "quote_failure",
+        nextAction: "request_fresh_quote",
+        reason: currentQuote === "superseded" ? "superseded" : "mismatched_session",
+      })
+    }
+    let currentHold: BookingHoldInternalRecord | null = null
+    if (input.hold) {
+      const loaded = persistedSourcedCommit
+        ? await loadPersistedSourcedHold(
+            input.repository,
+            input.hold.id,
+            currentSession,
+            currentQuote,
+          )
+        : await loadUsableHold(
+            input.repository,
+            input.hold.id,
+            currentSession,
+            currentQuote,
+            currentAt,
+          )
+      if (loaded === "expired") {
+        throw new CommitOutcomeError({
+          kind: "hold_failure",
+          nextAction: "request_new_hold",
+          reason: "expired",
+        })
+      }
+      if (!loaded) {
+        throw new CommitOutcomeError({
+          kind: "hold_failure",
+          nextAction: "request_new_hold",
+          reason: "missing",
+        })
+      }
+      currentHold = loaded
+    }
+    if (input.recomposeQuote) {
+      const currentQuoteResult = await input.ports.composeQuote({
+        session: currentSession,
+        now: currentAt,
+        tx: input.tx,
+      })
+      if (
+        currentQuoteResult.status === "unavailable" ||
+        (await stableFingerprint(currentQuoteResult.pricing)) !== currentQuote.priceFingerprint
+      ) {
+        currentQuote.state = "superseded"
+        await input.repository.saveQuote(currentQuote)
+        throw new CommitOutcomeError({
+          kind: "quote_failure",
+          nextAction: "request_fresh_quote",
+          reason: "superseded",
+        })
+      }
+    }
+    await input.repository.consumeCommit({
+      sessionId: currentSession.id,
+      quoteId: currentQuote.id,
+      ...(currentHold ? { holdId: currentHold.id } : {}),
+      idempotencyKey: input.input.idempotencyKey,
+      requestFingerprint: input.requestFingerprint,
+      outcome,
+      bookingId: input.bookingId,
+      now: currentAt,
+    })
+    if (input.paymentSessionId && input.ports.payments) {
+      await input.ports.payments.transferToBooking({
+        tx: input.tx,
+        paymentSessionId: input.paymentSessionId,
+        bookingSessionId: currentSession.id,
+        bookingId: input.bookingId,
+      })
+    }
+    await appendSessionAudit(input.repository, currentSession, "commit", input.access, currentAt, {
+      bookingId: input.bookingId,
+      quoteId: currentQuote.id,
+      ...(currentHold ? { holdId: currentHold.id } : {}),
+      ...(input.supplierOperationId ? { supplierOperationId: input.supplierOperationId } : {}),
+    })
+  })
 }
 
 type FailedCommitOutcome = Exclude<
@@ -1563,6 +1711,20 @@ async function loadUsableQuote(
   return quote
 }
 
+async function loadPersistedSourcedQuote(
+  repository: BookingSessionRepository,
+  quoteId: string,
+  session: BookingSessionInternalRecord,
+): Promise<BookingQuoteInternalRecord | "expired" | "superseded" | null> {
+  const quote = await repository.getQuote(quoteId)
+  if (!quote || quote.sessionId !== session.id || quote.sessionRevision !== session.revision) {
+    return null
+  }
+  if (quote.state === "expired") return "expired"
+  if (quote.state !== "active") return "superseded"
+  return quote
+}
+
 async function loadUsableHold(
   repository: BookingSessionRepository,
   holdId: string,
@@ -1577,6 +1739,18 @@ async function loadUsableHold(
     return "expired"
   }
   return hold
+}
+
+async function loadPersistedSourcedHold(
+  repository: BookingSessionRepository,
+  holdId: string,
+  session: BookingSessionInternalRecord,
+  quote: BookingQuoteInternalRecord,
+): Promise<BookingHoldInternalRecord | "expired" | null> {
+  const hold = await repository.getHold(holdId)
+  if (!hold || hold.sessionId !== session.id || hold.quoteId !== quote.id) return null
+  if (hold.state === "expired") return "expired"
+  return hold.state === "active" ? hold : null
 }
 
 function capacityKeyForTarget(target: BookingSessionTargetV1): string {

--- a/packages/catalog/src/booking-engine/supplier-operation-workflow.test.ts
+++ b/packages/catalog/src/booking-engine/supplier-operation-workflow.test.ts
@@ -1,0 +1,337 @@
+import { describe, expect, it, vi } from "vitest"
+import { ReservationDispatchError, type SourceAdapter } from "../adapter/contract.js"
+
+import { createSourceAdapterRegistry } from "./registry.js"
+import { createSupplierOperationWorkflow } from "./supplier-operation-workflow.js"
+import type {
+  CreateSupplierOperationResult,
+  SupplierOperationInternalRecord,
+  SupplierOperationRepository,
+} from "./supplier-operations.js"
+
+describe("Supplier Operation workflow", () => {
+  it("persists stable intent before dispatch and forwards the same idempotency key", async () => {
+    const repository = memoryRepository()
+    const reserve = vi.fn(async (_context, request) => {
+      expect(repository.rows[0]).toMatchObject({ state: "submitted", attemptCount: 1 })
+      expect(request.idempotency_key).toBe("bses_1:commit-key:reserve")
+      return { upstream_ref: "UP-1", status: "confirmed" as const }
+    })
+    const workflow = workflowWith(repository, { reserve })
+
+    await expect(workflow.dispatch(input())).resolves.toMatchObject({
+      kind: "secured",
+      operation: {
+        state: "succeeded",
+        upstreamRef: "UP-1",
+        adapterIdempotencyKey: "bses_1:commit-key:reserve",
+      },
+    })
+    expect(reserve).toHaveBeenCalledTimes(1)
+  })
+
+  it("never blindly retries a possibly-dispatched reservation", async () => {
+    const repository = memoryRepository()
+    const reserve = vi.fn(async () => {
+      throw new Error("upstream timed out")
+    })
+    const workflow = workflowWith(repository, { reserve })
+
+    await expect(workflow.dispatch(input())).resolves.toMatchObject({
+      kind: "in_doubt",
+      operation: { state: "in_doubt", attemptCount: 1 },
+    })
+    await expect(workflow.dispatch(input())).resolves.toMatchObject({
+      kind: "in_doubt",
+      operation: { state: "in_doubt", attemptCount: 1 },
+    })
+    expect(reserve).toHaveBeenCalledTimes(1)
+  })
+
+  it("reconciles timeout-after-send by the stable idempotency key", async () => {
+    const repository = memoryRepository()
+    let sentKey: string | undefined
+    const reserve = vi.fn(async (_context, request) => {
+      sentKey = request.idempotency_key
+      throw new Error("response lost after supplier accepted reservation")
+    })
+    const getReservation = vi.fn(async (_context, request) =>
+      request.idempotency_key === sentKey
+        ? { upstream_ref: "UP-LOST-RESPONSE", status: "confirmed" as const }
+        : null,
+    )
+    const workflow = workflowWith(repository, { reserve, getReservation })
+
+    const dispatched = await workflow.dispatch(input())
+    if (dispatched.kind !== "in_doubt") throw new Error("expected in-doubt operation")
+    expect(dispatched.operation.upstreamRef).toBeUndefined()
+
+    await expect(
+      workflow.reconcile(dispatched.operation, {
+        adapterContext: { connection_id: "conn_1" },
+        now: new Date("2026-08-02T09:03:00.000Z"),
+      }),
+    ).resolves.toMatchObject({
+      kind: "secured",
+      operation: { state: "succeeded", upstreamRef: "UP-LOST-RESPONSE" },
+    })
+    expect(getReservation).toHaveBeenCalledWith(
+      { connection_id: "conn_1" },
+      { idempotency_key: "bses_1:commit-key:reserve" },
+    )
+    expect(reserve).toHaveBeenCalledTimes(1)
+  })
+
+  it("keeps an ambiguous not-found lookup in doubt instead of authorizing a duplicate", async () => {
+    const repository = memoryRepository()
+    const reserve = vi.fn(async () => {
+      throw new Error("response lost after dispatch")
+    })
+    const getReservation = vi.fn(async () => null)
+    const workflow = workflowWith(repository, { reserve, getReservation })
+    const dispatched = await workflow.dispatch(input())
+    if (dispatched.kind !== "in_doubt") throw new Error("expected in-doubt operation")
+
+    await expect(
+      workflow.reconcile(dispatched.operation, {
+        adapterContext: { connection_id: "conn_1" },
+        now: new Date("2026-08-02T09:03:00.000Z"),
+      }),
+    ).resolves.toMatchObject({
+      kind: "in_doubt",
+      operation: {
+        state: "in_doubt",
+        lastErrorClass: "reservation_not_found",
+        nextReconcileAt: new Date("2026-08-02T09:04:00.000Z"),
+      },
+    })
+    await expect(workflow.dispatch(input())).resolves.toMatchObject({ kind: "in_doubt" })
+    expect(reserve).toHaveBeenCalledTimes(1)
+  })
+
+  it("allows only one reservation intent per Session across different Commit keys", async () => {
+    const repository = memoryRepository()
+    const reserve = vi.fn(async () => ({
+      upstream_ref: "UP-SESSION",
+      status: "confirmed" as const,
+    }))
+    const workflow = workflowWith(repository, { reserve })
+
+    await expect(workflow.dispatch(input())).resolves.toMatchObject({ kind: "secured" })
+    await expect(
+      workflow.dispatch({ ...input(), commitIdempotencyKey: "another-key" }),
+    ).resolves.toMatchObject({ kind: "idempotency_conflict" })
+    expect(reserve).toHaveBeenCalledTimes(1)
+  })
+
+  it("retries only when the adapter proves the request was not sent", async () => {
+    const repository = memoryRepository()
+    const reserve = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new ReservationDispatchError("socket unavailable", "not_sent", "connect_failed"),
+      )
+      .mockResolvedValueOnce({ upstream_ref: "UP-2", status: "held" as const })
+    const workflow = workflowWith(repository, { reserve })
+
+    await expect(workflow.dispatch(input())).resolves.toMatchObject({
+      kind: "pending",
+      operation: { state: "queued", attemptCount: 1 },
+    })
+    await expect(workflow.dispatch(input())).resolves.toMatchObject({
+      kind: "secured",
+      operation: { state: "succeeded", attemptCount: 2, upstreamRef: "UP-2" },
+    })
+  })
+
+  it("reconciles a pending reservation by point read without redispatch", async () => {
+    const repository = memoryRepository()
+    const reserve = vi.fn(async () => ({ upstream_ref: "UP-3", status: "pending" as const }))
+    const getReservation = vi.fn(async () => ({
+      upstream_ref: "UP-3",
+      status: "confirmed" as const,
+      source_updated_at: new Date("2026-08-02T09:02:00.000Z"),
+    }))
+    const workflow = workflowWith(repository, { reserve, getReservation })
+    const dispatched = await workflow.dispatch(input())
+    if (dispatched.kind !== "pending") throw new Error("expected pending operation")
+
+    await expect(
+      workflow.reconcile(dispatched.operation, {
+        adapterContext: { connection_id: "conn_1" },
+        now: new Date("2026-08-02T09:03:00.000Z"),
+      }),
+    ).resolves.toMatchObject({ kind: "secured", operation: { state: "succeeded" } })
+    expect(reserve).toHaveBeenCalledTimes(1)
+    expect(getReservation).toHaveBeenCalledTimes(1)
+  })
+
+  it("ignores a stale supplier observation after a newer confirmation", async () => {
+    const repository = memoryRepository()
+    const reserve = vi.fn(async () => ({ upstream_ref: "UP-4", status: "pending" as const }))
+    const getReservation = vi
+      .fn()
+      .mockResolvedValueOnce({
+        upstream_ref: "UP-4",
+        status: "confirmed" as const,
+        source_updated_at: new Date("2026-08-02T09:10:00.000Z"),
+        upstream_payload: { revision: 2 },
+      })
+      .mockResolvedValueOnce({
+        upstream_ref: "UP-4",
+        status: "pending" as const,
+        source_updated_at: new Date("2026-08-02T09:05:00.000Z"),
+        upstream_payload: { revision: 1 },
+      })
+    const workflow = workflowWith(repository, { reserve, getReservation })
+    const dispatched = await workflow.dispatch(input())
+    if (dispatched.kind !== "pending") throw new Error("expected pending operation")
+    const secured = await workflow.reconcile(dispatched.operation, {
+      adapterContext: { connection_id: "conn_1" },
+      now: new Date("2026-08-02T09:11:00.000Z"),
+    })
+    if (secured.kind !== "secured") throw new Error("expected secured operation")
+
+    await expect(
+      workflow.reconcile(secured.operation, {
+        adapterContext: { connection_id: "conn_1" },
+        now: new Date("2026-08-02T09:12:00.000Z"),
+      }),
+    ).resolves.toMatchObject({
+      kind: "secured",
+      operation: { state: "succeeded", safeEvidence: { revision: 2 } },
+    })
+  })
+
+  it("records newer supplier-side modifications on reconciliation replay", async () => {
+    const repository = memoryRepository()
+    const reserve = vi.fn(async () => ({ upstream_ref: "UP-5", status: "pending" as const }))
+    const getReservation = vi
+      .fn()
+      .mockResolvedValueOnce({
+        upstream_ref: "UP-5",
+        status: "confirmed" as const,
+        source_updated_at: new Date("2026-08-02T09:10:00.000Z"),
+        upstream_payload: { cabin: "A1" },
+      })
+      .mockResolvedValueOnce({
+        upstream_ref: "UP-5",
+        status: "confirmed" as const,
+        source_updated_at: new Date("2026-08-02T09:20:00.000Z"),
+        upstream_payload: { cabin: "B2" },
+      })
+    const workflow = workflowWith(repository, { reserve, getReservation })
+    const dispatched = await workflow.dispatch(input())
+    if (dispatched.kind !== "pending") throw new Error("expected pending operation")
+    const first = await workflow.reconcile(dispatched.operation, {
+      adapterContext: { connection_id: "conn_1" },
+      now: new Date("2026-08-02T09:11:00.000Z"),
+    })
+    if (first.kind !== "secured") throw new Error("expected secured operation")
+
+    await expect(
+      workflow.reconcile(first.operation, {
+        adapterContext: { connection_id: "conn_1" },
+        now: new Date("2026-08-02T09:21:00.000Z"),
+      }),
+    ).resolves.toMatchObject({
+      kind: "secured",
+      operation: { safeEvidence: { cabin: "B2" } },
+    })
+    expect(reserve).toHaveBeenCalledTimes(1)
+  })
+})
+
+function workflowWith(
+  repository: ReturnType<typeof memoryRepository>,
+  methods: Pick<SourceAdapter, "reserve"> & Partial<Pick<SourceAdapter, "getReservation">>,
+) {
+  const registry = createSourceAdapterRegistry()
+  registry.register("conn_1", {
+    kind: "cruise:test",
+    capabilities: {
+      verticals: ["cruises"],
+      supportsLiveResolution: true,
+      supportsDriftDetection: false,
+      supportsBookingForwarding: true,
+      supportsReservationRetrieval: Boolean(methods.getReservation),
+      supportsReservationLookupByIdempotencyKey: Boolean(methods.getReservation),
+      postBookOperations: ["status"],
+    },
+    ...methods,
+  })
+  return createSupplierOperationWorkflow({ repository, registry })
+}
+
+function input() {
+  return {
+    sessionId: "bses_1",
+    quoteId: "bsqu_1",
+    commitIdempotencyKey: "commit-key",
+    requestFingerprint: "fingerprint-1",
+    entityModule: "cruises",
+    entityId: "crus_1",
+    sourceKind: "cruise:test",
+    sourceConnectionId: "conn_1",
+    sourceRef: "CRUISE-1",
+    request: {
+      entity_module: "cruises",
+      entity_id: "crus_1",
+      parameters: { sailingId: "sail_1", cabinCategoryId: "cabin_1" },
+    },
+    adapterContext: { connection_id: "conn_1" },
+    now: new Date("2026-08-02T09:00:00.000Z"),
+  }
+}
+
+function memoryRepository(): SupplierOperationRepository & {
+  rows: SupplierOperationInternalRecord[]
+} {
+  const rows: SupplierOperationInternalRecord[] = []
+  return {
+    rows,
+    async createOrReplay(record): Promise<CreateSupplierOperationResult> {
+      const existing = rows.find((row) => row.sessionId === record.sessionId)
+      if (!existing) {
+        rows.push(record)
+        return { status: "created", operation: record }
+      }
+      return existing.commitIdempotencyKey === record.commitIdempotencyKey &&
+        existing.requestFingerprint === record.requestFingerprint
+        ? { status: "replay", operation: existing }
+        : { status: "conflict" }
+    },
+    async get(operationId) {
+      return rows.find((row) => row.id === operationId) ?? null
+    },
+    async getByCommit(sessionId, commitIdempotencyKey) {
+      return (
+        rows.find(
+          (row) => row.sessionId === sessionId && row.commitIdempotencyKey === commitIdempotencyKey,
+        ) ?? null
+      )
+    },
+    async getBySession(sessionId) {
+      return rows.find((row) => row.sessionId === sessionId) ?? null
+    },
+    async getForUpdate(operationId) {
+      return rows.find((row) => row.id === operationId) ?? null
+    },
+    async list() {
+      return rows
+    },
+    async claimDispatch(operationId, at) {
+      const operation = rows.find((row) => row.id === operationId && row.state === "queued")
+      if (!operation) return null
+      operation.state = "submitted"
+      operation.version += 1
+      operation.attemptCount += 1
+      operation.submittedAt = at
+      operation.updatedAt = at
+      return operation
+    },
+    async save(operation) {
+      operation.version += 1
+    },
+  }
+}

--- a/packages/catalog/src/booking-engine/supplier-operation-workflow.test.ts
+++ b/packages/catalog/src/booking-engine/supplier-operation-workflow.test.ts
@@ -124,6 +124,32 @@ describe("Supplier Operation workflow", () => {
     expect(reserve).toHaveBeenCalledTimes(1)
   })
 
+  it("allows a new reservation intent after a definitive refusal", async () => {
+    const repository = memoryRepository()
+    const reserve = vi
+      .fn()
+      .mockResolvedValueOnce({ upstream_ref: "UP-REFUSED", status: "failed" as const })
+      .mockResolvedValueOnce({ upstream_ref: "UP-ALTERNATIVE", status: "confirmed" as const })
+    const workflow = workflowWith(repository, { reserve })
+
+    await expect(workflow.dispatch(input())).resolves.toMatchObject({
+      kind: "failed",
+      operation: { state: "refused" },
+    })
+    await expect(
+      workflow.dispatch({
+        ...input(),
+        commitIdempotencyKey: "alternative-key",
+        requestFingerprint: "fingerprint-2",
+      }),
+    ).resolves.toMatchObject({
+      kind: "secured",
+      operation: { state: "succeeded", upstreamRef: "UP-ALTERNATIVE" },
+    })
+    expect(repository.rows).toHaveLength(2)
+    expect(reserve).toHaveBeenCalledTimes(2)
+  })
+
   it("retries only when the adapter proves the request was not sent", async () => {
     const repository = memoryRepository()
     const reserve = vi
@@ -291,15 +317,24 @@ function memoryRepository(): SupplierOperationRepository & {
   return {
     rows,
     async createOrReplay(record): Promise<CreateSupplierOperationResult> {
-      const existing = rows.find((row) => row.sessionId === record.sessionId)
-      if (!existing) {
-        rows.push(record)
-        return { status: "created", operation: record }
+      const replay = rows.find(
+        (row) =>
+          row.sessionId === record.sessionId &&
+          row.commitIdempotencyKey === record.commitIdempotencyKey,
+      )
+      if (replay) {
+        return replay.requestFingerprint === record.requestFingerprint
+          ? { status: "replay", operation: replay }
+          : { status: "conflict" }
       }
-      return existing.commitIdempotencyKey === record.commitIdempotencyKey &&
-        existing.requestFingerprint === record.requestFingerprint
-        ? { status: "replay", operation: existing }
-        : { status: "conflict" }
+      const blocking = rows.find(
+        (row) => row.sessionId === record.sessionId && blocksReplacement(row),
+      )
+      if (blocking) {
+        return { status: "conflict" }
+      }
+      rows.push(record)
+      return { status: "created", operation: record }
     },
     async get(operationId) {
       return rows.find((row) => row.id === operationId) ?? null
@@ -312,7 +347,14 @@ function memoryRepository(): SupplierOperationRepository & {
       )
     },
     async getBySession(sessionId) {
-      return rows.find((row) => row.sessionId === sessionId) ?? null
+      for (let index = rows.length - 1; index >= 0; index -= 1) {
+        const row = rows[index]
+        if (row?.sessionId === sessionId) return row
+      }
+      return null
+    },
+    async getBlockingBySession(sessionId) {
+      return rows.find((row) => row.sessionId === sessionId && blocksReplacement(row)) ?? null
     },
     async getForUpdate(operationId) {
       return rows.find((row) => row.id === operationId) ?? null
@@ -334,4 +376,16 @@ function memoryRepository(): SupplierOperationRepository & {
       operation.version += 1
     },
   }
+}
+
+function blocksReplacement(operation: SupplierOperationInternalRecord): boolean {
+  return (
+    operation.state === "queued" ||
+    operation.state === "submitted" ||
+    operation.state === "pending" ||
+    operation.state === "succeeded" ||
+    operation.state === "in_doubt" ||
+    operation.state === "manual_review" ||
+    (operation.state === "manually_resolved" && operation.upstreamStatus === "succeeded")
+  )
 }

--- a/packages/catalog/src/booking-engine/supplier-operation-workflow.ts
+++ b/packages/catalog/src/booking-engine/supplier-operation-workflow.ts
@@ -1,0 +1,402 @@
+import {
+  ReservationDispatchError,
+  type ReserveRequest,
+  type ReserveResult,
+  type SourceAdapterContext,
+} from "../adapter/contract.js"
+import type { SourceAdapterRegistry } from "./registry.js"
+import {
+  createSupplierOperationRecord,
+  type SupplierOperationInternalRecord,
+  type SupplierOperationRepository,
+} from "./supplier-operations.js"
+
+export type SupplierOperationWorkflowOutcome =
+  | { kind: "secured"; operation: SupplierOperationInternalRecord; result: ReserveResult }
+  | { kind: "pending"; operation: SupplierOperationInternalRecord }
+  | { kind: "in_doubt"; operation: SupplierOperationInternalRecord }
+  | { kind: "failed"; operation: SupplierOperationInternalRecord }
+  | { kind: "idempotency_conflict" }
+
+export interface DispatchSupplierReservationInput {
+  sessionId: string
+  quoteId: string
+  holdId?: string
+  commitIdempotencyKey: string
+  requestFingerprint: string
+  entityModule: string
+  entityId: string
+  sourceKind: string
+  sourceConnectionId: string
+  sourceRef: string
+  request: ReserveRequest
+  adapterContext: SourceAdapterContext
+  now: Date
+}
+
+export interface SupplierOperationWorkflow {
+  dispatch(input: DispatchSupplierReservationInput): Promise<SupplierOperationWorkflowOutcome>
+  reconcile(
+    operation: SupplierOperationInternalRecord,
+    input: { adapterContext: SourceAdapterContext; now: Date },
+  ): Promise<SupplierOperationWorkflowOutcome>
+}
+
+export function createSupplierOperationWorkflow(deps: {
+  repository: SupplierOperationRepository
+  registry: SourceAdapterRegistry
+  reconcileAfterMs?: number
+}): SupplierOperationWorkflow {
+  const reconcileAfterMs = deps.reconcileAfterMs ?? 60_000
+
+  return {
+    async dispatch(input) {
+      const adapter = deps.registry.resolveByConnection(input.sourceConnectionId)
+      if (!adapter?.capabilities.supportsBookingForwarding || !adapter.reserve) {
+        return operationFailedWithoutDispatch(
+          deps.repository,
+          input,
+          "booking_forwarding_unsupported",
+        )
+      }
+      const adapterIdempotencyKey = `${input.sessionId}:${input.commitIdempotencyKey}:reserve`
+      const claim = await deps.repository.createOrReplay(
+        createSupplierOperationRecord({
+          sessionId: input.sessionId,
+          quoteId: input.quoteId,
+          ...(input.holdId ? { holdId: input.holdId } : {}),
+          commitIdempotencyKey: input.commitIdempotencyKey,
+          entityModule: input.entityModule,
+          entityId: input.entityId,
+          sourceKind: input.sourceKind,
+          sourceConnectionId: input.sourceConnectionId,
+          sourceRef: input.sourceRef,
+          adapterKind: adapter.kind,
+          requestFingerprint: input.requestFingerprint,
+          adapterIdempotencyKey,
+          requestPayload: safeSupplierRequestPayload(input.request),
+          now: input.now,
+        }),
+      )
+      if (claim.status === "conflict") return { kind: "idempotency_conflict" }
+      const replay = outcomeForStoredOperation(claim.operation)
+      if (claim.status === "replay" && replay) return replay
+
+      const operation =
+        claim.operation.state === "queued"
+          ? await deps.repository.claimDispatch(claim.operation.id, input.now)
+          : null
+      if (!operation) {
+        const current = await deps.repository.get(claim.operation.id)
+        return current
+          ? (outcomeForStoredOperation(current) ?? { kind: "in_doubt", operation: current })
+          : { kind: "in_doubt", operation: claim.operation }
+      }
+
+      try {
+        const result = await adapter.reserve(input.adapterContext, {
+          ...input.request,
+          idempotency_key: operation.adapterIdempotencyKey,
+        })
+        const at = input.now
+        operation.updatedAt = at
+        operation.upstreamRef = result.upstream_ref
+        operation.upstreamStatus = result.status
+        operation.safeEvidence = safeEvidence(result)
+        if (result.status === "pending") {
+          operation.state = "pending"
+          operation.nextReconcileAt = new Date(at.getTime() + reconcileAfterMs)
+          await deps.repository.save(operation)
+          return { kind: "pending", operation }
+        }
+        operation.resolvedAt = at
+        operation.nextReconcileAt = undefined
+        if (result.status === "failed") {
+          operation.state = "refused"
+          await deps.repository.save(operation)
+          return { kind: "failed", operation }
+        }
+        operation.state = "succeeded"
+        await deps.repository.save(operation)
+        return { kind: "secured", operation, result }
+      } catch (error) {
+        operation.updatedAt = input.now
+        operation.lastErrorClass = errorClass(error)
+        if (error instanceof ReservationDispatchError && error.certainty === "not_sent") {
+          operation.state = "queued"
+          operation.submittedAt = undefined
+          operation.nextReconcileAt = new Date(input.now.getTime() + reconcileAfterMs)
+          operation.safeEvidence = { dispatchCertainty: "not_sent" }
+          await deps.repository.save(operation)
+          return { kind: "pending", operation }
+        }
+        operation.state = "in_doubt"
+        operation.nextReconcileAt = new Date(input.now.getTime() + reconcileAfterMs)
+        operation.safeEvidence = { dispatchCertainty: "possibly_sent" }
+        await deps.repository.save(operation)
+        return { kind: "in_doubt", operation }
+      }
+    },
+
+    async reconcile(operation, input) {
+      const terminal = outcomeForStoredOperation(operation)
+      if (
+        terminal &&
+        operation.state !== "pending" &&
+        operation.state !== "in_doubt" &&
+        operation.state !== "succeeded"
+      ) {
+        return terminal
+      }
+      const adapter = deps.registry.resolveByConnection(operation.sourceConnectionId)
+      if (
+        !adapter?.capabilities.supportsReservationRetrieval ||
+        !adapter.getReservation ||
+        (!operation.upstreamRef && !adapter.capabilities.supportsReservationLookupByIdempotencyKey)
+      ) {
+        operation.state = "manual_review"
+        operation.lastCheckedAt = input.now
+        operation.updatedAt = input.now
+        operation.nextReconcileAt = undefined
+        operation.lastErrorClass = "reservation_retrieval_unsupported"
+        await deps.repository.save(operation)
+        return { kind: "in_doubt", operation }
+      }
+      try {
+        const result = await adapter.getReservation(
+          input.adapterContext,
+          operation.upstreamRef
+            ? { upstream_ref: operation.upstreamRef }
+            : { idempotency_key: operation.adapterIdempotencyKey },
+        )
+        operation.lastCheckedAt = input.now
+        operation.updatedAt = input.now
+        if (
+          result?.source_updated_at &&
+          operation.sourceUpdatedAt &&
+          result.source_updated_at <= operation.sourceUpdatedAt
+        ) {
+          await deps.repository.save(operation)
+          return outcomeForStoredOperation(operation) ?? { kind: "in_doubt", operation }
+        }
+        operation.sourceUpdatedAt = result?.source_updated_at ?? operation.sourceUpdatedAt
+        operation.upstreamRef = result?.upstream_ref ?? operation.upstreamRef
+        if (!result) {
+          operation.state = "in_doubt"
+          operation.lastErrorClass = "reservation_not_found"
+          operation.nextReconcileAt = new Date(input.now.getTime() + reconcileAfterMs)
+          await deps.repository.save(operation)
+          return { kind: "in_doubt", operation }
+        }
+        if (result.status === "failed" || result.status === "refused") {
+          operation.state = "refused"
+          operation.resolvedAt = input.now
+          operation.nextReconcileAt = undefined
+          operation.safeEvidence = {
+            ...operation.safeEvidence,
+            ...redactSupplierEvidence(result?.upstream_payload),
+          }
+          await deps.repository.save(operation)
+          return { kind: "failed", operation }
+        }
+        if (result.status === "cancelled") {
+          operation.state = "cancelled"
+          operation.resolvedAt = input.now
+          operation.nextReconcileAt = undefined
+          operation.safeEvidence = {
+            ...operation.safeEvidence,
+            ...redactSupplierEvidence(result.upstream_payload),
+          }
+          await deps.repository.save(operation)
+          return { kind: "failed", operation }
+        }
+        if (result.status === "pending" || result.status === "cancelling") {
+          operation.state = "pending"
+          operation.nextReconcileAt = new Date(input.now.getTime() + reconcileAfterMs)
+          operation.safeEvidence = {
+            ...operation.safeEvidence,
+            ...redactSupplierEvidence(result.upstream_payload),
+          }
+          await deps.repository.save(operation)
+          return { kind: "pending", operation }
+        }
+        operation.state = "succeeded"
+        operation.upstreamStatus = result.status
+        operation.resolvedAt = input.now
+        operation.nextReconcileAt = undefined
+        operation.safeEvidence = {
+          ...operation.safeEvidence,
+          ...redactSupplierEvidence(result.upstream_payload),
+        }
+        await deps.repository.save(operation)
+        return {
+          kind: "secured",
+          operation,
+          result: {
+            upstream_ref: result.upstream_ref,
+            status: result.status,
+            upstream_payload: result.upstream_payload,
+          },
+        }
+      } catch (error) {
+        operation.state = "in_doubt"
+        operation.lastCheckedAt = input.now
+        operation.updatedAt = input.now
+        operation.nextReconcileAt = new Date(input.now.getTime() + reconcileAfterMs)
+        operation.lastErrorClass = errorClass(error)
+        await deps.repository.save(operation)
+        return { kind: "in_doubt", operation }
+      }
+    },
+  }
+}
+
+async function operationFailedWithoutDispatch(
+  repository: SupplierOperationRepository,
+  input: DispatchSupplierReservationInput,
+  reason: string,
+): Promise<SupplierOperationWorkflowOutcome> {
+  const operation = createSupplierOperationRecord({
+    sessionId: input.sessionId,
+    quoteId: input.quoteId,
+    ...(input.holdId ? { holdId: input.holdId } : {}),
+    commitIdempotencyKey: input.commitIdempotencyKey,
+    entityModule: input.entityModule,
+    entityId: input.entityId,
+    sourceKind: input.sourceKind,
+    sourceConnectionId: input.sourceConnectionId,
+    sourceRef: input.sourceRef,
+    adapterKind: input.sourceKind,
+    requestFingerprint: input.requestFingerprint,
+    adapterIdempotencyKey: `${input.sessionId}:${input.commitIdempotencyKey}:reserve`,
+    requestPayload: safeSupplierRequestPayload(input.request),
+    now: input.now,
+  })
+  operation.state = "refused"
+  operation.lastErrorClass = reason
+  operation.resolvedAt = input.now
+  const claim = await repository.createOrReplay(operation)
+  if (claim.status === "conflict") return { kind: "idempotency_conflict" }
+  const storedOutcome = outcomeForStoredOperation(claim.operation)
+  if (storedOutcome) return storedOutcome
+  claim.operation.state = "refused"
+  claim.operation.lastErrorClass = reason
+  claim.operation.resolvedAt = input.now
+  claim.operation.updatedAt = input.now
+  await repository.save(claim.operation)
+  return { kind: "failed", operation: claim.operation }
+}
+
+function outcomeForStoredOperation(
+  operation: SupplierOperationInternalRecord,
+): SupplierOperationWorkflowOutcome | null {
+  switch (operation.state) {
+    case "queued":
+      return null
+    case "submitted":
+    case "in_doubt":
+    case "manual_review":
+      return { kind: "in_doubt", operation }
+    case "pending":
+      return { kind: "pending", operation }
+    case "refused":
+    case "cancelled":
+      return { kind: "failed", operation }
+    case "manually_resolved":
+      return operation.upstreamStatus === "succeeded"
+        ? {
+            kind: "secured",
+            operation,
+            result: {
+              upstream_ref: requiredUpstreamRef(operation),
+              status: "confirmed",
+              upstream_payload: operation.safeEvidence,
+            },
+          }
+        : { kind: "failed", operation }
+    case "succeeded":
+      return {
+        kind: "secured",
+        operation,
+        result: {
+          upstream_ref: requiredUpstreamRef(operation),
+          status: securedStatus(operation.upstreamStatus),
+          upstream_payload: operation.safeEvidence,
+        },
+      }
+  }
+}
+
+function safeEvidence(result: ReserveResult): Record<string, unknown> {
+  return {
+    dispatchCertainty: "acknowledged",
+    upstreamStatus: result.status,
+    ...(result.upstream_payload
+      ? { upstreamPayload: redactSupplierEvidence(result.upstream_payload) }
+      : {}),
+  }
+}
+
+export function safeSupplierRequestPayload(request: ReserveRequest): Record<string, unknown> {
+  return {
+    entity_module: request.entity_module,
+    entity_id: request.entity_id,
+    ...(request.source_ref ? { source_ref: request.source_ref } : {}),
+    parameters: redactSupplierParameters(request.parameters),
+    ...(request.payment_intent
+      ? {
+          paymentIntentSummary: {
+            kind: request.payment_intent.kind,
+            type: request.payment_intent.type,
+            mode: request.payment_intent.mode,
+          },
+        }
+      : {}),
+    ...(request.scope ? { scope: request.scope } : {}),
+    partySummary: {
+      passengerCount: Array.isArray(request.party?.passengers)
+        ? request.party.passengers.length
+        : undefined,
+      hasContact: Boolean(request.party?.contact),
+    },
+  }
+}
+
+function redactSupplierParameters(parameters: Record<string, unknown>): Record<string, unknown> {
+  const { draft: _draft, contact: _contact, passengers: _passengers, ...safe } = parameters
+  return safe
+}
+
+function redactSupplierEvidence(value: unknown): Record<string, unknown> {
+  const redacted = redactEvidenceValue(value)
+  return redacted && typeof redacted === "object" && !Array.isArray(redacted)
+    ? (redacted as Record<string, unknown>)
+    : {}
+}
+
+function redactEvidenceValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(redactEvidenceValue)
+  if (!value || typeof value !== "object") return value
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .filter(([key]) => !SUPPLIER_EVIDENCE_PII_KEYS.test(key))
+      .map(([key, item]) => [key, redactEvidenceValue(item)]),
+  )
+}
+
+const SUPPLIER_EVIDENCE_PII_KEYS =
+  /(passengers?|travelers?|contact|first_?name|last_?name|email|phone|address|postal_?code|passport|document)/i
+
+function requiredUpstreamRef(operation: SupplierOperationInternalRecord): string {
+  if (!operation.upstreamRef) throw new Error("succeeded supplier operation has no upstream ref")
+  return operation.upstreamRef
+}
+
+function securedStatus(value: string | undefined): "held" | "confirmed" | "ticketed" {
+  return value === "held" || value === "ticketed" ? value : "confirmed"
+}
+
+function errorClass(error: unknown): string {
+  if (error instanceof ReservationDispatchError) return error.errorClass
+  return error instanceof Error ? error.name || "Error" : "unknown_error"
+}

--- a/packages/catalog/src/booking-engine/supplier-operations-operator.ts
+++ b/packages/catalog/src/booking-engine/supplier-operations-operator.ts
@@ -1,0 +1,223 @@
+import type {
+  ReconcileSupplierOperationV1,
+  ResolveSupplierOperationV1,
+  SupplierOperationRecordV1,
+  SupplierOperationStateV1,
+} from "@voyant-travel/catalog-contracts/booking-engine/supplier-operations"
+import { newId } from "@voyant-travel/db/lib/typeid"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import type { SourceAdapterRegistry } from "./registry.js"
+import { createDrizzleBookingSessionRepository } from "./sessions-drizzle.js"
+import type { BookingSessionAccessContext } from "./sessions-service.js"
+import { createSupplierOperationWorkflow } from "./supplier-operation-workflow.js"
+import {
+  createDrizzleSupplierOperationRepository,
+  serializeSupplierOperation,
+} from "./supplier-operations.js"
+
+export interface SupplierOperationOperatorService {
+  list(
+    input: {
+      state?: SupplierOperationStateV1
+      sessionId?: string
+      limit: number
+    },
+    access: BookingSessionAccessContext,
+  ): Promise<SupplierOperationRecordV1[]>
+  get(
+    operationId: string,
+    access: BookingSessionAccessContext,
+  ): Promise<SupplierOperationRecordV1 | null>
+  reconcile(
+    operationId: string,
+    input: ReconcileSupplierOperationV1,
+    access: BookingSessionAccessContext,
+  ): Promise<SupplierOperationRecordV1>
+  resolve(
+    operationId: string,
+    input: ResolveSupplierOperationV1,
+    access: BookingSessionAccessContext,
+  ): Promise<SupplierOperationRecordV1>
+}
+
+export function createSupplierOperationOperatorService(deps: {
+  db: PostgresJsDatabase
+  resolveRegistry(): SourceAdapterRegistry | Promise<SourceAdapterRegistry>
+  now?: () => Date
+}): SupplierOperationOperatorService {
+  const now = deps.now ?? (() => new Date())
+  return {
+    async list(input, access) {
+      requireOperator(access)
+      return (
+        await createDrizzleSupplierOperationRepository(deps.db).list({
+          ...(input.state ? { state: input.state } : {}),
+          ...(input.sessionId ? { sessionId: input.sessionId } : {}),
+          limit: input.limit,
+        })
+      ).map(serializeSupplierOperation)
+    },
+    async get(operationId, access) {
+      requireOperator(access)
+      const operation = await createDrizzleSupplierOperationRepository(deps.db).get(operationId)
+      return operation ? serializeSupplierOperation(operation) : null
+    },
+    async reconcile(operationId, input, access) {
+      requireOperator(access)
+      const repository = createDrizzleSupplierOperationRepository(deps.db)
+      const operation = await repository.get(operationId)
+      if (!operation) throw new Error("supplier_operation_not_found")
+      const prior = operation.safeEvidence.lastOperatorReconcile
+      if (
+        prior &&
+        typeof prior === "object" &&
+        Reflect.get(prior, "idempotencyKey") === input.idempotencyKey
+      ) {
+        return serializeSupplierOperation(operation)
+      }
+      const workflow = createSupplierOperationWorkflow({
+        repository,
+        registry: await deps.resolveRegistry(),
+      })
+      const outcome = await workflow.reconcile(operation, {
+        adapterContext: { connection_id: operation.sourceConnectionId },
+        now: now(),
+      })
+      if (outcome.kind === "idempotency_conflict") {
+        throw new Error("supplier_operation_idempotency_conflict")
+      }
+      if (outcome.kind === "failed") {
+        await reopenSupplierPendingSession(deps.db, outcome.operation.sessionId, now())
+      }
+      outcome.operation.safeEvidence = {
+        ...outcome.operation.safeEvidence,
+        lastOperatorReconcile: {
+          idempotencyKey: input.idempotencyKey,
+          at: now().toISOString(),
+        },
+      }
+      await repository.save(outcome.operation)
+      await appendOperatorAudit(
+        deps.db,
+        outcome.operation.sessionId,
+        "supplier_reconcile",
+        access,
+        {
+          supplierOperationId: outcome.operation.id,
+          state: outcome.operation.state,
+          idempotencyKey: input.idempotencyKey,
+        },
+      )
+      return serializeSupplierOperation(outcome.operation)
+    },
+    async resolve(operationId, input, access) {
+      requireOperator(access)
+      return deps.db.transaction(async (rawTx) => {
+        const tx = rawTx as PostgresJsDatabase
+        const repository = createDrizzleSupplierOperationRepository(tx)
+        const operation = await repository.getForUpdate(operationId)
+        if (!operation) throw new Error("supplier_operation_not_found")
+        const prior = operation.safeEvidence.manualResolution
+        if (prior && typeof prior === "object") {
+          const idempotencyKey = Reflect.get(prior, "idempotencyKey")
+          const resolution = Reflect.get(prior, "resolution")
+          const reason = Reflect.get(prior, "reason")
+          if (
+            idempotencyKey === input.idempotencyKey &&
+            resolution === input.resolution &&
+            reason === input.reason
+          ) {
+            return serializeSupplierOperation(operation)
+          }
+          throw new Error("supplier_operation_resolution_conflict")
+        }
+        if (
+          operation.state === "succeeded" ||
+          operation.state === "refused" ||
+          operation.state === "cancelled"
+        ) {
+          throw new Error("supplier_operation_already_terminal")
+        }
+        const upstreamRef = input.upstreamRef ?? operation.upstreamRef
+        if (input.resolution === "succeeded" && !upstreamRef) {
+          throw new Error("supplier_operation_upstream_ref_required")
+        }
+        const at = now()
+        operation.state = "manually_resolved"
+        operation.upstreamStatus = input.resolution
+        operation.upstreamRef = upstreamRef
+        operation.resolvedAt = at
+        operation.updatedAt = at
+        operation.nextReconcileAt = undefined
+        operation.resolvedBy = access.principalId ?? "operator"
+        operation.resolutionReason = input.reason
+        operation.safeEvidence = {
+          ...operation.safeEvidence,
+          manualResolution: {
+            idempotencyKey: input.idempotencyKey,
+            resolution: input.resolution,
+            reason: input.reason,
+          },
+        }
+        await repository.save(operation)
+        if (input.resolution !== "succeeded") {
+          const sessions = createDrizzleBookingSessionRepository(tx)
+          const session = await sessions.getSession(operation.sessionId)
+          if (session?.state === "supplier_pending") {
+            session.state = "active"
+            session.updatedAt = at
+            await sessions.saveSession(session)
+          }
+        }
+        await appendOperatorAudit(tx, operation.sessionId, "supplier_manual_resolve", access, {
+          supplierOperationId: operation.id,
+          resolution: input.resolution,
+          reason: input.reason,
+        })
+        return serializeSupplierOperation(operation)
+      })
+    },
+  }
+}
+
+async function reopenSupplierPendingSession(
+  db: PostgresJsDatabase,
+  sessionId: string,
+  at: Date,
+): Promise<void> {
+  const sessions = createDrizzleBookingSessionRepository(db)
+  await sessions.withSessionTransaction(sessionId, async () => {
+    const session = await sessions.getSession(sessionId)
+    if (session?.state !== "supplier_pending") return
+    session.state = "active"
+    session.updatedAt = at
+    await sessions.saveSession(session)
+  })
+}
+
+function requireOperator(access: BookingSessionAccessContext): void {
+  if (access.actorKind !== "staff" || !access.staffAuthority?.admitted) {
+    throw new Error("supplier_operation_operator_authority_required")
+  }
+}
+
+async function appendOperatorAudit(
+  db: PostgresJsDatabase,
+  sessionId: string,
+  action: "supplier_reconcile" | "supplier_manual_resolve",
+  access: BookingSessionAccessContext,
+  metadata: Record<string, unknown>,
+): Promise<void> {
+  await createDrizzleBookingSessionRepository(db).appendAudit({
+    id: newId("booking_session_audit_events"),
+    sessionId,
+    action,
+    actorKind: access.actorKind,
+    principalId: access.principalId,
+    organizationId: access.organizationId,
+    authorityReason: access.staffAuthority?.reason,
+    metadata,
+    createdAt: new Date(),
+  })
+}

--- a/packages/catalog/src/booking-engine/supplier-operations-schema.ts
+++ b/packages/catalog/src/booking-engine/supplier-operations-schema.ts
@@ -77,10 +77,15 @@ export const supplierOperationsTable = pgTable(
     ),
     check("supplier_operations_attempt_count", sql`${table.attemptCount} >= 0`),
     check("supplier_operations_version", sql`${table.version} >= 0`),
-    uniqueIndex("uidx_supplier_operations_session_reserve").on(
+    uniqueIndex("uidx_supplier_operations_session_commit").on(
       table.sessionId,
-      table.operationKind,
+      table.commitIdempotencyKey,
     ),
+    uniqueIndex("uidx_supplier_operations_session_reserve_guard")
+      .on(table.sessionId, table.operationKind)
+      .where(
+        sql`${table.state} IN ('queued','submitted','pending','succeeded','in_doubt','manual_review') OR (${table.state} = 'manually_resolved' AND ${table.upstreamStatus} = 'succeeded')`,
+      ),
     uniqueIndex("uidx_supplier_operations_adapter_idem").on(
       table.sourceConnectionId,
       table.adapterIdempotencyKey,

--- a/packages/catalog/src/booking-engine/supplier-operations-schema.ts
+++ b/packages/catalog/src/booking-engine/supplier-operations-schema.ts
@@ -1,0 +1,95 @@
+import type {
+  SupplierCommitmentPolicyV1,
+  SupplierOperationStateV1,
+} from "@voyant-travel/catalog-contracts/booking-engine/supplier-operations"
+import { typeId, typeIdRef } from "@voyant-travel/db/lib/typeid-column"
+import { sql } from "drizzle-orm"
+import {
+  check,
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+} from "drizzle-orm/pg-core"
+
+import {
+  bookingSessionHoldsTable,
+  bookingSessionQuotesTable,
+  bookingSessionsTable,
+} from "./sessions-schema.js"
+
+export const supplierOperationsTable = pgTable(
+  "supplier_operations",
+  {
+    id: typeId("supplier_operations"),
+    sessionId: typeIdRef("session_id")
+      .notNull()
+      .references(() => bookingSessionsTable.id, { onDelete: "restrict" }),
+    quoteId: typeIdRef("quote_id")
+      .notNull()
+      .references(() => bookingSessionQuotesTable.id, { onDelete: "restrict" }),
+    holdId: typeIdRef("hold_id").references(() => bookingSessionHoldsTable.id, {
+      onDelete: "restrict",
+    }),
+    commitIdempotencyKey: text("commit_idempotency_key").notNull(),
+    operationKind: text("operation_kind").notNull(),
+    state: text("state").$type<SupplierOperationStateV1>().notNull(),
+    commitmentPolicy: text("commitment_policy").$type<SupplierCommitmentPolicyV1>().notNull(),
+    entityModule: text("entity_module").notNull(),
+    entityId: text("entity_id").notNull(),
+    sourceKind: text("source_kind").notNull(),
+    sourceConnectionId: text("source_connection_id").notNull(),
+    sourceRef: text("source_ref").notNull(),
+    adapterKind: text("adapter_kind").notNull(),
+    requestFingerprint: text("request_fingerprint").notNull(),
+    adapterIdempotencyKey: text("adapter_idempotency_key").notNull(),
+    requestPayload: jsonb("request_payload").$type<Record<string, unknown>>().notNull(),
+    version: integer("version").notNull().default(0),
+    attemptCount: integer("attempt_count").notNull().default(0),
+    upstreamRef: text("upstream_ref"),
+    upstreamStatus: text("upstream_status"),
+    bookingId: text("booking_id"),
+    lastErrorClass: text("last_error_class"),
+    safeEvidence: jsonb("safe_evidence").$type<Record<string, unknown>>().notNull().default({}),
+    submittedAt: timestamp("submitted_at", { withTimezone: true }),
+    lastCheckedAt: timestamp("last_checked_at", { withTimezone: true }),
+    sourceUpdatedAt: timestamp("source_updated_at", { withTimezone: true }),
+    nextReconcileAt: timestamp("next_reconcile_at", { withTimezone: true }),
+    resolvedAt: timestamp("resolved_at", { withTimezone: true }),
+    resolvedBy: text("resolved_by"),
+    resolutionReason: text("resolution_reason"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    check("supplier_operations_id_typeid", sql`${table.id} LIKE 'suop_%'`),
+    check("supplier_operations_kind", sql`${table.operationKind} = 'reserve'`),
+    check(
+      "supplier_operations_state",
+      sql`${table.state} IN ('queued','submitted','pending','succeeded','refused','cancelled','in_doubt','manual_review','manually_resolved')`,
+    ),
+    check(
+      "supplier_operations_policy",
+      sql`${table.commitmentPolicy} IN ('supplier_first','operator_backed')`,
+    ),
+    check("supplier_operations_attempt_count", sql`${table.attemptCount} >= 0`),
+    check("supplier_operations_version", sql`${table.version} >= 0`),
+    uniqueIndex("uidx_supplier_operations_session_reserve").on(
+      table.sessionId,
+      table.operationKind,
+    ),
+    uniqueIndex("uidx_supplier_operations_adapter_idem").on(
+      table.sourceConnectionId,
+      table.adapterIdempotencyKey,
+    ),
+    index("idx_supplier_operations_state_reconcile").on(table.state, table.nextReconcileAt),
+    index("idx_supplier_operations_session_created").on(table.sessionId, table.createdAt),
+    index("idx_supplier_operations_upstream").on(table.sourceConnectionId, table.upstreamRef),
+  ],
+)
+
+export type SelectSupplierOperation = typeof supplierOperationsTable.$inferSelect
+export type InsertSupplierOperation = typeof supplierOperationsTable.$inferInsert

--- a/packages/catalog/src/booking-engine/supplier-operations.ts
+++ b/packages/catalog/src/booking-engine/supplier-operations.ts
@@ -4,7 +4,7 @@ import type {
   SupplierOperationStateV1,
 } from "@voyant-travel/catalog-contracts/booking-engine/supplier-operations"
 import { newId } from "@voyant-travel/db/lib/typeid"
-import { and, desc, eq, sql } from "drizzle-orm"
+import { and, desc, eq, inArray, or, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import {
@@ -61,6 +61,7 @@ export interface SupplierOperationRepository {
     commitIdempotencyKey: string,
   ): Promise<SupplierOperationInternalRecord | null>
   getBySession(sessionId: string): Promise<SupplierOperationInternalRecord | null>
+  getBlockingBySession(sessionId: string): Promise<SupplierOperationInternalRecord | null>
   getForUpdate(operationId: string): Promise<SupplierOperationInternalRecord | null>
   list(input: {
     state?: SupplierOperationStateV1
@@ -79,19 +80,76 @@ export function createDrizzleSupplierOperationRepository(
       .select()
       .from(supplierOperationsTable)
       .where(eq(supplierOperationsTable.sessionId, sessionId))
+      .orderBy(desc(supplierOperationsTable.createdAt), desc(supplierOperationsTable.id))
+      .limit(1)
+    return row ? mapSupplierOperation(row) : null
+  }
+
+  async function getBlockingBySession(
+    sessionId: string,
+  ): Promise<SupplierOperationInternalRecord | null> {
+    const [row] = await db
+      .select()
+      .from(supplierOperationsTable)
+      .where(
+        and(
+          eq(supplierOperationsTable.sessionId, sessionId),
+          or(
+            inArray(supplierOperationsTable.state, [
+              "queued",
+              "submitted",
+              "pending",
+              "succeeded",
+              "in_doubt",
+              "manual_review",
+            ]),
+            and(
+              eq(supplierOperationsTable.state, "manually_resolved"),
+              eq(supplierOperationsTable.upstreamStatus, "succeeded"),
+            ),
+          ),
+        ),
+      )
+      .orderBy(desc(supplierOperationsTable.createdAt), desc(supplierOperationsTable.id))
+      .limit(1)
+    return row ? mapSupplierOperation(row) : null
+  }
+
+  async function getByCommit(
+    sessionId: string,
+    commitIdempotencyKey: string,
+  ): Promise<SupplierOperationInternalRecord | null> {
+    const [row] = await db
+      .select()
+      .from(supplierOperationsTable)
+      .where(
+        and(
+          eq(supplierOperationsTable.sessionId, sessionId),
+          eq(supplierOperationsTable.commitIdempotencyKey, commitIdempotencyKey),
+        ),
+      )
       .limit(1)
     return row ? mapSupplierOperation(row) : null
   }
 
   return {
     async createOrReplay(record) {
+      const replay = await getByCommit(record.sessionId, record.commitIdempotencyKey)
+      if (replay) {
+        return replay.requestFingerprint === record.requestFingerprint
+          ? { status: "replay", operation: replay }
+          : { status: "conflict" }
+      }
+      if (await getBlockingBySession(record.sessionId)) {
+        return { status: "conflict" }
+      }
       const [created] = await db
         .insert(supplierOperationsTable)
         .values(toInsert(record))
         .onConflictDoNothing()
         .returning()
       if (created) return { status: "created", operation: mapSupplierOperation(created) }
-      const existing = await getBySession(record.sessionId)
+      const existing = await getByCommit(record.sessionId, record.commitIdempotencyKey)
       if (
         !existing ||
         existing.commitIdempotencyKey !== record.commitIdempotencyKey ||
@@ -112,12 +170,15 @@ export function createDrizzleSupplierOperationRepository(
     },
 
     async getByCommit(sessionId, commitIdempotencyKey) {
-      const existing = await getBySession(sessionId)
-      return existing?.commitIdempotencyKey === commitIdempotencyKey ? existing : null
+      return getByCommit(sessionId, commitIdempotencyKey)
     },
 
     async getBySession(sessionId) {
       return getBySession(sessionId)
+    },
+
+    async getBlockingBySession(sessionId) {
+      return getBlockingBySession(sessionId)
     },
 
     async getForUpdate(operationId) {

--- a/packages/catalog/src/booking-engine/supplier-operations.ts
+++ b/packages/catalog/src/booking-engine/supplier-operations.ts
@@ -1,0 +1,344 @@
+import type {
+  SupplierCommitmentPolicyV1,
+  SupplierOperationRecordV1,
+  SupplierOperationStateV1,
+} from "@voyant-travel/catalog-contracts/booking-engine/supplier-operations"
+import { newId } from "@voyant-travel/db/lib/typeid"
+import { and, desc, eq, sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import {
+  type SelectSupplierOperation,
+  supplierOperationsTable,
+} from "./supplier-operations-schema.js"
+
+export interface SupplierOperationInternalRecord {
+  id: string
+  sessionId: string
+  quoteId: string
+  holdId?: string
+  commitIdempotencyKey: string
+  operationKind: "reserve"
+  state: SupplierOperationStateV1
+  commitmentPolicy: SupplierCommitmentPolicyV1
+  entityModule: string
+  entityId: string
+  sourceKind: string
+  sourceConnectionId: string
+  sourceRef: string
+  adapterKind: string
+  requestFingerprint: string
+  adapterIdempotencyKey: string
+  requestPayload: Record<string, unknown>
+  version: number
+  attemptCount: number
+  upstreamRef?: string
+  upstreamStatus?: string
+  bookingId?: string
+  lastErrorClass?: string
+  safeEvidence: Record<string, unknown>
+  submittedAt?: Date
+  lastCheckedAt?: Date
+  sourceUpdatedAt?: Date
+  nextReconcileAt?: Date
+  resolvedAt?: Date
+  resolvedBy?: string
+  resolutionReason?: string
+  createdAt: Date
+  updatedAt: Date
+}
+
+export type CreateSupplierOperationResult =
+  | { status: "created"; operation: SupplierOperationInternalRecord }
+  | { status: "replay"; operation: SupplierOperationInternalRecord }
+  | { status: "conflict" }
+
+export interface SupplierOperationRepository {
+  createOrReplay(record: SupplierOperationInternalRecord): Promise<CreateSupplierOperationResult>
+  get(operationId: string): Promise<SupplierOperationInternalRecord | null>
+  getByCommit(
+    sessionId: string,
+    commitIdempotencyKey: string,
+  ): Promise<SupplierOperationInternalRecord | null>
+  getBySession(sessionId: string): Promise<SupplierOperationInternalRecord | null>
+  getForUpdate(operationId: string): Promise<SupplierOperationInternalRecord | null>
+  list(input: {
+    state?: SupplierOperationStateV1
+    sessionId?: string
+    limit: number
+  }): Promise<SupplierOperationInternalRecord[]>
+  claimDispatch(operationId: string, at: Date): Promise<SupplierOperationInternalRecord | null>
+  save(record: SupplierOperationInternalRecord): Promise<void>
+}
+
+export function createDrizzleSupplierOperationRepository(
+  db: PostgresJsDatabase,
+): SupplierOperationRepository {
+  async function getBySession(sessionId: string): Promise<SupplierOperationInternalRecord | null> {
+    const [row] = await db
+      .select()
+      .from(supplierOperationsTable)
+      .where(eq(supplierOperationsTable.sessionId, sessionId))
+      .limit(1)
+    return row ? mapSupplierOperation(row) : null
+  }
+
+  return {
+    async createOrReplay(record) {
+      const [created] = await db
+        .insert(supplierOperationsTable)
+        .values(toInsert(record))
+        .onConflictDoNothing()
+        .returning()
+      if (created) return { status: "created", operation: mapSupplierOperation(created) }
+      const existing = await getBySession(record.sessionId)
+      if (
+        !existing ||
+        existing.commitIdempotencyKey !== record.commitIdempotencyKey ||
+        existing.requestFingerprint !== record.requestFingerprint
+      ) {
+        return { status: "conflict" }
+      }
+      return { status: "replay", operation: existing }
+    },
+
+    async get(operationId) {
+      const [row] = await db
+        .select()
+        .from(supplierOperationsTable)
+        .where(eq(supplierOperationsTable.id, operationId))
+        .limit(1)
+      return row ? mapSupplierOperation(row) : null
+    },
+
+    async getByCommit(sessionId, commitIdempotencyKey) {
+      const existing = await getBySession(sessionId)
+      return existing?.commitIdempotencyKey === commitIdempotencyKey ? existing : null
+    },
+
+    async getBySession(sessionId) {
+      return getBySession(sessionId)
+    },
+
+    async getForUpdate(operationId) {
+      const [row] = await db
+        .select()
+        .from(supplierOperationsTable)
+        .where(eq(supplierOperationsTable.id, operationId))
+        .limit(1)
+        .for("update")
+      return row ? mapSupplierOperation(row) : null
+    },
+
+    async list(input) {
+      const conditions = [
+        ...(input.state ? [eq(supplierOperationsTable.state, input.state)] : []),
+        ...(input.sessionId ? [eq(supplierOperationsTable.sessionId, input.sessionId)] : []),
+      ]
+      const rows = await db
+        .select()
+        .from(supplierOperationsTable)
+        .where(conditions.length > 0 ? and(...conditions) : undefined)
+        .orderBy(desc(supplierOperationsTable.createdAt))
+        .limit(Math.max(1, Math.min(input.limit, 100)))
+      return rows.map(mapSupplierOperation)
+    },
+
+    async claimDispatch(operationId, at) {
+      const [row] = await db
+        .update(supplierOperationsTable)
+        .set({
+          state: "submitted",
+          version: sql`${supplierOperationsTable.version} + 1`,
+          attemptCount: sql`${supplierOperationsTable.attemptCount} + 1`,
+          submittedAt: at,
+          updatedAt: at,
+        })
+        .where(
+          and(
+            eq(supplierOperationsTable.id, operationId),
+            eq(supplierOperationsTable.state, "queued"),
+          ),
+        )
+        .returning()
+      return row ? mapSupplierOperation(row) : null
+    },
+
+    async save(record) {
+      const [saved] = await db
+        .update(supplierOperationsTable)
+        .set({
+          state: record.state,
+          version: record.version + 1,
+          attemptCount: record.attemptCount,
+          upstreamRef: record.upstreamRef ?? null,
+          upstreamStatus: record.upstreamStatus ?? null,
+          bookingId: record.bookingId ?? null,
+          lastErrorClass: record.lastErrorClass ?? null,
+          safeEvidence: record.safeEvidence,
+          submittedAt: record.submittedAt ?? null,
+          lastCheckedAt: record.lastCheckedAt ?? null,
+          sourceUpdatedAt: record.sourceUpdatedAt ?? null,
+          nextReconcileAt: record.nextReconcileAt ?? null,
+          resolvedAt: record.resolvedAt ?? null,
+          resolvedBy: record.resolvedBy ?? null,
+          resolutionReason: record.resolutionReason ?? null,
+          updatedAt: record.updatedAt,
+        })
+        .where(
+          and(
+            eq(supplierOperationsTable.id, record.id),
+            eq(supplierOperationsTable.version, record.version),
+          ),
+        )
+        .returning({ version: supplierOperationsTable.version })
+      if (!saved) throw new Error("supplier_operation_concurrent_update")
+      record.version = saved.version
+    },
+  }
+}
+
+export function createSupplierOperationRecord(input: {
+  sessionId: string
+  quoteId: string
+  holdId?: string
+  commitIdempotencyKey: string
+  commitmentPolicy?: SupplierCommitmentPolicyV1
+  entityModule: string
+  entityId: string
+  sourceKind: string
+  sourceConnectionId: string
+  sourceRef: string
+  adapterKind: string
+  requestFingerprint: string
+  adapterIdempotencyKey: string
+  requestPayload: Record<string, unknown>
+  now: Date
+}): SupplierOperationInternalRecord {
+  return {
+    id: newId("supplier_operations"),
+    sessionId: input.sessionId,
+    quoteId: input.quoteId,
+    ...(input.holdId ? { holdId: input.holdId } : {}),
+    commitIdempotencyKey: input.commitIdempotencyKey,
+    operationKind: "reserve",
+    state: "queued",
+    commitmentPolicy: input.commitmentPolicy ?? "supplier_first",
+    entityModule: input.entityModule,
+    entityId: input.entityId,
+    sourceKind: input.sourceKind,
+    sourceConnectionId: input.sourceConnectionId,
+    sourceRef: input.sourceRef,
+    adapterKind: input.adapterKind,
+    requestFingerprint: input.requestFingerprint,
+    adapterIdempotencyKey: input.adapterIdempotencyKey,
+    requestPayload: input.requestPayload,
+    version: 0,
+    attemptCount: 0,
+    safeEvidence: { intentPersistedBeforeDispatch: true },
+    createdAt: input.now,
+    updatedAt: input.now,
+  }
+}
+
+export function serializeSupplierOperation(
+  operation: SupplierOperationInternalRecord,
+): SupplierOperationRecordV1 {
+  return {
+    id: operation.id,
+    sessionId: operation.sessionId,
+    quoteId: operation.quoteId,
+    holdId: operation.holdId ?? null,
+    operationKind: operation.operationKind,
+    state: operation.state,
+    commitmentPolicy: operation.commitmentPolicy,
+    entityModule: operation.entityModule,
+    entityId: operation.entityId,
+    sourceKind: operation.sourceKind,
+    sourceConnectionId: operation.sourceConnectionId,
+    sourceRef: operation.sourceRef,
+    adapterKind: operation.adapterKind,
+    requestFingerprint: operation.requestFingerprint,
+    adapterIdempotencyKey: operation.adapterIdempotencyKey,
+    attemptCount: operation.attemptCount,
+    upstreamRef: operation.upstreamRef ?? null,
+    upstreamStatus: operation.upstreamStatus ?? null,
+    bookingId: operation.bookingId ?? null,
+    lastErrorClass: operation.lastErrorClass ?? null,
+    safeEvidence: operation.safeEvidence,
+    submittedAt: operation.submittedAt?.toISOString() ?? null,
+    lastCheckedAt: operation.lastCheckedAt?.toISOString() ?? null,
+    sourceUpdatedAt: operation.sourceUpdatedAt?.toISOString() ?? null,
+    nextReconcileAt: operation.nextReconcileAt?.toISOString() ?? null,
+    resolvedAt: operation.resolvedAt?.toISOString() ?? null,
+    resolvedBy: operation.resolvedBy ?? null,
+    resolutionReason: operation.resolutionReason ?? null,
+    createdAt: operation.createdAt.toISOString(),
+    updatedAt: operation.updatedAt.toISOString(),
+  }
+}
+
+function toInsert(record: SupplierOperationInternalRecord) {
+  return {
+    id: record.id,
+    sessionId: record.sessionId,
+    quoteId: record.quoteId,
+    holdId: record.holdId,
+    commitIdempotencyKey: record.commitIdempotencyKey,
+    operationKind: record.operationKind,
+    state: record.state,
+    commitmentPolicy: record.commitmentPolicy,
+    entityModule: record.entityModule,
+    entityId: record.entityId,
+    sourceKind: record.sourceKind,
+    sourceConnectionId: record.sourceConnectionId,
+    sourceRef: record.sourceRef,
+    adapterKind: record.adapterKind,
+    requestFingerprint: record.requestFingerprint,
+    adapterIdempotencyKey: record.adapterIdempotencyKey,
+    requestPayload: record.requestPayload,
+    version: record.version,
+    attemptCount: record.attemptCount,
+    safeEvidence: record.safeEvidence,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+  }
+}
+
+function mapSupplierOperation(row: SelectSupplierOperation): SupplierOperationInternalRecord {
+  return {
+    id: row.id,
+    sessionId: row.sessionId,
+    quoteId: row.quoteId,
+    ...(row.holdId ? { holdId: row.holdId } : {}),
+    commitIdempotencyKey: row.commitIdempotencyKey,
+    operationKind: "reserve",
+    state: row.state,
+    commitmentPolicy: row.commitmentPolicy,
+    entityModule: row.entityModule,
+    entityId: row.entityId,
+    sourceKind: row.sourceKind,
+    sourceConnectionId: row.sourceConnectionId,
+    sourceRef: row.sourceRef,
+    adapterKind: row.adapterKind,
+    requestFingerprint: row.requestFingerprint,
+    adapterIdempotencyKey: row.adapterIdempotencyKey,
+    requestPayload: row.requestPayload,
+    version: row.version,
+    attemptCount: row.attemptCount,
+    ...(row.upstreamRef ? { upstreamRef: row.upstreamRef } : {}),
+    ...(row.upstreamStatus ? { upstreamStatus: row.upstreamStatus } : {}),
+    ...(row.bookingId ? { bookingId: row.bookingId } : {}),
+    ...(row.lastErrorClass ? { lastErrorClass: row.lastErrorClass } : {}),
+    safeEvidence: row.safeEvidence,
+    ...(row.submittedAt ? { submittedAt: row.submittedAt } : {}),
+    ...(row.lastCheckedAt ? { lastCheckedAt: row.lastCheckedAt } : {}),
+    ...(row.sourceUpdatedAt ? { sourceUpdatedAt: row.sourceUpdatedAt } : {}),
+    ...(row.nextReconcileAt ? { nextReconcileAt: row.nextReconcileAt } : {}),
+    ...(row.resolvedAt ? { resolvedAt: row.resolvedAt } : {}),
+    ...(row.resolvedBy ? { resolvedBy: row.resolvedBy } : {}),
+    ...(row.resolutionReason ? { resolutionReason: row.resolutionReason } : {}),
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  }
+}

--- a/packages/catalog/src/index.ts
+++ b/packages/catalog/src/index.ts
@@ -71,6 +71,7 @@ export {
   type PushBookingResult,
   type PushContentRequest,
   type PushContentResult,
+  ReservationDispatchError,
   type ReservationStatus,
   type ReserveRequest,
   type ReserveResult,
@@ -106,6 +107,25 @@ export {
   createCatalogBookingApiModule,
   createCatalogBookingRoutes,
 } from "./booking-engine/routes.js"
+export {
+  createSupplierOperationWorkflow,
+  type DispatchSupplierReservationInput,
+  type SupplierOperationWorkflow,
+  type SupplierOperationWorkflowOutcome,
+} from "./booking-engine/supplier-operation-workflow.js"
+export {
+  type CreateSupplierOperationResult,
+  createDrizzleSupplierOperationRepository,
+  createSupplierOperationRecord,
+  type SupplierOperationInternalRecord,
+  type SupplierOperationRepository,
+  serializeSupplierOperation,
+} from "./booking-engine/supplier-operations.js"
+export {
+  type InsertSupplierOperation,
+  type SelectSupplierOperation,
+  supplierOperationsTable,
+} from "./booking-engine/supplier-operations-schema.js"
 export * from "./contract.js"
 // Drift events.
 export {

--- a/packages/catalog/src/runtime-contributor.ts
+++ b/packages/catalog/src/runtime-contributor.ts
@@ -231,6 +231,8 @@ export function createCatalogRuntimePortContribution(
           db,
           repository: createDrizzleBookingSessionRepository(db),
           resolveOwnedHandlers: () => services.getOwnedHandlers(host.primitives.env(undefined)),
+          resolveSourceRegistry: () =>
+            services.ensureSourceRegistry(host.primitives.env(undefined)),
           payments: {
             inventory,
             distribution,

--- a/packages/catalog/src/runtime/booking-engine-runtime.ts
+++ b/packages/catalog/src/runtime/booking-engine-runtime.ts
@@ -75,7 +75,7 @@ function warmBookingEngineConnectSources(env: BookingEngineEnv): Promise<void> {
     warn: (message) => console.warn(`[booking-engine] ${message}`),
   })
     .then((sources) => {
-      registerVoyantConnectSources(registry, sources)
+      registerConnectSources(registry, sources)
       // Per-connection Connect cruise shims just landed — back-fill the vertical
       // registry so admin/public external cruise reads resolve them too.
       catalogRuntimeExtensions().cruises.syncRegistry(registry)
@@ -149,6 +149,22 @@ export interface BookingEngineEnv {
 const CONNECT_CRUISE_MEMOIZE = { memoize: { ttlMs: 60_000 } } as const
 
 /**
+ * Connect is released independently and its registration helper is compiled
+ * against the previous Catalog contract. Its adapters return a strict subset
+ * of the current reserve outcomes, so the registry mutation remains compatible;
+ * keep that version bridge isolated here until the next Connect release.
+ */
+function registerConnectSources(
+  registry: SourceAdapterRegistry,
+  sources: Parameters<typeof registerVoyantConnectSources>[1],
+): void {
+  registerVoyantConnectSources(
+    registry as unknown as Parameters<typeof registerVoyantConnectSources>[0],
+    sources,
+  )
+}
+
+/**
  * Register the un-scoped Voyant Connect default adapter pair synchronously — the
  * cold-window fallback used until `warmBookingEngineConnectSources` registers the
  * per-connection adapters. Connect env resolution (key fallback, operator id,
@@ -163,7 +179,7 @@ function registerVoyantConnectFallback(
     warn: (message) => console.warn(`[booking-engine] ${message}`),
   })
   if (!config) return
-  registerVoyantConnectSources(
+  registerConnectSources(
     registry,
     createVoyantConnectSources({ ...config, cruise: CONNECT_CRUISE_MEMOIZE }),
   )

--- a/packages/catalog/src/runtime/booking-runtime.ts
+++ b/packages/catalog/src/runtime/booking-runtime.ts
@@ -4,6 +4,7 @@ import {
   type CatalogBookingRoutesOptions,
   catalogQuotesTable,
   createProductionBookingSessionModule,
+  createSupplierOperationOperatorService,
   OWNED_SOURCE_KIND,
   type QuoteEntityResult,
 } from "@voyant-travel/catalog/booking-engine"
@@ -89,6 +90,7 @@ export function createOperatorCatalogBookingRouteModuleOptions(options: {
           db,
           repository: createDrizzleBookingSessionRepository(db),
           resolveOwnedHandlers: () => getOwnedBookingHandlerRegistryFromContext(c),
+          resolveSourceRegistry: () => getBookingEngineRegistryFromContext(c),
           relationships: {
             async loadPersonTravelSnapshot(...args) {
               const runtime = await requireRelationshipsRuntime(options)
@@ -115,6 +117,12 @@ export function createOperatorCatalogBookingRouteModuleOptions(options: {
             resolvePaymentAdapter: options.resolvePaymentAdapter,
             paymentAdapterContext: { env: c.env as Readonly<Record<string, unknown>> },
           },
+        })
+      },
+      resolveSupplierOperations(c) {
+        return createSupplierOperationOperatorService({
+          db: getCatalogBookingDb(c) as PostgresJsDatabase,
+          resolveRegistry: () => getBookingEngineRegistryFromContext(c),
         })
       },
       resolveAccess(c, actorKind) {

--- a/packages/catalog/src/schema.ts
+++ b/packages/catalog/src/schema.ts
@@ -46,6 +46,11 @@ export {
   type SelectBookingSessionQuote,
 } from "./booking-engine/sessions-schema.js"
 export {
+  type InsertSupplierOperation,
+  type SelectSupplierOperation,
+  supplierOperationsTable,
+} from "./booking-engine/supplier-operations-schema.js"
+export {
   catalogOverlayHistoryTable,
   catalogOverlayTable,
   type InsertCatalogOverlay,

--- a/packages/catalog/tests/integration/booking-sessions-v1.test.ts
+++ b/packages/catalog/tests/integration/booking-sessions-v1.test.ts
@@ -15,11 +15,8 @@ import {
   bookingItemsRef,
   bookingsRef,
 } from "../../src/booking-engine/bookings-ref.js"
-import { createDrizzleBookingSessionRepository } from "../../src/booking-engine/sessions-drizzle.js"
 import { createSourceAdapterRegistry } from "../../src/booking-engine/registry.js"
-import { createSupplierOperationWorkflow } from "../../src/booking-engine/supplier-operation-workflow.js"
-import { supplierOperationsTable } from "../../src/booking-engine/supplier-operations-schema.js"
-import { createDrizzleSupplierOperationRepository } from "../../src/booking-engine/supplier-operations.js"
+import { createDrizzleBookingSessionRepository } from "../../src/booking-engine/sessions-drizzle.js"
 import {
   bookingSessionAuditEventsTable,
   bookingSessionCommitsTable,
@@ -33,6 +30,9 @@ import {
   type CommitOwnedBookingInput,
   createBookingSessionModule,
 } from "../../src/booking-engine/sessions-service.js"
+import { createSupplierOperationWorkflow } from "../../src/booking-engine/supplier-operation-workflow.js"
+import { createDrizzleSupplierOperationRepository } from "../../src/booking-engine/supplier-operations.js"
+import { supplierOperationsTable } from "../../src/booking-engine/supplier-operations-schema.js"
 
 const DB_AVAILABLE = Boolean(process.env.TEST_DATABASE_URL)
 const ACCESS = {

--- a/packages/catalog/tests/integration/booking-sessions-v1.test.ts
+++ b/packages/catalog/tests/integration/booking-sessions-v1.test.ts
@@ -16,6 +16,10 @@ import {
   bookingsRef,
 } from "../../src/booking-engine/bookings-ref.js"
 import { createDrizzleBookingSessionRepository } from "../../src/booking-engine/sessions-drizzle.js"
+import { createSourceAdapterRegistry } from "../../src/booking-engine/registry.js"
+import { createSupplierOperationWorkflow } from "../../src/booking-engine/supplier-operation-workflow.js"
+import { supplierOperationsTable } from "../../src/booking-engine/supplier-operations-schema.js"
+import { createDrizzleSupplierOperationRepository } from "../../src/booking-engine/supplier-operations.js"
 import {
   bookingSessionAuditEventsTable,
   bookingSessionCommitsTable,
@@ -194,6 +198,83 @@ describe.skipIf(!DB_AVAILABLE)("Booking Session v1 PostgreSQL invariants", () =>
     await expect(db.select().from(bookingSessionHoldsTable)).resolves.toEqual([
       expect.objectContaining({ id: prepared.hold.id, state: "active" }),
     ])
+  })
+
+  it("serializes one durable supplier reservation intent across competing Commit keys", async () => {
+    const sessions = createDrizzleBookingSessionRepository(db)
+    const module = createBookingSessionModule({
+      ports: {
+        repository: sessions,
+        normalizeSelection: async ({ selection }) => selection,
+        composeQuote: async () => ({ status: "quoted", pricing: PRICING }),
+        placeCapacityHold: async () => "unavailable",
+        releaseCapacityHold: async () => {},
+        commitOwnedBooking: async () => {
+          throw new Error("owned commit is not used")
+        },
+      },
+    })
+    const created = await module.createSession(
+      {
+        idempotencyKey: "postgres_supplier_session",
+        target: { kind: "catalog_item", catalogItemId: "crus_pg_supplier" },
+      },
+      ACCESS,
+    )
+    if (created.kind !== "session_created") throw new Error("session not created")
+    const quoted = await module.quoteSession(
+      created.session.id,
+      { expectedRevision: created.session.revision, idempotencyKey: "postgres_supplier_quote" },
+      ACCESS,
+    )
+    if (quoted.kind !== "quote_created") throw new Error("quote not created")
+
+    let reservationCalls = 0
+    const registry = createSourceAdapterRegistry()
+    registry.register("conn_pg_supplier", {
+      kind: "cruise:postgres",
+      capabilities: {
+        verticals: ["cruises"],
+        supportsLiveResolution: true,
+        supportsDriftDetection: false,
+        supportsBookingForwarding: true,
+        postBookOperations: ["status"],
+      },
+      async reserve() {
+        reservationCalls += 1
+        return { upstream_ref: "PG-UPSTREAM-1", status: "confirmed" }
+      },
+    })
+    const workflow = createSupplierOperationWorkflow({
+      repository: createDrizzleSupplierOperationRepository(db),
+      registry,
+    })
+    const base = {
+      sessionId: created.session.id,
+      quoteId: quoted.quote.id,
+      requestFingerprint: "postgres_supplier_fingerprint",
+      entityModule: "cruises",
+      entityId: "crus_pg_supplier",
+      sourceKind: "cruise:postgres",
+      sourceConnectionId: "conn_pg_supplier",
+      sourceRef: "upstream-cruise",
+      request: {
+        entity_module: "cruises",
+        entity_id: "crus_pg_supplier",
+        parameters: {},
+      },
+      adapterContext: { connection_id: "conn_pg_supplier" },
+      now: new Date("2026-08-02T10:00:00.000Z"),
+    }
+    const outcomes = await Promise.all([
+      workflow.dispatch({ ...base, commitIdempotencyKey: "postgres_supplier_commit_a" }),
+      workflow.dispatch({ ...base, commitIdempotencyKey: "postgres_supplier_commit_b" }),
+    ])
+
+    expect(outcomes.filter((outcome) => outcome.kind === "secured")).toHaveLength(1)
+    expect(outcomes.filter((outcome) => outcome.kind === "idempotency_conflict")).toHaveLength(1)
+    expect(reservationCalls).toBe(1)
+    await expect(db.select().from(supplierOperationsTable)).resolves.toHaveLength(1)
   })
 
   it("continues a paid Session into exactly one Booking under a concurrent Commit retry", async () => {
@@ -417,6 +498,7 @@ async function insertBookingGraph(db: PostgresJsDatabase) {
 async function resetTables(db: PostgresJsDatabase) {
   await db.execute(sql`
     TRUNCATE
+      supplier_operations,
       booking_session_commits,
       booking_session_operations,
       booking_session_holds,

--- a/packages/catalog/tests/integration/booking-sessions-v1.test.ts
+++ b/packages/catalog/tests/integration/booking-sessions-v1.test.ts
@@ -200,7 +200,7 @@ describe.skipIf(!DB_AVAILABLE)("Booking Session v1 PostgreSQL invariants", () =>
     ])
   })
 
-  it("serializes one durable supplier reservation intent across competing Commit keys", async () => {
+  it("serializes active supplier intents and permits a replacement after refusal", async () => {
     const sessions = createDrizzleBookingSessionRepository(db)
     const module = createBookingSessionModule({
       ports: {
@@ -242,11 +242,14 @@ describe.skipIf(!DB_AVAILABLE)("Booking Session v1 PostgreSQL invariants", () =>
       },
       async reserve() {
         reservationCalls += 1
-        return { upstream_ref: "PG-UPSTREAM-1", status: "confirmed" }
+        return reservationCalls === 1
+          ? { upstream_ref: "PG-UPSTREAM-1", status: "pending" }
+          : { upstream_ref: "PG-UPSTREAM-2", status: "confirmed" }
       },
     })
+    const supplierOperations = createDrizzleSupplierOperationRepository(db)
     const workflow = createSupplierOperationWorkflow({
-      repository: createDrizzleSupplierOperationRepository(db),
+      repository: supplierOperations,
       registry,
     })
     const base = {
@@ -271,10 +274,33 @@ describe.skipIf(!DB_AVAILABLE)("Booking Session v1 PostgreSQL invariants", () =>
       workflow.dispatch({ ...base, commitIdempotencyKey: "postgres_supplier_commit_b" }),
     ])
 
-    expect(outcomes.filter((outcome) => outcome.kind === "secured")).toHaveLength(1)
+    expect(outcomes.filter((outcome) => outcome.kind === "pending")).toHaveLength(1)
     expect(outcomes.filter((outcome) => outcome.kind === "idempotency_conflict")).toHaveLength(1)
     expect(reservationCalls).toBe(1)
     await expect(db.select().from(supplierOperationsTable)).resolves.toHaveLength(1)
+
+    const firstOperation = await supplierOperations.getBySession(created.session.id)
+    if (!firstOperation) throw new Error("supplier operation not created")
+    firstOperation.state = "refused"
+    firstOperation.upstreamStatus = "failed"
+    firstOperation.resolvedAt = new Date("2026-08-02T10:01:00.000Z")
+    firstOperation.updatedAt = firstOperation.resolvedAt
+    firstOperation.nextReconcileAt = undefined
+    await supplierOperations.save(firstOperation)
+
+    await expect(
+      workflow.dispatch({
+        ...base,
+        commitIdempotencyKey: "postgres_supplier_commit_alternative",
+        requestFingerprint: "postgres_supplier_fingerprint_alternative",
+        now: new Date("2026-08-02T10:02:00.000Z"),
+      }),
+    ).resolves.toMatchObject({
+      kind: "secured",
+      operation: { upstreamRef: "PG-UPSTREAM-2", state: "succeeded" },
+    })
+    expect(reservationCalls).toBe(2)
+    await expect(db.select().from(supplierOperationsTable)).resolves.toHaveLength(2)
   })
 
   it("continues a paid Session into exactly one Booking under a concurrent Commit retry", async () => {

--- a/packages/catalog/tsconfig.build.json
+++ b/packages/catalog/tsconfig.build.json
@@ -379,6 +379,9 @@
       "@voyant-travel/bookings/runtime-contributor": ["../bookings/dist/runtime-contributor.d.ts"],
       "@voyant-travel/bookings/runtime-port": ["../bookings/dist/runtime-port.d.ts"],
       "@voyant-travel/bookings/schema": ["../bookings/dist/schema.d.ts"],
+      "@voyant-travel/bookings/service-sourced-commitment": [
+        "../bookings/dist/service-sourced-commitment.d.ts"
+      ],
       "@voyant-travel/bookings/stale-holds-job": ["../bookings/dist/stale-holds-job.d.ts"],
       "@voyant-travel/bookings/status": ["../bookings/dist/status.d.ts"],
       "@voyant-travel/bookings/status-dispatch": ["../bookings/dist/status-dispatch.d.ts"],
@@ -421,6 +424,9 @@
       ],
       "@voyant-travel/catalog-contracts/booking-engine/session-contracts": [
         "../catalog-contracts/dist/booking-engine/session-contracts.d.ts"
+      ],
+      "@voyant-travel/catalog-contracts/booking-engine/supplier-operations": [
+        "../catalog-contracts/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog-contracts/content": ["../catalog-contracts/dist/content.d.ts"],
       "@voyant-travel/catalog-contracts/contract": ["../catalog-contracts/dist/contract.d.ts"],

--- a/packages/catalog/tsconfig.typecheck.json
+++ b/packages/catalog/tsconfig.typecheck.json
@@ -380,6 +380,9 @@
       "@voyant-travel/bookings/runtime-contributor": ["../bookings/dist/runtime-contributor.d.ts"],
       "@voyant-travel/bookings/runtime-port": ["../bookings/dist/runtime-port.d.ts"],
       "@voyant-travel/bookings/schema": ["../bookings/dist/schema.d.ts"],
+      "@voyant-travel/bookings/service-sourced-commitment": [
+        "../bookings/dist/service-sourced-commitment.d.ts"
+      ],
       "@voyant-travel/bookings/stale-holds-job": ["../bookings/dist/stale-holds-job.d.ts"],
       "@voyant-travel/bookings/status": ["../bookings/dist/status.d.ts"],
       "@voyant-travel/bookings/status-dispatch": ["../bookings/dist/status-dispatch.d.ts"],
@@ -422,6 +425,9 @@
       ],
       "@voyant-travel/catalog-contracts/booking-engine/session-contracts": [
         "../catalog-contracts/dist/booking-engine/session-contracts.d.ts"
+      ],
+      "@voyant-travel/catalog-contracts/booking-engine/supplier-operations": [
+        "../catalog-contracts/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog-contracts/content": ["../catalog-contracts/dist/content.d.ts"],
       "@voyant-travel/catalog-contracts/contract": ["../catalog-contracts/dist/contract.d.ts"],

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -386,6 +386,9 @@
       "@voyant-travel/bookings/runtime-contributor": ["../bookings/dist/runtime-contributor.d.ts"],
       "@voyant-travel/bookings/runtime-port": ["../bookings/dist/runtime-port.d.ts"],
       "@voyant-travel/bookings/schema": ["../bookings/dist/schema.d.ts"],
+      "@voyant-travel/bookings/service-sourced-commitment": [
+        "../bookings/dist/service-sourced-commitment.d.ts"
+      ],
       "@voyant-travel/bookings/stale-holds-job": ["../bookings/dist/stale-holds-job.d.ts"],
       "@voyant-travel/bookings/status": ["../bookings/dist/status.d.ts"],
       "@voyant-travel/bookings/status-dispatch": ["../bookings/dist/status-dispatch.d.ts"],
@@ -429,6 +432,9 @@
       ],
       "@voyant-travel/catalog-contracts/booking-engine/session-contracts": [
         "../catalog-contracts/dist/booking-engine/session-contracts.d.ts"
+      ],
+      "@voyant-travel/catalog-contracts/booking-engine/supplier-operations": [
+        "../catalog-contracts/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog-contracts/content": ["../catalog-contracts/dist/content.d.ts"],
       "@voyant-travel/catalog-contracts/contract": ["../catalog-contracts/dist/contract.d.ts"],
@@ -487,6 +493,9 @@
       ],
       "@voyant-travel/catalog/booking-engine/sessions-schema": [
         "../catalog/dist/booking-engine/sessions-schema.d.ts"
+      ],
+      "@voyant-travel/catalog/booking-engine/supplier-operations": [
+        "../catalog/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog/booking-session-maintenance-job": [
         "../catalog/dist/booking-session-maintenance-job.d.ts"

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -380,6 +380,9 @@
       "@voyant-travel/bookings/runtime-contributor": ["../bookings/dist/runtime-contributor.d.ts"],
       "@voyant-travel/bookings/runtime-port": ["../bookings/dist/runtime-port.d.ts"],
       "@voyant-travel/bookings/schema": ["../bookings/dist/schema.d.ts"],
+      "@voyant-travel/bookings/service-sourced-commitment": [
+        "../bookings/dist/service-sourced-commitment.d.ts"
+      ],
       "@voyant-travel/bookings/stale-holds-job": ["../bookings/dist/stale-holds-job.d.ts"],
       "@voyant-travel/bookings/status": ["../bookings/dist/status.d.ts"],
       "@voyant-travel/bookings/status-dispatch": ["../bookings/dist/status-dispatch.d.ts"],
@@ -423,6 +426,9 @@
       ],
       "@voyant-travel/catalog-contracts/booking-engine/session-contracts": [
         "../catalog-contracts/dist/booking-engine/session-contracts.d.ts"
+      ],
+      "@voyant-travel/catalog-contracts/booking-engine/supplier-operations": [
+        "../catalog-contracts/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog-contracts/content": ["../catalog-contracts/dist/content.d.ts"],
       "@voyant-travel/catalog-contracts/contract": ["../catalog-contracts/dist/contract.d.ts"],
@@ -481,6 +487,9 @@
       ],
       "@voyant-travel/catalog/booking-engine/sessions-schema": [
         "../catalog/dist/booking-engine/sessions-schema.d.ts"
+      ],
+      "@voyant-travel/catalog/booking-engine/supplier-operations": [
+        "../catalog/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog/booking-session-maintenance-job": [
         "../catalog/dist/booking-session-maintenance-job.d.ts"

--- a/packages/cruises/src/adapters/index.ts
+++ b/packages/cruises/src/adapters/index.ts
@@ -308,6 +308,8 @@ export type ExternalContactInput = {
 }
 
 export type CreateExternalBookingInput = {
+  /** Stable across retries of the same Voyant Supplier Operation. */
+  idempotencyKey?: string
   sailingRef: SourceRef
   cabinCategoryRef: SourceRef
   occupancy: number
@@ -373,6 +375,12 @@ export interface CruiseAdapter {
    * Throws on upstream errors so the caller's transaction rolls back.
    */
   createBooking(input: CreateExternalBookingInput): Promise<ExternalBookingResult>
+
+  /** Optional point read used to reconcile pending or ambiguous reservations. */
+  getBooking?(connectorBookingRef: string): Promise<ExternalBookingResult | null>
+
+  /** Lookup for the timeout-after-send case where no confirmation ref was returned. */
+  getBookingByIdempotencyKey?(idempotencyKey: string): Promise<ExternalBookingResult | null>
 }
 
 export type AdapterCallContext = { adapterName: string; method: string }

--- a/packages/cruises/src/adapters/memoize.ts
+++ b/packages/cruises/src/adapters/memoize.ts
@@ -156,5 +156,12 @@ export function memoizeCruiseAdapter(
 
     // Bookings never cached.
     createBooking: (input) => adapter.createBooking(input),
+    getBooking: adapter.getBooking
+      ? (connectorBookingRef) => adapter.getBooking?.(connectorBookingRef) ?? Promise.resolve(null)
+      : undefined,
+    getBookingByIdempotencyKey: adapter.getBookingByIdempotencyKey
+      ? (idempotencyKey) =>
+          adapter.getBookingByIdempotencyKey?.(idempotencyKey) ?? Promise.resolve(null)
+      : undefined,
   }
 }

--- a/packages/cruises/src/adapters/mock.ts
+++ b/packages/cruises/src/adapters/mock.ts
@@ -58,6 +58,8 @@ export class MockCruiseAdapter implements CruiseAdapter {
   private readonly cruisesByRef = new Map<string, SeededCruise>()
   private readonly shipsByRef = new Map<string, ExternalShip>()
   private readonly bookingResults = new Map<string, ExternalBookingResult>()
+  private readonly bookingsByIdempotencyKey = new Map<string, ExternalBookingResult>()
+  private readonly bookingsByRef = new Map<string, ExternalBookingResult>()
 
   // Telemetry — useful for assertions in tests.
   callCount = 0
@@ -237,14 +239,30 @@ export class MockCruiseAdapter implements CruiseAdapter {
 
   async createBooking(input: CreateExternalBookingInput): Promise<ExternalBookingResult> {
     this.tickAndCheck()
+    if (input.idempotencyKey) {
+      const replay = this.bookingsByIdempotencyKey.get(input.idempotencyKey)
+      if (replay) return replay
+    }
     this.bookingCount++
     const programmed = this.bookingResults.get(
       `${refKey(input.sailingRef)}::${refKey(input.cabinCategoryRef)}`,
     )
-    if (programmed) return programmed
-    return {
+    const result = programmed ?? {
       connectorBookingRef: `MOCK-${this.bookingCount.toString().padStart(6, "0")}`,
       connectorStatus: "confirmed",
     }
+    if (input.idempotencyKey) this.bookingsByIdempotencyKey.set(input.idempotencyKey, result)
+    this.bookingsByRef.set(result.connectorBookingRef, result)
+    return result
+  }
+
+  async getBooking(connectorBookingRef: string): Promise<ExternalBookingResult | null> {
+    this.tickAndCheck()
+    return this.bookingsByRef.get(connectorBookingRef) ?? null
+  }
+
+  async getBookingByIdempotencyKey(idempotencyKey: string): Promise<ExternalBookingResult | null> {
+    this.tickAndCheck()
+    return this.bookingsByIdempotencyKey.get(idempotencyKey) ?? null
   }
 }

--- a/packages/cruises/src/adapters/source-adapter-shim.ts
+++ b/packages/cruises/src/adapters/source-adapter-shim.ts
@@ -43,12 +43,15 @@ import type {
   SourceAdapter,
   SourceAdapterContext,
 } from "@voyant-travel/catalog"
+import { ReservationDispatchError } from "@voyant-travel/catalog"
 import type { Provenance } from "@voyant-travel/catalog/provenance"
 
 import { CRUISES_CONTENT_SCHEMA_VERSION, type CruiseContent } from "../content-shape.js"
 import { decodeSourceRef, encodeSourceRef } from "../lib/key.js"
+import { composeQuote } from "../service-pricing.js"
 
 import type {
+  CreateExternalBookingInput,
   CruiseAdapter,
   CruiseSearchProjectionEntry,
   ExternalCabinCategory,
@@ -229,8 +232,27 @@ export function cruiseAdapterToSourceAdapter(
           failed[id] = "unavailable"
           continue
         }
+        const quote = composeQuote({
+          price: {
+            pricePerPerson: row.pricePerPerson,
+            originalPricePerPerson: row.originalPricePerPerson ?? null,
+            secondGuestPricePerPerson: row.secondGuestPricePerPerson ?? null,
+            singlePricePerPerson: row.singlePricePerPerson ?? null,
+            singleSupplementPercent: row.singleSupplementPercent ?? null,
+            currency: row.currency,
+            fareCode: row.fareCode ?? null,
+            fareCodeName: row.fareCodeName ?? null,
+            fareVariant: row.fareVariant ?? "cruise_only",
+            earlyBookingDeadline: row.earlyBookingDeadline ?? null,
+            earlyBookingBonusDescription: row.earlyBookingBonusDescription ?? null,
+          },
+          components: row.components ?? [],
+          occupancy,
+          guestCount: occupancy,
+          ...(row.bookingTerms !== undefined ? { bookingTerms: row.bookingTerms } : {}),
+        })
         values[id] = {
-          priceCents: Math.round(Number.parseFloat(row.pricePerPerson) * 100) * occupancy,
+          priceCents: decimalAmountToCents(quote.totalForCabin),
           currency: row.currency,
           availability: row.availability,
           sailingRef,
@@ -289,43 +311,57 @@ export function cruiseAdapterToSourceAdapter(
     },
 
     async reserve(_ctx: SourceAdapterContext, request: ReserveRequest): Promise<ReserveResult> {
-      const sailingRef = requiredSourceRef(request.parameters.sailingId, "sailingId")
-      const cabinCategoryRef = requiredSourceRef(
-        request.parameters.cabinCategoryRef ?? request.parameters.cabinCategoryId,
-        "cabinCategoryId",
-      )
-      const occupancy = positiveInteger(request.parameters.occupancy)
-      const party = recordValue(request.party)
-      const contact = requiredRecord(party?.contact, "party.contact")
-      const passengers = Array.isArray(party?.passengers) ? party.passengers : []
-      if (!occupancy || passengers.length === 0) {
-        throw new Error("cruise reservation requires occupancy and passengers")
+      let sailing: ExternalSailing
+      let bookingInput: CreateExternalBookingInput
+      try {
+        const sailingRef = requiredSourceRef(request.parameters.sailingId, "sailingId")
+        const cabinCategoryRef = requiredSourceRef(
+          request.parameters.cabinCategoryRef ?? request.parameters.cabinCategoryId,
+          "cabinCategoryId",
+        )
+        const occupancy = positiveInteger(request.parameters.occupancy)
+        const party = recordValue(request.party)
+        const contact = requiredRecord(party?.contact, "party.contact")
+        const passengers = Array.isArray(party?.passengers) ? party.passengers : []
+        if (!occupancy || passengers.length === 0) {
+          throw new Error("cruise reservation requires occupancy and passengers")
+        }
+        const resolvedSailing = await cruiseAdapter.fetchSailing(sailingRef)
+        if (!resolvedSailing) throw new Error("cruise reservation sailing is unavailable")
+        sailing = resolvedSailing
+        bookingInput = {
+          ...(request.idempotency_key ? { idempotencyKey: request.idempotency_key } : {}),
+          sailingRef,
+          cabinCategoryRef,
+          occupancy,
+          passengerComposition: externalPassengerComposition(
+            request.parameters.passengerComposition,
+          ),
+          fareCode: optionalString(request.parameters.fareCode),
+          fareVariant: fareVariant(request.parameters.fareVariant),
+          passengers: passengers.map((passenger) => externalPassenger(passenger)),
+          contact: externalContact(contact),
+          bookingTerms: recordValue(request.parameters.bookingTerms) as never,
+          notes: optionalString(request.parameters.notes),
+        }
+      } catch (error) {
+        throw new ReservationDispatchError(
+          error instanceof Error ? error.message : "invalid cruise reservation request",
+          "not_sent",
+          "cruise_reservation_preflight_failed",
+        )
       }
-      const sailing = await cruiseAdapter.fetchSailing(sailingRef)
-      if (!sailing) throw new Error("cruise reservation sailing is unavailable")
-      const result = await cruiseAdapter.createBooking({
-        ...(request.idempotency_key ? { idempotencyKey: request.idempotency_key } : {}),
-        sailingRef,
-        cabinCategoryRef,
-        occupancy,
-        passengerComposition: externalPassengerComposition(request.parameters.passengerComposition),
-        fareCode: optionalString(request.parameters.fareCode),
-        fareVariant: fareVariant(request.parameters.fareVariant),
-        passengers: passengers.map((passenger) => externalPassenger(passenger)),
-        contact: externalContact(contact),
-        bookingTerms: recordValue(request.parameters.bookingTerms) as never,
-        notes: optionalString(request.parameters.notes),
-      })
+      const result = await cruiseAdapter.createBooking(bookingInput)
       return {
         upstream_ref: result.connectorBookingRef,
-        status: result.connectorStatus === "pending" ? "pending" : "confirmed",
+        status: reserveStatusFromConnector(result.connectorStatus),
         upstream_payload: {
           connectorStatus: result.connectorStatus ?? null,
           sailing: {
             departureDate: sailing.departureDate,
             returnDate: sailing.returnDate,
-            sailingRef,
-            cabinCategoryRef,
+            sailingRef: bookingInput.sailingRef,
+            cabinCategoryRef: bookingInput.cabinCategoryRef,
           },
           ...(result.finalQuote ? { finalQuote: result.finalQuote } : {}),
           ...(result.finalComponents ? { finalComponents: result.finalComponents } : {}),
@@ -347,7 +383,7 @@ export function cruiseAdapterToSourceAdapter(
       if (!result) return null
       return {
         upstream_ref: result.connectorBookingRef,
-        status: result.connectorStatus === "pending" ? "pending" : "confirmed",
+        status: reservationStatusFromConnector(result.connectorStatus),
         upstream_payload: {
           connectorStatus: result.connectorStatus ?? null,
           ...(result.finalQuote ? { finalQuote: result.finalQuote } : {}),
@@ -363,6 +399,51 @@ export function cruiseAdapterToSourceAdapter(
       throw new Error("cruise cancellation via catalog SourceAdapter is not supported in v1")
     },
   }
+}
+
+function reserveStatusFromConnector(value: string | null | undefined): ReserveResult["status"] {
+  const normalized = value?.trim().toLowerCase()
+  switch (normalized) {
+    case "held":
+    case "confirmed":
+    case "ticketed":
+      return normalized
+    case "failed":
+    case "refused":
+    case "cancelled":
+      return "failed"
+    default:
+      return "pending"
+  }
+}
+
+function reservationStatusFromConnector(
+  value: string | null | undefined,
+): GetReservationResult["status"] {
+  const normalized = value?.trim().toLowerCase()
+  switch (normalized) {
+    case "held":
+    case "confirmed":
+    case "ticketed":
+    case "failed":
+    case "refused":
+    case "cancelled":
+    case "cancelling":
+    case "pending":
+      return normalized
+    default:
+      return "pending"
+  }
+}
+
+function decimalAmountToCents(value: string): number {
+  const match = /^(-?)(\d+)\.(\d{2})$/.exec(value)
+  if (!match) throw new Error(`invalid composed cruise amount: ${value}`)
+  const cents = BigInt(match[2] ?? "0") * 100n + BigInt(match[3] ?? "0")
+  const signed = match[1] === "-" ? -cents : cents
+  const result = Number(signed)
+  if (!Number.isSafeInteger(result)) throw new Error(`cruise amount exceeds safe cents: ${value}`)
+  return result
 }
 
 function sourceRefFromParameter(value: unknown): SourceRef | null {

--- a/packages/cruises/src/adapters/source-adapter-shim.ts
+++ b/packages/cruises/src/adapters/source-adapter-shim.ts
@@ -246,7 +246,10 @@ export function cruiseAdapterToSourceAdapter(
             earlyBookingDeadline: row.earlyBookingDeadline ?? null,
             earlyBookingBonusDescription: row.earlyBookingBonusDescription ?? null,
           },
-          components: row.components ?? [],
+          components: (row.components ?? []).map((component) => ({
+            ...component,
+            label: component.label ?? null,
+          })),
           occupancy,
           guestCount: occupancy,
           ...(row.bookingTerms !== undefined ? { bookingTerms: row.bookingTerms } : {}),

--- a/packages/cruises/src/adapters/source-adapter-shim.ts
+++ b/packages/cruises/src/adapters/source-adapter-shim.ts
@@ -34,6 +34,8 @@ import type {
   DiscoveryPage,
   GetContentRequest,
   GetContentResult,
+  GetReservationRequest,
+  GetReservationResult,
   LiveResolveRequest,
   LiveResolveResult,
   ReserveRequest,
@@ -50,8 +52,12 @@ import type {
   CruiseAdapter,
   CruiseSearchProjectionEntry,
   ExternalCabinCategory,
+  ExternalContactInput,
   ExternalCruise,
+  ExternalFareVariant,
   ExternalItineraryDay,
+  ExternalPassengerComposition,
+  ExternalPassengerInput,
   ExternalSailing,
   ExternalShip,
   SourceRef,
@@ -123,6 +129,10 @@ export function cruiseAdapterToSourceAdapter(
     supportsLiveResolution: true,
     supportsDriftDetection: false,
     supportsBookingForwarding: true,
+    supportsReservationRetrieval: Boolean(
+      cruiseAdapter.getBooking || cruiseAdapter.getBookingByIdempotencyKey,
+    ),
+    supportsReservationLookupByIdempotencyKey: Boolean(cruiseAdapter.getBookingByIdempotencyKey),
     postBookOperations: ["cancel", "status"],
     supportsContentFetch,
     supportedContentLocales: options.supportedContentLocales,
@@ -193,21 +203,45 @@ export function cruiseAdapterToSourceAdapter(
 
     async liveResolve(
       _ctx: SourceAdapterContext,
-      _request: LiveResolveRequest,
+      request: LiveResolveRequest,
     ): Promise<LiveResolveResult> {
-      // Cruise pricing flows through `fetchSailingPricing` per
-      // sailing — but the catalog `LiveResolveRequest` is keyed by
-      // entity_id (the cruise typeid), not by sailing. v1 leaves
-      // this as an explicit not-supported: callers should use the
-      // cruises module's per-sailing pricing routes directly. The
-      // catalog plane's quote engine still works because cruises'
-      // own quote path is exercised through the vertical's routes.
-      return {
-        values: {},
-        failed: {
-          /* nothing — empty result is the contract */
-        },
+      const values: LiveResolveResult["values"] = {}
+      const failed: NonNullable<LiveResolveResult["failed"]> = {}
+      const sailingRef = sourceRefFromParameter(request.parameters?.sailingId)
+      const cabinCategoryRef = sourceRefFromParameter(
+        request.parameters?.cabinCategoryRef ?? request.parameters?.cabinCategoryId,
+      )
+      const occupancy = positiveInteger(request.parameters?.occupancy)
+      if (!sailingRef || !cabinCategoryRef || !occupancy) {
+        for (const id of request.ids) failed[id] = "unsupported"
+        return { values, failed }
       }
+      const rows = await cruiseAdapter.fetchSailingPricing(sailingRef)
+      const row = rows.find(
+        (candidate) =>
+          sourceRefsMatch(candidate.cabinCategoryRef, cabinCategoryRef) &&
+          candidate.occupancy === occupancy &&
+          optionalStringMatches(candidate.fareCode, request.parameters?.fareCode) &&
+          optionalStringMatches(candidate.fareVariant, request.parameters?.fareVariant),
+      )
+      for (const id of request.ids) {
+        if (!row || row.availability === "sold_out") {
+          failed[id] = "unavailable"
+          continue
+        }
+        values[id] = {
+          priceCents: Math.round(Number.parseFloat(row.pricePerPerson) * 100) * occupancy,
+          currency: row.currency,
+          availability: row.availability,
+          sailingRef,
+          cabinCategoryRef,
+          occupancy,
+          fareCode: row.fareCode ?? null,
+          fareVariant: row.fareVariant ?? null,
+          bookingTerms: row.bookingTerms ?? null,
+        }
+      }
+      return Object.keys(failed).length > 0 ? { values, failed } : { values }
     },
 
     async getContent(
@@ -254,16 +288,73 @@ export function cruiseAdapterToSourceAdapter(
       }
     },
 
-    async reserve(_ctx: SourceAdapterContext, _request: ReserveRequest): Promise<ReserveResult> {
-      // Cruise reservations require per-sailing context (cabin
-      // category, occupancy, fare code, passengers). The catalog
-      // `ReserveRequest` doesn't carry that level of detail, so v1
-      // leaves cruise booking on the vertical's own commit path
-      // (`POST /v1/admin/cruises/:key/booking`). When the journey
-      // standardizes the descriptor, this shim can route through.
-      throw new Error(
-        `cruise booking via catalog SourceAdapter is not supported in v1 — call the cruises vertical's commit path directly (POST /v1/admin/cruises/:key/booking)`,
+    async reserve(_ctx: SourceAdapterContext, request: ReserveRequest): Promise<ReserveResult> {
+      const sailingRef = requiredSourceRef(request.parameters.sailingId, "sailingId")
+      const cabinCategoryRef = requiredSourceRef(
+        request.parameters.cabinCategoryRef ?? request.parameters.cabinCategoryId,
+        "cabinCategoryId",
       )
+      const occupancy = positiveInteger(request.parameters.occupancy)
+      const party = recordValue(request.party)
+      const contact = requiredRecord(party?.contact, "party.contact")
+      const passengers = Array.isArray(party?.passengers) ? party.passengers : []
+      if (!occupancy || passengers.length === 0) {
+        throw new Error("cruise reservation requires occupancy and passengers")
+      }
+      const sailing = await cruiseAdapter.fetchSailing(sailingRef)
+      if (!sailing) throw new Error("cruise reservation sailing is unavailable")
+      const result = await cruiseAdapter.createBooking({
+        ...(request.idempotency_key ? { idempotencyKey: request.idempotency_key } : {}),
+        sailingRef,
+        cabinCategoryRef,
+        occupancy,
+        passengerComposition: externalPassengerComposition(request.parameters.passengerComposition),
+        fareCode: optionalString(request.parameters.fareCode),
+        fareVariant: fareVariant(request.parameters.fareVariant),
+        passengers: passengers.map((passenger) => externalPassenger(passenger)),
+        contact: externalContact(contact),
+        bookingTerms: recordValue(request.parameters.bookingTerms) as never,
+        notes: optionalString(request.parameters.notes),
+      })
+      return {
+        upstream_ref: result.connectorBookingRef,
+        status: result.connectorStatus === "pending" ? "pending" : "confirmed",
+        upstream_payload: {
+          connectorStatus: result.connectorStatus ?? null,
+          sailing: {
+            departureDate: sailing.departureDate,
+            returnDate: sailing.returnDate,
+            sailingRef,
+            cabinCategoryRef,
+          },
+          ...(result.finalQuote ? { finalQuote: result.finalQuote } : {}),
+          ...(result.finalComponents ? { finalComponents: result.finalComponents } : {}),
+          ...(result.finalBookingTerms ? { finalBookingTerms: result.finalBookingTerms } : {}),
+        },
+      }
+    },
+
+    async getReservation(
+      _ctx: SourceAdapterContext,
+      request: GetReservationRequest,
+    ): Promise<GetReservationResult | null> {
+      const result =
+        request.upstream_ref !== undefined
+          ? await cruiseAdapter.getBooking?.(request.upstream_ref)
+          : request.idempotency_key !== undefined
+            ? await cruiseAdapter.getBookingByIdempotencyKey?.(request.idempotency_key)
+            : null
+      if (!result) return null
+      return {
+        upstream_ref: result.connectorBookingRef,
+        status: result.connectorStatus === "pending" ? "pending" : "confirmed",
+        upstream_payload: {
+          connectorStatus: result.connectorStatus ?? null,
+          ...(result.finalQuote ? { finalQuote: result.finalQuote } : {}),
+          ...(result.finalComponents ? { finalComponents: result.finalComponents } : {}),
+          ...(result.finalBookingTerms ? { finalBookingTerms: result.finalBookingTerms } : {}),
+        },
+      }
     },
 
     async cancel(_ctx: SourceAdapterContext, _request: CancelRequest): Promise<CancelResult> {
@@ -271,6 +362,120 @@ export function cruiseAdapterToSourceAdapter(
       // cruise vertical's own routes for now.
       throw new Error("cruise cancellation via catalog SourceAdapter is not supported in v1")
     },
+  }
+}
+
+function sourceRefFromParameter(value: unknown): SourceRef | null {
+  if (typeof value === "string" && value.trim()) {
+    return decodeSourceRef(value) ?? { externalId: value.trim() }
+  }
+  const record = recordValue(value)
+  return typeof record?.externalId === "string" && record.externalId.trim()
+    ? (record as SourceRef)
+    : null
+}
+
+function requiredSourceRef(value: unknown, field: string): SourceRef {
+  const ref = sourceRefFromParameter(value)
+  if (!ref) throw new Error(`cruise reservation requires ${field}`)
+  return ref
+}
+
+function sourceRefsMatch(left: SourceRef, right: SourceRef): boolean {
+  return encodeSourceRef(left) === encodeSourceRef(right) || left.externalId === right.externalId
+}
+
+function positiveInteger(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : null
+}
+
+function optionalString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null
+}
+
+function optionalStringMatches(actual: unknown, requested: unknown): boolean {
+  const expected = optionalString(requested)
+  return !expected || actual === expected
+}
+
+function fareVariant(value: unknown): ExternalFareVariant | null {
+  return value === "cruise_only" || value === "air_inclusive" ? value : null
+}
+
+function externalPassengerComposition(value: unknown): ExternalPassengerComposition | null {
+  const composition = recordValue(value)
+  const adults = positiveInteger(composition?.adults) ?? 0
+  const children = positiveInteger(composition?.children) ?? 0
+  const infants = positiveInteger(composition?.infants) ?? 0
+  const seniors = positiveInteger(composition?.seniors) ?? 0
+  if (adults + children + infants + seniors === 0) return null
+  return {
+    adults,
+    ...(children > 0 ? { children } : {}),
+    ...(infants > 0 ? { infants } : {}),
+    ...(seniors > 0 ? { seniors } : {}),
+    ...(Array.isArray(composition?.childAges)
+      ? {
+          childAges: composition.childAges.filter(
+            (age): age is number => typeof age === "number" && Number.isInteger(age) && age >= 0,
+          ),
+        }
+      : {}),
+  }
+}
+
+function recordValue(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+function requiredRecord(value: unknown, field: string): Record<string, unknown> {
+  const record = recordValue(value)
+  if (!record) throw new Error(`cruise reservation requires ${field}`)
+  return record
+}
+
+function requiredString(value: unknown, field: string): string {
+  const result = optionalString(value)
+  if (!result) throw new Error(`cruise reservation requires ${field}`)
+  return result
+}
+
+function externalPassenger(value: unknown): ExternalPassengerInput {
+  const passenger = requiredRecord(value, "party.passengers[]")
+  const category = optionalString(passenger.travelerCategory)
+  return {
+    firstName: requiredString(passenger.firstName, "passenger.firstName"),
+    lastName: requiredString(passenger.lastName, "passenger.lastName"),
+    email: optionalString(passenger.email),
+    phone: optionalString(passenger.phone),
+    travelerCategory:
+      category === "adult" ||
+      category === "child" ||
+      category === "infant" ||
+      category === "senior" ||
+      category === "other"
+        ? category
+        : null,
+    preferredLanguage: optionalString(passenger.preferredLanguage),
+    specialRequests: optionalString(passenger.specialRequests),
+    isPrimary: passenger.isPrimary === true,
+  }
+}
+
+function externalContact(contact: Record<string, unknown>): ExternalContactInput {
+  return {
+    firstName: requiredString(contact.firstName, "contact.firstName"),
+    lastName: requiredString(contact.lastName, "contact.lastName"),
+    email: optionalString(contact.email),
+    phone: optionalString(contact.phone),
+    language: optionalString(contact.language),
+    country: optionalString(contact.country),
+    region: optionalString(contact.region),
+    city: optionalString(contact.city),
+    address: optionalString(contact.address),
+    postalCode: optionalString(contact.postalCode),
   }
 }
 

--- a/packages/cruises/tests/unit/source-adapter-shim.booking.test.ts
+++ b/packages/cruises/tests/unit/source-adapter-shim.booking.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest"
+import { MockCruiseAdapter } from "../../src/adapters/mock.js"
+import { cruiseAdapterToSourceAdapter } from "../../src/adapters/source-adapter-shim.js"
+import { encodeSourceRef } from "../../src/lib/key.js"
+
+describe("cruise SourceAdapter booking tracer", () => {
+  it("quotes and reserves a sailing with replay-safe supplier idempotency", async () => {
+    const cruiseRef = { externalId: "cruise-1" }
+    const shipRef = { externalId: "ship-1" }
+    const sailingRef = { externalId: "sailing-1" }
+    const cabinCategoryRef = { externalId: "balcony" }
+    const cruise = new MockCruiseAdapter({ name: "tracer" })
+    cruise.addCruise(
+      {
+        sourceRef: cruiseRef,
+        name: "Northern Lights",
+        slug: "northern-lights",
+        cruiseType: "ocean",
+        lineName: "Example Line",
+        defaultShipRef: shipRef,
+        nights: 7,
+      },
+      [
+        {
+          sourceRef: sailingRef,
+          cruiseRef,
+          shipRef,
+          departureDate: "2027-02-01",
+          returnDate: "2027-02-08",
+          salesStatus: "open",
+        },
+      ],
+    )
+    cruise.setSailingPricing(sailingRef, [
+      {
+        cabinCategoryRef,
+        occupancy: 2,
+        fareCode: "FLEX",
+        currency: "EUR",
+        pricePerPerson: "1250.00",
+        availability: "available",
+      },
+    ])
+    const adapter = cruiseAdapterToSourceAdapter(cruise)
+    const entityId = `crus_${encodeSourceRef(cruiseRef)}`
+    const parameters = {
+      sailingId: encodeSourceRef(sailingRef),
+      cabinCategoryId: encodeSourceRef(cabinCategoryRef),
+      occupancy: 2,
+      fareCode: "FLEX",
+    }
+
+    await expect(
+      adapter.liveResolve?.(
+        { connection_id: "conn_cruise" },
+        {
+          ids: [entityId],
+          source_refs: { [entityId]: encodeSourceRef(cruiseRef) },
+          scope: { locale: "en", audience: "customer", market: "default" },
+          parameters,
+        },
+      ),
+    ).resolves.toMatchObject({
+      values: { [entityId]: { priceCents: 250000, currency: "EUR" } },
+    })
+
+    const request = {
+      entity_module: "cruises",
+      entity_id: entityId,
+      source_ref: encodeSourceRef(cruiseRef),
+      parameters,
+      party: {
+        contact: { firstName: "Ada", lastName: "Lovelace", email: "ada@example.test" },
+        passengers: [
+          { firstName: "Ada", lastName: "Lovelace", travelerCategory: "adult" },
+          { firstName: "Charles", lastName: "Babbage", travelerCategory: "adult" },
+        ],
+      },
+      idempotency_key: "bses_1:commit_1:reserve",
+    }
+    const first = await adapter.reserve?.({ connection_id: "conn_cruise" }, request)
+    const replay = await adapter.reserve?.({ connection_id: "conn_cruise" }, request)
+
+    expect(first).toMatchObject({ status: "confirmed" })
+    expect(replay?.upstream_ref).toBe(first?.upstream_ref)
+    expect(cruise.bookingCount).toBe(1)
+    await expect(
+      adapter.getReservation?.(
+        { connection_id: "conn_cruise" },
+        { upstream_ref: first?.upstream_ref ?? "missing" },
+      ),
+    ).resolves.toMatchObject({ status: "confirmed" })
+    await expect(
+      adapter.getReservation?.(
+        { connection_id: "conn_cruise" },
+        { idempotency_key: request.idempotency_key },
+      ),
+    ).resolves.toMatchObject({ upstream_ref: first?.upstream_ref, status: "confirmed" })
+  })
+})

--- a/packages/cruises/tests/unit/source-adapter-shim.booking.test.ts
+++ b/packages/cruises/tests/unit/source-adapter-shim.booking.test.ts
@@ -38,6 +38,23 @@ describe("cruise SourceAdapter booking tracer", () => {
         fareCode: "FLEX",
         currency: "EUR",
         pricePerPerson: "1250.00",
+        secondGuestPricePerPerson: "950.00",
+        components: [
+          {
+            kind: "tax",
+            amount: "100.00",
+            currency: "EUR",
+            direction: "addition",
+            perPerson: true,
+          },
+          {
+            kind: "onboard_credit",
+            amount: "50.00",
+            currency: "EUR",
+            direction: "credit",
+            perPerson: false,
+          },
+        ],
         availability: "available",
       },
     ])
@@ -61,7 +78,7 @@ describe("cruise SourceAdapter booking tracer", () => {
         },
       ),
     ).resolves.toMatchObject({
-      values: { [entityId]: { priceCents: 250000, currency: "EUR" } },
+      values: { [entityId]: { priceCents: 235000, currency: "EUR" } },
     })
 
     const request = {
@@ -96,5 +113,73 @@ describe("cruise SourceAdapter booking tracer", () => {
         { idempotency_key: request.idempotency_key },
       ),
     ).resolves.toMatchObject({ upstream_ref: first?.upstream_ref, status: "confirmed" })
+  })
+
+  it("maps only explicit secured connector statuses to a secured reservation", async () => {
+    const cruiseRef = { externalId: "cruise-status" }
+    const shipRef = { externalId: "ship-status" }
+    const sailingRef = { externalId: "sailing-status" }
+    const cabinCategoryRef = { externalId: "suite" }
+    const cruise = new MockCruiseAdapter({ name: "status-tracer" })
+    cruise.addCruise(
+      {
+        sourceRef: cruiseRef,
+        name: "Status Cruise",
+        slug: "status-cruise",
+        cruiseType: "ocean",
+        lineName: "Example Line",
+        defaultShipRef: shipRef,
+        nights: 3,
+      },
+      [
+        {
+          sourceRef: sailingRef,
+          cruiseRef,
+          shipRef,
+          departureDate: "2027-03-01",
+          returnDate: "2027-03-04",
+          salesStatus: "open",
+        },
+      ],
+    )
+    const adapter = cruiseAdapterToSourceAdapter(cruise)
+    const request = {
+      entity_module: "cruises",
+      entity_id: `crus_${encodeSourceRef(cruiseRef)}`,
+      parameters: {
+        sailingId: encodeSourceRef(sailingRef),
+        cabinCategoryId: encodeSourceRef(cabinCategoryRef),
+        occupancy: 1,
+      },
+      party: {
+        contact: { firstName: "Ada", lastName: "Lovelace" },
+        passengers: [{ firstName: "Ada", lastName: "Lovelace" }],
+      },
+    }
+
+    cruise.setBookingResult(sailingRef, cabinCategoryRef, {
+      connectorBookingRef: "UP-FAILED",
+      connectorStatus: "cancelled",
+    })
+    await expect(
+      adapter.reserve?.(
+        { connection_id: "conn_cruise" },
+        { ...request, idempotency_key: "failed-key" },
+      ),
+    ).resolves.toMatchObject({ upstream_ref: "UP-FAILED", status: "failed" })
+
+    cruise.setBookingResult(sailingRef, cabinCategoryRef, {
+      connectorBookingRef: "UP-UNKNOWN",
+      connectorStatus: "deposit_required",
+    })
+    await expect(
+      adapter.reserve?.(
+        { connection_id: "conn_cruise" },
+        { ...request, idempotency_key: "unknown-key" },
+      ),
+    ).resolves.toMatchObject({ upstream_ref: "UP-UNKNOWN", status: "pending" })
+    await expect(
+      adapter.getReservation?.({ connection_id: "conn_cruise" }, { upstream_ref: "UP-UNKNOWN" }),
+    ).resolves.toMatchObject({ status: "pending" })
   })
 })

--- a/packages/cruises/tests/unit/source-adapter-shim.test.ts
+++ b/packages/cruises/tests/unit/source-adapter-shim.test.ts
@@ -408,15 +408,15 @@ describe("cruiseAdapterToSourceAdapter.getContent", () => {
   })
 })
 
-describe("cruiseAdapterToSourceAdapter.reserve / cancel — capability stubs", () => {
-  it("reserve throws to keep cruise booking on the vertical's commit path in v1", async () => {
+describe("cruiseAdapterToSourceAdapter.reserve / cancel", () => {
+  it("reserve rejects an incomplete sourced booking selection", async () => {
     const shim = cruiseAdapterToSourceAdapter(makeStubAdapter())
     await expect(
       shim.reserve!(
         { connection_id: "conn-x" },
         { entity_module: "cruises", entity_id: "crus_x", parameters: {} },
       ),
-    ).rejects.toThrow(/not supported/i)
+    ).rejects.toThrow(/requires sailingId/i)
   })
 
   it("cancel throws to keep cruise cancellation on the vertical's commit path in v1", async () => {

--- a/packages/cruises/tests/unit/source-adapter-shim.test.ts
+++ b/packages/cruises/tests/unit/source-adapter-shim.test.ts
@@ -416,7 +416,11 @@ describe("cruiseAdapterToSourceAdapter.reserve / cancel", () => {
         { connection_id: "conn-x" },
         { entity_module: "cruises", entity_id: "crus_x", parameters: {} },
       ),
-    ).rejects.toThrow(/requires sailingId/i)
+    ).rejects.toMatchObject({
+      message: expect.stringMatching(/requires sailingId/i),
+      certainty: "not_sent",
+      errorClass: "cruise_reservation_preflight_failed",
+    })
   })
 
   it("cancel throws to keep cruise cancellation on the vertical's commit path in v1", async () => {

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -379,6 +379,9 @@
       "@voyant-travel/bookings/runtime-contributor": ["../bookings/dist/runtime-contributor.d.ts"],
       "@voyant-travel/bookings/runtime-port": ["../bookings/dist/runtime-port.d.ts"],
       "@voyant-travel/bookings/schema": ["../bookings/dist/schema.d.ts"],
+      "@voyant-travel/bookings/service-sourced-commitment": [
+        "../bookings/dist/service-sourced-commitment.d.ts"
+      ],
       "@voyant-travel/bookings/stale-holds-job": ["../bookings/dist/stale-holds-job.d.ts"],
       "@voyant-travel/bookings/status": ["../bookings/dist/status.d.ts"],
       "@voyant-travel/bookings/status-dispatch": ["../bookings/dist/status-dispatch.d.ts"],
@@ -422,6 +425,9 @@
       ],
       "@voyant-travel/catalog-contracts/booking-engine/session-contracts": [
         "../catalog-contracts/dist/booking-engine/session-contracts.d.ts"
+      ],
+      "@voyant-travel/catalog-contracts/booking-engine/supplier-operations": [
+        "../catalog-contracts/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog-contracts/content": ["../catalog-contracts/dist/content.d.ts"],
       "@voyant-travel/catalog-contracts/contract": ["../catalog-contracts/dist/contract.d.ts"],
@@ -480,6 +486,9 @@
       ],
       "@voyant-travel/catalog/booking-engine/sessions-schema": [
         "../catalog/dist/booking-engine/sessions-schema.d.ts"
+      ],
+      "@voyant-travel/catalog/booking-engine/supplier-operations": [
+        "../catalog/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog/booking-session-maintenance-job": [
         "../catalog/dist/booking-session-maintenance-job.d.ts"

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -380,6 +380,9 @@
       "@voyant-travel/bookings/runtime-contributor": ["../bookings/dist/runtime-contributor.d.ts"],
       "@voyant-travel/bookings/runtime-port": ["../bookings/dist/runtime-port.d.ts"],
       "@voyant-travel/bookings/schema": ["../bookings/dist/schema.d.ts"],
+      "@voyant-travel/bookings/service-sourced-commitment": [
+        "../bookings/dist/service-sourced-commitment.d.ts"
+      ],
       "@voyant-travel/bookings/stale-holds-job": ["../bookings/dist/stale-holds-job.d.ts"],
       "@voyant-travel/bookings/status": ["../bookings/dist/status.d.ts"],
       "@voyant-travel/bookings/status-dispatch": ["../bookings/dist/status-dispatch.d.ts"],
@@ -423,6 +426,9 @@
       ],
       "@voyant-travel/catalog-contracts/booking-engine/session-contracts": [
         "../catalog-contracts/dist/booking-engine/session-contracts.d.ts"
+      ],
+      "@voyant-travel/catalog-contracts/booking-engine/supplier-operations": [
+        "../catalog-contracts/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog-contracts/content": ["../catalog-contracts/dist/content.d.ts"],
       "@voyant-travel/catalog-contracts/contract": ["../catalog-contracts/dist/contract.d.ts"],
@@ -481,6 +487,9 @@
       ],
       "@voyant-travel/catalog/booking-engine/sessions-schema": [
         "../catalog/dist/booking-engine/sessions-schema.d.ts"
+      ],
+      "@voyant-travel/catalog/booking-engine/supplier-operations": [
+        "../catalog/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog/booking-session-maintenance-job": [
         "../catalog/dist/booking-session-maintenance-job.d.ts"

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -379,6 +379,9 @@
       "@voyant-travel/bookings/runtime-contributor": ["../bookings/dist/runtime-contributor.d.ts"],
       "@voyant-travel/bookings/runtime-port": ["../bookings/dist/runtime-port.d.ts"],
       "@voyant-travel/bookings/schema": ["../bookings/dist/schema.d.ts"],
+      "@voyant-travel/bookings/service-sourced-commitment": [
+        "../bookings/dist/service-sourced-commitment.d.ts"
+      ],
       "@voyant-travel/bookings/stale-holds-job": ["../bookings/dist/stale-holds-job.d.ts"],
       "@voyant-travel/bookings/status": ["../bookings/dist/status.d.ts"],
       "@voyant-travel/bookings/status-dispatch": ["../bookings/dist/status-dispatch.d.ts"],
@@ -422,6 +425,9 @@
       ],
       "@voyant-travel/catalog-contracts/booking-engine/session-contracts": [
         "../catalog-contracts/dist/booking-engine/session-contracts.d.ts"
+      ],
+      "@voyant-travel/catalog-contracts/booking-engine/supplier-operations": [
+        "../catalog-contracts/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog-contracts/content": ["../catalog-contracts/dist/content.d.ts"],
       "@voyant-travel/catalog-contracts/contract": ["../catalog-contracts/dist/contract.d.ts"],
@@ -480,6 +486,9 @@
       ],
       "@voyant-travel/catalog/booking-engine/sessions-schema": [
         "../catalog/dist/booking-engine/sessions-schema.d.ts"
+      ],
+      "@voyant-travel/catalog/booking-engine/supplier-operations": [
+        "../catalog/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog/booking-session-maintenance-job": [
         "../catalog/dist/booking-session-maintenance-job.d.ts"

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -380,6 +380,9 @@
       "@voyant-travel/bookings/runtime-contributor": ["../bookings/dist/runtime-contributor.d.ts"],
       "@voyant-travel/bookings/runtime-port": ["../bookings/dist/runtime-port.d.ts"],
       "@voyant-travel/bookings/schema": ["../bookings/dist/schema.d.ts"],
+      "@voyant-travel/bookings/service-sourced-commitment": [
+        "../bookings/dist/service-sourced-commitment.d.ts"
+      ],
       "@voyant-travel/bookings/stale-holds-job": ["../bookings/dist/stale-holds-job.d.ts"],
       "@voyant-travel/bookings/status": ["../bookings/dist/status.d.ts"],
       "@voyant-travel/bookings/status-dispatch": ["../bookings/dist/status-dispatch.d.ts"],
@@ -423,6 +426,9 @@
       ],
       "@voyant-travel/catalog-contracts/booking-engine/session-contracts": [
         "../catalog-contracts/dist/booking-engine/session-contracts.d.ts"
+      ],
+      "@voyant-travel/catalog-contracts/booking-engine/supplier-operations": [
+        "../catalog-contracts/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog-contracts/content": ["../catalog-contracts/dist/content.d.ts"],
       "@voyant-travel/catalog-contracts/contract": ["../catalog-contracts/dist/contract.d.ts"],
@@ -481,6 +487,9 @@
       ],
       "@voyant-travel/catalog/booking-engine/sessions-schema": [
         "../catalog/dist/booking-engine/sessions-schema.d.ts"
+      ],
+      "@voyant-travel/catalog/booking-engine/supplier-operations": [
+        "../catalog/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog/booking-session-maintenance-job": [
         "../catalog/dist/booking-session-maintenance-job.d.ts"

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -385,6 +385,9 @@
       "@voyant-travel/bookings/runtime-contributor": ["../bookings/dist/runtime-contributor.d.ts"],
       "@voyant-travel/bookings/runtime-port": ["../bookings/dist/runtime-port.d.ts"],
       "@voyant-travel/bookings/schema": ["../bookings/dist/schema.d.ts"],
+      "@voyant-travel/bookings/service-sourced-commitment": [
+        "../bookings/dist/service-sourced-commitment.d.ts"
+      ],
       "@voyant-travel/bookings/stale-holds-job": ["../bookings/dist/stale-holds-job.d.ts"],
       "@voyant-travel/bookings/status": ["../bookings/dist/status.d.ts"],
       "@voyant-travel/bookings/status-dispatch": ["../bookings/dist/status-dispatch.d.ts"],
@@ -428,6 +431,9 @@
       ],
       "@voyant-travel/catalog-contracts/booking-engine/session-contracts": [
         "../catalog-contracts/dist/booking-engine/session-contracts.d.ts"
+      ],
+      "@voyant-travel/catalog-contracts/booking-engine/supplier-operations": [
+        "../catalog-contracts/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog-contracts/content": ["../catalog-contracts/dist/content.d.ts"],
       "@voyant-travel/catalog-contracts/contract": ["../catalog-contracts/dist/contract.d.ts"],
@@ -486,6 +492,9 @@
       ],
       "@voyant-travel/catalog/booking-engine/sessions-schema": [
         "../catalog/dist/booking-engine/sessions-schema.d.ts"
+      ],
+      "@voyant-travel/catalog/booking-engine/supplier-operations": [
+        "../catalog/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog/booking-session-maintenance-job": [
         "../catalog/dist/booking-session-maintenance-job.d.ts"

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -380,6 +380,9 @@
       "@voyant-travel/bookings/runtime-contributor": ["../bookings/dist/runtime-contributor.d.ts"],
       "@voyant-travel/bookings/runtime-port": ["../bookings/dist/runtime-port.d.ts"],
       "@voyant-travel/bookings/schema": ["../bookings/dist/schema.d.ts"],
+      "@voyant-travel/bookings/service-sourced-commitment": [
+        "../bookings/dist/service-sourced-commitment.d.ts"
+      ],
       "@voyant-travel/bookings/stale-holds-job": ["../bookings/dist/stale-holds-job.d.ts"],
       "@voyant-travel/bookings/status": ["../bookings/dist/status.d.ts"],
       "@voyant-travel/bookings/status-dispatch": ["../bookings/dist/status-dispatch.d.ts"],
@@ -423,6 +426,9 @@
       ],
       "@voyant-travel/catalog-contracts/booking-engine/session-contracts": [
         "../catalog-contracts/dist/booking-engine/session-contracts.d.ts"
+      ],
+      "@voyant-travel/catalog-contracts/booking-engine/supplier-operations": [
+        "../catalog-contracts/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog-contracts/content": ["../catalog-contracts/dist/content.d.ts"],
       "@voyant-travel/catalog-contracts/contract": ["../catalog-contracts/dist/contract.d.ts"],
@@ -481,6 +487,9 @@
       ],
       "@voyant-travel/catalog/booking-engine/sessions-schema": [
         "../catalog/dist/booking-engine/sessions-schema.d.ts"
+      ],
+      "@voyant-travel/catalog/booking-engine/supplier-operations": [
+        "../catalog/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog/booking-session-maintenance-job": [
         "../catalog/dist/booking-session-maintenance-job.d.ts"

--- a/packages/finance/src/index.ts
+++ b/packages/finance/src/index.ts
@@ -39,6 +39,12 @@ import {
 
 export { FINANCE_BOOKING_CREATE_SELF_SERVICE_ROUTE_ACTION } from "./booking-create-policy.js"
 export {
+  type AllocateBookingNumberOptions,
+  allocateBookingNumber,
+  BOOKING_NUMBER_PATTERN,
+  formatBookingNumber,
+} from "./booking-number.js"
+export {
   BookingSessionPaymentIdempotencyConflictError,
   type BookingSessionPaymentState,
   bookingSessionPaymentIdempotencyKey,

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -379,6 +379,9 @@
       "@voyant-travel/bookings/runtime-contributor": ["../bookings/dist/runtime-contributor.d.ts"],
       "@voyant-travel/bookings/runtime-port": ["../bookings/dist/runtime-port.d.ts"],
       "@voyant-travel/bookings/schema": ["../bookings/dist/schema.d.ts"],
+      "@voyant-travel/bookings/service-sourced-commitment": [
+        "../bookings/dist/service-sourced-commitment.d.ts"
+      ],
       "@voyant-travel/bookings/stale-holds-job": ["../bookings/dist/stale-holds-job.d.ts"],
       "@voyant-travel/bookings/status": ["../bookings/dist/status.d.ts"],
       "@voyant-travel/bookings/status-dispatch": ["../bookings/dist/status-dispatch.d.ts"],
@@ -422,6 +425,9 @@
       ],
       "@voyant-travel/catalog-contracts/booking-engine/session-contracts": [
         "../catalog-contracts/dist/booking-engine/session-contracts.d.ts"
+      ],
+      "@voyant-travel/catalog-contracts/booking-engine/supplier-operations": [
+        "../catalog-contracts/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog-contracts/content": ["../catalog-contracts/dist/content.d.ts"],
       "@voyant-travel/catalog-contracts/contract": ["../catalog-contracts/dist/contract.d.ts"],
@@ -480,6 +486,9 @@
       ],
       "@voyant-travel/catalog/booking-engine/sessions-schema": [
         "../catalog/dist/booking-engine/sessions-schema.d.ts"
+      ],
+      "@voyant-travel/catalog/booking-engine/supplier-operations": [
+        "../catalog/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog/booking-session-maintenance-job": [
         "../catalog/dist/booking-session-maintenance-job.d.ts"

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -380,6 +380,9 @@
       "@voyant-travel/bookings/runtime-contributor": ["../bookings/dist/runtime-contributor.d.ts"],
       "@voyant-travel/bookings/runtime-port": ["../bookings/dist/runtime-port.d.ts"],
       "@voyant-travel/bookings/schema": ["../bookings/dist/schema.d.ts"],
+      "@voyant-travel/bookings/service-sourced-commitment": [
+        "../bookings/dist/service-sourced-commitment.d.ts"
+      ],
       "@voyant-travel/bookings/stale-holds-job": ["../bookings/dist/stale-holds-job.d.ts"],
       "@voyant-travel/bookings/status": ["../bookings/dist/status.d.ts"],
       "@voyant-travel/bookings/status-dispatch": ["../bookings/dist/status-dispatch.d.ts"],
@@ -423,6 +426,9 @@
       ],
       "@voyant-travel/catalog-contracts/booking-engine/session-contracts": [
         "../catalog-contracts/dist/booking-engine/session-contracts.d.ts"
+      ],
+      "@voyant-travel/catalog-contracts/booking-engine/supplier-operations": [
+        "../catalog-contracts/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog-contracts/content": ["../catalog-contracts/dist/content.d.ts"],
       "@voyant-travel/catalog-contracts/contract": ["../catalog-contracts/dist/contract.d.ts"],
@@ -481,6 +487,9 @@
       ],
       "@voyant-travel/catalog/booking-engine/sessions-schema": [
         "../catalog/dist/booking-engine/sessions-schema.d.ts"
+      ],
+      "@voyant-travel/catalog/booking-engine/supplier-operations": [
+        "../catalog/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog/booking-session-maintenance-job": [
         "../catalog/dist/booking-session-maintenance-job.d.ts"

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -385,6 +385,9 @@
       "@voyant-travel/bookings/runtime-contributor": ["../bookings/dist/runtime-contributor.d.ts"],
       "@voyant-travel/bookings/runtime-port": ["../bookings/dist/runtime-port.d.ts"],
       "@voyant-travel/bookings/schema": ["../bookings/dist/schema.d.ts"],
+      "@voyant-travel/bookings/service-sourced-commitment": [
+        "../bookings/dist/service-sourced-commitment.d.ts"
+      ],
       "@voyant-travel/bookings/stale-holds-job": ["../bookings/dist/stale-holds-job.d.ts"],
       "@voyant-travel/bookings/status": ["../bookings/dist/status.d.ts"],
       "@voyant-travel/bookings/status-dispatch": ["../bookings/dist/status-dispatch.d.ts"],
@@ -428,6 +431,9 @@
       ],
       "@voyant-travel/catalog-contracts/booking-engine/session-contracts": [
         "../catalog-contracts/dist/booking-engine/session-contracts.d.ts"
+      ],
+      "@voyant-travel/catalog-contracts/booking-engine/supplier-operations": [
+        "../catalog-contracts/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog-contracts/content": ["../catalog-contracts/dist/content.d.ts"],
       "@voyant-travel/catalog-contracts/contract": ["../catalog-contracts/dist/contract.d.ts"],
@@ -486,6 +492,9 @@
       ],
       "@voyant-travel/catalog/booking-engine/sessions-schema": [
         "../catalog/dist/booking-engine/sessions-schema.d.ts"
+      ],
+      "@voyant-travel/catalog/booking-engine/supplier-operations": [
+        "../catalog/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog/booking-session-maintenance-job": [
         "../catalog/dist/booking-session-maintenance-job.d.ts"

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -380,6 +380,9 @@
       "@voyant-travel/bookings/runtime-contributor": ["../bookings/dist/runtime-contributor.d.ts"],
       "@voyant-travel/bookings/runtime-port": ["../bookings/dist/runtime-port.d.ts"],
       "@voyant-travel/bookings/schema": ["../bookings/dist/schema.d.ts"],
+      "@voyant-travel/bookings/service-sourced-commitment": [
+        "../bookings/dist/service-sourced-commitment.d.ts"
+      ],
       "@voyant-travel/bookings/stale-holds-job": ["../bookings/dist/stale-holds-job.d.ts"],
       "@voyant-travel/bookings/status": ["../bookings/dist/status.d.ts"],
       "@voyant-travel/bookings/status-dispatch": ["../bookings/dist/status-dispatch.d.ts"],
@@ -423,6 +426,9 @@
       ],
       "@voyant-travel/catalog-contracts/booking-engine/session-contracts": [
         "../catalog-contracts/dist/booking-engine/session-contracts.d.ts"
+      ],
+      "@voyant-travel/catalog-contracts/booking-engine/supplier-operations": [
+        "../catalog-contracts/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog-contracts/content": ["../catalog-contracts/dist/content.d.ts"],
       "@voyant-travel/catalog-contracts/contract": ["../catalog-contracts/dist/contract.d.ts"],
@@ -481,6 +487,9 @@
       ],
       "@voyant-travel/catalog/booking-engine/sessions-schema": [
         "../catalog/dist/booking-engine/sessions-schema.d.ts"
+      ],
+      "@voyant-travel/catalog/booking-engine/supplier-operations": [
+        "../catalog/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog/booking-session-maintenance-job": [
         "../catalog/dist/booking-session-maintenance-job.d.ts"

--- a/packages/inventory/tsconfig.build.json
+++ b/packages/inventory/tsconfig.build.json
@@ -379,6 +379,9 @@
       "@voyant-travel/bookings/runtime-contributor": ["../bookings/dist/runtime-contributor.d.ts"],
       "@voyant-travel/bookings/runtime-port": ["../bookings/dist/runtime-port.d.ts"],
       "@voyant-travel/bookings/schema": ["../bookings/dist/schema.d.ts"],
+      "@voyant-travel/bookings/service-sourced-commitment": [
+        "../bookings/dist/service-sourced-commitment.d.ts"
+      ],
       "@voyant-travel/bookings/stale-holds-job": ["../bookings/dist/stale-holds-job.d.ts"],
       "@voyant-travel/bookings/status": ["../bookings/dist/status.d.ts"],
       "@voyant-travel/bookings/status-dispatch": ["../bookings/dist/status-dispatch.d.ts"],
@@ -422,6 +425,9 @@
       ],
       "@voyant-travel/catalog-contracts/booking-engine/session-contracts": [
         "../catalog-contracts/dist/booking-engine/session-contracts.d.ts"
+      ],
+      "@voyant-travel/catalog-contracts/booking-engine/supplier-operations": [
+        "../catalog-contracts/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog-contracts/content": ["../catalog-contracts/dist/content.d.ts"],
       "@voyant-travel/catalog-contracts/contract": ["../catalog-contracts/dist/contract.d.ts"],
@@ -480,6 +486,9 @@
       ],
       "@voyant-travel/catalog/booking-engine/sessions-schema": [
         "../catalog/dist/booking-engine/sessions-schema.d.ts"
+      ],
+      "@voyant-travel/catalog/booking-engine/supplier-operations": [
+        "../catalog/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog/booking-session-maintenance-job": [
         "../catalog/dist/booking-session-maintenance-job.d.ts"

--- a/packages/inventory/tsconfig.typecheck.json
+++ b/packages/inventory/tsconfig.typecheck.json
@@ -380,6 +380,9 @@
       "@voyant-travel/bookings/runtime-contributor": ["../bookings/dist/runtime-contributor.d.ts"],
       "@voyant-travel/bookings/runtime-port": ["../bookings/dist/runtime-port.d.ts"],
       "@voyant-travel/bookings/schema": ["../bookings/dist/schema.d.ts"],
+      "@voyant-travel/bookings/service-sourced-commitment": [
+        "../bookings/dist/service-sourced-commitment.d.ts"
+      ],
       "@voyant-travel/bookings/stale-holds-job": ["../bookings/dist/stale-holds-job.d.ts"],
       "@voyant-travel/bookings/status": ["../bookings/dist/status.d.ts"],
       "@voyant-travel/bookings/status-dispatch": ["../bookings/dist/status-dispatch.d.ts"],
@@ -423,6 +426,9 @@
       ],
       "@voyant-travel/catalog-contracts/booking-engine/session-contracts": [
         "../catalog-contracts/dist/booking-engine/session-contracts.d.ts"
+      ],
+      "@voyant-travel/catalog-contracts/booking-engine/supplier-operations": [
+        "../catalog-contracts/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog-contracts/content": ["../catalog-contracts/dist/content.d.ts"],
       "@voyant-travel/catalog-contracts/contract": ["../catalog-contracts/dist/contract.d.ts"],
@@ -481,6 +487,9 @@
       ],
       "@voyant-travel/catalog/booking-engine/sessions-schema": [
         "../catalog/dist/booking-engine/sessions-schema.d.ts"
+      ],
+      "@voyant-travel/catalog/booking-engine/supplier-operations": [
+        "../catalog/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog/booking-session-maintenance-job": [
         "../catalog/dist/booking-session-maintenance-job.d.ts"

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -385,6 +385,9 @@
       "@voyant-travel/bookings/runtime-contributor": ["../bookings/dist/runtime-contributor.d.ts"],
       "@voyant-travel/bookings/runtime-port": ["../bookings/dist/runtime-port.d.ts"],
       "@voyant-travel/bookings/schema": ["../bookings/dist/schema.d.ts"],
+      "@voyant-travel/bookings/service-sourced-commitment": [
+        "../bookings/dist/service-sourced-commitment.d.ts"
+      ],
       "@voyant-travel/bookings/stale-holds-job": ["../bookings/dist/stale-holds-job.d.ts"],
       "@voyant-travel/bookings/status": ["../bookings/dist/status.d.ts"],
       "@voyant-travel/bookings/status-dispatch": ["../bookings/dist/status-dispatch.d.ts"],
@@ -428,6 +431,9 @@
       ],
       "@voyant-travel/catalog-contracts/booking-engine/session-contracts": [
         "../catalog-contracts/dist/booking-engine/session-contracts.d.ts"
+      ],
+      "@voyant-travel/catalog-contracts/booking-engine/supplier-operations": [
+        "../catalog-contracts/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog-contracts/content": ["../catalog-contracts/dist/content.d.ts"],
       "@voyant-travel/catalog-contracts/contract": ["../catalog-contracts/dist/contract.d.ts"],
@@ -486,6 +492,9 @@
       ],
       "@voyant-travel/catalog/booking-engine/sessions-schema": [
         "../catalog/dist/booking-engine/sessions-schema.d.ts"
+      ],
+      "@voyant-travel/catalog/booking-engine/supplier-operations": [
+        "../catalog/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog/booking-session-maintenance-job": [
         "../catalog/dist/booking-session-maintenance-job.d.ts"

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -380,6 +380,9 @@
       "@voyant-travel/bookings/runtime-contributor": ["../bookings/dist/runtime-contributor.d.ts"],
       "@voyant-travel/bookings/runtime-port": ["../bookings/dist/runtime-port.d.ts"],
       "@voyant-travel/bookings/schema": ["../bookings/dist/schema.d.ts"],
+      "@voyant-travel/bookings/service-sourced-commitment": [
+        "../bookings/dist/service-sourced-commitment.d.ts"
+      ],
       "@voyant-travel/bookings/stale-holds-job": ["../bookings/dist/stale-holds-job.d.ts"],
       "@voyant-travel/bookings/status": ["../bookings/dist/status.d.ts"],
       "@voyant-travel/bookings/status-dispatch": ["../bookings/dist/status-dispatch.d.ts"],
@@ -423,6 +426,9 @@
       ],
       "@voyant-travel/catalog-contracts/booking-engine/session-contracts": [
         "../catalog-contracts/dist/booking-engine/session-contracts.d.ts"
+      ],
+      "@voyant-travel/catalog-contracts/booking-engine/supplier-operations": [
+        "../catalog-contracts/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog-contracts/content": ["../catalog-contracts/dist/content.d.ts"],
       "@voyant-travel/catalog-contracts/contract": ["../catalog-contracts/dist/contract.d.ts"],
@@ -481,6 +487,9 @@
       ],
       "@voyant-travel/catalog/booking-engine/sessions-schema": [
         "../catalog/dist/booking-engine/sessions-schema.d.ts"
+      ],
+      "@voyant-travel/catalog/booking-engine/supplier-operations": [
+        "../catalog/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog/booking-session-maintenance-job": [
         "../catalog/dist/booking-session-maintenance-job.d.ts"

--- a/packages/schema-kit/src/typeid/typeid-prefixes.ts
+++ b/packages/schema-kit/src/typeid/typeid-prefixes.ts
@@ -404,6 +404,7 @@ export const PREFIXES = {
   booking_session_commits: "bscm",
   booking_session_operations: "bsop",
   booking_session_audit_events: "bsae",
+  supplier_operations: "suop",
 
   // --- TRAVEL COMPOSER ---
   trip_envelopes: "trip",

--- a/packages/trips-react/package.json
+++ b/packages/trips-react/package.json
@@ -97,6 +97,7 @@
     "zod": "catalog:"
   },
   "dependencies": {
+    "@voyant-travel/catalog-contracts": "workspace:^",
     "@voyant-travel/i18n": "workspace:^",
     "@voyant-travel/react": "workspace:^"
   },

--- a/packages/trips-react/src/admin/trips-panels/catalog-options.tsx
+++ b/packages/trips-react/src/admin/trips-panels/catalog-options.tsx
@@ -2,7 +2,7 @@
 
 import { useOperatorAdminMessages as useAdminMessages } from "@voyant-travel/admin"
 import { type Draft, setAccommodation, setAddons } from "@voyant-travel/bookings-react/journey"
-import type { BookingDraftShape } from "@voyant-travel/catalog/booking-engine"
+import type { BookingDraftShape } from "@voyant-travel/catalog-contracts/booking-engine/draft-shape"
 import { Badge } from "@voyant-travel/ui/components/badge"
 import { Button } from "@voyant-travel/ui/components/button"
 import { Minus, Plus } from "lucide-react"

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -378,6 +378,9 @@
       "@voyant-travel/bookings/runtime-contributor": ["../bookings/dist/runtime-contributor.d.ts"],
       "@voyant-travel/bookings/runtime-port": ["../bookings/dist/runtime-port.d.ts"],
       "@voyant-travel/bookings/schema": ["../bookings/dist/schema.d.ts"],
+      "@voyant-travel/bookings/service-sourced-commitment": [
+        "../bookings/dist/service-sourced-commitment.d.ts"
+      ],
       "@voyant-travel/bookings/stale-holds-job": ["../bookings/dist/stale-holds-job.d.ts"],
       "@voyant-travel/bookings/status": ["../bookings/dist/status.d.ts"],
       "@voyant-travel/bookings/status-dispatch": ["../bookings/dist/status-dispatch.d.ts"],
@@ -421,6 +424,9 @@
       ],
       "@voyant-travel/catalog-contracts/booking-engine/session-contracts": [
         "../catalog-contracts/dist/booking-engine/session-contracts.d.ts"
+      ],
+      "@voyant-travel/catalog-contracts/booking-engine/supplier-operations": [
+        "../catalog-contracts/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog-contracts/content": ["../catalog-contracts/dist/content.d.ts"],
       "@voyant-travel/catalog-contracts/contract": ["../catalog-contracts/dist/contract.d.ts"],
@@ -479,6 +485,9 @@
       ],
       "@voyant-travel/catalog/booking-engine/sessions-schema": [
         "../catalog/dist/booking-engine/sessions-schema.d.ts"
+      ],
+      "@voyant-travel/catalog/booking-engine/supplier-operations": [
+        "../catalog/dist/booking-engine/supplier-operations.d.ts"
       ],
       "@voyant-travel/catalog/booking-session-maintenance-job": [
         "../catalog/dist/booking-session-maintenance-job.d.ts"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5341,6 +5341,9 @@ importers:
 
   packages/trips-react:
     dependencies:
+      '@voyant-travel/catalog-contracts':
+        specifier: workspace:^
+        version: link:../catalog-contracts
       '@voyant-travel/i18n':
         specifier: workspace:^
         version: link:../i18n


### PR DESCRIPTION
Closes #4012

## Summary

- persist one durable, optimistic-lock-protected Supplier Operation before any sourced reservation call
- enforce supplier-first commitment semantics, stable adapter idempotency, honest pending/in-doubt outcomes, and no blind retry after possible dispatch
- reconcile by supplier reference or the original idempotency key, with stale-observation protection and admitted/audited operator resolution routes
- materialize the confirmed Booking, Item, Allocation, origin, snapshot, Session/Quote consumption, and payment transfer in one PostgreSQL transaction
- make sourced cruises the first complete Quote-to-Commit tracer and keep adapter/connection/upstream provenance server-owned

## Verification

- Catalog, Catalog Contracts, Bookings, and Cruises package typechecks
- 58 focused Catalog lifecycle/production/workflow tests
- 85 adapter-contract, schema, and operator-route tests
- sourced cruise tracer test
- Biome checks for all changed package areas
- PostgreSQL concurrency invariant test added for competing Commit keys

## Operational notes

- adds the `supplier_operations` migration and Booking Session/audit state constraints
- persisted supplier request/evidence is redacted of contact, passenger, document, and payment credential data
- the independently released Connect plugin is bridged at one documented compatibility boundary until its next release