### PR TITLE
fix(framework-migrations): require the rename increment before recording a migration unrun

### DIFF
--- a/.changeset/olive-jars-repeat.md
+++ b/.changeset/olive-jars-repeat.md
@@ -1,0 +1,19 @@
+---
+"@voyant-travel/framework-migrations": patch
+---
+
+Require the rename adoption increment before accepting a quotes → proposals
+migration without executing it.
+
+`SUPERSEDED_LEDGER_IDENTITIES` and `EQUIVALENT_MIGRATION_HASHES` both record a
+migration as applied without running its SQL, and both are sound only because
+the owning module ships a post-cutline increment that renames the legacy objects
+into the new shape. Those two halves live in different packages, so a deployment
+that assembles its own dependency graph can hold the framework side without the
+module side — and then the baselines are recorded, nothing is renamed, and the
+database keeps its `quote_*` objects while the application queries `proposal_*`.
+
+The collector now checks that the required increment is in the plan and raises
+`MigrationRenameCompanionMissingError` naming the skewed package when it is not.
+Only the upgrade direction is gated; a rolled-back image verifying older SQL
+against a newer ledger is unaffected.

--- a/docs/architecture/migration-collector-d2.md
+++ b/docs/architecture/migration-collector-d2.md
@@ -232,6 +232,21 @@ The supported shape has three parts, and none of them may be used alone:
    Equivalence marks a migration applied, so on its own it would leave the
    database on the old names while the application queries the new ones.
 
