### PR TITLE
Bind every new departure to its Product Version

### DIFF
--- a/.changeset/departure-binds-version-by-default.md
+++ b/.changeset/departure-binds-version-by-default.md
@@ -1,0 +1,27 @@
+---
+"@voyant-travel/operations": minor
+---
+
+Bind every new departure to its Product Version, not just generated ones.
+
+The version binding landed with only recurring generation resolving a version
+automatically; a departure created through the admin route recorded none. That
+left the guarantee — a departure can always name the definition it sells —
+true of the bulk path but not the manual one.
+
+`createSlot` now resolves the product's currently published version itself, and
+generation falls back to the same resolver when no override is supplied. An
+explicit `productVersionId` still wins, so a caller can materialize against a
+chosen version.
+
+The version is read through a local `productVersionsRef`, the same escape hatch
+`productsRef` and `productOptionsRef` already use: Inventory owns
+`product_versions` and already depends on Operations, so importing it would
+close a dependency cycle.
+
+`service-core.ts` had grown past the size gate while owning four unrelated
+aggregates, which blocked touching it at all. Availability rules and start
+times move to `service-rules.ts` and the shared static-availability guard to
+`service-product-guard.ts` — pure moves with no behaviour change, leaving slot
+and closeout lifecycle behind. `availabilityService` re-exports everything as
+before, so no caller changes.

--- a/packages/operations/src/availability/generate-slots.ts
+++ b/packages/operations/src/availability/generate-slots.ts
@@ -1,6 +1,7 @@
 import { availabilityRules, availabilitySlots } from "@voyant-travel/availability/schema"
 import { and, eq, inArray } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { resolveCurrentProductVersionId } from "./products-ref.js"
 import { expandRRule } from "./rrule.js"
 import { materializeSlotResourcesFromTemplateDefaults } from "./service-allocation-automation.js"
 import { localToInstant } from "./slot-timezone.js"
@@ -33,8 +34,8 @@ export type GenerateAvailabilitySlotsOptions = {
    * departures split across two definitions. Already-generated departures are
    * never rewritten by a later run.
    *
-   * Supplied by the deployment; `product_versions` is Inventory-owned and
-   * Inventory already depends on Operations. See #4032.
+   * Defaults to reading the product's highest version number directly. Supply
+   * an override to materialize a run against a specific definition. See #4032.
    */
   resolveCurrentProductVersionId?: (productId: string) => Promise<string | null>
 }
