### PR TITLE
fix(operations): wake the expired-hold reaper instead of polling for it

### DIFF
--- a/.changeset/wake-driven-hold-expiry.md
+++ b/.changeset/wake-driven-hold-expiry.md
@@ -1,0 +1,28 @@
+---
+"@voyant-travel/core": minor
+"@voyant-travel/framework": minor
+"@voyant-travel/operations": minor
+"@voyant-travel/inventory": patch
+"@voyant-travel/runtime": patch
+---
+
+Wake the expired-hold reaper instead of polling for it.
+
+An availability hold records the instant it becomes reapable, so nothing has to
+poll to discover that work. `operations.release-expired-availability-holds` is
+now `wakeup: true`: placing or extending a hold reports the new expiry, the
+reaper re-arms itself from the earliest outstanding expiry after every run, and
+the cron drops to a six-hourly backstop for a wake lost to a restart.
+
+Hosts gain a target-neutral way to carry that request.
+`VoyantRuntimeHostPrimitives.jobs.wakeAt(jobId, at)` asks the deployment to
+invoke a wakeable job at an instant; the Node host arms one in-process timer per
+job, keeps the earliest pending instant, and declines anything past its horizon.
+A requested wake is a prompt and never durable — the declared cadence stays the
+recovery authority, as it already is for a wake arriving over
+`POST /__voyant/jobs/:id`.
+
+On a managed deployment this is what stops an idle tenant from paying for its
+database. A tenant with no live holds now arms nothing and never wakes its
+compute for this job; one with holds wakes exactly when there is capacity to
+give back, which is sooner than the fifteen-minute sweep it replaces.

--- a/docs/architecture/deployment-targets.md
+++ b/docs/architecture/deployment-targets.md
@@ -180,6 +180,25 @@ another scheduler. Package code never imports a vendor SDK or assumes which
 control plane requested the wake. The declared cadence remains the recovery
 authority when a wake is lost or coalesced.
 
+A package may also ask for a wake itself, through
+`VoyantRuntimeHostPrimitives.jobs.wakeAt(jobId, at)`. This is the same signal
+arriving from inside the process rather than over HTTP, and it carries the same
+weight: the Node host arms one in-process timer per job, keeps the earliest
+pending instant, declines anything past its horizon, and forgets every armed
+wake on restart. A Worker host accepts the call and does nothing, because a
+Worker invocation ends with its response. Nothing about a requested wake is
+durable, so a package may only use it to make work *timelier* than its declared
+cadence — never to replace the cadence, and never for work the cadence would
+not eventually do anyway.
+
+This is what lets a job whose due time is written down be wake-driven instead
+of polled. `operations.release-expired-availability-holds` is the worked
+example: a hold records the instant it becomes reapable, so the runtime arms
+the reaper for that instant and its cron falls back to a six-hourly backstop. A
+tenant holding nothing arms nothing and stops touching its database, which on a
+managed deployment is the difference between an idle database that stays
+suspended and one billed for a five-minute minimum four times an hour.
+
 The optional `scale-to-zero` scheduling profile aligns frequent recovery work
 on a 15-minute floor, leaving enough idle time for a five-minute database
 autosuspend window while bounding recovery when a wake is lost. Longer-running

--- a/docs/architecture/workflow-product-removal-rfc.md
+++ b/docs/architecture/workflow-product-removal-rfc.md
@@ -163,6 +163,7 @@ Domain packages retain the durable records that make a job safe to retry:
 | Notification reminders | reminder and delivery records | Sweep due records; make delivery idempotent at the record level. |
 | Promotion boundaries | promotion state and product index state | Idempotent time-based sweep; reindex affected products. |
 | Booking draft expiry | booking draft and hold state | Idempotent expiry sweep; release a hold before deleting the draft. |
+| Availability hold expiry | `availability_holds.expires_at` | Wake at the earliest outstanding expiry and re-arm from the same column after every run; the declared cadence recovers a wake lost to a restart. |
 
 The event outbox is particularly important: an immediate wakeup improves
 latency, but a scheduled drain remains mandatory so a missed wakeup cannot lose
@@ -187,6 +188,7 @@ The current first-party workflow definitions move as follows:
 | `promotions.reindex-all-products` | Wakeable job with scheduled recovery | A domain-owned reindex intent or checkpoint, added before cutover. |
 | `catalog.reap-expired-booking-drafts` | Scheduled job | Booking draft and hold state; reconcile ownership with stale-hold expiry before migration. |
 | `bookings.expire-stale-holds` | Scheduled job | Booking hold and payment-session state; reconcile ownership with draft reaping before migration. |
