### PR TITLE
fix(release): verify the published surface by installing it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,3 +219,16 @@ jobs:
       - name: No release action needed
         if: steps.release_plan.outputs.has_releasable_changesets != 'true' && steps.release_plan.outputs.pending != 'true'
         run: echo "No releasable changesets and npm is already up to date."
+
+      # Asks the only question the steps above cannot: can an outside consumer
+      # install what main says is published, and import it? See issue #4086 —
+      # a package can be published and still be uninstallable, and neither the
+      # publish step nor any manifest inspection notices.
+      #
+      # Last in the job, and `!cancelled()` rather than `success()`, on purpose.
+      # A failed publish is exactly when the surface is split between what
+      # shipped and what did not, so this must still run and say which. Running
+      # it last keeps a broken surface from also blocking the release PR.
+      - name: Verify the published surface installs
+        if: ${{ !cancelled() }}
+        run: pnpm verify:published-surface

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "verify:ui-orientation-selectors": "node scripts/check-ui-orientation-selectors.mjs",
     "verify:date-picker-single-source": "node scripts/check-date-picker-single-source.mjs",
     "verify:publish-tarballs": "node --test scripts/tests/packed-exports.test.mjs scripts/tests/packed-install.test.mjs scripts/tests/packed-sourcemaps.test.mjs && node scripts/verify-package-tarballs.mjs",
+    "verify:published-surface": "node --test scripts/tests/published-surface.test.mjs && node scripts/verify-published-surface.mjs",
     "verify:tenant-scoping": "node scripts/check-tenant-scoping.mjs",
     "verify:route-authoring": "node scripts/check-route-authoring.mjs",
     "verify:api-runtime-vocabulary": "node scripts/check-api-runtime-vocabulary.mjs",

