### PR TITLE
fix(auth): resolve a storefront by origin against its jsonb column

### DIFF
--- a/.changeset/storefront-origin-jsonb-lookup.md
+++ b/.changeset/storefront-origin-jsonb-lookup.md
@@ -1,0 +1,26 @@
+---
+"@voyant-travel/auth": patch
+---
+
+Resolve a storefront by origin against the jsonb column it actually has.
+
+`resolveStorefrontByOrigin` filtered `storefronts.allowed_origins` as if it were
+a Postgres `text[]`: exact matches used `@> ARRAY[$1]::text[]` and the wildcard
+candidate scan used `unnest(...)`. The column is declared `jsonb`
+(`packages/db/src/schema/iam/storefronts.ts`), and neither `jsonb @> text[]` nor
+`unnest(jsonb)` exists, so both statements failed to plan.
+
+Because it is a type error rather than a data condition, it fired on every call
+regardless of what was stored — an empty `storefronts` table reproduces it. Any
+public storefront request carrying an `Origin` header returned 500, which covers
+keyless preflight authorization and origin-resolved storefront reads.
+
+The filters now speak jsonb: `@> $1::jsonb` for exact containment and
+`jsonb_array_elements_text(...)` for the wildcard candidate scan. Both were
+executed against Postgres rather than reviewed by eye.
+
+`packages/auth/tests/integration/local-storefront.test.ts` already covered this
+and already asserted the right thing — it fails with the query error the moment
+a database is present. It never ran: the suite is `describe.skipIf(!TEST_DATABASE_URL)`
+and the `db-integration` CI lane enumerates its files by hand, with no
+`@voyant-travel/auth` entry. That file is now in the lane, so the fix is guarded.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,6 +365,8 @@ jobs:
                 tests/integration/durable-sourcing.test.ts
               pnpm --filter @voyant-travel/flights exec vitest run \
                 tests/integration/durable-action-command.test.ts
+              pnpm --filter @voyant-travel/auth exec vitest run \
+                tests/integration/local-storefront.test.ts
               ;;
           esac
 