+| `operations.release-expired-availability-holds` | Wakeable job with scheduled recovery | `availability_holds.expires_at` is the dispatcher: it records when the work becomes due, so nothing has to poll to find it (#4067). |
 | `cruises.external-catalog-refresh` | Scheduled job | Selected cruises capability state and refresh checkpoint. |
 | `products.generate-pdf` | Domain command, not a job | Generate synchronously or persist a document-generation intent consumed by a package job. |
 

--- a/packages/auth/src/runtime-contributor.test.ts
+++ b/packages/auth/src/runtime-contributor.test.ts
@@ -50,6 +50,7 @@ function hostWithAuthProvider(
       database: {} as VoyantRuntimeHostPrimitives["database"],
       storage: {} as VoyantRuntimeHostPrimitives["storage"],
       events: {} as VoyantRuntimeHostPrimitives["events"],
+      jobs: {} as VoyantRuntimeHostPrimitives["jobs"],
       config: {
         read: (_bindings, key) => {
           if (key === "deployment.providers.adminAuth") return provider

--- a/packages/auth/tests/unit/team-management-runtime-port.test.ts
+++ b/packages/auth/tests/unit/team-management-runtime-port.test.ts
@@ -37,6 +37,7 @@ function hostWithAuthProvider(provider: "better-auth" | "voyant-cloud") {
       database: {} as VoyantRuntimeHostPrimitives["database"],
       storage: {} as VoyantRuntimeHostPrimitives["storage"],
       events: {} as VoyantRuntimeHostPrimitives["events"],
+      jobs: {} as VoyantRuntimeHostPrimitives["jobs"],
       config: {
         read: (_bindings, key) => (key === "deployment.providers.adminAuth" ? provider : undefined),
       },

--- a/packages/core/src/runtime-host.ts
+++ b/packages/core/src/runtime-host.ts
@@ -14,6 +14,18 @@ export interface VoyantRuntimeHostPrimitives {
   events: {
     deliver(event: unknown, bindings: unknown): Promise<unknown>
   }
+  jobs: {
+    /**
+     * Ask the deployment host to invoke a `wakeup: true` job at `at`.
+     *
+     * A prompt, never a promise: the host may coalesce, drop, or decline the
+     * request, and nothing about it is durable across a restart. The job's
+     * declared cadence remains the recovery authority, exactly as it is for a
+     * wake requested from outside the process. Callers therefore write their
+     * durable state first and request the wake afterwards.
+     */
+    wakeAt(jobId: string, at: Date): void
+  }
   config: {
     read(bindings: unknown, key: string): unknown
   }

--- a/packages/framework/src/deployment-artifacts.ts
+++ b/packages/framework/src/deployment-artifacts.ts
@@ -936,15 +936,14 @@ if (isMainModule) {
     process.env,
     resolveVoyantNodeProviderPlan(deployment.providers),
   )
-  const runtimePorts = createGeneratedGraphRuntimePorts({
-    primitives: createVoyantNodeRuntimeHostPrimitives({
-      env,
-      config: {
-        "deployment.providers.adminAuth": deployment.providers.adminAuth,
-        "deployment.providers.customerAuth": deployment.providers.customerAuth,
-      },
-    }),
+  const primitives = createVoyantNodeRuntimeHostPrimitives({
+    env,
+    config: {
+      "deployment.providers.adminAuth": deployment.providers.adminAuth,
+      "deployment.providers.customerAuth": deployment.providers.customerAuth,
+    },
   })
+  const runtimePorts = createGeneratedGraphRuntimePorts({ primitives })
   const handle = await startVoyantNodeRuntime({
     deployment,
     deploymentRequirements: resolveGeneratedDeploymentRequirements(),
@@ -952,6 +951,11 @@ if (isMainModule) {
     graphRuntime: createGeneratedGraphRuntime(),
     jobs: GENERATED_PRODUCT_JOBS,
     runtimePorts,
+    jobWakeups: {
+      bind: (wakeAt) => {
+        primitives.jobs.wakeAt = wakeAt
+      },
+    },
   })
   console.info(
     \`[node-runtime] Node runtime listening on :\${handle.port} (\${GENERATED_DEPLOYMENT_GRAPH_HASH})\`,

--- a/packages/framework/src/node-job-host.test.ts
+++ b/packages/framework/src/node-job-host.test.ts
@@ -18,6 +18,7 @@ function jobRuntime(
     every: "5m",
     overlap: "queue",
   },
+  wakeup = true,
 ): VoyantGraphRuntime {
   return createVoyantGraphRuntime({
     graphHash: "sha256:job-host",
@@ -43,7 +44,7 @@ function jobRuntime(
             unitId,
             declaration: {
               id: jobId,
-              wakeup: true,
+              ...(wakeup ? { wakeup: true as const } : {}),
               schedule,
               runtime: { entry: "./jobs", export: "runJob" },
             },
@@ -65,6 +66,7 @@ function inventory(
     every: "5m",
     overlap: "queue",
   },
+  wakeup = true,
 ) {
   return [
     {
@@ -72,7 +74,7 @@ function inventory(
       unitId,
       packageName: unitId,
       schedule,
-      wakeup: true,
+      wakeup,
     },
   ]
 }
@@ -383,6 +385,89 @@ describe("Voyant Node product job host", () => {
       })
       expect(() => host.start()).toThrow(/unsupported every cadence/)
     }
+  })
+
+  it("arms a deferred wake and lets the earliest request win", async () => {
+    vi.useFakeTimers()
+    const handler = vi.fn(async () => {})
+    const host = createVoyantNodeJobHost({ runtime: jobRuntime(handler), jobs: inventory() })
+    const start = Date.now()
+
+    expect(host.wakeAt(jobId, new Date(start + 600_000))).toBe("armed")
+    // A later instant must not push the pending wake out.
+    expect(host.wakeAt(jobId, new Date(start + 900_000))).toBe("pending-earlier")
+    // An earlier one must.
+    expect(host.wakeAt(jobId, new Date(start + 120_000))).toBe("armed")
+
+    await vi.advanceTimersByTimeAsync(119_000)
+    expect(handler).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(2_000)
+    await vi.waitFor(() => expect(handler).toHaveBeenCalledTimes(1))
+    expect(host.health()[0]?.lastSource).toBe("wakeup")
+
+    // The armed wake is spent, so the next request arms afresh.
+    expect(host.wakeAt(jobId, new Date(Date.now() + 60_000))).toBe("armed")
+    host.stop()
+    vi.useRealTimers()
+  })
+
+  it("floors an already-due wake instead of spinning against its own clock", async () => {
+    vi.useFakeTimers()
+    const handler = vi.fn(async () => {})
+    const host = createVoyantNodeJobHost({
+      runtime: jobRuntime(handler),
+      jobs: inventory(),
+      minimumWakeDelayMs: 1_000,
+    })
+
+    expect(host.wakeAt(jobId, new Date(Date.now() - 60_000))).toBe("armed")
+    await vi.advanceTimersByTimeAsync(999)
+    expect(handler).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(2)
+    await vi.waitFor(() => expect(handler).toHaveBeenCalledTimes(1))
+    host.stop()
+    vi.useRealTimers()
+  })
+
+  it("declines a wake past the horizon and leaves it to the declared cadence", () => {
+    vi.useFakeTimers()
+    const handler = vi.fn(async () => {})
+    const host = createVoyantNodeJobHost({
+      runtime: jobRuntime(handler),
+      jobs: inventory(),
+      maximumWakeHorizonMs: 60_000,
+    })
+
+    expect(host.wakeAt(jobId, new Date(Date.now() + 60_001))).toBe("beyond-horizon")
+    host.stop()
+    vi.useRealTimers()
+  })
+
+  it("drops armed wakes when the host stops", async () => {
+    vi.useFakeTimers()
+    const handler = vi.fn(async () => {})
+    const host = createVoyantNodeJobHost({ runtime: jobRuntime(handler), jobs: inventory() })
+
+    expect(host.wakeAt(jobId, new Date(Date.now() + 30_000))).toBe("armed")
+    host.stop()
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(handler).not.toHaveBeenCalled()
+    vi.useRealTimers()
+  })
+
+  it("refuses to wake a job the graph did not declare wakeable", () => {
+    const schedule = { every: "5m", overlap: "queue" } as const
+    const host = createVoyantNodeJobHost({
+      runtime: jobRuntime(() => {}, schedule, false),
+      jobs: inventory(schedule, false),
+    })
+
+    expect(() => host.wakeAt(jobId, new Date(Date.now() + 30_000))).toThrow(
+      /is not declared wakeup: true/,
+    )
+    expect(() => host.wakeAt("notifications.absent", new Date())).toThrow(
+      /is not selected by the graph/,
+    )
   })
 
   it("uses standard cron OR semantics for restricted day-of-month and day-of-week", async () => {

--- a/packages/framework/src/node-job-host.ts
+++ b/packages/framework/src/node-job-host.ts
@@ -59,6 +59,17 @@ export interface CreateVoyantNodeJobHostOptions {
   now?: () => Date
   sleep?: (milliseconds: number) => Promise<void>
   schedulerPollMs?: number
+  /**
+   * Floor applied to a deferred wake. Keeps a job that re-arms itself from a
+   * timestamp it just acted on from spinning against its own clock.
+   */
+  minimumWakeDelayMs?: number
+  /**
+   * Furthest ahead a deferred wake is armed. Beyond it the declared cadence is
+   * the cheaper recovery: a resident timer that far out survives nothing a
+   * cron tick would not also repair.
+   */
+  maximumWakeHorizonMs?: number
   /** Required for the fixed internal HTTP invocation surface. */
   originTrustSecret?: string
   /** Best-effort terminal execution reporting; failures never repeat domain work. */
@@ -81,6 +92,15 @@ export interface VoyantNodeJobHost {
     correlation?: VoyantProductJobExecutionCorrelation,
   ) => Promise<"started" | "queued" | "skipped">
   dispatchSchedule: (event: { scheduleId?: string; cron?: string }) => Promise<void>
+  /**
+   * Arm an in-process wake for a `wakeup: true` job at `at`.
+   *
+   * Earliest request wins: a job holds at most one armed wake, and a later
+   * instant never displaces an earlier one. Returns what the host did so a
+   * caller can log it; no caller should branch on delivery, because the
+   * declared cadence is what actually guarantees the work runs.
+   */
+  wakeAt: (jobId: string, at: Date) => "armed" | "pending-earlier" | "beyond-horizon"
   handleRequest: (request: Request, originTrustSecret?: string) => Promise<Response | undefined>
   health: () => readonly VoyantNodeJobHealth[]
   /** Resolve after the current invocation and any coalesced follow-up are idle. */
@@ -122,6 +142,14 @@ export function createVoyantNodeJobHost(
   const sleep =
     options.sleep ?? ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)))
   const schedulerPollMs = positiveInteger(options.schedulerPollMs ?? 1_000, "schedulerPollMs")
+  const minimumWakeDelayMs = nonNegativeNumber(
+    options.minimumWakeDelayMs ?? 1_000,
+    "minimumWakeDelayMs",
+  )
+  const maximumWakeHorizonMs = positiveInteger(
+    options.maximumWakeHorizonMs ?? 6 * 60 * 60 * 1_000,
+    "maximumWakeHorizonMs",
+  )
   const states = new Map<string, JobExecutionState>(
     inventory.map((job) => [job.id, { pending: false } satisfies JobExecutionState]),
   )
@@ -133,6 +161,7 @@ export function createVoyantNodeJobHost(
   )
   const lastCronTick = new Map<string, string>()
   const nextEveryTick = new Map<string, number>()
+  const armedWakes = new Map<string, { at: number; timer: ReturnType<typeof setTimeout> }>()
   let timer: ReturnType<typeof setInterval> | undefined
 
   const run = async (
@@ -267,6 +296,36 @@ export function createVoyantNodeJobHost(
     await invoke(job.id, "schedule")
   }
 
+  const wakeAt = (jobId: string, at: Date): "armed" | "pending-earlier" | "beyond-horizon" => {
+    const job = jobsById.get(jobId)
+    if (!job) {
+      throw new Error(`Voyant Node job host: job "${jobId}" is not selected by the graph.`)
+    }
+    if (!job.wakeup) {
+      throw new Error(`Voyant Node job host: job "${jobId}" is not declared wakeup: true.`)
+    }
+    const requestedAt = at.getTime()
+    if (!Number.isFinite(requestedAt)) {
+      throw new TypeError(`Voyant Node job host: job "${jobId}" was woken at an invalid date.`)
+    }
+    const current = now().getTime()
+    const delayMs = Math.max(requestedAt - current, minimumWakeDelayMs)
+    if (delayMs > maximumWakeHorizonMs) return "beyond-horizon"
+
+    const armAt = current + delayMs
+    const armed = armedWakes.get(jobId)
+    if (armed && armed.at <= armAt) return "pending-earlier"
+    if (armed) clearTimeout(armed.timer)
+
+    const wakeTimer = setTimeout(() => {
+      armedWakes.delete(jobId)
+      void invoke(jobId, "wakeup")
+    }, delayMs)
+    wakeTimer.unref?.()
+    armedWakes.set(jobId, { at: armAt, timer: wakeTimer })
+    return "armed"
+  }
+
   const handleRequest = async (
     request: Request,
     requestOriginTrustSecret?: string,
@@ -358,6 +417,7 @@ export function createVoyantNodeJobHost(
     inventory,
     invoke,
     dispatchSchedule,
+    wakeAt,
     handleRequest,
     health: () => inventory.map((job) => ({ ...requireMapValue(healthById, job.id) })),
     settled: async (jobId) => {
@@ -372,6 +432,8 @@ export function createVoyantNodeJobHost(
     stop: () => {
       if (timer) clearInterval(timer)
       timer = undefined
+      for (const { timer: wakeTimer } of armedWakes.values()) clearTimeout(wakeTimer)
+      armedWakes.clear()
     },
   }
 }

--- a/packages/framework/src/node-runtime.ts
+++ b/packages/framework/src/node-runtime.ts
@@ -176,6 +176,12 @@ export function createVoyantNodeRuntimeHostPrimitives(
         return options.deliverEvent(event, bindings)
       },
     },
+    // Left inert until a deployment binds it through
+    // `loadVoyantNodeRuntime({ jobWakeups })`. Contributors are composed before
+    // the job host exists, and a package that asks for a wake it cannot get is
+    // no worse off than one whose wake was dropped in flight — its declared
+    // cadence still runs the work.
+    jobs: { wakeAt: () => {} },
     config: {
       read: (bindings, key) =>
         Object.hasOwn(options.config ?? {}, key)
@@ -220,6 +226,15 @@ export interface VoyantNodeRuntimeOptions {
   eventDelivery?: {
     bind(deliver: (event: EventEnvelope) => Promise<unknown>): void
   }
+  /**
+   * Routes package wake requests into this process's job host after boot, the
+   * same way `eventDelivery` routes durable event delivery. Without it a
+   * package's `primitives.jobs.wakeAt` stays inert and every job runs purely
+   * on its declared cadence.
+   */
+  jobWakeups?: {
+    bind(wakeAt: (jobId: string, at: Date) => void): void
+  }
   /** Node-owned durable boundary for graph-selected outbound webhook events. */
   outboundWebhooks?: {
     enqueue: (event: EventEnvelope, bindings: unknown) => Promise<unknown>
@@ -253,6 +268,7 @@ export interface VoyantNodeRuntime {
     inventory: readonly VoyantGraphProvisionedJob[]
     health: () => readonly VoyantNodeJobHealth[]
     invoke: VoyantNodeJobHost["invoke"]
+    wakeAt: VoyantNodeJobHost["wakeAt"]
   }
   fetch: (
     request: Request,
@@ -397,6 +413,19 @@ export async function loadVoyantNodeRuntime(
     ),
   })
 
+  // A package asks for a wake on the request path that wrote the work — a
+  // checkout placing a hold, say. `wakeAt` rejects a job the graph did not
+  // select or declare wakeable, which is a real manifest bug, but failing the
+  // customer's request over a timeliness hint is the wrong trade: report it and
+  // let the job's declared cadence do the work.
+  options.jobWakeups?.bind((jobId, at) => {
+    try {
+      jobHost.wakeAt(jobId, at)
+    } catch (error) {
+      console.warn(`[node-runtime] job wake request rejected: ${errorMessage(error)}`)
+    }
+  })
+
   options.eventDelivery?.bind(async (envelope) => {
     await app.ready(env)
     if (app.eventBus.deliver) return app.eventBus.deliver(envelope)
@@ -431,6 +460,7 @@ export async function loadVoyantNodeRuntime(
       inventory: jobHost.inventory,
       health: jobHost.health,
       invoke: jobHost.invoke,
+      wakeAt: jobHost.wakeAt,
     },
     fetch,
     start: (serverOptions = {}) =>
@@ -798,6 +828,10 @@ function nodeRuntimeEnvIssues(
 
 function formatIssues(issues: readonly string[]): string {
   return issues.map((issue) => `- ${issue}`).join("\n")
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
 }
 
 function getEnvValue(env: VoyantNodeRuntimeEnv, name: string): unknown {

--- a/packages/framework/src/worker-job-host.ts
+++ b/packages/framework/src/worker-job-host.ts
@@ -152,6 +152,11 @@ export function createVoyantWorkerRuntimeHostPrimitives<TBindings extends object
       deliver: (event, bindings) =>
         options.deliverEvent?.(event, bindingsFor(bindings)) ?? missing("events.deliver"),
     },
+    // A Worker invocation ends when its response does, so there is no resident
+    // timer to arm. Wakes for a Worker deployment arrive over
+    // `POST /__voyant/jobs/:id` from whichever scheduler the deployment
+    // selected; the declared cadence covers everything else.
+    jobs: { wakeAt: () => {} },
     config: {
       read: (bindings, key) =>
         options.readConfig?.(bindingsFor(bindings), key) ?? Reflect.get(bindingsFor(bindings), key),

--- a/packages/inventory/src/booking-engine/product-runtime.ts
+++ b/packages/inventory/src/booking-engine/product-runtime.ts
@@ -25,6 +25,7 @@ import {
   extendAvailabilityHold,
   placeAvailabilityHold,
   releaseAvailabilityHold,
+  requestAvailabilityHoldExpiryWake,
 } from "@voyant-travel/operations"
 import { resolveBookingTaxSettings } from "@voyant-travel/operator-settings"
 import { and, asc, eq, inArray, or } from "drizzle-orm"
@@ -106,6 +107,10 @@ export function registerProductBookingHandler(
           const db = asPostgresDb(ctx.db)
           const result = await placeAvailabilityHold(db, input)
           if (result.status === "ok") {
+            // The seats are decremented now and only the reaper gives them
+            // back, so tell the host when to run it rather than leaving the
+            // capacity to a poll.
+            requestAvailabilityHoldExpiryWake(result.hold.expiresAt)
             return {
               status: "ok",
               holdToken: result.hold.holdToken,
@@ -113,6 +118,7 @@ export function registerProductBookingHandler(
             }
           }
           if (result.status === "slot_unlimited") {
+            requestAvailabilityHoldExpiryWake(result.expiresAt)
             return {
               status: "ok",
               holdToken: result.holdToken,
@@ -131,7 +137,10 @@ export function registerProductBookingHandler(
         async extend(ctx, input) {
           const db = asPostgresDb(ctx.db)
           const result = await extendAvailabilityHold(db, input)
-          if (result.status === "ok") return { status: "ok", expiresAt: result.expiresAt }
+          if (result.status === "ok") {
+            requestAvailabilityHoldExpiryWake(result.expiresAt)
+            return { status: "ok", expiresAt: result.expiresAt }
+          }
           return { status: "not_found" }
         },
         async release(ctx, holdToken) {

--- a/packages/operations/src/availability/hold-expiry-wake.ts
+++ b/packages/operations/src/availability/hold-expiry-wake.ts
@@ -1,0 +1,52 @@
+/**
+ * Wake channel for the expired-hold reaper.
+ *
+ * A hold decrements `availability_slots.remaining_pax` the moment a checkout
+ * reserves seats, and only the reaper puts them back — so how late the reaper
+ * runs is how long capacity nobody can book stays unbookable. Polling for that
+ * meant every managed tenant woke its database four times an hour whether or
+ * not a single hold existed.
+ *
+ * The expiry instant is known when the hold is written, so the reaper does not
+ * need a poll to discover it. Whoever places or extends a hold reports the new
+ * expiry here, and the deployment host arms a wake for it. The reaper re-arms
+ * itself from the database on every run, which is what recovers the timer
+ * after a restart.
+ *
+ * Every step is best-effort by design: an unbound channel, a dropped wake, or
+ * a process that dies with a timer armed all fall back to the job's declared
+ * cadence, which stays the recovery authority.
+ */
+
+/** Graph job id of the reaper this channel wakes. */
+export const OPERATIONS_EXPIRED_HOLDS_JOB_ID = "operations.release-expired-availability-holds"
+
+export type AvailabilityHoldExpiryWake = (jobId: string, at: Date) => void
+
+let requestWake: AvailabilityHoldExpiryWake | undefined
+
+/**
+ * Bind the deployment's job-wake channel. Called once by the Operations
+ * runtime contributor, which is the only place that holds host primitives.
+ */
+export function configureAvailabilityHoldExpiryWake(wake: AvailabilityHoldExpiryWake): void {
+  requestWake = wake
+}
+
+/** Test seam: drop the bound channel so a suite cannot leak into the next one. */
+export function resetAvailabilityHoldExpiryWake(): void {
+  requestWake = undefined
+}
+
+/**
+ * Ask for the reaper to run once `expiresAt` has passed.
+ *
+ * Safe to call before the hold's transaction commits, and safe to call for a
+ * hold whose transaction then rolls back: the wake is armed for a future
+ * instant the write will long since have settled by, and a wake that finds
+ * nothing to reap simply re-arms from whatever the database does hold.
+ */
+export function requestAvailabilityHoldExpiryWake(expiresAt: Date): void {
+  if (!requestWake) return
+  requestWake(OPERATIONS_EXPIRED_HOLDS_JOB_ID, expiresAt)
+}

--- a/packages/operations/src/availability/service-holds.ts
+++ b/packages/operations/src/availability/service-holds.ts
@@ -359,6 +359,28 @@ export async function releaseExpiredHolds(
 }
 
 /**
+ * When the oldest live hold becomes reapable, or `undefined` when nothing is
+ * outstanding.
+ *
+ * This is what lets the reaper be woken instead of polled: the instant is
+ * already recorded at write time, so the job can arm its own next run rather
+ * than have a cadence rediscover it. A tenant with no live holds returns
+ * `undefined` and stops touching its database entirely.
+ */
+export async function earliestOutstandingHoldExpiry(
+  db: PostgresJsDatabase,
+): Promise<Date | undefined> {
+  const [row] = await db
+    .select({ expiresAt: availabilityHolds.expiresAt })
+    .from(availabilityHolds)
+    .where(and(isNull(availabilityHolds.releasedAt), isNull(availabilityHolds.convertedAt)))
+    .orderBy(asc(availabilityHolds.expiresAt))
+    .limit(1)
+
+  return row?.expiresAt
+}
+
+/**
  * Looks up the hold(s) for a draft id. Multiple holds per draft
  * are possible (e.g. a multi-day product touching several slots);
  * the journey reaper releases them all at once.

--- a/packages/operations/src/expired-holds-job.ts
+++ b/packages/operations/src/expired-holds-job.ts
@@ -1,6 +1,7 @@
 import type { VoyantGraphRuntimeFactoryContext } from "@voyant-travel/core/project"
 
-import { releaseExpiredHolds } from "./availability/service-holds.js"
+import { requestAvailabilityHoldExpiryWake } from "./availability/hold-expiry-wake.js"
+import { earliestOutstandingHoldExpiry, releaseExpiredHolds } from "./availability/service-holds.js"
 import { operationsExpiredHoldsJobRuntimePort } from "./expired-holds-job-runtime-port.js"
 
 export { operationsExpiredHoldsJobRuntimePort } from "./expired-holds-job-runtime-port.js"
@@ -14,6 +15,12 @@ export { operationsExpiredHoldsJobRuntimePort } from "./expired-holds-job-runtim
  * into a departure: the sandbox's 27 Jul departure sat at 1 of 10 seats with
  * only 4 pax genuinely held or confirmed — the other 5 were stuck in four
  * long-expired holds.
+ *
+ * The job is wake-driven (#4067). Every run ends by arming the next one from
+ * the earliest expiry still outstanding, which is both more timely than a poll
+ * and free when nothing is held — a tenant with no live holds arms nothing and
+ * stops waking its database. The declared cadence remains the backstop for a
+ * wake lost to a restart.
  */
 export async function runOperationsReleaseExpiredHoldsJob(
   context: VoyantGraphRuntimeFactoryContext,
@@ -21,4 +28,7 @@ export async function runOperationsReleaseExpiredHoldsJob(
   const runtime = await context.getPort(operationsExpiredHoldsJobRuntimePort)
   const db = await runtime.resolveDb()
   await releaseExpiredHolds(db)
+
+  const next = await earliestOutstandingHoldExpiry(db)
+  if (next) requestAvailabilityHoldExpiryWake(next)
 }

--- a/packages/operations/src/index.ts
+++ b/packages/operations/src/index.ts
@@ -40,6 +40,12 @@ export const createOperationsVoyantRuntime = defineGraphRuntimeFactory(
   }),
 )
 
+// Only the request side is package API. Binding the channel is deployment
+// wiring and stays with the runtime contributor.
+export {
+  OPERATIONS_EXPIRED_HOLDS_JOB_ID,
+  requestAvailabilityHoldExpiryWake,
+} from "./availability/hold-expiry-wake.js"
 export * from "./availability/index.js"
 export * from "./availability/rrule.js"
 export * from "./availability/service-catalog-plane-departures.js"

--- a/packages/operations/src/runtime-contributor.ts
+++ b/packages/operations/src/runtime-contributor.ts
@@ -5,6 +5,7 @@ import {
 import { catalogOperationsRuntimeExtensionPort } from "@voyant-travel/catalog/runtime-contracts"
 import type { VoyantRuntimeHostPrimitives } from "@voyant-travel/core"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { configureAvailabilityHoldExpiryWake } from "./availability/hold-expiry-wake.js"
 import { createBookingActionProjectionService } from "./booking-actions/service.js"
 import { catalogOperationsRuntimeExtension } from "./catalog-runtime-extension.js"
 import {
@@ -19,6 +20,10 @@ export interface OperationsRuntimeContributorHost {
 export function createOperationsRuntimePortContribution(
   host: OperationsRuntimeContributorHost,
 ): Readonly<Record<string, unknown>> {
+  // Hold expiry is known at write time, so the reaper is woken rather than
+  // polled. The host owns the timer; this only hands the domain a way to ask.
+  configureAvailabilityHoldExpiryWake((jobId, at) => host.primitives.jobs.wakeAt(jobId, at))
+
   const bookingActions: BookingActionProjectionRuntime = {
     create: createBookingActionProjectionService,
     async synchronize(sources, mode) {

--- a/packages/operations/src/voyant.ts
+++ b/packages/operations/src/voyant.ts
@@ -55,14 +55,21 @@ export const operationsVoyantModule = defineModule({
   ],
   jobs: [
     {
+      // Wake-driven (#4067). A hold's expiry is known when it is written, so
+      // the runtime arms the reaper for that instant instead of rediscovering
+      // it on a poll — more timely than a fifteen-minute sweep, and free for a
+      // tenant holding nothing. The cron here is the recovery backstop for a
+      // wake lost to a restart, which is why it can sit at six hours: on a
+      // managed deployment every tick resumes a database that scaled to zero.
       id: "operations.release-expired-availability-holds",
-      schedule: { cron: "*/5 * * * *", overlap: "skip" },
+      wakeup: true,
+      schedule: { cron: "*/15 * * * *", overlap: "skip" },
       scheduling: {
         required: true,
         profiles: {
-          eager: { cron: "* * * * *", overlap: "skip" },
-          economical: { cron: "*/15 * * * *", overlap: "skip" },
-          "scale-to-zero": { cron: "*/15 * * * *", overlap: "skip" },
+          eager: { cron: "*/5 * * * *", overlap: "skip" },
+          economical: { cron: "40 */6 * * *", overlap: "skip" },
+          "scale-to-zero": { cron: "40 */6 * * *", overlap: "skip" },
         },
       },
       runtime: {

--- a/packages/operations/tests/unit/expired-holds-job.test.ts
+++ b/packages/operations/tests/unit/expired-holds-job.test.ts
@@ -1,0 +1,70 @@
+import type { VoyantGraphRuntimeFactoryContext } from "@voyant-travel/core/project"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import {
+  configureAvailabilityHoldExpiryWake,
+  OPERATIONS_EXPIRED_HOLDS_JOB_ID,
+  requestAvailabilityHoldExpiryWake,
+  resetAvailabilityHoldExpiryWake,
+} from "../../src/availability/hold-expiry-wake.js"
+import * as holds from "../../src/availability/service-holds.js"
+import { runOperationsReleaseExpiredHoldsJob } from "../../src/expired-holds-job.js"
+import { operationsExpiredHoldsJobRuntimePort } from "../../src/expired-holds-job-runtime-port.js"
+
+const db = {} as never
+
+function jobContext(): VoyantGraphRuntimeFactoryContext {
+  return {
+    getPort: async (port: { id: string }) => {
+      expect(port.id).toBe(operationsExpiredHoldsJobRuntimePort.id)
+      return { resolveDb: () => db }
+    },
+  } as unknown as VoyantGraphRuntimeFactoryContext
+}
+
+afterEach(() => {
+  resetAvailabilityHoldExpiryWake()
+  vi.restoreAllMocks()
+})
+
+describe("availability hold expiry wake channel", () => {
+  it("stays inert until a deployment binds it", () => {
+    expect(() => requestAvailabilityHoldExpiryWake(new Date())).not.toThrow()
+  })
+
+  it("addresses the reaper by its graph job id", () => {
+    const wake = vi.fn()
+    configureAvailabilityHoldExpiryWake(wake)
+    const expiresAt = new Date("2026-08-03T10:15:00.000Z")
+
+    requestAvailabilityHoldExpiryWake(expiresAt)
+
+    expect(wake).toHaveBeenCalledWith(OPERATIONS_EXPIRED_HOLDS_JOB_ID, expiresAt)
+  })
+})
+
+describe("runOperationsReleaseExpiredHoldsJob", () => {
+  it("arms its own next run from the earliest hold still outstanding", async () => {
+    const next = new Date("2026-08-03T10:45:00.000Z")
+    const releaseExpiredHolds = vi.spyOn(holds, "releaseExpiredHolds").mockResolvedValue(2)
+    vi.spyOn(holds, "earliestOutstandingHoldExpiry").mockResolvedValue(next)
+    const wake = vi.fn()
+    configureAvailabilityHoldExpiryWake(wake)
+
+    await runOperationsReleaseExpiredHoldsJob(jobContext())
+
+    expect(releaseExpiredHolds).toHaveBeenCalledWith(db)
+    expect(wake).toHaveBeenCalledWith(OPERATIONS_EXPIRED_HOLDS_JOB_ID, next)
+  })
+
+  it("arms nothing when no hold is outstanding, so an idle tenant stops waking", async () => {
+    vi.spyOn(holds, "releaseExpiredHolds").mockResolvedValue(0)
+    vi.spyOn(holds, "earliestOutstandingHoldExpiry").mockResolvedValue(undefined)
+    const wake = vi.fn()
+    configureAvailabilityHoldExpiryWake(wake)
+
+    await runOperationsReleaseExpiredHoldsJob(jobContext())
+
+    expect(wake).not.toHaveBeenCalled()
+  })
+})

--- a/packages/operations/tests/unit/voyant-manifest.test.ts
+++ b/packages/operations/tests/unit/voyant-manifest.test.ts
@@ -28,6 +28,16 @@ describe("operations deployment manifest", () => {
       jobs: [
         {
           id: "operations.release-expired-availability-holds",
+          // Wake-driven: expiry is known at write time, so the cron is only the
+          // backstop for a wake lost to a restart (#4067).
+          wakeup: true,
+          schedule: { cron: "*/15 * * * *", overlap: "skip" },
+          scheduling: {
+            profiles: {
+              economical: { cron: "40 */6 * * *", overlap: "skip" },
+              "scale-to-zero": { cron: "40 */6 * * *", overlap: "skip" },
+            },
+          },
           runtime: {
             entry: "@voyant-travel/operations/expired-holds-job",
             export: "runOperationsReleaseExpiredHoldsJob",

--- a/packages/runtime/src/deployment-resources.test.ts
+++ b/packages/runtime/src/deployment-resources.test.ts
@@ -22,6 +22,7 @@ function primitives(): VoyantRuntimeHostPrimitives {
       downloadUrl: async () => null,
     },
     events: { deliver: vi.fn(async () => ["queued"]) },
+    jobs: { wakeAt: vi.fn() },
     config: { read: () => undefined },
   }
 }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -330,6 +330,11 @@ export async function loadVoyantProject(
       deploymentResources.primitives.events.deliver = (event) => deliver(event as EventEnvelope)
     },
   }
+  const jobWakeups = {
+    bind(wakeAt: (jobId: string, at: Date) => void) {
+      deploymentResources.primitives.jobs.wakeAt = wakeAt
+    },
+  }
   const customerBusinessAccountOnboarding = deploymentResources.ports[
     customerBusinessAccountOnboardingRuntimePort.id
   ] as CustomerBusinessAccountOnboardingRuntimeProvider | undefined
@@ -410,6 +415,7 @@ export async function loadVoyantProject(
     deploymentRequirements,
     runtimePorts: deploymentResources.ports,
     eventDelivery,
+    jobWakeups,
     resources: deploymentResources.capabilities,
     outboundWebhooks: deploymentResources.outboundWebhooks,
     appWebhooks,


### PR DESCRIPTION
Closes #4067.

## The floor, and what is left of it

The issue names two jobs holding managed tenants at four database resumes an
hour. One of them, `bookings.expire-stale-holds`, was deleted earlier today by
#4100 along with the beta booking lifecycle it belonged to. This PR takes the
one that remains, `operations.release-expired-availability-holds`, which is now
the whole of that floor.

Its cadence genuinely could not be stretched. An availability hold decrements
`availability_slots.remaining_pax` the moment a checkout reserves seats, and
only the reaper puts them back, so a later sweep is capacity nobody can book.

## Nothing had to poll to find that work

`availability_holds.expires_at` records the instant the work becomes due, at
write time. So the job is now `wakeup: true`:

- placing or extending a hold reports the new expiry
- the reaper re-arms itself from the earliest outstanding expiry after **every**
  run, which is what recovers the timer across a restart
- its cron drops to `40 */6` on the `economical` and `scale-to-zero` profiles as
  the backstop for a wake lost to a restart

A tenant with no live holds arms nothing and stops waking its database for this
job at all. A tenant with holds wakes exactly when there is capacity to give
back — sooner than the fifteen-minute sweep this replaces, not later.

## The host seam

`VoyantRuntimeHostPrimitives.jobs.wakeAt(jobId, at)` asks the deployment to
invoke a wakeable job at an instant. It is the same signal that already arrives
over `POST /__voyant/jobs/:id`, raised from inside the process instead, and the
architecture doc already sanctioned an in-process timer as one of its sources.

The Node host arms one timer per job: earliest request wins, an already-due
request is floored so a self-arming job cannot spin against its own clock,
anything past a six-hour horizon is declined to the declared cadence, and every
armed wake is dropped on `stop()`. `loadVoyantNodeRuntime({ jobWakeups })`
routes package requests into it, mirroring the existing `eventDelivery` binding.
A Worker host accepts the call and does nothing — a Worker invocation ends with
its response.

**A requested wake is a prompt and is never durable.** An unbound channel, a
dropped wake, or a process that dies with a timer armed all fall back to the
declared cadence, which stays the recovery authority. A package may therefore
only use this to make work *timelier* than its cadence, never to replace it.
The Node binding reports a rejected request rather than throwing, so a manifest
bug cannot fail a customer's checkout over a timeliness hint.

No Cloud-side change, as the issue anticipated: the wake endpoint and the
`wakeable` flag both already exist.

## Verification

- `verify:architecture` — full chain, clean
- unit tests: framework (392), operations, inventory, runtime, auth, catalog,
  notifications, operator-standard
- new coverage: deferred-wake arming/coalescing/floor/horizon/stop in the job
  host; the reaper's self-arming and its no-holds silence
- `biome check .` clean (remaining warnings are pre-existing, in untouched files)
- typecheck: `core`, `framework`, `catalog`, `auth`, `operations` clean locally;
  `inventory`, `runtime`, `notifications` were repeatedly killed by local heap
  pressure rather than type errors, so `build-graph` is the authority on those
