### PR TITLE
refactor(catalog): stop naming a vendor in the spine

### DIFF
--- a/.changeset/catalog-vendor-neutral.md
+++ b/.changeset/catalog-vendor-neutral.md
@@ -1,0 +1,17 @@
+---
+"@voyant-travel/catalog": minor
+"@voyant-travel/plugin-voyant-connect": minor
+---
+
+Remove the last vendor references from the catalog spine.
+
+`offers-runtime` resolved its offers client by importing
+`@voyant-travel/connect-sdk` directly, contradicting the design already stated
+in `offers/operator-routes.ts` — *"the package never imports
+`@voyant-travel/connect-sdk`"*. The channel now supplies that client through
+`CatalogSourcesRuntimeExtension.createOffersClient`, and catalog no longer
+depends on the SDK.
+
+`BookingEngineEnv` named seven `VOYANT_*`/`VOYANT_CONNECT_*` variables that
+nothing in catalog read; they were passed straight to the channel. It is now an
+opaque environment record.

--- a/packages/catalog/package.json
+++ b/packages/catalog/package.json
@@ -448,7 +448,6 @@
     "@voyant-travel/catalog-contracts": "workspace:^",
     "@voyant-travel/bookings": "workspace:^",
     "@voyant-travel/bookings-contracts": "workspace:^",
-    "@voyant-travel/connect-sdk": "0.9.1",
     "@voyant-travel/core": "workspace:^",
     "@voyant-travel/db": "workspace:^",
     "@voyant-travel/finance": "workspace:^",

