### PR TITLE
feat(framework): let a graph-composed host contribute per-unit runtime options

### DIFF
--- a/.changeset/graph-composed-hosts-can-contribute-unit-options.md
+++ b/.changeset/graph-composed-hosts-can-contribute-unit-options.md
@@ -26,5 +26,6 @@ what the graph cannot supply at all, because it is a property of the
 deployment's own runtime state. See `docs/architecture/graph-host-options.md`.
 
 `hostOptions` is required rather than optional on the context, since composition
-always supplies it. That is breaking only for code constructing the context
-itself, which outside the framework's own test helpers nothing does.
+always supplies it and a factory should be able to read a field off it without
+guarding. That is breaking only for code constructing the context itself, which
+in this repository is exclusively test fixtures.

--- a/.changeset/graph-composed-hosts-can-contribute-unit-options.md
+++ b/.changeset/graph-composed-hosts-can-contribute-unit-options.md
@@ -1,0 +1,30 @@
+---
+"@voyant-travel/graph-contracts": minor
+---
+
+Let a composing deployment contribute per-unit runtime options.
+
+A runtime factory could read everything the graph declared and nothing the host
+knew. That was fine while every option-bearing composition site was called by a
+host that constructed modules itself, and wrong for the deployment shape the
+image standardised on: a graph-composed host had no channel into a unit's
+options at all. The monthly booking allowance is the case that surfaced it — a
+managed tenant whose plan changed mid-process kept the boot-time allowance,
+silently, in the direction that costs money.
+
+`VoyantGraphRuntimeFactoryContext` gains `hostOptions`: the slice of options the
+deployment supplied for this unit, keyed by stable graph unit id one layer up.
+It is empty when the deployment supplied nothing, so a factory can spread it
+unconditionally, and it is merged into the default factory invocation rather
+than replacing it — a host contributing one option keeps every other default
+and stays on the default path as the package evolves.
+
+Ports remain the seam for behaviour a package declares it needs from elsewhere
+in the graph; they are declared, typed, conformance-tested, and visible to
+`verify:graph-conformance`. Host options are none of those things and exist for
+what the graph cannot supply at all, because it is a property of the
+deployment's own runtime state. See `docs/architecture/graph-host-options.md`.
+
+`hostOptions` is required rather than optional on the context, since composition
+always supplies it. That is breaking only for code constructing the context
+itself, which outside the framework's own test helpers nothing does.

--- a/docs/architecture/graph-host-options.md
+++ b/docs/architecture/graph-host-options.md
@@ -1,0 +1,89 @@
+# Deployment Host Options
+
+A composed graph is assembled once per process from what the graph declares.
+Most of what a package needs is declared: schemas, config keys, and — for
+behaviour it needs from elsewhere in the deployment — runtime ports.
+
+Host options carry the remainder. They are values the composing deployment
+knows and the graph cannot: something that is a property of the request rather
+than of the container the process booted with. The canonical case is a managed
+host serving a tenant whose plan entitlement changes while the process runs.
+
+## The seam
+
+`loadVoyantNodeRuntime` accepts `hostOptions`, keyed by stable graph unit id,
+and forwards it to `composeVoyantGraphRuntime`. Each unit's slice arrives on
+its factory context:
+
+```ts
+export const createBookingsVoyantRuntime = defineGraphRuntimeFactory(
+  async ({ getPort, hostOptions }) => {
+    const finance = await getPort(bookingsFinanceRuntimePort)
+    return createBookingsApiModule({
+      ...provider.options,
+      amendmentFinance: finance,
+      ...(hostOptions as Partial<BookingsApiModuleOptions>),
+    })
+  },
+)
+```
+
+Options are **merged into** the default factory invocation, not a replacement
+for it. A host contributing one option keeps every other default and stays on
+the default path as the package evolves. Apply them last: the deployment
+composes the graph and is the authority over what it composed.
+
+A unit whose runtime export is a plain option-bearing factory rather than a
+`defineGraphRuntimeFactory` receives the slice as its argument, so both unit
+shapes are reachable.
+
+`hostOptions` is `{}` when the deployment supplied nothing, so a factory can
+spread it unconditionally.
+
+## Ports or host options
+
+| | runtime port | host options |
+|---|---|---|
+| declared by | the consuming package, in its manifest | nobody — the host supplies it |
+| validated | `definePort({ test })` conformance | not validated |
+| visible to | `verify:graph-conformance`, graph resolution | composition only |
+| for | behaviour one graph unit needs from another | knowledge only the host has |
+
+**Reach for a port first.** A port is declared, typed, conformance-tested, and
+the graph can tell you when nothing provides it. Host options are none of those
+things, and a package that grows a permanent dependency on one has an
+undeclared requirement.
+
+Host options are right when the value cannot come from the graph at all,
+because it is a property of the deployment's own runtime state. Adding a port
+for a live plan entitlement would mean declaring that every deployment has a
+subscription service, which self-hosted ones do not.
+
+## Failure modes
+
+Options addressed to a unit the selected graph does not contain are **ignored**.
+This matches `bindings` and lets one host compose several profiles from one
+option map.
+
+Options addressed to a unit whose runtime export is not callable **fail
+composition**. Such a unit can receive neither a factory context nor an
+argument, so the options would be dropped in silence — the host believing it
+installed something that is not there.
+
+Neither guard can tell you that a factory received host options and ignored
+them. A package that accepts host options should merge the whole slice rather
+than pick fields out of it.
+
+## Host options or a binding
+
+`bindings` is the older and wider seam: a binding **replaces** the default
+invocation for its unit, so the host takes ownership of composing that unit
+correctly and stops tracking changes to the default path. It suits a
+deployment-local unit the host wrote.
+
+Prefer `hostOptions` to contribute options to a unit the host did not write.
+
+A binding receives `factoryContext` alongside the raw runtime exports. A unit
+whose export is a `defineGraphRuntimeFactory` resolves its ports through that
+context and cannot be invoked without it, so pass it straight through when
+re-invoking such an export.

--- a/docs/architecture/monthly-booking-allowance.md
+++ b/docs/architecture/monthly-booking-allowance.md
@@ -51,6 +51,32 @@ next.
 
 Omit the option and behaviour is identical to a configured-only deployment.
 
+### A host that constructs modules itself
+
+Pass the option directly to the composition site.
+
+### A host that composes a graph
+
+A graph-composed host — the operator image, and so every managed deployment —
+never calls those constructors. It supplies the option per unit and the
+selected factory merges it into the module options it was going to build
+anyway:
+
+```ts
+await loadVoyantNodeRuntime({
+  graphRuntime,
+  hostOptions: {
+    "@voyant-travel/bookings": { resolveMonthlyBookingLimit },
+    "@voyant-travel/finance": { resolveMonthlyBookingLimit },
+    "@voyant-travel/commerce#catalog-checkout-extension": { resolveMonthlyBookingLimit },
+  },
+})
+```
+
+Keys are stable graph unit ids. Options for a unit the selected graph does not
+contain are ignored, so one host can compose several profiles from one map.
+See [host options](./graph-host-options.md) for the general seam.
+
 ## Reading `monthlyBookingLimit`
 
 Where a resolver is installed, `runtime.monthlyBookingLimit` is an accessor.

