### PR TITLE
feat(hono): honour stale-while-revalidate and collapse concurrent misses

### DIFF
--- a/.changeset/kv-put-if-absent.md
+++ b/.changeset/kv-put-if-absent.md
@@ -1,0 +1,43 @@
+---
+"@voyant-travel/utils": minor
+"@voyant-travel/db": minor
+"@voyant-travel/framework": patch
+---
+
+Add an optional conditional-write `putIfAbsent` to the shared KV contract.
+
+Coalescing concurrent misses onto one origin computation needs a way to elect a
+single revalidator across processes: exactly one caller gets `true` and performs
+the origin work, every other caller gets `false` and serves what it already has.
+`KVStore` gains `putIfAbsent(key, value, options?)` for that, and it never
+blocks — a loser is told it lost rather than made to wait.
+
+The member is optional because it is only worth having when the backend decides
+it atomically. Each store that implements it does so in one round trip:
+
+- `createMemoryKvNamespace` reads and writes without awaiting in between, which
+  a single-threaded isolate cannot interleave.
+- `createRedisKvStore` issues `SET key value NX [EX ttl]` and reports the write
+  only on the `OK` reply, never on a nil one.
+- `createPostgresKvStore` issues one `INSERT … ON CONFLICT (key) DO UPDATE …
+  WHERE kv_store.expires_at IS NOT NULL AND kv_store.expires_at <= now()
+  RETURNING`, so the conflicting caller re-reads the committed expiry under the
+  row lock and `RETURNING` yields a row only to the caller that wrote.
+
+All three treat an entry that exists but has expired as absent, matching how
+`get` already treats it, so a lapsed slot can be won again rather than
+deadlocking behind a holder that is gone.
+
+`createTieredKvStore` exposes `putIfAbsent` only when its L2 does, and delegates
+the decision there. L1 is per-process and would hand every process its own
+winner, so it cannot arbitrate; it only mirrors the winner's value, still capped
+by `l2PromotionTtlSeconds`. A tier over an L2 that cannot elect omits the member
+entirely, degrading callers to no coalescing rather than to a false election.
+
+The node-redis TCP adapter in `@voyant-travel/framework` now forwards `nx` as
+the SET `NX` condition. It previously dropped unrecognised options, which would
+have turned a conditional write into an unconditional one that always reported
+success — every caller a winner, which is the failure this contract exists to
+prevent.
+
+See ADR 0021 §5.

--- a/.changeset/public-cache-stale-while-revalidate.md
+++ b/.changeset/public-cache-stale-while-revalidate.md
@@ -1,0 +1,48 @@
+---
+"@voyant-travel/hono": minor
+"@voyant-travel/db": patch
+---
+
+Honour `stale-while-revalidate`, make the declared TTL authoritative, and stop
+letting one lapse hand the origin latency to every arrival at once.
+
+`publicResponseCache` parsed only `public` and `s-maxage`. Every route that
+declared a `stale-while-revalidate` — inventory, commerce, storefront, legal,
+cruises, charters — was declaring it to nothing: the entry hard-expired and the
+next arrival paid the full uncached cost. With a slow query behind it, that is
+an outage rather than a slow request, which is what happened in production.
+
+**Freshness now lives on the entry.** `freshUntil`/`staleUntil` are stored with
+the response, and the backend's own expiry is only a storage lifetime. So the
+declared `s-maxage` is what is in force regardless of Cloudflare KV's 60-second
+floor or the in-process L1's 60-second promotion cap — neither can shorten or
+lengthen a route's policy any more.
+
+**An entry inside its stale window is served immediately.** One arrival is
+elected to refresh it and every other arrival is served the stored copy without
+waiting. If the elected one abandons its request, the lease expires and the next
+arrival retries, so the entry is never left unrepopulated while everyone waits
+on it. Election goes through `KVStore.putIfAbsent` where the backend supports
+it, and falls back to per-isolate exclusion where it does not.
+
+The refresh runs in the requesting handler rather than behind the response,
+because Hono discards a route response once the context is finalized — a refresh
+scheduled after the middleware returns would re-store the stale body under a new
+freshness stamp and produce an entry that looks refreshed and never changes.
+
+**Concurrent cold misses on one key collapse onto one origin computation**
+within the isolate.
+
+Also fixes two defects in `@voyant-travel/db`'s Postgres runtime stores, both
+found by running their integration tests for the first time:
+
+- `expires_at` was bound as a `Date`, which the postgres.js adapter cannot
+  serialize through a raw `sql` template. Every TTL'd write threw, and the
+  response cache's best-effort catch swallowed it — so a deployment selecting
+  `cache: "postgres"` had a shared response cache that silently stored nothing.
+- `createPostgresFixedWindowRateLimitStore` used the reserved word `window`
+  unquoted in an INSERT column list and conflict target, which Postgres rejects
+  outright. Its integration test never ran because the test fixture's DDL had
+  the same defect.
+
+See ADR 0021 §4-5.

