### PR TITLE
One declaration per app compatibility axis

### DIFF
--- a/.changeset/one-declaration-per-compatibility-axis.md
+++ b/.changeset/one-declaration-per-compatibility-axis.md
@@ -1,0 +1,18 @@
+---
+"@voyant-travel/app-manifest": minor
+"@voyant-travel/apps": patch
+"@voyant-travel/mcp": patch
+---
+
+Define every app compatibility version once, in the package a publisher can install.
+
+`VOYANT_APP_CONTRACT_VERSIONS` collects the versions an app declares itself
+compatible with — the dated `/v1/app/*` surface, the manifest schema, the admin
+extension protocol major, and the event catalog — each derived from the constant
+that owns it rather than restated as a literal. They were previously written out
+by hand wherever a check needed them, including in another repository, so
+nothing connected a bump to the checks meant to enforce it.
+
+`APP_API_VERSION` moves here from `@voyant-travel/apps` and is re-exported from
+its old path. The old home is a private package: a publisher pinning
+`appApiVersions` could not read the contract they were pinning to.

--- a/docs/architecture/admin-ui-extensions.md
+++ b/docs/architecture/admin-ui-extensions.md
@@ -158,7 +158,7 @@ const extension = createUiExtensionsAdminExtension({ client })
 ## Versioning policy
 
 `ADMIN_UI_EXTENSION_API_VERSION` is the semver the host implements (currently
-`1.0.0`). Extensions declare a compatible **range** in their manifest's
+`1.1.0`). Extensions declare a compatible **range** in their manifest's
 `extensionApi` field (`"^1"`, `"^1.2"`, `"1.x"`, or an exact `"1.2.3"`); the
 host evaluates it at render time and refuses incompatible descriptors.
 

--- a/docs/architecture/app-compatibility-axes.md
+++ b/docs/architecture/app-compatibility-axes.md
@@ -1,0 +1,97 @@
+# App and extension compatibility axes
+
+What a third-party app declares compatibility against, what the platform checks,
+and where an incompatibility surfaces.
+
+The short version: **not the image, and not the Framework version.** An app
+declares against the contracts it actually consumes, each versioned in its own
+currency. `VOYANT_APP_CONTRACT_VERSIONS` in `@voyant-travel/app-manifest` is the
+single place those versions are defined.
+
+## Why the obvious answers are wrong
+
+Before the runtime became an image, compatibility was per-package semver: an
+extension declared a range against a package and npm resolution enforced it.
+With ten public packages and a `ghcr.io/voyant-travel/operator@sha256:…`
+runtime, three candidates present themselves, and all three are worse than what
+we have:
+
+- **The image tag or digest** is the least stable identifier in the system.
+  Every Platform build mints a new one, and it says nothing about whether an
+  app still works.
+- **The Framework version** moves every release. A publisher has no way to know
+  which Framework releases changed anything they touch, so exposing it as the
+  public axis makes every release look potentially breaking. It is a legitimate
+  internal record — the release provenance binds it — and it must stay one.
+- **A single new extension protocol version** collapses surfaces that fail
+  independently. The frame and the backend of one app break for different
+  reasons at different times.
+
+## The axes
+
+| Axis | Versioned as | Owned by | Covers |
+|---|---|---|---|
+| `appApiVersion` | a date — `2026-07-01` | `@voyant-travel/app-manifest` | the `/v1/app/*` HTTP surface |
+| `manifestSchemaVersion` | schema id | `@voyant-travel/app-manifest` | the manifest the publisher authored |
+| `adminExtensionVersion` | integer major | `@voyant-travel/admin-extension-sdk` | the admin UI extension protocol |
+| `eventSchemaVersion` | schema id | `@voyant-travel/graph-contracts` | webhook event contracts |
+| `artifactFormatVersion` | schema id | the Marketplace | the release envelope |
+| ~~`runtimeVersions`~~ | Framework semver | the build | **recorded, never gated** |
+
+A release records all six. Five are checked. The Framework version is not: it is
+provenance, and gating on it meant every runtime pin bump invalidated every
+release admitted before it — which is exactly what happened to an app admitted
+against `0.62.3` once the fleet moved past it.
+
+### Why the app API is dated
+
+Publishers consume `/v1/app/*` over HTTP and install no Voyant packages — the
+one real third-party app's backend imports zero of them. A package range would
+describe nothing they have. A date does, and it lets the runtime serve several
+at once while an old one retires.
+
+### Why the extension protocol is a major
+
+The SDK carries a full semver because a manifest declares a *range* against it
+(`"^1"`, `"1.x"`, `"1.2.3"`) which the host evaluates at render time. Between a
+release and a runtime the question is coarser — has the protocol broken? — so
+the axis is the major, derived from the SDK constant rather than restated.
+
+## Two surfaces, two axes
+
+An app is not one thing. The distinction is not academic; it is what the axes
+follow:
+
+| Surface | Depends on | Declares against |
+|---|---|---|
+| Framed admin page | `admin-extension-sdk`, `ui`, protocol messages | `adminExtensionVersion` |
+| Publisher backend | `/v1/app/*`, webhook wire format, OAuth ceremony | `appApiVersion`, `eventSchemaVersion` |
+
+Only the first is a package relationship. The second never was, which is why
+relocating "the npm range" was the wrong question to start from.
+
+## Where incompatibility surfaces
+
+**At Marketplace admission**, against a release pinned to `sourceRepository` and
+`sourceRevision` — not at install time, and not at render time. Managed
+instances update fleet-wide and automatically, so an app must not be able to
+hold an operator's runtime back, and the runtime must not silently drop an app
+whose contracts did not change.
+
+Render-time compatibility (`isUiExtensionCompatible`) remains as a fail-soft
+backstop for a descriptor that reaches a host it cannot speak to. It is not the
+gate.
+
+## Adding or bumping an axis
+
+1. Move the owning constant. Never write the version as a literal in a check.
+2. `VOYANT_APP_CONTRACT_VERSIONS` picks it up; anything reading that object
+   follows.
+3. For a breaking bump, serve both versions until the old one retires, and say
+   so in the release notes — a publisher cannot redeploy on your schedule.
+
+Contract versions are defined in
+`packages/app-manifest/src/contract-versions.ts`. Related:
+[admin-ui-extensions.md](./admin-ui-extensions.md) for the protocol itself, and
+[operator-image-distribution.md](./operator-image-distribution.md) for why the
+image version is not one of these.