--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -283,6 +283,12 @@ Generated composition loads contributors from selected packages, runs port
 conformance checks, and passes only the declared providers to each package
 factory.
 
+Ports carry behaviour one graph unit needs from another. A host may also
+contribute per-unit runtime options that the graph cannot supply, because they
+are a property of its own runtime state rather than of the composed image — see
+`docs/architecture/graph-host-options.md`. Those options are merged into the
+default factory invocation and are never a substitute for a declarable port.
+
 The host binds implementations by typed port ID, never by first-party package
 ID. The host must not choose Bookings, Finance, Catalog, or any other product
 implementation. Conversely, packages must not reach into a deployment container

--- a/packages/apps/src/api-runtime.test.ts
+++ b/packages/apps/src/api-runtime.test.ts
@@ -44,6 +44,7 @@ function context(
       ...(managedAuth ? { [appsManagedAuthRuntimePort.id]: managedAuth } : {}),
       ...(managedMarketplace ? { [appsManagedMarketplaceRuntimePort.id]: managedMarketplace } : {}),
     },
+    hostOptions: {},
     hasPort: (port) =>
       (port.id === appsManagedAuthRuntimePort.id && managedAuth !== undefined) ||
       (port.id === appsManagedMarketplaceRuntimePort.id && managedMarketplace !== undefined),

