### PR TITLE
refactor(payments): make the adapter contract a leaf

### DIFF
--- a/.changeset/payments-leaf.md
+++ b/.changeset/payments-leaf.md
@@ -1,0 +1,15 @@
+---
+"@voyant-travel/payments": minor
+---
+
+Depend on `@voyant-travel/graph-contracts` instead of `@voyant-travel/core` for
+`definePort`.
+
+`@voyant-travel/payments` is the canonical payment adapter contract — 25 type
+exports against 5 values, every file importing only its siblings. Its single
+external import was `definePort`, which pulled in the whole runtime kernel and
+forced every adapter author to install it.
+
+With that repointed the package has no workspace dependencies and joins the
+public surface as a leaf, so implementing a payment adapter no longer requires
+the DI container, registry, event bus, saga, or locking.

--- a/packages/payments/package.json
+++ b/packages/payments/package.json
@@ -42,7 +42,7 @@
     "types": "./dist/index.d.ts"
   },
   "dependencies": {
-    "@voyant-travel/core": "workspace:^"
+    "@voyant-travel/graph-contracts": "workspace:^"
   },
   "devDependencies": {
     "@voyant-travel/voyant-typescript-config": "workspace:^",

--- a/packages/payments/src/index.ts
+++ b/packages/payments/src/index.ts
@@ -1,4 +1,4 @@
-import { definePort } from "@voyant-travel/core/project"
+import { definePort } from "@voyant-travel/graph-contracts"
 
 export const PAYMENT_ADAPTER_CONTRACT_VERSION = "voyant.payment-adapter.v1" as const
 export const PAYMENT_ADAPTER_RUNTIME_PORT_ID = "payments.adapter.runtime" as const

--- a/packages/payments/src/runtime-port.ts
+++ b/packages/payments/src/runtime-port.ts
@@ -9,7 +9,7 @@
  * `docs/adr/0015-payment-adapter-transports-and-managed-connect.md`.
  */
 
-import { definePort } from "@voyant-travel/core/project"
+import { definePort } from "@voyant-travel/graph-contracts"
 
 import type { PaymentProviderRegistry } from "./provider-catalog.js"
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4684,9 +4684,9 @@ importers:
 
   packages/payments:
     dependencies:
-      '@voyant-travel/core':
+      '@voyant-travel/graph-contracts':
         specifier: workspace:^
-        version: link:../core
+        version: link:../graph-contracts
     devDependencies:
       '@voyant-travel/voyant-typescript-config':
         specifier: workspace:^

--- a/scripts/checks/manifests/public-surface.json
+++ b/scripts/checks/manifests/public-surface.json
@@ -21,6 +21,7 @@
     "@voyant-travel/charters-contracts",
     "@voyant-travel/cruises-contracts",
     "@voyant-travel/flights-contracts",
+    "@voyant-travel/payments",
     "@voyant-travel/products-contracts",
     "@voyant-travel/schema-kit"
   ],


### PR DESCRIPTION
Instance 2 of #4075 — and it needed no extraction.

## The finding

I scoped a `payments-contracts` package and it should not exist. **`@voyant-travel/payments` already is the canonical payment adapter contract.** Its `index.ts` is 25 type exports against 5 values, three of which are constants, and every file in `src/` imports only its siblings:

```
index.ts        → ./conformance, ./default-catalog, ./provider-catalog,
                  ./remote-adapter, ./remote-transport, ./runtime-port,
                  @voyant-travel/core/project      ← the only external import
runtime-port.ts → ./provider-catalog, @voyant-travel/core/project
conformance.ts, default-catalog.ts, provider-catalog.ts,
remote-adapter.ts, remote-transport.ts → siblings only
```

Both external imports were for one symbol: `definePort`. That single import is what made implementing a payment adapter require the DI container, registry, event bus, saga, and locking.

## The change

Repoint those two imports at `@voyant-travel/graph-contracts` — the package created in #4079 for exactly this — and drop the `@voyant-travel/core` dependency.

`@voyant-travel/payments` now has **zero workspace dependencies** and joins the public surface as a leaf:

```
verify:public-surface: 14 packages on the public surface, closure is 14 — closed.
```

No new package, no code moves, no duplicated contract, and nothing for `netopia-adapter` to migrate onto beyond what it already imports.

## Why this matters for netopia

netopia-adapter#14's first checkbox — extract the payment adapter contract — is satisfied by this. Its `payments` imports are exactly `PaymentInitiationInput`, `PaymentInitiationResult`, `PaymentCallbackRequest`, `PaymentSessionState`, `PaymentStatusResult`, and `PaymentMoney`, all in this contract. What remains there is the architectural half: routing `financeService` and notification dispatch through runtime ports.

## Verification

- `pnpm verify:architecture` — **passes end to end**
- `payments` — **41 tests pass**; typecheck clean
- `finance`, `commerce` — typecheck clean
- `verify:public-surface` — 14, closure 14, closed
- `biome check .` — exit 0

## Note on the approach

Three instances in #4075, three different answers: **extract** for package declaration (#4079), **invert** for the inventory channel (#4082), and **repoint one import** here. "Extract a contracts package" was my default for all three and was right for one — the better first question is *why* the contract is coupled to the runtime.

Refs #4075, voyant-travel/netopia-adapter#14