### PR TITLE
fix(release): make the published contract packages installable

### DIFF
--- a/.changeset/republish-webhook-delivery-contracts.md
+++ b/.changeset/republish-webhook-delivery-contracts.md
@@ -1,0 +1,12 @@
+---
+"@voyant-travel/webhook-delivery-contracts": patch
+---
+
+Republish so the package resolves for consumers.
+
+`0.1.0` was published without its `publishConfig` overrides applied, so the
+released manifest kept `exports: { ".": "./src/index.ts" }` while `files` only
+ships `dist`. Every consumer resolving the package hit a missing module, which
+also made `@voyant-travel/app-manifest` unimportable through its dependency on
+this package. No source change is required — the existing `publishConfig` is
+correct and is applied by the release pipeline.

--- a/packages/app-manifest/package.json
+++ b/packages/app-manifest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyant-travel/app-manifest",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Validate and compile a Voyant app release manifest, and reproduce the release digest the marketplace admits.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/custom-fields-contracts/package.json
+++ b/packages/custom-fields-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyant-travel/custom-fields-contracts",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Custom field definition contracts for app publishers and external consumers, without the custom-fields runtime.",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Installing all fourteen public packages into a clean directory and importing each one showed three could not be used. This fixes the one bad publish behind them and reconciles two versions with the registry.

## What was broken

| Package | Symptom | Cause |
|---|---|---|
| `webhook-delivery-contracts` | `Cannot find module .../src/index.ts` | published without `publishConfig` applied |
| `app-manifest` | same error, transitively | depends on the package above |
| `app-manifest`, `custom-fields-contracts` | n/a | repo said `0.1.0`, registry said `0.1.1` |

`webhook-delivery-contracts@0.1.0` is the only one of the fourteen whose published manifest still carries a `publishConfig` block — it was never applied, so `exports` stayed at `{ ".": "./src/index.ts" }` while `files` ships only `dist`. It is the sole root cause of two of the three failures.

## What this changes

- A changeset republishes `webhook-delivery-contracts` through the release pipeline, which applies `publishConfig` correctly. **No source change** — the existing config is already right.
- `app-manifest` and `custom-fields-contracts` move to `0.1.1` to match what is on npm. Without this the next release would try to publish versions that already exist.

`app-manifest` depends on the range `^0.1.0`, so the republished `0.1.1` repairs the already-published `app-manifest@0.1.1` with no further release.

## Verification

All fourteen installed into a clean directory: install exit `0`, then each imported. Thirteen resolve; `webhook-delivery-contracts` is the failure this PR fixes. `@voyant-travel/ui` has no `"."` export by design — `ui/components` (363 exports) and `ui/lib/utils` both resolve.

## Follow-up

This class of defect is invisible to every current gate: the manifest looked correct and the version resolved. Only a real install catches it. Noted on #4086 — the release-time check there should install and import the surface, not inspect manifests.