--- a/scripts/lib/published-surface.mjs
+++ b/scripts/lib/published-surface.mjs
@@ -1,0 +1,184 @@
+/**
+ * The published public surface must be installable, not merely present.
+ *
+ * Issue #4086 found the same surface broken three different ways in one day,
+ * and every weaker check passed on all three:
+ *
+ * - `@voyant-travel/graph-contracts@0.2.0` was bumped in the repo and never
+ *   reached the registry — the first publish of a name needs an npm Trusted
+ *   Publisher, and without one the release fails with an E404 that reads like a
+ *   package.json problem.
+ * - `custom-fields-contracts` and `app-manifest` shipped `catalog:` and
+ *   `workspace:^` specifiers, which only pnpm rewrites, so `npm install` of a
+ *   published version could not resolve.
+ * - `webhook-delivery-contracts@0.1.0` published with `publishConfig` never
+ *   applied, leaving `exports` at `./src/index.ts` while `files` shipped only
+ *   `dist` — a path that looks plausible in the manifest and resolves to
+ *   nothing.
+ *
+ * `verify:public-surface` asserts the dependency *graph* is closed, which
+ * stayed true throughout. Closure and installability are different properties.
+ * The functions here derive what a real consumer would exercise; the runner
+ * beside them installs from the registry and exercises it.
+ */
+
+/** publishConfig keys whose survival proves publishConfig was never applied. */
+const OVERRIDE_KEYS = ["exports", "main", "module", "types", "typings", "files", "bin"]
+
+/** pnpm-only dependency protocols. npm cannot resolve either one. */
+const WORKSPACE_PROTOCOLS = ["workspace:", "catalog:"]
+
+const DEPENDENCY_FIELDS = ["dependencies", "peerDependencies", "optionalDependencies"]
+
+/** Node resolution conditions, most specific first, as a consumer would hit them. */
+const IMPORT_CONDITIONS = ["import", "node", "default", "require"]
+
+export function selectPublishedPackages(manifests) {
+  return manifests
+    .filter((manifest) => manifest.private !== true)
+    .sort((left, right) => left.name.localeCompare(right.name))
+}
+
+function resolveConditionalTarget(value) {
+  if (typeof value === "string") return value
+  if (!value || typeof value !== "object") return undefined
+  for (const condition of IMPORT_CONDITIONS) {
+    const resolved = resolveConditionalTarget(value[condition])
+    if (resolved) return resolved
+  }
+  return undefined
+}
+
+/**
+ * Expand one wildcard export against the files a package actually shipped.
+ *
+ * `"./lib/*": "./dist/lib/*.js"` is not a specifier a consumer can import; the
+ * specifiers are whatever `dist/lib/*.js` turned out to be. Probing the pattern
+ * would assert nothing, and skipping it silently would leave the subpaths a
+ * consumer really uses — `@voyant-travel/ui/lib/utils` — unexercised.
+ */
+export function expandExportPattern(subpath, target, files) {
+  const starIndex = target.indexOf("*")
+  if (starIndex === -1) return []
+
+  const prefix = target.slice(0, starIndex)
+  const suffix = target.slice(starIndex + 1)
+
+  return files
+    .filter(
+      (file) =>
+        file.startsWith(prefix) &&
+        file.endsWith(suffix) &&
+        file.length > prefix.length + suffix.length,
+    )
+    .map((file) => subpath.replace("*", file.slice(prefix.length, file.length - suffix.length)))
+    .sort()
+}
+
+/** Assets a bundler consumes and Node cannot; skipping these asserts nothing either way. */
+const ASSET_EXTENSIONS = /\.(css|json|wasm|svg|png|woff2?)$/
+
+/**
+ * The specifiers a consumer can `import()` from a published package, plus the
+ * export targets that are defects in themselves.
+ *
+ * A target such as `./src/index.ts` is the second kind. Node cannot import it,
+ * the tarball does not ship `src`, and no amount of probing the *other*
+ * subpaths would say so — `webhook-delivery-contracts@0.1.0` published exactly
+ * that and read as a package with nothing to check.
+ *
+ * `files` are package-relative paths (`./dist/lib/utils.js`) as shipped in the
+ * tarball; pass an empty list when the tarball is not available and wildcard
+ * exports will simply contribute nothing.
+ */
+export function importProbeSpecifiers(manifest, files = []) {
+  const exports = manifest.exports
+
+  // No exports map: the package root is the only entry point a consumer has.
+  if (!exports || typeof exports !== "object") {
+    return { specifiers: [manifest.name], unsupported: [] }
+  }
+
+  const specifiers = []
+  const unsupported = []
+
+  for (const [subpath, value] of Object.entries(exports)) {
+    if (!subpath.startsWith(".")) continue
+    if (subpath === "./package.json") continue
+
+    // A `null` target is a deliberate block, not an omission.
+    const target = resolveConditionalTarget(value)
+    if (!target) continue
+    if (ASSET_EXTENSIONS.test(target)) continue
+
+    if (!/\.(js|mjs|cjs)$/.test(target)) {
+      unsupported.push(
+        `${manifest.name}@${manifest.version} exports "${subpath}" as "${target}", which Node ` +
+          `cannot import. A published package must point at built output; a source path here ` +
+          `means the manifest describes the repository rather than the tarball.`,
+      )
+      continue
+    }
+
+    const resolved = subpath.includes("*") ? expandExportPattern(subpath, target, files) : [subpath]
+
+    for (const entry of resolved) {
+      specifiers.push(entry === "." ? manifest.name : `${manifest.name}/${entry.slice(2)}`)
+    }
+  }
+
+  return { specifiers, unsupported }
+}
+
+/**
+ * Dependency specifiers no npm consumer can resolve.
+ *
+ * Only `pnpm publish` rewrites `workspace:` and `catalog:` into concrete
+ * ranges. A package published any other way carries them through to the
+ * registry, where they abort every consumer install.
+ */
+export function unresolvedProtocolViolations(manifest) {
+  const violations = []
+  for (const field of DEPENDENCY_FIELDS) {
+    for (const [dependency, range] of Object.entries(manifest[field] ?? {})) {
+      if (!WORKSPACE_PROTOCOLS.some((protocol) => String(range).startsWith(protocol))) continue
+      violations.push(
+        `${manifest.name}@${manifest.version} published ${field}.${dependency} as "${range}". ` +
+          `Only pnpm rewrites that protocol, so npm consumers cannot install this version. ` +
+          `Republish through the release pipeline rather than \`npm publish\`.`,
+      )
+    }
+  }
+  return violations
+}
+
+/**
+ * `publishConfig` overrides that survived into the published manifest.
+ *
+ * A published manifest keeps `publishConfig.access`, which is inert. What it
+ * must not keep is an override of `exports` or `files`: those exist precisely
+ * to be folded into the manifest at publish time, and their survival means the
+ * published package points at source paths it never shipped.
+ */
+export function unappliedPublishConfigViolations(manifest) {
+  const overrides = OVERRIDE_KEYS.filter((key) => manifest.publishConfig?.[key] !== undefined)
+  if (overrides.length === 0) return []
+
+  return [
+    `${manifest.name}@${manifest.version} published with publishConfig.${overrides.join(", publishConfig.")} ` +
+      `still unapplied, so its manifest describes the source tree rather than the tarball. ` +
+      `This is what \`npm publish\` does to a pnpm workspace package; republish through the release pipeline.`,
+  ]
+}
+
+export function formatMissingVersion(name, version) {
+  return (
+    `${name}@${version} is the version in the repository and is not on the registry. ` +
+    `A first publish of a new package name fails with E404 until npm Trusted Publishers ` +
+    `is configured for it — see #4048 and #4086.`
+  )
+}
+
+export function formatImportFailure(specifier, error) {
+  return `import("${specifier}") failed: ${error}`
+}

