### PR TITLE
fix(release): ask the registry, not npm, whether a version is published

### DIFF
--- a/scripts/lib/published-surface.mjs
+++ b/scripts/lib/published-surface.mjs
@@ -22,6 +22,38 @@
  * beside them installs from the registry and exercises it.
  */
 
+export const REGISTRY = "https://registry.npmjs.org"
+
+/**
+ * Ask the registry directly, over anonymous HTTP.
+ *
+ * Not `npm view`. The release job points `NPM_CONFIG_USERCONFIG` at an npmrc
+ * carrying `NODE_AUTH_TOKEN`, which is a placeholder unless a secret is set, so
+ * every npm call there fails on auth in under a millisecond. Reading that as
+ * "the version is not published" reported all fourteen packages missing when
+ * all fourteen were fine — a confident, specific, wrong diagnosis, which is
+ * worse than no check at all. A raw fetch has no credentials to get wrong, and
+ * it asks the truer question: this gate is about what a stranger can install.
+ *
+ * Only a clean 200 or a clean 404 is an answer. Anything else throws, because a
+ * registry outage must never be indistinguishable from an unpublished package.
+ */
+export async function registryHasVersion(name, version, options = {}) {
+  const { fetch: fetchImpl = fetch, registry = REGISTRY } = options
+
+  const response = await fetchImpl(`${registry}/${name.replace("/", "%2f")}`, {
+    headers: { accept: "application/vnd.npm.install-v1+json" },
+  })
+
+  if (response.status === 404) return false
+  if (!response.ok) {
+    throw new Error(`registry returned ${response.status} ${response.statusText} for ${name}`)
+  }
+
+  const packument = await response.json()
+  return Object.hasOwn(packument.versions ?? {}, version)
+}
+
 /** publishConfig keys whose survival proves publishConfig was never applied. */
 const OVERRIDE_KEYS = ["exports", "main", "module", "types", "typings", "files", "bin"]
 

--- a/scripts/tests/published-surface.test.mjs
+++ b/scripts/tests/published-surface.test.mjs
@@ -4,10 +4,66 @@ import { test } from "node:test"
 import {
   expandExportPattern,
   importProbeSpecifiers,
+  registryHasVersion,
   selectPublishedPackages,
   unappliedPublishConfigViolations,
   unresolvedProtocolViolations,
 } from "../lib/published-surface.mjs"
