### PR TITLE
feat(hono): cache body-keyed public POST reads and let catalog search declare a policy

### DIFF
--- a/.changeset/public-cache-body-keyed-reads.md
+++ b/.changeset/public-cache-body-keyed-reads.md
@@ -1,0 +1,35 @@
+---
+"@voyant-travel/hono": minor
+"@voyant-travel/catalog": minor
+---
+
+Cache body-keyed public POST reads in the framework, and let catalog search
+declare its own policy.
+
+`publicResponseCache` was GET-only, so `POST /v1/public/catalog/search` — the
+slowest public read there is — could not declare a cache policy at all. The gap
+was filled downstream by a bespoke cache in the Voyant Cloud dispatcher that
+hardcoded the route path, invented its own TTL, and omitted
+`stale-while-revalidate`. Self-hosted deployments got nothing, and any second
+body-keyed read would have needed the same bespoke treatment.
+
+A module now declares participation with `bodyKeyedCache`, listing public
+sub-paths whose POST reads are keyed on the canonicalized request body as well
+as the URL and the variant headers. The declaration lives at mount time rather
+than in a response header because the middleware has to canonicalize the body
+*before* the route runs; the policy itself still lives on the response, which is
+what lets an edge tier honour the same contract instead of matching a path.
+
+Keying is fail-closed. A request goes to the origin uncached when it carries a
+query string (an unknown parameter must not alias a body-only key), a non-JSON
+or oversized body (64 KiB), `Authorization`, or a caller-specific body field
+anywhere in the payload — embeddings, personalization, session, customer, user,
+preview, or debug. Bodies differing only in property order share an entry.
+
+`POST /v1/public/catalog/search` declares
+`public, s-maxage=60, stale-while-revalidate=300` for an empty-query browse and
+`s-maxage=30` for a keyword search, on the public surface only. The TTLs stay
+short on purpose: the key carries no catalog projection generation, so the clock
+is still the only invalidation there is (voyant-travel/platform#1726).
+
+See ADR 0021 §2.

--- a/docs/architecture/public-route-cache-policy.md
+++ b/docs/architecture/public-route-cache-policy.md
@@ -29,8 +29,15 @@ Cloudflare Cache API.
 - `live-by-correctness`: volatile price quote, hold, booking, payment mutation,
   eligibility, or write flow where stale data can change correctness.
 - `index-backed`: search/index reads. GET searches can use shared response
-  cache when non-personalized; POST searches are not cached by the current
-  public response cache because the cache key is URL-only.
+  cache when non-personalized; POST searches use `body-keyed-shared-cache`.
+- `body-keyed-shared-cache`: a non-personalized POST read whose result is
+  determined by its request body. The module declares participation at mount
+  time via `bodyKeyedCache` (the middleware has to canonicalize the body before
+  the route runs, so a response header cannot carry that decision), and the
+  route still declares the policy itself with
+  `Cache-Control: public, s-maxage=..., stale-while-revalidate=...`. A request
+  carrying a query string, a non-JSON or oversized body, `Authorization`, or a
+  caller-specific body field goes to the origin uncached.
 
 ## Route Matrix
 
@@ -48,7 +55,7 @@ Cloudflare Cache API.
 | Operator public profile, public operator settings, payment-link config | `shared-response-cache` | Public deploy configuration and operator identity; payment sessions remain private/live. |
 | Payment link sessions, payment resolve/retry/card start, trip summaries | `private-no-store` or `live-by-correctness` | Session-specific and payment-state dependent. |
 | Proposals, finance customer portal, document delivery | `private-no-store` | Customer-facing but bearer/session scoped. |
-| Catalog POST search | `index-backed` | Not response-cached today because the request body is outside the URL cache key. Use GET/hash read models before adding shared response caching. |
+| Catalog POST search | `body-keyed-shared-cache` | Declares `bodyKeyedCache: ["/search"]` and a per-request policy: 60s for an empty-query browse, 30s for a keyword search, both with `stale-while-revalidate=300`. TTLs stay short because the key carries no catalog projection generation, so the clock is the only invalidation (voyant-travel/platform#1726). |
 
 ## Authoring Rule
 
@@ -59,8 +66,9 @@ When adding a public route:
    `Cache-Control` with `s-maxage`.
 3. For personalized or bearer-like public routes, set `private, no-store` when
    returning sensitive state.
-4. Do not cache a route that varies by request headers unless the route also
-   emits the correct `Vary` header or normalizes the variant into the URL.
+4. Do not cache a route that varies by request headers unless that header is a
+   cache-key contributor (`keyHeaders`, which covers the storefront key by
+   default). A response declaring a `Vary` the key does not model is refused.
 5. Do not use KV or response cache as a correctness primitive; the live DB path
    must remain correct on every cache miss.
 

--- a/packages/catalog/src/search/routes.test.ts
+++ b/packages/catalog/src/search/routes.test.ts
@@ -226,6 +226,59 @@ describe("createCatalogSearchRoutes", () => {
     expect(executeSearch.mock.calls[1]?.[0].slice.channel).toBe("chan_website")
   })
 
+  it("declares a shared-cache policy on the public search read only", async () => {
+    const executeSearch = vi.fn(
+      async (_input: CatalogSearchExecuteInput): Promise<SearchResults> => emptyResults,
+    )
+    const module = createCatalogSearchApiModule({
+      resolveRuntime: () => ({
+        indexer: createIndexer(),
+        defaultScope: { locale: "en-GB", audience: "staff", market: "default" },
+      }),
+      executeSearch,
+    })
+    const app = new Hono()
+    app.use("/v1/public/*", async (c, next) => {
+      c.set("storefrontChannel" as never, activeStorefrontChannel as never)
+      await next()
+    })
+    app.route("/v1/admin/catalog", module.adminRoutes!)
+    app.route("/v1/public/catalog", module.publicRoutes!)
+
+    const search = (surface: string, body: Record<string, unknown>) =>
+      app.request(`/v1/${surface}/catalog/search`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ vertical: "products", mode: "keyword", ...body }),
+      })
+
+    // An empty-query browse is the storefront landing read: longer window.
+    const browse = await search("public", {})
+    expect(browse.headers.get("cache-control")).toBe(
+      "public, s-maxage=60, stale-while-revalidate=300",
+    )
+
+    const keyword = await search("public", { query: "crete" })
+    expect(keyword.headers.get("cache-control")).toBe(
+      "public, s-maxage=30, stale-while-revalidate=300",
+    )
+
+    // The staff surface is never shared-cached.
+    const admin = await search("admin", { query: "crete" })
+    expect(admin.headers.get("cache-control")).toBeNull()
+  })
+
+  it("declares the public search path as a body-keyed cache participant", () => {
+    const module = createCatalogSearchApiModule({
+      resolveRuntime: () => ({
+        indexer: createIndexer(),
+        defaultScope: { locale: "en-GB", audience: "staff", market: "default" },
+      }),
+    })
+
+    expect(module.bodyKeyedCache).toEqual(["/search"])
+  })
+
   it("denies public search without an active storefront channel context", async () => {
     const executeSearch = vi.fn(
       async (_input: CatalogSearchExecuteInput): Promise<SearchResults> => emptyResults,

--- a/packages/catalog/src/search/routes.ts
+++ b/packages/catalog/src/search/routes.ts
@@ -331,12 +331,39 @@ export function createCatalogSearchApiModule(options: CatalogSearchRoutesOptions
     adminRoutes: createCatalogSearchRoutes({ ...options, surface: "admin" }),
     publicRoutes: createCatalogSearchRoutes({ ...options, surface: "public" }),
     optionalCustomerAuth: true,
+    // The public search read is keyed on its request body, so the framework
+    // caches it in-process and a self-hosted deployment gets the same
+    // behaviour a hosting proxy used to provide for managed ones only.
+    bodyKeyedCache: ["/search"],
   }
 }
 
 export function mountCatalogSearchRoutes(hono: HonoApp, options: CatalogSearchRoutesOptions): void {
   hono.route("/v1/admin/catalog", createCatalogSearchRoutes({ ...options, surface: "admin" }))
   hono.route("/v1/public/catalog", createCatalogSearchRoutes({ ...options, surface: "public" }))
+}
+
+/**
+ * Shared-cache policy for the public search read (ADR 0021, voyant#4091).
+ *
+ * Declared on the route so the framework's body-keyed cache and any edge tier
+ * in front of it read the same contract, instead of a proxy inventing a TTL
+ * for a hardcoded path. Applied to the public surface only — the staff surface
+ * is never shared-cached.
+ *
+ * A browse with no query term is the storefront's landing read: hottest, and
+ * the one whose result set changes least, so it gets the longer window. Both
+ * carry `stale-while-revalidate`, which is what keeps a lapse from handing the
+ * uncached search latency to whoever arrives first.
+ *
+ * The TTLs stay short deliberately: without a catalog projection generation in
+ * the cache key (voyant-travel/platform#1726) the clock is the only
+ * invalidation there is, so a longer window would just mean staler results
+ * with no bound but time.
+ */
+function setPublicSearchCacheHeaders(c: Context, body: CatalogSearchBody): void {
+  const sMaxage = (body.query ?? "").trim().length === 0 ? 60 : 30
+  c.header("Cache-Control", `public, s-maxage=${sMaxage}, stale-while-revalidate=300`)
 }
 
 async function handleSearch(
@@ -384,6 +411,7 @@ async function handleSearch(
       slice,
       request,
     })
+    if (options.surface === "public") setPublicSearchCacheHeaders(c, body)
     return c.json({
       vertical: body.vertical,
       mode: responseMode,

--- a/packages/hono/src/app.ts
+++ b/packages/hono/src/app.ts
@@ -47,6 +47,7 @@ import { securityHeaders } from "./middleware/security-headers.js"
 import { resolveSurfaceMountPath } from "./mount-paths.js"
 import { noopReporter, safeCaptureException } from "./observability/reporter.js"
 import { getRequestId } from "./observability/request-context.js"
+import { assembleBodyKeyedCachePaths } from "./public-cache-paths.js"
 import type { VoyantAppConfig, VoyantBindings, VoyantDb, VoyantVariables } from "./types.js"
 
 const WRITE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"])
@@ -246,6 +247,7 @@ export function mountApp<TBindings extends VoyantBindings>(
   ])
   const optionalCustomerAuthPaths = assembleOptionalCustomerAuthPaths(allModules, allExtensions)
   const clientAuthenticatedRoutes = assembleClientAuthenticatedRoutes(allModules)
+  const bodyKeyedCachePaths = assembleBodyKeyedCachePaths(allModules, allExtensions)
   const composedAuth = composeAuthAugmentations(config.auth, allModules)
   // When the framework owns the bus, route subscriber-dispatch failures
   // (including the workflow forwarder) to the reporter — they're otherwise
@@ -540,7 +542,14 @@ export function mountApp<TBindings extends VoyantBindings>(
   // route explicitly marks `Cache-Control: public, s-maxage=…` are
   // stored (see middleware docs).
   if (config.publicCache !== false) {
-    app.use("*", publicResponseCache(config.publicCache ?? {}))
+    app.use(
+      "*",
+      publicResponseCache({
+        // Module-declared body-keyed reads, unless the deployment named its own.
+        bodyKeyedPaths: bodyKeyedCachePaths,
+        ...(config.publicCache ?? {}),
+      }),
+    )
   }
 
   // Per-request outbox store factory: emits happen in route handlers,

--- a/packages/hono/src/middleware/public-cache.ts
+++ b/packages/hono/src/middleware/public-cache.ts
@@ -36,6 +36,22 @@ export interface PublicCacheOptions {
    * Defaults to `["x-api-key"]` (ADR 0021 §3).
    */
   keyHeaders?: string[]
+  /**
+   * Absolute paths whose public POST reads are keyed on the canonicalized
+   * request body in addition to the URL and the variant headers.
+   *
+   * Assembled from module `bodyKeyedCache` declarations, so a second cacheable
+   * body-keyed read is a declaration next to the route rather than a change to
+   * a proxy (ADR 0021 §2). Eligibility only; the response still has to mark
+   * itself `public, s-maxage=…` to be stored.
+   */
+  bodyKeyedPaths?: readonly string[]
+  /**
+   * Request bodies larger than this are not keyed — the request goes to the
+   * origin uncached. Default 64 KiB, matching the bound the Voyant Cloud
+   * dispatcher already applies to catalog search.
+   */
+  maxKeyedRequestBodyBytes?: number
 }
 
 const DEFAULT_PREFIXES = ["/v1/public/"]
@@ -49,6 +65,29 @@ const KV_KEY_PREFIX = "respcache:v2:"
 /** Cloudflare KV rejects expirationTtl below 60 seconds. */
 const KV_MIN_TTL_SECONDS = 60
 const DEFAULT_KEY_HEADERS = ["x-api-key"]
+const DEFAULT_MAX_KEYED_BODY_BYTES = 64 * 1024
+
+/**
+ * Body fields that make a response specific to one caller, anywhere in the
+ * request. Their presence takes the request to the origin uncached rather than
+ * letting a personalized answer be keyed as if it were shareable.
+ */
+const KEYED_BODY_BYPASS_FIELDS = new Set([
+  "query_embedding",
+  "queryEmbedding",
+  "caller_embedding",
+  "callerEmbedding",
+  "debug",
+  "preview",
+  "personalized",
+  "personalization",
+  "customer_id",
+  "customerId",
+  "session_id",
+  "sessionId",
+  "user_id",
+  "userId",
+])
 
 /**
  * Headers never persisted into the shared cache: per-request identifiers
@@ -117,6 +156,75 @@ async function variantDigest(values: Array<string | undefined>): Promise<string>
   const canonical = values.map((value) => value ?? "").join("\u0000")
   const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(canonical))
   return hex(digest).slice(0, 32)
+}
+
+function normalizePath(path: string): string {
+  const trimmed = path.replace(/\/+$/, "")
+  return trimmed === "" ? "/" : trimmed
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
+
+function hasBypassField(value: unknown): boolean {
+  if (Array.isArray(value)) return value.some(hasBypassField)
+  if (!isPlainObject(value)) return false
+  return Object.entries(value).some(
+    ([field, child]) => KEYED_BODY_BYPASS_FIELDS.has(field) || hasBypassField(child),
+  )
+}
+
+/**
+ * Stable text for a JSON body: object keys sorted at every depth, so two
+ * requests that differ only in property order share an entry.
+ */
+export function canonicalizeKeyedBody(value: unknown): string {
+  const canonical = (child: unknown): unknown => {
+    if (Array.isArray(child)) return child.map(canonical)
+    if (!isPlainObject(child)) return child
+    return Object.fromEntries(
+      Object.keys(child)
+        .sort()
+        .map((field) => [field, canonical(child[field])]),
+    )
+  }
+  return JSON.stringify(canonical(value))
+}
+
+/**
+ * Digest of a body-keyed request, or `null` when the request must not be
+ * cached at all: a query string (unknown parameters may gain meaning later and
+ * must not alias a body-only key), a non-JSON body, an oversized body, a body
+ * that is not a JSON object, or one carrying a caller-specific field.
+ */
+async function keyedRequestBodyDigest(request: Request, maxBytes: number): Promise<string | null> {
+  if (new URL(request.url).search.length > 0) return null
+  if (!request.headers.get("content-type")?.toLowerCase().startsWith("application/json")) {
+    return null
+  }
+  const declaredLength = Number(request.headers.get("content-length"))
+  if (Number.isFinite(declaredLength) && declaredLength > maxBytes) return null
+
+  try {
+    // Clone: the route still has to read this body itself.
+    const bytes = new Uint8Array(await request.clone().arrayBuffer())
+    if (bytes.byteLength > maxBytes) return null
+    const body: unknown = JSON.parse(new TextDecoder().decode(bytes))
+    if (!isPlainObject(body)) return null
+    if (hasBypassField(body)) return null
+    const digest = await crypto.subtle.digest(
+      "SHA-256",
+      new TextEncoder().encode(canonicalizeKeyedBody(body)),
+    )
+    return hex(digest)
+  } catch {
+    // Unreadable or pathological JSON degrades to an origin request rather
+    // than turning canonicalization into a request failure.
+    return null
+  }
 }
 
 /** Test hook — resets the memoized Cache API probe state. */
@@ -284,9 +392,13 @@ export function publicResponseCache<TBindings extends VoyantBindings>(
   const maxKvBodyBytes = options.maxKvBodyBytes ?? DEFAULT_MAX_KV_BODY_BYTES
   const keyHeaders = options.keyHeaders ?? DEFAULT_KEY_HEADERS
 
+  const bodyKeyedPaths = new Set(options.bodyKeyedPaths ?? [])
+  const maxKeyedBodyBytes = options.maxKeyedRequestBodyBytes ?? DEFAULT_MAX_KEYED_BODY_BYTES
+
   return async (c, next) => {
-    if (c.req.method !== "GET") return next()
     const path = c.req.path
+    const isBodyKeyed = c.req.method === "POST" && bodyKeyedPaths.has(normalizePath(path))
+    if (c.req.method !== "GET" && !isBodyKeyed) return next()
     if (!prefixes.some((prefix) => path.startsWith(prefix))) return next()
     // A credentialed request is outside the shared representation contract:
     // it is neither served from nor stored into an entry other requesters
@@ -297,9 +409,15 @@ export function publicResponseCache<TBindings extends VoyantBindings>(
     const requestDirective = c.req.header("cache-control")?.toLowerCase() ?? ""
     const bypass = requestDirective.includes("no-cache") || requestDirective.includes("no-store")
 
+    // A body-keyed read has to be canonicalized before the route runs, and any
+    // condition that makes the body an unsafe key takes the request straight
+    // to the origin rather than caching it under a partial one.
+    const bodyDigest = isBodyKeyed ? await keyedRequestBodyDigest(c.req.raw, maxKeyedBodyBytes) : ""
+    if (isBodyKeyed && bodyDigest === null) return next()
+
     const key = kvKeyFor(
       c.req.url,
-      await variantDigest(keyHeaders.map((name) => c.req.header(name))),
+      await variantDigest([...keyHeaders.map((name) => c.req.header(name)), bodyDigest ?? ""]),
     )
     const kv = c.env.CACHE
 

--- a/packages/hono/src/module.ts
+++ b/packages/hono/src/module.ts
@@ -65,6 +65,18 @@ export interface ApiModule {
   /** Anonymous paths that also attempt live customer-session resolution. */
   optionalCustomerAuth?: boolean | readonly string[]
   /**
+   * Public sub-paths whose POST reads are keyed on the request body as well as
+   * the URL, making them eligible for the shared response cache (ADR 0021 §2).
+   *
+   * Paths are relative to the public mount, the same as `anonymous`. Eligibility
+   * is declared here rather than by a response header because the middleware has
+   * to canonicalize the request body before the route runs; the cache policy
+   * itself still lives on the response, so an edge tier reads the same
+   * declaration. A declared path whose response is not marked
+   * `public, s-maxage=…` is still never stored.
+   */
+  bodyKeyedCache?: readonly string[]
+  /**
    * Concrete admin endpoints whose credential is validated by the route itself
    * instead of by the staff-session middleware. Each declaration is matched by
    * exact HTTP method and exact path; it never opens sibling or child routes.
@@ -140,6 +152,18 @@ export interface ApiExtension {
   anonymous?: boolean | readonly string[]
   /** Anonymous paths that also attempt live customer-session resolution. */
   optionalCustomerAuth?: boolean | readonly string[]
+  /**
+   * Public sub-paths whose POST reads are keyed on the request body as well as
+   * the URL, making them eligible for the shared response cache (ADR 0021 §2).
+   *
+   * Paths are relative to the public mount, the same as `anonymous`. Eligibility
+   * is declared here rather than by a response header because the middleware has
+   * to canonicalize the request body before the route runs; the cache policy
+   * itself still lives on the response, so an edge tier reads the same
+   * declaration. A declared path whose response is not marked
+   * `public, s-maxage=…` is still never stored.
+   */
+  bodyKeyedCache?: readonly string[]
   /**
    * Absolute transactional path prefixes — same semantics as
    * {@link ApiModule.transactionalPaths}.

--- a/packages/hono/src/public-cache-paths.ts
+++ b/packages/hono/src/public-cache-paths.ts
@@ -1,0 +1,41 @@
+import type { ApiExtension, ApiModule } from "./module.js"
+import { resolveSurfaceMountPath } from "./mount-paths.js"
+
+/**
+ * Assemble the absolute paths whose public POST reads participate in the
+ * body-keyed response cache (ADR 0021 §2).
+ *
+ * A `Cache-Control` header cannot carry this declaration on its own: the
+ * middleware has to decide whether to read and canonicalize the request body
+ * BEFORE the route runs, and the header only exists on the way back. So
+ * participation is declared at mount time next to the routes it describes —
+ * the same shape as `anonymous` and `optionalCustomerAuth` — while the policy
+ * itself (TTL, stale-while-revalidate) still lives on the response, which is
+ * what lets an edge tier honour the same declaration.
+ *
+ * Declaring a path only makes it eligible. A response that does not mark
+ * itself `public, s-maxage=…` is still never stored.
+ */
+export function assembleBodyKeyedCachePaths(
+  modules: readonly ApiModule[],
+  extensions: readonly ApiExtension[],
+): string[] {
+  const paths = new Set<string>()
+
+  const add = (mount: string, declaration: readonly string[] | undefined): void => {
+    if (!declaration) return
+    for (const sub of declaration) {
+      const trimmed = sub.trim().replace(/^\/+|\/+$/g, "")
+      paths.add(trimmed ? `${mount}/${trimmed}` : mount)
+    }
+  }
+
+  for (const m of modules) {
+    add(resolveSurfaceMountPath("/v1/public", m.publicPath, m.module.name), m.bodyKeyedCache)
+  }
+  for (const e of extensions) {
+    add(resolveSurfaceMountPath("/v1/public", e.publicPath, e.extension.module), e.bodyKeyedCache)
+  }
+
+  return [...paths].sort()
+}

--- a/packages/hono/tests/unit/public-cache.test.ts
+++ b/packages/hono/tests/unit/public-cache.test.ts
@@ -596,6 +596,226 @@ describe("publicResponseCache (KV fallback — no Cache API in the test runtime)
     expect(handler).toHaveBeenCalledTimes(2)
   })
 
+  describe("body-keyed POST reads", () => {
+    const SEARCH = "/v1/public/catalog/search"
+
+    function buildSearchApp(
+      kv: ReturnType<typeof fakeKv>,
+      handler: (body: unknown) => Response | Promise<Response>,
+    ) {
+      const app = new Hono<{ Bindings: TestBindings }>()
+      app.use("*", publicResponseCache({ bodyKeyedPaths: [SEARCH] }))
+      app.post(SEARCH, async (c) => handler(await c.req.json()))
+      const env = { DATABASE_URL: "postgres://localhost/test", CACHE: kv }
+      return {
+        post: (body: unknown, init?: RequestInit) =>
+          app.request(
+            SEARCH,
+            {
+              ...init,
+              method: "POST",
+              headers: { "content-type": "application/json", ...(init?.headers ?? {}) },
+              body: JSON.stringify(body),
+            },
+            testEnv(env),
+          ),
+      }
+    }
+
+    const cacheable = (payload: unknown) =>
+      new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+          "cache-control": "public, s-maxage=60, stale-while-revalidate=300",
+        },
+      })
+
+    it("caches a declared body-keyed POST and serves the repeat from cache", async () => {
+      const kv = fakeKv()
+      const handler = vi.fn(() => cacheable({ hits: [1] }))
+      const app = buildSearchApp(kv, handler)
+
+      const first = await app.post({ vertical: "products", query: "crete" })
+      expect(first.status).toBe(200)
+      await flush()
+
+      const second = await app.post({ vertical: "products", query: "crete" })
+      expect(second.headers.get("x-voyant-cache")).toBe("hit")
+      expect(await second.json()).toEqual({ hits: [1] })
+      expect(handler).toHaveBeenCalledTimes(1)
+    })
+
+    it("keys on the body, so a different search is a different entry", async () => {
+      const kv = fakeKv()
+      const handler = vi.fn((body: unknown) => cacheable(body))
+      const app = buildSearchApp(kv, handler)
+
+      await app.post({ vertical: "products", query: "crete" })
+      await flush()
+      const other = await app.post({ vertical: "products", query: "rhodes" })
+      await flush()
+
+      expect(handler).toHaveBeenCalledTimes(2)
+      expect(await other.json()).toEqual({ vertical: "products", query: "rhodes" })
+    })
+
+    it("treats bodies differing only in key order as the same read", async () => {
+      const kv = fakeKv()
+      const handler = vi.fn(() => cacheable({ hits: [] }))
+      const app = buildSearchApp(kv, handler)
+
+      await app.post({ vertical: "products", query: "crete" })
+      await flush()
+      const reordered = await app.post({ query: "crete", vertical: "products" })
+
+      expect(reordered.headers.get("x-voyant-cache")).toBe("hit")
+      expect(handler).toHaveBeenCalledTimes(1)
+    })
+
+    it("never caches a POST to a path that did not declare itself", async () => {
+      const kv = fakeKv()
+      const app = new Hono<{ Bindings: TestBindings }>()
+      app.use("*", publicResponseCache({ bodyKeyedPaths: [SEARCH] }))
+      const handler = vi.fn(() => cacheable({ ok: true }))
+      app.post("/v1/public/catalog/quote", handler)
+      const env = { DATABASE_URL: "x", CACHE: kv }
+
+      await app.request(
+        "/v1/public/catalog/quote",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ vertical: "products" }),
+        },
+        testEnv(env),
+      )
+      await flush()
+
+      expect(kv.put).not.toHaveBeenCalled()
+    })
+
+    it.each([
+      ["a caller embedding", { vertical: "products", query_embedding: [0.1, 0.2] }],
+      ["a nested personalization id", { vertical: "products", filters: { customerId: "c_1" } }],
+      ["a preview flag", { vertical: "products", preview: true }],
+      ["a debug flag", { vertical: "products", debug: true }],
+    ])("bypasses the cache for a body carrying %s", async (_label, body) => {
+      const kv = fakeKv()
+      const handler = vi.fn(() => cacheable({ hits: [] }))
+      const app = buildSearchApp(kv, handler)
+
+      await app.post(body)
+      await flush()
+
+      expect(kv.put).not.toHaveBeenCalled()
+      expect(handler).toHaveBeenCalledOnce()
+    })
+
+    it("bypasses the cache for an oversized body", async () => {
+      const kv = fakeKv()
+      const handler = vi.fn(() => cacheable({ hits: [] }))
+      const app = buildSearchApp(kv, handler)
+
+      await app.post({ vertical: "products", note: "x".repeat(64 * 1024) })
+      await flush()
+
+      expect(kv.put).not.toHaveBeenCalled()
+    })
+
+    it("bypasses the cache when a query string is present", async () => {
+      const kv = fakeKv()
+      const handler = vi.fn(() => cacheable({ hits: [] }))
+      const app = new Hono<{ Bindings: TestBindings }>()
+      app.use("*", publicResponseCache({ bodyKeyedPaths: [SEARCH] }))
+      app.post(SEARCH, handler)
+      const env = { DATABASE_URL: "x", CACHE: kv }
+
+      await app.request(
+        `${SEARCH}?trace=1`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ vertical: "products" }),
+        },
+        testEnv(env),
+      )
+      await flush()
+
+      expect(kv.put).not.toHaveBeenCalled()
+    })
+
+    it("bypasses the cache for a non-JSON body", async () => {
+      const kv = fakeKv()
+      const handler = vi.fn(() => cacheable({ hits: [] }))
+      const app = new Hono<{ Bindings: TestBindings }>()
+      app.use("*", publicResponseCache({ bodyKeyedPaths: [SEARCH] }))
+      app.post(SEARCH, handler)
+      const env = { DATABASE_URL: "x", CACHE: kv }
+
+      await app.request(
+        SEARCH,
+        {
+          method: "POST",
+          headers: { "content-type": "text/plain" },
+          body: "vertical=products",
+        },
+        testEnv(env),
+      )
+      await flush()
+
+      expect(kv.put).not.toHaveBeenCalled()
+    })
+
+    it("neither reads nor writes for a credentialed body-keyed request", async () => {
+      const kv = fakeKv()
+      const handler = vi.fn(() => cacheable({ hits: [] }))
+      const app = buildSearchApp(kv, handler)
+
+      await app.post({ vertical: "products" })
+      await flush()
+      expect(kv.put).toHaveBeenCalledOnce()
+
+      const authed = await app.post(
+        { vertical: "products" },
+        { headers: { authorization: "Bearer t" } },
+      )
+      await flush()
+
+      expect(authed.headers.get("x-voyant-cache")).toBeNull()
+      expect(handler).toHaveBeenCalledTimes(2)
+      expect(kv.put).toHaveBeenCalledOnce()
+    })
+
+    it("does not share an entry between storefront keys for the same body", async () => {
+      const kv = fakeKv()
+      const handler = vi.fn(() => cacheable({ hits: [] }))
+      const app = buildSearchApp(kv, handler)
+
+      await app.post({ vertical: "products" }, { headers: { "x-api-key": "pk_website" } })
+      await flush()
+      const b2b = await app.post({ vertical: "products" }, { headers: { "x-api-key": "pk_b2b" } })
+      await flush()
+
+      expect(b2b.headers.get("x-voyant-cache")).toBeNull()
+      expect(handler).toHaveBeenCalledTimes(2)
+      expect(kv.store.size).toBe(2)
+    })
+
+    it("leaves the request body readable by the route", async () => {
+      const kv = fakeKv()
+      const seen: unknown[] = []
+      const app = buildSearchApp(kv, (body) => {
+        seen.push(body)
+        return cacheable({ ok: true })
+      })
+
+      await app.post({ vertical: "products", query: "crete" })
+
+      expect(seen).toEqual([{ vertical: "products", query: "crete" }])
+    })
+  })
+
   it("is a transparent no-op when neither Cache API nor KV is available", async () => {
     const handler = vi.fn(
       () =>

--- a/scripts/check-public-cache-policy.mjs
+++ b/scripts/check-public-cache-policy.mjs
@@ -132,8 +132,18 @@ function checkKvCacheBindings() {
 function checkSourceMarkers() {
   requireContains(
     "packages/hono/src/app.ts",
-    "publicResponseCache(config.publicCache ?? {})",
+    "publicResponseCache({",
     "public response cache middleware must stay mounted by default",
+  )
+  requireContains(
+    "packages/hono/src/app.ts",
+    "...(config.publicCache ?? {})",
+    "deployment public-cache config must still override the assembled defaults",
+  )
+  requireContains(
+    "packages/hono/src/app.ts",
+    "bodyKeyedPaths: bodyKeyedCachePaths",
+    "module-declared body-keyed reads must reach the middleware",
   )
   requireContains(
     "packages/hono/src/middleware/public-cache.ts",


### PR DESCRIPTION
Closes #4091. Stacked on #4102 (which is stacked on #4099) — review those first. ADR 0021 (#4094).

## Problem

`publicResponseCache` was GET-only, so `POST /v1/public/catalog/search` — the slowest
public read there is — could not declare a cache policy at all. The gap was filled
downstream by a bespoke cache in the Voyant Cloud dispatcher that hardcoded the route
path, invented its own TTL, and omitted `stale-while-revalidate`. Self-hosted got
nothing, and any second body-keyed read would have needed the same bespoke treatment.

## Change

A module declares participation with `bodyKeyedCache: ["/search"]` — public sub-paths,
same shape as `anonymous`/`optionalCustomerAuth`. `assembleBodyKeyedCachePaths` turns
those into absolute paths and `app.ts` hands them to the middleware.

**Why a mount-time declaration and not a header.** The middleware has to read and
canonicalize the request body *before* the route runs, and a `Cache-Control` header only
exists on the way back. So eligibility is declared next to the routes; the policy itself
still lives on the response, which is what lets an edge tier honour the same contract
instead of matching a path.

**Keying.** URL + variant-header digest (from #4099) + SHA-256 of the canonicalized body,
with object keys sorted at every depth so property order doesn't fragment entries.

**Fail-closed bypasses**, all going to the origin uncached:

- a query string — an unknown parameter may gain meaning later and must not alias a body-only key
- non-JSON content type, or a body that is not a JSON object
- body over 64 KiB (matching the dispatcher's existing bound)
- `Authorization`
- a caller-specific field anywhere in the payload: embeddings, personalization, session,
  customer, user, preview, debug

**`POST /v1/public/catalog/search` declares a policy** — `public, s-maxage=60,
stale-while-revalidate=300` for an empty-query browse (the storefront landing read:
hottest, changes least), `s-maxage=30` for a keyword search. Public surface only; the
staff surface is never shared-cached.

The TTLs stay short deliberately. Without a catalog projection generation in the key
(voyant-travel/platform#1726) the clock is the only invalidation there is, so a longer
window would just mean staler results with no bound but time.

## Docs and guardrail

`public-route-cache-policy.md` gains a `body-keyed-shared-cache` class and its
"Catalog POST search" row now describes the declared policy instead of saying it cannot
be cached. Authoring rule 4 is rewritten: header variance is fine when the header is a
key contributor. `check-public-cache-policy.mjs` asserts the new mount shape and that
module-declared paths reach the middleware.

## Verification

| Command | Result |
| --- | --- |
| `pnpm --filter @voyant-travel/hono test` | 348 passed (36 files) |
| `pnpm --filter @voyant-travel/hono typecheck` | pass |
| `catalog: vitest run src/search/routes.test.ts` | 14 passed |
| `node scripts/check-public-cache-policy.mjs` | OK |
| `biome check` on touched trees | clean |

Full `@voyant-travel/catalog` typecheck was still running locally when I pushed (this
monorepo's catalog typecheck takes >15 min under load) — CI is the authoritative run
here. 12 new body-keyed tests cover the round trip, body keying, key-order stability,
undeclared paths, every bypass, credentialed requests, per-storefront isolation, and that
the route can still read the body the middleware inspected.
