### PR TITLE
fix(operations): decide auto-allocation under the same lock that writes it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,6 +357,8 @@ jobs:
                 tests/integration/booking-create.test.ts
               pnpm --filter @voyant-travel/bookings exec vitest run \
                 tests/integration/booking-amendments.test.ts
+              pnpm --filter @voyant-travel/operations exec vitest run \
+                tests/availability/integration/auto-allocate-concurrency.test.ts
               pnpm --filter @voyant-travel/legal exec vitest run \
                 tests/integration/contract-lifecycle-command.test.ts
               pnpm --filter @voyant-travel/notifications exec vitest run \

--- a/packages/operations/src/availability/booking-statuses.ts
+++ b/packages/operations/src/availability/booking-statuses.ts
@@ -1,12 +1,17 @@
 import { type SQL, sql } from "drizzle-orm"
 
-export const ACTIVE_BOOKING_STATUSES_FOR_SLOT = [
-  "on_hold",
-  "awaiting_payment",
-  "confirmed",
-  "in_progress",
-  "completed",
-] as const
+/**
+ * Booking statuses that still hold a slot's inventory. Must stay a subset of
+ * `booking_status`: these values are bound as parameters against `bookings.
+ * status`, so Postgres types them as the enum and rejects the whole query
+ * with `22P02` on any value the enum no longer has. The v1 commitment
+ * lifecycle (#4100) contracted the enum to
+ * confirmed/in_progress/completed/cancelled -- the pre-commitment statuses
+ * this list used to carry (`on_hold`, `awaiting_payment`) are booking
+ * sessions now, not bookings. Mirrors the same list in bookings'
+ * `extras/service-manifest.ts`.
+ */
+export const ACTIVE_BOOKING_STATUSES_FOR_SLOT = ["confirmed", "in_progress", "completed"] as const
 
 const activeBookingStatusesForSlot = new Set<string>(ACTIVE_BOOKING_STATUSES_FOR_SLOT)
 

