### PR TITLE
feat(bookings): add priced traveler roster amendments

### DIFF
--- a/.changeset/bright-rosters-amend.md
+++ b/.changeset/bright-rosters-amend.md
@@ -1,0 +1,14 @@
+---
+"@voyant-travel/bookings-contracts": minor
+"@voyant-travel/bookings": minor
+"@voyant-travel/catalog": minor
+"@voyant-travel/finance": minor
+"@voyant-travel/schema-kit": minor
+---
+
+Add the Booking v1 priced traveler-roster Amendment lifecycle: immutable and
+expiring exact-revision previews, server-owned price/tax and collection/refund
+consequences, acceptance, transactional owned-capacity projection, durable
+sourced Supplier Operation dispatch and reconciliation, explicit partial and
+uncertain outcomes, and consistent authenticated, storefront, and Tool
+transports.

--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -138,7 +138,7 @@ Generic first-party **Order** is retired from v1 runtime language by ADR-0005; u
 | **Booking Session**     | The revisioned, resumable pre-Booking aggregate for one bookable target and selection. Anonymous access uses a hash-at-rest action-scoped capability; authenticated customers may atomically adopt it. Expiry or abandonment makes it unspendable and releases Holds; Commit consumes it. Its identifier is never authorization. | *cart id, checkout id, booking draft when referring to the canonical aggregate* |
 | **Booking**             | The durable first-party commercial commitment and customer-safe operational record, created only at the policy-defined Commit point: Travelers, booking items, Allocations, Fulfillments, redemptions, origin/provenance, and state. Distinct from customer intent, payment state, supplier confirmation, and fulfillment. | *reservation, booking-record, Order* |
 | **Booking Revision**    | An immutable before or proposed-after snapshot of one stable Booking aggregate. The Booking's integer revision is the optimistic-concurrency token; applying an Amendment advances it without changing Booking identity or reference. | *booking copy, replacement booking* |
-| **Booking Amendment**   | The admitted preview → accept when required → apply aggregate for changing an existing Booking. It owns policy decisions, price delta, downstream-effect classification, idempotency, and immutable Booking Revisions. | *edit booking, cancel-and-rebook* |
+| **Booking Amendment**   | The admitted preview → accept when required → apply aggregate for changing an existing Booking. It owns an expiring exact-revision quote, policy decisions, server-calculated price/fee/tax delta, collection/refund consequences, downstream-effect classification, idempotency, supplier-operation links, and immutable Booking Revisions. | *edit booking, cancel-and-rebook, client-calculated adjustment* |
 | **Booking Origin**      | Bookings-owned provenance describing how a Booking was created: Proposal Version, Trip snapshot, Catalog price/availability response, provider/source order ref, or legacy transaction id. | *booking_transaction_details, order link* |
 | **Booking Item**        | A line item on a Booking (unit, service, extra, fee, tax, discount, accommodation, transport). | *line, row, order item*  |
 | **Allocation**          | A capacity hold against a Slot, Pickup, or Resource — `held` → `confirmed` → `fulfilled`.        | *reservation-line, hold-record* |
@@ -146,6 +146,13 @@ Generic first-party **Order** is retired from v1 runtime language by ADR-0005; u
 | **Hold**                | A temporary, time-limited claim on inventory before Booking confirmation; expires.               | *option, soft-hold*      |
 | **Commit**              | The Booking Platform operation that may create a Booking. Owned inventory Commit validates exact Booking Session revision, Quote, live Hold, and required payment guarantee, then creates Booking, converts Hold to Allocation, and consumes Session/Quote in one transaction. Sourced inventory defaults to supplier-first and creates no Booking until supplier security unless an explicit operator-backed policy accepts fulfillment risk. | *checkout submit, book, confirm when ambiguous* |
 | **Supplier Operation**  | A persisted sourced-inventory upstream intent and dispatch record for reserve, modify, or cancel. Its subject is either a pre-Booking Booking Session or a post-Booking Booking Amendment linked to the affected Booking Item. It tracks pending, secured, refused, failed, or in-doubt outcomes separately from Booking status. | *draft booking, supplier booking status as booking status* |
+
+A priced traveler add/drop always previews and accepts an exact Booking Revision
+before apply. Owned capacity, Allocation, Booking Items, traveler assignments,
+the Finance adjustment, and the Booking revision change atomically. Sourced
+changes dispatch durable Supplier Operations first; only all-secured operations
+may project locally, while pending, in-doubt, refused, and partial outcomes stay
+explicit and reconcilable.
 
 ## Fulfillment & operations
 

--- a/docs/adr/0020-booking-amendments-and-immutable-revisions.md
+++ b/docs/adr/0020-booking-amendments-and-immutable-revisions.md
@@ -1,7 +1,7 @@
 # ADR-0020: Booking Amendments and immutable Booking revisions
 
 - **Status:** Accepted (2026-08-02)
-- **Closes:** [#4014](https://github.com/voyant-travel/voyant/issues/4014)
+- **Closes:** [#4014](https://github.com/voyant-travel/voyant/issues/4014), [#4015](https://github.com/voyant-travel/voyant/issues/4015)
 - **Builds on:** [ADR-0019](./0019-booking-v1-commitment-point-policies.md)
 
 ## Context
@@ -15,8 +15,10 @@ semantics.
 ## Decision
 
 Every v1 change to an existing Booking goes through a Booking Amendment. The
-first complete tracer is a traveler contact/name correction with no price,
-supplier, Finance, Legal, document, or fulfillment effect.
+first tracers are a traveler contact/name correction with no external effects
+and a priced traveler add/drop that changes the exact item roster, allocation,
+price, Finance consequences, supplier desired state, documents, and
+fulfillment follow-up.
 
 The Booking owns a positive integer `revision`. Every mutation of the Booking
 aggregate or its operational child state advances that token, including the
@@ -33,10 +35,38 @@ Amendment applied in the same PostgreSQL transaction. Two Amendments may be
 previewed from the same base revision, but at most one can apply; every later
 attempt observes `stale_revision`.
 
-The v1 lifecycle is `proposed → accepted → applied` when acceptance is required
-and `proposed → applied` when policy admits direct application. `rejected` and
-`failed` are reserved terminal states for the supplier-affecting workflow in
-#4015; this tracer does not manufacture transitions it cannot yet execute.
+The v1 lifecycle is `proposed → accepted → applying → applied` for priced or
+supplier-affecting changes and `proposed → applied` when policy admits direct
+application. `failed`, `in_doubt`, and `manual_review` are explicit outcomes;
+they are never collapsed into Booking status.
+
+### Priced traveler roster changes
+
+Preview binds a server-calculated price, fee, tax, collection/refund amounts,
+Finance consequences, exact Booking revision, proposed traveler/item/allocation
+snapshot, and a short expiry to the Amendment. The client supplies requested
+intent, never monetary deltas. Add/drop always requires acceptance of the
+specific proposed Booking Revision before expiry.
+
+For owned inventory, apply locks the Booking and Allocation, conditionally
+changes capacity, updates traveler assignments and item quantities, records the
+Finance adjustment, advances the Booking revision, and marks the Amendment
+applied in one PostgreSQL transaction. A capacity or revision race rolls the
+whole projection back.
+
+For sourced inventory, the immutable Amendment operation plan is first
+dispatched through durable Supplier Operations outside the Booking transaction.
+Only an all-secured result may enter the local transaction. Pending and
+in-doubt operations remain reconcilable; refusal is explicit; mixed outcomes
+stop in manual review. Reconciliation reads the same durable operations rather
+than creating a second upstream intent. Supplier calls are never made while a
+Booking database transaction is open.
+
+Finance owns price/tax policy and persists one idempotent Amendment adjustment.
+Catalog owns supplier dispatch and reconciliation. Bookings owns the Amendment
+aggregate and atomically projects the accepted result. These dependencies enter
+Bookings through runtime ports, avoiding package cycles and transport-specific
+implementations.
 
 Preview, acceptance, and apply are idempotent admitted commands. Anonymous
 customers use a Booking-scoped action capability, authenticated customers use
@@ -59,11 +89,13 @@ timestamps, changed fields, and the immutable snapshots.
 - Direct beta traveler mutation routes remain migration surfaces only; new v1
   callers use Amendment preview/accept/apply. Until those routes are retired,
   they advance the same Booking revision so outstanding previews become stale.
-- Name/contact corrections in this tracer always have a zero price delta and
+- Name/contact corrections always have a zero price delta and
   explicitly report every downstream effect as `not_required`.
-- Any change that may affect supplier inventory, price, fees, documents, or
-  fulfillment must use the priced supplier-affecting Amendment workflow in
-  #4015 rather than widening this tracer's policy.
+- Priced roster changes expose follow-up actions for collection/refund and
+  document reissue after the Booking projection commits; payment state and
+  document state remain owned by their respective modules.
+- Unsupported allocation shapes or incomplete supplier provenance fail closed
+  at preview rather than guessing how to mutate inventory.
 - Revision snapshots are immutable. The current Booking and traveler tables
   remain the operational projection.
 

--- a/packages/bookings-contracts/src/amendments.ts
+++ b/packages/bookings-contracts/src/amendments.ts
@@ -5,9 +5,12 @@ import { bookingTravelerCategorySchema } from "./validation-shared.js"
 export const bookingAmendmentStatusSchema = z.enum([
   "proposed",
   "accepted",
+  "applying",
   "applied",
   "rejected",
   "failed",
+  "in_doubt",
+  "manual_review",
 ])
 
 export const bookingRevisionRoleSchema = z.enum(["before", "proposed_after"])
@@ -34,6 +37,46 @@ export const previewTravelerCorrectionSchema = z.object({
   ),
 })
 
+const bookingItemIdsSchema = z
+  .array(z.string().min(1))
+  .min(1)
+  .refine((ids) => new Set(ids).size === ids.length, {
+    message: "Booking item ids must be unique",
+  })
+  .describe("One or more distinct Booking Item ids; duplicate ids are rejected.")
+
+export const travelerRosterAdditionSchema = z.object({
+  type: z.literal("traveler_add"),
+  bookingItemIds: bookingItemIdsSchema,
+  traveler: z.object({
+    personId: z.string().min(1).nullable().optional(),
+    participantType: z.enum(["traveler", "occupant", "other"]).default("traveler"),
+    travelerCategory: bookingTravelerCategorySchema.nullable().optional(),
+    firstName: z.string().trim().min(1).max(255),
+    lastName: z.string().trim().min(1).max(255),
+    email: z.string().email().nullable().optional(),
+    phone: z.string().max(50).nullable().optional(),
+    preferredLanguage: z.string().max(35).nullable().optional(),
+  }),
+})
+
+export const travelerRosterRemovalSchema = z.object({
+  type: z.literal("traveler_drop"),
+  bookingItemIds: bookingItemIdsSchema,
+  travelerId: z.string().min(1),
+})
+
+export const travelerRosterChangeSchema = z.discriminatedUnion("type", [
+  travelerRosterAdditionSchema,
+  travelerRosterRemovalSchema,
+])
+
+export const previewTravelerRosterChangeSchema = z.object({
+  expectedBookingRevision: z.number().int().positive(),
+  reason: z.string().trim().min(1).max(2_000),
+  change: travelerRosterChangeSchema,
+})
+
 export const acceptBookingAmendmentSchema = z.object({
   proposedRevisionId: z.string().min(1),
 })
@@ -51,11 +94,48 @@ export const bookingAmendmentPolicyDecisionSchema = z.object({
 })
 
 export const bookingAmendmentEffectsSchema = z.object({
-  finance: z.literal("not_required"),
-  legal: z.literal("not_required"),
-  documents: z.literal("not_required"),
-  fulfillment: z.literal("not_required"),
-  supplier: z.literal("not_required"),
+  finance: z.enum(["not_required", "collection_required", "refund_required", "recorded"]),
+  legal: z.enum(["not_required", "review_required"]),
+  documents: z.enum(["not_required", "reissue_required"]),
+  fulfillment: z.enum(["not_required", "reissue_required"]),
+  supplier: z.enum([
+    "not_required",
+    "modify_required",
+    "pending",
+    "secured",
+    "refused",
+    "in_doubt",
+    "manual_review",
+  ]),
+  allocation: z.enum(["not_required", "increase_required", "release_required", "applied"]),
+})
+
+export const bookingAmendmentPriceSchema = z.object({
+  currency: z.string().min(3).max(8),
+  subtotalDeltaCents: z.number().int(),
+  feeDeltaCents: z.number().int(),
+  taxDeltaCents: z.number().int(),
+  amountCents: z.number().int(),
+  collectionAmountCents: z.number().int().nonnegative(),
+  refundAmountCents: z.number().int().nonnegative(),
+  taxLines: z.array(
+    z.object({
+      bookingItemId: z.string(),
+      code: z.string().nullable(),
+      name: z.string(),
+      amountCents: z.number().int(),
+      rateBasisPoints: z.number().int().nullable(),
+      includedInPrice: z.boolean(),
+    }),
+  ),
+})
+
+export const bookingAmendmentFinancialConsequencesSchema = z.object({
+  collection: z.enum(["not_required", "required"]),
+  refund: z.enum(["not_required", "required"]),
+  invoice: z.enum(["not_required", "reissue_required"]),
+  creditNote: z.enum(["not_required", "issue_required"]),
+  paymentSchedule: z.enum(["not_required", "recalculate_required"]),
 })
 
 export const bookingRevisionTravelerSchema = z.object({
@@ -75,7 +155,26 @@ export const bookingRevisionSnapshotSchema = z.object({
   bookingId: z.string(),
   bookingNumber: z.string(),
   revision: z.number().int().positive(),
+  sellAmountCents: z.number().int().nullable().optional(),
+  pax: z.number().int().nonnegative().nullable().optional(),
   travelers: z.array(bookingRevisionTravelerSchema),
+  items: z
+    .array(
+      z.object({
+        id: z.string(),
+        quantity: z.number().int().nonnegative(),
+        totalSellAmountCents: z.number().int().nullable(),
+        travelerIds: z.array(z.string()),
+        allocations: z.array(
+          z.object({
+            id: z.string(),
+            quantity: z.number().int().nonnegative(),
+            status: z.string(),
+          }),
+        ),
+      }),
+    )
+    .optional(),
 })
 
 export const bookingRevisionSchema = z.object({
@@ -95,15 +194,31 @@ export const bookingAmendmentSchema = z.object({
   id: z.string(),
   bookingId: z.string(),
   travelerId: z.string(),
-  kind: z.literal("traveler_correction"),
+  kind: z.enum(["traveler_correction", "traveler_add", "traveler_drop"]),
   status: bookingAmendmentStatusSchema,
   baseBookingRevision: z.number().int().positive(),
   resultBookingRevision: z.number().int().positive(),
   acceptanceRequired: z.boolean(),
   policyDecisions: z.array(bookingAmendmentPolicyDecisionSchema),
-  priceDelta: z.object({ amountCents: z.literal(0), currency: z.string() }),
+  priceDelta: bookingAmendmentPriceSchema,
+  financialConsequences: bookingAmendmentFinancialConsequencesSchema,
   effects: bookingAmendmentEffectsSchema,
-  nextActions: z.array(z.enum(["accept", "apply"])),
+  nextActions: z.array(
+    z.enum([
+      "accept",
+      "apply",
+      "wait_supplier",
+      "reconcile_supplier",
+      "manual_review",
+      "collect_payment",
+      "issue_refund",
+      "reissue_documents",
+    ]),
+  ),
+  quotedAt: z.string(),
+  quoteExpiresAt: z.string().nullable(),
+  supplierOperationIds: z.array(z.string()),
+  failureCode: z.string().nullable(),
   requestedBy: z.string().nullable(),
   requestedActor: z.enum(["customer", "staff", "partner", "system"]),
   reason: z.string(),
@@ -128,6 +243,28 @@ export const bookingAmendmentPreviewResultSchema = z.discriminatedUnion("status"
   }),
   z.object({ status: z.literal("not_found") }),
   z.object({ status: z.literal("idempotency_conflict") }),
+  z.object({ status: z.literal("unsupported_configuration"), reason: z.string() }),
+  z.object({ status: z.literal("availability_changed"), bookingItemId: z.string() }),
+  z.object({
+    status: z.literal("stale_revision"),
+    currentBookingRevision: z.number().int().positive(),
+  }),
+])
+
+export const bookingAmendmentApplyResultSchema = z.discriminatedUnion("status", [
+  z.object({ status: z.literal("ok"), amendment: bookingAmendmentSchema }),
+  z.object({ status: z.literal("supplier_pending"), amendment: bookingAmendmentSchema }),
+  z.object({ status: z.literal("supplier_in_doubt"), amendment: bookingAmendmentSchema }),
+  z.object({ status: z.literal("supplier_refused"), amendment: bookingAmendmentSchema }),
+  z.object({ status: z.literal("manual_review"), amendment: bookingAmendmentSchema }),
+  z.object({ status: z.literal("not_found") }),
+  z.object({ status: z.literal("revision_mismatch") }),
+  z.object({ status: z.literal("acceptance_required") }),
+  z.object({ status: z.literal("invalid_state") }),
+  z.object({ status: z.literal("idempotency_conflict") }),
+  z.object({ status: z.literal("quote_expired") }),
+  z.object({ status: z.literal("unsupported_capability") }),
+  z.object({ status: z.literal("availability_changed"), bookingItemId: z.string() }),
   z.object({
     status: z.literal("stale_revision"),
     currentBookingRevision: z.number().int().positive(),
@@ -135,8 +272,14 @@ export const bookingAmendmentPreviewResultSchema = z.discriminatedUnion("status"
 ])
 
 export type BookingAmendment = z.infer<typeof bookingAmendmentSchema>
+export type BookingAmendmentFinancialConsequences = z.infer<
+  typeof bookingAmendmentFinancialConsequencesSchema
+>
+export type BookingAmendmentPrice = z.infer<typeof bookingAmendmentPriceSchema>
 export type BookingRevisionSnapshot = z.infer<typeof bookingRevisionSnapshotSchema>
 export type PreviewTravelerCorrectionInput = z.infer<typeof previewTravelerCorrectionSchema>
+export type PreviewTravelerRosterChangeInput = z.infer<typeof previewTravelerRosterChangeSchema>
+export type TravelerRosterChange = z.infer<typeof travelerRosterChangeSchema>
 export type TravelerCorrectionPatch = z.infer<typeof travelerCorrectionPatchSchema>
 export type AcceptBookingAmendmentInput = z.infer<typeof acceptBookingAmendmentSchema>
 export type ApplyBookingAmendmentInput = z.infer<typeof applyBookingAmendmentSchema>

--- a/packages/bookings-contracts/src/contracts.test.ts
+++ b/packages/bookings-contracts/src/contracts.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import {
   bookingStatusSchema,
   bookingTravelerBedPreferenceSchema,
+  previewTravelerRosterChangeSchema,
   travelerAllocationMapSchema,
 } from "./index.js"
 
@@ -17,5 +18,31 @@ describe("@voyant-travel/bookings-contracts", () => {
     expect(bookingTravelerBedPreferenceSchema.safeParse("waterbed").success).toBe(false)
     expect(travelerAllocationMapSchema.safeParse({ trav_1: "room_a" }).success).toBe(true)
     expect(travelerAllocationMapSchema.safeParse({ trav_1: 42 }).success).toBe(false)
+  })
+
+  it("validates explicit add and drop roster changes", () => {
+    expect(
+      previewTravelerRosterChangeSchema.parse({
+        expectedBookingRevision: 4,
+        reason: "Add a traveler",
+        change: {
+          type: "traveler_add",
+          bookingItemIds: ["bitm_1", "bitm_2"],
+          traveler: { firstName: "Ada", lastName: "Lovelace" },
+        },
+      }),
+    ).toMatchObject({ change: { type: "traveler_add", traveler: { participantType: "traveler" } } })
+
+    expect(
+      previewTravelerRosterChangeSchema.safeParse({
+        expectedBookingRevision: 4,
+        reason: "Drop a traveler",
+        change: {
+          type: "traveler_drop",
+          bookingItemIds: ["bitm_1", "bitm_1"],
+          travelerId: "btr_1",
+        },
+      }).success,
+    ).toBe(false)
   })
 })

--- a/packages/bookings/migrations/20260802180000_priced_roster_amendments.sql
+++ b/packages/bookings/migrations/20260802180000_priced_roster_amendments.sql
@@ -1,0 +1,77 @@
+ALTER TABLE "booking_amendments"
+RENAME COLUMN "requested_patch" TO "requested_change";
+--> statement-breakpoint
+UPDATE "booking_amendments"
+SET "requested_change" = jsonb_build_object(
+  'type', 'traveler_correction',
+  'travelerId', "traveler_id",
+  'patch', "requested_change"
+);
+--> statement-breakpoint
+ALTER TABLE "booking_amendments"
+ADD COLUMN "subtotal_delta_cents" integer DEFAULT 0 NOT NULL,
+ADD COLUMN "fee_delta_cents" integer DEFAULT 0 NOT NULL,
+ADD COLUMN "tax_delta_cents" integer DEFAULT 0 NOT NULL,
+ADD COLUMN "collection_amount_cents" integer DEFAULT 0 NOT NULL,
+ADD COLUMN "refund_amount_cents" integer DEFAULT 0 NOT NULL,
+ADD COLUMN "tax_lines" jsonb DEFAULT '[]'::jsonb NOT NULL,
+ADD COLUMN "financial_consequences" jsonb DEFAULT '{"collection":"not_required","refund":"not_required","invoice":"not_required","creditNote":"not_required","paymentSchedule":"not_required"}'::jsonb NOT NULL,
+ADD COLUMN "quoted_at" timestamp with time zone DEFAULT now() NOT NULL,
+ADD COLUMN "quote_expires_at" timestamp with time zone,
+ADD COLUMN "supplier_operation_ids" jsonb DEFAULT '[]'::jsonb NOT NULL,
+ADD COLUMN "operation_plan" jsonb DEFAULT '[]'::jsonb NOT NULL,
+ADD COLUMN "failure_code" text,
+ADD COLUMN "apply_started_at" timestamp with time zone;
+--> statement-breakpoint
+UPDATE "booking_amendments"
+SET "effects" = "effects" || '{"allocation":"not_required"}'::jsonb;
+--> statement-breakpoint
+ALTER TABLE "booking_amendments"
+DROP CONSTRAINT "ck_booking_amendments_kind",
+DROP CONSTRAINT "ck_booking_amendments_status",
+DROP CONSTRAINT "ck_booking_amendments_lifecycle",
+DROP CONSTRAINT "ck_booking_amendments_zero_delta";
+--> statement-breakpoint
+ALTER TABLE "booking_amendments"
+ADD CONSTRAINT "ck_booking_amendments_kind"
+  CHECK ("kind" IN ('traveler_correction', 'traveler_add', 'traveler_drop')),
+ADD CONSTRAINT "ck_booking_amendments_status"
+  CHECK ("status" IN ('proposed', 'accepted', 'applying', 'applied', 'rejected', 'failed', 'in_doubt', 'manual_review')),
+ADD CONSTRAINT "ck_booking_amendments_lifecycle" CHECK (
+  (
+    "status" = 'proposed'
+    AND "accepted_at" IS NULL
+    AND "accepted_by" IS NULL
+    AND "accepted_actor" IS NULL
+    AND "accept_idempotency_key" IS NULL
+    AND "applied_at" IS NULL
+    AND "applied_actor" IS NULL
+    AND "apply_idempotency_key" IS NULL
+  ) OR (
+    "status" = 'accepted'
+    AND "acceptance_required" = true
+    AND "accepted_at" IS NOT NULL
+    AND "accepted_actor" IS NOT NULL
+    AND "accept_idempotency_key" IS NOT NULL
+    AND "applied_at" IS NULL
+    AND "applied_by" IS NULL
+    AND "applied_actor" IS NULL
+    AND "apply_idempotency_key" IS NULL
+  ) OR (
+    "status" = 'applied'
+    AND "applied_at" IS NOT NULL
+    AND "applied_actor" IS NOT NULL
+    AND "apply_idempotency_key" IS NOT NULL
+    AND (
+      ("acceptance_required" = false AND "accepted_at" IS NULL AND "accept_idempotency_key" IS NULL)
+      OR
+      ("acceptance_required" = true AND "accepted_at" IS NOT NULL AND "accept_idempotency_key" IS NOT NULL)
+    )
+  ) OR "status" IN ('applying', 'in_doubt', 'manual_review', 'rejected', 'failed')
+),
+ADD CONSTRAINT "ck_booking_amendments_money" CHECK (
+  "price_delta_cents" = "subtotal_delta_cents" + "fee_delta_cents" + "tax_delta_cents"
+  AND "collection_amount_cents" >= 0
+  AND "refund_amount_cents" >= 0
+  AND NOT ("collection_amount_cents" > 0 AND "refund_amount_cents" > 0)
+);

--- a/packages/bookings/migrations/meta/_journal.json
+++ b/packages/bookings/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1785686400000,
       "tag": "20260802160000_booking_traveler_amendments",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1785693600000,
+      "tag": "20260802180000_priced_roster_amendments",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/bookings/openapi/admin/bookings.json
+++ b/packages/bookings/openapi/admin/bookings.json
@@ -122,6 +122,591 @@
             "required": ["kind", "clauses"]
           }
         ]
+      },
+      "BookingAmendment": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "bookingId": {
+            "type": "string"
+          },
+          "travelerId": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string",
+            "enum": ["traveler_correction", "traveler_add", "traveler_drop"]
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "proposed",
+              "accepted",
+              "applying",
+              "applied",
+              "rejected",
+              "failed",
+              "in_doubt",
+              "manual_review"
+            ]
+          },
+          "baseBookingRevision": {
+            "type": "integer",
+            "exclusiveMinimum": 0
+          },
+          "resultBookingRevision": {
+            "type": "integer",
+            "exclusiveMinimum": 0
+          },
+          "acceptanceRequired": {
+            "type": "boolean"
+          },
+          "policyDecisions": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "code": {
+                  "type": "string"
+                },
+                "version": {
+                  "type": "string"
+                },
+                "decision": {
+                  "type": "string",
+                  "enum": ["allowed", "acceptance_required"]
+                },
+                "reason": {
+                  "type": "string"
+                }
+              },
+              "required": ["code", "version", "decision", "reason"]
+            }
+          },
+          "priceDelta": {
+            "type": "object",
+            "properties": {
+              "currency": {
+                "type": "string",
+                "minLength": 3,
+                "maxLength": 8
+              },
+              "subtotalDeltaCents": {
+                "type": "integer"
+              },
+              "feeDeltaCents": {
+                "type": "integer"
+              },
+              "taxDeltaCents": {
+                "type": "integer"
+              },
+              "amountCents": {
+                "type": "integer"
+              },
+              "collectionAmountCents": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "refundAmountCents": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "taxLines": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": ["string", "null"]
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "amountCents": {
+                      "type": "integer"
+                    },
+                    "rateBasisPoints": {
+                      "type": ["integer", "null"]
+                    },
+                    "includedInPrice": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "bookingItemId",
+                    "code",
+                    "name",
+                    "amountCents",
+                    "rateBasisPoints",
+                    "includedInPrice"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "currency",
+              "subtotalDeltaCents",
+              "feeDeltaCents",
+              "taxDeltaCents",
+              "amountCents",
+              "collectionAmountCents",
+              "refundAmountCents",
+              "taxLines"
+            ]
+          },
+          "financialConsequences": {
+            "type": "object",
+            "properties": {
+              "collection": {
+                "type": "string",
+                "enum": ["not_required", "required"]
+              },
+              "refund": {
+                "type": "string",
+                "enum": ["not_required", "required"]
+              },
+              "invoice": {
+                "type": "string",
+                "enum": ["not_required", "reissue_required"]
+              },
+              "creditNote": {
+                "type": "string",
+                "enum": ["not_required", "issue_required"]
+              },
+              "paymentSchedule": {
+                "type": "string",
+                "enum": ["not_required", "recalculate_required"]
+              }
+            },
+            "required": ["collection", "refund", "invoice", "creditNote", "paymentSchedule"]
+          },
+          "effects": {
+            "type": "object",
+            "properties": {
+              "finance": {
+                "type": "string",
+                "enum": ["not_required", "collection_required", "refund_required", "recorded"]
+              },
+              "legal": {
+                "type": "string",
+                "enum": ["not_required", "review_required"]
+              },
+              "documents": {
+                "type": "string",
+                "enum": ["not_required", "reissue_required"]
+              },
+              "fulfillment": {
+                "type": "string",
+                "enum": ["not_required", "reissue_required"]
+              },
+              "supplier": {
+                "type": "string",
+                "enum": [
+                  "not_required",
+                  "modify_required",
+                  "pending",
+                  "secured",
+                  "refused",
+                  "in_doubt",
+                  "manual_review"
+                ]
+              },
+              "allocation": {
+                "type": "string",
+                "enum": ["not_required", "increase_required", "release_required", "applied"]
+              }
+            },
+            "required": ["finance", "legal", "documents", "fulfillment", "supplier", "allocation"]
+          },
+          "nextActions": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "accept",
+                "apply",
+                "wait_supplier",
+                "reconcile_supplier",
+                "manual_review",
+                "collect_payment",
+                "issue_refund",
+                "reissue_documents"
+              ]
+            }
+          },
+          "quotedAt": {
+            "type": "string"
+          },
+          "quoteExpiresAt": {
+            "type": ["string", "null"]
+          },
+          "supplierOperationIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "failureCode": {
+            "type": ["string", "null"]
+          },
+          "requestedBy": {
+            "type": ["string", "null"]
+          },
+          "requestedActor": {
+            "type": "string",
+            "enum": ["customer", "staff", "partner", "system"]
+          },
+          "reason": {
+            "type": "string"
+          },
+          "acceptedAt": {
+            "type": ["string", "null"]
+          },
+          "acceptedBy": {
+            "type": ["string", "null"]
+          },
+          "acceptedActor": {
+            "type": ["string", "null"],
+            "enum": ["customer", "staff", "partner", "system", null]
+          },
+          "appliedAt": {
+            "type": ["string", "null"]
+          },
+          "appliedBy": {
+            "type": ["string", "null"]
+          },
+          "appliedActor": {
+            "type": ["string", "null"],
+            "enum": ["customer", "staff", "partner", "system", null]
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          },
+          "revisions": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "amendmentId": {
+                  "type": "string"
+                },
+                "bookingId": {
+                  "type": "string"
+                },
+                "bookingRevision": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0
+                },
+                "role": {
+                  "type": "string",
+                  "enum": ["before", "proposed_after"]
+                },
+                "snapshot": {
+                  "type": "object",
+                  "properties": {
+                    "bookingId": {
+                      "type": "string"
+                    },
+                    "bookingNumber": {
+                      "type": "string"
+                    },
+                    "revision": {
+                      "type": "integer",
+                      "exclusiveMinimum": 0
+                    },
+                    "sellAmountCents": {
+                      "type": ["integer", "null"]
+                    },
+                    "pax": {
+                      "type": ["integer", "null"],
+                      "minimum": 0
+                    },
+                    "travelers": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "personId": {
+                            "type": ["string", "null"]
+                          },
+                          "participantType": {
+                            "type": "string",
+                            "enum": ["traveler", "occupant", "other"]
+                          },
+                          "travelerCategory": {
+                            "type": ["string", "null"],
+                            "enum": ["adult", "child", "infant", "senior", "other", null]
+                          },
+                          "firstName": {
+                            "type": "string"
+                          },
+                          "lastName": {
+                            "type": "string"
+                          },
+                          "email": {
+                            "type": ["string", "null"]
+                          },
+                          "phone": {
+                            "type": ["string", "null"]
+                          },
+                          "preferredLanguage": {
+                            "type": ["string", "null"]
+                          },
+                          "isPrimary": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "personId",
+                          "participantType",
+                          "travelerCategory",
+                          "firstName",
+                          "lastName",
+                          "email",
+                          "phone",
+                          "preferredLanguage",
+                          "isPrimary"
+                        ]
+                      }
+                    },
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "quantity": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "totalSellAmountCents": {
+                            "type": ["integer", "null"]
+                          },
+                          "travelerIds": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "allocations": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
+                                },
+                                "quantity": {
+                                  "type": "integer",
+                                  "minimum": 0
+                                },
+                                "status": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["id", "quantity", "status"]
+                            }
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "quantity",
+                          "totalSellAmountCents",
+                          "travelerIds",
+                          "allocations"
+                        ]
+                      }
+                    }
+                  },
+                  "required": ["bookingId", "bookingNumber", "revision", "travelers"]
+                },
+                "changedFields": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "authorizedBy": {
+                  "type": ["string", "null"]
+                },
+                "reason": {
+                  "type": "string"
+                },
+                "createdAt": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "amendmentId",
+                "bookingId",
+                "bookingRevision",
+                "role",
+                "snapshot",
+                "changedFields",
+                "authorizedBy",
+                "reason",
+                "createdAt"
+              ]
+            }
+          }
+        },
+        "required": [
+          "id",
+          "bookingId",
+          "travelerId",
+          "kind",
+          "status",
+          "baseBookingRevision",
+          "resultBookingRevision",
+          "acceptanceRequired",
+          "policyDecisions",
+          "priceDelta",
+          "financialConsequences",
+          "effects",
+          "nextActions",
+          "quotedAt",
+          "quoteExpiresAt",
+          "supplierOperationIds",
+          "failureCode",
+          "requestedBy",
+          "requestedActor",
+          "reason",
+          "acceptedAt",
+          "acceptedBy",
+          "acceptedActor",
+          "appliedAt",
+          "appliedBy",
+          "appliedActor",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "BookingAmendmentApplyPendingResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string",
+                "enum": ["supplier_pending", "supplier_in_doubt", "manual_review"]
+              },
+              "amendment": {
+                "$ref": "#/components/schemas/BookingAmendment"
+              }
+            },
+            "required": ["status", "amendment"]
+          }
+        },
+        "required": ["data"]
+      },
+      "BookingAmendmentApplyConflictResponse": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "error": {
+                "type": "string"
+              },
+              "currentBookingRevision": {
+                "type": "integer",
+                "exclusiveMinimum": 0
+              },
+              "bookingItemId": {
+                "type": "string"
+              },
+              "reason": {
+                "type": "string"
+              }
+            },
+            "required": ["error"]
+          },
+          {
+            "$ref": "#/components/schemas/BookingAmendmentApplyRefusedResponse"
+          }
+        ]
+      },
+      "BookingAmendmentApplyRefusedResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string",
+                "enum": ["supplier_refused"]
+              },
+              "amendment": {
+                "$ref": "#/components/schemas/BookingAmendment"
+              }
+            },
+            "required": ["status", "amendment"]
+          }
+        },
+        "required": ["data"]
+      },
+      "BookingAmendmentPreviewNoOpResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string",
+                "enum": ["no_op"]
+              },
+              "bookingId": {
+                "type": "string"
+              },
+              "travelerId": {
+                "type": "string"
+              },
+              "bookingRevision": {
+                "type": "integer",
+                "exclusiveMinimum": 0
+              }
+            },
+            "required": ["status", "bookingId", "travelerId", "bookingRevision"]
+          }
+        },
+        "required": ["data"]
+      },
+      "BookingAmendmentOkResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string",
+                "enum": ["ok"]
+              },
+              "amendment": {
+                "$ref": "#/components/schemas/BookingAmendment"
+              }
+            },
+            "required": ["status", "amendment"]
+          }
+        },
+        "required": ["data"]
       }
     },
     "parameters": {}
@@ -11260,7 +11845,8 @@
                         "maxLength": 35
                       }
                     },
-                    "additionalProperties": false
+                    "additionalProperties": false,
+                    "description": "At least one traveler correction field must be provided."
                   }
                 },
                 "required": ["travelerId", "expectedBookingRevision", "reason", "patch"]
@@ -11274,378 +11860,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "oneOf": [
-                        {
-                          "type": "object",
-                          "properties": {
-                            "status": {
-                              "type": "string",
-                              "enum": ["ok"]
-                            },
-                            "amendment": {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string"
-                                },
-                                "bookingId": {
-                                  "type": "string"
-                                },
-                                "travelerId": {
-                                  "type": "string"
-                                },
-                                "kind": {
-                                  "type": "string",
-                                  "enum": ["traveler_correction"]
-                                },
-                                "status": {
-                                  "type": "string",
-                                  "enum": ["proposed", "accepted", "applied", "rejected", "failed"]
-                                },
-                                "baseBookingRevision": {
-                                  "type": "integer",
-                                  "exclusiveMinimum": 0
-                                },
-                                "resultBookingRevision": {
-                                  "type": "integer",
-                                  "exclusiveMinimum": 0
-                                },
-                                "acceptanceRequired": {
-                                  "type": "boolean"
-                                },
-                                "policyDecisions": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "code": {
-                                        "type": "string"
-                                      },
-                                      "version": {
-                                        "type": "string"
-                                      },
-                                      "decision": {
-                                        "type": "string",
-                                        "enum": ["allowed", "acceptance_required"]
-                                      },
-                                      "reason": {
-                                        "type": "string"
-                                      }
-                                    },
-                                    "required": ["code", "version", "decision", "reason"]
-                                  }
-                                },
-                                "priceDelta": {
-                                  "type": "object",
-                                  "properties": {
-                                    "amountCents": {
-                                      "type": "number",
-                                      "enum": [0]
-                                    },
-                                    "currency": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "required": ["amountCents", "currency"]
-                                },
-                                "effects": {
-                                  "type": "object",
-                                  "properties": {
-                                    "finance": {
-                                      "type": "string",
-                                      "enum": ["not_required"]
-                                    },
-                                    "legal": {
-                                      "type": "string",
-                                      "enum": ["not_required"]
-                                    },
-                                    "documents": {
-                                      "type": "string",
-                                      "enum": ["not_required"]
-                                    },
-                                    "fulfillment": {
-                                      "type": "string",
-                                      "enum": ["not_required"]
-                                    },
-                                    "supplier": {
-                                      "type": "string",
-                                      "enum": ["not_required"]
-                                    }
-                                  },
-                                  "required": [
-                                    "finance",
-                                    "legal",
-                                    "documents",
-                                    "fulfillment",
-                                    "supplier"
-                                  ]
-                                },
-                                "nextActions": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string",
-                                    "enum": ["accept", "apply"]
-                                  }
-                                },
-                                "requestedBy": {
-                                  "type": ["string", "null"]
-                                },
-                                "requestedActor": {
-                                  "type": "string",
-                                  "enum": ["customer", "staff", "partner", "system"]
-                                },
-                                "reason": {
-                                  "type": "string"
-                                },
-                                "acceptedAt": {
-                                  "type": ["string", "null"]
-                                },
-                                "acceptedBy": {
-                                  "type": ["string", "null"]
-                                },
-                                "acceptedActor": {
-                                  "type": ["string", "null"],
-                                  "enum": ["customer", "staff", "partner", "system", null]
-                                },
-                                "appliedAt": {
-                                  "type": ["string", "null"]
-                                },
-                                "appliedBy": {
-                                  "type": ["string", "null"]
-                                },
-                                "appliedActor": {
-                                  "type": ["string", "null"],
-                                  "enum": ["customer", "staff", "partner", "system", null]
-                                },
-                                "createdAt": {
-                                  "type": "string"
-                                },
-                                "updatedAt": {
-                                  "type": "string"
-                                },
-                                "revisions": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "id": {
-                                        "type": "string"
-                                      },
-                                      "amendmentId": {
-                                        "type": "string"
-                                      },
-                                      "bookingId": {
-                                        "type": "string"
-                                      },
-                                      "bookingRevision": {
-                                        "type": "integer",
-                                        "exclusiveMinimum": 0
-                                      },
-                                      "role": {
-                                        "type": "string",
-                                        "enum": ["before", "proposed_after"]
-                                      },
-                                      "snapshot": {
-                                        "type": "object",
-                                        "properties": {
-                                          "bookingId": {
-                                            "type": "string"
-                                          },
-                                          "bookingNumber": {
-                                            "type": "string"
-                                          },
-                                          "revision": {
-                                            "type": "integer",
-                                            "exclusiveMinimum": 0
-                                          },
-                                          "travelers": {
-                                            "type": "array",
-                                            "items": {
-                                              "type": "object",
-                                              "properties": {
-                                                "id": {
-                                                  "type": "string"
-                                                },
-                                                "personId": {
-                                                  "type": ["string", "null"]
-                                                },
-                                                "participantType": {
-                                                  "type": "string",
-                                                  "enum": ["traveler", "occupant", "other"]
-                                                },
-                                                "travelerCategory": {
-                                                  "type": ["string", "null"],
-                                                  "enum": [
-                                                    "adult",
-                                                    "child",
-                                                    "infant",
-                                                    "senior",
-                                                    "other",
-                                                    null
-                                                  ]
-                                                },
-                                                "firstName": {
-                                                  "type": "string"
-                                                },
-                                                "lastName": {
-                                                  "type": "string"
-                                                },
-                                                "email": {
-                                                  "type": ["string", "null"]
-                                                },
-                                                "phone": {
-                                                  "type": ["string", "null"]
-                                                },
-                                                "preferredLanguage": {
-                                                  "type": ["string", "null"]
-                                                },
-                                                "isPrimary": {
-                                                  "type": "boolean"
-                                                }
-                                              },
-                                              "required": [
-                                                "id",
-                                                "personId",
-                                                "participantType",
-                                                "travelerCategory",
-                                                "firstName",
-                                                "lastName",
-                                                "email",
-                                                "phone",
-                                                "preferredLanguage",
-                                                "isPrimary"
-                                              ]
-                                            }
-                                          }
-                                        },
-                                        "required": [
-                                          "bookingId",
-                                          "bookingNumber",
-                                          "revision",
-                                          "travelers"
-                                        ]
-                                      },
-                                      "changedFields": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "string"
-                                        }
-                                      },
-                                      "authorizedBy": {
-                                        "type": ["string", "null"]
-                                      },
-                                      "reason": {
-                                        "type": "string"
-                                      },
-                                      "createdAt": {
-                                        "type": "string"
-                                      }
-                                    },
-                                    "required": [
-                                      "id",
-                                      "amendmentId",
-                                      "bookingId",
-                                      "bookingRevision",
-                                      "role",
-                                      "snapshot",
-                                      "changedFields",
-                                      "authorizedBy",
-                                      "reason",
-                                      "createdAt"
-                                    ]
-                                  }
-                                }
-                              },
-                              "required": [
-                                "id",
-                                "bookingId",
-                                "travelerId",
-                                "kind",
-                                "status",
-                                "baseBookingRevision",
-                                "resultBookingRevision",
-                                "acceptanceRequired",
-                                "policyDecisions",
-                                "priceDelta",
-                                "effects",
-                                "nextActions",
-                                "requestedBy",
-                                "requestedActor",
-                                "reason",
-                                "acceptedAt",
-                                "acceptedBy",
-                                "acceptedActor",
-                                "appliedAt",
-                                "appliedBy",
-                                "appliedActor",
-                                "createdAt",
-                                "updatedAt"
-                              ]
-                            }
-                          },
-                          "required": ["status", "amendment"]
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "status": {
-                              "type": "string",
-                              "enum": ["no_op"]
-                            },
-                            "bookingId": {
-                              "type": "string"
-                            },
-                            "travelerId": {
-                              "type": "string"
-                            },
-                            "bookingRevision": {
-                              "type": "integer",
-                              "exclusiveMinimum": 0
-                            }
-                          },
-                          "required": ["status", "bookingId", "travelerId", "bookingRevision"]
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "status": {
-                              "type": "string",
-                              "enum": ["not_found"]
-                            }
-                          },
-                          "required": ["status"]
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "status": {
-                              "type": "string",
-                              "enum": ["idempotency_conflict"]
-                            }
-                          },
-                          "required": ["status"]
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "status": {
-                              "type": "string",
-                              "enum": ["stale_revision"]
-                            },
-                            "currentBookingRevision": {
-                              "type": "integer",
-                              "exclusiveMinimum": 0
-                            }
-                          },
-                          "required": ["status", "currentBookingRevision"]
-                        }
-                      ]
-                    }
-                  },
-                  "required": ["data"]
+                  "$ref": "#/components/schemas/BookingAmendmentPreviewNoOpResponse"
                 }
               }
             }
@@ -11655,378 +11870,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "oneOf": [
-                        {
-                          "type": "object",
-                          "properties": {
-                            "status": {
-                              "type": "string",
-                              "enum": ["ok"]
-                            },
-                            "amendment": {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string"
-                                },
-                                "bookingId": {
-                                  "type": "string"
-                                },
-                                "travelerId": {
-                                  "type": "string"
-                                },
-                                "kind": {
-                                  "type": "string",
-                                  "enum": ["traveler_correction"]
-                                },
-                                "status": {
-                                  "type": "string",
-                                  "enum": ["proposed", "accepted", "applied", "rejected", "failed"]
-                                },
-                                "baseBookingRevision": {
-                                  "type": "integer",
-                                  "exclusiveMinimum": 0
-                                },
-                                "resultBookingRevision": {
-                                  "type": "integer",
-                                  "exclusiveMinimum": 0
-                                },
-                                "acceptanceRequired": {
-                                  "type": "boolean"
-                                },
-                                "policyDecisions": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "code": {
-                                        "type": "string"
-                                      },
-                                      "version": {
-                                        "type": "string"
-                                      },
-                                      "decision": {
-                                        "type": "string",
-                                        "enum": ["allowed", "acceptance_required"]
-                                      },
-                                      "reason": {
-                                        "type": "string"
-                                      }
-                                    },
-                                    "required": ["code", "version", "decision", "reason"]
-                                  }
-                                },
-                                "priceDelta": {
-                                  "type": "object",
-                                  "properties": {
-                                    "amountCents": {
-                                      "type": "number",
-                                      "enum": [0]
-                                    },
-                                    "currency": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "required": ["amountCents", "currency"]
-                                },
-                                "effects": {
-                                  "type": "object",
-                                  "properties": {
-                                    "finance": {
-                                      "type": "string",
-                                      "enum": ["not_required"]
-                                    },
-                                    "legal": {
-                                      "type": "string",
-                                      "enum": ["not_required"]
-                                    },
-                                    "documents": {
-                                      "type": "string",
-                                      "enum": ["not_required"]
-                                    },
-                                    "fulfillment": {
-                                      "type": "string",
-                                      "enum": ["not_required"]
-                                    },
-                                    "supplier": {
-                                      "type": "string",
-                                      "enum": ["not_required"]
-                                    }
-                                  },
-                                  "required": [
-                                    "finance",
-                                    "legal",
-                                    "documents",
-                                    "fulfillment",
-                                    "supplier"
-                                  ]
-                                },
-                                "nextActions": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string",
-                                    "enum": ["accept", "apply"]
-                                  }
-                                },
-                                "requestedBy": {
-                                  "type": ["string", "null"]
-                                },
-                                "requestedActor": {
-                                  "type": "string",
-                                  "enum": ["customer", "staff", "partner", "system"]
-                                },
-                                "reason": {
-                                  "type": "string"
-                                },
-                                "acceptedAt": {
-                                  "type": ["string", "null"]
-                                },
-                                "acceptedBy": {
-                                  "type": ["string", "null"]
-                                },
-                                "acceptedActor": {
-                                  "type": ["string", "null"],
-                                  "enum": ["customer", "staff", "partner", "system", null]
-                                },
-                                "appliedAt": {
-                                  "type": ["string", "null"]
-                                },
-                                "appliedBy": {
-                                  "type": ["string", "null"]
-                                },
-                                "appliedActor": {
-                                  "type": ["string", "null"],
-                                  "enum": ["customer", "staff", "partner", "system", null]
-                                },
-                                "createdAt": {
-                                  "type": "string"
-                                },
-                                "updatedAt": {
-                                  "type": "string"
-                                },
-                                "revisions": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "id": {
-                                        "type": "string"
-                                      },
-                                      "amendmentId": {
-                                        "type": "string"
-                                      },
-                                      "bookingId": {
-                                        "type": "string"
-                                      },
-                                      "bookingRevision": {
-                                        "type": "integer",
-                                        "exclusiveMinimum": 0
-                                      },
-                                      "role": {
-                                        "type": "string",
-                                        "enum": ["before", "proposed_after"]
-                                      },
-                                      "snapshot": {
-                                        "type": "object",
-                                        "properties": {
-                                          "bookingId": {
-                                            "type": "string"
-                                          },
-                                          "bookingNumber": {
-                                            "type": "string"
-                                          },
-                                          "revision": {
-                                            "type": "integer",
-                                            "exclusiveMinimum": 0
-                                          },
-                                          "travelers": {
-                                            "type": "array",
-                                            "items": {
-                                              "type": "object",
-                                              "properties": {
-                                                "id": {
-                                                  "type": "string"
-                                                },
-                                                "personId": {
-                                                  "type": ["string", "null"]
-                                                },
-                                                "participantType": {
-                                                  "type": "string",
-                                                  "enum": ["traveler", "occupant", "other"]
-                                                },
-                                                "travelerCategory": {
-                                                  "type": ["string", "null"],
-                                                  "enum": [
-                                                    "adult",
-                                                    "child",
-                                                    "infant",
-                                                    "senior",
-                                                    "other",
-                                                    null
-                                                  ]
-                                                },
-                                                "firstName": {
-                                                  "type": "string"
-                                                },
-                                                "lastName": {
-                                                  "type": "string"
-                                                },
-                                                "email": {
-                                                  "type": ["string", "null"]
-                                                },
-                                                "phone": {
-                                                  "type": ["string", "null"]
-                                                },
-                                                "preferredLanguage": {
-                                                  "type": ["string", "null"]
-                                                },
-                                                "isPrimary": {
-                                                  "type": "boolean"
-                                                }
-                                              },
-                                              "required": [
-                                                "id",
-                                                "personId",
-                                                "participantType",
-                                                "travelerCategory",
-                                                "firstName",
-                                                "lastName",
-                                                "email",
-                                                "phone",
-                                                "preferredLanguage",
-                                                "isPrimary"
-                                              ]
-                                            }
-                                          }
-                                        },
-                                        "required": [
-                                          "bookingId",
-                                          "bookingNumber",
-                                          "revision",
-                                          "travelers"
-                                        ]
-                                      },
-                                      "changedFields": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "string"
-                                        }
-                                      },
-                                      "authorizedBy": {
-                                        "type": ["string", "null"]
-                                      },
-                                      "reason": {
-                                        "type": "string"
-                                      },
-                                      "createdAt": {
-                                        "type": "string"
-                                      }
-                                    },
-                                    "required": [
-                                      "id",
-                                      "amendmentId",
-                                      "bookingId",
-                                      "bookingRevision",
-                                      "role",
-                                      "snapshot",
-                                      "changedFields",
-                                      "authorizedBy",
-                                      "reason",
-                                      "createdAt"
-                                    ]
-                                  }
-                                }
-                              },
-                              "required": [
-                                "id",
-                                "bookingId",
-                                "travelerId",
-                                "kind",
-                                "status",
-                                "baseBookingRevision",
-                                "resultBookingRevision",
-                                "acceptanceRequired",
-                                "policyDecisions",
-                                "priceDelta",
-                                "effects",
-                                "nextActions",
-                                "requestedBy",
-                                "requestedActor",
-                                "reason",
-                                "acceptedAt",
-                                "acceptedBy",
-                                "acceptedActor",
-                                "appliedAt",
-                                "appliedBy",
-                                "appliedActor",
-                                "createdAt",
-                                "updatedAt"
-                              ]
-                            }
-                          },
-                          "required": ["status", "amendment"]
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "status": {
-                              "type": "string",
-                              "enum": ["no_op"]
-                            },
-                            "bookingId": {
-                              "type": "string"
-                            },
-                            "travelerId": {
-                              "type": "string"
-                            },
-                            "bookingRevision": {
-                              "type": "integer",
-                              "exclusiveMinimum": 0
-                            }
-                          },
-                          "required": ["status", "bookingId", "travelerId", "bookingRevision"]
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "status": {
-                              "type": "string",
-                              "enum": ["not_found"]
-                            }
-                          },
-                          "required": ["status"]
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "status": {
-                              "type": "string",
-                              "enum": ["idempotency_conflict"]
-                            }
-                          },
-                          "required": ["status"]
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "status": {
-                              "type": "string",
-                              "enum": ["stale_revision"]
-                            },
-                            "currentBookingRevision": {
-                              "type": "integer",
-                              "exclusiveMinimum": 0
-                            }
-                          },
-                          "required": ["status", "currentBookingRevision"]
-                        }
-                      ]
-                    }
-                  },
-                  "required": ["data"]
+                  "$ref": "#/components/schemas/BookingAmendmentOkResponse"
                 }
               }
             }
@@ -12044,6 +11888,12 @@
                     "currentBookingRevision": {
                       "type": "integer",
                       "exclusiveMinimum": 0
+                    },
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
                     }
                   },
                   "required": ["error"]
@@ -12064,6 +11914,12 @@
                     "currentBookingRevision": {
                       "type": "integer",
                       "exclusiveMinimum": 0
+                    },
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
                     }
                   },
                   "required": ["error"]
@@ -12084,6 +11940,12 @@
                     "currentBookingRevision": {
                       "type": "integer",
                       "exclusiveMinimum": 0
+                    },
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
                     }
                   },
                   "required": ["error"]
@@ -12118,298 +11980,7 @@
                     "data": {
                       "type": "array",
                       "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string"
-                          },
-                          "bookingId": {
-                            "type": "string"
-                          },
-                          "travelerId": {
-                            "type": "string"
-                          },
-                          "kind": {
-                            "type": "string",
-                            "enum": ["traveler_correction"]
-                          },
-                          "status": {
-                            "type": "string",
-                            "enum": ["proposed", "accepted", "applied", "rejected", "failed"]
-                          },
-                          "baseBookingRevision": {
-                            "type": "integer",
-                            "exclusiveMinimum": 0
-                          },
-                          "resultBookingRevision": {
-                            "type": "integer",
-                            "exclusiveMinimum": 0
-                          },
-                          "acceptanceRequired": {
-                            "type": "boolean"
-                          },
-                          "policyDecisions": {
-                            "type": "array",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "code": {
-                                  "type": "string"
-                                },
-                                "version": {
-                                  "type": "string"
-                                },
-                                "decision": {
-                                  "type": "string",
-                                  "enum": ["allowed", "acceptance_required"]
-                                },
-                                "reason": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": ["code", "version", "decision", "reason"]
-                            }
-                          },
-                          "priceDelta": {
-                            "type": "object",
-                            "properties": {
-                              "amountCents": {
-                                "type": "number",
-                                "enum": [0]
-                              },
-                              "currency": {
-                                "type": "string"
-                              }
-                            },
-                            "required": ["amountCents", "currency"]
-                          },
-                          "effects": {
-                            "type": "object",
-                            "properties": {
-                              "finance": {
-                                "type": "string",
-                                "enum": ["not_required"]
-                              },
-                              "legal": {
-                                "type": "string",
-                                "enum": ["not_required"]
-                              },
-                              "documents": {
-                                "type": "string",
-                                "enum": ["not_required"]
-                              },
-                              "fulfillment": {
-                                "type": "string",
-                                "enum": ["not_required"]
-                              },
-                              "supplier": {
-                                "type": "string",
-                                "enum": ["not_required"]
-                              }
-                            },
-                            "required": ["finance", "legal", "documents", "fulfillment", "supplier"]
-                          },
-                          "nextActions": {
-                            "type": "array",
-                            "items": {
-                              "type": "string",
-                              "enum": ["accept", "apply"]
-                            }
-                          },
-                          "requestedBy": {
-                            "type": ["string", "null"]
-                          },
-                          "requestedActor": {
-                            "type": "string",
-                            "enum": ["customer", "staff", "partner", "system"]
-                          },
-                          "reason": {
-                            "type": "string"
-                          },
-                          "acceptedAt": {
-                            "type": ["string", "null"]
-                          },
-                          "acceptedBy": {
-                            "type": ["string", "null"]
-                          },
-                          "acceptedActor": {
-                            "type": ["string", "null"],
-                            "enum": ["customer", "staff", "partner", "system", null]
-                          },
-                          "appliedAt": {
-                            "type": ["string", "null"]
-                          },
-                          "appliedBy": {
-                            "type": ["string", "null"]
-                          },
-                          "appliedActor": {
-                            "type": ["string", "null"],
-                            "enum": ["customer", "staff", "partner", "system", null]
-                          },
-                          "createdAt": {
-                            "type": "string"
-                          },
-                          "updatedAt": {
-                            "type": "string"
-                          },
-                          "revisions": {
-                            "type": "array",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string"
-                                },
-                                "amendmentId": {
-                                  "type": "string"
-                                },
-                                "bookingId": {
-                                  "type": "string"
-                                },
-                                "bookingRevision": {
-                                  "type": "integer",
-                                  "exclusiveMinimum": 0
-                                },
-                                "role": {
-                                  "type": "string",
-                                  "enum": ["before", "proposed_after"]
-                                },
-                                "snapshot": {
-                                  "type": "object",
-                                  "properties": {
-                                    "bookingId": {
-                                      "type": "string"
-                                    },
-                                    "bookingNumber": {
-                                      "type": "string"
-                                    },
-                                    "revision": {
-                                      "type": "integer",
-                                      "exclusiveMinimum": 0
-                                    },
-                                    "travelers": {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "object",
-                                        "properties": {
-                                          "id": {
-                                            "type": "string"
-                                          },
-                                          "personId": {
-                                            "type": ["string", "null"]
-                                          },
-                                          "participantType": {
-                                            "type": "string",
-                                            "enum": ["traveler", "occupant", "other"]
-                                          },
-                                          "travelerCategory": {
-                                            "type": ["string", "null"],
-                                            "enum": [
-                                              "adult",
-                                              "child",
-                                              "infant",
-                                              "senior",
-                                              "other",
-                                              null
-                                            ]
-                                          },
-                                          "firstName": {
-                                            "type": "string"
-                                          },
-                                          "lastName": {
-                                            "type": "string"
-                                          },
-                                          "email": {
-                                            "type": ["string", "null"]
-                                          },
-                                          "phone": {
-                                            "type": ["string", "null"]
-                                          },
-                                          "preferredLanguage": {
-                                            "type": ["string", "null"]
-                                          },
-                                          "isPrimary": {
-                                            "type": "boolean"
-                                          }
-                                        },
-                                        "required": [
-                                          "id",
-                                          "personId",
-                                          "participantType",
-                                          "travelerCategory",
-                                          "firstName",
-                                          "lastName",
-                                          "email",
-                                          "phone",
-                                          "preferredLanguage",
-                                          "isPrimary"
-                                        ]
-                                      }
-                                    }
-                                  },
-                                  "required": [
-                                    "bookingId",
-                                    "bookingNumber",
-                                    "revision",
-                                    "travelers"
-                                  ]
-                                },
-                                "changedFields": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string"
-                                  }
-                                },
-                                "authorizedBy": {
-                                  "type": ["string", "null"]
-                                },
-                                "reason": {
-                                  "type": "string"
-                                },
-                                "createdAt": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": [
-                                "id",
-                                "amendmentId",
-                                "bookingId",
-                                "bookingRevision",
-                                "role",
-                                "snapshot",
-                                "changedFields",
-                                "authorizedBy",
-                                "reason",
-                                "createdAt"
-                              ]
-                            }
-                          }
-                        },
-                        "required": [
-                          "id",
-                          "bookingId",
-                          "travelerId",
-                          "kind",
-                          "status",
-                          "baseBookingRevision",
-                          "resultBookingRevision",
-                          "acceptanceRequired",
-                          "policyDecisions",
-                          "priceDelta",
-                          "effects",
-                          "nextActions",
-                          "requestedBy",
-                          "requestedActor",
-                          "reason",
-                          "acceptedAt",
-                          "acceptedBy",
-                          "acceptedActor",
-                          "appliedAt",
-                          "appliedBy",
-                          "appliedActor",
-                          "createdAt",
-                          "updatedAt"
-                        ]
+                        "$ref": "#/components/schemas/BookingAmendment"
                       }
                     }
                   },
@@ -12451,293 +12022,7 @@
                   "type": "object",
                   "properties": {
                     "data": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "string"
-                        },
-                        "bookingId": {
-                          "type": "string"
-                        },
-                        "travelerId": {
-                          "type": "string"
-                        },
-                        "kind": {
-                          "type": "string",
-                          "enum": ["traveler_correction"]
-                        },
-                        "status": {
-                          "type": "string",
-                          "enum": ["proposed", "accepted", "applied", "rejected", "failed"]
-                        },
-                        "baseBookingRevision": {
-                          "type": "integer",
-                          "exclusiveMinimum": 0
-                        },
-                        "resultBookingRevision": {
-                          "type": "integer",
-                          "exclusiveMinimum": 0
-                        },
-                        "acceptanceRequired": {
-                          "type": "boolean"
-                        },
-                        "policyDecisions": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "code": {
-                                "type": "string"
-                              },
-                              "version": {
-                                "type": "string"
-                              },
-                              "decision": {
-                                "type": "string",
-                                "enum": ["allowed", "acceptance_required"]
-                              },
-                              "reason": {
-                                "type": "string"
-                              }
-                            },
-                            "required": ["code", "version", "decision", "reason"]
-                          }
-                        },
-                        "priceDelta": {
-                          "type": "object",
-                          "properties": {
-                            "amountCents": {
-                              "type": "number",
-                              "enum": [0]
-                            },
-                            "currency": {
-                              "type": "string"
-                            }
-                          },
-                          "required": ["amountCents", "currency"]
-                        },
-                        "effects": {
-                          "type": "object",
-                          "properties": {
-                            "finance": {
-                              "type": "string",
-                              "enum": ["not_required"]
-                            },
-                            "legal": {
-                              "type": "string",
-                              "enum": ["not_required"]
-                            },
-                            "documents": {
-                              "type": "string",
-                              "enum": ["not_required"]
-                            },
-                            "fulfillment": {
-                              "type": "string",
-                              "enum": ["not_required"]
-                            },
-                            "supplier": {
-                              "type": "string",
-                              "enum": ["not_required"]
-                            }
-                          },
-                          "required": ["finance", "legal", "documents", "fulfillment", "supplier"]
-                        },
-                        "nextActions": {
-                          "type": "array",
-                          "items": {
-                            "type": "string",
-                            "enum": ["accept", "apply"]
-                          }
-                        },
-                        "requestedBy": {
-                          "type": ["string", "null"]
-                        },
-                        "requestedActor": {
-                          "type": "string",
-                          "enum": ["customer", "staff", "partner", "system"]
-                        },
-                        "reason": {
-                          "type": "string"
-                        },
-                        "acceptedAt": {
-                          "type": ["string", "null"]
-                        },
-                        "acceptedBy": {
-                          "type": ["string", "null"]
-                        },
-                        "acceptedActor": {
-                          "type": ["string", "null"],
-                          "enum": ["customer", "staff", "partner", "system", null]
-                        },
-                        "appliedAt": {
-                          "type": ["string", "null"]
-                        },
-                        "appliedBy": {
-                          "type": ["string", "null"]
-                        },
-                        "appliedActor": {
-                          "type": ["string", "null"],
-                          "enum": ["customer", "staff", "partner", "system", null]
-                        },
-                        "createdAt": {
-                          "type": "string"
-                        },
-                        "updatedAt": {
-                          "type": "string"
-                        },
-                        "revisions": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "id": {
-                                "type": "string"
-                              },
-                              "amendmentId": {
-                                "type": "string"
-                              },
-                              "bookingId": {
-                                "type": "string"
-                              },
-                              "bookingRevision": {
-                                "type": "integer",
-                                "exclusiveMinimum": 0
-                              },
-                              "role": {
-                                "type": "string",
-                                "enum": ["before", "proposed_after"]
-                              },
-                              "snapshot": {
-                                "type": "object",
-                                "properties": {
-                                  "bookingId": {
-                                    "type": "string"
-                                  },
-                                  "bookingNumber": {
-                                    "type": "string"
-                                  },
-                                  "revision": {
-                                    "type": "integer",
-                                    "exclusiveMinimum": 0
-                                  },
-                                  "travelers": {
-                                    "type": "array",
-                                    "items": {
-                                      "type": "object",
-                                      "properties": {
-                                        "id": {
-                                          "type": "string"
-                                        },
-                                        "personId": {
-                                          "type": ["string", "null"]
-                                        },
-                                        "participantType": {
-                                          "type": "string",
-                                          "enum": ["traveler", "occupant", "other"]
-                                        },
-                                        "travelerCategory": {
-                                          "type": ["string", "null"],
-                                          "enum": [
-                                            "adult",
-                                            "child",
-                                            "infant",
-                                            "senior",
-                                            "other",
-                                            null
-                                          ]
-                                        },
-                                        "firstName": {
-                                          "type": "string"
-                                        },
-                                        "lastName": {
-                                          "type": "string"
-                                        },
-                                        "email": {
-                                          "type": ["string", "null"]
-                                        },
-                                        "phone": {
-                                          "type": ["string", "null"]
-                                        },
-                                        "preferredLanguage": {
-                                          "type": ["string", "null"]
-                                        },
-                                        "isPrimary": {
-                                          "type": "boolean"
-                                        }
-                                      },
-                                      "required": [
-                                        "id",
-                                        "personId",
-                                        "participantType",
-                                        "travelerCategory",
-                                        "firstName",
-                                        "lastName",
-                                        "email",
-                                        "phone",
-                                        "preferredLanguage",
-                                        "isPrimary"
-                                      ]
-                                    }
-                                  }
-                                },
-                                "required": ["bookingId", "bookingNumber", "revision", "travelers"]
-                              },
-                              "changedFields": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
-                              },
-                              "authorizedBy": {
-                                "type": ["string", "null"]
-                              },
-                              "reason": {
-                                "type": "string"
-                              },
-                              "createdAt": {
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "id",
-                              "amendmentId",
-                              "bookingId",
-                              "bookingRevision",
-                              "role",
-                              "snapshot",
-                              "changedFields",
-                              "authorizedBy",
-                              "reason",
-                              "createdAt"
-                            ]
-                          }
-                        }
-                      },
-                      "required": [
-                        "id",
-                        "bookingId",
-                        "travelerId",
-                        "kind",
-                        "status",
-                        "baseBookingRevision",
-                        "resultBookingRevision",
-                        "acceptanceRequired",
-                        "policyDecisions",
-                        "priceDelta",
-                        "effects",
-                        "nextActions",
-                        "requestedBy",
-                        "requestedActor",
-                        "reason",
-                        "acceptedAt",
-                        "acceptedBy",
-                        "acceptedActor",
-                        "appliedAt",
-                        "appliedBy",
-                        "appliedActor",
-                        "createdAt",
-                        "updatedAt"
-                      ]
+                      "$ref": "#/components/schemas/BookingAmendment"
                     }
                   },
                   "required": ["data"]
@@ -12758,6 +12043,12 @@
                     "currentBookingRevision": {
                       "type": "integer",
                       "exclusiveMinimum": 0
+                    },
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
                     }
                   },
                   "required": ["error"]
@@ -12815,293 +12106,7 @@
                   "type": "object",
                   "properties": {
                     "data": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "string"
-                        },
-                        "bookingId": {
-                          "type": "string"
-                        },
-                        "travelerId": {
-                          "type": "string"
-                        },
-                        "kind": {
-                          "type": "string",
-                          "enum": ["traveler_correction"]
-                        },
-                        "status": {
-                          "type": "string",
-                          "enum": ["proposed", "accepted", "applied", "rejected", "failed"]
-                        },
-                        "baseBookingRevision": {
-                          "type": "integer",
-                          "exclusiveMinimum": 0
-                        },
-                        "resultBookingRevision": {
-                          "type": "integer",
-                          "exclusiveMinimum": 0
-                        },
-                        "acceptanceRequired": {
-                          "type": "boolean"
-                        },
-                        "policyDecisions": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "code": {
-                                "type": "string"
-                              },
-                              "version": {
-                                "type": "string"
-                              },
-                              "decision": {
-                                "type": "string",
-                                "enum": ["allowed", "acceptance_required"]
-                              },
-                              "reason": {
-                                "type": "string"
-                              }
-                            },
-                            "required": ["code", "version", "decision", "reason"]
-                          }
-                        },
-                        "priceDelta": {
-                          "type": "object",
-                          "properties": {
-                            "amountCents": {
-                              "type": "number",
-                              "enum": [0]
-                            },
-                            "currency": {
-                              "type": "string"
-                            }
-                          },
-                          "required": ["amountCents", "currency"]
-                        },
-                        "effects": {
-                          "type": "object",
-                          "properties": {
-                            "finance": {
-                              "type": "string",
-                              "enum": ["not_required"]
-                            },
-                            "legal": {
-                              "type": "string",
-                              "enum": ["not_required"]
-                            },
-                            "documents": {
-                              "type": "string",
-                              "enum": ["not_required"]
-                            },
-                            "fulfillment": {
-                              "type": "string",
-                              "enum": ["not_required"]
-                            },
-                            "supplier": {
-                              "type": "string",
-                              "enum": ["not_required"]
-                            }
-                          },
-                          "required": ["finance", "legal", "documents", "fulfillment", "supplier"]
-                        },
-                        "nextActions": {
-                          "type": "array",
-                          "items": {
-                            "type": "string",
-                            "enum": ["accept", "apply"]
-                          }
-                        },
-                        "requestedBy": {
-                          "type": ["string", "null"]
-                        },
-                        "requestedActor": {
-                          "type": "string",
-                          "enum": ["customer", "staff", "partner", "system"]
-                        },
-                        "reason": {
-                          "type": "string"
-                        },
-                        "acceptedAt": {
-                          "type": ["string", "null"]
-                        },
-                        "acceptedBy": {
-                          "type": ["string", "null"]
-                        },
-                        "acceptedActor": {
-                          "type": ["string", "null"],
-                          "enum": ["customer", "staff", "partner", "system", null]
-                        },
-                        "appliedAt": {
-                          "type": ["string", "null"]
-                        },
-                        "appliedBy": {
-                          "type": ["string", "null"]
-                        },
-                        "appliedActor": {
-                          "type": ["string", "null"],
-                          "enum": ["customer", "staff", "partner", "system", null]
-                        },
-                        "createdAt": {
-                          "type": "string"
-                        },
-                        "updatedAt": {
-                          "type": "string"
-                        },
-                        "revisions": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "id": {
-                                "type": "string"
-                              },
-                              "amendmentId": {
-                                "type": "string"
-                              },
-                              "bookingId": {
-                                "type": "string"
-                              },
-                              "bookingRevision": {
-                                "type": "integer",
-                                "exclusiveMinimum": 0
-                              },
-                              "role": {
-                                "type": "string",
-                                "enum": ["before", "proposed_after"]
-                              },
-                              "snapshot": {
-                                "type": "object",
-                                "properties": {
-                                  "bookingId": {
-                                    "type": "string"
-                                  },
-                                  "bookingNumber": {
-                                    "type": "string"
-                                  },
-                                  "revision": {
-                                    "type": "integer",
-                                    "exclusiveMinimum": 0
-                                  },
-                                  "travelers": {
-                                    "type": "array",
-                                    "items": {
-                                      "type": "object",
-                                      "properties": {
-                                        "id": {
-                                          "type": "string"
-                                        },
-                                        "personId": {
-                                          "type": ["string", "null"]
-                                        },
-                                        "participantType": {
-                                          "type": "string",
-                                          "enum": ["traveler", "occupant", "other"]
-                                        },
-                                        "travelerCategory": {
-                                          "type": ["string", "null"],
-                                          "enum": [
-                                            "adult",
-                                            "child",
-                                            "infant",
-                                            "senior",
-                                            "other",
-                                            null
-                                          ]
-                                        },
-                                        "firstName": {
-                                          "type": "string"
-                                        },
-                                        "lastName": {
-                                          "type": "string"
-                                        },
-                                        "email": {
-                                          "type": ["string", "null"]
-                                        },
-                                        "phone": {
-                                          "type": ["string", "null"]
-                                        },
-                                        "preferredLanguage": {
-                                          "type": ["string", "null"]
-                                        },
-                                        "isPrimary": {
-                                          "type": "boolean"
-                                        }
-                                      },
-                                      "required": [
-                                        "id",
-                                        "personId",
-                                        "participantType",
-                                        "travelerCategory",
-                                        "firstName",
-                                        "lastName",
-                                        "email",
-                                        "phone",
-                                        "preferredLanguage",
-                                        "isPrimary"
-                                      ]
-                                    }
-                                  }
-                                },
-                                "required": ["bookingId", "bookingNumber", "revision", "travelers"]
-                              },
-                              "changedFields": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
-                              },
-                              "authorizedBy": {
-                                "type": ["string", "null"]
-                              },
-                              "reason": {
-                                "type": "string"
-                              },
-                              "createdAt": {
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "id",
-                              "amendmentId",
-                              "bookingId",
-                              "bookingRevision",
-                              "role",
-                              "snapshot",
-                              "changedFields",
-                              "authorizedBy",
-                              "reason",
-                              "createdAt"
-                            ]
-                          }
-                        }
-                      },
-                      "required": [
-                        "id",
-                        "bookingId",
-                        "travelerId",
-                        "kind",
-                        "status",
-                        "baseBookingRevision",
-                        "resultBookingRevision",
-                        "acceptanceRequired",
-                        "policyDecisions",
-                        "priceDelta",
-                        "effects",
-                        "nextActions",
-                        "requestedBy",
-                        "requestedActor",
-                        "reason",
-                        "acceptedAt",
-                        "acceptedBy",
-                        "acceptedActor",
-                        "appliedAt",
-                        "appliedBy",
-                        "appliedActor",
-                        "createdAt",
-                        "updatedAt"
-                      ]
+                      "$ref": "#/components/schemas/BookingAmendment"
                     }
                   },
                   "required": ["data"]
@@ -13122,6 +12127,12 @@
                     "currentBookingRevision": {
                       "type": "integer",
                       "exclusiveMinimum": 0
+                    },
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
                     }
                   },
                   "required": ["error"]
@@ -13142,6 +12153,12 @@
                     "currentBookingRevision": {
                       "type": "integer",
                       "exclusiveMinimum": 0
+                    },
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
                     }
                   },
                   "required": ["error"]
@@ -13162,6 +12179,12 @@
                     "currentBookingRevision": {
                       "type": "integer",
                       "exclusiveMinimum": 0
+                    },
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
                     }
                   },
                   "required": ["error"]
@@ -13220,299 +12243,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "string"
-                        },
-                        "bookingId": {
-                          "type": "string"
-                        },
-                        "travelerId": {
-                          "type": "string"
-                        },
-                        "kind": {
-                          "type": "string",
-                          "enum": ["traveler_correction"]
-                        },
-                        "status": {
-                          "type": "string",
-                          "enum": ["proposed", "accepted", "applied", "rejected", "failed"]
-                        },
-                        "baseBookingRevision": {
-                          "type": "integer",
-                          "exclusiveMinimum": 0
-                        },
-                        "resultBookingRevision": {
-                          "type": "integer",
-                          "exclusiveMinimum": 0
-                        },
-                        "acceptanceRequired": {
-                          "type": "boolean"
-                        },
-                        "policyDecisions": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "code": {
-                                "type": "string"
-                              },
-                              "version": {
-                                "type": "string"
-                              },
-                              "decision": {
-                                "type": "string",
-                                "enum": ["allowed", "acceptance_required"]
-                              },
-                              "reason": {
-                                "type": "string"
-                              }
-                            },
-                            "required": ["code", "version", "decision", "reason"]
-                          }
-                        },
-                        "priceDelta": {
-                          "type": "object",
-                          "properties": {
-                            "amountCents": {
-                              "type": "number",
-                              "enum": [0]
-                            },
-                            "currency": {
-                              "type": "string"
-                            }
-                          },
-                          "required": ["amountCents", "currency"]
-                        },
-                        "effects": {
-                          "type": "object",
-                          "properties": {
-                            "finance": {
-                              "type": "string",
-                              "enum": ["not_required"]
-                            },
-                            "legal": {
-                              "type": "string",
-                              "enum": ["not_required"]
-                            },
-                            "documents": {
-                              "type": "string",
-                              "enum": ["not_required"]
-                            },
-                            "fulfillment": {
-                              "type": "string",
-                              "enum": ["not_required"]
-                            },
-                            "supplier": {
-                              "type": "string",
-                              "enum": ["not_required"]
-                            }
-                          },
-                          "required": ["finance", "legal", "documents", "fulfillment", "supplier"]
-                        },
-                        "nextActions": {
-                          "type": "array",
-                          "items": {
-                            "type": "string",
-                            "enum": ["accept", "apply"]
-                          }
-                        },
-                        "requestedBy": {
-                          "type": ["string", "null"]
-                        },
-                        "requestedActor": {
-                          "type": "string",
-                          "enum": ["customer", "staff", "partner", "system"]
-                        },
-                        "reason": {
-                          "type": "string"
-                        },
-                        "acceptedAt": {
-                          "type": ["string", "null"]
-                        },
-                        "acceptedBy": {
-                          "type": ["string", "null"]
-                        },
-                        "acceptedActor": {
-                          "type": ["string", "null"],
-                          "enum": ["customer", "staff", "partner", "system", null]
-                        },
-                        "appliedAt": {
-                          "type": ["string", "null"]
-                        },
-                        "appliedBy": {
-                          "type": ["string", "null"]
-                        },
-                        "appliedActor": {
-                          "type": ["string", "null"],
-                          "enum": ["customer", "staff", "partner", "system", null]
-                        },
-                        "createdAt": {
-                          "type": "string"
-                        },
-                        "updatedAt": {
-                          "type": "string"
-                        },
-                        "revisions": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "id": {
-                                "type": "string"
-                              },
-                              "amendmentId": {
-                                "type": "string"
-                              },
-                              "bookingId": {
-                                "type": "string"
-                              },
-                              "bookingRevision": {
-                                "type": "integer",
-                                "exclusiveMinimum": 0
-                              },
-                              "role": {
-                                "type": "string",
-                                "enum": ["before", "proposed_after"]
-                              },
-                              "snapshot": {
-                                "type": "object",
-                                "properties": {
-                                  "bookingId": {
-                                    "type": "string"
-                                  },
-                                  "bookingNumber": {
-                                    "type": "string"
-                                  },
-                                  "revision": {
-                                    "type": "integer",
-                                    "exclusiveMinimum": 0
-                                  },
-                                  "travelers": {
-                                    "type": "array",
-                                    "items": {
-                                      "type": "object",
-                                      "properties": {
-                                        "id": {
-                                          "type": "string"
-                                        },
-                                        "personId": {
-                                          "type": ["string", "null"]
-                                        },
-                                        "participantType": {
-                                          "type": "string",
-                                          "enum": ["traveler", "occupant", "other"]
-                                        },
-                                        "travelerCategory": {
-                                          "type": ["string", "null"],
-                                          "enum": [
-                                            "adult",
-                                            "child",
-                                            "infant",
-                                            "senior",
-                                            "other",
-                                            null
-                                          ]
-                                        },
-                                        "firstName": {
-                                          "type": "string"
-                                        },
-                                        "lastName": {
-                                          "type": "string"
-                                        },
-                                        "email": {
-                                          "type": ["string", "null"]
-                                        },
-                                        "phone": {
-                                          "type": ["string", "null"]
-                                        },
-                                        "preferredLanguage": {
-                                          "type": ["string", "null"]
-                                        },
-                                        "isPrimary": {
-                                          "type": "boolean"
-                                        }
-                                      },
-                                      "required": [
-                                        "id",
-                                        "personId",
-                                        "participantType",
-                                        "travelerCategory",
-                                        "firstName",
-                                        "lastName",
-                                        "email",
-                                        "phone",
-                                        "preferredLanguage",
-                                        "isPrimary"
-                                      ]
-                                    }
-                                  }
-                                },
-                                "required": ["bookingId", "bookingNumber", "revision", "travelers"]
-                              },
-                              "changedFields": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
-                              },
-                              "authorizedBy": {
-                                "type": ["string", "null"]
-                              },
-                              "reason": {
-                                "type": "string"
-                              },
-                              "createdAt": {
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "id",
-                              "amendmentId",
-                              "bookingId",
-                              "bookingRevision",
-                              "role",
-                              "snapshot",
-                              "changedFields",
-                              "authorizedBy",
-                              "reason",
-                              "createdAt"
-                            ]
-                          }
-                        }
-                      },
-                      "required": [
-                        "id",
-                        "bookingId",
-                        "travelerId",
-                        "kind",
-                        "status",
-                        "baseBookingRevision",
-                        "resultBookingRevision",
-                        "acceptanceRequired",
-                        "policyDecisions",
-                        "priceDelta",
-                        "effects",
-                        "nextActions",
-                        "requestedBy",
-                        "requestedActor",
-                        "reason",
-                        "acceptedAt",
-                        "acceptedBy",
-                        "acceptedActor",
-                        "appliedAt",
-                        "appliedBy",
-                        "appliedActor",
-                        "createdAt",
-                        "updatedAt"
-                      ]
-                    }
-                  },
-                  "required": ["data"]
+                  "$ref": "#/components/schemas/BookingAmendmentOkResponse"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Booking Amendment is waiting for supplier reconciliation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BookingAmendmentApplyPendingResponse"
                 }
               }
             }
@@ -13530,6 +12271,12 @@
                     "currentBookingRevision": {
                       "type": "integer",
                       "exclusiveMinimum": 0
+                    },
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
                     }
                   },
                   "required": ["error"]
@@ -13550,6 +12297,12 @@
                     "currentBookingRevision": {
                       "type": "integer",
                       "exclusiveMinimum": 0
+                    },
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
                     }
                   },
                   "required": ["error"]
@@ -13562,6 +12315,162 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "$ref": "#/components/schemas/BookingAmendmentApplyConflictResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/admin/bookings/{bookingId}/amendments/traveler-roster/preview": {
+      "post": {
+        "x-voyant-api-id": "@voyant-travel/bookings#api.admin",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "bookingId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "expectedBookingRevision": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0
+                  },
+                  "reason": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 2000
+                  },
+                  "change": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": ["traveler_add"]
+                          },
+                          "bookingItemIds": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "minItems": 1,
+                            "description": "One or more distinct Booking Item ids; duplicate ids are rejected."
+                          },
+                          "traveler": {
+                            "type": "object",
+                            "properties": {
+                              "personId": {
+                                "type": ["string", "null"],
+                                "minLength": 1
+                              },
+                              "participantType": {
+                                "type": "string",
+                                "enum": ["traveler", "occupant", "other"],
+                                "default": "traveler"
+                              },
+                              "travelerCategory": {
+                                "type": ["string", "null"],
+                                "enum": ["adult", "child", "infant", "senior", "other", null]
+                              },
+                              "firstName": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 255
+                              },
+                              "lastName": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 255
+                              },
+                              "email": {
+                                "type": ["string", "null"],
+                                "format": "email"
+                              },
+                              "phone": {
+                                "type": ["string", "null"],
+                                "maxLength": 50
+                              },
+                              "preferredLanguage": {
+                                "type": ["string", "null"],
+                                "maxLength": 35
+                              }
+                            },
+                            "required": ["firstName", "lastName"]
+                          }
+                        },
+                        "required": ["type", "bookingItemIds", "traveler"]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": ["traveler_drop"]
+                          },
+                          "bookingItemIds": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "minItems": 1,
+                            "description": "One or more distinct Booking Item ids; duplicate ids are rejected."
+                          },
+                          "travelerId": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "required": ["type", "bookingItemIds", "travelerId"]
+                      }
+                    ]
+                  }
+                },
+                "required": ["expectedBookingRevision", "reason", "change"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Idempotent or no-op preview",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BookingAmendmentPreviewNoOpResponse"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Traveler correction preview",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BookingAmendmentOkResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid Idempotency-Key header",
+            "content": {
+              "application/json": {
+                "schema": {
                   "type": "object",
                   "properties": {
                     "error": {
@@ -13570,9 +12479,174 @@
                     "currentBookingRevision": {
                       "type": "integer",
                       "exclusiveMinimum": 0
+                    },
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
                     }
                   },
                   "required": ["error"]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Booking or traveler not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "currentBookingRevision": {
+                      "type": "integer",
+                      "exclusiveMinimum": 0
+                    },
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Revision or idempotency conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "currentBookingRevision": {
+                      "type": "integer",
+                      "exclusiveMinimum": 0
+                    },
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/admin/bookings/{bookingId}/amendments/{amendmentId}/reconcile": {
+      "post": {
+        "x-voyant-api-id": "@voyant-travel/bookings#api.admin",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "bookingId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "amendmentId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Applied Booking Amendment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BookingAmendmentOkResponse"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Booking Amendment is waiting for supplier reconciliation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BookingAmendmentApplyPendingResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid Idempotency-Key header",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "currentBookingRevision": {
+                      "type": "integer",
+                      "exclusiveMinimum": 0
+                    },
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Booking Amendment not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "currentBookingRevision": {
+                      "type": "integer",
+                      "exclusiveMinimum": 0
+                    },
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Apply conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BookingAmendmentApplyConflictResponse"
                 }
               }
             }

--- a/packages/bookings/openapi/storefront/bookings.json
+++ b/packages/bookings/openapi/storefront/bookings.json
@@ -122,6 +122,591 @@
             "required": ["kind", "clauses"]
           }
         ]
+      },
+      "BookingAmendment": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "bookingId": {
+            "type": "string"
+          },
+          "travelerId": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string",
+            "enum": ["traveler_correction", "traveler_add", "traveler_drop"]
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "proposed",
+              "accepted",
+              "applying",
+              "applied",
+              "rejected",
+              "failed",
+              "in_doubt",
+              "manual_review"
+            ]
+          },
+          "baseBookingRevision": {
+            "type": "integer",
+            "exclusiveMinimum": 0
+          },
+          "resultBookingRevision": {
+            "type": "integer",
+            "exclusiveMinimum": 0
+          },
+          "acceptanceRequired": {
+            "type": "boolean"
+          },
+          "policyDecisions": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "code": {
+                  "type": "string"
+                },
+                "version": {
+                  "type": "string"
+                },
+                "decision": {
+                  "type": "string",
+                  "enum": ["allowed", "acceptance_required"]
+                },
+                "reason": {
+                  "type": "string"
+                }
+              },
+              "required": ["code", "version", "decision", "reason"]
+            }
+          },
+          "priceDelta": {
+            "type": "object",
+            "properties": {
+              "currency": {
+                "type": "string",
+                "minLength": 3,
+                "maxLength": 8
+              },
+              "subtotalDeltaCents": {
+                "type": "integer"
+              },
+              "feeDeltaCents": {
+                "type": "integer"
+              },
+              "taxDeltaCents": {
+                "type": "integer"
+              },
+              "amountCents": {
+                "type": "integer"
+              },
+              "collectionAmountCents": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "refundAmountCents": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "taxLines": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": ["string", "null"]
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "amountCents": {
+                      "type": "integer"
+                    },
+                    "rateBasisPoints": {
+                      "type": ["integer", "null"]
+                    },
+                    "includedInPrice": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "bookingItemId",
+                    "code",
+                    "name",
+                    "amountCents",
+                    "rateBasisPoints",
+                    "includedInPrice"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "currency",
+              "subtotalDeltaCents",
+              "feeDeltaCents",
+              "taxDeltaCents",
+              "amountCents",
+              "collectionAmountCents",
+              "refundAmountCents",
+              "taxLines"
+            ]
+          },
+          "financialConsequences": {
+            "type": "object",
+            "properties": {
+              "collection": {
+                "type": "string",
+                "enum": ["not_required", "required"]
+              },
+              "refund": {
+                "type": "string",
+                "enum": ["not_required", "required"]
+              },
+              "invoice": {
+                "type": "string",
+                "enum": ["not_required", "reissue_required"]
+              },
+              "creditNote": {
+                "type": "string",
+                "enum": ["not_required", "issue_required"]
+              },
+              "paymentSchedule": {
+                "type": "string",
+                "enum": ["not_required", "recalculate_required"]
+              }
+            },
+            "required": ["collection", "refund", "invoice", "creditNote", "paymentSchedule"]
+          },
+          "effects": {
+            "type": "object",
+            "properties": {
+              "finance": {
+                "type": "string",
+                "enum": ["not_required", "collection_required", "refund_required", "recorded"]
+              },
+              "legal": {
+                "type": "string",
+                "enum": ["not_required", "review_required"]
+              },
+              "documents": {
+                "type": "string",
+                "enum": ["not_required", "reissue_required"]
+              },
+              "fulfillment": {
+                "type": "string",
+                "enum": ["not_required", "reissue_required"]
+              },
+              "supplier": {
+                "type": "string",
+                "enum": [
+                  "not_required",
+                  "modify_required",
+                  "pending",
+                  "secured",
+                  "refused",
+                  "in_doubt",
+                  "manual_review"
+                ]
+              },
+              "allocation": {
+                "type": "string",
+                "enum": ["not_required", "increase_required", "release_required", "applied"]
+              }
+            },
+            "required": ["finance", "legal", "documents", "fulfillment", "supplier", "allocation"]
+          },
+          "nextActions": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "accept",
+                "apply",
+                "wait_supplier",
+                "reconcile_supplier",
+                "manual_review",
+                "collect_payment",
+                "issue_refund",
+                "reissue_documents"
+              ]
+            }
+          },
+          "quotedAt": {
+            "type": "string"
+          },
+          "quoteExpiresAt": {
+            "type": ["string", "null"]
+          },
+          "supplierOperationIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "failureCode": {
+            "type": ["string", "null"]
+          },
+          "requestedBy": {
+            "type": ["string", "null"]
+          },
+          "requestedActor": {
+            "type": "string",
+            "enum": ["customer", "staff", "partner", "system"]
+          },
+          "reason": {
+            "type": "string"
+          },
+          "acceptedAt": {
+            "type": ["string", "null"]
+          },
+          "acceptedBy": {
+            "type": ["string", "null"]
+          },
+          "acceptedActor": {
+            "type": ["string", "null"],
+            "enum": ["customer", "staff", "partner", "system", null]
+          },
+          "appliedAt": {
+            "type": ["string", "null"]
+          },
+          "appliedBy": {
+            "type": ["string", "null"]
+          },
+          "appliedActor": {
+            "type": ["string", "null"],
+            "enum": ["customer", "staff", "partner", "system", null]
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          },
+          "revisions": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "amendmentId": {
+                  "type": "string"
+                },
+                "bookingId": {
+                  "type": "string"
+                },
+                "bookingRevision": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0
+                },
+                "role": {
+                  "type": "string",
+                  "enum": ["before", "proposed_after"]
+                },
+                "snapshot": {
+                  "type": "object",
+                  "properties": {
+                    "bookingId": {
+                      "type": "string"
+                    },
+                    "bookingNumber": {
+                      "type": "string"
+                    },
+                    "revision": {
+                      "type": "integer",
+                      "exclusiveMinimum": 0
+                    },
+                    "sellAmountCents": {
+                      "type": ["integer", "null"]
+                    },
+                    "pax": {
+                      "type": ["integer", "null"],
+                      "minimum": 0
+                    },
+                    "travelers": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "personId": {
+                            "type": ["string", "null"]
+                          },
+                          "participantType": {
+                            "type": "string",
+                            "enum": ["traveler", "occupant", "other"]
+                          },
+                          "travelerCategory": {
+                            "type": ["string", "null"],
+                            "enum": ["adult", "child", "infant", "senior", "other", null]
+                          },
+                          "firstName": {
+                            "type": "string"
+                          },
+                          "lastName": {
+                            "type": "string"
+                          },
+                          "email": {
+                            "type": ["string", "null"]
+                          },
+                          "phone": {
+                            "type": ["string", "null"]
+                          },
+                          "preferredLanguage": {
+                            "type": ["string", "null"]
+                          },
+                          "isPrimary": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "personId",
+                          "participantType",
+                          "travelerCategory",
+                          "firstName",
+                          "lastName",
+                          "email",
+                          "phone",
+                          "preferredLanguage",
+                          "isPrimary"
+                        ]
+                      }
+                    },
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "quantity": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "totalSellAmountCents": {
+                            "type": ["integer", "null"]
+                          },
+                          "travelerIds": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "allocations": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
+                                },
+                                "quantity": {
+                                  "type": "integer",
+                                  "minimum": 0
+                                },
+                                "status": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["id", "quantity", "status"]
+                            }
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "quantity",
+                          "totalSellAmountCents",
+                          "travelerIds",
+                          "allocations"
+                        ]
+                      }
+                    }
+                  },
+                  "required": ["bookingId", "bookingNumber", "revision", "travelers"]
+                },
+                "changedFields": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "authorizedBy": {
+                  "type": ["string", "null"]
+                },
+                "reason": {
+                  "type": "string"
+                },
+                "createdAt": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "amendmentId",
+                "bookingId",
+                "bookingRevision",
+                "role",
+                "snapshot",
+                "changedFields",
+                "authorizedBy",
+                "reason",
+                "createdAt"
+              ]
+            }
+          }
+        },
+        "required": [
+          "id",
+          "bookingId",
+          "travelerId",
+          "kind",
+          "status",
+          "baseBookingRevision",
+          "resultBookingRevision",
+          "acceptanceRequired",
+          "policyDecisions",
+          "priceDelta",
+          "financialConsequences",
+          "effects",
+          "nextActions",
+          "quotedAt",
+          "quoteExpiresAt",
+          "supplierOperationIds",
+          "failureCode",
+          "requestedBy",
+          "requestedActor",
+          "reason",
+          "acceptedAt",
+          "acceptedBy",
+          "acceptedActor",
+          "appliedAt",
+          "appliedBy",
+          "appliedActor",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "BookingAmendmentApplyPendingResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string",
+                "enum": ["supplier_pending", "supplier_in_doubt", "manual_review"]
+              },
+              "amendment": {
+                "$ref": "#/components/schemas/BookingAmendment"
+              }
+            },
+            "required": ["status", "amendment"]
+          }
+        },
+        "required": ["data"]
+      },
+      "BookingAmendmentApplyConflictResponse": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "error": {
+                "type": "string"
+              },
+              "currentBookingRevision": {
+                "type": "integer",
+                "exclusiveMinimum": 0
+              },
+              "bookingItemId": {
+                "type": "string"
+              },
+              "reason": {
+                "type": "string"
+              }
+            },
+            "required": ["error"]
+          },
+          {
+            "$ref": "#/components/schemas/BookingAmendmentApplyRefusedResponse"
+          }
+        ]
+      },
+      "BookingAmendmentApplyRefusedResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string",
+                "enum": ["supplier_refused"]
+              },
+              "amendment": {
+                "$ref": "#/components/schemas/BookingAmendment"
+              }
+            },
+            "required": ["status", "amendment"]
+          }
+        },
+        "required": ["data"]
+      },
+      "BookingAmendmentPreviewNoOpResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string",
+                "enum": ["no_op"]
+              },
+              "bookingId": {
+                "type": "string"
+              },
+              "travelerId": {
+                "type": "string"
+              },
+              "bookingRevision": {
+                "type": "integer",
+                "exclusiveMinimum": 0
+              }
+            },
+            "required": ["status", "bookingId", "travelerId", "bookingRevision"]
+          }
+        },
+        "required": ["data"]
+      },
+      "BookingAmendmentOkResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string",
+                "enum": ["ok"]
+              },
+              "amendment": {
+                "$ref": "#/components/schemas/BookingAmendment"
+              }
+            },
+            "required": ["status", "amendment"]
+          }
+        },
+        "required": ["data"]
       }
     },
     "parameters": {}
@@ -4354,7 +4939,8 @@
                         "maxLength": 35
                       }
                     },
-                    "additionalProperties": false
+                    "additionalProperties": false,
+                    "description": "At least one traveler correction field must be provided."
                   }
                 },
                 "required": ["travelerId", "expectedBookingRevision", "reason", "patch"]
@@ -4368,378 +4954,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "oneOf": [
-                        {
-                          "type": "object",
-                          "properties": {
-                            "status": {
-                              "type": "string",
-                              "enum": ["ok"]
-                            },
-                            "amendment": {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string"
-                                },
-                                "bookingId": {
-                                  "type": "string"
-                                },
-                                "travelerId": {
-                                  "type": "string"
-                                },
-                                "kind": {
-                                  "type": "string",
-                                  "enum": ["traveler_correction"]
-                                },
-                                "status": {
-                                  "type": "string",
-                                  "enum": ["proposed", "accepted", "applied", "rejected", "failed"]
-                                },
-                                "baseBookingRevision": {
-                                  "type": "integer",
-                                  "exclusiveMinimum": 0
-                                },
-                                "resultBookingRevision": {
-                                  "type": "integer",
-                                  "exclusiveMinimum": 0
-                                },
-                                "acceptanceRequired": {
-                                  "type": "boolean"
-                                },
-                                "policyDecisions": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "code": {
-                                        "type": "string"
-                                      },
-                                      "version": {
-                                        "type": "string"
-                                      },
-                                      "decision": {
-                                        "type": "string",
-                                        "enum": ["allowed", "acceptance_required"]
-                                      },
-                                      "reason": {
-                                        "type": "string"
-                                      }
-                                    },
-                                    "required": ["code", "version", "decision", "reason"]
-                                  }
-                                },
-                                "priceDelta": {
-                                  "type": "object",
-                                  "properties": {
-                                    "amountCents": {
-                                      "type": "number",
-                                      "enum": [0]
-                                    },
-                                    "currency": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "required": ["amountCents", "currency"]
-                                },
-                                "effects": {
-                                  "type": "object",
-                                  "properties": {
-                                    "finance": {
-                                      "type": "string",
-                                      "enum": ["not_required"]
-                                    },
-                                    "legal": {
-                                      "type": "string",
-                                      "enum": ["not_required"]
-                                    },
-                                    "documents": {
-                                      "type": "string",
-                                      "enum": ["not_required"]
-                                    },
-                                    "fulfillment": {
-                                      "type": "string",
-                                      "enum": ["not_required"]
-                                    },
-                                    "supplier": {
-                                      "type": "string",
-                                      "enum": ["not_required"]
-                                    }
-                                  },
-                                  "required": [
-                                    "finance",
-                                    "legal",
-                                    "documents",
-                                    "fulfillment",
-                                    "supplier"
-                                  ]
-                                },
-                                "nextActions": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string",
-                                    "enum": ["accept", "apply"]
-                                  }
-                                },
-                                "requestedBy": {
-                                  "type": ["string", "null"]
-                                },
-                                "requestedActor": {
-                                  "type": "string",
-                                  "enum": ["customer", "staff", "partner", "system"]
-                                },
-                                "reason": {
-                                  "type": "string"
-                                },
-                                "acceptedAt": {
-                                  "type": ["string", "null"]
-                                },
-                                "acceptedBy": {
-                                  "type": ["string", "null"]
-                                },
-                                "acceptedActor": {
-                                  "type": ["string", "null"],
-                                  "enum": ["customer", "staff", "partner", "system", null]
-                                },
-                                "appliedAt": {
-                                  "type": ["string", "null"]
-                                },
-                                "appliedBy": {
-                                  "type": ["string", "null"]
-                                },
-                                "appliedActor": {
-                                  "type": ["string", "null"],
-                                  "enum": ["customer", "staff", "partner", "system", null]
-                                },
-                                "createdAt": {
-                                  "type": "string"
-                                },
-                                "updatedAt": {
-                                  "type": "string"
-                                },
-                                "revisions": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "id": {
-                                        "type": "string"
-                                      },
-                                      "amendmentId": {
-                                        "type": "string"
-                                      },
-                                      "bookingId": {
-                                        "type": "string"
-                                      },
-                                      "bookingRevision": {
-                                        "type": "integer",
-                                        "exclusiveMinimum": 0
-                                      },
-                                      "role": {
-                                        "type": "string",
-                                        "enum": ["before", "proposed_after"]
-                                      },
-                                      "snapshot": {
-                                        "type": "object",
-                                        "properties": {
-                                          "bookingId": {
-                                            "type": "string"
-                                          },
-                                          "bookingNumber": {
-                                            "type": "string"
-                                          },
-                                          "revision": {
-                                            "type": "integer",
-                                            "exclusiveMinimum": 0
-                                          },
-                                          "travelers": {
-                                            "type": "array",
-                                            "items": {
-                                              "type": "object",
-                                              "properties": {
-                                                "id": {
-                                                  "type": "string"
-                                                },
-                                                "personId": {
-                                                  "type": ["string", "null"]
-                                                },
-                                                "participantType": {
-                                                  "type": "string",
-                                                  "enum": ["traveler", "occupant", "other"]
-                                                },
-                                                "travelerCategory": {
-                                                  "type": ["string", "null"],
-                                                  "enum": [
-                                                    "adult",
-                                                    "child",
-                                                    "infant",
-                                                    "senior",
-                                                    "other",
-                                                    null
-                                                  ]
-                                                },
-                                                "firstName": {
-                                                  "type": "string"
-                                                },
-                                                "lastName": {
-                                                  "type": "string"
-                                                },
-                                                "email": {
-                                                  "type": ["string", "null"]
-                                                },
-                                                "phone": {
-                                                  "type": ["string", "null"]
-                                                },
-                                                "preferredLanguage": {
-                                                  "type": ["string", "null"]
-                                                },
-                                                "isPrimary": {
-                                                  "type": "boolean"
-                                                }
-                                              },
-                                              "required": [
-                                                "id",
-                                                "personId",
-                                                "participantType",
-                                                "travelerCategory",
-                                                "firstName",
-                                                "lastName",
-                                                "email",
-                                                "phone",
-                                                "preferredLanguage",
-                                                "isPrimary"
-                                              ]
-                                            }
-                                          }
-                                        },
-                                        "required": [
-                                          "bookingId",
-                                          "bookingNumber",
-                                          "revision",
-                                          "travelers"
-                                        ]
-                                      },
-                                      "changedFields": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "string"
-                                        }
-                                      },
-                                      "authorizedBy": {
-                                        "type": ["string", "null"]
-                                      },
-                                      "reason": {
-                                        "type": "string"
-                                      },
-                                      "createdAt": {
-                                        "type": "string"
-                                      }
-                                    },
-                                    "required": [
-                                      "id",
-                                      "amendmentId",
-                                      "bookingId",
-                                      "bookingRevision",
-                                      "role",
-                                      "snapshot",
-                                      "changedFields",
-                                      "authorizedBy",
-                                      "reason",
-                                      "createdAt"
-                                    ]
-                                  }
-                                }
-                              },
-                              "required": [
-                                "id",
-                                "bookingId",
-                                "travelerId",
-                                "kind",
-                                "status",
-                                "baseBookingRevision",
-                                "resultBookingRevision",
-                                "acceptanceRequired",
-                                "policyDecisions",
-                                "priceDelta",
-                                "effects",
-                                "nextActions",
-                                "requestedBy",
-                                "requestedActor",
-                                "reason",
-                                "acceptedAt",
-                                "acceptedBy",
-                                "acceptedActor",
-                                "appliedAt",
-                                "appliedBy",
-                                "appliedActor",
-                                "createdAt",
-                                "updatedAt"
-                              ]
-                            }
-                          },
-                          "required": ["status", "amendment"]
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "status": {
-                              "type": "string",
-                              "enum": ["no_op"]
-                            },
-                            "bookingId": {
-                              "type": "string"
-                            },
-                            "travelerId": {
-                              "type": "string"
-                            },
-                            "bookingRevision": {
-                              "type": "integer",
-                              "exclusiveMinimum": 0
-                            }
-                          },
-                          "required": ["status", "bookingId", "travelerId", "bookingRevision"]
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "status": {
-                              "type": "string",
-                              "enum": ["not_found"]
-                            }
-                          },
-                          "required": ["status"]
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "status": {
-                              "type": "string",
-                              "enum": ["idempotency_conflict"]
-                            }
-                          },
-                          "required": ["status"]
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "status": {
-                              "type": "string",
-                              "enum": ["stale_revision"]
-                            },
-                            "currentBookingRevision": {
-                              "type": "integer",
-                              "exclusiveMinimum": 0
-                            }
-                          },
-                          "required": ["status", "currentBookingRevision"]
-                        }
-                      ]
-                    }
-                  },
-                  "required": ["data"]
+                  "$ref": "#/components/schemas/BookingAmendmentPreviewNoOpResponse"
                 }
               }
             }
@@ -4749,378 +4964,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "oneOf": [
-                        {
-                          "type": "object",
-                          "properties": {
-                            "status": {
-                              "type": "string",
-                              "enum": ["ok"]
-                            },
-                            "amendment": {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string"
-                                },
-                                "bookingId": {
-                                  "type": "string"
-                                },
-                                "travelerId": {
-                                  "type": "string"
-                                },
-                                "kind": {
-                                  "type": "string",
-                                  "enum": ["traveler_correction"]
-                                },
-                                "status": {
-                                  "type": "string",
-                                  "enum": ["proposed", "accepted", "applied", "rejected", "failed"]
-                                },
-                                "baseBookingRevision": {
-                                  "type": "integer",
-                                  "exclusiveMinimum": 0
-                                },
-                                "resultBookingRevision": {
-                                  "type": "integer",
-                                  "exclusiveMinimum": 0
-                                },
-                                "acceptanceRequired": {
-                                  "type": "boolean"
-                                },
-                                "policyDecisions": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "code": {
-                                        "type": "string"
-                                      },
-                                      "version": {
-                                        "type": "string"
-                                      },
-                                      "decision": {
-                                        "type": "string",
-                                        "enum": ["allowed", "acceptance_required"]
-                                      },
-                                      "reason": {
-                                        "type": "string"
-                                      }
-                                    },
-                                    "required": ["code", "version", "decision", "reason"]
-                                  }
-                                },
-                                "priceDelta": {
-                                  "type": "object",
-                                  "properties": {
-                                    "amountCents": {
-                                      "type": "number",
-                                      "enum": [0]
-                                    },
-                                    "currency": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "required": ["amountCents", "currency"]
-                                },
-                                "effects": {
-                                  "type": "object",
-                                  "properties": {
-                                    "finance": {
-                                      "type": "string",
-                                      "enum": ["not_required"]
-                                    },
-                                    "legal": {
-                                      "type": "string",
-                                      "enum": ["not_required"]
-                                    },
-                                    "documents": {
-                                      "type": "string",
-                                      "enum": ["not_required"]
-                                    },
-                                    "fulfillment": {
-                                      "type": "string",
-                                      "enum": ["not_required"]
-                                    },
-                                    "supplier": {
-                                      "type": "string",
-                                      "enum": ["not_required"]
-                                    }
-                                  },
-                                  "required": [
-                                    "finance",
-                                    "legal",
-                                    "documents",
-                                    "fulfillment",
-                                    "supplier"
-                                  ]
-                                },
-                                "nextActions": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string",
-                                    "enum": ["accept", "apply"]
-                                  }
-                                },
-                                "requestedBy": {
-                                  "type": ["string", "null"]
-                                },
-                                "requestedActor": {
-                                  "type": "string",
-                                  "enum": ["customer", "staff", "partner", "system"]
-                                },
-                                "reason": {
-                                  "type": "string"
-                                },
-                                "acceptedAt": {
-                                  "type": ["string", "null"]
-                                },
-                                "acceptedBy": {
-                                  "type": ["string", "null"]
-                                },
-                                "acceptedActor": {
-                                  "type": ["string", "null"],
-                                  "enum": ["customer", "staff", "partner", "system", null]
-                                },
-                                "appliedAt": {
-                                  "type": ["string", "null"]
-                                },
-                                "appliedBy": {
-                                  "type": ["string", "null"]
-                                },
-                                "appliedActor": {
-                                  "type": ["string", "null"],
-                                  "enum": ["customer", "staff", "partner", "system", null]
-                                },
-                                "createdAt": {
-                                  "type": "string"
-                                },
-                                "updatedAt": {
-                                  "type": "string"
-                                },
-                                "revisions": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "id": {
-                                        "type": "string"
-                                      },
-                                      "amendmentId": {
-                                        "type": "string"
-                                      },
-                                      "bookingId": {
-                                        "type": "string"
-                                      },
-                                      "bookingRevision": {
-                                        "type": "integer",
-                                        "exclusiveMinimum": 0
-                                      },
-                                      "role": {
-                                        "type": "string",
-                                        "enum": ["before", "proposed_after"]
-                                      },
-                                      "snapshot": {
-                                        "type": "object",
-                                        "properties": {
-                                          "bookingId": {
-                                            "type": "string"
-                                          },
-                                          "bookingNumber": {
-                                            "type": "string"
-                                          },
-                                          "revision": {
-                                            "type": "integer",
-                                            "exclusiveMinimum": 0
-                                          },
-                                          "travelers": {
-                                            "type": "array",
-                                            "items": {
-                                              "type": "object",
-                                              "properties": {
-                                                "id": {
-                                                  "type": "string"
-                                                },
-                                                "personId": {
-                                                  "type": ["string", "null"]
-                                                },
-                                                "participantType": {
-                                                  "type": "string",
-                                                  "enum": ["traveler", "occupant", "other"]
-                                                },
-                                                "travelerCategory": {
-                                                  "type": ["string", "null"],
-                                                  "enum": [
-                                                    "adult",
-                                                    "child",
-                                                    "infant",
-                                                    "senior",
-                                                    "other",
-                                                    null
-                                                  ]
-                                                },
-                                                "firstName": {
-                                                  "type": "string"
-                                                },
-                                                "lastName": {
-                                                  "type": "string"
-                                                },
-                                                "email": {
-                                                  "type": ["string", "null"]
-                                                },
-                                                "phone": {
-                                                  "type": ["string", "null"]
-                                                },
-                                                "preferredLanguage": {
-                                                  "type": ["string", "null"]
-                                                },
-                                                "isPrimary": {
-                                                  "type": "boolean"
-                                                }
-                                              },
-                                              "required": [
-                                                "id",
-                                                "personId",
-                                                "participantType",
-                                                "travelerCategory",
-                                                "firstName",
-                                                "lastName",
-                                                "email",
-                                                "phone",
-                                                "preferredLanguage",
-                                                "isPrimary"
-                                              ]
-                                            }
-                                          }
-                                        },
-                                        "required": [
-                                          "bookingId",
-                                          "bookingNumber",
-                                          "revision",
-                                          "travelers"
-                                        ]
-                                      },
-                                      "changedFields": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "string"
-                                        }
-                                      },
-                                      "authorizedBy": {
-                                        "type": ["string", "null"]
-                                      },
-                                      "reason": {
-                                        "type": "string"
-                                      },
-                                      "createdAt": {
-                                        "type": "string"
-                                      }
-                                    },
-                                    "required": [
-                                      "id",
-                                      "amendmentId",
-                                      "bookingId",
-                                      "bookingRevision",
-                                      "role",
-                                      "snapshot",
-                                      "changedFields",
-                                      "authorizedBy",
-                                      "reason",
-                                      "createdAt"
-                                    ]
-                                  }
-                                }
-                              },
-                              "required": [
-                                "id",
-                                "bookingId",
-                                "travelerId",
-                                "kind",
-                                "status",
-                                "baseBookingRevision",
-                                "resultBookingRevision",
-                                "acceptanceRequired",
-                                "policyDecisions",
-                                "priceDelta",
-                                "effects",
-                                "nextActions",
-                                "requestedBy",
-                                "requestedActor",
-                                "reason",
-                                "acceptedAt",
-                                "acceptedBy",
-                                "acceptedActor",
-                                "appliedAt",
-                                "appliedBy",
-                                "appliedActor",
-                                "createdAt",
-                                "updatedAt"
-                              ]
-                            }
-                          },
-                          "required": ["status", "amendment"]
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "status": {
-                              "type": "string",
-                              "enum": ["no_op"]
-                            },
-                            "bookingId": {
-                              "type": "string"
-                            },
-                            "travelerId": {
-                              "type": "string"
-                            },
-                            "bookingRevision": {
-                              "type": "integer",
-                              "exclusiveMinimum": 0
-                            }
-                          },
-                          "required": ["status", "bookingId", "travelerId", "bookingRevision"]
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "status": {
-                              "type": "string",
-                              "enum": ["not_found"]
-                            }
-                          },
-                          "required": ["status"]
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "status": {
-                              "type": "string",
-                              "enum": ["idempotency_conflict"]
-                            }
-                          },
-                          "required": ["status"]
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "status": {
-                              "type": "string",
-                              "enum": ["stale_revision"]
-                            },
-                            "currentBookingRevision": {
-                              "type": "integer",
-                              "exclusiveMinimum": 0
-                            }
-                          },
-                          "required": ["status", "currentBookingRevision"]
-                        }
-                      ]
-                    }
-                  },
-                  "required": ["data"]
+                  "$ref": "#/components/schemas/BookingAmendmentOkResponse"
                 }
               }
             }
@@ -5138,6 +4982,12 @@
                     "currentBookingRevision": {
                       "type": "integer",
                       "exclusiveMinimum": 0
+                    },
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
                     }
                   },
                   "required": ["error"]
@@ -5158,6 +5008,12 @@
                     "currentBookingRevision": {
                       "type": "integer",
                       "exclusiveMinimum": 0
+                    },
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
                     }
                   },
                   "required": ["error"]
@@ -5178,6 +5034,12 @@
                     "currentBookingRevision": {
                       "type": "integer",
                       "exclusiveMinimum": 0
+                    },
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
                     }
                   },
                   "required": ["error"]
@@ -5198,6 +5060,12 @@
                     "currentBookingRevision": {
                       "type": "integer",
                       "exclusiveMinimum": 0
+                    },
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
                     }
                   },
                   "required": ["error"]
@@ -5232,298 +5100,7 @@
                     "data": {
                       "type": "array",
                       "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string"
-                          },
-                          "bookingId": {
-                            "type": "string"
-                          },
-                          "travelerId": {
-                            "type": "string"
-                          },
-                          "kind": {
-                            "type": "string",
-                            "enum": ["traveler_correction"]
-                          },
-                          "status": {
-                            "type": "string",
-                            "enum": ["proposed", "accepted", "applied", "rejected", "failed"]
-                          },
-                          "baseBookingRevision": {
-                            "type": "integer",
-                            "exclusiveMinimum": 0
-                          },
-                          "resultBookingRevision": {
-                            "type": "integer",
-                            "exclusiveMinimum": 0
-                          },
-                          "acceptanceRequired": {
-                            "type": "boolean"
-                          },
-                          "policyDecisions": {
-                            "type": "array",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "code": {
-                                  "type": "string"
-                                },
-                                "version": {
-                                  "type": "string"
-                                },
-                                "decision": {
-                                  "type": "string",
-                                  "enum": ["allowed", "acceptance_required"]
-                                },
-                                "reason": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": ["code", "version", "decision", "reason"]
-                            }
-                          },
-                          "priceDelta": {
-                            "type": "object",
-                            "properties": {
-                              "amountCents": {
-                                "type": "number",
-                                "enum": [0]
-                              },
-                              "currency": {
-                                "type": "string"
-                              }
-                            },
-                            "required": ["amountCents", "currency"]
-                          },
-                          "effects": {
-                            "type": "object",
-                            "properties": {
-                              "finance": {
-                                "type": "string",
-                                "enum": ["not_required"]
-                              },
-                              "legal": {
-                                "type": "string",
-                                "enum": ["not_required"]
-                              },
-                              "documents": {
-                                "type": "string",
-                                "enum": ["not_required"]
-                              },
-                              "fulfillment": {
-                                "type": "string",
-                                "enum": ["not_required"]
-                              },
-                              "supplier": {
-                                "type": "string",
-                                "enum": ["not_required"]
-                              }
-                            },
-                            "required": ["finance", "legal", "documents", "fulfillment", "supplier"]
-                          },
-                          "nextActions": {
-                            "type": "array",
-                            "items": {
-                              "type": "string",
-                              "enum": ["accept", "apply"]
-                            }
-                          },
-                          "requestedBy": {
-                            "type": ["string", "null"]
-                          },
-                          "requestedActor": {
-                            "type": "string",
-                            "enum": ["customer", "staff", "partner", "system"]
-                          },
-                          "reason": {
-                            "type": "string"
-                          },
-                          "acceptedAt": {
-                            "type": ["string", "null"]
-                          },
-                          "acceptedBy": {
-                            "type": ["string", "null"]
-                          },
-                          "acceptedActor": {
-                            "type": ["string", "null"],
-                            "enum": ["customer", "staff", "partner", "system", null]
-                          },
-                          "appliedAt": {
-                            "type": ["string", "null"]
-                          },
-                          "appliedBy": {
-                            "type": ["string", "null"]
-                          },
-                          "appliedActor": {
-                            "type": ["string", "null"],
-                            "enum": ["customer", "staff", "partner", "system", null]
-                          },
-                          "createdAt": {
-                            "type": "string"
-                          },
-                          "updatedAt": {
-                            "type": "string"
-                          },
-                          "revisions": {
-                            "type": "array",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string"
-                                },
-                                "amendmentId": {
-                                  "type": "string"
-                                },
-                                "bookingId": {
-                                  "type": "string"
-                                },
-                                "bookingRevision": {
-                                  "type": "integer",
-                                  "exclusiveMinimum": 0
-                                },
-                                "role": {
-                                  "type": "string",
-                                  "enum": ["before", "proposed_after"]
-                                },
-                                "snapshot": {
-                                  "type": "object",
-                                  "properties": {
-                                    "bookingId": {
-                                      "type": "string"
-                                    },
-                                    "bookingNumber": {
-                                      "type": "string"
-                                    },
-                                    "revision": {
-                                      "type": "integer",
-                                      "exclusiveMinimum": 0
-                                    },
-                                    "travelers": {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "object",
-                                        "properties": {
-                                          "id": {
-                                            "type": "string"
-                                          },
-                                          "personId": {
-                                            "type": ["string", "null"]
-                                          },
-                                          "participantType": {
-                                            "type": "string",
-                                            "enum": ["traveler", "occupant", "other"]
-                                          },
-                                          "travelerCategory": {
-                                            "type": ["string", "null"],
-                                            "enum": [
-                                              "adult",
-                                              "child",
-                                              "infant",
-                                              "senior",
-                                              "other",
-                                              null
-                                            ]
-                                          },
-                                          "firstName": {
-                                            "type": "string"
-                                          },
-                                          "lastName": {
-                                            "type": "string"
-                                          },
-                                          "email": {
-                                            "type": ["string", "null"]
-                                          },
-                                          "phone": {
-                                            "type": ["string", "null"]
-                                          },
-                                          "preferredLanguage": {
-                                            "type": ["string", "null"]
-                                          },
-                                          "isPrimary": {
-                                            "type": "boolean"
-                                          }
-                                        },
-                                        "required": [
-                                          "id",
-                                          "personId",
-                                          "participantType",
-                                          "travelerCategory",
-                                          "firstName",
-                                          "lastName",
-                                          "email",
-                                          "phone",
-                                          "preferredLanguage",
-                                          "isPrimary"
-                                        ]
-                                      }
-                                    }
-                                  },
-                                  "required": [
-                                    "bookingId",
-                                    "bookingNumber",
-                                    "revision",
-                                    "travelers"
-                                  ]
-                                },
-                                "changedFields": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string"
-                                  }
-                                },
-                                "authorizedBy": {
-                                  "type": ["string", "null"]
-                                },
-                                "reason": {
-                                  "type": "string"
-                                },
-                                "createdAt": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": [
-                                "id",
-                                "amendmentId",
-                                "bookingId",
-                                "bookingRevision",
-                                "role",
-                                "snapshot",
-                                "changedFields",
-                                "authorizedBy",
-                                "reason",
-                                "createdAt"
-                              ]
-                            }
-                          }
-                        },
-                        "required": [
-                          "id",
-                          "bookingId",
-                          "travelerId",
-                          "kind",
-                          "status",
-                          "baseBookingRevision",
-                          "resultBookingRevision",
-                          "acceptanceRequired",
-                          "policyDecisions",
-                          "priceDelta",
-                          "effects",
-                          "nextActions",
-                          "requestedBy",
-                          "requestedActor",
-                          "reason",
-                          "acceptedAt",
-                          "acceptedBy",
-                          "acceptedActor",
-                          "appliedAt",
-                          "appliedBy",
-                          "appliedActor",
-                          "createdAt",
-                          "updatedAt"
-                        ]
+                        "$ref": "#/components/schemas/BookingAmendment"
                       }
                     }
                   },
@@ -5545,6 +5122,12 @@
                     "currentBookingRevision": {
                       "type": "integer",
                       "exclusiveMinimum": 0
+                    },
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
                     }
                   },
                   "required": ["error"]
@@ -5585,293 +5168,7 @@
                   "type": "object",
                   "properties": {
                     "data": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "string"
-                        },
-                        "bookingId": {
-                          "type": "string"
-                        },
-                        "travelerId": {
-                          "type": "string"
-                        },
-                        "kind": {
-                          "type": "string",
-                          "enum": ["traveler_correction"]
-                        },
-                        "status": {
-                          "type": "string",
-                          "enum": ["proposed", "accepted", "applied", "rejected", "failed"]
-                        },
-                        "baseBookingRevision": {
-                          "type": "integer",
-                          "exclusiveMinimum": 0
-                        },
-                        "resultBookingRevision": {
-                          "type": "integer",
-                          "exclusiveMinimum": 0
-                        },
-                        "acceptanceRequired": {
-                          "type": "boolean"
-                        },
-                        "policyDecisions": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "code": {
-                                "type": "string"
-                              },
-                              "version": {
-                                "type": "string"
-                              },
-                              "decision": {
-                                "type": "string",
-                                "enum": ["allowed", "acceptance_required"]
-                              },
-                              "reason": {
-                                "type": "string"
-                              }
-                            },
-                            "required": ["code", "version", "decision", "reason"]
-                          }
-                        },
-                        "priceDelta": {
-                          "type": "object",
-                          "properties": {
-                            "amountCents": {
-                              "type": "number",
-                              "enum": [0]
-                            },
-                            "currency": {
-                              "type": "string"
-                            }
-                          },
-                          "required": ["amountCents", "currency"]
-                        },
-                        "effects": {
-                          "type": "object",
-                          "properties": {
-                            "finance": {
-                              "type": "string",
-                              "enum": ["not_required"]
-                            },
-                            "legal": {
-                              "type": "string",
-                              "enum": ["not_required"]
-                            },
-                            "documents": {
-                              "type": "string",
-                              "enum": ["not_required"]
-                            },
-                            "fulfillment": {
-                              "type": "string",
-                              "enum": ["not_required"]
-                            },
-                            "supplier": {
-                              "type": "string",
-                              "enum": ["not_required"]
-                            }
-                          },
-                          "required": ["finance", "legal", "documents", "fulfillment", "supplier"]
-                        },
-                        "nextActions": {
-                          "type": "array",
-                          "items": {
-                            "type": "string",
-                            "enum": ["accept", "apply"]
-                          }
-                        },
-                        "requestedBy": {
-                          "type": ["string", "null"]
-                        },
-                        "requestedActor": {
-                          "type": "string",
-                          "enum": ["customer", "staff", "partner", "system"]
-                        },
-                        "reason": {
-                          "type": "string"
-                        },
-                        "acceptedAt": {
-                          "type": ["string", "null"]
-                        },
-                        "acceptedBy": {
-                          "type": ["string", "null"]
-                        },
-                        "acceptedActor": {
-                          "type": ["string", "null"],
-                          "enum": ["customer", "staff", "partner", "system", null]
-                        },
-                        "appliedAt": {
-                          "type": ["string", "null"]
-                        },
-                        "appliedBy": {
-                          "type": ["string", "null"]
-                        },
-                        "appliedActor": {
-                          "type": ["string", "null"],
-                          "enum": ["customer", "staff", "partner", "system", null]
-                        },
-                        "createdAt": {
-                          "type": "string"
-                        },
-                        "updatedAt": {
-                          "type": "string"
-                        },
-                        "revisions": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "id": {
-                                "type": "string"
-                              },
-                              "amendmentId": {
-                                "type": "string"
-                              },
-                              "bookingId": {
-                                "type": "string"
-                              },
-                              "bookingRevision": {
-                                "type": "integer",
-                                "exclusiveMinimum": 0
-                              },
-                              "role": {
-                                "type": "string",
-                                "enum": ["before", "proposed_after"]
-                              },
-                              "snapshot": {
-                                "type": "object",
-                                "properties": {
-                                  "bookingId": {
-                                    "type": "string"
-                                  },
-                                  "bookingNumber": {
-                                    "type": "string"
-                                  },
-                                  "revision": {
-                                    "type": "integer",
-                                    "exclusiveMinimum": 0
-                                  },
-                                  "travelers": {
-                                    "type": "array",
-                                    "items": {
-                                      "type": "object",
-                                      "properties": {
-                                        "id": {
-                                          "type": "string"
-                                        },
-                                        "personId": {
-                                          "type": ["string", "null"]
-                                        },
-                                        "participantType": {
-                                          "type": "string",
-                                          "enum": ["traveler", "occupant", "other"]
-                                        },
-                                        "travelerCategory": {
-                                          "type": ["string", "null"],
-                                          "enum": [
-                                            "adult",
-                                            "child",
-                                            "infant",
-                                            "senior",
-                                            "other",
-                                            null
-                                          ]
-                                        },
-                                        "firstName": {
-                                          "type": "string"
-                                        },
-                                        "lastName": {
-                                          "type": "string"
-                                        },
-                                        "email": {
-                                          "type": ["string", "null"]
-                                        },
-                                        "phone": {
-                                          "type": ["string", "null"]
-                                        },
-                                        "preferredLanguage": {
-                                          "type": ["string", "null"]
-                                        },
-                                        "isPrimary": {
-                                          "type": "boolean"
-                                        }
-                                      },
-                                      "required": [
-                                        "id",
-                                        "personId",
-                                        "participantType",
-                                        "travelerCategory",
-                                        "firstName",
-                                        "lastName",
-                                        "email",
-                                        "phone",
-                                        "preferredLanguage",
-                                        "isPrimary"
-                                      ]
-                                    }
-                                  }
-                                },
-                                "required": ["bookingId", "bookingNumber", "revision", "travelers"]
-                              },
-                              "changedFields": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
-                              },
-                              "authorizedBy": {
-                                "type": ["string", "null"]
-                              },
-                              "reason": {
-                                "type": "string"
-                              },
-                              "createdAt": {
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "id",
-                              "amendmentId",
-                              "bookingId",
-                              "bookingRevision",
-                              "role",
-                              "snapshot",
-                              "changedFields",
-                              "authorizedBy",
-                              "reason",
-                              "createdAt"
-                            ]
-                          }
-                        }
-                      },
-                      "required": [
-                        "id",
-                        "bookingId",
-                        "travelerId",
-                        "kind",
-                        "status",
-                        "baseBookingRevision",
-                        "resultBookingRevision",
-                        "acceptanceRequired",
-                        "policyDecisions",
-                        "priceDelta",
-                        "effects",
-                        "nextActions",
-                        "requestedBy",
-                        "requestedActor",
-                        "reason",
-                        "acceptedAt",
-                        "acceptedBy",
-                        "acceptedActor",
-                        "appliedAt",
-                        "appliedBy",
-                        "appliedActor",
-                        "createdAt",
-                        "updatedAt"
-                      ]
+                      "$ref": "#/components/schemas/BookingAmendment"
                     }
                   },
                   "required": ["data"]
@@ -5892,6 +5189,12 @@
                     "currentBookingRevision": {
                       "type": "integer",
                       "exclusiveMinimum": 0
+                    },
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
                     }
                   },
                   "required": ["error"]
@@ -5912,6 +5215,12 @@
                     "currentBookingRevision": {
                       "type": "integer",
                       "exclusiveMinimum": 0
+                    },
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
                     }
                   },
                   "required": ["error"]
@@ -5969,293 +5278,7 @@
                   "type": "object",
                   "properties": {
                     "data": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "string"
-                        },
-                        "bookingId": {
-                          "type": "string"
-                        },
-                        "travelerId": {
-                          "type": "string"
-                        },
-                        "kind": {
-                          "type": "string",
-                          "enum": ["traveler_correction"]
-                        },
-                        "status": {
-                          "type": "string",
-                          "enum": ["proposed", "accepted", "applied", "rejected", "failed"]
-                        },
-                        "baseBookingRevision": {
-                          "type": "integer",
-                          "exclusiveMinimum": 0
-                        },
-                        "resultBookingRevision": {
-                          "type": "integer",
-                          "exclusiveMinimum": 0
-                        },
-                        "acceptanceRequired": {
-                          "type": "boolean"
-                        },
-                        "policyDecisions": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "code": {
-                                "type": "string"
-                              },
-                              "version": {
-                                "type": "string"
-                              },
-                              "decision": {
-                                "type": "string",
-                                "enum": ["allowed", "acceptance_required"]
-                              },
-                              "reason": {
-                                "type": "string"
-                              }
-                            },
-                            "required": ["code", "version", "decision", "reason"]
-                          }
-                        },
-                        "priceDelta": {
-                          "type": "object",
-                          "properties": {
-                            "amountCents": {
-                              "type": "number",
-                              "enum": [0]
-                            },
-                            "currency": {
-                              "type": "string"
-                            }
-                          },
-                          "required": ["amountCents", "currency"]
-                        },
-                        "effects": {
-                          "type": "object",
-                          "properties": {
-                            "finance": {
-                              "type": "string",
-                              "enum": ["not_required"]
-                            },
-                            "legal": {
-                              "type": "string",
-                              "enum": ["not_required"]
-                            },
-                            "documents": {
-                              "type": "string",
-                              "enum": ["not_required"]
-                            },
-                            "fulfillment": {
-                              "type": "string",
-                              "enum": ["not_required"]
-                            },
-                            "supplier": {
-                              "type": "string",
-                              "enum": ["not_required"]
-                            }
-                          },
-                          "required": ["finance", "legal", "documents", "fulfillment", "supplier"]
-                        },
-                        "nextActions": {
-                          "type": "array",
-                          "items": {
-                            "type": "string",
-                            "enum": ["accept", "apply"]
-                          }
-                        },
-                        "requestedBy": {
-                          "type": ["string", "null"]
-                        },
-                        "requestedActor": {
-                          "type": "string",
-                          "enum": ["customer", "staff", "partner", "system"]
-                        },
-                        "reason": {
-                          "type": "string"
-                        },
-                        "acceptedAt": {
-                          "type": ["string", "null"]
-                        },
-                        "acceptedBy": {
-                          "type": ["string", "null"]
-                        },
-                        "acceptedActor": {
-                          "type": ["string", "null"],
-                          "enum": ["customer", "staff", "partner", "system", null]
-                        },
-                        "appliedAt": {
-                          "type": ["string", "null"]
-                        },
-                        "appliedBy": {
-                          "type": ["string", "null"]
-                        },
-                        "appliedActor": {
-                          "type": ["string", "null"],
-                          "enum": ["customer", "staff", "partner", "system", null]
-                        },
-                        "createdAt": {
-                          "type": "string"
-                        },
-                        "updatedAt": {
-                          "type": "string"
-                        },
-                        "revisions": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "id": {
-                                "type": "string"
-                              },
-                              "amendmentId": {
-                                "type": "string"
-                              },
-                              "bookingId": {
-                                "type": "string"
-                              },
-                              "bookingRevision": {
-                                "type": "integer",
-                                "exclusiveMinimum": 0
-                              },
-                              "role": {
-                                "type": "string",
-                                "enum": ["before", "proposed_after"]
-                              },
-                              "snapshot": {
-                                "type": "object",
-                                "properties": {
-                                  "bookingId": {
-                                    "type": "string"
-                                  },
-                                  "bookingNumber": {
-                                    "type": "string"
-                                  },
-                                  "revision": {
-                                    "type": "integer",
-                                    "exclusiveMinimum": 0
-                                  },
-                                  "travelers": {
-                                    "type": "array",
-                                    "items": {
-                                      "type": "object",
-                                      "properties": {
-                                        "id": {
-                                          "type": "string"
-                                        },
-                                        "personId": {
-                                          "type": ["string", "null"]
-                                        },
-                                        "participantType": {
-                                          "type": "string",
-                                          "enum": ["traveler", "occupant", "other"]
-                                        },
-                                        "travelerCategory": {
-                                          "type": ["string", "null"],
-                                          "enum": [
-                                            "adult",
-                                            "child",
-                                            "infant",
-                                            "senior",
-                                            "other",
-                                            null
-                                          ]
-                                        },
-                                        "firstName": {
-                                          "type": "string"
-                                        },
-                                        "lastName": {
-                                          "type": "string"
-                                        },
-                                        "email": {
-                                          "type": ["string", "null"]
-                                        },
-                                        "phone": {
-                                          "type": ["string", "null"]
-                                        },
-                                        "preferredLanguage": {
-                                          "type": ["string", "null"]
-                                        },
-                                        "isPrimary": {
-                                          "type": "boolean"
-                                        }
-                                      },
-                                      "required": [
-                                        "id",
-                                        "personId",
-                                        "participantType",
-                                        "travelerCategory",
-                                        "firstName",
-                                        "lastName",
-                                        "email",
-                                        "phone",
-                                        "preferredLanguage",
-                                        "isPrimary"
-                                      ]
-                                    }
-                                  }
-                                },
-                                "required": ["bookingId", "bookingNumber", "revision", "travelers"]
-                              },
-                              "changedFields": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
-                              },
-                              "authorizedBy": {
-                                "type": ["string", "null"]
-                              },
-                              "reason": {
-                                "type": "string"
-                              },
-                              "createdAt": {
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "id",
-                              "amendmentId",
-                              "bookingId",
-                              "bookingRevision",
-                              "role",
-                              "snapshot",
-                              "changedFields",
-                              "authorizedBy",
-                              "reason",
-                              "createdAt"
-                            ]
-                          }
-                        }
-                      },
-                      "required": [
-                        "id",
-                        "bookingId",
-                        "travelerId",
-                        "kind",
-                        "status",
-                        "baseBookingRevision",
-                        "resultBookingRevision",
-                        "acceptanceRequired",
-                        "policyDecisions",
-                        "priceDelta",
-                        "effects",
-                        "nextActions",
-                        "requestedBy",
-                        "requestedActor",
-                        "reason",
-                        "acceptedAt",
-                        "acceptedBy",
-                        "acceptedActor",
-                        "appliedAt",
-                        "appliedBy",
-                        "appliedActor",
-                        "createdAt",
-                        "updatedAt"
-                      ]
+                      "$ref": "#/components/schemas/BookingAmendment"
                     }
                   },
                   "required": ["data"]
@@ -6276,6 +5299,12 @@
                     "currentBookingRevision": {
                       "type": "integer",
                       "exclusiveMinimum": 0
+                    },
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
                     }
                   },
                   "required": ["error"]
@@ -6296,6 +5325,12 @@
                     "currentBookingRevision": {
                       "type": "integer",
                       "exclusiveMinimum": 0
+                    },
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
                     }
                   },
                   "required": ["error"]
@@ -6316,6 +5351,12 @@
                     "currentBookingRevision": {
                       "type": "integer",
                       "exclusiveMinimum": 0
+                    },
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
                     }
                   },
                   "required": ["error"]
@@ -6336,6 +5377,12 @@
                     "currentBookingRevision": {
                       "type": "integer",
                       "exclusiveMinimum": 0
+                    },
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
                     }
                   },
                   "required": ["error"]
@@ -6394,299 +5441,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "string"
-                        },
-                        "bookingId": {
-                          "type": "string"
-                        },
-                        "travelerId": {
-                          "type": "string"
-                        },
-                        "kind": {
-                          "type": "string",
-                          "enum": ["traveler_correction"]
-                        },
-                        "status": {
-                          "type": "string",
-                          "enum": ["proposed", "accepted", "applied", "rejected", "failed"]
-                        },
-                        "baseBookingRevision": {
-                          "type": "integer",
-                          "exclusiveMinimum": 0
-                        },
-                        "resultBookingRevision": {
-                          "type": "integer",
-                          "exclusiveMinimum": 0
-                        },
-                        "acceptanceRequired": {
-                          "type": "boolean"
-                        },
-                        "policyDecisions": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "code": {
-                                "type": "string"
-                              },
-                              "version": {
-                                "type": "string"
-                              },
-                              "decision": {
-                                "type": "string",
-                                "enum": ["allowed", "acceptance_required"]
-                              },
-                              "reason": {
-                                "type": "string"
-                              }
-                            },
-                            "required": ["code", "version", "decision", "reason"]
-                          }
-                        },
-                        "priceDelta": {
-                          "type": "object",
-                          "properties": {
-                            "amountCents": {
-                              "type": "number",
-                              "enum": [0]
-                            },
-                            "currency": {
-                              "type": "string"
-                            }
-                          },
-                          "required": ["amountCents", "currency"]
-                        },
-                        "effects": {
-                          "type": "object",
-                          "properties": {
-                            "finance": {
-                              "type": "string",
-                              "enum": ["not_required"]
-                            },
-                            "legal": {
-                              "type": "string",
-                              "enum": ["not_required"]
-                            },
-                            "documents": {
-                              "type": "string",
-                              "enum": ["not_required"]
-                            },
-                            "fulfillment": {
-                              "type": "string",
-                              "enum": ["not_required"]
-                            },
-                            "supplier": {
-                              "type": "string",
-                              "enum": ["not_required"]
-                            }
-                          },
-                          "required": ["finance", "legal", "documents", "fulfillment", "supplier"]
-                        },
-                        "nextActions": {
-                          "type": "array",
-                          "items": {
-                            "type": "string",
-                            "enum": ["accept", "apply"]
-                          }
-                        },
-                        "requestedBy": {
-                          "type": ["string", "null"]
-                        },
-                        "requestedActor": {
-                          "type": "string",
-                          "enum": ["customer", "staff", "partner", "system"]
-                        },
-                        "reason": {
-                          "type": "string"
-                        },
-                        "acceptedAt": {
-                          "type": ["string", "null"]
-                        },
-                        "acceptedBy": {
-                          "type": ["string", "null"]
-                        },
-                        "acceptedActor": {
-                          "type": ["string", "null"],
-                          "enum": ["customer", "staff", "partner", "system", null]
-                        },
-                        "appliedAt": {
-                          "type": ["string", "null"]
-                        },
-                        "appliedBy": {
-                          "type": ["string", "null"]
-                        },
-                        "appliedActor": {
-                          "type": ["string", "null"],
-                          "enum": ["customer", "staff", "partner", "system", null]
-                        },
-                        "createdAt": {
-                          "type": "string"
-                        },
-                        "updatedAt": {
-                          "type": "string"
-                        },
-                        "revisions": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "id": {
-                                "type": "string"
-                              },
-                              "amendmentId": {
-                                "type": "string"
-                              },
-                              "bookingId": {
-                                "type": "string"
-                              },
-                              "bookingRevision": {
-                                "type": "integer",
-                                "exclusiveMinimum": 0
-                              },
-                              "role": {
-                                "type": "string",
-                                "enum": ["before", "proposed_after"]
-                              },
-                              "snapshot": {
-                                "type": "object",
-                                "properties": {
-                                  "bookingId": {
-                                    "type": "string"
-                                  },
-                                  "bookingNumber": {
-                                    "type": "string"
-                                  },
-                                  "revision": {
-                                    "type": "integer",
-                                    "exclusiveMinimum": 0
-                                  },
-                                  "travelers": {
-                                    "type": "array",
-                                    "items": {
-                                      "type": "object",
-                                      "properties": {
-                                        "id": {
-                                          "type": "string"
-                                        },
-                                        "personId": {
-                                          "type": ["string", "null"]
-                                        },
-                                        "participantType": {
-                                          "type": "string",
-                                          "enum": ["traveler", "occupant", "other"]
-                                        },
-                                        "travelerCategory": {
-                                          "type": ["string", "null"],
-                                          "enum": [
-                                            "adult",
-                                            "child",
-                                            "infant",
-                                            "senior",
-                                            "other",
-                                            null
-                                          ]
-                                        },
-                                        "firstName": {
-                                          "type": "string"
-                                        },
-                                        "lastName": {
-                                          "type": "string"
-                                        },
-                                        "email": {
-                                          "type": ["string", "null"]
-                                        },
-                                        "phone": {
-                                          "type": ["string", "null"]
-                                        },
-                                        "preferredLanguage": {
-                                          "type": ["string", "null"]
-                                        },
-                                        "isPrimary": {
-                                          "type": "boolean"
-                                        }
-                                      },
-                                      "required": [
-                                        "id",
-                                        "personId",
-                                        "participantType",
-                                        "travelerCategory",
-                                        "firstName",
-                                        "lastName",
-                                        "email",
-                                        "phone",
-                                        "preferredLanguage",
-                                        "isPrimary"
-                                      ]
-                                    }
-                                  }
-                                },
-                                "required": ["bookingId", "bookingNumber", "revision", "travelers"]
-                              },
-                              "changedFields": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
-                              },
-                              "authorizedBy": {
-                                "type": ["string", "null"]
-                              },
-                              "reason": {
-                                "type": "string"
-                              },
-                              "createdAt": {
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "id",
-                              "amendmentId",
-                              "bookingId",
-                              "bookingRevision",
-                              "role",
-                              "snapshot",
-                              "changedFields",
-                              "authorizedBy",
-                              "reason",
-                              "createdAt"
-                            ]
-                          }
-                        }
-                      },
-                      "required": [
-                        "id",
-                        "bookingId",
-                        "travelerId",
-                        "kind",
-                        "status",
-                        "baseBookingRevision",
-                        "resultBookingRevision",
-                        "acceptanceRequired",
-                        "policyDecisions",
-                        "priceDelta",
-                        "effects",
-                        "nextActions",
-                        "requestedBy",
-                        "requestedActor",
-                        "reason",
-                        "acceptedAt",
-                        "acceptedBy",
-                        "acceptedActor",
-                        "appliedAt",
-                        "appliedBy",
-                        "appliedActor",
-                        "createdAt",
-                        "updatedAt"
-                      ]
-                    }
-                  },
-                  "required": ["data"]
+                  "$ref": "#/components/schemas/BookingAmendmentOkResponse"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Booking Amendment is waiting for supplier reconciliation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BookingAmendmentApplyPendingResponse"
                 }
               }
             }
@@ -6704,6 +5469,12 @@
                     "currentBookingRevision": {
                       "type": "integer",
                       "exclusiveMinimum": 0
+                    },
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
                     }
                   },
                   "required": ["error"]
@@ -6724,6 +5495,12 @@
                     "currentBookingRevision": {
                       "type": "integer",
                       "exclusiveMinimum": 0
+                    },
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
                     }
                   },
                   "required": ["error"]
@@ -6744,6 +5521,12 @@
                     "currentBookingRevision": {
                       "type": "integer",
                       "exclusiveMinimum": 0
+                    },
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
                     }
                   },
                   "required": ["error"]
@@ -6756,6 +5539,162 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "$ref": "#/components/schemas/BookingAmendmentApplyConflictResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/public/bookings/{bookingId}/amendments/traveler-roster/preview": {
+      "post": {
+        "x-voyant-api-id": "@voyant-travel/bookings#api.public",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "bookingId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "expectedBookingRevision": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0
+                  },
+                  "reason": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 2000
+                  },
+                  "change": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": ["traveler_add"]
+                          },
+                          "bookingItemIds": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "minItems": 1,
+                            "description": "One or more distinct Booking Item ids; duplicate ids are rejected."
+                          },
+                          "traveler": {
+                            "type": "object",
+                            "properties": {
+                              "personId": {
+                                "type": ["string", "null"],
+                                "minLength": 1
+                              },
+                              "participantType": {
+                                "type": "string",
+                                "enum": ["traveler", "occupant", "other"],
+                                "default": "traveler"
+                              },
+                              "travelerCategory": {
+                                "type": ["string", "null"],
+                                "enum": ["adult", "child", "infant", "senior", "other", null]
+                              },
+                              "firstName": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 255
+                              },
+                              "lastName": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 255
+                              },
+                              "email": {
+                                "type": ["string", "null"],
+                                "format": "email"
+                              },
+                              "phone": {
+                                "type": ["string", "null"],
+                                "maxLength": 50
+                              },
+                              "preferredLanguage": {
+                                "type": ["string", "null"],
+                                "maxLength": 35
+                              }
+                            },
+                            "required": ["firstName", "lastName"]
+                          }
+                        },
+                        "required": ["type", "bookingItemIds", "traveler"]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": ["traveler_drop"]
+                          },
+                          "bookingItemIds": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "minItems": 1,
+                            "description": "One or more distinct Booking Item ids; duplicate ids are rejected."
+                          },
+                          "travelerId": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "required": ["type", "bookingItemIds", "travelerId"]
+                      }
+                    ]
+                  }
+                },
+                "required": ["expectedBookingRevision", "reason", "change"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Idempotent or no-op preview",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BookingAmendmentPreviewNoOpResponse"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Traveler correction preview",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BookingAmendmentOkResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid Idempotency-Key header",
+            "content": {
+              "application/json": {
+                "schema": {
                   "type": "object",
                   "properties": {
                     "error": {
@@ -6764,9 +5703,226 @@
                     "currentBookingRevision": {
                       "type": "integer",
                       "exclusiveMinimum": 0
+                    },
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
                     }
                   },
                   "required": ["error"]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Missing or mismatched Booking access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "currentBookingRevision": {
+                      "type": "integer",
+                      "exclusiveMinimum": 0
+                    },
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Booking or traveler not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "currentBookingRevision": {
+                      "type": "integer",
+                      "exclusiveMinimum": 0
+                    },
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Revision or idempotency conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "currentBookingRevision": {
+                      "type": "integer",
+                      "exclusiveMinimum": 0
+                    },
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/public/bookings/{bookingId}/amendments/{amendmentId}/reconcile": {
+      "post": {
+        "x-voyant-api-id": "@voyant-travel/bookings#api.public",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "bookingId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "amendmentId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Applied Booking Amendment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BookingAmendmentOkResponse"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Booking Amendment is waiting for supplier reconciliation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BookingAmendmentApplyPendingResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid Idempotency-Key header",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "currentBookingRevision": {
+                      "type": "integer",
+                      "exclusiveMinimum": 0
+                    },
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Missing or mismatched Booking access",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "currentBookingRevision": {
+                      "type": "integer",
+                      "exclusiveMinimum": 0
+                    },
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Booking Amendment not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "currentBookingRevision": {
+                      "type": "integer",
+                      "exclusiveMinimum": 0
+                    },
+                    "bookingItemId": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Apply conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BookingAmendmentApplyConflictResponse"
                 }
               }
             }

--- a/packages/bookings/src/action-declarations.ts
+++ b/packages/bookings/src/action-declarations.ts
@@ -174,6 +174,20 @@ export const BOOKING_ACTION_DECLARATIONS = {
         ),
       },
     },
+    previewTravelerRosterChange: {
+      ...amendmentWriteCapability,
+      id: "bookings:amendments:preview-traveler-roster-change",
+      resource: "booking",
+      action: "preview_traveler_roster_change_amendment",
+      graph: {
+        ...amendmentWriteCapability.graph,
+        id: "@voyant-travel/bookings#action.preview-traveler-roster-change-amendment",
+        commandTargetField: "bookingId",
+        from: amendmentToolBinding(
+          "@voyant-travel/bookings#tool.preview-traveler-roster-change-amendment",
+        ),
+      },
+    },
     accept: {
       ...amendmentWriteCapability,
       id: "bookings:amendments:accept",
@@ -196,6 +210,18 @@ export const BOOKING_ACTION_DECLARATIONS = {
         id: "@voyant-travel/bookings#action.apply-booking-amendment",
         commandTargetField: "amendmentId",
         from: amendmentToolBinding("@voyant-travel/bookings#tool.apply-booking-amendment"),
+      },
+    },
+    reconcile: {
+      ...amendmentWriteCapability,
+      id: "bookings:amendments:reconcile",
+      resource: "booking-amendment",
+      action: "reconcile",
+      graph: {
+        ...amendmentWriteCapability.graph,
+        id: "@voyant-travel/bookings#action.reconcile-booking-amendment",
+        commandTargetField: "amendmentId",
+        from: amendmentToolBinding("@voyant-travel/bookings#tool.reconcile-booking-amendment"),
       },
     },
   },

--- a/packages/bookings/src/index.ts
+++ b/packages/bookings/src/index.ts
@@ -22,11 +22,13 @@ import { createBookingsRuntime } from "./runtime.js"
 import {
   type BookingsGuestVerificationRuntime,
   type BookingsSelfServiceCreateRuntime,
+  type BookingsSupplierAmendmentRuntime,
   bookingsAccommodationRuntimePort,
   bookingsFinanceRuntimePort,
   bookingsGuestVerificationRuntimePort,
   bookingsRelationshipsRuntimePort,
   bookingsSelfServiceCreateRuntimePort,
+  bookingsSupplierAmendmentRuntimePort,
 } from "./runtime-port.js"
 
 export {
@@ -98,6 +100,7 @@ export {
   type BookingAmendmentCommandContext,
   bookingAmendmentService,
   type PreviewTravelerCorrectionResult,
+  type PreviewTravelerRosterChangeResult,
 } from "./service-amendments.js"
 export {
   type AddBookingGroupMemberInput,
@@ -225,11 +228,16 @@ export const createBookingsVoyantRuntime = defineGraphRuntimeFactory(
     const guestVerification = hasPort(bookingsGuestVerificationRuntimePort)
       ? ((await getPort(bookingsGuestVerificationRuntimePort)) as BookingsGuestVerificationRuntime)
       : undefined
+    const amendmentSupplier = hasPort(bookingsSupplierAmendmentRuntimePort)
+      ? ((await getPort(bookingsSupplierAmendmentRuntimePort)) as BookingsSupplierAmendmentRuntime)
+      : undefined
 
     const configured = createBookingsApiModule({
       ...provider.options,
       ...(selfServiceCreate ? { resolveSelfServiceCreate: () => selfServiceCreate } : {}),
       ...(guestVerification ? { resolveGuestVerification: () => guestVerification } : {}),
+      amendmentFinance: finance,
+      ...(amendmentSupplier ? { amendmentSupplier } : {}),
       resolveAuthenticatedPersonId: (c) => readCustomerPrincipal(c).personId,
       resolveAuthenticatedUserId: (c) => readCustomerPrincipal(c).userId,
     })

--- a/packages/bookings/src/mcp-runtime.ts
+++ b/packages/bookings/src/mcp-runtime.ts
@@ -55,6 +55,11 @@ export const voyantToolContextContribution = defineToolContextContribution({
       isInternalRequest: c.var.isInternalRequest,
       enforceRbac: isStaffRbacEnforced(c.env),
     })
+    const amendmentRuntime = getBookingToolRouteRuntime(c)
+    const amendmentDependencies = {
+      finance: amendmentRuntime.amendmentFinance,
+      supplier: amendmentRuntime.amendmentSupplier,
+    }
     const buildBookingDetail = async (
       row: Awaited<ReturnType<typeof bookingsService.getBookingById>>,
     ) => {
@@ -136,6 +141,20 @@ export const voyantToolContextContribution = defineToolContextContribution({
               bookingId,
               command,
               bookingAmendmentToolCommandContext(c, idempotencyKey),
+              amendmentDependencies,
+            )
+            return visibleBookingAmendmentToolResult(db, c, reveal, "preview", result)
+          },
+          async previewTravelerRosterChangeAmendment(
+            input: Parameters<BookingsToolServices["previewTravelerRosterChangeAmendment"]>[0],
+          ) {
+            const { bookingId, idempotencyKey, ...command } = input
+            const result = await bookingAmendmentService.previewTravelerRosterChange(
+              db,
+              bookingId,
+              command,
+              bookingAmendmentToolCommandContext(c, idempotencyKey),
+              amendmentDependencies,
             )
             return visibleBookingAmendmentToolResult(db, c, reveal, "preview", result)
           },
@@ -150,6 +169,7 @@ export const voyantToolContextContribution = defineToolContextContribution({
               amendmentId,
               proposedRevisionId,
               bookingAmendmentToolCommandContext(c, idempotencyKey),
+              amendmentDependencies,
             )
             return visibleBookingAmendmentToolResult(db, c, reveal, "accept", result)
           },
@@ -164,8 +184,22 @@ export const voyantToolContextContribution = defineToolContextContribution({
               amendmentId,
               command,
               bookingAmendmentToolCommandContext(c, idempotencyKey),
+              amendmentDependencies,
             )
             return visibleBookingAmendmentToolResult(db, c, reveal, "apply", result)
+          },
+          async reconcileBookingAmendment(
+            input: Parameters<BookingsToolServices["reconcileBookingAmendment"]>[0],
+          ) {
+            const { bookingId, amendmentId, idempotencyKey } = input
+            const result = await bookingAmendmentService.reconcile(
+              db,
+              bookingId,
+              amendmentId,
+              bookingAmendmentToolCommandContext(c, idempotencyKey),
+              amendmentDependencies,
+            )
+            return visibleBookingAmendmentToolResult(db, c, reveal, "reconcile", result)
           },
         },
       },
@@ -187,7 +221,7 @@ async function visibleBookingAmendmentToolResult(
   db: Parameters<typeof bookingAmendmentService.get>[0],
   c: Context<Env>,
   reveal: boolean,
-  action: "preview" | "accept" | "apply",
+  action: "preview" | "accept" | "apply" | "reconcile",
   result: unknown,
 ) {
   if (!isRecord(result) || !isRecord(result.amendment)) return result

--- a/packages/bookings/src/route-runtime.ts
+++ b/packages/bookings/src/route-runtime.ts
@@ -5,6 +5,7 @@ import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { resolveMonthlyBookingLimit } from "./booking-plan-limit.js"
 import type { BookingTravelerSnapshot } from "./pii.js"
 import type { KmsBindings } from "./routes-shared.js"
+import type { BookingsFinanceRuntime, BookingsSupplierAmendmentRuntime } from "./runtime-port.js"
 import type { BookingStatus } from "./state-machine.js"
 
 export const BOOKING_ROUTE_RUNTIME_CONTAINER_KEY = "runtime.bookings.routes"
@@ -140,6 +141,8 @@ export interface BookingRouteRuntime {
   customFieldsForWrite?: CustomFieldRegistryResolver
   /** Per-`booking_item_type` public-overview enrichers (issue #2969). */
   overviewItemEnrichers?: Partial<Record<string, BookingOverviewItemEnricher>>
+  amendmentFinance?: BookingsFinanceRuntime
+  amendmentSupplier?: BookingsSupplierAmendmentRuntime
 }
 
 /**
@@ -164,6 +167,8 @@ export interface BookingRouteRuntimeOptions {
   recordCancellationFinancialSettlement?: RecordCancellationFinancialSettlement
   customFieldsForWrite?: CustomFieldRegistryResolver
   overviewItemEnrichers?: Partial<Record<string, BookingOverviewItemEnricher>>
+  amendmentFinance?: BookingsFinanceRuntime
+  amendmentSupplier?: BookingsSupplierAmendmentRuntime
 }
 
 function buildRuntimeEnv(bindings: KmsBindings): Record<string, string | undefined> {
@@ -203,5 +208,7 @@ export function buildBookingRouteRuntime(
     recordCancellationFinancialSettlement: options.recordCancellationFinancialSettlement,
     customFieldsForWrite: options.customFieldsForWrite,
     overviewItemEnrichers: options.overviewItemEnrichers,
+    amendmentFinance: options.amendmentFinance,
+    amendmentSupplier: options.amendmentSupplier,
   }
 }

--- a/packages/bookings/src/routes-amendments.ts
+++ b/packages/bookings/src/routes-amendments.ts
@@ -1,16 +1,18 @@
+// agent-quality: file-size exception -- owner: bookings; staff and customer Amendment routes share one set of schemas, outcome mappings, and service handlers.
 import { OpenAPIHono, z } from "@hono/zod-openapi"
 import {
   acceptBookingAmendmentSchema,
   applyBookingAmendmentSchema,
-  bookingAmendmentPreviewResultSchema,
   bookingAmendmentSchema,
   previewTravelerCorrectionSchema,
+  previewTravelerRosterChangeSchema,
 } from "@voyant-travel/bookings-contracts"
 import { idempotencyKey, isStaffRbacEnforced, openApiValidationHook } from "@voyant-travel/hono"
 import type { Context } from "hono"
 
 import { type GuestBookingAccessAction, requireGuestBookingAccess } from "./checkout-capability.js"
 import { redactTravelerIdentity, shouldRevealBookingPii } from "./pii-redaction.js"
+import { BOOKING_ROUTE_RUNTIME_CONTAINER_KEY, type BookingRouteRuntime } from "./route-runtime.js"
 import { createBookingsAdminRoute, createBookingsPublicRoute } from "./routes-openapi.js"
 import { requireBookingStorefrontOrigin } from "./routes-public.js"
 import { type Env, getRuntimeEnv } from "./routes-shared.js"
@@ -25,10 +27,49 @@ const bookingParamsSchema = z.object({ bookingId: z.string() })
 const errorSchema = z.object({
   error: z.string(),
   currentBookingRevision: z.number().int().positive().optional(),
+  bookingItemId: z.string().optional(),
+  reason: z.string().optional(),
 })
-const amendmentDataSchema = z.object({ data: bookingAmendmentSchema })
-const previewDataSchema = z.object({ data: bookingAmendmentPreviewResultSchema })
-const amendmentListDataSchema = z.object({ data: z.array(bookingAmendmentSchema) })
+const bookingAmendmentOpenApiSchema = bookingAmendmentSchema.openapi("BookingAmendment")
+const amendmentDataSchema = z.object({ data: bookingAmendmentOpenApiSchema })
+const amendmentListDataSchema = z.object({ data: z.array(bookingAmendmentOpenApiSchema) })
+const amendmentOkDataSchema = z
+  .object({
+    data: z.object({
+      status: z.literal("ok"),
+      amendment: bookingAmendmentOpenApiSchema,
+    }),
+  })
+  .openapi("BookingAmendmentOkResponse")
+const previewNoOpDataSchema = z
+  .object({
+    data: z.object({
+      status: z.literal("no_op"),
+      bookingId: z.string(),
+      travelerId: z.string(),
+      bookingRevision: z.number().int().positive(),
+    }),
+  })
+  .openapi("BookingAmendmentPreviewNoOpResponse")
+const applyPendingDataSchema = z
+  .object({
+    data: z.object({
+      status: z.enum(["supplier_pending", "supplier_in_doubt", "manual_review"]),
+      amendment: bookingAmendmentOpenApiSchema,
+    }),
+  })
+  .openapi("BookingAmendmentApplyPendingResponse")
+const applyRefusedDataSchema = z
+  .object({
+    data: z.object({
+      status: z.literal("supplier_refused"),
+      amendment: bookingAmendmentOpenApiSchema,
+    }),
+  })
+  .openapi("BookingAmendmentApplyRefusedResponse")
+const applyConflictDataSchema = z
+  .union([errorSchema, applyRefusedDataSchema])
+  .openapi("BookingAmendmentApplyConflictResponse")
 const publicForbiddenResponse = {
   description: "Missing or mismatched Booking access",
   content: { "application/json": { schema: errorSchema } },
@@ -51,9 +92,24 @@ function mutationContext(
   }
 }
 
+function amendmentDependencies(c: Context<Env>) {
+  const runtime = c
+    .get("container")
+    ?.resolve<BookingRouteRuntime>(BOOKING_ROUTE_RUNTIME_CONTAINER_KEY)
+  return {
+    finance: runtime?.amendmentFinance,
+    supplier: runtime?.amendmentSupplier,
+  }
+}
+
 function amendmentError(
   c: Context<Env>,
-  result: { status: string; currentBookingRevision?: number },
+  result: {
+    status: string
+    currentBookingRevision?: number
+    bookingItemId?: string
+    reason?: string
+  },
 ) {
   if (result.status === "not_found") return c.json({ error: "amendment_not_found" }, 404)
   if (result.status === "stale_revision") {
@@ -65,7 +121,14 @@ function amendmentError(
       409,
     )
   }
-  return c.json({ error: result.status }, 409)
+  return c.json(
+    {
+      error: result.status,
+      ...(result.bookingItemId ? { bookingItemId: result.bookingItemId } : {}),
+      ...(result.reason ? { reason: result.reason } : {}),
+    },
+    409,
+  )
 }
 
 function redactAmendmentHistory(amendment: z.infer<typeof bookingAmendmentSchema>) {
@@ -170,11 +233,11 @@ const adminPreviewRoute = createBookingsAdminRoute({
     400: idempotencyRequiredResponse,
     201: {
       description: "Traveler correction preview",
-      content: { "application/json": { schema: previewDataSchema } },
+      content: { "application/json": { schema: amendmentOkDataSchema } },
     },
     200: {
       description: "Idempotent or no-op preview",
-      content: { "application/json": { schema: previewDataSchema } },
+      content: { "application/json": { schema: previewNoOpDataSchema } },
     },
     404: {
       description: "Booking or traveler not found",
@@ -185,6 +248,19 @@ const adminPreviewRoute = createBookingsAdminRoute({
       content: { "application/json": { schema: errorSchema } },
     },
   },
+})
+
+const adminRosterPreviewRoute = createBookingsAdminRoute({
+  method: "post",
+  path: "/{bookingId}/amendments/traveler-roster/preview",
+  request: {
+    params: bookingParamsSchema,
+    body: {
+      required: true,
+      content: { "application/json": { schema: previewTravelerRosterChangeSchema } },
+    },
+  },
+  responses: adminPreviewRoute.responses,
 })
 
 const adminListRoute = createBookingsAdminRoute({
@@ -256,7 +332,11 @@ const adminApplyRoute = createBookingsAdminRoute({
     400: idempotencyRequiredResponse,
     200: {
       description: "Applied Booking Amendment",
-      content: { "application/json": { schema: amendmentDataSchema } },
+      content: { "application/json": { schema: amendmentOkDataSchema } },
+    },
+    202: {
+      description: "Booking Amendment is waiting for supplier reconciliation",
+      content: { "application/json": { schema: applyPendingDataSchema } },
     },
     404: {
       description: "Booking Amendment not found",
@@ -264,14 +344,25 @@ const adminApplyRoute = createBookingsAdminRoute({
     },
     409: {
       description: "Apply conflict",
-      content: { "application/json": { schema: errorSchema } },
+      content: { "application/json": { schema: applyConflictDataSchema } },
     },
   },
+})
+
+const adminReconcileRoute = createBookingsAdminRoute({
+  method: "post",
+  path: "/{bookingId}/amendments/{amendmentId}/reconcile",
+  request: { params: amendmentParamsSchema },
+  responses: adminApplyRoute.responses,
 })
 
 const adminApp = new OpenAPIHono<Env>({ defaultHook: openApiValidationHook })
 adminApp.use(
   "/:bookingId/amendments/traveler-corrections/preview",
+  idempotencyKey<Env["Bindings"], Env["Variables"]>({ required: true }),
+)
+adminApp.use(
+  "/:bookingId/amendments/traveler-roster/preview",
   idempotencyKey<Env["Bindings"], Env["Variables"]>({ required: true }),
 )
 adminApp.use(
@@ -282,6 +373,10 @@ adminApp.use(
   "/:bookingId/amendments/:amendmentId/apply",
   idempotencyKey<Env["Bindings"], Env["Variables"]>({ required: true }),
 )
+adminApp.use(
+  "/:bookingId/amendments/:amendmentId/reconcile",
+  idempotencyKey<Env["Bindings"], Env["Variables"]>({ required: true }),
+)
 
 export const bookingAmendmentAdminRoutes = adminApp
   .openapi(adminPreviewRoute, async (c) => {
@@ -290,6 +385,7 @@ export const bookingAmendmentAdminRoutes = adminApp
       c.req.valid("param").bookingId,
       c.req.valid("json"),
       mutationContext(c, "staff"),
+      amendmentDependencies(c),
     )
     if (result.status === "ok") {
       return c.json(
@@ -306,6 +402,30 @@ export const bookingAmendmentAdminRoutes = adminApp
       )
     }
     if (result.status === "no_op") return c.json({ data: result }, 200)
+    return amendmentError(c, result)
+  })
+  .openapi(adminRosterPreviewRoute, async (c) => {
+    const result = await bookingAmendmentService.previewTravelerRosterChange(
+      c.get("db"),
+      c.req.valid("param").bookingId,
+      c.req.valid("json"),
+      mutationContext(c, "staff"),
+      amendmentDependencies(c),
+    )
+    if (result.status === "ok") {
+      return c.json(
+        {
+          data: {
+            ...result,
+            amendment: await visibleAdminAmendment(c, result.amendment, {
+              amendmentId: result.amendment.id,
+              operation: "preview_roster_change",
+            }),
+          },
+        },
+        201,
+      )
+    }
     return amendmentError(c, result)
   })
   .openapi(adminListRoute, async (c) => {
@@ -332,6 +452,7 @@ export const bookingAmendmentAdminRoutes = adminApp
       amendmentId,
       c.req.valid("json").proposedRevisionId,
       mutationContext(c, "staff"),
+      amendmentDependencies(c),
     )
     if (result.status === "ok" || result.status === "already_applied") {
       return c.json(
@@ -355,17 +476,68 @@ export const bookingAmendmentAdminRoutes = adminApp
       amendmentId,
       c.req.valid("json"),
       mutationContext(c, "staff"),
+      amendmentDependencies(c),
     )
     if (result.status === "ok") {
-      return c.json(
-        {
-          data: await visibleAdminAmendment(c, result.amendment, {
-            amendmentId,
-            operation: "apply",
-          }),
-        },
-        200,
-      )
+      const amendment = await visibleAdminAmendment(c, result.amendment, {
+        amendmentId,
+        operation: "apply",
+      })
+      return c.json({ data: { status: "ok" as const, amendment } }, 200)
+    }
+    if (result.status === "supplier_refused") {
+      const amendment = await visibleAdminAmendment(c, result.amendment, {
+        amendmentId,
+        operation: "apply",
+      })
+      return c.json({ data: { status: "supplier_refused" as const, amendment } }, 409)
+    }
+    if (
+      result.status === "supplier_pending" ||
+      result.status === "supplier_in_doubt" ||
+      result.status === "manual_review"
+    ) {
+      const amendment = await visibleAdminAmendment(c, result.amendment, {
+        amendmentId,
+        operation: "apply",
+      })
+      return c.json({ data: { status: result.status, amendment } }, 202)
+    }
+    return amendmentError(c, result)
+  })
+  .openapi(adminReconcileRoute, async (c) => {
+    const { bookingId, amendmentId } = c.req.valid("param")
+    const result = await bookingAmendmentService.reconcile(
+      c.get("db"),
+      bookingId,
+      amendmentId,
+      mutationContext(c, "staff"),
+      amendmentDependencies(c),
+    )
+    if (result.status === "ok") {
+      const amendment = await visibleAdminAmendment(c, result.amendment, {
+        amendmentId,
+        operation: "reconcile",
+      })
+      return c.json({ data: { status: "ok" as const, amendment } }, 200)
+    }
+    if (result.status === "supplier_refused") {
+      const amendment = await visibleAdminAmendment(c, result.amendment, {
+        amendmentId,
+        operation: "reconcile",
+      })
+      return c.json({ data: { status: "supplier_refused" as const, amendment } }, 409)
+    }
+    if (
+      result.status === "supplier_pending" ||
+      result.status === "supplier_in_doubt" ||
+      result.status === "manual_review"
+    ) {
+      const amendment = await visibleAdminAmendment(c, result.amendment, {
+        amendmentId,
+        operation: "reconcile",
+      })
+      return c.json({ data: { status: result.status, amendment } }, 202)
     }
     return amendmentError(c, result)
   })
@@ -396,6 +568,12 @@ const publicPreviewRoute = createBookingsPublicRoute({
   request: adminPreviewRoute.request,
   responses: { ...adminPreviewRoute.responses, 403: publicForbiddenResponse },
 })
+const publicRosterPreviewRoute = createBookingsPublicRoute({
+  method: "post",
+  path: "/{bookingId}/amendments/traveler-roster/preview",
+  request: adminRosterPreviewRoute.request,
+  responses: { ...adminRosterPreviewRoute.responses, 403: publicForbiddenResponse },
+})
 const publicListRoute = createBookingsPublicRoute({
   method: "get",
   path: "/{bookingId}/amendments",
@@ -420,10 +598,20 @@ const publicApplyRoute = createBookingsPublicRoute({
   request: adminApplyRoute.request,
   responses: { ...adminApplyRoute.responses, 403: publicForbiddenResponse },
 })
+const publicReconcileRoute = createBookingsPublicRoute({
+  method: "post",
+  path: "/{bookingId}/amendments/{amendmentId}/reconcile",
+  request: adminReconcileRoute.request,
+  responses: { ...adminReconcileRoute.responses, 403: publicForbiddenResponse },
+})
 
 const publicApp = new OpenAPIHono<Env>({ defaultHook: openApiValidationHook })
 publicApp.use(
   "/:bookingId/amendments/traveler-corrections/preview",
+  idempotencyKey<Env["Bindings"], Env["Variables"]>({ required: true }),
+)
+publicApp.use(
+  "/:bookingId/amendments/traveler-roster/preview",
   idempotencyKey<Env["Bindings"], Env["Variables"]>({ required: true }),
 )
 publicApp.use(
@@ -432,6 +620,10 @@ publicApp.use(
 )
 publicApp.use(
   "/:bookingId/amendments/:amendmentId/apply",
+  idempotencyKey<Env["Bindings"], Env["Variables"]>({ required: true }),
+)
+publicApp.use(
+  "/:bookingId/amendments/:amendmentId/reconcile",
   idempotencyKey<Env["Bindings"], Env["Variables"]>({ required: true }),
 )
 
@@ -445,6 +637,7 @@ export const bookingAmendmentPublicRoutes = publicApp
       bookingId,
       c.req.valid("json"),
       mutationContext(c, "customer"),
+      amendmentDependencies(c),
     )
     if (result.status === "ok") {
       return c.json(
@@ -461,6 +654,33 @@ export const bookingAmendmentPublicRoutes = publicApp
       )
     }
     if (result.status === "no_op") return c.json({ data: result }, 200)
+    return amendmentError(c, result)
+  })
+  .openapi(publicRosterPreviewRoute, async (c) => {
+    const bookingId = c.req.valid("param").bookingId
+    const denied = await requirePublicAccess(c, bookingId, "amendment:preview")
+    if (denied) return denied
+    const result = await bookingAmendmentService.previewTravelerRosterChange(
+      c.get("db"),
+      bookingId,
+      c.req.valid("json"),
+      mutationContext(c, "customer"),
+      amendmentDependencies(c),
+    )
+    if (result.status === "ok") {
+      return c.json(
+        {
+          data: {
+            ...result,
+            amendment: await auditedPublicAmendment(c, result.amendment, {
+              amendmentId: result.amendment.id,
+              operation: "preview_roster_change",
+            }),
+          },
+        },
+        201,
+      )
+    }
     return amendmentError(c, result)
   })
   .openapi(publicListRoute, async (c) => {
@@ -491,6 +711,7 @@ export const bookingAmendmentPublicRoutes = publicApp
       amendmentId,
       c.req.valid("json").proposedRevisionId,
       mutationContext(c, "customer"),
+      amendmentDependencies(c),
     )
     if (result.status === "ok" || result.status === "already_applied") {
       return c.json(
@@ -516,17 +737,70 @@ export const bookingAmendmentPublicRoutes = publicApp
       amendmentId,
       c.req.valid("json"),
       mutationContext(c, "customer"),
+      amendmentDependencies(c),
     )
     if (result.status === "ok") {
-      return c.json(
-        {
-          data: await auditedPublicAmendment(c, result.amendment, {
-            amendmentId,
-            operation: "apply",
-          }),
-        },
-        200,
-      )
+      const amendment = await auditedPublicAmendment(c, result.amendment, {
+        amendmentId,
+        operation: "apply",
+      })
+      return c.json({ data: { status: "ok" as const, amendment } }, 200)
+    }
+    if (result.status === "supplier_refused") {
+      const amendment = await auditedPublicAmendment(c, result.amendment, {
+        amendmentId,
+        operation: "apply",
+      })
+      return c.json({ data: { status: "supplier_refused" as const, amendment } }, 409)
+    }
+    if (
+      result.status === "supplier_pending" ||
+      result.status === "supplier_in_doubt" ||
+      result.status === "manual_review"
+    ) {
+      const amendment = await auditedPublicAmendment(c, result.amendment, {
+        amendmentId,
+        operation: "apply",
+      })
+      return c.json({ data: { status: result.status, amendment } }, 202)
+    }
+    return amendmentError(c, result)
+  })
+  .openapi(publicReconcileRoute, async (c) => {
+    const { bookingId, amendmentId } = c.req.valid("param")
+    const denied = await requirePublicAccess(c, bookingId, "amendment:apply")
+    if (denied) return denied
+    const result = await bookingAmendmentService.reconcile(
+      c.get("db"),
+      bookingId,
+      amendmentId,
+      mutationContext(c, "customer"),
+      amendmentDependencies(c),
+    )
+    if (result.status === "ok") {
+      const amendment = await auditedPublicAmendment(c, result.amendment, {
+        amendmentId,
+        operation: "reconcile",
+      })
+      return c.json({ data: { status: "ok" as const, amendment } }, 200)
+    }
+    if (result.status === "supplier_refused") {
+      const amendment = await auditedPublicAmendment(c, result.amendment, {
+        amendmentId,
+        operation: "reconcile",
+      })
+      return c.json({ data: { status: "supplier_refused" as const, amendment } }, 409)
+    }
+    if (
+      result.status === "supplier_pending" ||
+      result.status === "supplier_in_doubt" ||
+      result.status === "manual_review"
+    ) {
+      const amendment = await auditedPublicAmendment(c, result.amendment, {
+        amendmentId,
+        operation: "reconcile",
+      })
+      return c.json({ data: { status: result.status, amendment } }, 202)
     }
     return amendmentError(c, result)
   })

--- a/packages/bookings/src/runtime-port.ts
+++ b/packages/bookings/src/runtime-port.ts
@@ -1,3 +1,7 @@
+import type {
+  BookingAmendmentFinancialConsequences,
+  BookingAmendmentPrice,
+} from "@voyant-travel/bookings-contracts"
 import { definePort } from "@voyant-travel/core/project"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
@@ -24,6 +28,76 @@ export interface BookingsFinanceRuntime {
     resolveDb: () => PostgresJsDatabase | Promise<PostgresJsDatabase>
     userId?: string
   }): BookingsExpireStaleHoldsJobRuntime
+  quoteBookingAmendment(
+    db: PostgresJsDatabase,
+    input: {
+      bookingId: string
+      currency: string
+      lines: ReadonlyArray<{
+        bookingItemId: string
+        productId: string | null
+        subtotalDeltaCents: number
+      }>
+    },
+  ): Promise<{
+    price: BookingAmendmentPrice
+    consequences: BookingAmendmentFinancialConsequences
+    policyVersion: string
+  }>
+  recordBookingAmendment(
+    tx: PostgresJsDatabase,
+    input: {
+      amendmentId: string
+      bookingId: string
+      idempotencyKey: string
+      price: BookingAmendmentPrice
+      consequences: BookingAmendmentFinancialConsequences
+      reason: string
+    },
+  ): Promise<{ adjustmentId: string; status: "recorded" | "replay" }>
+}
+
+export interface BookingSupplierAmendmentOperationInput {
+  bookingItemId: string
+  entityModule: string
+  entityId: string
+  sourceKind: string
+  sourceConnectionId: string
+  sourceRef: string
+  upstreamRef: string
+  desiredState: {
+    parameters?: Record<string, unknown>
+    party: { passengers: ReadonlyArray<Record<string, unknown>> }
+  }
+  requestFingerprint: string
+}
+
+export interface BookingsSupplierAmendmentRuntime {
+  dispatch(input: {
+    db: PostgresJsDatabase
+    amendmentId: string
+    bookingId: string
+    idempotencyKey: string
+    operations: ReadonlyArray<BookingSupplierAmendmentOperationInput>
+    now: Date
+  }): Promise<
+    ReadonlyArray<{
+      bookingItemId: string
+      supplierOperationId: string | null
+      outcome: "secured" | "pending" | "in_doubt" | "refused" | "idempotency_conflict"
+    }>
+  >
+  reconcile(input: {
+    db: PostgresJsDatabase
+    supplierOperationIds: ReadonlyArray<string>
+    now: Date
+  }): Promise<
+    ReadonlyArray<{
+      bookingItemId: string
+      supplierOperationId: string | null
+      outcome: "secured" | "pending" | "in_doubt" | "refused" | "idempotency_conflict"
+    }>
+  >
 }
 
 export interface BookingsInventoryRuntime {
@@ -154,7 +228,11 @@ export const bookingsAccommodationRuntimePort = objectPort<BookingsAccommodation
 )
 export const bookingsFinanceRuntimePort = objectPort<BookingsFinanceRuntime>(
   "bookings.finance.runtime",
-  ["createStaleBookingHoldsJobRuntime"],
+  ["createStaleBookingHoldsJobRuntime", "quoteBookingAmendment", "recordBookingAmendment"],
+)
+export const bookingsSupplierAmendmentRuntimePort = objectPort<BookingsSupplierAmendmentRuntime>(
+  "bookings.supplier-amendment.runtime",
+  ["dispatch", "reconcile"],
 )
 export const bookingsInventoryRuntimePort = objectPort<BookingsInventoryRuntime>(
   "bookings.inventory.runtime",

--- a/packages/bookings/src/schema-amendments.ts
+++ b/packages/bookings/src/schema-amendments.ts
@@ -1,6 +1,8 @@
 import type {
+  BookingAmendmentFinancialConsequences,
   BookingRevisionSnapshot,
   TravelerCorrectionPatch,
+  TravelerRosterChange,
 } from "@voyant-travel/bookings-contracts"
 import { typeId, typeIdRef } from "@voyant-travel/db/lib/typeid-column"
 import { sql } from "drizzle-orm"
@@ -18,9 +20,22 @@ import {
 
 import { bookings } from "./schema-core.js"
 
-export type BookingAmendmentStatus = "proposed" | "accepted" | "applied" | "rejected" | "failed"
+export type BookingAmendmentStatus =
+  | "proposed"
+  | "accepted"
+  | "applying"
+  | "applied"
+  | "rejected"
+  | "failed"
+  | "in_doubt"
+  | "manual_review"
 export type BookingAmendmentActor = "customer" | "staff" | "partner" | "system"
 export type BookingRevisionRole = "before" | "proposed_after"
+export type BookingAmendmentKind = "traveler_correction" | "traveler_add" | "traveler_drop"
+
+export type BookingAmendmentRequestedChange =
+  | { type: "traveler_correction"; travelerId: string; patch: TravelerCorrectionPatch }
+  | (TravelerRosterChange & { travelerId: string })
 
 export interface BookingAmendmentPolicyDecision {
   code: string
@@ -30,11 +45,50 @@ export interface BookingAmendmentPolicyDecision {
 }
 
 export interface BookingAmendmentEffects {
-  finance: "not_required"
-  legal: "not_required"
-  documents: "not_required"
-  fulfillment: "not_required"
-  supplier: "not_required"
+  finance: "not_required" | "collection_required" | "refund_required" | "recorded"
+  legal: "not_required" | "review_required"
+  documents: "not_required" | "reissue_required"
+  fulfillment: "not_required" | "reissue_required"
+  supplier:
+    | "not_required"
+    | "modify_required"
+    | "pending"
+    | "secured"
+    | "refused"
+    | "in_doubt"
+    | "manual_review"
+  allocation: "not_required" | "increase_required" | "release_required" | "applied"
+}
+
+export interface BookingAmendmentTaxLine {
+  bookingItemId: string
+  code: string | null
+  name: string
+  amountCents: number
+  rateBasisPoints: number | null
+  includedInPrice: boolean
+}
+
+export interface BookingAmendmentRosterItemPlan {
+  bookingItemId: string
+  quantityDelta: 1 | -1
+  unitSellAmountCents: number
+  allocationId: string
+  allocationQuantityBefore: number
+  availabilitySlotId: string | null
+  supplierOperation: {
+    entityModule: string
+    entityId: string
+    sourceKind: string
+    sourceConnectionId: string
+    sourceRef: string
+    upstreamRef: string
+    desiredState: {
+      parameters?: Record<string, unknown>
+      party: { passengers: Record<string, unknown>[] }
+    }
+    requestFingerprint: string
+  } | null
 }
 
 export const bookingAmendments = pgTable(
@@ -45,19 +99,36 @@ export const bookingAmendments = pgTable(
       .notNull()
       .references(() => bookings.id, { onDelete: "cascade" }),
     travelerId: text("traveler_id").notNull(),
-    kind: text("kind").notNull().default("traveler_correction"),
+    kind: text("kind").$type<BookingAmendmentKind>().notNull().default("traveler_correction"),
     status: text("status").$type<BookingAmendmentStatus>().notNull().default("proposed"),
     baseBookingRevision: integer("base_booking_revision").notNull(),
     resultBookingRevision: integer("result_booking_revision").notNull(),
-    requestedPatch: jsonb("requested_patch").$type<TravelerCorrectionPatch>().notNull(),
+    requestedChange: jsonb("requested_change").$type<BookingAmendmentRequestedChange>().notNull(),
     acceptanceRequired: boolean("acceptance_required").notNull().default(false),
     policyDecisions: jsonb("policy_decisions")
       .$type<BookingAmendmentPolicyDecision[]>()
       .notNull()
       .default([]),
+    subtotalDeltaCents: integer("subtotal_delta_cents").notNull().default(0),
+    feeDeltaCents: integer("fee_delta_cents").notNull().default(0),
+    taxDeltaCents: integer("tax_delta_cents").notNull().default(0),
     priceDeltaCents: integer("price_delta_cents").notNull().default(0),
     priceCurrency: text("price_currency").notNull(),
+    collectionAmountCents: integer("collection_amount_cents").notNull().default(0),
+    refundAmountCents: integer("refund_amount_cents").notNull().default(0),
+    taxLines: jsonb("tax_lines").$type<BookingAmendmentTaxLine[]>().notNull().default([]),
+    financialConsequences: jsonb("financial_consequences")
+      .$type<BookingAmendmentFinancialConsequences>()
+      .notNull(),
     effects: jsonb("effects").$type<BookingAmendmentEffects>().notNull(),
+    quotedAt: timestamp("quoted_at", { withTimezone: true }).notNull().defaultNow(),
+    quoteExpiresAt: timestamp("quote_expires_at", { withTimezone: true }),
+    supplierOperationIds: jsonb("supplier_operation_ids").$type<string[]>().notNull().default([]),
+    operationPlan: jsonb("operation_plan")
+      .$type<BookingAmendmentRosterItemPlan[]>()
+      .notNull()
+      .default([]),
+    failureCode: text("failure_code"),
     previewIdempotencyKey: text("preview_idempotency_key").notNull(),
     acceptIdempotencyKey: text("accept_idempotency_key"),
     applyIdempotencyKey: text("apply_idempotency_key"),
@@ -70,6 +141,7 @@ export const bookingAmendments = pgTable(
     appliedAt: timestamp("applied_at", { withTimezone: true }),
     appliedBy: text("applied_by"),
     appliedActor: text("applied_actor").$type<BookingAmendmentActor>(),
+    applyStartedAt: timestamp("apply_started_at", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
@@ -81,25 +153,34 @@ export const bookingAmendments = pgTable(
     index("idx_booking_amendments_booking_created").on(table.bookingId, table.createdAt),
     index("idx_booking_amendments_traveler").on(table.travelerId),
     index("idx_booking_amendments_status").on(table.status),
-    check("ck_booking_amendments_kind", sql`${table.kind} = 'traveler_correction'`),
+    check(
+      "ck_booking_amendments_kind",
+      // agent-quality: raw-sql reviewed -- owner: bookings; static enum membership constraint over Drizzle identifiers.
+      sql`${table.kind} IN ('traveler_correction', 'traveler_add', 'traveler_drop')`,
+    ),
     check(
       "ck_booking_amendments_status",
-      sql`${table.status} IN ('proposed', 'accepted', 'applied', 'rejected', 'failed')`,
+      // agent-quality: raw-sql reviewed -- owner: bookings; static lifecycle membership constraint over a Drizzle identifier.
+      sql`${table.status} IN ('proposed', 'accepted', 'applying', 'applied', 'rejected', 'failed', 'in_doubt', 'manual_review')`,
     ),
     check(
       "ck_booking_amendments_actor",
+      // agent-quality: raw-sql reviewed -- owner: bookings; static actor membership constraint over a Drizzle identifier.
       sql`${table.requestedActor} IN ('customer', 'staff', 'partner', 'system')`,
     ),
     check(
       "ck_booking_amendments_accepted_actor",
+      // agent-quality: raw-sql reviewed -- owner: bookings; static nullable actor constraint over a Drizzle identifier.
       sql`${table.acceptedActor} IS NULL OR ${table.acceptedActor} IN ('customer', 'staff', 'partner', 'system')`,
     ),
     check(
       "ck_booking_amendments_applied_actor",
+      // agent-quality: raw-sql reviewed -- owner: bookings; static nullable actor constraint over a Drizzle identifier.
       sql`${table.appliedActor} IS NULL OR ${table.appliedActor} IN ('customer', 'staff', 'partner', 'system')`,
     ),
     check(
       "ck_booking_amendments_lifecycle",
+      // agent-quality: raw-sql reviewed -- owner: bookings; lifecycle nullability invariant uses only Drizzle column identifiers and SQL literals.
       sql`(
         ${table.status} = 'proposed'
         AND ${table.acceptedAt} IS NULL
@@ -139,13 +220,21 @@ export const bookingAmendments = pgTable(
             AND ${table.acceptIdempotencyKey} IS NOT NULL
           )
         )
-      ) OR ${table.status} IN ('rejected', 'failed')`,
+      ) OR ${table.status} IN ('applying', 'in_doubt', 'manual_review', 'rejected', 'failed')`,
     ),
     check(
       "ck_booking_amendments_revision_step",
+      // agent-quality: raw-sql reviewed -- owner: bookings; exact revision-step invariant over Drizzle identifiers.
       sql`${table.baseBookingRevision} > 0 AND ${table.resultBookingRevision} = ${table.baseBookingRevision} + 1`,
     ),
-    check("ck_booking_amendments_zero_delta", sql`${table.priceDeltaCents} = 0`),
+    check(
+      "ck_booking_amendments_money",
+      // agent-quality: raw-sql reviewed -- owner: bookings; monetary balance invariant over Drizzle identifiers and integer literals.
+      sql`${table.priceDeltaCents} = ${table.subtotalDeltaCents} + ${table.feeDeltaCents} + ${table.taxDeltaCents}
+          AND ${table.collectionAmountCents} >= 0
+          AND ${table.refundAmountCents} >= 0
+          AND NOT (${table.collectionAmountCents} > 0 AND ${table.refundAmountCents} > 0)`,
+    ),
   ],
 )
 
@@ -170,7 +259,9 @@ export const bookingRevisions = pgTable(
   (table) => [
     uniqueIndex("uq_booking_revisions_amendment_role").on(table.amendmentId, table.role),
     index("idx_booking_revisions_booking_revision").on(table.bookingId, table.bookingRevision),
+    // agent-quality: raw-sql reviewed -- owner: bookings; positive revision constraint over a Drizzle identifier.
     check("ck_booking_revisions_revision_positive", sql`${table.bookingRevision} > 0`),
+    // agent-quality: raw-sql reviewed -- owner: bookings; static revision-role membership constraint over a Drizzle identifier.
     check("ck_booking_revisions_role", sql`${table.role} IN ('before', 'proposed_after')`),
   ],
 )

--- a/packages/bookings/src/service-amendments.ts
+++ b/packages/bookings/src/service-amendments.ts
@@ -1,27 +1,59 @@
+// agent-quality: file-size exception -- owner: bookings; preview, acceptance, supplier settlement, reconciliation, and atomic projection form one Amendment protocol with shared invariants.
 import type {
   BookingAmendment,
+  BookingAmendmentFinancialConsequences,
+  BookingAmendmentPrice,
   BookingRevisionSnapshot,
   PreviewTravelerCorrectionInput,
+  PreviewTravelerRosterChangeInput,
   TravelerCorrectionPatch,
 } from "@voyant-travel/bookings-contracts"
 import { newId } from "@voyant-travel/db/lib/typeid"
-import { and, asc, eq, or } from "drizzle-orm"
+import { and, asc, eq, inArray, or, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
+import { availabilitySlotsRef } from "./availability-ref.js"
+import type { BookingsFinanceRuntime, BookingsSupplierAmendmentRuntime } from "./runtime-port.js"
 import {
-  type BookingAmendmentActor,
-  type BookingAmendmentEffects,
-  type BookingAmendmentPolicyDecision,
-  type BookingAmendmentRow,
-  type BookingRevisionRow,
   bookingActivityLog,
+  bookingAllocations,
   bookingAmendments,
+  bookingItems,
+  bookingItemTravelers,
   bookingRevisions,
   bookings,
   bookingTravelers,
 } from "./schema.js"
+import type {
+  BookingAmendmentActor,
+  BookingAmendmentEffects,
+  BookingAmendmentPolicyDecision,
+  BookingAmendmentRosterItemPlan,
+  BookingAmendmentRow,
+  BookingRevisionRow,
+} from "./schema-amendments.js"
 
 const TRAVELER_IDENTITY_FIELDS = new Set<keyof TravelerCorrectionPatch>(["firstName", "lastName"])
+export const DEFAULT_BOOKING_AMENDMENT_QUOTE_TTL_MS = 30 * 60 * 1_000
+
+const ZERO_PRICE = (currency: string): BookingAmendmentPrice => ({
+  currency,
+  subtotalDeltaCents: 0,
+  feeDeltaCents: 0,
+  taxDeltaCents: 0,
+  amountCents: 0,
+  collectionAmountCents: 0,
+  refundAmountCents: 0,
+  taxLines: [],
+})
+
+const NO_FINANCIAL_CONSEQUENCES: BookingAmendmentFinancialConsequences = {
+  collection: "not_required",
+  refund: "not_required",
+  invoice: "not_required",
+  creditNote: "not_required",
+  paymentSchedule: "not_required",
+}
 
 const NO_EXTERNAL_EFFECTS: BookingAmendmentEffects = {
   finance: "not_required",
@@ -29,12 +61,20 @@ const NO_EXTERNAL_EFFECTS: BookingAmendmentEffects = {
   documents: "not_required",
   fulfillment: "not_required",
   supplier: "not_required",
+  allocation: "not_required",
 }
 
 export interface BookingAmendmentCommandContext {
   actor: BookingAmendmentActor
   actorId?: string | null
   idempotencyKey: string
+}
+
+export interface BookingAmendmentServiceDependencies {
+  finance?: BookingsFinanceRuntime
+  supplier?: BookingsSupplierAmendmentRuntime
+  now?: () => Date
+  quoteTtlMs?: number
 }
 
 export type PreviewTravelerCorrectionResult =
@@ -44,16 +84,59 @@ export type PreviewTravelerCorrectionResult =
   | { status: "idempotency_conflict" }
   | { status: "stale_revision"; currentBookingRevision: number }
 
+export type PreviewTravelerRosterChangeResult =
+  | { status: "ok"; amendment: BookingAmendment }
+  | { status: "not_found" | "idempotency_conflict" }
+  | { status: "unsupported_configuration"; reason: string }
+  | { status: "availability_changed"; bookingItemId: string }
+  | { status: "stale_revision"; currentBookingRevision: number }
+
 export type AcceptBookingAmendmentResult =
   | { status: "ok"; amendment: BookingAmendment }
-  | { status: "not_found" | "revision_mismatch" | "acceptance_not_required" }
+  | { status: "not_found" | "revision_mismatch" | "acceptance_not_required" | "quote_expired" }
   | { status: "already_applied"; amendment: BookingAmendment }
   | { status: "stale_revision"; currentBookingRevision: number }
 
 export type ApplyBookingAmendmentResult =
   | { status: "ok"; amendment: BookingAmendment }
-  | { status: "not_found" | "revision_mismatch" | "acceptance_required" | "invalid_state" }
+  | {
+      status: "supplier_pending" | "supplier_in_doubt" | "supplier_refused" | "manual_review"
+      amendment: BookingAmendment
+    }
+  | {
+      status:
+        | "not_found"
+        | "revision_mismatch"
+        | "acceptance_required"
+        | "invalid_state"
+        | "idempotency_conflict"
+        | "quote_expired"
+        | "unsupported_capability"
+    }
+  | { status: "availability_changed"; bookingItemId: string }
   | { status: "stale_revision"; currentBookingRevision: number }
+
+type BookingRow = typeof bookings.$inferSelect
+type TravelerRow = typeof bookingTravelers.$inferSelect
+type ItemRow = typeof bookingItems.$inferSelect
+type AllocationRow = typeof bookingAllocations.$inferSelect
+
+interface SnapshotState {
+  travelers: TravelerRow[]
+  items: ItemRow[]
+  allocations: AllocationRow[]
+  travelerIdsByItem: Map<string, string[]>
+}
+
+class RosterPlanError extends Error {
+  constructor(
+    readonly code: "not_found" | "unsupported_configuration" | "availability_changed",
+    message: string,
+    readonly bookingItemId?: string,
+  ) {
+    super(message)
+  }
+}
 
 function serializeRevision(row: BookingRevisionRow) {
   return {
@@ -70,27 +153,49 @@ function serializeRevision(row: BookingRevisionRow) {
   }
 }
 
-function serializeAmendment(row: BookingAmendmentRow, revisions: BookingRevisionRow[]) {
-  const nextActions: ("accept" | "apply")[] = []
-  if (row.status === "proposed") {
-    nextActions.push(row.acceptanceRequired ? "accept" : "apply")
-  } else if (row.status === "accepted") {
-    nextActions.push("apply")
+function nextActionsFor(row: BookingAmendmentRow) {
+  const nextActions: BookingAmendment["nextActions"] = []
+  if (row.status === "proposed") nextActions.push(row.acceptanceRequired ? "accept" : "apply")
+  if (row.status === "accepted") nextActions.push("apply")
+  if (row.status === "applying") nextActions.push("wait_supplier")
+  if (row.status === "in_doubt") nextActions.push("reconcile_supplier")
+  if (row.status === "manual_review") nextActions.push("manual_review")
+  if (row.status === "applied") {
+    if (row.collectionAmountCents > 0) nextActions.push("collect_payment")
+    if (row.refundAmountCents > 0) nextActions.push("issue_refund")
+    if (row.effects.documents === "reissue_required") nextActions.push("reissue_documents")
   }
+  return nextActions
+}
 
+function serializeAmendment(row: BookingAmendmentRow, revisions: BookingRevisionRow[]) {
   return {
     id: row.id,
     bookingId: row.bookingId,
     travelerId: row.travelerId,
-    kind: "traveler_correction" as const,
+    kind: row.kind,
     status: row.status,
     baseBookingRevision: row.baseBookingRevision,
     resultBookingRevision: row.resultBookingRevision,
     acceptanceRequired: row.acceptanceRequired,
     policyDecisions: row.policyDecisions,
-    priceDelta: { amountCents: 0 as const, currency: row.priceCurrency },
+    priceDelta: {
+      currency: row.priceCurrency,
+      subtotalDeltaCents: row.subtotalDeltaCents,
+      feeDeltaCents: row.feeDeltaCents,
+      taxDeltaCents: row.taxDeltaCents,
+      amountCents: row.priceDeltaCents,
+      collectionAmountCents: row.collectionAmountCents,
+      refundAmountCents: row.refundAmountCents,
+      taxLines: row.taxLines,
+    },
+    financialConsequences: row.financialConsequences,
     effects: row.effects,
-    nextActions,
+    nextActions: nextActionsFor(row),
+    quotedAt: row.quotedAt.toISOString(),
+    quoteExpiresAt: row.quoteExpiresAt?.toISOString() ?? null,
+    supplierOperationIds: row.supplierOperationIds,
+    failureCode: row.failureCode,
     requestedBy: row.requestedBy,
     requestedActor: row.requestedActor,
     reason: row.reason,
@@ -115,7 +220,7 @@ async function hydrateAmendment(db: PostgresJsDatabase, row: BookingAmendmentRow
   return serializeAmendment(row, revisions)
 }
 
-function snapshotTraveler(row: typeof bookingTravelers.$inferSelect) {
+function snapshotTraveler(row: TravelerRow) {
   return {
     id: row.id,
     personId: row.personId,
@@ -130,10 +235,92 @@ function snapshotTraveler(row: typeof bookingTravelers.$inferSelect) {
   }
 }
 
-function changedTravelerFields(
-  traveler: typeof bookingTravelers.$inferSelect,
-  patch: TravelerCorrectionPatch,
-) {
+async function loadSnapshotState(
+  db: PostgresJsDatabase,
+  bookingId: string,
+): Promise<SnapshotState> {
+  const [travelers, items, allocations, participants] = await Promise.all([
+    db
+      .select()
+      .from(bookingTravelers)
+      .where(eq(bookingTravelers.bookingId, bookingId))
+      .orderBy(asc(bookingTravelers.createdAt), asc(bookingTravelers.id)),
+    db
+      .select()
+      .from(bookingItems)
+      .where(eq(bookingItems.bookingId, bookingId))
+      .orderBy(asc(bookingItems.createdAt), asc(bookingItems.id)),
+    db
+      .select()
+      .from(bookingAllocations)
+      .where(eq(bookingAllocations.bookingId, bookingId))
+      .orderBy(asc(bookingAllocations.createdAt), asc(bookingAllocations.id)),
+    db
+      .select({
+        bookingItemId: bookingItemTravelers.bookingItemId,
+        travelerId: bookingItemTravelers.travelerId,
+      })
+      .from(bookingItemTravelers)
+      .innerJoin(bookingItems, eq(bookingItems.id, bookingItemTravelers.bookingItemId))
+      .where(eq(bookingItems.bookingId, bookingId)),
+  ])
+  const travelerIdsByItem = new Map<string, string[]>()
+  for (const participant of participants) {
+    const ids = travelerIdsByItem.get(participant.bookingItemId) ?? []
+    ids.push(participant.travelerId)
+    travelerIdsByItem.set(participant.bookingItemId, ids)
+  }
+  for (const ids of travelerIdsByItem.values()) ids.sort()
+  return { travelers, items, allocations, travelerIdsByItem }
+}
+
+function snapshotBooking(
+  booking: BookingRow,
+  revision: number,
+  state: SnapshotState,
+  overrides: {
+    travelers?: ReturnType<typeof snapshotTraveler>[]
+    itemQuantityDelta?: Map<string, number>
+    itemTravelerIds?: Map<string, string[]>
+    allocationQuantityDelta?: Map<string, number>
+    sellAmountDeltaCents?: number
+    paxDelta?: number
+  } = {},
+): BookingRevisionSnapshot {
+  const itemQuantityDelta = overrides.itemQuantityDelta ?? new Map()
+  const itemTravelerIds = overrides.itemTravelerIds ?? state.travelerIdsByItem
+  const allocationQuantityDelta = overrides.allocationQuantityDelta ?? new Map()
+  return {
+    bookingId: booking.id,
+    bookingNumber: booking.bookingNumber,
+    revision,
+    sellAmountCents:
+      booking.sellAmountCents == null
+        ? null
+        : booking.sellAmountCents + (overrides.sellAmountDeltaCents ?? 0),
+    pax: booking.pax == null ? null : Math.max(0, booking.pax + (overrides.paxDelta ?? 0)),
+    travelers: overrides.travelers ?? state.travelers.map(snapshotTraveler),
+    items: state.items.map((item) => ({
+      id: item.id,
+      quantity: item.quantity + (itemQuantityDelta.get(item.id) ?? 0),
+      totalSellAmountCents:
+        item.totalSellAmountCents == null
+          ? null
+          : item.totalSellAmountCents +
+            (itemQuantityDelta.get(item.id) ?? 0) * (item.unitSellAmountCents ?? 0),
+      travelerIds: [...(itemTravelerIds.get(item.id) ?? [])].sort(),
+      allocations: state.allocations
+        .filter((allocation) => allocation.bookingItemId === item.id)
+        .map((allocation) => ({
+          id: allocation.id,
+          quantity: allocation.quantity + (allocationQuantityDelta.get(allocation.id) ?? 0),
+          status: allocation.status,
+        })),
+    })),
+  }
+}
+
+function changedTravelerFields(traveler: TravelerRow, patch: TravelerCorrectionPatch) {
   return (Object.keys(patch) as (keyof TravelerCorrectionPatch)[])
     .filter((field) => patch[field] !== traveler[field])
     .sort()
@@ -150,7 +337,7 @@ function sameTravelerPatch(left: TravelerCorrectionPatch, right: TravelerCorrect
   )
 }
 
-function policyFor(input: {
+function correctionPolicy(input: {
   actor: BookingAmendmentActor
   changedFields: (keyof TravelerCorrectionPatch)[]
 }): { acceptanceRequired: boolean; decisions: BookingAmendmentPolicyDecision[] } {
@@ -171,11 +358,255 @@ function policyFor(input: {
   }
 }
 
-function applyTravelerPatch(
-  traveler: ReturnType<typeof snapshotTraveler>,
-  patch: TravelerCorrectionPatch,
+function rosterPolicy(financePolicyVersion: string): BookingAmendmentPolicyDecision[] {
+  return [
+    {
+      code: "priced-traveler-roster-change",
+      version: "v1",
+      decision: "acceptance_required",
+      reason: "Traveler roster changes alter price, inventory, or supplier state.",
+    },
+    {
+      code: "booking-amendment-finance",
+      version: financePolicyVersion,
+      decision: "acceptance_required",
+      reason: "The exact server-calculated financial delta is bound to this Booking revision.",
+    },
+  ]
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {}
+}
+
+function stringField(record: Record<string, unknown>, key: string) {
+  const value = record[key]
+  return typeof value === "string" && value.length > 0 ? value : null
+}
+
+function supplierPassenger(traveler: ReturnType<typeof snapshotTraveler>) {
+  return {
+    id: traveler.id,
+    first_name: traveler.firstName,
+    last_name: traveler.lastName,
+    ...(traveler.travelerCategory ? { category: traveler.travelerCategory } : {}),
+    ...(traveler.email ? { email: traveler.email } : {}),
+    ...(traveler.phone ? { phone: traveler.phone } : {}),
+  }
+}
+
+async function buildRosterPlans(
+  db: PostgresJsDatabase,
+  booking: BookingRow,
+  state: SnapshotState,
+  input: PreviewTravelerRosterChangeInput,
+  travelerId: string,
 ) {
-  return { ...traveler, ...patch }
+  const selectedIds = new Set(input.change.bookingItemIds)
+  const selectedItems = state.items.filter((item) => selectedIds.has(item.id))
+  if (selectedItems.length !== selectedIds.size) {
+    throw new RosterPlanError("not_found", "One or more Booking Items do not exist")
+  }
+  const existingTraveler = state.travelers.find((traveler) => traveler.id === travelerId)
+  if (input.change.type === "traveler_drop" && !existingTraveler) {
+    throw new RosterPlanError("not_found", "Traveler does not exist")
+  }
+  if (input.change.type === "traveler_drop") {
+    const assignedItemIds = [...state.travelerIdsByItem]
+      .filter(([, travelerIds]) => travelerIds.includes(travelerId))
+      .map(([itemId]) => itemId)
+      .sort()
+    const selectedItemIds = [...input.change.bookingItemIds].sort()
+    if (assignedItemIds.join("\u0000") !== selectedItemIds.join("\u0000")) {
+      throw new RosterPlanError(
+        "unsupported_configuration",
+        "Dropping a traveler must include every Booking Item currently assigned to that traveler",
+      )
+    }
+  }
+
+  const proposedTravelers =
+    input.change.type === "traveler_add"
+      ? [
+          ...state.travelers.map(snapshotTraveler),
+          {
+            id: travelerId,
+            personId: input.change.traveler.personId ?? null,
+            participantType: input.change.traveler.participantType,
+            travelerCategory: input.change.traveler.travelerCategory ?? null,
+            firstName: input.change.traveler.firstName,
+            lastName: input.change.traveler.lastName,
+            email: input.change.traveler.email ?? null,
+            phone: input.change.traveler.phone ?? null,
+            preferredLanguage: input.change.traveler.preferredLanguage ?? null,
+            isPrimary: false,
+          },
+        ]
+      : state.travelers.map(snapshotTraveler).filter((traveler) => traveler.id !== travelerId)
+
+  const proposedTravelerIdsByItem = new Map(
+    [...state.travelerIdsByItem].map(([itemId, ids]) => [itemId, [...ids]]),
+  )
+  for (const item of selectedItems) {
+    const currentIds = proposedTravelerIdsByItem.get(item.id) ?? []
+    if (input.change.type === "traveler_drop" && !currentIds.includes(travelerId)) {
+      throw new RosterPlanError(
+        "unsupported_configuration",
+        "Traveler is not assigned to every selected Booking Item",
+        item.id,
+      )
+    }
+    proposedTravelerIdsByItem.set(
+      item.id,
+      input.change.type === "traveler_add"
+        ? [...currentIds, travelerId].sort()
+        : currentIds.filter((id) => id !== travelerId),
+    )
+  }
+
+  const quantityDelta = input.change.type === "traveler_add" ? (1 as const) : (-1 as const)
+  const plans: BookingAmendmentRosterItemPlan[] = []
+  for (const item of selectedItems) {
+    if (item.status !== "confirmed" && item.status !== "on_hold") {
+      throw new RosterPlanError(
+        "unsupported_configuration",
+        "Only active Booking Items can change traveler roster",
+        item.id,
+      )
+    }
+    if (
+      item.sellCurrency !== booking.sellCurrency ||
+      item.unitSellAmountCents == null ||
+      item.totalSellAmountCents == null
+    ) {
+      throw new RosterPlanError(
+        "unsupported_configuration",
+        "Booking Item has no authoritative per-traveler price in the Booking currency",
+        item.id,
+      )
+    }
+    const activeAllocations = state.allocations.filter(
+      (allocation) =>
+        allocation.bookingItemId === item.id &&
+        (allocation.status === "held" || allocation.status === "confirmed"),
+    )
+    if (activeAllocations.length !== 1) {
+      throw new RosterPlanError(
+        "unsupported_configuration",
+        "Traveler roster changes require exactly one active capacity allocation per Booking Item",
+        item.id,
+      )
+    }
+    const allocation = activeAllocations[0]!
+    if (allocation.quantity + quantityDelta < 0) {
+      throw new RosterPlanError(
+        "unsupported_configuration",
+        "Allocation quantity cannot become negative",
+        item.id,
+      )
+    }
+    const allocationMetadata = asRecord(allocation.metadata)
+    const itemMetadata = asRecord(item.metadata)
+    const sourceConnectionId = stringField(allocationMetadata, "sourceConnectionId")
+    const upstreamRef =
+      stringField(allocationMetadata, "upstreamRef") ?? stringField(itemMetadata, "upstreamRef")
+    const sourceKind = stringField(allocationMetadata, "sourceKind")
+    const sourced = Boolean(sourceConnectionId || upstreamRef || sourceKind)
+    if (sourced && (!sourceConnectionId || !upstreamRef || !sourceKind)) {
+      throw new RosterPlanError(
+        "unsupported_configuration",
+        "Sourced allocation provenance is incomplete",
+        item.id,
+      )
+    }
+    if (!sourced && !allocation.availabilitySlotId) {
+      throw new RosterPlanError(
+        "unsupported_configuration",
+        "Owned allocation has no authoritative availability slot",
+        item.id,
+      )
+    }
+    if (quantityDelta > 0 && allocation.availabilitySlotId) {
+      const [slot] = await db
+        .select({
+          status: availabilitySlotsRef.status,
+          unlimited: availabilitySlotsRef.unlimited,
+          remainingPax: availabilitySlotsRef.remainingPax,
+          pastCutoff: availabilitySlotsRef.pastCutoff,
+          tooEarly: availabilitySlotsRef.tooEarly,
+        })
+        .from(availabilitySlotsRef)
+        .where(eq(availabilitySlotsRef.id, allocation.availabilitySlotId))
+        .limit(1)
+      if (
+        slot?.status !== "open" ||
+        slot.pastCutoff ||
+        slot.tooEarly ||
+        (!slot.unlimited && (slot.remainingPax ?? 0) < 1)
+      ) {
+        throw new RosterPlanError("availability_changed", "Availability changed", item.id)
+      }
+    }
+    const desiredPassengers = (proposedTravelerIdsByItem.get(item.id) ?? []).flatMap((id) => {
+      const traveler = proposedTravelers.find((candidate) => candidate.id === id)
+      return traveler ? [supplierPassenger(traveler)] : []
+    })
+    const desiredState = {
+      parameters: { quantity: item.quantity + quantityDelta },
+      party: { passengers: desiredPassengers },
+    }
+    plans.push({
+      bookingItemId: item.id,
+      quantityDelta,
+      unitSellAmountCents: item.unitSellAmountCents,
+      allocationId: allocation.id,
+      allocationQuantityBefore: allocation.quantity,
+      availabilitySlotId: allocation.availabilitySlotId,
+      supplierOperation: sourced
+        ? {
+            entityModule: stringField(itemMetadata, "entityModule") ?? "catalog",
+            entityId: stringField(itemMetadata, "entityId") ?? item.productId ?? item.id,
+            sourceKind: sourceKind!,
+            sourceConnectionId: sourceConnectionId!,
+            sourceRef: item.sourceOfferId ?? item.id,
+            upstreamRef: upstreamRef!,
+            desiredState,
+            requestFingerprint: await stableFingerprint(desiredState),
+          }
+        : null,
+    })
+  }
+  return { plans, proposedTravelers, proposedTravelerIdsByItem }
+}
+
+function rosterEffects(
+  kind: "traveler_add" | "traveler_drop",
+  price: BookingAmendmentPrice,
+  supplierRequired: boolean,
+): BookingAmendmentEffects {
+  return {
+    finance:
+      price.collectionAmountCents > 0
+        ? "collection_required"
+        : price.refundAmountCents > 0
+          ? "refund_required"
+          : "not_required",
+    legal: "not_required",
+    documents: "reissue_required",
+    fulfillment: "reissue_required",
+    supplier: supplierRequired ? "modify_required" : "not_required",
+    allocation: kind === "traveler_add" ? "increase_required" : "release_required",
+  }
+}
+
+function mapPlanError(error: RosterPlanError): PreviewTravelerRosterChangeResult {
+  if (error.code === "not_found") return { status: "not_found" }
+  if (error.code === "availability_changed") {
+    return { status: "availability_changed", bookingItemId: error.bookingItemId ?? "unknown" }
+  }
+  return { status: "unsupported_configuration", reason: error.message }
 }
 
 export const bookingAmendmentService = {
@@ -184,6 +615,7 @@ export const bookingAmendmentService = {
     bookingId: string,
     input: PreviewTravelerCorrectionInput,
     context: BookingAmendmentCommandContext,
+    dependencies: BookingAmendmentServiceDependencies = {},
   ): Promise<PreviewTravelerCorrectionResult> {
     return db.transaction(async (rawTx) => {
       const tx = rawTx as PostgresJsDatabase
@@ -206,19 +638,19 @@ export const bookingAmendmentService = {
         )
         .limit(1)
       if (existing) {
+        const requested = existing.requestedChange
         const sameRequest =
-          existing.travelerId === input.travelerId &&
+          requested.type === "traveler_correction" &&
+          requested.travelerId === input.travelerId &&
           existing.baseBookingRevision === input.expectedBookingRevision &&
           existing.reason === input.reason &&
-          sameTravelerPatch(existing.requestedPatch, input.patch)
+          sameTravelerPatch(requested.patch, input.patch)
         if (!sameRequest) return { status: "idempotency_conflict" as const }
         return { status: "ok" as const, amendment: await hydrateAmendment(tx, existing) }
       }
-
       if (booking.revision !== input.expectedBookingRevision) {
         return { status: "stale_revision" as const, currentBookingRevision: booking.revision }
       }
-
       const [traveler] = await tx
         .select()
         .from(bookingTravelers)
@@ -230,7 +662,6 @@ export const bookingAmendmentService = {
         )
         .limit(1)
       if (!traveler) return { status: "not_found" as const }
-
       const changedFields = changedTravelerFields(traveler, input.patch)
       if (changedFields.length === 0) {
         return {
@@ -240,32 +671,47 @@ export const bookingAmendmentService = {
           bookingRevision: booking.revision,
         }
       }
-
-      const travelers = await tx
-        .select()
-        .from(bookingTravelers)
-        .where(eq(bookingTravelers.bookingId, booking.id))
-        .orderBy(asc(bookingTravelers.createdAt), asc(bookingTravelers.id))
-      const beforeTravelers = travelers.map(snapshotTraveler)
-      const proposedTravelers = beforeTravelers.map((row) =>
-        row.id === traveler.id ? applyTravelerPatch(row, input.patch) : row,
+      const state = await loadSnapshotState(tx, booking.id)
+      const before = snapshotBooking(booking, booking.revision, state)
+      const proposedTravelers = state.travelers.map((row) =>
+        row.id === traveler.id
+          ? { ...snapshotTraveler(row), ...input.patch }
+          : snapshotTraveler(row),
       )
-      const policy = policyFor({ actor: context.actor, changedFields })
+      const proposed = snapshotBooking(booking, booking.revision + 1, state, {
+        travelers: proposedTravelers,
+      })
+      const policy = correctionPolicy({ actor: context.actor, changedFields })
       const amendmentId = newId("booking_amendments")
-      const now = new Date()
+      const now = dependencies.now?.() ?? new Date()
+      const price = ZERO_PRICE(booking.sellCurrency)
       const [amendment] = await tx
         .insert(bookingAmendments)
         .values({
           id: amendmentId,
           bookingId: booking.id,
           travelerId: traveler.id,
+          kind: "traveler_correction",
           baseBookingRevision: booking.revision,
           resultBookingRevision: booking.revision + 1,
-          requestedPatch: input.patch,
+          requestedChange: {
+            type: "traveler_correction",
+            travelerId: traveler.id,
+            patch: input.patch,
+          },
           acceptanceRequired: policy.acceptanceRequired,
           policyDecisions: policy.decisions,
-          priceCurrency: booking.sellCurrency,
+          subtotalDeltaCents: price.subtotalDeltaCents,
+          feeDeltaCents: price.feeDeltaCents,
+          taxDeltaCents: price.taxDeltaCents,
+          priceDeltaCents: price.amountCents,
+          priceCurrency: price.currency,
+          collectionAmountCents: 0,
+          refundAmountCents: 0,
+          taxLines: [],
+          financialConsequences: NO_FINANCIAL_CONSEQUENCES,
           effects: NO_EXTERNAL_EFFECTS,
+          quotedAt: now,
           previewIdempotencyKey: context.idempotencyKey,
           requestedBy: context.actorId ?? null,
           requestedActor: context.actor,
@@ -275,46 +721,150 @@ export const bookingAmendmentService = {
         })
         .returning()
       if (!amendment) throw new Error("Booking Amendment insert did not return a row")
+      const revisions = await insertRevisions(tx, amendmentId, booking.id, [before, proposed], {
+        changedFields,
+        authorizedBy: context.actorId ?? null,
+        reason: input.reason,
+        now,
+      })
+      return { status: "ok" as const, amendment: serializeAmendment(amendment, revisions) }
+    })
+  },
 
-      const snapshots: { role: "before" | "proposed_after"; snapshot: BookingRevisionSnapshot }[] =
-        [
-          {
-            role: "before",
-            snapshot: {
-              bookingId: booking.id,
-              bookingNumber: booking.bookingNumber,
-              revision: booking.revision,
-              travelers: beforeTravelers,
-            },
-          },
-          {
-            role: "proposed_after",
-            snapshot: {
-              bookingId: booking.id,
-              bookingNumber: booking.bookingNumber,
-              revision: booking.revision + 1,
-              travelers: proposedTravelers,
-            },
-          },
-        ]
-      const revisions = await tx
-        .insert(bookingRevisions)
-        .values(
-          snapshots.map(({ role, snapshot }) => ({
-            id: newId("booking_revisions"),
-            amendmentId,
-            bookingId: booking.id,
-            bookingRevision: snapshot.revision,
-            role,
-            snapshot,
-            changedFields,
-            authorizedBy: context.actorId ?? null,
-            reason: input.reason,
-            createdAt: now,
-          })),
+  async previewTravelerRosterChange(
+    db: PostgresJsDatabase,
+    bookingId: string,
+    input: PreviewTravelerRosterChangeInput,
+    context: BookingAmendmentCommandContext,
+    dependencies: BookingAmendmentServiceDependencies,
+  ): Promise<PreviewTravelerRosterChangeResult> {
+    if (!dependencies.finance) {
+      return {
+        status: "unsupported_configuration",
+        reason: "Finance runtime is required for priced Booking Amendments",
+      }
+    }
+    const finance = dependencies.finance
+    return db.transaction(async (rawTx) => {
+      const tx = rawTx as PostgresJsDatabase
+      const [booking] = await tx
+        .select()
+        .from(bookings)
+        .where(eq(bookings.id, bookingId))
+        .for("update")
+        .limit(1)
+      if (!booking) return { status: "not_found" as const }
+      const [existing] = await tx
+        .select()
+        .from(bookingAmendments)
+        .where(
+          and(
+            eq(bookingAmendments.bookingId, booking.id),
+            eq(bookingAmendments.previewIdempotencyKey, context.idempotencyKey),
+          ),
         )
+        .limit(1)
+      if (existing) {
+        if (!sameRosterRequest(existing, input)) return { status: "idempotency_conflict" as const }
+        return { status: "ok" as const, amendment: await hydrateAmendment(tx, existing) }
+      }
+      if (booking.revision !== input.expectedBookingRevision) {
+        return { status: "stale_revision" as const, currentBookingRevision: booking.revision }
+      }
+      const state = await loadSnapshotState(tx, booking.id)
+      const travelerId =
+        input.change.type === "traveler_add" ? newId("booking_travelers") : input.change.travelerId
+      let roster: Awaited<ReturnType<typeof buildRosterPlans>>
+      try {
+        roster = await buildRosterPlans(tx, booking, state, input, travelerId)
+      } catch (error) {
+        if (error instanceof RosterPlanError) return mapPlanError(error)
+        throw error
+      }
+      const financeQuote = await finance.quoteBookingAmendment(tx, {
+        bookingId: booking.id,
+        currency: booking.sellCurrency,
+        lines: roster.plans.map((plan) => ({
+          bookingItemId: plan.bookingItemId,
+          productId: state.items.find((item) => item.id === plan.bookingItemId)?.productId ?? null,
+          subtotalDeltaCents: plan.unitSellAmountCents * plan.quantityDelta,
+        })),
+      })
+      const now = dependencies.now?.() ?? new Date()
+      const quoteExpiresAt = new Date(
+        now.getTime() + (dependencies.quoteTtlMs ?? DEFAULT_BOOKING_AMENDMENT_QUOTE_TTL_MS),
+      )
+      const itemQuantityDelta = new Map(
+        roster.plans.map((plan) => [plan.bookingItemId, plan.quantityDelta]),
+      )
+      const allocationQuantityDelta = new Map(
+        roster.plans.map((plan) => [plan.allocationId, plan.quantityDelta]),
+      )
+      const before = snapshotBooking(booking, booking.revision, state)
+      const proposed = snapshotBooking(booking, booking.revision + 1, state, {
+        travelers: roster.proposedTravelers,
+        itemQuantityDelta,
+        itemTravelerIds: roster.proposedTravelerIdsByItem,
+        allocationQuantityDelta,
+        sellAmountDeltaCents: financeQuote.price.amountCents,
+        paxDelta: input.change.type === "traveler_add" ? 1 : -1,
+      })
+      const effects = rosterEffects(
+        input.change.type,
+        financeQuote.price,
+        roster.plans.some((plan) => plan.supplierOperation !== null),
+      )
+      const amendmentId = newId("booking_amendments")
+      const [amendment] = await tx
+        .insert(bookingAmendments)
+        .values({
+          id: amendmentId,
+          bookingId: booking.id,
+          travelerId,
+          kind: input.change.type,
+          baseBookingRevision: booking.revision,
+          resultBookingRevision: booking.revision + 1,
+          requestedChange: { ...input.change, travelerId },
+          acceptanceRequired: true,
+          policyDecisions: rosterPolicy(financeQuote.policyVersion),
+          subtotalDeltaCents: financeQuote.price.subtotalDeltaCents,
+          feeDeltaCents: financeQuote.price.feeDeltaCents,
+          taxDeltaCents: financeQuote.price.taxDeltaCents,
+          priceDeltaCents: financeQuote.price.amountCents,
+          priceCurrency: financeQuote.price.currency,
+          collectionAmountCents: financeQuote.price.collectionAmountCents,
+          refundAmountCents: financeQuote.price.refundAmountCents,
+          taxLines: financeQuote.price.taxLines,
+          financialConsequences: financeQuote.consequences,
+          effects,
+          quotedAt: now,
+          quoteExpiresAt,
+          operationPlan: roster.plans,
+          previewIdempotencyKey: context.idempotencyKey,
+          requestedBy: context.actorId ?? null,
+          requestedActor: context.actor,
+          reason: input.reason,
+          createdAt: now,
+          updatedAt: now,
+        })
         .returning()
-
+      if (!amendment) throw new Error("Booking Amendment insert did not return a row")
+      const changedFields = [
+        "travelers",
+        ...roster.plans.flatMap((plan) => [
+          `items.${plan.bookingItemId}.quantity`,
+          `items.${plan.bookingItemId}.travelers`,
+          `allocations.${plan.allocationId}.quantity`,
+        ]),
+        "sellAmountCents",
+        "pax",
+      ]
+      const revisions = await insertRevisions(tx, amendmentId, booking.id, [before, proposed], {
+        changedFields,
+        authorizedBy: context.actorId ?? null,
+        reason: input.reason,
+        now,
+      })
       return { status: "ok" as const, amendment: serializeAmendment(amendment, revisions) }
     })
   },
@@ -324,43 +874,14 @@ export const bookingAmendmentService = {
     amendmentId: string,
     proposedRevisionId: string,
     context: BookingAmendmentCommandContext,
+    dependencies: BookingAmendmentServiceDependencies = {},
   ): Promise<AcceptBookingAmendmentResult> {
     return db.transaction(async (rawTx) => {
       const tx = rawTx as PostgresJsDatabase
-      const [candidate] = await tx
-        .select({ bookingId: bookingAmendments.bookingId })
-        .from(bookingAmendments)
-        .where(eq(bookingAmendments.id, amendmentId))
-        .limit(1)
-      if (!candidate) return { status: "not_found" as const }
-
-      // Booking first is the global lock order for every Amendment transition.
-      const [booking] = await tx
-        .select({ revision: bookings.revision })
-        .from(bookings)
-        .where(eq(bookings.id, candidate.bookingId))
-        .for("update")
-        .limit(1)
-      if (!booking) return { status: "not_found" as const }
-      const [amendment] = await tx
-        .select()
-        .from(bookingAmendments)
-        .where(eq(bookingAmendments.id, amendmentId))
-        .for("update")
-        .limit(1)
-      if (!amendment) return { status: "not_found" as const }
-
-      const [proposed] = await tx
-        .select({ id: bookingRevisions.id })
-        .from(bookingRevisions)
-        .where(
-          and(
-            eq(bookingRevisions.id, proposedRevisionId),
-            eq(bookingRevisions.amendmentId, amendment.id),
-            eq(bookingRevisions.role, "proposed_after"),
-          ),
-        )
-        .limit(1)
+      const locked = await lockAmendment(tx, amendmentId)
+      if (!locked) return { status: "not_found" as const }
+      const { booking, amendment } = locked
+      const proposed = await findProposedRevision(tx, amendment.id, proposedRevisionId)
       if (!proposed) return { status: "revision_mismatch" as const }
       if (amendment.status === "applied") {
         return {
@@ -371,12 +892,20 @@ export const bookingAmendmentService = {
       if (booking.revision !== amendment.baseBookingRevision) {
         return { status: "stale_revision" as const, currentBookingRevision: booking.revision }
       }
+      const now = dependencies.now?.() ?? new Date()
+      if (amendment.quoteExpiresAt && amendment.quoteExpiresAt <= now) {
+        return { status: "quote_expired" as const }
+      }
       if (!amendment.acceptanceRequired) return { status: "acceptance_not_required" as const }
       if (amendment.status !== "proposed" && amendment.status !== "accepted") {
         return { status: "not_found" as const }
       }
-
-      const now = new Date()
+      if (
+        amendment.status === "accepted" &&
+        amendment.acceptIdempotencyKey !== context.idempotencyKey
+      ) {
+        return { status: "revision_mismatch" as const }
+      }
       const [accepted] =
         amendment.status === "accepted"
           ? [amendment]
@@ -402,116 +931,76 @@ export const bookingAmendmentService = {
     amendmentId: string,
     input: { expectedBookingRevision: number; proposedRevisionId: string },
     context: BookingAmendmentCommandContext,
+    dependencies: BookingAmendmentServiceDependencies = {},
   ): Promise<ApplyBookingAmendmentResult> {
-    return db.transaction(async (rawTx) => {
-      const tx = rawTx as PostgresJsDatabase
-      const [candidate] = await tx
-        .select({ bookingId: bookingAmendments.bookingId })
-        .from(bookingAmendments)
-        .where(eq(bookingAmendments.id, amendmentId))
-        .limit(1)
-      if (!candidate) return { status: "not_found" as const }
-
-      // Booking first is the global lock order for conflicting amendments.
-      const [booking] = await tx
-        .select()
-        .from(bookings)
-        .where(eq(bookings.id, candidate.bookingId))
-        .for("update")
-        .limit(1)
-      if (!booking) return { status: "not_found" as const }
-      const [amendment] = await tx
-        .select()
-        .from(bookingAmendments)
-        .where(eq(bookingAmendments.id, amendmentId))
-        .for("update")
-        .limit(1)
-      if (!amendment) return { status: "not_found" as const }
-
-      const [proposed] = await tx
-        .select()
-        .from(bookingRevisions)
-        .where(
-          and(
-            eq(bookingRevisions.id, input.proposedRevisionId),
-            eq(bookingRevisions.amendmentId, amendment.id),
-            eq(bookingRevisions.role, "proposed_after"),
-          ),
-        )
-        .limit(1)
-      if (!proposed) return { status: "revision_mismatch" as const }
-      if (amendment.status === "applied") {
-        return { status: "ok" as const, amendment: await hydrateAmendment(tx, amendment) }
-      }
-      if (
-        booking.revision !== input.expectedBookingRevision ||
-        booking.revision !== amendment.baseBookingRevision
-      ) {
-        return { status: "stale_revision" as const, currentBookingRevision: booking.revision }
-      }
-      if (amendment.acceptanceRequired && amendment.status !== "accepted") {
-        return { status: "acceptance_required" as const }
-      }
-      if (amendment.status !== "proposed" && amendment.status !== "accepted") {
-        return { status: "invalid_state" as const }
-      }
-
-      const [traveler] = await tx
-        .update(bookingTravelers)
-        .set({ ...amendment.requestedPatch, updatedAt: new Date() })
-        .where(
-          and(
-            eq(bookingTravelers.id, amendment.travelerId),
-            eq(bookingTravelers.bookingId, booking.id),
-          ),
-        )
-        .returning({ id: bookingTravelers.id })
-      if (!traveler) {
-        throw new Error("Booking Amendment traveler disappeared while the Booking lock was held")
-      }
-
-      const now = new Date()
-      const [updatedBooking] = await tx
-        .update(bookings)
-        .set({ revision: amendment.resultBookingRevision, updatedAt: now })
-        .where(
-          and(eq(bookings.id, booking.id), eq(bookings.revision, amendment.baseBookingRevision)),
-        )
-        .returning({ revision: bookings.revision })
-      if (!updatedBooking) {
-        throw new Error("Booking Amendment revision advance failed while the Booking lock was held")
-      }
-
-      const [applied] = await tx
-        .update(bookingAmendments)
-        .set({
-          status: "applied",
-          applyIdempotencyKey: context.idempotencyKey,
-          appliedAt: now,
-          appliedBy: context.actorId ?? null,
-          appliedActor: context.actor,
-          updatedAt: now,
-        })
-        .where(eq(bookingAmendments.id, amendment.id))
-        .returning()
-      if (!applied) throw new Error("Booking Amendment apply did not return a row")
-
-      await tx.insert(bookingActivityLog).values({
-        bookingId: booking.id,
-        actorId: context.actorId ?? null,
-        activityType: "traveler_update",
-        description: "Traveler correction applied through Booking Amendment",
-        metadata: {
-          amendmentId: amendment.id,
-          travelerId: amendment.travelerId,
-          bookingRevision: amendment.resultBookingRevision,
-          reason: amendment.reason,
-          actor: context.actor,
-        },
-      })
-
-      return { status: "ok" as const, amendment: await hydrateAmendment(tx, applied) }
+    const staged = await stageApply(db, amendmentId, input, context, dependencies)
+    if (staged.status !== "staged") return staged.result
+    if (staged.amendment.kind === "traveler_correction") {
+      return applyCorrection(db, staged.amendment.id, context, dependencies)
+    }
+    const supplierPlans = staged.amendment.operationPlan.flatMap((plan) =>
+      plan.supplierOperation
+        ? [{ ...plan.supplierOperation, bookingItemId: plan.bookingItemId }]
+        : [],
+    )
+    if (supplierPlans.length === 0) {
+      return finalizeRosterApply(db, staged.amendment.id, context, dependencies)
+    }
+    if (!dependencies.supplier) {
+      await setAmendmentFailure(
+        db,
+        staged.amendment.id,
+        "failed",
+        "supplier_runtime_unavailable",
+        dependencies.now?.() ?? new Date(),
+      )
+      return { status: "unsupported_capability" }
+    }
+    const now = dependencies.now?.() ?? new Date()
+    const outcomes = await dependencies.supplier.dispatch({
+      db,
+      amendmentId: staged.amendment.id,
+      bookingId: staged.amendment.bookingId,
+      idempotencyKey: context.idempotencyKey,
+      operations: supplierPlans,
+      now,
     })
+    const supplierResult = await persistSupplierOutcomes(db, staged.amendment.id, outcomes, now)
+    if (supplierResult === "secured") {
+      return finalizeRosterApply(db, staged.amendment.id, context, dependencies)
+    }
+    if (supplierResult === "idempotency_conflict") return { status: "idempotency_conflict" }
+    const amendment = await this.get(db, staged.amendment.bookingId, staged.amendment.id)
+    if (!amendment) return { status: "not_found" }
+    return { status: supplierResult, amendment }
+  },
+
+  async reconcile(
+    db: PostgresJsDatabase,
+    bookingId: string,
+    amendmentId: string,
+    context: BookingAmendmentCommandContext,
+    dependencies: BookingAmendmentServiceDependencies,
+  ): Promise<ApplyBookingAmendmentResult> {
+    const amendment = await this.get(db, bookingId, amendmentId)
+    if (!amendment) return { status: "not_found" }
+    if (amendment.status === "applied") return { status: "ok", amendment }
+    if (!dependencies.supplier || amendment.supplierOperationIds.length === 0) {
+      return { status: "unsupported_capability" }
+    }
+    const now = dependencies.now?.() ?? new Date()
+    const outcomes = await dependencies.supplier.reconcile({
+      db,
+      supplierOperationIds: amendment.supplierOperationIds,
+      now,
+    })
+    const supplierResult = await persistSupplierOutcomes(db, amendmentId, outcomes, now)
+    if (supplierResult === "secured") {
+      return finalizeRosterApply(db, amendmentId, context, dependencies)
+    }
+    if (supplierResult === "idempotency_conflict") return { status: "idempotency_conflict" }
+    const current = await this.get(db, bookingId, amendmentId)
+    return current ? { status: supplierResult, amendment: current } : { status: "not_found" }
   },
 
   async get(db: PostgresJsDatabase, bookingId: string, amendmentId: string) {
@@ -548,9 +1037,8 @@ export const bookingAmendmentService = {
         ),
       )
     }
-    if (identity.organizationId) {
+    if (identity.organizationId)
       ownerConditions.push(eq(bookings.organizationId, identity.organizationId))
-    }
     const [row] = await db
       .selectDistinct({ id: bookings.id })
       .from(bookings)
@@ -559,4 +1047,607 @@ export const bookingAmendmentService = {
       .limit(1)
     return Boolean(row)
   },
+}
+
+async function insertRevisions(
+  tx: PostgresJsDatabase,
+  amendmentId: string,
+  bookingId: string,
+  snapshots: [BookingRevisionSnapshot, BookingRevisionSnapshot],
+  input: { changedFields: string[]; authorizedBy: string | null; reason: string; now: Date },
+) {
+  return tx
+    .insert(bookingRevisions)
+    .values(
+      snapshots.map((snapshot, index) => ({
+        id: newId("booking_revisions"),
+        amendmentId,
+        bookingId,
+        bookingRevision: snapshot.revision,
+        role: index === 0 ? ("before" as const) : ("proposed_after" as const),
+        snapshot,
+        changedFields: input.changedFields,
+        authorizedBy: input.authorizedBy,
+        reason: input.reason,
+        createdAt: input.now,
+      })),
+    )
+    .returning()
+}
+
+function sameRosterRequest(row: BookingAmendmentRow, input: PreviewTravelerRosterChangeInput) {
+  const requested = row.requestedChange
+  if (requested.type !== input.change.type) return false
+  if (row.baseBookingRevision !== input.expectedBookingRevision || row.reason !== input.reason) {
+    return false
+  }
+  if (requested.bookingItemIds.join("\u0000") !== input.change.bookingItemIds.join("\u0000")) {
+    return false
+  }
+  if (requested.type === "traveler_drop" && input.change.type === "traveler_drop") {
+    return requested.travelerId === input.change.travelerId
+  }
+  return (
+    requested.type === "traveler_add" &&
+    input.change.type === "traveler_add" &&
+    JSON.stringify(requested.traveler) === JSON.stringify(input.change.traveler)
+  )
+}
+
+async function lockAmendment(db: PostgresJsDatabase, amendmentId: string) {
+  const [candidate] = await db
+    .select({ bookingId: bookingAmendments.bookingId })
+    .from(bookingAmendments)
+    .where(eq(bookingAmendments.id, amendmentId))
+    .limit(1)
+  if (!candidate) return null
+  const [booking] = await db
+    .select()
+    .from(bookings)
+    .where(eq(bookings.id, candidate.bookingId))
+    .for("update")
+    .limit(1)
+  if (!booking) return null
+  const [amendment] = await db
+    .select()
+    .from(bookingAmendments)
+    .where(eq(bookingAmendments.id, amendmentId))
+    .for("update")
+    .limit(1)
+  return amendment ? { booking, amendment } : null
+}
+
+async function findProposedRevision(
+  db: PostgresJsDatabase,
+  amendmentId: string,
+  revisionId: string,
+) {
+  const [proposed] = await db
+    .select()
+    .from(bookingRevisions)
+    .where(
+      and(
+        eq(bookingRevisions.id, revisionId),
+        eq(bookingRevisions.amendmentId, amendmentId),
+        eq(bookingRevisions.role, "proposed_after"),
+      ),
+    )
+    .limit(1)
+  return proposed ?? null
+}
+
+async function stageApply(
+  db: PostgresJsDatabase,
+  amendmentId: string,
+  input: { expectedBookingRevision: number; proposedRevisionId: string },
+  context: BookingAmendmentCommandContext,
+  dependencies: BookingAmendmentServiceDependencies,
+): Promise<
+  | { status: "staged"; amendment: BookingAmendmentRow }
+  | { status: "result"; result: ApplyBookingAmendmentResult }
+> {
+  return db.transaction(async (rawTx) => {
+    const tx = rawTx as PostgresJsDatabase
+    const locked = await lockAmendment(tx, amendmentId)
+    if (!locked) return { status: "result", result: { status: "not_found" } }
+    const { booking, amendment } = locked
+    const proposed = await findProposedRevision(tx, amendment.id, input.proposedRevisionId)
+    if (!proposed) return { status: "result", result: { status: "revision_mismatch" } }
+    if (amendment.status === "applied") {
+      return {
+        status: "result",
+        result: { status: "ok", amendment: await hydrateAmendment(tx, amendment) },
+      }
+    }
+    if (
+      booking.revision !== input.expectedBookingRevision ||
+      booking.revision !== amendment.baseBookingRevision
+    ) {
+      return {
+        status: "result",
+        result: { status: "stale_revision", currentBookingRevision: booking.revision },
+      }
+    }
+    if (amendment.acceptanceRequired && amendment.status === "proposed") {
+      return { status: "result", result: { status: "acceptance_required" } }
+    }
+    if (amendment.status === "manual_review") {
+      return {
+        status: "result",
+        result: { status: "manual_review", amendment: await hydrateAmendment(tx, amendment) },
+      }
+    }
+    if (!["proposed", "accepted", "applying", "in_doubt", "failed"].includes(amendment.status)) {
+      return { status: "result", result: { status: "invalid_state" } }
+    }
+    if (amendment.applyIdempotencyKey && amendment.applyIdempotencyKey !== context.idempotencyKey) {
+      return { status: "result", result: { status: "idempotency_conflict" } }
+    }
+    const now = dependencies.now?.() ?? new Date()
+    if (!amendment.applyStartedAt && amendment.quoteExpiresAt && amendment.quoteExpiresAt <= now) {
+      return { status: "result", result: { status: "quote_expired" } }
+    }
+    const [staged] = await tx
+      .update(bookingAmendments)
+      .set({
+        status: "applying",
+        applyIdempotencyKey: context.idempotencyKey,
+        applyStartedAt: amendment.applyStartedAt ?? now,
+        failureCode: null,
+        updatedAt: now,
+      })
+      .where(eq(bookingAmendments.id, amendment.id))
+      .returning()
+    if (!staged) throw new Error("Booking Amendment apply stage did not return a row")
+    return { status: "staged", amendment: staged }
+  })
+}
+
+async function applyCorrection(
+  db: PostgresJsDatabase,
+  amendmentId: string,
+  context: BookingAmendmentCommandContext,
+  dependencies: BookingAmendmentServiceDependencies,
+): Promise<ApplyBookingAmendmentResult> {
+  return db.transaction(async (rawTx) => {
+    const tx = rawTx as PostgresJsDatabase
+    const locked = await lockAmendment(tx, amendmentId)
+    if (!locked) return { status: "not_found" as const }
+    const { booking, amendment } = locked
+    if (amendment.status === "applied") {
+      return { status: "ok" as const, amendment: await hydrateAmendment(tx, amendment) }
+    }
+    if (booking.revision !== amendment.baseBookingRevision) {
+      return { status: "stale_revision" as const, currentBookingRevision: booking.revision }
+    }
+    const requested = amendment.requestedChange
+    if (requested.type !== "traveler_correction") return { status: "invalid_state" as const }
+    const [traveler] = await tx
+      .update(bookingTravelers)
+      .set({ ...requested.patch, updatedAt: dependencies.now?.() ?? new Date() })
+      .where(
+        and(
+          eq(bookingTravelers.id, amendment.travelerId),
+          eq(bookingTravelers.bookingId, booking.id),
+        ),
+      )
+      .returning({ id: bookingTravelers.id })
+    if (!traveler) throw new Error("Booking Amendment traveler disappeared while locked")
+    const now = dependencies.now?.() ?? new Date()
+    await advanceBookingRevision(tx, booking.id, amendment.baseBookingRevision, {
+      revision: amendment.resultBookingRevision,
+      updatedAt: now,
+    })
+    const applied = await markApplied(tx, amendment, context, now, {
+      ...amendment.effects,
+      finance: "not_required",
+    })
+    await writeActivity(tx, amendment, context, "Traveler correction applied", now)
+    return { status: "ok", amendment: await hydrateAmendment(tx, applied) }
+  })
+}
+
+async function finalizeRosterApply(
+  db: PostgresJsDatabase,
+  amendmentId: string,
+  context: BookingAmendmentCommandContext,
+  dependencies: BookingAmendmentServiceDependencies,
+): Promise<ApplyBookingAmendmentResult> {
+  if (!dependencies.finance) return { status: "unsupported_capability" }
+  const finance = dependencies.finance
+  try {
+    return await db.transaction(async (rawTx) => {
+      const tx = rawTx as PostgresJsDatabase
+      const locked = await lockAmendment(tx, amendmentId)
+      if (!locked) return { status: "not_found" as const }
+      const { booking, amendment } = locked
+      if (amendment.status === "applied") {
+        return { status: "ok" as const, amendment: await hydrateAmendment(tx, amendment) }
+      }
+      if (booking.revision !== amendment.baseBookingRevision) {
+        return { status: "stale_revision" as const, currentBookingRevision: booking.revision }
+      }
+      if (amendment.kind !== "traveler_add" && amendment.kind !== "traveler_drop") {
+        return { status: "invalid_state" as const }
+      }
+      if (
+        amendment.effects.supplier !== "not_required" &&
+        amendment.effects.supplier !== "secured"
+      ) {
+        return { status: "invalid_state" as const }
+      }
+      const now = dependencies.now?.() ?? new Date()
+      await applyCapacityAndAllocationPlan(tx, amendment.operationPlan, now)
+      const requested = amendment.requestedChange
+      if (requested.type === "traveler_add") {
+        await tx.insert(bookingTravelers).values({
+          id: amendment.travelerId,
+          bookingId: booking.id,
+          personId: requested.traveler.personId ?? null,
+          participantType: requested.traveler.participantType,
+          travelerCategory: requested.traveler.travelerCategory ?? null,
+          firstName: requested.traveler.firstName,
+          lastName: requested.traveler.lastName,
+          email: requested.traveler.email ?? null,
+          phone: requested.traveler.phone ?? null,
+          preferredLanguage: requested.traveler.preferredLanguage ?? null,
+          isPrimary: false,
+          createdAt: now,
+          updatedAt: now,
+        })
+        await tx.insert(bookingItemTravelers).values(
+          requested.bookingItemIds.map((bookingItemId) => ({
+            id: newId("booking_item_travelers"),
+            bookingItemId,
+            travelerId: amendment.travelerId,
+            role: "traveler" as const,
+            isPrimary: false,
+            createdAt: now,
+          })),
+        )
+      } else if (requested.type === "traveler_drop") {
+        await tx
+          .delete(bookingItemTravelers)
+          .where(
+            and(
+              eq(bookingItemTravelers.travelerId, amendment.travelerId),
+              inArray(bookingItemTravelers.bookingItemId, requested.bookingItemIds),
+            ),
+          )
+        const [remainingAssignment] = await tx
+          .select({ id: bookingItemTravelers.id })
+          .from(bookingItemTravelers)
+          .where(eq(bookingItemTravelers.travelerId, amendment.travelerId))
+          .limit(1)
+        if (!remainingAssignment) {
+          await tx
+            .delete(bookingTravelers)
+            .where(
+              and(
+                eq(bookingTravelers.id, amendment.travelerId),
+                eq(bookingTravelers.bookingId, booking.id),
+              ),
+            )
+        }
+      } else {
+        return { status: "invalid_state" as const }
+      }
+      for (const plan of amendment.operationPlan) {
+        await tx
+          .update(bookingItems)
+          // agent-quality: raw-sql reviewed -- owner: bookings; integer deltas are server-derived from the immutable Amendment plan and Drizzle binds them.
+          .set({
+            quantity: sql`${bookingItems.quantity} + ${plan.quantityDelta}`,
+            totalSellAmountCents: sql`${bookingItems.totalSellAmountCents} + ${plan.unitSellAmountCents * plan.quantityDelta}`,
+            updatedAt: now,
+          })
+          .where(
+            and(eq(bookingItems.id, plan.bookingItemId), eq(bookingItems.bookingId, booking.id)),
+          )
+      }
+      const price = priceFromRow(amendment)
+      await finance.recordBookingAmendment(tx, {
+        amendmentId: amendment.id,
+        bookingId: booking.id,
+        idempotencyKey: context.idempotencyKey,
+        price,
+        consequences: amendment.financialConsequences,
+        reason: amendment.reason,
+      })
+      await advanceBookingRevision(tx, booking.id, amendment.baseBookingRevision, {
+        revision: amendment.resultBookingRevision,
+        sellAmountCents:
+          booking.sellAmountCents == null
+            ? amendment.priceDeltaCents
+            : booking.sellAmountCents + amendment.priceDeltaCents,
+        pax: Math.max(0, (booking.pax ?? 0) + (amendment.kind === "traveler_add" ? 1 : -1)),
+        updatedAt: now,
+      })
+      const applied = await markApplied(tx, amendment, context, now, {
+        ...amendment.effects,
+        finance: "recorded",
+        supplier: amendment.effects.supplier === "not_required" ? "not_required" : "secured",
+        allocation: "applied",
+      })
+      await writeActivity(tx, amendment, context, "Priced traveler roster change applied", now)
+      return { status: "ok", amendment: await hydrateAmendment(tx, applied) }
+    })
+  } catch (error) {
+    if (error instanceof RosterPlanError && error.code === "availability_changed") {
+      const [current] = await db
+        .select()
+        .from(bookingAmendments)
+        .where(eq(bookingAmendments.id, amendmentId))
+        .limit(1)
+      const supplierAlreadySecured = current?.effects.supplier === "secured"
+      await setAmendmentFailure(
+        db,
+        amendmentId,
+        supplierAlreadySecured ? "manual_review" : "failed",
+        supplierAlreadySecured
+          ? "local_projection_failed_after_supplier_secured"
+          : "availability_changed",
+        dependencies.now?.() ?? new Date(),
+      )
+      if (supplierAlreadySecured && current) {
+        const [failed] = await db
+          .select()
+          .from(bookingAmendments)
+          .where(eq(bookingAmendments.id, amendmentId))
+          .limit(1)
+        if (!failed) return { status: "not_found" }
+        const amendment = await hydrateAmendment(db, failed)
+        return { status: "manual_review", amendment }
+      }
+      return { status: "availability_changed", bookingItemId: error.bookingItemId ?? "unknown" }
+    }
+    throw error
+  }
+}
+
+async function applyCapacityAndAllocationPlan(
+  tx: PostgresJsDatabase,
+  plans: BookingAmendmentRosterItemPlan[],
+  now: Date,
+) {
+  for (const plan of plans) {
+    const [allocation] = await tx
+      .select()
+      .from(bookingAllocations)
+      .where(eq(bookingAllocations.id, plan.allocationId))
+      .for("update")
+      .limit(1)
+    if (!allocation || allocation.quantity !== plan.allocationQuantityBefore) {
+      throw new RosterPlanError("availability_changed", "Allocation changed", plan.bookingItemId)
+    }
+    if (plan.availabilitySlotId && plan.quantityDelta > 0) {
+      const [updated] = await tx
+        .update(availabilitySlotsRef)
+        // agent-quality: raw-sql reviewed -- owner: bookings; conditional capacity decrement uses locked, server-owned plan data and Drizzle identifiers.
+        .set({
+          remainingPax: sql`CASE WHEN ${availabilitySlotsRef.unlimited} THEN ${availabilitySlotsRef.remainingPax} ELSE ${availabilitySlotsRef.remainingPax} - 1 END`,
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(availabilitySlotsRef.id, plan.availabilitySlotId),
+            eq(availabilitySlotsRef.status, "open"),
+            eq(availabilitySlotsRef.pastCutoff, false),
+            eq(availabilitySlotsRef.tooEarly, false),
+            // agent-quality: raw-sql reviewed -- owner: bookings; atomic positive-capacity guard over a Drizzle identifier.
+            or(
+              eq(availabilitySlotsRef.unlimited, true),
+              sql`${availabilitySlotsRef.remainingPax} >= 1`,
+            ),
+          ),
+        )
+        .returning({ id: availabilitySlotsRef.id })
+      if (!updated) {
+        throw new RosterPlanError(
+          "availability_changed",
+          "Availability changed",
+          plan.bookingItemId,
+        )
+      }
+    }
+    if (plan.availabilitySlotId && plan.quantityDelta < 0) {
+      await tx
+        .update(availabilitySlotsRef)
+        // agent-quality: raw-sql reviewed -- owner: bookings; conditional capacity release uses locked, server-owned plan data and Drizzle identifiers.
+        .set({
+          remainingPax: sql`CASE WHEN ${availabilitySlotsRef.unlimited} THEN ${availabilitySlotsRef.remainingPax} ELSE COALESCE(${availabilitySlotsRef.remainingPax}, 0) + 1 END`,
+          updatedAt: now,
+        })
+        .where(eq(availabilitySlotsRef.id, plan.availabilitySlotId))
+    }
+    const [updatedAllocation] = await tx
+      .update(bookingAllocations)
+      .set({ quantity: allocation.quantity + plan.quantityDelta, updatedAt: now })
+      .where(
+        and(
+          eq(bookingAllocations.id, allocation.id),
+          eq(bookingAllocations.quantity, plan.allocationQuantityBefore),
+        ),
+      )
+      .returning({ id: bookingAllocations.id })
+    if (!updatedAllocation) {
+      throw new RosterPlanError("availability_changed", "Allocation changed", plan.bookingItemId)
+    }
+  }
+}
+
+function priceFromRow(row: BookingAmendmentRow): BookingAmendmentPrice {
+  return {
+    currency: row.priceCurrency,
+    subtotalDeltaCents: row.subtotalDeltaCents,
+    feeDeltaCents: row.feeDeltaCents,
+    taxDeltaCents: row.taxDeltaCents,
+    amountCents: row.priceDeltaCents,
+    collectionAmountCents: row.collectionAmountCents,
+    refundAmountCents: row.refundAmountCents,
+    taxLines: row.taxLines,
+  }
+}
+
+async function advanceBookingRevision(
+  tx: PostgresJsDatabase,
+  bookingId: string,
+  baseRevision: number,
+  values: Partial<typeof bookings.$inferInsert>,
+) {
+  const [updated] = await tx
+    .update(bookings)
+    .set(values)
+    .where(and(eq(bookings.id, bookingId), eq(bookings.revision, baseRevision)))
+    .returning({ id: bookings.id })
+  if (!updated) throw new Error("Booking Amendment revision advance failed while locked")
+}
+
+async function markApplied(
+  tx: PostgresJsDatabase,
+  amendment: BookingAmendmentRow,
+  context: BookingAmendmentCommandContext,
+  now: Date,
+  effects: BookingAmendmentEffects,
+) {
+  const [applied] = await tx
+    .update(bookingAmendments)
+    .set({
+      status: "applied",
+      effects,
+      appliedAt: now,
+      appliedBy: context.actorId ?? null,
+      appliedActor: context.actor,
+      failureCode: null,
+      updatedAt: now,
+    })
+    .where(eq(bookingAmendments.id, amendment.id))
+    .returning()
+  if (!applied) throw new Error("Booking Amendment apply did not return a row")
+  return applied
+}
+
+async function writeActivity(
+  tx: PostgresJsDatabase,
+  amendment: BookingAmendmentRow,
+  context: BookingAmendmentCommandContext,
+  description: string,
+  now: Date,
+) {
+  await tx.insert(bookingActivityLog).values({
+    bookingId: amendment.bookingId,
+    actorId: context.actorId ?? null,
+    activityType: "traveler_update",
+    description,
+    metadata: {
+      amendmentId: amendment.id,
+      travelerId: amendment.travelerId,
+      bookingRevision: amendment.resultBookingRevision,
+      reason: amendment.reason,
+      actor: context.actor,
+      appliedAt: now.toISOString(),
+    },
+  })
+}
+
+async function setAmendmentFailure(
+  db: PostgresJsDatabase,
+  amendmentId: string,
+  status: "failed" | "in_doubt" | "manual_review",
+  failureCode: string,
+  now: Date,
+) {
+  await db
+    .update(bookingAmendments)
+    .set({ status, failureCode, updatedAt: now })
+    .where(eq(bookingAmendments.id, amendmentId))
+}
+
+async function persistSupplierOutcomes(
+  db: PostgresJsDatabase,
+  amendmentId: string,
+  outcomes: Awaited<ReturnType<BookingsSupplierAmendmentRuntime["dispatch"]>>,
+  now: Date,
+): Promise<
+  | "secured"
+  | "supplier_pending"
+  | "supplier_in_doubt"
+  | "supplier_refused"
+  | "manual_review"
+  | "idempotency_conflict"
+> {
+  const operationIds = outcomes.flatMap((outcome) =>
+    outcome.supplierOperationId ? [outcome.supplierOperationId] : [],
+  )
+  const secured = outcomes.filter((outcome) => outcome.outcome === "secured").length
+  const hasConflict = outcomes.some((outcome) => outcome.outcome === "idempotency_conflict")
+  const hasInDoubt = outcomes.some((outcome) => outcome.outcome === "in_doubt")
+  const hasPending = outcomes.some((outcome) => outcome.outcome === "pending")
+  const hasRefused = outcomes.some((outcome) => outcome.outcome === "refused")
+  const partial = secured > 0 && secured < outcomes.length
+  const result = hasConflict
+    ? ("idempotency_conflict" as const)
+    : partial
+      ? ("manual_review" as const)
+      : hasInDoubt
+        ? ("supplier_in_doubt" as const)
+        : hasPending
+          ? ("supplier_pending" as const)
+          : hasRefused
+            ? ("supplier_refused" as const)
+            : ("secured" as const)
+  const status =
+    result === "secured"
+      ? ("applying" as const)
+      : result === "supplier_pending"
+        ? ("applying" as const)
+        : result === "supplier_in_doubt"
+          ? ("in_doubt" as const)
+          : result === "supplier_refused"
+            ? ("failed" as const)
+            : ("manual_review" as const)
+  const supplierEffect =
+    result === "secured"
+      ? ("secured" as const)
+      : result === "supplier_pending"
+        ? ("pending" as const)
+        : result === "supplier_in_doubt"
+          ? ("in_doubt" as const)
+          : result === "supplier_refused"
+            ? ("refused" as const)
+            : ("manual_review" as const)
+  const [current] = await db
+    .select({ effects: bookingAmendments.effects })
+    .from(bookingAmendments)
+    .where(eq(bookingAmendments.id, amendmentId))
+    .limit(1)
+  await db
+    .update(bookingAmendments)
+    .set({
+      status,
+      supplierOperationIds: operationIds,
+      effects: { ...(current?.effects ?? NO_EXTERNAL_EFFECTS), supplier: supplierEffect },
+      failureCode: result === "secured" || result === "supplier_pending" ? null : result,
+      updatedAt: now,
+    })
+    .where(eq(bookingAmendments.id, amendmentId))
+  return result
+}
+
+async function stableFingerprint(value: unknown): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(JSON.stringify(sortForStableJson(value))),
+  )
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("")
+}
+
+function sortForStableJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortForStableJson)
+  if (!value || typeof value !== "object") return value
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => [key, sortForStableJson(entry)]),
+  )
 }

--- a/packages/bookings/src/tools.ts
+++ b/packages/bookings/src/tools.ts
@@ -1,3 +1,4 @@
+// agent-quality: file-size exception -- owner: bookings; the package Tool registry stays centralized so definitions, admission policies, and output schemas remain one public surface.
 /**
  * Bookings agent tools on the framework tool contract. Thin wrappers over the
  * existing bookings service; the service is injected on the tool context
@@ -12,9 +13,11 @@
 import {
   acceptBookingAmendmentSchema,
   applyBookingAmendmentSchema,
+  bookingAmendmentApplyResultSchema,
   bookingAmendmentPreviewResultSchema,
   bookingAmendmentSchema,
   previewTravelerCorrectionSchema,
+  previewTravelerRosterChangeSchema,
 } from "@voyant-travel/bookings-contracts"
 import {
   admitHandlerActionPolicy,
@@ -97,11 +100,17 @@ export interface BookingsToolServices {
   previewTravelerCorrectionAmendment(
     input: z.infer<typeof previewTravelerCorrectionAmendmentToolInputSchema>,
   ): Promise<unknown>
+  previewTravelerRosterChangeAmendment(
+    input: z.infer<typeof previewTravelerRosterChangeAmendmentToolInputSchema>,
+  ): Promise<unknown>
   acceptBookingAmendment(
     input: z.infer<typeof acceptBookingAmendmentToolInputSchema>,
   ): Promise<unknown>
   applyBookingAmendment(
     input: z.infer<typeof applyBookingAmendmentToolInputSchema>,
+  ): Promise<unknown>
+  reconcileBookingAmendment(
+    input: z.infer<typeof reconcileBookingAmendmentToolInputSchema>,
   ): Promise<unknown>
 }
 
@@ -337,6 +346,12 @@ export const previewTravelerCorrectionAmendmentToolInputSchema =
     idempotencyKey: amendmentCommandFields.idempotencyKey,
   })
 
+export const previewTravelerRosterChangeAmendmentToolInputSchema =
+  previewTravelerRosterChangeSchema.extend({
+    bookingId: amendmentCommandFields.bookingId,
+    idempotencyKey: amendmentCommandFields.idempotencyKey,
+  })
+
 export const acceptBookingAmendmentToolInputSchema = acceptBookingAmendmentSchema.extend({
   bookingId: amendmentCommandFields.bookingId,
   amendmentId: amendmentCommandFields.amendmentId,
@@ -349,29 +364,26 @@ export const applyBookingAmendmentToolInputSchema = applyBookingAmendmentSchema.
   idempotencyKey: amendmentCommandFields.idempotencyKey,
 })
 
+export const reconcileBookingAmendmentToolInputSchema = z.object({
+  bookingId: amendmentCommandFields.bookingId,
+  amendmentId: amendmentCommandFields.amendmentId,
+  idempotencyKey: amendmentCommandFields.idempotencyKey,
+})
+
 const acceptBookingAmendmentToolOutputSchema = z.discriminatedUnion("status", [
   z.object({ status: z.literal("ok"), amendment: bookingAmendmentSchema }),
   z.object({ status: z.literal("already_applied"), amendment: bookingAmendmentSchema }),
   z.object({ status: z.literal("not_found") }),
   z.object({ status: z.literal("revision_mismatch") }),
   z.object({ status: z.literal("acceptance_not_required") }),
+  z.object({ status: z.literal("quote_expired") }),
   z.object({
     status: z.literal("stale_revision"),
     currentBookingRevision: z.number().int().positive(),
   }),
 ])
 
-const applyBookingAmendmentToolOutputSchema = z.discriminatedUnion("status", [
-  z.object({ status: z.literal("ok"), amendment: bookingAmendmentSchema }),
-  z.object({ status: z.literal("not_found") }),
-  z.object({ status: z.literal("revision_mismatch") }),
-  z.object({ status: z.literal("acceptance_required") }),
-  z.object({ status: z.literal("invalid_state") }),
-  z.object({
-    status: z.literal("stale_revision"),
-    currentBookingRevision: z.number().int().positive(),
-  }),
-])
+const applyBookingAmendmentToolOutputSchema = bookingAmendmentApplyResultSchema
 
 const bookingAmendmentWriteRisk = {
   destructive: false,
@@ -399,6 +411,28 @@ export const previewTravelerCorrectionAmendmentTool = defineTool({
     return parseJsonResult(
       bookingAmendmentPreviewResultSchema,
       await bookings(ctx).previewTravelerCorrectionAmendment(input),
+    )
+  },
+})
+
+export const previewTravelerRosterChangeAmendmentTool = defineTool({
+  owner: "@voyant-travel/bookings",
+  capabilityId: "@voyant-travel/bookings#tool.preview-traveler-roster-change-amendment",
+  capabilityVersion: "v1",
+  name: "preview_traveler_roster_change_amendment",
+  description:
+    "Quote an immutable traveler add/drop Amendment with server-calculated price, tax, inventory, supplier, and financial consequences.",
+  inputSchema: previewTravelerRosterChangeAmendmentToolInputSchema,
+  outputSchema: bookingAmendmentPreviewResultSchema,
+  requiredScopes: ["bookings:write"],
+  audience: { source: "grant", allowed: ["staff"] },
+  tier: "write",
+  riskPolicy: bookingAmendmentWriteRisk,
+  annotations: { idempotentHint: true },
+  async handler(input, ctx: BookingsToolContext) {
+    return parseJsonResult(
+      bookingAmendmentPreviewResultSchema,
+      await bookings(ctx).previewTravelerRosterChangeAmendment(input),
     )
   },
 })
@@ -447,14 +481,38 @@ export const applyBookingAmendmentTool = defineTool({
   },
 })
 
+export const reconcileBookingAmendmentTool = defineTool({
+  owner: "@voyant-travel/bookings",
+  capabilityId: "@voyant-travel/bookings#tool.reconcile-booking-amendment",
+  capabilityVersion: "v1",
+  name: "reconcile_booking_amendment",
+  description:
+    "Reconcile durable Supplier Operations for a Booking Amendment and atomically apply it only when every effect is proven.",
+  inputSchema: reconcileBookingAmendmentToolInputSchema,
+  outputSchema: applyBookingAmendmentToolOutputSchema,
+  requiredScopes: ["bookings:write"],
+  audience: { source: "grant", allowed: ["staff"] },
+  tier: "write",
+  riskPolicy: bookingAmendmentWriteRisk,
+  annotations: { idempotentHint: true },
+  async handler(input, ctx: BookingsToolContext) {
+    return parseJsonResult(
+      applyBookingAmendmentToolOutputSchema,
+      await bookings(ctx).reconcileBookingAmendment(input),
+    )
+  },
+})
+
 export const bookingsTools = [
   listBookingsTool,
   getBookingTool,
   confirmBookingTool,
   cancelBookingTool,
   previewTravelerCorrectionAmendmentTool,
+  previewTravelerRosterChangeAmendmentTool,
   acceptBookingAmendmentTool,
   applyBookingAmendmentTool,
+  reconcileBookingAmendmentTool,
 ] as const
 
 // Extension Tools are wrapped at the package's canonical `./tools` entry so

--- a/packages/bookings/src/voyant.ts
+++ b/packages/bookings/src/voyant.ts
@@ -22,6 +22,7 @@ import {
   bookingsInventoryRuntimePort,
   bookingsRelationshipsRuntimePort,
   bookingsSelfServiceCreateRuntimePort,
+  bookingsSupplierAmendmentRuntimePort,
 } from "./runtime-port.js"
 import { bookingsStaleHoldsJobRuntimePort } from "./stale-holds-job-runtime-port.js"
 import { bookingsVoyantAdmin } from "./voyant-admin.js"
@@ -342,6 +343,7 @@ export const bookingsVoyantModule = defineModule({
     // Authorizes a guest create. Without it only authenticated customers can
     // use the public create route.
     requirePort(bookingsGuestVerificationRuntimePort, { optional: true }),
+    requirePort(bookingsSupplierAmendmentRuntimePort, { optional: true }),
   ],
   customFieldTargets: [
     {
@@ -602,11 +604,33 @@ export const bookingsVoyantModule = defineModule({
       risk: "medium",
     },
     {
+      id: "@voyant-travel/bookings#tool.preview-traveler-roster-change-amendment",
+      name: "preview_traveler_roster_change_amendment",
+      runtime: {
+        entry: "@voyant-travel/bookings/tools",
+        export: "previewTravelerRosterChangeAmendmentTool",
+      },
+      requiredScopes: ["bookings:write"],
+      context: ["bookings"],
+      risk: "medium",
+    },
+    {
       id: "@voyant-travel/bookings#tool.apply-booking-amendment",
       name: "apply_booking_amendment",
       runtime: {
         entry: "@voyant-travel/bookings/tools",
         export: "applyBookingAmendmentTool",
+      },
+      requiredScopes: ["bookings:write"],
+      context: ["bookings"],
+      risk: "medium",
+    },
+    {
+      id: "@voyant-travel/bookings#tool.reconcile-booking-amendment",
+      name: "reconcile_booking_amendment",
+      runtime: {
+        entry: "@voyant-travel/bookings/tools",
+        export: "reconcileBookingAmendmentTool",
       },
       requiredScopes: ["bookings:write"],
       context: ["bookings"],

--- a/packages/bookings/tests/integration/booking-amendments.test.ts
+++ b/packages/bookings/tests/integration/booking-amendments.test.ts
@@ -1,6 +1,18 @@
+// agent-quality: file-size exception -- owner: bookings; one live-database suite proves the complete Amendment protocol, fault outcomes, rollback, and replay invariants.
 import { eq } from "drizzle-orm"
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
-import { bookings, bookingTravelers } from "../../src/schema.js"
+import { availabilitySlotsRef } from "../../src/availability-ref.js"
+import type {
+  BookingsFinanceRuntime,
+  BookingsSupplierAmendmentRuntime,
+} from "../../src/runtime-port.js"
+import {
+  bookingAllocations,
+  bookingItems,
+  bookingItemTravelers,
+  bookings,
+  bookingTravelers,
+} from "../../src/schema.js"
 import { bookingAmendmentService } from "../../src/service-amendments.js"
 
 const DB_AVAILABLE = Boolean(process.env.TEST_DATABASE_URL)
@@ -46,6 +58,96 @@ describe.skipIf(!DB_AVAILABLE)("Booking traveler Amendments", () => {
       })
       .returning()
     return { booking: booking!, traveler: traveler! }
+  }
+
+  function financeRuntime(): BookingsFinanceRuntime {
+    return {
+      createStaleBookingHoldsJobRuntime() {
+        throw new Error("not used by Amendment tests")
+      },
+      async quoteBookingAmendment(_db, input) {
+        const amountCents = input.lines.reduce((sum, line) => sum + line.subtotalDeltaCents, 0)
+        return {
+          price: {
+            currency: input.currency,
+            subtotalDeltaCents: amountCents,
+            feeDeltaCents: 0,
+            taxDeltaCents: 0,
+            amountCents,
+            collectionAmountCents: Math.max(amountCents, 0),
+            refundAmountCents: Math.max(-amountCents, 0),
+            taxLines: [],
+          },
+          consequences: {
+            collection: amountCents > 0 ? "required" : "not_required",
+            refund: amountCents < 0 ? "required" : "not_required",
+            invoice: amountCents > 0 ? "reissue_required" : "not_required",
+            creditNote: amountCents < 0 ? "issue_required" : "not_required",
+            paymentSchedule: amountCents === 0 ? "not_required" : "recalculate_required",
+          },
+          policyVersion: "test-finance-v1",
+        }
+      },
+      async recordBookingAmendment() {
+        return { adjustmentId: "faad_test", status: "recorded" }
+      },
+    }
+  }
+
+  async function seedOwnedRosterBooking() {
+    const seeded = await seed()
+    const now = new Date("2026-08-02T10:00:00.000Z")
+    const [slot] = await db
+      .insert(availabilitySlotsRef)
+      .values({
+        productId: "prod_roster",
+        dateLocal: "2026-09-10",
+        startsAt: new Date("2026-09-10T08:00:00.000Z"),
+        timezone: "Europe/Bucharest",
+        status: "open",
+        unlimited: false,
+        initialPax: 3,
+        remainingPax: 2,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning()
+    const [item] = await db
+      .insert(bookingItems)
+      .values({
+        bookingId: seeded.booking.id,
+        title: "Priced departure",
+        status: "confirmed",
+        quantity: 1,
+        sellCurrency: "EUR",
+        unitSellAmountCents: 10_000,
+        totalSellAmountCents: 10_000,
+        productId: "prod_roster",
+        availabilitySlotId: slot!.id,
+      })
+      .returning()
+    const [allocation] = await db
+      .insert(bookingAllocations)
+      .values({
+        bookingId: seeded.booking.id,
+        bookingItemId: item!.id,
+        productId: "prod_roster",
+        availabilitySlotId: slot!.id,
+        quantity: 1,
+        status: "confirmed",
+      })
+      .returning()
+    await db.insert(bookingItemTravelers).values({
+      bookingItemId: item!.id,
+      travelerId: seeded.traveler.id,
+      role: "traveler",
+    })
+    const [booking] = await db
+      .update(bookings)
+      .set({ sellAmountCents: 10_000, pax: 1 })
+      .where(eq(bookings.id, seeded.booking.id))
+      .returning()
+    return { ...seeded, booking: booking!, slot: slot!, item: item!, allocation: allocation! }
   }
 
   it("previews and applies an immutable correction without replacing the Booking", async () => {
@@ -289,5 +391,498 @@ describe.skipIf(!DB_AVAILABLE)("Booking traveler Amendments", () => {
         { actor: "customer", actorId: traveler.personId, idempotencyKey: "apply-second" },
       ),
     ).resolves.toEqual({ status: "stale_revision", currentBookingRevision: 2 })
+  })
+
+  it("quotes, accepts, and atomically applies an owned traveler addition", async () => {
+    const { booking, slot, item, allocation } = await seedOwnedRosterBooking()
+    const finance = financeRuntime()
+    const now = new Date("2026-08-02T10:00:00.000Z")
+    const dependencies = { finance, now: () => now }
+    const preview = await bookingAmendmentService.previewTravelerRosterChange(
+      db,
+      booking.id,
+      {
+        expectedBookingRevision: 1,
+        reason: "Add Ada to the departure",
+        change: {
+          type: "traveler_add",
+          bookingItemIds: [item.id],
+          traveler: { firstName: "Ada", lastName: "Lovelace" },
+        },
+      },
+      { actor: "staff", actorId: "usr_staff", idempotencyKey: "roster-add-preview" },
+      dependencies,
+    )
+    if (preview.status !== "ok") throw new Error(`Expected preview, received ${preview.status}`)
+    expect(preview.amendment).toMatchObject({
+      bookingId: booking.id,
+      kind: "traveler_add",
+      status: "proposed",
+      priceDelta: {
+        amountCents: 10_000,
+        collectionAmountCents: 10_000,
+        refundAmountCents: 0,
+      },
+      effects: {
+        finance: "collection_required",
+        supplier: "not_required",
+        allocation: "increase_required",
+      },
+      nextActions: ["accept"],
+    })
+    const proposed = preview.amendment.revisions!.find(
+      (revision) => revision.role === "proposed_after",
+    )!
+    expect(proposed.snapshot).toMatchObject({
+      bookingId: booking.id,
+      revision: 2,
+      sellAmountCents: 20_000,
+      pax: 2,
+      items: [{ id: item.id, quantity: 2, totalSellAmountCents: 20_000 }],
+    })
+
+    await expect(
+      bookingAmendmentService.accept(
+        db,
+        preview.amendment.id,
+        proposed.id,
+        { actor: "staff", actorId: "usr_staff", idempotencyKey: "roster-add-accept" },
+        dependencies,
+      ),
+    ).resolves.toMatchObject({ status: "ok", amendment: { status: "accepted" } })
+    const applied = await bookingAmendmentService.apply(
+      db,
+      preview.amendment.id,
+      { expectedBookingRevision: 1, proposedRevisionId: proposed.id },
+      { actor: "staff", actorId: "usr_staff", idempotencyKey: "roster-add-apply" },
+      dependencies,
+    )
+    expect(applied).toMatchObject({
+      status: "ok",
+      amendment: {
+        status: "applied",
+        nextActions: ["collect_payment", "reissue_documents"],
+        effects: { finance: "recorded", allocation: "applied" },
+      },
+    })
+    await expect(
+      bookingAmendmentService.apply(
+        db,
+        preview.amendment.id,
+        { expectedBookingRevision: 1, proposedRevisionId: proposed.id },
+        { actor: "staff", actorId: "usr_staff", idempotencyKey: "roster-add-apply" },
+        dependencies,
+      ),
+    ).resolves.toEqual(applied)
+
+    const [[currentBooking], [currentItem], [currentAllocation], [currentSlot], travelers] =
+      await Promise.all([
+        db.select().from(bookings).where(eq(bookings.id, booking.id)),
+        db.select().from(bookingItems).where(eq(bookingItems.id, item.id)),
+        db.select().from(bookingAllocations).where(eq(bookingAllocations.id, allocation.id)),
+        db.select().from(availabilitySlotsRef).where(eq(availabilitySlotsRef.id, slot.id)),
+        db.select().from(bookingTravelers).where(eq(bookingTravelers.bookingId, booking.id)),
+      ])
+    expect(currentBooking).toMatchObject({ revision: 2, sellAmountCents: 20_000, pax: 2 })
+    expect(currentItem).toMatchObject({ quantity: 2, totalSellAmountCents: 20_000 })
+    expect(currentAllocation).toMatchObject({ quantity: 2 })
+    expect(currentSlot).toMatchObject({ remainingPax: 1 })
+    expect(travelers).toHaveLength(2)
+  })
+
+  it("quotes a refund and releases capacity when dropping a traveler", async () => {
+    const { booking, traveler, slot, item, allocation } = await seedOwnedRosterBooking()
+    const dependencies = { finance: financeRuntime() }
+    const preview = await bookingAmendmentService.previewTravelerRosterChange(
+      db,
+      booking.id,
+      {
+        expectedBookingRevision: 1,
+        reason: "Traveler can no longer attend",
+        change: {
+          type: "traveler_drop",
+          bookingItemIds: [item.id],
+          travelerId: traveler.id,
+        },
+      },
+      { actor: "staff", actorId: "usr_staff", idempotencyKey: "roster-drop-preview" },
+      dependencies,
+    )
+    if (preview.status !== "ok") throw new Error("Expected preview")
+    expect(preview.amendment).toMatchObject({
+      kind: "traveler_drop",
+      priceDelta: { amountCents: -10_000, refundAmountCents: 10_000 },
+      effects: { finance: "refund_required", allocation: "release_required" },
+    })
+    const proposed = preview.amendment.revisions!.find(
+      (revision) => revision.role === "proposed_after",
+    )!
+    await bookingAmendmentService.accept(
+      db,
+      preview.amendment.id,
+      proposed.id,
+      { actor: "staff", actorId: "usr_staff", idempotencyKey: "roster-drop-accept" },
+      dependencies,
+    )
+    await expect(
+      bookingAmendmentService.apply(
+        db,
+        preview.amendment.id,
+        { expectedBookingRevision: 1, proposedRevisionId: proposed.id },
+        { actor: "staff", actorId: "usr_staff", idempotencyKey: "roster-drop-apply" },
+        dependencies,
+      ),
+    ).resolves.toMatchObject({
+      status: "ok",
+      amendment: { nextActions: ["issue_refund", "reissue_documents"] },
+    })
+    const [[currentBooking], [currentItem], [currentAllocation], [currentSlot], travelers] =
+      await Promise.all([
+        db.select().from(bookings).where(eq(bookings.id, booking.id)),
+        db.select().from(bookingItems).where(eq(bookingItems.id, item.id)),
+        db.select().from(bookingAllocations).where(eq(bookingAllocations.id, allocation.id)),
+        db.select().from(availabilitySlotsRef).where(eq(availabilitySlotsRef.id, slot.id)),
+        db.select().from(bookingTravelers).where(eq(bookingTravelers.bookingId, booking.id)),
+      ])
+    expect(currentBooking).toMatchObject({ revision: 2, sellAmountCents: 0, pax: 0 })
+    expect(currentItem).toMatchObject({ quantity: 0, totalSellAmountCents: 0 })
+    expect(currentAllocation).toMatchObject({ quantity: 0 })
+    expect(currentSlot).toMatchObject({ remainingPax: 3 })
+    expect(travelers).toEqual([])
+  })
+
+  it("expires immutable roster quotes and rejects changed capacity without partial local writes", async () => {
+    const { booking, slot, item, allocation } = await seedOwnedRosterBooking()
+    const finance = financeRuntime()
+    let now = new Date("2026-08-02T10:00:00.000Z")
+    const dependencies = { finance, now: () => now, quoteTtlMs: 60_000 }
+    const preview = await bookingAmendmentService.previewTravelerRosterChange(
+      db,
+      booking.id,
+      {
+        expectedBookingRevision: 1,
+        reason: "Add a traveler",
+        change: {
+          type: "traveler_add",
+          bookingItemIds: [item.id],
+          traveler: { firstName: "Grace", lastName: "Hopper" },
+        },
+      },
+      { actor: "staff", actorId: "usr_staff", idempotencyKey: "expiring-preview" },
+      dependencies,
+    )
+    if (preview.status !== "ok") throw new Error("Expected preview")
+    const proposed = preview.amendment.revisions!.find(
+      (revision) => revision.role === "proposed_after",
+    )!
+    now = new Date("2026-08-02T10:01:01.000Z")
+    await expect(
+      bookingAmendmentService.accept(
+        db,
+        preview.amendment.id,
+        proposed.id,
+        { actor: "staff", actorId: "usr_staff", idempotencyKey: "expired-accept" },
+        dependencies,
+      ),
+    ).resolves.toEqual({ status: "quote_expired" })
+
+    now = new Date("2026-08-02T10:00:30.000Z")
+    await bookingAmendmentService.accept(
+      db,
+      preview.amendment.id,
+      proposed.id,
+      { actor: "staff", actorId: "usr_staff", idempotencyKey: "valid-accept" },
+      dependencies,
+    )
+    await db
+      .update(availabilitySlotsRef)
+      .set({ remainingPax: 0 })
+      .where(eq(availabilitySlotsRef.id, slot.id))
+    await expect(
+      bookingAmendmentService.apply(
+        db,
+        preview.amendment.id,
+        { expectedBookingRevision: 1, proposedRevisionId: proposed.id },
+        { actor: "staff", actorId: "usr_staff", idempotencyKey: "capacity-race-apply" },
+        dependencies,
+      ),
+    ).resolves.toEqual({ status: "availability_changed", bookingItemId: item.id })
+
+    const [[currentBooking], [currentItem], [currentAllocation], travelers] = await Promise.all([
+      db.select().from(bookings).where(eq(bookings.id, booking.id)),
+      db.select().from(bookingItems).where(eq(bookingItems.id, item.id)),
+      db.select().from(bookingAllocations).where(eq(bookingAllocations.id, allocation.id)),
+      db.select().from(bookingTravelers).where(eq(bookingTravelers.bookingId, booking.id)),
+    ])
+    expect(currentBooking).toMatchObject({ revision: 1, sellAmountCents: 10_000, pax: 1 })
+    expect(currentItem).toMatchObject({ quantity: 1, totalSellAmountCents: 10_000 })
+    expect(currentAllocation).toMatchObject({ quantity: 1 })
+    expect(travelers).toHaveLength(1)
+  })
+
+  it("surfaces an in-doubt dispatch and reconciles the same durable supplier operation", async () => {
+    const { booking, item, allocation } = await seedOwnedRosterBooking()
+    await db
+      .update(bookingAllocations)
+      .set({
+        availabilitySlotId: null,
+        metadata: {
+          sourceKind: "test-source",
+          sourceConnectionId: "conn_1",
+          upstreamRef: "upstream_1",
+        },
+      })
+      .where(eq(bookingAllocations.id, allocation.id))
+    const finance = financeRuntime()
+    let supplierOutcome: "refused" | "in_doubt" | "secured" = "in_doubt"
+    const supplier: BookingsSupplierAmendmentRuntime = {
+      async dispatch(input) {
+        return input.operations.map((operation) => ({
+          bookingItemId: operation.bookingItemId,
+          supplierOperationId: "suop_1",
+          outcome: supplierOutcome,
+        }))
+      },
+      async reconcile(input) {
+        return input.supplierOperationIds.map(() => ({
+          bookingItemId: item.id,
+          supplierOperationId: "suop_1",
+          outcome: supplierOutcome,
+        }))
+      },
+    }
+    const dependencies = { finance, supplier }
+    const preview = await bookingAmendmentService.previewTravelerRosterChange(
+      db,
+      booking.id,
+      {
+        expectedBookingRevision: 1,
+        reason: "Add a sourced traveler",
+        change: {
+          type: "traveler_add",
+          bookingItemIds: [item.id],
+          traveler: { firstName: "Katherine", lastName: "Johnson" },
+        },
+      },
+      { actor: "staff", actorId: "usr_staff", idempotencyKey: "supplier-preview" },
+      dependencies,
+    )
+    if (preview.status !== "ok") throw new Error("Expected preview")
+    const proposed = preview.amendment.revisions!.find(
+      (revision) => revision.role === "proposed_after",
+    )!
+    await bookingAmendmentService.accept(
+      db,
+      preview.amendment.id,
+      proposed.id,
+      { actor: "staff", actorId: "usr_staff", idempotencyKey: "supplier-accept" },
+      dependencies,
+    )
+    await expect(
+      bookingAmendmentService.apply(
+        db,
+        preview.amendment.id,
+        { expectedBookingRevision: 1, proposedRevisionId: proposed.id },
+        { actor: "staff", actorId: "usr_staff", idempotencyKey: "supplier-apply" },
+        dependencies,
+      ),
+    ).resolves.toMatchObject({
+      status: "supplier_in_doubt",
+      amendment: {
+        status: "in_doubt",
+        failureCode: "supplier_in_doubt",
+        effects: { supplier: "in_doubt" },
+        nextActions: ["reconcile_supplier"],
+      },
+    })
+    const [unchanged] = await db.select().from(bookings).where(eq(bookings.id, booking.id))
+    expect(unchanged).toMatchObject({ revision: 1, sellAmountCents: 10_000, pax: 1 })
+
+    supplierOutcome = "secured"
+    await expect(
+      bookingAmendmentService.reconcile(
+        db,
+        booking.id,
+        preview.amendment.id,
+        { actor: "staff", actorId: "usr_staff", idempotencyKey: "supplier-reconcile" },
+        dependencies,
+      ),
+    ).resolves.toMatchObject({ status: "ok", amendment: { status: "applied" } })
+  })
+
+  it("records supplier refusal without mutating the Booking projection", async () => {
+    const { booking, item, allocation } = await seedOwnedRosterBooking()
+    await db
+      .update(bookingAllocations)
+      .set({
+        availabilitySlotId: null,
+        metadata: {
+          sourceKind: "test-source",
+          sourceConnectionId: "conn_1",
+          upstreamRef: "upstream_refusal",
+        },
+      })
+      .where(eq(bookingAllocations.id, allocation.id))
+    const supplier: BookingsSupplierAmendmentRuntime = {
+      async dispatch(input) {
+        return input.operations.map((operation) => ({
+          bookingItemId: operation.bookingItemId,
+          supplierOperationId: "suop_refused",
+          outcome: "refused" as const,
+        }))
+      },
+      async reconcile() {
+        throw new Error("not used")
+      },
+    }
+    const dependencies = { finance: financeRuntime(), supplier }
+    const preview = await bookingAmendmentService.previewTravelerRosterChange(
+      db,
+      booking.id,
+      {
+        expectedBookingRevision: 1,
+        reason: "Add a sourced traveler",
+        change: {
+          type: "traveler_add",
+          bookingItemIds: [item.id],
+          traveler: { firstName: "Mary", lastName: "Jackson" },
+        },
+      },
+      { actor: "staff", actorId: "usr_staff", idempotencyKey: "refused-preview" },
+      dependencies,
+    )
+    if (preview.status !== "ok") throw new Error("Expected preview")
+    const proposed = preview.amendment.revisions!.find(
+      (revision) => revision.role === "proposed_after",
+    )!
+    await bookingAmendmentService.accept(
+      db,
+      preview.amendment.id,
+      proposed.id,
+      { actor: "staff", actorId: "usr_staff", idempotencyKey: "refused-accept" },
+      dependencies,
+    )
+    await expect(
+      bookingAmendmentService.apply(
+        db,
+        preview.amendment.id,
+        { expectedBookingRevision: 1, proposedRevisionId: proposed.id },
+        { actor: "staff", actorId: "usr_staff", idempotencyKey: "refused-apply" },
+        dependencies,
+      ),
+    ).resolves.toMatchObject({
+      status: "supplier_refused",
+      amendment: {
+        status: "failed",
+        failureCode: "supplier_refused",
+        effects: { supplier: "refused" },
+      },
+    })
+    const [unchanged] = await db.select().from(bookings).where(eq(bookings.id, booking.id))
+    expect(unchanged).toMatchObject({ revision: 1, sellAmountCents: 10_000, pax: 1 })
+  })
+
+  it("stops in manual review when supplier operations only partially secure", async () => {
+    const { booking, traveler, item, allocation } = await seedOwnedRosterBooking()
+    await db
+      .update(bookingAllocations)
+      .set({
+        availabilitySlotId: null,
+        metadata: {
+          sourceKind: "test-source",
+          sourceConnectionId: "conn_1",
+          upstreamRef: "upstream_1",
+        },
+      })
+      .where(eq(bookingAllocations.id, allocation.id))
+    const [secondItem] = await db
+      .insert(bookingItems)
+      .values({
+        bookingId: booking.id,
+        title: "Second sourced service",
+        status: "confirmed",
+        quantity: 1,
+        sellCurrency: "EUR",
+        unitSellAmountCents: 5_000,
+        totalSellAmountCents: 5_000,
+        productId: "prod_second",
+      })
+      .returning()
+    await db.insert(bookingAllocations).values({
+      bookingId: booking.id,
+      bookingItemId: secondItem!.id,
+      productId: "prod_second",
+      quantity: 1,
+      status: "confirmed",
+      metadata: {
+        sourceKind: "test-source",
+        sourceConnectionId: "conn_1",
+        upstreamRef: "upstream_2",
+      },
+    })
+    await db.insert(bookingItemTravelers).values({
+      bookingItemId: secondItem!.id,
+      travelerId: traveler.id,
+      role: "traveler",
+    })
+    await db.update(bookings).set({ sellAmountCents: 15_000 }).where(eq(bookings.id, booking.id))
+    const supplier: BookingsSupplierAmendmentRuntime = {
+      async dispatch(input) {
+        return input.operations.map((operation, index) => ({
+          bookingItemId: operation.bookingItemId,
+          supplierOperationId: `suop_${index + 1}`,
+          outcome: index === 0 ? ("secured" as const) : ("refused" as const),
+        }))
+      },
+      async reconcile() {
+        throw new Error("not used")
+      },
+    }
+    const dependencies = { finance: financeRuntime(), supplier }
+    const preview = await bookingAmendmentService.previewTravelerRosterChange(
+      db,
+      booking.id,
+      {
+        expectedBookingRevision: 1,
+        reason: "Add a traveler across sourced services",
+        change: {
+          type: "traveler_add",
+          bookingItemIds: [item.id, secondItem!.id],
+          traveler: { firstName: "Dorothy", lastName: "Vaughan" },
+        },
+      },
+      { actor: "staff", actorId: "usr_staff", idempotencyKey: "partial-preview" },
+      dependencies,
+    )
+    if (preview.status !== "ok") throw new Error("Expected preview")
+    const proposed = preview.amendment.revisions!.find(
+      (revision) => revision.role === "proposed_after",
+    )!
+    await bookingAmendmentService.accept(
+      db,
+      preview.amendment.id,
+      proposed.id,
+      { actor: "staff", actorId: "usr_staff", idempotencyKey: "partial-accept" },
+      dependencies,
+    )
+    await expect(
+      bookingAmendmentService.apply(
+        db,
+        preview.amendment.id,
+        { expectedBookingRevision: 1, proposedRevisionId: proposed.id },
+        { actor: "staff", actorId: "usr_staff", idempotencyKey: "partial-apply" },
+        dependencies,
+      ),
+    ).resolves.toMatchObject({
+      status: "manual_review",
+      amendment: {
+        status: "manual_review",
+        supplierOperationIds: ["suop_1", "suop_2"],
+        effects: { supplier: "manual_review" },
+        nextActions: ["manual_review"],
+      },
+    })
+    const [unchanged] = await db.select().from(bookings).where(eq(bookings.id, booking.id))
+    expect(unchanged).toMatchObject({ revision: 1, sellAmountCents: 15_000, pax: 1 })
   })
 })

--- a/packages/bookings/tests/tools.test.ts
+++ b/packages/bookings/tests/tools.test.ts
@@ -136,6 +136,8 @@ describe("bookings tools", () => {
       "get_booking",
       "list_bookings",
       "preview_traveler_correction_amendment",
+      "preview_traveler_roster_change_amendment",
+      "reconcile_booking_amendment",
     ])
     for (const t of list.filter((tool) => ["get_booking", "list_bookings"].includes(tool.name))) {
       expect(t.tier).toBe("read")
@@ -145,6 +147,8 @@ describe("bookings tools", () => {
       "accept_booking_amendment",
       "apply_booking_amendment",
       "preview_traveler_correction_amendment",
+      "preview_traveler_roster_change_amendment",
+      "reconcile_booking_amendment",
     ]) {
       expect(list.find((tool) => tool.name === name)).toMatchObject({
         tier: "write",
@@ -337,6 +341,53 @@ describe("bookings tools", () => {
       travelerId: "btr_1",
       bookingRevision: 1,
     })
+  })
+
+  it("dispatches priced roster previews and supplier reconciliation through the shared Amendment service", async () => {
+    const registry = createToolRegistry()
+    registry.registerAll(bookingsTools)
+    const preview = await registry.dispatch(
+      "preview_traveler_roster_change_amendment",
+      {
+        bookingId: "bk_1",
+        expectedBookingRevision: 3,
+        reason: "Add another traveler",
+        change: {
+          type: "traveler_add",
+          bookingItemIds: ["bitm_1"],
+          traveler: { firstName: "Ada", lastName: "Lovelace" },
+        },
+        idempotencyKey: "roster-preview-bk-1",
+      },
+      ctx({
+        async previewTravelerRosterChangeAmendment(input) {
+          expect(input).toMatchObject({
+            bookingId: "bk_1",
+            expectedBookingRevision: 3,
+            idempotencyKey: "roster-preview-bk-1",
+            change: { type: "traveler_add", bookingItemIds: ["bitm_1"] },
+          })
+          return { status: "availability_changed", bookingItemId: "bitm_1" }
+        },
+      }),
+    )
+    expect(preview).toEqual({ status: "availability_changed", bookingItemId: "bitm_1" })
+
+    const reconciled = await registry.dispatch(
+      "reconcile_booking_amendment",
+      { bookingId: "bk_1", amendmentId: "bamd_1", idempotencyKey: "test-key-1" },
+      ctx({
+        async reconcileBookingAmendment(input) {
+          expect(input).toEqual({
+            bookingId: "bk_1",
+            amendmentId: "bamd_1",
+            idempotencyKey: "test-key-1",
+          })
+          return { status: "not_found" }
+        },
+      }),
+    )
+    expect(reconciled).toEqual({ status: "not_found" })
   })
 
   it("resolves a booking by its human-readable booking number", async () => {

--- a/packages/bookings/tests/unit/priced-roster-amendment-migration.test.ts
+++ b/packages/bookings/tests/unit/priced-roster-amendment-migration.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+
+const migration = readFileSync(
+  new URL("../../migrations/20260802180000_priced_roster_amendments.sql", import.meta.url),
+  "utf8",
+)
+
+describe("priced roster Amendment migration", () => {
+  it("preserves correction data and installs the v1 lifecycle invariants", () => {
+    expect(migration).toContain('RENAME COLUMN "requested_patch" TO "requested_change"')
+    expect(migration).toContain("'type', 'traveler_correction'")
+    expect(migration).toContain("'traveler_add', 'traveler_drop'")
+    expect(migration).toContain("'applying', 'in_doubt', 'manual_review'")
+    expect(migration).toContain('CONSTRAINT "ck_booking_amendments_money"')
+    expect(migration).toContain(
+      '"price_delta_cents" = "subtotal_delta_cents" + "fee_delta_cents" + "tax_delta_cents"',
+    )
+  })
+})

--- a/packages/bookings/tests/unit/voyant-manifest.test.ts
+++ b/packages/bookings/tests/unit/voyant-manifest.test.ts
@@ -37,6 +37,7 @@ describe("bookings deployment manifest", () => {
         // Authorizes a guest create; without it only authenticated customers
         // can use the public create route.
         { id: "bookings.guest-verification.runtime", optional: true },
+        { id: "bookings.supplier-amendment.runtime", optional: true },
       ],
       api: [
         {
@@ -270,7 +271,19 @@ describe("bookings deployment manifest", () => {
             }),
             resolveVisibleValues: async () => ({}),
           },
-          "bookings.finance.runtime": { createStaleBookingHoldsJobRuntime: () => ({}) },
+          "bookings.finance.runtime": {
+            createStaleBookingHoldsJobRuntime: () => ({}),
+            quoteBookingAmendment: async () => {
+              throw new Error("not used")
+            },
+            recordBookingAmendment: async () => {
+              throw new Error("not used")
+            },
+          },
+          "bookings.supplier-amendment.runtime": {
+            dispatch: async () => [],
+            reconcile: async () => [],
+          },
           "bookings.relationships.runtime": {
             loadPersonTravelSnapshot: async () => null,
             upsertPersonFromContact: async () => null,

--- a/packages/catalog/src/booking-engine/amendment-runtime.ts
+++ b/packages/catalog/src/booking-engine/amendment-runtime.ts
@@ -1,0 +1,122 @@
+import type {
+  BookingSupplierAmendmentOperationInput,
+  BookingsSupplierAmendmentRuntime,
+} from "@voyant-travel/bookings/runtime-port"
+
+import type { SourceAdapterRegistry } from "./registry.js"
+import { createSupplierOperationWorkflow } from "./supplier-operation-workflow.js"
+import {
+  createDrizzleSupplierOperationRepository,
+  type SupplierOperationInternalRecord,
+} from "./supplier-operations.js"
+
+export function createCatalogBookingAmendmentRuntime(options: {
+  resolveRegistry(): Promise<SourceAdapterRegistry>
+}): BookingsSupplierAmendmentRuntime {
+  return {
+    async dispatch(input) {
+      const registry = await options.resolveRegistry()
+      const workflow = createSupplierOperationWorkflow({
+        repository: createDrizzleSupplierOperationRepository(input.db),
+        registry,
+      })
+      const outcomes = []
+      for (const operation of input.operations) {
+        const outcome = await workflow.dispatchAmendment({
+          amendmentId: input.amendmentId,
+          bookingId: input.bookingId,
+          bookingItemId: operation.bookingItemId,
+          scopeKey: operation.bookingItemId,
+          idempotencyKey: input.idempotencyKey,
+          requestFingerprint: operation.requestFingerprint,
+          operationKind: "modify",
+          entityModule: operation.entityModule,
+          entityId: operation.entityId,
+          sourceKind: operation.sourceKind,
+          sourceConnectionId: operation.sourceConnectionId,
+          sourceRef: operation.sourceRef,
+          request: {
+            upstream_ref: operation.upstreamRef,
+            desired_state: {
+              ...(operation.desiredState.parameters
+                ? { parameters: operation.desiredState.parameters }
+                : {}),
+              party: { passengers: [...operation.desiredState.party.passengers] },
+            },
+            idempotency_key: `${input.amendmentId}:${operation.bookingItemId}:${input.idempotencyKey}:modify`,
+          },
+          adapterContext: { connection_id: operation.sourceConnectionId },
+          now: input.now,
+        })
+        outcomes.push(mapOutcome(operation, outcome))
+      }
+      return outcomes
+    },
+
+    async reconcile(input) {
+      const registry = await options.resolveRegistry()
+      const repository = createDrizzleSupplierOperationRepository(input.db)
+      const workflow = createSupplierOperationWorkflow({ repository, registry })
+      const outcomes = []
+      for (const operationId of input.supplierOperationIds) {
+        const operation = await repository.get(operationId)
+        if (!operation) {
+          outcomes.push({
+            bookingItemId: "unknown",
+            supplierOperationId: null,
+            outcome: "in_doubt" as const,
+          })
+          continue
+        }
+        const outcome = await workflow.reconcile(operation, {
+          adapterContext: { connection_id: operation.sourceConnectionId },
+          now: input.now,
+        })
+        outcomes.push(mapStoredOutcome(operation, outcome))
+      }
+      return outcomes
+    },
+  }
+}
+
+function mapOutcome(
+  input: BookingSupplierAmendmentOperationInput,
+  outcome: Awaited<
+    ReturnType<ReturnType<typeof createSupplierOperationWorkflow>["dispatchAmendment"]>
+  >,
+) {
+  if (outcome.kind === "idempotency_conflict") {
+    return {
+      bookingItemId: input.bookingItemId,
+      supplierOperationId: null,
+      outcome: "idempotency_conflict" as const,
+    }
+  }
+  return {
+    bookingItemId: input.bookingItemId,
+    supplierOperationId: outcome.operation.id,
+    outcome: mapKind(outcome.kind),
+  }
+}
+
+function mapStoredOutcome(
+  operation: SupplierOperationInternalRecord,
+  outcome: Awaited<ReturnType<ReturnType<typeof createSupplierOperationWorkflow>["reconcile"]>>,
+) {
+  if (outcome.kind === "idempotency_conflict") {
+    return {
+      bookingItemId: operation.bookingItemId ?? "unknown",
+      supplierOperationId: operation.id,
+      outcome: "idempotency_conflict" as const,
+    }
+  }
+  return {
+    bookingItemId: operation.bookingItemId ?? "unknown",
+    supplierOperationId: operation.id,
+    outcome: mapKind(outcome.kind),
+  }
+}
+
+function mapKind(kind: "secured" | "pending" | "in_doubt" | "failed") {
+  return kind === "failed" ? ("refused" as const) : kind
+}

--- a/packages/catalog/src/runtime-contributor.ts
+++ b/packages/catalog/src/runtime-contributor.ts
@@ -1,6 +1,9 @@
+// agent-quality: file-size exception -- owner: catalog; one generated-runtime contributor map centralizes the package's lazy port factories and shared host primitives.
 import {
   type BookingsRelationshipsRuntime,
+  type BookingsSupplierAmendmentRuntime,
   bookingsRelationshipsRuntimePort,
+  bookingsSupplierAmendmentRuntimePort,
 } from "@voyant-travel/bookings/runtime-port"
 import type { CatalogSearchRuntimeOptions } from "@voyant-travel/catalog/api-runtime-ports"
 import {
@@ -41,6 +44,7 @@ import {
 import { financeSelfServiceBookingSourceRuntimePort } from "@voyant-travel/finance/self-service-booking-source"
 import { sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { createCatalogBookingAmendmentRuntime } from "./booking-engine/amendment-runtime.js"
 import { DEFAULT_BOOKING_SESSION_TERMINAL_RETENTION_MS } from "./booking-session-maintenance-job.js"
 import {
   type CatalogBookingSessionMaintenanceJobRuntime,
@@ -183,6 +187,13 @@ export function createCatalogRuntimePortContribution(
     [catalogProjectionRuntimePort.id]: contribution.then((runtime) => runtime.projection),
     [catalogBookingSnapshotRuntimePort.id]: contribution.then((runtime) => runtime.bookingSnapshot),
     [catalogRuntimeServicesPort.id]: contribution.then((runtime) => runtime.services),
+    [bookingsSupplierAmendmentRuntimePort.id]: createCatalogBookingAmendmentRuntime({
+      async resolveRegistry() {
+        const runtime = await contribution
+        const services = await runtime.services
+        return services.ensureSourceRegistry(host.primitives.env(undefined))
+      },
+    }) satisfies BookingsSupplierAmendmentRuntime,
     // Gates Finance's self-service create action.
     [financeSelfServiceBookingSourceRuntimePort.id]: createSelfServiceBookingSourceProvider({
       async resolveOwnedHandlers() {

--- a/packages/catalog/src/voyant.ts
+++ b/packages/catalog/src/voyant.ts
@@ -1,4 +1,8 @@
-import { bookingsRelationshipsRuntimePort } from "@voyant-travel/bookings/runtime-port"
+// agent-quality: file-size exception -- owner: catalog; the package-owned manifest centralizes its APIs, Tools, runtime ports, and deployment declarations.
+import {
+  bookingsRelationshipsRuntimePort,
+  bookingsSupplierAmendmentRuntimePort,
+} from "@voyant-travel/bookings/runtime-port"
 import {
   defineExtension,
   defineModule,
@@ -96,6 +100,7 @@ export const catalogVoyantModule = defineModule({
       providePort(catalogDraftReaperJobRuntimePort),
       providePort(catalogReindexJobRuntimePort),
       providePort(catalogSourcesSyncJobRuntimePort),
+      providePort(bookingsSupplierAmendmentRuntimePort),
       cruisesRoutesRuntimePortReference,
     ],
   },

--- a/packages/catalog/tests/unit/voyant-manifest.test.ts
+++ b/packages/catalog/tests/unit/voyant-manifest.test.ts
@@ -29,6 +29,7 @@ describe("catalog deployment manifest", () => {
           { id: "catalog.draft-reaper-job" },
           { id: "catalog.reindex-products-job" },
           { id: "catalog.sources-sync-job" },
+          { id: "bookings.supplier-amendment.runtime" },
           { id: "cruises.routes-runtime" },
         ],
       },

--- a/packages/finance/migrations/20260802180500_booking_amendment_adjustments.sql
+++ b/packages/finance/migrations/20260802180500_booking_amendment_adjustments.sql
@@ -1,0 +1,35 @@
+CREATE TABLE "finance_amendment_adjustments" (
+  "id" text PRIMARY KEY NOT NULL,
+  "amendment_id" text NOT NULL,
+  "booking_id" text NOT NULL,
+  "idempotency_key" text NOT NULL,
+  "currency" text NOT NULL,
+  "subtotal_delta_cents" integer NOT NULL,
+  "fee_delta_cents" integer NOT NULL,
+  "tax_delta_cents" integer NOT NULL,
+  "total_delta_cents" integer NOT NULL,
+  "collection_amount_cents" integer DEFAULT 0 NOT NULL,
+  "refund_amount_cents" integer DEFAULT 0 NOT NULL,
+  "status" text NOT NULL,
+  "consequences" jsonb NOT NULL,
+  "reason" text NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "ck_finance_amendment_adjustments_status"
+    CHECK ("status" IN ('no_action', 'collection_required', 'refund_required')),
+  CONSTRAINT "ck_finance_amendment_adjustments_money" CHECK (
+    "total_delta_cents" = "subtotal_delta_cents" + "fee_delta_cents" + "tax_delta_cents"
+    AND "collection_amount_cents" >= 0
+    AND "refund_amount_cents" >= 0
+    AND NOT ("collection_amount_cents" > 0 AND "refund_amount_cents" > 0)
+  )
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_finance_amendment_adjustments_amendment"
+ON "finance_amendment_adjustments" USING btree ("amendment_id");
+--> statement-breakpoint
+CREATE INDEX "idx_finance_amendment_adjustments_booking_created"
+ON "finance_amendment_adjustments" USING btree ("booking_id", "created_at");
+--> statement-breakpoint
+CREATE INDEX "idx_finance_amendment_adjustments_status"
+ON "finance_amendment_adjustments" USING btree ("status");

--- a/packages/finance/migrations/meta/_journal.json
+++ b/packages/finance/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1785602400000,
       "tag": "20260801164000_booking_session_payment_target_v1",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1785693900000,
+      "tag": "20260802180500_booking_amendment_adjustments",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/finance/package.json
+++ b/packages/finance/package.json
@@ -53,6 +53,7 @@
     "@hono/zod-openapi": "catalog:",
     "@voyant-travel/action-ledger": "workspace:^",
     "@voyant-travel/bookings": "workspace:^",
+    "@voyant-travel/bookings-contracts": "workspace:^",
     "@voyant-travel/core": "workspace:^",
     "@voyant-travel/data-sdk": "^0.7.1",
     "@voyant-travel/db": "workspace:^",

--- a/packages/finance/src/booking-amendment-runtime.ts
+++ b/packages/finance/src/booking-amendment-runtime.ts
@@ -1,0 +1,136 @@
+import type { BookingsFinanceRuntime } from "@voyant-travel/bookings/runtime-port"
+import { and, eq } from "drizzle-orm"
+
+import type { ResolveBookingTaxSettings } from "./booking-tax.js"
+import { computeBookingItemTaxLine, resolveBookingSellTaxRate } from "./booking-tax.js"
+import { financeAmendmentAdjustments } from "./schema.js"
+
+export const BOOKING_AMENDMENT_FINANCE_POLICY_VERSION = "booking-amendment-finance-v1"
+
+export function createBookingAmendmentFinanceRuntime(
+  options: { resolveBookingTaxSettings?: ResolveBookingTaxSettings } = {},
+): Pick<BookingsFinanceRuntime, "quoteBookingAmendment" | "recordBookingAmendment"> {
+  return {
+    async quoteBookingAmendment(db, input) {
+      const quotedLines = await Promise.all(
+        input.lines.map(async (line, index) => {
+          const sign = Math.sign(line.subtotalDeltaCents)
+          const taxRate = await resolveBookingSellTaxRate(
+            db,
+            { productId: line.productId },
+            { resolveBookingTaxSettings: options.resolveBookingTaxSettings },
+          )
+          const unsignedTax = computeBookingItemTaxLine(
+            taxRate,
+            Math.abs(line.subtotalDeltaCents),
+            input.currency,
+            index,
+          )
+          const signedTaxCents = (unsignedTax?.amountCents ?? 0) * sign
+          return {
+            bookingItemId: line.bookingItemId,
+            subtotalDeltaCents:
+              unsignedTax?.includedInPrice === true
+                ? line.subtotalDeltaCents - signedTaxCents
+                : line.subtotalDeltaCents,
+            taxDeltaCents: signedTaxCents,
+            taxAddsToTotal: unsignedTax?.includedInPrice !== true,
+            taxLine: unsignedTax
+              ? {
+                  bookingItemId: line.bookingItemId,
+                  code: unsignedTax.code ?? null,
+                  name: unsignedTax.name,
+                  amountCents: signedTaxCents,
+                  rateBasisPoints: unsignedTax.rateBasisPoints ?? null,
+                  includedInPrice: unsignedTax.includedInPrice,
+                }
+              : null,
+          }
+        }),
+      )
+
+      const subtotalDeltaCents = quotedLines.reduce((sum, line) => sum + line.subtotalDeltaCents, 0)
+      const taxDeltaCents = quotedLines.reduce((sum, line) => sum + line.taxDeltaCents, 0)
+      const feeDeltaCents = 0
+      const amountCents = input.lines.reduce(
+        (sum, line, index) =>
+          sum +
+          line.subtotalDeltaCents +
+          (quotedLines[index]?.taxAddsToTotal ? (quotedLines[index]?.taxDeltaCents ?? 0) : 0),
+        feeDeltaCents,
+      )
+      const collectionAmountCents = Math.max(amountCents, 0)
+      const refundAmountCents = Math.max(-amountCents, 0)
+
+      return {
+        price: {
+          currency: input.currency,
+          subtotalDeltaCents,
+          feeDeltaCents,
+          taxDeltaCents,
+          amountCents,
+          collectionAmountCents,
+          refundAmountCents,
+          taxLines: quotedLines.flatMap((line) => (line.taxLine ? [line.taxLine] : [])),
+        },
+        consequences: {
+          collection: collectionAmountCents > 0 ? "required" : "not_required",
+          refund: refundAmountCents > 0 ? "required" : "not_required",
+          invoice: collectionAmountCents > 0 ? "reissue_required" : "not_required",
+          creditNote: refundAmountCents > 0 ? "issue_required" : "not_required",
+          paymentSchedule: amountCents === 0 ? "not_required" : "recalculate_required",
+        },
+        policyVersion: BOOKING_AMENDMENT_FINANCE_POLICY_VERSION,
+      }
+    },
+
+    async recordBookingAmendment(tx, input) {
+      const status =
+        input.price.collectionAmountCents > 0
+          ? ("collection_required" as const)
+          : input.price.refundAmountCents > 0
+            ? ("refund_required" as const)
+            : ("no_action" as const)
+      const [created] = await tx
+        .insert(financeAmendmentAdjustments)
+        .values({
+          amendmentId: input.amendmentId,
+          bookingId: input.bookingId,
+          idempotencyKey: input.idempotencyKey,
+          currency: input.price.currency,
+          subtotalDeltaCents: input.price.subtotalDeltaCents,
+          feeDeltaCents: input.price.feeDeltaCents,
+          taxDeltaCents: input.price.taxDeltaCents,
+          totalDeltaCents: input.price.amountCents,
+          collectionAmountCents: input.price.collectionAmountCents,
+          refundAmountCents: input.price.refundAmountCents,
+          status,
+          consequences: input.consequences,
+          reason: input.reason,
+        })
+        .onConflictDoNothing({ target: financeAmendmentAdjustments.amendmentId })
+        .returning({ id: financeAmendmentAdjustments.id })
+      if (created) return { adjustmentId: created.id, status: "recorded" }
+
+      const [existing] = await tx
+        .select()
+        .from(financeAmendmentAdjustments)
+        .where(
+          and(
+            eq(financeAmendmentAdjustments.amendmentId, input.amendmentId),
+            eq(financeAmendmentAdjustments.bookingId, input.bookingId),
+          ),
+        )
+        .limit(1)
+      if (
+        !existing ||
+        existing.idempotencyKey !== input.idempotencyKey ||
+        existing.totalDeltaCents !== input.price.amountCents ||
+        existing.currency !== input.price.currency
+      ) {
+        throw new Error("Booking Amendment finance idempotency conflict")
+      }
+      return { adjustmentId: existing.id, status: "replay" }
+    },
+  }
+}

--- a/packages/finance/src/runtime-contributor.ts
+++ b/packages/finance/src/runtime-contributor.ts
@@ -15,8 +15,13 @@ import { createRouteActionRegistry } from "@voyant-travel/tools"
 import { eq } from "drizzle-orm"
 import { checkFinanceActionLedgerDrift } from "./action-ledger-drift.js"
 import { createFinanceAppApiRuntime } from "./app-api-runtime.js"
+import { createBookingAmendmentFinanceRuntime } from "./booking-amendment-runtime.js"
 import { FINANCE_BOOKING_CREATE_SELF_SERVICE_ROUTE_ACTION } from "./booking-create-policy.js"
-import { financeHostRuntimePort } from "./runtime-port.js"
+import {
+  type FinanceOperatorSettingsRuntime,
+  financeHostRuntimePort,
+  financeOperatorSettingsRuntimePort,
+} from "./runtime-port.js"
 import type { SelfServiceBookingSourceRuntime } from "./self-service-booking-source.js"
 import { financeSelfServiceBookingSourceRuntimePort } from "./self-service-booking-source.js"
 import { createSelfServiceCreateRuntime } from "./self-service-create-runtime.js"
@@ -34,6 +39,14 @@ export function createFinanceRuntimePortContribution(
 ): Readonly<Record<string, unknown>> {
   const hasSource = host.hasRuntimePort?.(financeSelfServiceBookingSourceRuntimePort) === true
   const routeActions = createRouteActionRegistry()
+  const amendmentRuntime = createBookingAmendmentFinanceRuntime({
+    resolveBookingTaxSettings: async (db) =>
+      (
+        await host.getRuntimePort<FinanceOperatorSettingsRuntime>(
+          financeOperatorSettingsRuntimePort,
+        )
+      ).resolveBookingTaxSettings(db),
+  })
   if (hasSource) routeActions.register(FINANCE_BOOKING_CREATE_SELF_SERVICE_ROUTE_ACTION)
   return {
     [financeAppApiRuntimePort.id]: createFinanceAppApiRuntime(host.primitives),
@@ -43,6 +56,7 @@ export function createFinanceRuntimePortContribution(
     [financeHostRuntimePort.id]: { primitives: host.primitives },
     [bookingsFinanceRuntimePort.id]: {
       createStaleBookingHoldsJobRuntime: createFinanceStaleBookingHoldsJobRuntime,
+      ...amendmentRuntime,
     } satisfies BookingsFinanceRuntime,
     // The public create route lives in Bookings; Finance supplies the durable
     // command. Only contributed when a source provider is selected, so the

--- a/packages/finance/src/schema.ts
+++ b/packages/finance/src/schema.ts
@@ -1,3 +1,4 @@
+export * from "./schema/amendments.js"
 export * from "./schema/booking-billing.js"
 export * from "./schema/enums.js"
 export * from "./schema/invoice-documents.js"

--- a/packages/finance/src/schema/amendments.ts
+++ b/packages/finance/src/schema/amendments.ts
@@ -1,0 +1,60 @@
+import type { BookingAmendmentFinancialConsequences } from "@voyant-travel/bookings-contracts"
+import { typeId } from "@voyant-travel/db/lib/typeid-column"
+import { sql } from "drizzle-orm"
+import {
+  check,
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+} from "drizzle-orm/pg-core"
+
+export type FinanceAmendmentAdjustmentStatus =
+  | "no_action"
+  | "collection_required"
+  | "refund_required"
+
+export const financeAmendmentAdjustments = pgTable(
+  "finance_amendment_adjustments",
+  {
+    id: typeId("finance_amendment_adjustments"),
+    amendmentId: text("amendment_id").notNull(),
+    bookingId: text("booking_id").notNull(),
+    idempotencyKey: text("idempotency_key").notNull(),
+    currency: text("currency").notNull(),
+    subtotalDeltaCents: integer("subtotal_delta_cents").notNull(),
+    feeDeltaCents: integer("fee_delta_cents").notNull(),
+    taxDeltaCents: integer("tax_delta_cents").notNull(),
+    totalDeltaCents: integer("total_delta_cents").notNull(),
+    collectionAmountCents: integer("collection_amount_cents").notNull().default(0),
+    refundAmountCents: integer("refund_amount_cents").notNull().default(0),
+    status: text("status").$type<FinanceAmendmentAdjustmentStatus>().notNull(),
+    consequences: jsonb("consequences").$type<BookingAmendmentFinancialConsequences>().notNull(),
+    reason: text("reason").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("uq_finance_amendment_adjustments_amendment").on(table.amendmentId),
+    index("idx_finance_amendment_adjustments_booking_created").on(table.bookingId, table.createdAt),
+    index("idx_finance_amendment_adjustments_status").on(table.status),
+    check(
+      "ck_finance_amendment_adjustments_status",
+      // agent-quality: raw-sql reviewed -- owner: finance; static status membership constraint over a Drizzle identifier.
+      sql`${table.status} IN ('no_action', 'collection_required', 'refund_required')`,
+    ),
+    check(
+      "ck_finance_amendment_adjustments_money",
+      // agent-quality: raw-sql reviewed -- owner: finance; monetary balance invariant over Drizzle identifiers and integer literals.
+      sql`${table.totalDeltaCents} = ${table.subtotalDeltaCents} + ${table.feeDeltaCents} + ${table.taxDeltaCents}
+        AND ${table.collectionAmountCents} >= 0
+        AND ${table.refundAmountCents} >= 0
+        AND NOT (${table.collectionAmountCents} > 0 AND ${table.refundAmountCents} > 0)`,
+    ),
+  ],
+)
+
+export type FinanceAmendmentAdjustment = typeof financeAmendmentAdjustments.$inferSelect

--- a/packages/finance/tests/unit/booking-amendment-migration.test.ts
+++ b/packages/finance/tests/unit/booking-amendment-migration.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+
+const migration = readFileSync(
+  new URL("../../migrations/20260802180500_booking_amendment_adjustments.sql", import.meta.url),
+  "utf8",
+)
+
+describe("Booking Amendment adjustment migration", () => {
+  it("creates one idempotent financial adjustment per Amendment", () => {
+    expect(migration).toContain('CREATE TABLE "finance_amendment_adjustments"')
+    expect(migration).toContain('CREATE UNIQUE INDEX "uq_finance_amendment_adjustments_amendment"')
+    expect(migration).toContain('CONSTRAINT "ck_finance_amendment_adjustments_money"')
+    expect(migration).toContain(
+      '"total_delta_cents" = "subtotal_delta_cents" + "fee_delta_cents" + "tax_delta_cents"',
+    )
+  })
+})

--- a/packages/finance/tests/unit/booking-amendment-runtime.test.ts
+++ b/packages/finance/tests/unit/booking-amendment-runtime.test.ts
@@ -1,0 +1,146 @@
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { describe, expect, it, vi } from "vitest"
+
+import { createBookingAmendmentFinanceRuntime } from "../../src/booking-amendment-runtime.js"
+
+function taxDb(priceMode: "inclusive" | "exclusive") {
+  const resultQueue = [
+    [{ id: "profile_1", code: "ro-b2c", active: true }],
+    [{ condition: { always: true }, taxRegimeId: "regime_1" }],
+    [{ code: "standard", name: "TVA Standard", ratePercent: 21 }],
+  ]
+  const takeResult = async () => resultQueue.shift() ?? []
+  const select = () => {
+    const chain = {
+      from: () => chain,
+      where: () => chain,
+      orderBy: takeResult,
+      limit: takeResult,
+    }
+    return chain
+  }
+  return {
+    db: { select, execute: vi.fn(async () => []) } as PostgresJsDatabase,
+    resolveBookingTaxSettings: vi.fn(async () => ({
+      taxPriceMode: priceMode,
+      taxPolicyProfileId: "profile_1",
+    })),
+  }
+}
+
+describe("Booking Amendment finance runtime", () => {
+  it("quotes exclusive tax and collection consequences server-side", async () => {
+    const { db, resolveBookingTaxSettings } = taxDb("exclusive")
+    const runtime = createBookingAmendmentFinanceRuntime({ resolveBookingTaxSettings })
+
+    await expect(
+      runtime.quoteBookingAmendment(db, {
+        bookingId: "bk_1",
+        currency: "RON",
+        lines: [{ bookingItemId: "bitm_1", productId: "prod_1", subtotalDeltaCents: 10_000 }],
+      }),
+    ).resolves.toMatchObject({
+      price: {
+        subtotalDeltaCents: 10_000,
+        taxDeltaCents: 2_100,
+        amountCents: 12_100,
+        collectionAmountCents: 12_100,
+        refundAmountCents: 0,
+      },
+      consequences: {
+        collection: "required",
+        refund: "not_required",
+        invoice: "reissue_required",
+        creditNote: "not_required",
+        paymentSchedule: "recalculate_required",
+      },
+    })
+  })
+
+  it("preserves an inclusive gross price and produces refund consequences for a drop", async () => {
+    const { db, resolveBookingTaxSettings } = taxDb("inclusive")
+    const runtime = createBookingAmendmentFinanceRuntime({ resolveBookingTaxSettings })
+
+    await expect(
+      runtime.quoteBookingAmendment(db, {
+        bookingId: "bk_1",
+        currency: "RON",
+        lines: [{ bookingItemId: "bitm_1", productId: "prod_1", subtotalDeltaCents: -12_100 }],
+      }),
+    ).resolves.toMatchObject({
+      price: {
+        subtotalDeltaCents: -10_000,
+        taxDeltaCents: -2_100,
+        amountCents: -12_100,
+        collectionAmountCents: 0,
+        refundAmountCents: 12_100,
+      },
+      consequences: {
+        collection: "not_required",
+        refund: "required",
+        invoice: "not_required",
+        creditNote: "issue_required",
+        paymentSchedule: "recalculate_required",
+      },
+    })
+  })
+
+  it("records one idempotent adjustment and rejects a mismatched replay", async () => {
+    const input = {
+      amendmentId: "bamd_1",
+      bookingId: "bk_1",
+      idempotencyKey: "apply-1",
+      price: {
+        currency: "EUR",
+        subtotalDeltaCents: 10_000,
+        feeDeltaCents: 0,
+        taxDeltaCents: 0,
+        amountCents: 10_000,
+        collectionAmountCents: 10_000,
+        refundAmountCents: 0,
+        taxLines: [],
+      },
+      consequences: {
+        collection: "required" as const,
+        refund: "not_required" as const,
+        invoice: "reissue_required" as const,
+        creditNote: "not_required" as const,
+        paymentSchedule: "recalculate_required" as const,
+      },
+      reason: "Add a traveler",
+    }
+    let existing = {
+      id: "faad_1",
+      amendmentId: input.amendmentId,
+      bookingId: input.bookingId,
+      idempotencyKey: input.idempotencyKey,
+      totalDeltaCents: input.price.amountCents,
+      currency: input.price.currency,
+    }
+    const returning = vi.fn(async () => [])
+    const insertChain = {
+      values: () => insertChain,
+      onConflictDoNothing: () => insertChain,
+      returning,
+    }
+    const selectChain = {
+      from: () => selectChain,
+      where: () => selectChain,
+      limit: async () => [existing],
+    }
+    const db = {
+      insert: vi.fn(() => insertChain),
+      select: vi.fn(() => selectChain),
+    } as PostgresJsDatabase
+    const runtime = createBookingAmendmentFinanceRuntime()
+
+    await expect(runtime.recordBookingAmendment(db, input)).resolves.toEqual({
+      adjustmentId: "faad_1",
+      status: "replay",
+    })
+    existing = { ...existing, totalDeltaCents: 9_999 }
+    await expect(runtime.recordBookingAmendment(db, input)).rejects.toThrow(
+      "Booking Amendment finance idempotency conflict",
+    )
+  })
+})

--- a/packages/schema-kit/src/typeid/typeid-prefixes.ts
+++ b/packages/schema-kit/src/typeid/typeid-prefixes.ts
@@ -173,6 +173,7 @@ export const PREFIXES = {
   supplier_invoice_attachments: "sina",
   cost_categories: "ccat",
   finance_notes: "fnot",
+  finance_amendment_adjustments: "faad",
   resources: "res",
   resource_pools: "repl",
   resource_pool_members: "repm",

--- a/packages/schema-kit/src/typeid/typeid-schemas.ts
+++ b/packages/schema-kit/src/typeid/typeid-schemas.ts
@@ -164,6 +164,7 @@ export const typeIdSchemas = {
   creditNoteLineItem: typeIdSchema("credit_note_line_items"),
   supplierPayment: typeIdSchema("supplier_payments"),
   financeNote: typeIdSchema("finance_notes"),
+  financeAmendmentAdjustment: typeIdSchema("finance_amendment_adjustments"),
   resource: typeIdSchema("resources"),
   resourcePool: typeIdSchema("resource_pools"),
   resourcePoolMember: typeIdSchema("resource_pool_members"),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2636,6 +2636,9 @@ importers:
       '@voyant-travel/bookings':
         specifier: workspace:^
         version: link:../bookings
+      '@voyant-travel/bookings-contracts':
+        specifier: workspace:^
+        version: link:../bookings-contracts
       '@voyant-travel/core':
         specifier: workspace:^
         version: link:../core

--- a/scripts/tool-refinement-inventory.json
+++ b/scripts/tool-refinement-inventory.json
@@ -13,6 +13,11 @@
       "note": "Documented. The `patch` field description states that at least one traveler correction field must be provided."
     },
     {
+      "id": "@voyant-travel/bookings:preview_traveler_roster_change_amendment:change|0.bookingItemIds",
+      "documented": true,
+      "note": "Documented. The Booking Item id field description states that one or more distinct ids are required and duplicate ids are rejected."
+    },
+    {
       "id": "@voyant-travel/commerce:create_promotion:<root>",
       "documented": false,
       "note": "Not stated. The discount-type/amount pairing rule (percent vs fixed amount, and the currency it needs) is enforced only by the refinement."


### PR DESCRIPTION
## What changed

- adds an end-to-end traveler add/drop Amendment journey: exact-revision preview and expiring server Quote, explicit acceptance, apply, and supplier reconciliation
- keeps Booking identity stable while atomically projecting traveler assignments, Booking Items, Allocations, owned capacity, price, pax, Finance adjustment, and Booking revision
- routes sourced changes through durable Supplier Operations with explicit pending, in-doubt, refusal, partial-success/manual-review, and replay outcomes
- exposes the same typed lifecycle through admin, storefront, and Tool transports
- adds Finance-owned tax/collection/refund consequences, migrations, immutable snapshots, OpenAPI contracts, architecture documentation, and release metadata

## Why

Booking Platform v1 needs a commercially meaningful post-commit change that does not mutate history or cancel-and-rebook. This slice establishes the long-term Amendment protocol and preserves module ownership: Bookings owns the projection, Finance owns monetary policy and adjustments, and Catalog owns supplier operation dispatch and reconciliation.

## Validation

- remote typechecks: bookings-contracts, schema-kit, finance, catalog, bookings
- Finance suite: 503 passed, 364 skipped where database integration was unavailable
- Catalog suite: 720 passed, 52 skipped
- Bookings focused suite: contracts, tools, manifests, OpenAPI coverage, and migration tests green
- Booking Amendment integration suite expanded for collection, refund, capacity races, refusal, in-doubt reconciliation, partial success, and replay; live PostgreSQL execution delegated to CI
- Booking v1 lifecycle, runtime-port, Tool coverage/refinement, migration-boundary, OpenAPI-authority, dependency, and agent-quality checks green

Closes #4015
Contributes to #3963