### PR TITLE
fix(inventory): derive booking item lines from pax bands for person-priced products

### DIFF
--- a/.changeset/person-priced-products-storefront-booking.md
+++ b/.changeset/person-priced-products-storefront-booking.md
@@ -1,0 +1,41 @@
+---
+"@voyant-travel/inventory": patch
+---
+
+Derive booking item lines from pax bands so person-priced products can be
+booked from the storefront.
+
+A product whose selected option carried more than one `person` unit and flagged
+none of them `is_required` could be quoted, held and filled in, and then failed
+closed on `POST /v1/public/bookings` with "Several units are available and none
+is required, so the booking would reserve nothing." Adult / Child 6-12 /
+Child 0-5 is an ordinary per-person price structure, so this took out whole
+catalogues rather than an edge case (voyant#4113).
+
+Two halves of the booking engine disagreed about who names the units.
+`buildOwnedProductDraftShape` adds the journey's `option-units` step only for
+options that sell room or vehicle inventory — a person-only product prices by
+pax band alone — so the draft never carried `configure.optionSelections`.
+`deriveSelfServiceCommand` then derived its item lines from those selections
+alone, and the command reached booking creation with none. The refusal itself
+was right: a booking with no items reserves nothing. The storefront was simply
+incapable of supplying what the commit required for this product shape.
+
+Derivation now falls back to the pax bands, which is the only thing the shopper
+was actually asked for. The preferred source is the option price rule's
+per-band unit prices, shared with `priceQuote` through one
+`paxBandUnitCharges` function so the quote and the commit cannot drift about
+which units a person-priced product reserves: each item line corresponds 1:1 to
+an accepted quote base line. Amounts stay unset and are filled from the
+accepted quote, so the price the shopper saw still wins over a resolver reading
+taken at commit time.
+
+When the option's price lives at the option or product level and there are no
+per-band unit prices to derive from, the units are mapped onto the bands by
+their own age window instead. Two units deriving the same band — "Child 6-12"
+and "Child 0-5" both derive `child` — give the count to the first in sort order
+rather than each reserving the party in full.
+
+Quote band lines now also carry their `optionId` / `optionUnitId`, the same
+provenance the unit-selection path already emitted, so the commit matches item
+lines back to quote lines by unit rather than by position.

--- a/packages/inventory/src/booking-engine/handler-support.ts
+++ b/packages/inventory/src/booking-engine/handler-support.ts
@@ -13,9 +13,11 @@ import { productPaxPricingTiers, products } from "../schema-core.js"
 import type {
   CreateProductsBookingHandlerOptions,
   DraftLike,
+  OptionUnitBandCandidate,
   ResolvedOptionPrice,
   ResolvedPaxPricingTier,
 } from "./handler.js"
+import { deriveTravelerCategory } from "./product-runtime-support.js"
 
 export async function loadProduct(
   db: AnyDrizzleDb,
@@ -527,6 +529,43 @@ export function bookingExtraLinesFromAddonSelections(input: {
 }
 
 /**
+ * One (option unit × pax band) charge resolved from an option price rule.
+ *
+ * `priceQuote` renders these as the quote's base lines and
+ * `bookingItemLinesFromPaxBands` turns the same list into the commit's booking
+ * item lines. Deriving both from one function is what keeps the quote and the
+ * commit from disagreeing about which units a person-priced product reserves.
+ */
+export interface PaxBandUnitCharge {
+  unitId: string
+  travelerCategory: string
+  count: number
+  sellAmountCents: number
+}
+
+export function paxBandUnitCharges(
+  resolvedPrice: ResolvedOptionPrice | null | undefined,
+  pax: Partial<Record<string, number>> | undefined,
+): PaxBandUnitCharge[] {
+  if (!resolvedPrice) return []
+  return resolvedPrice.unitPrices.flatMap((unit) => {
+    if (!unit.travelerCategory) return []
+    const count = pax?.[unit.travelerCategory] ?? 0
+    if (count <= 0) return []
+    const sellAmountCents = unit.sellAmountCents ?? 0
+    if (sellAmountCents <= 0) return []
+    return [
+      {
+        unitId: unit.unitId,
+        travelerCategory: unit.travelerCategory,
+        count,
+        sellAmountCents,
+      },
+    ]
+  })
+}
+
+/**
  * Three-way price computation:
  *
  * 1. **Per-band** (preferred): when `resolvedPrice.unitPrices` matches
@@ -546,32 +585,30 @@ export function priceQuote(input: {
   resolvedPrice: ResolvedOptionPrice | null
   pax: Partial<Record<string, number>> | undefined
   effectivePax: number
+  /** Option the resolved price belongs to, stamped onto the band lines as
+   *  quote provenance so the commit can match them back to its item lines. */
+  optionId?: string | null
 }): PricedQuote {
   const { product, resolvedPrice, pax, effectivePax } = input
 
-  if (resolvedPrice && resolvedPrice.unitPrices.length > 0) {
-    const bandLines: PricedLine[] = []
+  const bandCharges = paxBandUnitCharges(resolvedPrice, pax)
+  if (bandCharges.length > 0) {
     let total = 0
-    for (const unit of resolvedPrice.unitPrices) {
-      if (!unit.travelerCategory) continue
-      const count = pax?.[unit.travelerCategory] ?? 0
-      if (count <= 0) continue
-      const sell = unit.sellAmountCents ?? 0
-      if (sell <= 0) continue
-      const lineTotal = sell * count
+    const bandLines: PricedLine[] = bandCharges.map((charge) => {
+      const lineTotal = charge.sellAmountCents * charge.count
       total += lineTotal
-      bandLines.push({
+      return {
         kind: "base",
-        label: `${product.name} — ${unit.travelerCategory}`,
-        quantity: count,
-        unitAmount: sell,
+        label: `${product.name} — ${charge.travelerCategory}`,
+        quantity: charge.count,
+        unitAmount: charge.sellAmountCents,
         totalAmount: lineTotal,
         pricingBasis: "per_person",
-      })
-    }
-    if (bandLines.length > 0) {
-      return { totalCents: total, lines: bandLines }
-    }
+        ...(input.optionId ? { optionId: input.optionId } : {}),
+        optionUnitId: charge.unitId,
+      }
+    })
+    return { totalCents: total, lines: bandLines }
   }
 
   if (resolvedPrice && resolvedPrice.baseSellAmountCents !== null) {
@@ -641,6 +678,69 @@ export function bookingItemLinesFromOptionSelections(
         ]
       : [],
   )
+  return lines.length > 0 ? lines : undefined
+}
+
+/**
+ * Item lines for a product the journey never showed a units step for.
+ *
+ * `buildOwnedProductDraftShape` renders the `option-units` sub-step only for
+ * options that sell room/vehicle inventory, so a person-priced product's draft
+ * carries pax bands and no `configure.optionSelections`. Without this the
+ * commit arrived with no item lines at all and booking creation refused it
+ * (voyant#4113).
+ *
+ * Preferred source: the option price rule's per-band unit prices, which is
+ * exactly what `priceQuote` charged for. Deriving from the same
+ * `paxBandUnitCharges` list means each line corresponds 1:1 to an accepted
+ * quote base line, so `fillMissingBookingItemSellAmounts` can reconcile them
+ * by provenance and the customer is billed per unit what they were quoted.
+ *
+ * Amounts are deliberately left unset: the accepted quote is authoritative, so
+ * the price the shopper saw wins over whatever the resolver says at commit
+ * time.
+ */
+export function bookingItemLinesFromPaxBands(input: {
+  optionId: string
+  resolvedPrice: ResolvedOptionPrice | null | undefined
+  pax: Partial<Record<string, number>> | undefined
+}): SelfServiceItemLines | undefined {
+  const lines = paxBandUnitCharges(input.resolvedPrice, input.pax).map((charge) => ({
+    optionId: input.optionId,
+    optionUnitId: charge.unitId,
+    quantity: charge.count,
+  }))
+  return lines.length > 0 ? lines : undefined
+}
+
+/**
+ * Fallback item lines for a person-priced option whose price is configured at
+ * the option or product level rather than per unit — there is no per-band unit
+ * price to derive from, but the units still exist and each pax band still has
+ * to reserve one.
+ *
+ * Bands map onto units by the unit's own age window (`deriveTravelerCategory`,
+ * the same rule the price resolver uses). When two units derive the same band
+ * — "Child 6-12" and "Child 0-5" both derive `child` — the first in sort order
+ * takes the whole band's count rather than each taking it in full, which would
+ * reserve the party twice. A band with no matching unit is dropped: the option
+ * has nothing to reserve for it, and inventing a unit would bill a traveler
+ * against someone else's rate.
+ */
+export function bookingItemLinesFromPaxBandUnits(input: {
+  optionId: string
+  units: ReadonlyArray<OptionUnitBandCandidate>
+  pax: Partial<Record<string, number>> | undefined
+}): SelfServiceItemLines | undefined {
+  const claimed = new Set<string>()
+  const lines = input.units.flatMap((unit) => {
+    const band = deriveTravelerCategory(unit)
+    if (!band || claimed.has(band)) return []
+    const quantity = input.pax?.[band] ?? 0
+    if (quantity <= 0) return []
+    claimed.add(band)
+    return [{ optionId: input.optionId, optionUnitId: unit.id, quantity }]
+  })
   return lines.length > 0 ? lines : undefined
 }
 

--- a/packages/inventory/src/booking-engine/handler.ts
+++ b/packages/inventory/src/booking-engine/handler.ts
@@ -42,6 +42,8 @@ import {
   applyAddonSelections,
   bookingExtraLinesFromAddonSelections,
   bookingItemLinesFromOptionSelections,
+  bookingItemLinesFromPaxBands,
+  bookingItemLinesFromPaxBandUnits,
   fillMissingBookingItemSellAmounts,
   loadProduct,
   normalizeOptionSelections,
@@ -200,6 +202,15 @@ export interface ResolvedOptionPrice {
   unitPrices: ReadonlyArray<ResolvedUnitPrice>
 }
 
+/** An option unit, reduced to what pax-band mapping needs: its age window
+ *  decides which traveler band reserves it. */
+export interface OptionUnitBandCandidate {
+  id: string
+  unitType: string
+  minAge: number | null
+  maxAge: number | null
+}
+
 /** Option/unit-specific pax-tier price from `product_pax_pricing_tiers`. */
 export interface ResolvedPaxPricingTier {
   pricePerPaxCents: number
@@ -334,6 +345,18 @@ export interface OwnedProductsShapeLoaders {
   ) => Promise<ResolvedPaxPricingTier | null>
 
   /**
+   * Resolve an option's bookable units, age windows included, so a
+   * person-priced product whose price lives at the option or product level
+   * can still map its pax bands onto units at commit time. Caller-supplied
+   * like the rest; when omitted, commits fall back to the per-band unit
+   * prices alone.
+   */
+  loadOptionUnits?: (
+    ctx: OwnedHandlerContext,
+    args: { productId: string; optionId: string },
+  ) => Promise<ReadonlyArray<OptionUnitBandCandidate>>
+
+  /**
    * Look up the local date of a departure slot (`availability_slots`).
    * Caller-supplied so the Inventory package does not import
    * `@voyant-travel/operations`. Returns null when the slot is missing.
@@ -403,6 +426,56 @@ async function safeLoad<T>(label: string, promise: Promise<T> | undefined): Prom
     console.warn(`[products/booking-engine] ${label} failed; continuing without it`, error)
     return undefined
   }
+}
+
+/**
+ * Item lines for a draft that carries pax bands but no unit selections.
+ *
+ * Resolves the option price the same way `computeQuote` did — same slot date,
+ * same loader — so the per-band lines derived here are the ones the shopper
+ * was quoted. When the option carries no per-band unit prices (its price lives
+ * at the option or product level) the units themselves are mapped onto the
+ * bands instead.
+ *
+ * Enrichment failures degrade to "no lines" rather than rejecting the commit:
+ * that leaves booking creation to apply its own refusal, which is a clearer
+ * signal than a derivation error.
+ */
+async function paxBandItemLines(input: {
+  ctx: OwnedHandlerContext
+  options: CreateProductsBookingHandlerOptions
+  productId: string
+  optionId: string
+  draft: DraftLike
+}) {
+  const { ctx, options, productId, optionId, draft } = input
+  const pax = draft.configure?.pax
+  if (sumPax(pax) <= 0) return undefined
+
+  const slotId = draft.configure?.departureSlotId
+  const slotDate =
+    (slotId && options.loadSlotDate
+      ? await safeLoad("loadSlotDate", options.loadSlotDate(ctx, slotId))
+      : null) ??
+    draft.configure?.departureDate ??
+    null
+
+  const resolvedPrice =
+    slotDate && options.loadResolvedOptionPrice
+      ? await safeLoad(
+          "loadResolvedOptionPrice",
+          options.loadResolvedOptionPrice(ctx, { productId, optionId, date: slotDate }),
+        )
+      : null
+
+  const bandLines = bookingItemLinesFromPaxBands({ optionId, resolvedPrice, pax })
+  if (bandLines) return bandLines
+
+  const units = await safeLoad(
+    "loadOptionUnits",
+    options.loadOptionUnits?.(ctx, { productId, optionId }),
+  )
+  return units ? bookingItemLinesFromPaxBandUnits({ optionId, units, pax }) : undefined
 }
 
 export function createProductsBookingHandler(
@@ -523,6 +596,7 @@ export function createProductsBookingHandler(
                 resolvedPrice,
                 pax: draft.configure?.pax,
                 effectivePax,
+                optionId,
               })
         const pricedWithAddons = applyAddonSelections({
           priced,
@@ -710,10 +784,26 @@ export function createProductsBookingHandler(
         quantityMultiplier: Math.max(1, travelers.length),
       })
 
+      // A product the journey never showed a units step for reaches here with
+      // no selections at all. Fall back to the pax bands, which is the only
+      // thing the shopper was actually asked for, so the command still names
+      // the units it reserves instead of arriving empty (voyant#4113).
+      const derivedItemLines =
+        bookingItemLinesFromOptionSelections(optionSelections) ??
+        (primaryOptionId
+          ? await paxBandItemLines({
+              ctx,
+              options,
+              productId: product.id,
+              optionId: primaryOptionId,
+              draft,
+            })
+          : undefined)
+
       let itemLines: ReturnType<typeof fillMissingBookingItemSellAmounts> | undefined
       try {
         itemLines = fillMissingBookingItemSellAmounts({
-          itemLines: bookingItemLinesFromOptionSelections(optionSelections),
+          itemLines: derivedItemLines,
           pricing: request.pricing,
           targetSellAmountCents: sellAmountCentsOverride,
           extraLines,

--- a/packages/inventory/src/booking-engine/product-runtime.ts
+++ b/packages/inventory/src/booking-engine/product-runtime.ts
@@ -433,6 +433,26 @@ export function registerProductBookingHandler(
           return undefined
         }
       },
+      async loadOptionUnits(ctx, args) {
+        const db = asPostgresDb(ctx.db)
+        return db
+          .select({
+            id: optionUnits.id,
+            unitType: optionUnits.unitType,
+            minAge: optionUnits.minAge,
+            maxAge: optionUnits.maxAge,
+          })
+          .from(optionUnits)
+          .innerJoin(productOptions, eq(optionUnits.optionId, productOptions.id))
+          .where(
+            and(
+              eq(optionUnits.optionId, args.optionId),
+              eq(productOptions.productId, args.productId),
+              eq(optionUnits.isHidden, false),
+            ),
+          )
+          .orderBy(asc(optionUnits.sortOrder), asc(optionUnits.createdAt))
+      },
       async loadSlotDate(ctx, slotId) {
         const db = asPostgresDb(ctx.db)
         const [slot] = await db

--- a/packages/inventory/tests/unit/booking-engine-quote.test.ts
+++ b/packages/inventory/tests/unit/booking-engine-quote.test.ts
@@ -117,8 +117,20 @@ describe("createProductsBookingHandler.computeQuote", () => {
     const breakdown = result.pricing?.breakdown as Record<string, unknown>
     // 2 × 16000 + 1 × 9500 = 41500. Infant (sell=0) drops out.
     expect(breakdown?.total).toBe(41500)
-    const lines = breakdown?.lines as Array<{ quantity: number; unitAmount: number }>
+    const lines = breakdown?.lines as Array<{
+      quantity: number
+      unitAmount: number
+      optionId?: string
+      optionUnitId?: string
+    }>
     expect(lines).toHaveLength(2)
+    // Band lines carry the unit they priced. The commit matches its item lines
+    // back to these, so a quote without provenance can only be reconciled
+    // positionally (voyant#4113).
+    expect(lines.map((line) => [line.optionId, line.optionUnitId])).toEqual([
+      ["opt_default", "u_adult"],
+      ["opt_default", "u_child"],
+    ])
     expect(lines.map((l) => `${l.quantity}×${l.unitAmount}`)).toEqual(["2×16000", "1×9500"])
   })
 

--- a/packages/inventory/tests/unit/self-service-pax-band-item-lines.test.ts
+++ b/packages/inventory/tests/unit/self-service-pax-band-item-lines.test.ts
@@ -1,0 +1,215 @@
+import type {
+  ComputeQuoteRequest,
+  OwnedHandlerContext,
+  PricingBasis,
+} from "@voyant-travel/catalog/booking-engine"
+import { describe, expect, it } from "vitest"
+
+import {
+  createProductsBookingHandler,
+  type OptionUnitBandCandidate,
+  type ResolvedOptionPrice,
+} from "../../src/booking-engine/handler.js"
+
+/**
+ * A person-priced product never renders the journey's units step — the shape
+ * descriptor adds `option-units` only for room/vehicle inventory — so its draft
+ * reaches the commit with pax bands and no `configure.optionSelections`.
+ * Booking creation refuses a command with no item lines when the option has
+ * several optional units, which made every Adult / Child product with more than
+ * one unit unbookable from the storefront (voyant#4113).
+ *
+ * These cases quote first and then derive from that exact quote, because the
+ * defect is a disagreement between the two halves: anything that only exercises
+ * derivation in isolation would not have caught it.
+ */
+describe("deriveSelfServiceCommand for person-priced products", () => {
+  const perBandPrice: ResolvedOptionPrice = {
+    baseSellAmountCents: 16000,
+    unitPrices: [
+      { unitId: "u_adult", unitType: "person", travelerCategory: "adult", sellAmountCents: 16000 },
+      { unitId: "u_child", unitType: "person", travelerCategory: "child", sellAmountCents: 9500 },
+    ],
+  }
+
+  it("derives one item line per pax band from the option's per-band unit prices", async () => {
+    const handler = createProductsBookingHandler({
+      loadSlotDate: async () => "2026-06-21",
+      loadResolvedOptionPrice: async () => perBandPrice,
+    })
+
+    const command = await quoteThenDerive(handler, draft({ adult: 2, child: 1 }))
+
+    // Not one merged line: each band reserves its own unit, and the amounts
+    // come back from the accepted quote rather than from a fresh price lookup.
+    // Titles come from the quote line each item matched, which is what makes
+    // the per-band split legible on the booking.
+    expect(command.itemLines).toEqual([
+      {
+        optionId: "opt_1",
+        optionUnitId: "u_adult",
+        quantity: 2,
+        title: "Danube Delta Day Trip — adult",
+        unitSellAmountCents: 16000,
+        totalSellAmountCents: 32000,
+      },
+      {
+        optionId: "opt_1",
+        optionUnitId: "u_child",
+        quantity: 1,
+        title: "Danube Delta Day Trip — child",
+        unitSellAmountCents: 9500,
+        totalSellAmountCents: 9500,
+      },
+    ])
+    // 2 × 16000 + 1 × 9500 — the item lines account for the whole booking.
+    expect(command.sellAmountCentsOverride).toBe(41500)
+  })
+
+  it("drops a band the shopper booked nobody into", async () => {
+    const handler = createProductsBookingHandler({
+      loadSlotDate: async () => "2026-06-21",
+      loadResolvedOptionPrice: async () => perBandPrice,
+    })
+
+    const command = await quoteThenDerive(handler, draft({ adult: 1 }))
+
+    expect(command.itemLines).toEqual([
+      {
+        optionId: "opt_1",
+        optionUnitId: "u_adult",
+        quantity: 1,
+        title: "Danube Delta Day Trip — adult",
+        unitSellAmountCents: 16000,
+        totalSellAmountCents: 16000,
+      },
+    ])
+  })
+
+  it("maps bands onto units by age window when the price lives on the option", async () => {
+    // No per-band unit prices to derive from: the option is priced as a whole,
+    // so the units themselves have to say which band reserves which.
+    const handler = createProductsBookingHandler({
+      loadSlotDate: async () => "2026-06-21",
+      loadResolvedOptionPrice: async () => ({ baseSellAmountCents: 18000, unitPrices: [] }),
+      loadOptionUnits: async () => units,
+    })
+
+    const command = await quoteThenDerive(handler, draft({ adult: 2, child: 1 }))
+
+    expect(command.itemLines?.map((line) => [line.optionUnitId, line.quantity])).toEqual([
+      ["u_adult", 2],
+      ["u_child_6_12", 1],
+    ])
+    // 18000 × 3 pax, split across the lines by their traveler counts.
+    expect(command.sellAmountCentsOverride).toBe(54000)
+    expect(sumLineTotals(command.itemLines)).toBe(54000)
+  })
+
+  it("gives a band to a single unit when two units derive the same band", async () => {
+    // "Child 6-12" and "Child 0-5" both derive `child`. Giving each the full
+    // child count would reserve the same children twice.
+    const handler = createProductsBookingHandler({
+      loadSlotDate: async () => "2026-06-21",
+      loadResolvedOptionPrice: async () => ({ baseSellAmountCents: 18000, unitPrices: [] }),
+      loadOptionUnits: async () => units,
+    })
+
+    const command = await quoteThenDerive(handler, draft({ adult: 1, child: 2 }))
+
+    expect(command.itemLines?.map((line) => line.optionUnitId)).toEqual(["u_adult", "u_child_6_12"])
+    expect(sumLineTotals(command.itemLines)).toBe(command.sellAmountCentsOverride)
+  })
+
+  it("leaves the command without item lines when nothing can resolve the units", async () => {
+    // Neither loader is wired, so there is nothing to derive from. Booking
+    // creation still applies its own refusal — derivation must not invent a
+    // unit to keep the commit moving.
+    const handler = createProductsBookingHandler({})
+
+    const command = await quoteThenDerive(handler, draft({ adult: 2 }))
+
+    expect(command.itemLines).toBeUndefined()
+  })
+})
+
+const units: OptionUnitBandCandidate[] = [
+  { id: "u_adult", unitType: "person", minAge: 18, maxAge: null },
+  { id: "u_child_6_12", unitType: "person", minAge: 6, maxAge: 12 },
+  { id: "u_child_0_5", unitType: "person", minAge: 0, maxAge: 5 },
+]
+
+const product = {
+  id: "prod_1",
+  name: "Danube Delta Day Trip",
+  status: "active" as const,
+  sellAmountCents: 16000,
+  sellCurrency: "RON",
+}
+
+function draft(pax: Record<string, number>) {
+  return {
+    configure: { variantId: "opt_1", departureSlotId: "slot_1", pax },
+    travelers: Object.entries(pax).flatMap(([band, count]) =>
+      Array.from({ length: count }, (_, index) => ({
+        firstName: `${band}-${index}`,
+        lastName: "Traveler",
+        band,
+      })),
+    ),
+  }
+}
+
+/**
+ * Quote the draft, then derive the create command from that quote — the same
+ * order the storefront journey does it in, so the accepted price and the
+ * derived item lines have to reconcile the way they would in production.
+ */
+async function quoteThenDerive(
+  handler: ReturnType<typeof createProductsBookingHandler>,
+  draftPayload: ReturnType<typeof draft>,
+) {
+  const quote = await handler.computeQuote(context(), {
+    entityModule: "products",
+    entityId: product.id,
+    scope: { locale: "en", audience: "customer", market: "RO" },
+    draft: draftPayload,
+  } satisfies ComputeQuoteRequest)
+  expect(quote.available).toBe(true)
+
+  const derive = handler.deriveSelfServiceCommand
+  if (!derive) throw new Error("products handler must implement deriveSelfServiceCommand")
+  const result = await derive(context(), {
+    entityModule: "products",
+    entityId: product.id,
+    draft: draftPayload,
+    pricing: quote.pricing as PricingBasis,
+    billing: {
+      personId: "per_1",
+      organizationId: null,
+      contactFirstName: "Ada",
+      contactLastName: "Traveler",
+      contactEmail: "guest@example.com",
+      contactPhone: null,
+    },
+  })
+  if (result.status !== "ok") throw new Error(`expected ok, got ${result.status}`)
+  return result.command
+}
+
+function sumLineTotals(lines: { totalSellAmountCents?: number | null }[] | undefined) {
+  return (lines ?? []).reduce((sum, line) => sum + (line.totalSellAmountCents ?? 0), 0)
+}
+
+/** Derivation only reads the product row, so the double implements exactly
+ *  the select chain `loadProduct` walks. */
+function context(): OwnedHandlerContext {
+  return {
+    db: {
+      select: () => ({
+        from: () => ({ where: () => ({ limit: async () => [product] }) }),
+      }),
+    },
+    adapterContext: {},
+  } as unknown as OwnedHandlerContext
+}


### PR DESCRIPTION
Fixes #4113.

## The defect

A product whose selected option carries more than one `option_units` row of
`unit_type = 'person'`, none flagged `is_required`, could be quoted, could hold
inventory, could collect traveler details — and then failed closed on
`POST /v1/public/bookings` with `BookingItemsUnresolvedError`. Adult /
Child 6-12 / Child 0-5 is an ordinary per-person price structure, so this took
out whole catalogues rather than an edge case: on the reporting operator, 13 of
39 product options were unbookable online.

## Root cause

Two halves of the booking engine disagreed about who names the units.

`buildOwnedProductDraftShape` adds the journey's `option-units` sub-step only
for options that sell room or vehicle inventory — a person-only product prices
by pax band alone — so the storefront draft never carried
`configure.optionSelections`. `deriveSelfServiceCommand` then derived its item
lines from those selections and nothing else, and the command reached booking
creation carrying none. Booking creation refuses that, correctly: a booking
with no items reserves nothing, holds no inventory and cannot be invoiced. The
storefront was simply incapable of supplying what the commit required for this
product shape.

The admin manual-booking form always writes `optionSelections` from an explicit
unit-quantity picker, which is why every staff booking and every test driving
that surface passed.

## The fix

Derivation now falls back to the pax bands, which is the only thing the shopper
was actually asked for.

**Preferred source — the option price rule's per-band unit prices.** This is
exactly what `priceQuote` charged for. Both now derive from one
`paxBandUnitCharges` function, so the quote and the commit cannot drift about
which units a person-priced product reserves: each item line corresponds 1:1 to
an accepted quote base line. Amounts are deliberately left unset and filled
from the accepted quote by `fillMissingBookingItemSellAmounts`, so the price
the shopper saw still wins over a resolver reading taken at commit time — a
price change between quote and commit does not become a hard failure.

**Fallback — age windows.** When the option's price lives at the option or
product level there are no per-band unit prices to derive from, but the units
still exist and each band still has to reserve one. Units map onto bands by
their own age window via `deriveTravelerCategory`, the same rule the price
resolver uses. A band is claimed by a single unit: "Child 6-12" and
"Child 0-5" both derive `child`, and giving each the full child count would
reserve the same children twice. A band with no matching unit is dropped —
inventing a unit would bill a traveler against someone else's rate. This path
needs a new `loadOptionUnits` loader, wired in `product-runtime.ts` the same
way the other enrichment loaders are.

**Quote provenance.** Band lines now carry their `optionId` / `optionUnitId`,
the same provenance the unit-selection path already emitted. Item lines match
back to quote lines by unit rather than by position.

The `BookingItemsUnresolvedError` guard in `service-core.ts` is deliberately
left intact. It is a genuine last-resort refusal, and the issue's alternative
of relaxing `unitsToSeed` was not taken: item lines invented inside
`service-core` would bypass `deriveSelfServiceCommand`'s `price_changed` check,
so the quote and the commit could disagree silently.

Enrichment failures degrade to "no item lines" rather than rejecting the
commit, leaving booking creation to apply its own refusal — a clearer signal
than a derivation error.

## Tests

`self-service-pax-band-item-lines.test.ts` quotes first and then derives from
that exact quote, in the order the storefront journey does it. The defect was a
disagreement between the two halves, so anything exercising derivation in
isolation would not have caught it. It covers the per-band path, a band with no
travelers, the option-level-price fallback, the two-units-one-band collision,
and the case where nothing can resolve the units (still no item lines, refusal
preserved). `booking-engine-quote.test.ts` pins the new quote provenance.

## Verification

- `pnpm -F @voyant-travel/inventory typecheck` — pass
- `pnpm -F @voyant-travel/inventory test` — 496 passed
- `pnpm -F @voyant-travel/bookings -F @voyant-travel/finance -F @voyant-travel/catalog test` — pass (one catalog runtime test times out only under parallel load; passes on its own and is unrelated)
- `biome check` on the changed files — clean

Not verified locally: the end-to-end storefront journey against a seeded
person-only product. The reproduction in the issue is the acceptance test.