--- a/scripts/tests/published-surface.test.mjs
+++ b/scripts/tests/published-surface.test.mjs
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import {
+  expandExportPattern,
+  importProbeSpecifiers,
+  selectPublishedPackages,
+  unappliedPublishConfigViolations,
+  unresolvedProtocolViolations,
+} from "../lib/published-surface.mjs"
+
+test("selects the publishable packages in a stable order", () => {
+  const selected = selectPublishedPackages([
+    { name: "@voyant-travel/zeta", version: "1.0.0" },
+    { name: "operator", version: "1.0.0", private: true },
+    { name: "@voyant-travel/alpha", version: "1.0.0" },
+  ])
+
+  assert.deepEqual(
+    selected.map((manifest) => manifest.name),
+    ["@voyant-travel/alpha", "@voyant-travel/zeta"],
+  )
+})
+
+test("treats the package root as the entry point when no exports map is declared", () => {
+  assert.deepEqual(importProbeSpecifiers({ name: "@voyant-travel/legacy" }).specifiers, [
+    "@voyant-travel/legacy",
+  ])
+})
+
+test("derives one specifier per declared subpath", () => {
+  const { specifiers, unsupported } = importProbeSpecifiers({
+    name: "@voyant-travel/app-manifest",
+    exports: {
+      ".": { types: "./dist/index.d.ts", import: "./dist/index.js" },
+      "./compiler": "./dist/compiler.js",
+      "./package.json": "./package.json",
+    },
+  })
+
+  assert.deepEqual(specifiers, [
+    "@voyant-travel/app-manifest",
+    "@voyant-travel/app-manifest/compiler",
+  ])
+  assert.deepEqual(unsupported, [])
+})
+
+test("skips assets Node could never import however correctly they were published", () => {
+  const { specifiers, unsupported } = importProbeSpecifiers({
+    name: "@voyant-travel/ui",
+    exports: {
+      "./globals.css": "./dist/globals.css",
+      "./components": "./dist/components/index.js",
+      "./blocked": null,
+    },
+  })
+
+  assert.deepEqual(specifiers, ["@voyant-travel/ui/components"])
+  assert.deepEqual(unsupported, [])
+})
+
+test("rejects an export that points at a source path the tarball never shipped", () => {
+  // `@voyant-travel/webhook-delivery-contracts@0.1.0`. Probing the other
+  // subpaths would have reported nothing: this one had no others.
+  const { specifiers, unsupported } = importProbeSpecifiers({
+    name: "@voyant-travel/webhook-delivery-contracts",
+    version: "0.1.0",
+    exports: { ".": "./src/index.ts" },
+  })
+
+  assert.deepEqual(specifiers, [])
+  assert.equal(unsupported.length, 1)
+  assert.match(unsupported[0], /exports "\." as "\.\/src\/index\.ts", which Node cannot import/)
+})
+
+test("expands a wildcard export against the files the package shipped", () => {
+  const expanded = expandExportPattern("./lib/*", "./dist/lib/*.js", [
+    "./dist/lib/utils.js",
+    "./dist/lib/format.js",
+    "./dist/lib/utils.d.ts",
+    "./dist/components/index.js",
+  ])
+
+  assert.deepEqual(expanded, ["./lib/format", "./lib/utils"])
+})
+
+test("exercises the subpaths behind a wildcard rather than the pattern", () => {
+  const { specifiers } = importProbeSpecifiers(
+    {
+      name: "@voyant-travel/ui",
+      exports: { "./lib/*": { import: "./dist/lib/*.js" } },
+    },
+    ["./dist/lib/utils.js"],
+  )
+
+  assert.deepEqual(specifiers, ["@voyant-travel/ui/lib/utils"])
+})
+
+test("rejects a published manifest carrying pnpm-only protocols", () => {
+  // The shape `@voyant-travel/app-manifest@0.1.0` actually went out with (#4086).
+  const violations = unresolvedProtocolViolations({
+    name: "@voyant-travel/app-manifest",
+    version: "0.1.0",
+    dependencies: { zod: "catalog:", "@voyant-travel/graph-contracts": "workspace:^" },
+    peerDependencies: { react: "^19.0.0" },
+  })
+
+  assert.equal(violations.length, 2)
+  assert.match(violations[0], /published dependencies\.zod as "catalog:"/)
+  assert.match(
+    violations[1],
+    /published dependencies\.@voyant-travel\/graph-contracts as "workspace:\^"/,
+  )
+  assert.ok(
+    violations.every((violation) => violation.includes("@voyant-travel/app-manifest@0.1.0")),
+  )
+})
+
+test("accepts a published manifest whose ranges are concrete", () => {
+  assert.deepEqual(
+    unresolvedProtocolViolations({
+      name: "@voyant-travel/graph-contracts",
+      version: "0.1.0",
+      dependencies: { zod: "^4.4.3" },
+    }),
+    [],
+  )
+})
+
+test("rejects a published manifest whose publishConfig was never applied", () => {
+  // `@voyant-travel/webhook-delivery-contracts@0.1.0`: `exports` stayed at the
+  // source path while `files` shipped only `dist`, so every consumer resolved
+  // a missing module (#4086, fixed by #4109).
+  const violations = unappliedPublishConfigViolations({
+    name: "@voyant-travel/webhook-delivery-contracts",
+    version: "0.1.0",
+    exports: { ".": "./src/index.ts" },
+    publishConfig: { access: "public", exports: { ".": "./dist/index.js" } },
+  })
+
+  assert.equal(violations.length, 1)
+  assert.match(violations[0], /publishConfig\.exports/)
+})
+
+test("accepts the inert publishConfig every published package keeps", () => {
+  assert.deepEqual(
+    unappliedPublishConfigViolations({
+      name: "@voyant-travel/graph-contracts",
+      version: "0.2.0",
+      publishConfig: { access: "public" },
+    }),
+    [],
+  )
+})

