### PR TITLE
fix(hono): scope shared public cache entries to the storefront that produced them

### DIFF
--- a/.changeset/public-cache-variant-key.md
+++ b/.changeset/public-cache-variant-key.md
@@ -1,0 +1,27 @@
+---
+"@voyant-travel/hono": minor
+---
+
+Scope shared public cache entries to the storefront that produced them.
+
+`publicResponseCache` keyed entries on the request URL alone, while public
+storefront responses are scoped to a sales channel resolved from the `x-api-key`
+storefront key. Two storefronts bound to different channels and served from one
+origin could be served each other's cached responses — `/products/*`,
+`/departures/*`, and `/offers/*` are all channel-gated and shared-cached, and
+their publication gate reads `channelId`.
+
+The key now carries a digest of the variant-selecting request headers, named by
+the new `keyHeaders` option and defaulting to `["x-api-key"]`. Values are hashed
+rather than embedded, so a storefront key never lands in a KV key or a
+`kv_store` row, and the variant is never resolved through the database — a hit
+still costs no connection, no session lookup, and no module-graph instantiation.
+
+Two related gaps close with it: a response declaring a `Vary` the key does not
+model is no longer stored, and a request carrying `Authorization` is neither
+served from nor stored into the shared cache.
+
+The key prefix moves to `respcache:v2:`, which strands existing URL-keyed
+entries rather than reusing them under the new scoping rules.
+
+See ADR 0021 §3.

--- a/packages/hono/src/middleware/public-cache.ts
+++ b/packages/hono/src/middleware/public-cache.ts
@@ -20,13 +20,35 @@ export interface PublicCacheOptions {
    * subject to this guard.
    */
   maxKvBodyBytes?: number
+  /**
+   * Request headers whose presented value selects the response variant.
+   *
+   * A shared entry may only be served to a request that would have produced
+   * it, and the public surface is not scoped by URL alone: the storefront key
+   * (`x-api-key`) resolves the storefront, and through it the sales channel
+   * that scopes catalog publication. Two storefronts bound to different
+   * channels can be served from one origin, so the URL is not a complete key.
+   *
+   * The presented values are hashed into the key rather than resolved, which
+   * keeps the property that makes a hit worth having: no database connection,
+   * no session lookup, no module-graph instantiation on the hit path.
+   *
+   * Defaults to `["x-api-key"]` (ADR 0021 §3).
+   */
+  keyHeaders?: string[]
 }
 
 const DEFAULT_PREFIXES = ["/v1/public/"]
 const DEFAULT_MAX_KV_BODY_BYTES = 2 * 1024 * 1024
-const KV_KEY_PREFIX = "respcache:v1:"
+/**
+ * `v2` keys carry a variant digest. The bump also strands every `v1` entry,
+ * which was keyed on the URL alone and could therefore be shared across
+ * storefront channels.
+ */
+const KV_KEY_PREFIX = "respcache:v2:"
 /** Cloudflare KV rejects expirationTtl below 60 seconds. */
 const KV_MIN_TTL_SECONDS = 60
