### PR TITLE
refactor(catalog): resolve the inventory channel through a port

### DIFF
--- a/.changeset/catalog-sources-channel-seam.md
+++ b/.changeset/catalog-sources-channel-seam.md
@@ -1,0 +1,17 @@
+---
+"@voyant-travel/catalog": minor
+"@voyant-travel/plugin-voyant-connect": minor
+---
+
+Resolve the catalog's inventory channel through a runtime port instead of
+importing Voyant Connect.
+
+`CatalogSourcesRuntimeExtension` is the channel contract — `registerFallback`
+for the synchronous cold window, `warm` for per-connection enumeration, and
+`resolveDestinationNames`. It is optional: a deployment may bind no channel.
+
+Voyant Connect now provides that port rather than being imported by the catalog
+spine, so it is one channel implementation and a self-hosted integration can
+provide its own. This also removes the
+`catalog -> plugin-voyant-connect -> cruises -> catalog` dependency cycle, which
+had been hiding as a build-ordering race.

--- a/packages/accommodations/tsconfig.build.json
+++ b/packages/accommodations/tsconfig.build.json
@@ -1657,6 +1657,13 @@
       "@voyant-travel/plugin-sanity-cms/types": ["../plugins/sanity-cms/dist/types.d.ts"],
       "@voyant-travel/plugin-sanity-cms/voyant": ["../plugins/sanity-cms/dist/voyant.d.ts"],
       "@voyant-travel/plugin-voyant-connect": ["../plugins/voyant-connect/dist/index.d.ts"],