--- a/scripts/verify-published-surface.mjs
+++ b/scripts/verify-published-surface.mjs
@@ -1,0 +1,250 @@
+#!/usr/bin/env node
+/**
+ * Runner for the published-surface installability gate. See lib/published-surface.mjs
+ * for why "exists on the registry" is not the property worth asserting.
+ *
+ * This runs *after* publish, because it asks a question only the registry can
+ * answer: can an outside consumer install what we just shipped and import it?
+ * It installs every non-private workspace package at the version in the
+ * repository into a scratch directory and exercises each declared entry point.
+ *
+ * Usage: node scripts/verify-published-surface.mjs [--keep] [--attempts <n>]
+ */
+import { execFile } from "node:child_process"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { promisify } from "node:util"
+
+import { parse as parseYaml } from "yaml"
+
+import {
+  formatImportFailure,
+  formatMissingVersion,
+  importProbeSpecifiers,
+  selectPublishedPackages,
+  unappliedPublishConfigViolations,
+  unresolvedProtocolViolations,
+} from "./lib/published-surface.mjs"
+
+const execFileAsync = promisify(execFile)
+
+const KEEP = process.argv.includes("--keep")
+const ATTEMPTS = Number(process.argv[process.argv.indexOf("--attempts") + 1] ?? 6)
+/** The registry is read-your-writes only eventually; a fresh publish can 404 briefly. */
+const RETRY_DELAY_MS = 10_000
+
+function workspaceManifests() {
+  const workspace = parseYaml(fs.readFileSync("pnpm-workspace.yaml", "utf8"))
+  const directories = (workspace.packages ?? [])
+    .filter((pattern) => pattern.endsWith("/*"))
+    .map((pattern) => pattern.slice(0, -2))
+
+  const manifests = []
+  for (const directory of directories) {
+    if (!fs.existsSync(directory)) continue
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue
+      const file = path.join(directory, entry.name, "package.json")
+      if (!fs.existsSync(file)) continue
+      manifests.push(JSON.parse(fs.readFileSync(file, "utf8")))
+    }
+  }
+  return manifests
+}
+
+async function registryHasVersion(name, version) {
+  try {
+    await execFileAsync("npm", ["view", `${name}@${version}`, "version"], { encoding: "utf8" })
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Wait for every version to appear rather than failing the first one that has
+ * not propagated. A missing version and a slow CDN look identical for a few
+ * seconds after a release, and only one of them is a defect.
+ */
+async function awaitRegistry(packages) {
+  let pending = packages
+  for (let attempt = 1; attempt <= ATTEMPTS; attempt += 1) {
+    const results = await Promise.all(
+      pending.map(async (entry) => ({
+        entry,
+        published: await registryHasVersion(entry.name, entry.version),
+      })),
+    )
+    pending = results.filter((result) => !result.published).map((result) => result.entry)
+    if (pending.length === 0) return []
+    if (attempt === ATTEMPTS) break
+    console.log(
+      `  ${pending.length} version(s) not resolvable yet; retrying in ${RETRY_DELAY_MS / 1000}s ` +
+        `(attempt ${attempt}/${ATTEMPTS})`,
+    )
+    await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS))
+  }
+  return pending
+}
+
+async function installSurface(packages, installDir) {
+  const manifest = {
+    name: "voyant-published-surface-verification",
+    version: "0.0.0",
+    private: true,
+    dependencies: Object.fromEntries(packages.map(({ name, version }) => [name, version])),
+  }
+  fs.writeFileSync(path.join(installDir, "package.json"), `${JSON.stringify(manifest, null, 2)}\n`)
+
+  // `--no-legacy-peer-deps` pins the modern resolver explicitly. A developer
+  // whose ~/.npmrc sets `legacy-peer-deps=true` would otherwise skip peer
+  // installation and see entry points fail here that resolve fine for a
+  // consumer on npm's defaults — `@voyant-travel/ui/components/chart` needs the
+  // `recharts` peer to load at all.
+  await execFileAsync(
+    "npm",
+    [
+      "install",
+      "--ignore-scripts",
+      "--no-audit",
+      "--no-fund",
+      "--no-legacy-peer-deps",
+      "--loglevel",
+      "error",
+    ],
+    { cwd: installDir, encoding: "utf8", maxBuffer: 64 * 1024 * 1024, env: process.env },
+  )
+}
+
+/** Package-relative paths of everything the tarball shipped, for wildcard exports. */
+function shippedFiles(packageDir) {
+  const files = []
+  const walk = (directory, prefix) => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      if (entry.name === "node_modules") continue
+      const relative = `${prefix}${entry.name}`
+      if (entry.isDirectory()) walk(path.join(directory, entry.name), `${relative}/`)
+      else files.push(`./${relative}`)
+    }
+  }
+  walk(packageDir, "")
+  return files
+}
+
+async function probeImports(installDir, specifiers) {
+  const probeFile = path.join(installDir, "probe.mjs")
+  fs.writeFileSync(
+    probeFile,
+    `const specifiers = ${JSON.stringify(specifiers, null, 2)}\n` +
+      `const failures = []\n` +
+      `for (const specifier of specifiers) {\n` +
+      `  try {\n` +
+      `    await import(specifier)\n` +
+      `  } catch (error) {\n` +
+      `    failures.push({ specifier, code: error?.code ?? "", message: String(error?.message ?? error).split("\\n")[0] })\n` +
+      `  }\n` +
+      `}\n` +
+      `process.stdout.write(JSON.stringify(failures))\n`,
+  )
+
+  const { stdout } = await execFileAsync(process.execPath, [probeFile], {
+    cwd: installDir,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  })
+  return JSON.parse(stdout)
+}
+
+/**
+ * A specifier that does not resolve is the defect this gate exists for. A
+ * specifier that resolves and then throws is a different claim — a package may
+ * legitimately need a browser global — so it is reported without failing.
+ */
+const RESOLUTION_ERROR_CODES = new Set([
+  "ERR_MODULE_NOT_FOUND",
+  "ERR_PACKAGE_PATH_NOT_EXPORTED",
+  "ERR_PACKAGE_IMPORT_NOT_DEFINED",
+  "ERR_UNSUPPORTED_DIR_IMPORT",
+  "ERR_INVALID_PACKAGE_TARGET",
+  "ERR_INVALID_PACKAGE_CONFIG",
+  "ERR_UNKNOWN_FILE_EXTENSION",
+])
+
+function report(violations, warnings) {
+  for (const warning of warnings) console.warn(`  ! ${warning}`)
+
+  if (violations.length > 0) {
+    console.error("\nPublished surface check failed.\n")
+    for (const violation of violations) console.error(`  - ${violation}`)
+    console.error(
+      "\nThese packages are published for external consumers. See issue #4086 for why this " +
+        "gate installs from the registry instead of inspecting manifests.",
+    )
+    process.exit(1)
+  }
+}
+
+async function main() {
+  const packages = selectPublishedPackages(workspaceManifests())
+  if (packages.length === 0) {
+    console.log("verify:published-surface: no publishable workspace packages.")
+    return
+  }
+
+  console.log(`verify:published-surface: ${packages.length} publishable packages.`)
+
+  const unpublished = await awaitRegistry(packages)
+  if (unpublished.length > 0) {
+    report(
+      unpublished.map((entry) => formatMissingVersion(entry.name, entry.version)),
+      [],
+    )
+  }
+
+  const installDir = fs.mkdtempSync(path.join(os.tmpdir(), "voyant-published-surface-"))
+  const violations = []
+  const warnings = []
+
+  try {
+    try {
+      await installSurface(packages, installDir)
+    } catch (error) {
+      const detail =
+        error.stderr?.toString().trim() || error.stdout?.toString().trim() || error.message
+      report([`npm could not install the published surface: ${detail}`], [])
+    }
+
+    const specifiers = []
+    for (const { name } of packages) {
+      const packageDir = path.join(installDir, "node_modules", ...name.split("/"))
+      const installed = JSON.parse(fs.readFileSync(path.join(packageDir, "package.json"), "utf8"))
+
+      violations.push(...unresolvedProtocolViolations(installed))
+      violations.push(...unappliedPublishConfigViolations(installed))
+
+      const probes = importProbeSpecifiers(installed, shippedFiles(packageDir))
+      violations.push(...probes.unsupported)
+      if (probes.specifiers.length === 0 && probes.unsupported.length === 0) {
+        warnings.push(`${name}: no importable entry point declared; nothing to exercise.`)
+      }
+      specifiers.push(...probes.specifiers)
+    }
+
+    console.log(`  installed; exercising ${specifiers.length} entry points.`)
+
+    for (const failure of await probeImports(installDir, specifiers)) {
+      const message = formatImportFailure(failure.specifier, `${failure.code} ${failure.message}`)
+      if (RESOLUTION_ERROR_CODES.has(failure.code)) violations.push(message)
+      else warnings.push(`${message} (resolved, then threw — not treated as a publish defect)`)
+    }
+  } finally {
+    if (KEEP) console.log(`  scratch install kept at ${installDir}`)
+    else fs.rmSync(installDir, { recursive: true, force: true })
+  }
+
+  report(violations, warnings)
+  console.log("verify:published-surface: every published entry point installs and resolves.")
+}
+
+await main()