--- a/packages/catalog/src/runtime-contracts.ts
+++ b/packages/catalog/src/runtime-contracts.ts
@@ -226,6 +226,12 @@ export interface CatalogSourcesRuntimeExtension {
    * resets on failure so a later request retries.
    */
   warm(registry: SourceAdapterRegistry, env: Record<string, string | undefined>): Promise<void>
+  /**
+   * The channel's offers client, or null when it is unconfigured. Catalog
+   * declares the shape it needs (`CatalogOffersConnectClient`) and the channel
+   * constructs it, so the spine never imports a vendor SDK.
+   */
+  createOffersClient(env: Record<string, string | undefined>): unknown | null
   /** Human labels for destination codes; falls back to the code itself. */
   resolveDestinationNames(
     codes: readonly string[],

--- a/packages/catalog/src/runtime/booking-engine-runtime.ts
+++ b/packages/catalog/src/runtime/booking-engine-runtime.ts
@@ -132,15 +132,13 @@ export function getOwnedBookingHandlerRegistry(env: BookingEngineEnv): OwnedBook
   return _ownedHandlers
 }
 
-export interface BookingEngineEnv {
-  VOYANT_API_KEY?: string
-  VOYANT_CLOUD_API_KEY?: string
-  VOYANT_CONNECT_API_KEY?: string
-  VOYANT_CONNECT_API_URL?: string
-  VOYANT_CONNECT_MARKET?: string
-  VOYANT_CONNECT_OPERATOR_ID?: string
-  VOYANT_CONNECT_SYNC_LIMIT?: string
-}
+/**
+ * Deployment environment as the booking engine sees it: an opaque record it
+ * passes to whichever inventory channel is bound. The spine reads none of these
+ * keys — naming a vendor's variables here would make the catalog know one
+ * channel, which is exactly what the sources port exists to avoid.
+ */
+export type BookingEngineEnv = Record<string, string | undefined>
 
 /**
  * Convenience helper for route handlers — pulls env from the Hono context,

--- a/packages/catalog/src/runtime/offers-runtime.ts
+++ b/packages/catalog/src/runtime/offers-runtime.ts
@@ -8,48 +8,27 @@ import {
   createCatalogOffersSearchResolvers,
 } from "@voyant-travel/catalog/runtime-support"
 import type { IndexerAdapter } from "@voyant-travel/catalog-contracts/indexer/contract"
-import { createVoyantConnectClient } from "@voyant-travel/connect-sdk"
 import type { Context } from "hono"
 import { catalogRuntimeExtensions } from "./host.js"
 
-interface PackageOffersEnv {
-  VOYANT_API_KEY?: string
-  VOYANT_CONNECT_API_KEY?: string
-  VOYANT_CLOUD_API_KEY?: string
-  VOYANT_CONNECT_OPERATOR_ID?: string
-  VOYANT_CONNECT_API_URL?: string
-}
-
-function connectApiKey(env: PackageOffersEnv): string | undefined {
-  return env.VOYANT_API_KEY ?? env.VOYANT_CONNECT_API_KEY ?? env.VOYANT_CLOUD_API_KEY
-}
-
 function resolveConnectClient(c: Context): CatalogOffersConnectClient | null {
-  const env = c.env as PackageOffersEnv
-  const apiKey = connectApiKey(env)
-  const operatorId = env.VOYANT_CONNECT_OPERATOR_ID
-  if (!apiKey || !operatorId) return null
-  return createVoyantConnectClient({
-    apiKey,
-    operatorId,
-    ...(env.VOYANT_CONNECT_API_URL ? { baseUrl: env.VOYANT_CONNECT_API_URL } : {}),
-  }) as CatalogOffersConnectClient
+  const sources = catalogRuntimeExtensions().sources
+  if (!sources) return null
+  return (sources.createOffersClient(c.env as Record<string, string | undefined>) ??
+    null) as CatalogOffersConnectClient | null
 }
 
 async function resolveAirportLabels(
   c: Context,
   codes: string[],
 ): Promise<CatalogOffersAirportLabel[]> {
-  const env = c.env as PackageOffersEnv
+  const env = c.env as Record<string, string | undefined>
   const sorted = [...new Set(codes)].sort()
   if (sorted.length === 0) return []
   const sources = catalogRuntimeExtensions().sources
   if (!sources) return sorted.map((code) => ({ code, label: code }))
   try {
-    const resolved = await sources.resolveDestinationNames(
-      sorted,
-      env as Record<string, string | undefined>,
-    )
+    const resolved = await sources.resolveDestinationNames(sorted, env)
     const byCode = new Map(resolved.map((entry) => [entry.code, entry.label]))
     return sorted.map((code) => ({ code, label: byCode.get(code) ?? code }))
   } catch {

--- a/packages/plugins/voyant-connect/src/catalog-sources-extension.ts
+++ b/packages/plugins/voyant-connect/src/catalog-sources-extension.ts
@@ -3,6 +3,8 @@ import type {
   SourceAdapterRegistry,
 } from "@voyant-travel/catalog/runtime-contracts"
 
+import { createVoyantConnectClient } from "@voyant-travel/connect-sdk"
+
 import { prepareVoyantConnectSources, resolveVoyantConnectEnv } from "./env.js"
 import { createDestinationNameResolver } from "./geo-resolver.js"
 import { createVoyantConnectSources, registerVoyantConnectSources } from "./sources.js"
@@ -48,6 +50,17 @@ export function createVoyantConnectCatalogSourcesExtension(): CatalogSourcesRunt
         warn: (message) => console.warn(`[voyant-connect] ${message}`),
       })
       register(registry, sources)
+    },
+
+    createOffersClient(env) {
+      const apiKey = env.VOYANT_API_KEY ?? env.VOYANT_CONNECT_API_KEY ?? env.VOYANT_CLOUD_API_KEY
+      const operatorId = env.VOYANT_CONNECT_OPERATOR_ID
+      if (!apiKey || !operatorId) return null
+      return createVoyantConnectClient({
+        apiKey,
+        operatorId,
+        ...(env.VOYANT_CONNECT_API_URL ? { baseUrl: env.VOYANT_CONNECT_API_URL } : {}),
+      })
     },
 
     async resolveDestinationNames(codes, env) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,7 +249,7 @@ importers:
         version: 1.6.0(@date-fns/tz@1.4.1)(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@better-auth/api-key':
         specifier: 1.6.23
-        version: 1.6.23(4cc07405e1e664eaf96048bc4329d318)
+        version: 1.6.23(1ac6a98f3eafa8cc5361cfcd8d9e497a)
       '@fontsource-variable/inter-tight':
         specifier: ^5.2.7
         version: 5.2.7
@@ -1697,9 +1697,6 @@ importers:
       '@voyant-travel/catalog-contracts':
         specifier: workspace:^
         version: link:../catalog-contracts
-      '@voyant-travel/connect-sdk':
-        specifier: 0.9.1
-        version: 0.9.1
       '@voyant-travel/core':
         specifier: workspace:^
         version: link:../core
@@ -13188,14 +13185,6 @@ snapshots:
   '@better-auth/api-key@1.6.23(1ac6a98f3eafa8cc5361cfcd8d9e497a)':
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0)
-      '@better-auth/utils': 0.4.2
-      better-auth: 1.6.23(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.3)(rollup@4.60.2)(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9))(mongodb@7.1.0(socks@2.8.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.11)(vitest@4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)))(vue@3.5.39(typescript@6.0.3))
-      better-call: 1.3.7(zod@4.4.3)
-      zod: 4.4.3
-
-  '@better-auth/api-key@1.6.23(4cc07405e1e664eaf96048bc4329d318)':
-    dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
       better-auth: 1.6.23(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.3)(rollup@4.60.2)(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9))(mongodb@7.1.0(socks@2.8.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.11)(vitest@4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)))(vue@3.5.39(typescript@6.0.3))
       better-call: 1.3.7(zod@4.4.3)

--- a/scripts/check-node-runtime-product-authority.mjs
+++ b/scripts/check-node-runtime-product-authority.mjs
@@ -139,7 +139,9 @@ for (const [source, required] of [
   ],
   [
     movedRuntimeFactories[5],
-    ["createVoyantConnectClient", "createCatalogOffersSearchResolvers", "resolveAirportLabels"],
+    // The offers client comes from the bound channel; the channel package owns
+    // its construction. Still package-owned, which is what this asserts.
+    ["sources.createOffersClient", "createCatalogOffersSearchResolvers", "resolveAirportLabels"],
   ],
   [
     movedRuntimeFactories[6],


### PR DESCRIPTION
Follow-ups from #4082. The catalog spine now names no vendor in code, types, or environment.

## 1. The offers client contradicted its own documented design

`offers/operator-routes.ts` states the intent plainly:

> *"so this package never statically imports connect-sdk / typesense / geo"*
> *"the package never imports `@voyant-travel/connect-sdk`"*

The injection point existed — `resolveConnectClient` is passed in. But `runtime/offers-runtime.ts` bypassed it and constructed the client with the vendor SDK directly:

```ts
import { createVoyantConnectClient } from "@voyant-travel/connect-sdk"
```

The bound channel now supplies it through `CatalogSourcesRuntimeExtension.createOffersClient`, and **`catalog` drops its `@voyant-travel/connect-sdk` dependency**. Catalog still declares the client shape it needs; it just no longer builds one.

## 2. The env type named seven of one vendor's variables

```ts
export interface BookingEngineEnv {
  VOYANT_API_KEY?: string
  VOYANT_CLOUD_API_KEY?: string
  VOYANT_CONNECT_API_KEY?: string
  VOYANT_CONNECT_API_URL?: string
  VOYANT_CONNECT_MARKET?: string
  VOYANT_CONNECT_OPERATOR_ID?: string
  VOYANT_CONNECT_SYNC_LIMIT?: string
}
```

**No catalog code read any of them** — they were handed to the channel untouched. Naming one vendor's environment in the spine is the same coupling the sources port removes, so it is now an opaque record.

## Result

`grep VOYANT_CONNECT packages/catalog/src/runtime/*.ts` returns only a test fixture.

## Verification

- `pnpm verify:architecture` — **passes end to end**
- `catalog` — **720 tests pass**; typecheck clean
- `plugin-voyant-connect` — typecheck clean
- `turbo run build --dry` — still acyclic
- `biome check .` — exit 0

`check-node-runtime-product-authority` required `createVoyantConnectClient` in `offers-runtime.ts`. Same reasoning as #4082: that check asserts the wiring is *package-owned*, and it still is — construction moved to the channel package. Repointed at `sources.createOffersClient` rather than weakened.

Refs #4075.