--- a/packages/app-manifest/package.json
+++ b/packages/app-manifest/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "@voyant-travel/admin-extension-sdk": "workspace:^",
     "@voyant-travel/custom-fields-contracts": "workspace:^",
+    "@voyant-travel/graph-contracts": "workspace:^",
     "@voyant-travel/webhook-delivery-contracts": "workspace:^",
     "zod": "catalog:"
   },

--- a/packages/app-manifest/src/contract-versions.test.ts
+++ b/packages/app-manifest/src/contract-versions.test.ts
@@ -1,0 +1,34 @@
+import { ADMIN_UI_EXTENSION_API_VERSION } from "@voyant-travel/admin-extension-sdk"
+import { VOYANT_EVENT_CATALOG_SCHEMA_VERSION } from "@voyant-travel/graph-contracts"
+import { describe, expect, it } from "vitest"
+import {
+  APP_API_VERSION,
+  APP_MANIFEST_SCHEMA_VERSION,
+  VOYANT_APP_CONTRACT_VERSIONS,
+} from "./index.js"
+
+describe("VOYANT_APP_CONTRACT_VERSIONS", () => {
+  it("takes every axis from the constant that owns it", () => {
+    // Each of these was a hand-typed literal in at least one compatibility
+    // check before this object existed. A bump has to move the check with it.
+    expect(VOYANT_APP_CONTRACT_VERSIONS).toEqual({
+      appApiVersion: APP_API_VERSION,
+      manifestSchemaVersion: APP_MANIFEST_SCHEMA_VERSION,
+      eventSchemaVersion: VOYANT_EVENT_CATALOG_SCHEMA_VERSION,
+      adminExtensionVersion: ADMIN_UI_EXTENSION_API_VERSION.split(".")[0],
+    })
+  })
+
+  it("declares the admin extension protocol by major only", () => {
+    // The SDK version is a full semver because a manifest declares a range
+    // against it. Compatibility is the major: that is what a breaking
+    // protocol change moves, and what an admitted release records.
+    expect(VOYANT_APP_CONTRACT_VERSIONS.adminExtensionVersion).toMatch(/^\d+$/)
+  })
+
+  it("dates the app API rather than versioning it as semver", () => {
+    // Publishers consume this surface over HTTP and install no packages, so a
+    // package range would describe nothing they have.
+    expect(VOYANT_APP_CONTRACT_VERSIONS.appApiVersion).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+})

--- a/packages/app-manifest/src/contract-versions.ts
+++ b/packages/app-manifest/src/contract-versions.ts
@@ -1,0 +1,68 @@
+/**
+ * The contract versions a Voyant runtime implements, in one place.
+ *
+ * An app is compatible with a runtime along several independent axes, each
+ * versioned in its own currency: the HTTP surface it calls, the manifest it
+ * authored, the admin extension protocol its frame speaks, and the event
+ * contracts its webhooks receive. A publisher pins these; the platform checks
+ * them when it admits a release.
+ *
+ * Every value here is derived from the constant that owns it. That is the
+ * point of the file: these versions were previously restated as literals
+ * wherever a check needed them — including in a different repository, where
+ * `"2026-07-01"` and `"1"` were typed by hand next to the Framework version —
+ * so nothing connected a bump to the checks that were supposed to enforce it.
+ * Read this object instead of writing the string.
+ *
+ * Two axes a release also declares are deliberately absent:
+ *
+ * - the **release envelope format** belongs to the Marketplace, which produces
+ *   the artifact. The runtime never authors one.
+ * - the **Framework version** is an internal build identity. It is recorded in
+ *   a release's provenance and it must not gate anything a publisher declares:
+ *   it moves every release, and no publisher can tell which of those releases
+ *   touched anything they depend on.
+ */
+import { ADMIN_UI_EXTENSION_API_VERSION } from "@voyant-travel/admin-extension-sdk"
+import { VOYANT_EVENT_CATALOG_SCHEMA_VERSION } from "@voyant-travel/graph-contracts"
+import { APP_MANIFEST_SCHEMA_VERSION } from "./contracts.js"
+
+/**
+ * The dated `/v1/app/*` surface an installed app calls.
+ *
+ * Dated rather than semver because it is consumed over HTTP by publishers who
+ * install no packages, so a package range would describe nothing they have.
+ * Bump by publishing a new date and supporting both until the old one retires;
+ * a release declares the dates it was built against and the runtime honours
+ * any it still serves.
+ */
+export const APP_API_VERSION = "2026-07-01"
+
+/**
+ * The admin UI-extension protocol major an extension frame negotiates.
+ *
+ * The SDK carries a full semver (`ADMIN_UI_EXTENSION_API_VERSION`) because a
+ * manifest declares a *range* against it and the host evaluates that range at
+ * render time. Compatibility between a release and a runtime is coarser: it is
+ * the major, because that is what a breaking protocol change moves. Deriving
+ * it here means the two can never claim different numbers.
+ */
+export const ADMIN_UI_EXTENSION_API_MAJOR = extractMajor(ADMIN_UI_EXTENSION_API_VERSION)
+
+function extractMajor(version: string): string {
+  const major = version.split(".")[0]
+  if (!major || !/^\d+$/.test(major)) {
+    throw new Error(`Admin UI extension API version "${version}" is not a semver version.`)
+  }
+  return major
+}
+
+/** Every contract version this runtime implements, keyed by axis. */
+export const VOYANT_APP_CONTRACT_VERSIONS = {
+  appApiVersion: APP_API_VERSION,
+  manifestSchemaVersion: APP_MANIFEST_SCHEMA_VERSION,
+  eventSchemaVersion: VOYANT_EVENT_CATALOG_SCHEMA_VERSION,
+  adminExtensionVersion: ADMIN_UI_EXTENSION_API_MAJOR,
+} as const
+
+export type VoyantAppContractVersions = typeof VOYANT_APP_CONTRACT_VERSIONS

--- a/packages/app-manifest/src/index.ts
+++ b/packages/app-manifest/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./compiler.js"
+export * from "./contract-versions.js"
 export * from "./contracts.js"
 export * from "./primitives.js"

--- a/packages/apps/src/app-api-contracts.ts
+++ b/packages/apps/src/app-api-contracts.ts
@@ -15,7 +15,13 @@ import type {
 } from "@voyant-travel/finance-contracts/app-api"
 import { z } from "zod"
 
-export const APP_API_VERSION = "2026-07-01"
+/**
+ * Re-exported so every existing importer keeps its path. The value is defined
+ * in `@voyant-travel/app-manifest`, alongside the other contract versions a
+ * release declares — and, unlike this package, that one is published, so a
+ * publisher can read the version they are pinning to.
+ */
+export { APP_API_VERSION } from "@voyant-travel/app-manifest"
 
 export const appApiVersionHeader = "voyant-app-api-version"
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -14,7 +14,7 @@
     "kind": "module",
     "manifest": "./voyant",
     "compatibleWith": {
-      "framework": ">=0.65.0 <2.0.0",
+      "framework": ">=0.65.0",
       "targets": [
         "node"
       ],
@@ -78,7 +78,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@voyant-travel/framework": "workspace:>=0.65.0 <2.0.0"
+    "@voyant-travel/framework": "workspace:*"
   },
   "repository": {
     "type": "git",

--- a/packages/mcp/tests/package-contract.test.ts
+++ b/packages/mcp/tests/package-contract.test.ts
@@ -13,14 +13,21 @@ interface McpPackageJson {
 }
 
 describe("@voyant-travel/mcp package contract", () => {
-  it("requires the same framework line that its graph adapter imports", async () => {
+  it("states its framework compatibility once, where the graph reads it", async () => {
     const packageJson = JSON.parse(
       await readFile(new URL("../package.json", import.meta.url), "utf8"),
     ) as McpPackageJson
-    const frameworkRange = packageJson.peerDependencies?.["@voyant-travel/framework"]
 
-    expect(frameworkRange).toBe("workspace:>=0.65.0 <2.0.0")
-    expect(packageJson.voyant?.compatibleWith?.framework).toBe(">=0.65.0 <2.0.0")
+    // The graph evaluates this when it composes the module into a build. It is
+    // the only declaration of the supported line.
+    expect(packageJson.voyant?.compatibleWith?.framework).toBe(">=0.65.0")
+
+    // A semver peer range would be a second copy of that statement — and this
+    // package is the one changesets rewrote to a version npm did not have yet,
+    // which broke the release. `workspace:*` is always satisfied inside the
+    // workspace, so there is nothing to rewrite. The package is never
+    // published, so the range says nothing to a consumer either way.
+    expect(packageJson.peerDependencies?.["@voyant-travel/framework"]).toBe("workspace:*")
     expect(packageJson.dependencies?.["@voyant-travel/framework"]).toBeUndefined()
     expect(packageJson.peerDependenciesMeta?.["@voyant-travel/framework"]).toBeUndefined()
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,7 +249,7 @@ importers:
         version: 1.6.0(@date-fns/tz@1.4.1)(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@better-auth/api-key':
         specifier: 1.6.23
-        version: 1.6.23(1ac6a98f3eafa8cc5361cfcd8d9e497a)
+        version: 1.6.23(4cc07405e1e664eaf96048bc4329d318)
       '@fontsource-variable/inter-tight':
         specifier: ^5.2.7
         version: 5.2.7
@@ -1232,6 +1232,9 @@ importers:
       '@voyant-travel/custom-fields-contracts':
         specifier: workspace:^
         version: link:../custom-fields-contracts
+      '@voyant-travel/graph-contracts':
+        specifier: workspace:^
+        version: link:../graph-contracts
       '@voyant-travel/webhook-delivery-contracts':
         specifier: workspace:^
         version: link:../webhook-delivery-contracts
@@ -3618,7 +3621,7 @@ importers:
         specifier: workspace:^
         version: link:../core
       '@voyant-travel/framework':
-        specifier: workspace:>=0.65.0 <2.0.0
+        specifier: workspace:*
         version: link:../framework
       '@voyant-travel/hono':
         specifier: workspace:^
@@ -13163,6 +13166,14 @@ snapshots:
   '@better-auth/api-key@1.6.23(1ac6a98f3eafa8cc5361cfcd8d9e497a)':
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0)
+      '@better-auth/utils': 0.4.2
+      better-auth: 1.6.23(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.3)(rollup@4.60.2)(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9))(mongodb@7.1.0(socks@2.8.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.11)(vitest@4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)))(vue@3.5.39(typescript@6.0.3))
+      better-call: 1.3.7(zod@4.4.3)
+      zod: 4.4.3
+
+  '@better-auth/api-key@1.6.23(4cc07405e1e664eaf96048bc4329d318)':
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
       better-auth: 1.6.23(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.3)(rollup@4.60.2)(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9))(mongodb@7.1.0(socks@2.8.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.11)(vitest@4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)))(vue@3.5.39(typescript@6.0.3))
       better-call: 1.3.7(zod@4.4.3)

--- a/scripts/check-dependency-versions.mjs
+++ b/scripts/check-dependency-versions.mjs
@@ -45,6 +45,33 @@ for (const packageJsonFile of packageJsonFiles) {
         )
       }
     }
+
+    // A module declares its Framework compatibility once, in
+    // `voyant.compatibleWith.framework`, which the deployment graph evaluates
+    // when it composes the module into a build. A semver range in
+    // peerDependencies is a second copy of that statement that changesets
+    // rewrites on release — and it rewrote @voyant-travel/mcp's to a bare
+    // caret against a version npm did not have yet, so the release could not
+    // install and nothing published. Pin the workspace protocol instead: it is
+    // always satisfied inside the workspace, so there is nothing to rewrite.
+    const frameworkPeerRange = packageJson.peerDependencies?.["@voyant-travel/framework"]
+    if (frameworkPeerRange && frameworkPeerRange !== "workspace:*") {
+      violations.push(
+        `${packageJsonFile}: peerDependencies["@voyant-travel/framework"] must be workspace:* (found ${frameworkPeerRange}). ` +
+          "Express the supported Framework range in voyant.compatibleWith.framework, which is the declaration the deployment graph reads.",
+      )
+    }
+
+    // The graph check is a lower bound: it asks whether this module can be
+    // composed into the build in hand. An upper bound there cannot express
+    // anything true — the module is built from the very Framework it would be
+    // excluding — and mcp only carried one to mirror the peer range above.
+    const frameworkCompatRange = packageJson.voyant?.compatibleWith?.framework
+    if (typeof frameworkCompatRange === "string" && /[<~^]/.test(frameworkCompatRange)) {
+      violations.push(
+        `${packageJsonFile}: voyant.compatibleWith.framework must be an open lower bound such as ">=0.65.0" (found ${frameworkCompatRange}).`,
+      )
+    }
   }
 }
 


### PR DESCRIPTION
Closes #4151. Closes #4152. Part of #4062, #4153.

An app declares compatibility along several independent axes. Each was written
out as a literal wherever a check needed one — including in the control plane,
where `"2026-07-01"` and `"1"` sat hand-typed next to the Framework version with
nothing tying either back to the constants that own them.

### `VOYANT_APP_CONTRACT_VERSIONS` (#4151)

New in `@voyant-travel/app-manifest`, derived from the owning constants:

| Axis | From |
|---|---|
| `appApiVersion` | `APP_API_VERSION` |
| `manifestSchemaVersion` | `APP_MANIFEST_SCHEMA_VERSION` |
| `adminExtensionVersion` | MAJOR of `ADMIN_UI_EXTENSION_API_VERSION` |
| `eventSchemaVersion` | `VOYANT_EVENT_CATALOG_SCHEMA_VERSION` |

The admin extension axis was the specific mismatch #4151 opened on: the
marketplace recorded `["1"]`, the SDK said `"1.1.0"`, and nothing derived one
from the other. It is now the major, computed.

`APP_API_VERSION` moves here from `@voyant-travel/apps` (re-exported from its
old path, so no importer changes). `apps` is private — a publisher pinning
`appApiVersions` could not install the package defining the version.

The release envelope format and the Framework version are deliberately not
here: the first belongs to the Marketplace, the second is provenance.

### mcp declares Framework compatibility once (#4152)

`@voyant-travel/mcp` was the only package with a semver `peerDependencies`
range on the Framework, so it was the only one changesets rewrote — to a
version npm did not have yet, which is what broke the release. The package is
`private: true` and has never been published, so that range said nothing to
anyone. It is now `workspace:*`; `voyant.compatibleWith.framework` is the sole
declaration, at `>=0.65.0` like the 39 other module manifests.
`check-dependency-versions` enforces both halves.

### Docs (#4153, partial)

`docs/architecture/app-compatibility-axes.md` records the axes, why the image
digest and Framework version are not among them, and where incompatibility
surfaces. The publisher-facing page ships in the platform repo alongside the
App API reference.

### Verification

- `pnpm -F @voyant-travel/app-manifest -F @voyant-travel/apps -F @voyant-travel/mcp test` — 224 pass
- `pnpm -F ... typecheck` clean
- `verify:dep-paths`, `verify:public-surface` (closure 14/14), `verify:package-descriptions`, `verify:graph-conformance`, `verify:deployment-graph` — all pass
- `check-dependency-versions` fails on the exact manifest state that broke the release, and passes on the fix