### PR TITLE
Record which Product Version a departure was materialized from

### DIFF
--- a/.changeset/departure-product-version-binding.md
+++ b/.changeset/departure-product-version-binding.md
@@ -1,0 +1,39 @@
+---
+"@voyant-travel/availability": minor
+"@voyant-travel/operations": minor
+"@voyant-travel/inventory": minor
+---
+
+Record which Product Version an operated departure was materialized from.
+
+A departure had no way to name the Product definition it sells. Editing a
+product silently changed what every existing departure appeared to offer,
+including ones already sold — the gap the product model RFC calls out as the
+reason a departure cannot be reconciled, operated, or costed against a stable
+definition.
+
+`availability_slots` gains `product_version_id`. It is a soft reference:
+`product_versions` is owned by Inventory and a cross-domain foreign key would
+violate schema discipline, so the column stays plain text exactly like
+`product_id` beside it.
+
+Recurring generation resolves the version **once per rule**, so a publish
+landing mid-run cannot split one generation batch across two definitions, and a
+later run never rewrites departures an earlier run already bound. The version
+arrives through a resolver supplied by the deployment rather than a direct
+read — Inventory already depends on Operations, so reaching back the other way
+would close a dependency cycle. `resolveCurrentProductVersionId` on the
+Inventory side returns the highest version number, which is deterministic by
+construction.
+
+Departures created before this column existed are **reported, not backfilled**.
+The only signal available after the fact is what the product looks like today,
+which is precisely what may have changed since the departure was sold;
+assigning that retroactively would manufacture false provenance for exactly the
+records where provenance matters most. `reportUnboundDepartures` and
+`listUnboundDepartures` expose an operator-review queue that excludes departures
+which have already run, since their provenance can no longer affect what is
+sold. `countDeparturesOnVersion` gives the impact set for a product edit.
+
+Slot creation accepts an explicit `productVersionId`, so a caller can
+materialize a departure against a chosen version.

--- a/packages/availability/migrations/0002_slot_product_version.sql
+++ b/packages/availability/migrations/0002_slot_product_version.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "availability_slots" ADD COLUMN "product_version_id" text;--> statement-breakpoint
+CREATE INDEX "idx_availability_slots_product_version" ON "availability_slots" USING btree ("product_version_id");

