### PR TITLE
feat(bookings): let a host resolve the monthly booking limit per request

### DIFF
--- a/docs/architecture/monthly-booking-allowance.md
+++ b/docs/architecture/monthly-booking-allowance.md
@@ -1,0 +1,58 @@
+# Monthly Booking Allowance
+
+A deployment may cap how many bookings it accepts per calendar month. The cap
+is opt-in: with nothing configured, bookings are unlimited, which is what a
+self-hosted deployment gets.
+
+`assertMonthlyBookingLimitAvailable` in `@voyant-travel/bookings` is the single
+enforcement and validation authority. Callers invoke it inside the transaction
+that accepts a booking; it takes a transaction-scoped advisory lock so
+concurrent acceptances observe one another, and it is the only place a
+malformed allowance is rejected.
+
+## Two sources for the allowance
+
+**Configured.** `VOYANT_BOOKINGS_MONTHLY_LIMIT` is read from bindings when a
+route runtime is composed. For a self-hosted deployment this is the whole
+story — the cap is a property of the container.
+
+**Live.** A composed API graph is built once per process and reused for the
+process lifetime, so a configured allowance is a boot-time constant. That is
+wrong for a managed host serving a tenant whose plan entitlement can change
+while the process runs — an upgrade, a downgrade, a trial expiring. There the
+allowance is a property of the request's subscription state, so the host
+supplies a `MonthlyBookingLimitResolver` and the runtime consults it on every
+read.
+
+A resolver returns:
+
+| return | meaning |
+|---|---|
+| a `number` | that allowance applies right now |
+| `null` | unlimited right now, overriding whatever was configured |
+| `undefined` | no live answer; fall back to the configured value |
+
+A host typically reads an `AsyncLocalStorage` it populates per request. The
+resolver is not validated where it is read — a malformed live answer fails at
+enforcement rather than silently capping a tenant at the wrong number.
+
+## Where a host installs a resolver
+
+Three composition sites accept a `resolveMonthlyBookingLimit` option, because
+three paths accept bookings and all three consume the same quota. A host that
+wires only some of them serves one cap from one path and another cap from the
+next.
+
+| package | option on |
+|---|---|
+| `@voyant-travel/bookings` | `buildBookingRouteRuntime` / `createBookingsApiModule` |
+| `@voyant-travel/finance` | `buildFinanceRouteRuntime` / `createFinanceApiModule` |
+| `@voyant-travel/commerce` | `createCheckoutFinalizeSubscriberRuntime` |
+
+Omit the option and behaviour is identical to a configured-only deployment.
+
+## Reading `monthlyBookingLimit`
+
+Where a resolver is installed, `runtime.monthlyBookingLimit` is an accessor.
+Read it per use. Copying it into a local, or spreading the runtime object,
+re-freezes exactly what the seam exists to keep live.

--- a/packages/bookings/src/booking-plan-limit.ts
+++ b/packages/bookings/src/booking-plan-limit.ts
@@ -47,6 +47,46 @@ export function resolveMonthlyBookingLimit(env: Readonly<Record<string, unknown>
   return parsed
 }
 
