### PR TITLE
fix(release): stop the surface gate skipping its own registry check

### DIFF
--- a/scripts/lib/published-surface.mjs
+++ b/scripts/lib/published-surface.mjs
@@ -22,6 +22,32 @@
  * beside them installs from the registry and exercises it.
  */
 
+export const DEFAULT_ATTEMPTS = 6
+
+/**
+ * How many times to ask the registry before calling a version unpublished.
+ *
+ * This was `Number(argv[argv.indexOf("--attempts") + 1] ?? 6)`. With the flag
+ * absent, `indexOf` returns -1 and `argv[0]` is the path to the node binary, so
+ * the count was `NaN`, `attempt <= NaN` was false, the retry loop never ran a
+ * single iteration, and every package came back "not on the registry" without
+ * one request being made. Every local run passed `--attempts`, so the default
+ * path — the only one CI takes — was never exercised until it failed a release.
+ *
+ * Hence both the explicit index check and the validation: a count that is not a
+ * positive integer must stop the run, never quietly skip the work.
+ */
+export function parseAttempts(argv) {
+  const index = argv.indexOf("--attempts")
+  if (index === -1) return DEFAULT_ATTEMPTS
+
+  const attempts = Number(argv[index + 1])
+  if (!Number.isInteger(attempts) || attempts < 1) {
+    throw new Error(`--attempts must be a positive integer, received "${argv[index + 1]}"`)
+  }
+  return attempts
+}
+
 export const REGISTRY = "https://registry.npmjs.org"
 
 /**

--- a/scripts/tests/published-surface.test.mjs
+++ b/scripts/tests/published-surface.test.mjs
@@ -2,8 +2,10 @@ import assert from "node:assert/strict"
 import { test } from "node:test"
 
 import {
+  DEFAULT_ATTEMPTS,
   expandExportPattern,
   importProbeSpecifiers,
+  parseAttempts,
   registryHasVersion,
   selectPublishedPackages,
   unappliedPublishConfigViolations,
@@ -18,6 +20,34 @@ function registryResponse({ status = 200, statusText = "OK", body = {} }) {
     json: async () => body,
   })
 }
+
+test("defaults the attempt count when no flag is passed", () => {
+  // The case CI takes and no local run ever did. `argv.indexOf` returns -1 with
+  // the flag absent, so the old `argv[index + 1]` read `argv[0]` — the node
+  // binary's path — and `Number(...)` of it was NaN. `attempt <= NaN` is false,
+  // so the retry loop ran zero times and every package was reported missing
+  // without one request being made.
+  assert.equal(parseAttempts(["/usr/bin/node", "/repo/scripts/verify.mjs"]), DEFAULT_ATTEMPTS)
+  assert.ok(DEFAULT_ATTEMPTS >= 1)
+})
+
+test("reads an explicit attempt count", () => {
+  assert.equal(parseAttempts(["/usr/bin/node", "/repo/scripts/verify.mjs", "--attempts", "2"]), 2)
+})
+
+test("refuses an attempt count that would skip the work", () => {
+  for (const value of ["0", "-1", "banana", "1.5"]) {
+    assert.throws(
+      () => parseAttempts(["/usr/bin/node", "/repo/scripts/verify.mjs", "--attempts", value]),
+      /--attempts must be a positive integer/,
+    )
+  }
+
+  assert.throws(
+    () => parseAttempts(["/usr/bin/node", "/repo/scripts/verify.mjs", "--attempts"]),
+    /--attempts must be a positive integer/,
+  )
+})
 
 test("reads a published version out of the packument", async () => {
   const published = await registryHasVersion("@voyant-travel/payments", "0.9.2", {

--- a/scripts/verify-published-surface.mjs
+++ b/scripts/verify-published-surface.mjs
@@ -22,6 +22,7 @@ import {
   formatImportFailure,
   formatMissingVersion,
   importProbeSpecifiers,
+  parseAttempts,
   REGISTRY,
   registryHasVersion,
   selectPublishedPackages,
@@ -32,7 +33,7 @@ import {
 const execFileAsync = promisify(execFile)
 
 const KEEP = process.argv.includes("--keep")
-const ATTEMPTS = Number(process.argv[process.argv.indexOf("--attempts") + 1] ?? 6)
+const ATTEMPTS = parseAttempts(process.argv)
 /** The registry is read-your-writes only eventually; a fresh publish can 404 briefly. */
 const RETRY_DELAY_MS = 10_000
 
@@ -62,7 +63,9 @@ function workspaceManifests() {
  */
 async function awaitRegistry(packages) {
   let pending = packages
+  let asked = false
   for (let attempt = 1; attempt <= ATTEMPTS; attempt += 1) {
+    asked = true
     const results = await Promise.all(
       pending.map(async (entry) => {
         try {
@@ -88,6 +91,13 @@ async function awaitRegistry(packages) {
     )
     await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS))
   }
+
+  // Returning `pending` untouched would name every package as unpublished
+  // without a single request having been made. That is precisely the shape the
+  // `NaN` attempt count produced, so the impossible case gets an assertion
+  // rather than a silent verdict.
+  if (!asked) throw new Error(`the registry was never queried (attempts=${ATTEMPTS})`)
+
   return pending
 }
 


### PR DESCRIPTION
The surface gate reported **all fourteen public packages as unpublished** on two consecutive release runs, while every one of them was on the registry. #4154 attributed that to npm auth. It was wrong, and the same failure repeated after it merged.

## The actual cause

```js
const ATTEMPTS = Number(process.argv[process.argv.indexOf("--attempts") + 1] ?? 6)
```

With the flag absent, `indexOf` returns `-1`, so this reads `process.argv[0]` — the path to the node binary — and `Number("/usr/bin/node")` is `NaN`. The retry loop is:

```js
for (let attempt = 1; attempt <= ATTEMPTS; attempt += 1)
```

`1 <= NaN` is false. **It ran zero iterations**, returned the full pending list, and every package was named unpublished without a single request being made. That is why both runs finished in under a second — no network happened.

The `??` never helped: `argv[0]` is a string, so it is never nullish.

**Every local run passed `--attempts`.** The default path — the only one CI takes — was never exercised until it failed a release. Two false diagnoses came out of that gap, both of which pointed the reader at npm Trusted Publishers, which was configured correctly the whole time.

## Fix

- `parseAttempts` checks the index explicitly and rejects anything that is not a positive integer, so a bad count stops the run rather than quietly skipping the work.
- `awaitRegistry` asserts it actually queried before returning a verdict. "Everything is missing" and "nothing was checked" produced byte-identical output, and only one of them was true.

## On #4154

Not reverted, and it was not this bug. Querying the registry anonymously, refusing to treat a `401` or an outage as a missing package, and installing as a stranger are all correct on their own terms — an authenticated install would also hide a package accidentally published `restricted`. They just did not fix anything, because npm was never being called.

## Verification

Run the way it should have been the first time — **with no flags, exactly as CI invokes it**:

```
verify:published-surface: 14 publishable packages.
  installed; exercising 172 entry points.
verify:published-surface: every published entry point installs and resolves.
REAL_EXIT=0
```

Repeated under a replica of the release job's npmrc (placeholder `_authToken`, `always-auth=true`): also exit 0. 18 tests, three of them on the flag parsing including the no-flag default this turned on. `biome check` clean.