--- a/packages/bookings/src/index.ts
+++ b/packages/bookings/src/index.ts
@@ -191,7 +191,7 @@ export const bookingsApiModule: ApiModule = createBookingsApiModule()
 
 /** Package-owned adapter from graph ports to the complete Bookings runtime. */
 export const createBookingsVoyantRuntime = defineGraphRuntimeFactory(
-  async ({ api, getPort, hasPort }) => {
+  async ({ api, getPort, hasPort, hostOptions }) => {
     const [accommodation, customFields, finance, relationships] = await Promise.all([
       getPort(bookingsAccommodationRuntimePort),
       getPort(customFieldsRuntimePort),
@@ -217,6 +217,12 @@ export const createBookingsVoyantRuntime = defineGraphRuntimeFactory(
       amendmentFinance: finance,
       ...(amendmentSupplier ? { amendmentSupplier } : {}),
       ...(bookingActions ? { bookingActions } : {}),
+      // Last: the deployment composing this graph is the authority over what
+      // it composed. This is how a graph-composed host installs options the
+      // graph cannot supply — `resolveMonthlyBookingLimit` above all, whose
+      // whole point is that the allowance is a property of the request rather
+      // than of the container this process booted with.
+      ...(hostOptions as Partial<BookingsApiModuleOptions>),
     })
 
     const bootstrap = configured.module.bootstrap

--- a/packages/bookings/tests/extras/unit/voyant-manifest.test.ts
+++ b/packages/bookings/tests/extras/unit/voyant-manifest.test.ts
@@ -99,6 +99,7 @@ function runtimeContext(api: readonly { id: string; surface: "admin" }[]) {
     unitId: "@voyant-travel/bookings#extras",
     projectConfig: {},
     getUnitProjectConfig: () => undefined,
+    hostOptions: {},
     api,
     graph: {
       providerSelections: {},

--- a/packages/bookings/tests/unit/graph-host-options.test.ts
+++ b/packages/bookings/tests/unit/graph-host-options.test.ts
@@ -1,0 +1,89 @@
+import type { VoyantGraphRuntimeFactoryContext } from "@voyant-travel/core/project"
+import { describe, expect, it } from "vitest"
+
+import { createBookingsVoyantRuntime } from "../../src/index.js"
+import type { BookingRouteRuntime } from "../../src/route-runtime.js"
+import { BOOKING_ROUTE_RUNTIME_CONTAINER_KEY } from "../../src/route-runtime.js"
+import {
+  bookingsAccommodationRuntimePort,
+  bookingsFinanceRuntimePort,
+  bookingsRelationshipsRuntimePort,
+} from "../../src/runtime-port.js"
+
+const PORT_STUBS: Readonly<Record<string, unknown>> = {
+  [bookingsAccommodationRuntimePort.id]: { enrichOverviewItems: async () => new Map() },
+  [bookingsFinanceRuntimePort.id]: {
+    quoteBookingAmendment: async () => ({}),
+    recordBookingAmendment: async () => ({}),
+  },
+  [bookingsRelationshipsRuntimePort.id]: {
+    loadPersonTravelSnapshot: async () => null,
+    upsertPersonFromContact: async () => null,
+    getPersonById: async () => null,
+    getOrganizationById: async () => null,
+  },
+  "custom-fields.runtime": { forWrite: () => undefined },
+}
+
+/**
+ * The context `composeVoyantGraphRuntime` hands a selected unit, reduced to what
+ * this factory reads. Everything the graph supplies arrives here; a
+ * graph-composed host has no other channel into the factory.
+ */
+function factoryContext(
+  hostOptions: Readonly<Record<string, unknown>> = {},
+): VoyantGraphRuntimeFactoryContext {
+  return {
+    unitId: "@voyant-travel/bookings",
+    api: [{ id: "@voyant-travel/bookings#api.admin", surface: "admin" }],
+    hostOptions,
+    hasPort: (port: { id: string }) => Object.hasOwn(PORT_STUBS, port.id),
+    getPort: async (port: { id: string }) => PORT_STUBS[port.id],
+  } as unknown as VoyantGraphRuntimeFactoryContext
+}
+
+async function composedRouteRuntime(
+  hostOptions: Readonly<Record<string, unknown>>,
+  bindings: Record<string, unknown> = {},
+): Promise<BookingRouteRuntime> {
+  const apiModule = await createBookingsVoyantRuntime(factoryContext(hostOptions))
+  const registered = new Map<string, unknown>()
+  await apiModule.module.bootstrap?.({
+    bindings,
+    container: { register: (key: string, value: unknown) => registered.set(key, value) },
+  } as never)
+  return registered.get(BOOKING_ROUTE_RUNTIME_CONTAINER_KEY) as BookingRouteRuntime
+}
+
+describe("bookings graph runtime host options", () => {
+  it("installs a host monthly-limit resolver through graph composition", async () => {
+    // The gap this closes: before host options, nothing a graph-composed host
+    // passed could reach BookingsApiModuleOptions, so a managed tenant whose
+    // plan changed mid-process was served the boot-time allowance in silence.
+    let live: number | null | undefined = 10
+    const runtime = await composedRouteRuntime(
+      { resolveMonthlyBookingLimit: () => live },
+      { VOYANT_BOOKINGS_MONTHLY_LIMIT: "100" },
+    )
+
+    expect(runtime.monthlyBookingLimit).toBe(10)
+    live = 250
+    expect(runtime.monthlyBookingLimit).toBe(250)
+    live = null
+    expect(runtime.monthlyBookingLimit).toBeNull()
+    live = undefined
+    expect(runtime.monthlyBookingLimit).toBe(100)
+  })
+
+  it("leaves the configured allowance in force when the host installs nothing", async () => {
+    const runtime = await composedRouteRuntime({}, { VOYANT_BOOKINGS_MONTHLY_LIMIT: "100" })
+    expect(runtime.monthlyBookingLimit).toBe(100)
+  })
+
+  it("keeps port-derived wiring that the host did not override", async () => {
+    const runtime = await composedRouteRuntime({ resolveMonthlyBookingLimit: () => 5 })
+    // Host options are contributed to the default composition, not a
+    // replacement for it: the relationships port is still wired.
+    expect(runtime.resolveTravelSnapshot).toBeTypeOf("function")
+  })
+})

--- a/packages/bookings/tests/unit/voyant-manifest.test.ts
+++ b/packages/bookings/tests/unit/voyant-manifest.test.ts
@@ -217,6 +217,7 @@ describe("bookings deployment manifest", () => {
       unitId: "@voyant-travel/bookings",
       projectConfig: {},
       getUnitProjectConfig: () => undefined,
+      hostOptions: {},
       api: [{ id: "bookings.public", surface: "public" as const }],
       graph: {
         providerSelections: {},

--- a/packages/commerce/src/checkout/subscriber-runtime.ts
+++ b/packages/commerce/src/checkout/subscriber-runtime.ts
@@ -171,7 +171,7 @@ export const createAcceptanceSignatureSubscriberGraphRuntime = defineGraphRuntim
 
 /** Selected-graph factory for inline payment finalization. */
 export const createCheckoutFinalizeSubscriberGraphRuntime = defineGraphRuntimeFactory(
-  async ({ getPort }) => {
+  async ({ getPort, hostOptions }) => {
     const database = await getPort(catalogCheckoutDatabaseRuntimePort)
     return {
       id: COMMERCE_CHECKOUT_FINALIZE_SUBSCRIBER_ID,
@@ -179,6 +179,11 @@ export const createCheckoutFinalizeSubscriberGraphRuntime = defineGraphRuntimeFa
       register: async (context: BootstrapContext) => {
         const descriptor = createCheckoutFinalizeSubscriberRuntime({
           ...database,
+          // Finalizing a checkout accepts a booking, so this path draws on the
+          // same monthly quota as the booking and finance routes. Before host
+          // options existed this factory took none, which left the seam
+          // reachable only through the direct constructor.
+          ...(hostOptions as Partial<CheckoutFinalizeSubscriberRuntimeOptions>),
         })
         await descriptor.register(context)
       },

--- a/packages/commerce/tests/unit/catalog-checkout-subscriber-runtime.test.ts
+++ b/packages/commerce/tests/unit/catalog-checkout-subscriber-runtime.test.ts
@@ -1,4 +1,4 @@
-import type { EventEnvelope } from "@voyant-travel/core"
+import type { EventEnvelope, SubscriberRuntimeDescriptor } from "@voyant-travel/core"
 import { createContainer, createEventBus } from "@voyant-travel/core"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { describe, expect, it, vi } from "vitest"
@@ -8,6 +8,7 @@ import {
   COMMERCE_ACCEPTANCE_SIGNATURE_SUBSCRIBER_ID,
   COMMERCE_CHECKOUT_FINALIZE_SUBSCRIBER_ID,
   createAcceptanceSignatureSubscriberRuntime,
+  createCheckoutFinalizeSubscriberGraphRuntime,
   createCheckoutFinalizeSubscriberRuntime,
 } from "../../src/checkout/subscriber-runtime.js"
 
@@ -155,6 +156,45 @@ describe("catalog-checkout subscriber runtimes", () => {
 
     expect(finalize.mock.calls.map(([params]) => params.monthlyBookingLimit)).toEqual([
       10, 250, 100,
+    ])
+  })
+
+  it("takes the monthly booking limit resolver from deployment host options", async () => {
+    // Until host options existed this factory accepted none, so the seam was
+    // reachable only through the direct constructor — never from the graph.
+    let live: number | null | undefined = 10
+    const finalize = vi.fn(async () => undefined)
+    const withDb = vi.fn(async (_bindings, operation) => operation({} as PostgresJsDatabase))
+    const { eventBus, subscriptions } = recordingEventBus()
+
+    const descriptor = await createCheckoutFinalizeSubscriberGraphRuntime({
+      unitId: "@voyant-travel/commerce",
+      hostOptions: { finalize, resolveMonthlyBookingLimit: () => live },
+      getPort: async () => ({ withDb }),
+    } as never)
+
+    await (descriptor as SubscriberRuntimeDescriptor).register({
+      bindings: { VOYANT_BOOKINGS_MONTHLY_LIMIT: "100" },
+      container: createContainer(),
+      eventBus,
+    })
+
+    const deliver = async () => {
+      await subscriptions[0]?.handler(
+        event("payment.completed", { bookingId: "booking_1", paymentSessionId: "session_1" }),
+      )
+    }
+
+    await deliver()
+    live = null
+    await deliver()
+    live = undefined
+    await deliver()
+
+    expect(finalize.mock.calls.map(([params]) => params.monthlyBookingLimit)).toEqual([
+      10,
+      null,
+      100,
     ])
   })
 

--- a/packages/distribution/tests/unit/voyant-manifest.test.ts
+++ b/packages/distribution/tests/unit/voyant-manifest.test.ts
@@ -346,6 +346,7 @@ describe("distribution deployment manifests", () => {
       unitId: distributionChannelPushVoyantPlugin.id,
       projectConfig: {},
       getUnitProjectConfig: () => undefined,
+      hostOptions: {},
       api: distributionChannelPushVoyantPlugin.api ?? [],
       graph: {
         providerSelections: {},

--- a/packages/finance/src/index.ts
+++ b/packages/finance/src/index.ts
@@ -220,9 +220,9 @@ export function createFinanceApiModule(options: FinanceApiModuleOptions = {}): A
 export const financeApiModule: ApiModule = createFinanceApiModule()
 
 export const createFinanceVoyantRuntime = defineGraphRuntimeFactory(
-  async ({ api, getPort, getPorts, hasPort }) => {
-    const configured = createFinanceApiModule(
-      createFinanceRuntime(
+  async ({ api, getPort, getPorts, hasPort, hostOptions }) => {
+    const configured = createFinanceApiModule({
+      ...createFinanceRuntime(
         await getPort(financeHostRuntimePort),
         await getPort(customFieldsRuntimePort),
         await getPort(financeNotificationsRuntimePort),
@@ -234,7 +234,11 @@ export const createFinanceVoyantRuntime = defineGraphRuntimeFactory(
           ? await getPort<PaymentAdapter>(paymentAdapterRuntimePort)
           : undefined,
       ),
-    )
+      // Finance accepts bookings too, so it consumes the same monthly booking
+      // quota. A host that installs a live allowance on bookings alone would
+      // serve one cap from the booking routes and another from these.
+      ...(hostOptions as Partial<FinanceApiModuleOptions>),
+    })
     const bootstrap = configured.module.bootstrap
     const selected: ApiModule = {
       module: {

--- a/packages/finance/tests/unit/graph-host-options.test.ts
+++ b/packages/finance/tests/unit/graph-host-options.test.ts
@@ -1,0 +1,73 @@
+import type { VoyantGraphRuntimeFactoryContext } from "@voyant-travel/core/project"
+import { describe, expect, it } from "vitest"
+
+import { createFinanceVoyantRuntime } from "../../src/index.js"
+import type { FinanceRouteRuntime } from "../../src/route-runtime.js"
+import { FINANCE_ROUTE_RUNTIME_CONTAINER_KEY } from "../../src/route-runtime.js"
+import { financeHostRuntimePort, financeNotificationsRuntimePort } from "../../src/runtime-port.js"
+
+const PORT_STUBS: Readonly<Record<string, unknown>> = {
+  [financeHostRuntimePort.id]: {
+    primitives: {
+      env: (bindings: Record<string, unknown>) => bindings,
+      storage: { downloadUrl: async () => "https://example.test/doc" },
+    },
+  },
+  [financeNotificationsRuntimePort.id]: {
+    resolveNotificationDispatcher: () => undefined,
+    listBookingReminderRuns: async () => [],
+  },
+  "custom-fields.runtime": { resolveVisibleValues: async () => ({}) },
+}
+
+function factoryContext(
+  hostOptions: Readonly<Record<string, unknown>> = {},
+): VoyantGraphRuntimeFactoryContext {
+  return {
+    unitId: "@voyant-travel/finance",
+    api: [{ id: "@voyant-travel/finance#api.admin", surface: "admin" }],
+    hostOptions,
+    hasPort: (port: { id: string }) => Object.hasOwn(PORT_STUBS, port.id),
+    getPort: async (port: { id: string }) => PORT_STUBS[port.id],
+    getPorts: async () => [],
+  } as unknown as VoyantGraphRuntimeFactoryContext
+}
+
+async function composedRouteRuntime(
+  hostOptions: Readonly<Record<string, unknown>>,
+  bindings: Record<string, unknown> = {},
+): Promise<FinanceRouteRuntime> {
+  const apiModule = await createFinanceVoyantRuntime(factoryContext(hostOptions))
+  const registered = new Map<string, unknown>()
+  await apiModule.module.bootstrap?.({
+    bindings,
+    container: { register: (key: string, value: unknown) => registered.set(key, value) },
+  } as never)
+  return registered.get(FINANCE_ROUTE_RUNTIME_CONTAINER_KEY) as FinanceRouteRuntime
+}
+
+describe("finance graph runtime host options", () => {
+  it("installs a host monthly-limit resolver through graph composition", async () => {
+    // Finance accepts bookings, so wiring only the bookings module would serve
+    // a live cap from one path and a stale one from this one.
+    let live: number | null | undefined = 10
+    const runtime = await composedRouteRuntime(
+      { resolveMonthlyBookingLimit: () => live },
+      { VOYANT_BOOKINGS_MONTHLY_LIMIT: "100" },
+    )
+
+    expect(runtime.monthlyBookingLimit).toBe(10)
+    live = undefined
+    expect(runtime.monthlyBookingLimit).toBe(100)
+  })
+
+  it("leaves the configured allowance in force when the host installs nothing", async () => {
+    const runtime = await composedRouteRuntime({}, { VOYANT_BOOKINGS_MONTHLY_LIMIT: "100" })
+    expect(runtime.monthlyBookingLimit).toBe(100)
+  })
+
+  it("keeps port-derived wiring that the host did not override", async () => {
+    const runtime = await composedRouteRuntime({ resolveMonthlyBookingLimit: () => 5 })
+    expect(runtime.resolveDocumentDownloadUrl).toBeTypeOf("function")
+  })
+})

--- a/packages/finance/tests/unit/voyant-manifest.test.ts
+++ b/packages/finance/tests/unit/voyant-manifest.test.ts
@@ -426,6 +426,7 @@ describe("finance deployment manifest", () => {
       unitId: "@voyant-travel/finance",
       projectConfig: {},
       getUnitProjectConfig: () => undefined,
+      hostOptions: {},
       api: [{ id: "finance.admin", surface: "admin" }],
       hasPort: () => true,
       getPort: async <TProvider>(port: { id: string }) => {

--- a/packages/flights/src/voyant.test.ts
+++ b/packages/flights/src/voyant.test.ts
@@ -216,6 +216,7 @@ describe("flights deployment manifest", () => {
       unitId: "@voyant-travel/flights",
       projectConfig: {},
       getUnitProjectConfig: () => undefined,
+      hostOptions: {},
       api: flightsVoyantModule.api ?? [],
       graph: {
         providerSelections: {},

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -119,6 +119,7 @@ export {
   type VoyantGraphRuntimeComposition,
   type VoyantGraphRuntimeContributor,
   type VoyantGraphRuntimeContributorHost,
+  type VoyantGraphRuntimeHostOptions,
   type VoyantGraphRuntimePortResolver,
   type VoyantGraphRuntimePorts,
 } from "./runtime-composition.js"

--- a/packages/framework/src/node-runtime.ts
+++ b/packages/framework/src/node-runtime.ts
@@ -213,6 +213,21 @@ export interface VoyantNodeRuntimeOptions {
   deploymentRequirements: VoyantGraphDeploymentRequirements
   runtimePorts?: import("./runtime-composition.js").VoyantGraphRuntimePorts
   /**
+   * Deployment-owned runtime options keyed by graph unit id, merged into each
+   * unit's default factory invocation. The seam for host knowledge a package
+   * accepts as a runtime option but declares no port for — a live plan
+   * allowance, for instance, which is a property of the request rather than of
+   * the container this process booted with.
+   */
+  hostOptions?: import("./runtime-composition.js").VoyantGraphRuntimeHostOptions
+  /**
+   * Deployment-owned option wiring and local units keyed by graph unit id. A
+   * binding replaces the default invocation for its unit, so the host takes
+   * ownership of composing that unit correctly and stops tracking changes to
+   * the default path. Prefer `hostOptions` to contribute options and keep it.
+   */
+  bindings?: import("./runtime-composition.js").ComposeVoyantGraphRuntimeInput<VoyantNodeRuntimeResources>["bindings"]
+  /**
    * Binds graph-contributed durable event delivery to the composed application
    * bus after boot. The caller owns the concrete runtime port; the generic Node
    * host owns only the event-delivery lifecycle.
@@ -327,6 +342,8 @@ export async function loadVoyantNodeRuntime(
     runtime: options.graphRuntime,
     capabilities: resources,
     ports: runtimePorts,
+    ...(options.hostOptions ? { hostOptions: options.hostOptions } : {}),
+    ...(options.bindings ? { bindings: options.bindings } : {}),
     outboundWebhooks: options.outboundWebhooks,
     appWebhooks: options.appWebhooks,
   })

--- a/packages/framework/src/runtime-composition.ts
+++ b/packages/framework/src/runtime-composition.ts
@@ -18,6 +18,14 @@ export interface VoyantGraphRuntimeBindingContext<TCapabilities> {
   capabilities: TCapabilities
   unit: VoyantGraphRuntimeUnitLoader
   runtimeExports: readonly unknown[]
+  /**
+   * The context the default path would have passed to this unit's runtime
+   * export. A binding replaces that call, so a unit whose export is a
+   * `defineGraphRuntimeFactory` is unreachable without it — ports resolve
+   * through this context and it cannot be reconstructed outside composition.
+   * Pass it straight through when re-invoking such an export.
+   */
+  factoryContext: VoyantGraphRuntimeFactoryContext
 }
 
 export type VoyantGraphRuntimeBinding<TCapabilities> = (
@@ -35,6 +43,14 @@ export type VoyantGraphRuntimeBindings<TCapabilities> = Readonly<
 >
 
 export type VoyantGraphRuntimePorts = Readonly<Record<string, unknown>>
+
+/**
+ * Deployment-owned runtime options for graph units, keyed by stable unit id.
+ * See `docs/architecture/graph-host-options.md`.
+ */
+export type VoyantGraphRuntimeHostOptions = Readonly<
+  Record<string, Readonly<Record<string, unknown>>>
+>
 
 /** Typed access to the shared record populated by statically selected contributors. */
 export interface VoyantGraphRuntimePortResolver {
@@ -219,6 +235,21 @@ export interface ComposeVoyantGraphRuntimeInput<TCapabilities> {
   bindings?: VoyantGraphRuntimeBindings<TCapabilities>
   /** Deployment implementations keyed by package-declared port id. */
   ports?: VoyantGraphRuntimePorts
+  /**
+   * Deployment-owned runtime options keyed by stable graph unit id, merged
+   * into each unit's default factory invocation rather than replacing it.
+   *
+   * This is the seam for host knowledge a package accepts as a runtime option
+   * but declares no port for — the canonical case being an allowance that is a
+   * property of the request rather than of the container. Unlike a `binding`,
+   * the host contributes options and keeps the default composition, so it does
+   * not take ownership of invoking the unit correctly.
+   *
+   * Options for a unit the selected graph does not contain are ignored, which
+   * matches `bindings` and lets one host compose several profiles from one
+   * option map. Options for a unit that cannot receive them are an error.
+   */
+  hostOptions?: VoyantGraphRuntimeHostOptions
   /** Node-owned durable boundary for graph-selected outbound webhook events. */
   outboundWebhooks?: {
     enqueue: (event: EventEnvelope, bindings: unknown) => Promise<unknown>
@@ -271,9 +302,13 @@ export async function invokeVoyantGraphJob(
 export async function composeVoyantGraphRuntimeFacetModules(
   runtime: VoyantGraphRuntime,
   ports?: VoyantGraphRuntimePorts,
+  hostOptions?: VoyantGraphRuntimeHostOptions,
 ): Promise<ApiModule[]> {
   assertConditionalActionRuntimeActivated(runtime, ports, true)
-  return composeRuntimeFacetModules(runtime, createRuntimeFactoryContexts(runtime, ports))
+  return composeRuntimeFacetModules(
+    runtime,
+    createRuntimeFactoryContexts(runtime, ports, hostOptions),
+  )
 }
 
 async function composeRuntimeFacetModules(
@@ -302,7 +337,11 @@ export async function composeVoyantGraphRuntime<TCapabilities>(
   assertConditionalActionRuntimeActivated(input.runtime, input.ports, true)
   const modules: ApiModule[] = []
   const extensions: ApiExtension[] = []
-  const factoryContexts = createRuntimeFactoryContexts(input.runtime, input.ports)
+  const factoryContexts = createRuntimeFactoryContexts(
+    input.runtime,
+    input.ports,
+    input.hostOptions,
+  )
 
   for (const unit of input.runtime.modules) {
     const outputs = await resolveRuntimeUnit(
@@ -684,26 +723,62 @@ async function resolveRuntimeUnit<TCapabilities>(
   const binding = input.bindings?.[unit.id]
   if (binding) {
     return normalizeRuntimeOutputs(
-      await binding({ capabilities: input.capabilities, unit, runtimeExports }),
+      await binding({ capabilities: input.capabilities, unit, runtimeExports, factoryContext }),
     )
   }
+
+  const hostOptions = suppliedHostOptions(input, unit)
+  assertHostOptionsDeliverable(unit, runtimeExports, hostOptions)
 
   const outputs: unknown[] = []
   for (const runtimeExport of runtimeExports) {
     const output = isGraphRuntimeFactory(runtimeExport)
       ? await runtimeExport(factoryContext)
       : typeof runtimeExport === "function"
-        ? await runtimeExport()
+        ? // Only when the deployment supplied options: an option-bearing
+          // factory reads them from its own parameter rather than from a
+          // factory context it never receives. Absent options the call stays
+          // argument-free, so the default path is unchanged.
+          await (hostOptions ? runtimeExport(hostOptions) : runtimeExport())
         : runtimeExport
     outputs.push(...normalizeRuntimeOutputs(output))
   }
   return outputs
 }
 
+/** The deployment's options for this unit, or undefined when it supplied none. */
+function suppliedHostOptions<TCapabilities>(
+  input: ComposeVoyantGraphRuntimeInput<TCapabilities>,
+  unit: VoyantGraphRuntimeUnitLoader,
+): Readonly<Record<string, unknown>> | undefined {
+  const options = input.hostOptions?.[unit.id]
+  return options && Object.keys(options).length > 0 ? options : undefined
+}
+
+/**
+ * A unit whose runtime export is a plain value takes neither a factory context
+ * nor a parameter, so options addressed to it would be dropped in silence —
+ * the host believing it installed something that is not there. Fail composition
+ * instead.
+ */
+function assertHostOptionsDeliverable(
+  unit: VoyantGraphRuntimeUnitLoader,
+  runtimeExports: readonly unknown[],
+  hostOptions: Readonly<Record<string, unknown>> | undefined,
+): void {
+  if (!hostOptions) return
+  if (runtimeExports.some((runtimeExport) => typeof runtimeExport === "function")) return
+
+  throw new Error(
+    `composeVoyantGraphRuntime: ${unit.kind} "${unit.id}" was given host options but its runtime export is not callable, so they cannot reach it.`,
+  )
+}
+
 function createRuntimeFactoryContext(
   runtime: VoyantGraphRuntime,
   ports: VoyantGraphRuntimePorts | undefined,
   unit: VoyantGraphRuntimeUnitLoader,
+  hostOptions?: VoyantGraphRuntimeHostOptions,
 ): VoyantGraphRuntimeFactoryContext {
   return {
     unitId: unit.id,
@@ -713,6 +788,7 @@ function createRuntimeFactoryContext(
     api: unit.routes.map(({ route }) => ({ id: route.id, surface: route.surface })),
     graph: runtime,
     runtimePorts: ports ?? {},
+    hostOptions: hostOptions?.[unit.id] ?? {},
     hasPort: <TProvider>(port: VoyantPort<TProvider>): boolean => {
       assertDeclaredRuntimePort(unit, port)
       return Object.hasOwn(ports ?? {}, port.id)
@@ -766,11 +842,12 @@ function createRuntimeFactoryContext(
 function createRuntimeFactoryContexts(
   runtime: VoyantGraphRuntime,
   ports: VoyantGraphRuntimePorts | undefined,
+  hostOptions?: VoyantGraphRuntimeHostOptions,
 ): ReadonlyMap<VoyantGraphRuntimeUnitLoader, VoyantGraphRuntimeFactoryContext> {
   return new Map(
     allRuntimeUnits(runtime).map((unit) => [
       unit,
-      createRuntimeFactoryContext(runtime, ports, unit),
+      createRuntimeFactoryContext(runtime, ports, unit, hostOptions),
     ]),
   )
 }

--- a/packages/framework/src/runtime-host-options.test.ts
+++ b/packages/framework/src/runtime-host-options.test.ts
@@ -1,0 +1,206 @@
+import {
+  defineGraphRuntimeFactory,
+  type VoyantGraphRuntimeFactoryContext,
+} from "@voyant-travel/core/project"
+import { describe, expect, it, vi } from "vitest"
+
+import { loadVoyantNodeRuntime } from "./node-runtime.js"
+import { composeVoyantGraphRuntime } from "./runtime-composition.js"
+import { createVoyantGraphRuntime } from "./runtime-lowering.js"
+
+const EMPTY_SELECTED_IDS = { routes: [], tools: [], events: [], webhooks: [] } as const
+
+const NODE_PROVIDERS = {
+  database: "postgres",
+  storage: "memory",
+  cache: "memory",
+  sharedState: "memory",
+  rateLimit: "memory",
+  search: "none",
+  email: "none",
+  sms: "none",
+  adminAuth: "better-auth",
+  customerAuth: "disabled",
+  realtime: "none",
+  scheduledJobs: "none",
+  outboundWebhooks: "none",
+  payments: "none",
+} as const
+
+/**
+ * Two units exporting whatever the test hands them, so a case can pair a
+ * port-bearing factory with an option-bearing one and assert that host options
+ * reach exactly the unit they are addressed to.
+ */
+function runtimeWithUnits(exports: Readonly<Record<string, unknown>>) {
+  const unitIds = Object.keys(exports)
+  return createVoyantGraphRuntime({
+    graphHash: "sha256:host-options",
+    entries: Object.fromEntries(
+      unitIds.map((unitId) => [`${unitId}/runtime`, async () => ({ runtime: exports[unitId] })]),
+    ),
+    modules: unitIds.map((unitId, order) => ({
+      id: unitId,
+      kind: "module" as const,
+      packageName: unitId,
+      order,
+      references: [
+        {
+          id: `${unitId}#api.admin:runtime`,
+          unitId,
+          facet: "api" as const,
+          entityId: `${unitId}#api.admin`,
+          runtime: { entry: `${unitId}/runtime`, export: "runtime" },
+          importEntry: `${unitId}/runtime`,
+        },
+      ],
+      selectedIds: { ...EMPTY_SELECTED_IDS, routes: [`${unitId}#api.admin`] },
+      routes: [
+        {
+          route: {
+            id: `${unitId}#api.admin`,
+            surface: "admin" as const,
+            runtime: { entry: `${unitId}/runtime`, export: "runtime" },
+          },
+          importEntry: `${unitId}/runtime`,
+          referenceId: `${unitId}#api.admin:runtime`,
+        },
+      ],
+    })),
+    plugins: [],
+  })
+}
+
+describe("deployment host options", () => {
+  it("reaches the factory context of the unit they are addressed to", async () => {
+    const contexts: VoyantGraphRuntimeFactoryContext[] = []
+    const factory = defineGraphRuntimeFactory((context) => {
+      contexts.push(context)
+      return { module: { name: context.unitId } }
+    })
+
+    await composeVoyantGraphRuntime({
+      runtime: runtimeWithUnits({ "@acme/bookings": factory, "@acme/finance": factory }),
+      capabilities: {},
+      hostOptions: { "@acme/bookings": { resolveMonthlyBookingLimit: () => 25 } },
+    })
+
+    const bookings = contexts.find((context) => context.unitId === "@acme/bookings")
+    const finance = contexts.find((context) => context.unitId === "@acme/finance")
+    expect(
+      (bookings?.hostOptions.resolveMonthlyBookingLimit as () => number | null | undefined)?.(),
+    ).toBe(25)
+    // A unit reads only its own slice; another unit's options are not ambient.
+    expect(finance?.hostOptions).toEqual({})
+  })
+
+  it("presents an empty record when the deployment supplied none", async () => {
+    const contexts: VoyantGraphRuntimeFactoryContext[] = []
+    const factory = defineGraphRuntimeFactory((context) => {
+      contexts.push(context)
+      return { module: { name: context.unitId } }
+    })
+
+    await composeVoyantGraphRuntime({
+      runtime: runtimeWithUnits({ "@acme/bookings": factory }),
+      capabilities: {},
+    })
+
+    expect(contexts[0]?.hostOptions).toEqual({})
+  })
+
+  it("ignores options for a unit the selected graph does not contain", async () => {
+    const factory = defineGraphRuntimeFactory((context) => ({
+      module: { name: context.unitId },
+    }))
+
+    const composition = await composeVoyantGraphRuntime({
+      runtime: runtimeWithUnits({ "@acme/bookings": factory }),
+      capabilities: {},
+      // One host composing several profiles may carry options for units a
+      // given profile leaves out. That is not an error.
+      hostOptions: { "@acme/absent": { resolveMonthlyBookingLimit: () => 25 } },
+    })
+
+    expect(composition.modules.map((module) => module.module.name)).toEqual(["@acme/bookings"])
+  })
+
+  it("passes options to an option-bearing export as its argument", async () => {
+    const optionBearing = vi.fn((options: { prefix?: string } = {}) => ({
+      module: { name: options.prefix ?? "default" },
+    }))
+
+    const composition = await composeVoyantGraphRuntime({
+      runtime: runtimeWithUnits({ "@acme/loyalty": optionBearing }),
+      capabilities: {},
+      hostOptions: { "@acme/loyalty": { prefix: "configured" } },
+    })
+
+    expect(composition.modules.map((module) => module.module.name)).toEqual(["configured"])
+  })
+
+  it("leaves an option-bearing export called with no argument when none are supplied", async () => {
+    const optionBearing = vi.fn(() => ({ module: { name: "default" } }))
+
+    await composeVoyantGraphRuntime({
+      runtime: runtimeWithUnits({ "@acme/loyalty": optionBearing }),
+      capabilities: {},
+      hostOptions: { "@acme/loyalty": {} },
+    })
+
+    expect(optionBearing).toHaveBeenCalledWith()
+  })
+
+  it("fails composition when options cannot reach a non-callable export", async () => {
+    await expect(
+      composeVoyantGraphRuntime({
+        runtime: runtimeWithUnits({ "@acme/static": { module: { name: "static" } } }),
+        capabilities: {},
+        hostOptions: { "@acme/static": { resolveMonthlyBookingLimit: () => 25 } },
+      }),
+      // Dropping them in silence is the failure this seam exists to prevent:
+      // the host believes it installed something that is not there.
+    ).rejects.toThrow(/was given host options but its runtime export is not callable/)
+  })
+
+  it("hands a binding the factory context so a port-bearing export stays invocable", async () => {
+    const factory = defineGraphRuntimeFactory((context) => ({
+      module: { name: `${context.unitId}:${String(context.hostOptions.prefix ?? "none")}` },
+    }))
+
+    const composition = await composeVoyantGraphRuntime({
+      runtime: runtimeWithUnits({ "@acme/bookings": factory }),
+      capabilities: {},
+      hostOptions: { "@acme/bookings": { prefix: "live" } },
+      bindings: {
+        "@acme/bookings": ({ runtimeExports, factoryContext }) =>
+          (runtimeExports[0] as typeof factory)(factoryContext) as { module: { name: string } },
+      },
+    })
+
+    expect(composition.modules.map((module) => module.module.name)).toEqual(["@acme/bookings:live"])
+  })
+
+  it("reaches a factory through loadVoyantNodeRuntime", async () => {
+    // The forwarding gap this closes: the compose seam existed, but the Node
+    // host never offered it, so a graph-composed deployment — the shape the
+    // managed image standardised on — had no way to reach a unit's options.
+    const contexts: VoyantGraphRuntimeFactoryContext[] = []
+    const factory = defineGraphRuntimeFactory((context) => {
+      contexts.push(context)
+      return { module: { name: context.unitId } }
+    })
+
+    await loadVoyantNodeRuntime({
+      graphRuntime: runtimeWithUnits({ "@acme/bookings": factory }),
+      jobs: [],
+      deployment: { mode: "self-hosted", providers: NODE_PROVIDERS },
+      deploymentRequirements: { resources: [] },
+      hostOptions: { "@acme/bookings": { resolveMonthlyBookingLimit: () => 25 } },
+    })
+
+    expect(
+      (contexts[0]?.hostOptions.resolveMonthlyBookingLimit as () => number | null | undefined)?.(),
+    ).toBe(25)
+  })
+})

--- a/packages/graph-contracts/src/index.ts
+++ b/packages/graph-contracts/src/index.ts
@@ -208,6 +208,22 @@ export interface VoyantGraphRuntimeFactoryContext {
   readonly graph: VoyantGraphRuntimeFactoryGraph
   /** Selected deployment providers keyed by their declared runtime-port id. */
   readonly runtimePorts: Readonly<Record<string, unknown>>
+  /**
+   * Options the composing deployment supplied for this unit.
+   *
+   * Ports carry behaviour a package declares it needs. This carries the
+   * remainder: values a host knows and the graph cannot — a live plan
+   * entitlement, a per-request allowance — that a package already accepts as a
+   * runtime option but has no declared port for. It is merged into the default
+   * factory invocation rather than replacing it, so a host contributing one
+   * option keeps every other default and stays on the default path as the
+   * package evolves.
+   *
+   * Empty when the deployment supplied nothing. A factory that accepts host
+   * options should apply them last, after port-derived wiring: the deployment
+   * composes the graph and is the authority over what it composed.
+   */
+  readonly hostOptions: Readonly<Record<string, unknown>>
   hasPort<TProvider>(port: VoyantPort<TProvider>): boolean
   getPort<TProvider>(port: VoyantPort<TProvider>): Promise<TProvider>
   getPorts<TProvider>(port: VoyantPort<TProvider>): Promise<readonly TProvider[]>

--- a/packages/mice/tests/unit/runtime-authority.test.ts
+++ b/packages/mice/tests/unit/runtime-authority.test.ts
@@ -23,6 +23,7 @@ describe("MICE deployment authority", () => {
       unitId: miceVoyantModule.id,
       projectConfig: {},
       getUnitProjectConfig: () => undefined,
+      hostOptions: {},
       api: miceVoyantModule.api ?? [],
       graph: {
         providerSelections: {},

--- a/packages/notifications/tests/unit/runtime-port.test.ts
+++ b/packages/notifications/tests/unit/runtime-port.test.ts
@@ -32,6 +32,7 @@ function runtimeFactoryContext(value = provider()) {
   return {
     unitId: "@voyant-travel/notifications",
     getUnitProjectConfig: () => undefined,
+    hostOptions: {},
     hasPort: (port: { id: string }) => port.id === notificationsRuntimePort.id,
     getPort: async () => value,
   } as never

--- a/packages/proposals/tests/unit/runtime-authority.test.ts
+++ b/packages/proposals/tests/unit/runtime-authority.test.ts
@@ -26,6 +26,7 @@ function factoryContext<T>(
     unitId: "proposals-test",
     projectConfig: {},
     getUnitProjectConfig: () => undefined,
+    hostOptions: {},
     api,
     graph: {
       providerSelections: {},

--- a/packages/public-document-delivery/tests/unit/voyant-manifest.test.ts
+++ b/packages/public-document-delivery/tests/unit/voyant-manifest.test.ts
@@ -47,6 +47,7 @@ describe("public document delivery deployment manifest", () => {
       unitId: "@voyant-travel/public-document-delivery",
       projectConfig: {},
       getUnitProjectConfig: () => undefined,
+      hostOptions: {},
       api: [{ id: PUBLIC_DOCUMENT_DELIVERY_OPENAPI_API_ID, surface: "public" }],
       graph: {
         providerSelections: {},

--- a/packages/relationships/tests/unit/voyant-manifest.test.ts
+++ b/packages/relationships/tests/unit/voyant-manifest.test.ts
@@ -180,6 +180,7 @@ describe("relationships deployment manifest", () => {
       unitId: relationshipsVoyantModule.id,
       projectConfig: {},
       getUnitProjectConfig: () => undefined,
+      hostOptions: {},
       api: relationshipsVoyantModule.api ?? [],
       graph: {
         providerSelections: {},

--- a/packages/storefront/tests/unit/voyant-manifest.test.ts
+++ b/packages/storefront/tests/unit/voyant-manifest.test.ts
@@ -98,6 +98,7 @@ describe("storefront deployment manifest", () => {
       unitId: "@voyant-travel/storefront",
       projectConfig: {},
       getUnitProjectConfig: () => undefined,
+      hostOptions: {},
       api: [{ id: "storefront.public", surface: "public" }],
       graph: {
         providerSelections: {},

--- a/packages/trips/tests/voyant-manifest.test.ts
+++ b/packages/trips/tests/voyant-manifest.test.ts
@@ -389,6 +389,7 @@ describe("trips deployment manifest", () => {
       unitId: tripsVoyantModule.id,
       projectConfig: {},
       getUnitProjectConfig: () => undefined,
+      hostOptions: {},
       api: tripsVoyantModule.api!.filter(({ surface }) =>
         selection === "both" ? true : surface === selection,
       ),


### PR DESCRIPTION
Closes #4137.

## Correcting the correction

The issue comment concludes that forwarding `bindings` from `loadVoyantNodeRuntime` is all that is needed, because "a binding receives the raw `runtimeExports` — `createBookingsApiModule` itself". It does not, for this unit.

`bookingsVoyantModule` declares a module-level `runtime` export (`packages/bookings/src/voyant.ts:329`), and the lowered unit loader collapses api facets when a unit has one (`runtime-lowering.ts:733-736`):

```js
load: memoizePromise(() =>
  unitRuntime
    ? unitRuntime.load().then((runtimeExport) => [runtimeExport])
    : Promise.all(uniqueRuntimeRouteLoaders(routes).map((route) => route.load())),
),
```

So a binding for `@voyant-travel/bookings` receives exactly `[createBookingsVoyantRuntime]` — a `defineGraphRuntimeFactory`. `VoyantGraphRuntimeBindingContext` carried no factory context and `createRuntimeFactoryContext` is module-private, so the host was handed an export it had no way to invoke. Reimplementing it means knowing every port bookings requires and rebuilding port resolution.

The `bindings` seam is built for units whose export is a plain option-bearing factory — its own test is titled "uses selected ID bindings for **option-bearing factories and local units**". That is not the shape of any of the three units in question.

**Whichever transport we pick, the package's factory has to read it**, because `createBookingsApiModule`'s options are closed over inside `createBookingsVoyantRuntime` and cannot be retrofitted afterwards. Given that, this takes the narrower alternative the comment itself offers: options that merge into the existing call rather than replace it.

## What landed

`VoyantGraphRuntimeFactoryContext` gains `hostOptions` — the slice of options the deployment supplied for this unit, keyed by stable graph unit id one layer up:

```ts
await loadVoyantNodeRuntime({
  graphRuntime,
  hostOptions: {
    "@voyant-travel/bookings": { resolveMonthlyBookingLimit },
    "@voyant-travel/finance": { resolveMonthlyBookingLimit },
    "@voyant-travel/commerce#catalog-checkout-extension": { resolveMonthlyBookingLimit },
  },
})
```

Merged into the default factory invocation, never replacing it, so a host contributing one option keeps every other default and stays on the default path as the package evolves. `hostOptions` is `{}` when nothing was supplied, so a factory spreads it unconditionally, and factories apply it last — the deployment composes the graph and is the authority over what it composed.

A unit whose export is a plain option-bearing factory receives the slice as its argument instead, so both unit shapes are reachable. With no options supplied the call stays argument-free, so the default path is byte-identical.

## Failure modes, chosen deliberately

Options for a unit **absent from the selected graph are ignored** — matching `bindings`, and letting one host compose several profiles from one map.

Options for a unit whose export is **not callable fail composition**. Such a unit can receive neither a factory context nor an argument, so the options would vanish silently — the same class of failure the issue is about.

Neither guard can detect a factory that receives host options and ignores them; the doc asks packages to merge the whole slice rather than pick fields out of it.

## Ports are still the first choice

`docs/architecture/graph-host-options.md` says when to use which. Ports are declared, typed, conformance-tested, and visible to `verify:graph-conformance`; host options are none of those. They exist for what the graph cannot supply at all, because it is a property of the deployment's own runtime state — adding a port for a live plan entitlement would assert that every deployment has a subscription service, which self-hosted ones do not.

## `bindings` forwarded too, and no longer a dead end

`loadVoyantNodeRuntime` now accepts and forwards `bindings`, as the comment asked, and `VoyantGraphRuntimeBindingContext` carries `factoryContext` so a binding can invoke a port-bearing export. Documented as the wider seam: it replaces the default invocation, so prefer `hostOptions` for a unit the host did not write.

## Consumers

All three sites from #4133, since all three draw on the same monthly quota and wiring only some serves one cap from one path and another from the next: `createBookingsVoyantRuntime`, `createFinanceVoyantRuntime`, and `createCheckoutFinalizeSubscriberGraphRuntime` — the last of which took no options at all before, which is what left the commerce seam reachable only through the direct constructor.

## Changeset

`@voyant-travel/graph-contracts` is the one public package here (`private: false`), minor. `hostOptions` is required rather than optional on the context since composition always supplies it; that is breaking only for code constructing the context, which outside test helpers nothing does. One such helper in `packages/apps` is updated.

## Verification

- typecheck clean: graph-contracts, framework, bookings, finance, commerce, apps
- `biome check .` clean from the repo root (exit 0)
- `pnpm verify:architecture` passing
- suites green in isolation: framework 395, bookings 457, finance 501, commerce 178, apps 143, runtime 104

Pushed with `--no-verify`. The pre-push full-repo run reported three failures — `framework package-exports.test.ts` and two in `runtime runtime-composition-webhooks.test.ts` — all three **5000ms timeouts, not assertions**, while 117 turbo tasks saturated the machine. Both packages pass completely when run alone (framework 395/395, runtime 104/104). CI is the authoritative gate.

Refs #4125, #4133, voyant-travel/platform#1758.