### PR DESCRIPTION
Closes the second half of #4086: the gate. The bad artifacts were repaired by #4109; what was still missing is the check that would have caught them — and, running it, a live break nobody had noticed.

## What it found on `main` today

- **`@voyant-travel/graph-contracts@0.2.0` is in `main` and not on npm.** Released by #4112; every release run since has failed at `Publish pending packages` with `E404 Not Found - PUT .../graph-contracts`. Only `0.1.0` exists, and that one was published by hand.
- **`@voyant-travel/payments@0.9.2` — the latest published version of a Connect-surface package — cannot be installed by anyone**, because it depends on `@voyant-travel/graph-contracts@^0.2.0`:

  ```
  npm error code ETARGET
  npm error notarget No matching version found for @voyant-travel/graph-contracts@^0.2.0.
  ```

Neither is fixed by code. `graph-contracts` needs npm Trusted Publishers configured for the name, the #4048 precedent; `payments` repairs itself the moment `0.2.0` publishes.

## Why a new check

`verify:public-surface` asserts the dependency *graph* is closed. That stayed true through all four defects on #4086. Closure and installability are different properties, and only one of them is what an external consumer experiences.

Every existing gate also inspects artifacts we produced. All three failure modes on that issue lived in the gap between the local tarball and the published one — `publishConfig` not applied, `catalog:` not rewritten — so a local pack cannot reproduce any of them. The only place they are visible is the registry.

