### PR TITLE
Surface the under-allocated remainder of a supplier invoice

### DIFF
--- a/.changeset/surface-under-allocated-supplier-cost.md
+++ b/.changeset/surface-under-allocated-supplier-cost.md
@@ -1,0 +1,29 @@
+---
+"@voyant-travel/finance": minor
+"@voyant-travel/finance-react": minor
+---
+
+Surface the under-allocated remainder of a supplier invoice.
+
+Allocating a supplier invoice has always permitted under-allocation, and the
+invariant docs said the leftover "is reported as `unattributed` by the read
+model". It was not. The profitability read model's unattributed figure sums
+`supplier_cost_allocations` rows whose `targetType` is `unattributed`, so it
+answers "how much did someone deliberately mark as belonging to no departure" —
+a remainder nobody allocated has no row at all and could never appear. An
+invoice of 1000 with 600 allocated reported 600 of cost and nothing else; the
+missing 400 quietly inflated margin everywhere the read model is read.
+
+The departure and product reports now carry a second, separate figure,
+`unallocated` (and `unallocatedCents` in the accounting-base rollup): per
+invoice, its total minus every allocation row against it. The two are not
+merged, because "we decided this cost belongs to no departure" and "nobody has
+allocated this yet" are different signals and only the second is a backlog. The
+remainder gets the same FX treatment as the rest of the model — pro-rated from
+the invoice's own issue-date base snapshot, with only un-snapshotted legacy
+rows converted at a fallback rate — and void and soft-deleted invoices are
+excluded, as in the neighbouring queries.
+
+Both CSV exports gain a trailing per-currency block listing the two kinds of
+unaccounted cost. It is emitted only when there is something to report, so an
+export from a fully allocated ledger is unchanged.

--- a/docs/architecture/supplier-invoices-profitability.md
+++ b/docs/architecture/supplier-invoices-profitability.md
@@ -279,7 +279,7 @@ Pin these down in PR1's validation + tests:
 1. **No mixing modes per invoice.** An invoice is allocated **either** whole-invoice (line-less rows, `supplierInvoiceLineId = null`) **or** per-line — never both. Reject the second mode once the first exists on an invoice.
 2. **Exactly one target per allocation** (§6 table note): a check constraint requires the id column matching `targetType` to be non-null and the others null.
 3. **No over-allocation.** Σ(allocations of a line) ≤ line `totalAmountCents`; for whole-invoice mode, Σ ≤ invoice `totalCents`. Over-allocation rejected.
-4. **Under-allocation → explicit remainder.** The remainder is **not** silently dropped: the read model reports it as an `unattributed` figure per invoice (data-quality signal). Whether to also *materialise* a synthetic `unattributed` allocation row vs compute it on read is a PR1 call — recommendation: compute on read, don't store.
+4. **Under-allocation → explicit remainder.** The remainder is **not** silently dropped: the read model computes it on read (nothing is stored) and reports it per currency as `unallocated`, separately from `unattributed`. The two are different signals — `unattributed` is cost someone decided belongs to no departure, `unallocated` is cost nobody has touched yet — so merging them would hide a backlog behind a decision.
 5. **Currency.** An allocation inherits the invoice currency; `baseAmountCents` is computed via the invoice's `fxRateSetId` at record time (§9). Allocations never mix currencies within one invoice.
 6. **Supplier credit notes** (§5.6 / §15-Q5): a credit note (negative invoice in the lean v1) produces **negative** allocations against the same targets, so the read model nets them. Define the matching rule (credit references the original `supplier_invoices.id`) and forbid a credit's allocations from exceeding the original's per-target totals.
 
@@ -322,7 +322,9 @@ profitCents         -- revenue − actual
 marginPercent       -- profit / revenue
 varianceCents       -- planned − actual   (negative = overspend)
 costByServiceType   -- breakdown for the stacked-bar chart
