### PR TITLE
Separate operator release digests from main snapshots

### DIFF
--- a/apps/operator/README.md
+++ b/apps/operator/README.md
@@ -158,7 +158,10 @@ gcloud run deploy operator \
 The GHCR package is the sole public operator image. Cloud Run can pull a public
 GHCR image directly, so this path does not require copying or retagging the base
 into another registry. Resolve a release tag to its accepted digest before
-deployment; never place `latest` in a service specification.
+deployment; never place `latest` in a service specification. Release tags are
+bare semver such as `0.1.1`; the `sha-<git-sha>` tag published for every
+image-impacting main commit is a build snapshot, not a release, and its
+`org.opencontainers.image.version` says so.
 
 The image uses the providers compiled from `voyant.config.ts` by default. To
 boot that same image with different infrastructure, set

--- a/docs/architecture/operator-image-distribution.md
+++ b/docs/architecture/operator-image-distribution.md
@@ -28,6 +28,27 @@ versioned client or extension protocols.
 - all `promote-latest` dispatches share one version-independent concurrency
   group, so two release promotions can never move `latest` concurrently.
 
+### Releases and main snapshots
+
+Both publication paths produce equally accepted, equally attested digests, and
+neither is a draft. They differ in what they claim:
+
+- a **release** is dispatched deliberately and carries a bare semver in both its
+  tag and `org.opencontainers.image.version`. It is the only artifact with
+  release lineage, because the version label is what ties a pinned digest back
+  to a published version;
+- a **main snapshot** is published automatically for every image-impacting
+  commit and carries `sha-<git-sha>` in both its tag and version label. It
+  records which commit was built, not which version was released. A commit that
+  releases npm packages is still an ordinary commit here; it produces a snapshot
+  like any other.
+
+A downstream that admits the base by digest and asserts a released version must
+resolve a semver tag to its digest, not a `sha-` tag. A snapshot failing that
+assertion is the contract working: the snapshot never claimed to be a release.
+When main carries a fix that a deployment needs, the unblocking step is
+dispatching **publish-release** for it, not admitting the snapshot.
+
 The `linux/amd64` and `linux/arm64` variants build concurrently on matching
 native GitHub runners. The workflow deliberately does not use QEMU: the
 production deploy tree includes architecture-specific native modules, so each
@@ -111,7 +132,9 @@ Each platform-specific runtime image configuration carries these OCI labels:
 
 The digest, rather than any label or tag, is the deployment identity. A semver
 release and a SHA build from the same revision may have different digests
-because the version label is part of the image configuration.
+because the version label is part of the image configuration. The two version
+shapes are the release/snapshot distinction above; the label never carries a
+version the workflow was not asked to publish.
 
 ## Compatibility boundaries
 

--- a/scripts/check-operator-image-publication.mjs
+++ b/scripts/check-operator-image-publication.mjs
@@ -185,6 +185,10 @@ requireFragments(OPERATOR_README, operatorReadme, [
     "operator deployment guidance must pin the sole public GHCR image by digest",
   ],
   ["sole public operator image", "operator deployment guidance must identify one public image"],
+  [
+    "a build snapshot, not a release",
+    "operator deployment guidance must separate release tags from main snapshots",
+  ],
 ])
 requireFragments(SMOKE, smoke, [
   ["node run-generated-migrations.mjs", "image acceptance must run embedded migrations"],
@@ -298,6 +302,14 @@ requireFragments(CONTRACT, contract, [
   ],
   ["canonical base for downstream private products", "contract must define private derivatives"],
   ["@sha256:<digest>", "distribution contract must require digest pinning"],
+  [
+    "resolve a semver tag to its digest",
+    "distribution contract must tell downstreams to admit releases by semver tag",
+  ],
+  [
+    "not admitting the snapshot",
+    "distribution contract must route a needed main fix through a release dispatch",
+  ],
   ["ADMIN_UI_EXTENSION_API_VERSION", "contract must separate extension API versioning"],
   ["APP_API_VERSION", "contract must separate Apps API versioning"],
   ["deployment.providers", "contract must define provider selection authority"],


### PR DESCRIPTION
Closes #4168.

## What the registry says

#4168 reports that operator images published on 2026-08-04 regressed to a commit sha in `org.opencontainers.image.version`. They did not. Resolving the cited digests against GHCR:

| Cited digest | Tag | Version label |
| --- | --- | --- |
| `sha256:2d905404…` ("good", 2026-08-01) | `0.1.0` | `0.1.0` |
| `sha256:99b27c7b…` (#4158) | `sha-7de4013cf1…` | `sha-7de4013cf1…` |
| `sha256:d85e857b…` (#4165) | `sha-4397736329…` | `sha-4397736329…` |

The good one is a dispatched **release**. The other two are **main snapshots**, which have carried `sha-<git-sha>` in that label since the workflow was introduced in #4024. `.github/workflows/operator-image.yml` derives the label from one planned value per path — `$RELEASE_VERSION` for a dispatch, `sha-$GITHUB_SHA` for a push — and #4158 did not touch it. The current `latest` is `0.1.1`, semver-labelled.

The second snapshot is the one that misleads: its commit is `chore: release packages (#4165)`, which releases npm packages, not an image. Nothing distinguishes it from any other main commit here.

So the consumer's assertion was working correctly — it rejected two artifacts that never claimed to be releases.

## What this changes

No workflow or label behaviour. What was missing is the statement a consumer needs at the moment that assertion fails.

`docs/architecture/operator-image-distribution.md` gains a **Releases and main snapshots** section: both paths produce equally accepted and attested digests differing only in what they claim; admitting a release means resolving a semver tag to its digest, not a `sha-` tag; and a fix sitting on main is unblocked by dispatching **publish-release**, not by admitting the snapshot carrying it. The OCI identity table now points at that distinction instead of leaving two label shapes side by side unexplained.

`apps/operator/README.md` says the same thing where the pinning guidance already lives.

`check-operator-image-publication` pins all three statements, so the distinction cannot drift back out of the contract or the deployment guidance.

## Still open, and not fixable in a PR

#4168's underlying blocker is real. The newest **release** image is `0.1.1` at revision `de133b857` (`chore: release packages (#4112)`, 2026-08-03), which predates the `quotes` → `proposals` migration path from #4143 / #4148. Until **Operator image / publish-release** is dispatched from main with a new semver, there is no release digest carrying it, and deployments on the pre-rename schema stay blocked. That dispatch is an operator action.

## Verification

```
node scripts/check-operator-image-publication.mjs   # OK
npx biome check scripts/check-operator-image-publication.mjs   # clean
```
Each new fragment was negative-tested by perturbing the source line and confirming the checker fails on it.