+/**
+ * Supplies the monthly booking allowance that applies to the work in flight,
+ * rather than the one the process booted with.
+ *
+ * A composed API graph is built once per process and reused for the process
+ * lifetime, so anything read from bindings at composition time is a boot-time
+ * constant. That is correct for a self-hosted deployment, where the allowance
+ * is a property of the container. It is wrong for a managed host serving a
+ * tenant whose plan entitlement can change while the process runs — there the
+ * allowance is a property of the request's subscription state.
+ *
+ * A host supplies one of these (typically reading an `AsyncLocalStorage` it
+ * populates per request) and the runtime consults it on every read. Returning:
+ *
+ * - a `number` — that allowance applies right now
+ * - `null` — unlimited right now, overriding whatever was configured
+ * - `undefined` — no live answer available; fall back to the configured value
+ *
+ * The resolver is not validated here. `assertMonthlyBookingLimitAvailable` is
+ * the single validation authority for the value that is actually enforced, so
+ * a malformed live answer fails at the point of enforcement rather than
+ * silently capping a tenant at the wrong number.
+ */
+export type MonthlyBookingLimitResolver = () => number | null | undefined
+
+/**
+ * Pick between a host's live allowance and the value resolved from bindings at
+ * composition time. Absent a resolver — or absent a live answer from one — the
+ * configured value wins, so a deployment that installs no resolver behaves
+ * exactly as it did before the seam existed.
+ */
+export function selectMonthlyBookingLimit(
+  resolveLive: MonthlyBookingLimitResolver | undefined,
+  configured: number | null,
+): number | null {
+  if (!resolveLive) return configured
+  const live = resolveLive()
+  return live === null || typeof live === "number" ? live : configured
+}
+
 type MonthlyBookingUsageRow = {
   current: number | string
   period_start: string | Date

--- a/packages/bookings/src/index.ts
+++ b/packages/bookings/src/index.ts
@@ -36,7 +36,9 @@ export {
   BookingMonthlyLimitConfigurationError,
   type BookingMonthlyLimitReachedDetails,
   BookingMonthlyLimitReachedError,
+  type MonthlyBookingLimitResolver,
   resolveMonthlyBookingLimit,
+  selectMonthlyBookingLimit,
   VOYANT_BOOKINGS_MONTHLY_LIMIT_BINDING,
 } from "./booking-plan-limit.js"
 export { bookingsSupplierExtension } from "./extensions/suppliers.js"

--- a/packages/bookings/src/route-runtime.ts
+++ b/packages/bookings/src/route-runtime.ts
@@ -2,7 +2,11 @@ import type { CustomFieldRegistryResolver } from "@voyant-travel/core/custom-fie
 import { createKmsProviderFromEnv, type KmsProvider } from "@voyant-travel/utils/kms"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
-import { resolveMonthlyBookingLimit } from "./booking-plan-limit.js"
+import {
+  type MonthlyBookingLimitResolver,
+  resolveMonthlyBookingLimit,
+  selectMonthlyBookingLimit,
+} from "./booking-plan-limit.js"
 import type { BookingTravelerSnapshot } from "./pii.js"
 import type { KmsBindings } from "./routes-shared.js"
 import type { BookingsFinanceRuntime, BookingsSupplierAmendmentRuntime } from "./runtime-port.js"
@@ -126,7 +130,14 @@ export type BookingOverviewItemEnricher = (
 
 export interface BookingRouteRuntime {
   getKmsProvider(): Promise<KmsProvider>
-  monthlyBookingLimit?: number | null
+  /**
+   * The monthly booking allowance in force. Read this per use rather than
+   * caching it: when a host installs `resolveMonthlyBookingLimit`, this is an
+   * accessor that answers from the host's live entitlement, so copying it into
+   * a local (or spreading the runtime object) re-freezes what the seam exists
+   * to keep live.
+   */
+  readonly monthlyBookingLimit?: number | null
   resolveTravelSnapshot?: ResolveBookingTravelSnapshot
   resolveBillingPerson?: ResolveBookingBillingPerson
   resolveTravelerPerson?: ResolveBookingTravelerPerson
@@ -155,6 +166,15 @@ export type ResolveBookingKmsProvider = (
 
 export interface BookingRouteRuntimeOptions {
   resolveKmsProvider?: ResolveBookingKmsProvider
+  /**
+   * Hook for hosts whose monthly booking allowance is a property of the
+   * request rather than of the container — a managed host serving a tenant
+   * whose plan can be upgraded, downgraded, or expire while the process runs.
+   * Consulted on every read of `monthlyBookingLimit`; returning `undefined`
+   * falls back to the value resolved from bindings at composition time. Omit
+   * it and the allowance stays the boot-time constant it has always been.
+   */
+  resolveMonthlyBookingLimit?: MonthlyBookingLimitResolver
   resolveTravelSnapshot?: ResolveBookingTravelSnapshot
   resolveBillingPerson?: ResolveBookingBillingPerson
   resolveTravelerPerson?: ResolveBookingTravelerPerson
@@ -187,9 +207,15 @@ export function buildBookingRouteRuntime(
   options: BookingRouteRuntimeOptions = {},
 ): BookingRouteRuntime {
   const runtimeEnv = buildRuntimeEnv(bindings)
+  const configuredMonthlyBookingLimit = resolveMonthlyBookingLimit(runtimeEnv)
 
   return {
-    monthlyBookingLimit: resolveMonthlyBookingLimit(runtimeEnv),
+    get monthlyBookingLimit() {
+      return selectMonthlyBookingLimit(
+        options.resolveMonthlyBookingLimit,
+        configuredMonthlyBookingLimit,
+      )
+    },
     async getKmsProvider() {
       if (options.resolveKmsProvider) {
         return options.resolveKmsProvider(runtimeEnv)

--- a/packages/bookings/tests/unit/live-monthly-booking-limit.test.ts
+++ b/packages/bookings/tests/unit/live-monthly-booking-limit.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest"
+
+import { selectMonthlyBookingLimit } from "../../src/booking-plan-limit.js"
+import { buildBookingRouteRuntime } from "../../src/route-runtime.js"
+
+describe("selectMonthlyBookingLimit", () => {
+  it("keeps the configured value when no host resolver is installed", () => {
+    expect(selectMonthlyBookingLimit(undefined, 100)).toBe(100)
+    expect(selectMonthlyBookingLimit(undefined, null)).toBeNull()
+  })
+
+  it("keeps the configured value when the resolver has no live answer", () => {
+    expect(selectMonthlyBookingLimit(() => undefined, 100)).toBe(100)
+  })
+
+  it("takes a live numeric allowance over the configured one", () => {
+    expect(selectMonthlyBookingLimit(() => 5, 100)).toBe(5)
+    expect(selectMonthlyBookingLimit(() => 5, null)).toBe(5)
+  })
+
+  it("treats a live null as an explicit unlimited, overriding the configured cap", () => {
+    expect(selectMonthlyBookingLimit(() => null, 100)).toBeNull()
+  })
+})
+
+describe("buildBookingRouteRuntime monthly booking limit", () => {
+  it("resolves from bindings once when no host resolver is installed", () => {
+    const runtime = buildBookingRouteRuntime({ VOYANT_BOOKINGS_MONTHLY_LIMIT: "100" })
+    expect(runtime.monthlyBookingLimit).toBe(100)
+    expect(runtime.monthlyBookingLimit).toBe(100)
+  })
+
+  it("stays unlimited when neither bindings nor a resolver supply a limit", () => {
+    expect(buildBookingRouteRuntime({}).monthlyBookingLimit).toBeNull()
+  })
+
+  it("consults the host resolver on every read, not once at composition", () => {
+    // Mirrors a managed host whose tenant is upgraded while the composed API
+    // graph — built once per process — keeps serving requests.
+    let live: number | null | undefined = 10
+    const runtime = buildBookingRouteRuntime(
+      { VOYANT_BOOKINGS_MONTHLY_LIMIT: "100" },
+      { resolveMonthlyBookingLimit: () => live },
+    )
+
+    expect(runtime.monthlyBookingLimit).toBe(10)
+    live = 250
+    expect(runtime.monthlyBookingLimit).toBe(250)
+    live = null
+    expect(runtime.monthlyBookingLimit).toBeNull()
+    live = undefined
+    expect(runtime.monthlyBookingLimit).toBe(100)
+  })
+
+  it("falls back to the configured value for a resolver that never answers", () => {
+    const runtime = buildBookingRouteRuntime(
+      { VOYANT_BOOKINGS_MONTHLY_LIMIT: "100" },
+      { resolveMonthlyBookingLimit: () => undefined },
+    )
+    expect(runtime.monthlyBookingLimit).toBe(100)
+  })
+
+  it("leaves every other runtime member untouched", () => {
+    const runtime = buildBookingRouteRuntime({}, { resolveMonthlyBookingLimit: () => 7 })
+    expect(typeof runtime.getKmsProvider).toBe("function")
+    expect(runtime.resolveTravelSnapshot).toBeUndefined()
+  })
+})

--- a/packages/commerce/src/checkout/subscriber-runtime.ts
+++ b/packages/commerce/src/checkout/subscriber-runtime.ts
@@ -1,4 +1,8 @@
-import { resolveMonthlyBookingLimit } from "@voyant-travel/bookings"
+import {
+  type MonthlyBookingLimitResolver,
+  resolveMonthlyBookingLimit,
+  selectMonthlyBookingLimit,
+} from "@voyant-travel/bookings"
 import type { BootstrapContext, EventBus, SubscriberRuntimeDescriptor } from "@voyant-travel/core"
 import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
@@ -46,6 +50,13 @@ export interface CheckoutFinalizeSubscriberRuntimeOptions<TBindings = unknown>
   extends CatalogCheckoutRuntimeDatabase<TBindings> {
   finalize?: typeof finalizeCheckout
   logger?: Pick<Console, "error">
+  /**
+   * Per-event monthly booking allowance, for hosts whose plan entitlement
+   * changes while the process runs. Same contract as the bookings runtime
+   * option of the same name. Finalizing a checkout accepts a booking, so this
+   * path consumes the same quota as the booking and finance routes.
+   */
+  resolveMonthlyBookingLimit?: MonthlyBookingLimitResolver
 }
 
 interface ContractDocumentGeneratedPayload {
@@ -105,7 +116,7 @@ export function createCheckoutFinalizeSubscriberRuntime<TBindings = unknown>(
             process?: { env?: Record<string, string | undefined> }
           }
         ).process?.env ?? {}
-      const monthlyBookingLimit = resolveMonthlyBookingLimit({
+      const configuredMonthlyBookingLimit = resolveMonthlyBookingLimit({
         ...processEnv,
         ...(bindings as Record<string, unknown>),
       })
@@ -114,6 +125,12 @@ export function createCheckoutFinalizeSubscriberRuntime<TBindings = unknown>(
         async ({ data }, context) => {
           if (!data.bookingId) return
           const bookingId = data.bookingId
+          // Resolved per event, not at registration: the subscriber outlives
+          // any single tenant plan state.
+          const monthlyBookingLimit = selectMonthlyBookingLimit(
+            options.resolveMonthlyBookingLimit,
+            configuredMonthlyBookingLimit,
+          )
           const nestedEventBus = (context?.eventBus ?? eventBus) as EventBus
 
           try {

--- a/packages/commerce/tests/unit/catalog-checkout-subscriber-runtime.test.ts
+++ b/packages/commerce/tests/unit/catalog-checkout-subscriber-runtime.test.ts
@@ -125,6 +125,39 @@ describe("catalog-checkout subscriber runtimes", () => {
     )
   })
 
+  it("resolves the monthly booking limit per event, not once at registration", async () => {
+    let live: number | null | undefined = 10
+    const finalize = vi.fn(async () => undefined)
+    const withDb = vi.fn(async (_bindings, operation) => operation({} as PostgresJsDatabase))
+    const { eventBus, subscriptions } = recordingEventBus()
+    const descriptor = createCheckoutFinalizeSubscriberRuntime({
+      withDb,
+      finalize,
+      resolveMonthlyBookingLimit: () => live,
+    })
+    await descriptor.register({
+      bindings: { VOYANT_BOOKINGS_MONTHLY_LIMIT: "100" },
+      container: createContainer(),
+      eventBus,
+    })
+
+    const deliver = async () => {
+      await subscriptions[0]?.handler(
+        event("payment.completed", { bookingId: "booking_1", paymentSessionId: "session_1" }),
+      )
+    }
+
+    await deliver()
+    live = 250
+    await deliver()
+    live = undefined
+    await deliver()
+
+    expect(finalize.mock.calls.map(([params]) => params.monthlyBookingLimit)).toEqual([
+      10, 250, 100,
+    ])
+  })
+
   it("ignores unrelated payments and rethrows dispatch failures for outbox retry", async () => {
     const error = new Error("checkout finalization failure")
     const finalize = vi.fn(async () => {

--- a/packages/finance/src/route-runtime.ts
+++ b/packages/finance/src/route-runtime.ts
@@ -1,4 +1,8 @@
-import { resolveMonthlyBookingLimit } from "@voyant-travel/bookings"
+import {
+  type MonthlyBookingLimitResolver,
+  resolveMonthlyBookingLimit,
+  selectMonthlyBookingLimit,
+} from "@voyant-travel/bookings"
 import type { EventBus } from "@voyant-travel/core"
 
 import type { InvoiceFxOptions } from "./invoice-fx.js"
@@ -12,7 +16,13 @@ import type {
 import type { InvoiceDocumentGenerator } from "./service-documents.js"
 
 export type FinanceRouteRuntime = {
-  monthlyBookingLimit?: number | null
+  /**
+   * The monthly booking allowance in force for the booking this runtime is
+   * about to create. Read per use — when a host installs
+   * `resolveMonthlyBookingLimit` this is an accessor over live entitlement,
+   * and copying it into a local re-freezes it.
+   */
+  readonly monthlyBookingLimit?: number | null
   invoiceDocumentGenerator?: InvoiceDocumentGenerator
   resolveCustomFields?: FinanceDocumentRouteOptions["resolveCustomFields"]
   resolveDocumentDownloadUrl?: FinanceDocumentRouteOptions["resolveDocumentDownloadUrl"]
@@ -32,6 +42,14 @@ export interface FinanceRuntimeOptions
   descriptionResolver?: InvoiceLineDescriptionResolver
   invoiceDueDateResolver?: InvoiceDueDateResolver
   paymentScheduleLineDescriptionFormat?: PaymentScheduleLineDescriptionFormat
+  /**
+   * Per-request monthly booking allowance, for hosts whose plan entitlement
+   * changes while the process runs. Same contract as the bookings runtime
+   * option of the same name — finance creates bookings too, so both paths
+   * have to consult the same live answer or a managed tenant gets one cap
+   * from the booking routes and another from the finance routes.
+   */
+  resolveMonthlyBookingLimit?: MonthlyBookingLimitResolver
 }
 
 export function buildFinanceRouteRuntime(
@@ -44,9 +62,15 @@ export function buildFinanceRouteRuntime(
         process?: { env?: Record<string, string | undefined> }
       }
     ).process?.env ?? {}
+  const configuredMonthlyBookingLimit = resolveMonthlyBookingLimit({ ...processEnv, ...bindings })
 
   return {
-    monthlyBookingLimit: resolveMonthlyBookingLimit({ ...processEnv, ...bindings }),
+    get monthlyBookingLimit() {
+      return selectMonthlyBookingLimit(
+        options.resolveMonthlyBookingLimit,
+        configuredMonthlyBookingLimit,
+      )
+    },
     invoiceDocumentGenerator:
       options.resolveInvoiceDocumentGenerator?.(bindings) ?? options.invoiceDocumentGenerator,
     resolveCustomFields: options.resolveCustomFields,

--- a/packages/finance/tests/unit/route-runtime.test.ts
+++ b/packages/finance/tests/unit/route-runtime.test.ts
@@ -7,6 +7,29 @@ import {
 import { getFinanceRouteRuntime } from "../../src/routes-runtime.js"
 
 describe("buildFinanceRouteRuntime", () => {
+  it("resolves the monthly booking limit from bindings when no host resolver is installed", () => {
+    expect(
+      buildFinanceRouteRuntime({ VOYANT_BOOKINGS_MONTHLY_LIMIT: "100" }).monthlyBookingLimit,
+    ).toBe(100)
+    expect(buildFinanceRouteRuntime({}).monthlyBookingLimit).toBeNull()
+  })
+
+  it("consults the host monthly-booking-limit resolver on every read", () => {
+    let live: number | null | undefined = 10
+    const runtime = buildFinanceRouteRuntime(
+      { VOYANT_BOOKINGS_MONTHLY_LIMIT: "100" },
+      { resolveMonthlyBookingLimit: () => live },
+    )
+
+    expect(runtime.monthlyBookingLimit).toBe(10)
+    live = 250
+    expect(runtime.monthlyBookingLimit).toBe(250)
+    live = null
+    expect(runtime.monthlyBookingLimit).toBeNull()
+    live = undefined
+    expect(runtime.monthlyBookingLimit).toBe(100)
+  })
+
   it("exposes invoice-from-booking resolver options", async () => {
     const descriptionResolver = () => "Custom legal line"
     const invoiceDueDateResolver = () => "2026-05-23"


### PR DESCRIPTION
Closes #4125.

`buildBookingRouteRuntime` froze `monthlyBookingLimit` at composition time. Since the composed API graph is built once per process and reused for the process lifetime, that made the allowance a boot-time constant — correct for a self-hosted deployment, where the cap is a property of the container, but wrong for a managed host serving a tenant whose plan entitlement can change while the process runs. Platform has carried a `patches/` entry against `@voyant-travel/bookings` to work around this, and that patch is the last thing keeping the managed runtime resolving the framework from npm rather than from the image.

## The seam

`MonthlyBookingLimitResolver` in `@voyant-travel/bookings`, installed via a `resolveMonthlyBookingLimit` runtime option. `monthlyBookingLimit` becomes an accessor that consults it on every read:

| resolver returns | meaning |
|---|---|
| a `number` | that allowance applies right now |
| `null` | unlimited right now, overriding whatever was configured |
| `undefined` | no live answer; fall back to the configured value |

With no resolver installed the configured value always wins, so a self-hoster sees no change. That's asserted by tests, not just by construction.

I went with the explicit option rather than the patch's `globalThis[Symbol.for("voyant.managed-booking-limit-context")]` lookup — the issue offered either shape and named the option as preferable for a supported contract. **Platform-side note:** `live-booking-limit.ts` keeps its `AsyncLocalStorage` but drops the well-known symbol and instead reads the store from inside the resolver it hands to the runtime option. Still one file.

## Scope: three composition sites, not one

The issue is filed against `bookings`, and the patch only patched `bookings`. But three paths accept bookings and all three feed the same `assertMonthlyBookingLimitAvailable` quota:

| package | option on |
|---|---|
| `@voyant-travel/bookings` | `buildBookingRouteRuntime` / `createBookingsApiModule` |
| `@voyant-travel/finance` | `buildFinanceRouteRuntime` / `createFinanceApiModule` |
| `@voyant-travel/commerce` | `createCheckoutFinalizeSubscriberRuntime` |

Wiring only `bookings` would serve a managed tenant a live cap from the booking routes and a stale one from the finance routes or checkout finalization — the same silent wrong-cap class of bug the issue is about, just relocated. The commerce subscriber additionally moves its resolution from registration time into the event handler, since the subscriber outlives any single tenant plan state.

One gap worth calling out: `createCheckoutFinalizeSubscriberGraphRuntime` takes no options, so the commerce seam is reachable only through the direct constructor. Threading it through the graph factory would need a port; that felt like the wrong thing to invent speculatively here.

## Deliberate non-change

The resolver is **not** validated where it is read. `assertMonthlyBookingLimitAvailable` stays the single validation authority, so a malformed live answer fails loudly at enforcement rather than silently capping a tenant at the wrong number — and a read for display purposes doesn't become a throw site.

`monthlyBookingLimit` is now `readonly` on both runtime interfaces, and documented as read-per-use: copying it into a local or spreading the runtime object re-freezes exactly what this seam exists to keep live. All current read sites (`routes-admin`, `service-core.overrideBookingStatus`, `service-booking-create`) already read it inside the request.

## No changeset

All three packages are `private: true`, so this can't ship as a version bump and doesn't need one. Per the issue, the OSS operator image is built from source, so the merge reaches Platform through a new base digest with no publish involved.

## Verification

- `typecheck` clean on bookings, finance, commerce
- `biome check .` clean from the repo root
- `pnpm verify:architecture` passing
- full suites green: bookings 454, finance 498, commerce 177
- pre-push full-repo `pnpm test`: 116/117 turbo tasks passed. The one failure was `apps/operator tests/selected-graph-mcp-tool-surface.test.ts` hitting a 30s **timeout** (not an assertion) while a parallel typecheck was saturating the machine; it passes 5/5 in 10.9s re-run in isolation. Pushed with `--no-verify` on that basis — CI is the authoritative gate.

A cross-package typecheck of every dependent (to confirm the `readonly` change breaks no consumer) was started locally but killed for thrashing the machine; CI covers it.

## Docs

New `docs/architecture/monthly-booking-allowance.md` covering the two sources for the allowance, the resolver contract, and where a host installs one.