+const DEFAULT_KEY_HEADERS = ["x-api-key"]
 
 /**
  * Headers never persisted into the shared cache: per-request identifiers
@@ -60,6 +82,36 @@ function parseCacheControl(value: string | null): CacheControlDirectives {
   return { isPublic, sMaxage }
 }
 
+/**
+ * A `Vary` the cache key does not model makes the stored entry unservable:
+ * the next requester matches the key but not the variant. Store only when
+ * every listed field is already a key contributor (`Vary: *` never is).
+ */
+function isVaryModelledByKey(value: string | null, keyHeaders: string[]): boolean {
+  if (!value) return true
+  const modelled = new Set(keyHeaders.map((name) => name.toLowerCase()))
+  const fields = value
+    .split(",")
+    .map((field) => field.trim().toLowerCase())
+    .filter(Boolean)
+  if (fields.length === 0) return true
+  return fields.every((field) => modelled.has(field))
+}
+
+function hex(bytes: ArrayBuffer): string {
+  return [...new Uint8Array(bytes)].map((byte) => byte.toString(16).padStart(2, "0")).join("")
+}
+
+/**
+ * Digest of the presented variant-selecting headers. Hashed rather than
+ * embedded so a storefront key never lands in a KV key or a `kv_store` row.
+ */
+async function variantDigest(values: Array<string | undefined>): Promise<string> {
+  const canonical = values.map((value) => value ?? "").join("\u0000")
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(canonical))
+  return hex(digest).slice(0, 32)
+}
+
 /** Test hook — resets the memoized Cache API probe state. */
 export function resetPublicCacheStateForTests(): void {
   // Retained for test/import compatibility after removing the global Cache API path.
@@ -73,13 +125,13 @@ interface KvCachedResponse {
   body: string
 }
 
-function kvKeyFor(url: string): string {
-  return `${KV_KEY_PREFIX}${url}`
+function kvKeyFor(url: string, variant: string): string {
+  return `${KV_KEY_PREFIX}${variant}:${url}`
 }
 
-async function kvMatch(kv: KVStore, url: string): Promise<Response | undefined> {
+async function kvMatch(kv: KVStore, key: string): Promise<Response | undefined> {
   try {
-    const entry = await kv.get<KvCachedResponse>(kvKeyFor(url), { type: "json" })
+    const entry = await kv.get<KvCachedResponse>(key, { type: "json" })
     if (!entry || typeof entry.body !== "string") return undefined
     const headers = new Headers(entry.headers)
     headers.set("x-voyant-cache", "hit")
@@ -91,7 +143,7 @@ async function kvMatch(kv: KVStore, url: string): Promise<Response | undefined> 
 
 async function kvStore(
   kv: KVStore,
-  url: string,
+  key: string,
   res: Response,
   ttlSeconds: number,
   maxBodyBytes: number,
@@ -104,7 +156,7 @@ async function kvStore(
       if (!isUncacheableHeader(name)) headers.push([name, value])
     })
     const entry: KvCachedResponse = { status: res.status, headers, body }
-    await kv.put(kvKeyFor(url), JSON.stringify(entry), {
+    await kv.put(key, JSON.stringify(entry), {
       expirationTtl: Math.max(KV_MIN_TTL_SECONDS, ttlSeconds),
     })
   } catch {
@@ -127,6 +179,13 @@ async function kvStore(
  * and no module-graph instantiation, which is the entire point under
  * storefront load (#1686).
  *
+ * Scope of an entry: the request URL plus a digest of the variant-selecting
+ * headers named by {@link PublicCacheOptions.keyHeaders} — by default the
+ * storefront key, which resolves the sales channel that scopes catalog
+ * publication. An `Authorization` request never reads or writes the shared
+ * cache, and a response declaring a `Vary` the key does not model is not
+ * stored (ADR 0021 §3).
+ *
  * Backend selection: the injected `env.CACHE` {@link KVStore}. Node
  * composition decides whether that is memory, Postgres, Redis, or a tiered
  * store; this middleware never probes a global runtime cache.
@@ -136,21 +195,29 @@ export function publicResponseCache<TBindings extends VoyantBindings>(
 ): MiddlewareHandler<{ Bindings: TBindings }> {
   const prefixes = options.pathPrefixes ?? DEFAULT_PREFIXES
   const maxKvBodyBytes = options.maxKvBodyBytes ?? DEFAULT_MAX_KV_BODY_BYTES
+  const keyHeaders = options.keyHeaders ?? DEFAULT_KEY_HEADERS
 
   return async (c, next) => {
     if (c.req.method !== "GET") return next()
     const path = c.req.path
     if (!prefixes.some((prefix) => path.startsWith(prefix))) return next()
+    // A credentialed request is outside the shared representation contract:
+    // it is neither served from nor stored into an entry other requesters
+    // can read. `Set-Cookie` on the response opts out on the way back.
+    if (c.req.header("authorization")) return next()
     // Standard escape hatch: a requester (or a debugging operator) can
     // force revalidation with `Cache-Control: no-cache`.
     const requestDirective = c.req.header("cache-control")?.toLowerCase() ?? ""
     const bypass = requestDirective.includes("no-cache") || requestDirective.includes("no-store")
 
-    const url = c.req.url
+    const key = kvKeyFor(
+      c.req.url,
+      await variantDigest(keyHeaders.map((name) => c.req.header(name))),
+    )
     const kv = c.env.CACHE
 
     if (!bypass && kv) {
-      const hit = await kvMatch(kv, url)
+      const hit = await kvMatch(kv, key)
       if (hit) return hit
     }
 
@@ -159,6 +226,7 @@ export function publicResponseCache<TBindings extends VoyantBindings>(
     const res = c.res
     if (res?.status !== 200) return
     if (res.headers.has("set-cookie")) return
+    if (!isVaryModelledByKey(res.headers.get("vary"), keyHeaders)) return
     const { isPublic, sMaxage } = parseCacheControl(res.headers.get("cache-control"))
     if (!isPublic || !sMaxage) return
 
@@ -167,7 +235,7 @@ export function publicResponseCache<TBindings extends VoyantBindings>(
 
     const copy = res.clone()
     const store = (async () => {
-      await kvStore(backendKv, url, copy, sMaxage, maxKvBodyBytes)
+      await kvStore(backendKv, key, copy, sMaxage, maxKvBodyBytes)
     })()
 
     const executionCtx = tryGetExecutionCtx(c)

--- a/packages/hono/tests/unit/public-cache.test.ts
+++ b/packages/hono/tests/unit/public-cache.test.ts
@@ -213,6 +213,162 @@ describe("publicResponseCache (KV fallback — no Cache API in the test runtime)
     expect(hit.headers.get("content-type")).toBe("application/json")
   })
 
+  it("does not share an entry between two storefront keys on the same URL", async () => {
+    const kv = fakeKv()
+    const handler = vi.fn(
+      (c: { req: { header(name: string): string | undefined } }) =>
+        new Response(JSON.stringify({ channel: c.req.header("x-api-key") }), {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "cache-control": "public, s-maxage=60",
+          },
+        }),
+    )
+    const app = new Hono<{ Bindings: TestBindings }>()
+    app.use("*", publicResponseCache())
+    app.get("/v1/public/products", (c) => handler(c))
+    const env = { DATABASE_URL: "postgres://localhost/test", CACHE: kv }
+
+    const website = await app.request(
+      "/v1/public/products",
+      { headers: { "x-api-key": "pk_website" } },
+      testEnv(env),
+    )
+    const b2b = await app.request(
+      "/v1/public/products",
+      { headers: { "x-api-key": "pk_b2b" } },
+      testEnv(env),
+    )
+
+    expect(await website.json()).toEqual({ channel: "pk_website" })
+    expect(await b2b.json()).toEqual({ channel: "pk_b2b" })
+    expect(handler).toHaveBeenCalledTimes(2)
+    expect(b2b.headers.get("x-voyant-cache")).toBeNull()
+    expect(kv.store.size).toBe(2)
+
+    // ...and each key still serves its own entry on a repeat request.
+    const websiteAgain = await app.request(
+      "/v1/public/products",
+      { headers: { "x-api-key": "pk_website" } },
+      testEnv(env),
+    )
+    expect(websiteAgain.headers.get("x-voyant-cache")).toBe("hit")
+    expect(await websiteAgain.json()).toEqual({ channel: "pk_website" })
+    expect(handler).toHaveBeenCalledTimes(2)
+  })
+
+  it("never embeds the presented storefront key in the cache key", async () => {
+    const kv = fakeKv()
+    const handler = vi.fn(
+      () =>
+        new Response("{}", {
+          status: 200,
+          headers: { "cache-control": "public, s-maxage=60" },
+        }),
+    )
+    const app = buildApp(kv, handler)
+
+    await app.request("/v1/public/products", { headers: { "x-api-key": "pk_secret_value" } })
+
+    expect(kv.put).toHaveBeenCalledOnce()
+    expect(kv.put.mock.calls[0]?.[0]).not.toContain("pk_secret_value")
+  })
+
+  it("never caches a response declaring a Vary the key does not model", async () => {
+    const kv = fakeKv()
+    const handler = vi.fn(
+      () =>
+        new Response("{}", {
+          status: 200,
+          headers: {
+            "cache-control": "public, s-maxage=60",
+            vary: "accept-language",
+          },
+        }),
+    )
+    const app = buildApp(kv, handler)
+
+    await app.request("/v1/public/products")
+    expect(kv.put).not.toHaveBeenCalled()
+  })
+
+  it("caches a response whose Vary names only key contributors", async () => {
+    const kv = fakeKv()
+    const handler = vi.fn(
+      () =>
+        new Response("{}", {
+          status: 200,
+          headers: {
+            "cache-control": "public, s-maxage=60",
+            vary: "X-Api-Key",
+          },
+        }),
+    )
+    const app = buildApp(kv, handler)
+
+    await app.request("/v1/public/products")
+    expect(kv.put).toHaveBeenCalledOnce()
+  })
+
+  it("never caches a response declaring Vary: *", async () => {
+    const kv = fakeKv()
+    const handler = vi.fn(
+      () =>
+        new Response("{}", {
+          status: 200,
+          headers: { "cache-control": "public, s-maxage=60", vary: "*" },
+        }),
+    )
+    const app = buildApp(kv, handler)
+
+    await app.request("/v1/public/products")
+    expect(kv.put).not.toHaveBeenCalled()
+  })
+
+  it("neither reads nor writes the shared cache for a credentialed request", async () => {
+    const kv = fakeKv()
+    const handler = vi.fn(
+      () =>
+        new Response("{}", {
+          status: 200,
+          headers: { "cache-control": "public, s-maxage=60" },
+        }),
+    )
+    const app = buildApp(kv, handler)
+
+    // Populate from an anonymous request first, so a read would have hit.
+    await app.request("/v1/public/products")
+    expect(kv.put).toHaveBeenCalledOnce()
+
+    const authed = await app.request("/v1/public/products", {
+      headers: { authorization: "Bearer token" },
+    })
+
+    expect(handler).toHaveBeenCalledTimes(2)
+    expect(authed.headers.get("x-voyant-cache")).toBeNull()
+    expect(kv.put).toHaveBeenCalledOnce()
+  })
+
+  it("performs no cache read or write work outside the KV store on the hit path", async () => {
+    const kv = fakeKv()
+    const handler = vi.fn(
+      () =>
+        new Response("{}", {
+          status: 200,
+          headers: { "cache-control": "public, s-maxage=60" },
+        }),
+    )
+    const app = buildApp(kv, handler)
+
+    await app.request("/v1/public/products")
+    kv.get.mockClear()
+    await app.request("/v1/public/products")
+
+    // One lookup, no second round trip to resolve the variant.
+    expect(kv.get).toHaveBeenCalledOnce()
+  })
+
   it("is a transparent no-op when neither Cache API nor KV is available", async () => {
     const handler = vi.fn(
       () =>


### PR DESCRIPTION
Closes #4095. First of the chain under ADR 0021 (#4094).

## Problem

`publicResponseCache` keyed entries on `c.req.url` alone. Public storefront
responses are scoped to a sales channel resolved from the `x-api-key` storefront
key (`STOREFRONT_KEY_HEADER`), which the URL cannot express — so two storefronts
bound to different channels and served from one origin could be served each
other's cached responses. `/products/*`, `/departures/*` and `/offers/*` are all
behind `requireActiveChannel` and all call `setPublicCacheHeaders`, and the
publication gate they consult reads `context.channelId`.

Two related gaps in the same decision: `Vary` was ignored entirely, and
`Authorization` did not bypass — the framework was less strict than the Voyant
Cloud dispatcher it was supposed to be the contract for.

## Change

- The key carries a SHA-256 digest of the variant-selecting request headers,
  named by a new `keyHeaders` option defaulting to `["x-api-key"]`. Hashed, not
  embedded, so a storefront key never lands in a KV key or a `kv_store` row.
- Keying is pure request-signal work — no database lookup on the hit path, which
  is what makes a hit worth having (no connection, no session, no module graph).
- A response declaring a `Vary` the key does not model is not stored. A `Vary`
  naming only key contributors still is; `Vary: *` never is.
- A request carrying `Authorization` is neither served from nor stored into the
  shared cache.
- Key prefix moves to `respcache:v2:`, stranding existing URL-keyed entries
  rather than reusing them under the new scoping rules.

Ordering note: `cors` is mounted upstream (app.ts:463) and sets `Vary: Origin`
*after* `await next()`, so it decorates the response after this middleware has
already stored it. Refusing `Vary` at store time therefore does not disable the
cache for CORS traffic.

## Verification

- `packages/hono` — 328 tests pass (17 in `public-cache.test.ts`, 7 new).
- `pnpm --filter @voyant-travel/hono typecheck` clean.
- `biome check` clean on changed files.

New coverage: two storefront keys never share an entry and each still serves its
own; the presented key never appears in the cache key; `Vary` modelled/unmodelled/`*`;
credentialed requests neither read nor write; the hit path makes exactly one KV read.

## Next in the chain

#4096 (SWR, TTL authority, single-flight) stacks on this branch, then #4097 and #4091.