-unattributedCents   -- AP recorded but not yet attributed (data-quality signal)
+unattributedCents   -- AP allocated to `unattributed` on purpose (excluded from P&L)
+unallocatedCents    -- AP with no allocation row at all: the under-allocated
+                    -- remainder, Σ(invoice total − Σ its allocations) (backlog signal)
 ```
 
 ### `getProductProfitability({ from, to })`

--- a/packages/finance-contracts/src/validation-profitability.ts
+++ b/packages/finance-contracts/src/validation-profitability.ts
@@ -5,6 +5,13 @@ import { z } from "zod"
  * stored: actual cost from `supplier_cost_allocations`, revenue from issued
  * customer invoices (AR), planned cost from `booking_items`. Rows are emitted
  * **per currency** — amounts are never summed across currencies (no FX in v1).
+ *
+ * Only the query inputs are contracts here; the response shapes are authored
+ * from the service interfaces next to the routes that serve them
+ * (`@voyant-travel/finance` `routes-reports.ts`). Alongside the rows those
+ * responses carry two separate unaccounted-cost figures: `unattributed` (cost
+ * allocated to no departure on purpose) and `unallocated` (the under-allocated
+ * remainder of a supplier invoice, which has no allocation row at all).
  */
 
 export const departureProfitabilityQuerySchema = z.object({

--- a/packages/finance-react/src/components/profitability-page.tsx
+++ b/packages/finance-react/src/components/profitability-page.tsx
@@ -239,6 +239,16 @@ export function ProfitabilityPage({
     )
   }, [departureReport, baseMode, activeCurrency])
 
+  // Supplier cost nobody has allocated yet — shown next to, never merged into,
+  // the deliberately-unattributed figure above.
+  const unallocated = useMemo(() => {
+    if (baseMode) return departureReport?.base?.unallocatedCents ?? 0
+    return (
+      (departureReport?.unallocated ?? []).find((u) => u.currency === activeCurrency)
+        ?.amountCents ?? 0
+    )
+  }, [departureReport, baseMode, activeCurrency])
+
   const chartData = useMemo(
     () =>
       [...departureRows]
@@ -404,6 +414,11 @@ export function ProfitabilityPage({
               accent={totals.variance >= 0 ? "positive" : "negative"}
             />
             <KpiCard label={t.kpis.unattributed} value={money(unattributed)} />
+            <KpiCard
+              label={t.kpis.unallocated}
+              value={money(unallocated)}
+              accent={unallocated > 0 ? "negative" : undefined}
+            />
           </div>
 
           <div className="grid min-w-0 gap-4 lg:grid-cols-2">

--- a/packages/finance-react/src/i18n/en/profitability.ts
+++ b/packages/finance-react/src/i18n/en/profitability.ts
@@ -25,6 +25,7 @@ export const profitability = {
     plannedCost: "Planned cost",
     variance: "Variance",
     unattributed: "Unattributed cost",
+    unallocated: "Unallocated cost",
   },
   charts: {
     departurePnl: "Departure P&L",

--- a/packages/finance-react/src/i18n/messages/profitability.ts
+++ b/packages/finance-react/src/i18n/messages/profitability.ts
@@ -26,6 +26,7 @@ export type ProfitabilityMessages = {
     plannedCost: string
     variance: string
     unattributed: string
+    unallocated: string
   }
   charts: {
     departurePnl: string

--- a/packages/finance-react/src/i18n/ro/profitability.ts
+++ b/packages/finance-react/src/i18n/ro/profitability.ts
@@ -25,6 +25,7 @@ export const profitability = {
     plannedCost: "Cost planificat",
     variance: "Diferenta",
     unattributed: "Cost neatribuit",
+    unallocated: "Cost nealocat",
   },
   charts: {
     departurePnl: "P&L pe plecare",

--- a/packages/finance-react/src/profitability-page.test.tsx
+++ b/packages/finance-react/src/profitability-page.test.tsx
@@ -41,6 +41,7 @@ vi.mock("./index.js", () => ({
           { serviceType: "accommodation", currency: "RON", amountCents: 7500050 },
         ],
         unattributed: [{ currency: "RON", amountCents: 120050 }],
+        unallocated: [{ currency: "RON", amountCents: 45000 }],
         base: {
           currency: "RON",
           rows: [departureRow],
@@ -48,6 +49,7 @@ vi.mock("./index.js", () => ({
             { serviceType: "accommodation", currency: "RON", amountCents: 7500050 },
           ],
           unattributedCents: 120050,
+          unallocatedCents: 45000,
           unconvertibleCurrencies: [],
         },
       },
@@ -62,6 +64,7 @@ vi.mock("./index.js", () => ({
           { serviceType: "accommodation", currency: "RON", amountCents: 7500050 },
         ],
         unattributed: [{ currency: "RON", amountCents: 120050 }],
+        unallocated: [{ currency: "RON", amountCents: 45000 }],
         base: {
           currency: "RON",
           rows: [productRow],
@@ -69,6 +72,7 @@ vi.mock("./index.js", () => ({
             { serviceType: "accommodation", currency: "RON", amountCents: 7500050 },
           ],
           unattributedCents: 120050,
+          unallocatedCents: 45000,
           unconvertibleCurrencies: [],
         },
       },

--- a/packages/finance-react/src/schemas/profitability.ts
+++ b/packages/finance-react/src/schemas/profitability.ts
@@ -15,6 +15,17 @@ export const profitabilityUnattributedSchema = z.object({
 })
 export type ProfitabilityUnattributed = z.infer<typeof profitabilityUnattributedSchema>
 
+/**
+ * The under-allocated remainder of recorded supplier cost — an invoice total
+ * minus every allocation row against it. Distinct from `unattributed`, which is
+ * cost deliberately allocated to no departure.
+ */
+export const profitabilityUnallocatedSchema = z.object({
+  currency: z.string(),
+  amountCents: z.number().int(),
+})
+export type ProfitabilityUnallocated = z.infer<typeof profitabilityUnallocatedSchema>
+
 export const departureProfitabilityRowSchema = z.object({
   departureId: z.string(),
   departureLabel: z.string().nullable(),
@@ -36,6 +47,7 @@ export const departureProfitabilityBaseRollupSchema = z.object({
   rows: z.array(departureProfitabilityRowSchema),
   costByServiceType: z.array(profitabilityCostByServiceTypeSchema),
   unattributedCents: z.number().int(),
+  unallocatedCents: z.number().int(),
   unconvertibleCurrencies: z.array(z.string()),
 })
 export type DepartureProfitabilityBaseRollup = z.infer<
@@ -46,6 +58,7 @@ export const departureProfitabilityReportSchema = z.object({
   rows: z.array(departureProfitabilityRowSchema),
   costByServiceType: z.array(profitabilityCostByServiceTypeSchema),
   unattributed: z.array(profitabilityUnattributedSchema),
+  unallocated: z.array(profitabilityUnallocatedSchema),
   base: departureProfitabilityBaseRollupSchema.optional(),
 })
 export type DepartureProfitabilityReport = z.infer<typeof departureProfitabilityReportSchema>
@@ -69,6 +82,7 @@ export const productProfitabilityBaseRollupSchema = z.object({
   rows: z.array(productProfitabilityRowSchema),
   costByServiceType: z.array(profitabilityCostByServiceTypeSchema),
   unattributedCents: z.number().int(),
+  unallocatedCents: z.number().int(),
   unconvertibleCurrencies: z.array(z.string()),
 })
 export type ProductProfitabilityBaseRollup = z.infer<typeof productProfitabilityBaseRollupSchema>
@@ -77,6 +91,7 @@ export const productProfitabilityReportSchema = z.object({
   rows: z.array(productProfitabilityRowSchema),
   costByServiceType: z.array(profitabilityCostByServiceTypeSchema),
   unattributed: z.array(profitabilityUnattributedSchema),
+  unallocated: z.array(profitabilityUnallocatedSchema),
   base: productProfitabilityBaseRollupSchema.optional(),
 })
 export type ProductProfitabilityReport = z.infer<typeof productProfitabilityReportSchema>

--- a/packages/finance/openapi/admin/finance.json
+++ b/packages/finance/openapi/admin/finance.json
@@ -9096,6 +9096,24 @@
                             ]
                           }
                         },
+                        "unallocated": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "currency": {
+                                "type": "string"
+                              },
+                              "amountCents": {
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "currency",
+                              "amountCents"
+                            ]
+                          }
+                        },
                         "base": {
                           "type": "object",
                           "properties": {
@@ -9200,6 +9218,9 @@
                             "unattributedCents": {
                               "type": "integer"
                             },
+                            "unallocatedCents": {
+                              "type": "integer"
+                            },
                             "unconvertibleCurrencies": {
                               "type": "array",
                               "items": {
@@ -9212,6 +9233,7 @@
                             "rows",
                             "costByServiceType",
                             "unattributedCents",
+                            "unallocatedCents",
                             "unconvertibleCurrencies"
                           ]
                         }
@@ -9219,7 +9241,8 @@
                       "required": [
                         "rows",
                         "costByServiceType",
-                        "unattributed"
+                        "unattributed",
+                        "unallocated"
                       ]
                     }
                   },
@@ -9383,6 +9406,24 @@
                             ]
                           }
                         },
+                        "unallocated": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "currency": {
+                                "type": "string"
+                              },
+                              "amountCents": {
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "currency",
+                              "amountCents"
+                            ]
+                          }
+                        },
                         "base": {
                           "type": "object",
                           "properties": {
@@ -9470,6 +9511,9 @@
                             "unattributedCents": {
                               "type": "integer"
                             },
+                            "unallocatedCents": {
+                              "type": "integer"
+                            },
                             "unconvertibleCurrencies": {
                               "type": "array",
                               "items": {
@@ -9482,6 +9526,7 @@
                             "rows",
                             "costByServiceType",
                             "unattributedCents",
+                            "unallocatedCents",
                             "unconvertibleCurrencies"
                           ]
                         }
@@ -9489,7 +9534,8 @@
                       "required": [
                         "rows",
                         "costByServiceType",
-                        "unattributed"
+                        "unattributed",
+                        "unallocated"
                       ]
                     }
                   },

--- a/packages/finance/src/routes-reports.ts
+++ b/packages/finance/src/routes-reports.ts
@@ -92,6 +92,16 @@ const profitabilityUnattributedSchema = z.object({
   amountCents: z.number().int(),
 })
 
+/**
+ * The under-allocated remainder of recorded supplier cost — an invoice total
+ * minus every allocation row against it. Distinct from `unattributed`, which is
+ * cost deliberately allocated to no departure.
+ */
+const profitabilityUnallocatedSchema = z.object({
+  currency: z.string(),
+  amountCents: z.number().int(),
+})
+
 const departureProfitabilityRowSchema = z.object({
   departureId: z.string(),
   departureLabel: z.string().nullable(),
@@ -111,12 +121,14 @@ const departureProfitabilityReportSchema = z.object({
   rows: z.array(departureProfitabilityRowSchema),
   costByServiceType: z.array(profitabilityCostByServiceTypeSchema),
   unattributed: z.array(profitabilityUnattributedSchema),
+  unallocated: z.array(profitabilityUnallocatedSchema),
   base: z
     .object({
       currency: z.string(),
       rows: z.array(departureProfitabilityRowSchema),
       costByServiceType: z.array(profitabilityCostByServiceTypeSchema),
       unattributedCents: z.number().int(),
+      unallocatedCents: z.number().int(),
       unconvertibleCurrencies: z.array(z.string()),
     })
     .optional(),
@@ -139,12 +151,14 @@ const productProfitabilityReportSchema = z.object({
   rows: z.array(productProfitabilityRowSchema),
   costByServiceType: z.array(profitabilityCostByServiceTypeSchema),
   unattributed: z.array(profitabilityUnattributedSchema),
+  unallocated: z.array(profitabilityUnallocatedSchema),
   base: z
     .object({
       currency: z.string(),
       rows: z.array(productProfitabilityRowSchema),
       costByServiceType: z.array(profitabilityCostByServiceTypeSchema),
       unattributedCents: z.number().int(),
+      unallocatedCents: z.number().int(),
       unconvertibleCurrencies: z.array(z.string()),
     })
     .optional(),

--- a/packages/finance/src/service-profitability.ts
+++ b/packages/finance/src/service-profitability.ts
@@ -38,6 +38,11 @@ export type ProfitabilityFxRuntime = InvoiceFxOptions
  * - Actual cost = `supplier_cost_allocations` targeted at the departure/product.
  * - Planned cost = `booking_items.totalCostAmountCents` (what we expected to pay).
  * - Profit = revenue − actual cost. Variance = planned − actual cost.
+ *
+ * Two further figures account for supplier cost that reaches no departure, and
+ * are reported separately because they mean different things: `unattributed` is
+ * cost someone allocated to nothing on purpose, `unallocated` is the
+ * under-allocated remainder of an invoice that carries no allocation row at all.
  */
 
 export interface ProfitabilityCostByServiceType {
@@ -47,6 +52,22 @@ export interface ProfitabilityCostByServiceType {
 }
 
 export interface ProfitabilityUnattributed {
+  currency: string
+  amountCents: number
+}
+
+/**
+ * The under-allocated remainder of recorded AP cost: a supplier invoice's total
+ * minus every allocation row written against it, whatever those rows target.
+ *
+ * Deliberately separate from {@link ProfitabilityUnattributed}. "We decided this
+ * cost belongs to no departure" (an allocation row with
+ * `targetType = 'unattributed'`) and "nobody has allocated this yet" (no row at
+ * all) are different operational signals, and only the second one is a backlog.
+ * Together with the departure/product-targeted allocations the three figures
+ * partition an invoice's total.
+ */
+export interface ProfitabilityUnallocated {
   currency: string
   amountCents: number
 }
@@ -71,6 +92,7 @@ export interface DepartureProfitabilityBaseRollup {
   rows: DepartureProfitabilityRow[]
   costByServiceType: ProfitabilityCostByServiceType[]
   unattributedCents: number
+  unallocatedCents: number
   /** Source currencies with no resolvable FX rate — excluded from the rollup. */
   unconvertibleCurrencies: string[]
 }
@@ -79,6 +101,7 @@ export interface DepartureProfitabilityReport {
   rows: DepartureProfitabilityRow[]
   costByServiceType: ProfitabilityCostByServiceType[]
   unattributed: ProfitabilityUnattributed[]
+  unallocated: ProfitabilityUnallocated[]
   base?: DepartureProfitabilityBaseRollup
 }
 
@@ -100,6 +123,7 @@ export interface ProductProfitabilityBaseRollup {
   rows: ProductProfitabilityRow[]
   costByServiceType: ProfitabilityCostByServiceType[]
   unattributedCents: number
+  unallocatedCents: number
   unconvertibleCurrencies: string[]
 }
 
@@ -107,6 +131,7 @@ export interface ProductProfitabilityReport {
   rows: ProductProfitabilityRow[]
   costByServiceType: ProfitabilityCostByServiceType[]
   unattributed: ProfitabilityUnattributed[]
+  unallocated: ProfitabilityUnallocated[]
   base?: ProductProfitabilityBaseRollup
 }
 
@@ -192,6 +217,8 @@ interface LoadedAccumulators {
   costByServiceTypeBase: Map<string, BaseSplit>
   unattributed: ProfitabilityUnattributed[]
   unattributedBase: BaseSplit
+  unallocated: ProfitabilityUnallocated[]
+  unallocatedBase: BaseSplit
 }
 
 /**
@@ -217,8 +244,19 @@ async function loadDepartureAccumulators(
   const invSnapshotted = sql`${invoices.baseCurrency} = ${base} and ${invoices.baseTotalCents} is not null`
   // agent-quality: raw-sql reviewed -- owner: finance; dynamic SQL interpolation uses Drizzle parameter binding or vetted SQL identifiers.
   const allocSnapshotted = sql`${supplierInvoices.baseCurrency} = ${base} and ${supplierCostAllocations.baseAmountCents} is not null`
+  // True when a supplier invoice carries a usable base snapshot AND a non-zero
+  // total, so a part of it (a line, or the unallocated remainder) can be
+  // pro-rated into the accounting base at the invoice's own issue-date rate.
   // agent-quality: raw-sql reviewed -- owner: finance; dynamic SQL interpolation uses Drizzle parameter binding or vetted SQL identifiers.
-  const lineSnapshotted = sql`${supplierInvoices.baseCurrency} = ${base} and ${supplierInvoices.baseTotalCents} is not null and ${supplierInvoices.totalCents} <> 0`
+  const apProRatable = sql`${supplierInvoices.baseCurrency} = ${base} and ${supplierInvoices.baseTotalCents} is not null and ${supplierInvoices.totalCents} <> 0`
+  // Under-allocated remainder per invoice: the total minus every allocation row
+  // against it, regardless of what those rows target. `greatest(…, 0)` guards
+  // the one path that can outrun the write-time over-allocation check — editing
+  // an invoice's header total downwards does not re-validate its allocations.
+  // agent-quality: raw-sql reviewed -- owner: finance; dynamic SQL interpolation uses Drizzle parameter binding or vetted SQL identifiers.
+  const allocatedCents = sql`coalesce((select sum(${supplierCostAllocations.amountCents}) from ${supplierCostAllocations} where ${supplierCostAllocations.supplierInvoiceId} = ${supplierInvoices.id}), 0)`
+  // agent-quality: raw-sql reviewed -- owner: finance; dynamic SQL interpolation uses Drizzle parameter binding or vetted SQL identifiers.
+  const remainderCents = sql`greatest(${supplierInvoices.totalCents} - ${allocatedCents}, 0)`
 
   const [
     itemRows,
@@ -227,6 +265,7 @@ async function loadDepartureAccumulators(
     productCostRows,
     serviceTypeRows,
     unattributedRows,
+    unallocatedRows,
   ] = await Promise.all([
     // Booked sell + planned cost per (departure, booking), with display snapshots.
     db
@@ -328,8 +367,8 @@ async function loadDepartureAccumulators(
         serviceType: sql<string>`coalesce(${costCategories.name}, 'Uncategorized')`,
         currency: supplierInvoices.currency,
         amountCents: sql<number>`coalesce(sum(${supplierInvoiceLines.totalAmountCents}), 0)::bigint`,
-        baseAmountCents: sql<number>`coalesce(sum(case when ${lineSnapshotted} then round(${supplierInvoiceLines.totalAmountCents}::numeric * ${supplierInvoices.baseTotalCents} / ${supplierInvoices.totalCents}) else 0 end), 0)::bigint`,
-        residualAmountCents: sql<number>`coalesce(sum(case when ${lineSnapshotted} then 0 else ${supplierInvoiceLines.totalAmountCents} end), 0)::bigint`,
+        baseAmountCents: sql<number>`coalesce(sum(case when ${apProRatable} then round(${supplierInvoiceLines.totalAmountCents}::numeric * ${supplierInvoices.baseTotalCents} / ${supplierInvoices.totalCents}) else 0 end), 0)::bigint`,
+        residualAmountCents: sql<number>`coalesce(sum(case when ${apProRatable} then 0 else ${supplierInvoiceLines.totalAmountCents} end), 0)::bigint`,
       })
       .from(supplierInvoiceLines)
       .innerJoin(supplierInvoices, eq(supplierInvoiceLines.supplierInvoiceId, supplierInvoices.id))
@@ -357,6 +396,31 @@ async function loadDepartureAccumulators(
           isNull(supplierInvoices.deletedAt),
         ),
       )
+      .groupBy(supplierInvoices.currency),
+    // Under-allocated remainder — recorded AP cost that carries NO allocation
+    // row at all. Invariant §6.1(4) permits under-allocation and stores nothing
+    // for the leftover, so it exists only as arithmetic on the invoice: without
+    // this query the shortfall is invisible and silently inflates margin.
+    //
+    // One formula covers both allocation modes. In whole-invoice mode the cap is
+    // the invoice total; in per-line mode it is each line's total, and since
+    // `validateAllocations` holds every line at or under its own total,
+    // Σ(lineTotal − Σalloc) collapses to (Σ lineTotal − Σ alloc). Anchoring on
+    // the header total additionally catches a header that outruns its lines.
+    //
+    // Base treatment mirrors the cost-by-category query: the remainder is
+    // pro-rated by the invoice's snapshotted base/total ratio (its issue-date
+    // rate), never re-valued at today's rate; invoices without a snapshot fall
+    // to the residual bucket and convert once via the fallback rate.
+    db
+      .select({
+        currency: supplierInvoices.currency,
+        amountCents: sql<number>`coalesce(sum(${remainderCents}), 0)::bigint`,
+        baseAmountCents: sql<number>`coalesce(sum(case when ${apProRatable} then round(${remainderCents}::numeric * ${supplierInvoices.baseTotalCents} / ${supplierInvoices.totalCents}) else 0 end), 0)::bigint`,
+        residualAmountCents: sql<number>`coalesce(sum(case when ${apProRatable} then 0 else ${remainderCents} end), 0)::bigint`,
+      })
+      .from(supplierInvoices)
+      .where(and(ne(supplierInvoices.status, "void"), isNull(supplierInvoices.deletedAt)))
       .groupBy(supplierInvoices.currency),
   ])
 
@@ -533,6 +597,15 @@ async function loadDepartureAccumulators(
     addResidual(unattributedBase.residual, row.currency, num(row.residualAmountCents))
   }
 
+  const unallocated: ProfitabilityUnallocated[] = []
+  const unallocatedBase = newBaseSplit()
+  for (const row of unallocatedRows) {
+    const amountCents = num(row.amountCents)
+    if (amountCents !== 0) unallocated.push({ currency: row.currency, amountCents })
+    unallocatedBase.snapshotBase += num(row.baseAmountCents)
+    addResidual(unallocatedBase.residual, row.currency, num(row.residualAmountCents))
+  }
+
   return {
     baseCurrency: base,
     departures,
@@ -542,6 +615,8 @@ async function loadDepartureAccumulators(
     costByServiceTypeBase,
     unattributed,
     unattributedBase,
+    unallocated,
+    unallocatedBase,
   }
 }
 
@@ -560,8 +635,15 @@ export async function getDepartureProfitability(
 ): Promise<DepartureProfitabilityReport> {
   const baseCurrency = (await resolveInvoiceFxSettingsOrDefault(db, options)).baseCurrency
   const loaded = await loadDepartureAccumulators(db, baseCurrency)
-  const { departures, costByServiceType, costByServiceTypeBase, unattributed, unattributedBase } =
-    loaded
+  const {
+    departures,
+    costByServiceType,
+    costByServiceTypeBase,
+    unattributed,
+    unattributedBase,
+    unallocated,
+    unallocatedBase,
+  } = loaded
 
   const rows: DepartureProfitabilityRow[] = []
   const filtered: DepartureAcc[] = []
@@ -607,6 +689,7 @@ export async function getDepartureProfitability(
     filtered.flatMap((acc) => [...acc.residual.keys()]),
     costByServiceTypeBase,
     unattributedBase,
+    unallocatedBase,
   )
   const { rates, unconvertible } = await buildBaseRates(
     db,
@@ -647,11 +730,13 @@ export async function getDepartureProfitability(
     rows,
     costByServiceType: filterCostByCurrency(costByServiceType, query.currency),
     unattributed: filterCostByCurrency(unattributed, query.currency),
+    unallocated: filterCostByCurrency(unallocated, query.currency),
     base: {
       currency: baseCurrency,
       rows: baseRows,
       costByServiceType: baseCostByServiceType(costByServiceTypeBase, rates, baseCurrency),
       unattributedCents: Math.round(resolveBaseSplit(unattributedBase, rates, new Set())),
+      unallocatedCents: Math.round(resolveBaseSplit(unallocatedBase, rates, new Set())),
       unconvertibleCurrencies: unconvertible,
     },
   }
@@ -672,6 +757,8 @@ export async function getProductProfitability(
     costByServiceTypeBase,
     unattributed,
     unattributedBase,
+    unallocated,
+    unallocatedBase,
   } = loaded
 
   interface ProductAcc {
@@ -784,6 +871,7 @@ export async function getProductProfitability(
     [...products.values()].flatMap((acc) => [...acc.residual.keys()]),
     costByServiceTypeBase,
     unattributedBase,
+    unallocatedBase,
   )
   const { rates, unconvertible } = await buildBaseRates(
     db,
@@ -818,11 +906,13 @@ export async function getProductProfitability(
     rows,
     costByServiceType: filterCostByCurrency(costByServiceType, query.currency),
     unattributed: filterCostByCurrency(unattributed, query.currency),
+    unallocated: filterCostByCurrency(unallocated, query.currency),
     base: {
       currency: baseCurrency,
       rows: baseRows,
       costByServiceType: baseCostByServiceType(costByServiceTypeBase, rates, baseCurrency),
       unattributedCents: Math.round(resolveBaseSplit(unattributedBase, rates, new Set())),
+      unallocatedCents: Math.round(resolveBaseSplit(unallocatedBase, rates, new Set())),
       unconvertibleCurrencies: unconvertible,
     },
   }
@@ -1096,6 +1186,34 @@ const csvDocument = (rows: string[]): string => `﻿${rows.join("\r\n")}\r\n`
 const major = (cents: number): string => (cents / 100).toFixed(2)
 const marginCell = (value: number | null): string => (value == null ? "" : value.toFixed(1))
 
+/**
+ * Trailing block for AP cost that never reached a departure, per currency. The
+ * two kinds stay on separate lines because they are separate signals:
+ * `explicitly_unattributed` was allocated to nothing on purpose, whereas
+ * `unallocated_remainder` is the under-allocated leftover nobody has touched.
+ *
+ * Emitted only when there is something to report, so an export from a fully
+ * allocated ledger is byte-identical to one produced before this block existed.
+ */
+function unaccountedCostRows(report: {
+  unattributed: ProfitabilityUnattributed[]
+  unallocated: ProfitabilityUnallocated[]
+}): string[] {
+  const entries: Array<[string, { currency: string; amountCents: number }]> = [
+    ...report.unattributed.map((entry): [string, typeof entry] => [
+      "explicitly_unattributed",
+      entry,
+    ]),
+    ...report.unallocated.map((entry): [string, typeof entry] => ["unallocated_remainder", entry]),
+  ]
+  if (entries.length === 0) return []
+  return [
+    "",
+    csvRow(["unaccounted_cost", "currency", "amount"]),
+    ...entries.map(([kind, entry]) => csvRow([kind, entry.currency, major(entry.amountCents)])),
+  ]
+}
+
 export function buildDepartureProfitabilityCsv(report: DepartureProfitabilityReport): string {
   const header = [
     "departure_id",
@@ -1127,7 +1245,7 @@ export function buildDepartureProfitabilityCsv(report: DepartureProfitabilityRep
       major(r.varianceCents),
     ]),
   )
-  return csvDocument([csvRow(header), ...rows])
+  return csvDocument([csvRow(header), ...rows, ...unaccountedCostRows(report)])
 }
 
 export function buildProductProfitabilityCsv(report: ProductProfitabilityReport): string {
@@ -1157,5 +1275,5 @@ export function buildProductProfitabilityCsv(report: ProductProfitabilityReport)
       major(r.varianceCents),
     ]),
   )
-  return csvDocument([csvRow(header), ...rows])
+  return csvDocument([csvRow(header), ...rows, ...unaccountedCostRows(report)])
 }

--- a/packages/finance/src/service-supplier-invoices.ts
+++ b/packages/finance/src/service-supplier-invoices.ts
@@ -304,8 +304,12 @@ export type AllocationCheckResult =
  *  2. Exactly-one-target is enforced upstream by the zod schema + DB check.
  *  3. No over-allocation — Σ per line ≤ that line's total; for whole-invoice
  *     mode, Σ ≤ the invoice total.
- *  4. Under-allocation is allowed (the remainder is reported as `unattributed`
- *     by the read model, not stored).
+ *  4. Under-allocation is allowed. Nothing is stored for the remainder; the
+ *     profitability read model derives it per currency and reports it as
+ *     `unallocated` (`service-profitability.ts`). It is kept apart from that
+ *     model's `unattributed` figure, which counts allocations deliberately
+ *     targeted at nothing — an untouched leftover is a backlog, a deliberate
+ *     `unattributed` allocation is a decision.
  */
 export function validateAllocations(params: {
   invoiceTotalCents: number

--- a/packages/finance/tests/integration/profitability.test.ts
+++ b/packages/finance/tests/integration/profitability.test.ts
@@ -10,7 +10,7 @@
 
 import { bookingItems, bookings, bookingTravelers } from "@voyant-travel/bookings/schema"
 import { sql } from "drizzle-orm"
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { exchangeRatesRef } from "../../src/markets-ref.js"
 import { invoices } from "../../src/schema.js"
@@ -18,6 +18,13 @@ import { financeService } from "../../src/service.js"
 import { supplierInvoicesService } from "../../src/service-supplier-invoices.js"
 
 const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+// Seeding a scenario here means real inserts across bookings, invoices and
+// several supplier invoices, which comfortably outruns the 5s default. A test
+// that trips that limit does not stop its in-flight queries, so its writes land
+// after the next test's `cleanupTestDb` and corrupt an unrelated assertion —
+// give the bodies the same headroom the hooks already have.
+vi.setConfig({ testTimeout: 60_000 })
 
 let seq = 0
 const next = () => {
@@ -34,6 +41,12 @@ async function seedSupplierCost(
     amountCents: number
     costCategoryId?: string
     target: { targetType: "departure"; departureId: string } | { targetType: "unattributed" }
+    /**
+     * Allocate less than the invoice total. `validateAllocations` permits this
+     * and stores nothing for the leftover, so the remainder only exists as
+     * arithmetic on the invoice.
+     */
+    allocateCents?: number
   },
 ) {
   const created = await supplierInvoicesService.create(db, {
@@ -57,22 +70,26 @@ async function seedSupplierCost(
   })
   const id = created?.id as string
   const lineId = created?.lines?.[0]?.id as string
-  await supplierInvoicesService.setAllocations(db, id, {
-    allocations: [
-      opts.target.targetType === "departure"
-        ? {
-            targetType: "departure",
-            departureId: opts.target.departureId,
-            supplierInvoiceLineId: lineId,
-            amountCents: opts.amountCents,
-          }
-        : {
-            targetType: "unattributed",
-            supplierInvoiceLineId: lineId,
-            amountCents: opts.amountCents,
-          },
-    ],
-  })
+  const allocateCents = opts.allocateCents ?? opts.amountCents
+  if (allocateCents > 0) {
+    await supplierInvoicesService.setAllocations(db, id, {
+      allocations: [
+        opts.target.targetType === "departure"
+          ? {
+              targetType: "departure",
+              departureId: opts.target.departureId,
+              supplierInvoiceLineId: lineId,
+              amountCents: allocateCents,
+            }
+          : {
+              targetType: "unattributed",
+              supplierInvoiceLineId: lineId,
+              amountCents: allocateCents,
+            },
+      ],
+    })
+  }
+  return id
 }
 
 describe.skipIf(!DB_AVAILABLE)("profitability read model", () => {
@@ -89,6 +106,11 @@ describe.skipIf(!DB_AVAILABLE)("profitability read model", () => {
     seq = 0
     const { cleanupTestDb } = await import("@voyant-travel/db/test-utils")
     await cleanupTestDb(db)
+    // `supplier_invoices.supplierId` is validated against `suppliers` whenever
+    // that table exists, so every supplier invoice below needs a real row.
+    await db.execute(
+      sql`insert into suppliers (id, name, type) values ('supp_test', 'Test Supplier', 'other')`,
+    )
   })
 
   afterAll(async () => {
@@ -118,6 +140,7 @@ describe.skipIf(!DB_AVAILABLE)("profitability read model", () => {
       {
         bookingId: "book_b1",
         title: "Tour P1",
+        status: "confirmed",
         availabilitySlotId: "avsl_d1",
         productId: "prod_p1",
         productNameSnapshot: "Tour P1",
@@ -132,6 +155,7 @@ describe.skipIf(!DB_AVAILABLE)("profitability read model", () => {
       {
         bookingId: "book_b2",
         title: "Tour P1",
+        status: "confirmed",
         availabilitySlotId: "avsl_d1",
         productId: "prod_p1",
         productNameSnapshot: "Tour P1",
@@ -146,6 +170,7 @@ describe.skipIf(!DB_AVAILABLE)("profitability read model", () => {
       {
         bookingId: "book_b2",
         title: "Tour P1",
+        status: "confirmed",
         availabilitySlotId: "avsl_d2",
         productId: "prod_p1",
         productNameSnapshot: "Tour P1",
@@ -253,6 +278,9 @@ describe.skipIf(!DB_AVAILABLE)("profitability read model", () => {
     })
 
     expect(report.unattributed).toContainEqual({ currency: "EUR", amountCents: 5000 })
+    // Every seeded invoice is allocated in full, so there is no remainder — the
+    // explicitly-unattributed 5000 EUR must not leak into this figure.
+    expect(report.unallocated).toEqual([])
     // Breakdown is by configurable cost category name.
     expect(report.costByServiceType).toContainEqual({
       serviceType: "Transport",
@@ -296,6 +324,7 @@ describe.skipIf(!DB_AVAILABLE)("profitability read model", () => {
     await db.insert(bookingItems).values({
       bookingId: "book_c",
       title: "Tour C",
+      status: "confirmed",
       availabilitySlotId: "avsl_c",
       productId: "prod_c",
       startsAt: new Date("2026-07-01T09:00:00Z"),
@@ -490,6 +519,167 @@ describe.skipIf(!DB_AVAILABLE)("profitability read model", () => {
     expect(row?.actualCostCents).toBe(500000)
   })
 
+  it("surfaces an under-allocated invoice's remainder, distinct from explicit unattributed cost", async () => {
+    await seedBaseScenario()
+    // 100000 EUR invoiced, only 60000 allocated to D1: 40000 is unaccounted for
+    // and, before this figure existed, silently inflated D1's margin.
+    await seedSupplierCost(db, {
+      currency: "EUR",
+      serviceType: "transport",
+      amountCents: 100000,
+      allocateCents: 60000,
+      target: { targetType: "departure", departureId: "avsl_d1" },
+    })
+
+    const report = await financeService.getDepartureProfitability(db, {})
+
+    // Only the allocated part is attributed to the departure.
+    const d1Eur = report.rows.find((r) => r.departureId === "avsl_d1" && r.currency === "EUR")
+    expect(d1Eur?.actualCostCents).toBe(130000) // 70000 fully allocated + 60000 partial
+
+    // The remainder surfaces on its own, and does NOT merge with the 5000 EUR
+    // that was deliberately allocated to `unattributed`.
+    expect(report.unallocated).toEqual([{ currency: "EUR", amountCents: 40000 }])
+    expect(report.unattributed).toContainEqual({ currency: "EUR", amountCents: 5000 })
+
+    // The product rollup reports the same two figures.
+    const products = await financeService.getProductProfitability(db, {})
+    expect(products.unallocated).toEqual([{ currency: "EUR", amountCents: 40000 }])
+    expect(products.unattributed).toContainEqual({ currency: "EUR", amountCents: 5000 })
+  })
+
+  it("counts an invoice with no allocations at all as fully unallocated", async () => {
+    await seedSupplierCost(db, {
+      currency: "EUR",
+      serviceType: "other",
+      amountCents: 25000,
+      allocateCents: 0,
+      target: { targetType: "unattributed" },
+    })
+
+    const report = await financeService.getDepartureProfitability(db, {})
+    expect(report.unallocated).toEqual([{ currency: "EUR", amountCents: 25000 }])
+    expect(report.unattributed).toEqual([])
+  })
+
+  it("keeps remainders in separate per-currency buckets and filters with the rest", async () => {
+    await seedSupplierCost(db, {
+      currency: "EUR",
+      serviceType: "transport",
+      amountCents: 100000,
+      allocateCents: 60000,
+      target: { targetType: "departure", departureId: "avsl_d1" },
+    })
+    await seedSupplierCost(db, {
+      currency: "RON",
+      serviceType: "guide",
+      amountCents: 50000,
+      allocateCents: 12500,
+      target: { targetType: "departure", departureId: "avsl_d1" },
+    })
+
+    const report = await financeService.getDepartureProfitability(db, {})
+    expect([...report.unallocated].sort((a, b) => a.currency.localeCompare(b.currency))).toEqual([
+      { currency: "EUR", amountCents: 40000 },
+      { currency: "RON", amountCents: 37500 },
+    ])
+
+    // The currency filter applies to the remainder exactly as to every other
+    // per-currency figure — RON amounts are never folded into a EUR view.
+    const onlyRon = await financeService.getDepartureProfitability(db, { currency: "RON" })
+    expect(onlyRon.unallocated).toEqual([{ currency: "RON", amountCents: 37500 }])
+  })
+
+  it("excludes void and soft-deleted invoices from the remainder", async () => {
+    const voidedId = await seedSupplierCost(db, {
+      currency: "EUR",
+      serviceType: "other",
+      amountCents: 80000,
+      allocateCents: 0,
+      target: { targetType: "unattributed" },
+    })
+    const deletedId = await seedSupplierCost(db, {
+      currency: "EUR",
+      serviceType: "other",
+      amountCents: 90000,
+      allocateCents: 0,
+      target: { targetType: "unattributed" },
+    })
+    await supplierInvoicesService.update(db, voidedId, { status: "void" })
+    await supplierInvoicesService.softDelete(db, deletedId)
+
+    const report = await financeService.getDepartureProfitability(db, {})
+    expect(report.unallocated).toEqual([])
+  })
+
+  it("converts the remainder at the invoice's own issue-date rate, not the latest one", async () => {
+    // EUR→RON = 5 on the issue date, so a EUR invoice snapshots its base then.
+    await db.execute(
+      sql`insert into fx_rate_sets (id, base_currency, effective_at) values ('fxrs_rem', 'RON', now())`,
+    )
+    await db.insert(exchangeRatesRef).values({
+      fxRateSetId: "fxrs_rem",
+      baseCurrency: "EUR",
+      quoteCurrency: "RON",
+      rateDecimal: "5",
+      observedAt: new Date("2026-06-01T00:00:00Z"),
+      createdAt: new Date("2026-06-01T00:00:00Z"),
+    })
+
+    await seedSupplierCost(db, {
+      currency: "EUR",
+      serviceType: "transport",
+      amountCents: 100000,
+      allocateCents: 60000,
+      target: { targetType: "departure", departureId: "avsl_rem" },
+    })
+
+    // A later, different rate must not re-value the snapshotted remainder.
+    await db.execute(
+      sql`insert into fx_rate_sets (id, base_currency, effective_at) values ('fxrs_rem_late', 'RON', now())`,
+    )
+    await db.insert(exchangeRatesRef).values({
+      fxRateSetId: "fxrs_rem_late",
+      baseCurrency: "EUR",
+      quoteCurrency: "RON",
+      rateDecimal: "10",
+      observedAt: new Date("2026-09-01T00:00:00Z"),
+      createdAt: new Date("2026-09-01T00:00:00Z"),
+    })
+
+    const report = await financeService.getDepartureProfitability(db, {})
+    expect(report.unallocated).toEqual([{ currency: "EUR", amountCents: 40000 }])
+    // 40000 EUR pro-rated from the issue-date snapshot = 200000 RON, not 400000.
+    expect(report.base?.unallocatedCents).toBe(200000)
+    expect(report.base?.unattributedCents).toBe(0)
+  })
+
+  it("converts a legacy remainder with no base snapshot at the fallback rate", async () => {
+    // Invoice created with no rate anywhere → no base snapshot (residual).
+    await seedSupplierCost(db, {
+      currency: "EUR",
+      serviceType: "transport",
+      amountCents: 100000,
+      allocateCents: 60000,
+      target: { targetType: "departure", departureId: "avsl_legacy" },
+    })
+    // The rate only shows up afterwards, so the residual converts at it.
+    await db.execute(
+      sql`insert into fx_rate_sets (id, base_currency, effective_at) values ('fxrs_legacy', 'EUR', now())`,
+    )
+    await db.insert(exchangeRatesRef).values({
+      fxRateSetId: "fxrs_legacy",
+      baseCurrency: "RON",
+      quoteCurrency: "EUR",
+      rateDecimal: "0.2",
+      createdAt: new Date("2026-06-01T00:00:00Z"),
+    })
+
+    const report = await financeService.getDepartureProfitability(db, {})
+    expect(report.base?.unconvertibleCurrencies).toEqual([])
+    expect(report.base?.unallocatedCents).toBe(200000) // 40000 EUR × 5
+  })
+
   it("splits a departure's revenue and cost across its travellers (equal)", async () => {
     await db.insert(bookings).values({
       id: "book_t1",
@@ -501,6 +691,7 @@ describe.skipIf(!DB_AVAILABLE)("profitability read model", () => {
     await db.insert(bookingItems).values({
       bookingId: "book_t1",
       title: "Tour T",
+      status: "confirmed",
       availabilitySlotId: "avsl_t",
       productId: "prod_t",
       startsAt: new Date("2026-07-01T09:00:00Z"),

--- a/packages/finance/tests/unit/profitability-csv.test.ts
+++ b/packages/finance/tests/unit/profitability-csv.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildDepartureProfitabilityCsv,
+  buildProductProfitabilityCsv,
+  type DepartureProfitabilityReport,
+  type ProductProfitabilityReport,
+} from "../../src/service-profitability.js"
+
+/**
+ * The accountant-facing exports carry a trailing block for supplier cost that
+ * never reached a departure. The two kinds stay on separate lines — cost
+ * allocated to nothing on purpose is a decision, an under-allocated remainder
+ * is a backlog — and the block is omitted entirely when there is nothing to
+ * report, so a fully allocated ledger exports exactly as it did before.
+ */
+
+const departureRow: DepartureProfitabilityReport["rows"][number] = {
+  departureId: "slot_1",
+  departureLabel: "Spring departure",
+  productId: "prod_1",
+  productName: "Tuscany 7D",
+  departureDate: "2026-04-10",
+  currency: "EUR",
+  revenueCents: 500000,
+  actualCostCents: 300000,
+  plannedCostCents: 320000,
+  profitCents: 200000,
+  marginPercent: 40,
+  varianceCents: 20000,
+}
+
+const productRow: ProductProfitabilityReport["rows"][number] = {
+  productId: "prod_1",
+  productName: "Tuscany 7D",
+  currency: "EUR",
+  departureCount: 3,
+  revenueCents: 1500000,
+  actualCostCents: 900000,
+  plannedCostCents: 960000,
+  profitCents: 600000,
+  marginPercent: 40,
+  varianceCents: 60000,
+}
+
+describe("profitability CSV exports", () => {
+  it("reports the unallocated remainder separately from deliberate unattributed cost", () => {
+    const csv = buildDepartureProfitabilityCsv({
+      rows: [departureRow],
+      costByServiceType: [],
+      unattributed: [{ currency: "EUR", amountCents: 5000 }],
+      unallocated: [
+        { currency: "EUR", amountCents: 40000 },
+        { currency: "RON", amountCents: 37500 },
+      ],
+    })
+    const lines = csv.replace(/^﻿/, "").trimEnd().split("\r\n")
+
+    expect(lines.slice(-5)).toEqual([
+      "",
+      "unaccounted_cost,currency,amount",
+      "explicitly_unattributed,EUR,50.00",
+      "unallocated_remainder,EUR,400.00",
+      "unallocated_remainder,RON,375.00",
+    ])
+  })
+
+  it("omits the block entirely when every invoice is fully allocated", () => {
+    const fullyAllocated = buildDepartureProfitabilityCsv({
+      rows: [departureRow],
+      costByServiceType: [],
+      unattributed: [],
+      unallocated: [],
+    })
+    expect(fullyAllocated.trimEnd().split("\r\n")).toHaveLength(2) // header + the one row
+    expect(fullyAllocated).not.toContain("unaccounted_cost")
+  })
+
+  it("carries the same block on the product export", () => {
+    const csv = buildProductProfitabilityCsv({
+      rows: [productRow],
+      costByServiceType: [],
+      unattributed: [],
+      unallocated: [{ currency: "EUR", amountCents: 40000 }],
+    })
+    expect(csv).toContain("unaccounted_cost,currency,amount")
+    expect(csv).toContain("unallocated_remainder,EUR,400.00")
+    expect(csv).not.toContain("explicitly_unattributed")
+  })
+})

--- a/packages/finance/tests/unit/reports-contract.test.ts
+++ b/packages/finance/tests/unit/reports-contract.test.ts
@@ -29,6 +29,11 @@ const profitabilityUnattributedSchema = z.object({
   amountCents: z.number().int(),
 })
 
+const profitabilityUnallocatedSchema = z.object({
+  currency: z.string(),
+  amountCents: z.number().int(),
+})
+
 const departureProfitabilityRowSchema = z.object({
   departureId: z.string(),
   departureLabel: z.string().nullable(),
@@ -48,12 +53,14 @@ const departureProfitabilityReportSchema = z.object({
   rows: z.array(departureProfitabilityRowSchema),
   costByServiceType: z.array(profitabilityCostByServiceTypeSchema),
   unattributed: z.array(profitabilityUnattributedSchema),
+  unallocated: z.array(profitabilityUnallocatedSchema),
   base: z
     .object({
       currency: z.string(),
       rows: z.array(departureProfitabilityRowSchema),
       costByServiceType: z.array(profitabilityCostByServiceTypeSchema),
       unattributedCents: z.number().int(),
+      unallocatedCents: z.number().int(),
       unconvertibleCurrencies: z.array(z.string()),
     })
     .optional(),
@@ -76,12 +83,14 @@ const productProfitabilityReportSchema = z.object({
   rows: z.array(productProfitabilityRowSchema),
   costByServiceType: z.array(profitabilityCostByServiceTypeSchema),
   unattributed: z.array(profitabilityUnattributedSchema),
+  unallocated: z.array(profitabilityUnallocatedSchema),
   base: z
     .object({
       currency: z.string(),
       rows: z.array(productProfitabilityRowSchema),
       costByServiceType: z.array(profitabilityCostByServiceTypeSchema),
       unattributedCents: z.number().int(),
+      unallocatedCents: z.number().int(),
       unconvertibleCurrencies: z.array(z.string()),
     })
     .optional(),
@@ -135,11 +144,13 @@ const departureReport: DepartureProfitabilityReport = {
   ],
   costByServiceType: [{ serviceType: "transportation", currency: "EUR", amountCents: 120000 }],
   unattributed: [{ currency: "EUR", amountCents: 0 }],
+  unallocated: [{ currency: "EUR", amountCents: 40000 }],
   base: {
     currency: "RON",
     rows: [],
     costByServiceType: [],
     unattributedCents: 0,
+    unallocatedCents: 200000,
     unconvertibleCurrencies: [],
   },
 }
@@ -161,6 +172,7 @@ const productReport: ProductProfitabilityReport = {
   ],
   costByServiceType: [],
   unattributed: [],
+  unallocated: [],
 }
 
 const travelerReport: TravelerProfitabilityReport = {

--- a/packages/finance/tests/unit/service-supplier-invoices.test.ts
+++ b/packages/finance/tests/unit/service-supplier-invoices.test.ts
@@ -214,7 +214,7 @@ describe("validateAllocations (§6.1 invariants)", () => {
     ).toEqual({ ok: true })
   })
 
-  it("allows under-allocation (remainder reported as unattributed, not stored)", () => {
+  it("allows under-allocation (remainder derived as unallocated on read, not stored)", () => {
     expect(
       validateAllocations({
         invoiceTotalCents: 1000,


### PR DESCRIPTION
## Why

Allocating a supplier invoice has always permitted under-allocation, and the invariant docstring in `service-supplier-invoices.ts` said the leftover *"is reported as `unattributed` by the read model"*.

It was not. The read model's unattributed query filters `targetType = 'unattributed'`, so it only counts cost someone **deliberately** marked as belonging to no departure. A remainder nobody allocated has no row at all, so it could never appear.

An invoice of 1000 with 600 allocated reported 600 of cost and nothing else. The missing 400 silently inflated margin everywhere the read model is consumed, and cost completeness could not be computed. Since under-allocation is explicitly permitted by the validator, this is a normal state, not a corrupt one.

## What changed

- **New `unallocated` figure** (per-currency) and `unallocatedCents` (base rollup) on both the departure and product reports: per invoice, `total_cents - Σ allocations.amount_cents`, clamped at zero.
- **Deliberately not merged with `unattributed`.** "This cost belongs to no departure" and "nobody has allocated this yet" are different operational signals, and only the second is a backlog. Attributed + explicitly-unattributed + unallocated now partition an invoice's total.
- **One formula covers both allocation modes.** In per-line mode `validateAllocations` caps each line at its own total, so `Σ_lines(lineTotal − Σalloc_line)` collapses to `Σ lineTotal − Σ alloc`. Anchoring on the header total yields the same number *and* additionally catches a header that outruns its lines — reachable, because `update()` can rewrite `totalCents` without revalidating allocations. The `greatest(…, 0)` clamp guards that path; it cannot mask credit notes because `validateHeaderTotals` rejects negative totals.
- **FX matches the existing discipline**: the remainder is pro-rated by the invoice's own snapshotted `base_total/total` ratio, so it is valued at the issue-date rate and immune to later rate changes. Un-snapshotted invoices go to the residual bucket and their currencies join `unconvertibleCurrencies` rather than being guessed.
- **Docstring reconciled** so the stated invariant is now true.
- **CSV**: both exports gain a trailing per-currency `unaccounted_cost` block, emitted only when non-empty — a fully allocated ledger exports byte-identically to before.
- **UI**: an eighth KPI card on the profitability page, en + ro parity.

## Reviewer notes

- **The integration suite was dead and broken before this change.** `packages/finance/tests/integration/profitability.test.ts` is gated on `TEST_DATABASE_URL` and is **not** in the CI `db-lanes/integration` matrix — only `booking-create.test.ts` is. Running it surfaced 14 pre-existing failures: every `booking_items` insert omits the NOT NULL `status`, and `seedSupplierCost` referenced `supp_test` with no matching `suppliers` row. Both are repaired here, otherwise the fix could not be proven end to end. **Consider adding this file to the CI lane** — it is currently unguarded.
- The filter is `void` + soft-deleted only, matching the neighbouring queries. This means **`draft` invoices count toward unallocated**, so a freshly captured draft shows its full total. Consistent with `unattributed` and `costByServiceType`, but the one knob worth a second opinion.
- `finance.json` was regenerated structurally; `JSON.stringify(…, null, 2)` round-trips the committed file byte-identically, so only the four intended objects moved.
- The brief for this work named `finance-contracts/src/validation-profitability.ts` as the home for response contracts. That file holds **query** schemas only; the response shapes live in `routes-reports.ts` and are mirrored in `finance-react/src/schemas/profitability.ts`. Both real places were updated and a pointer docstring left in the contracts file rather than inventing a third source of truth.

## Verification

- `pnpm -F @voyant-travel/finance test` — 504 passed, 369 skipped (83 files)
- `pnpm -F @voyant-travel/finance-react test` — 51 passed (18 files)
- DB-backed integration run against an isolated Postgres — 14 passed
- `pnpm exec biome check .` from the root — zero errors (20 warnings / 8 infos all pre-existing)
- `pnpm i18n:check` — parity passed, 49 definition sets across 38 entrypoints
- `typecheck` did not complete locally: this machine was thrashing (swap 37.8/38.9 GB) under concurrent worktrees, the documented failure mode for local `tsc` here. **Relying on CI `build-graph` for it.**

Closes #4163