--- a/packages/auth/src/storefront-local-adapter.ts
+++ b/packages/auth/src/storefront-local-adapter.ts
@@ -370,21 +370,26 @@ export function createLocalStorefrontAdapter(options: {
       origin: string,
     ): Promise<StorefrontDto | null> {
       // Preflight authorization is keyless, so it cannot select a single
-      // storefront up front. Exact-origin entries are filtered in SQL via array
+      // storefront up front. Exact-origin entries are filtered in SQL via
       // containment; wildcard (`https://*.host`) declarations are matched in
       // memory over the small self-host storefront set. Multiple matches are
       // rejected so keyless preflight cannot authorize an ambiguous origin.
+      //
+      // `allowed_origins` is a jsonb array, not a Postgres text[]. Both filters
+      // below have to speak jsonb: `jsonb @> text[]` and `unnest(jsonb)` do not
+      // exist, so the text[] forms failed to plan and every origin-bearing
+      // request 500ed regardless of the stored data.
       const exactMatches = await context.db
         .select()
         .from(storefronts)
-        // agent-quality: raw-sql reviewed -- Postgres text[] containment authorizes the exact declared origin without loading every row.
-        .where(sql`${storefronts.allowedOrigins} @> ARRAY[${origin}]::text[]`)
+        // agent-quality: raw-sql reviewed -- jsonb containment authorizes the exact declared origin without loading every row.
+        .where(sql`${storefronts.allowedOrigins} @> ${JSON.stringify([origin])}::jsonb`)
       const wildcardCandidates = await context.db
         .select()
         .from(storefronts)
         // agent-quality: raw-sql reviewed -- Only rows carrying a wildcard origin declaration are considered for the in-memory match.
         .where(
-          sql`EXISTS (SELECT 1 FROM unnest(${storefronts.allowedOrigins}) AS o WHERE o LIKE 'https://*.%')`,
+          sql`EXISTS (SELECT 1 FROM jsonb_array_elements_text(${storefronts.allowedOrigins}) AS o WHERE o LIKE 'https://*.%')`,
         )
       const wildcardMatches = wildcardCandidates.filter((row) =>
         isStorefrontOriginAllowed(origin, row.allowedOrigins),


### PR DESCRIPTION
Found while setting up a local storefront to validate #4113 end-to-end. Unrelated to that work.

## The bug

`resolveStorefrontByOrigin` (`packages/auth/src/storefront-local-adapter.ts:377-388`) filtered `storefronts.allowed_origins` as a Postgres `text[]`. The column is declared `jsonb` (`packages/db/src/schema/iam/storefronts.ts:82`).

Verified by execution against Postgres 16, not by reading:

| SQL | Result |
|---|---|
| `allowed_origins @> ARRAY['http://x']::text[]` *(was)* | **error** — no operator `jsonb @> text[]` |
| `unnest(allowed_origins)` *(was)* | **error** — no function matches |
| `allowed_origins @> '["http://x"]'::jsonb` *(now)* | runs |
| `jsonb_array_elements_text(allowed_origins)` *(now)* | runs |

Both lines carried an `agent-quality: raw-sql reviewed` comment stating the false premise out loud — *"Postgres text[] containment"*. The review asserted the column type instead of checking it.

## Impact

It is a type error at plan time, not a data condition, so it fires on every call regardless of what is stored — an **empty `storefronts` table reproduces it**. Any public storefront request carrying an `Origin` header returns 500. That covers keyless preflight authorization and origin-resolved storefront reads.

Observed as:

```
GET /v1/public/storefront/config → 500
err: Failed query: select … from "storefronts" where "storefronts"."allowed_origins" @> ARRAY[$1]::text[]
cause: PostgresError: operator does not exist: jsonb @> text[]
```

I can't size the blast radius across deployment shapes from here — managed deployments may resolve storefronts by a different path — so this is scoped as "the local adapter is broken", not "all storefronts are down".

## Why it shipped, and what stops it recurring

`packages/auth/tests/integration/local-storefront.test.ts:152` already covered this and already asserted the right thing. Given a database it fails immediately:

```
AssertionError: expected [Function] to throw error matching /multiple storefronts/i
but got 'Failed query: select "id", "organization_id", … @> ARRAY[$1]::text[]'
```

It never ran. The suite is `describe.skipIf(!TEST_DATABASE_URL)`, and the `db-integration` CI lane enumerates its test files **by hand** — with no `@voyant-travel/auth` entry. A correct test plus a hand-maintained list it was never added to equals silent zero coverage.

This PR adds that file to the lane, so the fix is guarded rather than merely applied.

## A larger gap this exposes, not fixed here

The repo has **118** `tests/integration/*.test.ts` files. The `db-integration` lane names **14**. At least these suites `skipIf(!TEST_DATABASE_URL)` and therefore never run in CI:

- `packages/auth/tests/integration/local-team-management.test.ts`
- `packages/auth/tests/integration/customer-business-better-auth.test.ts`
- `packages/auth/tests/integration/customer-session-liveness.test.ts`
- `packages/storefront/tests/integration/customer-buyer-authorization.test.ts`
- `packages/storefront/tests/integration/customer-business-onboarding-runtime.test.ts`
- `packages/action-ledger/tests/integration/created-command.test.ts`

Enumerating the lane by hand means new integration tests are opt-in and default to not running. Worth a separate decision — glob the files, or make the skip loud — rather than expanding this PR.

## Verification

- The pre-existing integration test: **red before, green after**, against real Postgres
- `pnpm -F @voyant-travel/auth test` with `TEST_DATABASE_URL` set — 276 passed, 6 skipped, exit 0
- `biome check` on the changed files — clean

Not verified: behaviour on a deployment that resolves storefronts through a non-local adapter.
