### PR TITLE
fix(tools): diagnose handler admission failures and duplicate installs

### DIFF
--- a/packages/mcp/src/dispatch.ts
+++ b/packages/mcp/src/dispatch.ts
@@ -16,6 +16,7 @@ import {
   ToolError,
   type ToolManifestEntry,
   type ToolRegistry,
+  toToolError,
 } from "@voyant-travel/tools"
 
 import { isRecord } from "./guards.js"
@@ -107,11 +108,10 @@ export async function dispatchToResult(
     // Normalize any thrown value into a ToolError so the envelope always carries
     // the actionable fields. An unknown throw maps to PROVIDER_ERROR (terminal),
     // the safe-for-writes default — a blind retry of an unknown failure could
-    // duplicate a write.
-    const toolError =
-      err instanceof ToolError
-        ? err
-        : new ToolError(err instanceof Error ? err.message : String(err), "PROVIDER_ERROR")
+    // duplicate a write. `toToolError` recognises a ToolError raised by another
+    // loaded copy of @voyant-travel/tools, so a duplicated install does not
+    // strip its code and remediation here (voyant#4115).
+    const toolError = toToolError(err)
     const error = {
       contractVersion: TOOL_CONTRACT_VERSION,
       code: toolError.code,

--- a/packages/mcp/src/meta-tools.ts
+++ b/packages/mcp/src/meta-tools.ts
@@ -24,6 +24,7 @@ import {
   ToolError,
   type ToolManifestEntry,
   type ToolRegistry,
+  toToolError,
 } from "@voyant-travel/tools"
 import type { AccessCatalog, ApiKeyPermissions } from "@voyant-travel/types/api-keys"
 import { isAuthorized } from "./authorization.js"
@@ -449,10 +450,9 @@ function unknownToolResult(name: string): CallToolResult {
 }
 
 function errorResult(err: unknown): CallToolResult {
-  const toolError =
-    err instanceof ToolError
-      ? err
-      : new ToolError(err instanceof Error ? err.message : String(err), "PROVIDER_ERROR")
+  // Recognises a ToolError from another loaded copy of @voyant-travel/tools so
+  // a duplicated install cannot flatten its code into PROVIDER_ERROR.
+  const toolError = toToolError(err)
   return {
     isError: true,
     content: [{ type: "text", text: `[${toolError.code}] ${toolError.message}` }],

--- a/packages/tools/src/errors.ts
+++ b/packages/tools/src/errors.ts
@@ -106,6 +106,15 @@ export const TOOL_ERROR_DEFAULTS: Record<ToolErrorCode, ToolErrorDefault> = {
 }
 
 /**
+ * Well-known brand identifying a {@link ToolError} across copies of this
+ * package. `instanceof` compares against one module evaluation's class, so an
+ * error thrown by a second loaded copy fails it and gets re-wrapped — turning
+ * a precise code such as `ACTION_POLICY_REQUIRED` into a generic
+ * `PROVIDER_ERROR` whose text reaches the caller verbatim (voyant#4115).
+ */
+const TOOL_ERROR_BRAND = Symbol.for("@voyant-travel/tools.ToolError")
+
+/**
  * Standard error for tool failures. The transport adapter catches these and
  * translates them into its own error envelope (e.g. an MCP `isError` result).
  * The core stays transport-neutral — no `content[]` envelope here.
@@ -149,7 +158,67 @@ export class ToolError extends Error {
     if (details?.didYouMean) {
       this.didYouMean = details.didYouMean
     }
+    Object.defineProperty(this, TOOL_ERROR_BRAND, {
+      value: true,
+      enumerable: false,
+      configurable: false,
+      writable: false,
+    })
   }
+}
+
+/**
+ * Recognise a {@link ToolError} thrown by any loaded copy of this package.
+ *
+ * Prefer this over `instanceof` at a transport boundary: a duplicated install
+ * would otherwise strip the error's code and actionable fields and surface its
+ * raw message as provider error text.
+ */
+export function isToolError(value: unknown): value is ToolError {
+  if (value instanceof ToolError) return true
+  if (typeof value !== "object" || value === null) return false
+  if ((value as Record<symbol, unknown>)[TOOL_ERROR_BRAND] === true) return true
+  // A copy predating the brand still identifies itself by name and carries a
+  // string code, which is enough to forward it rather than flatten it.
+  const candidate = value as { name?: unknown; code?: unknown; message?: unknown }
+  return (
+    value instanceof Error &&
+    candidate.name === "ToolError" &&
+    typeof candidate.code === "string" &&
+    typeof candidate.message === "string"
+  )
+}
+
+/**
+ * Normalise any thrown value into a {@link ToolError} of *this* copy.
+ *
+ * A branded error from another copy keeps its code, message, meta and
+ * actionable fields; anything else becomes the conservative terminal
+ * `PROVIDER_ERROR` default.
+ */
+export function toToolError(value: unknown): ToolError {
+  if (value instanceof ToolError) return value
+  if (isToolError(value)) {
+    const foreign = value as unknown as ToolError
+    return new ToolError(
+      foreign.message,
+      foreign.code,
+      foreign.meta,
+      { cause: value },
+      {
+        retryable: foreign.retryable,
+        ...(foreign.nextSteps?.length ? { nextSteps: foreign.nextSteps } : {}),
+        ...(foreign.candidates?.length ? { candidates: foreign.candidates } : {}),
+        ...(foreign.didYouMean ? { didYouMean: foreign.didYouMean } : {}),
+      },
+    )
+  }
+  return new ToolError(
+    value instanceof Error ? value.message : String(value),
+    "PROVIDER_ERROR",
+    undefined,
+    { cause: value },
+  )
 }
 
 /**

--- a/packages/tools/src/handler-action-policy.ts
+++ b/packages/tools/src/handler-action-policy.ts
@@ -6,8 +6,27 @@ import {
 } from "./binding.js"
 import type { ToolContext, ToolHandlerActionPolicyContext } from "./context.js"
 import { ToolError } from "./errors.js"
+import {
+  DUPLICATE_TOOLS_INSTANCE_REMEDIATION,
+  loadedToolsPackageInstanceCount,
+  TOOLS_PACKAGE_INSTANCE,
+  TOOLS_PACKAGE_NAME,
+  type ToolsPackageInstance,
+} from "./package-instance.js"
 
 const authenticHandlerAdmissions = new WeakSet<object>()
+
+/**
+ * Non-enumerable stamp naming the loaded copy of this package that minted an
+ * admission. `Symbol.for` on purpose: the whole point is that a *different*
+ * copy can read it.
+ *
+ * The stamp is a diagnostic, never a credential — it is trivially forgeable and
+ * is only ever read after the authenticity `WeakSet` has already refused. It
+ * lets the refusal say "minted by another copy of the package" instead of
+ * reporting a packaging fault as a forgery attempt.
+ */
+const ADMISSION_MINT_BRAND = Symbol.for("@voyant-travel/tools.handlerAdmissionMintedBy")
 
 export interface HandlerActionPolicyExpectation {
   capabilityId: string
@@ -61,7 +80,7 @@ export function assertAdmittedActionPolicy(
   admitted: ToolHandlerActionPolicyContext | undefined,
   expected: HandlerActionPolicyExpectation,
 ): asserts admitted is ToolHandlerActionPolicyContext {
-  assertAuthenticHandlerActionPolicyContext(admitted)
+  assertAuthenticHandlerActionPolicyContext(admitted, expected)
   if (admitted.actionPolicy.enforcement !== "handler") {
     throw new ToolError(
       "Handler-owned action policy context is required for this action.",
@@ -110,26 +129,138 @@ export function assertAdmissionTransport(
   }
 }
 
+/** Why an admission failed the authenticity check. */
+export type HandlerAdmissionAuthenticityFailure =
+  /** No admission reached the assertion, or it is not an object at all. */
+  | "admission-absent"
+  /** An object that this package never minted — a structural lookalike. */
+  | "admission-not-minted"
+  /** Genuinely minted, but by a *different* loaded copy of this package. */
+  | "admission-minted-by-another-package-instance"
+
+/** The identity fields a failure reports, when the caller can supply them. */
+export interface HandlerAdmissionIdentityHint {
+  capabilityId?: string
+  canonicalName?: string
+}
+
 /**
  * Assert that a handler admission was minted by the Tool registry while
  * dispatching a selected handler-owned action.
  *
  * Structural lookalikes are deliberately rejected: action-ledger command
  * entrypoints use this assertion before any claim or mutation lease is minted.
+ *
+ * Failures carry the same diagnostic detail every sibling guard in this file
+ * attaches, plus a `reason` separating the three situations that used to be
+ * indistinguishable from the outside — nothing admitted, a lookalike, and a
+ * duplicate-install packaging fault (voyant#4115).
+ *
+ * Pass `identity` where the caller pins one static expectation, so the failure
+ * names the action rather than only the fact that one failed.
  */
 export function assertAuthenticHandlerActionPolicyContext(
   admitted: unknown,
+  identity?: HandlerAdmissionIdentityHint,
 ): asserts admitted is ToolHandlerActionPolicyContext {
-  if (
-    typeof admitted !== "object" ||
-    admitted === null ||
-    !authenticHandlerAdmissions.has(admitted)
-  ) {
-    throw new ToolError(
-      "Authentic handler-owned action admission is required.",
+  if (typeof admitted !== "object" || admitted === null) {
+    throw admissionAuthenticityError("admission-absent", admitted, identity)
+  }
+  if (authenticHandlerAdmissions.has(admitted)) return
+  const mintedBy = readAdmissionMintBrand(admitted)
+  throw admissionAuthenticityError(
+    mintedBy ? "admission-minted-by-another-package-instance" : "admission-not-minted",
+    admitted,
+    identity,
+    mintedBy,
+  )
+}
+
+function admissionAuthenticityError(
+  reason: HandlerAdmissionAuthenticityFailure,
+  admitted: unknown,
+  identity: HandlerAdmissionIdentityHint | undefined,
+  mintedBy?: ToolsPackageInstance,
+): ToolError {
+  // The expectation is trustworthy; anything read off the admission is the
+  // caller's own claim and is reported under a distinct key so an operator
+  // reading the meta is never misled about its provenance.
+  const claimed = claimedAdmissionIdentity(admitted)
+  const subject = identity?.canonicalName ?? identity?.capabilityId ?? claimed.capabilityId
+  const meta: Record<string, unknown> = {
+    reason,
+    ...(identity?.capabilityId ? { capabilityId: identity.capabilityId } : {}),
+    ...(identity?.canonicalName ? { canonicalName: identity.canonicalName } : {}),
+    ...(claimed.capabilityId ? { claimedCapabilityId: claimed.capabilityId } : {}),
+    ...(claimed.actionId ? { claimedActionId: claimed.actionId } : {}),
+    assertedBy: TOOLS_PACKAGE_INSTANCE,
+    loadedPackageInstances: loadedToolsPackageInstanceCount(),
+  }
+  const named = subject ? ` for "${subject}"` : ""
+
+  if (reason === "admission-minted-by-another-package-instance") {
+    return new ToolError(
+      `The handler-owned action admission${named} was minted by a different loaded copy of ${TOOLS_PACKAGE_NAME}, so it is not authentic to the copy checking it. This is a packaging fault in the deployment, not a rejected caller.`,
       "ACTION_POLICY_REQUIRED",
+      { ...meta, mintedBy },
+      undefined,
+      { nextSteps: DUPLICATE_TOOLS_INSTANCE_REMEDIATION },
     )
   }
+
+  const duplicateHint =
+    loadedToolsPackageInstanceCount() > 1 ? DUPLICATE_TOOLS_INSTANCE_REMEDIATION : []
+  if (reason === "admission-absent") {
+    return new ToolError(
+      `No handler-owned action admission reached this action${named}. It must be dispatched through the Tool registry or through the route that serves it.`,
+      "ACTION_POLICY_REQUIRED",
+      meta,
+      undefined,
+      {
+        nextSteps: [
+          "Invoke this action through its registered Tool or route so the registry mints an admission; a handler cannot admit itself.",
+          ...duplicateHint,
+        ],
+      },
+    )
+  }
+  return new ToolError(
+    `The handler-owned action admission${named} was not minted by this Tool registry.`,
+    "ACTION_POLICY_REQUIRED",
+    meta,
+    undefined,
+    {
+      nextSteps: [
+        "Admissions cannot be constructed by a caller. Dispatch through the registered Tool or route action so the registry mints one.",
+        ...duplicateHint,
+      ],
+    },
+  )
+}
+
+/** Identity the untrusted admission claims for itself, used for reporting only. */
+function claimedAdmissionIdentity(admitted: unknown): {
+  capabilityId?: string
+  actionId?: string
+} {
+  if (typeof admitted !== "object" || admitted === null) return {}
+  const candidate = admitted as { capabilityId?: unknown; actionPolicy?: { id?: unknown } }
+  const capabilityId = candidate.capabilityId
+  const actionId = candidate.actionPolicy?.id
+  return {
+    ...(typeof capabilityId === "string" ? { capabilityId } : {}),
+    ...(typeof actionId === "string" ? { actionId } : {}),
+  }
+}
+
+function readAdmissionMintBrand(admitted: object): ToolsPackageInstance | undefined {
+  const branded = (admitted as Record<symbol, unknown>)[ADMISSION_MINT_BRAND]
+  if (typeof branded !== "object" || branded === null) return undefined
+  const candidate = branded as Partial<ToolsPackageInstance>
+  if (candidate.package !== TOOLS_PACKAGE_NAME || typeof candidate.instance !== "number") {
+    return undefined
+  }
+  return candidate as ToolsPackageInstance
 }
 
 /**
@@ -176,37 +307,58 @@ export function mintHandlerActionPolicyContext(
   admitted: ToolHandlerActionPolicyContext,
   transport: ToolAdmissionTransport = "tool",
 ): ToolHandlerActionPolicyContext {
-  const minted = deepFreezeAdmission({
-    ...admitted,
-    transport,
-    actionPolicy: {
-      ...admitted.actionPolicy,
-      ...(admitted.actionPolicy.existingTarget
-        ? { existingTarget: { ...admitted.actionPolicy.existingTarget } }
-        : {}),
-      ...(admitted.actionPolicy.createdTarget
-        ? {
-            createdTarget: {
-              ...admitted.actionPolicy.createdTarget,
-              ...(admitted.actionPolicy.createdTarget.parentAnchor
-                ? { parentAnchor: { ...admitted.actionPolicy.createdTarget.parentAnchor } }
-                : {}),
-            },
-          }
-        : {}),
-      ...(admitted.actionPolicy.allowedActorTypes
-        ? { allowedActorTypes: [...admitted.actionPolicy.allowedActorTypes] }
-        : {}),
-      invocation: {
-        ...admitted.actionPolicy.invocation,
-        requiredFields: [...admitted.actionPolicy.invocation.requiredFields],
-        optionalFields: [...admitted.actionPolicy.invocation.optionalFields],
+  const minted = deepFreezeAdmission(
+    brandMintedAdmission({
+      ...admitted,
+      transport,
+      actionPolicy: {
+        ...admitted.actionPolicy,
+        ...(admitted.actionPolicy.existingTarget
+          ? { existingTarget: { ...admitted.actionPolicy.existingTarget } }
+          : {}),
+        ...(admitted.actionPolicy.createdTarget
+          ? {
+              createdTarget: {
+                ...admitted.actionPolicy.createdTarget,
+                ...(admitted.actionPolicy.createdTarget.parentAnchor
+                  ? { parentAnchor: { ...admitted.actionPolicy.createdTarget.parentAnchor } }
+                  : {}),
+              },
+            }
+          : {}),
+        ...(admitted.actionPolicy.allowedActorTypes
+          ? { allowedActorTypes: [...admitted.actionPolicy.allowedActorTypes] }
+          : {}),
+        invocation: {
+          ...admitted.actionPolicy.invocation,
+          requiredFields: [...admitted.actionPolicy.invocation.requiredFields],
+          optionalFields: [...admitted.actionPolicy.invocation.optionalFields],
+        },
       },
-    },
-    invocation: { ...admitted.invocation },
-  })
+      invocation: { ...admitted.invocation },
+    }),
+  )
   authenticHandlerAdmissions.add(minted)
   return minted
+}
+
+/**
+ * Stamp the minting copy of this package onto a fresh admission.
+ *
+ * Applied before the deep freeze, because a frozen object cannot take new
+ * properties. Non-enumerable so it never widens the admission's shape for
+ * spreads, `JSON.stringify`, or the identity comparisons below.
+ */
+function brandMintedAdmission(
+  admitted: ToolHandlerActionPolicyContext,
+): ToolHandlerActionPolicyContext {
+  Object.defineProperty(admitted, ADMISSION_MINT_BRAND, {
+    value: TOOLS_PACKAGE_INSTANCE,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  })
+  return admitted
 }
 
 function deepFreezeAdmission(

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -37,11 +37,13 @@ export {
 export { defineTool, type ToolDefinition } from "./define-tool.js"
 export {
   enforceAudienceAuthorization,
+  isToolError,
   requireService,
   TOOL_ERROR_DEFAULTS,
   ToolError,
   type ToolErrorCode,
   type ToolErrorDetails,
+  toToolError,
 } from "./errors.js"
 export {
   admitHandlerActionPolicy,
@@ -49,8 +51,19 @@ export {
   assertAdmittedActionPolicy,
   assertAuthenticHandlerActionPolicyContext,
   type HandlerActionPolicyExpectation,
+  type HandlerAdmissionAuthenticityFailure,
+  type HandlerAdmissionIdentityHint,
   withServerResolvedIdempotencyKey,
 } from "./handler-action-policy.js"
+export {
+  assertSingleToolsPackageInstance,
+  DUPLICATE_TOOLS_INSTANCE_REMEDIATION,
+  isToolsPackageDuplicated,
+  loadedToolsPackageInstanceCount,
+  TOOLS_PACKAGE_INSTANCE,
+  TOOLS_PACKAGE_NAME,
+  type ToolsPackageInstance,
+} from "./package-instance.js"
 export {
   createToolRegistry,
   type PreparedToolAction,

--- a/packages/tools/src/package-instance.ts
+++ b/packages/tools/src/package-instance.ts
@@ -1,0 +1,118 @@
+/**
+ * Identity for one loaded copy of this package.
+ *
+ * Handler admission authenticity is proved by membership in a module-level
+ * `WeakSet` (see `handler-action-policy.ts`). That is unforgeable, but it is
+ * also *per module evaluation*: a deployment whose dependency graph resolves
+ * two copies of `@voyant-travel/tools` gets two independent registries, so an
+ * admission minted by one copy is not authentic to the other. Every
+ * handler-owned action then fails closed despite correct configuration.
+ *
+ * That is a packaging fault, not a forgery, and the two must not be reported
+ * identically. This module gives each loaded copy a stable identity recorded on
+ * a well-known global, so a minted admission can be stamped with the copy that
+ * produced it and a failing assertion can name the real cause.
+ */
+
+/** Package name, carried on the brand so a stamped admission is self-describing. */
+export const TOOLS_PACKAGE_NAME = "@voyant-travel/tools"
+
+/**
+ * Well-known key, so every loaded copy shares one ledger. `Symbol.for` is
+ * deliberate: a module-private symbol would defeat the entire point.
+ */
+const INSTANCE_LEDGER_KEY = Symbol.for("@voyant-travel/tools.loadedInstances")
+
+export interface ToolsPackageInstance {
+  /** Always {@link TOOLS_PACKAGE_NAME}. */
+  readonly package: string
+  /** 1-based load order of this module evaluation within the process. */
+  readonly instance: number
+}
+
+interface ToolsPackageInstanceLedger {
+  readonly instances: ToolsPackageInstance[]
+}
+
+function instanceLedger(): ToolsPackageInstanceLedger {
+  const host = globalThis as typeof globalThis & {
+    [INSTANCE_LEDGER_KEY]?: ToolsPackageInstanceLedger
+  }
+  const existing = host[INSTANCE_LEDGER_KEY]
+  if (existing) return existing
+  const created: ToolsPackageInstanceLedger = { instances: [] }
+  Object.defineProperty(host, INSTANCE_LEDGER_KEY, {
+    value: created,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  })
+  return created
+}
+
+function registerThisInstance(): ToolsPackageInstance {
+  const ledger = instanceLedger()
+  const identity: ToolsPackageInstance = Object.freeze({
+    package: TOOLS_PACKAGE_NAME,
+    instance: ledger.instances.length + 1,
+  })
+  ledger.instances.push(identity)
+  return identity
+}
+
+/**
+ * This module evaluation's identity. Distinct for every loaded copy of the
+ * package, and stable for the life of the process.
+ */
+export const TOOLS_PACKAGE_INSTANCE: ToolsPackageInstance = registerThisInstance()
+
+/** How many copies of this package have been evaluated in this process. */
+export function loadedToolsPackageInstanceCount(): number {
+  return instanceLedger().instances.length
+}
+
+/**
+ * Whether this process has evaluated more than one copy of the package.
+ *
+ * Only copies carrying this module can be counted. A copy predating it is
+ * invisible here, which is why the admission brand is also checked directly.
+ */
+export function isToolsPackageDuplicated(): boolean {
+  return loadedToolsPackageInstanceCount() > 1
+}
+
+export const DUPLICATE_TOOLS_INSTANCE_REMEDIATION = [
+  `This deployment resolves more than one copy of ${TOOLS_PACKAGE_NAME}. Handler-owned action admissions are authentic only to the copy that minted them, so they fail closed across copies.`,
+  `Deduplicate the install (\`pnpm why ${TOOLS_PACKAGE_NAME}\` / inspect the lockfile) so every package resolves the same copy, then redeploy.`,
+] as const
+
+let warned = false
+
+/**
+ * Report a duplicated install once per loaded copy.
+ *
+ * This warns rather than throws. A duplicated graph can be entirely functional
+ * — it only breaks where an admission crosses copies — and refusing to boot
+ * would turn a latent packaging fault into an outage. Deployments that want the
+ * stricter posture call {@link assertSingleToolsPackageInstance} at startup.
+ */
+export function warnOnDuplicateToolsPackageInstance(): void {
+  if (warned || !isToolsPackageDuplicated()) return
+  warned = true
+  console.error(
+    `[${TOOLS_PACKAGE_NAME}] ${loadedToolsPackageInstanceCount()} copies of this package are loaded. ${DUPLICATE_TOOLS_INSTANCE_REMEDIATION.join(" ")}`,
+  )
+}
+
+/**
+ * Fail loudly at boot when the package is duplicated.
+ *
+ * Intended for a deployment's startup path, where failing on a packaging fault
+ * is better than failing on the first destructive Tool call.
+ */
+export function assertSingleToolsPackageInstance(): void {
+  if (!isToolsPackageDuplicated()) return
+  throw new Error(
+    `${loadedToolsPackageInstanceCount()} copies of ${TOOLS_PACKAGE_NAME} are loaded. ${DUPLICATE_TOOLS_INSTANCE_REMEDIATION.join(" ")}`,
+  )
+}

--- a/packages/tools/src/registry.ts
+++ b/packages/tools/src/registry.ts
@@ -4,11 +4,12 @@ import {
   type ToolManifestEntry,
 } from "./binding.js"
 import type { ToolContext, ToolHandlerActionPolicyContext } from "./context.js"
-import { ToolError } from "./errors.js"
+import { isToolError, ToolError, toToolError } from "./errors.js"
 import {
   firstHandlerActionPolicyIdentityMismatch,
   mintHandlerActionPolicyContext,
 } from "./handler-action-policy.js"
+import { warnOnDuplicateToolsPackageInstance } from "./package-instance.js"
 import {
   type AnyToolDefinition,
   createRegisteredTool,
@@ -74,6 +75,10 @@ export interface ToolRegistry {
 }
 
 export function createToolRegistry(): ToolRegistry {
+  // A duplicated install makes every cross-copy admission fail closed. Say so
+  // at construction rather than leaving it to be discovered on the first
+  // destructive Tool call (voyant#4115).
+  warnOnDuplicateToolsPackageInstance()
   const tools = new Map<string, RegisteredTool>()
   const invocationNames = new Map<string, RegisteredTool>()
   const capabilities = new Map<string, RegisteredTool>()
@@ -330,7 +335,10 @@ async function executeTool(
   try {
     result = await tool.handler(input, ctx)
   } catch (err) {
-    if (err instanceof ToolError) throw err
+    // A ToolError thrown by another loaded copy of this package must keep its
+    // code and remediation. `instanceof` alone would flatten it into a generic
+    // PROVIDER_ERROR whose raw text reaches the caller (voyant#4115).
+    if (isToolError(err)) throw toToolError(err)
     const message = err instanceof Error ? err.message : String(err)
     throw new ToolError(`Tool "${name}" failed: ${message}`, "PROVIDER_ERROR", undefined, {
       cause: err,

--- a/packages/tools/tests/handler-admission-diagnostics.test.ts
+++ b/packages/tools/tests/handler-admission-diagnostics.test.ts
@@ -1,0 +1,214 @@
+import { beforeAll, describe, expect, it, vi } from "vitest"
+
+import {
+  assertAuthenticHandlerActionPolicyContext,
+  assertSingleToolsPackageInstance,
+  createToolRegistry,
+  isToolError,
+  isToolsPackageDuplicated,
+  loadedToolsPackageInstanceCount,
+  type RouteActionBinding,
+  TOOLS_PACKAGE_INSTANCE,
+  type ToolActionPolicyBinding,
+  ToolError,
+  type ToolHandlerActionPolicyContext,
+  toToolError,
+} from "../src/index.js"
+
+const ACTION_ID = "@voyant-travel/finance#bookings-create-extension.action.create-booking-self"
+const CAPABILITY_ID = "@voyant-travel/finance#bookings-create-extension.route.create-booking-self"
+const CANONICAL_NAME = "create_booking_self_service"
+
+const invocation = {
+  controlField: "_voyant",
+  requiredFields: ["idempotencyKey"],
+  optionalFields: [],
+  fingerprintAlgorithm: "action-ledger-command-v1",
+} as const
+
+const routePolicy = {
+  id: ACTION_ID,
+  capabilityId: ACTION_ID,
+  version: "v1",
+  kind: "execute",
+  targetType: "booking",
+  targetLifecycle: "created",
+  createdTarget: {
+    commandTargetType: "finance_booking_create_command",
+    resultReferenceType: "booking",
+    durability: "handler-command-claim-v1",
+  },
+  risk: "high",
+  ledger: "required",
+  approval: "never",
+  reversible: false,
+  allowedActorTypes: ["customer"],
+  transport: "route",
+} satisfies ToolActionPolicyBinding
+
+const routeBinding: RouteActionBinding = {
+  capabilityId: CAPABILITY_ID,
+  capabilityVersion: "v1",
+  canonicalName: CANONICAL_NAME,
+  actionPolicy: routePolicy,
+  invocation,
+}
+
+const identity = { capabilityId: CAPABILITY_ID, canonicalName: CANONICAL_NAME }
+
+function mintHere(): ToolHandlerActionPolicyContext {
+  const registry = createToolRegistry()
+  registry.registerRouteAction(routeBinding)
+  return registry.admitRouteAction(ACTION_ID, {
+    actor: "customer",
+    invocation: { idempotencyKey: "req_1" },
+  })
+}
+
+function thrownBy(admitted: unknown, hint?: typeof identity): ToolError {
+  try {
+    assertAuthenticHandlerActionPolicyContext(admitted, hint)
+  } catch (err) {
+    return err as ToolError
+  }
+  throw new Error("expected the authenticity assertion to throw")
+}
+
+describe("handler admission authenticity diagnostics", () => {
+  it("names the action and the reason when no admission was supplied", () => {
+    const err = thrownBy(undefined, identity)
+
+    expect(err.code).toBe("ACTION_POLICY_REQUIRED")
+    expect(err.message).toContain(CANONICAL_NAME)
+    expect(err.meta).toMatchObject({
+      reason: "admission-absent",
+      capabilityId: CAPABILITY_ID,
+      canonicalName: CANONICAL_NAME,
+      assertedBy: TOOLS_PACKAGE_INSTANCE,
+    })
+  })
+
+  it("distinguishes a structural lookalike from a missing admission", () => {
+    const err = thrownBy({ ...mintHere() }, identity)
+
+    expect(err.meta).toMatchObject({
+      reason: "admission-not-minted",
+      capabilityId: CAPABILITY_ID,
+      // The clone's own claim, reported separately from the pinned expectation.
+      claimedCapabilityId: CAPABILITY_ID,
+      claimedActionId: ACTION_ID,
+    })
+  })
+
+  it("still reports the claimed identity when the caller pins no expectation", () => {
+    const err = thrownBy({ ...mintHere() })
+
+    expect(err.message).toContain(CAPABILITY_ID)
+    expect(err.meta).toMatchObject({ reason: "admission-not-minted" })
+    expect(err.meta).not.toHaveProperty("capabilityId")
+  })
+
+  it("accepts an admission minted by this copy of the package", () => {
+    expect(() => assertAuthenticHandlerActionPolicyContext(mintHere(), identity)).not.toThrow()
+  })
+})
+
+describe("duplicate package instances", () => {
+  /** A second, independently evaluated copy of this package. */
+  let second: typeof import("../src/index.js")
+
+  beforeAll(async () => {
+    vi.resetModules()
+    second = await import("../src/index.js")
+    vi.resetModules()
+  })
+
+  it("gives each loaded copy a distinct identity", () => {
+    expect(second.TOOLS_PACKAGE_INSTANCE.instance).not.toBe(TOOLS_PACKAGE_INSTANCE.instance)
+    expect(loadedToolsPackageInstanceCount()).toBeGreaterThan(1)
+    expect(isToolsPackageDuplicated()).toBe(true)
+  })
+
+  it("reports a cross-copy admission as a packaging fault, not a forgery", () => {
+    const registry = second.createToolRegistry()
+    registry.registerRouteAction(routeBinding as never)
+    const foreign = registry.admitRouteAction(ACTION_ID, {
+      actor: "customer",
+      invocation: { idempotencyKey: "req_1" },
+    })
+
+    // Authentic to the copy that minted it...
+    expect(() => second.assertAuthenticHandlerActionPolicyContext(foreign, identity)).not.toThrow()
+
+    // ...and refused by this copy, but named for what it is.
+    const err = thrownBy(foreign, identity)
+    expect(err.meta).toMatchObject({
+      reason: "admission-minted-by-another-package-instance",
+      mintedBy: second.TOOLS_PACKAGE_INSTANCE,
+      assertedBy: TOOLS_PACKAGE_INSTANCE,
+    })
+    expect(err.message).toContain("packaging fault")
+    expect(err.nextSteps.join(" ")).toContain("Deduplicate the install")
+  })
+
+  it("keeps the mint brand off the admission's enumerable shape", () => {
+    const admitted = mintHere()
+
+    expect(Object.keys(admitted)).not.toContain("package")
+    expect(JSON.parse(JSON.stringify(admitted))).toEqual({
+      capabilityId: CAPABILITY_ID,
+      capabilityVersion: "v1",
+      canonicalName: CANONICAL_NAME,
+      actionPolicy: { ...routePolicy, enforcement: "handler", invocation },
+      invocation: { idempotencyKey: "req_1" },
+      transport: "route",
+    })
+  })
+
+  it("reports the duplicate once, at registry construction", async () => {
+    vi.resetModules()
+    const third = await import("../src/index.js")
+    vi.resetModules()
+    const reported = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    third.createToolRegistry()
+    third.createToolRegistry()
+
+    expect(reported).toHaveBeenCalledTimes(1)
+    expect(reported.mock.calls[0]?.[0]).toContain("copies of this package are loaded")
+    reported.mockRestore()
+  })
+
+  it("fails loudly when a deployment asserts a single instance", () => {
+    expect(() => assertSingleToolsPackageInstance()).toThrowError(/copies of @voyant-travel\/tools/)
+  })
+})
+
+describe("cross-copy ToolError recognition", () => {
+  it("recognises and preserves a ToolError raised by another copy", async () => {
+    vi.resetModules()
+    const second = await import("../src/index.js")
+    vi.resetModules()
+
+    const foreign = new second.ToolError("Approval is required.", "APPROVAL_REQUIRED", {
+      actionId: ACTION_ID,
+    })
+
+    expect(foreign instanceof ToolError).toBe(false)
+    expect(isToolError(foreign)).toBe(true)
+
+    const normalized = toToolError(foreign)
+    expect(normalized).toBeInstanceOf(ToolError)
+    expect(normalized.code).toBe("APPROVAL_REQUIRED")
+    expect(normalized.message).toBe("Approval is required.")
+    expect(normalized.meta).toEqual({ actionId: ACTION_ID })
+    expect(normalized.nextSteps).toEqual(foreign.nextSteps)
+  })
+
+  it("maps an unrecognised throw to the terminal provider default", () => {
+    const normalized = toToolError(new Error("boom"))
+
+    expect(normalized.code).toBe("PROVIDER_ERROR")
+    expect(normalized.retryable).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #4115.

## The problem

`assertAuthenticHandlerActionPolicyContext` proves admission authenticity by membership in a module-level `WeakSet`. On failure it raised `Authentic handler-owned action admission is required.` carrying **no context at all**, while every sibling guard in the same file attaches `capabilityId`, `mismatch`, `actionId`, `expected`/`minted`.

Three very different situations were indistinguishable from the outside:

1. A genuine forgery attempt — what the guard exists to stop.
2. A structural lookalike built by a caller that never went through the registry.
3. An admission minted by a **different loaded copy** of `@voyant-travel/tools`, where the object is authentic but the `WeakSet` checking it is not the one it was added to.

Case 3 is a packaging fault, not a security event, and it is reachable: the `WeakSet` is module state, so any deployment resolving two copies of the package gets two independent registries and every handler-owned Tool fails closed regardless of correct configuration.

## What changed

**Diagnostics on the authenticity failure** (`handler-action-policy.ts`)

The assertion takes an optional identity hint, which `assertAdmittedActionPolicy` now passes from its pinned expectation. Failures carry a `reason` discriminator — `admission-absent` / `admission-not-minted` / `admission-minted-by-another-package-instance` — plus `capabilityId`/`canonicalName` from the trusted expectation and, under distinct `claimed*` keys, the identity the untrusted admission asserts for itself. Each reason gets its own message and `nextSteps`.

**Explicit duplicate-instance detection** (`package-instance.ts`, new)

Each loaded copy registers an identity on a well-known global (`Symbol.for`), and `mintHandlerActionPolicyContext` stamps every minted admission with a non-enumerable brand naming the minting copy. The brand is applied before the deep freeze and is a *diagnostic, never a credential* — it is trivially forgeable and is only read after the `WeakSet` has already refused. That is enough to turn "authentic admission required" into "minted by a different loaded copy of `@voyant-travel/tools`; deduplicate the install".

**Detection at boot rather than on the first destructive call**

`createToolRegistry()` reports a duplicated install once, and `assertSingleToolsPackageInstance()` is exported for deployments that want to fail hard at startup. Construction only warns by design: a duplicated graph can be entirely functional — it breaks only where an admission crosses copies — so refusing to boot would turn a latent packaging fault into an outage.

**Stop flattening a `ToolError` from another copy** (`errors.ts`, `registry.ts`, `packages/mcp`)

This is how the raw text reached the operator. `err instanceof ToolError` compares against one module evaluation's class, so a `ToolError` raised by a second copy fails the check and gets re-wrapped — `ACTION_POLICY_REQUIRED` becomes a generic `PROVIDER_ERROR` whose message is surfaced verbatim as `[PROVIDER_ERROR] Tool "create_booking" failed: …`. `ToolError` now carries a well-known symbol brand, and `isToolError`/`toToolError` recognise a foreign one (with a name+code structural fallback for a copy predating the brand), preserving its code, meta and actionable fields. The registry handler catch and both MCP envelope sites route through it.

## Verification

- `pnpm -F @voyant-travel/tools -F @voyant-travel/mcp -F @voyant-travel/action-ledger typecheck` — clean
- `pnpm -F @voyant-travel/tools -F @voyant-travel/mcp -F @voyant-travel/action-ledger test` — 71 / 78 / 240 passing
- `pnpm verify:architecture` — exit 0
- `biome check packages/tools packages/mcp` — clean (one pre-existing warning in `packages/mcp/tests/response-budget.test.ts`, unchanged from main)

New tests (`packages/tools/tests/handler-admission-diagnostics.test.ts`) load a second copy of the package via `vi.resetModules()` and assert the real cross-copy behaviour: the same admission is authentic to its minting copy and reported as a packaging fault by the other; the brand stays off the admission's enumerable shape; the duplicate is reported once at construction; and a foreign `ToolError` keeps its code through `toToolError`.

No changeset: both `@voyant-travel/tools` and `@voyant-travel/mcp` are `private: true`.