### PR TITLE
fix(migrations): carry the proposal rename onto the constraint names

### DIFF
--- a/.changeset/proposal-constraint-name-alignment.md
+++ b/.changeset/proposal-constraint-name-alignment.md
@@ -1,0 +1,32 @@
+---
+"@voyant-travel/framework-migrations": patch
+"@voyant-travel/proposals": patch
+"@voyant-travel/mice": patch
+---
+
+Carry the proposal rename onto the constraint names it left behind.
+
+`ALTER TABLE ... RENAME` renames a table, its columns and its indexes, but never
+a constraint. The adoption migrations therefore moved every object the retired
+module owned except the NOT NULL constraints PostgreSQL 18 catalogues one per
+NOT NULL column — a deployment repaired by them kept 69 of those on the retired
+vocabulary while a freshly provisioned one had them on the current one. Two
+populations with equivalent but not identical schemas is precisely the condition
+the rename came out of, and the next `DROP CONSTRAINT` written against a fresh
+deployment is what would break on a repaired one.
+
+The alignment increment DERIVES each target name the way PostgreSQL does —
+`makeObjectName(table, column, 'not_null')`, shaving the longer of the two until
+the result fits 63 bytes — so it lands the exact name a fresh provision holds,
+including the truncated ones, and follows the tables if they are renamed again.
+Older PostgreSQL does not catalogue these constraints at all, so it finds
+nothing there. It also repairs one foreign key the adoption migration addressed
+by a name longer than an identifier can be, which meant it addressed a name the
+database never held.
+
+`verify:migration-replay-parity` now fingerprints constraints from
+`pg_constraint` with their NAMES rather than from
+`information_schema.table_constraints` without them, which is what surfaces this
+class of drift instead of relying on someone enumerating objects by hand. It
+runs on PostgreSQL 18 as well as 16, because 18 is the only version on which the
+NOT NULL names exist to be compared, and it now reports which of the two it saw.

--- a/.depot/workflows/ci.yml
+++ b/.depot/workflows/ci.yml
@@ -180,12 +180,21 @@ jobs:
         include:
           - lane: replay
             size: 4x16
+            postgres_image: postgres:16
+          # PostgreSQL 18 catalogues a named constraint per NOT NULL column, so
+          # it is the only version on which the replay oracle can see that class
+          # of name drift at all (voyant#4148).
+          - lane: replay-pg18
+            size: 4x16
+            postgres_image: postgres:18
           - lane: union
             size: 4x16
+            postgres_image: postgres:16
           # The migration process can reserve 8 GB; leave enough headroom for
           # Postgres and the package-manager/runtime processes around it.
           - lane: integration
             size: 8x32
+            postgres_image: postgres:16
     runs-on:
       size: ${{ matrix.size }}
       image: 5ctgrq9prr.registry.depot.dev/voyant/ci:node24-pnpm10-playwright1.61.1-workspace
@@ -196,7 +205,7 @@ jobs:
       DATABASE_URL: postgresql://voyant:voyant@localhost:5432/voyant_test
     services:
       postgres:
-        image: postgres:16
+        image: ${{ matrix.postgres_image }}
         env:
           POSTGRES_USER: voyant
           POSTGRES_PASSWORD: voyant
@@ -219,7 +228,7 @@ jobs:
         shell: bash
         run: |
           case "${{ matrix.lane }}" in
-            replay)
+            replay | replay-pg18)
               node scripts/verify-migration-replay-parity.mjs
               ;;
             union)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,10 +289,19 @@ jobs:
         include:
           - lane: replay
             runner: ubuntu-24.04
+            postgres_image: postgres:16
+          # PostgreSQL 18 catalogues a named constraint per NOT NULL column, so
+          # it is the only version on which the replay oracle can see that class
+          # of name drift at all (voyant#4148).
+          - lane: replay-pg18
+            runner: ubuntu-24.04
+            postgres_image: postgres:18
           - lane: union
             runner: ubuntu-24.04