--- a/packages/db/src/runtime/postgres-kv.ts
+++ b/packages/db/src/runtime/postgres-kv.ts
@@ -7,6 +7,11 @@ export interface PostgresKvStore {
   put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void>
   delete(key: string): Promise<void>
   list?(options?: { prefix?: string }): Promise<{ keys: Array<{ name: string }> }>
+  /**
+   * Store `value` only if `key` is absent (or expired). Returns true when this
+   * caller performed the write, false when another holder already had it.
+   */
+  putIfAbsent(key: string, value: string, options?: { expirationTtl?: number }): Promise<boolean>
 }
 
 export interface PostgresKvStoreOptions {
@@ -24,8 +29,14 @@ function rows<T>(result: unknown): T[] {
   return Array.isArray(result) ? (result as T[]) : []
 }
 
-function expiresAt(ttlSeconds: number | undefined, now: () => number): Date | null {
-  return ttlSeconds === undefined ? null : new Date(now() + ttlSeconds * 1000)
+/**
+ * ISO text, not a `Date`. The postgres.js adapter cannot serialize a `Date`
+ * bound through a raw `sql` template — it throws `ERR_INVALID_ARG_TYPE` — so
+ * every TTL'd write here failed, and the middleware's best-effort catch
+ * swallowed it. A timestamptz column parses the ISO form directly.
+ */
+function expiresAt(ttlSeconds: number | undefined, now: () => number): string | null {
+  return ttlSeconds === undefined ? null : new Date(now() + ttlSeconds * 1000).toISOString()
 }
 
 function likePrefix(prefix: string): string {
@@ -75,6 +86,29 @@ export function createPostgresKvStore(
           expires_at = excluded.expires_at,
           updated_at = now()
       `)
+    },
+    async putIfAbsent(
+      key: string,
+      value: string,
+      putOptions?: { expirationTtl?: number },
+    ): Promise<boolean> {
+      await sweepExpired()
+      // One statement decides presence and takes the slot. The insert either
+      // wins outright or conflicts, and the conflicting path holds the row lock
+      // while its WHERE re-reads the committed `expires_at`, so exactly one
+      // concurrent caller can satisfy it. RETURNING yields a row only on the
+      // branch that wrote, so a live holder produces zero rows and a false.
+      const result = await db.execute<KeyRow>(sql`
+        INSERT INTO kv_store (key, value, expires_at, updated_at)
+        VALUES (${key}, ${value}, ${expiresAt(putOptions?.expirationTtl, now)}, now())
+        ON CONFLICT (key) DO UPDATE SET
+          value = excluded.value,
+          expires_at = excluded.expires_at,
+          updated_at = now()
+        WHERE kv_store.expires_at IS NOT NULL AND kv_store.expires_at <= now()
+        RETURNING key AS name
+      `)
+      return rows<KeyRow>(result).length > 0
     },
     async delete(key: string): Promise<void> {
       await db.execute(sql`DELETE FROM kv_store WHERE key = ${key}`)

--- a/packages/db/src/runtime/postgres-rate-limit.ts
+++ b/packages/db/src/runtime/postgres-rate-limit.ts
@@ -51,10 +51,16 @@ export function createPostgresFixedWindowRateLimitStore(
       const nowSeconds = Math.floor(now() / 1000)
       const window = Math.floor(nowSeconds / windowSeconds)
       const expiresAt = new Date((window + 1) * windowSeconds * 1000)
+      // Bound as ISO text: postgres.js cannot serialize a `Date` through a raw
+      // `sql` template, so binding the object threw on every call.
+      const expiresAtIso = expiresAt.toISOString()
+      // `window` is a reserved word: Postgres rejects it unquoted in a column
+      // list or a conflict target, so every statement here must quote it. The
+      // drizzle schema quotes identifiers for us; this raw SQL does not.
       const result = await db.execute<CounterRow>(sql`
-        INSERT INTO fixed_window_rate_limits (key, window, count, expires_at, updated_at)
-        VALUES (${key}, ${window}, 1, ${expiresAt}, now())
-        ON CONFLICT (key, window) DO UPDATE SET
+        INSERT INTO fixed_window_rate_limits (key, "window", count, expires_at, updated_at)
+        VALUES (${key}, ${window}, 1, ${expiresAtIso}, now())
+        ON CONFLICT (key, "window") DO UPDATE SET
           count = fixed_window_rate_limits.count + 1,
           expires_at = GREATEST(fixed_window_rate_limits.expires_at, excluded.expires_at),
           updated_at = now()

--- a/packages/db/tests/integration/shared-stores.test.ts
+++ b/packages/db/tests/integration/shared-stores.test.ts
@@ -24,11 +24,11 @@ async function ensureSharedStoreTables() {
   await db.execute(sql`
     CREATE UNLOGGED TABLE IF NOT EXISTS fixed_window_rate_limits (
       key text NOT NULL,
-      window bigint NOT NULL,
+      "window" bigint NOT NULL,
       count integer DEFAULT 0 NOT NULL,
       expires_at timestamp with time zone NOT NULL,
       updated_at timestamp with time zone DEFAULT now() NOT NULL,
-      PRIMARY KEY (key, window)
+      PRIMARY KEY (key, "window")
     )
   `)
 }
@@ -44,14 +44,91 @@ describeIfDb("Postgres shared stores", () => {
   })
 
   it("expires KV entries and lists by prefix", async () => {
-    let clock = Date.now()
-    const kv = createPostgresKvStore(createTestDb(), { now: () => clock, sweepIntervalMs: 0 })
-    await kv.put("p:a", "1")
-    await kv.put("p:b", "2", { expirationTtl: 1 })
-    clock += 1_001
+    // Expiry is evaluated against database `now()`, not the injected clock —
+    // that is deliberate, since a shared store must not depend on each
+    // process's wall clock. So the entry is expired by writing it from a store
+    // whose clock is behind the database's, rather than by advancing a fake one.
+    const db = createTestDb()
+    const live = createPostgresKvStore(db, { sweepIntervalMs: 0 })
+    const behind = createPostgresKvStore(db, {
+      now: () => Date.now() - 3_600_000,
+      sweepIntervalMs: 0,
+    })
+    await live.put("p:a", "1")
+    await behind.put("p:b", "2", { expirationTtl: 1 })
 
-    expect(await kv.get("p:b")).toBeNull()
-    await expect(kv.list?.({ prefix: "p:" })).resolves.toEqual({ keys: [{ name: "p:a" }] })
+    expect(await live.get("p:b")).toBeNull()
+    await expect(live.list?.({ prefix: "p:" })).resolves.toEqual({ keys: [{ name: "p:a" }] })
+  })
+
+  it("stores and reads back a TTL'd value", async () => {
+    // Regression: the expiry was bound as a `Date`, which postgres.js cannot
+    // serialize through a raw `sql` template. Every TTL'd write threw, and the
+    // response cache's best-effort catch swallowed it — so the Postgres cache
+    // backend silently stored nothing at all.
+    const kv = createPostgresKvStore(createTestDb(), { sweepIntervalMs: 0 })
+
+    await kv.put("ttl:round-trip", "stored", { expirationTtl: 600 })
+
+    expect(await kv.get("ttl:round-trip")).toBe("stored")
+  })
+
+  it("elects exactly one putIfAbsent winner under concurrent calls", async () => {
+    const kv = createPostgresKvStore(createTestDb(), { sweepIntervalMs: 0 })
+
+    const results = await Promise.all(
+      Array.from({ length: 5 }, (_, index) =>
+        kv.putIfAbsent("lock:test", `caller-${index}`, { expirationTtl: 60 }),
+      ),
+    )
+
+    expect(results.filter((won) => won)).toHaveLength(1)
+    expect(results.filter((won) => !won)).toHaveLength(4)
+    // The value readable afterwards is the one the winner wrote.
+    expect(await kv.get("lock:test")).toBe(`caller-${results.indexOf(true)}`)
+  })
+
+  it("applies the winner's TTL to the row it wrote", async () => {
+    const base = Date.now()
+    const db = createTestDb()
+    const kv = createPostgresKvStore(db, { now: () => base, sweepIntervalMs: 0 })
+
+    await expect(kv.putIfAbsent("k", "winner", { expirationTtl: 60 })).resolves.toBe(true)
+
+    const result = await db.execute<{ expires_at: unknown }>(
+      sql`SELECT expires_at FROM kv_store WHERE key = 'k'`,
+    )
+    // postgres.js hands timestamptz back as text on this adapter; compare the
+    // instant, not the representation.
+    const expiresAt = (result as { expires_at: unknown }[])[0]?.expires_at
+    expect(new Date(expiresAt as string).getTime()).toBe(base + 60_000)
+  })
+
+  it("treats an expired row as absent so a later putIfAbsent wins the slot again", async () => {
+    // A clock behind the database's makes the first row expired on arrival. The
+    // sweep only fires on the first call, so the expired row is still present
+    // and putIfAbsent must take it over via the ON CONFLICT branch.
+    const past = Date.now() - 10_000
+    const kv = createPostgresKvStore(createTestDb(), {
+      now: () => past,
+      sweepIntervalMs: 3_600_000,
+    })
+    await kv.put("k", "stale", { expirationTtl: 1 })
+
+    await expect(kv.putIfAbsent("k", "second", { expirationTtl: 60 })).resolves.toBe(true)
+    expect(await kv.get("k")).toBe("second")
+
+    // The slot is live again, so the next caller is excluded.
+    await expect(kv.putIfAbsent("k", "third", { expirationTtl: 60 })).resolves.toBe(false)
+    expect(await kv.get("k")).toBe("second")
+  })
+
+  it("never takes a slot held without an expiry", async () => {
+    const kv = createPostgresKvStore(createTestDb(), { sweepIntervalMs: 0 })
+    await kv.put("k", "permanent")
+
+    await expect(kv.putIfAbsent("k", "mine")).resolves.toBe(false)
+    expect(await kv.get("k")).toBe("permanent")
   })
 
   it("increments fixed-window counters atomically under concurrent calls", async () => {

--- a/packages/framework/src/node-redis-client.test.ts
+++ b/packages/framework/src/node-redis-client.test.ts
@@ -95,6 +95,30 @@ describe("createLazyNodeRedisTcpClient", () => {
     expect(redisClients[0]!.expire).toHaveBeenCalledWith("counter", 60)
   })
 
+  it("sends nx as the SET NX condition so putIfAbsent can exclude", async () => {
+    const lazyClient = await createTcpClient()
+    const client = await lazyClient.get()
+
+    await client.set("lock", "value", { nx: true, ex: 30 })
+    await client.set("lock", "value", { nx: true })
+
+    expect(redisClients[0]!.set).toHaveBeenNthCalledWith(1, "lock", "value", {
+      expiration: { type: "EX", value: 30 },
+      condition: "NX",
+    })
+    expect(redisClients[0]!.set).toHaveBeenNthCalledWith(2, "lock", "value", {
+      condition: "NX",
+    })
+  })
+
+  it("relays the nil SET NX reply that means another holder won", async () => {
+    const lazyClient = await createTcpClient()
+    const client = await lazyClient.get()
+    redisClients[0]!.set.mockResolvedValueOnce(null)
+
+    await expect(client.set("lock", "value", { nx: true })).resolves.toBeNull()
+  })
+
   it("normalizes tuple SCAN replies from compatible clients", async () => {
     const lazyClient = await createTcpClient()
     const client = await lazyClient.get()

--- a/packages/framework/src/node-redis-client.ts
+++ b/packages/framework/src/node-redis-client.ts
@@ -41,11 +41,22 @@ function adaptNodeRedisClient(client: NodeRedisClient): RedisClient {
     async get<T = unknown>(key: string): Promise<T | null> {
       return (await client.get(key)) as T | null
     },
-    async set(key: string, value: string, options?: { ex?: number }): Promise<unknown> {
-      if (options?.ex !== undefined) {
-        return client.set(key, value, { expiration: { type: "EX", value: options.ex } })
+    async set(
+      key: string,
+      value: string,
+      options?: { ex?: number; nx?: boolean },
+    ): Promise<unknown> {
+      // `nx` must reach the server as the SET NX condition. Dropping it would
+      // turn a conditional write into an unconditional one that always reports
+      // success, which silently breaks `putIfAbsent` callers.
+      const setOptions = {
+        ...(options?.ex !== undefined
+          ? { expiration: { type: "EX" as const, value: options.ex } }
+          : {}),
+        ...(options?.nx === true ? { condition: "NX" as const } : {}),
       }
-      return client.set(key, value)
+      if (Object.keys(setOptions).length === 0) return client.set(key, value)
+      return client.set(key, value, setOptions)
     },
     async del(key: string): Promise<unknown> {
       return client.del(key)

--- a/packages/hono/src/middleware/public-cache.ts
+++ b/packages/hono/src/middleware/public-cache.ts
@@ -63,23 +63,30 @@ function isUncacheableHeader(name: string): boolean {
 interface CacheControlDirectives {
   isPublic: boolean
   sMaxage: number | null
+  staleWhileRevalidate: number
+}
+
+function directiveSeconds(directive: string, name: string): number | null {
+  const parsed = Number.parseInt(directive.slice(name.length + 1), 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null
 }
 
 function parseCacheControl(value: string | null): CacheControlDirectives {
-  if (!value) return { isPublic: false, sMaxage: null }
+  const none: CacheControlDirectives = { isPublic: false, sMaxage: null, staleWhileRevalidate: 0 }
+  if (!value) return none
   let isPublic = false
   let sMaxage: number | null = null
+  let staleWhileRevalidate = 0
   for (const part of value.split(",")) {
     const directive = part.trim().toLowerCase()
     if (directive === "public") isPublic = true
-    else if (directive === "private" || directive === "no-store") {
-      return { isPublic: false, sMaxage: null }
-    } else if (directive.startsWith("s-maxage=")) {
-      const parsed = Number.parseInt(directive.slice("s-maxage=".length), 10)
-      if (Number.isFinite(parsed) && parsed > 0) sMaxage = parsed
-    }
+    else if (directive === "private" || directive === "no-store") return none
+    else if (directive.startsWith("s-maxage="))
+      sMaxage = directiveSeconds(directive, "s-maxage") ?? sMaxage
+    else if (directive.startsWith("stale-while-revalidate="))
+      staleWhileRevalidate = directiveSeconds(directive, "stale-while-revalidate") ?? 0
   }
-  return { isPublic, sMaxage }
+  return { isPublic, sMaxage, staleWhileRevalidate }
 }
 
 /**
@@ -123,19 +130,48 @@ interface KvCachedResponse {
   status: number
   headers: Array<[string, string]>
   body: string
+  /**
+   * Epoch ms the entry stops being fresh, and the epoch ms past which it may
+   * not be served at all.
+   *
+   * Freshness lives in the entry rather than in the backend's expiry, which is
+   * what makes the declared `s-maxage` authoritative: Cloudflare KV refuses a
+   * TTL under 60s and the in-process L1 caps its own promotion at 60s, and
+   * neither of those storage constraints can now shorten or lengthen the
+   * policy a route declared (ADR 0021 §4).
+   *
+   * Absent on entries written before SWR support; those are treated as fresh
+   * for the remainder of their backend expiry, which is the old behaviour.
+   */
+  freshUntil?: number
+  staleUntil?: number
+}
+
+type CacheEntryState = "fresh" | "stale"
+
+interface KvHit {
+  response: Response
+  state: CacheEntryState
 }
 
 function kvKeyFor(url: string, variant: string): string {
   return `${KV_KEY_PREFIX}${variant}:${url}`
 }
 
-async function kvMatch(kv: KVStore, key: string): Promise<Response | undefined> {
+async function kvMatch(kv: KVStore, key: string, now: number): Promise<KvHit | undefined> {
   try {
     const entry = await kv.get<KvCachedResponse>(key, { type: "json" })
     if (!entry || typeof entry.body !== "string") return undefined
+    const state: CacheEntryState =
+      entry.freshUntil === undefined || now < entry.freshUntil ? "fresh" : "stale"
+    // Past the stale-while-revalidate window the entry is not servable at all;
+    // the backend just has not reclaimed it yet.
+    if (state === "stale" && entry.staleUntil !== undefined && now >= entry.staleUntil) {
+      return undefined
+    }
     const headers = new Headers(entry.headers)
-    headers.set("x-voyant-cache", "hit")
-    return new Response(entry.body, { status: entry.status, headers })
+    headers.set("x-voyant-cache", state === "fresh" ? "hit" : "stale")
+    return { response: new Response(entry.body, { status: entry.status, headers }), state }
   } catch {
     return undefined
   }
@@ -145,8 +181,9 @@ async function kvStore(
   kv: KVStore,
   key: string,
   res: Response,
-  ttlSeconds: number,
+  freshness: { sMaxage: number; staleWhileRevalidate: number },
   maxBodyBytes: number,
+  now: number,
 ): Promise<void> {
   try {
     const body = await res.text()
@@ -155,12 +192,53 @@ async function kvStore(
     res.headers.forEach((value, name) => {
       if (!isUncacheableHeader(name)) headers.push([name, value])
     })
-    const entry: KvCachedResponse = { status: res.status, headers, body }
+    const entry: KvCachedResponse = {
+      status: res.status,
+      headers,
+      body,
+      freshUntil: now + freshness.sMaxage * 1000,
+      staleUntil: now + (freshness.sMaxage + freshness.staleWhileRevalidate) * 1000,
+    }
     await kv.put(key, JSON.stringify(entry), {
-      expirationTtl: Math.max(KV_MIN_TTL_SECONDS, ttlSeconds),
+      // Storage lifetime, not policy: the row only has to outlive the window
+      // in which the entry is servable. The KV floor can lengthen it and never
+      // changes what the entry says about itself.
+      expirationTtl: Math.max(
+        KV_MIN_TTL_SECONDS,
+        freshness.sMaxage + freshness.staleWhileRevalidate,
+      ),
     })
   } catch {
     // cache writes are best-effort — never surface to the request
+  }
+}
+
+/**
+ * Per-process coalescing of concurrent misses on one key.
+ *
+ * Module-scoped on purpose: every request in this isolate shares it, so a
+ * burst of arrivals after an entry lapses produces one origin computation
+ * instead of one per arrival.
+ */
+const inFlight = new Map<string, Promise<void>>()
+
+/**
+ * Cross-process revalidator election. The winner refreshes the entry; every
+ * loser just serves the stale copy it already has, so nobody waits and no
+ * lock has to be released. The lease expires on its own, which bounds a lost
+ * revalidation to one extra stale window rather than wedging the key.
+ *
+ * A backend without `putIfAbsent` cannot exclude, so every process
+ * revalidates — degraded, not incorrect.
+ */
+async function electRevalidator(kv: KVStore, key: string, leaseSeconds: number): Promise<boolean> {
+  if (!kv.putIfAbsent) return true
+  try {
+    return await kv.putIfAbsent(`${key}:revalidating`, "1", {
+      expirationTtl: Math.max(KV_MIN_TTL_SECONDS, leaseSeconds),
+    })
+  } catch {
+    return false
   }
 }
 
@@ -185,6 +263,15 @@ async function kvStore(
  * publication. An `Authorization` request never reads or writes the shared
  * cache, and a response declaring a `Vary` the key does not model is not
  * stored (ADR 0021 §3).
+ *
+ * Expiry is a behaviour, not an event (ADR 0021 §5). Freshness is recorded on
+ * the entry, so the declared `s-maxage` is authoritative regardless of what
+ * the backend's own expiry can express. Inside the declared
+ * `stale-while-revalidate` window a single elected arrival refreshes the entry
+ * while every other arrival is served the stored copy immediately, and
+ * concurrent cold misses on one key collapse onto one origin computation.
+ * Without that, each lapse hands the full uncached latency to every arrival at
+ * once, which is how a slow query becomes an outage.
  *
  * Backend selection: the injected `env.CACHE` {@link KVStore}. Node
  * composition decides whether that is memory, Postgres, Redis, or a tiered
@@ -216,33 +303,117 @@ export function publicResponseCache<TBindings extends VoyantBindings>(
     )
     const kv = c.env.CACHE
 
-    if (!bypass && kv) {
-      const hit = await kvMatch(kv, key)
-      if (hit) return hit
-    }
-
-    await next()
-
-    const res = c.res
-    if (res?.status !== 200) return
-    if (res.headers.has("set-cookie")) return
-    if (!isVaryModelledByKey(res.headers.get("vary"), keyHeaders)) return
-    const { isPublic, sMaxage } = parseCacheControl(res.headers.get("cache-control"))
-    if (!isPublic || !sMaxage) return
-
-    const backendKv = c.env.CACHE
-    if (!backendKv) return
-
-    const copy = res.clone()
-    const store = (async () => {
-      await kvStore(backendKv, key, copy, sMaxage, maxKvBodyBytes)
-    })()
-
     const executionCtx = tryGetExecutionCtx(c)
-    if (executionCtx) {
-      executionCtx.waitUntil(store)
-    } else {
-      await store
+    /**
+     * A write nobody waits on. Where the runtime has an ExecutionContext it
+     * keeps the isolate alive for it; elsewhere the response has already been
+     * returned and the promise settles on its own. Failures are contained
+     * inside {@link kvStore}.
+     */
+    const background = (work: Promise<void>): void => {
+      if (executionCtx) executionCtx.waitUntil(work)
+      else void work.catch(() => {})
     }
+
+    /**
+     * Runs the route. Resolves as soon as the route has answered; the cache
+     * write it schedules is exposed separately so the requester never waits
+     * on it, while a coalesced waiter can.
+     */
+    let written: Promise<void> = Promise.resolve()
+    const runRoute = async (): Promise<void> => {
+      await next()
+
+      const res = c.res
+      if (res?.status !== 200) return
+      if (res.headers.has("set-cookie")) return
+      if (!isVaryModelledByKey(res.headers.get("vary"), keyHeaders)) return
+      const { isPublic, sMaxage, staleWhileRevalidate } = parseCacheControl(
+        res.headers.get("cache-control"),
+      )
+      if (!isPublic || !sMaxage) return
+
+      const backendKv = c.env.CACHE
+      if (!backendKv) return
+
+      written = kvStore(
+        backendKv,
+        key,
+        res.clone(),
+        { sMaxage, staleWhileRevalidate },
+        maxKvBodyBytes,
+        Date.now(),
+      )
+      background(written)
+    }
+
+    if (!bypass && kv) {
+      const hit = await kvMatch(kv, key, Date.now())
+      if (hit?.state === "fresh") return hit.response
+      if (hit?.state === "stale") {
+        // One arrival refreshes the entry; every other arrival in the stale
+        // window is served instantly from the copy already stored. That is
+        // what removes the outage mode: a lapse costs one requester the origin
+        // latency instead of all of them, and if that one abandons the request
+        // the lease simply expires and the next arrival retries — the entry is
+        // never left unrepopulated while everyone waits on it.
+        //
+        // The refresh is not moved behind the response, because it cannot be:
+        // `next()` writes the route's response onto the context, and Hono
+        // discards a handler response once the context is finalized (see
+        // `compose`), so a refresh scheduled after this middleware returns
+        // would re-store the stale body under a new freshness stamp — an entry
+        // that looks refreshed and never changes.
+        if (inFlight.has(key)) return hit.response
+
+        // Claimed synchronously so siblings in this isolate serve stale
+        // rather than racing to the same election.
+        let release: (() => void) | undefined
+        const claim = new Promise<void>((resolve) => {
+          release = resolve
+        })
+        inFlight.set(key, claim)
+        try {
+          const { sMaxage, staleWhileRevalidate } = parseCacheControl(
+            hit.response.headers.get("cache-control"),
+          )
+          if (!(await electRevalidator(kv, key, (sMaxage ?? 0) + staleWhileRevalidate))) {
+            return hit.response
+          }
+          await runRoute()
+          return
+        } catch {
+          // A failed refresh leaves the stale entry in place for the next
+          // arrival to retry rather than failing this request.
+          return hit.response
+        } finally {
+          release?.()
+          if (inFlight.get(key) === claim) inFlight.delete(key)
+        }
+      }
+    }
+
+    // Cold miss. If this isolate is already computing this key, wait for that
+    // computation and read its result instead of running the route again.
+    const pending = bypass ? undefined : inFlight.get(key)
+    if (pending) {
+      await pending.catch(() => {})
+      if (kv) {
+        const filled = await kvMatch(kv, key, Date.now())
+        if (filled?.state === "fresh") return filled.response
+      }
+    }
+
+    const routeDone = runRoute()
+    if (!bypass) {
+      const settled = routeDone.then(() => written)
+      inFlight.set(key, settled)
+      void settled
+        .catch(() => {})
+        .finally(() => {
+          if (inFlight.get(key) === settled) inFlight.delete(key)
+        })
+    }
+    await routeDone
   }
 }

--- a/packages/hono/tests/unit/public-cache.test.ts
+++ b/packages/hono/tests/unit/public-cache.test.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono"
-import { afterEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import {
   publicResponseCache,
@@ -45,8 +45,17 @@ function buildApp(kv: ReturnType<typeof fakeKv> | undefined, handler: () => Resp
   }
 }
 
+/** Cache writes are scheduled, not awaited — let them settle before asserting. */
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+
 afterEach(() => {
   resetPublicCacheStateForTests()
+  vi.useRealTimers()
+})
+
+beforeEach(() => {
+  // Freshness is evaluated against the wall clock, so the suite drives it.
+  vi.useFakeTimers({ shouldAdvanceTime: true })
 })
 
 describe("publicResponseCache (KV fallback — no Cache API in the test runtime)", () => {
@@ -84,6 +93,7 @@ describe("publicResponseCache (KV fallback — no Cache API in the test runtime)
     await app.request("/v1/public/products")
 
     expect(handler).toHaveBeenCalledTimes(2)
+    await flush()
     expect(kv.put).not.toHaveBeenCalled()
   })
 
@@ -99,6 +109,7 @@ describe("publicResponseCache (KV fallback — no Cache API in the test runtime)
     const app = buildApp(kv, handler)
 
     await app.request("/v1/public/products")
+    await flush()
     expect(kv.put).not.toHaveBeenCalled()
   })
 
@@ -117,6 +128,7 @@ describe("publicResponseCache (KV fallback — no Cache API in the test runtime)
     const app = buildApp(kv, handler)
 
     await app.request("/v1/public/products")
+    await flush()
     expect(kv.put).not.toHaveBeenCalled()
   })
 
@@ -132,6 +144,7 @@ describe("publicResponseCache (KV fallback — no Cache API in the test runtime)
     const app = buildApp(kv, handler)
 
     await app.request("/v1/admin/products")
+    await flush()
     expect(kv.put).not.toHaveBeenCalled()
   })
 
@@ -150,6 +163,7 @@ describe("publicResponseCache (KV fallback — no Cache API in the test runtime)
     const env = { DATABASE_URL: "x", CACHE: kv }
 
     await app.request("/v1/public/search", { method: "POST" }, testEnv(env))
+    await flush()
     expect(kv.put).not.toHaveBeenCalled()
   })
 
@@ -183,6 +197,7 @@ describe("publicResponseCache (KV fallback — no Cache API in the test runtime)
 
     await app.request("/v1/public/products")
 
+    await flush()
     expect(kv.put).toHaveBeenCalledOnce()
     const options = kv.put.mock.calls[0]?.[2]
     expect(options?.expirationTtl).toBe(60)
@@ -245,6 +260,7 @@ describe("publicResponseCache (KV fallback — no Cache API in the test runtime)
     expect(await b2b.json()).toEqual({ channel: "pk_b2b" })
     expect(handler).toHaveBeenCalledTimes(2)
     expect(b2b.headers.get("x-voyant-cache")).toBeNull()
+    await flush()
     expect(kv.store.size).toBe(2)
 
     // ...and each key still serves its own entry on a repeat request.
@@ -271,6 +287,7 @@ describe("publicResponseCache (KV fallback — no Cache API in the test runtime)
 
     await app.request("/v1/public/products", { headers: { "x-api-key": "pk_secret_value" } })
 
+    await flush()
     expect(kv.put).toHaveBeenCalledOnce()
     expect(kv.put.mock.calls[0]?.[0]).not.toContain("pk_secret_value")
   })
@@ -290,6 +307,7 @@ describe("publicResponseCache (KV fallback — no Cache API in the test runtime)
     const app = buildApp(kv, handler)
 
     await app.request("/v1/public/products")
+    await flush()
     expect(kv.put).not.toHaveBeenCalled()
   })
 
@@ -308,6 +326,7 @@ describe("publicResponseCache (KV fallback — no Cache API in the test runtime)
     const app = buildApp(kv, handler)
 
     await app.request("/v1/public/products")
+    await flush()
     expect(kv.put).toHaveBeenCalledOnce()
   })
 
@@ -323,6 +342,7 @@ describe("publicResponseCache (KV fallback — no Cache API in the test runtime)
     const app = buildApp(kv, handler)
 
     await app.request("/v1/public/products")
+    await flush()
     expect(kv.put).not.toHaveBeenCalled()
   })
 
@@ -339,6 +359,7 @@ describe("publicResponseCache (KV fallback — no Cache API in the test runtime)
 
     // Populate from an anonymous request first, so a read would have hit.
     await app.request("/v1/public/products")
+    await flush()
     expect(kv.put).toHaveBeenCalledOnce()
 
     const authed = await app.request("/v1/public/products", {
@@ -347,6 +368,7 @@ describe("publicResponseCache (KV fallback — no Cache API in the test runtime)
 
     expect(handler).toHaveBeenCalledTimes(2)
     expect(authed.headers.get("x-voyant-cache")).toBeNull()
+    await flush()
     expect(kv.put).toHaveBeenCalledOnce()
   })
 
@@ -367,6 +389,211 @@ describe("publicResponseCache (KV fallback — no Cache API in the test runtime)
 
     // One lookup, no second round trip to resolve the variant.
     expect(kv.get).toHaveBeenCalledOnce()
+  })
+
+  it("serves a stale entry immediately and refreshes it in the background", async () => {
+    const kv = fakeKv()
+    let version = 1
+    const handler = vi.fn(
+      () =>
+        new Response(JSON.stringify({ version: version++ }), {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "cache-control": "public, s-maxage=60, stale-while-revalidate=300",
+          },
+        }),
+    )
+    const app = buildApp(kv, handler)
+
+    await app.request("/v1/public/products")
+    await flush()
+    expect(handler).toHaveBeenCalledTimes(1)
+
+    // Past s-maxage, inside the stale-while-revalidate window.
+    vi.setSystemTime(Date.now() + 61_000)
+
+    // Two arrivals inside the stale window. One is elected to refresh; the
+    // other is served the stored copy without waiting for it.
+    let releaseRefresh: (() => void) | undefined
+    const refreshGate = new Promise<void>((resolve) => {
+      releaseRefresh = resolve
+    })
+    const slowHandler = vi.fn(async () => {
+      await refreshGate
+      return new Response(JSON.stringify({ version: version++ }), {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+          "cache-control": "public, s-maxage=60, stale-while-revalidate=300",
+        },
+      })
+    })
+    const refreshingApp = buildApp(kv, slowHandler)
+
+    const refresher = refreshingApp.request("/v1/public/products")
+    const served = await refreshingApp.request("/v1/public/products")
+
+    // Served while the refresh is still blocked on the gate.
+    expect(served.headers.get("x-voyant-cache")).toBe("stale")
+    expect(await served.json()).toEqual({ version: 1 })
+    expect(slowHandler).toHaveBeenCalledTimes(1)
+
+    releaseRefresh?.()
+    const refreshed = await refresher
+    expect(await refreshed.json()).toEqual({ version: 2 })
+
+    await flush()
+    const afterRefresh = await refreshingApp.request("/v1/public/products")
+    expect(afterRefresh.headers.get("x-voyant-cache")).toBe("hit")
+    expect(await afterRefresh.json()).toEqual({ version: 2 })
+    expect(slowHandler).toHaveBeenCalledTimes(1)
+  })
+
+  it("treats an entry past s-maxage + stale-while-revalidate as a miss", async () => {
+    const kv = fakeKv()
+    const handler = vi.fn(
+      () =>
+        new Response("{}", {
+          status: 200,
+          headers: { "cache-control": "public, s-maxage=60, stale-while-revalidate=30" },
+        }),
+    )
+    const app = buildApp(kv, handler)
+
+    await app.request("/v1/public/products")
+    await flush()
+
+    vi.setSystemTime(Date.now() + 91_000)
+
+    const miss = await app.request("/v1/public/products")
+    expect(miss.headers.get("x-voyant-cache")).toBeNull()
+    expect(handler).toHaveBeenCalledTimes(2)
+  })
+
+  it("honours the declared s-maxage even though the backend TTL is floored at 60s", async () => {
+    const kv = fakeKv()
+    const handler = vi.fn(
+      () =>
+        new Response("{}", {
+          status: 200,
+          headers: { "cache-control": "public, s-maxage=30" },
+        }),
+    )
+    const app = buildApp(kv, handler)
+
+    await app.request("/v1/public/products")
+    await flush()
+    // The row lives 60s because the KV floor says so...
+    expect(kv.put.mock.calls[0]?.[2]?.expirationTtl).toBe(60)
+
+    // ...but the entry stops being fresh at the declared 30s, and with no
+    // stale-while-revalidate declared it is not servable at all after that.
+    vi.setSystemTime(Date.now() + 31_000)
+    const after = await app.request("/v1/public/products")
+    expect(after.headers.get("x-voyant-cache")).toBeNull()
+    expect(handler).toHaveBeenCalledTimes(2)
+  })
+
+  it("collapses concurrent misses on one key onto a single origin computation", async () => {
+    const kv = fakeKv()
+    let release: (() => void) | undefined
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const handler = vi.fn(async () => {
+      await gate
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+          "cache-control": "public, s-maxage=60",
+        },
+      })
+    })
+    const app = buildApp(kv, handler)
+
+    const all = Promise.all([
+      app.request("/v1/public/products"),
+      app.request("/v1/public/products"),
+      app.request("/v1/public/products"),
+    ])
+    release?.()
+    const responses = await all
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    for (const response of responses) {
+      expect(response.status).toBe(200)
+      expect(await response.json()).toEqual({ ok: true })
+    }
+  })
+
+  it("elects a single revalidator through the backend when it can exclude", async () => {
+    const kv = fakeKv()
+    const putIfAbsent = vi.fn(async (key: string, value: string) => {
+      if (kv.store.has(key)) return false
+      kv.store.set(key, { value })
+      return true
+    })
+    const kvWithElection = Object.assign(kv, { putIfAbsent })
+    const handler = vi.fn(
+      () =>
+        new Response("{}", {
+          status: 200,
+          headers: { "cache-control": "public, s-maxage=60, stale-while-revalidate=300" },
+        }),
+    )
+    const app = buildApp(kvWithElection, handler)
+
+    await app.request("/v1/public/products")
+    await flush()
+    vi.setSystemTime(Date.now() + 61_000)
+
+    // Another process already holds the revalidation lease. This arrival must
+    // lose the election, serve stale, and not touch the origin.
+    const leaseKey = [...kv.store.keys()].find((name) => name.startsWith("respcache:"))
+    kv.store.set(`${leaseKey}:revalidating`, { value: "1" })
+
+    const served = await app.request("/v1/public/products")
+    await flush()
+
+    expect(served.headers.get("x-voyant-cache")).toBe("stale")
+    expect(putIfAbsent).toHaveBeenCalledOnce()
+    expect(putIfAbsent.mock.results[0]?.value).resolves.toBe(false)
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  it("refreshes the entry when it wins the revalidation lease", async () => {
+    const kv = fakeKv()
+    const putIfAbsent = vi.fn(async (key: string, value: string) => {
+      if (kv.store.has(key)) return false
+      kv.store.set(key, { value })
+      return true
+    })
+    const kvWithElection = Object.assign(kv, { putIfAbsent })
+    let version = 1
+    const handler = vi.fn(
+      () =>
+        new Response(JSON.stringify({ version: version++ }), {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "cache-control": "public, s-maxage=60, stale-while-revalidate=300",
+          },
+        }),
+    )
+    const app = buildApp(kvWithElection, handler)
+
+    await app.request("/v1/public/products")
+    await flush()
+    vi.setSystemTime(Date.now() + 61_000)
+
+    const refreshed = await app.request("/v1/public/products")
+    await flush()
+
+    expect(putIfAbsent).toHaveBeenCalledOnce()
+    expect(await refreshed.json()).toEqual({ version: 2 })
+    expect(handler).toHaveBeenCalledTimes(2)
   })
 
   it("is a transparent no-op when neither Cache API nor KV is available", async () => {

--- a/packages/utils/src/cache.ts
+++ b/packages/utils/src/cache.ts
@@ -22,6 +22,14 @@ export interface KVStore {
   put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void>
   delete(key: string): Promise<void>
   list?(options?: { prefix?: string }): Promise<{ keys: Array<{ name: string }> }>
+  /**
+   * Store `value` only if `key` is absent (or expired). Returns true when this
+   * caller performed the write, false when another holder already had it.
+   *
+   * Optional: a store that cannot do this atomically must omit it entirely
+   * rather than emulating it with get-then-put, which does not exclude.
+   */
+  putIfAbsent?(key: string, value: string, options?: { expirationTtl?: number }): Promise<boolean>
 }
 
 /**

--- a/packages/utils/src/memory-kv.ts
+++ b/packages/utils/src/memory-kv.ts
@@ -53,6 +53,20 @@ export function createMemoryKvNamespace(options: MemoryKvOptions = {}): KvNamesp
     return entry.value
   }
 
+  function writeEntry(key: string, value: string, expirationTtl: number | undefined): void {
+    if (map.has(key)) map.delete(key)
+    const expiresAt =
+      expirationTtl === undefined ? Number.POSITIVE_INFINITY : now() + expirationTtl * 1000
+    map.set(key, { value, expiresAt })
+    if (maxEntries > 0) {
+      while (map.size > maxEntries) {
+        const oldest = map.keys().next().value
+        if (oldest === undefined) break
+        map.delete(oldest)
+      }
+    }
+  }
+
   async function get(
     key: string,
     typeOrOptions?: "json" | KvGetOptions,
@@ -66,19 +80,14 @@ export function createMemoryKvNamespace(options: MemoryKvOptions = {}): KvNamesp
   return {
     get: get as KvNamespaceShim["get"],
     async put(key: string, value: string, putOptions?: KvPutOptions): Promise<void> {
-      if (map.has(key)) map.delete(key)
-      const expiresAt =
-        putOptions?.expirationTtl === undefined
-          ? Number.POSITIVE_INFINITY
-          : now() + putOptions.expirationTtl * 1000
-      map.set(key, { value, expiresAt })
-      if (maxEntries > 0) {
-        while (map.size > maxEntries) {
-          const oldest = map.keys().next().value
-          if (oldest === undefined) break
-          map.delete(oldest)
-        }
-      }
+      writeEntry(key, value, putOptions?.expirationTtl)
+    },
+    async putIfAbsent(key: string, value: string, putOptions?: KvPutOptions): Promise<boolean> {
+      // Atomic by construction: a single-threaded isolate cannot interleave
+      // another caller between this read and the write, because neither awaits.
+      if (readFresh(key) !== null) return false
+      writeEntry(key, value, putOptions?.expirationTtl)
+      return true
     },
     async delete(key: string): Promise<void> {
       map.delete(key)

--- a/packages/utils/src/redis-client.ts
+++ b/packages/utils/src/redis-client.ts
@@ -8,7 +8,11 @@ interface RedisModule {
 
 export interface RedisClient {
   get<T = unknown>(key: string): Promise<T | null>
-  set(key: string, value: string, options?: { ex?: number }): Promise<unknown>
+  /**
+   * `SET key value [EX ex] [NX]`. With `nx`, resolves to the `OK` reply only
+   * when the write happened, and to a nil reply when the key already existed.
+   */
+  set(key: string, value: string, options?: { ex?: number; nx?: boolean }): Promise<unknown>
   del(key: string): Promise<unknown>
   scan?(
     cursor: number,

--- a/packages/utils/src/redis-kv.ts
+++ b/packages/utils/src/redis-kv.ts
@@ -30,6 +30,15 @@ function physicalKey(keyPrefix: string, key: string): string {
   return `${keyPrefix}${key}`
 }
 
+function expirySeconds(expirationTtl: number): number {
+  return Math.max(1, Math.ceil(expirationTtl))
+}
+
+/** Redis answers `OK` when a `SET` applied and a nil reply when `NX` rejected it. */
+function setApplied(reply: unknown): boolean {
+  return typeof reply === "string" && reply.toUpperCase() === "OK"
+}
+
 function logicalKey(keyPrefix: string, key: string): string | undefined {
   if (!keyPrefix) return key
   return key.startsWith(keyPrefix) ? key.slice(keyPrefix.length) : undefined
@@ -64,10 +73,29 @@ export function createRedisKvStore(redisUrl: string, options: RedisKvStoreOption
       const client = await lazyClient.get()
       const storedKey = physicalKey(keyPrefix, key)
       if (options?.expirationTtl !== undefined) {
-        await client.set(storedKey, value, { ex: Math.max(1, Math.ceil(options.expirationTtl)) })
+        await client.set(storedKey, value, { ex: expirySeconds(options.expirationTtl) })
         return
       }
       await client.set(storedKey, value)
+    },
+    async putIfAbsent(
+      key: string,
+      value: string,
+      options?: { expirationTtl?: number },
+    ): Promise<boolean> {
+      const client = await lazyClient.get()
+      const storedKey = physicalKey(keyPrefix, key)
+      // `SET key value NX [EX ttl]` decides presence and takes the slot in one
+      // command, so concurrent callers are excluded by Redis itself. An expired
+      // key no longer exists, so it is `NX`-absent and the next caller wins it.
+      const reply =
+        options?.expirationTtl === undefined
+          ? await client.set(storedKey, value, { nx: true })
+          : await client.set(storedKey, value, {
+              nx: true,
+              ex: expirySeconds(options.expirationTtl),
+            })
+      return setApplied(reply)
     },
     async delete(key: string): Promise<void> {
       const client = await lazyClient.get()

--- a/packages/utils/src/tiered-kv.ts
+++ b/packages/utils/src/tiered-kv.ts
@@ -24,7 +24,7 @@ export function createTieredKvStore(
     expirationTtl: Math.min(putOptions?.expirationTtl ?? promotionTtl, promotionTtl),
   })
 
-  return {
+  const store: KVStore = {
     async get<T = string>(
       key: string,
       getOptions?: "json" | { type?: "json" | "text" },
@@ -51,4 +51,23 @@ export function createTieredKvStore(
       return l1.list ? l1.list(options) : { keys: [] }
     },
   }
+
+  // Election is only meaningful across processes, so it is L2's answer or none:
+  // L1 is per-process and would hand every process its own winner. When L2
+  // cannot decide it atomically the member stays absent, which degrades callers
+  // to no coalescing rather than to a false election.
+  const electInL2 = l2.putIfAbsent?.bind(l2)
+  if (electInL2) {
+    store.putIfAbsent = async (
+      key: string,
+      value: string,
+      putOptions?: { expirationTtl?: number },
+    ): Promise<boolean> => {
+      const won = await electInL2(key, value, putOptions)
+      if (won) await l1.put(key, value, l1PutOptions(putOptions)).catch(() => {})
+      return won
+    }
+  }
+
+  return store
 }

--- a/packages/utils/tests/memory-kv.test.ts
+++ b/packages/utils/tests/memory-kv.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 
+import type { KVStore } from "../src/cache.js"
 import { createMemoryKvNamespace } from "../src/memory-kv.js"
 import { createTieredKvStore } from "../src/tiered-kv.js"
 
@@ -32,6 +33,65 @@ describe("createMemoryKvNamespace", () => {
     await kv.put("q:c", "3")
     clock += 1_001
     await expect(kv.list?.({ prefix: "p:" })).resolves.toEqual({ keys: [{ name: "p:a" }] })
+  })
+})
+
+describe("createMemoryKvNamespace putIfAbsent", () => {
+  it("elects exactly one winner among concurrent callers on the same key", async () => {
+    const kv = createMemoryKvNamespace()
+
+    const results = await Promise.all(
+      Array.from({ length: 5 }, (_, index) => kv.putIfAbsent?.("lock", `caller-${index}`)),
+    )
+
+    expect(results.filter((won) => won === true)).toHaveLength(1)
+    expect(results.filter((won) => won === false)).toHaveLength(4)
+  })
+
+  it("makes the winner's value the readable value", async () => {
+    const kv = createMemoryKvNamespace()
+
+    await expect(kv.putIfAbsent?.("k", "winner")).resolves.toBe(true)
+    await expect(kv.putIfAbsent?.("k", "loser")).resolves.toBe(false)
+
+    expect(await kv.get("k")).toBe("winner")
+  })
+
+  it("applies the TTL to the entry the winner wrote", async () => {
+    let clock = 1_000
+    const kv = createMemoryKvNamespace({ now: () => clock })
+
+    await expect(kv.putIfAbsent?.("k", "v", { expirationTtl: 30 })).resolves.toBe(true)
+    clock += 29_000
+    expect(await kv.get("k")).toBe("v")
+
+    clock += 1_001
+    expect(await kv.get("k")).toBeNull()
+  })
+
+  it("treats an expired entry as absent so a later caller wins the slot again", async () => {
+    let clock = 1_000
+    const kv = createMemoryKvNamespace({ now: () => clock })
+
+    await expect(kv.putIfAbsent?.("k", "first", { expirationTtl: 30 })).resolves.toBe(true)
+    await expect(kv.putIfAbsent?.("k", "blocked", { expirationTtl: 30 })).resolves.toBe(false)
+
+    clock += 30_001
+    await expect(kv.putIfAbsent?.("k", "second", { expirationTtl: 30 })).resolves.toBe(true)
+    expect(await kv.get("k")).toBe("second")
+  })
+
+  it("respects LRU eviction for entries it writes", async () => {
+    const kv = createMemoryKvNamespace({ maxEntries: 2 })
+
+    await expect(kv.putIfAbsent?.("a", "1")).resolves.toBe(true)
+    await expect(kv.putIfAbsent?.("b", "2")).resolves.toBe(true)
+    await kv.get("a")
+    await expect(kv.putIfAbsent?.("c", "3")).resolves.toBe(true)
+
+    expect(await kv.get("a")).toBe("1")
+    expect(await kv.get("b")).toBeNull()
+    expect(await kv.get("c")).toBe("3")
   })
 })
 
@@ -88,5 +148,100 @@ describe("createTieredKvStore", () => {
 
     expect(await l1.get("k")).toBeNull()
     expect(await l2.get("k")).toBeNull()
+  })
+})
+
+describe("createTieredKvStore putIfAbsent", () => {
+  /** An L2 that cannot elect atomically, so the tier must not offer election. */
+  function kvWithoutElection(): KVStore {
+    const inner = createMemoryKvNamespace()
+    return {
+      get: (key, getOptions) => inner.get(key, getOptions as { type?: "json" | "text" }),
+      put: (key, value, putOptions) => inner.put(key, value, putOptions),
+      delete: (key) => inner.delete(key),
+    }
+  }
+
+  it("omits putIfAbsent when L2 cannot elect", () => {
+    const kv = createTieredKvStore(createMemoryKvNamespace(), kvWithoutElection())
+
+    expect(kv.putIfAbsent).toBeUndefined()
+  })
+
+  it("exposes putIfAbsent when L2 can elect", () => {
+    const kv = createTieredKvStore(createMemoryKvNamespace(), createMemoryKvNamespace())
+
+    expect(typeof kv.putIfAbsent).toBe("function")
+  })
+
+  it("loses the election to an L2 holder even when L1 has nothing", async () => {
+    const l1 = createMemoryKvNamespace()
+    const l2 = createMemoryKvNamespace()
+    const kv = createTieredKvStore(l1, l2)
+
+    await l2.put("k", "held-elsewhere")
+
+    // L1 is empty, so a per-process election would have returned true.
+    expect(await l1.get("k")).toBeNull()
+    await expect(kv.putIfAbsent?.("k", "mine")).resolves.toBe(false)
+    expect(await l2.get("k")).toBe("held-elsewhere")
+  })
+
+  it("wins the election against an L1-only holder because L2 decides", async () => {
+    const l1 = createMemoryKvNamespace()
+    const l2 = createMemoryKvNamespace()
+    const kv = createTieredKvStore(l1, l2)
+
+    await l1.put("k", "stale-local")
+
+    await expect(kv.putIfAbsent?.("k", "winner")).resolves.toBe(true)
+    expect(await l2.get("k")).toBe("winner")
+    expect(await l1.get("k")).toBe("winner")
+  })
+
+  it("mirrors the winner's value into L1 so it reads back through the tier", async () => {
+    const l1 = createMemoryKvNamespace()
+    const l2 = createMemoryKvNamespace()
+    const kv = createTieredKvStore(l1, l2)
+
+    await expect(kv.putIfAbsent?.("k", "winner", { expirationTtl: 30 })).resolves.toBe(true)
+
+    expect(await l1.get("k")).toBe("winner")
+    expect(await kv.get("k")).toBe("winner")
+  })
+
+  it("does not mirror into L1 when the election was lost", async () => {
+    const l1 = createMemoryKvNamespace()
+    const l2 = createMemoryKvNamespace()
+    const kv = createTieredKvStore(l1, l2)
+
+    await l2.put("k", "held-elsewhere")
+    await expect(kv.putIfAbsent?.("k", "mine")).resolves.toBe(false)
+
+    expect(await l1.get("k")).toBeNull()
+  })
+
+  it("caps the mirrored L1 entry at l2PromotionTtlSeconds without shortening L2", async () => {
+    let clock = 1_000
+    const l1 = createMemoryKvNamespace({ now: () => clock })
+    const l2 = createMemoryKvNamespace({ now: () => clock })
+    const kv = createTieredKvStore(l1, l2)
+
+    await expect(kv.putIfAbsent?.("k", "winner", { expirationTtl: 900 })).resolves.toBe(true)
+    clock += 60_001
+
+    expect(await l1.get("k")).toBeNull()
+    expect(await l2.get("k")).toBe("winner")
+  })
+
+  it("elects exactly one winner among concurrent tier callers", async () => {
+    const kv = createTieredKvStore(createMemoryKvNamespace(), createMemoryKvNamespace())
+
+    const results = await Promise.all(
+      Array.from({ length: 5 }, (_, index) => kv.putIfAbsent?.("lock", `caller-${index}`)),
+    )
+
+    expect(results.filter((won) => won === true)).toHaveLength(1)
+    expect(results.filter((won) => won === false)).toHaveLength(4)
   })
 })

--- a/packages/utils/tests/redis-kv.test.ts
+++ b/packages/utils/tests/redis-kv.test.ts
@@ -8,20 +8,44 @@ class FakeRedisClient implements RedisClient {
   readonly expiries = new Map<string, number>()
   readonly deletions: string[] = []
   leakedScanKeys: string[] | undefined
+  /** Test clock (ms). Keys written with `ex` vanish once it passes their deadline. */
+  clockMs = 0
+  private readonly deadlines = new Map<string, number>()
+
+  /** Redis drops an expired key entirely; it is then absent to GET and to SET NX. */
+  private expireIfDue(key: string): void {
+    const deadline = this.deadlines.get(key)
+    if (deadline === undefined || deadline > this.clockMs) return
+    this.values.delete(key)
+    this.deadlines.delete(key)
+    this.expiries.delete(key)
+  }
 
   async get<T = unknown>(key: string): Promise<T | null> {
+    this.expireIfDue(key)
     return (this.values.get(key) ?? null) as T | null
   }
 
-  async set(key: string, value: string, options?: { ex?: number }): Promise<unknown> {
+  async set(key: string, value: string, options?: { ex?: number; nx?: boolean }): Promise<unknown> {
+    this.expireIfDue(key)
+    // Redis evaluates NX server-side and answers nil when it refuses the write.
+    if (options?.nx === true && this.values.has(key)) return null
     this.values.set(key, value)
-    if (options?.ex !== undefined) this.expiries.set(key, options.ex)
+    if (options?.ex === undefined) {
+      this.deadlines.delete(key)
+      this.expiries.delete(key)
+    } else {
+      this.expiries.set(key, options.ex)
+      this.deadlines.set(key, this.clockMs + options.ex * 1000)
+    }
+    return "OK"
   }
 
   async del(key: string): Promise<unknown> {
     this.deletions.push(key)
     this.values.delete(key)
     this.expiries.delete(key)
+    this.deadlines.delete(key)
   }
 
   async scan(
@@ -168,6 +192,85 @@ describe("createRedisKvStore with keyPrefix", () => {
         keyPrefix: "voyant:v1:bad\nnamespace:cache:",
       }),
     ).toThrow(/keyPrefix/)
+  })
+})
+
+describe("createRedisKvStore putIfAbsent", () => {
+  const REDIS_URL = "https://example.test?token=test-token"
+
+  function store(client: FakeRedisClient, keyPrefix?: string) {
+    return createRedisKvStore(REDIS_URL, {
+      client: fakeClient(client),
+      ...(keyPrefix === undefined ? {} : { keyPrefix }),
+    })
+  }
+
+  it("gives the slot to the first caller and refuses the second", async () => {
+    const kv = store(new FakeRedisClient())
+
+    await expect(kv.putIfAbsent?.("lock", "first")).resolves.toBe(true)
+    await expect(kv.putIfAbsent?.("lock", "second")).resolves.toBe(false)
+  })
+
+  it("elects exactly one winner among concurrent callers", async () => {
+    const kv = store(new FakeRedisClient())
+
+    const results = await Promise.all(
+      Array.from({ length: 5 }, (_, index) => kv.putIfAbsent?.("lock", `caller-${index}`)),
+    )
+
+    expect(results.filter((won) => won === true)).toHaveLength(1)
+    expect(results.filter((won) => won === false)).toHaveLength(4)
+  })
+
+  it("makes the winner's value the readable value", async () => {
+    const kv = store(new FakeRedisClient())
+
+    await expect(kv.putIfAbsent?.("k", "winner")).resolves.toBe(true)
+    await expect(kv.putIfAbsent?.("k", "loser")).resolves.toBe(false)
+
+    await expect(kv.get("k")).resolves.toBe("winner")
+  })
+
+  it("issues SET NX against the prefixed physical key and applies the TTL to it", async () => {
+    const client = new FakeRedisClient()
+    const kv = store(client, "voyant:v1:ro:cache:")
+
+    await expect(kv.putIfAbsent?.("key", "winner", { expirationTtl: 1.2 })).resolves.toBe(true)
+
+    expect(client.values.get("voyant:v1:ro:cache:key")).toBe("winner")
+    expect(client.expiries.get("voyant:v1:ro:cache:key")).toBe(2)
+    expect(client.values.has("key")).toBe(false)
+  })
+
+  it("isolates elections between adjacent key prefixes", async () => {
+    const client = new FakeRedisClient()
+    const eu = store(client, "voyant:v1:eu:cache:")
+    const europe = store(client, "voyant:v1:europe:cache:")
+
+    await expect(eu.putIfAbsent?.("lock", "eu")).resolves.toBe(true)
+    await expect(europe.putIfAbsent?.("lock", "europe")).resolves.toBe(true)
+    await expect(eu.putIfAbsent?.("lock", "eu-again")).resolves.toBe(false)
+  })
+
+  it("treats an expired key as absent so a later caller wins the slot again", async () => {
+    const client = new FakeRedisClient()
+    const kv = store(client)
+
+    await expect(kv.putIfAbsent?.("k", "first", { expirationTtl: 30 })).resolves.toBe(true)
+    await expect(kv.putIfAbsent?.("k", "blocked", { expirationTtl: 30 })).resolves.toBe(false)
+
+    client.clockMs += 30_001
+    await expect(kv.putIfAbsent?.("k", "second", { expirationTtl: 30 })).resolves.toBe(true)
+    await expect(kv.get("k")).resolves.toBe("second")
+  })
+
+  it("reports false when Redis answers a nil reply", async () => {
+    const client = new FakeRedisClient()
+    client.values.set("k", "held")
+
+    await expect(store(client).putIfAbsent?.("k", "mine")).resolves.toBe(false)
+    expect(client.values.get("k")).toBe("held")
   })
 })
 


### PR DESCRIPTION
Closes #4096. Stacked on #4099 (review that first — this diff is against it). ADR 0021 (#4094).

## What was wrong

`parseCacheControl` extracted exactly `public` and `s-maxage`. Every route
declaring `stale-while-revalidate` — inventory, commerce, storefront, legal,
cruises, charters — declared it to nothing. The entry hard-expired, and the next
arrival paid the full uncached cost. With a 5-8s query behind it that is an
outage, not a slow request.

Two clamps also meant a declared TTL was not the TTL: `Math.max(60, ttl)` for
the Cloudflare KV floor, and the tiered store's 60s L1 promotion cap.

## Change

**Freshness moved onto the entry.** `freshUntil`/`staleUntil` are stored with the
response; the backend's expiry is now only a storage lifetime. A declared
`s-maxage=30` is honoured as 30s even though the row lives 60s, and the L1 cap
no longer changes policy — it just means an L2 read. This removes the clamp
problem by construction rather than by reporting it.

**Stale entries are served immediately.** One arrival is elected to refresh;
every other arrival in the stale window gets the stored copy without waiting. If
the elected one abandons, the lease expires and the next arrival retries — the
entry is never left unrepopulated while everyone waits on it, which is the
specific loop that wedged protravel.ro.

**Election** goes through the new `KVStore.putIfAbsent` where the backend has it,
with per-isolate exclusion as the floor. **Cold misses** on one key collapse onto
one origin computation within the isolate.

### Why the refresh is not behind the response

`next()` writes the route's response onto the context, and Hono's `compose`
drops a handler response once the context is finalized:

```js
if (res && (context.finalized === false || isError)) { context.res = res }
```

A refresh scheduled after the middleware returns therefore cannot see the fresh
body — it would re-store the *stale* one under a new freshness stamp, producing
an entry that looks refreshed and never changes. I wrote it that way first; the
test caught it. Electing one blocking refresher gives the same outcome for
everyone else and is deterministic.

## Two production defects found by running tests that had never run

`packages/db`'s Postgres runtime stores have integration tests gated on
`TEST_DATABASE_URL`. I ran them against a real Postgres:

1. **`expires_at` was bound as a `Date`**, which the postgres.js adapter cannot
   serialize through a raw `sql` template (`ERR_INVALID_ARG_TYPE`). Every TTL'd
   write to `createPostgresKvStore` threw, and the response cache's best-effort
   catch swallowed it. **A deployment selecting `cache: "postgres"` — which is
   the standard self-hosted profile — had a shared response cache that silently
   stored nothing.** Only the 60s per-process L1 was doing anything.
2. **`createPostgresFixedWindowRateLimitStore` used the reserved word `window`
   unquoted** in an INSERT column list and conflict target, which Postgres
   rejects outright. Its own integration test never ran because the fixture DDL
   had the same defect.

Both fixed, both now covered. This is context for #4097: the posture is worse
than that issue describes.

## Verification

| Command | Result |
| --- | --- |
| `pnpm --filter @voyant-travel/hono typecheck` | pass |
| `pnpm --filter @voyant-travel/hono test` | 334 passed (36 files) |
| `pnpm --filter @voyant-travel/utils test` | 122 passed, 1 skipped |
| `pnpm --filter @voyant-travel/db test` | 129 passed, 15 files (7 skipped without a DB, as CI runs) |
| `shared-stores.test.ts` with a real Postgres | 8 passed |
| `biome check` on hono/utils/db/.changeset | clean |

New cache coverage: stale served immediately while one refresher runs; entry past
`s-maxage + swr` is a miss; declared `s-maxage` honoured despite the 60s floor;
concurrent cold misses produce one computation; an arrival that loses the lease
serves stale and does not touch the origin; an arrival that wins refreshes.

Running the db suite *with* a database also surfaces 19 failures in
`auth-user-identifier` and `outbox` — pre-existing, unrelated, and caused by the
local test database not having those migrations applied. Untouched here.

## Follow-up

ADR 0021 §5 names `ON CONFLICT DO NOTHING` for the Postgres election. That form
can never re-take an *expired* slot, so a lapsed lease would be permanently
unelectable. The implementation uses a filtered `DO UPDATE` instead; I'll correct
the ADR text on #4094.


---

Supersedes #4102, which GitHub closed when its base branch was deleted on merge. Same commit, rebased onto main.