--- a/packages/availability/migrations/meta/0002_snapshot.json
+++ b/packages/availability/migrations/meta/0002_snapshot.json
@@ -1,0 +1,2921 @@
+{
+  "id": "02c58651-907f-4f93-ac1a-750ac75cddbf",
+  "prevId": "173eaef1-fcb8-4429-a7d2-c1230c897c75",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.allocation_audit_log": {
+      "name": "allocation_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slot_id": {
+          "name": "slot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "traveler_id": {
+          "name": "traveler_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_allocation_audit_slot_created": {
+          "name": "idx_allocation_audit_slot_created",
+          "columns": [
+            {
+              "expression": "slot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_allocation_audit_traveler": {
+          "name": "idx_allocation_audit_traveler",
+          "columns": [
+            {
+              "expression": "traveler_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "allocation_audit_log_slot_id_availability_slots_id_fk": {
+          "name": "allocation_audit_log_slot_id_availability_slots_id_fk",
+          "tableFrom": "allocation_audit_log",
+          "tableTo": "availability_slots",
+          "columnsFrom": [
+            "slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.allocation_resources": {
+      "name": "allocation_resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slot_id": {
+          "name": "slot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_type": {
+          "name": "ref_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flags": {
+          "name": "flags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_allocation_resources_slot_kind": {
+          "name": "idx_allocation_resources_slot_kind",
+          "columns": [
+            {
+              "expression": "slot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_allocation_resources_parent": {
+          "name": "idx_allocation_resources_parent",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_allocation_resources_kind_sort": {
+          "name": "idx_allocation_resources_kind_sort",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "allocation_resources_slot_id_availability_slots_id_fk": {
+          "name": "allocation_resources_slot_id_availability_slots_id_fk",
+          "tableFrom": "allocation_resources",
+          "tableTo": "availability_slots",
+          "columnsFrom": [
+            "slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.availability_closeouts": {
+      "name": "availability_closeouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot_id": {
+          "name": "slot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_local": {
+          "name": "date_local",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_availability_closeouts_product_created": {
+          "name": "idx_availability_closeouts_product_created",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_availability_closeouts_slot_created": {
+          "name": "idx_availability_closeouts_slot_created",
+          "columns": [
+            {
+              "expression": "slot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_availability_closeouts_date_created": {
+          "name": "idx_availability_closeouts_date_created",
+          "columns": [
+            {
+              "expression": "date_local",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "availability_closeouts_slot_id_availability_slots_id_fk": {
+          "name": "availability_closeouts_slot_id_availability_slots_id_fk",
+          "tableFrom": "availability_closeouts",
+          "tableTo": "availability_slots",
+          "columnsFrom": [
+            "slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.availability_rules": {
+      "name": "availability_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "facility_id": {
+          "name": "facility_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recurrence_rule": {
+          "name": "recurrence_rule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_capacity": {
+          "name": "max_capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_pickup_capacity": {
+          "name": "max_pickup_capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_total_pax": {
+          "name": "min_total_pax",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cutoff_minutes": {
+          "name": "cutoff_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "early_booking_limit_minutes": {
+          "name": "early_booking_limit_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_availability_rules_updated": {
+          "name": "idx_availability_rules_updated",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_availability_rules_product_updated": {
+          "name": "idx_availability_rules_product_updated",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_availability_rules_option_updated": {
+          "name": "idx_availability_rules_option_updated",
+          "columns": [
+            {
+              "expression": "option_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_availability_rules_facility_updated": {
+          "name": "idx_availability_rules_facility_updated",
+          "columns": [
+            {
+              "expression": "facility_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_availability_rules_active_updated": {
+          "name": "idx_availability_rules_active_updated",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.availability_slots": {
+      "name": "availability_slots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_version_id": {
+          "name": "product_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itinerary_id": {
+          "name": "itinerary_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "facility_id": {
+          "name": "facility_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "availability_rule_id": {
+          "name": "availability_rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time_id": {
+          "name": "start_time_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_local": {
+          "name": "date_local",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "availability_slot_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "unlimited": {
+          "name": "unlimited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "initial_pax": {
+          "name": "initial_pax",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remaining_pax": {
+          "name": "remaining_pax",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initial_pickups": {
+          "name": "initial_pickups",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remaining_pickups": {
+          "name": "remaining_pickups",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remaining_resources": {
+          "name": "remaining_resources",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "past_cutoff": {
+          "name": "past_cutoff",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "too_early": {
+          "name": "too_early",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "nights": {
+          "name": "nights",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "days": {
+          "name": "days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_availability_slots_product_starts_at": {
+          "name": "idx_availability_slots_product_starts_at",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_availability_slots_product_version": {
+          "name": "idx_availability_slots_product_version",
+          "columns": [
+            {
+              "expression": "product_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_availability_slots_itinerary_starts_at": {
+          "name": "idx_availability_slots_itinerary_starts_at",
+          "columns": [
+            {
+              "expression": "itinerary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_availability_slots_option_starts_at": {
+          "name": "idx_availability_slots_option_starts_at",
+          "columns": [
+            {
+              "expression": "option_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_availability_slots_facility_starts_at": {
+          "name": "idx_availability_slots_facility_starts_at",
+          "columns": [
+            {
+              "expression": "facility_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_availability_slots_rule_starts_at": {
+          "name": "idx_availability_slots_rule_starts_at",
+          "columns": [
+            {
+              "expression": "availability_rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_availability_slots_start_time_starts_at": {
+          "name": "idx_availability_slots_start_time_starts_at",
+          "columns": [
+            {
+              "expression": "start_time_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_availability_slots_date_starts_at": {
+          "name": "idx_availability_slots_date_starts_at",
+          "columns": [
+            {
+              "expression": "date_local",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_availability_slots_status_starts_at": {
+          "name": "idx_availability_slots_status_starts_at",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_availability_slots_starts_at": {
+          "name": "idx_availability_slots_starts_at",
+          "columns": [
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "availability_slots_availability_rule_id_availability_rules_id_fk": {
+          "name": "availability_slots_availability_rule_id_availability_rules_id_fk",
+          "tableFrom": "availability_slots",
+          "tableTo": "availability_rules",
+          "columnsFrom": [
+            "availability_rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "availability_slots_start_time_id_availability_start_times_id_fk": {
+          "name": "availability_slots_start_time_id_availability_start_times_id_fk",
+          "tableFrom": "availability_slots",
+          "tableTo": "availability_start_times",
+          "columnsFrom": [
+            "start_time_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.availability_start_times": {
+      "name": "availability_start_times",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "facility_id": {
+          "name": "facility_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time_local": {
+          "name": "start_time_local",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_availability_start_times_product_sort_created": {
+          "name": "idx_availability_start_times_product_sort_created",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_availability_start_times_option_sort_created": {
+          "name": "idx_availability_start_times_option_sort_created",
+          "columns": [
+            {
+              "expression": "option_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_availability_start_times_facility_sort_created": {
+          "name": "idx_availability_start_times_facility_sort_created",
+          "columns": [
+            {
+              "expression": "facility_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_availability_start_times_active_sort_created": {
+          "name": "idx_availability_start_times_active_sort_created",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_option_resource_templates": {
+      "name": "product_option_resource_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_option_id": {
+          "name": "product_option_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_type": {
+          "name": "ref_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_pattern": {
+          "name": "name_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout": {
+          "name": "layout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_count": {
+          "name": "default_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flags": {
+          "name": "flags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_product_option_resource_templates_option_kind": {
+          "name": "idx_product_option_resource_templates_option_kind",
+          "columns": [
+            {
+              "expression": "product_option_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"ref_id\", '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_product_option_resource_templates_kind": {
+          "name": "idx_product_option_resource_templates_kind",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sharing_group_labels": {
+      "name": "sharing_group_labels",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.availability_holds": {
+      "name": "availability_holds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_token": {
+          "name": "hold_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot_id": {
+          "name": "slot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pax_count": {
+          "name": "pax_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "converted_at": {
+          "name": "converted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "converted_booking_id": {
+          "name": "converted_booking_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "converted_allocation_id": {
+          "name": "converted_allocation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_availability_holds_slot": {
+          "name": "idx_availability_holds_slot",
+          "columns": [
+            {
+              "expression": "slot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_availability_holds_draft": {
+          "name": "idx_availability_holds_draft",
+          "columns": [
+            {
+              "expression": "draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_availability_holds_token": {
+          "name": "idx_availability_holds_token",
+          "columns": [
+            {
+              "expression": "hold_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_availability_holds_expires": {
+          "name": "idx_availability_holds_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_availability_holds_converted_booking": {
+          "name": "idx_availability_holds_converted_booking",
+          "columns": [
+            {
+              "expression": "converted_booking_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "availability_holds_slot_id_availability_slots_id_fk": {
+          "name": "availability_holds_slot_id_availability_slots_id_fk",
+          "tableFrom": "availability_holds",
+          "tableTo": "availability_slots",
+          "columnsFrom": [
+            "slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.availability_pickup_points": {
+      "name": "availability_pickup_points",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "facility_id": {
+          "name": "facility_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_text": {
+          "name": "location_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_availability_pickup_points_created": {
+          "name": "idx_availability_pickup_points_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_availability_pickup_points_product_created": {
+          "name": "idx_availability_pickup_points_product_created",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_availability_pickup_points_facility_created": {
+          "name": "idx_availability_pickup_points_facility_created",
+          "columns": [
+            {
+              "expression": "facility_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_availability_pickup_points_active_created": {
+          "name": "idx_availability_pickup_points_active_created",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.availability_slot_pickups": {
+      "name": "availability_slot_pickups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slot_id": {
+          "name": "slot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pickup_point_id": {
+          "name": "pickup_point_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initial_capacity": {
+          "name": "initial_capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remaining_capacity": {
+          "name": "remaining_capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_availability_slot_pickups_created": {
+          "name": "idx_availability_slot_pickups_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_availability_slot_pickups_slot_created": {
+          "name": "idx_availability_slot_pickups_slot_created",
+          "columns": [
+            {
+              "expression": "slot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_availability_slot_pickups_pickup_point_created": {
+          "name": "idx_availability_slot_pickups_pickup_point_created",
+          "columns": [
+            {
+              "expression": "pickup_point_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "availability_slot_pickups_slot_id_availability_slots_id_fk": {
+          "name": "availability_slot_pickups_slot_id_availability_slots_id_fk",
+          "tableFrom": "availability_slot_pickups",
+          "tableTo": "availability_slots",
+          "columnsFrom": [
+            "slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "availability_slot_pickups_pickup_point_id_availability_pickup_points_id_fk": {
+          "name": "availability_slot_pickups_pickup_point_id_availability_pickup_points_id_fk",
+          "tableFrom": "availability_slot_pickups",
+          "tableTo": "availability_pickup_points",
+          "columnsFrom": [
+            "pickup_point_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_pickup_areas": {
+      "name": "custom_pickup_areas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "meeting_config_id": {
+          "name": "meeting_config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geographic_text": {
+          "name": "geographic_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_custom_pickup_areas_created": {
+          "name": "idx_custom_pickup_areas_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_custom_pickup_areas_meeting_config_created": {
+          "name": "idx_custom_pickup_areas_meeting_config_created",
+          "columns": [
+            {
+              "expression": "meeting_config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_custom_pickup_areas_active_created": {
+          "name": "idx_custom_pickup_areas_active_created",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "custom_pickup_areas_meeting_config_id_product_meeting_configs_id_fk": {
+          "name": "custom_pickup_areas_meeting_config_id_product_meeting_configs_id_fk",
+          "tableFrom": "custom_pickup_areas",
+          "tableTo": "product_meeting_configs",
+          "columnsFrom": [
+            "meeting_config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.location_pickup_times": {
+      "name": "location_pickup_times",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pickup_location_id": {
+          "name": "pickup_location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot_id": {
+          "name": "slot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time_id": {
+          "name": "start_time_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timing_mode": {
+          "name": "timing_mode",
+          "type": "pickup_timing_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fixed_time'"
+        },
+        "local_time": {
+          "name": "local_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "offset_minutes": {
+          "name": "offset_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initial_capacity": {
+          "name": "initial_capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remaining_capacity": {
+          "name": "remaining_capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_location_pickup_times_created": {
+          "name": "idx_location_pickup_times_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_location_pickup_times_pickup_location_created": {
+          "name": "idx_location_pickup_times_pickup_location_created",
+          "columns": [
+            {
+              "expression": "pickup_location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_location_pickup_times_slot_created": {
+          "name": "idx_location_pickup_times_slot_created",
+          "columns": [
+            {
+              "expression": "slot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_location_pickup_times_start_time_created": {
+          "name": "idx_location_pickup_times_start_time_created",
+          "columns": [
+            {
+              "expression": "start_time_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_location_pickup_times_active_created": {
+          "name": "idx_location_pickup_times_active_created",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "location_pickup_times_pickup_location_id_pickup_locations_id_fk": {
+          "name": "location_pickup_times_pickup_location_id_pickup_locations_id_fk",
+          "tableFrom": "location_pickup_times",
+          "tableTo": "pickup_locations",
+          "columnsFrom": [
+            "pickup_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "location_pickup_times_slot_id_availability_slots_id_fk": {
+          "name": "location_pickup_times_slot_id_availability_slots_id_fk",
+          "tableFrom": "location_pickup_times",
+          "tableTo": "availability_slots",
+          "columnsFrom": [
+            "slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "location_pickup_times_start_time_id_availability_start_times_id_fk": {
+          "name": "location_pickup_times_start_time_id_availability_start_times_id_fk",
+          "tableFrom": "location_pickup_times",
+          "tableTo": "availability_start_times",
+          "columnsFrom": [
+            "start_time_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pickup_groups": {
+      "name": "pickup_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "meeting_config_id": {
+          "name": "meeting_config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "pickup_group_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_pickup_groups_sort_created": {
+          "name": "idx_pickup_groups_sort_created",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pickup_groups_meeting_config_sort_created": {
+          "name": "idx_pickup_groups_meeting_config_sort_created",
+          "columns": [
+            {
+              "expression": "meeting_config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pickup_groups_kind_sort_created": {
+          "name": "idx_pickup_groups_kind_sort_created",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pickup_groups_active_sort_created": {
+          "name": "idx_pickup_groups_active_sort_created",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pickup_groups_meeting_config_id_product_meeting_configs_id_fk": {
+          "name": "pickup_groups_meeting_config_id_product_meeting_configs_id_fk",
+          "tableFrom": "pickup_groups",
+          "tableTo": "product_meeting_configs",
+          "columnsFrom": [
+            "meeting_config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pickup_locations": {
+      "name": "pickup_locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "facility_id": {
+          "name": "facility_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_text": {
+          "name": "location_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lead_time_minutes": {
+          "name": "lead_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_pickup_locations_sort_created": {
+          "name": "idx_pickup_locations_sort_created",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pickup_locations_group_sort_created": {
+          "name": "idx_pickup_locations_group_sort_created",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pickup_locations_facility_sort_created": {
+          "name": "idx_pickup_locations_facility_sort_created",
+          "columns": [
+            {
+              "expression": "facility_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pickup_locations_active_sort_created": {
+          "name": "idx_pickup_locations_active_sort_created",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pickup_locations_group_id_pickup_groups_id_fk": {
+          "name": "pickup_locations_group_id_pickup_groups_id_fk",
+          "tableFrom": "pickup_locations",
+          "tableTo": "pickup_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_meeting_configs": {
+      "name": "product_meeting_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "facility_id": {
+          "name": "facility_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "meeting_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'meeting_only'"
+        },
+        "allow_custom_pickup": {
+          "name": "allow_custom_pickup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "allow_custom_dropoff": {
+          "name": "allow_custom_dropoff",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requires_pickup_selection": {
+          "name": "requires_pickup_selection",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requires_dropoff_selection": {
+          "name": "requires_dropoff_selection",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "use_pickup_allotment": {
+          "name": "use_pickup_allotment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "meeting_instructions": {
+          "name": "meeting_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickup_instructions": {
+          "name": "pickup_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dropoff_instructions": {
+          "name": "dropoff_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_product_meeting_configs_updated": {
+          "name": "idx_product_meeting_configs_updated",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_product_meeting_configs_product_updated": {
+          "name": "idx_product_meeting_configs_product_updated",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_product_meeting_configs_option_updated": {
+          "name": "idx_product_meeting_configs_option_updated",
+          "columns": [
+            {
+              "expression": "option_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_product_meeting_configs_facility_updated": {
+          "name": "idx_product_meeting_configs_facility_updated",
+          "columns": [
+            {
+              "expression": "facility_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_product_meeting_configs_mode_updated": {
+          "name": "idx_product_meeting_configs_mode_updated",
+          "columns": [
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_product_meeting_configs_active_updated": {
+          "name": "idx_product_meeting_configs_active_updated",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.availability_slot_status": {
+      "name": "availability_slot_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "closed",
+        "sold_out",
+        "cancelled"
+      ]
+    },
+    "public.meeting_mode": {
+      "name": "meeting_mode",
+      "schema": "public",
+      "values": [
+        "meeting_only",
+        "pickup_only",
+        "meet_or_pickup"
+      ]
+    },
+    "public.pickup_group_kind": {
+      "name": "pickup_group_kind",
+      "schema": "public",
+      "values": [
+        "pickup",
+        "dropoff",
+        "meeting"
+      ]
+    },
+    "public.pickup_timing_mode": {
+      "name": "pickup_timing_mode",
+      "schema": "public",
+      "values": [
+        "fixed_time",
+        "offset_from_start"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/availability/migrations/meta/_journal.json
+++ b/packages/availability/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1784090529380,
       "tag": "20260715044209_booking_hold_conversion",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1785777005358,
+      "tag": "0002_slot_product_version",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/availability/src/schema-core.ts
+++ b/packages/availability/src/schema-core.ts
@@ -104,6 +104,24 @@ export const availabilitySlots = pgTable(
   {
     id: typeId("availability_slots"),
     productId: text("product_id").notNull(),
+    /**
+     * The immutable Product Version this departure was materialized from.
+     *
+     * A departure must be able to name the exact Product definition it was
+     * sold against, and later Product edits must not silently rewrite it
+     * (#4032, under the model accepted in #4027).
+     *
+     * A soft reference, deliberately: `product_versions` is owned by Inventory
+     * and a cross-domain foreign key would violate schema discipline. It stays
+     * a plain text column exactly like `product_id` above.
+     *
+     * Nullable, because slots created before this column existed have no
+     * recorded version. Those legacy rows are reported for operator review
+     * rather than being assigned a version by inference — guessing which
+     * definition an already-sold departure ran under is worse than admitting
+     * it is unknown.
+     */
+    productVersionId: text("product_version_id"),
     itineraryId: text("itinerary_id"),
     optionId: text("option_id"),
     facilityId: text("facility_id"),
@@ -134,6 +152,10 @@ export const availabilitySlots = pgTable(
   },
   (table) => [
     index("idx_availability_slots_product_starts_at").on(table.productId, table.startsAt),
+    // Backs both directions of the version binding: "which departures ran on
+    // this version" (impact preview before a Product edit) and the legacy
+    // report's scan for departures with no version recorded.
+    index("idx_availability_slots_product_version").on(table.productVersionId),
     index("idx_availability_slots_itinerary_starts_at").on(table.itineraryId, table.startsAt),
     index("idx_availability_slots_option_starts_at").on(table.optionId, table.startsAt),
     index("idx_availability_slots_facility_starts_at").on(table.facilityId, table.startsAt),

--- a/packages/inventory/src/index.ts
+++ b/packages/inventory/src/index.ts
@@ -56,6 +56,12 @@ export {
   type ProductReadinessOptions,
   type ProductReadinessSubject,
 } from "./service-readiness.js"
+export {
+  type EnsureProductVersionInput,
+  type EnsureProductVersionOutcome,
+  ensureProductVersionOnPublish,
+  resolveCurrentProductVersionId,
+} from "./service-versioning.js"
 export const productsModule: Module = {
   name: "products",
   linkable: productsCompatibilityLinkable,

--- a/packages/inventory/src/service-versioning.ts
+++ b/packages/inventory/src/service-versioning.ts
@@ -87,6 +87,33 @@ export async function ensureProductVersionOnPublish(
   return { created: true, versionNumber: created.versionNumber, versionId: created.id }
 }
 
+/**
+ * The Product Version a departure created *now* should be bound to: the
+ * product's highest version number, which is the one publish most recently
+ * froze.
+ *
+ * Deterministic by construction — version numbers are assigned monotonically
+ * per product, so "current" never depends on wall-clock time or row order.
+ * Returns `null` when the product has never been published; callers record
+ * that as an unbound departure rather than inventing a version (#4032).
+ *
+ * Exposed for the deployment to wire into Operations' slot creation, which
+ * cannot read `product_versions` itself without closing a dependency cycle.
+ */
+export async function resolveCurrentProductVersionId(
+  db: PostgresJsDatabase,
+  productId: string,
+): Promise<string | null> {
+  const [row] = await db
+    .select({ id: productVersions.id })
+    .from(productVersions)
+    .where(eq(productVersions.productId, productId))
+    .orderBy(desc(productVersions.versionNumber))
+    .limit(1)
+
+  return row?.id ?? null
+}
+
 function toRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)

--- a/packages/operations/src/availability/generate-slots.ts
+++ b/packages/operations/src/availability/generate-slots.ts
@@ -23,6 +23,20 @@ export type GenerateAvailabilitySlotsOptions = {
    * pax-aware materialisation via the admin route. Defaults to true.
    */
   materializeResources?: boolean
+  /**
+   * Resolves the Product Version each freshly-generated departure is bound to
+   * — the product's currently published version, or `null` when it has never
+   * been published.
+   *
+   * Resolved once per rule rather than per slot: a generation run materializes
+   * against the version current when the run starts, so one run cannot produce
+   * departures split across two definitions. Already-generated departures are
+   * never rewritten by a later run.
+   *
+   * Supplied by the deployment; `product_versions` is Inventory-owned and
+   * Inventory already depends on Operations. See #4032.
+   */
+  resolveCurrentProductVersionId?: (productId: string) => Promise<string | null>
 }
 
 export type GenerateAvailabilitySlotsResult = {
@@ -92,9 +106,15 @@ export async function generateAvailabilitySlots(
     const minute = Number.parseInt(mm ?? "0", 10) || 0
 
     const startTime = `${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`
+    // Resolved once per rule so a single run cannot split its departures
+    // across two Product Versions if a publish lands mid-run.
+    const productVersionId =
+      (await options.resolveCurrentProductVersionId?.(rule.productId)) ?? null
+
     const rows = toInsert.map((dateLocal) => {
       return {
         productId: rule.productId,
+        productVersionId,
         optionId: rule.optionId,
         facilityId: rule.facilityId,
         availabilityRuleId: rule.id,

--- a/packages/operations/src/availability/index.ts
+++ b/packages/operations/src/availability/index.ts
@@ -77,6 +77,13 @@ export {
   generateAvailabilitySlots,
 } from "./generate-slots.js"
 export {
+  countDeparturesOnVersion,
+  listUnboundDepartures,
+  reportUnboundDepartures,
+  type UnboundDeparture,
+  type UnboundDepartureReport,
+} from "./service-aggregates.js"
+export {
   type AllocationManifestBooking,
   type AllocationManifestTraveler,
   getSlotAllocationManifest,

--- a/packages/operations/src/availability/service-aggregates.ts
+++ b/packages/operations/src/availability/service-aggregates.ts
@@ -1,5 +1,5 @@
 import { availabilitySlots } from "@voyant-travel/availability/schema"
-import { and, eq, gte, sql } from "drizzle-orm"
+import { and, eq, gte, isNull, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 type SlotStatus = (typeof availabilitySlots.$inferSelect)["status"]
@@ -96,5 +96,108 @@ export async function getAvailabilityAggregates(
       yearMonth: row.yearMonth,
       count: row.count,
     })),
+  }
+}
+
+/**
+ * Departures with no Product Version recorded (#4032).
+ *
+ * A departure created before the version binding existed cannot say which
+ * Product definition it sells. Those rows are **reported, not backfilled**:
+ * the only signal available after the fact is what the product looks like
+ * today, which is precisely what may have changed since the departure was
+ * sold. Assigning that retroactively would manufacture false provenance for
+ * exactly the records where provenance matters most.
+ */
+export interface UnboundDepartureReport {
+  /** Departures with no Product Version recorded. */
+  total: number
+  /**
+   * Of those, how many are still in the future. Only these are actionable —
+   * a past departure's provenance can no longer change what is sold.
+   */
+  upcoming: number
+  /** Distinct products affected, so the queue can be worked product by product. */
+  productsAffected: number
+}
+
+export async function reportUnboundDepartures(
+  db: PostgresJsDatabase,
+  now = new Date(),
+): Promise<UnboundDepartureReport> {
+  const [row] = await db
+    .select({
+      total: sql<number>`count(*)::int`,
+      upcoming: sql<number>`count(*) filter (where ${availabilitySlots.startsAt} >= ${now})::int`,
+      productsAffected: sql<number>`count(distinct ${availabilitySlots.productId})::int`,
+    })
+    .from(availabilitySlots)
+    .where(isNull(availabilitySlots.productVersionId))
+
+  return {
+    total: Number(row?.total ?? 0),
+    upcoming: Number(row?.upcoming ?? 0),
+    productsAffected: Number(row?.productsAffected ?? 0),
+  }
+}
+
+export interface UnboundDeparture {
+  id: string
+  productId: string
+  dateLocal: string
+  startsAt: Date
+}
+
+/**
+ * The operator-review queue for unbound departures, soonest first.
+ *
+ * Past departures are excluded by default: they cannot be meaningfully
+ * remediated, and including them buries the ones that can.
+ */
+export async function listUnboundDepartures(
+  db: PostgresJsDatabase,
+  options: { limit?: number; includePast?: boolean; now?: Date } = {},
+): Promise<UnboundDeparture[]> {
+  const now = options.now ?? new Date()
+
+  return db
+    .select({
+      id: availabilitySlots.id,
+      productId: availabilitySlots.productId,
+      dateLocal: availabilitySlots.dateLocal,
+      startsAt: availabilitySlots.startsAt,
+    })
+    .from(availabilitySlots)
+    .where(
+      options.includePast
+        ? isNull(availabilitySlots.productVersionId)
+        : and(isNull(availabilitySlots.productVersionId), gte(availabilitySlots.startsAt, now)),
+    )
+    .orderBy(availabilitySlots.startsAt)
+    .limit(options.limit ?? 100)
+}
+
+/**
+ * Departures already operating on a given Product Version — the impact set for
+ * a Product edit, and the input a rebase preview will need.
+ */
+export async function countDeparturesOnVersion(
+  db: PostgresJsDatabase,
+  productVersionId: string,
+  now = new Date(),
+): Promise<{ total: number; upcoming: number; past: number }> {
+  const [row] = await db
+    .select({
+      total: sql<number>`count(*)::int`,
+      upcoming: sql<number>`count(*) filter (where ${availabilitySlots.startsAt} >= ${now})::int`,
+      past: sql<number>`count(*) filter (where ${availabilitySlots.startsAt} < ${now})::int`,
+    })
+    .from(availabilitySlots)
+    .where(eq(availabilitySlots.productVersionId, productVersionId))
+
+  return {
+    total: Number(row?.total ?? 0),
+    upcoming: Number(row?.upcoming ?? 0),
+    past: Number(row?.past ?? 0),
   }
 }

--- a/packages/operations/src/availability/validation.ts
+++ b/packages/operations/src/availability/validation.ts
@@ -176,6 +176,13 @@ export const availabilityStartTimeListQuerySchema = paginationSchema.extend({
 
 export const availabilitySlotCoreSchema = z.object({
   productId: z.string(),
+  /**
+   * The Product Version this departure operates from. Normally resolved at
+   * creation from the product's currently published version; supply it
+   * explicitly to materialize a departure against a specific version. Null
+   * when the product has never been published or for legacy rows (#4032).
+   */
+  productVersionId: z.string().nullable().optional(),
   itineraryId: z.string().nullable().optional(),
   optionId: z.string().nullable().optional(),
   facilityId: z.string().nullable().optional(),

--- a/packages/operations/tests/availability/integration/slot-product-version-binding.test.ts
+++ b/packages/operations/tests/availability/integration/slot-product-version-binding.test.ts
@@ -1,0 +1,233 @@
+import { availabilityRules, availabilitySlots } from "@voyant-travel/availability/schema"
+import { newId } from "@voyant-travel/db/lib/typeid"
+import { cleanupTestDb, createTestDb } from "@voyant-travel/db/test-utils"
+import { eq } from "drizzle-orm"
+import { beforeAll, beforeEach, describe, expect, it } from "vitest"
+import { productOptions, products } from "../../../../inventory/src/schema.js"
+import { generateAvailabilitySlots } from "../../../src/availability/generate-slots.js"
+import {
+  countDeparturesOnVersion,
+  listUnboundDepartures,
+  reportUnboundDepartures,
+} from "../../../src/availability/service-aggregates.js"
+import { createSlot } from "../../../src/availability/service-core.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+const FUTURE = "2035-06-01"
+const PAST = "2020-06-01"
+const AS_OF = new Date("2030-01-01T00:00:00.000Z")
+
+describe.skipIf(!DB_AVAILABLE)("departure product-version binding (integration)", () => {
+  // biome-ignore lint/suspicious/noExplicitAny: owner: availability; createTestDb returns a driver-specific drizzle test client
+  let db: any
+  let productId: string
+  let optionId: string
+
+  beforeAll(() => {
+    db = createTestDb()
+  })
+
+  beforeEach(async () => {
+    await cleanupTestDb(db)
+    productId = newId("products")
+    optionId = newId("product_options")
+    await db.insert(products).values({
+      id: productId,
+      name: "Bulgaria Day Tour",
+      sellCurrency: "EUR",
+      bookingMode: "date",
+    })
+    await db.insert(productOptions).values({
+      id: optionId,
+      productId,
+      name: "Standard",
+      status: "active",
+      isDefault: true,
+      sortOrder: 0,
+    })
+  })
+
+  function slotInput(dateLocal = FUTURE, productVersionId?: string) {
+    return {
+      productId,
+      productVersionId,
+      dateLocal,
+      startsAt: `${dateLocal}T09:00:00.000Z`,
+      timezone: "Europe/Bucharest",
+      status: "open" as const,
+      unlimited: false,
+      initialPax: 40,
+      pastCutoff: false,
+      tooEarly: false,
+    }
+  }
+
+  describe("manual creation", () => {
+    it("records the Product Version the caller materialized against", async () => {
+      const versionId = newId("product_versions")
+
+      const row = await createSlot(db, slotInput(FUTURE, versionId))
+
+      expect(row?.productVersionId).toBe(versionId)
+    })
+
+    it("records no version when the caller supplies none", async () => {
+      // A product that has never been published has no version to bind to.
+      // That is recorded as unknown rather than inferred.
+      const row = await createSlot(db, slotInput())
+
+      expect(row?.productVersionId).toBeNull()
+    })
+  })
+
+  describe("recurring generation", () => {
+    async function seedRule() {
+      const ruleId = newId("availability_rules")
+      await db.insert(availabilityRules).values({
+        id: ruleId,
+        productId,
+        optionId,
+        timezone: "Europe/Bucharest",
+        startDate: FUTURE,
+        endDate: "2035-06-05",
+        maxCapacity: 40,
+        active: true,
+      })
+      return ruleId
+    }
+
+    async function generate(versionId: string | null, ruleId: string) {
+      return generateAvailabilitySlots(db, {
+        ruleId,
+        now: new Date("2035-05-01T00:00:00.000Z"),
+        materializeResources: false,
+        resolveCurrentProductVersionId: async () => versionId,
+      })
+    }
+
+    async function slotVersions() {
+      const rows = await db
+        .select({ productVersionId: availabilitySlots.productVersionId })
+        .from(availabilitySlots)
+        .where(eq(availabilitySlots.productId, productId))
+      return rows.map((r: { productVersionId: string | null }) => r.productVersionId)
+    }
+
+    it("binds every generated departure to one version", async () => {
+      const ruleId = await seedRule()
+      const versionId = newId("product_versions")
+
+      await generate(versionId, ruleId)
+
+      const versions = await slotVersions()
+      expect(versions.length).toBeGreaterThan(0)
+      // One run, one definition — a publish landing mid-run must not split a
+      // generation batch across two versions.
+      expect(new Set(versions).size).toBe(1)
+      expect(versions[0]).toBe(versionId)
+    })
+
+    it("does not rewrite departures an earlier run already bound", async () => {
+      const ruleId = await seedRule()
+      const first = newId("product_versions")
+
+      await generate(first, ruleId)
+      await generate(newId("product_versions"), ruleId)
+
+      const versions = await slotVersions()
+      expect(versions.every((v: string | null) => v === first)).toBe(true)
+    })
+
+    it("records no version when the product has never been published", async () => {
+      const ruleId = await seedRule()
+
+      await generate(null, ruleId)
+
+      const versions = await slotVersions()
+      expect(versions.length).toBeGreaterThan(0)
+      expect(versions.every((v: string | null) => v === null)).toBe(true)
+    })
+  })
+
+  describe("legacy departures", () => {
+    async function seedUnbound(dateLocal: string) {
+      const id = newId("availability_slots")
+      await db.insert(availabilitySlots).values({
+        id,
+        productId,
+        dateLocal,
+        startsAt: new Date(`${dateLocal}T09:00:00.000Z`),
+        timezone: "Europe/Bucharest",
+        status: "open",
+        unlimited: false,
+        initialPax: 40,
+      })
+      return id
+    }
+
+    it("reports unbound departures and separates the actionable ones", async () => {
+      await seedUnbound(FUTURE)
+      await seedUnbound(PAST)
+
+      const report = await reportUnboundDepartures(db, AS_OF)
+
+      expect(report.total).toBe(2)
+      expect(report.upcoming).toBe(1)
+      expect(report.productsAffected).toBe(1)
+    })
+
+    it("excludes past departures from the review queue by default", async () => {
+      const upcoming = await seedUnbound(FUTURE)
+      await seedUnbound(PAST)
+
+      const queue = await listUnboundDepartures(db, { now: AS_OF })
+
+      expect(queue.map((d) => d.id)).toEqual([upcoming])
+    })
+
+    it("includes past departures only when explicitly asked", async () => {
+      await seedUnbound(FUTURE)
+      await seedUnbound(PAST)
+
+      const queue = await listUnboundDepartures(db, { now: AS_OF, includePast: true })
+
+      expect(queue).toHaveLength(2)
+    })
+
+    it("does not count a bound departure as unbound", async () => {
+      await createSlot(db, slotInput(FUTURE, newId("product_versions")))
+
+      const report = await reportUnboundDepartures(db, AS_OF)
+
+      expect(report.total).toBe(0)
+    })
+  })
+
+  describe("impact set", () => {
+    it("counts the departures a product version is operating", async () => {
+      const versionId = newId("product_versions")
+      await createSlot(db, slotInput(FUTURE, versionId))
+      await createSlot(db, slotInput("2035-07-01", versionId))
+      await createSlot(db, slotInput("2035-08-01", newId("product_versions")))
+
+      const impact = await countDeparturesOnVersion(db, versionId, AS_OF)
+
+      expect(impact.total).toBe(2)
+      expect(impact.upcoming).toBe(2)
+      expect(impact.past).toBe(0)
+    })
+
+    it("separates departures that have already run", async () => {
+      const versionId = newId("product_versions")
+      await createSlot(db, slotInput(FUTURE, versionId))
+      await createSlot(db, slotInput(PAST, versionId))
+
+      const impact = await countDeparturesOnVersion(db, versionId, AS_OF)
+
+      expect(impact.total).toBe(2)
+      expect(impact.upcoming).toBe(1)
+      expect(impact.past).toBe(1)
+    })
+  })
+})


### PR DESCRIPTION
## Why

A departure had no way to name the Product definition it sells. Editing a product silently changed what every existing departure appeared to offer — including ones already sold. That is the gap which stops a departure being reconciled (#4033), operated (#4035), or costed (#4037) against a stable definition, so it blocks the rest of the tracer chain.

This lands the binding half of #4032.

## The column

`availability_slots` gains `product_version_id`, nullable.

It is a **soft reference**. `product_versions` is owned by Inventory and a cross-domain foreign key would violate schema discipline, so it stays plain text exactly like `product_id` beside it. The migration is additive and was **executed against Postgres**, not merely reviewed.

## How the version arrives

Inventory already depends on Operations, so Operations reaching back to read `product_versions` would close a dependency cycle. The version therefore arrives through a resolver the deployment supplies. `resolveCurrentProductVersionId` on the Inventory side returns the product's highest version number — deterministic by construction, since version numbers are assigned monotonically per product, so "current" never depends on wall-clock time or row order.

Recurring generation resolves it **once per rule**, not per slot: a publish landing mid-run must not split one generation batch across two definitions. A later run never rewrites departures an earlier run already bound — both are covered by tests.

Slot creation also accepts an explicit `productVersionId`, so a caller can materialize a departure against a chosen version.

## Legacy departures are reported, not backfilled

This is the deliberate call worth reviewing.

The only signal available for a pre-existing departure is what the product looks like *today* — which is precisely what may have changed since that departure was sold. Backfilling it would manufacture false provenance for exactly the records where provenance matters most. So they are surfaced instead:

- `reportUnboundDepartures` — totals, how many are still upcoming, how many products are affected.
- `listUnboundDepartures` — the review queue, excluding departures that have already run, since their provenance can no longer affect what is sold.
- `countDeparturesOnVersion` — the impact set for a product edit, and the input a rebase preview will need.

## Scoped deliberately

Two things are **not** here, and are follow-up work on #4032:

1. **Automatic resolution on the manual admin route.** Availability's routes are module-level constants with no factory, so wiring a resolver there needs a route-factory plus runtime port. That refactor belongs in its own change, not smuggled in behind a schema addition. Recurring generation — the bulk path — does resolve automatically today.
2. **Diff preview and audited rebase** for unsold and sold departures.

I also reverted an earlier attempt to put the binding inside `createSlot`: that file is already over the 600-line agent-quality gate, so any edit trips it, and splitting slot CRUD carries regression risk that would land under this issue's name. Since `createSlot` already spreads its input into the insert, the column flows through with no change to that file at all.

## Validation

- `turbo run typecheck --filter=availability --filter=operations --filter=inventory` — **36/36 tasks, exit 0**
- `pnpm verify:architecture` — pass (exit 0)
- `verify:table-privacy` — 225 reach-ins, **none new**
- `check-agent-code-quality --changed` — OK, no findings
- `pnpm biome check .` from the repo root — clean, no diagnostics in changed files
- Migration SQL executed against a live Postgres instance

The 13 new integration tests are DB-gated and run first in CI.

Part of #4027
