### PR TITLE
fix(migrations): give the quotes to proposals rename an upgrade path

### DIFF
--- a/.changeset/proposal-rename-migration-path.md
+++ b/.changeset/proposal-rename-migration-path.md
@@ -1,0 +1,34 @@
+---
+"@voyant-travel/framework-migrations": patch
+"@voyant-travel/proposals": patch
+"@voyant-travel/relationships": patch
+"@voyant-travel/custom-fields": patch
+"@voyant-travel/bookings": patch
+"@voyant-travel/legal": patch
+"@voyant-travel/mice": patch
+"@voyant-travel/db": patch
+---
+
+Give the quotes → proposals rename a migration path for existing deployments.
+
+The rename was applied by editing shipped baselines in place, so every
+deployment provisioned before it was blocked from upgrading:
+`MigrationImmutabilityError` on the edited files, and
+`proposals/0000_proposals_baseline` either failing the baseline parity gate or
+colliding with the live `quote_*` tables.
+
+The collector gains **supersession**: a migration may declare the exact retired
+`(source, tag)` ledger rows it replaces, and is recorded rather than executed
+when all of them are present. Each source that owns renamed objects now ships a
+guarded adoption migration that RENAMES its legacy objects in place — tables,
+columns, constraints, indexes, enum types and enum labels — preserving rows,
+foreign keys and column defaults. Values stored as text rather than enums are
+migrated too: `custom_field_definitions.entity_type`, `booking_origins`'
+`accepted_quote_version`, and the `quotes` resource key in
+`user_profiles.permissions` and `apikey.permissions`. Hash equivalence for the
+eight edited files is declared only because those adoption migrations exist.
+
+Every step is a no-op on a database provisioned after the rename and on a
+re-run. `verify:migration-replay-parity` gains a lane that replays the
+pre-rename package history and fails unless it converges on a fresh replay
+exactly.

--- a/docs/architecture/migration-collector-d2.md
+++ b/docs/architecture/migration-collector-d2.md
@@ -193,6 +193,57 @@ allowlist are never considered for materialized adoption. The verifier supports
 only DDL forms it can prove from PostgreSQL catalogs and fails closed for an
 unsupported allowlisted migration.
 
+## Renaming a schema-owning module (voyant#4143)
+
+A module rename is not a source rename. When `quotes` became `proposals` its
+five `quotes/*` tags were replaced by one `proposals/0000_proposals_baseline`
+declaring the same tables under new names — and the rename was additionally
+applied by **editing** already-shipped migrations owned by other sources in
+place. On a database provisioned before the rename that produces two distinct
+failures, and both guards were doing their job:
+
+- the edited files trip `MigrationImmutabilityError`;
+- `proposals/0000_proposals_baseline` is unknown to the ledger, so it is either
+  parity-gated (its tables do not exist under the new names) or executed (which
+  collides with the live legacy tables).
+
+`legacySources` does not solve this. It maps a **source name** onto the same
+tag, and a rename changes the tags too.
+
+The supported shape has three parts, and none of them may be used alone:
+
+1. **Supersession.** `SUPERSEDED_LEDGER_IDENTITIES` in the collector declares
+   that a migration replaces an exact set of retired `(source, tag)` rows. When
+   **every** one is present in the ledger the migration is RECORDED without
+   executing, and `withoutUngatedMigrations` keeps it out of the parity gate.
+   The condition is all-or-nothing: a partially-migrated legacy source is not at
+   the shape the superseding migration declares, so the run must fail loudly
+   rather than record a false baseline.
+2. **An adoption increment per owning source.** Each source that owns renamed
+   objects ships a post-cutline migration that RENAMES them in place — tables,
+   columns, constraints, indexes, enum types and enum labels — guarded on the
+   legacy name being present and the new name being free, so it is a no-op on a
+   database provisioned after the rename and on a re-run. Renaming preserves
+   rows, foreign keys and enum-label OIDs (so column defaults follow); creating
+   and copying would not. Values stored as plain TEXT (a discriminator column, a
+   permissions map key) are NOT reached by an enum relabelling and need their
+   own guarded `UPDATE` in the owning package.
+3. **Hash equivalence for the edited files.** Only sound *because* (2) exists.
+   Equivalence marks a migration applied, so on its own it would leave the
+   database on the old names while the application queries the new ones.
+
+Append-only history that is deliberately left alone: `action_ledger_entries`
+records past `action_name`/`target_type` values under the vocabulary in force
+when they happened, and legacy delivery-request rows carry a `legacy.*` command
+scope no live command looks up. Rewriting either would falsify a record rather
+than migrate state.
+
+`scripts/verify-migration-replay-parity.mjs` proves the whole thing: its
+pre-rename lane replays the package history as it shipped before the rename
+(fixtures under `scripts/fixtures/pre-proposal-rename/`) plus the adoption
+increments, and fails unless the result matches a fresh replay column-,
+enum-, index- and constraint-for-constraint.
+
 ## References
 
 - `docs/architecture/migration-collector-d1.md` — the collector primitive + ledger D.2 reuses; the `assertSchemaAtBaseline` parity pattern.

--- a/packages/bookings/migrations/20260804000300_booking_origin_proposal_version.sql
+++ b/packages/bookings/migrations/20260804000300_booking_origin_proposal_version.sql
@@ -1,0 +1,42 @@
+-- Carry `booking_origins` across the quotes → proposals rename (voyant#4143).
+--
+-- The baseline was edited in place when `quotes` became `proposals` (#4004), so
+-- a deployment provisioned before that release still has
+-- `booking_origins.quote_version_id`, the `idx_booking_origins_quote_version`
+-- index, and a `ck_booking_origins_source` that admits `accepted_quote_version`
+-- rather than `accepted_proposal_version`. The booking-origin service reads and
+-- writes the proposal-named forms.
+--
+-- Every step is guarded so this is a no-op on a database provisioned after the
+-- rename and on a re-run.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = 'public'
+       AND table_name = 'booking_origins'
+       AND column_name = 'quote_version_id'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = 'public'
+       AND table_name = 'booking_origins'
+       AND column_name = 'proposal_version_id'
+  ) THEN
+    ALTER TABLE "booking_origins" RENAME COLUMN "quote_version_id" TO "proposal_version_id";
+  END IF;
+
+  IF to_regclass('public.idx_booking_origins_quote_version') IS NOT NULL
+     AND to_regclass('public.idx_booking_origins_proposal_version') IS NULL THEN
+    ALTER INDEX "public"."idx_booking_origins_quote_version"
+      RENAME TO "idx_booking_origins_proposal_version";
+  END IF;
+END $$;--> statement-breakpoint
+-- `origin_source` is plain text fenced by a CHECK, so the stored value has to be
+-- rewritten. Drop the constraint first: the legacy definition rejects the new
+-- value, and the current definition rejects the legacy one.
+ALTER TABLE "booking_origins" DROP CONSTRAINT IF EXISTS "ck_booking_origins_source";--> statement-breakpoint
+UPDATE "booking_origins"
+   SET "origin_source" = 'accepted_proposal_version',
+       "updated_at" = now()
+ WHERE "origin_source" = 'accepted_quote_version';--> statement-breakpoint
+ALTER TABLE "booking_origins" ADD CONSTRAINT "ck_booking_origins_source" CHECK ("booking_origins"."origin_source" IN ('manual', 'direct_b2c', 'accepted_proposal_version', 'catalog_price_availability', 'catalog_snapshot', 'provider_source_order', 'legacy_transaction'));

--- a/packages/bookings/migrations/meta/_journal.json
+++ b/packages/bookings/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1785700800000,
       "tag": "20260802200000_booking_v1_status_cutover",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1785801780000,
+      "tag": "20260804000300_booking_origin_proposal_version",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/custom-fields/migrations/20260804000500_proposal_custom_field_entity.sql
+++ b/packages/custom-fields/migrations/20260804000500_proposal_custom_field_entity.sql
@@ -1,0 +1,31 @@
+-- Retarget custom field definitions from `quote` to `proposal` (voyant#4143).
+--
+-- `custom_field_definitions.entity_type` is plain TEXT here (this package took
+-- authority for it and widened the column off the `custom_field_target` enum),
+-- so the enum relabelling in `relationships/20260804000100` does NOT reach the
+-- stored values. The registry looks definitions up by exact entity key
+-- (`eq(customFieldDefinitions.entityType, entity)`), so a deployment
+-- provisioned before the quotes → proposals rename would silently show no
+-- custom fields on proposals at all.
+--
+-- Guarded on the column having actually been widened to text: while it is still
+-- the `custom_field_target` enum the relabelling owns the value, and the later
+-- `USING entity_type::text` widening carries the new label across. A pre-rename
+-- database has no `proposal` definitions (the entity did not exist), so the
+-- uniqueness indexes on `(entity_type, key)` cannot collide; if one somehow
+-- does, failing loudly is correct.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = 'public'
+       AND table_name = 'custom_field_definitions'
+       AND column_name = 'entity_type'
+       AND data_type = 'text'
+  ) THEN
+    UPDATE "custom_field_definitions"
+       SET "entity_type" = 'proposal',
+           "updated_at" = now()
+     WHERE "entity_type" = 'quote';
+  END IF;
+END $$;

--- a/packages/custom-fields/migrations/meta/_journal.json
+++ b/packages/custom-fields/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1784192460000,
       "tag": "20260716000100_custom_field_namespace_ownership",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1785801900000,
+      "tag": "20260804000500_proposal_custom_field_entity",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/migrations/20260804000600_proposal_permission_resource.sql
+++ b/packages/db/migrations/20260804000600_proposal_permission_resource.sql
@@ -1,0 +1,61 @@
+-- Rename the `quotes` permission resource to `proposals` (voyant#4143).
+--
+-- Member and API-key permissions are stored as a `{resource: [action, …]}` map:
+-- `user_profiles.permissions` as jsonb, `apikey.permissions` as a JSON string.
+-- The quotes → proposals rename renamed the resource in the access catalog, and
+-- `assertKnownPermissions` REJECTS a resource the catalog does not list — so on
+-- a deployment provisioned before the rename every stored grant carrying
+-- `quotes` is both ineffective (proposals routes see no grant) and a hard
+-- validation error the moment those permissions are re-saved.
+--
+-- Both statements are guarded on the old key being present and the new one
+-- absent, so they are no-ops after the rename and on a re-run.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = 'public'
+       AND table_name = 'user_profiles'
+       AND column_name = 'permissions'
+       AND data_type = 'jsonb'
+  ) THEN
+    UPDATE "user_profiles"
+       SET "permissions" =
+             ("permissions" - 'quotes')
+             || jsonb_build_object('proposals', "permissions" -> 'quotes')
+     WHERE "permissions" IS NOT NULL
+       AND jsonb_typeof("permissions") = 'object'
+       AND "permissions" ? 'quotes'
+       AND NOT ("permissions" ? 'proposals');
+  END IF;
+END $$;--> statement-breakpoint
+-- `apikey.permissions` is TEXT holding JSON written by the auth library. Cast
+-- per row inside an exception handler so a row holding something that is not a
+-- JSON object is left alone rather than failing the whole migration.
+DO $$
+DECLARE
+  row_id text;
+  parsed jsonb;
+BEGIN
+  IF to_regclass('public.apikey') IS NULL THEN
+    RETURN;
+  END IF;
+
+  FOR row_id IN SELECT "id" FROM "apikey" WHERE "permissions" IS NOT NULL LOOP
+    BEGIN
+      SELECT "permissions"::jsonb INTO parsed FROM "apikey" WHERE "id" = row_id;
+    EXCEPTION WHEN others THEN
+      CONTINUE; -- not JSON; nothing this migration can or should do with it
+    END;
+
+    IF parsed IS NOT NULL
+       AND jsonb_typeof(parsed) = 'object'
+       AND parsed ? 'quotes'
+       AND NOT (parsed ? 'proposals') THEN
+      UPDATE "apikey"
+         SET "permissions" =
+               ((parsed - 'quotes') || jsonb_build_object('proposals', parsed -> 'quotes'))::text
+       WHERE "id" = row_id;
+    END IF;
+  END LOOP;
+END $$;

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1785605400000,
       "tag": "20260801173000_storefront_channel_binding_cutover",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1785801960000,
+      "tag": "20260804000600_proposal_permission_resource",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/framework-migrations/migrations/0011_adopt_legacy_quote_objects.sql
+++ b/packages/framework-migrations/migrations/0011_adopt_legacy_quote_objects.sql
@@ -1,0 +1,395 @@
+-- Adopt the objects the retired `quotes` module left behind (voyant#4143).
+--
+-- The framework bundle is the standard profile's own migration source, so it
+-- carries the same quotes -> proposals adoption the package sources ship as
+-- their own post-cutline increments. Both are guarded end to end and idempotent,
+-- so a deployment that runs BOTH paths converges to the same schema and the
+-- second pass changes nothing.
+--
+-- The bundle's frozen cutline slice (0000..0007) is not touched; the rename is
+-- expressed here as an append, the way every other bundle upgrade step is.
+-- proposals
+DO $$
+DECLARE
+  -- Enum TYPES the module owns. Renamed before the tables so the column type
+  -- references follow automatically.
+  type_renames text[] := ARRAY[
+    'quote_status', 'proposal_status',
+    'quote_version_status', 'proposal_version_status'
+  ];
+  table_renames text[] := ARRAY[
+    'quotes', 'proposals',
+    'quote_versions', 'proposal_versions',
+    'quote_participants', 'proposal_participants',
+    'quote_products', 'proposal_products',
+    'quote_version_lines', 'proposal_version_lines',
+    'quote_media', 'proposal_media',
+    'quote_proposal_delivery_requests', 'proposal_delivery_requests',
+    'booking_crm_details', 'booking_proposal_details'
+  ];
+BEGIN
+  FOR i IN 1 .. array_length(type_renames, 1) BY 2 LOOP
+    IF EXISTS (
+      SELECT 1 FROM pg_type t
+        JOIN pg_namespace n ON n.oid = t.typnamespace
+       WHERE n.nspname = 'public' AND t.typname = type_renames[i]
+    ) AND NOT EXISTS (
+      SELECT 1 FROM pg_type t
+        JOIN pg_namespace n ON n.oid = t.typnamespace
+       WHERE n.nspname = 'public' AND t.typname = type_renames[i + 1]
+    ) THEN
+      EXECUTE format('ALTER TYPE public.%I RENAME TO %I', type_renames[i], type_renames[i + 1]);
+    END IF;
+  END LOOP;
+
+  FOR i IN 1 .. array_length(table_renames, 1) BY 2 LOOP
+    IF to_regclass('public.' || quote_ident(table_renames[i])) IS NOT NULL
+       AND to_regclass('public.' || quote_ident(table_renames[i + 1])) IS NULL THEN
+      EXECUTE format('ALTER TABLE public.%I RENAME TO %I', table_renames[i], table_renames[i + 1]);
+    END IF;
+  END LOOP;
+END $$;--> statement-breakpoint
+-- Columns, addressed by their POST-rename table names.
+DO $$
+DECLARE
+  column_renames text[] := ARRAY[
+    'proposal_versions', 'quote_id', 'proposal_id',
+    'proposal_participants', 'quote_id', 'proposal_id',
+    'proposal_products', 'quote_id', 'proposal_id',
+    'proposal_media', 'quote_id', 'proposal_id',
+    'proposal_version_lines', 'quote_version_id', 'proposal_version_id',
+    'proposal_delivery_requests', 'quote_id', 'proposal_id',
+    'proposal_delivery_requests', 'quote_version_id', 'proposal_version_id',
+    'booking_proposal_details', 'quote_id', 'proposal_id',
+    'booking_proposal_details', 'quote_version_id', 'proposal_version_id'
+  ];
+BEGIN
+  FOR i IN 1 .. array_length(column_renames, 1) BY 3 LOOP
+    IF EXISTS (
+      SELECT 1 FROM information_schema.columns
+       WHERE table_schema = 'public'
+         AND table_name = column_renames[i]
+         AND column_name = column_renames[i + 1]
+    ) AND NOT EXISTS (
+      SELECT 1 FROM information_schema.columns
+       WHERE table_schema = 'public'
+         AND table_name = column_renames[i]
+         AND column_name = column_renames[i + 2]
+    ) THEN
+      EXECUTE format(
+        'ALTER TABLE public.%I RENAME COLUMN %I TO %I',
+        column_renames[i], column_renames[i + 1], column_renames[i + 2]
+      );
+    END IF;
+  END LOOP;
+END $$;--> statement-breakpoint
+-- Constraints (primary keys and foreign keys). Renaming a primary-key
+-- constraint renames its backing index too, so those are not listed again below.
+DO $$
+DECLARE
+  owner_table text;
+  constraint_renames text[] := ARRAY[
+    'proposals', 'quotes_pkey', 'proposals_pkey',
+    'proposals', 'quotes_pipeline_id_pipelines_id_fk', 'proposals_pipeline_id_pipelines_id_fk',
+    'proposals', 'quotes_stage_id_stages_id_fk', 'proposals_stage_id_stages_id_fk',
+    'proposal_versions', 'quote_versions_pkey', 'proposal_versions_pkey',
+    'proposal_versions', 'quote_versions_quote_id_quotes_id_fk', 'proposal_versions_proposal_id_proposals_id_fk',
+    'proposal_versions', 'quote_versions_supersedes_id_quote_versions_id_fk', 'proposal_versions_supersedes_id_proposal_versions_id_fk',
+    'proposal_participants', 'quote_participants_pkey', 'proposal_participants_pkey',
+    'proposal_participants', 'quote_participants_quote_id_quotes_id_fk', 'proposal_participants_proposal_id_proposals_id_fk',
+    'proposal_products', 'quote_products_pkey', 'proposal_products_pkey',
+    'proposal_products', 'quote_products_quote_id_quotes_id_fk', 'proposal_products_proposal_id_proposals_id_fk',
+    'proposal_version_lines', 'quote_version_lines_pkey', 'proposal_version_lines_pkey',
+    'proposal_version_lines', 'quote_version_lines_quote_version_id_quote_versions_id_fk', 'proposal_version_lines_proposal_version_id_proposal_versions_id_fk',
+    'proposal_media', 'quote_media_pkey', 'proposal_media_pkey',
+    'proposal_media', 'quote_media_quote_id_quotes_id_fk', 'proposal_media_proposal_id_proposals_id_fk',
+    'proposal_delivery_requests', 'quote_proposal_delivery_requests_pkey', 'proposal_delivery_requests_pkey',
+    'proposal_delivery_requests', 'quote_proposal_delivery_requests_quote_id_quotes_id_fk', 'proposal_delivery_requests_proposal_id_proposals_id_fk',
+    'proposal_delivery_requests', 'quote_proposal_delivery_requests_quote_version_id_quote_versions_id_fk', 'proposal_delivery_requests_proposal_version_id_proposal_versions_id_fk',
+    'booking_proposal_details', 'booking_crm_details_pkey', 'booking_proposal_details_pkey'
+  ];
+BEGIN
+  FOR i IN 1 .. array_length(constraint_renames, 1) BY 3 LOOP
+    owner_table := constraint_renames[i];
+    IF to_regclass('public.' || quote_ident(owner_table)) IS NOT NULL
+       AND EXISTS (
+         SELECT 1 FROM pg_constraint c
+          WHERE c.conrelid = to_regclass('public.' || quote_ident(owner_table))
+            AND c.conname = constraint_renames[i + 1]
+       )
+       AND NOT EXISTS (
+         SELECT 1 FROM pg_constraint c
+          WHERE c.conrelid = to_regclass('public.' || quote_ident(owner_table))
+            AND c.conname = constraint_renames[i + 2]
+       ) THEN
+      EXECUTE format(
+        'ALTER TABLE public.%I RENAME CONSTRAINT %I TO %I',
+        owner_table, constraint_renames[i + 1], constraint_renames[i + 2]
+      );
+    END IF;
+  END LOOP;
+END $$;--> statement-breakpoint
+-- Plain indexes.
+DO $$
+DECLARE
+  index_renames text[] := ARRAY[
+    'idx_bcd_quote', 'idx_booking_proposal_details_proposal',
+    'idx_bcd_quote_version', 'idx_booking_proposal_details_proposal_version',
+    'idx_quote_media_quote', 'idx_proposal_media_proposal',
+    'idx_quote_media_quote_sort', 'idx_proposal_media_proposal_sort',
+    'idx_quote_participants_quote', 'idx_proposal_participants_proposal',
+    'idx_quote_participants_quote_primary', 'idx_proposal_participants_proposal_primary',
+    'idx_quote_participants_person', 'idx_proposal_participants_person',
+    'uidx_quote_participants_unique', 'uidx_proposal_participants_unique',
+    'idx_quote_products_quote', 'idx_proposal_products_proposal',
+    'idx_quote_products_quote_created', 'idx_proposal_products_proposal_created',
+    'idx_quote_products_product', 'idx_proposal_products_product',
+    'idx_quote_products_supplier_service', 'idx_proposal_products_supplier_service',
+    'idx_quote_version_lines_version', 'idx_proposal_version_lines_version',
+    'idx_quote_version_lines_version_created', 'idx_proposal_version_lines_version_created',
+    'idx_quote_version_lines_product', 'idx_proposal_version_lines_product',
+    'idx_quote_version_lines_supplier_service', 'idx_proposal_version_lines_supplier_service',
+    'idx_quote_versions_quote', 'idx_proposal_versions_proposal',
+    'idx_quote_versions_status', 'idx_proposal_versions_status',
+    'idx_quote_versions_supersedes', 'idx_proposal_versions_supersedes',
+    'idx_quote_versions_trip_snapshot', 'idx_proposal_versions_trip_snapshot',
+    'idx_quote_versions_quote_updated', 'idx_proposal_versions_proposal_updated',
+    'idx_quote_versions_status_updated', 'idx_proposal_versions_status_updated',
+    'idx_quotes_person', 'idx_proposals_person',
+    'idx_quotes_org', 'idx_proposals_org',
+    'idx_quotes_pipeline', 'idx_proposals_pipeline',
+    'idx_quotes_stage', 'idx_proposals_stage',
+    'idx_quotes_owner', 'idx_proposals_owner',
+    'idx_quotes_status', 'idx_proposals_status',
+    'idx_quotes_accepted_version', 'idx_proposals_accepted_version',
+    'idx_quotes_person_updated', 'idx_proposals_person_updated',
+    'idx_quotes_org_updated', 'idx_proposals_org_updated',
+    'idx_quotes_pipeline_updated', 'idx_proposals_pipeline_updated',
+    'idx_quotes_stage_updated', 'idx_proposals_stage_updated',
+    'idx_quotes_owner_updated', 'idx_proposals_owner_updated',
+    'idx_quotes_status_updated', 'idx_proposals_status_updated',
+    'idx_quote_proposal_delivery_requests_quote', 'idx_proposal_delivery_requests_proposal',
+    'uidx_quote_proposal_delivery_requests_version', 'uidx_proposal_delivery_requests_version',
+    'uidx_quote_proposal_delivery_requests_command', 'uidx_proposal_delivery_requests_command',
+    'uidx_quote_proposal_delivery_requests_claim', 'uidx_proposal_delivery_requests_claim'
+  ];
+BEGIN
+  FOR i IN 1 .. array_length(index_renames, 1) BY 2 LOOP
+    IF to_regclass('public.' || quote_ident(index_renames[i])) IS NOT NULL
+       AND to_regclass('public.' || quote_ident(index_renames[i + 1])) IS NULL THEN
+      EXECUTE format('ALTER INDEX public.%I RENAME TO %I', index_renames[i], index_renames[i + 1]);
+    END IF;
+  END LOOP;
+END $$;--> statement-breakpoint
+-- The default pipeline seeded by the retired `quotes/20260727200000` migration
+-- named its third stage "Quote Sent". Relabel it only while it is still exactly
+-- the row that migration wrote — an operator who renamed their own stage keeps it.
+UPDATE "stages"
+   SET "name" = 'Proposal Sent',
+       "updated_at" = now()
+ WHERE "id" = 'stg_default_quote_sent'
+   AND "name" = 'Quote Sent';
+--> statement-breakpoint
+-- relationships
+DO $$
+DECLARE
+  label_renames text[] := ARRAY[
+    'entity_type', 'quote', 'proposal',
+    'custom_field_target', 'quote', 'proposal'
+  ];
+BEGIN
+  FOR i IN 1 .. array_length(label_renames, 1) BY 3 LOOP
+    IF EXISTS (
+      SELECT 1 FROM pg_enum e
+        JOIN pg_type t ON t.oid = e.enumtypid
+        JOIN pg_namespace n ON n.oid = t.typnamespace
+       WHERE n.nspname = 'public'
+         AND t.typname = label_renames[i]
+         AND e.enumlabel = label_renames[i + 1]
+    ) AND NOT EXISTS (
+      SELECT 1 FROM pg_enum e
+        JOIN pg_type t ON t.oid = e.enumtypid
+        JOIN pg_namespace n ON n.oid = t.typnamespace
+       WHERE n.nspname = 'public'
+         AND t.typname = label_renames[i]
+         AND e.enumlabel = label_renames[i + 2]
+    ) THEN
+      EXECUTE format(
+        'ALTER TYPE public.%I RENAME VALUE %L TO %L',
+        label_renames[i], label_renames[i + 1], label_renames[i + 2]
+      );
+    END IF;
+  END LOOP;
+END $$;
+--> statement-breakpoint
+-- legal
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_enum e
+      JOIN pg_type t ON t.oid = e.enumtypid
+      JOIN pg_namespace n ON n.oid = t.typnamespace
+     WHERE n.nspname = 'public'
+       AND t.typname = 'legal_target_kind'
+       AND e.enumlabel = 'quote_version'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM pg_enum e
+      JOIN pg_type t ON t.oid = e.enumtypid
+      JOIN pg_namespace n ON n.oid = t.typnamespace
+     WHERE n.nspname = 'public'
+       AND t.typname = 'legal_target_kind'
+       AND e.enumlabel = 'proposal_version'
+  ) THEN
+    ALTER TYPE "public"."legal_target_kind" RENAME VALUE 'quote_version' TO 'proposal_version';
+  END IF;
+END $$;
+--> statement-breakpoint
+-- bookings
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = 'public'
+       AND table_name = 'booking_origins'
+       AND column_name = 'quote_version_id'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = 'public'
+       AND table_name = 'booking_origins'
+       AND column_name = 'proposal_version_id'
+  ) THEN
+    ALTER TABLE "booking_origins" RENAME COLUMN "quote_version_id" TO "proposal_version_id";
+  END IF;
+
+  IF to_regclass('public.idx_booking_origins_quote_version') IS NOT NULL
+     AND to_regclass('public.idx_booking_origins_proposal_version') IS NULL THEN
+    ALTER INDEX "public"."idx_booking_origins_quote_version"
+      RENAME TO "idx_booking_origins_proposal_version";
+  END IF;
+END $$;--> statement-breakpoint
+-- `origin_source` is plain text fenced by a CHECK, so the stored value has to be
+-- rewritten. Drop the constraint first: the legacy definition rejects the new
+-- value, and the current definition rejects the legacy one.
+ALTER TABLE "booking_origins" DROP CONSTRAINT IF EXISTS "ck_booking_origins_source";--> statement-breakpoint
+UPDATE "booking_origins"
+   SET "origin_source" = 'accepted_proposal_version',
+       "updated_at" = now()
+ WHERE "origin_source" = 'accepted_quote_version';--> statement-breakpoint
+ALTER TABLE "booking_origins" ADD CONSTRAINT "ck_booking_origins_source" CHECK ("booking_origins"."origin_source" IN ('manual', 'direct_b2c', 'accepted_proposal_version', 'catalog_price_availability', 'catalog_snapshot', 'provider_source_order', 'legacy_transaction'));
+--> statement-breakpoint
+-- mice
+DO $$
+BEGIN
+  IF to_regclass('public.quotes_quote_mice_program') IS NOT NULL
+     AND to_regclass('public.proposals_proposal_mice_program') IS NULL THEN
+    ALTER TABLE "quotes_quote_mice_program" RENAME TO "proposals_proposal_mice_program";
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = 'public'
+       AND table_name = 'proposals_proposal_mice_program'
+       AND column_name = 'quotes_quote_id'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = 'public'
+       AND table_name = 'proposals_proposal_mice_program'
+       AND column_name = 'proposals_proposal_id'
+  ) THEN
+    ALTER TABLE "proposals_proposal_mice_program"
+      RENAME COLUMN "quotes_quote_id" TO "proposals_proposal_id";
+  END IF;
+
+  IF to_regclass('public.proposals_proposal_mice_program') IS NOT NULL
+     AND EXISTS (
+       SELECT 1 FROM pg_constraint
+        WHERE conrelid = to_regclass('public.proposals_proposal_mice_program')
+          AND conname = 'quotes_quote_mice_program_pkey'
+     ) THEN
+    ALTER TABLE "proposals_proposal_mice_program"
+      RENAME CONSTRAINT "quotes_quote_mice_program_pkey" TO "proposals_proposal_mice_program_pkey";
+  END IF;
+END $$;--> statement-breakpoint
+DO $$
+DECLARE
+  index_renames text[] := ARRAY[
+    'quotes_quote_mice_program_pair_idx', 'proposals_proposal_mice_program_pair_idx',
+    'quotes_quote_mice_program_l_uniq', 'proposals_proposal_mice_program_l_uniq',
+    'quotes_quote_mice_program_r_uniq', 'proposals_proposal_mice_program_r_uniq'
+  ];
+BEGIN
+  FOR i IN 1 .. array_length(index_renames, 1) BY 2 LOOP
+    IF to_regclass('public.' || quote_ident(index_renames[i])) IS NOT NULL
+       AND to_regclass('public.' || quote_ident(index_renames[i + 1])) IS NULL THEN
+      EXECUTE format('ALTER INDEX public.%I RENAME TO %I', index_renames[i], index_renames[i + 1]);
+    END IF;
+  END LOOP;
+END $$;
+--> statement-breakpoint
+-- custom-fields
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = 'public'
+       AND table_name = 'custom_field_definitions'
+       AND column_name = 'entity_type'
+       AND data_type = 'text'
+  ) THEN
+    UPDATE "custom_field_definitions"
+       SET "entity_type" = 'proposal',
+           "updated_at" = now()
+     WHERE "entity_type" = 'quote';
+  END IF;
+END $$;
+--> statement-breakpoint
+-- db
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = 'public'
+       AND table_name = 'user_profiles'
+       AND column_name = 'permissions'
+       AND data_type = 'jsonb'
+  ) THEN
+    UPDATE "user_profiles"
+       SET "permissions" =
+             ("permissions" - 'quotes')
+             || jsonb_build_object('proposals', "permissions" -> 'quotes')
+     WHERE "permissions" IS NOT NULL
+       AND jsonb_typeof("permissions") = 'object'
+       AND "permissions" ? 'quotes'
+       AND NOT ("permissions" ? 'proposals');
+  END IF;
+END $$;--> statement-breakpoint
+-- `apikey.permissions` is TEXT holding JSON written by the auth library. Cast
+-- per row inside an exception handler so a row holding something that is not a
+-- JSON object is left alone rather than failing the whole migration.
+DO $$
+DECLARE
+  row_id text;
+  parsed jsonb;
+BEGIN
+  IF to_regclass('public.apikey') IS NULL THEN
+    RETURN;
+  END IF;
+
+  FOR row_id IN SELECT "id" FROM "apikey" WHERE "permissions" IS NOT NULL LOOP
+    BEGIN
+      SELECT "permissions"::jsonb INTO parsed FROM "apikey" WHERE "id" = row_id;
+    EXCEPTION WHEN others THEN
+      CONTINUE; -- not JSON; nothing this migration can or should do with it
+    END;
+
+    IF parsed IS NOT NULL
+       AND jsonb_typeof(parsed) = 'object'
+       AND parsed ? 'quotes'
+       AND NOT (parsed ? 'proposals') THEN
+      UPDATE "apikey"
+         SET "permissions" =
+               ((parsed - 'quotes') || jsonb_build_object('proposals', parsed -> 'quotes'))::text
+       WHERE "id" = row_id;
+    END IF;
+  END LOOP;
+END $$;

