### PR TITLE
feat(framework): make the response-cache posture declarable and report it

### DIFF
--- a/.changeset/response-cache-posture.md
+++ b/.changeset/response-cache-posture.md
@@ -1,0 +1,58 @@
+---
+"@voyant-travel/graph-contracts": minor
+"@voyant-travel/framework": minor
+"@voyant-travel/operator-standard": minor
+"@voyant-travel/runtime": patch
+---
+
+Make the response-cache posture of a deployment declarable, and report it.
+
+A route that declares `Cache-Control: public, s-maxage=900` is addressing every
+shared cache at once, but nothing told its author which of them the deployment
+actually has. The standard self-hosted profile selects `cache: "postgres"`, so
+the tier meant to shield the database *is* the database, with only a per-process
+in-memory cache in front of it whose entries are capped at 60 seconds. Managed
+deployments select Redis and put the Voyant Cloud dispatcher at the edge. The
+two products cached public responses very differently and neither said so.
+
+`deployment.responseCache` is where a deployment now states how it serves shared
+public responses:
+
+    responseCache: { edge: "declared" | "none" }
+
+`"declared"` means an HTTP cache in front of the origin honours the route's
+`Cache-Control` — a CDN, a reverse proxy, or the dispatcher. `"none"` means the
+origin is the only shared cache. The field is optional and absent reads as
+`"none"`, never as a tier that might be there.
+
+It is deliberately not a provider role. Nothing is bound or constructed from it,
+so it has no entry in `VoyantDeploymentProviders` or
+`DEPLOYMENT_PROVIDER_CONTRACTS`. It records the one thing the provider
+selections cannot express — whether anything sits in front of the origin — and
+it travels with the deployment through `defineProject`, the resolved graph, and
+the generated Node artifact.
+
+The Node runtime reports three postures once at startup, on the console channel
+the generated entrypoint already uses for boot messages:
+
+- public routes mounted over `cache: "postgres"` with no declared edge tier,
+  naming both remedies: a response cache that is not the database, or an edge
+  tier the deployment declares;
+- `rateLimit: "memory"`, which keeps counters per process — the runtime cannot
+  observe the instance count, so it states the condition rather than guessing
+  the multiplier;
+- `sharedState: "memory"`, which is not shared across processes despite the name.
+
+None of these fail the boot. Every posture is supported; what was not supported
+was the deployment being unable to tell.
+
+`@voyant-travel/operator-standard` declares `{ edge: "none" }`, which is what it
+already was. Its `cache` provider is unchanged — the point is to make the choice
+visible, not to change it. The guardrail in
+`scripts/check-public-cache-policy.mjs` now asserts that the standard profile
+declares a posture rather than pinning the `cache: "postgres"` literal that kept
+the pattern in place.
+
+See ADR 0021 section 7 and `docs/architecture/caching-architecture.md` rule 12,
+which documents the two postures a self-hosted deployment can declare to reach
+managed response-caching behaviour without adopting a Voyant-specific component.

--- a/docs/architecture/caching-architecture.md
+++ b/docs/architecture/caching-architecture.md
@@ -19,6 +19,12 @@ The goal is simple:
 
 Caching should be a performance optimization, not part of the correctness model.
 
+This guide governs cache-aside *data* caching. HTTP *response* caching — the
+tier in front of the origin, the `Cache-Control` a public route declares, and
+which deployment postures can honour it — is owned by
+[ADR 0021](../adr/0021-http-response-cache-tiers.md). Rule 12 below states only
+what a deployment has to declare; the reasoning lives in the ADR.
+
 For active guidance on transactions, row locks, and when a first-class locking
 surface is still deferred, see
 [`locking-and-concurrency-policy.md`](./locking-and-concurrency-policy.md).
@@ -229,6 +235,60 @@ Rule:
 
 Cache backend selection is a deployment concern, not a reason to fork the
 framework surface.
+
+### 12. A deployment that serves public routes declares its response-cache posture
+
+Rule 11 leaves the cache backend with the deployment. Serving a public
+storefront adds a second choice the backend cannot express: whether anything
+caches responses *in front of* the origin. `deployment.responseCache` is where
+that is stated.
+
+    responseCache: { edge: "declared" | "none" }
+
+Two postures are supported, and both reach the same behaviour:
+
+- **Origin-cached.** A non-database shared cache at the origin —
+  `providers.cache: "redis"` — with `responseCache: { edge: "none" }`. Every
+  process shares one cache; the database is not in the response path.
+- **Edge-cached.** A standards-compliant HTTP cache in front of the origin — a
+  CDN, a reverse proxy, or the Voyant Cloud dispatcher — with
+  `responseCache: { edge: "declared" }`. The origin cache then only backstops
+  what the edge misses, so a small deployment can keep `providers.cache:
+  "memory"` behind it.
+
+Absent means undeclared, and undeclared reads as `"none"`. The standard
+self-hosted profile declares `{ edge: "none" }` over `providers.cache:
+"postgres"`, which is the one combination the Node runtime reports at startup:
+shared public responses are read from and written to the same Postgres the
+routes query, and the only tier in front of it is a per-process in-memory cache
+capped at 60 seconds. That posture is supported and reasonable for a small
+single-instance deployment. It is not a posture for serving a storefront under
+load, which is why it is reported rather than assumed.
+
+The same profile selects per-process `sharedState` and `rateLimit`, which the
+runtime reports for the same reason: a per-process rate limit means N instances
+enforce the configured limit N times over. The standard profile is a
+single-instance profile until those are moved to a cross-process provider.
+
+**Parity is a declaration, not a component.** Managed deployments get their
+response caching from Redis at the origin plus the dispatcher at the edge. A
+self-hosted deployment reaches the same behaviour by declaring one of the two
+postures above — it does not need any Voyant-specific component to do it. That
+holds only because the framework's obligation is *standard* HTTP cache
+semantics: routes declare `Cache-Control: public, s-maxage=…,
+stale-while-revalidate=…`, and the framework emits and honours `s-maxage`,
+`stale-while-revalidate`, `Vary`, and request-side `no-cache`/`no-store`. Any
+conforming shared cache can therefore substitute for any other, which is what
+makes an ordinary CDN an exact substitute for the dispatcher. A host-specific
+cache keyed on a hardcoded route path would not be substitutable, and is a
+defect under [ADR 0021](../adr/0021-http-response-cache-tiers.md).
+
+Rule:
+
+A deployment that mounts public routes declares how it serves them. Undeclared
+is read as no tier in front of the origin, and a database-backed response cache
+with no declared edge tier is reported at startup rather than left for a route
+author to discover from a header that did not behave as written.
 
 ## Practical Checklist
 