@@ -108,8 +109,9 @@ export async function generateAvailabilitySlots(
     const startTime = `${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`
     // Resolved once per rule so a single run cannot split its departures
     // across two Product Versions if a publish lands mid-run.
-    const productVersionId =
-      (await options.resolveCurrentProductVersionId?.(rule.productId)) ?? null
+    const productVersionId = options.resolveCurrentProductVersionId
+      ? await options.resolveCurrentProductVersionId(rule.productId)
+      : await resolveCurrentProductVersionId(db, rule.productId)
 
     const rows = toInsert.map((dateLocal) => {
       return {

--- a/packages/operations/src/availability/products-ref.ts
+++ b/packages/operations/src/availability/products-ref.ts
@@ -1,10 +1,27 @@
+import { desc, eq } from "drizzle-orm"
 import { boolean, integer, pgTable, text } from "drizzle-orm/pg-core"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 /** Minimal reference to the products table for LEFT JOIN enrichment. */
 export const productsRef = pgTable("products", {
   id: text("id").primaryKey(),
   name: text("name").notNull(),
   bookingMode: text("booking_mode").notNull(),
+})
+
+/**
+ * Minimal reference to product_versions, so a departure can be bound at
+ * creation to the Product definition it operates from (#4032).
+ *
+ * Declared locally rather than imported: Inventory owns `product_versions` and
+ * already depends on Operations, so importing it here would close a dependency
+ * cycle. This is the same escape hatch `productsRef` and `productOptionsRef`
+ * already use for cross-module reads.
+ */
+export const productVersionsRef = pgTable("product_versions", {
+  id: text("id").primaryKey(),
+  productId: text("product_id").notNull(),
+  versionNumber: integer("version_number").notNull(),
 })
 
 /** Minimal reference to product_options for validating explicit slot option links. */
@@ -16,3 +33,26 @@ export const productOptionsRef = pgTable("product_options", {
   isDefault: boolean("is_default").notNull(),
   sortOrder: integer("sort_order").notNull(),
 })
+
+/**
+ * The Product Version a departure created now operates from: the product's
+ * highest version number, which is the one publish most recently froze.
+ *
+ * Deterministic by construction — version numbers are assigned monotonically
+ * per product, so "current" never depends on wall-clock time or row order.
+ * Returns null when the product has never been published; that is recorded as
+ * unknown rather than inferred (#4032).
+ */
+export async function resolveCurrentProductVersionId(
+  db: PostgresJsDatabase,
+  productId: string,
+): Promise<string | null> {
+  const [row] = await db
+    .select({ id: productVersionsRef.id })
+    .from(productVersionsRef)
+    .where(eq(productVersionsRef.productId, productId))
+    .orderBy(desc(productVersionsRef.versionNumber))
+    .limit(1)
+
+  return row?.id ?? null
+}

--- a/packages/operations/src/availability/service-core.ts
+++ b/packages/operations/src/availability/service-core.ts
@@ -1,35 +1,25 @@
 import {
   type AvailabilitySlot,
   availabilityCloseouts,
-  availabilityRules,
   availabilitySlots,
-  availabilityStartTimes,
 } from "@voyant-travel/availability/schema"
 import type { EventBus } from "@voyant-travel/core"
 import { RequestValidationError } from "@voyant-travel/hono"
 import { and, asc, desc, eq, getTableColumns, gte, lt, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { AVAILABILITY_SLOT_CHANGED_EVENT, type AvailabilitySlotChangedEvent } from "./events.js"
-import { productOptionsRef, productsRef } from "./products-ref.js"
+import { productOptionsRef, productsRef, resolveCurrentProductVersionId } from "./products-ref.js"
+import { assertProductAllowsStaticAvailability } from "./service-product-guard.js"
 import type {
   AvailabilityCloseoutListQuery,
-  AvailabilityRuleListQuery,
   AvailabilitySlotListQuery,
-  AvailabilityStartTimeListQuery,
   CreateAvailabilityCloseoutInput,
-  CreateAvailabilityRuleInput,
   CreateAvailabilitySlotInput,
-  CreateAvailabilityStartTimeInput,
   UpdateAvailabilityCloseoutInput,
-  UpdateAvailabilityRuleInput,
   UpdateAvailabilitySlotInput,
-  UpdateAvailabilityStartTimeInput,
 } from "./service-shared.js"
 import { paginate, toDateOrNull } from "./service-shared.js"
-import {
-  assertAvailabilityRecurrenceRule,
-  assertSlotTimingAndCapacity,
-} from "./service-validation.js"
+import { assertSlotTimingAndCapacity } from "./service-validation.js"
 import { slotEndDateLocal } from "./slot-timezone.js"
 
 export type AvailabilitySlotWithEndDateLocal = AvailabilitySlot & {
@@ -77,184 +67,6 @@ async function assertSlotOptionBelongsToProduct(
       optionId: input.optionId,
     })
   }
-}
-
-const DYNAMIC_BOOKING_MODES = new Set(["open", "stay"])
-
-async function getProductBookingMode(db: PostgresJsDatabase, productId: string) {
-  const [product] = await db
-    .select({ bookingMode: productsRef.bookingMode })
-    .from(productsRef)
-    .where(eq(productsRef.id, productId))
-    .limit(1)
-
-  return product?.bookingMode ?? null
-}
-
-async function assertProductAllowsStaticAvailability(
-  db: PostgresJsDatabase,
-  productId: string,
-  kind: "slot" | "rule",
-) {
-  const bookingMode = await getProductBookingMode(db, productId)
-  if (bookingMode && DYNAMIC_BOOKING_MODES.has(bookingMode)) {
-    throw new RequestValidationError(
-      `Dynamic ${bookingMode} products cannot author static availability ${kind}s`,
-      {
-        code: "dynamic_product_static_availability",
-        productId,
-        bookingMode,
-        kind,
-      },
-    )
-  }
-}
-
-export async function listRules(db: PostgresJsDatabase, query: AvailabilityRuleListQuery) {
-  const conditions = []
-  if (query.productId) conditions.push(eq(availabilityRules.productId, query.productId))
-  if (query.optionId) conditions.push(eq(availabilityRules.optionId, query.optionId))
-  if (query.facilityId) conditions.push(eq(availabilityRules.facilityId, query.facilityId))
-  if (query.active !== undefined) conditions.push(eq(availabilityRules.active, query.active))
-
-  const where = conditions.length ? and(...conditions) : undefined
-  return paginate(
-    db
-      .select({ ...getTableColumns(availabilityRules), productName: productsRef.name })
-      .from(availabilityRules)
-      .leftJoin(productsRef, eq(availabilityRules.productId, productsRef.id))
-      .where(where)
-      .limit(query.limit)
-      .offset(query.offset)
-      .orderBy(desc(availabilityRules.updatedAt)),
-    db.select({ count: sql<number>`count(*)::int` }).from(availabilityRules).where(where),
-    query.limit,
-    query.offset,
-  )
-}
-
-export async function getRuleById(db: PostgresJsDatabase, id: string) {
-  const [row] = await db
-    .select()
-    .from(availabilityRules)
-    .where(eq(availabilityRules.id, id))
-    .limit(1)
-  return row ?? null
-}
-
-export async function createRule(db: PostgresJsDatabase, data: CreateAvailabilityRuleInput) {
-  assertAvailabilityRecurrenceRule(data.recurrenceRule)
-
-  if (data.active !== false) {
-    await assertProductAllowsStaticAvailability(db, data.productId, "rule")
-  }
-
-  const [row] = await db.insert(availabilityRules).values(data).returning()
-  return row
-}
-
-export async function updateRule(
-  db: PostgresJsDatabase,
-  id: string,
-  data: UpdateAvailabilityRuleInput,
-) {
-  if (data.recurrenceRule !== undefined) {
-    assertAvailabilityRecurrenceRule(data.recurrenceRule)
-  }
-
-  if (data.productId !== undefined || data.active === true) {
-    const [current] = await db
-      .select({ productId: availabilityRules.productId, active: availabilityRules.active })
-      .from(availabilityRules)
-      .where(eq(availabilityRules.id, id))
-      .limit(1)
-    if (!current) return null
-
-    const nextProductId = data.productId ?? current.productId
-    const nextActive = data.active ?? current.active
-    if (nextActive) {
-      await assertProductAllowsStaticAvailability(db, nextProductId, "rule")
-    }
-  }
-
-  const [row] = await db
-    .update(availabilityRules)
-    .set({ ...data, updatedAt: new Date() })
-    .where(eq(availabilityRules.id, id))
-    .returning()
-  return row ?? null
-}
-
-export async function deleteRule(db: PostgresJsDatabase, id: string) {
-  const [row] = await db
-    .delete(availabilityRules)
-    .where(eq(availabilityRules.id, id))
-    .returning({ id: availabilityRules.id })
-  return row ?? null
-}
-
-export async function listStartTimes(
-  db: PostgresJsDatabase,
-  query: AvailabilityStartTimeListQuery,
-) {
-  const conditions = []
-  if (query.productId) conditions.push(eq(availabilityStartTimes.productId, query.productId))
-  if (query.optionId) conditions.push(eq(availabilityStartTimes.optionId, query.optionId))
-  if (query.facilityId) conditions.push(eq(availabilityStartTimes.facilityId, query.facilityId))
-  if (query.active !== undefined) conditions.push(eq(availabilityStartTimes.active, query.active))
-  const where = conditions.length ? and(...conditions) : undefined
-
-  return paginate(
-    db
-      .select({ ...getTableColumns(availabilityStartTimes), productName: productsRef.name })
-      .from(availabilityStartTimes)
-      .leftJoin(productsRef, eq(availabilityStartTimes.productId, productsRef.id))
-      .where(where)
-      .limit(query.limit)
-      .offset(query.offset)
-      .orderBy(availabilityStartTimes.sortOrder, availabilityStartTimes.createdAt),
-    db.select({ count: sql<number>`count(*)::int` }).from(availabilityStartTimes).where(where),
-    query.limit,
-    query.offset,
-  )
-}
-
-export async function getStartTimeById(db: PostgresJsDatabase, id: string) {
-  const [row] = await db
-    .select()
-    .from(availabilityStartTimes)
-    .where(eq(availabilityStartTimes.id, id))
-    .limit(1)
-  return row ?? null
-}
-
-export async function createStartTime(
-  db: PostgresJsDatabase,
-  data: CreateAvailabilityStartTimeInput,
-) {
-  const [row] = await db.insert(availabilityStartTimes).values(data).returning()
-  return row
-}
-
-export async function updateStartTime(
-  db: PostgresJsDatabase,
-  id: string,
-  data: UpdateAvailabilityStartTimeInput,
-) {
-  const [row] = await db
-    .update(availabilityStartTimes)
-    .set({ ...data, updatedAt: new Date() })
-    .where(eq(availabilityStartTimes.id, id))
-    .returning()
-  return row ?? null
-}
-
-export async function deleteStartTime(db: PostgresJsDatabase, id: string) {
-  const [row] = await db
-    .delete(availabilityStartTimes)
-    .where(eq(availabilityStartTimes.id, id))
-    .returning({ id: availabilityStartTimes.id })
-  return row ?? null
 }
 
 export async function listSlots(db: PostgresJsDatabase, query: AvailabilitySlotListQuery) {
@@ -362,10 +174,18 @@ export async function createSlot(
       ? data.initialPax
       : data.remainingPax
 
+  // Bind the departure to the Product definition it is created from, so later
+  // Product edits cannot silently rewrite what it sells (#4032). An explicit
+  // value wins — that is how a caller materializes against a chosen version
+  // rather than whatever is currently published.
+  const productVersionId =
+    data.productVersionId ?? (await resolveCurrentProductVersionId(db, data.productId))
+
   const [row] = await db
     .insert(availabilitySlots)
     .values({
       ...data,
+      productVersionId,
       remainingPax,
       startsAt: new Date(data.startsAt),
       endsAt: toDateOrNull(data.endsAt),

--- a/packages/operations/src/availability/service-product-guard.ts
+++ b/packages/operations/src/availability/service-product-guard.ts
@@ -1,0 +1,46 @@
+/**
+ * Guard shared by every static-availability author.
+ *
+ * A dynamically-supplied product (`open`, `stay`) resolves its availability at
+ * quote time, so authoring fixed rules or slots against one is a category
+ * error rather than a capacity problem. Lives here rather than in
+ * `service-core.ts` so both the slot path and the rule path can reach it
+ * without either owning the other.
+ */
+
+import { RequestValidationError } from "@voyant-travel/hono"
+import { eq } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import { productsRef } from "./products-ref.js"
+
+const DYNAMIC_BOOKING_MODES = new Set(["open", "stay"])
+
+async function getProductBookingMode(db: PostgresJsDatabase, productId: string) {
+  const [product] = await db
+    .select({ bookingMode: productsRef.bookingMode })
+    .from(productsRef)
+    .where(eq(productsRef.id, productId))
+    .limit(1)
+
+  return product?.bookingMode ?? null
+}
+
+export async function assertProductAllowsStaticAvailability(
+  db: PostgresJsDatabase,
+  productId: string,
+  kind: "slot" | "rule",
+) {
+  const bookingMode = await getProductBookingMode(db, productId)
+  if (bookingMode && DYNAMIC_BOOKING_MODES.has(bookingMode)) {
+    throw new RequestValidationError(
+      `Dynamic ${bookingMode} products cannot author static availability ${kind}s`,
+      {
+        code: "dynamic_product_static_availability",
+        productId,
+        bookingMode,
+        kind,
+      },
+    )
+  }
+}

--- a/packages/operations/src/availability/service-rules.ts
+++ b/packages/operations/src/availability/service-rules.ts
@@ -1,0 +1,172 @@
+/**
+ * Availability rules and start times — the recurring-supply authoring surface.
+ *
+ * Split out of `service-core.ts`, which had grown past the size gate while
+ * owning four unrelated aggregates. Rules and start times are self-contained:
+ * they touch neither `availability_slots` nor the slot mutation lifecycle, so
+ * they move as a unit with no behaviour change.
+ */
+
+import { availabilityRules, availabilityStartTimes } from "@voyant-travel/availability/schema"
+import { and, desc, eq, getTableColumns, sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import { productsRef } from "./products-ref.js"
+import { assertProductAllowsStaticAvailability } from "./service-product-guard.js"
+import type {
+  AvailabilityRuleListQuery,
+  AvailabilityStartTimeListQuery,
+  CreateAvailabilityRuleInput,
+  CreateAvailabilityStartTimeInput,
+  UpdateAvailabilityRuleInput,
+  UpdateAvailabilityStartTimeInput,
+} from "./service-shared.js"
+import { paginate } from "./service-shared.js"
+import { assertAvailabilityRecurrenceRule } from "./service-validation.js"
+
+export async function listRules(db: PostgresJsDatabase, query: AvailabilityRuleListQuery) {
+  const conditions = []
+  if (query.productId) conditions.push(eq(availabilityRules.productId, query.productId))
+  if (query.optionId) conditions.push(eq(availabilityRules.optionId, query.optionId))
+  if (query.facilityId) conditions.push(eq(availabilityRules.facilityId, query.facilityId))
+  if (query.active !== undefined) conditions.push(eq(availabilityRules.active, query.active))
+
+  const where = conditions.length ? and(...conditions) : undefined
+  return paginate(
+    db
+      .select({ ...getTableColumns(availabilityRules), productName: productsRef.name })
+      .from(availabilityRules)
+      .leftJoin(productsRef, eq(availabilityRules.productId, productsRef.id))
+      .where(where)
+      .limit(query.limit)
+      .offset(query.offset)
+      .orderBy(desc(availabilityRules.updatedAt)),
+    db.select({ count: sql<number>`count(*)::int` }).from(availabilityRules).where(where),
+    query.limit,
+    query.offset,
+  )
+}
+
+export async function getRuleById(db: PostgresJsDatabase, id: string) {
+  const [row] = await db
+    .select()
+    .from(availabilityRules)
+    .where(eq(availabilityRules.id, id))
+    .limit(1)
+  return row ?? null
+}
+
+export async function createRule(db: PostgresJsDatabase, data: CreateAvailabilityRuleInput) {
+  assertAvailabilityRecurrenceRule(data.recurrenceRule)
+
+  if (data.active !== false) {
+    await assertProductAllowsStaticAvailability(db, data.productId, "rule")
+  }
+
+  const [row] = await db.insert(availabilityRules).values(data).returning()
+  return row
+}
+
+export async function updateRule(
+  db: PostgresJsDatabase,
+  id: string,
+  data: UpdateAvailabilityRuleInput,
+) {
+  if (data.recurrenceRule !== undefined) {
+    assertAvailabilityRecurrenceRule(data.recurrenceRule)
+  }
+
+  if (data.productId !== undefined || data.active === true) {
+    const [current] = await db
+      .select({ productId: availabilityRules.productId, active: availabilityRules.active })
+      .from(availabilityRules)
+      .where(eq(availabilityRules.id, id))
+      .limit(1)
+    if (!current) return null
+
+    const nextProductId = data.productId ?? current.productId
+    const nextActive = data.active ?? current.active
+    if (nextActive) {
+      await assertProductAllowsStaticAvailability(db, nextProductId, "rule")
+    }
+  }
+
+  const [row] = await db
+    .update(availabilityRules)
+    .set({ ...data, updatedAt: new Date() })
+    .where(eq(availabilityRules.id, id))
+    .returning()
+  return row ?? null
+}
+
+export async function deleteRule(db: PostgresJsDatabase, id: string) {
+  const [row] = await db
+    .delete(availabilityRules)
+    .where(eq(availabilityRules.id, id))
+    .returning({ id: availabilityRules.id })
+  return row ?? null
+}
+
+export async function listStartTimes(
+  db: PostgresJsDatabase,
+  query: AvailabilityStartTimeListQuery,
+) {
+  const conditions = []
+  if (query.productId) conditions.push(eq(availabilityStartTimes.productId, query.productId))
+  if (query.optionId) conditions.push(eq(availabilityStartTimes.optionId, query.optionId))
+  if (query.facilityId) conditions.push(eq(availabilityStartTimes.facilityId, query.facilityId))
+  if (query.active !== undefined) conditions.push(eq(availabilityStartTimes.active, query.active))
+  const where = conditions.length ? and(...conditions) : undefined
+
+  return paginate(
+    db
+      .select({ ...getTableColumns(availabilityStartTimes), productName: productsRef.name })
+      .from(availabilityStartTimes)
+      .leftJoin(productsRef, eq(availabilityStartTimes.productId, productsRef.id))
+      .where(where)
+      .limit(query.limit)
+      .offset(query.offset)
+      .orderBy(availabilityStartTimes.sortOrder, availabilityStartTimes.createdAt),
+    db.select({ count: sql<number>`count(*)::int` }).from(availabilityStartTimes).where(where),
+    query.limit,
+    query.offset,
+  )
+}
+
+export async function getStartTimeById(db: PostgresJsDatabase, id: string) {
+  const [row] = await db
+    .select()
+    .from(availabilityStartTimes)
+    .where(eq(availabilityStartTimes.id, id))
+    .limit(1)
+  return row ?? null
+}
+
+export async function createStartTime(
+  db: PostgresJsDatabase,
+  data: CreateAvailabilityStartTimeInput,
+) {
+  const [row] = await db.insert(availabilityStartTimes).values(data).returning()
+  return row
+}
+
+export async function updateStartTime(
+  db: PostgresJsDatabase,
+  id: string,
+  data: UpdateAvailabilityStartTimeInput,
+) {
+  const [row] = await db
+    .update(availabilityStartTimes)
+    .set({ ...data, updatedAt: new Date() })
+    .where(eq(availabilityStartTimes.id, id))
+    .returning()
+  return row ?? null
+}
+
+export async function deleteStartTime(db: PostgresJsDatabase, id: string) {
+  const [row] = await db
+    .delete(availabilityStartTimes)
+    .where(eq(availabilityStartTimes.id, id))
+    .returning({ id: availabilityStartTimes.id })
+  return row ?? null
+}

--- a/packages/operations/src/availability/service.ts
+++ b/packages/operations/src/availability/service.ts
@@ -11,25 +11,15 @@ import {
 } from "./service-allocation.js"
 import {
   createCloseout,
-  createRule,
   createSlot,
-  createStartTime,
   deleteCloseout,
-  deleteRule,
   deleteSlot,
-  deleteStartTime,
   getCloseoutById,
-  getRuleById,
   getSlotById,
-  getStartTimeById,
   listCloseouts,
-  listRules,
   listSlots,
-  listStartTimes,
   updateCloseout,
-  updateRule,
   updateSlot,
-  updateStartTime,
 } from "./service-core.js"
 import { getAvailabilityOverview } from "./service-overview.js"
 import {
@@ -69,6 +59,18 @@ import {
   updatePickupPoint,
   updateSlotPickup,
 } from "./service-pickups.js"
+import {
+  createRule,
+  createStartTime,
+  deleteRule,
+  deleteStartTime,
+  getRuleById,
+  getStartTimeById,
+  listRules,
+  listStartTimes,
+  updateRule,
+  updateStartTime,
+} from "./service-rules.js"
 import { getSlotUnitAvailability } from "./service-unit-availability.js"
 
 export const availabilityService = {


### PR DESCRIPTION
## Why

The first half of #4032 added `product_version_id` but only recurring generation resolved a version automatically. A departure created through the admin route recorded none — so the guarantee that *a departure can always name the definition it sells* held for the bulk path and not the manual one. This closes that gap.

## Binding by default

`createSlot` now resolves the product's currently published version itself, and generation falls back to the same resolver when no override is supplied. An explicit `productVersionId` still wins, so a caller can deliberately materialize a departure against a chosen version.

The version is read through a local `productVersionsRef` — the same escape hatch `productsRef` and `productOptionsRef` already use in this file. Inventory owns `product_versions` and already depends on Operations, so importing it would close a dependency cycle. Reading through a local ref keeps the `operations->availability` table-privacy pair exactly at its baseline (the ratchet counts imported table *names*, and this declares its own).

## Why service-core.ts is split

`service-core.ts` was **680 lines against a 600-line gate**, so any edit to it — including a three-line binding — failed `check-agent-code-quality`. It had grown that way while owning four unrelated aggregates: rules, start times, slots, and closeouts.

- Availability rules + start times → `service-rules.ts`
- The shared static-availability guard (`assertProductAllowsStaticAvailability`, used by both the rule and slot paths) → `service-product-guard.ts`

Both are **pure moves with no behaviour change**. Slot and closeout lifecycle stay behind. `availabilityService` re-exports everything exactly as before, so no caller changes — `routes-core.ts` and `mcp-runtime.ts` reach these through the service object and are untouched.

`service-core.ts` drops from 680 to 477 lines.

I chose the split over a documented file-size exception because the existing exceptions in this directory are all mechanically-repetitive route files, which this is not — and because rules/start-times were a genuine seam, not an arbitrary cut to get under a number.

## Validation

- `turbo run typecheck --filter=operations --filter=inventory` — **35/35 tasks, exit 0**
- `pnpm verify:architecture` — exit 0
- `verify:table-privacy` — 225 reach-ins, **none new** (pair held at baseline)
- `check-agent-code-quality --changed` — clean (the file-size error this split resolves is gone)
- 160 operations unit tests pass
- `pnpm biome check .` from the repo root — clean

## Still open on the tracer

Diff preview and audited rebase for unsold and sold departures remain. They are a distinct feature — admission, impact preview, audit trail — and want their own change rather than riding along behind a refactor. `countDeparturesOnVersion` from the first PR is the impact-set query they will build on.

Part of #4027
Closes #4032
