### PR TITLE
Resume payment setup instead of opening a free mode

### DIFF
--- a/packages/operator-settings-react/src/payments-settings-page.test.tsx
+++ b/packages/operator-settings-react/src/payments-settings-page.test.tsx
@@ -9,7 +9,9 @@ import {
   type PaymentEmbeddedOnboardingClientProps,
   paymentActivationControlState,
   paymentConnectionStatusLabel,
+  paymentProviderSetupMode,
   requestPaymentOnboardingSession,
+  resumablePaymentProviderConnection,
 } from "./payments-settings-page.js"
 
 describe("PaymentEmbeddedOnboardingBoundary", () => {
@@ -231,6 +233,47 @@ describe("payments settings contract", () => {
         { providerId: "voyant-pay", mode: "live" },
       ]),
     ).toBeNull()
+  })
+
+  it("resumes an unfinished connection instead of opening a free mode", () => {
+    const provider = { id: "voyant-pay", modes: ["sandbox", "live"] as const }
+
+    // The reported bug: Live exists but is not ready, so a second click on the
+    // setup action must reopen Live rather than mint a Sandbox account.
+    expect(
+      paymentProviderSetupMode(provider, [
+        { providerId: "voyant-pay", mode: "live", readiness: "not_ready" },
+      ]),
+    ).toBe("live")
+    expect(
+      resumablePaymentProviderConnection(provider, [
+        { providerId: "voyant-pay", mode: "live", readiness: "not_ready" },
+      ]),
+    ).toMatchObject({ mode: "live" })
+  })
+
+  it("opens the real-money mode first and the free mode only once it is taken", () => {
+    const provider = { id: "voyant-pay", modes: ["sandbox", "live"] as const }
+
+    expect(paymentProviderSetupMode(provider, undefined)).toBe("live")
+    expect(paymentProviderSetupMode(provider, [])).toBe("live")
+    expect(
+      paymentProviderSetupMode(provider, [
+        { providerId: "voyant-pay", mode: "live", readiness: "ready" },
+      ]),
+    ).toBe("sandbox")
+    // Another provider's connections never steer this provider's mode.
+    expect(
+      paymentProviderSetupMode(provider, [
+        { providerId: "netopia", mode: "live", readiness: "ready" },
+      ]),
+    ).toBe("live")
+  })
+
+  it("keeps a sandbox-only provider on its advertised mode", () => {
+    expect(
+      paymentProviderSetupMode({ id: "voyant-pay", modes: ["sandbox"] as const }, undefined),
+    ).toBe("sandbox")
   })
 
   it("only enables activation for ready, inactive, writable connections", () => {

--- a/packages/operator-settings-react/src/payments-settings-page.tsx
+++ b/packages/operator-settings-react/src/payments-settings-page.tsx
@@ -295,6 +295,49 @@ export function firstUnconfiguredPaymentProviderMode(
 }
 
 /**
+ * The connection whose setup this provider's action should resume, if any.
+ *
+ * A hosted provider mints a real processor account the first time a mode is set
+ * up, so an unfinished connection has to be resumed rather than replaced by a
+ * second one in whichever mode happens to be free.
+ */
+export function resumablePaymentProviderConnection(
+  provider: { id: ProviderDescriptor["id"] },
+  connections: readonly Pick<ConnectionSummary, "providerId" | "mode" | "readiness">[] | undefined,
+): Pick<ConnectionSummary, "providerId" | "mode" | "readiness"> | null {
+  return (
+    connections?.find(
+      (connection) =>
+        connection.providerId === provider.id &&
+        connection.readiness !== "ready" &&
+        connection.mode !== null,
+    ) ?? null
+  )
+}
+
+/**
+ * The mode the setup action should open in.
+ *
+ * Resuming an unfinished connection wins, then the provider's real-money mode,
+ * and only then whichever mode is still unconfigured. Picking the unconfigured
+ * mode first is what let a second click on "Set up" open Sandbox behind a
+ * finished Live connection and create a throwaway processor account.
+ */
+export function paymentProviderSetupMode(
+  provider: { id: ProviderDescriptor["id"]; modes: readonly ProviderMode[] },
+  connections: readonly Pick<ConnectionSummary, "providerId" | "mode" | "readiness">[] | undefined,
+): ProviderMode {
+  const resumable = resumablePaymentProviderConnection(provider, connections)
+  if (resumable?.mode && provider.modes.includes(resumable.mode)) return resumable.mode
+  const preferred = provider.modes.includes("live") ? "live" : (provider.modes[0] ?? "live")
+  const preferredTaken = connections?.some(
+    (connection) => connection.providerId === provider.id && connection.mode === preferred,
+  )
+  if (!preferredTaken) return preferred
+  return firstUnconfiguredPaymentProviderMode(provider, connections) ?? preferred
+}
+
+/**
  * A connection can be made the active default only when it is ready (its
  * lifecycle reached `connected`) and it is not already the active one. This
  * gates the "Make active" control so a not-ready or already-active connection
@@ -346,6 +389,48 @@ function modeLabel(
   if (mode === "live") return labels.live
   if (mode === "test") return labels.test
   return labels.sandbox
+}
+
+/**
+ * What the processor still needs before this connection can go live.
+ *
+ * Without it a not-ready connection shows a badge and no explanation, which
+ * reads as the platform being wrong rather than as work that is outstanding.
+ */
+function RequirementsAlert({
+  requirements,
+  title,
+  deadlineTemplate,
+}: {
+  requirements: ConnectionRequirement[] | undefined
+  title: string
+  deadlineTemplate: string
+}) {
+  if (!requirements?.length) return null
+  return (
+    <Alert>
+      <TriangleAlert aria-hidden="true" />
+      <AlertTitle>{title}</AlertTitle>
+      <AlertDescription>
+        <ul className="flex list-disc flex-col gap-2 pl-5">
+          {requirements.map((requirement) => (
+            <li key={`${requirement.code}:${requirement.deadlineAt ?? ""}`}>
+              <span>{requirement.message}</span>
+              {requirement.deadlineAt ? (
+                <span className="text-muted-foreground">
+                  {" "}
+                  {deadlineTemplate.replace(
+                    "{date}",
+                    new Date(requirement.deadlineAt).toLocaleDateString(),
+                  )}
+                </span>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      </AlertDescription>
+    </Alert>
+  )
 }
 
 function ModeField({
@@ -591,10 +676,7 @@ export function PaymentsSettingsPage({ embeddedOnboardingClient }: PaymentsSetti
     setDialogProvider(provider)
     setCredentials({})
     setOnboardingSession(null)
-    setMode(
-      firstUnconfiguredPaymentProviderMode(provider, connection?.connections) ??
-        (provider.modes.includes("sandbox") ? "sandbox" : (provider.modes[0] ?? "live")),
-    )
+    setMode(paymentProviderSetupMode(provider, connection?.connections))
   }
 
   const modeLabels = {
@@ -652,30 +734,11 @@ export function PaymentsSettingsPage({ embeddedOnboardingClient }: PaymentsSetti
                   ) : null}
                 </div>
 
-                {connection.requirements?.length ? (
-                  <Alert>
-                    <TriangleAlert aria-hidden="true" />
-                    <AlertTitle>{t.requirementsTitle}</AlertTitle>
-                    <AlertDescription>
-                      <ul className="flex list-disc flex-col gap-2 pl-5">
-                        {connection.requirements.map((requirement) => (
-                          <li key={`${requirement.code}:${requirement.deadlineAt ?? ""}`}>
-                            <span>{requirement.message}</span>
-                            {requirement.deadlineAt ? (
-                              <span className="text-muted-foreground">
-                                {" "}
-                                {t.requirementDeadline.replace(
-                                  "{date}",
-                                  new Date(requirement.deadlineAt).toLocaleDateString(),
-                                )}
-                              </span>
-                            ) : null}
-                          </li>
-                        ))}
-                      </ul>
-                    </AlertDescription>
-                  </Alert>
-                ) : null}
+                <RequirementsAlert
+                  requirements={connection.requirements}
+                  title={t.requirementsTitle}
+                  deadlineTemplate={t.requirementDeadline}
+                />
               </CardContent>
               <CardFooter>
                 {canDisconnectPaymentProvider(activeProvider) ? (
@@ -735,6 +798,15 @@ export function PaymentsSettingsPage({ embeddedOnboardingClient }: PaymentsSetti
                             ) : null}
                           </div>
                         </CardHeader>
+                        {summary.requirements?.length ? (
+                          <CardContent>
+                            <RequirementsAlert
+                              requirements={summary.requirements}
+                              title={t.requirementsTitle}
+                              deadlineTemplate={t.requirementDeadline}
+                            />
+                          </CardContent>
+                        ) : null}
                         <CardFooter className="flex flex-wrap items-center gap-3">
                           {control === "active" ? (
                             <span className="text-sm font-medium text-muted-foreground">
@@ -800,8 +872,12 @@ export function PaymentsSettingsPage({ embeddedOnboardingClient }: PaymentsSetti
                 {providers.map((provider) => {
                   const isActive = provider.id === activeId
                   const unavailable = !canConfigurePaymentProvider(provider)
+                  const hosted = provider.connectionMethod === "embedded_onboarding"
+                  const resumable =
+                    hosted &&
+                    resumablePaymentProviderConnection(provider, connection?.connections) !== null
                   const hasAdditionalHostedMode =
-                    provider.connectionMethod === "embedded_onboarding" &&
+                    hosted &&
                     firstUnconfiguredPaymentProviderMode(provider, connection?.connections) !== null
                   return (
                     <Card key={provider.id}>
@@ -820,11 +896,15 @@ export function PaymentsSettingsPage({ embeddedOnboardingClient }: PaymentsSetti
                         <Button
                           size="sm"
                           variant={isActive ? "outline" : "default"}
-                          disabled={unavailable || (isActive && !hasAdditionalHostedMode)}
+                          disabled={
+                            unavailable || (isActive && !hasAdditionalHostedMode && !resumable)
+                          }
                           onClick={() => openConnect(provider)}
                         >
-                          {provider.connectionMethod === "embedded_onboarding"
-                            ? t.startOnboarding
+                          {hosted
+                            ? resumable
+                              ? t.continueOnboarding
+                              : t.startOnboarding
                             : t.connect}
                         </Button>
                       </CardFooter>


### PR DESCRIPTION
Reported from a managed operator: the Payments page listed **two** Voyant Pay connections, and neither reflected what the processor actually said.

## Setup opened whichever mode was free

`openConnect` chose the mode via `firstUnconfiguredPaymentProviderMode`, which returns the first advertised mode without a connection. With Live already present, a second click on "Set up" silently opened **Sandbox**, and for a hosted provider that mints a real processor account.

That is exactly what happened: an operator trying to finish an unfinished Live connection created a throwaway sandbox account beside it. Hosted connections cannot be disconnected from the UI, so the stray one could not be removed either.

Setup now resolves the mode in this order:

1. an unfinished connection for that provider, so setup resumes it
2. the provider's real-money mode
3. whichever mode is still unconfigured

The action reads "Continue setup" when there is something to resume, and stays enabled for an active provider that still has an unfinished connection.

## Not-ready connections explained nothing

Connection cards rendered a "Not ready" badge, a lifecycle badge, and "This connection isn't ready to be made active yet." The `requirements` array the API already returns was rendered only for the active provider, so on a connection card the operator saw a verdict with no reason. The existing alert is now a shared component used by both surfaces.

## Verification

- `@voyant-travel/operator-settings-react`: 34 tests passing, including four new cases covering resume, the live-first fallback, cross-provider isolation, and a sandbox-only provider
- Lint clean on both changed files

## Related

The processor-side half of this is in the platform repo: readiness was also mapping Accounts v2 `past_due` to `restricted`, which labelled every account restricted from creation. Fixed separately in voyant-travel/platform#1732. This change is what surfaces those corrected requirement messages to the operator.