+            postgres_image: postgres:16
           - lane: integration
             runner: ubuntu-24.04
+            postgres_image: postgres:16
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 10
     env:
@@ -305,7 +314,7 @@ jobs:
       DATABASE_URL: postgresql://voyant:voyant@localhost:5432/voyant_test
     services:
       postgres:
-        image: postgres:16
+        image: ${{ matrix.postgres_image }}
         env:
           POSTGRES_USER: voyant
           POSTGRES_PASSWORD: voyant
@@ -328,7 +337,7 @@ jobs:
         shell: bash
         run: |
           case "${{ matrix.lane }}" in
-            replay)
+            replay | replay-pg18)
               node scripts/verify-migration-replay-parity.mjs
               ;;
             union)

--- a/docs/architecture/migration-collector-d2.md
+++ b/docs/architecture/migration-collector-d2.md
@@ -238,11 +238,41 @@ when they happened, and legacy delivery-request rows carry a `legacy.*` command
 scope no live command looks up. Rewriting either would falsify a record rather
 than migrate state.
 
+### Constraint names do not follow a rename (voyant#4148)
+
+`ALTER TABLE ... RENAME` moves the table, its columns and its indexes. It never
+moves a **constraint name**, and from PostgreSQL 18 on the catalogue holds one
+constraint per NOT NULL column — so an adoption increment that enumerates only
+its primary and foreign keys leaves dozens of names on the retired vocabulary.
+Nothing resolves a constraint by name at runtime, so this is not a live fault;
+it is two populations whose schemas are equivalent but **not identical**, which
+is the condition a rename must not leave behind. The next `DROP CONSTRAINT`
+written against a freshly provisioned deployment is what breaks on a repaired
+one.
+
+Two rules follow, and both are worth more than the object list itself:
+
+- **Derive the target name, do not enumerate it.** PostgreSQL builds an implicit
+  constraint name as `makeObjectName(table, column, label)`: join with an
+  underscore, append the label, then shave a character off whichever of the two
+  is longer until the result fits 63 bytes. An increment that reproduces that
+  lands exactly the name a fresh provision holds — including the truncated ones,
+  which is also where a hand-written rename goes wrong: address a constraint by
+  a name longer than an identifier can be and it matches nothing and silently
+  does nothing.
+- **Assert names, not just shapes.** Read the fingerprint from `pg_constraint`
+  and `pg_indexes` with the NAME included.
+  `information_schema.table_constraints` reports type and columns without a
+  name, so a lane can be constraint-for-constraint equal and still be drifted.
+
 `scripts/verify-migration-replay-parity.mjs` proves the whole thing: its
 pre-rename lane replays the package history as it shipped before the rename
 (fixtures under `scripts/fixtures/pre-proposal-rename/`) plus the adoption
 increments, and fails unless the result matches a fresh replay column-,
-enum-, index- and constraint-for-constraint.
+enum-, index- and constraint-for-constraint, names included. It runs on
+PostgreSQL 18 as well as 16 — 18 is the only version on which the NOT NULL
+constraint names exist to be compared — and reports which of the two it saw so a
+green run is not read as coverage it does not have.
 
 ## References
 