## What `verify:published-surface` does

Installs every non-private workspace package at the version in the repository, from the registry, into a scratch directory, then imports each declared entry point. It fails on:

| Failure | Real instance |
|---|---|
| a version that does not resolve | `graph-contracts@0.2.0`, live |
| `workspace:`/`catalog:` in a published manifest | `app-manifest@0.1.0`, `custom-fields-contracts@0.1.0` |
| a `publishConfig` override that survived publish | `webhook-delivery-contracts@0.1.0` |
| an export target Node cannot import, incl. a `src` path | `webhook-delivery-contracts@0.1.0` |
| an entry point that resolves to nothing | `app-manifest@0.1.1`, transitively |

Resolution is retried before failing, so CDN lag right after a publish is not mistaken for a missing one.

Wildcard exports are expanded against the files the tarball actually shipped, so `@voyant-travel/ui/lib/utils` is exercised rather than the `./lib/*` pattern, which no consumer can import. A specifier that resolves and then throws is reported without failing — needing a browser global is not a publish defect.

## Where it runs

Last in the release job, on `!cancelled()` rather than `success()`. A failed publish is exactly when the surface is split between what shipped and what did not, so it must still run and say which. Running it last keeps a broken surface from also blocking the release PR.

It is deliberately not in `verify:full` or CI: it compares the repository against the registry, which only holds on `main` after a release.

## Verification

- `pnpm verify:published-surface` against the live registry fails on `graph-contracts@0.2.0` with the Trusted Publishers diagnosis, and on the install of `payments`.
- With those two excluded, all 12 remaining packages install and **167 entry points** import cleanly.
- The three historical bad publishes were replayed through the checks from their real published manifests; each is rejected with the specific cause.
- 11 unit tests over the pure derivation; `biome check .` clean.

The install pins `--no-legacy-peer-deps` so an `~/.npmrc` carrying `legacy-peer-deps=true` cannot silently skip peers and report `@voyant-travel/ui/components/chart` as broken when it is fine on npm's defaults.

## Not in scope

A pre-publish preflight that refuses to start a release when a bumped package name has never been published would turn the mid-batch `E404` into an early, explanatory failure. It would have prevented the partial release wave behind #4086. Worth doing separately — it changes release behaviour, whereas this only observes.
