### PR TITLE
fix(auth): let storefronts carry runtime-provider hosting kinds

### DIFF
--- a/.changeset/storefront-hosting-kind-transport-contract.md
+++ b/.changeset/storefront-hosting-kind-transport-contract.md
@@ -1,0 +1,11 @@
+---
+"@voyant-travel/auth": patch
+"@voyant-travel/auth-react": patch
+---
+
+Stop rejecting storefronts whose hosting kind belongs to the runtime provider.
+The storefront admin response contract enumerated `cloud_site` and `external`,
+so a deployment backed by a control plane that mints its own hosting kinds
+failed the whole list response and rendered the storefronts page error state on
+a healthy 200. Response hosting kinds are now open; the create input keeps the
+operator enum, exported as `operatorStorefrontHostingKindSchema`.

--- a/packages/auth-react/src/components/storefronts-page.tsx
+++ b/packages/auth-react/src/components/storefronts-page.tsx
@@ -1,7 +1,10 @@
 "use client"
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
-import type { StorefrontDto } from "@voyant-travel/auth/storefront-admin-contracts"
+import type {
+  OperatorStorefrontHostingKind,
+  StorefrontDto,
+} from "@voyant-travel/auth/storefront-admin-contracts"
 import { useVoyantReactContext } from "@voyant-travel/react"
 import {
   Badge,
@@ -121,7 +124,7 @@ function CreateStorefrontForm({
   const copy = useAuthUiI18nOrDefault().messages.storefrontsPage.create
   const [name, setName] = useState("")
   const [slug, setSlug] = useState("")
-  const [hostingKind, setHostingKind] = useState<StorefrontDto["hostingKind"]>("external")
+  const [hostingKind, setHostingKind] = useState<OperatorStorefrontHostingKind>("external")
   const [siteId, setSiteId] = useState("")
 
   const create = useMutation({
@@ -197,7 +200,7 @@ function CreateStorefrontForm({
               id="storefront-hosting"
               value={hostingKind}
               onChange={(event) =>
-                setHostingKind(event.target.value as StorefrontDto["hostingKind"])
+                setHostingKind(event.target.value as OperatorStorefrontHostingKind)
               }
               className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
             >

--- a/packages/auth-react/src/storefronts-page.test.tsx
+++ b/packages/auth-react/src/storefronts-page.test.tsx
@@ -13,7 +13,7 @@ import { describe, expect, it, vi } from "vitest"
 import { createSelectedStorefrontAdminExtension } from "./admin.js"
 import { StorefrontsPage } from "./components/storefronts-page.js"
 import { authQueryKeys } from "./query-keys.js"
-import type { StorefrontsAdminApi } from "./storefronts-admin-api.js"
+import { createStorefrontsAdminApi, type StorefrontsAdminApi } from "./storefronts-admin-api.js"
 
 ;(
   globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
@@ -99,6 +99,19 @@ describe("storefront admin surface", () => {
     ])
     expect(fetcher.mock.calls.every(([, init]) => init?.credentials === "include")).toBe(true)
     expect(queryClient.getQueryData(authQueryKeys.storefrontList())).toEqual([STOREFRONT])
+  })
+
+  it("lists storefronts whose hosting kind is owned by the runtime provider", async () => {
+    // Voyant Cloud hosts the customer portal and booking engine itself and
+    // reports hosting kinds this package does not enumerate. Validating them
+    // against a closed enum rejects the whole array, so a healthy 200 renders
+    // as "Storefronts unavailable" with no console error to explain it.
+    const managed = { ...STOREFRONT, id: "storefront_2", hostingKind: "managed_portal" }
+    const api = createStorefrontsAdminApi("/api", async () =>
+      Response.json({ data: [STOREFRONT, managed] }),
+    )
+
+    await expect(api.listStorefronts()).resolves.toEqual([STOREFRONT, managed])
   })
 
   it("disables business controls when the runtime capability is unavailable", async () => {

--- a/packages/auth/src/storefront-admin-contracts.ts
+++ b/packages/auth/src/storefront-admin-contracts.ts
@@ -3,13 +3,35 @@
  *
  * These mirror the DTOs on {@link storefrontRuntimePort} without importing the
  * DB schema, so the admin React client can validate responses and request
- * bodies without pulling server-only modules into the browser bundle. The
- * literal unions are kept in lockstep with the persisted schema; the runtime
- * adapter re-normalizes every write, so these are the transport contract only.
+ * bodies without pulling server-only modules into the browser bundle. Request
+ * bodies are validated strictly against the literals this deployment accepts;
+ * response fields whose vocabulary belongs to the runtime provider rather than
+ * to this package stay open, so a control plane on its own release cadence can
+ * add to them without breaking an older admin bundle. The runtime adapter
+ * re-normalizes every write, so these are the transport contract only.
  */
 import { z } from "zod"
 
-export const storefrontHostingKindSchema = z.enum(["cloud_site", "external"])
+/**
+ * The hosting kinds an operator can pick when creating a storefront:
+ * `cloud_site` (a first-party site whose origin is known from the linked site)
+ * or `external` (anywhere else — third-party clouds, static hosts, localhost).
+ */
+export const operatorStorefrontHostingKindSchema = z.enum(["cloud_site", "external"])
+
+/**
+ * A hosting kind as it arrives on the wire, which is deliberately not the
+ * operator enum above. The storefront runtime is a port: a deployment can be
+ * backed by a control plane that owns hosting kinds this package never sees.
+ * Voyant Cloud mints platform-owned `managed_portal` and
+ * `managed_booking_engine` storefronts that way. Enumerating here would make
+ * every such addition fail the whole list response — one unknown kind rejects
+ * the array and the storefronts page renders its error state with a healthy
+ * 200 on the wire. Consumers narrow with `operatorStorefrontHostingKindSchema`
+ * where the distinction matters, and treat anything else as read-only hosting
+ * they did not provision.
+ */
+export const storefrontHostingKindSchema = z.string().min(1)
 export const storefrontApiKeyKindSchema = z.enum(["publishable", "secret"])
 export const storefrontSocialProviderSchema = z.enum(["google", "facebook", "apple"])
 
@@ -103,7 +125,7 @@ export const createStorefrontInputSchema = z
   .object({
     name: z.string().trim().min(1).max(200),
     slug: z.string().trim().min(1).max(120),
-    hostingKind: storefrontHostingKindSchema,
+    hostingKind: operatorStorefrontHostingKindSchema,
     siteId: z.string().trim().min(1).nullable().optional(),
     allowedOrigins: z.array(z.string().trim().min(1)).default([]),
     methods: storefrontCustomerAuthMethodsSchema,
@@ -140,6 +162,7 @@ export const putStorefrontProviderCredentialInputSchema = z
   })
   .strict()
 
+export type OperatorStorefrontHostingKind = z.infer<typeof operatorStorefrontHostingKindSchema>
 export type StorefrontHostingKind = z.infer<typeof storefrontHostingKindSchema>
 export type StorefrontApiKeyKind = z.infer<typeof storefrontApiKeyKindSchema>
 export type StorefrontSocialProvider = z.infer<typeof storefrontSocialProviderSchema>

--- a/packages/auth/tests/unit/storefront-admin-contracts.test.ts
+++ b/packages/auth/tests/unit/storefront-admin-contracts.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  createStorefrontInputSchema,
+  storefrontSchema,
+} from "../../src/storefront-admin-contracts.js"
+
+const STOREFRONT = {
+  id: "storefront_1",
+  organizationId: "org_1",
+  name: "Customer portal",
+  slug: "customer-portal",
+  hostingKind: "external",
+  siteId: null,
+  allowedOrigins: ["https://shop.example"],
+  methods: { emailCode: true, emailPassword: false, google: false, facebook: false, apple: false },
+  accountPolicy: {
+    allowedKinds: ["personal"],
+    personalSignup: "open",
+    businessOnboarding: "disabled",
+  },
+  hostOnlyCookies: true,
+  createdAt: "2026-07-15T00:00:00.000Z",
+  updatedAt: "2026-07-15T00:00:00.000Z",
+}
+
+describe("storefrontSchema", () => {
+  it("decodes hosting kinds owned by the runtime provider, not just this package's", () => {
+    // Voyant Cloud mints these for the portal and booking engine it hosts. A
+    // closed enum here rejects the whole list response and blanks the page.
+    for (const hostingKind of ["managed_portal", "managed_booking_engine"]) {
+      expect(storefrontSchema.parse({ ...STOREFRONT, hostingKind })).toMatchObject({ hostingKind })
+    }
+  })
+
+  it("still requires a hosting kind to be present", () => {
+    expect(storefrontSchema.safeParse({ ...STOREFRONT, hostingKind: "" }).success).toBe(false)
+    expect(storefrontSchema.safeParse({ ...STOREFRONT, hostingKind: null }).success).toBe(false)
+  })
+})
+
+describe("createStorefrontInputSchema", () => {
+  const input = {
+    name: "Web store",
+    slug: "web",
+    allowedOrigins: ["https://shop.example"],
+    methods: STOREFRONT.methods,
+  }
+
+  it("accepts the hosting kinds an operator provisions", () => {
+    for (const hostingKind of ["cloud_site", "external"]) {
+      expect(createStorefrontInputSchema.parse({ ...input, hostingKind })).toMatchObject({
+        hostingKind,
+      })
+    }
+  })
+
+  it("refuses platform-owned hosting kinds an operator cannot provision", () => {
+    expect(
+      createStorefrontInputSchema.safeParse({ ...input, hostingKind: "managed_portal" }).success,
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
## What broke

`sandbox.onvoyant.com/storefronts` renders "Storefronts unavailable" while the API is healthy:

```
GET /api/v1/admin/storefronts/storefronts → 200
{"data":[
  {"id":"sf_ma3snj8n1t6l","name":"Booking engine","hostingKind":"managed_booking_engine",…},
  {"id":"sf_km1j5lwnx9bv","name":"Customer portal","hostingKind":"managed_portal",…}
]}
```

`storefrontHostingKindSchema` was `z.enum(["cloud_site","external"])`, and the list envelope is a strict `z.array(storefrontSchema)`. One out-of-enum `hostingKind` rejects the whole array, `fetchWithValidation` throws, and the page falls into `storefrontsQuery.isError`. React Query swallows the throw, so there is no console error pointing at the cause — it reads as a backend outage. Every storefront in that org is a managed kind, so "Try again" can never recover.

Verified against the deployed bundle: `assets/use-storefronts-api-*.js` contains `a(["cloud_site","external"])` and no `managed_portal` / `managed_booking_engine`.

## Why it's a contract bug, not a missing enum member

The storefront runtime is a port. `storefront-local-adapter` backs a self-host deployment whose DB enum really is two-valued, but a deployment can be backed by a control plane that owns hosting kinds this package never sees — Voyant Cloud mints platform-owned `managed_portal` and `managed_booking_engine` storefronts, and it ships on its own release cadence. Re-enumerating here just moves the next outage to the next kind, against admin bundles already in the field.

So the direction of validation now follows who owns the vocabulary:

- **Responses** — `storefrontHostingKindSchema` is `z.string().min(1)`. Unknown kinds decode and render; the badge already degrades (`hostingKind === "cloud_site" ? Voyant : External`).
- **Requests** — `createStorefrontInputSchema` moves to the new `operatorStorefrontHostingKindSchema` (`cloud_site` | `external`), exported alongside `OperatorStorefrontHostingKind`. An operator still cannot provision a platform-owned kind; the create form is typed against it.

## Tests

Both fail on `main` and pass here (checked by reverting the schema line in place):

- `packages/auth/tests/unit/storefront-admin-contracts.test.ts` — the response schema decodes `managed_portal` / `managed_booking_engine`, still rejects empty/null, and the create input still refuses `managed_portal`.
- `packages/auth-react/src/storefronts-page.test.tsx` — `listStorefronts()` resolves a mixed list through the real client rather than throwing.

`pnpm test` (113 tasks), `tsc --noEmit` on both packages, and `biome check` on the touched files are green.

## Rollout

Patch changeset on `@voyant-travel/auth` + `@voyant-travel/auth-react`. The managed runtime picks this up on the next framework release; note the operator runtime carries its own lockfile, so an in-range bump alone will not resolve it — verify the resolved version after publishing.

Follow-up, not in this PR: the cloud storefronts page labels these platform-owned rows "External", which is accurate about hosting but hides that the operator did not provision them. That page lives in `voyant-travel/platform`.