--- a/packages/framework/src/deployment-artifacts.ts
+++ b/packages/framework/src/deployment-artifacts.ts
@@ -643,6 +643,9 @@ export function buildProjectRuntimeModule(input: BuildProjectRuntimeModuleInput)
   const deployment = {
     ...(input.graph.deployment.mode ? { mode: input.graph.deployment.mode } : {}),
     providers: input.graph.deployment.providers,
+    ...(input.graph.deployment.responseCache
+      ? { responseCache: input.graph.deployment.responseCache }
+      : {}),
   }
 
   return `${graphRuntime}
@@ -846,7 +849,7 @@ export function resolveGeneratedRuntimeDeployment(): VoyantNodeRuntimeDeployment
   if (!deployment || typeof deployment !== "object" || Array.isArray(deployment)) {
     throw new Error("Generated deployment graph deployment is missing or invalid")
   }
-  const candidate = deployment as { mode?: unknown; providers?: unknown }
+  const candidate = deployment as { mode?: unknown; providers?: unknown; responseCache?: unknown }
   if (
     candidate.mode !== "local" &&
     candidate.mode !== "managed-cloud" &&
@@ -861,7 +864,22 @@ export function resolveGeneratedRuntimeDeployment(): VoyantNodeRuntimeDeployment
   return {
     mode: candidate.mode,
     providers,
+    ...(candidate.responseCache === undefined
+      ? {}
+      : { responseCache: generatedResponseCachePosture(candidate.responseCache) }),
   }
+}
+
+function generatedResponseCachePosture(
+  value: unknown,
+): NonNullable<VoyantNodeRuntimeDeployment["responseCache"]> {
+  const edge = isGeneratedRecord(value) ? value.edge : undefined
+  if (edge !== "declared" && edge !== "none") {
+    throw new Error(
+      'Generated deployment graph deployment.responseCache.edge must be "declared" or "none"',
+    )
+  }
+  return { edge }
 }
 
 function requireGeneratedDeploymentProvider<
@@ -886,7 +904,7 @@ function isGeneratedRecord(value: unknown): value is Record<string, unknown> {
 function readGeneratedDeploymentGraph(): {
   schemaVersion?: unknown
   contentHash?: unknown
-  deployment?: { target?: unknown; mode?: unknown; providers?: unknown }
+  deployment?: { target?: unknown; mode?: unknown; providers?: unknown; responseCache?: unknown }
   requirements?: unknown
   diagnostics?: unknown
 } {
@@ -898,7 +916,7 @@ function readGeneratedDeploymentGraph(): {
   ) as {
     schemaVersion?: unknown
     contentHash?: unknown
-    deployment?: { target?: unknown; mode?: unknown; providers?: unknown }
+    deployment?: { target?: unknown; mode?: unknown; providers?: unknown; responseCache?: unknown }
     requirements?: unknown
     diagnostics?: unknown
   }

--- a/packages/framework/src/deployment-graph.test.ts
+++ b/packages/framework/src/deployment-graph.test.ts
@@ -270,6 +270,28 @@ describe("deployment graph v1", () => {
     )
   })
 
+  it("carries a declared response-cache posture from the project into the resolved graph", async () => {
+    const declared = defineProject({
+      modules: [],
+      deployment: { responseCache: { edge: "declared" } },
+    })
+    const undeclared = defineProject({ modules: [] })
+
+    expect((await resolveDeploymentGraph({ project: declared })).deployment.responseCache).toEqual({
+      edge: "declared",
+    })
+    // Absent stays absent in the artifact; the runtime is what reads it as "none".
+    expect(
+      (await resolveDeploymentGraph({ project: undeclared })).deployment.responseCache,
+    ).toBeUndefined()
+    expect(() =>
+      defineProject({
+        modules: [],
+        deployment: { responseCache: { edge: "cdn" } as never },
+      }),
+    ).toThrow(/deployment\.responseCache\.edge/)
+  })
+
   it("normalizes legacy v1 projects without an extension lane", async () => {
     const plugin = definePlugin({ id: "@acme/voyant-fiscal#smartbill" })
     const project = defineProject({ modules: [], plugins: [plugin] })

--- a/packages/framework/src/deployment-graph.ts
+++ b/packages/framework/src/deployment-graph.ts
@@ -36,6 +36,7 @@ import {
   type VoyantGraphProjectDeploymentMigration,
   type VoyantGraphProjectDeploymentMode,
   type VoyantGraphProjectJobScheduling,
+  type VoyantGraphProjectResponseCache,
   type VoyantGraphProjectSelections,
   type VoyantGraphProviderDeclaration,
   type VoyantGraphReportingCatalog,
@@ -306,6 +307,8 @@ export interface DefineVoyantGraphDeploymentInput {
   providers?: Partial<Record<VoyantDeploymentProviderRole | string, string>>
   migrations?: readonly VoyantGraphProjectDeploymentMigration[]
   mode?: VoyantGraphProjectDeploymentMode
+  /** How shared public responses reach requesters. See ADR 0021 section 7. */
+  responseCache?: VoyantGraphProjectResponseCache
   requirements?: VoyantGraphDeploymentRequirements
   meta?: VoyantGraphJsonObject
 }
@@ -324,6 +327,8 @@ export interface VoyantGraphDeployment {
   providers: Partial<Record<VoyantDeploymentProviderRole | string, string>>
   migrations?: readonly VoyantGraphProjectDeploymentMigration[]
   mode?: VoyantGraphProjectDeploymentMode
+  /** How shared public responses reach requesters. See ADR 0021 section 7. */
+  responseCache?: VoyantGraphProjectResponseCache
   requirements: VoyantGraphDeploymentRequirements
   meta?: VoyantGraphJsonObject
 }
@@ -456,6 +461,7 @@ export interface ResolvedVoyantDeploymentGraph {
     mode?: VoyantGraphProjectDeploymentMode
     providers: Partial<Record<VoyantDeploymentProviderRole | string, string>>
     migrations?: readonly VoyantGraphProjectDeploymentMigration[]
+    responseCache?: VoyantGraphProjectResponseCache
   }
   requirements: VoyantGraphDeploymentRequirements
   modules: readonly ResolvedVoyantGraphUnit[]
@@ -583,6 +589,11 @@ export function defineDeployment(input: DefineVoyantGraphDeploymentInput): Voyan
     providers,
     ...(input.migrations?.length ? { migrations: [...input.migrations] } : {}),
     ...(input.mode ? { mode: input.mode } : {}),
+    ...(input.responseCache
+      ? { responseCache: { edge: input.responseCache.edge } }
+      : input.project.deployment?.responseCache
+        ? { responseCache: { edge: input.project.deployment.responseCache.edge } }
+        : {}),
     requirements: normalizeDeploymentRequirements(
       input.requirements ?? deriveDeploymentRequirements(providers),
     ),
@@ -735,6 +746,7 @@ export async function resolveDeploymentGraph(
   const deploymentProviders = canonicalDeploymentProviders(input.deployment?.providers)
   const requirements = normalizeDeploymentRequirements(input.deployment?.requirements)
   const migrations = input.deployment?.migrations ?? input.project.deployment?.migrations
+  const responseCache = input.deployment?.responseCache ?? input.project.deployment?.responseCache
   const selectionConfigById = new Map(
     [
       ...(input.project.selections?.modules ?? []),
@@ -839,6 +851,7 @@ export async function resolveDeploymentGraph(
       ...(mode ? { mode } : {}),
       providers: deploymentProviders,
       ...(migrations?.length ? { migrations: [...migrations] } : {}),
+      ...(responseCache ? { responseCache: { edge: responseCache.edge } } : {}),
     },
     requirements,
     modules,

--- a/packages/framework/src/deployment-types.ts
+++ b/packages/framework/src/deployment-types.ts
@@ -18,6 +18,41 @@ export interface VoyantRedisBindingConstraints {
   network: VoyantRedisBindingNetwork
 }
 
+/**
+ * Whether an HTTP cache in front of the origin honours the route's
+ * `Cache-Control`.
+ *
+ * `"declared"` means the deployment has put one there — a CDN, a reverse proxy,
+ * or the Voyant Cloud dispatcher. `"none"` means the origin is the only shared
+ * cache a public response ever reaches.
+ */
+export type VoyantResponseCacheEdgeTier = "declared" | "none"
+
+/**
+ * How shared public responses reach requesters.
+ *
+ * This is a property of the deployment, not a provider role: nothing is bound
+ * or constructed from it, so it has no entry in {@link VoyantDeploymentProviders}.
+ * It records the one thing the provider selections cannot express — whether
+ * anything caches responses in front of the origin — so a deployment that
+ * mounts public routes states its posture instead of leaving it inferred.
+ */
+export interface VoyantResponseCachePosture {
+  edge: VoyantResponseCacheEdgeTier
+}
+
+/** Undeclared reads as no HTTP cache in front of the origin, never as one. */
+export const DEFAULT_RESPONSE_CACHE_POSTURE = {
+  edge: "none",
+} as const satisfies VoyantResponseCachePosture
+
+/** Read a declared posture, or the conservative default when none was declared. */
+export function resolveResponseCachePosture(
+  posture: VoyantResponseCachePosture | undefined,
+): VoyantResponseCachePosture {
+  return posture ?? DEFAULT_RESPONSE_CACHE_POSTURE
+}
+
 export type VoyantDeploymentProviderRole =
   | "database"
   | "storage"

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -26,8 +26,10 @@ export {
 export {
   canonicalDeploymentProvider,
   DEFAULT_MANAGED_CLOUD_PROVIDERS,
+  DEFAULT_RESPONSE_CACHE_POSTURE,
   DEPLOYMENT_PROVIDER_CONTRACTS,
   DEPLOYMENT_PROVIDER_ROLES,
+  resolveResponseCachePosture,
   type VoyantDeploymentEnvRequirement,
   type VoyantDeploymentEnvValueFormat,
   type VoyantDeploymentMode,
@@ -37,6 +39,8 @@ export {
   type VoyantRedisBindingConstraints,
   type VoyantRedisBindingIsolation,
   type VoyantRedisBindingNetwork,
+  type VoyantResponseCacheEdgeTier,
+  type VoyantResponseCachePosture,
 } from "./deployment-types.js"
 export {
   type DeploymentExtensionDeclaration,

--- a/packages/framework/src/node-provider-plan.test.ts
+++ b/packages/framework/src/node-provider-plan.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest"
 
+import { DEFAULT_RESPONSE_CACHE_POSTURE, resolveResponseCachePosture } from "./deployment-types"
 import {
   resolveVoyantNodeProviderPlan,
   validateVoyantNodeProviderPlanEnv,
+  voyantNodeDeploymentPostureReports,
 } from "./node-provider-plan"
 
 describe("resolveVoyantNodeProviderPlan", () => {
@@ -129,5 +131,88 @@ describe("resolveVoyantNodeProviderPlan", () => {
         rateLimit: "memory",
       }),
     ).toThrow(/providers\.sharedState/)
+  })
+})
+
+describe("response cache posture", () => {
+  const postgresCachePlan = resolveVoyantNodeProviderPlan({
+    storage: "memory",
+    cache: "postgres",
+    sharedState: "redis",
+    rateLimit: "redis",
+  })
+
+  it("reads an undeclared posture as no edge tier in front of the origin", () => {
+    expect(DEFAULT_RESPONSE_CACHE_POSTURE).toEqual({ edge: "none" })
+    expect(resolveResponseCachePosture(undefined)).toEqual({ edge: "none" })
+    expect(resolveResponseCachePosture({ edge: "declared" })).toEqual({ edge: "declared" })
+  })
+
+  it("reports a database-backed response cache with no declared edge tier", () => {
+    const reports = voyantNodeDeploymentPostureReports({
+      plan: postgresCachePlan,
+      mountsPublicRoutes: true,
+    })
+
+    expect(reports).toHaveLength(1)
+    expect(reports[0]).toContain('deployment.providers.cache = "postgres" and no declared edge')
+    expect(reports[0]).toContain("the same Postgres the routes query")
+    expect(reports[0]).toContain("capped at 60 seconds")
+    expect(reports[0]).toContain('deployment.providers.cache = "redis"')
+    expect(reports[0]).toContain('deployment.responseCache = { edge: "declared" }')
+  })
+
+  it("does not report a database-backed cache when an edge tier is declared", () => {
+    expect(
+      voyantNodeDeploymentPostureReports({
+        plan: postgresCachePlan,
+        responseCache: { edge: "declared" },
+        mountsPublicRoutes: true,
+      }),
+    ).toEqual([])
+  })
+
+  it("does not report a response cache that is not the database", () => {
+    expect(
+      voyantNodeDeploymentPostureReports({
+        plan: resolveVoyantNodeProviderPlan({
+          storage: "memory",
+          cache: "redis",
+          sharedState: "redis",
+          rateLimit: "redis",
+        }),
+        responseCache: { edge: "none" },
+        mountsPublicRoutes: true,
+      }),
+    ).toEqual([])
+  })
+
+  it("does not report a response-cache posture when no public routes are mounted", () => {
+    expect(
+      voyantNodeDeploymentPostureReports({
+        plan: postgresCachePlan,
+        responseCache: { edge: "none" },
+        mountsPublicRoutes: false,
+      }),
+    ).toEqual([])
+  })
+
+  it("states the per-process condition for memory rate limiting and shared state", () => {
+    const reports = voyantNodeDeploymentPostureReports({
+      plan: resolveVoyantNodeProviderPlan({
+        storage: "memory",
+        cache: "redis",
+        sharedState: "memory",
+        rateLimit: "memory",
+      }),
+      responseCache: { edge: "declared" },
+      mountsPublicRoutes: true,
+    })
+
+    expect(reports).toHaveLength(2)
+    expect(reports[0]).toContain('deployment.providers.rateLimit = "memory"')
+    expect(reports[0]).toContain("cannot observe how many instances or processes")
+    expect(reports[1]).toContain('deployment.providers.sharedState = "memory"')
+    expect(reports[1]).toContain("nothing is shared despite the name")
   })
 })

--- a/packages/framework/src/node-provider-plan.ts
+++ b/packages/framework/src/node-provider-plan.ts
@@ -1,3 +1,5 @@
+import { resolveResponseCachePosture, type VoyantResponseCachePosture } from "./deployment-types.js"
+
 export type VoyantNodeObjectStorageProvider = "memory" | "s3-compatible" | "gateway" | "custom"
 export type VoyantNodeKvProvider = "memory" | "postgres" | "redis"
 
@@ -49,6 +51,57 @@ export function validateVoyantNodeProviderPlanEnv(
     issues.push("env DATABASE_URL or DATABASE_URL_DIRECT is required by the Node provider plan")
   }
   return issues
+}
+
+export interface VoyantNodeDeploymentPostureInput {
+  plan: VoyantNodeProviderPlan
+  /** Declared response-cache posture, or undefined when the deployment declared none. */
+  responseCache?: VoyantResponseCachePosture
+  /** Whether the composed graph mounts any public route surface. */
+  mountsPublicRoutes: boolean
+}
+
+/**
+ * Describe the deployment postures a route author cannot see from the header
+ * they wrote.
+ *
+ * These are reports, not failures: every posture below is supported, and a
+ * single-instance deployment behind its own reverse proxy may want each one.
+ * What is not supported is the deployment being unable to tell.
+ */
+export function voyantNodeDeploymentPostureReports(
+  input: VoyantNodeDeploymentPostureInput,
+): string[] {
+  const reports: string[] = []
+  const posture = resolveResponseCachePosture(input.responseCache)
+
+  if (input.mountsPublicRoutes && input.plan.cache === "postgres" && posture.edge === "none") {
+    reports.push(
+      'Public routes are mounted with deployment.providers.cache = "postgres" and no declared edge tier. ' +
+        "Shared public responses will be read from and written to the same Postgres the routes query, so the tier meant to shield the database is the database. " +
+        "The only tier in front of it is a per-process in-memory cache whose entries are capped at 60 seconds, so a route declaring a longer s-maxage still reaches Postgres once per process per minute. " +
+        'Either select a response cache that is not the database (deployment.providers.cache = "redis"), or put a standards-compliant HTTP cache in front of the origin and declare it (deployment.responseCache = { edge: "declared" }). ' +
+        "See docs/adr/0021-http-response-cache-tiers.md section 7.",
+    )
+  }
+
+  if (input.plan.rateLimit === "memory") {
+    reports.push(
+      'deployment.providers.rateLimit = "memory" keeps rate-limit counters in this process only. ' +
+        "This runtime cannot observe how many instances or processes serve the deployment; if it is more than one, each enforces the configured limit on its own counter and the effective limit is that many times the declared one. " +
+        'Select "redis" or "postgres" for a shared counter, or run exactly one instance.',
+    )
+  }
+
+  if (input.plan.sharedState === "memory") {
+    reports.push(
+      'deployment.providers.sharedState = "memory" keeps state in this process only, so nothing is shared despite the name. ' +
+        "This runtime cannot observe how many instances or processes serve the deployment; if it is more than one, each holds its own copy and no write crosses them. " +
+        'Select "redis" or "postgres" for cross-process state, or run exactly one instance.',
+    )
+  }
+
+  return reports
 }
 
 function objectStorageProvider(

--- a/packages/framework/src/node-runtime.ts
+++ b/packages/framework/src/node-runtime.ts
@@ -47,6 +47,7 @@ import type {
   VoyantDeploymentMode,
   VoyantDeploymentProviders,
   VoyantRedisBindingConstraints,
+  VoyantResponseCachePosture,
 } from "./deployment-types.js"
 import { lowerVoyantGraphActionsToActionLedgerRegistry } from "./graph-action-ledger.js"
 import {
@@ -57,9 +58,11 @@ import {
 } from "./node-job-host.js"
 import {
   resolveVoyantNodeProviderPlan,
+  type VoyantNodeDeploymentPostureInput,
   type VoyantNodeKvProvider,
   type VoyantNodeProviderPlan,
   validateVoyantNodeProviderPlanEnv,
+  voyantNodeDeploymentPostureReports,
 } from "./node-provider-plan.js"
 import { createLazyNodeRedisTcpClient } from "./node-redis-client.js"
 import { composeVoyantGraphRuntime } from "./runtime-composition.js"
@@ -197,6 +200,8 @@ export interface VoyantNodeRuntimeDeployment {
     Partial<Pick<VoyantDeploymentProviders, "scheduledJobs">>
   /** Explicit properties of the concrete Redis binding selected at boot. */
   redis?: VoyantRedisBindingConstraints
+  /** How shared public responses reach requesters. Absent reads as no edge tier. */
+  responseCache?: VoyantResponseCachePosture
 }
 
 /** Inputs for booting a generated application graph in a resident Node process. */
@@ -344,6 +349,15 @@ export async function loadVoyantNodeRuntime(
     requirements,
     env,
     hasAuthIntegration: Boolean(auth),
+  })
+  reportVoyantNodeDeploymentPosture({
+    plan: providerPlan,
+    ...(options.deployment.responseCache
+      ? { responseCache: options.deployment.responseCache }
+      : {}),
+    mountsPublicRoutes:
+      graphComposition.routePosture.publicPaths.length > 0 ||
+      (options.app?.publicPaths?.length ?? 0) > 0,
   })
   const applicationId = options.applicationId?.trim() || "application"
   const app = createVoyantNodeApp({
@@ -732,6 +746,17 @@ function assertVoyantNodeRuntimeSupport(options: {
   }
 }
 
+/**
+ * Report the deployment postures a route author cannot see from the header
+ * they wrote. Reported once per runtime load, on the same console channel the
+ * generated Node entrypoint already uses for boot messages.
+ */
+function reportVoyantNodeDeploymentPosture(input: VoyantNodeDeploymentPostureInput): void {
+  for (const report of voyantNodeDeploymentPostureReports(input)) {
+    console.warn(`[node-runtime] ${report}`)
+  }
+}
+
 function resolveRedisBindingConstraints(
   deployment: VoyantNodeRuntimeDeployment,
 ): VoyantRedisBindingConstraints {
@@ -845,8 +870,17 @@ function resolveDb(env: unknown): VoyantDb {
   return resolveNodeDatabase(env as VoyantNodeRuntimeEnv) as VoyantDb
 }
 
-export type { StorageProvider, StorageProviderResolver, VoyantNodeProviderPlan }
-export { resolveVoyantNodeProviderPlan, validateVoyantNodeProviderPlanEnv }
+export type {
+  StorageProvider,
+  StorageProviderResolver,
+  VoyantNodeDeploymentPostureInput,
+  VoyantNodeProviderPlan,
+}
+export {
+  resolveVoyantNodeProviderPlan,
+  validateVoyantNodeProviderPlanEnv,
+  voyantNodeDeploymentPostureReports,
+}
 
 /**
  * Flatten the runtime env bag (string vars + provider bindings) into a plain

--- a/packages/framework/src/project-config.test.ts
+++ b/packages/framework/src/project-config.test.ts
@@ -67,4 +67,14 @@ describe("framework project config", () => {
       providers: { database: "postgres", cache: "postgres", storage: "memory" },
     })
   })
+
+  it("declares the standard response-cache posture and lets an author override it", () => {
+    expect(defineConfig().deployment?.responseCache).toEqual({ edge: "none" })
+
+    expect(
+      defineConfig({
+        deployment: { responseCache: { edge: "declared" } },
+      }).deployment?.responseCache,
+    ).toEqual({ edge: "declared" })
+  })
 })

--- a/packages/graph-contracts/src/index.ts
+++ b/packages/graph-contracts/src/index.ts
@@ -477,6 +477,20 @@ export interface VoyantGraphProjectDeploymentMigration {
 }
 
 /**
+ * How shared public responses reach requesters.
+ *
+ * `edge: "declared"` states that an HTTP cache in front of the origin honours
+ * the route's `Cache-Control`; `"none"` states that the origin is the only
+ * shared cache. Absent means undeclared, which reads as `"none"`.
+ *
+ * This is a deployment property, not a provider role: no component is resolved
+ * from it, so it is not part of `providers`.
+ */
+export interface VoyantGraphProjectResponseCache {
+  edge: "declared" | "none"
+}
+
+/**
  * Unified application graphs always compile to the Node runtime. Hosting
  * choices such as Voyant Cloud, Docker, Fly, or Railway are CLI target adapters
  * for that Node artifact, not alternate application runtimes.
@@ -486,6 +500,8 @@ export interface VoyantGraphProjectDeployment {
   mode?: VoyantGraphProjectDeploymentMode
   providers?: Readonly<Record<string, string>>
   migrations?: readonly VoyantGraphProjectDeploymentMigration[]
+  /** Declared by a deployment that mounts public routes. See ADR 0021 section 7. */
+  responseCache?: VoyantGraphProjectResponseCache
 }
 
 /** A host preference may select only package-declared profile names. */
@@ -730,11 +746,24 @@ function normalizeProjectDeployment(
     )
   }
 
+  let responseCache: VoyantGraphProjectResponseCache | undefined
+  if (input.responseCache !== undefined) {
+    if (!isPlainObject(input.responseCache)) {
+      throw new Error("defineProject: deployment.responseCache must be a plain object.")
+    }
+    const edge = (input.responseCache as { edge?: unknown }).edge
+    if (edge !== "declared" && edge !== "none") {
+      throw new Error('defineProject: deployment.responseCache.edge must be "declared" or "none".')
+    }
+    responseCache = { edge }
+  }
+
   if (
     !target &&
     input.mode === undefined &&
     Object.keys(providers).length === 0 &&
-    migrations.length === 0
+    migrations.length === 0 &&
+    responseCache === undefined
   ) {
     return undefined
   }
@@ -743,6 +772,7 @@ function normalizeProjectDeployment(
     ...(input.mode ? { mode: input.mode } : {}),
     ...(Object.keys(providers).length > 0 ? { providers } : {}),
     ...(migrations.length > 0 ? { migrations } : {}),
+    ...(responseCache ? { responseCache } : {}),
   }
 }
 

--- a/packages/operator-standard/src/index.ts
+++ b/packages/operator-standard/src/index.ts
@@ -95,9 +95,22 @@ export const STANDARD_OPERATOR_ACCESS: VoyantGraphProjectAccessDeclaration = {
   ],
 }
 
+/**
+ * The standard profile is a single-instance, self-hosted Node deployment that
+ * runs on nothing but Postgres, so it declares the posture that follows from
+ * that: no HTTP cache in front of the origin, and per-process `sharedState` and
+ * `rateLimit`. The declaration does not endorse the posture — it makes it
+ * visible, and the runtime reports the consequences at startup. A deployment
+ * that puts a CDN or reverse proxy in front of the origin overrides
+ * `responseCache` in its own `voyant.config.ts`.
+ *
+ * See docs/adr/0021-http-response-cache-tiers.md section 7 and
+ * docs/architecture/caching-architecture.md section 12.
+ */
 export const STANDARD_OPERATOR_DEPLOYMENT: VoyantGraphProjectDeployment = {
   target: "node",
   mode: "self-hosted",
+  responseCache: { edge: "none" },
   providers: {
     database: "postgres",
     storage: "memory",

--- a/packages/operator-standard/tests/standard-package-manifests.test.ts
+++ b/packages/operator-standard/tests/standard-package-manifests.test.ts
@@ -26,6 +26,15 @@ import {
 } from "../src/index.js"
 
 describe("standard package manifests", () => {
+  it("declares its response-cache posture alongside the cache backend it selected", () => {
+    // The profile is a single-instance self-hosted deployment with nothing but
+    // Postgres, so it declares that nothing caches responses in front of the
+    // origin. ADR 0021 section 7: the posture has to be one the deployment can
+    // observe, whichever backend it chose.
+    expect(STANDARD_OPERATOR_DEPLOYMENT.responseCache).toEqual({ edge: "none" })
+    expect(STANDARD_OPERATOR_DEPLOYMENT.providers?.cache).toBe("postgres")
+  })
+
   it("selects durable Postgres outbound webhook enqueueing explicitly", () => {
     expect(STANDARD_OPERATOR_DEPLOYMENT.providers?.outboundWebhooks).toBe("postgres")
     expect(validateGraphUnitManifest(operatorWebhooksVoyantModule, "module")).toEqual([])

--- a/packages/runtime/src/deployment-bindings.ts
+++ b/packages/runtime/src/deployment-bindings.ts
@@ -3,6 +3,7 @@ import {
   DEPLOYMENT_PROVIDER_CONTRACTS,
   type VoyantDeploymentMode,
   type VoyantRedisBindingConstraints,
+  type VoyantResponseCachePosture,
 } from "@voyant-travel/framework"
 
 export const VOYANT_DEPLOYMENT_BINDINGS_ENV = "VOYANT_DEPLOYMENT_BINDINGS_JSON" as const
@@ -10,6 +11,8 @@ export const VOYANT_DEPLOYMENT_BINDINGS_ENV = "VOYANT_DEPLOYMENT_BINDINGS_JSON" 
 export interface GeneratedRuntimeDeploymentBindings {
   mode?: VoyantDeploymentMode
   providers: Readonly<Record<string, string>>
+  /** Declared response-cache posture, carried verbatim from the generated graph. */
+  responseCache?: VoyantResponseCachePosture
 }
 
 export interface ResolvedRuntimeDeploymentBindings {
@@ -17,6 +20,8 @@ export interface ResolvedRuntimeDeploymentBindings {
   mode?: VoyantDeploymentMode
   providers: Readonly<Record<string, string>>
   redis: VoyantRedisBindingConstraints
+  /** Undefined when the deployment declared none; the runtime reads that as no edge tier. */
+  responseCache?: VoyantResponseCachePosture
   source: "generated" | "runtime"
 }
 
@@ -42,6 +47,7 @@ export function resolveRuntimeDeploymentBindings(
       ...(generated.mode ? { mode: generated.mode } : {}),
       providers: normalizeProviders(generated.providers, "generated deployment providers"),
       redis: legacyRedisConstraints(generated.mode),
+      ...(generated.responseCache ? { responseCache: generated.responseCache } : {}),
       source: "generated",
     }
   }
@@ -84,6 +90,7 @@ export function resolveRuntimeDeploymentBindings(
     ...(generated.mode ? { mode: generated.mode } : {}),
     providers,
     redis: decoded.redis ? parseRedisConstraints(decoded.redis) : dedicatedRedisConstraints(),
+    ...(generated.responseCache ? { responseCache: generated.responseCache } : {}),
     source: "runtime",
   }
 }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -405,6 +405,7 @@ export async function loadVoyantProject(
       ...(deployment.mode ? { mode: deployment.mode } : {}),
       providers: deployment.providers,
       redis: deployment.redis,
+      ...(deployment.responseCache ? { responseCache: deployment.responseCache } : {}),
     },
     deploymentRequirements,
     runtimePorts: deploymentResources.ports,

--- a/packages/runtime/src/project-artifacts.ts
+++ b/packages/runtime/src/project-artifacts.ts
@@ -47,6 +47,7 @@ export interface GeneratedProjectRuntime {
   deployment: {
     mode?: "local" | "managed-cloud" | "self-hosted"
     providers: VoyantNodeRuntime["deployment"]["providers"]
+    responseCache?: VoyantNodeRuntime["deployment"]["responseCache"]
   }
   graphRuntime: VoyantGraphRuntime
   /** Recreate the fixed graph with boot-selected provider bindings. */
@@ -123,7 +124,11 @@ async function loadDeploymentGraphRuntime(artifactRoot: string): Promise<Generat
   const graph = JSON.parse(
     await readFile(path.join(artifactRoot, PROJECT_GRAPH_ENTRY), "utf8"),
   ) as {
-    deployment?: { mode?: GeneratedProjectRuntime["deployment"]["mode"]; providers?: unknown }
+    deployment?: {
+      mode?: GeneratedProjectRuntime["deployment"]["mode"]
+      providers?: unknown
+      responseCache?: GeneratedProjectRuntime["deployment"]["responseCache"]
+    }
   }
   if (
     typeof namespace.GENERATED_GRAPH_RUNTIME_HASH !== "string" ||
@@ -142,6 +147,9 @@ async function loadDeploymentGraphRuntime(artifactRoot: string): Promise<Generat
     deployment: {
       mode: graph.deployment.mode,
       providers: { ...providers },
+      ...(graph.deployment.responseCache
+        ? { responseCache: { ...graph.deployment.responseCache } }
+        : {}),
     },
     graphRuntime: namespace.createGeneratedGraphRuntime(),
     createGraphRuntime: (providerSelections) =>

--- a/scripts/check-public-cache-policy.mjs
+++ b/scripts/check-public-cache-policy.mjs
@@ -36,6 +36,13 @@ function requireNotContains(relativePath, phrase, reason) {
   }
 }
 
+function requireMatches(relativePath, pattern, reason) {
+  const content = read(relativePath)
+  if (!pattern.test(content)) {
+    addViolation(`${relativePath}: missing required pattern ${pattern} (${reason})`)
+  }
+}
+
 function requireNotMatches(relativePath, pattern, reason) {
   const content = read(relativePath)
   if (pattern.test(content)) {
@@ -95,10 +102,14 @@ function checkKvCacheBindings() {
   // The operator is Node-only (voyant#2966): public-cache/rate-limit stores
   // are concrete Node providers in `src/server.ts`, while consumers type
   // against the KVStore-compatible CACHE member and RateLimitStore.
-  requireContains(
+  // The standard profile declares HOW it serves shared public responses, not
+  // WHICH cache backend it happens to select: pinning the backend literal here
+  // pins the pattern in place (ADR 0021 section 7). The posture is what a route
+  // author's `Cache-Control` header depends on, so that is what is asserted.
+  requireMatches(
     "packages/operator-standard/src/index.ts",
-    'cache: "postgres"',
-    "standard Node product cache backend",
+    /responseCache:\s*\{\s*edge:\s*"(declared|none)"\s*,?\s*\}/,
+    "standard profile must declare a response-cache posture",
   )
   requireNotContains(
     "apps/operator/voyant.config.ts",


### PR DESCRIPTION
Closes #4097. Stacked on #4102 — review that first. ADR 0021 §7 (#4094).

## Problem

A route author writes `Cache-Control: public, s-maxage=900` and has no way to learn what
the deployment will actually do with it. `STANDARD_OPERATOR_DEPLOYMENT` is `self-hosted`
with `cache: "postgres"`, `sharedState: "memory"`, `rateLimit: "memory"`, and no edge
tier — so the tier meant to shield the database *is* the database, and rate limiting is
per-process. Managed deployments use `cache: "redis"` plus the dispatcher in front, so
the two products have materially different caching and nothing says so.

Context from #4102: that Postgres cache also silently stored *nothing* until this chain
fixed its `Date` binding. The posture was worse than the issue described.

## Change

**A declarable posture.** `responseCache?: { edge: "declared" | "none" }` on the
deployment — optional, absent reads as `"none"`, and deliberately *not* a new
`VoyantDeploymentProviders` role, since nothing is constructed from it. Carried
project → graph → generated artifact → runtime so a declaration actually reaches boot.

**Three startup reports**, on the console channel the generated Node entrypoint already
uses. They are reports, not failures — every posture is supported; what is not supported
is the deployment being unable to tell. Each names the concrete consequence and both
remedies, e.g. shared public responses being read from and written to the same Postgres
the routes query, with only a per-process 60s-capped memory tier in front. The
rate-limit and shared-state reports say plainly that the runtime cannot observe instance
count, rather than guessing it.

**The standard profile declares its own posture** (`edge: "none"`) — its `cache`
provider is unchanged. The point of this PR is to make the choice visible, not to
change it.

**The guardrail moves.** `check-public-cache-policy.mjs` asserted the literal
`cache: "postgres"` as "standard Node product cache backend", which pinned the pattern
in place. It now asserts that the profile *declares a posture*, whatever backend it chose.

**`caching-architecture.md`** gains the ADR 0021 pointer and a rule covering the parity
path: the two supported postures, and why the framework emitting standard
`Cache-Control`/`stale-while-revalidate` is what makes an ordinary CDN a valid substitute
for the Voyant Cloud dispatcher.

## Verification

| Command | Result |
| --- | --- |
| `node scripts/check-public-cache-policy.mjs` | OK |
| `pnpm --filter @voyant-travel/framework typecheck` | pass |
| `pnpm --filter @voyant-travel/framework test` | 387 passed (39 files) |
| `pnpm --filter @voyant-travel/graph-contracts typecheck` | pass |
| `pnpm --filter @voyant-travel/operator-standard test` | 19 passed (5 files) |
| `biome check` on touched trees | clean |

`@voyant-travel/runtime` typecheck and the `runtime`/`graph-contracts` suites were still
running locally when I pushed — CI is authoritative for those. New tests cover the
posture default, the diagnostic firing for Postgres-cache-plus-no-edge, it not firing
for a non-database cache or a declared edge tier, carriage through the resolved graph,
and the standard profile's declaration.

## Note

Most of this was drafted by a subagent; I reviewed the diff, verified the packages it
had not, and corrected its claim that two typechecks had passed when they had in fact
been killed.
