### PR TITLE
refactor(framework): stop naming a payment processor in the contract

### DIFF
--- a/.changeset/payments-vendor-neutral.md
+++ b/.changeset/payments-vendor-neutral.md
@@ -1,0 +1,19 @@
+---
+"@voyant-travel/framework": minor
+---
+
+Stop encoding a specific payment processor in the deployment contract.
+
+`deployment-requirements` hardcoded Netopia's credential schema, so supporting a
+new processor meant a framework release per country. It was also stale: it
+demanded `NETOPIA_MERCHANT_ID`, which the provider catalog documents as not
+existing ("the POS signature is the identifier"), plus private/public keys that
+are not the credential model either.
+
+Managed deployments bind one generic remote adapter and the control plane
+resolves the connected processor and its credentials, so the deployment needs no
+processor environment at all. Self-hosted deployments use `custom` and bind
+their own adapter, which declares its own requirements.
+
+`providers.payments: "netopia"` is deprecated but still accepted, and the
+invalid-selection hint no longer names a vendor.

--- a/packages/framework/src/deployment-graph.ts
+++ b/packages/framework/src/deployment-graph.ts
@@ -4426,7 +4426,7 @@ function validatePaymentProviderSelection(
         facet: "deployment.providers.payments",
         message:
           "Payment-capable graphs must explicitly select one active deployment.providers.payments adapter.",
-        hint: 'Set deployment.providers.payments to "voyant-pay", "netopia", or "custom"; environment variables never select a payment processor.',
+        hint: 'Set deployment.providers.payments to "managed", "voyant-pay", or "custom"; environment variables never select a payment processor. A specific processor is chosen as catalog data, not here.',
       }),
     ]
   }

--- a/packages/framework/src/deployment-requirements.ts
+++ b/packages/framework/src/deployment-requirements.ts
@@ -304,14 +304,6 @@ function envForProvider(
         variable("VOYANT_PAYMENTS_API_URL", "Optional Voyant Pay API base URL.", false, "http-url"),
       ]
     }
-    if (provider === "netopia") {
-      return [
-        variable("NETOPIA_MERCHANT_ID", "Netopia merchant id."),
-        secret("NETOPIA_PRIVATE_KEY", "Netopia private key used to initiate payments."),
-        secret("NETOPIA_PUBLIC_KEY", "Netopia public key used to verify signed callbacks."),
-        variable("NETOPIA_SANDBOX", "Set to true for Netopia sandbox mode.", false),
-      ]
-    }
   }
   return []
 }

--- a/packages/framework/src/deployment-types.ts
+++ b/packages/framework/src/deployment-types.ts
@@ -53,6 +53,12 @@ export interface VoyantDeploymentProviders {
     | "voyant-pay"
     /** @deprecated Legacy deployment value; normalized to `voyant-pay`. */
     | "voyant-payments"
+    /**
+     * @deprecated A processor is chosen as catalog data, not as a deployment
+     * provider. Managed deployments bind one generic remote adapter and the
+     * control plane resolves the connected processor; self-hosted deployments
+     * use `custom`. Retained only while a live deployment still selects it.
+     */
     | "netopia"
     | "custom"
     | "none"


### PR DESCRIPTION
Payment adapters are first-party and managed — Voyant Pay plus local processors popular by country, eventually 60+, chosen by the operator in *Settings → Payments*. They cannot all be baked into the image, which is why they are worker-shaped and brokered.

Two things in `packages/framework` contradicted that.

## 1. A framework release per country

```ts
// deployment-requirements.ts
if (provider === "netopia") {
  return [
    variable("NETOPIA_MERCHANT_ID", "Netopia merchant id."),
    secret("NETOPIA_PRIVATE_KEY",  "…"),
    secret("NETOPIA_PUBLIC_KEY",   "…"),
    variable("NETOPIA_SANDBOX",    "…", false),
  ]
}
```

Supporting the 60th processor would mean a union member, a branch here, and a framework release. That is the "baked into the source" cost the remote-adapter design exists to avoid.

## 2. It was also wrong

The provider catalog documents the opposite:

> *"Netopia API v2 identifies the point of sale by its POS signature and authenticates requests with the account API key… **There is no separate 'merchant number' — the POS signature is the identifier — so that confusing field is not collected.**"*

Three inconsistent Netopia credential models existed:

| Source | Fields |
|---|---|
| `deployment-requirements.ts` | `MERCHANT_ID`, `PRIVATE_KEY`, `PUBLIC_KEY`, `SANDBOX` |
| `payments` provider catalog | `posSignature`, `apiKey`, … |
| `apps/operator/.env.example` | `MODE`, `URL`, `NOTIFY_URL` |

Only the catalog is authoritative — it is what the control plane actually brokers.

## The model that already exists

Platform's `apps/voyant-operator-runtime/src/payments/managed-payment-adapter.ts` says it plainly:

> *"ONE generic remote adapter that brokers every checkout op to the platform payments control plane, which resolves the deployment's CONNECTED processor + decrypts its creds + forwards to that processor's worker. The deployment ships no processor SDK."*

and for self-hosting:

> *"…or `null` when the deployment is not Cloud-connected (self-host installs a real adapter)."*

So a managed deployment needs **no** processor environment, and a self-hoster binds their own `PaymentAdapter` through `payments.adapter.runtime` with `providers.payments: "custom"` — never routed through us.

## Changes

- **Removed** the hardcoded processor credential branch from `deployment-requirements`
- **Deprecated** `providers.payments: "netopia"` — still accepted, since one deployment selects it while migrating to Voyant Pay
- **Hint no longer names a vendor**: now `"managed"`, `"voyant-pay"`, or `"custom"`, noting a processor is catalog data

## Why it is non-breaking

Removing a *requirement* only relaxes boot validation. `payments: "netopia"` still resolves, and the graph tests that exercise it are unchanged and passing.

## Verification

- `pnpm verify:architecture` — **passes end to end**
- `@voyant-travel/framework` — **377 tests pass**, typecheck clean
- `biome check .` — exit 0

## Follow-ups

- `apps/operator/.env.example` still documents the third credential set; likely dead since nothing installs the adapter, but out of scope here
- Dropping the `"netopia"` union member becomes a one-liner once Pro Travel finishes migrating
- netopia-adapter#14 — retiring that repo's in-process session orchestration, now confirmed unreachable: nothing in this repo or platform installs the adapter package, and nothing provides `payments.adapter.runtime` except platform's managed remote adapter

Refs #4059.