+      "@voyant-travel/plugin-voyant-connect/catalog-sources": [
+        "../plugins/voyant-connect/dist/catalog-sources-extension.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/runtime-contributor": [
+        "../plugins/voyant-connect/dist/runtime-contributor.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/voyant": ["../plugins/voyant-connect/dist/voyant.d.ts"],
       "@voyant-travel/products-contracts": ["../products-contracts/dist/index.d.ts"],
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"

--- a/packages/accommodations/tsconfig.typecheck.json
+++ b/packages/accommodations/tsconfig.typecheck.json
@@ -1658,6 +1658,13 @@
       "@voyant-travel/plugin-sanity-cms/types": ["../plugins/sanity-cms/dist/types.d.ts"],
       "@voyant-travel/plugin-sanity-cms/voyant": ["../plugins/sanity-cms/dist/voyant.d.ts"],
       "@voyant-travel/plugin-voyant-connect": ["../plugins/voyant-connect/dist/index.d.ts"],
+      "@voyant-travel/plugin-voyant-connect/catalog-sources": [
+        "../plugins/voyant-connect/dist/catalog-sources-extension.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/runtime-contributor": [
+        "../plugins/voyant-connect/dist/runtime-contributor.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/voyant": ["../plugins/voyant-connect/dist/voyant.d.ts"],
       "@voyant-travel/products-contracts": ["../products-contracts/dist/index.d.ts"],
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"

--- a/packages/catalog/package.json
+++ b/packages/catalog/package.json
@@ -453,7 +453,6 @@
     "@voyant-travel/db": "workspace:^",
     "@voyant-travel/finance": "workspace:^",
     "@voyant-travel/hono": "workspace:^",
-    "@voyant-travel/plugin-voyant-connect": "workspace:^",
     "@voyant-travel/tools": "workspace:^",
     "drizzle-orm": "catalog:",
     "hono": "catalog:",

--- a/packages/catalog/src/runtime-contracts.ts
+++ b/packages/catalog/src/runtime-contracts.ts
@@ -202,6 +202,37 @@ export interface CatalogOperationsRuntimeExtension {
   createDeparturesProjectionExtension(): CatalogProjectionExtension
 }
 
+/**
+ * A channel that sources inventory into the booking engine.
+ *
+ * Voyant Connect is one implementation; the catalog spine must not name it.
+ * Anything that can register `SourceAdapter`s — a self-hosted integration, a
+ * different vendor — provides this port instead.
+ */
+export type { SourceAdapterRegistry } from "./booking-engine/registry.js"
+
+export interface CatalogSourcesRuntimeExtension {
+  /**
+   * Register the un-scoped default adapters synchronously. This is the
+   * cold-window fallback that keeps sourced reads and quoting dispatching
+   * before {@link warm} completes. A channel with nothing to register, or with
+   * incomplete configuration, returns without touching the registry.
+   */
+  registerFallback(registry: SourceAdapterRegistry, env: Record<string, string | undefined>): void
+  /**
+   * Enumerate the operator's active connections and register one
+   * connection-scoped adapter set per connection, so the live book path
+   * resolves by connection id. Must be idempotent; the caller memoizes it and
+   * resets on failure so a later request retries.
+   */
+  warm(registry: SourceAdapterRegistry, env: Record<string, string | undefined>): Promise<void>
+  /** Human labels for destination codes; falls back to the code itself. */
+  resolveDestinationNames(
+    codes: readonly string[],
+    env: Record<string, string | undefined>,
+  ): Promise<ReadonlyArray<{ code: string; label: string }>>
+}
+
 export interface CatalogRuntimeExtensions {
   accommodations: CatalogAccommodationsRuntimeExtension
   charters: CatalogChartersRuntimeExtension
@@ -210,6 +241,8 @@ export interface CatalogRuntimeExtensions {
   cruises: CatalogCruisesRuntimeExtension
   inventory: CatalogInventoryRuntimeExtension
   operations: CatalogOperationsRuntimeExtension
+  /** Absent when the deployment binds no inventory channel. */
+  sources?: CatalogSourcesRuntimeExtension
 }
 
 function extensionPort<T extends object>(id: string) {
@@ -223,6 +256,9 @@ function extensionPort<T extends object>(id: string) {
   })
 }
 
+export const catalogSourcesRuntimeExtensionPort = extensionPort<CatalogSourcesRuntimeExtension>(
+  "catalog.extension.sources",
+)
 export const catalogAccommodationsRuntimeExtensionPort =
   extensionPort<CatalogAccommodationsRuntimeExtension>("catalog.extension.accommodations")
 export const catalogChartersRuntimeExtensionPort = extensionPort<CatalogChartersRuntimeExtension>(

--- a/packages/catalog/src/runtime-contributor.ts
+++ b/packages/catalog/src/runtime-contributor.ts
@@ -70,6 +70,7 @@ import {
   type CatalogInventoryRuntimeExtension,
   type CatalogOperationsRuntimeExtension,
   type CatalogRuntimeServices,
+  type CatalogSourcesRuntimeExtension,
   catalogAccommodationsRuntimeExtensionPort,
   catalogChartersRuntimeExtensionPort,
   catalogCommerceRuntimeExtensionPort,
@@ -78,6 +79,7 @@ import {
   catalogInventoryRuntimeExtensionPort,
   catalogOperationsRuntimeExtensionPort,
   catalogRuntimeServicesPort,
+  catalogSourcesRuntimeExtensionPort,
 } from "./runtime-contracts.js"
 import {
   type CatalogSourcesSyncJobRuntime,
@@ -109,6 +111,7 @@ export function createCatalogRuntimePortContribution(
   host: CatalogRuntimeContributorHost,
 ): Readonly<Record<string, unknown>> {
   const hasIndexerPort = host.hasRuntimePort?.(catalogIndexerProviderPort) === true
+  const hasSourcesPort = host.hasRuntimePort?.(catalogSourcesRuntimeExtensionPort) === true
   const dependencies = Promise.resolve().then(() =>
     Promise.all([
       host.getRuntimePort<CatalogAccommodationsRuntimeExtension>(
@@ -124,6 +127,9 @@ export function createCatalogRuntimePortContribution(
       host.getRuntimePort<CatalogOperationsRuntimeExtension>(catalogOperationsRuntimeExtensionPort),
       host.getRuntimePort<FinanceOperatorSettingsRuntime>(financeOperatorSettingsRuntimePort),
       hasIndexerPort ? host.getRuntimePort<unknown>(catalogIndexerProviderPort) : undefined,
+      hasSourcesPort
+        ? host.getRuntimePort<CatalogSourcesRuntimeExtension>(catalogSourcesRuntimeExtensionPort)
+        : undefined,
     ]),
   )
   const contribution = dependencies.then(
@@ -137,6 +143,7 @@ export function createCatalogRuntimePortContribution(
       operations,
       settings,
       indexer,
+      sources,
     ]) => {
       let catalogIndexer: CatalogIndexer | undefined
       if (hasIndexerPort) {
@@ -153,6 +160,7 @@ export function createCatalogRuntimePortContribution(
           cruises,
           inventory,
           operations,
+          ...(sources ? { sources } : {}),
         },
         settings,
         {

--- a/packages/catalog/src/runtime/booking-engine-runtime.test.ts
+++ b/packages/catalog/src/runtime/booking-engine-runtime.test.ts
@@ -6,28 +6,13 @@ import type { BookingEngineEnv } from "./booking-engine-runtime.js"
 // flake the suite. Give the file headroom — the assertions themselves are sync.
 vi.setConfig({ testTimeout: 20000 })
 
-// The plugin is mocked so the test exercises the runtime's warm/fallback wiring
-// (not the real Connect network calls). `registerVoyantConnectSources` mirrors
-// the real plugin: connection-scoped sources register by id, the default pair
-// registers by kind.
-const prepareVoyantConnectSources = vi.fn()
-const createVoyantConnectSources = vi.fn()
-const resolveVoyantConnectEnv = vi.fn()
+// A stub inventory channel. The catalog spine no longer imports Voyant Connect;
+// it resolves whatever channel the deployment bound to the sources port, so the
+// test provides one directly instead of mocking the plugin module.
+const registerFallback = vi.fn()
+const warm = vi.fn()
+const resolveDestinationNames = vi.fn()
 
-vi.mock("@voyant-travel/plugin-voyant-connect", () => ({
-  prepareVoyantConnectSources,
-  createVoyantConnectSources,
-  resolveVoyantConnectEnv,
-  registerVoyantConnectSources: (
-    registry: { register: (a: unknown, b?: unknown) => void },
-    sources: Array<{ connectionId?: string; adapter: unknown }>,
-  ) => {
-    for (const source of sources) {
-      if (source.connectionId) registry.register(source.connectionId, source.adapter)
-      else registry.register(source.adapter)
-    }
-  },
-}))
 vi.mock("./owned-booking-handlers.js", () => ({
   createOwnedBookingHandlersRegistry: vi.fn(),
 }))
@@ -41,7 +26,7 @@ function genericAdapter() {
   return { kind: "voyant-connect" } as never
 }
 
-async function loadRuntime() {
+async function loadRuntime({ withSources = true }: { withSources?: boolean } = {}) {
   vi.resetModules()
   const [runtime, host] = await Promise.all([
     import("./booking-engine-runtime.js"),
@@ -51,6 +36,7 @@ async function loadRuntime() {
     {} as never,
     {
       cruises: { registerAdapters: vi.fn(), syncRegistry: vi.fn() },
+      ...(withSources ? { sources: { registerFallback, warm, resolveDestinationNames } } : {}),
     } as never,
   )
   return runtime
@@ -58,21 +44,23 @@ async function loadRuntime() {
 
 beforeEach(() => {
   vi.clearAllMocks()
-  // Default-pair fallback (synchronous): resolveVoyantConnectEnv returns a
-  // config, createVoyantConnectSources returns the un-scoped pair.
-  resolveVoyantConnectEnv.mockReturnValue({ apiKey: "k", operatorId: "op_1" })
-  createVoyantConnectSources.mockReturnValue([{ adapter: genericAdapter() }])
-  // Per-connection warm result.
-  prepareVoyantConnectSources.mockResolvedValue([
-    { connectionId: "conn_1", adapter: genericAdapter() },
-  ])
+  // A configured channel: the fallback registers an un-scoped adapter by kind,
+  // the warm registers one connection-scoped adapter.
+  registerFallback.mockImplementation((registry: { register: (a: unknown, b?: unknown) => void }) =>
+    registry.register(genericAdapter()),
+  )
+  warm.mockImplementation(async (registry: { register: (a: unknown, b?: unknown) => void }) => {
+    // Real enumeration is a network round-trip; yield so the synchronous
+    // fallback is observable before the per-connection adapters land.
+    await Promise.resolve()
+    registry.register("conn_1", genericAdapter())
+  })
 })
 
 describe("getBookingEngineRegistry", () => {
   it("registers the un-scoped default synchronously before the warm completes", async () => {
     const { getBookingEngineRegistry } = await loadRuntime()
     const registry = getBookingEngineRegistry(CONNECT_ENV)
-    // Fallback is registered by kind; the per-connection entry is not yet present.
     expect(registry.hasKind("voyant-connect")).toBe(true)
     expect(registry.resolveByConnection("conn_1")).toBeUndefined()
   })
@@ -82,7 +70,6 @@ describe("ensureBookingEngineRegistry", () => {
   it("registers per-connection adapters after the warm", async () => {
     const { ensureBookingEngineRegistry } = await loadRuntime()
     const registry = await ensureBookingEngineRegistry(CONNECT_ENV)
-    // The connection-scoped adapter is now resolvable by its connection id.
     expect(registry.resolveByConnection("conn_1")).toBeDefined()
     // The un-scoped fallback still coexists for cold-window / connection-less rows.
     expect(registry.hasKind("voyant-connect")).toBe(true)
@@ -92,27 +79,21 @@ describe("ensureBookingEngineRegistry", () => {
     const { ensureBookingEngineRegistry } = await loadRuntime()
     await ensureBookingEngineRegistry(CONNECT_ENV)
     await ensureBookingEngineRegistry(CONNECT_ENV)
-    expect(prepareVoyantConnectSources).toHaveBeenCalledTimes(1)
+    expect(warm).toHaveBeenCalledTimes(1)
   })
-})
 
-describe("Connect cruise memoize", () => {
-  it("passes cruise memoization to the warm", async () => {
+  it("retries a failed warm rather than caching the failure", async () => {
+    warm.mockRejectedValueOnce(new Error("enumeration failed"))
     const { ensureBookingEngineRegistry } = await loadRuntime()
     await ensureBookingEngineRegistry(CONNECT_ENV)
-    const opts = prepareVoyantConnectSources.mock.calls[0]![1]
-    expect(opts.cruise?.memoize?.ttlMs).toBeGreaterThan(0)
+    await ensureBookingEngineRegistry(CONNECT_ENV)
+    expect(warm).toHaveBeenCalledTimes(2)
   })
 })
 
-describe("when Connect is unconfigured", () => {
-  beforeEach(() => {
-    resolveVoyantConnectEnv.mockReturnValue(null)
-    prepareVoyantConnectSources.mockResolvedValue([])
-  })
-
-  it("registers no Connect adapters and does not throw", async () => {
-    const { ensureBookingEngineRegistry } = await loadRuntime()
+describe("when no inventory channel is bound", () => {
+  it("registers nothing, does not throw, and still resolves a registry", async () => {
+    const { ensureBookingEngineRegistry } = await loadRuntime({ withSources: false })
     const registry = await ensureBookingEngineRegistry({})
     expect(registry.hasKind("voyant-connect")).toBe(false)
     expect(registry.connections()).toEqual([])

--- a/packages/catalog/src/runtime/booking-engine-runtime.ts
+++ b/packages/catalog/src/runtime/booking-engine-runtime.ts
@@ -9,12 +9,6 @@ import {
   type OwnedBookingHandlerRegistry,
   type SourceAdapterRegistry,
 } from "@voyant-travel/catalog/booking-engine"
-import {
-  createVoyantConnectSources,
-  prepareVoyantConnectSources,
-  registerVoyantConnectSources,
-  resolveVoyantConnectEnv,
-} from "@voyant-travel/plugin-voyant-connect"
 import type { Context } from "hono"
 import { catalogRuntimeExtensions } from "./host.js"
 import { createOwnedBookingHandlersRegistry } from "./owned-booking-handlers.js"
@@ -32,7 +26,10 @@ function ensureRegistry(env: BookingEngineEnv): SourceAdapterRegistry {
   if (!_registry) {
     const { cruises } = catalogRuntimeExtensions()
     const registry = createSourceAdapterRegistry()
-    registerVoyantConnectFallback(registry, env)
+    catalogRuntimeExtensions().sources?.registerFallback(
+      registry,
+      env as Record<string, string | undefined>,
+    )
     // Single activation point for cruise adapters: register deployment-owned
     // connectors into both planes and back-fill the vertical registry from the
     // un-scoped Connect cruise fallback registered just above. The per-connection
@@ -69,21 +66,22 @@ export function getBookingEngineRegistry(env: BookingEngineEnv): SourceAdapterRe
 function warmBookingEngineConnectSources(env: BookingEngineEnv): Promise<void> {
   if (_connectWarm) return _connectWarm
   const registry = ensureRegistry(env)
-  _connectWarm = prepareVoyantConnectSources(env, {
-    enumerate: true,
-    cruise: CONNECT_CRUISE_MEMOIZE,
-    warn: (message) => console.warn(`[booking-engine] ${message}`),
-  })
-    .then((sources) => {
-      registerConnectSources(registry, sources)
-      // Per-connection Connect cruise shims just landed — back-fill the vertical
-      // registry so admin/public external cruise reads resolve them too.
+  const sources = catalogRuntimeExtensions().sources
+  if (!sources) {
+    _connectWarm = Promise.resolve()
+    return _connectWarm
+  }
+  _connectWarm = sources
+    .warm(registry, env as Record<string, string | undefined>)
+    .then(() => {
+      // Per-connection shims just landed — back-fill the vertical registry so
+      // admin/public external cruise reads resolve them too.
       catalogRuntimeExtensions().cruises.syncRegistry(registry)
     })
     .catch((error) => {
       const message = error instanceof Error ? error.message : String(error)
       console.warn(
-        `[booking-engine] Connect connection warm failed; using un-scoped fallback: ${message}`,
+        `[booking-engine] channel source warm failed; using un-scoped fallback: ${message}`,
       )
       _connectWarm = undefined
     })
@@ -144,50 +142,9 @@ export interface BookingEngineEnv {
   VOYANT_CONNECT_SYNC_LIMIT?: string
 }
 
-/** Short-TTL read cache applied to Connect cruise reads on both the fallback and
- * per-connection warm paths (plugin >= 0.3.0). Shares the owned-adapter TTL. */
-const CONNECT_CRUISE_MEMOIZE = { memoize: { ttlMs: 60_000 } } as const
-
-/**
- * Connect is released independently and its registration helper is compiled
- * against the previous Catalog contract. Its adapters return a strict subset
- * of the current reserve outcomes, so the registry mutation remains compatible;
- * keep that version bridge isolated here until the next Connect release.
- */
-function registerConnectSources(
-  registry: SourceAdapterRegistry,
-  sources: Parameters<typeof registerVoyantConnectSources>[1],
-): void {
-  registerVoyantConnectSources(
-    registry as unknown as Parameters<typeof registerVoyantConnectSources>[0],
-    sources,
-  )
-}
-
-/**
- * Register the un-scoped Voyant Connect default adapter pair synchronously — the
- * cold-window fallback used until `warmBookingEngineConnectSources` registers the
- * per-connection adapters. Connect env resolution (key fallback, operator id,
- * market, sync limit, the incomplete-config warning) is shared with the
- * discovery-sync CLI via `resolveVoyantConnectEnv` so the two paths can't drift.
- */
-function registerVoyantConnectFallback(
-  registry: SourceAdapterRegistry,
-  env: BookingEngineEnv,
-): void {
-  const config = resolveVoyantConnectEnv(env, {
-    warn: (message) => console.warn(`[booking-engine] ${message}`),
-  })
-  if (!config) return
-  registerConnectSources(
-    registry,
-    createVoyantConnectSources({ ...config, cruise: CONNECT_CRUISE_MEMOIZE }),
-  )
-}
-
 /**
  * Convenience helper for route handlers — pulls env from the Hono context,
- * returns the cached source registry, and ties the per-connection Connect warm
+ * returns the cached source registry, and ties the per-connection channel warm
  * to the request via `ctx.waitUntil` so the enumeration isn't torn down when the
  * request ends. Non-blocking: the request proceeds on the un-scoped fallback
  * during the first per-isolate warm.

--- a/packages/catalog/src/runtime/offers-runtime.ts
+++ b/packages/catalog/src/runtime/offers-runtime.ts
@@ -9,8 +9,8 @@ import {
 } from "@voyant-travel/catalog/runtime-support"
 import type { IndexerAdapter } from "@voyant-travel/catalog-contracts/indexer/contract"
 import { createVoyantConnectClient } from "@voyant-travel/connect-sdk"
-import { createDestinationNameResolver } from "@voyant-travel/plugin-voyant-connect"
 import type { Context } from "hono"
+import { catalogRuntimeExtensions } from "./host.js"
 
 interface PackageOffersEnv {
   VOYANT_API_KEY?: string
@@ -42,25 +42,19 @@ async function resolveAirportLabels(
 ): Promise<CatalogOffersAirportLabel[]> {
   const env = c.env as PackageOffersEnv
   const sorted = [...new Set(codes)].sort()
-  const apiKey = connectApiKey(env)
-  if (!apiKey || sorted.length === 0) return sorted.map((code) => ({ code, label: code }))
-  let resolver: ReturnType<typeof createDestinationNameResolver> | null = null
+  if (sorted.length === 0) return []
+  const sources = catalogRuntimeExtensions().sources
+  if (!sources) return sorted.map((code) => ({ code, label: code }))
   try {
-    resolver = createDestinationNameResolver({ apiKey })
+    const resolved = await sources.resolveDestinationNames(
+      sorted,
+      env as Record<string, string | undefined>,
+    )
+    const byCode = new Map(resolved.map((entry) => [entry.code, entry.label]))
+    return sorted.map((code) => ({ code, label: byCode.get(code) ?? code }))
   } catch {
-    resolver = null
+    return sorted.map((code) => ({ code, label: code }))
   }
-  return Promise.all(
-    sorted.map(async (code) => {
-      if (!resolver) return { code, label: code }
-      try {
-        const city = await resolver.resolve(code)
-        return { code, label: city && city !== code ? `${city} (${code})` : code }
-      } catch {
-        return { code, label: code }
-      }
-    }),
-  )
 }
 
 export function createOperatorCatalogOffersRouteModuleOptions(

--- a/packages/catalog/src/voyant.ts
+++ b/packages/catalog/src/voyant.ts
@@ -37,6 +37,7 @@ import {
   catalogInventoryRuntimeExtensionPort,
   catalogOperationsRuntimeExtensionPort,
   catalogRuntimeServicesPort,
+  catalogSourcesRuntimeExtensionPort,
 } from "./runtime-contracts.js"
 import { catalogSourcesSyncJobRuntimePort } from "./sources-sync-job-runtime-port.js"
 import {
@@ -83,6 +84,7 @@ export const catalogVoyantModule = defineModule({
       requirePort(catalogCommerceRuntimeExtensionPort),
       requirePort(catalogDistributionRuntimeExtensionPort),
       requirePort(catalogCruisesRuntimeExtensionPort),
+      requirePort(catalogSourcesRuntimeExtensionPort, { optional: true }),
       requirePort(catalogInventoryRuntimeExtensionPort),
       requirePort(catalogOperationsRuntimeExtensionPort),
       requirePort(financeOperatorSettingsRuntimePort),

--- a/packages/catalog/tests/unit/voyant-manifest.test.ts
+++ b/packages/catalog/tests/unit/voyant-manifest.test.ts
@@ -42,6 +42,7 @@ describe("catalog deployment manifest", () => {
           { id: "catalog.extension.commerce" },
           { id: "catalog.extension.distribution" },
           { id: "catalog.extension.cruises" },
+          { id: "catalog.extension.sources", optional: true },
           { id: "catalog.extension.inventory" },
           { id: "catalog.extension.operations" },
           { id: "finance.operator-settings.runtime" },

--- a/packages/catalog/tsconfig.build.json
+++ b/packages/catalog/tsconfig.build.json
@@ -1604,6 +1604,13 @@
       "@voyant-travel/plugin-sanity-cms/types": ["../plugins/sanity-cms/dist/types.d.ts"],
       "@voyant-travel/plugin-sanity-cms/voyant": ["../plugins/sanity-cms/dist/voyant.d.ts"],
       "@voyant-travel/plugin-voyant-connect": ["../plugins/voyant-connect/dist/index.d.ts"],
+      "@voyant-travel/plugin-voyant-connect/catalog-sources": [
+        "../plugins/voyant-connect/dist/catalog-sources-extension.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/runtime-contributor": [
+        "../plugins/voyant-connect/dist/runtime-contributor.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/voyant": ["../plugins/voyant-connect/dist/voyant.d.ts"],
       "@voyant-travel/products-contracts": ["../products-contracts/dist/index.d.ts"],
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"

--- a/packages/catalog/tsconfig.typecheck.json
+++ b/packages/catalog/tsconfig.typecheck.json
@@ -1605,6 +1605,13 @@
       "@voyant-travel/plugin-sanity-cms/types": ["../plugins/sanity-cms/dist/types.d.ts"],
       "@voyant-travel/plugin-sanity-cms/voyant": ["../plugins/sanity-cms/dist/voyant.d.ts"],
       "@voyant-travel/plugin-voyant-connect": ["../plugins/voyant-connect/dist/index.d.ts"],
+      "@voyant-travel/plugin-voyant-connect/catalog-sources": [
+        "../plugins/voyant-connect/dist/catalog-sources-extension.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/runtime-contributor": [
+        "../plugins/voyant-connect/dist/runtime-contributor.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/voyant": ["../plugins/voyant-connect/dist/voyant.d.ts"],
       "@voyant-travel/products-contracts": ["../products-contracts/dist/index.d.ts"],
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -1617,6 +1617,13 @@
       "@voyant-travel/plugin-sanity-cms/types": ["../plugins/sanity-cms/dist/types.d.ts"],
       "@voyant-travel/plugin-sanity-cms/voyant": ["../plugins/sanity-cms/dist/voyant.d.ts"],
       "@voyant-travel/plugin-voyant-connect": ["../plugins/voyant-connect/dist/index.d.ts"],
+      "@voyant-travel/plugin-voyant-connect/catalog-sources": [
+        "../plugins/voyant-connect/dist/catalog-sources-extension.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/runtime-contributor": [
+        "../plugins/voyant-connect/dist/runtime-contributor.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/voyant": ["../plugins/voyant-connect/dist/voyant.d.ts"],
       "@voyant-travel/products-contracts": ["../products-contracts/dist/index.d.ts"],
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -1611,6 +1611,13 @@
       "@voyant-travel/plugin-sanity-cms/types": ["../plugins/sanity-cms/dist/types.d.ts"],
       "@voyant-travel/plugin-sanity-cms/voyant": ["../plugins/sanity-cms/dist/voyant.d.ts"],
       "@voyant-travel/plugin-voyant-connect": ["../plugins/voyant-connect/dist/index.d.ts"],
+      "@voyant-travel/plugin-voyant-connect/catalog-sources": [
+        "../plugins/voyant-connect/dist/catalog-sources-extension.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/runtime-contributor": [
+        "../plugins/voyant-connect/dist/runtime-contributor.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/voyant": ["../plugins/voyant-connect/dist/voyant.d.ts"],
       "@voyant-travel/products-contracts": ["../products-contracts/dist/index.d.ts"],
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -1662,6 +1662,13 @@
       "@voyant-travel/plugin-sanity-cms/types": ["../plugins/sanity-cms/dist/types.d.ts"],
       "@voyant-travel/plugin-sanity-cms/voyant": ["../plugins/sanity-cms/dist/voyant.d.ts"],
       "@voyant-travel/plugin-voyant-connect": ["../plugins/voyant-connect/dist/index.d.ts"],
+      "@voyant-travel/plugin-voyant-connect/catalog-sources": [
+        "../plugins/voyant-connect/dist/catalog-sources-extension.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/runtime-contributor": [
+        "../plugins/voyant-connect/dist/runtime-contributor.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/voyant": ["../plugins/voyant-connect/dist/voyant.d.ts"],
       "@voyant-travel/products-contracts": ["../products-contracts/dist/index.d.ts"],
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -1663,6 +1663,13 @@
       "@voyant-travel/plugin-sanity-cms/types": ["../plugins/sanity-cms/dist/types.d.ts"],
       "@voyant-travel/plugin-sanity-cms/voyant": ["../plugins/sanity-cms/dist/voyant.d.ts"],
       "@voyant-travel/plugin-voyant-connect": ["../plugins/voyant-connect/dist/index.d.ts"],
+      "@voyant-travel/plugin-voyant-connect/catalog-sources": [
+        "../plugins/voyant-connect/dist/catalog-sources-extension.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/runtime-contributor": [
+        "../plugins/voyant-connect/dist/runtime-contributor.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/voyant": ["../plugins/voyant-connect/dist/voyant.d.ts"],
       "@voyant-travel/products-contracts": ["../products-contracts/dist/index.d.ts"],
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -1669,6 +1669,13 @@
       "@voyant-travel/plugin-sanity-cms/types": ["../plugins/sanity-cms/dist/types.d.ts"],
       "@voyant-travel/plugin-sanity-cms/voyant": ["../plugins/sanity-cms/dist/voyant.d.ts"],
       "@voyant-travel/plugin-voyant-connect": ["../plugins/voyant-connect/dist/index.d.ts"],
+      "@voyant-travel/plugin-voyant-connect/catalog-sources": [
+        "../plugins/voyant-connect/dist/catalog-sources-extension.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/runtime-contributor": [
+        "../plugins/voyant-connect/dist/runtime-contributor.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/voyant": ["../plugins/voyant-connect/dist/voyant.d.ts"],
       "@voyant-travel/products-contracts": ["../products-contracts/dist/index.d.ts"],
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -1670,6 +1670,13 @@
       "@voyant-travel/plugin-sanity-cms/types": ["../plugins/sanity-cms/dist/types.d.ts"],
       "@voyant-travel/plugin-sanity-cms/voyant": ["../plugins/sanity-cms/dist/voyant.d.ts"],
       "@voyant-travel/plugin-voyant-connect": ["../plugins/voyant-connect/dist/index.d.ts"],
+      "@voyant-travel/plugin-voyant-connect/catalog-sources": [
+        "../plugins/voyant-connect/dist/catalog-sources-extension.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/runtime-contributor": [
+        "../plugins/voyant-connect/dist/runtime-contributor.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/voyant": ["../plugins/voyant-connect/dist/voyant.d.ts"],
       "@voyant-travel/products-contracts": ["../products-contracts/dist/index.d.ts"],
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -1698,6 +1698,13 @@
       "@voyant-travel/plugin-sanity-cms/types": ["../plugins/sanity-cms/dist/types.d.ts"],
       "@voyant-travel/plugin-sanity-cms/voyant": ["../plugins/sanity-cms/dist/voyant.d.ts"],
       "@voyant-travel/plugin-voyant-connect": ["../plugins/voyant-connect/dist/index.d.ts"],
+      "@voyant-travel/plugin-voyant-connect/catalog-sources": [
+        "../plugins/voyant-connect/dist/catalog-sources-extension.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/runtime-contributor": [
+        "../plugins/voyant-connect/dist/runtime-contributor.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/voyant": ["../plugins/voyant-connect/dist/voyant.d.ts"],
       "@voyant-travel/products-contracts": ["../products-contracts/dist/index.d.ts"],
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -1693,6 +1693,13 @@
       "@voyant-travel/plugin-sanity-cms/types": ["../plugins/sanity-cms/dist/types.d.ts"],
       "@voyant-travel/plugin-sanity-cms/voyant": ["../plugins/sanity-cms/dist/voyant.d.ts"],
       "@voyant-travel/plugin-voyant-connect": ["../plugins/voyant-connect/dist/index.d.ts"],
+      "@voyant-travel/plugin-voyant-connect/catalog-sources": [
+        "../plugins/voyant-connect/dist/catalog-sources-extension.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/runtime-contributor": [
+        "../plugins/voyant-connect/dist/runtime-contributor.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/voyant": ["../plugins/voyant-connect/dist/voyant.d.ts"],
       "@voyant-travel/products-contracts": ["../products-contracts/dist/index.d.ts"],
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -1700,6 +1700,13 @@
       "@voyant-travel/plugin-sanity-cms/types": ["../plugins/sanity-cms/dist/types.d.ts"],
       "@voyant-travel/plugin-sanity-cms/voyant": ["../plugins/sanity-cms/dist/voyant.d.ts"],
       "@voyant-travel/plugin-voyant-connect": ["../plugins/voyant-connect/dist/index.d.ts"],
+      "@voyant-travel/plugin-voyant-connect/catalog-sources": [
+        "../plugins/voyant-connect/dist/catalog-sources-extension.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/runtime-contributor": [
+        "../plugins/voyant-connect/dist/runtime-contributor.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/voyant": ["../plugins/voyant-connect/dist/voyant.d.ts"],
       "@voyant-travel/products-contracts": ["../products-contracts/dist/index.d.ts"],
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -1701,6 +1701,13 @@
       "@voyant-travel/plugin-sanity-cms/types": ["../plugins/sanity-cms/dist/types.d.ts"],
       "@voyant-travel/plugin-sanity-cms/voyant": ["../plugins/sanity-cms/dist/voyant.d.ts"],
       "@voyant-travel/plugin-voyant-connect": ["../plugins/voyant-connect/dist/index.d.ts"],
+      "@voyant-travel/plugin-voyant-connect/catalog-sources": [
+        "../plugins/voyant-connect/dist/catalog-sources-extension.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/runtime-contributor": [
+        "../plugins/voyant-connect/dist/runtime-contributor.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/voyant": ["../plugins/voyant-connect/dist/voyant.d.ts"],
       "@voyant-travel/products-contracts": ["../products-contracts/dist/index.d.ts"],
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -1698,6 +1698,13 @@
       "@voyant-travel/plugin-sanity-cms/types": ["../plugins/sanity-cms/dist/types.d.ts"],
       "@voyant-travel/plugin-sanity-cms/voyant": ["../plugins/sanity-cms/dist/voyant.d.ts"],
       "@voyant-travel/plugin-voyant-connect": ["../plugins/voyant-connect/dist/index.d.ts"],
+      "@voyant-travel/plugin-voyant-connect/catalog-sources": [
+        "../plugins/voyant-connect/dist/catalog-sources-extension.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/runtime-contributor": [
+        "../plugins/voyant-connect/dist/runtime-contributor.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/voyant": ["../plugins/voyant-connect/dist/voyant.d.ts"],
       "@voyant-travel/products-contracts": ["../products-contracts/dist/index.d.ts"],
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -1693,6 +1693,13 @@
       "@voyant-travel/plugin-sanity-cms/types": ["../plugins/sanity-cms/dist/types.d.ts"],
       "@voyant-travel/plugin-sanity-cms/voyant": ["../plugins/sanity-cms/dist/voyant.d.ts"],
       "@voyant-travel/plugin-voyant-connect": ["../plugins/voyant-connect/dist/index.d.ts"],
+      "@voyant-travel/plugin-voyant-connect/catalog-sources": [
+        "../plugins/voyant-connect/dist/catalog-sources-extension.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/runtime-contributor": [
+        "../plugins/voyant-connect/dist/runtime-contributor.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/voyant": ["../plugins/voyant-connect/dist/voyant.d.ts"],
       "@voyant-travel/products-contracts": ["../products-contracts/dist/index.d.ts"],
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"

--- a/packages/inventory/tsconfig.build.json
+++ b/packages/inventory/tsconfig.build.json
@@ -1630,6 +1630,13 @@
       "@voyant-travel/plugin-sanity-cms/types": ["../plugins/sanity-cms/dist/types.d.ts"],
       "@voyant-travel/plugin-sanity-cms/voyant": ["../plugins/sanity-cms/dist/voyant.d.ts"],
       "@voyant-travel/plugin-voyant-connect": ["../plugins/voyant-connect/dist/index.d.ts"],
+      "@voyant-travel/plugin-voyant-connect/catalog-sources": [
+        "../plugins/voyant-connect/dist/catalog-sources-extension.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/runtime-contributor": [
+        "../plugins/voyant-connect/dist/runtime-contributor.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/voyant": ["../plugins/voyant-connect/dist/voyant.d.ts"],
       "@voyant-travel/products-contracts": ["../products-contracts/dist/index.d.ts"],
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"

--- a/packages/inventory/tsconfig.typecheck.json
+++ b/packages/inventory/tsconfig.typecheck.json
@@ -1631,6 +1631,13 @@
       "@voyant-travel/plugin-sanity-cms/types": ["../plugins/sanity-cms/dist/types.d.ts"],
       "@voyant-travel/plugin-sanity-cms/voyant": ["../plugins/sanity-cms/dist/voyant.d.ts"],
       "@voyant-travel/plugin-voyant-connect": ["../plugins/voyant-connect/dist/index.d.ts"],
+      "@voyant-travel/plugin-voyant-connect/catalog-sources": [
+        "../plugins/voyant-connect/dist/catalog-sources-extension.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/runtime-contributor": [
+        "../plugins/voyant-connect/dist/runtime-contributor.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/voyant": ["../plugins/voyant-connect/dist/voyant.d.ts"],
       "@voyant-travel/products-contracts": ["../products-contracts/dist/index.d.ts"],
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -1597,6 +1597,13 @@
       "@voyant-travel/plugin-sanity-cms/types": ["../plugins/sanity-cms/dist/types.d.ts"],
       "@voyant-travel/plugin-sanity-cms/voyant": ["../plugins/sanity-cms/dist/voyant.d.ts"],
       "@voyant-travel/plugin-voyant-connect": ["../plugins/voyant-connect/dist/index.d.ts"],
+      "@voyant-travel/plugin-voyant-connect/catalog-sources": [
+        "../plugins/voyant-connect/dist/catalog-sources-extension.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/runtime-contributor": [
+        "../plugins/voyant-connect/dist/runtime-contributor.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/voyant": ["../plugins/voyant-connect/dist/voyant.d.ts"],
       "@voyant-travel/products-contracts": ["../products-contracts/dist/index.d.ts"],
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -1592,6 +1592,13 @@
       "@voyant-travel/plugin-sanity-cms/types": ["../plugins/sanity-cms/dist/types.d.ts"],
       "@voyant-travel/plugin-sanity-cms/voyant": ["../plugins/sanity-cms/dist/voyant.d.ts"],
       "@voyant-travel/plugin-voyant-connect": ["../plugins/voyant-connect/dist/index.d.ts"],
+      "@voyant-travel/plugin-voyant-connect/catalog-sources": [
+        "../plugins/voyant-connect/dist/catalog-sources-extension.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/runtime-contributor": [
+        "../plugins/voyant-connect/dist/runtime-contributor.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/voyant": ["../plugins/voyant-connect/dist/voyant.d.ts"],
       "@voyant-travel/products-contracts": ["../products-contracts/dist/index.d.ts"],
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"

--- a/packages/plugins/voyant-connect/package.json
+++ b/packages/plugins/voyant-connect/package.json
@@ -18,7 +18,10 @@
     "typescript"
   ],
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./catalog-sources": "./src/catalog-sources-extension.ts",
+    "./voyant": "./src/voyant.ts",
+    "./runtime-contributor": "./src/runtime-contributor.ts"
   },
   "files": [
     "dist"
@@ -35,7 +38,8 @@
     "@voyant-travel/connect-adapter": "^0.5.0",
     "@voyant-travel/connect-cruises": "^0.6.2",
     "@voyant-travel/connect-sdk": "^0.10.0",
-    "@voyant-travel/data-sdk": "^0.8.0"
+    "@voyant-travel/data-sdk": "^0.8.0",
+    "@voyant-travel/graph-contracts": "workspace:^"
   },
   "peerDependencies": {
     "@voyant-travel/catalog": "workspace:^",
@@ -52,6 +56,10 @@
     }
   },
   "devDependencies": {
+    "@voyant-travel/catalog": "workspace:^",
+    "@voyant-travel/catalog-contracts": "workspace:^",
+    "@voyant-travel/cruises": "workspace:^",
+    "@voyant-travel/cruises-contracts": "workspace:^",
     "@voyant-travel/voyant-typescript-config": "workspace:^",
     "typescript": "catalog:",
     "vitest": "catalog:"
@@ -63,9 +71,33 @@
         "types": "./dist/index.d.ts",
         "import": "./dist/index.js",
         "default": "./dist/index.js"
+      },
+      "./catalog-sources": {
+        "types": "./dist/catalog-sources-extension.d.ts",
+        "import": "./dist/catalog-sources-extension.js",
+        "default": "./dist/catalog-sources-extension.js"
+      },
+      "./voyant": {
+        "types": "./dist/voyant.d.ts",
+        "import": "./dist/voyant.js",
+        "default": "./dist/voyant.js"
+      },
+      "./runtime-contributor": {
+        "types": "./dist/runtime-contributor.d.ts",
+        "import": "./dist/runtime-contributor.js",
+        "default": "./dist/runtime-contributor.js"
       }
     },
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts"
+  },
+  "voyant": {
+    "schemaVersion": "voyant.package.v1",
+    "kind": "adapter",
+    "manifest": "./voyant",
+    "runtime": {
+      "entry": "./runtime-contributor",
+      "export": "createVoyantConnectRuntimePortContribution"
+    }
   }
 }

--- a/packages/plugins/voyant-connect/src/catalog-sources-extension.ts
+++ b/packages/plugins/voyant-connect/src/catalog-sources-extension.ts
@@ -1,0 +1,74 @@
+import type {
+  CatalogSourcesRuntimeExtension,
+  SourceAdapterRegistry,
+} from "@voyant-travel/catalog/runtime-contracts"
+
+import { prepareVoyantConnectSources, resolveVoyantConnectEnv } from "./env.js"
+import { createDestinationNameResolver } from "./geo-resolver.js"
+import { createVoyantConnectSources, registerVoyantConnectSources } from "./sources.js"
+
+/**
+ * Short-TTL read cache applied to cruise reads on both the fallback and the
+ * per-connection warm path. Shares the owned-adapter TTL.
+ */
+const CRUISE_MEMOIZE = { memoize: { ttlMs: 60_000 } } as const
+
+function register(
+  registry: SourceAdapterRegistry,
+  sources: Parameters<typeof registerVoyantConnectSources>[1],
+): void {
+  registerVoyantConnectSources(
+    registry as unknown as Parameters<typeof registerVoyantConnectSources>[0],
+    sources,
+  )
+}
+
+/**
+ * Voyant Connect as a catalog inventory channel.
+ *
+ * The catalog spine used to import these helpers directly, which made it depend
+ * on this package and hard-coded Connect as *the* channel. It now resolves this
+ * extension from a port, so Connect is one implementation and a self-hosted
+ * channel can provide its own.
+ */
+export function createVoyantConnectCatalogSourcesExtension(): CatalogSourcesRuntimeExtension {
+  return {
+    registerFallback(registry, env) {
+      const config = resolveVoyantConnectEnv(env, {
+        warn: (message) => console.warn(`[voyant-connect] ${message}`),
+      })
+      if (!config) return
+      register(registry, createVoyantConnectSources({ ...config, cruise: CRUISE_MEMOIZE }))
+    },
+
+    async warm(registry, env) {
+      const sources = await prepareVoyantConnectSources(env, {
+        enumerate: true,
+        cruise: CRUISE_MEMOIZE,
+        warn: (message) => console.warn(`[voyant-connect] ${message}`),
+      })
+      register(registry, sources)
+    },
+
+    async resolveDestinationNames(codes, env) {
+      const apiKey = env.VOYANT_API_KEY ?? env.VOYANT_CONNECT_API_KEY ?? env.VOYANT_CLOUD_API_KEY
+      if (!apiKey) return codes.map((code) => ({ code, label: code }))
+      let resolver: ReturnType<typeof createDestinationNameResolver> | null = null
+      try {
+        resolver = createDestinationNameResolver({ apiKey })
+      } catch {
+        return codes.map((code) => ({ code, label: code }))
+      }
+      return Promise.all(
+        codes.map(async (code) => {
+          try {
+            const city = await resolver?.resolve(code)
+            return { code, label: city && city !== code ? `${city} (${code})` : code }
+          } catch {
+            return { code, label: code }
+          }
+        }),
+      )
+    },
+  }
+}

--- a/packages/plugins/voyant-connect/src/index.ts
+++ b/packages/plugins/voyant-connect/src/index.ts
@@ -1,3 +1,4 @@
+export { createVoyantConnectCatalogSourcesExtension } from "./catalog-sources-extension.js"
 export {
   type ConnectCruiseSourceAdapterExtras,
   createConnectCruiseSourceAdapter,

--- a/packages/plugins/voyant-connect/src/runtime-contributor.ts
+++ b/packages/plugins/voyant-connect/src/runtime-contributor.ts
@@ -1,0 +1,10 @@
+import { catalogSourcesRuntimeExtensionPort } from "@voyant-travel/catalog/runtime-contracts"
+
+import { createVoyantConnectCatalogSourcesExtension } from "./catalog-sources-extension.js"
+
+/** Bind Voyant Connect as the deployment's catalog inventory channel. */
+export function createVoyantConnectRuntimePortContribution(): Readonly<Record<string, unknown>> {
+  return {
+    [catalogSourcesRuntimeExtensionPort.id]: createVoyantConnectCatalogSourcesExtension(),
+  }
+}

--- a/packages/plugins/voyant-connect/src/voyant.ts
+++ b/packages/plugins/voyant-connect/src/voyant.ts
@@ -1,4 +1,4 @@
-import { catalogSourcesRuntimeExtensionPort } from "@voyant-travel/catalog/runtime-contracts"
+import { catalogSourcesRuntimeExtensionPort } from "@voyant-travel/catalog/ports"
 import { defineAdapter, providePort } from "@voyant-travel/graph-contracts"
 
 /**
@@ -15,7 +15,14 @@ export const voyantConnectAdapter = defineAdapter({
   provides: {
     ports: [providePort(catalogSourcesRuntimeExtensionPort)],
   },
-  meta: { ownership: "package" },
+  meta: {
+    ownership: "package",
+    agentTools: {
+      posture: "not-applicable",
+      rationale:
+        "This adapter binds an inventory channel behind the catalog sources port; agents act on catalog and booking Tools, never on the channel directly.",
+    },
+  },
 })
 
 export default voyantConnectAdapter

--- a/packages/plugins/voyant-connect/src/voyant.ts
+++ b/packages/plugins/voyant-connect/src/voyant.ts
@@ -1,0 +1,21 @@
+import { catalogSourcesRuntimeExtensionPort } from "@voyant-travel/catalog/runtime-contracts"
+import { defineAdapter, providePort } from "@voyant-travel/graph-contracts"
+
+/**
+ * Voyant Connect as one catalog inventory channel.
+ *
+ * Declared as an adapter, not a plugin: RFC #3395 retired that classification,
+ * and the catalog spine resolves this through a port rather than importing it,
+ * so a self-hosted channel can provide the same contract.
+ */
+export const voyantConnectAdapter = defineAdapter({
+  id: "@voyant-travel/plugin-voyant-connect",
+  packageName: "@voyant-travel/plugin-voyant-connect",
+  localId: "voyant-connect",
+  provides: {
+    ports: [providePort(catalogSourcesRuntimeExtensionPort)],
+  },
+  meta: { ownership: "package" },
+})
+
+export default voyantConnectAdapter

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -1709,6 +1709,13 @@
       "@voyant-travel/plugin-sanity-cms/types": ["../plugins/sanity-cms/dist/types.d.ts"],
       "@voyant-travel/plugin-sanity-cms/voyant": ["../plugins/sanity-cms/dist/voyant.d.ts"],
       "@voyant-travel/plugin-voyant-connect": ["../plugins/voyant-connect/dist/index.d.ts"],
+      "@voyant-travel/plugin-voyant-connect/catalog-sources": [
+        "../plugins/voyant-connect/dist/catalog-sources-extension.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/runtime-contributor": [
+        "../plugins/voyant-connect/dist/runtime-contributor.d.ts"
+      ],
+      "@voyant-travel/plugin-voyant-connect/voyant": ["../plugins/voyant-connect/dist/voyant.d.ts"],
       "@voyant-travel/products-contracts": ["../products-contracts/dist/index.d.ts"],
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1712,9 +1712,6 @@ importers:
       '@voyant-travel/hono':
         specifier: workspace:^
         version: link:../hono
-      '@voyant-travel/plugin-voyant-connect':
-        specifier: workspace:^
-        version: link:../plugins/voyant-connect
       '@voyant-travel/tools':
         specifier: workspace:^
         version: link:../tools
@@ -4725,12 +4722,6 @@ importers:
 
   packages/plugins/voyant-connect:
     dependencies:
-      '@voyant-travel/catalog':
-        specifier: workspace:^
-        version: link:../../catalog
-      '@voyant-travel/catalog-contracts':
-        specifier: workspace:^
-        version: link:../../catalog-contracts
       '@voyant-travel/connect-adapter':
         specifier: ^0.5.0
         version: 0.5.0(@voyant-travel/catalog@packages+catalog)
@@ -4740,16 +4731,25 @@ importers:
       '@voyant-travel/connect-sdk':
         specifier: ^0.10.0
         version: 0.10.0
+      '@voyant-travel/data-sdk':
+        specifier: ^0.8.0
+        version: 0.8.0
+      '@voyant-travel/graph-contracts':
+        specifier: workspace:^
+        version: link:../../graph-contracts
+    devDependencies:
+      '@voyant-travel/catalog':
+        specifier: workspace:^
+        version: link:../../catalog
+      '@voyant-travel/catalog-contracts':
+        specifier: workspace:^
+        version: link:../../catalog-contracts
       '@voyant-travel/cruises':
         specifier: workspace:^
         version: link:../../cruises
       '@voyant-travel/cruises-contracts':
         specifier: workspace:^
         version: link:../../cruises-contracts
-      '@voyant-travel/data-sdk':
-        specifier: ^0.8.0
-        version: 0.8.0
-    devDependencies:
       '@voyant-travel/voyant-typescript-config':
         specifier: workspace:^
         version: link:../../typescript-config

--- a/scripts/check-deployment-graph-import-cheap.mjs
+++ b/scripts/check-deployment-graph-import-cheap.mjs
@@ -30,6 +30,8 @@ const DEFAULT_ENTRY_SURFACES = [
 const ALLOWED_EXTERNAL_IMPORTS = new Set(["@voyant-travel/hono/composition"])
 const ALLOWED_PACKAGE_MANIFEST_IMPORTS = new Set([
   "@voyant-travel/core/project",
+  // The authoring helpers moved here; core/project re-exports them.
+  "@voyant-travel/graph-contracts",
   "@voyant-travel/framework/project",
 ])
 

--- a/scripts/check-node-runtime-product-authority.mjs
+++ b/scripts/check-node-runtime-product-authority.mjs
@@ -125,7 +125,13 @@ for (const [source, required] of [
       "createOperatorCatalogBookingSnapshotRuntime",
     ],
   ],
-  [movedRuntimeFactories[3], ["createVoyantConnectSources", "createOwnedBookingHandlersRegistry"]],
+  // The booking engine resolves its inventory channel from the sources port
+  // rather than constructing Voyant Connect itself; the channel package owns
+  // that construction now. Still package-owned, which is what this asserts.
+  [
+    movedRuntimeFactories[3],
+    ["sources?.registerFallback", "createOwnedBookingHandlersRegistry"],
+  ],
   [
     movedRuntimeFactories[4],
     [

--- a/scripts/check-node-runtime-product-authority.mjs
+++ b/scripts/check-node-runtime-product-authority.mjs
@@ -128,10 +128,7 @@ for (const [source, required] of [
   // The booking engine resolves its inventory channel from the sources port
   // rather than constructing Voyant Connect itself; the channel package owns
   // that construction now. Still package-owned, which is what this asserts.
-  [
-    movedRuntimeFactories[3],
-    ["sources?.registerFallback", "createOwnedBookingHandlersRegistry"],
-  ],
+  [movedRuntimeFactories[3], ["sources?.registerFallback", "createOwnedBookingHandlersRegistry"]],
   [
     movedRuntimeFactories[4],
     [


### PR DESCRIPTION
Fixes a **latent, non-deterministic build failure on `main`**, and delivers #4075's channel seam. The two turn out to be the same problem.

## The failure

`operator-image-smoke` fails intermittently, deep inside an unrelated package:

```
plugin-voyant-connect:build: ../../bookings/src/index.ts(216,7):
  error TS2322: Type 'unknown' is not assignable to type 'CustomFieldsRuntime'
```

It is a race. #4070 and #4079 won it; #4074 lost it. My local builds passed only because `catalog/dist` already existed.

## Why

The catalog spine imported Voyant Connect and drove its whole lifecycle — env resolution, source construction, registration, the per-connection warm, destination naming. That closed a three-node cycle:

```
catalog → plugin-voyant-connect → cruises → catalog
```

#4070 hid that cycle from turbo by making `catalog`/`cruises` **optional peers** of the plugin. That removed the cycle from turbo's view — and with it the build *ordering* constraint. Turbo could then schedule the plugin before `catalog`, `tsc` resolved `catalog` through `node_modules` to source, and the build walked into `bookings` source and died.

## The fix

Catalog declares `CatalogSourcesRuntimeExtension` and resolves it from `catalog.extension.sources`, exactly as it already does for `cruises`, `accommodations`, and `inventory`:

```ts
registerFallback(registry, env)          // synchronous cold window
warm(registry, env): Promise<void>       // per-connection enumeration
resolveDestinationNames(codes, env)      // human labels
```

**Optional** — a deployment may bind no channel at all.

Voyant Connect implements that contract and provides the port through its own graph manifest, declared with `defineAdapter` (not the retired `definePlugin`). The catalog spine no longer names it.

With the backwards edge gone, `catalog` and `cruises` are ordinary devDependencies again and turbo has a real constraint:

```
plugin build depends on: catalog#build, catalog-contracts#build,
                         cruises#build, cruises-contracts#build
```

## Why this is the channel seam

Voyant Connect is one channel for receiving and pushing inventory, not the way in. Before this, the catalog hard-coded it; a self-hoster could not register their own without depending on our platform. Now anything that can register `SourceAdapter`s provides the same port. The build cycle was that architectural mistake showing up as a scheduling race.

## Checkers this tripped, all legitimately

| Checker | Caught |
|---|---|
| turbo build graph | the cycle itself |
| `node-runtime-product-authority` | runtime wiring changing owner — repointed at the wiring the booking engine still owns, rather than weakened |
| `deployment-graph-import-cheap` | the manifest importing a runtime-heavy path — now uses `catalog/ports`, as the cruises manifest does |
| `deployment-graph-import-cheap` | **`@voyant-travel/graph-contracts` was not an allowed manifest import.** A gap from #4079: no manifest could have adopted `defineAdapter` from its new home. This is the first one to try |
| `agent-tool-coverage` | a Tool-less module must state its agent posture |

## Verification

- `pnpm verify:architecture` — **passes end to end**
- `turbo run build --dry` — acyclic, ordering restored
- `catalog` — **720 tests pass**; typecheck clean
- `plugin-voyant-connect` — typecheck clean
- `biome check .` — the one error is in `.dependency-cruiser.cjs` / `biome.json` / a publish script, none touched here; pre-existing on `main`

The runtime test now provides a stub channel through the port instead of mocking the Connect module, plus new cases for **no channel bound** and **warm-failure retry**.

## Follow-ups, not in scope here

`catalog`'s `BookingEngineEnv` still names `VOYANT_CONNECT_*` variables, and `offers-runtime.ts` still imports `createVoyantConnectClient` from `connect-sdk` on a separate path. Neither is in the cycle, but both are the spine still knowing one vendor.

Unblocks #4074. Refs #4075.