### PR TITLE
feat(catalog): support Amendment Supplier Operations

### DIFF
--- a/.changeset/calm-cycles-support-amendments.md
+++ b/.changeset/calm-cycles-support-amendments.md
@@ -1,0 +1,10 @@
+---
+"@voyant-travel/catalog-contracts": minor
+"@voyant-travel/catalog": minor
+---
+
+Generalize durable Supplier Operations from Session-only reserve intents to
+explicit Booking Session or Booking Amendment subjects, with linked Booking
+Items and reserve, modify, and cancel operation kinds. Add the source-adapter
+desired-state modification contract and Amendment-safe dispatch,
+idempotency, ambiguity, and reconciliation behavior.

--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -145,7 +145,7 @@ Generic first-party **Order** is retired from v1 runtime language by ADR-0005; u
 | **Legacy Order Term**   | A pre-v1 transactions term attached to a Legacy Order. New v1 terms belong to Legal policy/contract targets and Finance collection targets. | *clause, Order Term as new public API* |
 | **Hold**                | A temporary, time-limited claim on inventory before Booking confirmation; expires.               | *option, soft-hold*      |
 | **Commit**              | The Booking Platform operation that may create a Booking. Owned inventory Commit validates exact Booking Session revision, Quote, live Hold, and required payment guarantee, then creates Booking, converts Hold to Allocation, and consumes Session/Quote in one transaction. Sourced inventory defaults to supplier-first and creates no Booking until supplier security unless an explicit operator-backed policy accepts fulfillment risk. | *checkout submit, book, confirm when ambiguous* |
-| **Supplier Operation**  | A persisted sourced-inventory Commit intent and upstream dispatch record. It tracks supplier pending, secured, failed, or in-doubt outcomes separately from Booking status. | *draft booking, supplier booking status as booking status* |
+| **Supplier Operation**  | A persisted sourced-inventory upstream intent and dispatch record for reserve, modify, or cancel. Its subject is either a pre-Booking Booking Session or a post-Booking Booking Amendment linked to the affected Booking Item. It tracks pending, secured, refused, failed, or in-doubt outcomes separately from Booking status. | *draft booking, supplier booking status as booking status* |
 
 ## Fulfillment & operations
 

--- a/docs/adr/0019-booking-v1-commitment-point-policies.md
+++ b/docs/adr/0019-booking-v1-commitment-point-policies.md
@@ -146,6 +146,12 @@ tracers.
   Allocation atomically.
 - Supplier Operation is sourced-inventory state, not a Booking. Supplier
   pending and ambiguity remain typed lifecycle outcomes.
+- Supplier Operation is not Commit-specific storage. Its subject is explicit:
+  a pre-Booking operation belongs to a Booking Session, while a post-Booking
+  operation belongs to a Booking Amendment and links the affected Booking Item.
+  Reserve, modify, and cancel share the same durable dispatch, idempotency, and
+  reconciliation rules; only their owning workflow decides when a local
+  projection may advance.
 - Finance collection, invoices, schedules, guarantees, and payment sessions use
   explicit Finance targets. They do not define Booking status.
 - Fulfillment starts after Booking creation. Service Voucher issuance,

--- a/packages/catalog-contracts/src/adapter/booking-forwarding.ts
+++ b/packages/catalog-contracts/src/adapter/booking-forwarding.ts
@@ -71,3 +71,26 @@ export interface CancelResult {
    */
   pending_channel?: string
 }
+
+/**
+ * Replace the mutable commercial party/selection of an existing reservation.
+ * The desired state is complete rather than patch-shaped so replay and
+ * reconciliation do not depend on an upstream partial-update vocabulary.
+ */
+export interface ModifyReservationRequest {
+  upstream_ref: string
+  desired_state: {
+    parameters?: Record<string, unknown>
+    party?: Record<string, unknown>
+  }
+  scope?: SourceAdapterRequestScope
+  /** Replay-safe write key. Same key means the same desired state. */
+  idempotency_key: string
+}
+
+export interface ModifyReservationResult {
+  upstream_ref: string
+  status: "pending" | "confirmed" | "ticketed" | "refused" | "failed"
+  source_updated_at?: Date
+  upstream_payload?: Record<string, unknown>
+}

--- a/packages/catalog-contracts/src/adapter/contract-shared.ts
+++ b/packages/catalog-contracts/src/adapter/contract-shared.ts
@@ -3,6 +3,7 @@
 import type { Provenance } from "../provenance.js"
 import type {
   CancelResult,
+  ModifyReservationResult,
   ReserveResult,
   SourceAdapterRequestScope,
 } from "./booking-forwarding.js"
@@ -11,6 +12,8 @@ import type { ProviderCapabilityDeclaration } from "./provider-contracts.js"
 export type {
   CancelRequest,
   CancelResult,
+  ModifyReservationRequest,
+  ModifyReservationResult,
   ReserveRequest,
   ReserveResult,
   SourceAdapterRequestScope,
@@ -63,11 +66,19 @@ export type GetReservationRequest =
       scope?: SourceAdapterRequestScope
     }
 