--- a/packages/operations/src/availability/service-allocation-automation.ts
+++ b/packages/operations/src/availability/service-allocation-automation.ts
@@ -202,32 +202,43 @@ export async function autoAllocateSlotResources(
   options: AllocationMutationOptions = {},
 ): Promise<AllocationAutomationResult> {
   const kind = input.kind ?? "room"
-  const manifest = await getSlotAllocationManifest(db, slotId)
-  if (!manifest) throw new AllocationServiceError("Availability slot not found", 404)
 
-  const resources = manifest.resources.filter((resource) => resource.kind === kind)
-  if (resources.length === 0) {
-    throw new AllocationServiceError("No resources for this allocation kind", 400, { kind })
-  }
+  // The capacity invariant lives in the *decision*, not in the write, so the
+  // manifest read, the plan and the upsert all sit inside one transaction
+  // behind the same `FOR UPDATE` over the slot's resources of this kind.
+  // Planning from a snapshot taken before the lock let a manual assignment
+  // (or a second auto-allocate) land in between; the plan was then applied
+  // verbatim and could push a resource past its capacity with no conflict
+  // raised. Serialising the writes alone never serialised the decision.
+  const plan = await db.transaction(async (tx) => {
+    const scoped = tx as PostgresJsDatabase
 
-  const travelers = toAllocatorTravelers(manifest, kind)
-  const allocatorResources = resources.map(toAllocatorResource)
-  const plan =
-    kind === "vehicle_seat"
-      ? planVehicleSeatAllocation(travelers, allocatorResources)
-      : planRoomAllocation(travelers, allocatorResources)
+    await scoped.execute(sql`
+      SELECT id
+      FROM allocation_resources
+      WHERE slot_id = ${slotId} AND kind = ${kind}
+      FOR UPDATE
+    `)
 
-  if (plan.assignments.length > 0) {
-    const travelerIds = plan.assignments.map((assignment) => assignment.travelerId)
-    const resourceIds = plan.assignments.map((assignment) => assignment.resourceId)
-    await db.transaction(async (tx) => {
-      await tx.execute(sql`
-        SELECT id
-        FROM allocation_resources
-        WHERE slot_id = ${slotId} AND kind = ${kind}
-        FOR UPDATE
-      `)
-      await tx.execute(sql`
+    const manifest = await getSlotAllocationManifest(scoped, slotId)
+    if (!manifest) throw new AllocationServiceError("Availability slot not found", 404)
+
+    const resources = manifest.resources.filter((resource) => resource.kind === kind)
+    if (resources.length === 0) {
+      throw new AllocationServiceError("No resources for this allocation kind", 400, { kind })
+    }
+
+    const travelers = toAllocatorTravelers(manifest, kind)
+    const allocatorResources = resources.map(toAllocatorResource)
+    const planned =
+      kind === "vehicle_seat"
+        ? planVehicleSeatAllocation(travelers, allocatorResources)
+        : planRoomAllocation(travelers, allocatorResources)
+
+    if (planned.assignments.length > 0) {
+      const travelerIds = planned.assignments.map((assignment) => assignment.travelerId)
+      const resourceIds = planned.assignments.map((assignment) => assignment.resourceId)
+      await scoped.execute(sql`
         INSERT INTO booking_traveler_travel_details (traveler_id, allocations)
         SELECT
           row.traveler_id,
@@ -239,8 +250,11 @@ export async function autoAllocateSlotResources(
             || EXCLUDED.allocations,
           updated_at = now()
       `)
-    })
-  }
+      await assertPlannedResourcesWithinCapacity(scoped, slotId, kind, resourceIds)
+    }
+
+    return planned
+  })
 
   await recordAllocationAudit(db, {
     slotId,
@@ -250,6 +264,62 @@ export async function autoAllocateSlotResources(
   })
 
   return { kind, assigned: plan.assignments.length, skipped: plan.skipped }
+}
+
+/**
+ * Post-write invariant check for the resources an auto-allocate plan
+ * touched. Re-planning under the lock already keeps the plan inside
+ * capacity, so this is a backstop against an allocator regression rather
+ * than the primary guard -- it runs inside the writing transaction, so a
+ * violation rolls the whole plan back instead of shipping an oversold slot.
+ * One aggregate query over the planned resources only: an unrelated
+ * resource that was already over capacity must not block the operator.
+ */
+async function assertPlannedResourcesWithinCapacity(
+  db: PostgresJsDatabase,
+  slotId: string,
+  kind: string,
+  resourceIds: string[],
+): Promise<void> {
+  const overflowing = await executeRows<{
+    id: string
+    label: string | null
+    capacity: number
+    assigned: number
+  }>(
+    db,
+    sql`
+      SELECT ar.id, ar.label, ar.capacity, usage.assigned
+      FROM allocation_resources ar
+      JOIN LATERAL (
+        SELECT COUNT(DISTINCT btd.traveler_id)::int AS assigned
+        FROM booking_traveler_travel_details btd
+        JOIN booking_travelers bt ON bt.id = btd.traveler_id
+        JOIN booking_allocations ba ON ba.booking_id = bt.booking_id
+        JOIN bookings b ON b.id = bt.booking_id
+        WHERE btd.allocations ->> ar.kind = ar.id
+          AND ba.availability_slot_id = ar.slot_id
+          AND b.status IN (${activeBookingStatusesForSlotSql()})
+          AND ba.status IN ('held', 'confirmed', 'fulfilled')
+      ) usage ON true
+      WHERE ar.slot_id = ${slotId}
+        AND ar.kind = ${kind}
+        AND ar.id = ANY(${sqlTextArray([...new Set(resourceIds)])})
+        AND usage.assigned > ar.capacity
+    `,
+  )
+
+  if (overflowing.length === 0) return
+
+  throw new AllocationServiceError("Resource over capacity", 409, {
+    kind,
+    resources: overflowing.map((resource) => ({
+      id: resource.id,
+      label: resource.label,
+      capacity: resource.capacity,
+      assigned: resource.assigned,
+    })),
+  })
 }
 
 export interface MaterializeSlotResourcesFromTemplatesOptions {

--- a/packages/operations/src/availability/service-allocation-manifest-queries.ts
+++ b/packages/operations/src/availability/service-allocation-manifest-queries.ts
@@ -9,7 +9,6 @@ export interface BookingRow {
   booking_number: string
   status: string
   created_at: string | Date | null
-  paid_at: string | Date | null
   contact_first_name: string | null
   contact_last_name: string | null
   contact_email: string | null
@@ -29,26 +28,26 @@ export type AllocationPaymentStatus = "paid" | "partial" | "unpaid"
  * status for the allocation chip's color coding. Signals checked in order:
  *
  *   1. Free booking (`sell_amount_cents <= 0`) -> `paid` (nothing owed).
- *   2. `bookings.paid_at` is set -> `paid` (operator marked the booking
- *      settled; this is authoritative regardless of invoice plumbing).
- *   3. Sum of `booking_payment_schedules.amount_cents WHERE status='paid'`
+ *   2. Sum of `booking_payment_schedules.amount_cents WHERE status='paid'`
  *      covers `sell_amount_cents` -> `paid` (deposit-milestone flows that
  *      never run a final invoice).
- *   4. That schedule sum is positive -> `partial`.
- *   5. No invoices issued (`invoice_total_cents = 0`) -> `unpaid`.
- *   6. `invoice_paid_cents <= 0` -> `unpaid`.
- *   7. `invoice_paid_cents >= invoice_total_cents` -> `paid`.
- *   8. Otherwise -> `partial`.
+ *   3. That schedule sum is positive -> `partial`.
+ *   4. No invoices issued (`invoice_total_cents = 0`) -> `unpaid`.
+ *   5. `invoice_paid_cents <= 0` -> `unpaid`.
+ *   6. `invoice_paid_cents >= invoice_total_cents` -> `paid`.
+ *   7. Otherwise -> `partial`.
  *
- * The schedule and `paid_at` checks were added because the invoice-only
- * rule mis-colored booked-and-settled trips as red whenever the operator
- * billed via schedules without issuing an invoice, or recorded settlement
- * on the schedule rather than a `payments` row (issue #1079).
+ * The schedule check was added because the invoice-only rule mis-colored
+ * booked-and-settled trips as red whenever the operator billed via
+ * schedules without issuing an invoice (issue #1079). That rule also
+ * consulted `bookings.paid_at` as an operator override; the v1 commitment
+ * lifecycle (#4100) dropped the column outright -- it was folded into
+ * `accepted_at`/`confirmed_at`, not into a settlement signal -- so
+ * settlement is now read from schedules and invoices only.
  */
 export function derivePaymentStatus(row: BookingRow): AllocationPaymentStatus {
   const sellAmount = row.sell_amount_cents ?? 0
   if (sellAmount <= 0) return "paid"
-  if (row.paid_at != null) return "paid"
 
   const schedulesPaid = row.schedules_paid_cents ?? 0
   if (schedulesPaid >= sellAmount) return "paid"
@@ -64,19 +63,16 @@ export function derivePaymentStatus(row: BookingRow): AllocationPaymentStatus {
 /**
  * Settled-amount counterpart to `derivePaymentStatus`. Returns the best
  * available signal of how much has actually been collected for the
- * booking -- the larger of schedule and invoice settlement, plus the full
- * sell amount when the operator has flagged `paid_at` (since that's an
- * explicit override). Capped at `sell_amount_cents` so partial-overpay
- * scenarios don't distort slot totals.
+ * booking -- the larger of schedule and invoice settlement. Capped at
+ * `sell_amount_cents` so partial-overpay scenarios don't distort slot
+ * totals.
  */
 export function derivePaidAmountCents(row: BookingRow): number {
   const sellAmount = row.sell_amount_cents ?? 0
   if (sellAmount <= 0) return 0
-  const explicit = row.paid_at != null ? sellAmount : 0
   const schedulesPaid = row.schedules_paid_cents ?? 0
   const invoicePaid = row.invoice_paid_cents ?? 0
-  const observed = Math.max(explicit, schedulesPaid, invoicePaid)
-  return Math.min(observed, sellAmount)
+  return Math.min(Math.max(schedulesPaid, invoicePaid), sellAmount)
 }
 
 interface TravelerRow {
@@ -152,7 +148,6 @@ async function loadSlotBookingRowsBothJoins(
       b.booking_number,
       b.status,
       b.created_at,
-      b.paid_at,
       b.contact_first_name,
       b.contact_last_name,
       b.contact_email,
@@ -202,7 +197,6 @@ async function loadSlotBookingRowsInvoicesOnly(
       b.booking_number,
       b.status,
       b.created_at,
-      b.paid_at,
       b.contact_first_name,
       b.contact_last_name,
       b.contact_email,
@@ -244,7 +238,6 @@ async function loadSlotBookingRowsSchedulesOnly(
       b.booking_number,
       b.status,
       b.created_at,
-      b.paid_at,
       b.contact_first_name,
       b.contact_last_name,
       b.contact_email,
@@ -287,7 +280,6 @@ async function loadSlotBookingRowsBare(
       b.booking_number,
       b.status,
       b.created_at,
-      b.paid_at,
       b.contact_first_name,
       b.contact_last_name,
       b.contact_email,

--- a/packages/operations/tests/availability/integration/auto-allocate-concurrency.test.ts
+++ b/packages/operations/tests/availability/integration/auto-allocate-concurrency.test.ts
@@ -1,0 +1,213 @@
+import { allocationResources, availabilitySlots } from "@voyant-travel/availability/schema"
+import { createDbClient } from "@voyant-travel/db"
+import { newId } from "@voyant-travel/db/lib/typeid"
+import { cleanupTestDb } from "@voyant-travel/db/test-utils"
+import { sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+import { products } from "../../../../inventory/src/schema.js"
+import { assignTravelerAllocation } from "../../../src/availability/service-allocation.js"
+import { autoAllocateSlotResources } from "../../../src/availability/service-allocation-automation.js"
+
+const DB_AVAILABLE = Boolean(process.env.TEST_DATABASE_URL)
+
+type ClosableTestDb = PostgresJsDatabase & {
+  $client: { end(options?: { timeout?: number | null }): Promise<unknown> }
+}
+
+function connect(maxConnections: number): ClosableTestDb {
+  return createDbClient(process.env.TEST_DATABASE_URL as string, {
+    adapter: "node",
+    nodeMaxConnections: maxConnections,
+    timeouts: { statementMs: false, queryMs: false, connectMs: false },
+  }) as ClosableTestDb
+}
+
+describe.skipIf(!DB_AVAILABLE)("auto-allocate concurrency (integration)", () => {
+  let db: ClosableTestDb
+  // Auto-allocate runs on its own single-connection client so the test can
+  // resolve its backend pid up front and wait for *that* backend to block
+  // on the resource lock, rather than guessing from global lock activity.
+  let autoDb: ClosableTestDb
+  let autoPid: number
+  let productId: string
+  let slotId: string
+
+  beforeAll(async () => {
+    db = connect(4)
+    autoDb = connect(1)
+    const [row] = await autoDb.execute<{ pid: number }>(sql`SELECT pg_backend_pid()::int AS pid`)
+    if (!row) throw new Error("failed to resolve the auto-allocate backend pid")
+    autoPid = row.pid
+  })
+
+  afterAll(async () => {
+    await autoDb.$client.end({ timeout: 0 })
+    await db.$client.end({ timeout: 0 })
+  })
+
+  beforeEach(async () => {
+    await cleanupTestDb(db)
+    productId = newId("products")
+    slotId = newId("availability_slots")
+    await db.insert(products).values({
+      id: productId,
+      name: "Transylvania Coach Tour",
+      sellCurrency: "EUR",
+      bookingMode: "date",
+    })
+    await db.insert(availabilitySlots).values({
+      id: slotId,
+      productId,
+      dateLocal: "2026-06-01",
+      startsAt: new Date("2026-06-01T08:00:00Z"),
+      timezone: "UTC",
+      status: "open",
+      unlimited: false,
+      initialPax: 20,
+      remainingPax: 20,
+    })
+  })
+
+  async function seedRoom(label: string, capacity: number, sortOrder: number) {
+    const id = newId("allocation_resources")
+    await db.insert(allocationResources).values({
+      id,
+      slotId,
+      kind: "room",
+      label,
+      capacity,
+      sortOrder,
+      flags: {},
+    })
+    return id
+  }
+
+  async function seedBooking(input: {
+    bookingNumber: string
+    travelerIds: string[]
+    allocations?: Record<string, Record<string, string>>
+  }) {
+    const bookingId = newId("bookings")
+    const bookingItemId = newId("booking_items")
+    await db.execute(sql`
+      INSERT INTO bookings (id, booking_number, status, sell_currency, pax)
+      VALUES (${bookingId}, ${input.bookingNumber}, 'confirmed', 'EUR', ${input.travelerIds.length})
+    `)
+    await db.execute(sql`
+      INSERT INTO booking_items (id, booking_id, title, status, quantity, sell_currency, product_id, availability_slot_id)
+      VALUES (${bookingItemId}, ${bookingId}, 'Coach seat', 'confirmed', ${input.travelerIds.length}, 'EUR', ${productId}, ${slotId})
+    `)
+    await db.execute(sql`
+      INSERT INTO booking_allocations (id, booking_id, booking_item_id, product_id, availability_slot_id, quantity, allocation_type, status)
+      VALUES (${newId("booking_allocations")}, ${bookingId}, ${bookingItemId}, ${productId}, ${slotId}, ${input.travelerIds.length}, 'unit', 'confirmed')
+    `)
+    for (const travelerId of input.travelerIds) {
+      await db.execute(sql`
+        INSERT INTO booking_travelers (id, booking_id, participant_type, first_name, last_name)
+        VALUES (${travelerId}, ${bookingId}, 'traveler', 'Test', ${input.bookingNumber})
+      `)
+      const allocations = input.allocations?.[travelerId]
+      if (allocations) {
+        await db.execute(sql`
+          INSERT INTO booking_traveler_travel_details (traveler_id, allocations)
+          VALUES (${travelerId}, ${JSON.stringify(allocations)}::jsonb)
+        `)
+      }
+    }
+    return bookingId
+  }
+
+  async function roomOccupancy() {
+    return db.execute<{ id: string; label: string | null; capacity: number; assigned: number }>(sql`
+      SELECT ar.id, ar.label, ar.capacity, COUNT(btd.traveler_id)::int AS assigned
+      FROM allocation_resources ar
+      LEFT JOIN booking_traveler_travel_details btd
+        ON btd.allocations ->> 'room' = ar.id
+      WHERE ar.slot_id = ${slotId} AND ar.kind = 'room'
+      GROUP BY ar.id, ar.label, ar.capacity
+      ORDER BY ar.sort_order
+    `)
+  }
+
+  // Regression for #4126. Auto-allocate used to compute its whole plan from
+  // a manifest read *outside* the write transaction, so an assignment that
+  // landed while it waited for the resource lock was invisible to the plan
+  // it then applied verbatim — pushing a room past its capacity with no
+  // conflict raised. The gate transaction below reproduces exactly that
+  // interleaving: it holds the lock auto-allocate needs, waits until the
+  // auto-allocate backend is blocked on it, and only then moves a traveler
+  // into the room auto-allocate is about to fill.
+  it("re-plans against state that landed while it waited for the resource lock", async () => {
+    const roomA = await seedRoom("DBL 1", 2, 1)
+    const roomB = await seedRoom("DBL 2", 2, 2)
+
+    const movedTravelerId = newId("booking_travelers")
+    await seedBooking({
+      bookingNumber: "ALLOC-CONC-SOLO",
+      travelerIds: [movedTravelerId],
+      allocations: { [movedTravelerId]: { room: roomB } },
+    })
+    const pairTravelerIds = [newId("booking_travelers"), newId("booking_travelers")]
+    await seedBooking({ bookingNumber: "ALLOC-CONC-PAIR", travelerIds: pairTravelerIds })
+
+    // With only roomA free for a pair, a plan computed before the move
+    // targets roomA for both travellers of the pair booking.
+    let lockHeld!: () => void
+    const lockIsHeld = new Promise<void>((resolve) => {
+      lockHeld = resolve
+    })
+    let allowMove!: () => void
+    const moveAllowed = new Promise<void>((resolve) => {
+      allowMove = resolve
+    })
+
+    const gate = db.transaction(async (tx) => {
+      await tx.execute(sql`
+        SELECT id FROM allocation_resources
+        WHERE slot_id = ${slotId} AND kind = 'room'
+        FOR UPDATE
+      `)
+      lockHeld()
+      await moveAllowed
+      await assignTravelerAllocation(tx as PostgresJsDatabase, slotId, movedTravelerId, {
+        kind: "room",
+        resourceId: roomA,
+      })
+    })
+
+    await lockIsHeld
+    const autoAllocate = autoAllocateSlotResources(autoDb, slotId, { kind: "room" })
+    try {
+      await waitForLockWait(db, autoPid)
+    } finally {
+      allowMove()
+    }
+    await gate
+    const result = await autoAllocate
+
+    const rooms = await roomOccupancy()
+    for (const room of rooms) {
+      expect
+        .soft(room.assigned, `${room.label} holds ${room.assigned} of ${room.capacity}`)
+        .toBeLessThanOrEqual(room.capacity)
+    }
+    // The pair still fits — in roomB, which the manual move vacated.
+    expect(result.assigned).toBe(2)
+    expect(rooms.find((room) => room.id === roomA)?.assigned).toBe(1)
+    expect(rooms.find((room) => room.id === roomB)?.assigned).toBe(2)
+  })
+})
+
+async function waitForLockWait(db: PostgresJsDatabase, pid: number) {
+  for (let attempt = 0; attempt < 800; attempt += 1) {
+    const [row] = await db.execute<{ waiting: boolean }>(sql`
+      SELECT (wait_event_type = 'Lock') AS waiting
+      FROM pg_stat_activity
+      WHERE pid = ${pid}
+    `)
+    if (row?.waiting) return
+    await new Promise((resolve) => setTimeout(resolve, 25))
+  }
+  throw new Error("auto-allocate did not wait on the allocation resource lock")
+}

--- a/packages/operations/tests/availability/integration/slot-resource-availability.test.ts
+++ b/packages/operations/tests/availability/integration/slot-resource-availability.test.ts
@@ -271,17 +271,17 @@ describe.skipIf(!DB_AVAILABLE)("slot resource availability (integration)", () =>
       VALUES (${bookingId}, 'BK-UNIT-EDIT', 'confirmed', 'USD')
     `)
     await db.execute(sql`
-      INSERT INTO booking_items (id, booking_id, title, sell_currency, quantity, option_id, option_unit_id)
+      INSERT INTO booking_items (id, booking_id, title, status, sell_currency, quantity, option_id, option_unit_id)
       VALUES
-        (${oldItemId}, ${bookingId}, 'Old DBL', 'USD', 2, ${optionId}, ${dblUnitId}),
-        (${newItemId}, ${bookingId}, 'New TWN', 'USD', 2, ${optionId}, ${twnUnitId})
+        (${oldItemId}, ${bookingId}, 'Old DBL', 'confirmed', 'USD', 2, ${optionId}, ${dblUnitId}),
+        (${newItemId}, ${bookingId}, 'New TWN', 'confirmed', 'USD', 2, ${optionId}, ${twnUnitId})
     `)
     await db.execute(sql`
       INSERT INTO booking_allocations
         (id, booking_id, booking_item_id, product_id, option_id, option_unit_id, availability_slot_id, quantity, allocation_type, status, created_at, updated_at)
       VALUES
-        (${newId("booking_allocations")}, ${bookingId}, ${oldItemId}, ${productId}, ${optionId}, ${dblUnitId}, ${slotId}, 2, 'unit', 'confirmed', ${new Date("2026-01-01T00:00:00Z")}, ${new Date("2026-01-01T00:00:00Z")}),
-        (${newId("booking_allocations")}, ${bookingId}, ${newItemId}, ${productId}, ${optionId}, ${twnUnitId}, ${slotId}, 2, 'unit', 'confirmed', ${new Date("2026-01-02T00:00:00Z")}, ${new Date("2026-01-02T00:00:00Z")})
+        (${newId("booking_allocations")}, ${bookingId}, ${oldItemId}, ${productId}, ${optionId}, ${dblUnitId}, ${slotId}, 2, 'unit', 'confirmed', ${"2026-01-01T00:00:00Z"}::timestamptz, ${"2026-01-01T00:00:00Z"}::timestamptz),
+        (${newId("booking_allocations")}, ${bookingId}, ${newItemId}, ${productId}, ${optionId}, ${twnUnitId}, ${slotId}, 2, 'unit', 'confirmed', ${"2026-01-02T00:00:00Z"}::timestamptz, ${"2026-01-02T00:00:00Z"}::timestamptz)
     `)
     await db.execute(sql`
       INSERT INTO booking_travelers (id, booking_id, participant_type, first_name, last_name)

--- a/packages/operations/tests/availability/integration/slot-resource-availability.test.ts
+++ b/packages/operations/tests/availability/integration/slot-resource-availability.test.ts
@@ -66,17 +66,22 @@ describe.skipIf(!DB_AVAILABLE)("slot resource availability (integration)", () =>
 
   async function seedBookingWithTraveler(input: {
     travelerId: string
-    status?: "draft" | "on_hold" | "awaiting_payment" | "confirmed" | "in_progress" | "completed"
+    status?: "confirmed" | "in_progress" | "completed" | "cancelled"
     allocations?: Record<string, string>
   }) {
     const bookingId = newId("bookings")
+    const bookingItemId = newId("booking_items")
     await db.execute(sql`
       INSERT INTO bookings (id, booking_number, status, sell_currency)
       VALUES (${bookingId}, ${`B${bookingId.slice(-6)}`}, ${input.status ?? "confirmed"}, 'USD')
     `)
     await db.execute(sql`
-      INSERT INTO booking_allocations (id, booking_id, availability_slot_id, quantity, allocation_type, status)
-      VALUES (${newId("booking_allocations")}, ${bookingId}, ${slotId}, 1, 'unit', 'confirmed')
+      INSERT INTO booking_items (id, booking_id, title, status, quantity, sell_currency, product_id, availability_slot_id)
+      VALUES (${bookingItemId}, ${bookingId}, 'Slot seat', 'confirmed', 1, 'USD', ${productId}, ${slotId})
+    `)
+    await db.execute(sql`
+      INSERT INTO booking_allocations (id, booking_id, booking_item_id, product_id, availability_slot_id, quantity, allocation_type, status)
+      VALUES (${newId("booking_allocations")}, ${bookingId}, ${bookingItemId}, ${productId}, ${slotId}, 1, 'unit', 'confirmed')
     `)
     await db.execute(sql`
       INSERT INTO booking_travelers (id, booking_id, participant_type, first_name, last_name)
@@ -110,12 +115,15 @@ describe.skipIf(!DB_AVAILABLE)("slot resource availability (integration)", () =>
     expect(sgl?.available).toBe(1)
   })
 
-  it("treats awaiting_payment bookings as active slot demand", async () => {
+  // The v1 commitment lifecycle (#4100) contracted `booking_status` to
+  // confirmed/in_progress/completed/cancelled — pre-commitment holds are
+  // booking sessions now, so `in_progress` is the mid-trip live booking.
+  it("treats in_progress bookings as active slot demand", async () => {
     const dblId = await seedResource({ kind: "room", capacity: 1, label: "DBL 1", sortOrder: 1 })
     const travelerId = newId("booking_travelers")
     await seedBookingWithTraveler({
       travelerId,
-      status: "awaiting_payment",
+      status: "in_progress",
       allocations: { room: dblId },
     })
 
@@ -123,7 +131,7 @@ describe.skipIf(!DB_AVAILABLE)("slot resource availability (integration)", () =>
     expect(resources.find((row) => row.id === dblId)?.assigned).toBe(1)
 
     const manifest = await getSlotAllocationManifest(db, slotId)
-    expect(manifest?.summary.bookingsByStatus.awaiting_payment).toBe(1)
+    expect(manifest?.summary.bookingsByStatus.in_progress).toBe(1)
     expect(manifest?.summary.travelerCount).toBe(1)
     expect(manifest?.bookings[0]?.travelers[0]?.id).toBe(travelerId)
 
@@ -133,11 +141,11 @@ describe.skipIf(!DB_AVAILABLE)("slot resource availability (integration)", () =>
     expect(violations[0]?.existingAssigned).toBe(1)
   })
 
-  it("excludes draft bookings from slot allocation demand", async () => {
+  it("excludes cancelled bookings from slot allocation demand", async () => {
     const dblId = await seedResource({ kind: "room", capacity: 1, label: "DBL 1", sortOrder: 1 })
     await seedBookingWithTraveler({
       travelerId: newId("booking_travelers"),
-      status: "draft",
+      status: "cancelled",
       allocations: { room: dblId },
     })
 
@@ -145,7 +153,7 @@ describe.skipIf(!DB_AVAILABLE)("slot resource availability (integration)", () =>
     expect(resources.find((row) => row.id === dblId)?.assigned).toBe(0)
 
     const manifest = await getSlotAllocationManifest(db, slotId)
-    expect(manifest?.summary.bookingsByStatus.draft).toBeUndefined()
+    expect(manifest?.summary.bookingsByStatus.cancelled).toBeUndefined()
     expect(manifest?.summary.travelerCount).toBe(0)
     expect(manifest?.bookings).toHaveLength(0)
 

--- a/packages/operations/tests/availability/unit/derive-payment-status.test.ts
+++ b/packages/operations/tests/availability/unit/derive-payment-status.test.ts
@@ -11,7 +11,6 @@ function bookingRow(overrides: Partial<BookingRow> = {}): BookingRow {
     booking_number: "B-001",
     status: "confirmed",
     created_at: "2026-05-22T08:00:00.000Z",
-    paid_at: null,
     contact_first_name: null,
     contact_last_name: null,
     contact_email: null,
@@ -32,22 +31,10 @@ describe("derivePaymentStatus", () => {
     expect(derivePaymentStatus(bookingRow({ sell_amount_cents: null }))).toBe("paid")
   })
 
-  it("prefers bookings.paid_at over invoice math (issue #1079, scenario 1)", () => {
-    // Operator confirmed and marked the booking paid via schedules; never
-    // issued an invoice — paid_at is set, invoice_total stays 0.
-    const row = bookingRow({
-      paid_at: "2026-05-22T09:00:00.000Z",
-      invoice_total_cents: 0,
-      invoice_paid_cents: 0,
-      schedules_paid_cents: 0,
-    })
-    expect(derivePaymentStatus(row)).toBe("paid")
-  })
-
   it("falls back to paid schedules when invoices are missing (issue #1079, scenario 2)", () => {
-    // Same flow but paid_at wasn't set; the schedule sum equals sell amount.
+    // Operator billed via schedules and never issued an invoice; the
+    // schedule sum equals the sell amount.
     const row = bookingRow({
-      paid_at: null,
       sell_amount_cents: 10_000,
       schedules_paid_cents: 10_000,
       invoice_total_cents: 0,
@@ -90,7 +77,6 @@ describe("derivePaymentStatus", () => {
       invoice_total_cents: 0,
       invoice_paid_cents: 0,
       schedules_paid_cents: 0,
-      paid_at: null,
     })
     expect(derivePaymentStatus(row)).toBe("unpaid")
   })
@@ -103,15 +89,15 @@ describe("derivePaymentStatus", () => {
     expect(derivePaymentStatus(row)).toBe("paid")
   })
 
-  it("returns paid when paid_at is set even with no invoice/schedule data", () => {
-    // Confirmation flow where the operator marks paid manually without
-    // issuing an invoice or recording the schedule rollup.
+  // `bookings.paid_at` used to short-circuit this to "paid" as an operator
+  // override. The v1 commitment lifecycle (#4100) dropped the column, so a
+  // booking with no invoice and no schedule rollup now reads as unpaid.
+  it("reads unpaid when no invoice or schedule settlement is recorded", () => {
     const row = bookingRow({
-      paid_at: "2026-05-22T10:00:00.000Z",
       invoice_total_cents: 0,
       invoice_paid_cents: 0,
       schedules_paid_cents: 0,
     })
-    expect(derivePaymentStatus(row)).toBe("paid")
+    expect(derivePaymentStatus(row)).toBe("unpaid")
   })
 })


### PR DESCRIPTION
Closes #4126.

## The bug

`autoAllocateSlotResources` read the slot manifest **outside** any transaction,
planned every assignment from that snapshot, and only then opened a transaction
to take `FOR UPDATE` on the slot's resources of that kind.

The lock serialised the *writes* but not the *decision*. A second caller — or a
manual `assignTravelerAllocation` — landing between the manifest read and the
lock was invisible to the plan, which the unconditional
`INSERT … ON CONFLICT DO UPDATE` then applied verbatim. A room or a coach could
end up carrying more travellers than its capacity, with no conflict raised and
no conflicts panel to catch it before departure day.

## The fix

Move the manifest read and the planning **inside** the transaction, after the
`FOR UPDATE`, so the decision and the write share one serialisation point. Under
READ COMMITTED the post-lock read sees everything the blocking transaction
committed, so the plan is computed against current truth.

On top of that, a post-write capacity assertion over the resources the plan
touched. Re-planning under the lock already keeps the plan inside capacity, so
this is a backstop against an allocator regression rather than the primary
guard — but it runs inside the writing transaction, so a violation rolls the
plan back and surfaces the route's existing `409` instead of committing an
oversold slot. It is one aggregate query, scoped to the planned resources only
so an unrelated resource that was already over capacity cannot block the
operator.

## Regression test

`tests/availability/integration/auto-allocate-concurrency.test.ts` drives the
exact interleaving rather than hoping to hit it: a gate transaction holds the
resource lock, waits (via `pg_stat_activity`) until the auto-allocate backend is
blocked on it, then moves a traveller into the room auto-allocate was about to
fill, and commits. Auto-allocate runs on its own single-connection client so its
backend pid is known up front.

Against the previous code that room ends up holding **3 of 2**. With the fix
auto-allocate re-plans around the move and places the pair in the room the move
vacated. The test is wired into the `db-lanes / integration` CI lane — the
`@voyant-travel/operations` integration tests are otherwise skipped everywhere
(`describe.skipIf(!TEST_DATABASE_URL)`), so a regression test left outside that
list would never actually run.

## Prerequisite: booking v1 lifecycle drift

The allocation surface could not execute at all against a current schema, so the
fix was unverifiable until this was repaired. The v1 commitment lifecycle
(#4100, merged 2026-08-02) contracted `booking_status` to
`confirmed/in_progress/completed/cancelled` and dropped `bookings.paid_at`, but
`packages/operations/src/availability/` was not updated:

- `ACTIVE_BOOKING_STATUSES_FOR_SLOT` still carried `on_hold` and
  `awaiting_payment`. Those values are bound as parameters against
  `bookings.status`, so Postgres types them as the enum and fails the **whole
  query** with `22P02`.
- Four manifest queries still selected `b.paid_at` → `42703`.

Net effect on `main`: every allocation manifest, capacity and assignment query
throws. The operator's rooming and seating board cannot load.

Narrowed the status list to the three that survive (mirroring bookings'
`extras/service-manifest.ts`, which #4100 did update), and dropped the `paid_at`
signal. **Behaviour change worth a look:** the cutover folded `paid_at` into
`accepted_at`/`confirmed_at`, not into any settlement signal, so the operator's
"marked paid" override has nothing to read. Settlement is now derived from
invoices and paid schedules only, and a booking with neither reads `unpaid`
instead of `paid`. If that override still matters operationally it needs to be
reintroduced deliberately.

## Verification

- `pnpm -F @voyant-travel/operations test` — 262 passed, 25 files skipped (no DB)
- Against a freshly-migrated Postgres: `auto-allocate-concurrency` (1),
  `slot-resource-availability` (9), `materialize-template-defaults` (5) all pass;
  the new test fails with "DBL 1 holds 3 of 2" when the fix is reverted
- `pnpm -F @voyant-travel/operations typecheck`, `biome check`,
  `verify:agent-quality:changed`, `verify:table-privacy` (none new),
  `verify:booking-v1-lifecycle-contract`

## Not fixed here

The rest of the availability integration suite still fails on a freshly-migrated
schema, in files this PR does not touch: `routes.test.ts` seeds `booking_items`
without the now-`NOT NULL` `status`, and `slot-product-version-binding.test.ts` /
`slot-option-validation.test.ts` time out in `cleanupTestDb` (a 10s hook budget
against a ~350-table `TRUNCATE`). Both are pre-existing and neither is on a CI
lane. Worth a follow-up issue; repairing them is not this bug.

No changeset — `@voyant-travel/operations` is `private: true`.