+"None of them may be used alone" is enforced, not just documented (voyant#4172).
+(1) and (3) each declare the adoption increment they depend on, and the collector
+refuses to record a migration without executing it — by either route — when that
+increment is absent from the plan, raising `MigrationRenameCompanionMissingError`.
+
+The gap that makes this worth a guard is **version skew**: (1) and (3) live in
+`@voyant-travel/framework-migrations`, while (2) ships in each owning module
+package. A deployment that assembles its own graph rather than taking the image
+whole can upgrade the framework while its module packages still predate the
+rename. Nothing in the ledger distinguishes that from a healthy upgrade, so the
+collector would happily record the baselines and rename nothing — trading a loud,
+safe failure for silent divergence. Only the upgrade direction is gated; a
+rolled-back image verifying older SQL against a newer ledger is what the
+symmetric closure exists to serve, and those renames have already run.
+
 Append-only history that is deliberately left alone: `action_ledger_entries`
 records past `action_name`/`target_type` values under the vocabulary in force
 when they happened, and legacy delivery-request rows carry a `legacy.*` command

--- a/packages/framework-migrations/src/collector.test.ts
+++ b/packages/framework-migrations/src/collector.test.ts
@@ -8,6 +8,7 @@ import {
   compatibilityPreflightStatementsForMigration,
   type MigrationClient,
   MigrationImmutabilityError,
+  MigrationRenameCompanionMissingError,
   type MigrationSource,
   planMigrations,
 } from "./collector.js"
@@ -224,10 +225,13 @@ describe("migration hash compatibility", () => {
     "utf8",
   )
 
-  it("accepts the pre-rename relationships baseline recorded before quotes became proposals", async () => {
-    const client: MigrationClient = {
-      async query(sql: string) {
-        if (sql.includes(`SELECT "content_hash"`)) {
+  /** A client whose ledger holds the pre-#4004 bytes of the relationships baseline. */
+  function preRenameRelationshipsClient(): MigrationClient {
+    return {
+      async query(sql: string, params: unknown[] = []) {
+        // Only the baseline is in the ledger — the rename increment, if this
+        // deployment ships one, is still pending.
+        if (sql.includes(`SELECT "content_hash"`) && params[1] === "0000_relationships_baseline") {
           return {
             rows: [
               // the bytes this file shipped with before #4004 renamed
@@ -241,15 +245,82 @@ describe("migration hash compatibility", () => {
         return { rows: [] }
       },
     }
+  }
+
+  const RELATIONSHIPS_RENAME_COMPANION = {
+    tag: "20260804000100_proposal_entity_labels",
+    sql: "ALTER TYPE entity_type RENAME VALUE 'quote' TO 'proposal';",
+  }
+
+  it("accepts the pre-rename relationships baseline when the rename increment ships with it", async () => {
+    await expect(
+      applyMigrations(
+        preRenameRelationshipsClient(),
+        [
+          {
+            name: "relationships",
+            priority: 0,
+            migrations: [
+              { tag: "0000_relationships_baseline", sql: relationshipsBaseline },
+              RELATIONSHIPS_RENAME_COMPANION,
+            ],
+          },
+        ],
+        ledgerOpts,
+      ),
+    ).resolves.toEqual({
+      executed: ["relationships/20260804000100_proposal_entity_labels"],
+      baselined: [],
+    })
+  })
+
+  it("refuses the equivalence when the module predates the rename increment (voyant#4172)", async () => {
+    // A deployment that upgraded the framework alone: the equivalence table is
+    // present, but `@voyant-travel/relationships` still ships only the baseline.
+    // Accepting here would record it applied and never rename `quote_*`.
+    const error = await applyMigrations(
+      preRenameRelationshipsClient(),
+      [
+        {
+          name: "relationships",
+          priority: 0,
+          migrations: [{ tag: "0000_relationships_baseline", sql: relationshipsBaseline }],
+        },
+      ],
+      ledgerOpts,
+    ).catch((thrown: unknown) => thrown)
+
+    expect(error).toBeInstanceOf(MigrationRenameCompanionMissingError)
+    expect(error).toMatchObject({
+      acceptance: "equivalence",
+      companion: { source: "relationships", tag: "20260804000100_proposal_entity_labels" },
+    })
+  })
+
+  it("leaves the other equivalence families ungated — only the rename needs a companion", async () => {
+    // `action-ledger/0000` is a formatting-only rewrite: both generations describe
+    // the same schema, so there is no companion increment to require.
+    const client: MigrationClient = {
+      async query(sql: string) {
+        if (sql.includes(`SELECT "content_hash"`)) {
+          return {
+            rows: [
+              { content_hash: "d63e6a73b58f985888e258b318255eba5181db307438b25f3d262350f837b2ce" },
+            ],
+          }
+        }
+        return { rows: [] }
+      },
+    }
 
     await expect(
       applyMigrations(
         client,
         [
           {
-            name: "relationships",
+            name: "action-ledger",
             priority: 0,
-            migrations: [{ tag: "0000_relationships_baseline", sql: relationshipsBaseline }],
+            migrations: [{ tag: "0000_action_ledger_baseline", sql: currentActionLedgerBaseline }],
           },
         ],
         ledgerOpts,
@@ -324,17 +395,49 @@ const proposalsBaselineSource: MigrationSource = {
   ],
 }
 
+/** The increment that renames the adopted `quote_*` objects into the proposals shape. */
+const PROPOSALS_RENAME_COMPANION = {
+  tag: "20260804000000_adopt_legacy_quote_objects",
+  sql: `ALTER TABLE "quotes" RENAME TO "proposals";`,
+}
+
+const proposalsWithCompanionSource: MigrationSource = {
+  ...proposalsBaselineSource,
+  migrations: [...proposalsBaselineSource.migrations, PROPOSALS_RENAME_COMPANION],
+}
+
 describe("retired-source supersession", () => {
   it("records the proposals baseline without executing when the whole quotes ledger is present", async () => {
     const { client, queries, inserted } = supersessionClient(RETIRED_QUOTES_TAGS)
 
-    await expect(applyMigrations(client, [proposalsBaselineSource], ledgerOpts)).resolves.toEqual({
-      executed: [],
+    await expect(
+      applyMigrations(client, [proposalsWithCompanionSource], ledgerOpts),
+    ).resolves.toEqual({
+      executed: ["proposals/20260804000000_adopt_legacy_quote_objects"],
       baselined: ["proposals/0000_proposals_baseline"],
     })
-    expect(inserted).toEqual([{ source: "proposals", tag: "0000_proposals_baseline" }])
-    expect(queries).not.toContain("BEGIN")
+    expect(inserted).toEqual([
+      { source: "proposals", tag: "0000_proposals_baseline" },
+      { source: "proposals", tag: "20260804000000_adopt_legacy_quote_objects" },
+    ])
     expect(queries.some((sql) => sql.startsWith(`CREATE TABLE "proposals"`))).toBe(false)
+  })
+
+  it("refuses to adopt the quotes ledger when the rename increment is absent (voyant#4172)", async () => {
+    // `@voyant-travel/proposals` at a version that predates the rename increment:
+    // recording the baseline would leave `quote_*` objects behind for good.
+    const { client, inserted } = supersessionClient(RETIRED_QUOTES_TAGS)
+
+    const error = await applyMigrations(client, [proposalsBaselineSource], ledgerOpts).catch(
+      (thrown: unknown) => thrown,
+    )
+
+    expect(error).toBeInstanceOf(MigrationRenameCompanionMissingError)
+    expect(error).toMatchObject({
+      acceptance: "superseded-source",
+      companion: { source: "proposals", tag: "20260804000000_adopt_legacy_quote_objects" },
+    })
+    expect(inserted).toEqual([])
   })
 
   it("executes normally on a fresh database with no quotes ledger at all", async () => {

--- a/packages/framework-migrations/src/collector.ts
+++ b/packages/framework-migrations/src/collector.ts
@@ -105,6 +105,38 @@ export class MigrationImmutabilityError extends Error {
   }
 }
 
+/**
+ * Thrown when a migration edited by the quotes → proposals rename would be
+ * accepted across that rename, but the increment that performs the rename is
+ * not in this deployment's plan — i.e. the module package predates the framework
+ * that carries the equivalence table.
+ */
+export class MigrationRenameCompanionMissingError extends Error {
+  constructor(
+    readonly source: string,
+    readonly tag: string,
+    readonly companion: { source: string; tag: string },
+    /** How this migration was about to be recorded without executing its SQL. */
+    readonly acceptance: "equivalence" | "superseded-source",
+  ) {
+    const because =
+      acceptance === "equivalence"
+        ? "is recorded at its pre-rename bytes and would be accepted as equivalent"
+        : "would be recorded without executing, because the retired `quotes` source it supersedes " +
+          "is fully applied"
+    super(
+      `migration rename companion missing: ${source}/${tag} ${because}, but its companion ` +
+        `increment ${companion.source}/${companion.tag} is not in this deployment's migration ` +
+        "plan. Recording it without that increment would leave the database holding its legacy " +
+        "`quote_*` objects while the application queries `proposal_*`. " +
+        `The \`${companion.source}\` migrations in this deployment predate the quotes → proposals ` +
+        "rename: align every module package with the framework that ships the rename support, " +
+        "rather than upgrading the framework alone.",
+    )
+    this.name = "MigrationRenameCompanionMissingError"
+  }
+}
+
 const contentHash = (sql: string) => createHash("sha256").update(sql).digest("hex")
 
 // `db/0001_db_baseline` originally shipped plain `ADD COLUMN` statements; both
@@ -229,6 +261,79 @@ const EQUIVALENT_MIGRATION_HASHES = new Map<string, ReadonlySet<string>>([
 ])
 
 /**
+ * The post-cutline increment that makes each rename equivalence SOUND.
+ *
+ * Accepting a pre-rename ledger hash against post-rename bytes marks the edited
+ * migration applied — so the objects it declares are never re-declared. That is
+ * only correct because the same release ships an increment that renames the
+ * legacy objects into the new shape. If a deployment assembles a graph where the
+ * framework carries the equivalence table but a module package predates the
+ * rename, the increment is absent: the baseline is recorded as applied, nothing
+ * renames anything, and the database keeps its `quote_*` objects while the
+ * application queries `proposal_*`.
+ *
+ * Silent divergence is strictly worse than the immutability error it replaces,
+ * so the equivalence is gated on its companion being present in the plan. See
+ * voyant#4143 and voyant#4172.
+ */
+const RENAME_COMPANION_INCREMENTS = new Map<string, { source: string; tag: string }>([
+  [
+    "bookings/0000_bookings_baseline",
+    { source: "bookings", tag: "20260804000300_booking_origin_proposal_version" },
+  ],
+  [
+    "legal/0000_legal_baseline",
+    { source: "legal", tag: "20260804000200_proposal_version_target_kind" },
+  ],
+  [
+    "mice/20260713000300_standard_links",
+    { source: "mice", tag: "20260804000400_proposal_mice_program_link" },
+  ],
+  [
+    "relationships/0000_relationships_baseline",
+    { source: "relationships", tag: "20260804000100_proposal_entity_labels" },
+  ],
+  [
+    "relationships/0003_add_booking_custom_field_target",
+    { source: "relationships", tag: "20260804000100_proposal_entity_labels" },
+  ],
+  [
+    "framework/0000_framework_baseline",
+    { source: "framework", tag: "0011_adopt_legacy_quote_objects" },
+  ],
+  [
+    "framework/0003_framework_baseline",
+    { source: "framework", tag: "0011_adopt_legacy_quote_objects" },
+  ],
+  [
+    "framework/0005_framework_baseline",
+    { source: "framework", tag: "0011_adopt_legacy_quote_objects" },
+  ],
+])
+
+/** Pre-rename bytes of each edited migration, keyed `source/tag`. */
+const PRE_RENAME_HASHES = new Map<string, string>(
+  PROPOSAL_RENAME_EDITED_HASHES.map(([key, [pre]]) => [key, pre]),
+)
+
+/**
+ * The companion increment this acceptance requires, or `undefined`.
+ *
+ * Only the UPGRADE direction needs one — ledger at pre-rename bytes, current SQL
+ * at post-rename bytes. The reverse (a rolled-back image shipping older SQL
+ * against a ledger a newer image wrote) is the case the symmetric closure exists
+ * to serve: those renames already ran, so there is nothing to gate.
+ */
+function renameCompanionRequiredFor(
+  migration: Pick<PlannedMigration, "source" | "tag" | "contentHash">,
+  ledgerHash: string,
+): { source: string; tag: string } | undefined {
+  const key = `${migration.source}/${migration.tag}`
+  if (PRE_RENAME_HASHES.get(key) !== ledgerHash) return undefined
+  return RENAME_COMPANION_INCREMENTS.get(key)
+}
+
+/**
  * Migrations that replace a RETIRED source's ledger history wholesale.
  *
  * A module rename produces a migration whose objects already exist under their
@@ -258,6 +363,18 @@ const SUPERSEDED_LEDGER_IDENTITIES = new Map<
       { source: "quotes", tag: "20260716000301_namespace_custom_field_values" },
       { source: "quotes", tag: "20260727200000_default_quote_pipeline" },
     ],
+  ],
+])
+
+/**
+ * The increment that renames a superseded source's legacy objects into the shape
+ * its superseding baseline declares. Recording that baseline without executing it
+ * is only sound while this ships alongside — see {@link RENAME_COMPANION_INCREMENTS}.
+ */
+const SUPERSEDING_COMPANION_INCREMENTS = new Map<string, { source: string; tag: string }>([
+  [
+    "proposals/0000_proposals_baseline",
+    { source: "proposals", tag: "20260804000000_adopt_legacy_quote_objects" },
   ],
 ])
 
@@ -439,7 +556,9 @@ async function applyMigrationsInternal(
 
   const executed: string[] = []
   const baselined: string[] = []
-  for (const m of planMigrations(sources)) {
+  const plan = planMigrations(sources)
+  const plannedIds = new Set(plan.map((m) => `${m.source}/${m.tag}`))
+  for (const m of plan) {
     const ledgerSources = [...new Set([m.source, ...(m.legacySources ?? [])])]
     const seen = await client.query(
       `SELECT "content_hash", "source" FROM ${ledger}
@@ -449,8 +568,19 @@ async function applyMigrationsInternal(
     if (seen.rows.length > 0) {
       for (const row of seen.rows) {
         const ledgerHash = String(row.content_hash ?? "")
-        if (ledgerHash !== m.contentHash && !isEquivalentMigrationHash(m, ledgerHash)) {
-          throw new MigrationImmutabilityError(m.source, m.tag, ledgerHash, m.contentHash)
+        if (ledgerHash !== m.contentHash) {
+          if (!isEquivalentMigrationHash(m, ledgerHash)) {
+            throw new MigrationImmutabilityError(m.source, m.tag, ledgerHash, m.contentHash)
+          }
+          const companion = renameCompanionRequiredFor(m, ledgerHash)
+          if (companion && !plannedIds.has(`${companion.source}/${companion.tag}`)) {
+            throw new MigrationRenameCompanionMissingError(
+              m.source,
+              m.tag,
+              companion,
+              "equivalence",
+            )
+          }
         }
       }
       const hasStableRow = seen.rows.some(
@@ -471,6 +601,15 @@ async function applyMigrationsInternal(
     if (await isSupersedingRetiredSource(client, ledger, m)) {
       // The objects exist under the retired source's identity → record without
       // executing; the source's own increment renames them into this shape.
+      const companion = SUPERSEDING_COMPANION_INCREMENTS.get(id)
+      if (companion && !plannedIds.has(`${companion.source}/${companion.tag}`)) {
+        throw new MigrationRenameCompanionMissingError(
+          m.source,
+          m.tag,
+          companion,
+          "superseded-source",
+        )
+      }
       await client.query(
         `INSERT INTO ${ledger} ("source", "tag", "content_hash") VALUES ($1, $2, $3)
          ON CONFLICT ("source", "tag") DO NOTHING`,

--- a/packages/framework-migrations/src/deployment-runner.test.ts
+++ b/packages/framework-migrations/src/deployment-runner.test.ts
@@ -169,6 +169,12 @@ describe("runDeploymentMigrations on a partially adopted database", () => {
               tag: "0000_proposals_baseline",
               sql: 'CREATE TABLE "proposals" ("id" text PRIMARY KEY);',
             },
+            // The increment that renames the legacy objects into this shape.
+            // Recording the baseline is only sound while it ships alongside.
+            {
+              tag: "20260804000000_adopt_legacy_quote_objects",
+              sql: 'ALTER TABLE "quotes" RENAME TO "proposals";',
+            },
           ],
         },
       ],
@@ -176,10 +182,13 @@ describe("runDeploymentMigrations on a partially adopted database", () => {
     )
 
     expect(result.existing).toBe(true)
-    expect(result.executed).toEqual([])
+    expect(result.executed).toEqual(["proposals/20260804000000_adopt_legacy_quote_objects"])
     expect(result.baselined).toEqual(["proposals/0000_proposals_baseline"])
     expect(executed).toEqual([])
-    expect(inserted).toEqual([{ source: "proposals", tag: "0000_proposals_baseline" }])
+    expect(inserted).toEqual([
+      { source: "proposals", tag: "0000_proposals_baseline" },
+      { source: "proposals", tag: "20260804000000_adopt_legacy_quote_objects" },
+    ])
   })
 
   function expansionClient(

--- a/packages/framework-migrations/src/index.ts
+++ b/packages/framework-migrations/src/index.ts
@@ -13,6 +13,7 @@ export {
   applyMigrations,
   type MigrationClient,
   MigrationImmutabilityError,
+  MigrationRenameCompanionMissingError,
   type MigrationSource,
   type MigrationStatement,
   type PlannedMigration,


### PR DESCRIPTION
Closes #4172.

## The report was right about the symptom and wrong about the cause

#4172 asks for a changeset so the `quotes` → `proposals` packages get published.
There is no missing changeset. All nine packages are `private: true` on `main`,
set deliberately by #4098 — changesets *versions* private packages but never
publishes them, which is exactly why the repo versions moved while npm stayed
put. The gap is the design, not a pipeline miss.

Reversing it is not local either. `verify:public-surface` asserts both that
every publishable package is on the allowlist and that the allowlist's
dependency closure equals the allowlist. `@voyant-travel/operator-standard`
alone declares 85 workspace dependencies — it *is* the npm assembly path #4098
closed. So this PR does not publish anything.

## Publishing `framework-migrations` alone would have been the worst outcome

The issue names it as the one that matters most, because its
`EQUIVALENT_MIGRATION_HASHES` is what stops the immutability gate firing. But
that equivalence is sound **only because** each owning module ships a
post-cutline increment that renames the legacy objects. The published tarballs
carry none of them:

| package | npm | `20260804*` increment |
|---|---|---|
| `relationships` | 0.133.5 | absent |
| `proposals` | 0.137.5 | absent |
| `legal` | 0.232.0 | absent |
| `bookings` | 0.232.0 | absent |
| `mice` | 0.88.0 | absent |

A consumer who bumped `framework-migrations` alone would get the edited
baselines marked *applied* while nothing renamed anything — the database keeps
`quote_*` while the application queries `proposal_*`. That trades today's loud,
safe `MigrationImmutabilityError` for silent divergence.

## What this changes

The collector has two routes that record a migration as applied without running
its SQL: `SUPERSEDED_LEDGER_IDENTITIES` and `EQUIVALENT_MIGRATION_HASHES`. Both
already documented their dependency on the adoption increment — the code in a
comment, `migration-collector-d2.md` in the words "none of them may be used
alone". Neither enforced it.

Both routes now declare the increment they depend on and refuse to proceed when
it is absent from the plan, raising `MigrationRenameCompanionMissingError` that
names the skewed package. Only the upgrade direction is gated (ledger at
pre-rename bytes, current SQL post-rename); a rolled-back image verifying older
SQL against a newer ledger is what the symmetric closure exists to serve, and
those renames have already run.

The version skew this catches is not hypothetical — it is precisely the graph
#4172 was asking us to make installable.

## Verification

- `pnpm --filter @voyant-travel/framework-migrations test` — **88/88**, run with
  `TEST_DATABASE_URL` set so the 12 real-Postgres integration tests execute
  rather than skip
- `pnpm --filter @voyant-travel/framework-migrations typecheck` — clean
- `biome check packages/framework-migrations/src` — clean

Two existing tests encoded the now-unsound behaviour (one per route) and were
updated to ship the companion increment; two new tests assert the refusal.
`scripts/verify-migration-replay-parity.mjs` replays raw SQL and does not go
through `applyMigrations`, so it is unaffected.

## What still unblocks the reporter

Not this PR. The fixed packages are already in the operator image
(`ghcr.io/voyant-travel/operator`, which #4172 confirms carries 0.10.11). A
derivative that layers on that base but reinstalls its own graph from the
registry does not use them — the real fix is platform#1622, with a `patches/`
entry as the interim. Until then this guard makes the mixed graph fail loudly
and say why, instead of quietly corrupting the schema.