-export type ReservationStatus = ReserveResult["status"] | CancelResult["status"] | "cancelling"
+export type ReservationStatus =
+  | ReserveResult["status"]
+  | CancelResult["status"]
+  | ModifyReservationResult["status"]
+  | "cancelling"
 
 export interface GetReservationResult {
   upstream_ref: string
   status: ReservationStatus
+  /** Stable write key of the last upstream mutation, when the source exposes it. */
+  last_operation_idempotency_key?: string
+  /** Adapter-computed fingerprint of the mutable reservation state. */
+  state_fingerprint?: string
   /** When the upstream itself last modified this reservation. */
   source_updated_at?: Date
   /** Opaque per-vertical payload (itinerary, pricing snapshot, traveler details). */

--- a/packages/catalog-contracts/src/adapter/schemas.ts
+++ b/packages/catalog-contracts/src/adapter/schemas.ts
@@ -325,6 +325,23 @@ export const cancelResultSchema = z.object({
   pending_channel: z.string().optional(),
 })
 
+export const modifyReservationRequestSchema = z.object({
+  upstream_ref: z.string().min(1),
+  desired_state: z.object({
+    parameters: recordSchema.optional(),
+    party: recordSchema.optional(),
+  }),
+  scope: sourceAdapterRequestScopeSchema.optional(),
+  idempotency_key: z.string().min(1),
+})
+
+export const modifyReservationResultSchema = z.object({
+  upstream_ref: z.string().min(1),
+  status: z.enum(["pending", "confirmed", "ticketed", "refused", "failed"]),
+  source_updated_at: z.date().optional(),
+  upstream_payload: recordSchema.optional(),
+})
+
 export const reservationStatusSchema = z.enum([
   "held",
   "confirmed",
@@ -352,6 +369,8 @@ export const getReservationRequestSchema = z.union([
 export const getReservationResultSchema = z.object({
   upstream_ref: z.string(),
   status: reservationStatusSchema,
+  last_operation_idempotency_key: z.string().optional(),
+  state_fingerprint: z.string().optional(),
   source_updated_at: z.date().optional(),
   upstream_payload: recordSchema.optional(),
 })

--- a/packages/catalog-contracts/src/adapter/source-adapter.ts
+++ b/packages/catalog-contracts/src/adapter/source-adapter.ts
@@ -5,6 +5,8 @@ import type { AvailabilitySearchRequest, AvailabilitySearchResult } from "./avai
 import type {
   CancelRequest,
   CancelResult,
+  ModifyReservationRequest,
+  ModifyReservationResult,
   ReserveRequest,
   ReserveResult,
 } from "./booking-forwarding.js"
@@ -138,6 +140,12 @@ export interface SourceAdapter {
 
   /** Forward a cancel request. */
   cancel?(ctx: SourceAdapterContext, request: CancelRequest): Promise<CancelResult>
+
+  /** Replace the desired mutable state of an existing reservation. */
+  modifyReservation?(
+    ctx: SourceAdapterContext,
+    request: ModifyReservationRequest,
+  ): Promise<ModifyReservationResult>
 
   /**
    * Fetch one reservation by upstream reference. Capability-gated by

--- a/packages/catalog-contracts/src/booking-engine/supplier-operations.ts
+++ b/packages/catalog-contracts/src/booking-engine/supplier-operations.ts
@@ -16,13 +16,23 @@ export type SupplierOperationStateV1 = z.infer<typeof supplierOperationStateV1>
 export const supplierCommitmentPolicyV1 = z.enum(["supplier_first", "operator_backed"])
 export type SupplierCommitmentPolicyV1 = z.infer<typeof supplierCommitmentPolicyV1>
 
+export const supplierOperationSubjectTypeV1 = z.enum(["booking_session", "booking_amendment"])
+export type SupplierOperationSubjectTypeV1 = z.infer<typeof supplierOperationSubjectTypeV1>
+
+export const supplierOperationKindV1 = z.enum(["reserve", "modify", "cancel"])
+export type SupplierOperationKindV1 = z.infer<typeof supplierOperationKindV1>
+
 export const supplierOperationRecordV1 = z.object({
   id: z.string().min(1),
-  sessionId: z.string().min(1),
+  subjectType: supplierOperationSubjectTypeV1,
+  subjectId: z.string().min(1),
+  sessionId: z.string().min(1).nullable(),
   scopeKey: z.string().min(1),
-  quoteId: z.string().min(1),
+  quoteId: z.string().min(1).nullable(),
   holdId: z.string().min(1).nullable(),
-  operationKind: z.literal("reserve"),
+  bookingItemId: z.string().min(1).nullable(),
+  amendmentId: z.string().min(1).nullable(),
+  operationKind: supplierOperationKindV1,
   state: supplierOperationStateV1,
   commitmentPolicy: supplierCommitmentPolicyV1,
   entityModule: z.string().min(1),
@@ -54,6 +64,7 @@ export type SupplierOperationRecordV1 = z.infer<typeof supplierOperationRecordV1
 export const listSupplierOperationsQueryV1 = z.object({
   state: supplierOperationStateV1.optional(),
   sessionId: z.string().min(1).optional(),
+  amendmentId: z.string().min(1).optional(),
   limit: z.coerce.number().int().min(1).max(100).default(50),
 })
 export type ListSupplierOperationsQueryV1 = z.input<typeof listSupplierOperationsQueryV1>

--- a/packages/catalog/migrations/20260802170000_amendment_supplier_operations.sql
+++ b/packages/catalog/migrations/20260802170000_amendment_supplier_operations.sql
@@ -1,0 +1,74 @@
+ALTER TABLE "supplier_operations"
+ADD COLUMN "subject_type" text;
+--> statement-breakpoint
+ALTER TABLE "supplier_operations"
+ADD COLUMN "subject_id" text;
+--> statement-breakpoint
+UPDATE "supplier_operations"
+SET "subject_type" = 'booking_session', "subject_id" = "session_id";
+--> statement-breakpoint
+ALTER TABLE "supplier_operations"
+ALTER COLUMN "subject_type" SET NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "supplier_operations"
+ALTER COLUMN "subject_id" SET NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "supplier_operations"
+RENAME COLUMN "commit_idempotency_key" TO "idempotency_key";
+--> statement-breakpoint
+ALTER TABLE "supplier_operations"
+ALTER COLUMN "session_id" DROP NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "supplier_operations"
+ALTER COLUMN "quote_id" DROP NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "supplier_operations"
+ADD COLUMN "booking_item_id" text;
+--> statement-breakpoint
+ALTER TABLE "supplier_operations"
+ADD COLUMN "amendment_id" text;
+--> statement-breakpoint
+ALTER TABLE "supplier_operations"
+DROP CONSTRAINT "supplier_operations_kind";
+--> statement-breakpoint
+ALTER TABLE "supplier_operations"
+ADD CONSTRAINT "supplier_operations_kind"
+CHECK ("operation_kind" IN ('reserve','modify','cancel'));
+--> statement-breakpoint
+ALTER TABLE "supplier_operations"
+ADD CONSTRAINT "supplier_operations_subject_type"
+CHECK ("subject_type" IN ('booking_session','booking_amendment'));
+--> statement-breakpoint
+ALTER TABLE "supplier_operations"
+ADD CONSTRAINT "supplier_operations_subject_shape" CHECK (
+  (
+    "subject_type" = 'booking_session'
+    AND "session_id" IS NOT NULL
+    AND "quote_id" IS NOT NULL
+    AND "amendment_id" IS NULL
+  ) OR (
+    "subject_type" = 'booking_amendment'
+    AND "session_id" IS NULL
+    AND "quote_id" IS NULL
+    AND "booking_id" IS NOT NULL
+    AND "booking_item_id" IS NOT NULL
+    AND "amendment_id" IS NOT NULL
+  )
+);
+--> statement-breakpoint
+DROP INDEX "uidx_supplier_operations_session_commit";
+--> statement-breakpoint
+DROP INDEX "uidx_supplier_operations_session_reserve_guard";
+--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_supplier_operations_subject_command"
+ON "supplier_operations" USING btree
+("subject_type","subject_id","scope_key","idempotency_key");
+--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_supplier_operations_subject_active_guard"
+ON "supplier_operations" USING btree
+("subject_type","subject_id","scope_key","operation_kind")
+WHERE "state" IN ('queued','submitted','pending','succeeded','in_doubt','manual_review')
+OR ("state" = 'manually_resolved' AND "upstream_status" = 'succeeded');
+--> statement-breakpoint
+CREATE INDEX "idx_supplier_operations_amendment_created"
+ON "supplier_operations" USING btree ("amendment_id","created_at");

--- a/packages/catalog/migrations/meta/_journal.json
+++ b/packages/catalog/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1785672000000,
       "tag": "20260802150000_booking_session_component_pending",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1785679200000,
+      "tag": "20260802170000_amendment_supplier_operations",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/catalog/src/booking-engine/index.ts
+++ b/packages/catalog/src/booking-engine/index.ts
@@ -283,6 +283,7 @@ export {
 } from "./sessions-service.js"
 export {
   createSupplierOperationWorkflow,
+  type DispatchSupplierAmendmentInput,
   type DispatchSupplierReservationInput,
   type SupplierOperationWorkflow,
   type SupplierOperationWorkflowOutcome,

--- a/packages/catalog/src/booking-engine/sessions-production.ts
+++ b/packages/catalog/src/booking-engine/sessions-production.ts
@@ -269,11 +269,14 @@ async function commitSourcedBooking(
       rawTx as PostgresJsDatabase,
     ).createOrReplay(
       createSupplierOperationRecord({
+        subjectType: "booking_session",
+        subjectId: input.session.id,
         sessionId: input.session.id,
         scopeKey: input.supplierOperationScope,
         quoteId: input.quote.id,
         ...(input.hold ? { holdId: input.hold.id } : {}),
-        commitIdempotencyKey: input.idempotencyKey,
+        idempotencyKey: input.idempotencyKey,
+        operationKind: "reserve",
         entityModule: sourced.entityModule,
         entityId: sourced.entityId,
         sourceKind: sourced.sourceKind,
@@ -333,7 +336,7 @@ async function commitSourcedBooking(
     }
   }
   if (result.kind === "failed") {
-    await reopenSessionAfterSupplierFailure(deps, result.operation.sessionId, input.now)
+    await reopenSessionAfterSupplierFailure(deps, input.session.id, input.now)
     return {
       kind: "supplier_failed" as const,
       nextAction:

--- a/packages/catalog/src/booking-engine/sessions-routes.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-routes.test.ts
@@ -18,10 +18,14 @@ const PUBLIC_CAPABILITY = `bcap_${"a".repeat(43)}`
 const WRONG_CAPABILITY = `bcap_${"b".repeat(43)}`
 const SUPPLIER_OPERATION = {
   id: "suop_route_1",
+  subjectType: "booking_session" as const,
+  subjectId: "bses_route_1",
   sessionId: "bses_route_1",
   scopeKey: "session",
   quoteId: "bsqu_route_1",
   holdId: null,
+  bookingItemId: null,
+  amendmentId: null,
   operationKind: "reserve" as const,
   state: "manual_review" as const,
   commitmentPolicy: "supplier_first" as const,

--- a/packages/catalog/src/booking-engine/supplier-operation-workflow.test.ts
+++ b/packages/catalog/src/booking-engine/supplier-operation-workflow.test.ts
@@ -307,11 +307,157 @@ describe("Supplier Operation workflow", () => {
     })
     expect(reserve).toHaveBeenCalledTimes(1)
   })
+
+  it("persists an Amendment modify intent before dispatch and replays it once", async () => {
+    const repository = memoryRepository()
+    const modifyReservation = vi.fn(async (_context, request) => {
+      expect(repository.rows[0]).toMatchObject({
+        subjectType: "booking_amendment",
+        subjectId: "bamd_1",
+        bookingId: "book_1",
+        bookingItemId: "bitm_1",
+        amendmentId: "bamd_1",
+        operationKind: "modify",
+        state: "submitted",
+        attemptCount: 1,
+      })
+      expect(request.idempotency_key).toBe("bamd_1:bitm_1:apply-key:modify")
+      return { upstream_ref: "UP-BOOKING", status: "confirmed" as const }
+    })
+    const workflow = workflowWith(repository, { modifyReservation })
+    const amendmentInput = {
+      amendmentId: "bamd_1",
+      bookingId: "book_1",
+      bookingItemId: "bitm_1",
+      idempotencyKey: "apply-key",
+      requestFingerprint: "roster-after-hash",
+      operationKind: "modify" as const,
+      entityModule: "cruises",
+      entityId: "crus_1",
+      sourceKind: "cruise:test",
+      sourceConnectionId: "conn_1",
+      sourceRef: "CRUISE-1",
+      request: {
+        upstream_ref: "UP-BOOKING",
+        desired_state: { party: { passengers: [{ id: "trav_1" }, { id: "trav_2" }] } },
+        idempotency_key: "caller-key-is-replaced",
+      },
+      adapterContext: { connection_id: "conn_1" },
+      now: new Date("2026-08-02T10:00:00.000Z"),
+    }
+
+    await expect(workflow.dispatchAmendment(amendmentInput)).resolves.toMatchObject({
+      kind: "secured",
+      operation: { state: "succeeded", upstreamRef: "UP-BOOKING" },
+    })
+    await expect(workflow.dispatchAmendment(amendmentInput)).resolves.toMatchObject({
+      kind: "secured",
+      operation: { attemptCount: 1 },
+    })
+    expect(modifyReservation).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not redispatch an ambiguous Amendment and reconciles it by upstream reference", async () => {
+    const repository = memoryRepository()
+    const modifyReservation = vi.fn(async () => {
+      throw new Error("supplier accepted the write but the response timed out")
+    })
+    const getReservation = vi.fn(async () => ({
+      upstream_ref: "UP-BOOKING",
+      status: "confirmed" as const,
+      last_operation_idempotency_key: "bamd_2:bitm_1:apply-key:modify",
+      source_updated_at: new Date("2026-08-02T10:01:00.000Z"),
+    }))
+    const workflow = workflowWith(repository, { modifyReservation, getReservation })
+    const amendmentInput = {
+      amendmentId: "bamd_2",
+      bookingId: "book_1",
+      bookingItemId: "bitm_1",
+      idempotencyKey: "apply-key",
+      requestFingerprint: "roster-after-hash",
+      operationKind: "modify" as const,
+      entityModule: "cruises",
+      entityId: "crus_1",
+      sourceKind: "cruise:test",
+      sourceConnectionId: "conn_1",
+      sourceRef: "CRUISE-1",
+      request: {
+        upstream_ref: "UP-BOOKING",
+        desired_state: { party: { passengers: [{ id: "trav_1" }] } },
+        idempotency_key: "ignored",
+      },
+      adapterContext: { connection_id: "conn_1" },
+      now: new Date("2026-08-02T10:00:00.000Z"),
+    }
+    const dispatched = await workflow.dispatchAmendment(amendmentInput)
+    if (dispatched.kind !== "in_doubt") throw new Error("expected in-doubt operation")
+    await expect(workflow.dispatchAmendment(amendmentInput)).resolves.toMatchObject({
+      kind: "in_doubt",
+      operation: { attemptCount: 1 },
+    })
+    await expect(
+      workflow.reconcile(dispatched.operation, {
+        adapterContext: { connection_id: "conn_1" },
+        now: new Date("2026-08-02T10:02:00.000Z"),
+      }),
+    ).resolves.toMatchObject({ kind: "secured", operation: { state: "succeeded" } })
+    expect(modifyReservation).toHaveBeenCalledTimes(1)
+  })
+
+  it("keeps a modification in doubt when the read cannot prove the desired effect", async () => {
+    const repository = memoryRepository()
+    const modifyReservation = vi.fn(async () => {
+      throw new Error("response timed out")
+    })
+    const getReservation = vi.fn(async () => ({
+      upstream_ref: "UP-BOOKING",
+      status: "confirmed" as const,
+      source_updated_at: new Date("2026-08-02T10:01:00.000Z"),
+    }))
+    const workflow = workflowWith(repository, { modifyReservation, getReservation })
+    const dispatched = await workflow.dispatchAmendment({
+      amendmentId: "bamd_3",
+      bookingId: "book_1",
+      bookingItemId: "bitm_1",
+      idempotencyKey: "apply-key",
+      requestFingerprint: "desired-state-hash",
+      operationKind: "modify",
+      entityModule: "cruises",
+      entityId: "crus_1",
+      sourceKind: "cruise:test",
+      sourceConnectionId: "conn_1",
+      sourceRef: "CRUISE-1",
+      request: {
+        upstream_ref: "UP-BOOKING",
+        desired_state: { party: { passengers: [{ id: "trav_1" }] } },
+        idempotency_key: "ignored",
+      },
+      adapterContext: { connection_id: "conn_1" },
+      now: new Date("2026-08-02T10:00:00.000Z"),
+    })
+    if (dispatched.kind !== "in_doubt") throw new Error("expected in-doubt operation")
+
+    await expect(
+      workflow.reconcile(dispatched.operation, {
+        adapterContext: { connection_id: "conn_1" },
+        now: new Date("2026-08-02T10:02:00.000Z"),
+      }),
+    ).resolves.toMatchObject({
+      kind: "in_doubt",
+      operation: {
+        state: "in_doubt",
+        lastErrorClass: "modification_effect_unproven",
+        safeEvidence: { modificationEffectProven: false },
+      },
+    })
+  })
 })
 
 function workflowWith(
   repository: ReturnType<typeof memoryRepository>,
-  methods: Pick<SourceAdapter, "reserve"> & Partial<Pick<SourceAdapter, "getReservation">>,
+  methods: Partial<
+    Pick<SourceAdapter, "reserve" | "modifyReservation" | "cancel" | "getReservation">
+  >,
 ) {
   const registry = createSourceAdapterRegistry()
   registry.register("conn_1", {
@@ -320,10 +466,14 @@ function workflowWith(
       verticals: ["cruises"],
       supportsLiveResolution: true,
       supportsDriftDetection: false,
-      supportsBookingForwarding: true,
+      supportsBookingForwarding: Boolean(methods.reserve),
       supportsReservationRetrieval: Boolean(methods.getReservation),
       supportsReservationLookupByIdempotencyKey: Boolean(methods.getReservation),
-      postBookOperations: ["status"],
+      postBookOperations: [
+        "status",
+        ...(methods.modifyReservation ? (["modify"] as const) : []),
+        ...(methods.cancel ? (["cancel"] as const) : []),
+      ],
     },
     ...methods,
   })
@@ -360,9 +510,10 @@ function memoryRepository(): SupplierOperationRepository & {
     async createOrReplay(record): Promise<CreateSupplierOperationResult> {
       const replay = rows.find(
         (row) =>
-          row.sessionId === record.sessionId &&
+          row.subjectType === record.subjectType &&
+          row.subjectId === record.subjectId &&
           row.scopeKey === record.scopeKey &&
-          row.commitIdempotencyKey === record.commitIdempotencyKey,
+          row.idempotencyKey === record.idempotencyKey,
       )
       if (replay) {
         return replay.requestFingerprint === record.requestFingerprint
@@ -371,7 +522,8 @@ function memoryRepository(): SupplierOperationRepository & {
       }
       const blocking = rows.find(
         (row) =>
-          row.sessionId === record.sessionId &&
+          row.subjectType === record.subjectType &&
+          row.subjectId === record.subjectId &&
           row.scopeKey === record.scopeKey &&
           blocksReplacement(row),
       )
@@ -384,13 +536,14 @@ function memoryRepository(): SupplierOperationRepository & {
     async get(operationId) {
       return rows.find((row) => row.id === operationId) ?? null
     },
-    async getByCommit(sessionId, commitIdempotencyKey, scopeKey) {
+    async getByIdempotency(subjectType, subjectId, idempotencyKey, scopeKey) {
       return (
         rows.find(
           (row) =>
-            row.sessionId === sessionId &&
+            row.subjectType === subjectType &&
+            row.subjectId === subjectId &&
             (!scopeKey || row.scopeKey === scopeKey) &&
-            row.commitIdempotencyKey === commitIdempotencyKey,
+            row.idempotencyKey === idempotencyKey,
         ) ?? null
       )
     },

--- a/packages/catalog/src/booking-engine/supplier-operation-workflow.ts
+++ b/packages/catalog/src/booking-engine/supplier-operation-workflow.ts
@@ -1,4 +1,6 @@
 import {
+  type CancelRequest,
+  type ModifyReservationRequest,
   ReservationDispatchError,
   type ReserveRequest,
   type ReserveResult,
@@ -35,8 +37,29 @@ export interface DispatchSupplierReservationInput {
   now: Date
 }
 
+export interface DispatchSupplierAmendmentInput {
+  amendmentId: string
+  bookingId: string
+  bookingItemId: string
+  scopeKey?: string
+  idempotencyKey: string
+  requestFingerprint: string
+  operationKind: "modify" | "cancel"
+  entityModule: string
+  entityId: string
+  sourceKind: string
+  sourceConnectionId: string
+  sourceRef: string
+  request: ModifyReservationRequest | CancelRequest
+  adapterContext: SourceAdapterContext
+  now: Date
+}
+
 export interface SupplierOperationWorkflow {
   dispatch(input: DispatchSupplierReservationInput): Promise<SupplierOperationWorkflowOutcome>
+  dispatchAmendment(
+    input: DispatchSupplierAmendmentInput,
+  ): Promise<SupplierOperationWorkflowOutcome>
   reconcile(
     operation: SupplierOperationInternalRecord,
     input: { adapterContext: SourceAdapterContext; now: Date },
@@ -68,11 +91,14 @@ export function createSupplierOperationWorkflow(deps: {
       )
       const claim = await deps.repository.createOrReplay(
         createSupplierOperationRecord({
+          subjectType: "booking_session",
+          subjectId: input.sessionId,
           sessionId: input.sessionId,
           scopeKey,
           quoteId: input.quoteId,
           ...(input.holdId ? { holdId: input.holdId } : {}),
-          commitIdempotencyKey: input.commitIdempotencyKey,
+          idempotencyKey: input.commitIdempotencyKey,
+          operationKind: "reserve",
           entityModule: input.entityModule,
           entityId: input.entityId,
           sourceKind: input.sourceKind,
@@ -126,6 +152,122 @@ export function createSupplierOperationWorkflow(deps: {
         operation.state = "succeeded"
         await deps.repository.save(operation)
         return { kind: "secured", operation, result }
+      } catch (error) {
+        operation.updatedAt = input.now
+        operation.lastErrorClass = errorClass(error)
+        if (error instanceof ReservationDispatchError && error.certainty === "not_sent") {
+          operation.state = "queued"
+          operation.submittedAt = undefined
+          operation.nextReconcileAt = new Date(input.now.getTime() + reconcileAfterMs)
+          operation.safeEvidence = { dispatchCertainty: "not_sent" }
+          await deps.repository.save(operation)
+          return { kind: "pending", operation }
+        }
+        operation.state = "in_doubt"
+        operation.nextReconcileAt = new Date(input.now.getTime() + reconcileAfterMs)
+        operation.safeEvidence = { dispatchCertainty: "possibly_sent" }
+        await deps.repository.save(operation)
+        return { kind: "in_doubt", operation }
+      }
+    },
+
+    async dispatchAmendment(input) {
+      const adapter = deps.registry.resolveByConnection(input.sourceConnectionId)
+      const supported =
+        input.operationKind === "modify"
+          ? adapter?.capabilities.postBookOperations.includes("modify") &&
+            Boolean(adapter.modifyReservation)
+          : adapter?.capabilities.postBookOperations.includes("cancel") && Boolean(adapter.cancel)
+      const adapterIdempotencyKey = `${input.amendmentId}:${input.bookingItemId}:${input.idempotencyKey}:${input.operationKind}`
+      const record = createSupplierOperationRecord({
+        subjectType: "booking_amendment",
+        subjectId: input.amendmentId,
+        scopeKey: input.scopeKey ?? input.bookingItemId,
+        bookingId: input.bookingId,
+        bookingItemId: input.bookingItemId,
+        amendmentId: input.amendmentId,
+        idempotencyKey: input.idempotencyKey,
+        operationKind: input.operationKind,
+        entityModule: input.entityModule,
+        entityId: input.entityId,
+        sourceKind: input.sourceKind,
+        sourceConnectionId: input.sourceConnectionId,
+        sourceRef: input.sourceRef,
+        upstreamRef: input.request.upstream_ref,
+        adapterKind: adapter?.kind ?? input.sourceKind,
+        requestFingerprint: input.requestFingerprint,
+        adapterIdempotencyKey,
+        requestPayload: safeAmendmentRequestPayload(input),
+        now: input.now,
+      })
+      if (!supported || !adapter) {
+        record.state = "refused"
+        record.lastErrorClass = `${input.operationKind}_unsupported`
+        record.resolvedAt = input.now
+        const claim = await deps.repository.createOrReplay(record)
+        if (claim.status === "conflict") return { kind: "idempotency_conflict" }
+        return { kind: "failed", operation: claim.operation }
+      }
+      const claim = await deps.repository.createOrReplay(record)
+      if (claim.status === "conflict") return { kind: "idempotency_conflict" }
+      const replay = outcomeForStoredOperation(claim.operation)
+      if (claim.status === "replay" && replay) return replay
+      const operation = await deps.repository.claimDispatch(claim.operation.id, input.now)
+      if (!operation) {
+        const current = await deps.repository.get(claim.operation.id)
+        return current
+          ? (outcomeForStoredOperation(current) ?? { kind: "in_doubt", operation: current })
+          : { kind: "in_doubt", operation: claim.operation }
+      }
+      try {
+        const result =
+          input.operationKind === "modify"
+            ? await adapter.modifyReservation!(input.adapterContext, {
+                ...(input.request as ModifyReservationRequest),
+                idempotency_key: operation.adapterIdempotencyKey,
+              })
+            : await adapter.cancel!(input.adapterContext, {
+                ...(input.request as CancelRequest),
+                idempotency_key: operation.adapterIdempotencyKey,
+              })
+        operation.updatedAt = input.now
+        operation.upstreamStatus = result.status
+        operation.safeEvidence = {
+          dispatchCertainty: "acknowledged",
+          upstreamStatus: result.status,
+          ...(input.operationKind === "cancel" && "refund_amount" in result
+            ? {
+                refundAmount: result.refund_amount,
+                refundCurrency: result.refund_currency,
+              }
+            : {}),
+          ...(input.operationKind === "modify" && "upstream_payload" in result
+            ? redactSupplierEvidence(result.upstream_payload)
+            : {}),
+        }
+        if (result.status === "pending") {
+          operation.state = "pending"
+          operation.nextReconcileAt = new Date(input.now.getTime() + reconcileAfterMs)
+          await deps.repository.save(operation)
+          return { kind: "pending", operation }
+        }
+        if (result.status === "failed" || result.status === "refused") {
+          operation.state = "refused"
+          operation.resolvedAt = input.now
+          await deps.repository.save(operation)
+          return { kind: "failed", operation }
+        }
+        operation.state = "succeeded"
+        operation.resolvedAt = input.now
+        await deps.repository.save(operation)
+        return {
+          kind: "secured",
+          operation,
+          result: {
+            upstream_ref: operation.upstreamRef!,
+            status: result.status === "cancelled" ? "confirmed" : result.status,
+          },
+        }
       } catch (error) {
         operation.updatedAt = input.now
         operation.lastErrorClass = errorClass(error)
@@ -207,7 +349,7 @@ export function createSupplierOperationWorkflow(deps: {
           return { kind: "failed", operation }
         }
         if (result.status === "cancelled") {
-          operation.state = "cancelled"
+          operation.state = operation.operationKind === "cancel" ? "succeeded" : "cancelled"
           operation.resolvedAt = input.now
           operation.nextReconcileAt = undefined
           operation.safeEvidence = {
@@ -215,7 +357,17 @@ export function createSupplierOperationWorkflow(deps: {
             ...redactSupplierEvidence(result.upstream_payload),
           }
           await deps.repository.save(operation)
-          return { kind: "failed", operation }
+          return operation.operationKind === "cancel"
+            ? {
+                kind: "secured",
+                operation,
+                result: {
+                  upstream_ref: result.upstream_ref,
+                  status: "confirmed",
+                  upstream_payload: result.upstream_payload,
+                },
+              }
+            : { kind: "failed", operation }
         }
         if (result.status === "pending" || result.status === "cancelling") {
           operation.state = "pending"
@@ -226,6 +378,22 @@ export function createSupplierOperationWorkflow(deps: {
           }
           await deps.repository.save(operation)
           return { kind: "pending", operation }
+        }
+        if (
+          operation.operationKind === "modify" &&
+          result.last_operation_idempotency_key !== operation.adapterIdempotencyKey &&
+          result.state_fingerprint !== operation.requestFingerprint
+        ) {
+          operation.state = "in_doubt"
+          operation.lastErrorClass = "modification_effect_unproven"
+          operation.nextReconcileAt = new Date(input.now.getTime() + reconcileAfterMs)
+          operation.safeEvidence = {
+            ...operation.safeEvidence,
+            observationStatus: result.status,
+            modificationEffectProven: false,
+          }
+          await deps.repository.save(operation)
+          return { kind: "in_doubt", operation }
         }
         operation.state = "succeeded"
         operation.upstreamStatus = result.status
@@ -258,17 +426,44 @@ export function createSupplierOperationWorkflow(deps: {
   }
 }
 
+function safeAmendmentRequestPayload(
+  input: DispatchSupplierAmendmentInput,
+): Record<string, unknown> {
+  if (input.operationKind === "cancel") {
+    const request = input.request as CancelRequest
+    return {
+      upstream_ref: request.upstream_ref,
+      ...(request.reason ? { reason: request.reason } : {}),
+      ...(request.scope ? { scope: request.scope } : {}),
+    }
+  }
+  const request = input.request as ModifyReservationRequest
+  return {
+    upstream_ref: request.upstream_ref,
+    desiredStateSummary: {
+      parameters: redactSupplierParameters(request.desired_state.parameters ?? {}),
+      passengerCount: Array.isArray(request.desired_state.party?.passengers)
+        ? request.desired_state.party.passengers.length
+        : undefined,
+    },
+    ...(request.scope ? { scope: request.scope } : {}),
+  }
+}
+
 async function operationFailedWithoutDispatch(
   repository: SupplierOperationRepository,
   input: DispatchSupplierReservationInput,
   reason: string,
 ): Promise<SupplierOperationWorkflowOutcome> {
   const operation = createSupplierOperationRecord({
+    subjectType: "booking_session",
+    subjectId: input.sessionId,
     sessionId: input.sessionId,
     scopeKey: input.scopeKey,
     quoteId: input.quoteId,
     ...(input.holdId ? { holdId: input.holdId } : {}),
-    commitIdempotencyKey: input.commitIdempotencyKey,
+    idempotencyKey: input.commitIdempotencyKey,
+    operationKind: "reserve",
     entityModule: input.entityModule,
     entityId: input.entityId,
     sourceKind: input.sourceKind,

--- a/packages/catalog/src/booking-engine/supplier-operations-operator.ts
+++ b/packages/catalog/src/booking-engine/supplier-operations-operator.ts
@@ -21,6 +21,7 @@ export interface SupplierOperationOperatorService {
     input: {
       state?: SupplierOperationStateV1
       sessionId?: string
+      amendmentId?: string
       limit: number
     },
     access: BookingSessionAccessContext,
@@ -54,6 +55,7 @@ export function createSupplierOperationOperatorService(deps: {
         await createDrizzleSupplierOperationRepository(deps.db).list({
           ...(input.state ? { state: input.state } : {}),
           ...(input.sessionId ? { sessionId: input.sessionId } : {}),
+          ...(input.amendmentId ? { amendmentId: input.amendmentId } : {}),
           limit: input.limit,
         })
       ).map(serializeSupplierOperation)
@@ -87,7 +89,7 @@ export function createSupplierOperationOperatorService(deps: {
       if (outcome.kind === "idempotency_conflict") {
         throw new Error("supplier_operation_idempotency_conflict")
       }
-      if (outcome.kind === "failed") {
+      if (outcome.kind === "failed" && outcome.operation.sessionId) {
         await reopenSupplierPendingSession(deps.db, outcome.operation.sessionId, now())
       }
       outcome.operation.safeEvidence = {
@@ -98,17 +100,19 @@ export function createSupplierOperationOperatorService(deps: {
         },
       }
       await repository.save(outcome.operation)
-      await appendOperatorAudit(
-        deps.db,
-        outcome.operation.sessionId,
-        "supplier_reconcile",
-        access,
-        {
-          supplierOperationId: outcome.operation.id,
-          state: outcome.operation.state,
-          idempotencyKey: input.idempotencyKey,
-        },
-      )
+      if (outcome.operation.sessionId) {
+        await appendOperatorAudit(
+          deps.db,
+          outcome.operation.sessionId,
+          "supplier_reconcile",
+          access,
+          {
+            supplierOperationId: outcome.operation.id,
+            state: outcome.operation.state,
+            idempotencyKey: input.idempotencyKey,
+          },
+        )
+      }
       return serializeSupplierOperation(outcome.operation)
     },
     async resolve(operationId, input, access) {
@@ -161,7 +165,7 @@ export function createSupplierOperationOperatorService(deps: {
           },
         }
         await repository.save(operation)
-        if (input.resolution !== "succeeded") {
+        if (input.resolution !== "succeeded" && operation.sessionId) {
           const sessions = createDrizzleBookingSessionRepository(tx)
           const session = await sessions.getSession(operation.sessionId)
           if (session?.state === "supplier_pending") {
@@ -170,11 +174,13 @@ export function createSupplierOperationOperatorService(deps: {
             await sessions.saveSession(session)
           }
         }
-        await appendOperatorAudit(tx, operation.sessionId, "supplier_manual_resolve", access, {
-          supplierOperationId: operation.id,
-          resolution: input.resolution,
-          reason: input.reason,
-        })
+        if (operation.sessionId) {
+          await appendOperatorAudit(tx, operation.sessionId, "supplier_manual_resolve", access, {
+            supplierOperationId: operation.id,
+            resolution: input.resolution,
+            reason: input.reason,
+          })
+        }
         return serializeSupplierOperation(operation)
       })
     },

--- a/packages/catalog/src/booking-engine/supplier-operations-schema.ts
+++ b/packages/catalog/src/booking-engine/supplier-operations-schema.ts
@@ -1,6 +1,8 @@
 import type {
   SupplierCommitmentPolicyV1,
+  SupplierOperationKindV1,
   SupplierOperationStateV1,
+  SupplierOperationSubjectTypeV1,
 } from "@voyant-travel/catalog-contracts/booking-engine/supplier-operations"
 import { typeId, typeIdRef } from "@voyant-travel/db/lib/typeid-column"
 import { sql } from "drizzle-orm"
@@ -25,18 +27,20 @@ export const supplierOperationsTable = pgTable(
   "supplier_operations",
   {
     id: typeId("supplier_operations"),
-    sessionId: typeIdRef("session_id")
-      .notNull()
-      .references(() => bookingSessionsTable.id, { onDelete: "restrict" }),
+    subjectType: text("subject_type").$type<SupplierOperationSubjectTypeV1>().notNull(),
+    subjectId: text("subject_id").notNull(),
+    sessionId: typeIdRef("session_id").references(() => bookingSessionsTable.id, {
+      onDelete: "restrict",
+    }),
     scopeKey: text("scope_key").notNull().default("session"),
-    quoteId: typeIdRef("quote_id")
-      .notNull()
-      .references(() => bookingSessionQuotesTable.id, { onDelete: "restrict" }),
+    quoteId: typeIdRef("quote_id").references(() => bookingSessionQuotesTable.id, {
+      onDelete: "restrict",
+    }),
     holdId: typeIdRef("hold_id").references(() => bookingSessionHoldsTable.id, {
       onDelete: "restrict",
     }),
-    commitIdempotencyKey: text("commit_idempotency_key").notNull(),
-    operationKind: text("operation_kind").notNull(),
+    idempotencyKey: text("idempotency_key").notNull(),
+    operationKind: text("operation_kind").$type<SupplierOperationKindV1>().notNull(),
     state: text("state").$type<SupplierOperationStateV1>().notNull(),
     commitmentPolicy: text("commitment_policy").$type<SupplierCommitmentPolicyV1>().notNull(),
     entityModule: text("entity_module").notNull(),
@@ -53,6 +57,8 @@ export const supplierOperationsTable = pgTable(
     upstreamRef: text("upstream_ref"),
     upstreamStatus: text("upstream_status"),
     bookingId: text("booking_id"),
+    bookingItemId: text("booking_item_id"),
+    amendmentId: text("amendment_id"),
     lastErrorClass: text("last_error_class"),
     safeEvidence: jsonb("safe_evidence").$type<Record<string, unknown>>().notNull().default({}),
     submittedAt: timestamp("submitted_at", { withTimezone: true }),
@@ -67,7 +73,15 @@ export const supplierOperationsTable = pgTable(
   },
   (table) => [
     check("supplier_operations_id_typeid", sql`${table.id} LIKE 'suop_%'`),
-    check("supplier_operations_kind", sql`${table.operationKind} = 'reserve'`),
+    check(
+      "supplier_operations_subject_type",
+      sql`${table.subjectType} IN ('booking_session','booking_amendment')`,
+    ),
+    check(
+      "supplier_operations_subject_shape",
+      sql`(${table.subjectType} = 'booking_session' AND ${table.sessionId} IS NOT NULL AND ${table.quoteId} IS NOT NULL AND ${table.amendmentId} IS NULL) OR (${table.subjectType} = 'booking_amendment' AND ${table.sessionId} IS NULL AND ${table.quoteId} IS NULL AND ${table.bookingId} IS NOT NULL AND ${table.bookingItemId} IS NOT NULL AND ${table.amendmentId} IS NOT NULL)`,
+    ),
+    check("supplier_operations_kind", sql`${table.operationKind} IN ('reserve','modify','cancel')`),
     check(
       "supplier_operations_state",
       sql`${table.state} IN ('queued','submitted','pending','succeeded','refused','cancelled','in_doubt','manual_review','manually_resolved')`,
@@ -78,13 +92,14 @@ export const supplierOperationsTable = pgTable(
     ),
     check("supplier_operations_attempt_count", sql`${table.attemptCount} >= 0`),
     check("supplier_operations_version", sql`${table.version} >= 0`),
-    uniqueIndex("uidx_supplier_operations_session_commit").on(
-      table.sessionId,
+    uniqueIndex("uidx_supplier_operations_subject_command").on(
+      table.subjectType,
+      table.subjectId,
       table.scopeKey,
-      table.commitIdempotencyKey,
+      table.idempotencyKey,
     ),
-    uniqueIndex("uidx_supplier_operations_session_reserve_guard")
-      .on(table.sessionId, table.scopeKey, table.operationKind)
+    uniqueIndex("uidx_supplier_operations_subject_active_guard")
+      .on(table.subjectType, table.subjectId, table.scopeKey, table.operationKind)
       .where(
         sql`${table.state} IN ('queued','submitted','pending','succeeded','in_doubt','manual_review') OR (${table.state} = 'manually_resolved' AND ${table.upstreamStatus} = 'succeeded')`,
       ),
@@ -94,6 +109,7 @@ export const supplierOperationsTable = pgTable(
     ),
     index("idx_supplier_operations_state_reconcile").on(table.state, table.nextReconcileAt),
     index("idx_supplier_operations_session_created").on(table.sessionId, table.createdAt),
+    index("idx_supplier_operations_amendment_created").on(table.amendmentId, table.createdAt),
     index("idx_supplier_operations_upstream").on(table.sourceConnectionId, table.upstreamRef),
   ],
 )

--- a/packages/catalog/src/booking-engine/supplier-operations.ts
+++ b/packages/catalog/src/booking-engine/supplier-operations.ts
@@ -1,7 +1,9 @@
 import type {
   SupplierCommitmentPolicyV1,
+  SupplierOperationKindV1,
   SupplierOperationRecordV1,
   SupplierOperationStateV1,
+  SupplierOperationSubjectTypeV1,
 } from "@voyant-travel/catalog-contracts/booking-engine/supplier-operations"
 import { newId } from "@voyant-travel/db/lib/typeid"
 import { and, desc, eq, inArray, or, sql } from "drizzle-orm"
@@ -14,12 +16,16 @@ import {
 
 export interface SupplierOperationInternalRecord {
   id: string
-  sessionId: string
+  subjectType: SupplierOperationSubjectTypeV1
+  subjectId: string
+  sessionId?: string
   scopeKey: string
-  quoteId: string
+  quoteId?: string
   holdId?: string
-  commitIdempotencyKey: string
-  operationKind: "reserve"
+  bookingItemId?: string
+  amendmentId?: string
+  idempotencyKey: string
+  operationKind: SupplierOperationKindV1
   state: SupplierOperationStateV1
   commitmentPolicy: SupplierCommitmentPolicyV1
   entityModule: string
@@ -57,9 +63,10 @@ export type CreateSupplierOperationResult =
 export interface SupplierOperationRepository {
   createOrReplay(record: SupplierOperationInternalRecord): Promise<CreateSupplierOperationResult>
   get(operationId: string): Promise<SupplierOperationInternalRecord | null>
-  getByCommit(
-    sessionId: string,
-    commitIdempotencyKey: string,
+  getByIdempotency(
+    subjectType: SupplierOperationSubjectTypeV1,
+    subjectId: string,
+    idempotencyKey: string,
     scopeKey?: string,
   ): Promise<SupplierOperationInternalRecord | null>
   getBySession(sessionId: string): Promise<SupplierOperationInternalRecord | null>
@@ -71,6 +78,7 @@ export interface SupplierOperationRepository {
   list(input: {
     state?: SupplierOperationStateV1
     sessionId?: string
+    amendmentId?: string
     limit: number
   }): Promise<SupplierOperationInternalRecord[]>
   claimDispatch(operationId: string, at: Date): Promise<SupplierOperationInternalRecord | null>
@@ -122,9 +130,10 @@ export function createDrizzleSupplierOperationRepository(
     return row ? mapSupplierOperation(row) : null
   }
 
-  async function getByCommit(
-    sessionId: string,
-    commitIdempotencyKey: string,
+  async function getByIdempotency(
+    subjectType: SupplierOperationSubjectTypeV1,
+    subjectId: string,
+    idempotencyKey: string,
     scopeKey?: string,
   ): Promise<SupplierOperationInternalRecord | null> {
     const [row] = await db
@@ -132,9 +141,10 @@ export function createDrizzleSupplierOperationRepository(
       .from(supplierOperationsTable)
       .where(
         and(
-          eq(supplierOperationsTable.sessionId, sessionId),
+          eq(supplierOperationsTable.subjectType, subjectType),
+          eq(supplierOperationsTable.subjectId, subjectId),
           ...(scopeKey ? [eq(supplierOperationsTable.scopeKey, scopeKey)] : []),
-          eq(supplierOperationsTable.commitIdempotencyKey, commitIdempotencyKey),
+          eq(supplierOperationsTable.idempotencyKey, idempotencyKey),
         ),
       )
       .limit(1)
@@ -143,9 +153,10 @@ export function createDrizzleSupplierOperationRepository(
 
   return {
     async createOrReplay(record) {
-      const replay = await getByCommit(
-        record.sessionId,
-        record.commitIdempotencyKey,
+      const replay = await getByIdempotency(
+        record.subjectType,
+        record.subjectId,
+        record.idempotencyKey,
         record.scopeKey,
       )
       if (replay) {
@@ -153,7 +164,27 @@ export function createDrizzleSupplierOperationRepository(
           ? { status: "replay", operation: replay }
           : { status: "conflict" }
       }
-      if (await getBlockingBySession(record.sessionId, record.scopeKey)) {
+      const [blocking] = await db
+        .select()
+        .from(supplierOperationsTable)
+        .where(
+          and(
+            eq(supplierOperationsTable.subjectType, record.subjectType),
+            eq(supplierOperationsTable.subjectId, record.subjectId),
+            eq(supplierOperationsTable.scopeKey, record.scopeKey),
+            eq(supplierOperationsTable.operationKind, record.operationKind),
+            inArray(supplierOperationsTable.state, [
+              "queued",
+              "submitted",
+              "pending",
+              "succeeded",
+              "in_doubt",
+              "manual_review",
+            ]),
+          ),
+        )
+        .limit(1)
+      if (blocking) {
         return { status: "conflict" }
       }
       const [created] = await db
@@ -162,14 +193,15 @@ export function createDrizzleSupplierOperationRepository(
         .onConflictDoNothing()
         .returning()
       if (created) return { status: "created", operation: mapSupplierOperation(created) }
-      const existing = await getByCommit(
-        record.sessionId,
-        record.commitIdempotencyKey,
+      const existing = await getByIdempotency(
+        record.subjectType,
+        record.subjectId,
+        record.idempotencyKey,
         record.scopeKey,
       )
       if (
         !existing ||
-        existing.commitIdempotencyKey !== record.commitIdempotencyKey ||
+        existing.idempotencyKey !== record.idempotencyKey ||
         existing.requestFingerprint !== record.requestFingerprint
       ) {
         return { status: "conflict" }
@@ -186,8 +218,8 @@ export function createDrizzleSupplierOperationRepository(
       return row ? mapSupplierOperation(row) : null
     },
 
-    async getByCommit(sessionId, commitIdempotencyKey, scopeKey) {
-      return getByCommit(sessionId, commitIdempotencyKey, scopeKey)
+    async getByIdempotency(subjectType, subjectId, idempotencyKey, scopeKey) {
+      return getByIdempotency(subjectType, subjectId, idempotencyKey, scopeKey)
     },
 
     async getBySession(sessionId) {
@@ -212,6 +244,7 @@ export function createDrizzleSupplierOperationRepository(
       const conditions = [
         ...(input.state ? [eq(supplierOperationsTable.state, input.state)] : []),
         ...(input.sessionId ? [eq(supplierOperationsTable.sessionId, input.sessionId)] : []),
+        ...(input.amendmentId ? [eq(supplierOperationsTable.amendmentId, input.amendmentId)] : []),
       ]
       const rows = await db
         .select()
@@ -277,11 +310,17 @@ export function createDrizzleSupplierOperationRepository(
 }
 
 export function createSupplierOperationRecord(input: {
-  sessionId: string
+  subjectType: SupplierOperationSubjectTypeV1
+  subjectId: string
+  sessionId?: string
   scopeKey?: string
-  quoteId: string
+  quoteId?: string
   holdId?: string
-  commitIdempotencyKey: string
+  bookingId?: string
+  bookingItemId?: string
+  amendmentId?: string
+  idempotencyKey: string
+  operationKind: SupplierOperationKindV1
   commitmentPolicy?: SupplierCommitmentPolicyV1
   entityModule: string
   entityId: string
@@ -292,16 +331,22 @@ export function createSupplierOperationRecord(input: {
   requestFingerprint: string
   adapterIdempotencyKey: string
   requestPayload: Record<string, unknown>
+  upstreamRef?: string
   now: Date
 }): SupplierOperationInternalRecord {
   return {
     id: newId("supplier_operations"),
-    sessionId: input.sessionId,
+    subjectType: input.subjectType,
+    subjectId: input.subjectId,
+    ...(input.sessionId ? { sessionId: input.sessionId } : {}),
     scopeKey: input.scopeKey ?? "session",
-    quoteId: input.quoteId,
+    ...(input.quoteId ? { quoteId: input.quoteId } : {}),
     ...(input.holdId ? { holdId: input.holdId } : {}),
-    commitIdempotencyKey: input.commitIdempotencyKey,
-    operationKind: "reserve",
+    ...(input.bookingId ? { bookingId: input.bookingId } : {}),
+    ...(input.bookingItemId ? { bookingItemId: input.bookingItemId } : {}),
+    ...(input.amendmentId ? { amendmentId: input.amendmentId } : {}),
+    idempotencyKey: input.idempotencyKey,
+    operationKind: input.operationKind,
     state: "queued",
     commitmentPolicy: input.commitmentPolicy ?? "supplier_first",
     entityModule: input.entityModule,
@@ -313,6 +358,7 @@ export function createSupplierOperationRecord(input: {
     requestFingerprint: input.requestFingerprint,
     adapterIdempotencyKey: input.adapterIdempotencyKey,
     requestPayload: input.requestPayload,
+    ...(input.upstreamRef ? { upstreamRef: input.upstreamRef } : {}),
     version: 0,
     attemptCount: 0,
     safeEvidence: { intentPersistedBeforeDispatch: true },
@@ -326,10 +372,14 @@ export function serializeSupplierOperation(
 ): SupplierOperationRecordV1 {
   return {
     id: operation.id,
-    sessionId: operation.sessionId,
+    subjectType: operation.subjectType,
+    subjectId: operation.subjectId,
+    sessionId: operation.sessionId ?? null,
     scopeKey: operation.scopeKey,
-    quoteId: operation.quoteId,
+    quoteId: operation.quoteId ?? null,
     holdId: operation.holdId ?? null,
+    bookingItemId: operation.bookingItemId ?? null,
+    amendmentId: operation.amendmentId ?? null,
     operationKind: operation.operationKind,
     state: operation.state,
     commitmentPolicy: operation.commitmentPolicy,
@@ -362,11 +412,13 @@ export function serializeSupplierOperation(
 function toInsert(record: SupplierOperationInternalRecord) {
   return {
     id: record.id,
+    subjectType: record.subjectType,
+    subjectId: record.subjectId,
     sessionId: record.sessionId,
     scopeKey: record.scopeKey,
     quoteId: record.quoteId,
     holdId: record.holdId,
-    commitIdempotencyKey: record.commitIdempotencyKey,
+    idempotencyKey: record.idempotencyKey,
     operationKind: record.operationKind,
     state: record.state,
     commitmentPolicy: record.commitmentPolicy,
@@ -379,6 +431,9 @@ function toInsert(record: SupplierOperationInternalRecord) {
     requestFingerprint: record.requestFingerprint,
     adapterIdempotencyKey: record.adapterIdempotencyKey,
     requestPayload: record.requestPayload,
+    bookingId: record.bookingId,
+    bookingItemId: record.bookingItemId,
+    amendmentId: record.amendmentId,
     version: record.version,
     attemptCount: record.attemptCount,
     safeEvidence: record.safeEvidence,
@@ -390,12 +445,16 @@ function toInsert(record: SupplierOperationInternalRecord) {
 function mapSupplierOperation(row: SelectSupplierOperation): SupplierOperationInternalRecord {
   return {
     id: row.id,
-    sessionId: row.sessionId,
+    subjectType: row.subjectType,
+    subjectId: row.subjectId,
+    ...(row.sessionId ? { sessionId: row.sessionId } : {}),
     scopeKey: row.scopeKey,
-    quoteId: row.quoteId,
+    ...(row.quoteId ? { quoteId: row.quoteId } : {}),
     ...(row.holdId ? { holdId: row.holdId } : {}),
-    commitIdempotencyKey: row.commitIdempotencyKey,
-    operationKind: "reserve",
+    ...(row.bookingItemId ? { bookingItemId: row.bookingItemId } : {}),
+    ...(row.amendmentId ? { amendmentId: row.amendmentId } : {}),
+    idempotencyKey: row.idempotencyKey,
+    operationKind: row.operationKind,
     state: row.state,
     commitmentPolicy: row.commitmentPolicy,
     entityModule: row.entityModule,

--- a/packages/catalog/src/index.ts
+++ b/packages/catalog/src/index.ts
@@ -109,6 +109,7 @@ export {
 } from "./booking-engine/routes.js"
 export {
   createSupplierOperationWorkflow,
+  type DispatchSupplierAmendmentInput,
   type DispatchSupplierReservationInput,
   type SupplierOperationWorkflow,
   type SupplierOperationWorkflowOutcome,

--- a/packages/catalog/tests/unit/amendment-supplier-operations-migration.test.ts
+++ b/packages/catalog/tests/unit/amendment-supplier-operations-migration.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+
+const migration = readFileSync(
+  new URL("../../migrations/20260802170000_amendment_supplier_operations.sql", import.meta.url),
+  "utf8",
+)
+
+describe("Amendment Supplier Operation migration", () => {
+  it("backfills the generic subject before enforcing it", () => {
+    const backfill = migration.indexOf(
+      `SET "subject_type" = 'booking_session', "subject_id" = "session_id"`,
+    )
+    const required = migration.indexOf('ALTER COLUMN "subject_type" SET NOT NULL')
+
+    expect(backfill).toBeGreaterThanOrEqual(0)
+    expect(required).toBeGreaterThan(backfill)
+  })
+
+  it("keeps Session and Amendment operation shapes mutually exclusive", () => {
+    expect(migration).toContain("\"subject_type\" = 'booking_session'")
+    expect(migration).toContain('"session_id" IS NOT NULL')
+    expect(migration).toContain('"quote_id" IS NOT NULL')
+    expect(migration).toContain("\"subject_type\" = 'booking_amendment'")
+    expect(migration).toContain('"session_id" IS NULL')
+    expect(migration).toContain('"booking_item_id" IS NOT NULL')
+    expect(migration).toContain('"amendment_id" IS NOT NULL')
+  })
+
+  it("moves idempotency and active-operation guards to the generic subject", () => {
+    expect(migration).toContain('"uidx_supplier_operations_subject_command"')
+    expect(migration).toContain('("subject_type","subject_id","scope_key","idempotency_key")')
+    expect(migration).toContain('"uidx_supplier_operations_subject_active_guard"')
+    expect(migration).toContain("('reserve','modify','cancel')")
+  })
+})


### PR DESCRIPTION
Part of #4015.

## What changed

- generalize durable Supplier Operations from Session-only reserve intents to explicit Booking Session or Booking Amendment subjects
- link post-Booking operations to the Booking, Booking Item, and Amendment they affect
- add reserve, modify, and cancel operation kinds with generic subject-scoped idempotency and active-operation guards
- add a desired-state reservation modification contract to source adapters
- persist Amendment intent before dispatch and preserve the existing no-blind-retry behavior for ambiguous writes
- require reconciliation evidence tied to the operation idempotency key or desired-state fingerprint before an ambiguous modification can succeed
- migrate existing Session operations without weakening their Session and Quote invariants
- update ADR-0019 and the ubiquitous language

## Why

The priced Booking Amendment tracer needs supplier changes after a Booking already exists. Reusing Session-shaped rows would create nullable-field quirks and mix pre-Booking Commit semantics with post-Booking change semantics. This establishes the durable, typed supplier-operation foundation first so the Booking projection can later remain unchanged through refusal, ambiguity, or partial success.

This PR intentionally does not close #4015. The next slice will build the priced traveler roster-change Amendment aggregate and orchestration on this seam.

## Validation

- Catalog Contracts typecheck
- Catalog typecheck with an 8 GB remote Node heap
- focused Supplier Operation and migration tests: 17 passed
- migration boundary checker
- migration cutline checker
- explicit Biome formatting check for all changed TypeScript files