--- a/packages/framework-migrations/migrations/0012_align_proposal_constraint_names.sql
+++ b/packages/framework-migrations/migrations/0012_align_proposal_constraint_names.sql
@@ -1,0 +1,177 @@
+-- Bring the NOT NULL constraint names across the rename too (voyant#4148).
+--
+-- The framework bundle is the standard profile's own migration source, so it
+-- carries the same alignment the package sources ship as their own post-cutline
+-- increments. Both are derived and guarded, so a deployment that runs BOTH paths
+-- converges to the same schema and the second pass changes nothing.
+--
+-- `0011` renames the tables, columns, enum types, indexes, primary keys and
+-- foreign keys the retired module left behind. It does not reach the NOT NULL
+-- constraints: `ALTER TABLE ... RENAME` never renames a constraint, and
+-- PostgreSQL 18 catalogues one per NOT NULL column in `pg_constraint`. A
+-- deployment repaired by `0011` therefore keeps those names on the retired
+-- vocabulary while a freshly provisioned one has them on the current one — two
+-- populations whose schemas are equivalent but not identical, which is the
+-- condition voyant#4143 came out of.
+--
+-- The target name is DERIVED rather than enumerated. PostgreSQL builds it as
+-- makeObjectName(table, column, 'not_null'): join the two with an underscore,
+-- append the label, and while the result would exceed the 63-byte identifier
+-- limit, shave a character off whichever of the two is longer. Reproducing that
+-- lands exactly the name a fresh provision has, including the truncated ones,
+-- and keeps following the tables if they are ever renamed again.
+--
+-- PostgreSQL 16 and 17 do not catalogue NOT NULL constraints at all, so the
+-- query simply returns nothing there. Guarded on the derived name being free, so
+-- this is a no-op on an already-aligned database and on a re-run.
+-- proposals
+DO $$
+DECLARE
+  -- Addressed by their POST-rename names: the `0011` renames have already run.
+  owned_tables text[] := ARRAY[
+    'proposals',
+    'proposal_versions',
+    'proposal_participants',
+    'proposal_products',
+    'proposal_version_lines',
+    'proposal_media',
+    'proposal_delivery_requests',
+    'booking_proposal_details'
+  ];
+  -- NAMEDATALEN - 1, less the separating underscore and the '_not_null' label.
+  budget constant int := 63 - 1 - length('_not_null');
+  candidate record;
+  table_chars int;
+  column_chars int;
+  derived_name text;
+BEGIN
+  FOR candidate IN
+    SELECT rel.oid AS table_oid, rel.relname AS table_name, c.conname, att.attname AS column_name
+      FROM pg_constraint c
+      JOIN pg_class rel ON rel.oid = c.conrelid
+      JOIN pg_namespace n ON n.oid = rel.relnamespace
+      JOIN pg_attribute att ON att.attrelid = c.conrelid AND att.attnum = c.conkey[1]
+     WHERE n.nspname = 'public'
+       AND c.contype = 'n'
+       AND array_length(c.conkey, 1) = 1
+       AND rel.relname = ANY (owned_tables)
+  LOOP
+    table_chars := length(candidate.table_name);
+    column_chars := length(candidate.column_name);
+    WHILE table_chars + column_chars > budget LOOP
+      IF table_chars > column_chars THEN
+        table_chars := table_chars - 1;
+      ELSE
+        column_chars := column_chars - 1;
+      END IF;
+    END LOOP;
+    derived_name :=
+      left(candidate.table_name, table_chars)
+      || '_' || left(candidate.column_name, column_chars)
+      || '_not_null';
+
+    IF candidate.conname <> derived_name
+       AND NOT EXISTS (
+         SELECT 1 FROM pg_constraint existing
+          WHERE existing.conrelid = candidate.table_oid
+            AND existing.conname = derived_name
+       ) THEN
+      EXECUTE format(
+        'ALTER TABLE public.%I RENAME CONSTRAINT %I TO %I',
+        candidate.table_name, candidate.conname, derived_name
+      );
+    END IF;
+  END LOOP;
+END $$;--> statement-breakpoint
+-- One foreign key `0011` addressed by a name the database never held.
+--
+-- Its generated name is longer than the 63-byte identifier limit, so what
+-- PostgreSQL actually stored was the truncated form — the rename matched
+-- nothing and silently did nothing. A freshly provisioned deployment holds the
+-- truncated form of the CURRENT name, so that is the target here.
+--
+-- Located by shape rather than by its old name, which is the only way to be
+-- sure of the exact bytes truncation left behind.
+DO $$
+DECLARE
+  target_name constant text := left(
+    'proposal_delivery_requests_proposal_version_id_proposal_versions_id_fk', 63
+  );
+  current_name text;
+BEGIN
+  IF to_regclass('public.proposal_delivery_requests') IS NULL
+     OR to_regclass('public.proposal_versions') IS NULL THEN
+    RETURN;
+  END IF;
+
+  SELECT c.conname INTO current_name
+    FROM pg_constraint c
+   WHERE c.conrelid = to_regclass('public.proposal_delivery_requests')
+     AND c.contype = 'f'
+     AND c.confrelid = to_regclass('public.proposal_versions')
+     AND pg_get_constraintdef(c.oid) LIKE 'FOREIGN KEY (proposal_version_id)%'
+   LIMIT 1;
+
+  IF current_name IS NOT NULL
+     AND current_name <> target_name
+     AND NOT EXISTS (
+       SELECT 1 FROM pg_constraint existing
+        WHERE existing.conrelid = to_regclass('public.proposal_delivery_requests')
+          AND existing.conname = target_name
+     ) THEN
+    EXECUTE format(
+      'ALTER TABLE public.proposal_delivery_requests RENAME CONSTRAINT %I TO %I',
+      current_name, target_name
+    );
+  END IF;
+END $$;--> statement-breakpoint
+-- mice
+DO $$
+DECLARE
+  -- Addressed by its POST-rename name: the `0011` renames have already run.
+  owned_tables text[] := ARRAY['proposals_proposal_mice_program'];
+  -- NAMEDATALEN - 1, less the separating underscore and the '_not_null' label.
+  budget constant int := 63 - 1 - length('_not_null');
+  candidate record;
+  table_chars int;
+  column_chars int;
+  derived_name text;
+BEGIN
+  FOR candidate IN
+    SELECT rel.oid AS table_oid, rel.relname AS table_name, c.conname, att.attname AS column_name
+      FROM pg_constraint c
+      JOIN pg_class rel ON rel.oid = c.conrelid
+      JOIN pg_namespace n ON n.oid = rel.relnamespace
+      JOIN pg_attribute att ON att.attrelid = c.conrelid AND att.attnum = c.conkey[1]
+     WHERE n.nspname = 'public'
+       AND c.contype = 'n'
+       AND array_length(c.conkey, 1) = 1
+       AND rel.relname = ANY (owned_tables)
+  LOOP
+    table_chars := length(candidate.table_name);
+    column_chars := length(candidate.column_name);
+    WHILE table_chars + column_chars > budget LOOP
+      IF table_chars > column_chars THEN
+        table_chars := table_chars - 1;
+      ELSE
+        column_chars := column_chars - 1;
+      END IF;
+    END LOOP;
+    derived_name :=
+      left(candidate.table_name, table_chars)
+      || '_' || left(candidate.column_name, column_chars)
+      || '_not_null';
+
+    IF candidate.conname <> derived_name
+       AND NOT EXISTS (
+         SELECT 1 FROM pg_constraint existing
+          WHERE existing.conrelid = candidate.table_oid
+            AND existing.conname = derived_name
+       ) THEN
+      EXECUTE format(
+        'ALTER TABLE public.%I RENAME CONSTRAINT %I TO %I',
+        candidate.table_name, candidate.conname, derived_name
+      );
+    END IF;
+  END LOOP;
+END $$;

--- a/packages/framework-migrations/migrations/meta/_journal.json
+++ b/packages/framework-migrations/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1785801900000,
       "tag": "0011_adopt_legacy_quote_objects",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1785888000000,
+      "tag": "0012_align_proposal_constraint_names",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/mice/migrations/20260805000100_align_proposal_link_constraint_names.sql
+++ b/packages/mice/migrations/20260805000100_align_proposal_link_constraint_names.sql
@@ -1,0 +1,67 @@
+-- Bring the link table's NOT NULL constraint names across the rename (voyant#4148).
+--
+-- `20260804000400` renames the table, its left-hand column, its primary key and
+-- its indexes. It does not reach the NOT NULL constraints: `ALTER TABLE ...
+-- RENAME` never renames a constraint, and PostgreSQL 18 catalogues one per NOT
+-- NULL column in `pg_constraint`. A deployment repaired by that migration
+-- therefore keeps those names on the retired vocabulary while a freshly
+-- provisioned one has them on the current one.
+--
+-- The target name is DERIVED rather than enumerated. PostgreSQL builds it as
+-- makeObjectName(table, column, 'not_null'): join the two with an underscore,
+-- append the label, and while the result would exceed the 63-byte identifier
+-- limit, shave a character off whichever of the two is longer. Reproducing that
+-- lands exactly the name a fresh provision has, including the truncated ones.
+--
+-- PostgreSQL 16 and 17 do not catalogue NOT NULL constraints at all, so the
+-- query simply returns nothing there. Guarded on the derived name being free, so
+-- this is a no-op on an already-aligned database and on a re-run.
+DO $$
+DECLARE
+  -- Addressed by its POST-rename name: `20260804000400` has already run.
+  owned_tables text[] := ARRAY['proposals_proposal_mice_program'];
+  -- NAMEDATALEN - 1, less the separating underscore and the '_not_null' label.
+  budget constant int := 63 - 1 - length('_not_null');
+  candidate record;
+  table_chars int;
+  column_chars int;
+  derived_name text;
+BEGIN
+  FOR candidate IN
+    SELECT rel.oid AS table_oid, rel.relname AS table_name, c.conname, att.attname AS column_name
+      FROM pg_constraint c
+      JOIN pg_class rel ON rel.oid = c.conrelid
+      JOIN pg_namespace n ON n.oid = rel.relnamespace
+      JOIN pg_attribute att ON att.attrelid = c.conrelid AND att.attnum = c.conkey[1]
+     WHERE n.nspname = 'public'
+       AND c.contype = 'n'
+       AND array_length(c.conkey, 1) = 1
+       AND rel.relname = ANY (owned_tables)
+  LOOP
+    table_chars := length(candidate.table_name);
+    column_chars := length(candidate.column_name);
+    WHILE table_chars + column_chars > budget LOOP
+      IF table_chars > column_chars THEN
+        table_chars := table_chars - 1;
+      ELSE
+        column_chars := column_chars - 1;
+      END IF;
+    END LOOP;
+    derived_name :=
+      left(candidate.table_name, table_chars)
+      || '_' || left(candidate.column_name, column_chars)
+      || '_not_null';
+
+    IF candidate.conname <> derived_name
+       AND NOT EXISTS (
+         SELECT 1 FROM pg_constraint existing
+          WHERE existing.conrelid = candidate.table_oid
+            AND existing.conname = derived_name
+       ) THEN
+      EXECUTE format(
+        'ALTER TABLE public.%I RENAME CONSTRAINT %I TO %I',
+        candidate.table_name, candidate.conname, derived_name
+      );
+    END IF;
+  END LOOP;
+END $$;

--- a/packages/mice/migrations/meta/_journal.json
+++ b/packages/mice/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1785801840000,
       "tag": "20260804000400_proposal_mice_program_link",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1785888060000,
+      "tag": "20260805000100_align_proposal_link_constraint_names",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/proposals/migrations/20260805000000_align_proposal_constraint_names.sql
+++ b/packages/proposals/migrations/20260805000000_align_proposal_constraint_names.sql
@@ -1,0 +1,122 @@
+-- Bring the NOT NULL constraint names across the rename too (voyant#4148).
+--
+-- `20260804000000` renames the tables, columns, enum types, indexes, primary
+-- keys and foreign keys the retired module left behind. It does not reach the
+-- NOT NULL constraints: `ALTER TABLE ... RENAME` never renames a constraint, and
+-- PostgreSQL 18 catalogues one per NOT NULL column in `pg_constraint`. A
+-- deployment repaired by that migration therefore keeps those names on the
+-- retired vocabulary while a freshly provisioned one has them on the current
+-- one — two populations whose schemas are equivalent but not identical, which is
+-- the condition voyant#4143 came out of. The next `DROP CONSTRAINT` written
+-- against a fresh deployment is what would break on a repaired one.
+--
+-- The target name is DERIVED rather than enumerated. PostgreSQL builds it as
+-- makeObjectName(table, column, 'not_null'): join the two with an underscore,
+-- append the label, and while the result would exceed the 63-byte identifier
+-- limit, shave a character off whichever of the two is longer. Reproducing that
+-- lands exactly the name a fresh provision has, including the truncated ones,
+-- and keeps following the tables if they are ever renamed again.
+--
+-- PostgreSQL 16 and 17 do not catalogue NOT NULL constraints at all, so the
+-- query simply returns nothing there. Guarded on the derived name being free, so
+-- this is a no-op on an already-aligned database and on a re-run.
+DO $$
+DECLARE
+  -- Addressed by their POST-rename names: `20260804000000` has already run.
+  owned_tables text[] := ARRAY[
+    'proposals',
+    'proposal_versions',
+    'proposal_participants',
+    'proposal_products',
+    'proposal_version_lines',
+    'proposal_media',
+    'proposal_delivery_requests',
+    'booking_proposal_details'
+  ];
+  -- NAMEDATALEN - 1, less the separating underscore and the '_not_null' label.
+  budget constant int := 63 - 1 - length('_not_null');
+  candidate record;
+  table_chars int;
+  column_chars int;
+  derived_name text;
+BEGIN
+  FOR candidate IN
+    SELECT rel.oid AS table_oid, rel.relname AS table_name, c.conname, att.attname AS column_name
+      FROM pg_constraint c
+      JOIN pg_class rel ON rel.oid = c.conrelid
+      JOIN pg_namespace n ON n.oid = rel.relnamespace
+      JOIN pg_attribute att ON att.attrelid = c.conrelid AND att.attnum = c.conkey[1]
+     WHERE n.nspname = 'public'
+       AND c.contype = 'n'
+       AND array_length(c.conkey, 1) = 1
+       AND rel.relname = ANY (owned_tables)
+  LOOP
+    table_chars := length(candidate.table_name);
+    column_chars := length(candidate.column_name);
+    WHILE table_chars + column_chars > budget LOOP
+      IF table_chars > column_chars THEN
+        table_chars := table_chars - 1;
+      ELSE
+        column_chars := column_chars - 1;
+      END IF;
+    END LOOP;
+    derived_name :=
+      left(candidate.table_name, table_chars)
+      || '_' || left(candidate.column_name, column_chars)
+      || '_not_null';
+
+    IF candidate.conname <> derived_name
+       AND NOT EXISTS (
+         SELECT 1 FROM pg_constraint existing
+          WHERE existing.conrelid = candidate.table_oid
+            AND existing.conname = derived_name
+       ) THEN
+      EXECUTE format(
+        'ALTER TABLE public.%I RENAME CONSTRAINT %I TO %I',
+        candidate.table_name, candidate.conname, derived_name
+      );
+    END IF;
+  END LOOP;
+END $$;--> statement-breakpoint
+-- One foreign key `20260804000000` addressed by a name the database never held.
+--
+-- Its generated name is longer than the 63-byte identifier limit, so what
+-- PostgreSQL actually stored was the truncated form — the rename matched
+-- nothing and silently did nothing. A freshly provisioned deployment holds the
+-- truncated form of the CURRENT name, so that is the target here.
+--
+-- Located by shape rather than by its old name, which is the only way to be
+-- sure of the exact bytes truncation left behind.
+DO $$
+DECLARE
+  target_name constant text := left(
+    'proposal_delivery_requests_proposal_version_id_proposal_versions_id_fk', 63
+  );
+  current_name text;
+BEGIN
+  IF to_regclass('public.proposal_delivery_requests') IS NULL
+     OR to_regclass('public.proposal_versions') IS NULL THEN
+    RETURN;
+  END IF;
+
+  SELECT c.conname INTO current_name
+    FROM pg_constraint c
+   WHERE c.conrelid = to_regclass('public.proposal_delivery_requests')
+     AND c.contype = 'f'
+     AND c.confrelid = to_regclass('public.proposal_versions')
+     AND pg_get_constraintdef(c.oid) LIKE 'FOREIGN KEY (proposal_version_id)%'
+   LIMIT 1;
+
+  IF current_name IS NOT NULL
+     AND current_name <> target_name
+     AND NOT EXISTS (
+       SELECT 1 FROM pg_constraint existing
+        WHERE existing.conrelid = to_regclass('public.proposal_delivery_requests')
+          AND existing.conname = target_name
+     ) THEN
+    EXECUTE format(
+      'ALTER TABLE public.proposal_delivery_requests RENAME CONSTRAINT %I TO %I',
+      current_name, target_name
+    );
+  END IF;
+END $$;

--- a/packages/proposals/migrations/meta/_journal.json
+++ b/packages/proposals/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1785801600000,
       "tag": "20260804000000_adopt_legacy_quote_objects",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1785888000000,
+      "tag": "20260805000000_align_proposal_constraint_names",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/verify-migration-replay-parity.mjs
+++ b/scripts/verify-migration-replay-parity.mjs
@@ -175,13 +175,18 @@ async function fingerprint(client) {
   const indexes = await q(`
     SELECT tablename, indexname, indexdef FROM pg_indexes WHERE schemaname='public'
     ORDER BY tablename, indexname`)
+  // Read from pg_constraint, not information_schema.table_constraints: the
+  // catalogue carries the constraint NAME, and on PostgreSQL 18+ it carries the
+  // NOT NULL constraints too. A rename that moves tables and columns but leaves
+  // constraint names on the old vocabulary is exactly the drift this oracle has
+  // to see (voyant#4148) — `ALTER TABLE ... RENAME` does not rename them.
   const constraints = await q(`
-    SELECT tc.table_name, tc.constraint_type, cc.column_name
-    FROM information_schema.table_constraints tc
-    LEFT JOIN information_schema.key_column_usage cc
-      ON cc.constraint_name=tc.constraint_name AND cc.table_schema=tc.table_schema
-    WHERE tc.table_schema='public'
-    ORDER BY tc.table_name, tc.constraint_type, cc.column_name`)
+    SELECT rel.relname AS table_name, c.conname, c.contype, pg_get_constraintdef(c.oid) AS definition
+    FROM pg_constraint c
+    JOIN pg_namespace n ON n.oid = c.connamespace
+    LEFT JOIN pg_class rel ON rel.oid = c.conrelid
+    WHERE n.nspname='public'
+    ORDER BY 1, 2, 3`)
   return { columns, enums, indexes, constraints }
 }
 
@@ -217,6 +222,19 @@ async function main() {
   const admin = new Client({ connectionString: urlFor("postgres") })
   await admin.connect()
   try {
+    // NOT NULL constraints only reach `pg_constraint` from PostgreSQL 18 on, so
+    // on anything older this run cannot see that class of name drift at all
+    // (voyant#4148). Say so rather than let a green run read as full coverage.
+    const serverVersion = Number(
+      (await admin.query("SHOW server_version_num")).rows[0].server_version_num,
+    )
+    console.log(
+      `  server: PostgreSQL ${Math.floor(serverVersion / 10000)}` +
+        (serverVersion < 180000
+          ? " — NOT NULL constraint names are not catalogued here and go unchecked"
+          : " — NOT NULL constraint names included"),
+    )
+
     const packageSources = discoverPackageSources()
 
     // Canonical current schema: every selected package migration from an empty DB.


### PR DESCRIPTION
Closes #4148.

`ALTER TABLE ... RENAME` moves a table, its columns and its indexes. It never
moves a **constraint name**. #4145 enumerated the primary and foreign keys
explicitly and stopped there, so the NOT NULL constraints PostgreSQL 18
catalogues one per NOT NULL column stayed on the retired vocabulary: **69** of
them on a deployment repaired by that migration, against a freshly provisioned
one that has them on the current names.

Nothing resolves a constraint by name at runtime, so this is not a live fault.
It is two populations whose schemas are equivalent but not identical — the same
condition #4143 came out of — and the next `DROP CONSTRAINT` written against a
fresh deployment is what breaks on a repaired one.

## What the oracle was missing

`verify:migration-replay-parity` fingerprinted constraints from
`information_schema.table_constraints`, which reports type and columns **without
the name**. A lane could be constraint-for-constraint equal and still be
drifted. It now reads `pg_constraint` with `conname` and
`pg_get_constraintdef`, which is what turns this class into a failing lane
rather than something someone enumerates by hand. (`pg_indexes` was already
compared with names.)

That assertion found two things the issue's hand-measured list did not:

- three more NOT NULL names — `booking_crm_details_{booking_id,created_at,updated_at}_not_null`
  on `booking_proposal_details`, for **69** rather than 66;
- a foreign key #4145 addressed by a name **longer than an identifier can be**.
  `quote_proposal_delivery_requests_quote_version_id_quote_versions_id_fk` is 70
  bytes; what the database stored was the 63-byte truncation, so that rename
  matched nothing and silently did nothing.

## The fix

The alignment increment **derives** each target name the way PostgreSQL does.
`makeObjectName(table, column, 'not_null')` joins the two with an underscore,
appends the label, then shaves a character off whichever of the two is longer
until the result fits 63 bytes. Reproducing that in the migration lands exactly
the name a fresh provision holds — including
`quote_proposal_delivery_reques_command_idempotency_key_not_null`'s counterpart
— and keeps following the tables if they are ever renamed again, instead of
going stale the way a list does.

PostgreSQL 16 and 17 do not catalogue NOT NULL constraints at all, so the query
finds nothing there. Every step is guarded on the derived name being free, so it
is a no-op on an aligned database and on a re-run (verified by applying it
twice). The over-long foreign key is located by shape — the FK on
`proposal_delivery_requests` over `proposal_version_id` referencing
`proposal_versions` — rather than by a legacy name, which is the only way to be
sure of the exact bytes truncation left behind.

Each owning source ships its own increment (`proposals`, `mice`), and the
framework bundle carries the same alignment as an append, exactly as #4145
placed `0011`. The frozen cutline slice is untouched.

## Why the replay lane now runs on PostgreSQL 18 too

CI runs `postgres:16`, where these constraints do not exist in the catalogue —
so on 16 the new assertion cannot see the class of drift this PR is about at
all. The `db-lanes` matrix gains a `replay-pg18` entry (`postgres_image` is now
a matrix key) so the oracle actually guards it, and the script prints the server
version it saw, so a green run on 16 is not read as coverage it does not have.

## Verification

Both lanes, both versions, locally:

```
PostgreSQL 18 — NOT NULL constraint names included
  OK  upgrade path columns (5649) enums (1441) indexes (2201) constraints (4205)
  OK  pre-rename history columns (5649) enums (1441) indexes (2201) constraints (4205)
verify-migration-replay-parity: OK — every upgrade path == package-owned replay

PostgreSQL 16 — NOT NULL constraint names are not catalogued here and go unchecked
  OK  ... constraints (960)
verify-migration-replay-parity: OK

verify-package-baseline --union: PASS on 16 and 18
  30 package source(s) apply together; 332 owned table(s) reconstitute the bundle
```

Before the fix, the pre-rename lane failed on 18 with exactly the 69 + 1
mismatches above. Also green: `verify:proposal-vocabulary` (the new files carry
no legacy term, so the checker's adoption allowlist did not need widening),
`verify:architecture`, `@voyant-travel/framework-migrations` tests, `biome check .`.

`docs/architecture/migration-collector-d2.md` records the two rules worth more
than the object list: derive implicit constraint names rather than enumerate
them, and assert names rather than shapes.