+
+function registryResponse({ status = 200, statusText = "OK", body = {} }) {
+  return async () => ({
+    status,
+    statusText,
+    ok: status >= 200 && status < 300,
+    json: async () => body,
+  })
+}
+
+test("reads a published version out of the packument", async () => {
+  const published = await registryHasVersion("@voyant-travel/payments", "0.9.2", {
+    fetch: registryResponse({ body: { versions: { "0.9.1": {}, "0.9.2": {} } } }),
+  })
+
+  assert.equal(published, true)
+})
+
+test("reports a version the packument does not carry", async () => {
+  const published = await registryHasVersion("@voyant-travel/graph-contracts", "0.2.0", {
+    fetch: registryResponse({ body: { versions: { "0.1.0": {} } } }),
+  })
+
+  assert.equal(published, false)
+})
+
+test("reports a package name that has never been published", async () => {
+  const published = await registryHasVersion("@voyant-travel/nothing", "1.0.0", {
+    fetch: registryResponse({ status: 404, statusText: "Not Found" }),
+  })
+
+  assert.equal(published, false)
+})
+
+test("refuses to call a registry failure an unpublished version", async () => {
+  // The whole gate reported all fourteen packages missing because `npm view`
+  // failed on a placeholder auth token and the failure was read as a verdict.
+  // An unauthorised or unavailable registry has told us nothing, and saying
+  // otherwise is worse than saying nothing.
+  await assert.rejects(
+    registryHasVersion("@voyant-travel/payments", "0.9.2", {
+      fetch: registryResponse({ status: 401, statusText: "Unauthorized" }),
+    }),
+    /registry returned 401 Unauthorized/,
+  )
+
+  await assert.rejects(
+    registryHasVersion("@voyant-travel/payments", "0.9.2", {
+      fetch: async () => {
+        throw new Error("ECONNRESET")
+      },
+    }),
+    /ECONNRESET/,
+  )
+})
 
 test("selects the publishable packages in a stable order", () => {
   const selected = selectPublishedPackages([

--- a/scripts/verify-published-surface.mjs
+++ b/scripts/verify-published-surface.mjs
@@ -22,6 +22,8 @@ import {
   formatImportFailure,
   formatMissingVersion,
   importProbeSpecifiers,
+  REGISTRY,
+  registryHasVersion,
   selectPublishedPackages,
   unappliedPublishConfigViolations,
   unresolvedProtocolViolations,
@@ -53,15 +55,6 @@ function workspaceManifests() {
   return manifests
 }
 
-async function registryHasVersion(name, version) {
-  try {
-    await execFileAsync("npm", ["view", `${name}@${version}`, "version"], { encoding: "utf8" })
-    return true
-  } catch {
-    return false
-  }
-}
-
 /**
  * Wait for every version to appear rather than failing the first one that has
  * not propagated. A missing version and a slow CDN look identical for a few
@@ -71,11 +64,21 @@ async function awaitRegistry(packages) {
   let pending = packages
   for (let attempt = 1; attempt <= ATTEMPTS; attempt += 1) {
     const results = await Promise.all(
-      pending.map(async (entry) => ({
-        entry,
-        published: await registryHasVersion(entry.name, entry.version),
-      })),
+      pending.map(async (entry) => {
+        try {
+          return { entry, published: await registryHasVersion(entry.name, entry.version) }
+        } catch (error) {
+          return { entry, published: false, error }
+        }
+      }),
     )
+
+    // A transient failure is worth another attempt, but it must never be
+    // reported as an unpublished version. If it is still failing on the last
+    // attempt, surface the registry's own error instead of a verdict.
+    const failure = results.find((result) => result.error)
+    if (failure && attempt === ATTEMPTS) throw failure.error
+
     pending = results.filter((result) => !result.published).map((result) => result.entry)
     if (pending.length === 0) return []
     if (attempt === ATTEMPTS) break
@@ -97,6 +100,18 @@ async function installSurface(packages, installDir) {
   }
   fs.writeFileSync(path.join(installDir, "package.json"), `${JSON.stringify(manifest, null, 2)}\n`)
 
+  // Install as a stranger would. The scratch project's own `.npmrc` names the
+  // public registry, and the user and global configs are pointed at empty files
+  // so the release job's credentials and any developer's `~/.npmrc` drop out.
+  // That is what an external consumer has, and it is the only way to notice a
+  // package published `restricted` by accident. npm refuses to load one file
+  // under two config scopes, so these are three distinct paths.
+  fs.writeFileSync(path.join(installDir, ".npmrc"), `registry=${REGISTRY}/\n`)
+  const userConfig = path.join(installDir, "npmrc-user")
+  const globalConfig = path.join(installDir, "npmrc-global")
+  fs.writeFileSync(userConfig, "")
+  fs.writeFileSync(globalConfig, "")
+
   // `--no-legacy-peer-deps` pins the modern resolver explicitly. A developer
   // whose ~/.npmrc sets `legacy-peer-deps=true` would otherwise skip peer
   // installation and see entry points fail here that resolve fine for a
@@ -113,7 +128,16 @@ async function installSurface(packages, installDir) {
       "--loglevel",
       "error",
     ],
-    { cwd: installDir, encoding: "utf8", maxBuffer: 64 * 1024 * 1024, env: process.env },
+    {
+      cwd: installDir,
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+      env: {
+        ...process.env,
+        NPM_CONFIG_USERCONFIG: userConfig,
+        NPM_CONFIG_GLOBALCONFIG: globalConfig,
+      },
+    },
   )
 }
 


### PR DESCRIPTION
The gate from #4142 failed its first real release run by reporting **all fourteen public packages as unpublished**. Every one of them was on the registry.

```
- @voyant-travel/accommodations-contracts@0.105.14 is the version in the repository and is not on the registry.
- @voyant-travel/admin-extension-sdk@0.3.1 is the version in the repository and is not on the registry.
  … all 14 …
```

The whole check ran in 0.1 seconds — fourteen registry round trips cannot.

## Cause

It shelled out to `npm view` and treated any non-zero exit as "not published":

```js
try { await execFileAsync("npm", ["view", `${name}@${version}`, "version"]); return true }
catch { return false }
```

The release job sets `NPM_CONFIG_USERCONFIG` to an npmrc carrying `NODE_AUTH_TOKEN`, which setup-node fills with a placeholder (`XXXXX-XXXXX-XXXXX-XXXXX`) when no secret is set. Every npm call failed on auth instantly, and fourteen failures became fourteen verdicts.

The diagnosis it printed pointed at npm Trusted Publishers — which had just been configured correctly. A confident, specific, wrong answer is worse than no check.

## Fix

**The version query is an anonymous `fetch` of the packument.** No npm, no npmrc, no credentials to get wrong. Only a clean `200` or a clean `404` is an answer; anything else throws with the registry's own status, so an outage can never be mistaken for a missing package. Transient failures are retried, and one still standing on the last attempt surfaces as an error rather than a verdict.

**The scratch install runs as a stranger too** — its own `.npmrc` names the public registry, and user and global configs point at empty files, dropping the release job's credentials and any developer's `~/.npmrc`. That is what an external consumer has, and it is the only way to notice a package published `restricted` by accident. npm refuses to load one file under two config scopes, hence three distinct paths.

Both changes make the check ask the question it claims to ask: what can a stranger install?

## Verification

- Against the live registry: **14 packages, 172 entry points**, all resolving.
- Again under a replica of the release job's npmrc (placeholder `_authToken`, `always-auth=true`): identical result. Before this change that configuration produced fourteen false positives.
- 4 new tests over the classification — published, absent from the packument, name never published, and that a `401` or a connection failure **raises** instead of answering. 15 total, `biome check` clean.

## Surface state

With Trusted Publishers now configured, the release wave published: `graph-contracts@0.3.0` is on npm and `npm install @voyant-travel/payments` succeeds again. All fourteen packages install and import cleanly — the first time that has been true since #4086 was opened.
