### PR TITLE
fix(inventory): charge and reserve one unit per pax band

### DIFF
--- a/.changeset/pax-band-collision-single-unit.md
+++ b/.changeset/pax-band-collision-single-unit.md
@@ -1,0 +1,41 @@
+---
+"@voyant-travel/inventory": patch
+---
+
+Charge and reserve one unit when several option units collapse onto the same
+pax band.
+
+`deriveTravelerCategory` maps every age tier under 18 onto `child`, so an
+operator selling "Child 6-12" alongside "Child 0-5" has two units competing for
+one band. `paxBandUnitCharges` had no record of which bands were already
+spoken for, so each unit contributed a full line carrying the whole band count.
+For `pax = { adult: 1, child: 1 }` against units priced 16000 / 13600 / 10400,
+the quote totalled 40000 for two travelers, and since voyant#4117 the commit
+also wrote three booking item lines and reserved three seats (voyant#4118).
+
+The overcharge predates voyant#4117 — `priceQuote` always had the ungated loop —
+but that change propagated it from the price into the reservation, which is the
+part that consumes departure capacity.
+
+A band is now claimed by exactly one unit, which is the rule the room path has
+always applied: `priceOptionSelections` keys its per-band prices on
+`option + band` and takes the first. The person-priced path was the outlier.
+
+The operator's `option_units.sort_order` decides the winner, so a contested band
+resolves to something the operator controls rather than to an accident of query
+planning. `sort_order` now travels on `ResolvedUnitPrice` and the charge list is
+sorted by it, with `unitId` breaking ties. This matters for correctness, not
+just predictability: `option_unit_price_rules` is selected with no `ORDER BY`,
+and the quote and the commit resolve prices in two separate calls, so a
+first-row-wins rule over unsorted rows could have picked one tier when quoting
+and another when committing.
+
+A zero-priced unit still does not claim a band. Free units produced no quote
+line and no reservation before this change, and letting one win a contested band
+would have quietly stopped charging for that band altogether.
+
+This does not make an operator with several child tiers expressible. The journey
+still collects one `child` count, so which tier the traveler belongs to remains
+unknown and the price for a contested band is still a guess — it is simply the
+operator's guess now, made once, instead of every tier being billed at once.
+Collecting pax per tier is the real fix and is tracked separately.

--- a/packages/inventory/src/booking-engine/handler-support.ts
+++ b/packages/inventory/src/booking-engine/handler-support.ts
@@ -548,12 +548,19 @@ export function paxBandUnitCharges(
   pax: Partial<Record<string, number>> | undefined,
 ): PaxBandUnitCharge[] {
   if (!resolvedPrice) return []
-  return resolvedPrice.unitPrices.flatMap((unit) => {
+  const claimed = new Set<string>()
+  return sortedByOperatorOrder(resolvedPrice.unitPrices).flatMap((unit) => {
     if (!unit.travelerCategory) return []
+    // One unit per band. `deriveTravelerCategory` collapses every age tier
+    // under 18 onto `child`, so an operator selling "Child 6-12" and
+    // "Child 0-5" has two units competing for one band. Charging both bills
+    // the same child twice and reserves two seats for them (voyant#4118).
+    if (claimed.has(unit.travelerCategory)) return []
     const count = pax?.[unit.travelerCategory] ?? 0
     if (count <= 0) return []
     const sellAmountCents = unit.sellAmountCents ?? 0
     if (sellAmountCents <= 0) return []
+    claimed.add(unit.travelerCategory)
     return [
       {
         unitId: unit.unitId,
@@ -562,6 +569,28 @@ export function paxBandUnitCharges(
         sellAmountCents,
       },
     ]
+  })
+}
+
+/**
+ * Order unit prices the way the operator ordered the units.
+ *
+ * Which unit wins a contested band has to be the operator's call, and it has
+ * to be the same call twice: the quote and the commit each resolve the price
+ * in a separate query, and the underlying `option_unit_price_rules` select
+ * carries no `ORDER BY`, so relying on the returned order would let the two
+ * disagree. `unitId` breaks ties so units sharing a `sort_order` — and the
+ * several category rows a single unit can carry — still land in a stable
+ * order.
+ */
+function sortedByOperatorOrder(
+  unitPrices: ReadonlyArray<ResolvedOptionPrice["unitPrices"][number]>,
+): ResolvedOptionPrice["unitPrices"][number][] {
+  return [...unitPrices].sort((left, right) => {
+    const leftOrder = left.sortOrder ?? Number.MAX_SAFE_INTEGER
+    const rightOrder = right.sortOrder ?? Number.MAX_SAFE_INTEGER
+    if (leftOrder !== rightOrder) return leftOrder - rightOrder
+    return left.unitId.localeCompare(right.unitId)
   })
 }
 

--- a/packages/inventory/src/booking-engine/handler.ts
+++ b/packages/inventory/src/booking-engine/handler.ts
@@ -191,6 +191,14 @@ export interface ResolvedUnitPrice {
   travelerCategory: "adult" | "child" | "infant" | "senior" | null
   pricingMode?: "per_unit" | "per_person" | "per_booking" | "included" | "free" | "on_request"
   sellAmountCents: number | null
+  /**
+   * The unit's `option_units.sort_order`. When several units collapse onto the
+   * same band, the operator's ordering decides which one wins, so this has to
+   * survive the price lookup — the underlying query returns rows in whatever
+   * order Postgres picks, and the quote and the commit resolve prices in two
+   * separate calls (voyant#4118).
+   */
+  sortOrder?: number | null
 }
 
 /** Output of `loadResolvedOptionPrice`. The handler prefers

--- a/packages/inventory/src/booking-engine/product-runtime.ts
+++ b/packages/inventory/src/booking-engine/product-runtime.ts
@@ -518,6 +518,7 @@ export function registerProductBookingHandler(
               unitType: optionUnits.unitType,
               minAge: optionUnits.minAge,
               maxAge: optionUnits.maxAge,
+              sortOrder: optionUnits.sortOrder,
             })
             .from(optionUnits)
             .where(and(eq(optionUnits.optionId, args.optionId), eq(optionUnits.isHidden, false))),
@@ -558,6 +559,7 @@ export function registerProductBookingHandler(
                 travelerCategory: band as "adult" | "child" | "infant" | "senior",
                 pricingMode: up.pricingMode,
                 sellAmountCents: up.sellAmountCents,
+                sortOrder: unit.sortOrder,
               },
             ]
           }
@@ -568,6 +570,7 @@ export function registerProductBookingHandler(
               travelerCategory: deriveTravelerCategory(unit),
               pricingMode: up.pricingMode,
               sellAmountCents: up.sellAmountCents,
+              sortOrder: unit.sortOrder,
             },
           ]
         })

--- a/packages/inventory/tests/unit/self-service-pax-band-item-lines.test.ts
+++ b/packages/inventory/tests/unit/self-service-pax-band-item-lines.test.ts
@@ -121,6 +121,88 @@ describe("deriveSelfServiceCommand for person-priced products", () => {
     expect(sumLineTotals(command.itemLines)).toBe(command.sellAmountCentsOverride)
   })
 
+  it("charges and reserves one unit when two priced tiers collapse onto a band", async () => {
+    // `deriveTravelerCategory` puts every age tier under 18 on `child`, so
+    // "Child 6-12" and "Child 0-5" compete for one band. Charging both bills
+    // the same child twice and reserves two seats for one traveler
+    // (voyant#4118).
+    const handler = createProductsBookingHandler({
+      loadSlotDate: async () => "2026-06-21",
+      loadResolvedOptionPrice: async () => twoChildTiers,
+    })
+
+    const command = await quoteThenDerive(handler, draft({ adult: 1, child: 1 }))
+
+    expect(command.itemLines?.map((line) => [line.optionUnitId, line.quantity])).toEqual([
+      ["u_adult", 1],
+      ["u_child_6_12", 1],
+    ])
+    // Two travelers, two seats — not the three the ungated loop reserved.
+    expect(sumQuantities(command.itemLines)).toBe(2)
+    // 16000 + 13600. The 10400 second child tier is not added on top.
+    expect(command.sellAmountCentsOverride).toBe(29600)
+  })
+
+  it("lets the operator's sort order pick the winner, whatever order the rows arrive in", async () => {
+    // `option_unit_price_rules` is selected without an ORDER BY, and the quote
+    // and the commit resolve prices in separate calls. Sorting on the unit's
+    // own `sort_order` is what stops the two picking different tiers.
+    const reversed: ResolvedOptionPrice = {
+      ...twoChildTiers,
+      unitPrices: [...twoChildTiers.unitPrices].reverse(),
+    }
+    const handler = createProductsBookingHandler({
+      loadSlotDate: async () => "2026-06-21",
+      loadResolvedOptionPrice: async () => reversed,
+    })
+
+    const command = await quoteThenDerive(handler, draft({ adult: 1, child: 1 }))
+
+    expect(command.itemLines?.map((line) => line.optionUnitId)).toEqual(["u_adult", "u_child_6_12"])
+    expect(command.sellAmountCentsOverride).toBe(29600)
+  })
+
+  it("passes a contested band to the next tier when the operator's first is free", async () => {
+    // A zero-priced unit produced no quote line and no reservation before the
+    // dedupe, and still does — claiming the band with it would silently stop
+    // charging for children.
+    const freeFirstTier: ResolvedOptionPrice = {
+      baseSellAmountCents: 16000,
+      unitPrices: [
+        {
+          unitId: "u_adult",
+          unitType: "person",
+          travelerCategory: "adult",
+          sellAmountCents: 16000,
+          sortOrder: 0,
+        },
+        {
+          unitId: "u_child_6_12",
+          unitType: "person",
+          travelerCategory: "child",
+          sellAmountCents: 0,
+          sortOrder: 1,
+        },
+        {
+          unitId: "u_child_0_5",
+          unitType: "person",
+          travelerCategory: "child",
+          sellAmountCents: 10400,
+          sortOrder: 2,
+        },
+      ],
+    }
+    const handler = createProductsBookingHandler({
+      loadSlotDate: async () => "2026-06-21",
+      loadResolvedOptionPrice: async () => freeFirstTier,
+    })
+
+    const command = await quoteThenDerive(handler, draft({ adult: 1, child: 1 }))
+
+    expect(command.itemLines?.map((line) => line.optionUnitId)).toEqual(["u_adult", "u_child_0_5"])
+    expect(command.sellAmountCentsOverride).toBe(26400)
+  })
+
   it("leaves the command without item lines when nothing can resolve the units", async () => {
     // Neither loader is wired, so there is nothing to derive from. Booking
     // creation still applies its own refusal — derivation must not invent a
@@ -132,6 +214,34 @@ describe("deriveSelfServiceCommand for person-priced products", () => {
     expect(command.itemLines).toBeUndefined()
   })
 })
+
+/** The reporting operator's shape: two child tiers on one option. */
+const twoChildTiers: ResolvedOptionPrice = {
+  baseSellAmountCents: 16000,
+  unitPrices: [
+    {
+      unitId: "u_adult",
+      unitType: "person",
+      travelerCategory: "adult",
+      sellAmountCents: 16000,
+      sortOrder: 0,
+    },
+    {
+      unitId: "u_child_6_12",
+      unitType: "person",
+      travelerCategory: "child",
+      sellAmountCents: 13600,
+      sortOrder: 1,
+    },
+    {
+      unitId: "u_child_0_5",
+      unitType: "person",
+      travelerCategory: "child",
+      sellAmountCents: 10400,
+      sortOrder: 2,
+    },
+  ],
+}
 
 const units: OptionUnitBandCandidate[] = [
   { id: "u_adult", unitType: "person", minAge: 18, maxAge: null },
@@ -199,6 +309,10 @@ async function quoteThenDerive(
 
 function sumLineTotals(lines: { totalSellAmountCents?: number | null }[] | undefined) {
   return (lines ?? []).reduce((sum, line) => sum + (line.totalSellAmountCents ?? 0), 0)
+}
+
+function sumQuantities(lines: { quantity: number }[] | undefined) {
+  return (lines ?? []).reduce((sum, line) => sum + line.quantity, 0)
 }
 
 /** Derivation only reads the product row, so the double implements exactly


### PR DESCRIPTION
Fixes #4118. Follow-up to #4117, which is already merged — this stacks on top of `41a65674af`.

## Confirmed the report

Reproduced on merged `main` before changing anything. Adult 16000 / Child 6-12 13600 / Child 0-5 10400, `pax = { adult: 1, child: 1 }`:

```
QUOTE TOTAL: 40000
QUOTE LINES: adult ×1 16000, child ×1 13600, child ×1 10400
ITEM LINES:  u_adult ×1, u_child_6_12 ×1, u_child_0_5 ×1
SEATS RESERVED: 3 for travelers: 2
```

`deriveTravelerCategory` maps every age tier under 18 onto `child`, so both child units compete for one band and `paxBandUnitCharges` gave each the full band count.

The issue is right that the overcharge predates #4117 — `priceQuote` always had the ungated loop. #4117 propagated it into item lines, which moved it from *price only* to *price and departure capacity*.

## The rule this restores

One band, one unit. That is what the room path has always done: `priceOptionSelections` keys its per-band prices on `option + band` and takes the first (`handler-support.ts:205-214`). The person-priced path was the outlier, so this is a consistency fix rather than a new rule.

## Why the winner is `sort_order`, and why that is correctness

`option_unit_price_rules` is selected with **no `ORDER BY`** (`product-runtime.ts:501`), and `loadResolvedOptionPrice` runs twice — once for the quote, once for the commit. A plain first-row-wins guard over unsorted rows could have claimed Child 6-12 when quoting and Child 0-5 when committing, breaking the quote/commit agreement #4117 set out to establish and potentially rejecting the commit as `price_changed`.

So `sort_order` now travels on `ResolvedUnitPrice` and the charge list is sorted by it, with `unitId` breaking ties (a single unit can carry several category rows). Beyond determinism, it puts a contested band under operator control instead of query planning.

The issue suggested narrowest age window as most defensible. I went with `sort_order` because it is the only option the operator can actually steer without a schema change, and because any age-based choice is still a guess about a traveler whose tier the journey never collected.

## Deliberately unchanged: free units do not claim a band

A zero-priced unit produced no quote line and no reservation before this change. Letting one win a contested band would have silently stopped charging for that band — an operator with a free "Child 6-12" would have made every child free. The guard therefore claims a band only after the price check, and there is a test pinning it.

## What this does not fix

An operator with several child tiers still has no correct configuration. The journey collects one `child` count, so which tier a traveler belongs to is unknown and the price for a contested band is still a guess — the operator's guess, made once, rather than every tier billed at once.

Collecting pax per tier is the real fix: `loadPaxBands` would stop deduping by `categoryType`, band codes would become tier-specific, and the pricing resolver would key on the tier. That is a journey-and-pricing change, not a patch, and #4118 should stay open for it after this lands.

## Tests

Three added to `self-service-pax-band-item-lines.test.ts`, all quoting first and deriving from that exact quote:

- two priced tiers collapsing onto one band charge 29600 and reserve 2 seats, not 40000 and 3
- reversing the resolver's row order changes nothing, pinning the determinism the missing `ORDER BY` would otherwise cost
- a free first tier passes the band to the next one rather than swallowing it

## Verification

- `vitest` on the three affected inventory suites — 31 passed
- `biome check` on the changed files — clean
- full `@voyant-travel/inventory` suite and `tsc` were still running locally when this was pushed (tsc takes ~10 min for this package); CI is the authority and I will follow up if either turns red

Not verified: the end-to-end journey against a seeded two-child-tier product.
