### PR TITLE
refactor(app-manifest): read the extension version from its narrow subpath

### DIFF
--- a/.changeset/narrow-extension-version-import.md
+++ b/.changeset/narrow-extension-version-import.md
@@ -1,0 +1,9 @@
+---
+"@voyant-travel/app-manifest": patch
+---
+
+Read the admin extension version from its narrow subpath.
+
+The control plane reads `VOYANT_APP_CONTRACT_VERSIONS` inside a Worker, where
+the SDK's iframe client is dead weight. `@voyant-travel/admin-extension-sdk/version`
+carries the constant on its own.

--- a/packages/app-manifest/src/contract-versions.test.ts
+++ b/packages/app-manifest/src/contract-versions.test.ts
@@ -1,4 +1,4 @@
-import { ADMIN_UI_EXTENSION_API_VERSION } from "@voyant-travel/admin-extension-sdk"
+import { ADMIN_UI_EXTENSION_API_VERSION } from "@voyant-travel/admin-extension-sdk/version"
 import { VOYANT_EVENT_CATALOG_SCHEMA_VERSION } from "@voyant-travel/graph-contracts"
 import { describe, expect, it } from "vitest"
 import {

--- a/packages/app-manifest/src/contract-versions.ts
+++ b/packages/app-manifest/src/contract-versions.ts
@@ -23,7 +23,9 @@
  *   it moves every release, and no publisher can tell which of those releases
  *   touched anything they depend on.
  */
-import { ADMIN_UI_EXTENSION_API_VERSION } from "@voyant-travel/admin-extension-sdk"
+// The narrow subpath, not the package root: this module is read by the control
+// plane inside a Worker, which has no use for the SDK's iframe client.
+import { ADMIN_UI_EXTENSION_API_VERSION } from "@voyant-travel/admin-extension-sdk/version"
 import { VOYANT_EVENT_CATALOG_SCHEMA_VERSION } from "@voyant-travel/graph-contracts"
 import { APP_MANIFEST_SCHEMA_VERSION } from "./contracts.js"
 


### PR DESCRIPTION
Follow-up to #4158, which merged while this was in flight.

`VOYANT_APP_CONTRACT_VERSIONS` imported `ADMIN_UI_EXTENSION_API_VERSION` from the SDK package root. The control plane reads that object inside a Worker (platform-side follow-up), where the SDK's iframe client is dead weight. `@voyant-travel/admin-extension-sdk/version` is an existing subpath carrying the constant alone — the same narrow-import style `contracts.ts` already uses for `/types`.

No behaviour change; `app-manifest` tests pass.