--- a/packages/framework-migrations/migrations/meta/_journal.json
+++ b/packages/framework-migrations/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1784674188000,
       "tag": "0010_retire_workflow_runs",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1785801900000,
+      "tag": "0011_adopt_legacy_quote_objects",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/framework-migrations/src/collector.test.ts
+++ b/packages/framework-migrations/src/collector.test.ts
@@ -218,6 +218,155 @@ describe("migration hash compatibility", () => {
       ),
     ).rejects.toBeInstanceOf(MigrationImmutabilityError)
   })
+
+  const relationshipsBaseline = readFileSync(
+    new URL("../../relationships/migrations/0000_relationships_baseline.sql", import.meta.url),
+    "utf8",
+  )
+
+  it("accepts the pre-rename relationships baseline recorded before quotes became proposals", async () => {
+    const client: MigrationClient = {
+      async query(sql: string) {
+        if (sql.includes(`SELECT "content_hash"`)) {
+          return {
+            rows: [
+              // the bytes this file shipped with before #4004 renamed
+              // `entity_type.quote` to `entity_type.proposal` in place.
+              {
+                content_hash: "2660a70a27fed3157299303cf022af08d5bc2f1628acc27d74f0465e1f82e198",
+              },
+            ],
+          }
+        }
+        return { rows: [] }
+      },
+    }
+
+    await expect(
+      applyMigrations(
+        client,
+        [
+          {
+            name: "relationships",
+            priority: 0,
+            migrations: [{ tag: "0000_relationships_baseline", sql: relationshipsBaseline }],
+          },
+        ],
+        ledgerOpts,
+      ),
+    ).resolves.toEqual({ executed: [], baselined: [] })
+  })
+
+  it("still rejects an unrelated hash for the relationships baseline", async () => {
+    const client: MigrationClient = {
+      async query(sql: string) {
+        if (sql.includes(`SELECT "content_hash"`)) {
+          return { rows: [{ content_hash: "unrelated-hash" }] }
+        }
+        return { rows: [] }
+      },
+    }
+
+    await expect(
+      applyMigrations(
+        client,
+        [
+          {
+            name: "relationships",
+            priority: 0,
+            migrations: [{ tag: "0000_relationships_baseline", sql: relationshipsBaseline }],
+          },
+        ],
+        ledgerOpts,
+      ),
+    ).rejects.toBeInstanceOf(MigrationImmutabilityError)
+  })
+})
+
+/** The retired `quotes` ledger identities `proposals/0000_proposals_baseline` replaces. */
+const RETIRED_QUOTES_TAGS = [
+  "0000_quotes_baseline",
+  "0001_proposal_delivery_requests",
+  "0002_durable_quote_delivery",
+  "20260716000301_namespace_custom_field_values",
+  "20260727200000_default_quote_pipeline",
+] as const
+
+function supersessionClient(recordedQuotesTags: readonly string[]) {
+  const queries: string[] = []
+  const inserted: Array<{ source: string; tag: string }> = []
+  const client: MigrationClient = {
+    async query(sql, params = []) {
+      queries.push(sql)
+      if (sql.includes(`SELECT "content_hash", "source"`)) return { rows: [] }
+      if (sql.includes("unnest($1::text[], $2::text[])")) {
+        const tags = params[1] as string[]
+        return {
+          rows: tags
+            .filter((tag) => recordedQuotesTags.includes(tag))
+            .map((tag) => ({ source: "quotes", tag })),
+        }
+      }
+      if (sql.startsWith("INSERT INTO")) {
+        inserted.push({ source: params[0] as string, tag: params[1] as string })
+      }
+      return { rows: [] }
+    },
+  }
+  return { client, queries, inserted }
+}
+
+const proposalsBaselineSource: MigrationSource = {
+  name: "proposals",
+  priority: 0,
+  migrations: [
+    { tag: "0000_proposals_baseline", sql: `CREATE TABLE "proposals" (\n\t"id" text\n);` },
+  ],
+}
+
+describe("retired-source supersession", () => {
+  it("records the proposals baseline without executing when the whole quotes ledger is present", async () => {
+    const { client, queries, inserted } = supersessionClient(RETIRED_QUOTES_TAGS)
+
+    await expect(applyMigrations(client, [proposalsBaselineSource], ledgerOpts)).resolves.toEqual({
+      executed: [],
+      baselined: ["proposals/0000_proposals_baseline"],
+    })
+    expect(inserted).toEqual([{ source: "proposals", tag: "0000_proposals_baseline" }])
+    expect(queries).not.toContain("BEGIN")
+    expect(queries.some((sql) => sql.startsWith(`CREATE TABLE "proposals"`))).toBe(false)
+  })
+
+  it("executes normally on a fresh database with no quotes ledger at all", async () => {
+    const { client, queries } = supersessionClient([])
+
+    await expect(applyMigrations(client, [proposalsBaselineSource], ledgerOpts)).resolves.toEqual({
+      executed: ["proposals/0000_proposals_baseline"],
+      baselined: [],
+    })
+    expect(queries).toContain("BEGIN")
+  })
+
+  it("does NOT adopt a partially-migrated quotes ledger — the legacy objects are not at the superseding shape", async () => {
+    const { client, queries } = supersessionClient(RETIRED_QUOTES_TAGS.slice(0, 3))
+
+    await expect(applyMigrations(client, [proposalsBaselineSource], ledgerOpts)).resolves.toEqual({
+      executed: ["proposals/0000_proposals_baseline"],
+      baselined: [],
+    })
+    // On a real database the CREATE TABLE then fails loudly, which is the point:
+    // a half-migrated legacy source must never be recorded as adopted.
+    expect(queries).toContain("BEGIN")
+  })
+
+  it("leaves an unrelated source's baseline on the ordinary execute path", async () => {
+    const { client, queries } = supersessionClient(RETIRED_QUOTES_TAGS)
+
+    await expect(
+      applyMigrations(client, [{ ...proposalsBaselineSource, name: "trips" }], ledgerOpts),
+    ).resolves.toEqual({ executed: ["trips/0000_proposals_baseline"], baselined: [] })
+    expect(queries.some((sql) => sql.includes("unnest($1::text[], $2::text[])"))).toBe(false)
+  })
 })
 
 describe("migration source aliases", () => {

--- a/packages/framework-migrations/src/collector.ts
+++ b/packages/framework-migrations/src/collector.ts
@@ -142,6 +142,77 @@ const ACTION_LEDGER_0000_HASHES = [
   "d63e6a73b58f985888e258b318255eba5181db307438b25f3d262350f837b2ce",
   "2c1f05738aedd395ffdecc7d5000144a41e6af7e7a85b85563302e89bb1f4f6c",
 ] as const
+// The quotes → proposals module rename (#4004) followed the new vocabulary into
+// eight already-shipped migrations owned by OTHER sources, renaming the shared
+// objects they declare: `booking_origins.proposal_version_id` and its index and
+// CHECK, the `entity_type` / `custom_field_target` / `legal_target_kind` enum
+// members, and the MICE link table. Each pair below is (pre-rename bytes,
+// post-rename bytes) of one such file.
+//
+// Equivalence alone would be WRONG here — it marks a migration applied, so the
+// renames would never run and the database would keep `quote_*` objects while
+// the application queries `proposal_*`. It is sound only BECAUSE each of these
+// sources also ships a post-cutline increment that performs the rename
+// idempotently (`20260804*` in proposals/relationships/legal/bookings/mice, and
+// `0011_adopt_legacy_quote_objects` in the framework bundle). See voyant#4143.
+const PROPOSAL_RENAME_EDITED_HASHES: ReadonlyArray<readonly [string, readonly [string, string]]> = [
+  [
+    "bookings/0000_bookings_baseline",
+    [
+      "cefee9e00d97fa1697c76da2330349e65bd54685ab2da2752efdb842beda7502",
+      "bc05323cc5cffb85ab200161e02974cc2725114d451f9f6fadbd02a5cdf9d445",
+    ],
+  ],
+  [
+    "legal/0000_legal_baseline",
+    [
+      "b30b6a23309ca4a8a5e80296c0d7de43c582aed47146f81ada1d829f351e55e6",
+      "e540418ac73cc4cac1c9f9b3a7be231094c4e899e2097b63070d1aeab1b20ca6",
+    ],
+  ],
+  [
+    "mice/20260713000300_standard_links",
+    [
+      "9f23e3505c4497324b75ce8002b6fec7665b414389a5268bbf7f9c6fdd1c1c84",
+      "d14b57455a2c87882ab1550f5074d1adc4a6c785c12dbe77b2b86ca330725377",
+    ],
+  ],
+  [
+    "relationships/0000_relationships_baseline",
+    [
+      "2660a70a27fed3157299303cf022af08d5bc2f1628acc27d74f0465e1f82e198",
+      "46b4c7170bee83715e2a426cc00edea03942f56c929163c6911ec0af5f23c6bf",
+    ],
+  ],
+  [
+    "relationships/0003_add_booking_custom_field_target",
+    [
+      "a47443332658c35f8bc1c2b8b8e18439be0c689a37dc8c3b07be49ff29acd2d0",
+      "003b6f7c8ee8d144839f674c3077d7403f9dfb3d09a7a481748ce114232e3191",
+    ],
+  ],
+  [
+    "framework/0000_framework_baseline",
+    [
+      "bcc871dce21fd64eac2facf9c86e477753d725733ffa8c2190e9d2d38e396382",
+      "494817097cca7018d5caec1cf6a44242aa62f45c7b438ae1022a552e478c64f1",
+    ],
+  ],
+  [
+    "framework/0003_framework_baseline",
+    [
+      "39de0659dfdf51ba3849679966a9573f7dd157d506ed5dc887bc14724471bfa5",
+      "492dacb13425ec0eefe3141e9530a9d4f995c508aeeac8f8133f9742623b028d",
+    ],
+  ],
+  [
+    "framework/0005_framework_baseline",
+    [
+      "18d4917e9d8f414db6947a780fcba5f729ce41131eef3bce74332635165d4d16",
+      "5028360f0cc33c47da8e9cbbf5ce4881f68259382e935ece943329009ee43524",
+    ],
+  ],
+]
 
 function equivalenceClosure(
   key: string,
@@ -154,7 +225,69 @@ const EQUIVALENT_MIGRATION_HASHES = new Map<string, ReadonlySet<string>>([
   ...equivalenceClosure("db/0001_db_baseline", DB_0001_HASHES),
   ...equivalenceClosure("framework/0004_framework_baseline", FRAMEWORK_0004_HASHES),
   ...equivalenceClosure("action-ledger/0000_action_ledger_baseline", ACTION_LEDGER_0000_HASHES),
+  ...PROPOSAL_RENAME_EDITED_HASHES.flatMap(([key, hashes]) => equivalenceClosure(key, hashes)),
 ])
+
+/**
+ * Migrations that replace a RETIRED source's ledger history wholesale.
+ *
+ * A module rename produces a migration whose objects already exist under their
+ * legacy identity: `proposals/0000_proposals_baseline` declares exactly the
+ * tables the retired `quotes` source built across its five tags. Executing it
+ * against such a database fails (the tables exist); skipping it silently would
+ * be worse. So when EVERY superseded `(source, tag)` is present in the ledger
+ * the migration is RECORDED without executing, and the source's own post-cutline
+ * increment renames the legacy objects into the new shape.
+ *
+ * The condition is all-or-nothing on purpose. A partially-migrated legacy source
+ * means the legacy objects are NOT at the shape the superseding migration
+ * declares, and the run must fail loudly rather than record a false baseline.
+ *
+ * See `docs/architecture/migration-collector-d2.md` and voyant#4143.
+ */
+const SUPERSEDED_LEDGER_IDENTITIES = new Map<
+  string,
+  ReadonlyArray<{ source: string; tag: string }>
+>([
+  [
+    "proposals/0000_proposals_baseline",
+    [
+      { source: "quotes", tag: "0000_quotes_baseline" },
+      { source: "quotes", tag: "0001_proposal_delivery_requests" },
+      { source: "quotes", tag: "0002_durable_quote_delivery" },
+      { source: "quotes", tag: "20260716000301_namespace_custom_field_values" },
+      { source: "quotes", tag: "20260727200000_default_quote_pipeline" },
+    ],
+  ],
+])
+
+/** The retired ledger identities `source/tag` replaces, or an empty list. */
+export function supersededLedgerIdentities(
+  source: string,
+  tag: string,
+): ReadonlyArray<{ source: string; tag: string }> {
+  return SUPERSEDED_LEDGER_IDENTITIES.get(`${source}/${tag}`) ?? []
+}
+
+/**
+ * True when `migration` supersedes a retired source whose history is FULLY
+ * recorded in the ledger — i.e. its objects exist under their legacy identity
+ * and it must be recorded rather than executed.
+ */
+async function isSupersedingRetiredSource(
+  client: MigrationClient,
+  ledger: string,
+  migration: Pick<PlannedMigration, "source" | "tag">,
+): Promise<boolean> {
+  const superseded = supersededLedgerIdentities(migration.source, migration.tag)
+  if (superseded.length === 0) return false
+  const recorded = await client.query(
+    `SELECT "source", "tag" FROM ${ledger}
+      WHERE ("source", "tag") IN (SELECT * FROM unnest($1::text[], $2::text[]))`,
+    [superseded.map((identity) => identity.source), superseded.map((identity) => identity.tag)],
+  )
+  return recorded.rows.length === superseded.length
+}
 
 function isEquivalentMigrationHash(
   migration: Pick<PlannedMigration, "source" | "tag" | "contentHash">,
@@ -334,6 +467,19 @@ async function applyMigrationsInternal(
     }
 
     const id = `${m.source}/${m.tag}`
+
+    if (await isSupersedingRetiredSource(client, ledger, m)) {
+      // The objects exist under the retired source's identity → record without
+      // executing; the source's own increment renames them into this shape.
+      await client.query(
+        `INSERT INTO ${ledger} ("source", "tag", "content_hash") VALUES ($1, $2, $3)
+         ON CONFLICT ("source", "tag") DO NOTHING`,
+        [m.source, m.tag, m.contentHash],
+      )
+      baselined.push(id)
+      options?.onBaselined?.(id)
+      continue
+    }
 
     if (existing && covered.get(m.source)?.has(m.tag)) {
       // Cutline-covered on an existing DB → record without executing.

--- a/packages/framework-migrations/src/deployment-runner.test.ts
+++ b/packages/framework-migrations/src/deployment-runner.test.ts
@@ -119,6 +119,69 @@ describe("runDeploymentMigrations on a partially adopted database", () => {
     expect(result.existing).toBe(true)
   })
 
+  it("records a superseding baseline instead of parity-gating it against the retired source's objects", async () => {
+    // A deployment provisioned before the quotes → proposals rename: the retired
+    // `quotes` source is fully recorded and its objects are live under their
+    // legacy names, so `proposals/0000_proposals_baseline` must be RECORDED
+    // rather than parity-gated (its tables do not yet exist under the new names)
+    // or executed (that would collide with the legacy objects).
+    const retiredQuotesTags = [
+      "0000_quotes_baseline",
+      "0001_proposal_delivery_requests",
+      "0002_durable_quote_delivery",
+      "20260716000301_namespace_custom_field_values",
+      "20260727200000_default_quote_pipeline",
+    ]
+    const executed: string[] = []
+    const inserted: Array<{ source: string; tag: string }> = []
+    const client: MigrationClient = {
+      async query(sql: string, params: unknown[] = []) {
+        if (sql.startsWith("SELECT to_regclass")) return { rows: [{ reg: String(params[0]) }] }
+        if (sql.includes("count(*)")) {
+          return { rows: [{ n: sql.includes(`"source" = 'framework'`) ? "1" : "0" }] }
+        }
+        if (sql.includes('SELECT "source", "tag" FROM') && sql.includes("unnest")) {
+          return { rows: retiredQuotesTags.map((tag) => ({ source: "quotes", tag })) }
+        }
+        if (sql.includes('SELECT "source", "tag" FROM')) {
+          return { rows: retiredQuotesTags.map((tag) => ({ source: "quotes", tag })) }
+        }
+        if (sql.includes('SELECT "content_hash", "source" FROM')) return { rows: [] }
+        if (sql.includes('SELECT DISTINCT "source"')) return { rows: [{ source: "quotes" }] }
+        if (sql.includes("information_schema")) return { rows: [] } // no proposal_* objects yet
+        if (sql.includes("pg_constraint")) return { rows: [] }
+        if (sql.startsWith('CREATE TABLE "')) executed.push(sql)
+        if (sql.startsWith("INSERT INTO") && params.length === 3) {
+          inserted.push({ source: String(params[0]), tag: String(params[1]) })
+        }
+        return { rows: [] }
+      },
+    }
+
+    const result = await runDeploymentMigrations(
+      client,
+      [
+        {
+          name: "proposals",
+          priority: 1,
+          migrations: [
+            {
+              tag: "0000_proposals_baseline",
+              sql: 'CREATE TABLE "proposals" ("id" text PRIMARY KEY);',
+            },
+          ],
+        },
+      ],
+      { proposals: ["0000_proposals_baseline"] },
+    )
+
+    expect(result.existing).toBe(true)
+    expect(result.executed).toEqual([])
+    expect(result.baselined).toEqual(["proposals/0000_proposals_baseline"])
+    expect(executed).toEqual([])
+    expect(inserted).toEqual([{ source: "proposals", tag: "0000_proposals_baseline" }])
+  })
+
   function expansionClient(
     options: {
       existing?: boolean

--- a/packages/framework-migrations/src/deployment-runner.ts
+++ b/packages/framework-migrations/src/deployment-runner.ts
@@ -24,6 +24,7 @@ import {
   MigrationImmutabilityError,
   type PlannedMigration,
   planMigrations,
+  supersededLedgerIdentities,
   VOYANT_MIGRATION_JOURNAL_LINEAGE,
 } from "./collector.js"
 import type { Cutline } from "./cutline.js"
@@ -464,15 +465,21 @@ function withoutCutlineMigrationIds(cutline: Cutline, excluded: ReadonlySet<stri
 }
 
 /**
- * Drop migrations already recorded in the ledger (under the source's stable OR
- * legacy names). The baseline parity gate must only assert the schema of
- * cutline entries it is ABOUT to import-baseline: once an entry is recorded,
- * later post-cutline migrations may legitimately have altered or dropped its
- * objects (e.g. a recorded source's outbox table retired by its own
- * increment), so re-asserting the cutline-era schema on every run would wedge
- * a partially-adopted database forever.
+ * Drop migrations the parity gate must not assert:
+ *
+ *   • already recorded in the ledger (under the source's stable OR legacy
+ *     names). The gate must only assert the schema of cutline entries it is
+ *     ABOUT to import-baseline: once an entry is recorded, later post-cutline
+ *     migrations may legitimately have altered or dropped its objects (e.g. a
+ *     recorded source's outbox table retired by its own increment), so
+ *     re-asserting the cutline-era schema on every run would wedge a
+ *     partially-adopted database forever;
+ *   • superseding a RETIRED source whose history is fully recorded. Its objects
+ *     exist under their legacy names, so the new names the gate would demand are
+ *     correctly absent — {@link applyMigrations} records the entry and the
+ *     source's own increment renames the objects.
  */
-async function withoutRecordedMigrations(
+async function withoutUngatedMigrations(
   client: MigrationClient,
   sources: MigrationSource[],
 ): Promise<MigrationSource[]> {
@@ -487,9 +494,21 @@ async function withoutRecordedMigrations(
   )
   const isRecorded = (source: MigrationSource, tag: string) =>
     [source.name, ...(source.legacyNames ?? [])].some((name) => recorded.has(`${name}\0${tag}`))
+  const supersedesRecordedRetiredSource = (source: MigrationSource, tag: string) => {
+    const superseded = supersededLedgerIdentities(source.name, tag)
+    return (
+      superseded.length > 0 &&
+      superseded.every((identity) => recorded.has(`${identity.source}\0${identity.tag}`))
+    )
+  }
 
   return sources
-    .map((s) => ({ ...s, migrations: s.migrations.filter((m) => !isRecorded(s, m.tag)) }))
+    .map((s) => ({
+      ...s,
+      migrations: s.migrations.filter(
+        (m) => !isRecorded(s, m.tag) && !supersedesRecordedRetiredSource(s, m.tag),
+      ),
+    }))
     .filter((s) => s.migrations.length > 0)
 }
 
@@ -543,7 +562,7 @@ export async function runDeploymentMigrations(
       // already-recorded entries' objects may have been legitimately reshaped by
       // applied post-cutline migrations.
       const pending = withoutMigrationIds(
-        await withoutRecordedMigrations(client, cutlineCovered(sources, cutline)),
+        await withoutUngatedMigrations(client, cutlineCovered(sources, cutline)),
         partiallyAdoptedIds,
       )
       if (pending.length > 0) {

--- a/packages/legal/migrations/20260804000200_proposal_version_target_kind.sql
+++ b/packages/legal/migrations/20260804000200_proposal_version_target_kind.sql
@@ -1,0 +1,28 @@
+-- Relabel `legal_target_kind.quote_version` (voyant#4143).
+--
+-- The enum is owned here and its shipped baseline was edited when `quotes`
+-- became `proposals` (#4004). A deployment provisioned before that release still
+-- has the `quote_version` label, so any legal document attached to a proposal
+-- version carries a target kind the application no longer knows.
+--
+-- RENAME VALUE keeps the label's OID, so existing rows follow without a rewrite.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_enum e
+      JOIN pg_type t ON t.oid = e.enumtypid
+      JOIN pg_namespace n ON n.oid = t.typnamespace
+     WHERE n.nspname = 'public'
+       AND t.typname = 'legal_target_kind'
+       AND e.enumlabel = 'quote_version'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM pg_enum e
+      JOIN pg_type t ON t.oid = e.enumtypid
+      JOIN pg_namespace n ON n.oid = t.typnamespace
+     WHERE n.nspname = 'public'
+       AND t.typname = 'legal_target_kind'
+       AND e.enumlabel = 'proposal_version'
+  ) THEN
+    ALTER TYPE "public"."legal_target_kind" RENAME VALUE 'quote_version' TO 'proposal_version';
+  END IF;
+END $$;

--- a/packages/mice/migrations/20260804000400_proposal_mice_program_link.sql
+++ b/packages/mice/migrations/20260804000400_proposal_mice_program_link.sql
@@ -1,0 +1,57 @@
+-- Rename the proposal ⇄ MICE-programme link table (voyant#4143).
+--
+-- Link tables are named from the two linkables they join, so `quotes.quote`
+-- becoming `proposals.proposal` (#4004) renamed the table and its left-hand
+-- column. The standard-links migration was edited in place, so a deployment
+-- provisioned before that release still has `quotes_quote_mice_program` while
+-- the link service resolves `proposals_proposal_mice_program`.
+--
+-- Guarded end to end: a no-op on a database provisioned after the rename and on
+-- a re-run.
+DO $$
+BEGIN
+  IF to_regclass('public.quotes_quote_mice_program') IS NOT NULL
+     AND to_regclass('public.proposals_proposal_mice_program') IS NULL THEN
+    ALTER TABLE "quotes_quote_mice_program" RENAME TO "proposals_proposal_mice_program";
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = 'public'
+       AND table_name = 'proposals_proposal_mice_program'
+       AND column_name = 'quotes_quote_id'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = 'public'
+       AND table_name = 'proposals_proposal_mice_program'
+       AND column_name = 'proposals_proposal_id'
+  ) THEN
+    ALTER TABLE "proposals_proposal_mice_program"
+      RENAME COLUMN "quotes_quote_id" TO "proposals_proposal_id";
+  END IF;
+
+  IF to_regclass('public.proposals_proposal_mice_program') IS NOT NULL
+     AND EXISTS (
+       SELECT 1 FROM pg_constraint
+        WHERE conrelid = to_regclass('public.proposals_proposal_mice_program')
+          AND conname = 'quotes_quote_mice_program_pkey'
+     ) THEN
+    ALTER TABLE "proposals_proposal_mice_program"
+      RENAME CONSTRAINT "quotes_quote_mice_program_pkey" TO "proposals_proposal_mice_program_pkey";
+  END IF;
+END $$;--> statement-breakpoint
+DO $$
+DECLARE
+  index_renames text[] := ARRAY[
+    'quotes_quote_mice_program_pair_idx', 'proposals_proposal_mice_program_pair_idx',
+    'quotes_quote_mice_program_l_uniq', 'proposals_proposal_mice_program_l_uniq',
+    'quotes_quote_mice_program_r_uniq', 'proposals_proposal_mice_program_r_uniq'
+  ];
+BEGIN
+  FOR i IN 1 .. array_length(index_renames, 1) BY 2 LOOP
+    IF to_regclass('public.' || quote_ident(index_renames[i])) IS NOT NULL
+       AND to_regclass('public.' || quote_ident(index_renames[i + 1])) IS NULL THEN
+      EXECUTE format('ALTER INDEX public.%I RENAME TO %I', index_renames[i], index_renames[i + 1]);
+    END IF;
+  END LOOP;
+END $$;

--- a/packages/mice/migrations/meta/_journal.json
+++ b/packages/mice/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1783890180000,
       "tag": "20260713000300_standard_links",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1785801840000,
+      "tag": "20260804000400_proposal_mice_program_link",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/proposals/migrations/20260804000000_adopt_legacy_quote_objects.sql
+++ b/packages/proposals/migrations/20260804000000_adopt_legacy_quote_objects.sql
@@ -1,0 +1,197 @@
+-- Adopt the objects the retired `quotes` module left behind (voyant#4143).
+--
+-- `quotes` became `proposals` in #4004, and the rename was expressed by editing
+-- shipped baselines in place. A deployment provisioned BEFORE that release still
+-- holds live rows in `quotes`, `quote_versions` and their satellites, and the
+-- proposal-named objects the application queries never come into existence.
+--
+-- This RENAMES the legacy objects rather than creating new ones: the rows must
+-- survive, and every foreign key, index and sequence follows the table it hangs
+-- off. Each step is guarded on the legacy name being present AND the new name
+-- being free, so the whole migration is a no-op on a database provisioned after
+-- the rename (and on a re-run).
+--
+-- The corresponding cross-module objects are renamed by their OWN packages:
+-- `booking_origins.proposal_version_id` (bookings), the `entity_type` /
+-- `custom_field_target` labels (relationships), `legal_target_kind`
+-- (legal) and the MICE link table (mice).
+DO $$
+DECLARE
+  -- Enum TYPES the module owns. Renamed before the tables so the column type
+  -- references follow automatically.
+  type_renames text[] := ARRAY[
+    'quote_status', 'proposal_status',
+    'quote_version_status', 'proposal_version_status'
+  ];
+  table_renames text[] := ARRAY[
+    'quotes', 'proposals',
+    'quote_versions', 'proposal_versions',
+    'quote_participants', 'proposal_participants',
+    'quote_products', 'proposal_products',
+    'quote_version_lines', 'proposal_version_lines',
+    'quote_media', 'proposal_media',
+    'quote_proposal_delivery_requests', 'proposal_delivery_requests',
+    'booking_crm_details', 'booking_proposal_details'
+  ];
+BEGIN
+  FOR i IN 1 .. array_length(type_renames, 1) BY 2 LOOP
+    IF EXISTS (
+      SELECT 1 FROM pg_type t
+        JOIN pg_namespace n ON n.oid = t.typnamespace
+       WHERE n.nspname = 'public' AND t.typname = type_renames[i]
+    ) AND NOT EXISTS (
+      SELECT 1 FROM pg_type t
+        JOIN pg_namespace n ON n.oid = t.typnamespace
+       WHERE n.nspname = 'public' AND t.typname = type_renames[i + 1]
+    ) THEN
+      EXECUTE format('ALTER TYPE public.%I RENAME TO %I', type_renames[i], type_renames[i + 1]);
+    END IF;
+  END LOOP;
+
+  FOR i IN 1 .. array_length(table_renames, 1) BY 2 LOOP
+    IF to_regclass('public.' || quote_ident(table_renames[i])) IS NOT NULL
+       AND to_regclass('public.' || quote_ident(table_renames[i + 1])) IS NULL THEN
+      EXECUTE format('ALTER TABLE public.%I RENAME TO %I', table_renames[i], table_renames[i + 1]);
+    END IF;
+  END LOOP;
+END $$;--> statement-breakpoint
+-- Columns, addressed by their POST-rename table names.
+DO $$
+DECLARE
+  column_renames text[] := ARRAY[
+    'proposal_versions', 'quote_id', 'proposal_id',
+    'proposal_participants', 'quote_id', 'proposal_id',
+    'proposal_products', 'quote_id', 'proposal_id',
+    'proposal_media', 'quote_id', 'proposal_id',
+    'proposal_version_lines', 'quote_version_id', 'proposal_version_id',
+    'proposal_delivery_requests', 'quote_id', 'proposal_id',
+    'proposal_delivery_requests', 'quote_version_id', 'proposal_version_id',
+    'booking_proposal_details', 'quote_id', 'proposal_id',
+    'booking_proposal_details', 'quote_version_id', 'proposal_version_id'
+  ];
+BEGIN
+  FOR i IN 1 .. array_length(column_renames, 1) BY 3 LOOP
+    IF EXISTS (
+      SELECT 1 FROM information_schema.columns
+       WHERE table_schema = 'public'
+         AND table_name = column_renames[i]
+         AND column_name = column_renames[i + 1]
+    ) AND NOT EXISTS (
+      SELECT 1 FROM information_schema.columns
+       WHERE table_schema = 'public'
+         AND table_name = column_renames[i]
+         AND column_name = column_renames[i + 2]
+    ) THEN
+      EXECUTE format(
+        'ALTER TABLE public.%I RENAME COLUMN %I TO %I',
+        column_renames[i], column_renames[i + 1], column_renames[i + 2]
+      );
+    END IF;
+  END LOOP;
+END $$;--> statement-breakpoint
+-- Constraints (primary keys and foreign keys). Renaming a primary-key
+-- constraint renames its backing index too, so those are not listed again below.
+DO $$
+DECLARE
+  owner_table text;
+  constraint_renames text[] := ARRAY[
+    'proposals', 'quotes_pkey', 'proposals_pkey',
+    'proposals', 'quotes_pipeline_id_pipelines_id_fk', 'proposals_pipeline_id_pipelines_id_fk',
+    'proposals', 'quotes_stage_id_stages_id_fk', 'proposals_stage_id_stages_id_fk',
+    'proposal_versions', 'quote_versions_pkey', 'proposal_versions_pkey',
+    'proposal_versions', 'quote_versions_quote_id_quotes_id_fk', 'proposal_versions_proposal_id_proposals_id_fk',
+    'proposal_versions', 'quote_versions_supersedes_id_quote_versions_id_fk', 'proposal_versions_supersedes_id_proposal_versions_id_fk',
+    'proposal_participants', 'quote_participants_pkey', 'proposal_participants_pkey',
+    'proposal_participants', 'quote_participants_quote_id_quotes_id_fk', 'proposal_participants_proposal_id_proposals_id_fk',
+    'proposal_products', 'quote_products_pkey', 'proposal_products_pkey',
+    'proposal_products', 'quote_products_quote_id_quotes_id_fk', 'proposal_products_proposal_id_proposals_id_fk',
+    'proposal_version_lines', 'quote_version_lines_pkey', 'proposal_version_lines_pkey',
+    'proposal_version_lines', 'quote_version_lines_quote_version_id_quote_versions_id_fk', 'proposal_version_lines_proposal_version_id_proposal_versions_id_fk',
+    'proposal_media', 'quote_media_pkey', 'proposal_media_pkey',
+    'proposal_media', 'quote_media_quote_id_quotes_id_fk', 'proposal_media_proposal_id_proposals_id_fk',
+    'proposal_delivery_requests', 'quote_proposal_delivery_requests_pkey', 'proposal_delivery_requests_pkey',
+    'proposal_delivery_requests', 'quote_proposal_delivery_requests_quote_id_quotes_id_fk', 'proposal_delivery_requests_proposal_id_proposals_id_fk',
+    'proposal_delivery_requests', 'quote_proposal_delivery_requests_quote_version_id_quote_versions_id_fk', 'proposal_delivery_requests_proposal_version_id_proposal_versions_id_fk',
+    'booking_proposal_details', 'booking_crm_details_pkey', 'booking_proposal_details_pkey'
+  ];
+BEGIN
+  FOR i IN 1 .. array_length(constraint_renames, 1) BY 3 LOOP
+    owner_table := constraint_renames[i];
+    IF to_regclass('public.' || quote_ident(owner_table)) IS NOT NULL
+       AND EXISTS (
+         SELECT 1 FROM pg_constraint c
+          WHERE c.conrelid = to_regclass('public.' || quote_ident(owner_table))
+            AND c.conname = constraint_renames[i + 1]
+       )
+       AND NOT EXISTS (
+         SELECT 1 FROM pg_constraint c
+          WHERE c.conrelid = to_regclass('public.' || quote_ident(owner_table))
+            AND c.conname = constraint_renames[i + 2]
+       ) THEN
+      EXECUTE format(
+        'ALTER TABLE public.%I RENAME CONSTRAINT %I TO %I',
+        owner_table, constraint_renames[i + 1], constraint_renames[i + 2]
+      );
+    END IF;
+  END LOOP;
+END $$;--> statement-breakpoint
+-- Plain indexes.
+DO $$
+DECLARE
+  index_renames text[] := ARRAY[
+    'idx_bcd_quote', 'idx_booking_proposal_details_proposal',
+    'idx_bcd_quote_version', 'idx_booking_proposal_details_proposal_version',
+    'idx_quote_media_quote', 'idx_proposal_media_proposal',
+    'idx_quote_media_quote_sort', 'idx_proposal_media_proposal_sort',
+    'idx_quote_participants_quote', 'idx_proposal_participants_proposal',
+    'idx_quote_participants_quote_primary', 'idx_proposal_participants_proposal_primary',
+    'idx_quote_participants_person', 'idx_proposal_participants_person',
+    'uidx_quote_participants_unique', 'uidx_proposal_participants_unique',
+    'idx_quote_products_quote', 'idx_proposal_products_proposal',
+    'idx_quote_products_quote_created', 'idx_proposal_products_proposal_created',
+    'idx_quote_products_product', 'idx_proposal_products_product',
+    'idx_quote_products_supplier_service', 'idx_proposal_products_supplier_service',
+    'idx_quote_version_lines_version', 'idx_proposal_version_lines_version',
+    'idx_quote_version_lines_version_created', 'idx_proposal_version_lines_version_created',
+    'idx_quote_version_lines_product', 'idx_proposal_version_lines_product',
+    'idx_quote_version_lines_supplier_service', 'idx_proposal_version_lines_supplier_service',
+    'idx_quote_versions_quote', 'idx_proposal_versions_proposal',
+    'idx_quote_versions_status', 'idx_proposal_versions_status',
+    'idx_quote_versions_supersedes', 'idx_proposal_versions_supersedes',
+    'idx_quote_versions_trip_snapshot', 'idx_proposal_versions_trip_snapshot',
+    'idx_quote_versions_quote_updated', 'idx_proposal_versions_proposal_updated',
+    'idx_quote_versions_status_updated', 'idx_proposal_versions_status_updated',
+    'idx_quotes_person', 'idx_proposals_person',
+    'idx_quotes_org', 'idx_proposals_org',
+    'idx_quotes_pipeline', 'idx_proposals_pipeline',
+    'idx_quotes_stage', 'idx_proposals_stage',
+    'idx_quotes_owner', 'idx_proposals_owner',
+    'idx_quotes_status', 'idx_proposals_status',
+    'idx_quotes_accepted_version', 'idx_proposals_accepted_version',
+    'idx_quotes_person_updated', 'idx_proposals_person_updated',
+    'idx_quotes_org_updated', 'idx_proposals_org_updated',
+    'idx_quotes_pipeline_updated', 'idx_proposals_pipeline_updated',
+    'idx_quotes_stage_updated', 'idx_proposals_stage_updated',
+    'idx_quotes_owner_updated', 'idx_proposals_owner_updated',
+    'idx_quotes_status_updated', 'idx_proposals_status_updated',
+    'idx_quote_proposal_delivery_requests_quote', 'idx_proposal_delivery_requests_proposal',
+    'uidx_quote_proposal_delivery_requests_version', 'uidx_proposal_delivery_requests_version',
+    'uidx_quote_proposal_delivery_requests_command', 'uidx_proposal_delivery_requests_command',
+    'uidx_quote_proposal_delivery_requests_claim', 'uidx_proposal_delivery_requests_claim'
+  ];
+BEGIN
+  FOR i IN 1 .. array_length(index_renames, 1) BY 2 LOOP
+    IF to_regclass('public.' || quote_ident(index_renames[i])) IS NOT NULL
+       AND to_regclass('public.' || quote_ident(index_renames[i + 1])) IS NULL THEN
+      EXECUTE format('ALTER INDEX public.%I RENAME TO %I', index_renames[i], index_renames[i + 1]);
+    END IF;
+  END LOOP;
+END $$;--> statement-breakpoint
+-- The default pipeline seeded by the retired `quotes/20260727200000` migration
+-- named its third stage "Quote Sent". Relabel it only while it is still exactly
+-- the row that migration wrote — an operator who renamed their own stage keeps it.
+UPDATE "stages"
+   SET "name" = 'Proposal Sent',
+       "updated_at" = now()
+ WHERE "id" = 'stg_default_quote_sent'
+   AND "name" = 'Quote Sent';

--- a/packages/proposals/migrations/meta/_journal.json
+++ b/packages/proposals/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1785564135452,
       "tag": "0000_proposals_baseline",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1785801600000,
+      "tag": "20260804000000_adopt_legacy_quote_objects",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/relationships/migrations/20260804000100_proposal_entity_labels.sql
+++ b/packages/relationships/migrations/20260804000100_proposal_entity_labels.sql
@@ -1,0 +1,42 @@
+-- Relabel the `quote` member of the shared entity enums (voyant#4143).
+--
+-- `entity_type` and `custom_field_target` are owned here and were edited in
+-- their shipped baselines when `quotes` became `proposals` (#4004). A deployment
+-- provisioned before that release still has the `quote` label, so `pipelines`,
+-- `activities` and `custom_field_definitions` carry a value the application no
+-- longer knows.
+--
+-- RENAME VALUE keeps the label's OID, so existing rows AND the column defaults
+-- that reference it (`pipelines.entity_type DEFAULT 'quote'`) follow the rename
+-- without a rewrite. Guarded on the old label being present and the new one
+-- absent, so this is a no-op after the rename and on a re-run.
+DO $$
+DECLARE
+  label_renames text[] := ARRAY[
+    'entity_type', 'quote', 'proposal',
+    'custom_field_target', 'quote', 'proposal'
+  ];
+BEGIN
+  FOR i IN 1 .. array_length(label_renames, 1) BY 3 LOOP
+    IF EXISTS (
+      SELECT 1 FROM pg_enum e
+        JOIN pg_type t ON t.oid = e.enumtypid
+        JOIN pg_namespace n ON n.oid = t.typnamespace
+       WHERE n.nspname = 'public'
+         AND t.typname = label_renames[i]
+         AND e.enumlabel = label_renames[i + 1]
+    ) AND NOT EXISTS (
+      SELECT 1 FROM pg_enum e
+        JOIN pg_type t ON t.oid = e.enumtypid
+        JOIN pg_namespace n ON n.oid = t.typnamespace
+       WHERE n.nspname = 'public'
+         AND t.typname = label_renames[i]
+         AND e.enumlabel = label_renames[i + 2]
+    ) THEN
+      EXECUTE format(
+        'ALTER TYPE public.%I RENAME VALUE %L TO %L',
+        label_renames[i], label_renames[i + 1], label_renames[i + 2]
+      );
+    END IF;
+  END LOOP;
+END $$;

--- a/packages/relationships/migrations/meta/_journal.json
+++ b/packages/relationships/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1784192582000,
       "tag": "20260716000302_namespace_custom_field_values",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1785801660000,
+      "tag": "20260804000100_proposal_entity_labels",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/check-proposal-vocabulary.mjs
+++ b/scripts/check-proposal-vocabulary.mjs
@@ -22,6 +22,18 @@ const skippedFiles = new Set([
   "scripts/tests/check-proposal-vocabulary.test.mjs",
 ])
 
+// Retiring the legacy vocabulary from a LIVE database requires naming it: an
+// adoption migration has to say `ALTER TABLE quotes RENAME TO proposals`, and
+// the parity fixtures ARE the pre-rename history byte for byte (voyant#4143).
+// Scoped to the exact artifacts that carry out or verify the rename, so the ban
+// stays exact everywhere else. Nothing may be added here to make new code pass —
+// only frozen history and the migrations that retire it.
+const legacyRenameAdoptionPaths = [
+  /^packages\/framework-migrations\/migrations\/0011_adopt_legacy_quote_objects\.sql$/,
+  /^packages\/(?:bookings|custom-fields|db|legal|mice|proposals|relationships)\/migrations\/20260804\d{6}_[a-z_]+\.sql$/,
+  /^scripts\/fixtures\/pre-proposal-rename\//,
+]
+
 const skippedExtensions = new Set([
   ".avif",
   ".bin",
@@ -131,6 +143,7 @@ function normalizePath(path) {
 function shouldSkipPath(path) {
   const normalized = normalizePath(relative(root, path))
   if (skippedFiles.has(normalized)) return true
+  if (legacyRenameAdoptionPaths.some((pattern) => pattern.test(normalized))) return true
   if (normalized.endsWith("/CHANGELOG.md")) return true
   if (normalized === "pnpm-lock.yaml") return false
   if (skippedExtensions.has(path.slice(path.lastIndexOf(".")).toLowerCase())) return true

--- a/scripts/fixtures/pre-proposal-rename/edited/bookings/0000_bookings_baseline.sql
+++ b/scripts/fixtures/pre-proposal-rename/edited/bookings/0000_bookings_baseline.sql
@@ -1,0 +1,743 @@
+DO $$ BEGIN
+ CREATE TYPE "public"."booking_extra_status" AS ENUM('draft', 'selected', 'confirmed', 'cancelled', 'fulfilled');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."extra_collection_mode" AS ENUM('booking_total', 'cash_on_trip', 'external', 'included', 'none');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."extra_collection_status" AS ENUM('not_required', 'pending', 'collected', 'waived', 'refunded');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."extra_participant_selection_status" AS ENUM('selected', 'cancelled', 'fulfilled', 'no_show');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."extra_pricing_mode" AS ENUM('included', 'per_person', 'per_booking', 'quantity_based', 'on_request', 'free');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."extra_selection_type" AS ENUM('optional', 'required', 'default_selected', 'unavailable');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."booking_answer_target" AS ENUM('booking', 'traveler', 'extra');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."booking_question_field_type" AS ENUM('text', 'textarea', 'number', 'email', 'phone', 'date', 'datetime', 'boolean', 'single_select', 'multi_select', 'file', 'country', 'other');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."booking_question_target" AS ENUM('booking', 'traveler', 'lead_traveler', 'booker', 'extra', 'service');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."booking_question_trigger_mode" AS ENUM('required', 'optional', 'hidden');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."contact_requirement_field" AS ENUM('first_name', 'last_name', 'email', 'phone', 'date_of_birth', 'nationality', 'passport_number', 'passport_expiry', 'dietary_requirements', 'accessibility_needs', 'special_requests', 'address', 'other');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."contact_requirement_scope" AS ENUM('booking', 'lead_traveler', 'traveler', 'booker');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."booking_group_kind" AS ENUM('shared_room', 'cruise_party', 'other');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."booking_group_member_role" AS ENUM('primary', 'shared');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."booking_activity_type" AS ENUM('booking_created', 'booking_reserved', 'booking_converted', 'booking_confirmed', 'booking_started', 'booking_completed', 'hold_extended', 'hold_expired', 'status_change', 'status_overridden', 'item_update', 'allocation_released', 'fulfillment_issued', 'fulfillment_updated', 'redemption_recorded', 'supplier_update', 'traveler_update', 'note_added', 'system_action');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."booking_allocation_status" AS ENUM('held', 'confirmed', 'released', 'expired', 'cancelled', 'fulfilled');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."booking_allocation_type" AS ENUM('unit', 'pickup', 'resource');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."booking_document_type" AS ENUM('visa', 'insurance', 'health', 'passport_copy', 'other');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."booking_fulfillment_delivery_channel" AS ENUM('download', 'email', 'api', 'wallet', 'other');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."booking_fulfillment_status" AS ENUM('pending', 'issued', 'reissued', 'revoked', 'failed');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."booking_fulfillment_type" AS ENUM('voucher', 'ticket', 'pdf', 'qr_code', 'barcode', 'mobile', 'other');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."booking_item_participant_role" AS ENUM('traveler', 'occupant', 'beneficiary', 'other');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."booking_item_status" AS ENUM('draft', 'on_hold', 'confirmed', 'cancelled', 'expired', 'fulfilled');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."booking_item_type" AS ENUM('unit', 'extra', 'service', 'fee', 'tax', 'discount', 'adjustment', 'accommodation', 'transport', 'other');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."booking_participant_type" AS ENUM('traveler', 'occupant', 'other');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."booking_pii_access_action" AS ENUM('read', 'update', 'delete');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."booking_pii_access_outcome" AS ENUM('allowed', 'denied');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."booking_redemption_method" AS ENUM('manual', 'scan', 'api', 'other');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."booking_source_type" AS ENUM('direct', 'manual', 'affiliate', 'ota', 'reseller', 'api_partner', 'internal');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."booking_staff_assignment_role" AS ENUM('service_assignee', 'other');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."booking_status" AS ENUM('draft', 'on_hold', 'awaiting_payment', 'confirmed', 'in_progress', 'completed', 'expired', 'cancelled');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."booking_traveler_category" AS ENUM('adult', 'child', 'infant', 'senior', 'other');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."supplier_confirmation_status" AS ENUM('pending', 'confirmed', 'rejected', 'cancelled');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+CREATE TABLE "booking_extras" (
+	"id" text PRIMARY KEY NOT NULL,
+	"booking_id" text NOT NULL,
+	"product_extra_id" text,
+	"option_extra_config_id" text,
+	"name" text NOT NULL,
+	"description" text,
+	"status" "booking_extra_status" DEFAULT 'draft' NOT NULL,
+	"pricing_mode" "extra_pricing_mode" DEFAULT 'per_booking' NOT NULL,
+	"priced_per_person" boolean DEFAULT false NOT NULL,
+	"quantity" integer DEFAULT 1 NOT NULL,
+	"sell_currency" text NOT NULL,
+	"unit_sell_amount_cents" integer,
+	"total_sell_amount_cents" integer,
+	"cost_currency" text,
+	"unit_cost_amount_cents" integer,
+	"total_cost_amount_cents" integer,
+	"notes" text,
+	"metadata" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "extra_participant_selections" (
+	"id" text PRIMARY KEY NOT NULL,
+	"booking_id" text NOT NULL,
+	"booking_item_id" text,
+	"traveler_id" text NOT NULL,
+	"product_extra_id" text NOT NULL,
+	"option_extra_config_id" text,
+	"status" "extra_participant_selection_status" DEFAULT 'selected' NOT NULL,
+	"collection_mode" "extra_collection_mode" DEFAULT 'booking_total' NOT NULL,
+	"collection_status" "extra_collection_status" DEFAULT 'not_required' NOT NULL,
+	"collection_currency" text,
+	"collection_amount_cents" integer,
+	"collected_at" timestamp with time zone,
+	"collected_by" text,
+	"notes" text,
+	"metadata" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "booking_answers" (
+	"id" text PRIMARY KEY NOT NULL,
+	"booking_id" text NOT NULL,
+	"product_booking_question_id" text NOT NULL,
+	"booking_traveler_id" text,
+	"booking_extra_id" text,
+	"target" "booking_answer_target" DEFAULT 'booking' NOT NULL,
+	"value_text" text,
+	"value_number" integer,
+	"value_boolean" boolean,
+	"value_json" jsonb,
+	"notes" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "booking_question_extra_triggers" (
+	"id" text PRIMARY KEY NOT NULL,
+	"product_booking_question_id" text NOT NULL,
+	"product_extra_id" text,
+	"option_extra_config_id" text,
+	"trigger_mode" "booking_question_trigger_mode" DEFAULT 'required' NOT NULL,
+	"min_quantity" integer,
+	"active" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "booking_question_option_triggers" (
+	"id" text PRIMARY KEY NOT NULL,
+	"product_booking_question_id" text NOT NULL,
+	"option_id" text NOT NULL,
+	"trigger_mode" "booking_question_trigger_mode" DEFAULT 'required' NOT NULL,
+	"active" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "booking_question_options" (
+	"id" text PRIMARY KEY NOT NULL,
+	"product_booking_question_id" text NOT NULL,
+	"value" text NOT NULL,
+	"label" text NOT NULL,
+	"sort_order" integer DEFAULT 0 NOT NULL,
+	"is_default" boolean DEFAULT false NOT NULL,
+	"active" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "booking_question_unit_triggers" (
+	"id" text PRIMARY KEY NOT NULL,
+	"product_booking_question_id" text NOT NULL,
+	"unit_id" text NOT NULL,
+	"trigger_mode" "booking_question_trigger_mode" DEFAULT 'required' NOT NULL,
+	"min_quantity" integer,
+	"active" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "option_booking_questions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"option_id" text NOT NULL,
+	"product_booking_question_id" text NOT NULL,
+	"is_required_override" boolean,
+	"active" boolean DEFAULT true NOT NULL,
+	"sort_order" integer DEFAULT 0 NOT NULL,
+	"notes" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "product_booking_questions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"product_id" text NOT NULL,
+	"code" text,
+	"label" text NOT NULL,
+	"description" text,
+	"target" "booking_question_target" DEFAULT 'booking' NOT NULL,
+	"field_type" "booking_question_field_type" DEFAULT 'text' NOT NULL,
+	"placeholder" text,
+	"help_text" text,
+	"is_required" boolean DEFAULT false NOT NULL,
+	"active" boolean DEFAULT true NOT NULL,
+	"sort_order" integer DEFAULT 0 NOT NULL,
+	"metadata" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "product_contact_requirements" (
+	"id" text PRIMARY KEY NOT NULL,
+	"product_id" text NOT NULL,
+	"option_id" text,
+	"field_key" "contact_requirement_field" NOT NULL,
+	"scope" "contact_requirement_scope" DEFAULT 'traveler' NOT NULL,
+	"is_required" boolean DEFAULT false NOT NULL,
+	"per_traveler" boolean DEFAULT false NOT NULL,
+	"active" boolean DEFAULT true NOT NULL,
+	"sort_order" integer DEFAULT 0 NOT NULL,
+	"notes" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "booking_traveler_travel_details" (
+	"traveler_id" text PRIMARY KEY NOT NULL,
+	"identity_encrypted" jsonb,
+	"dietary_encrypted" jsonb,
+	"accessibility_encrypted" jsonb,
+	"document_person_document_id" text,
+	"is_lead_traveler" boolean DEFAULT false NOT NULL,
+	"sharing_group_id" text,
+	"room_type_id" text,
+	"bed_preference" text,
+	"allocations" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "booking_pii_access_log" (
+	"id" text PRIMARY KEY NOT NULL,
+	"booking_id" text,
+	"traveler_id" text,
+	"actor_id" text,
+	"actor_type" text,
+	"caller_type" text,
+	"action" "booking_pii_access_action" NOT NULL,
+	"outcome" "booking_pii_access_outcome" NOT NULL,
+	"reason" text,
+	"metadata" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "booking_travelers" (
+	"id" text PRIMARY KEY NOT NULL,
+	"booking_id" text NOT NULL,
+	"person_id" text,
+	"participant_type" "booking_participant_type" DEFAULT 'traveler' NOT NULL,
+	"traveler_category" "booking_traveler_category",
+	"first_name" text NOT NULL,
+	"last_name" text NOT NULL,
+	"email" text,
+	"phone" text,
+	"preferred_language" text,
+	"special_requests" text,
+	"is_primary" boolean DEFAULT false NOT NULL,
+	"notes" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "bookings" (
+	"id" text PRIMARY KEY NOT NULL,
+	"booking_number" text NOT NULL,
+	"status" "booking_status" DEFAULT 'draft' NOT NULL,
+	"person_id" text,
+	"organization_id" text,
+	"source_type" "booking_source_type" DEFAULT 'manual' NOT NULL,
+	"external_booking_ref" text,
+	"communication_language" text,
+	"contact_first_name" text,
+	"contact_last_name" text,
+	"contact_party_type" text,
+	"contact_tax_id" text,
+	"contact_email" text,
+	"contact_phone" text,
+	"contact_preferred_language" text,
+	"contact_country" text,
+	"contact_region" text,
+	"contact_city" text,
+	"contact_address_line1" text,
+	"contact_address_line2" text,
+	"contact_postal_code" text,
+	"sell_currency" text NOT NULL,
+	"base_currency" text,
+	"fx_rate_set_id" text,
+	"sell_amount_cents" integer,
+	"base_sell_amount_cents" integer,
+	"cost_amount_cents" integer,
+	"base_cost_amount_cents" integer,
+	"margin_percent" integer,
+	"start_date" date,
+	"end_date" date,
+	"pax" integer,
+	"internal_notes" text,
+	"customer_payment_policy" jsonb,
+	"price_override" jsonb,
+	"custom_fields" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"hold_expires_at" timestamp with time zone,
+	"confirmed_at" timestamp with time zone,
+	"expired_at" timestamp with time zone,
+	"cancelled_at" timestamp with time zone,
+	"completed_at" timestamp with time zone,
+	"awaiting_payment_at" timestamp with time zone,
+	"paid_at" timestamp with time zone,
+	"redeemed_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "bookings_booking_number_unique" UNIQUE("booking_number"),
+	CONSTRAINT "ck_bookings_base_currency_amounts" CHECK (("bookings"."base_sell_amount_cents" IS NULL AND "bookings"."base_cost_amount_cents" IS NULL) OR "bookings"."base_currency" IS NOT NULL)
+);
+--> statement-breakpoint
+CREATE TABLE "booking_group_members" (
+	"id" text PRIMARY KEY NOT NULL,
+	"group_id" text NOT NULL,
+	"booking_id" text NOT NULL,
+	"role" "booking_group_member_role" DEFAULT 'shared' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "booking_groups" (
+	"id" text PRIMARY KEY NOT NULL,
+	"kind" "booking_group_kind" DEFAULT 'shared_room' NOT NULL,
+	"label" text NOT NULL,
+	"primary_booking_id" text,
+	"product_id" text,
+	"option_unit_id" text,
+	"metadata" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "booking_allocations" (
+	"id" text PRIMARY KEY NOT NULL,
+	"booking_id" text NOT NULL,
+	"booking_item_id" text NOT NULL,
+	"product_id" text,
+	"option_id" text,
+	"option_unit_id" text,
+	"pricing_category_id" text,
+	"availability_slot_id" text,
+	"quantity" integer DEFAULT 1 NOT NULL,
+	"allocation_type" "booking_allocation_type" DEFAULT 'unit' NOT NULL,
+	"status" "booking_allocation_status" DEFAULT 'held' NOT NULL,
+	"hold_expires_at" timestamp with time zone,
+	"confirmed_at" timestamp with time zone,
+	"released_at" timestamp with time zone,
+	"metadata" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "booking_fulfillments" (
+	"id" text PRIMARY KEY NOT NULL,
+	"booking_id" text NOT NULL,
+	"booking_item_id" text,
+	"traveler_id" text,
+	"fulfillment_type" "booking_fulfillment_type" NOT NULL,
+	"delivery_channel" "booking_fulfillment_delivery_channel" NOT NULL,
+	"status" "booking_fulfillment_status" DEFAULT 'pending' NOT NULL,
+	"artifact_url" text,
+	"payload" jsonb,
+	"issued_at" timestamp with time zone,
+	"revoked_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "booking_item_travelers" (
+	"id" text PRIMARY KEY NOT NULL,
+	"booking_item_id" text NOT NULL,
+	"traveler_id" text NOT NULL,
+	"role" "booking_item_participant_role" DEFAULT 'traveler' NOT NULL,
+	"is_primary" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "booking_items" (
+	"id" text PRIMARY KEY NOT NULL,
+	"booking_id" text NOT NULL,
+	"title" text NOT NULL,
+	"description" text,
+	"item_type" "booking_item_type" DEFAULT 'unit' NOT NULL,
+	"status" "booking_item_status" DEFAULT 'draft' NOT NULL,
+	"service_date" date,
+	"starts_at" timestamp with time zone,
+	"ends_at" timestamp with time zone,
+	"quantity" integer DEFAULT 1 NOT NULL,
+	"sell_currency" text NOT NULL,
+	"unit_sell_amount_cents" integer,
+	"total_sell_amount_cents" integer,
+	"cost_currency" text,
+	"unit_cost_amount_cents" integer,
+	"total_cost_amount_cents" integer,
+	"notes" text,
+	"product_id" text,
+	"option_id" text,
+	"option_unit_id" text,
+	"pricing_category_id" text,
+	"availability_slot_id" text,
+	"product_name_snapshot" text,
+	"option_name_snapshot" text,
+	"unit_name_snapshot" text,
+	"departure_label_snapshot" text,
+	"source_snapshot_id" text,
+	"source_offer_id" text,
+	"metadata" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "ck_booking_items_cost_currency_amounts" CHECK (("booking_items"."unit_cost_amount_cents" IS NULL AND "booking_items"."total_cost_amount_cents" IS NULL) OR "booking_items"."cost_currency" IS NOT NULL)
+);
+--> statement-breakpoint
+CREATE TABLE "booking_redemption_events" (
+	"id" text PRIMARY KEY NOT NULL,
+	"booking_id" text NOT NULL,
+	"booking_item_id" text,
+	"traveler_id" text,
+	"redeemed_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"redeemed_by" text,
+	"location" text,
+	"method" "booking_redemption_method" DEFAULT 'manual' NOT NULL,
+	"metadata" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "booking_activity_log" (
+	"id" text PRIMARY KEY NOT NULL,
+	"booking_id" text NOT NULL,
+	"actor_id" text,
+	"activity_type" "booking_activity_type" NOT NULL,
+	"description" text NOT NULL,
+	"metadata" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "booking_documents" (
+	"id" text PRIMARY KEY NOT NULL,
+	"booking_id" text NOT NULL,
+	"traveler_id" text,
+	"type" "booking_document_type" NOT NULL,
+	"file_name" text NOT NULL,
+	"file_url" text NOT NULL,
+	"expires_at" timestamp with time zone,
+	"notes" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "booking_notes" (
+	"id" text PRIMARY KEY NOT NULL,
+	"booking_id" text NOT NULL,
+	"author_id" text NOT NULL,
+	"content" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "booking_session_states" (
+	"id" text PRIMARY KEY NOT NULL,
+	"booking_id" text NOT NULL,
+	"state_key" text DEFAULT 'wizard' NOT NULL,
+	"current_step" text,
+	"completed_steps" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"payload" jsonb,
+	"version" integer DEFAULT 1 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "booking_supplier_statuses" (
+	"id" text PRIMARY KEY NOT NULL,
+	"booking_id" text NOT NULL,
+	"supplier_service_id" text,
+	"supplier_id" text,
+	"service_name" text NOT NULL,
+	"status" "supplier_confirmation_status" DEFAULT 'pending' NOT NULL,
+	"supplier_reference" text,
+	"cost_currency" text NOT NULL,
+	"cost_amount_cents" integer NOT NULL,
+	"supplier_invoice_line_id" text,
+	"notes" text,
+	"confirmed_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "booking_origins" (
+	"booking_id" text PRIMARY KEY NOT NULL,
+	"origin_source" text DEFAULT 'manual' NOT NULL,
+	"quote_version_id" text,
+	"trip_snapshot_id" text,
+	"reservation_plan_id" text,
+	"catalog_price_response_id" text,
+	"catalog_snapshot_id" text,
+	"provider_source_kind" text,
+	"provider_source_provider" text,
+	"provider_source_connection_id" text,
+	"provider_source_ref" text,
+	"provider_order_ref" text,
+	"legacy_transaction_offer_id" text,
+	"legacy_transaction_order_id" text,
+	"legacy_transaction_ids" jsonb,
+	"metadata" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "ck_booking_origins_source" CHECK ("booking_origins"."origin_source" IN ('manual', 'direct_b2c', 'accepted_quote_version', 'catalog_price_availability', 'catalog_snapshot', 'provider_source_order', 'legacy_transaction'))
+);
+--> statement-breakpoint
+CREATE TABLE "booking_staff_assignments" (
+	"id" text PRIMARY KEY NOT NULL,
+	"booking_id" text NOT NULL,
+	"booking_item_id" text,
+	"person_id" text,
+	"role" "booking_staff_assignment_role" DEFAULT 'service_assignee' NOT NULL,
+	"first_name" text NOT NULL,
+	"last_name" text NOT NULL,
+	"email" text,
+	"phone" text,
+	"preferred_language" text,
+	"is_primary" boolean DEFAULT false NOT NULL,
+	"notes" text,
+	"metadata" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "booking_answers" ADD CONSTRAINT "booking_answers_product_booking_question_id_product_booking_questions_id_fk" FOREIGN KEY ("product_booking_question_id") REFERENCES "public"."product_booking_questions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "booking_question_extra_triggers" ADD CONSTRAINT "booking_question_extra_triggers_product_booking_question_id_product_booking_questions_id_fk" FOREIGN KEY ("product_booking_question_id") REFERENCES "public"."product_booking_questions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "booking_question_option_triggers" ADD CONSTRAINT "booking_question_option_triggers_product_booking_question_id_product_booking_questions_id_fk" FOREIGN KEY ("product_booking_question_id") REFERENCES "public"."product_booking_questions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "booking_question_options" ADD CONSTRAINT "booking_question_options_product_booking_question_id_product_booking_questions_id_fk" FOREIGN KEY ("product_booking_question_id") REFERENCES "public"."product_booking_questions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "booking_question_unit_triggers" ADD CONSTRAINT "booking_question_unit_triggers_product_booking_question_id_product_booking_questions_id_fk" FOREIGN KEY ("product_booking_question_id") REFERENCES "public"."product_booking_questions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "option_booking_questions" ADD CONSTRAINT "option_booking_questions_product_booking_question_id_product_booking_questions_id_fk" FOREIGN KEY ("product_booking_question_id") REFERENCES "public"."product_booking_questions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "booking_traveler_travel_details" ADD CONSTRAINT "booking_traveler_travel_details_traveler_id_booking_travelers_id_fk" FOREIGN KEY ("traveler_id") REFERENCES "public"."booking_travelers"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "booking_travelers" ADD CONSTRAINT "booking_travelers_booking_id_bookings_id_fk" FOREIGN KEY ("booking_id") REFERENCES "public"."bookings"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "booking_group_members" ADD CONSTRAINT "booking_group_members_group_id_booking_groups_id_fk" FOREIGN KEY ("group_id") REFERENCES "public"."booking_groups"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "booking_group_members" ADD CONSTRAINT "booking_group_members_booking_id_bookings_id_fk" FOREIGN KEY ("booking_id") REFERENCES "public"."bookings"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "booking_allocations" ADD CONSTRAINT "booking_allocations_booking_id_bookings_id_fk" FOREIGN KEY ("booking_id") REFERENCES "public"."bookings"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "booking_allocations" ADD CONSTRAINT "booking_allocations_booking_item_id_booking_items_id_fk" FOREIGN KEY ("booking_item_id") REFERENCES "public"."booking_items"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "booking_fulfillments" ADD CONSTRAINT "booking_fulfillments_booking_id_bookings_id_fk" FOREIGN KEY ("booking_id") REFERENCES "public"."bookings"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "booking_fulfillments" ADD CONSTRAINT "booking_fulfillments_booking_item_id_booking_items_id_fk" FOREIGN KEY ("booking_item_id") REFERENCES "public"."booking_items"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "booking_fulfillments" ADD CONSTRAINT "booking_fulfillments_traveler_id_booking_travelers_id_fk" FOREIGN KEY ("traveler_id") REFERENCES "public"."booking_travelers"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "booking_item_travelers" ADD CONSTRAINT "booking_item_travelers_booking_item_id_booking_items_id_fk" FOREIGN KEY ("booking_item_id") REFERENCES "public"."booking_items"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "booking_item_travelers" ADD CONSTRAINT "booking_item_travelers_traveler_id_booking_travelers_id_fk" FOREIGN KEY ("traveler_id") REFERENCES "public"."booking_travelers"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "booking_items" ADD CONSTRAINT "booking_items_booking_id_bookings_id_fk" FOREIGN KEY ("booking_id") REFERENCES "public"."bookings"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "booking_redemption_events" ADD CONSTRAINT "booking_redemption_events_booking_id_bookings_id_fk" FOREIGN KEY ("booking_id") REFERENCES "public"."bookings"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "booking_redemption_events" ADD CONSTRAINT "booking_redemption_events_booking_item_id_booking_items_id_fk" FOREIGN KEY ("booking_item_id") REFERENCES "public"."booking_items"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "booking_redemption_events" ADD CONSTRAINT "booking_redemption_events_traveler_id_booking_travelers_id_fk" FOREIGN KEY ("traveler_id") REFERENCES "public"."booking_travelers"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "booking_activity_log" ADD CONSTRAINT "booking_activity_log_booking_id_bookings_id_fk" FOREIGN KEY ("booking_id") REFERENCES "public"."bookings"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "booking_documents" ADD CONSTRAINT "booking_documents_booking_id_bookings_id_fk" FOREIGN KEY ("booking_id") REFERENCES "public"."bookings"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "booking_documents" ADD CONSTRAINT "booking_documents_traveler_id_booking_travelers_id_fk" FOREIGN KEY ("traveler_id") REFERENCES "public"."booking_travelers"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "booking_notes" ADD CONSTRAINT "booking_notes_booking_id_bookings_id_fk" FOREIGN KEY ("booking_id") REFERENCES "public"."bookings"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "booking_session_states" ADD CONSTRAINT "booking_session_states_booking_id_bookings_id_fk" FOREIGN KEY ("booking_id") REFERENCES "public"."bookings"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "booking_supplier_statuses" ADD CONSTRAINT "booking_supplier_statuses_booking_id_bookings_id_fk" FOREIGN KEY ("booking_id") REFERENCES "public"."bookings"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "booking_origins" ADD CONSTRAINT "booking_origins_booking_id_bookings_id_fk" FOREIGN KEY ("booking_id") REFERENCES "public"."bookings"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "booking_staff_assignments" ADD CONSTRAINT "booking_staff_assignments_booking_id_bookings_id_fk" FOREIGN KEY ("booking_id") REFERENCES "public"."bookings"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "booking_staff_assignments" ADD CONSTRAINT "booking_staff_assignments_booking_item_id_booking_items_id_fk" FOREIGN KEY ("booking_item_id") REFERENCES "public"."booking_items"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_booking_extras_updated" ON "booking_extras" USING btree ("updated_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_extras_booking_updated" ON "booking_extras" USING btree ("booking_id","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_extras_product_extra_updated" ON "booking_extras" USING btree ("product_extra_id","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_extras_option_extra_config_updated" ON "booking_extras" USING btree ("option_extra_config_id","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_extras_status_updated" ON "booking_extras" USING btree ("status","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_extra_participant_selections_booking_updated" ON "extra_participant_selections" USING btree ("booking_id","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_extra_participant_selections_traveler_updated" ON "extra_participant_selections" USING btree ("traveler_id","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_extra_participant_selections_extra_updated" ON "extra_participant_selections" USING btree ("product_extra_id","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_extra_participant_selections_status_updated" ON "extra_participant_selections" USING btree ("status","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_extra_participant_selections_collection_updated" ON "extra_participant_selections" USING btree ("collection_status","updated_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_extra_participant_selection" ON "extra_participant_selections" USING btree ("booking_id","traveler_id","product_extra_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_answers_booking_updated" ON "booking_answers" USING btree ("booking_id","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_answers_question_updated" ON "booking_answers" USING btree ("product_booking_question_id","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_answers_traveler_updated" ON "booking_answers" USING btree ("booking_traveler_id","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_answers_booking_extra_updated" ON "booking_answers" USING btree ("booking_extra_id","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_answers_target_updated" ON "booking_answers" USING btree ("target","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_question_extra_triggers_created" ON "booking_question_extra_triggers" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_question_extra_triggers_question_created" ON "booking_question_extra_triggers" USING btree ("product_booking_question_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_question_extra_triggers_product_extra_created" ON "booking_question_extra_triggers" USING btree ("product_extra_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_question_extra_triggers_option_extra_config_created" ON "booking_question_extra_triggers" USING btree ("option_extra_config_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_question_extra_triggers_active_created" ON "booking_question_extra_triggers" USING btree ("active","created_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_question_option_triggers_created" ON "booking_question_option_triggers" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_question_option_triggers_question_created" ON "booking_question_option_triggers" USING btree ("product_booking_question_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_question_option_triggers_option_created" ON "booking_question_option_triggers" USING btree ("option_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_question_option_triggers_active_created" ON "booking_question_option_triggers" USING btree ("active","created_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_booking_question_option_triggers_question_option" ON "booking_question_option_triggers" USING btree ("product_booking_question_id","option_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_question_options_sort" ON "booking_question_options" USING btree ("sort_order");--> statement-breakpoint
+CREATE INDEX "idx_booking_question_options_question_sort" ON "booking_question_options" USING btree ("product_booking_question_id","sort_order");--> statement-breakpoint
+CREATE INDEX "idx_booking_question_options_active_sort" ON "booking_question_options" USING btree ("active","sort_order");--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_booking_question_options_question_value" ON "booking_question_options" USING btree ("product_booking_question_id","value");--> statement-breakpoint
+CREATE INDEX "idx_booking_question_unit_triggers_created" ON "booking_question_unit_triggers" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_question_unit_triggers_question_created" ON "booking_question_unit_triggers" USING btree ("product_booking_question_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_question_unit_triggers_unit_created" ON "booking_question_unit_triggers" USING btree ("unit_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_question_unit_triggers_active_created" ON "booking_question_unit_triggers" USING btree ("active","created_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_booking_question_unit_triggers_question_unit" ON "booking_question_unit_triggers" USING btree ("product_booking_question_id","unit_id");--> statement-breakpoint
+CREATE INDEX "idx_option_booking_questions_sort" ON "option_booking_questions" USING btree ("sort_order");--> statement-breakpoint
+CREATE INDEX "idx_option_booking_questions_option_sort" ON "option_booking_questions" USING btree ("option_id","sort_order");--> statement-breakpoint
+CREATE INDEX "idx_option_booking_questions_question_sort" ON "option_booking_questions" USING btree ("product_booking_question_id","sort_order");--> statement-breakpoint
+CREATE INDEX "idx_option_booking_questions_active_sort" ON "option_booking_questions" USING btree ("active","sort_order");--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_option_booking_questions_option_question" ON "option_booking_questions" USING btree ("option_id","product_booking_question_id");--> statement-breakpoint
+CREATE INDEX "idx_product_booking_questions_sort" ON "product_booking_questions" USING btree ("sort_order");--> statement-breakpoint
+CREATE INDEX "idx_product_booking_questions_product_sort" ON "product_booking_questions" USING btree ("product_id","sort_order");--> statement-breakpoint
+CREATE INDEX "idx_product_booking_questions_target_sort" ON "product_booking_questions" USING btree ("target","sort_order");--> statement-breakpoint
+CREATE INDEX "idx_product_booking_questions_field_type_sort" ON "product_booking_questions" USING btree ("field_type","sort_order");--> statement-breakpoint
+CREATE INDEX "idx_product_booking_questions_active_sort" ON "product_booking_questions" USING btree ("active","sort_order");--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_product_booking_questions_product_code" ON "product_booking_questions" USING btree ("product_id","code");--> statement-breakpoint
+CREATE INDEX "idx_product_contact_requirements_sort" ON "product_contact_requirements" USING btree ("sort_order");--> statement-breakpoint
+CREATE INDEX "idx_product_contact_requirements_product_sort" ON "product_contact_requirements" USING btree ("product_id","sort_order");--> statement-breakpoint
+CREATE INDEX "idx_product_contact_requirements_option_sort" ON "product_contact_requirements" USING btree ("option_id","sort_order");--> statement-breakpoint
+CREATE INDEX "idx_product_contact_requirements_active_sort" ON "product_contact_requirements" USING btree ("active","sort_order");--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_product_contact_requirements_scope_field" ON "product_contact_requirements" USING btree ("product_id","option_id","scope","field_key");--> statement-breakpoint
+CREATE INDEX "idx_bptd_lead_traveler" ON "booking_traveler_travel_details" USING btree ("is_lead_traveler");--> statement-breakpoint
+CREATE INDEX "idx_bptd_sharing_group" ON "booking_traveler_travel_details" USING btree ("sharing_group_id");--> statement-breakpoint
+CREATE INDEX "idx_bptd_room_type" ON "booking_traveler_travel_details" USING btree ("room_type_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_pii_access_log_booking" ON "booking_pii_access_log" USING btree ("booking_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_pii_access_log_traveler" ON "booking_pii_access_log" USING btree ("traveler_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_pii_access_log_actor" ON "booking_pii_access_log" USING btree ("actor_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_pii_access_log_created_at" ON "booking_pii_access_log" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_travelers_booking" ON "booking_travelers" USING btree ("booking_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_travelers_booking_primary_created" ON "booking_travelers" USING btree ("booking_id","is_primary","created_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_travelers_booking_type_created" ON "booking_travelers" USING btree ("booking_id","participant_type","created_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_travelers_type" ON "booking_travelers" USING btree ("participant_type");--> statement-breakpoint
+CREATE INDEX "idx_booking_travelers_person" ON "booking_travelers" USING btree ("person_id");--> statement-breakpoint
+CREATE INDEX "idx_bookings_status" ON "bookings" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "idx_bookings_status_created" ON "bookings" USING btree ("status","created_at");--> statement-breakpoint
+CREATE INDEX "idx_bookings_person" ON "bookings" USING btree ("person_id");--> statement-breakpoint
+CREATE INDEX "idx_bookings_organization" ON "bookings" USING btree ("organization_id");--> statement-breakpoint
+CREATE INDEX "idx_bookings_source_type" ON "bookings" USING btree ("source_type");--> statement-breakpoint
+CREATE INDEX "idx_bookings_number" ON "bookings" USING btree ("booking_number");--> statement-breakpoint
+CREATE UNIQUE INDEX "booking_group_members_booking_unique" ON "booking_group_members" USING btree ("booking_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_group_members_group_created" ON "booking_group_members" USING btree ("group_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_groups_kind_created" ON "booking_groups" USING btree ("kind","created_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_groups_product_created" ON "booking_groups" USING btree ("product_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_groups_option_unit_created" ON "booking_groups" USING btree ("option_unit_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_allocations_booking" ON "booking_allocations" USING btree ("booking_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_allocations_booking_created" ON "booking_allocations" USING btree ("booking_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_allocations_item" ON "booking_allocations" USING btree ("booking_item_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_allocations_slot" ON "booking_allocations" USING btree ("availability_slot_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_allocations_status" ON "booking_allocations" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "idx_booking_fulfillments_booking" ON "booking_fulfillments" USING btree ("booking_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_fulfillments_booking_created" ON "booking_fulfillments" USING btree ("booking_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_fulfillments_item" ON "booking_fulfillments" USING btree ("booking_item_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_fulfillments_traveler" ON "booking_fulfillments" USING btree ("traveler_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_fulfillments_status" ON "booking_fulfillments" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "idx_booking_item_travelers_item" ON "booking_item_travelers" USING btree ("booking_item_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_item_travelers_item_primary_created" ON "booking_item_travelers" USING btree ("booking_item_id","is_primary","created_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_item_travelers_traveler" ON "booking_item_travelers" USING btree ("traveler_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_items_booking" ON "booking_items" USING btree ("booking_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_items_booking_created" ON "booking_items" USING btree ("booking_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_items_status" ON "booking_items" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "idx_booking_redemption_events_booking" ON "booking_redemption_events" USING btree ("booking_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_redemption_events_booking_redeemed_created" ON "booking_redemption_events" USING btree ("booking_id","redeemed_at","created_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_redemption_events_item" ON "booking_redemption_events" USING btree ("booking_item_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_redemption_events_traveler" ON "booking_redemption_events" USING btree ("traveler_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_redemption_events_redeemed_at" ON "booking_redemption_events" USING btree ("redeemed_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_activity_log_booking" ON "booking_activity_log" USING btree ("booking_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_activity_log_booking_created" ON "booking_activity_log" USING btree ("booking_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_documents_booking" ON "booking_documents" USING btree ("booking_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_documents_booking_created" ON "booking_documents" USING btree ("booking_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_documents_traveler" ON "booking_documents" USING btree ("traveler_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_notes_booking" ON "booking_notes" USING btree ("booking_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_notes_booking_created" ON "booking_notes" USING btree ("booking_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_session_states_booking" ON "booking_session_states" USING btree ("booking_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_session_states_key" ON "booking_session_states" USING btree ("state_key");--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_booking_session_states_booking_key" ON "booking_session_states" USING btree ("booking_id","state_key");--> statement-breakpoint
+CREATE INDEX "idx_booking_supplier_statuses_booking" ON "booking_supplier_statuses" USING btree ("booking_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_supplier_statuses_booking_created" ON "booking_supplier_statuses" USING btree ("booking_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_supplier_statuses_service" ON "booking_supplier_statuses" USING btree ("supplier_service_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_supplier_statuses_supplier" ON "booking_supplier_statuses" USING btree ("supplier_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_supplier_statuses_invoice_line" ON "booking_supplier_statuses" USING btree ("supplier_invoice_line_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_origins_quote_version" ON "booking_origins" USING btree ("quote_version_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_origins_trip_snapshot" ON "booking_origins" USING btree ("trip_snapshot_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_origins_reservation_plan" ON "booking_origins" USING btree ("reservation_plan_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_origins_catalog_price_response" ON "booking_origins" USING btree ("catalog_price_response_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_origins_catalog_snapshot" ON "booking_origins" USING btree ("catalog_snapshot_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_origins_provider_order" ON "booking_origins" USING btree ("provider_order_ref");--> statement-breakpoint
+CREATE INDEX "idx_booking_origins_legacy_offer" ON "booking_origins" USING btree ("legacy_transaction_offer_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_origins_legacy_order" ON "booking_origins" USING btree ("legacy_transaction_order_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_staff_assignments_booking" ON "booking_staff_assignments" USING btree ("booking_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_staff_assignments_booking_role_created" ON "booking_staff_assignments" USING btree ("booking_id","role","created_at");--> statement-breakpoint
+CREATE INDEX "idx_booking_staff_assignments_item" ON "booking_staff_assignments" USING btree ("booking_item_id");--> statement-breakpoint
+CREATE INDEX "idx_booking_staff_assignments_person" ON "booking_staff_assignments" USING btree ("person_id");

--- a/scripts/fixtures/pre-proposal-rename/edited/legal/0000_legal_baseline.sql
+++ b/scripts/fixtures/pre-proposal-rename/edited/legal/0000_legal_baseline.sql
@@ -1,0 +1,403 @@
+DO $$ BEGIN
+ CREATE TYPE "public"."contract_body_format" AS ENUM('markdown', 'html', 'lexical_json');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."contract_number_reset_strategy" AS ENUM('never', 'annual', 'monthly');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."contract_scope" AS ENUM('customer', 'supplier', 'partner', 'channel', 'other');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."contract_signature_method" AS ENUM('manual', 'electronic', 'docusign', 'other');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."contract_status" AS ENUM('draft', 'issued', 'sent', 'signed', 'executed', 'expired', 'void');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."policy_acceptance_method" AS ENUM('implicit', 'explicit_checkbox', 'signature');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."policy_assignment_scope" AS ENUM('product', 'channel', 'supplier', 'market', 'organization', 'global');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."policy_kind" AS ENUM('cancellation', 'payment', 'terms_and_conditions', 'privacy', 'refund', 'commission', 'guarantee', 'other');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."policy_refund_type" AS ENUM('cash', 'credit', 'cash_or_credit', 'none');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."policy_rule_type" AS ENUM('window', 'percentage', 'flat_amount', 'date_range', 'custom');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."policy_version_status" AS ENUM('draft', 'published', 'retired');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."legal_target_kind" AS ENUM('booking', 'quote_version', 'program', 'product', 'inventory_item', 'supplier_channel_relationship', 'provider_source_ref');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."legal_term_acceptance_status" AS ENUM('not_required', 'pending', 'accepted', 'declined');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."legal_term_type" AS ENUM('terms_and_conditions', 'cancellation', 'guarantee', 'payment', 'pricing', 'commission', 'other');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+CREATE TABLE "contract_attachments" (
+	"id" text PRIMARY KEY NOT NULL,
+	"contract_id" text NOT NULL,
+	"kind" text DEFAULT 'appendix' NOT NULL,
+	"name" text NOT NULL,
+	"mime_type" text,
+	"file_size" integer,
+	"storage_key" text,
+	"checksum" text,
+	"target_kind" "legal_target_kind",
+	"target_id" text,
+	"target_provider" text,
+	"target_source_ref" text,
+	"legacy_transaction_offer_id" text,
+	"legacy_transaction_order_id" text,
+	"metadata" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "contract_number_series" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"prefix" text DEFAULT '' NOT NULL,
+	"separator" text DEFAULT '' NOT NULL,
+	"pad_length" integer DEFAULT 4 NOT NULL,
+	"current_sequence" integer DEFAULT 0 NOT NULL,
+	"reset_strategy" "contract_number_reset_strategy" DEFAULT 'never' NOT NULL,
+	"reset_at" timestamp with time zone,
+	"scope" "contract_scope" DEFAULT 'customer' NOT NULL,
+	"is_default" boolean DEFAULT false NOT NULL,
+	"external_provider" text,
+	"external_config_key" text,
+	"active" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "contract_signatures" (
+	"id" text PRIMARY KEY NOT NULL,
+	"contract_id" text NOT NULL,
+	"signer_name" text NOT NULL,
+	"signer_email" text,
+	"signer_role" text,
+	"person_id" text,
+	"target_kind" "legal_target_kind",
+	"target_id" text,
+	"target_provider" text,
+	"target_source_ref" text,
+	"legacy_transaction_offer_id" text,
+	"legacy_transaction_order_id" text,
+	"method" "contract_signature_method" DEFAULT 'manual' NOT NULL,
+	"provider" text,
+	"external_reference" text,
+	"signature_data" text,
+	"ip_address" text,
+	"user_agent" text,
+	"signed_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"metadata" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "contract_template_versions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"template_id" text NOT NULL,
+	"version" integer NOT NULL,
+	"body" text NOT NULL,
+	"variable_schema" jsonb,
+	"changelog" text,
+	"created_by" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "contract_templates" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"slug" text NOT NULL,
+	"scope" "contract_scope" NOT NULL,
+	"language" text DEFAULT 'en' NOT NULL,
+	"description" text,
+	"body" text NOT NULL,
+	"variable_schema" jsonb,
+	"current_version_id" text,
+	"channel_id" text,
+	"is_default" boolean DEFAULT false NOT NULL,
+	"active" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "contract_templates_slug_unique" UNIQUE("slug")
+);
+--> statement-breakpoint
+CREATE TABLE "contracts" (
+	"id" text PRIMARY KEY NOT NULL,
+	"contract_number" text,
+	"scope" "contract_scope" NOT NULL,
+	"status" "contract_status" DEFAULT 'draft' NOT NULL,
+	"stage_history" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"title" text NOT NULL,
+	"template_version_id" text,
+	"series_id" text,
+	"person_id" text,
+	"organization_id" text,
+	"supplier_id" text,
+	"channel_id" text,
+	"booking_id" text,
+	"target_kind" "legal_target_kind",
+	"target_id" text,
+	"target_provider" text,
+	"target_source_ref" text,
+	"legacy_transaction_offer_id" text,
+	"legacy_transaction_order_id" text,
+	"issued_at" timestamp with time zone,
+	"sent_at" timestamp with time zone,
+	"executed_at" timestamp with time zone,
+	"expires_at" timestamp with time zone,
+	"voided_at" timestamp with time zone,
+	"language" text DEFAULT 'en' NOT NULL,
+	"rendered_body_format" "contract_body_format" DEFAULT 'html' NOT NULL,
+	"rendered_body" text,
+	"variables" jsonb,
+	"metadata" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "contracts_contract_number_unique" UNIQUE("contract_number")
+);
+--> statement-breakpoint
+CREATE TABLE "policies" (
+	"id" text PRIMARY KEY NOT NULL,
+	"kind" "policy_kind" NOT NULL,
+	"name" text NOT NULL,
+	"slug" text NOT NULL,
+	"description" text,
+	"language" text DEFAULT 'en' NOT NULL,
+	"current_version_id" text,
+	"metadata" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "policies_slug_unique" UNIQUE("slug")
+);
+--> statement-breakpoint
+CREATE TABLE "policy_acceptances" (
+	"id" text PRIMARY KEY NOT NULL,
+	"policy_version_id" text NOT NULL,
+	"person_id" text,
+	"booking_id" text,
+	"target_kind" "legal_target_kind",
+	"target_id" text,
+	"target_provider" text,
+	"target_source_ref" text,
+	"legacy_transaction_offer_id" text,
+	"legacy_transaction_order_id" text,
+	"accepted_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"accepted_by" text,
+	"method" "policy_acceptance_method" DEFAULT 'implicit' NOT NULL,
+	"ip_address" text,
+	"user_agent" text,
+	"metadata" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "policy_assignments" (
+	"id" text PRIMARY KEY NOT NULL,
+	"policy_id" text NOT NULL,
+	"scope" "policy_assignment_scope" NOT NULL,
+	"product_id" text,
+	"channel_id" text,
+	"supplier_id" text,
+	"market_id" text,
+	"organization_id" text,
+	"valid_from" date,
+	"valid_to" date,
+	"priority" integer DEFAULT 0 NOT NULL,
+	"metadata" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "policy_rules" (
+	"id" text PRIMARY KEY NOT NULL,
+	"policy_version_id" text NOT NULL,
+	"rule_type" "policy_rule_type" NOT NULL,
+	"label" text,
+	"days_before_departure" integer,
+	"refund_percent" integer,
+	"refund_type" "policy_refund_type",
+	"flat_amount_cents" integer,
+	"currency" text,
+	"valid_from" date,
+	"valid_to" date,
+	"conditions" jsonb,
+	"sort_order" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "policy_versions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"policy_id" text NOT NULL,
+	"version" integer NOT NULL,
+	"status" "policy_version_status" DEFAULT 'draft' NOT NULL,
+	"title" text NOT NULL,
+	"body" text,
+	"published_at" timestamp with time zone,
+	"published_by" text,
+	"retired_at" timestamp with time zone,
+	"metadata" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "legal_terms" (
+	"id" text PRIMARY KEY NOT NULL,
+	"contract_id" text,
+	"policy_version_id" text,
+	"target_kind" "legal_target_kind",
+	"target_id" text,
+	"target_provider" text,
+	"target_source_ref" text,
+	"legacy_transaction_offer_id" text,
+	"legacy_transaction_order_id" text,
+	"term_type" "legal_term_type" DEFAULT 'terms_and_conditions' NOT NULL,
+	"title" text NOT NULL,
+	"body" text NOT NULL,
+	"language" text,
+	"required" boolean DEFAULT true NOT NULL,
+	"sort_order" integer DEFAULT 0 NOT NULL,
+	"acceptance_status" "legal_term_acceptance_status" DEFAULT 'pending' NOT NULL,
+	"accepted_at" timestamp with time zone,
+	"accepted_by" text,
+	"metadata" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "contract_attachments" ADD CONSTRAINT "contract_attachments_contract_id_contracts_id_fk" FOREIGN KEY ("contract_id") REFERENCES "public"."contracts"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "contract_signatures" ADD CONSTRAINT "contract_signatures_contract_id_contracts_id_fk" FOREIGN KEY ("contract_id") REFERENCES "public"."contracts"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "contract_template_versions" ADD CONSTRAINT "contract_template_versions_template_id_contract_templates_id_fk" FOREIGN KEY ("template_id") REFERENCES "public"."contract_templates"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "contracts" ADD CONSTRAINT "contracts_template_version_id_contract_template_versions_id_fk" FOREIGN KEY ("template_version_id") REFERENCES "public"."contract_template_versions"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "contracts" ADD CONSTRAINT "contracts_series_id_contract_number_series_id_fk" FOREIGN KEY ("series_id") REFERENCES "public"."contract_number_series"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "policy_acceptances" ADD CONSTRAINT "policy_acceptances_policy_version_id_policy_versions_id_fk" FOREIGN KEY ("policy_version_id") REFERENCES "public"."policy_versions"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "policy_assignments" ADD CONSTRAINT "policy_assignments_policy_id_policies_id_fk" FOREIGN KEY ("policy_id") REFERENCES "public"."policies"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "policy_rules" ADD CONSTRAINT "policy_rules_policy_version_id_policy_versions_id_fk" FOREIGN KEY ("policy_version_id") REFERENCES "public"."policy_versions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "policy_versions" ADD CONSTRAINT "policy_versions_policy_id_policies_id_fk" FOREIGN KEY ("policy_id") REFERENCES "public"."policies"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "legal_terms" ADD CONSTRAINT "legal_terms_contract_id_contracts_id_fk" FOREIGN KEY ("contract_id") REFERENCES "public"."contracts"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "legal_terms" ADD CONSTRAINT "legal_terms_policy_version_id_policy_versions_id_fk" FOREIGN KEY ("policy_version_id") REFERENCES "public"."policy_versions"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_contract_attachments_contract" ON "contract_attachments" USING btree ("contract_id");--> statement-breakpoint
+CREATE INDEX "idx_contract_attachments_contract_created" ON "contract_attachments" USING btree ("contract_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_contract_attachments_target" ON "contract_attachments" USING btree ("target_kind","target_id");--> statement-breakpoint
+CREATE INDEX "idx_contract_attachments_provider_source" ON "contract_attachments" USING btree ("target_provider","target_source_ref");--> statement-breakpoint
+CREATE INDEX "idx_contract_attachments_legacy_transaction_offer" ON "contract_attachments" USING btree ("legacy_transaction_offer_id");--> statement-breakpoint
+CREATE INDEX "idx_contract_attachments_legacy_transaction_order" ON "contract_attachments" USING btree ("legacy_transaction_order_id");--> statement-breakpoint
+CREATE INDEX "idx_contract_number_series_scope" ON "contract_number_series" USING btree ("scope");--> statement-breakpoint
+CREATE INDEX "idx_contract_number_series_active" ON "contract_number_series" USING btree ("active");--> statement-breakpoint
+CREATE INDEX "idx_contract_number_series_scope_default" ON "contract_number_series" USING btree ("scope","is_default");--> statement-breakpoint
+CREATE INDEX "idx_contract_number_series_external_provider" ON "contract_number_series" USING btree ("external_provider");--> statement-breakpoint
+CREATE INDEX "idx_contract_number_series_scope_updated" ON "contract_number_series" USING btree ("scope","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_contract_number_series_active_updated" ON "contract_number_series" USING btree ("active","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_contract_number_series_updated" ON "contract_number_series" USING btree ("updated_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_contract_number_series_prefix_scope_active" ON "contract_number_series" USING btree ("prefix","scope") WHERE "contract_number_series"."active" = true;--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_contract_number_series_default_scope_active" ON "contract_number_series" USING btree ("scope") WHERE "contract_number_series"."active" = true AND "contract_number_series"."is_default" = true;--> statement-breakpoint
+CREATE INDEX "idx_contract_signatures_contract" ON "contract_signatures" USING btree ("contract_id");--> statement-breakpoint
+CREATE INDEX "idx_contract_signatures_contract_signed" ON "contract_signatures" USING btree ("contract_id","signed_at");--> statement-breakpoint
+CREATE INDEX "idx_contract_signatures_person" ON "contract_signatures" USING btree ("person_id");--> statement-breakpoint
+CREATE INDEX "idx_contract_signatures_target" ON "contract_signatures" USING btree ("target_kind","target_id");--> statement-breakpoint
+CREATE INDEX "idx_contract_signatures_provider_source" ON "contract_signatures" USING btree ("target_provider","target_source_ref");--> statement-breakpoint
+CREATE INDEX "idx_contract_signatures_legacy_transaction_offer" ON "contract_signatures" USING btree ("legacy_transaction_offer_id");--> statement-breakpoint
+CREATE INDEX "idx_contract_signatures_legacy_transaction_order" ON "contract_signatures" USING btree ("legacy_transaction_order_id");--> statement-breakpoint
+CREATE INDEX "idx_contract_signatures_method" ON "contract_signatures" USING btree ("method");--> statement-breakpoint
+CREATE INDEX "idx_contract_template_versions_template" ON "contract_template_versions" USING btree ("template_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_contract_template_versions_template_version" ON "contract_template_versions" USING btree ("template_id","version");--> statement-breakpoint
+CREATE INDEX "idx_contract_templates_scope" ON "contract_templates" USING btree ("scope");--> statement-breakpoint
+CREATE INDEX "idx_contract_templates_language" ON "contract_templates" USING btree ("language");--> statement-breakpoint
+CREATE INDEX "idx_contract_templates_channel" ON "contract_templates" USING btree ("channel_id");--> statement-breakpoint
+CREATE INDEX "idx_contract_templates_active" ON "contract_templates" USING btree ("active");--> statement-breakpoint
+CREATE INDEX "idx_contract_templates_default_selector" ON "contract_templates" USING btree ("scope","channel_id","language","is_default","active");--> statement-breakpoint
+CREATE INDEX "idx_contract_templates_scope_updated" ON "contract_templates" USING btree ("scope","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_contract_templates_language_updated" ON "contract_templates" USING btree ("language","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_contract_templates_active_updated" ON "contract_templates" USING btree ("active","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_contract_templates_scope_active_updated" ON "contract_templates" USING btree ("scope","active","updated_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_contract_templates_slug" ON "contract_templates" USING btree ("slug");--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_contract_templates_default_global" ON "contract_templates" USING btree ("scope","language") WHERE "contract_templates"."is_default" = true AND "contract_templates"."channel_id" IS NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_contract_templates_default_channel" ON "contract_templates" USING btree ("scope","channel_id","language") WHERE "contract_templates"."is_default" = true AND "contract_templates"."channel_id" IS NOT NULL;--> statement-breakpoint
+CREATE INDEX "idx_contracts_scope" ON "contracts" USING btree ("scope");--> statement-breakpoint
+CREATE INDEX "idx_contracts_status" ON "contracts" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "idx_contracts_template_version" ON "contracts" USING btree ("template_version_id");--> statement-breakpoint
+CREATE INDEX "idx_contracts_series" ON "contracts" USING btree ("series_id");--> statement-breakpoint
+CREATE INDEX "idx_contracts_person" ON "contracts" USING btree ("person_id");--> statement-breakpoint
+CREATE INDEX "idx_contracts_organization" ON "contracts" USING btree ("organization_id");--> statement-breakpoint
+CREATE INDEX "idx_contracts_supplier" ON "contracts" USING btree ("supplier_id");--> statement-breakpoint
+CREATE INDEX "idx_contracts_booking" ON "contracts" USING btree ("booking_id");--> statement-breakpoint
+CREATE INDEX "idx_contracts_target" ON "contracts" USING btree ("target_kind","target_id");--> statement-breakpoint
+CREATE INDEX "idx_contracts_provider_source" ON "contracts" USING btree ("target_provider","target_source_ref");--> statement-breakpoint
+CREATE INDEX "idx_contracts_legacy_transaction_offer" ON "contracts" USING btree ("legacy_transaction_offer_id");--> statement-breakpoint
+CREATE INDEX "idx_contracts_legacy_transaction_order" ON "contracts" USING btree ("legacy_transaction_order_id");--> statement-breakpoint
+CREATE INDEX "idx_contracts_scope_created" ON "contracts" USING btree ("scope","created_at");--> statement-breakpoint
+CREATE INDEX "idx_contracts_status_created" ON "contracts" USING btree ("status","created_at");--> statement-breakpoint
+CREATE INDEX "idx_contracts_person_created" ON "contracts" USING btree ("person_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_contracts_organization_created" ON "contracts" USING btree ("organization_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_contracts_supplier_created" ON "contracts" USING btree ("supplier_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_contracts_booking_created" ON "contracts" USING btree ("booking_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_contracts_target_created" ON "contracts" USING btree ("target_kind","target_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_contracts_contract_number" ON "contracts" USING btree ("contract_number");--> statement-breakpoint
+CREATE INDEX "idx_policies_kind" ON "policies" USING btree ("kind");--> statement-breakpoint
+CREATE INDEX "idx_policies_language" ON "policies" USING btree ("language");--> statement-breakpoint
+CREATE INDEX "idx_policies_kind_updated" ON "policies" USING btree ("kind","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_policies_language_updated" ON "policies" USING btree ("language","updated_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_policies_slug" ON "policies" USING btree ("slug");--> statement-breakpoint
+CREATE INDEX "idx_policy_acceptances_version" ON "policy_acceptances" USING btree ("policy_version_id");--> statement-breakpoint
+CREATE INDEX "idx_policy_acceptances_person" ON "policy_acceptances" USING btree ("person_id");--> statement-breakpoint
+CREATE INDEX "idx_policy_acceptances_booking" ON "policy_acceptances" USING btree ("booking_id");--> statement-breakpoint
+CREATE INDEX "idx_policy_acceptances_target" ON "policy_acceptances" USING btree ("target_kind","target_id");--> statement-breakpoint
+CREATE INDEX "idx_policy_acceptances_provider_source" ON "policy_acceptances" USING btree ("target_provider","target_source_ref");--> statement-breakpoint
+CREATE INDEX "idx_policy_acceptances_legacy_transaction_offer" ON "policy_acceptances" USING btree ("legacy_transaction_offer_id");--> statement-breakpoint
+CREATE INDEX "idx_policy_acceptances_legacy_transaction_order" ON "policy_acceptances" USING btree ("legacy_transaction_order_id");--> statement-breakpoint
+CREATE INDEX "idx_policy_acceptances_version_accepted" ON "policy_acceptances" USING btree ("policy_version_id","accepted_at");--> statement-breakpoint
+CREATE INDEX "idx_policy_acceptances_person_accepted" ON "policy_acceptances" USING btree ("person_id","accepted_at");--> statement-breakpoint
+CREATE INDEX "idx_policy_acceptances_booking_accepted" ON "policy_acceptances" USING btree ("booking_id","accepted_at");--> statement-breakpoint
+CREATE INDEX "idx_policy_acceptances_target_accepted" ON "policy_acceptances" USING btree ("target_kind","target_id","accepted_at");--> statement-breakpoint
+CREATE INDEX "idx_policy_assignments_policy" ON "policy_assignments" USING btree ("policy_id");--> statement-breakpoint
+CREATE INDEX "idx_policy_assignments_scope" ON "policy_assignments" USING btree ("scope");--> statement-breakpoint
+CREATE INDEX "idx_policy_assignments_product" ON "policy_assignments" USING btree ("product_id");--> statement-breakpoint
+CREATE INDEX "idx_policy_assignments_channel" ON "policy_assignments" USING btree ("channel_id");--> statement-breakpoint
+CREATE INDEX "idx_policy_assignments_supplier" ON "policy_assignments" USING btree ("supplier_id");--> statement-breakpoint
+CREATE INDEX "idx_policy_assignments_market" ON "policy_assignments" USING btree ("market_id");--> statement-breakpoint
+CREATE INDEX "idx_policy_assignments_organization" ON "policy_assignments" USING btree ("organization_id");--> statement-breakpoint
+CREATE INDEX "idx_policy_assignments_priority" ON "policy_assignments" USING btree ("priority");--> statement-breakpoint
+CREATE INDEX "idx_policy_assignments_policy_priority_created" ON "policy_assignments" USING btree ("policy_id","priority","created_at");--> statement-breakpoint
+CREATE INDEX "idx_policy_assignments_scope_priority_created" ON "policy_assignments" USING btree ("scope","priority","created_at");--> statement-breakpoint
+CREATE INDEX "idx_policy_assignments_product_priority_created" ON "policy_assignments" USING btree ("product_id","priority","created_at");--> statement-breakpoint
+CREATE INDEX "idx_policy_assignments_channel_priority_created" ON "policy_assignments" USING btree ("channel_id","priority","created_at");--> statement-breakpoint
+CREATE INDEX "idx_policy_assignments_supplier_priority_created" ON "policy_assignments" USING btree ("supplier_id","priority","created_at");--> statement-breakpoint
+CREATE INDEX "idx_policy_assignments_market_priority_created" ON "policy_assignments" USING btree ("market_id","priority","created_at");--> statement-breakpoint
+CREATE INDEX "idx_policy_assignments_organization_priority_created" ON "policy_assignments" USING btree ("organization_id","priority","created_at");--> statement-breakpoint
+CREATE INDEX "idx_policy_rules_version" ON "policy_rules" USING btree ("policy_version_id");--> statement-breakpoint
+CREATE INDEX "idx_policy_rules_version_sort_created" ON "policy_rules" USING btree ("policy_version_id","sort_order","created_at");--> statement-breakpoint
+CREATE INDEX "idx_policy_rules_type" ON "policy_rules" USING btree ("rule_type");--> statement-breakpoint
+CREATE INDEX "idx_policy_rules_sort" ON "policy_rules" USING btree ("sort_order");--> statement-breakpoint
+CREATE INDEX "idx_policy_versions_policy" ON "policy_versions" USING btree ("policy_id");--> statement-breakpoint
+CREATE INDEX "idx_policy_versions_status" ON "policy_versions" USING btree ("status");--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_policy_versions_policy_version" ON "policy_versions" USING btree ("policy_id","version");--> statement-breakpoint
+CREATE INDEX "idx_legal_terms_contract_sort" ON "legal_terms" USING btree ("contract_id","sort_order","created_at");--> statement-breakpoint
+CREATE INDEX "idx_legal_terms_policy_version_sort" ON "legal_terms" USING btree ("policy_version_id","sort_order","created_at");--> statement-breakpoint
+CREATE INDEX "idx_legal_terms_target_sort" ON "legal_terms" USING btree ("target_kind","target_id","sort_order","created_at");--> statement-breakpoint
+CREATE INDEX "idx_legal_terms_provider_source_sort" ON "legal_terms" USING btree ("target_provider","target_source_ref","sort_order","created_at");--> statement-breakpoint
+CREATE INDEX "idx_legal_terms_legacy_transaction_offer_sort" ON "legal_terms" USING btree ("legacy_transaction_offer_id","sort_order","created_at");--> statement-breakpoint
+CREATE INDEX "idx_legal_terms_legacy_transaction_order_sort" ON "legal_terms" USING btree ("legacy_transaction_order_id","sort_order","created_at");--> statement-breakpoint
+CREATE INDEX "idx_legal_terms_type_sort" ON "legal_terms" USING btree ("term_type","sort_order","created_at");--> statement-breakpoint
+CREATE INDEX "idx_legal_terms_acceptance_sort" ON "legal_terms" USING btree ("acceptance_status","sort_order","created_at");

--- a/scripts/fixtures/pre-proposal-rename/edited/mice/20260713000300_standard_links.sql
+++ b/scripts/fixtures/pre-proposal-rename/edited/mice/20260713000300_standard_links.sql
@@ -1,0 +1,96 @@
+CREATE TABLE IF NOT EXISTS "quotes_quote_mice_program" (
+	"id" text PRIMARY KEY NOT NULL,
+	"quotes_quote_id" text NOT NULL,
+	"mice_program_id" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"deleted_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "relationships_organization_mice_program" (
+	"id" text PRIMARY KEY NOT NULL,
+	"relationships_organization_id" text NOT NULL,
+	"mice_program_id" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"deleted_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "operations_functionSpace_mice_session" (
+	"id" text PRIMARY KEY NOT NULL,
+	"operations_functionSpace_id" text NOT NULL,
+	"mice_session_id" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"deleted_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "mice_program_operations_spaceBlock" (
+	"id" text PRIMARY KEY NOT NULL,
+	"mice_program_id" text NOT NULL,
+	"operations_spaceBlock_id" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"deleted_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "accommodations_roomBlock_mice_roomingAssignment" (
+	"id" text PRIMARY KEY NOT NULL,
+	"accommodations_roomBlock_id" text NOT NULL,
+	"mice_roomingAssignment_id" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"deleted_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "bookings_booking_mice_delegate" (
+	"id" text PRIMARY KEY NOT NULL,
+	"bookings_booking_id" text NOT NULL,
+	"mice_delegate_id" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"deleted_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "relationships_person_mice_delegate" (
+	"id" text PRIMARY KEY NOT NULL,
+	"relationships_person_id" text NOT NULL,
+	"mice_delegate_id" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"deleted_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "suppliers_supplier_mice_bid" (
+	"id" text PRIMARY KEY NOT NULL,
+	"suppliers_supplier_id" text NOT NULL,
+	"mice_bid_id" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"deleted_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "quotes_quote_mice_program_pair_idx" ON "quotes_quote_mice_program" USING btree ("quotes_quote_id","mice_program_id") WHERE "deleted_at" IS NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "quotes_quote_mice_program_l_uniq" ON "quotes_quote_mice_program" USING btree ("quotes_quote_id") WHERE "deleted_at" IS NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "quotes_quote_mice_program_r_uniq" ON "quotes_quote_mice_program" USING btree ("mice_program_id") WHERE "deleted_at" IS NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "relationships_organization_mice_program_pair_idx" ON "relationships_organization_mice_program" USING btree ("relationships_organization_id","mice_program_id") WHERE "deleted_at" IS NULL;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "relationships_organization_mice_program_l_idx" ON "relationships_organization_mice_program" USING btree ("relationships_organization_id") WHERE "deleted_at" IS NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "relationships_organization_mice_program_r_uniq" ON "relationships_organization_mice_program" USING btree ("mice_program_id") WHERE "deleted_at" IS NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "operations_functionSpace_mice_session_pair_idx" ON "operations_functionSpace_mice_session" USING btree ("operations_functionSpace_id","mice_session_id") WHERE "deleted_at" IS NULL;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "operations_functionSpace_mice_session_l_idx" ON "operations_functionSpace_mice_session" USING btree ("operations_functionSpace_id") WHERE "deleted_at" IS NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "operations_functionSpace_mice_session_r_uniq" ON "operations_functionSpace_mice_session" USING btree ("mice_session_id") WHERE "deleted_at" IS NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "mice_program_operations_spaceBlock_pair_idx" ON "mice_program_operations_spaceBlock" USING btree ("mice_program_id","operations_spaceBlock_id") WHERE "deleted_at" IS NULL;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "mice_program_operations_spaceBlock_l_idx" ON "mice_program_operations_spaceBlock" USING btree ("mice_program_id") WHERE "deleted_at" IS NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "mice_program_operations_spaceBlock_r_uniq" ON "mice_program_operations_spaceBlock" USING btree ("operations_spaceBlock_id") WHERE "deleted_at" IS NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "accommodations_roomBlock_mice_roomingAssignment_pair_idx" ON "accommodations_roomBlock_mice_roomingAssignment" USING btree ("accommodations_roomBlock_id","mice_roomingAssignment_id") WHERE "deleted_at" IS NULL;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "accommodations_roomBlock_mice_roomingAssignment_l_idx" ON "accommodations_roomBlock_mice_roomingAssignment" USING btree ("accommodations_roomBlock_id") WHERE "deleted_at" IS NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "accommodations_roomBlock_mice_roomingAssignment_r_uniq" ON "accommodations_roomBlock_mice_roomingAssignment" USING btree ("mice_roomingAssignment_id") WHERE "deleted_at" IS NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "bookings_booking_mice_delegate_pair_idx" ON "bookings_booking_mice_delegate" USING btree ("bookings_booking_id","mice_delegate_id") WHERE "deleted_at" IS NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "bookings_booking_mice_delegate_l_uniq" ON "bookings_booking_mice_delegate" USING btree ("bookings_booking_id") WHERE "deleted_at" IS NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "bookings_booking_mice_delegate_r_uniq" ON "bookings_booking_mice_delegate" USING btree ("mice_delegate_id") WHERE "deleted_at" IS NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "relationships_person_mice_delegate_pair_idx" ON "relationships_person_mice_delegate" USING btree ("relationships_person_id","mice_delegate_id") WHERE "deleted_at" IS NULL;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "relationships_person_mice_delegate_l_idx" ON "relationships_person_mice_delegate" USING btree ("relationships_person_id") WHERE "deleted_at" IS NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "relationships_person_mice_delegate_r_uniq" ON "relationships_person_mice_delegate" USING btree ("mice_delegate_id") WHERE "deleted_at" IS NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "suppliers_supplier_mice_bid_pair_idx" ON "suppliers_supplier_mice_bid" USING btree ("suppliers_supplier_id","mice_bid_id") WHERE "deleted_at" IS NULL;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "suppliers_supplier_mice_bid_l_idx" ON "suppliers_supplier_mice_bid" USING btree ("suppliers_supplier_id") WHERE "deleted_at" IS NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "suppliers_supplier_mice_bid_r_uniq" ON "suppliers_supplier_mice_bid" USING btree ("mice_bid_id") WHERE "deleted_at" IS NULL;

--- a/scripts/fixtures/pre-proposal-rename/edited/relationships/0000_relationships_baseline.sql
+++ b/scripts/fixtures/pre-proposal-rename/edited/relationships/0000_relationships_baseline.sql
@@ -1,0 +1,333 @@
+DO $$ BEGIN
+ CREATE TYPE "public"."person_document_type" AS ENUM('passport', 'id_card', 'driver_license', 'visa', 'other');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."person_relationship_kind" AS ENUM('spouse', 'partner', 'parent', 'child', 'sibling', 'guardian', 'ward', 'emergency_contact', 'friend', 'travel_companion', 'other');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."activity_link_role" AS ENUM('primary', 'related');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."activity_status" AS ENUM('planned', 'done', 'cancelled');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."activity_type" AS ENUM('call', 'email', 'meeting', 'task', 'follow_up', 'note');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."communication_channel" AS ENUM('email', 'phone', 'whatsapp', 'sms', 'meeting', 'other');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."communication_direction" AS ENUM('inbound', 'outbound');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."custom_field_type" AS ENUM('varchar', 'text', 'double', 'monetary', 'date', 'boolean', 'enum', 'set', 'json', 'address', 'phone');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."entity_type" AS ENUM('organization', 'person', 'quote', 'activity');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."record_status" AS ENUM('active', 'inactive', 'archived');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."relation_type" AS ENUM('client', 'partner', 'supplier', 'other');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."customer_signal_kind" AS ENUM('wishlist', 'notify', 'inquiry', 'request_offer', 'referral');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."customer_signal_source" AS ENUM('form', 'phone', 'admin', 'abandoned_cart', 'website', 'booking');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."customer_signal_status" AS ENUM('new', 'contacted', 'qualified', 'converted', 'lost', 'expired');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+CREATE TABLE "communication_log" (
+	"id" text PRIMARY KEY NOT NULL,
+	"person_id" text NOT NULL,
+	"organization_id" text,
+	"channel" "communication_channel" NOT NULL,
+	"direction" "communication_direction" NOT NULL,
+	"subject" text,
+	"content" text,
+	"sent_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "organization_notes" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"author_id" text NOT NULL,
+	"content" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "organizations" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"legal_name" text,
+	"website" text,
+	"tax_id" text,
+	"industry" text,
+	"relation" "relation_type",
+	"owner_id" text,
+	"default_currency" text,
+	"preferred_language" text,
+	"payment_terms" integer,
+	"status" "record_status" DEFAULT 'active' NOT NULL,
+	"source" text,
+	"source_ref" text,
+	"tags" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"custom_fields" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"notes" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"archived_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE "people" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text,
+	"first_name" text NOT NULL,
+	"middle_name" text,
+	"last_name" text NOT NULL,
+	"gender" text,
+	"job_title" text,
+	"relation" "relation_type",
+	"preferred_language" text,
+	"preferred_currency" text,
+	"owner_id" text,
+	"status" "record_status" DEFAULT 'active' NOT NULL,
+	"source" text,
+	"source_ref" text,
+	"tags" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"custom_fields" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"date_of_birth" date,
+	"notes" text,
+	"accessibility_encrypted" jsonb,
+	"dietary_encrypted" jsonb,
+	"loyalty_encrypted" jsonb,
+	"insurance_encrypted" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"archived_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE "person_documents" (
+	"id" text PRIMARY KEY NOT NULL,
+	"person_id" text NOT NULL,
+	"type" "person_document_type" NOT NULL,
+	"number_encrypted" jsonb,
+	"issuing_authority" text,
+	"issuing_country" text,
+	"issue_date" date,
+	"expiry_date" date,
+	"attachment_id" text,
+	"is_primary" boolean DEFAULT false NOT NULL,
+	"notes" text,
+	"metadata" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "person_notes" (
+	"id" text PRIMARY KEY NOT NULL,
+	"person_id" text NOT NULL,
+	"author_id" text NOT NULL,
+	"content" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "person_payment_methods" (
+	"id" text PRIMARY KEY NOT NULL,
+	"person_id" text NOT NULL,
+	"brand" text NOT NULL,
+	"last4" text,
+	"holder_name" text,
+	"exp_month" integer,
+	"exp_year" integer,
+	"processor_token" text NOT NULL,
+	"is_default" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "person_relationships" (
+	"id" text PRIMARY KEY NOT NULL,
+	"from_person_id" text NOT NULL,
+	"to_person_id" text NOT NULL,
+	"kind" "person_relationship_kind" NOT NULL,
+	"inverse_kind" "person_relationship_kind",
+	"start_date" date,
+	"end_date" date,
+	"is_primary" boolean DEFAULT false NOT NULL,
+	"notes" text,
+	"metadata" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "person_relationships_no_self" CHECK ("person_relationships"."from_person_id" <> "person_relationships"."to_person_id")
+);
+--> statement-breakpoint
+CREATE TABLE "segment_members" (
+	"id" text PRIMARY KEY NOT NULL,
+	"segment_id" text NOT NULL,
+	"person_id" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "segments" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"description" text,
+	"conditions" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "activities" (
+	"id" text PRIMARY KEY NOT NULL,
+	"subject" text NOT NULL,
+	"type" "activity_type" NOT NULL,
+	"owner_id" text,
+	"status" "activity_status" DEFAULT 'planned' NOT NULL,
+	"due_at" timestamp with time zone,
+	"completed_at" timestamp with time zone,
+	"location" text,
+	"description" text,
+	"custom_fields" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "activity_links" (
+	"id" text PRIMARY KEY NOT NULL,
+	"activity_id" text NOT NULL,
+	"entity_type" "entity_type" NOT NULL,
+	"entity_id" text NOT NULL,
+	"role" "activity_link_role" DEFAULT 'related' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "activity_participants" (
+	"id" text PRIMARY KEY NOT NULL,
+	"activity_id" text NOT NULL,
+	"person_id" text NOT NULL,
+	"is_primary" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "custom_field_definitions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"entity_type" "entity_type" NOT NULL,
+	"key" text NOT NULL,
+	"label" text NOT NULL,
+	"field_type" "custom_field_type" NOT NULL,
+	"is_required" boolean DEFAULT false NOT NULL,
+	"is_searchable" boolean DEFAULT false NOT NULL,
+	"options" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "customer_signals" (
+	"id" text PRIMARY KEY NOT NULL,
+	"person_id" text NOT NULL,
+	"product_id" text,
+	"option_unit_id" text,
+	"kind" "customer_signal_kind" NOT NULL,
+	"source" "customer_signal_source" NOT NULL,
+	"status" "customer_signal_status" DEFAULT 'new' NOT NULL,
+	"priority" text DEFAULT 'normal' NOT NULL,
+	"notes" text,
+	"tags" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"assigned_to_user_id" text,
+	"follow_up_at" timestamp with time zone,
+	"resolved_booking_id" text,
+	"source_submission_id" text,
+	"metadata" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "communication_log" ADD CONSTRAINT "communication_log_person_id_people_id_fk" FOREIGN KEY ("person_id") REFERENCES "public"."people"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "communication_log" ADD CONSTRAINT "communication_log_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "organization_notes" ADD CONSTRAINT "organization_notes_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "people" ADD CONSTRAINT "people_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "person_documents" ADD CONSTRAINT "person_documents_person_id_people_id_fk" FOREIGN KEY ("person_id") REFERENCES "public"."people"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "person_notes" ADD CONSTRAINT "person_notes_person_id_people_id_fk" FOREIGN KEY ("person_id") REFERENCES "public"."people"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "person_payment_methods" ADD CONSTRAINT "person_payment_methods_person_id_people_id_fk" FOREIGN KEY ("person_id") REFERENCES "public"."people"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "person_relationships" ADD CONSTRAINT "person_relationships_from_person_id_people_id_fk" FOREIGN KEY ("from_person_id") REFERENCES "public"."people"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "person_relationships" ADD CONSTRAINT "person_relationships_to_person_id_people_id_fk" FOREIGN KEY ("to_person_id") REFERENCES "public"."people"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "segment_members" ADD CONSTRAINT "segment_members_segment_id_segments_id_fk" FOREIGN KEY ("segment_id") REFERENCES "public"."segments"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "segment_members" ADD CONSTRAINT "segment_members_person_id_people_id_fk" FOREIGN KEY ("person_id") REFERENCES "public"."people"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "activity_links" ADD CONSTRAINT "activity_links_activity_id_activities_id_fk" FOREIGN KEY ("activity_id") REFERENCES "public"."activities"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "activity_participants" ADD CONSTRAINT "activity_participants_activity_id_activities_id_fk" FOREIGN KEY ("activity_id") REFERENCES "public"."activities"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "activity_participants" ADD CONSTRAINT "activity_participants_person_id_people_id_fk" FOREIGN KEY ("person_id") REFERENCES "public"."people"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "customer_signals" ADD CONSTRAINT "customer_signals_person_id_people_id_fk" FOREIGN KEY ("person_id") REFERENCES "public"."people"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_communication_log_person" ON "communication_log" USING btree ("person_id");--> statement-breakpoint
+CREATE INDEX "idx_communication_log_person_created" ON "communication_log" USING btree ("person_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_communication_log_person_channel_created" ON "communication_log" USING btree ("person_id","channel","created_at");--> statement-breakpoint
+CREATE INDEX "idx_communication_log_person_direction_created" ON "communication_log" USING btree ("person_id","direction","created_at");--> statement-breakpoint
+CREATE INDEX "idx_communication_log_org" ON "communication_log" USING btree ("organization_id");--> statement-breakpoint
+CREATE INDEX "idx_communication_log_channel" ON "communication_log" USING btree ("channel");--> statement-breakpoint
+CREATE INDEX "idx_organization_notes_org" ON "organization_notes" USING btree ("organization_id");--> statement-breakpoint
+CREATE INDEX "idx_organization_notes_org_created" ON "organization_notes" USING btree ("organization_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_organizations_name" ON "organizations" USING btree ("name");--> statement-breakpoint
+CREATE INDEX "idx_organizations_owner" ON "organizations" USING btree ("owner_id");--> statement-breakpoint
+CREATE INDEX "idx_organizations_status" ON "organizations" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "idx_organizations_tax_id" ON "organizations" USING btree ("tax_id");--> statement-breakpoint
+CREATE INDEX "idx_organizations_owner_updated" ON "organizations" USING btree ("owner_id","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_organizations_relation_updated" ON "organizations" USING btree ("relation","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_organizations_status_updated" ON "organizations" USING btree ("status","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_people_org" ON "people" USING btree ("organization_id");--> statement-breakpoint
+CREATE INDEX "idx_people_owner" ON "people" USING btree ("owner_id");--> statement-breakpoint
+CREATE INDEX "idx_people_status" ON "people" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "idx_people_name" ON "people" USING btree ("first_name","last_name");--> statement-breakpoint
+CREATE INDEX "idx_people_org_updated" ON "people" USING btree ("organization_id","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_people_owner_updated" ON "people" USING btree ("owner_id","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_people_relation_updated" ON "people" USING btree ("relation","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_people_status_updated" ON "people" USING btree ("status","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_person_documents_person" ON "person_documents" USING btree ("person_id");--> statement-breakpoint
+CREATE INDEX "idx_person_documents_person_type" ON "person_documents" USING btree ("person_id","type");--> statement-breakpoint
+CREATE INDEX "idx_person_documents_expiry" ON "person_documents" USING btree ("expiry_date");--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_person_documents_primary_per_type" ON "person_documents" USING btree ("person_id","type") WHERE "person_documents"."is_primary" = true;--> statement-breakpoint
+CREATE INDEX "idx_person_notes_person" ON "person_notes" USING btree ("person_id");--> statement-breakpoint
+CREATE INDEX "idx_person_notes_person_created" ON "person_notes" USING btree ("person_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_person_payment_methods_person" ON "person_payment_methods" USING btree ("person_id");--> statement-breakpoint
+CREATE INDEX "idx_person_payment_methods_person_default" ON "person_payment_methods" USING btree ("person_id","is_default");--> statement-breakpoint
+CREATE INDEX "idx_person_relationships_from" ON "person_relationships" USING btree ("from_person_id");--> statement-breakpoint
+CREATE INDEX "idx_person_relationships_to" ON "person_relationships" USING btree ("to_person_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_person_relationships_pair_kind" ON "person_relationships" USING btree ("from_person_id","to_person_id","kind");--> statement-breakpoint
+CREATE INDEX "idx_segment_members_segment" ON "segment_members" USING btree ("segment_id");--> statement-breakpoint
+CREATE INDEX "idx_segment_members_person" ON "segment_members" USING btree ("person_id");--> statement-breakpoint
+CREATE INDEX "idx_segments_created" ON "segments" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX "idx_activities_owner" ON "activities" USING btree ("owner_id");--> statement-breakpoint
+CREATE INDEX "idx_activities_status" ON "activities" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "idx_activities_type" ON "activities" USING btree ("type");--> statement-breakpoint
+CREATE INDEX "idx_activities_owner_updated" ON "activities" USING btree ("owner_id","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_activities_status_updated" ON "activities" USING btree ("status","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_activities_type_updated" ON "activities" USING btree ("type","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_activity_links_activity" ON "activity_links" USING btree ("activity_id");--> statement-breakpoint
+CREATE INDEX "idx_activity_links_activity_role" ON "activity_links" USING btree ("activity_id","role","created_at");--> statement-breakpoint
+CREATE INDEX "idx_activity_links_entity" ON "activity_links" USING btree ("entity_type","entity_id");--> statement-breakpoint
+CREATE INDEX "idx_activity_participants_activity" ON "activity_participants" USING btree ("activity_id");--> statement-breakpoint
+CREATE INDEX "idx_activity_participants_activity_primary" ON "activity_participants" USING btree ("activity_id","is_primary","created_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_activity_participants_unique" ON "activity_participants" USING btree ("activity_id","person_id");--> statement-breakpoint
+CREATE INDEX "idx_custom_field_definitions_entity" ON "custom_field_definitions" USING btree ("entity_type");--> statement-breakpoint
+CREATE INDEX "idx_custom_field_definitions_entity_label" ON "custom_field_definitions" USING btree ("entity_type","label");--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_custom_field_definitions_key" ON "custom_field_definitions" USING btree ("entity_type","key");--> statement-breakpoint
+CREATE INDEX "idx_customer_signals_person_status_created" ON "customer_signals" USING btree ("person_id","status","created_at");--> statement-breakpoint
+CREATE INDEX "idx_customer_signals_assignee_status" ON "customer_signals" USING btree ("assigned_to_user_id","status");--> statement-breakpoint
+CREATE INDEX "idx_customer_signals_kind" ON "customer_signals" USING btree ("kind");--> statement-breakpoint
+CREATE INDEX "idx_customer_signals_resolved_booking" ON "customer_signals" USING btree ("resolved_booking_id");

--- a/scripts/fixtures/pre-proposal-rename/edited/relationships/0003_add_booking_custom_field_target.sql
+++ b/scripts/fixtures/pre-proposal-rename/edited/relationships/0003_add_booking_custom_field_target.sql
@@ -1,0 +1,7 @@
+DO $$ BEGIN
+ CREATE TYPE "public"."custom_field_target" AS ENUM('organization', 'person', 'quote', 'activity', 'booking');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+ALTER TABLE "custom_field_definitions" ALTER COLUMN "entity_type" SET DATA TYPE "public"."custom_field_target" USING "entity_type"::text::"public"."custom_field_target";--> statement-breakpoint
+ALTER TABLE "custom_field_definitions" ADD COLUMN "is_exportable" boolean DEFAULT true NOT NULL;--> statement-breakpoint
+ALTER TABLE "custom_field_definitions" ADD COLUMN "is_invoiceable" boolean DEFAULT false NOT NULL;

--- a/scripts/fixtures/pre-proposal-rename/quotes/0000_quotes_baseline.sql
+++ b/scripts/fixtures/pre-proposal-rename/quotes/0000_quotes_baseline.sql
@@ -1,0 +1,202 @@
+DO $$ BEGIN
+ CREATE TYPE "public"."entity_type" AS ENUM('organization', 'person', 'quote', 'activity');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."participant_role" AS ENUM('traveler', 'booker', 'decision_maker', 'finance', 'other');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."quote_status" AS ENUM('open', 'won', 'lost', 'archived');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."quote_version_status" AS ENUM('draft', 'sent', 'accepted', 'declined', 'superseded', 'expired');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+CREATE TABLE "booking_crm_details" (
+	"booking_id" text PRIMARY KEY NOT NULL,
+	"quote_id" text,
+	"quote_version_id" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "pipelines" (
+	"id" text PRIMARY KEY NOT NULL,
+	"entity_type" "entity_type" DEFAULT 'quote' NOT NULL,
+	"name" text NOT NULL,
+	"is_default" boolean DEFAULT false NOT NULL,
+	"sort_order" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "quote_media" (
+	"id" text PRIMARY KEY NOT NULL,
+	"quote_id" text NOT NULL,
+	"media_type" text NOT NULL,
+	"name" text NOT NULL,
+	"url" text NOT NULL,
+	"storage_key" text,
+	"mime_type" text,
+	"file_size" integer,
+	"alt_text" text,
+	"sort_order" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "quote_participants" (
+	"id" text PRIMARY KEY NOT NULL,
+	"quote_id" text NOT NULL,
+	"person_id" text NOT NULL,
+	"role" "participant_role" DEFAULT 'other' NOT NULL,
+	"is_primary" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "quote_products" (
+	"id" text PRIMARY KEY NOT NULL,
+	"quote_id" text NOT NULL,
+	"product_id" text,
+	"supplier_service_id" text,
+	"name_snapshot" text NOT NULL,
+	"description" text,
+	"quantity" integer DEFAULT 1 NOT NULL,
+	"unit_price_amount_cents" integer,
+	"cost_amount_cents" integer,
+	"currency" text,
+	"discount_amount_cents" integer,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "quote_version_lines" (
+	"id" text PRIMARY KEY NOT NULL,
+	"quote_version_id" text NOT NULL,
+	"product_id" text,
+	"supplier_service_id" text,
+	"description" text NOT NULL,
+	"quantity" integer DEFAULT 1 NOT NULL,
+	"unit_price_amount_cents" integer DEFAULT 0 NOT NULL,
+	"total_amount_cents" integer DEFAULT 0 NOT NULL,
+	"currency" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "quote_versions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"quote_id" text NOT NULL,
+	"label" text,
+	"status" "quote_version_status" DEFAULT 'draft' NOT NULL,
+	"supersedes_id" text,
+	"trip_snapshot_id" text,
+	"valid_until" date,
+	"currency" text NOT NULL,
+	"subtotal_amount_cents" integer DEFAULT 0 NOT NULL,
+	"tax_amount_cents" integer DEFAULT 0 NOT NULL,
+	"total_amount_cents" integer DEFAULT 0 NOT NULL,
+	"notes" text,
+	"sent_at" timestamp with time zone,
+	"viewed_at" timestamp with time zone,
+	"decided_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"archived_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE "quotes" (
+	"id" text PRIMARY KEY NOT NULL,
+	"title" text NOT NULL,
+	"person_id" text,
+	"organization_id" text,
+	"pipeline_id" text NOT NULL,
+	"stage_id" text NOT NULL,
+	"owner_id" text,
+	"status" "quote_status" DEFAULT 'open' NOT NULL,
+	"accepted_version_id" text,
+	"value_amount_cents" integer,
+	"value_currency" text,
+	"pax_count" integer,
+	"expected_close_date" date,
+	"source" text,
+	"source_ref" text,
+	"lost_reason" text,
+	"tags" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"custom_fields" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"description" text,
+	"created_by" text,
+	"updated_by" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"stage_changed_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"closed_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE "stages" (
+	"id" text PRIMARY KEY NOT NULL,
+	"pipeline_id" text NOT NULL,
+	"name" text NOT NULL,
+	"sort_order" integer DEFAULT 0 NOT NULL,
+	"probability" integer,
+	"is_closed" boolean DEFAULT false NOT NULL,
+	"is_won" boolean DEFAULT false NOT NULL,
+	"is_lost" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "quote_media" ADD CONSTRAINT "quote_media_quote_id_quotes_id_fk" FOREIGN KEY ("quote_id") REFERENCES "public"."quotes"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "quote_participants" ADD CONSTRAINT "quote_participants_quote_id_quotes_id_fk" FOREIGN KEY ("quote_id") REFERENCES "public"."quotes"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "quote_products" ADD CONSTRAINT "quote_products_quote_id_quotes_id_fk" FOREIGN KEY ("quote_id") REFERENCES "public"."quotes"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "quote_version_lines" ADD CONSTRAINT "quote_version_lines_quote_version_id_quote_versions_id_fk" FOREIGN KEY ("quote_version_id") REFERENCES "public"."quote_versions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "quote_versions" ADD CONSTRAINT "quote_versions_quote_id_quotes_id_fk" FOREIGN KEY ("quote_id") REFERENCES "public"."quotes"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "quote_versions" ADD CONSTRAINT "quote_versions_supersedes_id_quote_versions_id_fk" FOREIGN KEY ("supersedes_id") REFERENCES "public"."quote_versions"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "quotes" ADD CONSTRAINT "quotes_pipeline_id_pipelines_id_fk" FOREIGN KEY ("pipeline_id") REFERENCES "public"."pipelines"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "quotes" ADD CONSTRAINT "quotes_stage_id_stages_id_fk" FOREIGN KEY ("stage_id") REFERENCES "public"."stages"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "stages" ADD CONSTRAINT "stages_pipeline_id_pipelines_id_fk" FOREIGN KEY ("pipeline_id") REFERENCES "public"."pipelines"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_bcd_quote" ON "booking_crm_details" USING btree ("quote_id");--> statement-breakpoint
+CREATE INDEX "idx_bcd_quote_version" ON "booking_crm_details" USING btree ("quote_version_id");--> statement-breakpoint
+CREATE INDEX "idx_pipelines_entity" ON "pipelines" USING btree ("entity_type");--> statement-breakpoint
+CREATE INDEX "idx_pipelines_sort" ON "pipelines" USING btree ("sort_order","created_at");--> statement-breakpoint
+CREATE INDEX "idx_pipelines_entity_sort" ON "pipelines" USING btree ("entity_type","sort_order","created_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_pipelines_entity_name" ON "pipelines" USING btree ("entity_type","name");--> statement-breakpoint
+CREATE INDEX "idx_quote_media_quote" ON "quote_media" USING btree ("quote_id");--> statement-breakpoint
+CREATE INDEX "idx_quote_media_quote_sort" ON "quote_media" USING btree ("quote_id","sort_order");--> statement-breakpoint
+CREATE INDEX "idx_quote_participants_quote" ON "quote_participants" USING btree ("quote_id");--> statement-breakpoint
+CREATE INDEX "idx_quote_participants_quote_primary" ON "quote_participants" USING btree ("quote_id","is_primary","created_at");--> statement-breakpoint
+CREATE INDEX "idx_quote_participants_person" ON "quote_participants" USING btree ("person_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_quote_participants_unique" ON "quote_participants" USING btree ("quote_id","person_id");--> statement-breakpoint
+CREATE INDEX "idx_quote_products_quote" ON "quote_products" USING btree ("quote_id");--> statement-breakpoint
+CREATE INDEX "idx_quote_products_quote_created" ON "quote_products" USING btree ("quote_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_quote_products_product" ON "quote_products" USING btree ("product_id");--> statement-breakpoint
+CREATE INDEX "idx_quote_products_supplier_service" ON "quote_products" USING btree ("supplier_service_id");--> statement-breakpoint
+CREATE INDEX "idx_quote_version_lines_version" ON "quote_version_lines" USING btree ("quote_version_id");--> statement-breakpoint
+CREATE INDEX "idx_quote_version_lines_version_created" ON "quote_version_lines" USING btree ("quote_version_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_quote_version_lines_product" ON "quote_version_lines" USING btree ("product_id");--> statement-breakpoint
+CREATE INDEX "idx_quote_version_lines_supplier_service" ON "quote_version_lines" USING btree ("supplier_service_id");--> statement-breakpoint
+CREATE INDEX "idx_quote_versions_quote" ON "quote_versions" USING btree ("quote_id");--> statement-breakpoint
+CREATE INDEX "idx_quote_versions_status" ON "quote_versions" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "idx_quote_versions_supersedes" ON "quote_versions" USING btree ("supersedes_id");--> statement-breakpoint
+CREATE INDEX "idx_quote_versions_trip_snapshot" ON "quote_versions" USING btree ("trip_snapshot_id");--> statement-breakpoint
+CREATE INDEX "idx_quote_versions_quote_updated" ON "quote_versions" USING btree ("quote_id","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_quote_versions_status_updated" ON "quote_versions" USING btree ("status","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_quotes_person" ON "quotes" USING btree ("person_id");--> statement-breakpoint
+CREATE INDEX "idx_quotes_org" ON "quotes" USING btree ("organization_id");--> statement-breakpoint
+CREATE INDEX "idx_quotes_pipeline" ON "quotes" USING btree ("pipeline_id");--> statement-breakpoint
+CREATE INDEX "idx_quotes_stage" ON "quotes" USING btree ("stage_id");--> statement-breakpoint
+CREATE INDEX "idx_quotes_owner" ON "quotes" USING btree ("owner_id");--> statement-breakpoint
+CREATE INDEX "idx_quotes_status" ON "quotes" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "idx_quotes_accepted_version" ON "quotes" USING btree ("accepted_version_id");--> statement-breakpoint
+CREATE INDEX "idx_quotes_person_updated" ON "quotes" USING btree ("person_id","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_quotes_org_updated" ON "quotes" USING btree ("organization_id","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_quotes_pipeline_updated" ON "quotes" USING btree ("pipeline_id","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_quotes_stage_updated" ON "quotes" USING btree ("stage_id","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_quotes_owner_updated" ON "quotes" USING btree ("owner_id","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_quotes_status_updated" ON "quotes" USING btree ("status","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_stages_pipeline" ON "stages" USING btree ("pipeline_id");--> statement-breakpoint
+CREATE INDEX "idx_stages_sort" ON "stages" USING btree ("sort_order","created_at");--> statement-breakpoint
+CREATE INDEX "idx_stages_pipeline_sort" ON "stages" USING btree ("pipeline_id","sort_order","created_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_stages_pipeline_name" ON "stages" USING btree ("pipeline_id","name");

--- a/scripts/fixtures/pre-proposal-rename/quotes/0001_proposal_delivery_requests.sql
+++ b/scripts/fixtures/pre-proposal-rename/quotes/0001_proposal_delivery_requests.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "quote_proposal_delivery_requests" (
+	"idempotency_key" text PRIMARY KEY NOT NULL,
+	"request_fingerprint" text NOT NULL,
+	"quote_id" text NOT NULL,
+	"quote_version_id" text NOT NULL,
+	"proposal_url" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"completed_at" timestamp with time zone,
+	CONSTRAINT "quote_proposal_delivery_requests_quote_id_quotes_id_fk" FOREIGN KEY ("quote_id") REFERENCES "public"."quotes"("id") ON DELETE cascade ON UPDATE no action,
+	CONSTRAINT "quote_proposal_delivery_requests_quote_version_id_quote_versions_id_fk" FOREIGN KEY ("quote_version_id") REFERENCES "public"."quote_versions"("id") ON DELETE cascade ON UPDATE no action
+);--> statement-breakpoint
+CREATE INDEX "idx_quote_proposal_delivery_requests_quote" ON "quote_proposal_delivery_requests" USING btree ("quote_id","created_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_quote_proposal_delivery_requests_version" ON "quote_proposal_delivery_requests" USING btree ("quote_version_id");

--- a/scripts/fixtures/pre-proposal-rename/quotes/0002_durable_quote_delivery.sql
+++ b/scripts/fixtures/pre-proposal-rename/quotes/0002_durable_quote_delivery.sql
@@ -1,0 +1,27 @@
+ALTER TABLE "quote_proposal_delivery_requests" RENAME COLUMN "idempotency_key" TO "id";--> statement-breakpoint
+ALTER TABLE "quote_proposal_delivery_requests" ADD COLUMN "command_scope" text;--> statement-breakpoint
+ALTER TABLE "quote_proposal_delivery_requests" ADD COLUMN "command_idempotency_key" text;--> statement-breakpoint
+ALTER TABLE "quote_proposal_delivery_requests" ADD COLUMN "claim_action_id" text;--> statement-breakpoint
+ALTER TABLE "quote_proposal_delivery_requests" ADD COLUMN "organization_id" text;--> statement-breakpoint
+ALTER TABLE "quote_proposal_delivery_requests" ADD COLUMN "target_type" text;--> statement-breakpoint
+ALTER TABLE "quote_proposal_delivery_requests" ADD COLUMN "target_id" text;--> statement-breakpoint
+ALTER TABLE "quote_proposal_delivery_requests" ADD COLUMN "provider" text;--> statement-breakpoint
+ALTER TABLE "quote_proposal_delivery_requests" ADD COLUMN "result_snapshot" jsonb;--> statement-breakpoint
+UPDATE "quote_proposal_delivery_requests"
+SET
+	"command_scope" = 'legacy.quotes.snapshot-send',
+	"command_idempotency_key" = "id",
+	"claim_action_id" = "id",
+	"target_type" = 'quote',
+	"target_id" = "quote_id",
+	"provider" = 'historical-unavailable',
+	"result_snapshot" = '{}'::jsonb;--> statement-breakpoint
+ALTER TABLE "quote_proposal_delivery_requests" ALTER COLUMN "command_scope" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "quote_proposal_delivery_requests" ALTER COLUMN "command_idempotency_key" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "quote_proposal_delivery_requests" ALTER COLUMN "claim_action_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "quote_proposal_delivery_requests" ALTER COLUMN "target_type" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "quote_proposal_delivery_requests" ALTER COLUMN "target_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "quote_proposal_delivery_requests" ALTER COLUMN "provider" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "quote_proposal_delivery_requests" ALTER COLUMN "result_snapshot" SET NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_quote_proposal_delivery_requests_command" ON "quote_proposal_delivery_requests" USING btree ("command_scope","command_idempotency_key");--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_quote_proposal_delivery_requests_claim" ON "quote_proposal_delivery_requests" USING btree ("claim_action_id");

--- a/scripts/fixtures/pre-proposal-rename/quotes/20260716000301_namespace_custom_field_values.sql
+++ b/scripts/fixtures/pre-proposal-rename/quotes/20260716000301_namespace_custom_field_values.sql
@@ -1,0 +1,6 @@
+-- The cutline is intentionally one-way: custom fields were not used in
+-- production deployments before namespaced storage became authoritative.
+UPDATE "quotes"
+SET "custom_fields" = jsonb_build_object('custom', "custom_fields")
+WHERE "custom_fields" <> '{}'::jsonb
+  AND NOT ("custom_fields" ? 'custom');

--- a/scripts/fixtures/pre-proposal-rename/quotes/20260727200000_default_quote_pipeline.sql
+++ b/scripts/fixtures/pre-proposal-rename/quotes/20260727200000_default_quote_pipeline.sql
@@ -1,0 +1,38 @@
+-- Seed the default quote pipeline and its stages.
+--
+-- `quotes.pipeline_id` and `quotes.stage_id` are both NOT NULL, and nothing
+-- ever created a pipeline: not the module install, not a setup step, not a
+-- service-layer find-or-create. A fresh operator therefore had no pipeline and
+-- no stage, so `create_quote` could not succeed at all — the quotes surface was
+-- unusable until someone authored a pipeline by hand through the admin.
+--
+-- Both operators inspected had exactly one "Sales" pipeline created manually,
+-- one of them with its stages added two days after the pipeline itself, which
+-- is what hand-authoring looks like.
+--
+-- Guarded on the table being empty rather than on a fixed id, so an operator
+-- who already built their own pipeline (however they named it) is untouched.
+-- The `is_default` flag already exists for exactly this record.
+DO $$
+DECLARE
+  seeded_pipeline_id text := 'pipe_default_sales';
+BEGIN
+  IF EXISTS (SELECT 1 FROM "pipelines" WHERE "entity_type" = 'quote') THEN
+    RETURN;
+  END IF;
+
+  INSERT INTO "pipelines" ("id", "entity_type", "name", "is_default", "sort_order")
+  VALUES (seeded_pipeline_id, 'quote', 'Sales', true, 0);
+
+  -- Probability climbs with commitment; the two terminal stages carry the
+  -- closed/won/lost flags the pipeline reporting reads.
+  INSERT INTO "stages"
+    ("id", "pipeline_id", "name", "sort_order", "probability", "is_closed", "is_won", "is_lost")
+  VALUES
+    ('stg_default_new_inquiry', seeded_pipeline_id, 'New Inquiry',  0,  10, false, false, false),
+    ('stg_default_qualified',   seeded_pipeline_id, 'Qualified',    1,  25, false, false, false),
+    ('stg_default_quote_sent',  seeded_pipeline_id, 'Quote Sent',   2,  50, false, false, false),
+    ('stg_default_negotiation', seeded_pipeline_id, 'Negotiation',  3,  75, false, false, false),
+    ('stg_default_won',         seeded_pipeline_id, 'Won',          4, 100, true,  true,  false),
+    ('stg_default_lost',        seeded_pipeline_id, 'Lost',         5,   0, true,  false, true);
+END $$;

--- a/scripts/fixtures/pre-proposal-rename/quotes/_journal.json
+++ b/scripts/fixtures/pre-proposal-rename/quotes/_journal.json
@@ -5,36 +5,36 @@
     {
       "idx": 0,
       "version": "7",
-      "when": 1781947493896,
-      "tag": "0000_legal_baseline",
+      "when": 1781947484866,
+      "tag": "0000_quotes_baseline",
       "breakpoints": true
     },
     {
       "idx": 1,
       "version": "7",
-      "when": 1783900800000,
-      "tag": "20260713000400_standard_links",
+      "when": 1784116800000,
+      "tag": "0001_proposal_delivery_requests",
       "breakpoints": true
     },
     {
       "idx": 2,
       "version": "7",
-      "when": 1784876748180,
-      "tag": "20260724070548_contract_lifecycle_command_results",
+      "when": 1784192581000,
+      "tag": "20260716000301_namespace_custom_field_values",
       "breakpoints": true
     },
     {
       "idx": 3,
       "version": "7",
-      "when": 1784908800000,
-      "tag": "20260724160000_durable_contract_document_operations",
+      "when": 1784970000000,
+      "tag": "0002_durable_quote_delivery",
       "breakpoints": true
     },
     {
       "idx": 4,
       "version": "7",
-      "when": 1785801720000,
-      "tag": "20260804000200_proposal_version_target_kind",
+      "when": 1785182400000,
+      "tag": "20260727200000_default_quote_pipeline",
       "breakpoints": true
     }
   ]

--- a/scripts/tests/check-proposal-vocabulary.test.mjs
+++ b/scripts/tests/check-proposal-vocabulary.test.mjs
@@ -138,3 +138,33 @@ test("rejects active bespoke quote residues from proposal migration", (t) => {
   assert.match(output, /quotes: \\"Quotes\\"/)
   assert.match(output, /quote\.accepted/)
 })
+
+test("allows the rename adoption migrations and parity fixtures, and nothing beside them", (t) => {
+  const root = fixture(t)
+  // The migrations that retire the vocabulary from a live database, and the
+  // frozen pre-rename history the parity oracle replays.
+  write(
+    root,
+    "packages/proposals/migrations/20260804000000_adopt_legacy_quote_objects.sql",
+    'ALTER TABLE "quotes" RENAME TO "proposals";\n',
+  )
+  write(
+    root,
+    "packages/framework-migrations/migrations/0011_adopt_legacy_quote_objects.sql",
+    'ALTER TABLE "quote_versions" RENAME TO "proposal_versions";\n',
+  )
+  write(
+    root,
+    "scripts/fixtures/pre-proposal-rename/quotes/0000_quotes_baseline.sql",
+    'CREATE TABLE "quote_participants" ("id" text);\n',
+  )
+  assert.match(run(root), /OK proposal vocabulary/)
+
+  // A neighbouring migration in the same package is NOT covered.
+  write(
+    root,
+    "packages/proposals/migrations/20260901000000_something_else.sql",
+    'ALTER TABLE "quote_media" ADD COLUMN "x" text;\n',
+  )
+  assert.match(failure(root), /20260901000000_something_else\.sql/)
+})

--- a/scripts/verify-migration-replay-parity.mjs
+++ b/scripts/verify-migration-replay-parity.mjs
@@ -1,11 +1,19 @@
 /**
  * Replay-parity oracle for retiring the Operator deployment migration source.
- * Proves that the legacy upgrade path reconstitutes exactly the same schema as
- * a fresh replay of the selected packages:
+ * Proves that every upgrade path reconstitutes exactly the same schema as a
+ * fresh replay of the selected packages:
  *
- *   frozen framework bundle + retired deployment migrations
- *   + package post-cutline increments
+ *   (1) frozen framework bundle + retired deployment migrations
+ *       + package post-cutline increments
+ *   (2) the package history AS IT SHIPPED BEFORE the quotes → proposals rename
+ *       + package post-cutline increments
  *   === all current package-owned migrations
+ *
+ * Lane 2 is what a deployment provisioned before #4004 actually holds: the
+ * retired `quotes` source plus the pre-rename bytes of the migrations that
+ * rename touched in place (voyant#4143). It fails if the adoption increments
+ * miss an object, which is the whole point — the rename is only safe if the
+ * legacy shape converges on the current one exactly.
  *
  * The D.2 cutline and framework bundle remain frozen transition fixtures. The
  * retired deployment history is retained only under scripts/fixtures so this
@@ -39,6 +47,21 @@ const LEGACY_DEPLOYMENT_MIGRATIONS = join(
 )
 const OPERATOR_DIR = join(ROOT, "apps/operator")
 const OPERATOR_ARTIFACTS = join(OPERATOR_DIR, ".voyant")
+
+// The package history as it shipped BEFORE the quotes → proposals rename.
+const PRE_RENAME_FIXTURES = join(ROOT, "scripts/fixtures/pre-proposal-rename")
+// `proposals/0000_proposals_baseline` stands in for the whole retired `quotes`
+// source: a pre-rename deployment ran these five tags instead of it.
+const RETIRED_QUOTES_SOURCE = { source: "proposals", tag: "0000_proposals_baseline" }
+// `{source}/{tag}` whose shipped bytes the rename edited in place. A pre-rename
+// deployment holds the fixture bytes, not the ones in the package today.
+const PRE_RENAME_EDITED_TAGS = new Set([
+  "bookings/0000_bookings_baseline",
+  "legal/0000_legal_baseline",
+  "mice/20260713000300_standard_links",
+  "relationships/0000_relationships_baseline",
+  "relationships/0003_add_booking_custom_field_target",
+])
 
 execFileSync("pnpm", ["exec", "voyant", "build", "--json"], {
   cwd: OPERATOR_DIR,
@@ -107,6 +130,34 @@ async function applyFolders(client, folders) {
       await client.query(stmt)
     }
   }
+}
+
+/**
+ * A source's journal replayed as a PRE-RENAME deployment holds it: the retired
+ * `quotes` tags in place of the proposals baseline, the fixture bytes for the
+ * tags the rename edited, and the current bytes for everything else (including
+ * the adoption increments, which is what this lane exercises).
+ */
+function loadFolderPreRename(folder, sourceName) {
+  const journal = JSON.parse(readFileSync(join(folder, "meta", "_journal.json"), "utf8"))
+  return [...journal.entries]
+    .sort((a, b) => a.when - b.when)
+    .flatMap((entry) => {
+      const id = `${sourceName}/${entry.tag}`
+      if (sourceName === RETIRED_QUOTES_SOURCE.source && entry.tag === RETIRED_QUOTES_SOURCE.tag) {
+        const retired = join(PRE_RENAME_FIXTURES, "quotes")
+        const retiredJournal = JSON.parse(readFileSync(join(retired, "_journal.json"), "utf8"))
+        return [...retiredJournal.entries]
+          .sort((a, b) => a.when - b.when)
+          .flatMap((e) => splitStatements(readFileSync(join(retired, `${e.tag}.sql`), "utf8")))
+      }
+      if (PRE_RENAME_EDITED_TAGS.has(id)) {
+        return splitStatements(
+          readFileSync(join(PRE_RENAME_FIXTURES, "edited", sourceName, `${entry.tag}.sql`), "utf8"),
+        )
+      }
+      return splitStatements(readFileSync(join(folder, `${entry.tag}.sql`), "utf8"))
+    })
 }
 
 /** Canonical, order-independent fingerprint of the public schema. */
@@ -202,32 +253,56 @@ async function main() {
       })
     })
 
+    // Pre-rename package history: what a deployment provisioned before #4004
+    // holds, brought forward by the quotes → proposals adoption increments.
+    const preRenameFp = await withFreshDb(admin, "voyant_replay_pre_rename", async () => {
+      console.log("  sources: pre-rename package history (retired quotes source)")
+      return onDb("voyant_replay_pre_rename", async (c) => {
+        for (const ext of SEED_EXTENSIONS) await c.query(ext)
+        for (const source of packageSources) {
+          if (!source.hasMigrations) {
+            throw new Error(`schema source ${source.name} has no migrations folder`)
+          }
+          for (const stmt of loadFolderPreRename(source.migrationsDir, source.name)) {
+            await c.query(stmt)
+          }
+        }
+        return fingerprint(c)
+      })
+    })
+
     const sections = ["columns", "enums", "indexes", "constraints"]
+    const lanes = [
+      { label: "upgrade path", fingerprint: newFp },
+      { label: "pre-rename history", fingerprint: preRenameFp },
+    ]
     let ok = true
-    for (const s of sections) {
-      const a = hashOf(newFp[s])
-      const b = hashOf(packageFp[s])
-      if (a !== b) {
-        ok = false
-        console.error(`  MISMATCH  ${s}: upgrade=${a.slice(0, 12)} packages=${b.slice(0, 12)}`)
-        const aSet = new Set(newFp[s].map((r) => JSON.stringify(r)))
-        const bSet = new Set(packageFp[s].map((r) => JSON.stringify(r)))
-        const onlyNew = [...aSet].filter((r) => !bSet.has(r)).slice(0, 5)
-        const onlyPush = [...bSet].filter((r) => !aSet.has(r)).slice(0, 5)
-        for (const r of onlyNew) console.error(`    only in upgrade path: ${r}`)
-        for (const r of onlyPush) console.error(`    only in package replay: ${r}`)
-      } else {
-        console.log(`  OK  ${s} (${newFp[s].length} rows)`)
+    for (const lane of lanes) {
+      for (const s of sections) {
+        const a = hashOf(lane.fingerprint[s])
+        const b = hashOf(packageFp[s])
+        if (a !== b) {
+          ok = false
+          console.error(
+            `  MISMATCH  ${lane.label} ${s}: lane=${a.slice(0, 12)} packages=${b.slice(0, 12)}`,
+          )
+          const aSet = new Set(lane.fingerprint[s].map((r) => JSON.stringify(r)))
+          const bSet = new Set(packageFp[s].map((r) => JSON.stringify(r)))
+          const onlyLane = [...aSet].filter((r) => !bSet.has(r)).slice(0, 5)
+          const onlyPackages = [...bSet].filter((r) => !aSet.has(r)).slice(0, 5)
+          for (const r of onlyLane) console.error(`    only in ${lane.label}: ${r}`)
+          for (const r of onlyPackages) console.error(`    only in package replay: ${r}`)
+        } else {
+          console.log(`  OK  ${lane.label} ${s} (${lane.fingerprint[s].length} rows)`)
+        }
       }
     }
 
     if (!ok) {
-      console.error(
-        "\nreplay-parity FAIL — the legacy upgrade path and package-owned replay differ.",
-      )
+      console.error("\nreplay-parity FAIL — an upgrade path and the package-owned replay differ.")
       process.exit(1)
     }
-    console.log("\nverify-migration-replay-parity: OK — legacy upgrade == package-owned replay")
+    console.log("\nverify-migration-replay-parity: OK — every upgrade path == package-owned replay")
   } finally {
     await admin.end()
   }


### PR DESCRIPTION
Closes #4143.

## The problem

`quotes` became `proposals` in #4004: the five `quotes/*` migration tags were replaced by one `proposals/0000_proposals_baseline`, and the new vocabulary was followed into **eight already-shipped migrations owned by other sources by editing them in place**. Every deployment provisioned before that release is blocked from upgrading, and both guards that stop it are doing their job:

- the edited files trip `MigrationImmutabilityError`;
- `proposals/0000_proposals_baseline` is unknown to the ledger, so it is either parity-gated (its tables do not exist under the new names) or executed — which collides with the live `quote_*` tables.

The issue suggests `legacySources`. That does not work: it maps a **source name** onto the same tag, and the rename changed the tags too. The issue is right that hash equivalence alone would be actively harmful — it marks a migration applied, so the renames would never run and the database would keep `quote_*` while the application queries `proposal_*`.

The issue lists five edited files; there are eight. `framework/0000`, `framework/0003` and `framework/0005` in the bundle were edited as well.

## The fix

**1. Supersession in the collector.** `SUPERSEDED_LEDGER_IDENTITIES` declares the exact retired `(source, tag)` ledger rows a migration replaces. When **every** one is present, the migration is RECORDED without executing, and `withoutUngatedMigrations` keeps it out of the baseline parity gate — for the same reason that gate already skips recorded entries. All-or-nothing on purpose: a partially-migrated legacy source is not at the shape the superseding migration declares, so the run fails loudly rather than recording a false baseline.

**2. A guarded adoption increment per owning source.** Each source that owns renamed objects renames them **in place** — tables, columns, constraints, indexes, enum types and enum labels. Renaming rather than create-and-copy because observed deployments hold live rows, and because it preserves foreign keys and enum-label OIDs (so `pipelines.entity_type DEFAULT 'quote'` follows the relabelling without a rewrite — verified).

Values stored as plain **text** are not reached by an enum relabelling and get their own guarded `UPDATE` in the owning package. Three of these were not in the issue:

| where | legacy value | why it matters |
|---|---|---|
| `custom_field_definitions.entity_type` | `quote` | the column was widened off the enum by `custom-fields`; the registry looks definitions up by exact key, so proposals would show **no custom fields at all** |
| `booking_origins.origin_source` + its CHECK | `accepted_quote_version` | read by the booking-origin service |
| `user_profiles.permissions`, `apikey.permissions` | `quotes` resource key | `assertKnownPermissions` **rejects** a resource the catalog no longer lists |

**3. Hash equivalence for the eight edited files** — sound *only because* (2) exists.

The framework bundle carries the same adoption as an append (`0011`); its frozen cutline slice (`0000`..`0007`) is untouched.

**Deliberately not migrated.** `action_ledger_entries` records past `action_name`/`target_type` under the vocabulary in force when they happened, and legacy delivery-request rows carry a `legacy.quotes.*` command scope no live command looks up. Rewriting either would falsify a record rather than migrate state.

## Proof

`verify:migration-replay-parity` gains a lane that replays **the package history as it shipped before the rename** — the retired `quotes` source plus the pre-rename bytes of the five edited package migrations, vendored under `scripts/fixtures/pre-proposal-rename/` — followed by the adoption increments, and fails unless it matches a fresh replay column-, enum-, index- and constraint-for-constraint. Negative control run: with the proposals increment stubbed out it fails on `booking_crm_details`, `quote_status`, and the rest.

```
OK  upgrade path columns (5649)  enums (1441)  indexes (2201)  constraints (4231)
OK  pre-rename history columns (5649)  enums (1441)  indexes (2201)  constraints (4231)
```

Verified end to end against PostgreSQL 16 by building a **real** pre-rename deployment — 140 pre-rename ledger rows plus live legacy rows — and driving `runDeploymentMigrations` over it exactly as the node migration runner does:

```
db:            executed=[db/20260804000600_proposal_permission_resource]
bookings:      executed=[bookings/20260804000300_booking_origin_proposal_version]
legal:         executed=[legal/20260804000200_proposal_version_target_kind]
mice:          executed=[mice/20260804000400_proposal_mice_program_link]
proposals:     executed=[proposals/20260804000000_adopt_legacy_quote_objects]
               baselined=[proposals/0000_proposals_baseline]
relationships: executed=[relationships/20260804000100_proposal_entity_labels]
custom-fields: executed=[custom-fields/20260804000500_proposal_custom_field_entity]

proposal_rows: 1   version_rows: 1   participant_rows: 1
cfd_entity: 'proposal'
origin_source: 'accepted_proposal_version'   origin_version: 'qver_1'
user_perms: '{"crm": ["read"], "proposals": ["read", "write"]}'
key_perms:  '{"proposals": ["read"]}'        key2_perms: 'not json at all'  (untouched)
pipeline_default: "'proposal'::entity_type"  seeded_stage: 'Proposal Sent'
```

A second pass over the same database applies nothing. Schema fingerprint identical to a fresh install.

Also green: `verify-package-baseline --union`, `verify:migration-cutline`, `verify:architecture`, `operator db:migrate` fresh + re-run, `biome check`, and the unit suites for all eight touched packages.

## Notes for review

- `check-proposal-vocabulary.mjs` gets a narrow, pattern-scoped allowance: retiring the vocabulary from a live database means naming it, and the parity fixtures **are** the pre-rename history byte for byte. A test asserts a neighbouring migration in the same package is still rejected.
- Primary keys are **not** re-prefixed. Existing rows keep `quot_*` / `qver_*` typeids; new rows get `prps_*` / `prvr_*`. Prefixes are informational (`LinkableDefinition.idPrefix`, nothing validates them on read), and rewriting primary keys across every referencing table would be a far larger and riskier change than the rename requires. Worth a follow-up decision, not this PR.
- The rename commit also mutated the frozen framework bundle's cutline slice and swapped the frozen cutline's `quotes` entry for `proposals`. Both are now load-bearing for `verify-package-baseline --union`, so this PR does not unwind them — the ledger-side damage is repaired by the equivalence hashes instead. Flagging it because the freeze checker cannot currently catch that class of edit.
