### PR TITLE
Compose one departure summary with typed attention issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,6 +359,8 @@ jobs:
                 tests/integration/booking-amendments.test.ts
               pnpm --filter @voyant-travel/operations exec vitest run \
                 tests/availability/integration/auto-allocate-concurrency.test.ts
+              pnpm --filter @voyant-travel/operations exec vitest run \
+                tests/availability/integration/departure-summary.test.ts
               pnpm --filter @voyant-travel/legal exec vitest run \
                 tests/integration/contract-lifecycle-command.test.ts
               pnpm --filter @voyant-travel/notifications exec vitest run \

--- a/docs/architecture/operated-departure-logistics.md
+++ b/docs/architecture/operated-departure-logistics.md
@@ -25,6 +25,59 @@ kinds are always visible in the departure workspace so an operator can create
 a one-off logistics plan without first editing a product template. Product
 option templates remain the efficient way to materialize repeated layouts.
 
+## The canonical slot↔booking join
+
+Three different edges connect a booking to a departure today. They are not
+interchangeable, and picking one per feature by accident is how the same
+departure ends up with three different passenger counts.
+
+| Edge | Written by | Read by |
+|---|---|---|
+| `booking_allocations.availability_slot_id` | the reservation/allocation path | the allocation manifest, the extras manifest, resource capacity, the departure workspace |
+| `booking_items.metadata->>'availabilitySlotId'` | the product→booking convert flow | per-option-unit availability (`service-unit-availability.ts`) |
+| `booking_items.availability_slot_id` | the booking-item writer | Finance's profitability read model (`service-profitability.ts`) |
+
+**The departure workspace uses `booking_allocations.availability_slot_id`.**
+
+It is the only one of the three that carries a *lifecycle*. An allocation has
+its own status (`held`/`confirmed`/`fulfilled` versus
+`released`/`expired`/`cancelled`) and its own `hold_expires_at`, so it can
+answer "does this booking still consume a seat on this departure, and since
+when" — which is the whole question a capacity counter asks. The two
+`booking_items` edges are plain columns: they record which departure a line
+item was sold against and cannot express that the claim was later given back.
+`booking_allocations` is also the edge the traveler-assignment guardrails and
+the existing manifests already join on, so the workspace's counters and its
+rows agree by construction.
+
+The other two stay where they are:
+
+- `booking_items.metadata->>'availabilitySlotId'` is a **legacy** edge kept for
+  per-option-unit availability. New code must not add readers.
+- `booking_items.availability_slot_id` is **Finance's** edge. Revenue and cost
+  attribution follow the priced line item, not the seat claim, and a cancelled
+  allocation must not erase an invoice that was issued. Finance is deliberately
+  not migrated onto `booking_allocations`, and the departure workspace reads
+  Finance's answer through a runtime port rather than re-deriving money on the
+  allocation edge.
+
+## Shared booking lifecycle vocabulary
+
+The status sets that decide "this booking still counts" and "this allocation
+still holds a seat" live once, in
+`@voyant-travel/bookings-contracts`'s `booking-lifecycle.ts`
+(`ACTIVE_BOOKING_STATUSES`, `ACTIVE_BOOKING_ALLOCATION_STATUSES`). They are
+pinned against the Drizzle enums in `@voyant-travel/bookings`'s `status.ts`;
+the Drizzle `sql` fragment builders that bind them into raw queries live in
+Operations' `availability/booking-statuses.ts`, because a contracts package
+depends on `zod` only (ADR-0002).
+
+One list is deliberately **not** converged: Finance's duplicate-booking guard
+in `service-booking-create.ts` matches `('confirmed', 'in_progress')` only. It
+asks a narrower question — "would a new booking for this party duplicate one
+that has not yet been delivered" — and widening it to include `completed`
+would change behaviour. It stays a distinct, locally-documented vocabulary.
+
 ## Invariants
 
 - The traveler, resource, and availability slot must belong to the same live

--- a/packages/bookings-contracts/src/booking-lifecycle.ts
+++ b/packages/bookings-contracts/src/booking-lifecycle.ts
@@ -1,0 +1,68 @@
+/**
+ * Shared booking lifecycle vocabulary — the one place the "this booking is
+ * still live" and "this allocation still holds inventory" sets are written
+ * down.
+ *
+ * Both sets were copy-pasted into at least five packages (operations'
+ * availability queries, bookings' extras manifest and sharing groups,
+ * notifications' reminder gating, bookings' own resource-capacity helper). The
+ * copies drifted in shape — array, `Set`, `||` chain — while agreeing on the
+ * values, which is exactly the arrangement that silently disagrees the next
+ * time the enum moves. The v1 commitment lifecycle (#4100) already contracted
+ * `booking_status` once; the pre-commitment statuses these lists used to carry
+ * (`on_hold`, `awaiting_payment`) are booking sessions now, not bookings.
+ *
+ * Values only. These are bound as parameters against the `booking_status` and
+ * `booking_allocation_status` Postgres enums, so every member must stay a
+ * member of the enum or Postgres rejects the whole query with `22P02`. The
+ * type-level pin against the Drizzle enum lives in `@voyant-travel/bookings`'s
+ * `status.ts`, and the Drizzle `sql` fragment builders live in the runtime
+ * packages — a contracts package depends on `zod` only (ADR-0002).
+ */
+
+/**
+ * Booking statuses that still count: a committed booking that has not been
+ * cancelled. These consume slot capacity, are owed money, are carried on a
+ * departure manifest, and are reminded about.
+ *
+ * Deliberately *not* the same list as finance's duplicate-booking guard
+ * (`confirmed`/`in_progress` only, in `service-booking-create.ts`), which asks
+ * a narrower question — "would a new booking for this party duplicate one that
+ * has not yet been delivered" — and must not be widened to include
+ * `completed`.
+ */
+export const ACTIVE_BOOKING_STATUSES = ["confirmed", "in_progress", "completed"] as const
+
+export type ActiveBookingStatus = (typeof ACTIVE_BOOKING_STATUSES)[number]
+
+const activeBookingStatuses = new Set<string>(ACTIVE_BOOKING_STATUSES)
+
+export function isActiveBookingStatus(status: string): boolean {
+  return activeBookingStatuses.has(status)
+}
+
+/**
+ * `booking_allocations.status` values that still bind a booking to a
+ * departure. The remaining members of the enum (`released`, `expired`,
+ * `cancelled`) have given the seat back and must never be counted as
+ * consumption.
+ */
+export const ACTIVE_BOOKING_ALLOCATION_STATUSES = ["held", "confirmed", "fulfilled"] as const
+
+export type ActiveBookingAllocationStatus = (typeof ACTIVE_BOOKING_ALLOCATION_STATUSES)[number]
+
+const activeBookingAllocationStatuses = new Set<string>(ACTIVE_BOOKING_ALLOCATION_STATUSES)
+
+export function isActiveBookingAllocationStatus(status: string): boolean {
+  return activeBookingAllocationStatuses.has(status)
+}
+
+/**
+ * Allocation statuses that gave the seat back. The complement of
+ * `ACTIVE_BOOKING_ALLOCATION_STATUSES` within `booking_allocation_status`,
+ * spelled out so a counter can report *why* an allocation stopped consuming
+ * capacity instead of only that it did.
+ */
+export const RELEASED_BOOKING_ALLOCATION_STATUSES = ["released", "expired", "cancelled"] as const
+
+export type ReleasedBookingAllocationStatus = (typeof RELEASED_BOOKING_ALLOCATION_STATUSES)[number]

--- a/packages/bookings-contracts/src/index.ts
+++ b/packages/bookings-contracts/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./amendments.js"
 export * from "./booking-actions.js"
+export * from "./booking-lifecycle.js"
 export * from "./traveler-schemas.js"
 export * from "./validation.js"

--- a/packages/bookings/src/extras/routes.ts
+++ b/packages/bookings/src/extras/routes.ts
@@ -234,6 +234,16 @@ const slotExtraManifestSchema = z.object({
   travelers: z.array(manifestTravelerSchema),
   selections: z.array(manifestSelectionSchema),
   summaries: z.array(manifestSummarySchema),
+  /**
+   * Paging state for the traveler axis. `limit: null` means no page was
+   * requested. `total` is the whole departure's traveler count, so it — and
+   * every figure in `summaries` — is stable across pages.
+   */
+  pagination: z.object({
+    limit: z.number().int().nullable(),
+    offset: z.number().int(),
+    total: z.number().int(),
+  }),
 })
 
 // --- helpers ---------------------------------------------------------------

--- a/packages/bookings/src/extras/service-manifest.ts
+++ b/packages/bookings/src/extras/service-manifest.ts
@@ -1,3 +1,7 @@
+import {
+  ACTIVE_BOOKING_ALLOCATION_STATUSES,
+  ACTIVE_BOOKING_STATUSES,
+} from "@voyant-travel/bookings-contracts"
 import { newId } from "@voyant-travel/db/lib/typeid"
 import { and, asc, desc, eq, inArray, or } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
@@ -24,10 +28,6 @@ type SlotExtraManifestQuery = z.infer<typeof slotExtraManifestQuerySchema>
 type SlotExtraSelectionPatch = z.infer<typeof slotExtraSelectionPatchSchema>
 type SlotExtraSelectionBulk = z.infer<typeof slotExtraSelectionBulkSchema>
 type SlotExtraCollectionBulk = z.infer<typeof slotExtraCollectionBulkSchema>
-
-const activeBookingStatusesForSlot = ["confirmed", "in_progress", "completed"] as const
-
-const activeAllocationStatusesForSlot = ["held", "confirmed", "fulfilled"] as const
 
 function defaultCollectionStatus(collectionMode: string) {
   if (collectionMode === "cash_on_trip" || collectionMode === "external") return "pending"
@@ -129,7 +129,7 @@ export const bookingsExtrasManifestService = {
   async getSlotExtraManifest(
     db: PostgresJsDatabase,
     slotId: string,
-    query: SlotExtraManifestQuery = { includeInactiveExtras: false },
+    query: SlotExtraManifestQuery = { includeInactiveExtras: false, offset: 0 },
   ) {
     const [slot] = await db
       .select()
@@ -172,8 +172,8 @@ export const bookingsExtrasManifestService = {
         .where(
           and(
             eq(bookingAllocations.availabilitySlotId, slotId),
-            inArray(bookings.status, [...activeBookingStatusesForSlot]),
-            inArray(bookingAllocations.status, [...activeAllocationStatusesForSlot]),
+            inArray(bookings.status, [...ACTIVE_BOOKING_STATUSES]),
+            inArray(bookingAllocations.status, [...ACTIVE_BOOKING_ALLOCATION_STATUSES]),
             or(
               eq(bookingTravelers.participantType, "traveler"),
               eq(bookingTravelers.participantType, "occupant"),
@@ -293,17 +293,36 @@ export const bookingsExtrasManifestService = {
       }),
     )
 
+    // Rollups are computed over the whole departure *before* the page is cut,
+    // so `summaries` and `travelerTotal` are identical on every page. Only the
+    // per-traveler rows are sliced.
+    const summaries = summarizeSlotExtras(extras, travelers.length, selections)
+    const offset = query.offset ?? 0
+    const pagedTravelers =
+      query.limit === undefined ? travelers : travelers.slice(offset, offset + query.limit)
+    const pagedTravelerIds = new Set(pagedTravelers.map((traveler) => traveler.id))
+
     return {
       status: "ok" as const,
       data: {
         slot,
         extras,
-        travelers: travelers.map((traveler) => ({
+        travelers: pagedTravelers.map((traveler) => ({
           ...traveler,
           fullName: fullName(traveler.firstName, traveler.lastName),
         })),
-        selections,
-        summaries: summarizeSlotExtras(extras, travelers.length, selections),
+        selections:
+          query.limit === undefined
+            ? selections
+            : selections.filter((selection) => pagedTravelerIds.has(selection.travelerId)),
+        summaries,
+        pagination: {
+          /** `null` means "no page was requested — every traveler is here". */
+          limit: query.limit ?? null,
+          offset,
+          /** Travelers on the whole departure, not on this page. */
+          total: travelers.length,
+        },
       },
     }
   },
@@ -479,8 +498,8 @@ async function validateSlotSelection(
         eq(bookingTravelers.id, input.travelerId),
         eq(bookingTravelers.bookingId, input.bookingId),
         eq(bookingAllocations.availabilitySlotId, slotId),
-        inArray(bookings.status, [...activeBookingStatusesForSlot]),
-        inArray(bookingAllocations.status, [...activeAllocationStatusesForSlot]),
+        inArray(bookings.status, [...ACTIVE_BOOKING_STATUSES]),
+        inArray(bookingAllocations.status, [...ACTIVE_BOOKING_ALLOCATION_STATUSES]),
       ),
     )
     .limit(1)

--- a/packages/bookings/src/extras/validation.ts
+++ b/packages/bookings/src/extras/validation.ts
@@ -84,8 +84,16 @@ export const bookingExtraListQuerySchema = paginationSchema.extend({
   status: bookingExtraStatusSchema.optional(),
 })
 
+/**
+ * `limit`/`offset` page the **traveler** axis of the matrix only. The extras
+ * axis and every rollup in `summaries` stay whole-departure, so paging can
+ * never change a headline count. Omitting `limit` returns every traveler,
+ * which is the pre-pagination behaviour.
+ */
 export const slotExtraManifestQuerySchema = z.object({
   includeInactiveExtras: booleanQueryParam.default(false),
+  limit: z.coerce.number().int().min(1).max(500).optional(),
+  offset: z.coerce.number().int().min(0).default(0),
 })
 
 export const slotExtraSelectionPatchSchema = z.object({

--- a/packages/bookings/src/service-core.ts
+++ b/packages/bookings/src/service-core.ts
@@ -5,6 +5,11 @@ import {
   type CreatedTargetMutationLease,
   consumeCreatedTargetMutationLease,
 } from "@voyant-travel/action-ledger"
+import {
+  ACTIVE_BOOKING_ALLOCATION_STATUSES,
+  ACTIVE_BOOKING_STATUSES,
+  isActiveBookingStatus,
+} from "@voyant-travel/bookings-contracts"
 import type { EventBus } from "@voyant-travel/core"
 import type { NamespacedCustomFieldValues } from "@voyant-travel/core/custom-fields"
 import { lockBookingFinanceInsertionFence } from "@voyant-travel/db/booking-finance-fence"
@@ -593,8 +598,6 @@ export interface BookingTravelerSharingGroupSummary {
 
 const travelerParticipantTypes = ["traveler", "occupant"] as const
 type TravelerParticipantType = (typeof travelerParticipantTypes)[number]
-const sharingGroupBookingStatuses = ["confirmed", "in_progress", "completed"] as const
-const sharingGroupAllocationStatuses = ["held", "confirmed", "fulfilled"] as const
 
 class BookingServiceError extends Error {
   constructor(
@@ -619,7 +622,7 @@ function toTimestamp(value?: string | null) {
 }
 
 function isAcceptedBookingStatus(status: BookingStatus) {
-  return status === "confirmed" || status === "in_progress" || status === "completed"
+  return isActiveBookingStatus(status)
 }
 
 function confirmedAtForStatus(status: BookingStatus, value: Date | null, now = new Date()) {
@@ -3858,8 +3861,8 @@ const bookingsServiceInternal = {
           eq(bookingAllocations.availabilitySlotId, slotId),
           isNotNull(bookingTravelerTravelDetails.sharingGroupId),
           ne(bookingTravelerTravelDetails.sharingGroupId, ""),
-          inArray(bookings.status, sharingGroupBookingStatuses),
-          inArray(bookingAllocations.status, sharingGroupAllocationStatuses),
+          inArray(bookings.status, ACTIVE_BOOKING_STATUSES),
+          inArray(bookingAllocations.status, ACTIVE_BOOKING_ALLOCATION_STATUSES),
           or(...travelerParticipantTypes.map((type) => eq(bookingTravelers.participantType, type))),
         ),
       )
@@ -3920,8 +3923,8 @@ const bookingsServiceInternal = {
         and(
           eq(bookingAllocations.availabilitySlotId, slotId),
           eq(bookingTravelerTravelDetails.sharingGroupId, sharingGroupId),
-          inArray(bookings.status, sharingGroupBookingStatuses),
-          inArray(bookingAllocations.status, sharingGroupAllocationStatuses),
+          inArray(bookings.status, ACTIVE_BOOKING_STATUSES),
+          inArray(bookingAllocations.status, ACTIVE_BOOKING_ALLOCATION_STATUSES),
           or(...travelerParticipantTypes.map((type) => eq(bookingTravelers.participantType, type))),
         ),
       )

--- a/packages/bookings/src/status.ts
+++ b/packages/bookings/src/status.ts
@@ -1,14 +1,38 @@
+/**
+ * Runtime-typed view of the shared booking lifecycle vocabulary.
+ *
+ * The values live in `@voyant-travel/bookings-contracts` (a contracts package
+ * depends on `zod` only, per ADR-0002). This module is where they are pinned
+ * against the Drizzle enum: `satisfies readonly BookingStatus[]` fails the
+ * build the moment a status is dropped from `booking_status`, which is the
+ * check the copy-pasted duplicates never had. Packages that already depend on
+ * `@voyant-travel/bookings` should import from here
+ * (`@voyant-travel/bookings/status`) rather than restating the list.
+ */
+
+import { ACTIVE_BOOKING_STATUSES } from "@voyant-travel/bookings-contracts"
 import type { BookingStatus } from "./state-machine.js"
+
+export {
+  ACTIVE_BOOKING_ALLOCATION_STATUSES,
+  ACTIVE_BOOKING_STATUSES,
+  isActiveBookingAllocationStatus,
+  isActiveBookingStatus,
+  RELEASED_BOOKING_ALLOCATION_STATUSES,
+} from "@voyant-travel/bookings-contracts"
 
 export const BOOKING_RESOURCE_AVAILABILITY_STATUSES = [
   "confirmed",
   "in_progress",
 ] as const satisfies readonly BookingStatus[]
 
-export const BOOKING_RESOURCE_CAPACITY_STATUSES = [
-  ...BOOKING_RESOURCE_AVAILABILITY_STATUSES,
-  "completed",
-] as const satisfies readonly BookingStatus[]
+/**
+ * Bookings that still consume a departure's capacity — the same set as
+ * `ACTIVE_BOOKING_STATUSES`, re-exported under the capacity call sites' own
+ * name and pinned against the enum here.
+ */
+export const BOOKING_RESOURCE_CAPACITY_STATUSES =
+  ACTIVE_BOOKING_STATUSES satisfies readonly BookingStatus[]
 
 const bookingResourceAvailabilityStatuses = new Set<string>(BOOKING_RESOURCE_AVAILABILITY_STATUSES)
 

--- a/packages/bookings/tests/extras/unit/routes-contract.test.ts
+++ b/packages/bookings/tests/extras/unit/routes-contract.test.ts
@@ -227,12 +227,32 @@ describe("booking-extras admin contract", () => {
         travelers: [manifestTraveler],
         selections: [manifestSelectionRow],
         summaries: [manifestSummaryRow],
+        pagination: { limit: null, offset: 0, total: 1 },
       }),
     )
     expect(parsed.slot.id).toBe("avs_1")
     expect(parsed.extras).toHaveLength(1)
     expect(parsed.travelers[0]?.fullName).toBe("Ada Lovelace")
     expect(parsed.selections[0]?.productExtraId).toBe("pex_1")
+    expect(parsed.summaries[0]?.selectedTravelerCount).toBe(1)
+    expect(parsed.pagination.total).toBe(1)
+  })
+
+  it("slot manifest summaries stay whole-departure figures when a page is requested", () => {
+    const parsed = slotExtraManifestSchema.parse(
+      toWire({
+        slot: manifestSlot,
+        extras: [manifestExtra],
+        travelers: [manifestTraveler],
+        selections: [manifestSelectionRow],
+        summaries: [manifestSummaryRow],
+        pagination: { limit: 1, offset: 2, total: 9 },
+      }),
+    )
+    // `total` counts the departure, not the page, so a paged read still
+    // reports every traveler — and `summaries` is computed before the slice.
+    expect(parsed.travelers).toHaveLength(1)
+    expect(parsed.pagination).toEqual({ limit: 1, offset: 2, total: 9 })
     expect(parsed.summaries[0]?.selectedTravelerCount).toBe(1)
   })
 

--- a/packages/finance-contracts/src/runtime-port.ts
+++ b/packages/finance-contracts/src/runtime-port.ts
@@ -23,3 +23,85 @@ export const financeAppApiRuntimePort = Object.freeze({
     }
   },
 })
+
+/**
+ * The subset of Finance's departure profitability row a non-Finance module is
+ * allowed to read. Finance's own `DepartureProfitabilityRow` is structurally a
+ * superset, so the provider `satisfies` this without a mapping layer — and
+ * stops compiling if the read model ever loses one of these fields.
+ */
+export interface FinanceDepartureProfitabilityRow {
+  departureId: string
+  productId: string | null
+  departureDate: string | null
+  currency: string
+  revenueCents: number
+  actualCostCents: number
+  plannedCostCents: number
+  profitCents: number
+  marginPercent: number | null
+  varianceCents: number
+}
+
+/** Single-currency rollup of the rows above, in the operator's base currency. */
+export interface FinanceDepartureProfitabilityBaseRollup {
+  currency: string
+  rows: FinanceDepartureProfitabilityRow[]
+  /** Source currencies with no resolvable FX rate — excluded from the rollup. */
+  unconvertibleCurrencies: string[]
+}
+
+export interface FinanceDepartureProfitabilityReport {
+  rows: FinanceDepartureProfitabilityRow[]
+  base?: FinanceDepartureProfitabilityBaseRollup
+}
+
+export interface FinanceDepartureProfitabilityQuery {
+  departureId?: string
+  productId?: string
+  currency?: string
+}
+
+/**
+ * Read-only view of Finance's departure P&L.
+ *
+ * Exists so a module that renders a departure — Operations' departure
+ * workspace — can put a headline profit figure on it without depending on
+ * `@voyant-travel/finance` and without recomputing money. Finance stays the
+ * monetary authority: FX settings and the base-currency rollup are resolved
+ * inside the provider, which is why the seam takes no FX options.
+ *
+ * Optional on the consuming side — a deployment without Finance simply binds
+ * nothing and the consumer renders no money.
+ */
+export interface FinanceDepartureProfitabilityRuntime<TDatabase = unknown> {
+  getDepartureProfitability(
+    db: TDatabase,
+    query: FinanceDepartureProfitabilityQuery,
+  ): Promise<FinanceDepartureProfitabilityReport>
+}
+
+/**
+ * Import-cheap deployment declaration for the departure profitability read.
+ *
+ * Typed against the runtime interface (rather than `unknown`) so `getPort`
+ * infers the provider on the consuming side; the conformance kit still probes
+ * the raw value, because the whole point of a kit is that the binding might be
+ * anything.
+ */
+export const financeDepartureProfitabilityRuntimePort: {
+  readonly id: "finance.departure-profitability.runtime"
+  readonly test: (provider: FinanceDepartureProfitabilityRuntime) => void
+} = Object.freeze({
+  id: "finance.departure-profitability.runtime" as const,
+  test(provider: unknown) {
+    if (!provider || typeof provider !== "object") {
+      throw new Error("finance.departure-profitability.runtime provider must be an object.")
+    }
+    if (typeof Reflect.get(provider, "getDepartureProfitability") !== "function") {
+      throw new Error(
+        "finance.departure-profitability.runtime provider must implement getDepartureProfitability().",
+      )
+    }
+  },
+})

--- a/packages/finance/src/runtime-contributor.ts
+++ b/packages/finance/src/runtime-contributor.ts
@@ -11,6 +11,11 @@ import {
 import type { VoyantRuntimeHostPrimitives } from "@voyant-travel/core"
 import type { VoyantPort } from "@voyant-travel/core/project"
 import { financeAppApiRuntimePort } from "@voyant-travel/finance-contracts/app-api"
+import {
+  type FinanceDepartureProfitabilityRuntime,
+  financeDepartureProfitabilityRuntimePort,
+} from "@voyant-travel/finance-contracts/runtime-port"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { checkFinanceActionLedgerDrift } from "./action-ledger-drift.js"
 import { createFinanceAppApiRuntime } from "./app-api-runtime.js"
 import { financeBookingActionSource } from "./booking-action-source.js"
@@ -20,6 +25,7 @@ import {
   financeHostRuntimePort,
   financeOperatorSettingsRuntimePort,
 } from "./runtime-port.js"
+import { getDepartureProfitability } from "./service-profitability.js"
 
 export interface FinanceRuntimeContributorHost {
   primitives: VoyantRuntimeHostPrimitives
@@ -47,6 +53,13 @@ export function createFinanceRuntimePortContribution(
       checkFinanceDrift: checkFinanceActionLedgerDrift,
     } satisfies ActionLedgerFinanceDriftRuntime,
     [financeHostRuntimePort.id]: { primitives: host.primitives },
+    // Read-only P&L for one departure. FX settings are resolved inside
+    // `getDepartureProfitability` from the same database the caller hands in,
+    // so the seam carries no FX options and Finance stays the authority on
+    // what a departure is worth.
+    [financeDepartureProfitabilityRuntimePort.id]: {
+      getDepartureProfitability: (db, query) => getDepartureProfitability(db, query),
+    } satisfies FinanceDepartureProfitabilityRuntime<PostgresJsDatabase>,
     [bookingsFinanceRuntimePort.id]: {
       ...amendmentRuntime,
     } satisfies BookingsFinanceRuntime,

--- a/packages/finance/src/voyant.ts
+++ b/packages/finance/src/voyant.ts
@@ -12,7 +12,10 @@ import {
   type VoyantGraphJsonObject,
 } from "@voyant-travel/core/project"
 import { customFieldsRuntimePort } from "@voyant-travel/core/runtime-port"
-import { financeAppApiRuntimePort } from "@voyant-travel/finance-contracts/runtime-port"
+import {
+  financeAppApiRuntimePort,
+  financeDepartureProfitabilityRuntimePort,
+} from "@voyant-travel/finance-contracts/runtime-port"
 import {
   financeReceivablesDatasetDefinition,
   financeReportingTemplates,
@@ -71,6 +74,7 @@ export const financeVoyantModule = defineModule({
       providePort(bookingActionSourceRuntimePort),
       providePort(financeHostRuntimePort),
       providePort(financeAppApiRuntimePort),
+      providePort(financeDepartureProfitabilityRuntimePort),
     ],
   },
   api: [

--- a/packages/finance/tests/unit/voyant-manifest.test.ts
+++ b/packages/finance/tests/unit/voyant-manifest.test.ts
@@ -31,6 +31,7 @@ describe("finance deployment manifest", () => {
           { id: "bookings.booking-action-source.runtime" },
           { id: "finance.host.runtime" },
           { id: "finance.app-api.runtime" },
+          { id: "finance.departure-profitability.runtime" },
         ],
       },
       runtime: { entry: "@voyant-travel/finance", export: "createFinanceVoyantRuntime" },

--- a/packages/notifications/src/service-reminder-booking-context.ts
+++ b/packages/notifications/src/service-reminder-booking-context.ts
@@ -1,4 +1,5 @@
 import { bookings, bookingTravelers } from "@voyant-travel/bookings/schema"
+import { ACTIVE_BOOKING_STATUSES } from "@voyant-travel/bookings/status"
 import { bookingPaymentSchedules, invoices, paymentSessions } from "@voyant-travel/finance/schema"
 import { and, asc, desc, eq, gt, isNull, or } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
@@ -13,7 +14,12 @@ import type { BookingDocumentBundleItem, BookingPaymentScheduleRow } from "./ser
 import { listBookingNotificationItems, resolveReminderRecipient } from "./service-shared.js"
 import type { NotificationAttachment } from "./types.js"
 
-export const PAYABLE_BOOKING_STATUSES = new Set(["confirmed", "in_progress", "completed"])
+/**
+ * Bookings a reminder may still chase. Same set as the shared
+ * `ACTIVE_BOOKING_STATUSES` — a cancelled booking is owed nothing — kept under
+ * the reminder vocabulary's own name and no longer restated here.
+ */
+export const PAYABLE_BOOKING_STATUSES = new Set<string>(ACTIVE_BOOKING_STATUSES)
 export const OPEN_PAYMENT_SCHEDULE_STATUSES = new Set(["pending", "due"])
 
 export interface BookingEventReminderRuntimeOptions {

--- a/packages/notifications/src/service-sequence-targets.ts
+++ b/packages/notifications/src/service-sequence-targets.ts
@@ -1,4 +1,5 @@
 import { bookings } from "@voyant-travel/bookings/schema"
+import { ACTIVE_BOOKING_STATUSES } from "@voyant-travel/bookings/status"
 import { bookingPaymentSchedules, invoices } from "@voyant-travel/finance/schema"
 import { and, eq, gt, gte, inArray, lte, or } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
@@ -54,8 +55,6 @@ type DateEnvelopes = {
   invoiceIssueDate?: { from: string; to: string }
 }
 
-const PAYABLE_BOOKING_STATUSES = ["confirmed", "in_progress", "completed"] as const
-
 async function fetchOpenPaymentScheduleTargets(
   db: PostgresJsDatabase,
   envelopes: DateEnvelopes = {},
@@ -63,7 +62,7 @@ async function fetchOpenPaymentScheduleTargets(
 ): Promise<ReminderTargetSnapshot[]> {
   const conditions = [
     or(eq(bookingPaymentSchedules.status, "pending"), eq(bookingPaymentSchedules.status, "due")),
-    inArray(bookings.status, PAYABLE_BOOKING_STATUSES),
+    inArray(bookings.status, ACTIVE_BOOKING_STATUSES),
   ]
   if (envelopes.paymentScheduleDueDate) {
     conditions.push(

--- a/packages/operations/package.json
+++ b/packages/operations/package.json
@@ -38,6 +38,7 @@
     "@voyant-travel/catalog": "workspace:^",
     "@voyant-travel/core": "workspace:^",
     "@voyant-travel/db": "workspace:^",
+    "@voyant-travel/finance-contracts": "workspace:^",
     "@voyant-travel/types": "workspace:^",
     "@voyant-travel/hono": "workspace:^",
     "@voyant-travel/identity": "workspace:^",

--- a/packages/operations/src/availability/auto-allocator.ts
+++ b/packages/operations/src/availability/auto-allocator.ts
@@ -1,4 +1,4 @@
-import { isActiveBookingStatusForSlot } from "./booking-statuses.js"
+import { isActiveBookingStatus } from "./booking-statuses.js"
 
 export interface AllocatorTraveler {
   id: string
@@ -43,7 +43,7 @@ interface InternalGroup {
 }
 
 function activeTravelers(travelers: AllocatorTraveler[]): AllocatorTraveler[] {
-  return travelers.filter((traveler) => isActiveBookingStatusForSlot(traveler.bookingStatus))
+  return travelers.filter((traveler) => isActiveBookingStatus(traveler.bookingStatus))
 }
 
 function groupTravelers(travelers: AllocatorTraveler[]): Map<string, InternalGroup> {

--- a/packages/operations/src/availability/booking-statuses.ts
+++ b/packages/operations/src/availability/booking-statuses.ts
@@ -1,28 +1,39 @@
+import {
+  ACTIVE_BOOKING_ALLOCATION_STATUSES,
+  ACTIVE_BOOKING_STATUSES,
+} from "@voyant-travel/bookings-contracts"
 import { type SQL, sql } from "drizzle-orm"
 
+export {
+  ACTIVE_BOOKING_ALLOCATION_STATUSES,
+  ACTIVE_BOOKING_STATUSES,
+  isActiveBookingAllocationStatus,
+  isActiveBookingStatus,
+  RELEASED_BOOKING_ALLOCATION_STATUSES,
+} from "@voyant-travel/bookings-contracts"
+
 /**
- * Booking statuses that still hold a slot's inventory. Must stay a subset of
- * `booking_status`: these values are bound as parameters against `bookings.
- * status`, so Postgres types them as the enum and rejects the whole query
- * with `22P02` on any value the enum no longer has. The v1 commitment
- * lifecycle (#4100) contracted the enum to
- * confirmed/in_progress/completed/cancelled -- the pre-commitment statuses
- * this list used to carry (`on_hold`, `awaiting_payment`) are booking
- * sessions now, not bookings. Mirrors the same list in bookings'
- * `extras/service-manifest.ts`.
+ * Drizzle fragment builders over the shared booking lifecycle vocabulary.
+ *
+ * The values themselves live in `@voyant-travel/bookings-contracts`
+ * (`booking-lifecycle.ts`) — a contracts package cannot import drizzle-orm, so
+ * only the `sql` interpolation lives here. The members are bound as parameters
+ * against `bookings.status` / `booking_allocations.status`, which Postgres
+ * types as the enum: any value the enum no longer carries fails the whole
+ * query with `22P02`.
  */
-export const ACTIVE_BOOKING_STATUSES_FOR_SLOT = ["confirmed", "in_progress", "completed"] as const
-
-const activeBookingStatusesForSlot = new Set<string>(ACTIVE_BOOKING_STATUSES_FOR_SLOT)
-
-export function activeBookingStatusesForSlotSql(): SQL {
+export function activeBookingStatusesSql(): SQL {
   return sql.join(
     // agent-quality: raw-sql reviewed -- owner: availability; dynamic SQL interpolation uses Drizzle parameter binding or vetted SQL identifiers.
-    ACTIVE_BOOKING_STATUSES_FOR_SLOT.map((status) => sql`${status}`),
+    ACTIVE_BOOKING_STATUSES.map((status) => sql`${status}`),
     sql`, `,
   )
 }
 
-export function isActiveBookingStatusForSlot(status: string): boolean {
-  return activeBookingStatusesForSlot.has(status)
+export function activeBookingAllocationStatusesSql(): SQL {
+  return sql.join(
+    // agent-quality: raw-sql reviewed -- owner: availability; dynamic SQL interpolation uses Drizzle parameter binding or vetted SQL identifiers.
+    ACTIVE_BOOKING_ALLOCATION_STATUSES.map((status) => sql`${status}`),
+    sql`, `,
+  )
 }

--- a/packages/operations/src/availability/departure-profitability-runtime.ts
+++ b/packages/operations/src/availability/departure-profitability-runtime.ts
@@ -1,0 +1,77 @@
+/**
+ * Finance seam for the departure workspace.
+ *
+ * The workspace has to show what a departure is worth, and Operations must not
+ * work that out. Money is Finance's: revenue attribution, planned-versus-actual
+ * cost, FX, and the base-currency rollup all live in
+ * `getDepartureProfitability`. Operations reads the answer and never
+ * recomputes it.
+ *
+ * Reaching it as a graph runtime port rather than a package dependency keeps
+ * `@voyant-travel/operations` free of `@voyant-travel/finance` — only the
+ * import-cheap declaration in `@voyant-travel/finance-contracts` is depended
+ * on. The port is **optional**: a deployment assembled without Finance binds
+ * nothing, the channel stays unset, and the summary simply carries no money.
+ *
+ * The channel is a module-level binding for the same reason
+ * `hold-expiry-wake.ts` is: the availability routes are module-level constants
+ * mounted on two surfaces (legacy `/v1/operations/*` and admin
+ * `/v1/admin/operations/*`), so there is no single construction site to thread
+ * an option through. The Operations graph runtime factory — the only place
+ * that can resolve a port — binds it once at composition.
+ */
+
+import type {
+  FinanceDepartureProfitabilityQuery,
+  FinanceDepartureProfitabilityReport,
+} from "@voyant-travel/finance-contracts/runtime-port"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+export type DepartureProfitabilityReader = (
+  db: PostgresJsDatabase,
+  query: FinanceDepartureProfitabilityQuery,
+) => Promise<FinanceDepartureProfitabilityReport>
+
+let readDepartureProfitability: DepartureProfitabilityReader | undefined
+
+/**
+ * Bind the deployment's Finance profitability reader. Called once by the
+ * Operations graph runtime factory, which is the only place that can resolve a
+ * runtime port. Passing `undefined` is the "Finance is not deployed" case and
+ * is not an error.
+ */
+export function configureDepartureProfitabilityReader(
+  reader: DepartureProfitabilityReader | undefined,
+): void {
+  readDepartureProfitability = reader
+}
+
+/** Test seam: drop the bound reader so a suite cannot leak into the next one. */
+export function resetDepartureProfitabilityReader(): void {
+  readDepartureProfitability = undefined
+}
+
+/** Whether a Finance provider is bound in this deployment. */
+export function hasDepartureProfitabilityReader(): boolean {
+  return readDepartureProfitability !== undefined
+}
+
+/**
+ * Read one departure's P&L, or `undefined` when no Finance provider is bound.
+ *
+ * A Finance failure is not allowed to take the whole workspace down with it:
+ * the rest of the summary is operational truth the operator still needs at the
+ * gate. The caller sees `undefined` and renders the money section as
+ * unavailable.
+ */
+export async function readDepartureProfitabilityReport(
+  db: PostgresJsDatabase,
+  query: FinanceDepartureProfitabilityQuery,
+): Promise<FinanceDepartureProfitabilityReport | undefined> {
+  if (!readDepartureProfitability) return undefined
+  try {
+    return await readDepartureProfitability(db, query)
+  } catch {
+    return undefined
+  }
+}

--- a/packages/operations/src/availability/index.ts
+++ b/packages/operations/src/availability/index.ts
@@ -92,6 +92,8 @@ export {
   type PlannedAllocation,
   type ResourceCapacityViolation,
   type SlotAllocationManifest,
+  type SlotAllocationManifestOptions,
+  type SlotAllocationManifestPagination,
   type SlotResourceAvailability,
   validateSlotAllocationCapacity,
 } from "./service-allocation.js"
@@ -105,6 +107,33 @@ export {
   buildAllocationRoomingCsv,
 } from "./service-allocation-exports.js"
 export {
+  type DepartureAllocationCounters,
+  type DepartureBookingCounters,
+  type DepartureCapacityCounters,
+  type DepartureResourceCounters,
+  type DepartureTravelerCounters,
+  getDepartureCapacityCounters,
+} from "./service-departure-capacity.js"
+export {
+  type DepartureIssue,
+  type DepartureIssueCode,
+  type DepartureIssueInput,
+  type DepartureIssueSeverity,
+  type DepartureIssueSubjectType,
+  evaluateDepartureIssues,
+  getDepartureIssues,
+} from "./service-departure-issues.js"
+export {
+  type DepartureBookingQuantities,
+  type DepartureExtrasRollup,
+  type DepartureFinanceHeadline,
+  type DepartureFinanceLine,
+  type DepartureIdentity,
+  type DepartureOperationsReadiness,
+  type DepartureSummary,
+  getDepartureSummary,
+} from "./service-departure-summary.js"
+export {
   instantToSlotLocal,
   type LocalToInstantInput,
   localToInstant,
@@ -117,6 +146,7 @@ export {
 export {
   allocationAuditLogQuerySchema,
   allocationAutomationSchema,
+  allocationManifestQuerySchema,
   assignTravelerAllocationSchema,
   availabilityCloseoutListQuerySchema,
   availabilityOverviewQuerySchema,

--- a/packages/operations/src/availability/routes-allocation.ts
+++ b/packages/operations/src/availability/routes-allocation.ts
@@ -62,6 +62,7 @@ import {
 import {
   allocationAuditLogQuerySchema,
   allocationAutomationSchema,
+  allocationManifestQuerySchema,
   assignTravelerAllocationSchema,
   insertAllocationResourceSchema,
   materializeOpenSlotsSchema,
@@ -170,6 +171,12 @@ const slotAllocationManifestSchema = z.object({
   bookings: z.array(allocationManifestBookingSchema),
   resources: z.array(allocationResourceSchema),
   sharingGroupLabels: z.record(z.string(), z.string()),
+  /** `limit: null` means every booking is present; `total` is always the departure's. */
+  pagination: z.object({
+    limit: z.number().int().nullable(),
+    offset: z.number().int(),
+    total: z.number().int(),
+  }),
   summary: z.object({
     bookingCount: z.number().int(),
     travelerCount: z.number().int(),
@@ -302,7 +309,11 @@ function csvResponse(c: Context<Env>, csv: string, filename: string) {
 const getManifestRoute = createRoute({
   method: "get",
   path: "/slots/{id}/allocation",
-  request: { params: slotIdParamSchema },
+  description:
+    "The slot's allocation manifest. `limit`/`offset` page the booking axis; " +
+    "omitting `limit` returns every booking. The `summary` counters are " +
+    "whole-departure and do not change with the page.",
+  request: { params: slotIdParamSchema, query: allocationManifestQuerySchema },
   responses: {
     200: {
       description: "The slot's allocation manifest (bookings, travelers, resources, summary)",
@@ -379,7 +390,11 @@ const deleteResourceRoute = createRoute({
 
 const slotResourceRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidationHook })
   .openapi(getManifestRoute, async (c) => {
-    const manifest = await getSlotAllocationManifest(c.get("db"), c.req.valid("param").id)
+    const manifest = await getSlotAllocationManifest(
+      c.get("db"),
+      c.req.valid("param").id,
+      c.req.valid("query"),
+    )
     return manifest
       ? c.json({ data: manifest }, 200)
       : c.json({ error: "Availability slot not found" }, 404)

--- a/packages/operations/src/availability/routes-core.ts
+++ b/packages/operations/src/availability/routes-core.ts
@@ -156,6 +156,14 @@ const availabilityStartTimeListRowSchema = availabilityStartTimeSchema.extend({
 const availabilitySlotBaseSchema = z.object({
   id: idSchema,
   productId: z.string(),
+  /**
+   * The immutable Product Version this departure was materialized from.
+   * Persisted and accepted on write since #4032 but previously dropped on the
+   * way out, which left the operator unable to see which frozen definition a
+   * departure is operating. `null` on legacy rows and never-published
+   * products.
+   */
+  productVersionId: z.string().nullable(),
   itineraryId: z.string().nullable(),
   optionId: z.string().nullable(),
   facilityId: z.string().nullable(),
@@ -208,6 +216,166 @@ const slotUnitAvailabilitySchema = z.object({
   initial: z.number().int().nullable(),
   reserved: z.number().int(),
   remaining: z.number().int().nullable(),
+})
+
+// --- departure summary ------------------------------------------------------
+
+/**
+ * The composed departure envelope. Every field is a scalar, a small record, or
+ * a capped list — this route is the workspace's headline, and it must stay a
+ * single bounded response no matter how large the departure is.
+ */
+const departureIssueSchema = z.object({
+  code: z.string(),
+  severity: z.enum(["critical", "warning"]),
+  subjectType: z.enum([
+    "departure",
+    "booking",
+    "booking_allocation",
+    "availability_hold",
+    "allocation_resource",
+  ]),
+  subjectId: z.string(),
+  count: z.number().int(),
+  message: z.string(),
+})
+
+const departureHoldCountersSchema = z.object({
+  active: z.number().int(),
+  activePax: z.number().int(),
+  expired: z.number().int(),
+  expiredPax: z.number().int(),
+  released: z.number().int(),
+  converted: z.number().int(),
+})
+
+const departureAllocationCountersSchema = z.object({
+  held: z.number().int(),
+  confirmed: z.number().int(),
+  fulfilled: z.number().int(),
+  staleHeld: z.number().int(),
+  released: z.number().int(),
+  expired: z.number().int(),
+  cancelled: z.number().int(),
+  active: z.number().int(),
+  inactive: z.number().int(),
+})
+
+const departureTravelerCountersSchema = z.object({
+  entered: z.number().int(),
+  lead: z.number().int(),
+  assigned: z.number().int(),
+  unassigned: z.number().int(),
+  missing: z.number().int(),
+})
+
+const departureResourceCountersSchema = z.object({
+  total: z.number().int(),
+  seating: z.number().int(),
+  capacity: z.number().int(),
+  assigned: z.number().int(),
+  available: z.number().int(),
+  overCapacity: z.number().int(),
+})
+
+const departureResourceRowSchema = z.object({
+  id: idSchema,
+  slotId: z.string(),
+  kind: z.string(),
+  label: z.string().nullable(),
+  refType: z.string().nullable(),
+  refId: z.string().nullable(),
+  parentId: z.string().nullable(),
+  capacity: z.number().int(),
+  assigned: z.number().int(),
+  available: z.number().int(),
+  flags: z.record(z.string(), z.unknown()),
+  sortOrder: z.number().int(),
+})
+
+const departureCapacityCountersSchema = z.object({
+  slotId: z.string(),
+  unlimited: z.boolean(),
+  initialPax: z.number().int().nullable(),
+  effectivePax: z.number().int().nullable(),
+  remainingPax: z.number().int().nullable(),
+  derivedRemainingPax: z.number().int().nullable(),
+  derivedConsumedPax: z.number().int(),
+  holds: departureHoldCountersSchema,
+  allocations: departureAllocationCountersSchema,
+  bookings: z.object({
+    active: z.number().int(),
+    cancelledWithLiveAllocation: z.number().int(),
+    expectedPax: z.number().int(),
+    byStatus: z.record(z.string(), z.number().int()),
+  }),
+  travelers: departureTravelerCountersSchema,
+  resources: departureResourceCountersSchema,
+  resourceBreakdown: z.array(departureResourceRowSchema),
+})
+
+const departureFinanceLineSchema = z.object({
+  currency: z.string(),
+  revenueCents: z.number().int(),
+  actualCostCents: z.number().int(),
+  plannedCostCents: z.number().int(),
+  profitCents: z.number().int(),
+  marginPercent: z.number().nullable(),
+  varianceCents: z.number().int(),
+})
+
+const departureSummarySchema = z.object({
+  departure: z.object({
+    id: idSchema,
+    productId: z.string(),
+    productVersionId: z.string().nullable(),
+    itineraryId: z.string().nullable(),
+    optionId: z.string().nullable(),
+    facilityId: z.string().nullable(),
+    status: availabilitySlotStatusSchema,
+    dateLocal: z.string(),
+    startsAt: z.string(),
+    endsAt: z.string().nullable(),
+    timezone: z.string(),
+    notes: z.string().nullable(),
+  }),
+  capacity: departureCapacityCountersSchema,
+  bookings: z.object({
+    count: z.number().int(),
+    byStatus: z.record(z.string(), z.number().int()),
+    expectedPax: z.number().int(),
+    currency: z.string().nullable(),
+    soldAmountCents: z.number().int().nullable(),
+    paidAmountCents: z.number().int().nullable(),
+    outstandingAmountCents: z.number().int().nullable(),
+  }),
+  travelers: departureTravelerCountersSchema,
+  allocation: departureResourceCountersSchema,
+  operations: z.object({
+    issues: z.array(departureIssueSchema),
+    criticalCount: z.number().int(),
+    warningCount: z.number().int(),
+    clear: z.boolean(),
+  }),
+  /** Null when the Extras module is not deployed. */
+  extras: z
+    .object({
+      offered: z.number().int(),
+      withSelections: z.number().int(),
+      selectedTravelerCount: z.number().int(),
+      totalQuantity: z.number().int(),
+      outstandingCollectionCount: z.number().int(),
+      fulfilledExtraCount: z.number().int(),
+    })
+    .nullable(),
+  /** Null when no Finance provider is bound in this deployment. */
+  finance: z
+    .object({
+      perCurrency: z.array(departureFinanceLineSchema),
+      base: departureFinanceLineSchema.nullable(),
+      unconvertibleCurrencies: z.array(z.string()),
+    })
+    .nullable(),
 })
 
 const availabilityCloseoutSchema = z.object({
@@ -783,6 +951,30 @@ const getSlotUnitAvailabilityRoute = createRoute({
   },
 })
 
+const getDepartureSummaryRoute = createRoute({
+  method: "get",
+  path: "/slots/{id}/summary",
+  description:
+    "One bounded envelope for an operated Departure: slot + Product Version " +
+    "identity, capacity counters (holds, allocations, travelers, resources), " +
+    "booking quantities and settlement, typed attention issues, the extras " +
+    "rollup, and Finance's headline P&L. Composes existing truths — Finance " +
+    "remains the monetary authority and money is null when it is not deployed. " +
+    "Every counter is whole-departure, so paging the allocation manifest never " +
+    "changes a figure here.",
+  request: { params: idParamSchema },
+  responses: {
+    200: {
+      description: "The departure summary",
+      content: { "application/json": { schema: z.object({ data: departureSummarySchema }) } },
+    },
+    404: {
+      description: "Availability slot not found",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
 const updateSlotRoute = createRoute({
   method: "patch",
   path: "/slots/{id}",
@@ -869,6 +1061,15 @@ const slotRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidationHook })
     )
     return rows
       ? c.json({ data: rows }, 200)
+      : c.json({ error: "Availability slot not found" }, 404)
+  })
+  .openapi(getDepartureSummaryRoute, async (c) => {
+    const summary = await availabilityService.getDepartureSummary(
+      c.get("db"),
+      c.req.valid("param").id,
+    )
+    return summary
+      ? c.json({ data: summary }, 200)
       : c.json({ error: "Availability slot not found" }, 404)
   })
   .openapi(updateSlotRoute, async (c) => {

--- a/packages/operations/src/availability/service-allocation-automation.ts
+++ b/packages/operations/src/availability/service-allocation-automation.ts
@@ -13,7 +13,7 @@ import {
   planRoomAllocation,
   planVehicleSeatAllocation,
 } from "./auto-allocator.js"
-import { activeBookingStatusesForSlotSql } from "./booking-statuses.js"
+import { activeBookingAllocationStatusesSql, activeBookingStatusesSql } from "./booking-statuses.js"
 import {
   type AllocationMutationOptions,
   getSlotAllocationManifest,
@@ -111,8 +111,8 @@ async function autoMaterializeAllocationResourcesLocked(
         FROM bookings b
         JOIN booking_allocations ba ON ba.booking_id = b.id
         WHERE ba.availability_slot_id = ${slotId}
-          AND b.status IN (${activeBookingStatusesForSlotSql()})
-          AND ba.status IN ('held', 'confirmed', 'fulfilled')
+          AND b.status IN (${activeBookingStatusesSql()})
+          AND ba.status IN (${activeBookingAllocationStatusesSql()})
       ),
       -- Pax per option = sum of booking_item quantities for items belonging
       -- to bookings on this slot. The previous formulation joined
@@ -299,8 +299,8 @@ async function assertPlannedResourcesWithinCapacity(
         JOIN bookings b ON b.id = bt.booking_id
         WHERE btd.allocations ->> ar.kind = ar.id
           AND ba.availability_slot_id = ar.slot_id
-          AND b.status IN (${activeBookingStatusesForSlotSql()})
-          AND ba.status IN ('held', 'confirmed', 'fulfilled')
+          AND b.status IN (${activeBookingStatusesSql()})
+          AND ba.status IN (${activeBookingAllocationStatusesSql()})
       ) usage ON true
       WHERE ar.slot_id = ${slotId}
         AND ar.kind = ${kind}

--- a/packages/operations/src/availability/service-allocation-exports.ts
+++ b/packages/operations/src/availability/service-allocation-exports.ts
@@ -1,4 +1,4 @@
-import { isActiveBookingStatusForSlot } from "./booking-statuses.js"
+import { isActiveBookingStatus } from "./booking-statuses.js"
 import type { AllocationManifestTraveler, SlotAllocationManifest } from "./service-allocation.js"
 
 const PASSENGER_HEADERS = [
@@ -48,7 +48,7 @@ export function buildAllocationPassengersCsv(manifest: SlotAllocationManifest): 
 export function buildAllocationRoomingCsv(manifest: SlotAllocationManifest, kind = "room"): string {
   const rows: Array<Array<string | number | null>> = [[...ROOMING_HEADERS]]
   const travelers = manifest.bookings.flatMap((booking) =>
-    isActiveBookingStatusForSlot(booking.status) ? booking.travelers : [],
+    isActiveBookingStatus(booking.status) ? booking.travelers : [],
   )
   const travelersByResource = new Map<string, AllocationManifestTraveler[]>()
   const unallocated: AllocationManifestTraveler[] = []

--- a/packages/operations/src/availability/service-allocation-manifest-queries.ts
+++ b/packages/operations/src/availability/service-allocation-manifest-queries.ts
@@ -1,7 +1,7 @@
 import { sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
-import { activeBookingStatusesForSlotSql } from "./booking-statuses.js"
+import { activeBookingAllocationStatusesSql, activeBookingStatusesSql } from "./booking-statuses.js"
 import { executeRows, sqlTextArray } from "./service-allocation-sql.js"
 
 export interface BookingRow {
@@ -178,8 +178,8 @@ async function loadSlotBookingRowsBothJoins(
       GROUP BY booking_id
     ) sch ON sch.booking_id = b.id
     WHERE ba.availability_slot_id = ${slotId}
-      AND b.status IN (${activeBookingStatusesForSlotSql()})
-      AND ba.status IN ('held', 'confirmed', 'fulfilled')
+      AND b.status IN (${activeBookingStatusesSql()})
+      AND ba.status IN (${activeBookingAllocationStatusesSql()})
     ORDER BY b.created_at, b.booking_number
   `,
   )
@@ -219,8 +219,8 @@ async function loadSlotBookingRowsInvoicesOnly(
       GROUP BY booking_id
     ) inv ON inv.booking_id = b.id
     WHERE ba.availability_slot_id = ${slotId}
-      AND b.status IN (${activeBookingStatusesForSlotSql()})
-      AND ba.status IN ('held', 'confirmed', 'fulfilled')
+      AND b.status IN (${activeBookingStatusesSql()})
+      AND ba.status IN (${activeBookingAllocationStatusesSql()})
     ORDER BY b.created_at, b.booking_number
   `,
   )
@@ -259,8 +259,8 @@ async function loadSlotBookingRowsSchedulesOnly(
       GROUP BY booking_id
     ) sch ON sch.booking_id = b.id
     WHERE ba.availability_slot_id = ${slotId}
-      AND b.status IN (${activeBookingStatusesForSlotSql()})
-      AND ba.status IN ('held', 'confirmed', 'fulfilled')
+      AND b.status IN (${activeBookingStatusesSql()})
+      AND ba.status IN (${activeBookingAllocationStatusesSql()})
     ORDER BY b.created_at, b.booking_number
   `,
   )
@@ -290,8 +290,8 @@ async function loadSlotBookingRowsBare(
     FROM bookings b
     JOIN booking_allocations ba ON ba.booking_id = b.id
     WHERE ba.availability_slot_id = ${slotId}
-      AND b.status IN (${activeBookingStatusesForSlotSql()})
-      AND ba.status IN ('held', 'confirmed', 'fulfilled')
+      AND b.status IN (${activeBookingStatusesSql()})
+      AND ba.status IN (${activeBookingAllocationStatusesSql()})
     ORDER BY b.created_at, b.booking_number
   `,
   )
@@ -344,6 +344,39 @@ export async function loadSlotTravelerRows(
   )
 }
 
+/**
+ * Whole-departure traveler counts for the manifest's summary block.
+ *
+ * The summary used to be folded out of the returned `bookings` array, which
+ * was correct only for as long as the manifest returned every booking. Once it
+ * pages, counting the page would silently redefine "how many travelers are on
+ * this departure" as "how many are on this screen", so the counts are read as
+ * an aggregate over the full booking set instead.
+ */
+export async function loadSlotTravelerCounts(
+  db: PostgresJsDatabase,
+  bookingIds: string[],
+): Promise<{ travelerCount: number; leadTravelerCount: number }> {
+  if (bookingIds.length === 0) return { travelerCount: 0, leadTravelerCount: 0 }
+
+  const rows = await executeRows<{ traveler_count: number; lead_traveler_count: number }>(
+    db,
+    sql`
+    SELECT
+      COUNT(*)::int AS traveler_count,
+      COUNT(*) FILTER (WHERE btd.is_lead_traveler)::int AS lead_traveler_count
+    FROM booking_travelers bt
+    LEFT JOIN booking_traveler_travel_details btd ON btd.traveler_id = bt.id
+    WHERE bt.booking_id = ANY(${sqlTextArray(bookingIds)})
+  `,
+  )
+
+  return {
+    travelerCount: rows[0]?.traveler_count ?? 0,
+    leadTravelerCount: rows[0]?.lead_traveler_count ?? 0,
+  }
+}
+
 export async function loadSlotBookingUnitRows(
   db: PostgresJsDatabase,
   slotId: string,
@@ -362,7 +395,7 @@ export async function loadSlotBookingUnitRows(
       LEFT JOIN option_units ou ON ou.id = ba.option_unit_id
       WHERE ba.booking_id = ANY(${sqlTextArray(bookingIds)})
         AND ba.availability_slot_id = ${slotId}
-        AND ba.status IN ('held', 'confirmed', 'fulfilled')
+        AND ba.status IN (${activeBookingAllocationStatusesSql()})
       ORDER BY
         ba.booking_id,
         (ba.option_unit_id IS NULL),
@@ -391,7 +424,7 @@ export async function loadSlotBookingUnitRows(
     FROM booking_allocations ba
     WHERE ba.booking_id = ANY(${sqlTextArray(bookingIds)})
       AND ba.availability_slot_id = ${slotId}
-      AND ba.status IN ('held', 'confirmed', 'fulfilled')
+      AND ba.status IN (${activeBookingAllocationStatusesSql()})
     ORDER BY
       ba.booking_id,
       (ba.option_unit_id IS NULL),

--- a/packages/operations/src/availability/service-allocation-resource-capacity.ts
+++ b/packages/operations/src/availability/service-allocation-resource-capacity.ts
@@ -1,7 +1,7 @@
 import { allocationResources } from "@voyant-travel/availability/schema"
 import { asc, eq, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
-import { activeBookingStatusesForSlotSql } from "./booking-statuses.js"
+import { activeBookingAllocationStatusesSql, activeBookingStatusesSql } from "./booking-statuses.js"
 import { executeRows, type SqlExecutor, sqlTextArray } from "./service-allocation-sql.js"
 
 export async function listAllocationResources(db: PostgresJsDatabase, slotId: string) {
@@ -93,8 +93,8 @@ export async function getSlotsResourceAvailability(
         JOIN bookings b ON b.id = bt.booking_id
         WHERE btd.allocations ->> ar.kind = ar.id
           AND ba.availability_slot_id = ar.slot_id
-          AND b.status IN (${activeBookingStatusesForSlotSql()})
-          AND ba.status IN ('held', 'confirmed', 'fulfilled')
+          AND b.status IN (${activeBookingStatusesSql()})
+          AND ba.status IN (${activeBookingAllocationStatusesSql()})
       ) usage ON true
       WHERE ar.slot_id = ANY(${sqlTextArray(uniqueIds)})
       ORDER BY ar.slot_id, ar.kind, ar.sort_order, ar.created_at
@@ -234,8 +234,8 @@ export async function validateSlotAllocationCapacity(
         JOIN bookings b ON b.id = bt.booking_id
         WHERE btd.allocations ->> ${plan.kind} = ${resourceId}
           AND ba.availability_slot_id = ${slotId}
-          AND b.status IN (${activeBookingStatusesForSlotSql()})
-          AND ba.status IN ('held', 'confirmed', 'fulfilled')
+          AND b.status IN (${activeBookingStatusesSql()})
+          AND ba.status IN (${activeBookingAllocationStatusesSql()})
           AND btd.traveler_id <> ALL(${sqlTextArray(travelerIdsArr)})
       `,
     )
@@ -272,8 +272,8 @@ export async function countResourceOccupants(
     JOIN bookings b ON b.id = bt.booking_id
     WHERE btd.allocations ->> ${kind} = ${resourceId}
       AND ba.availability_slot_id = ${slotId}
-      AND b.status IN (${activeBookingStatusesForSlotSql()})
-      AND ba.status IN ('held', 'confirmed', 'fulfilled')
+      AND b.status IN (${activeBookingStatusesSql()})
+      AND ba.status IN (${activeBookingAllocationStatusesSql()})
       AND (${excludeTravelerId ?? null}::text IS NULL OR btd.traveler_id <> ${excludeTravelerId ?? null})
   `,
   )

--- a/packages/operations/src/availability/service-allocation.ts
+++ b/packages/operations/src/availability/service-allocation.ts
@@ -6,7 +6,7 @@ import {
 import { eq, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { z } from "zod"
-import { activeBookingStatusesForSlotSql } from "./booking-statuses.js"
+import { activeBookingAllocationStatusesSql, activeBookingStatusesSql } from "./booking-statuses.js"
 import { recordAllocationAudit } from "./service-allocation-audit.js"
 import { AllocationServiceError } from "./service-allocation-errors.js"
 import type { AllocationPaymentStatus } from "./service-allocation-manifest-queries.js"
@@ -15,6 +15,7 @@ import {
   derivePaymentStatus,
   loadSlotBookingRows,
   loadSlotBookingUnitRows,
+  loadSlotTravelerCounts,
   loadSlotTravelerRows,
   normalizeAllocationMap,
   serializeSlot,
@@ -131,6 +132,28 @@ export interface AllocationManifestBooking {
   travelers: AllocationManifestTraveler[]
 }
 
+/**
+ * Paging state for the manifest's booking axis.
+ *
+ * `limit: null` means no page was requested and every booking is present —
+ * the pre-pagination behaviour, kept as the default so existing callers are
+ * unaffected. `total` is always the departure's full booking count, never the
+ * page's, and every figure in `summary` is likewise whole-departure. Paging
+ * changes which rows come back; it never changes a count.
+ */
+export interface SlotAllocationManifestPagination {
+  limit: number | null
+  offset: number
+  total: number
+}
+
+export interface SlotAllocationManifestOptions {
+  /** Bookings per page. Omit to return every booking. */
+  limit?: number
+  /** Bookings to skip. Ignored when `limit` is omitted. */
+  offset?: number
+}
+
 export interface SlotAllocationManifest {
   slot: {
     id: string
@@ -141,6 +164,12 @@ export interface SlotAllocationManifest {
   bookings: AllocationManifestBooking[]
   resources: Array<typeof allocationResources.$inferSelect>
   sharingGroupLabels: Record<string, string>
+  pagination: SlotAllocationManifestPagination
+  /**
+   * Whole-departure headline counts. Deliberately not derived from `bookings`
+   * above — see `SlotAllocationManifestPagination`. The richer counters live
+   * in the departure summary (`service-departure-summary.ts`).
+   */
   summary: {
     bookingCount: number
     travelerCount: number
@@ -152,6 +181,7 @@ export interface SlotAllocationManifest {
 export async function getSlotAllocationManifest(
   db: PostgresJsDatabase,
   slotId: string,
+  options: SlotAllocationManifestOptions = {},
 ): Promise<SlotAllocationManifest | null> {
   const [slot] = await db
     .select({
@@ -167,13 +197,21 @@ export async function getSlotAllocationManifest(
   if (!slot) return null
 
   const resources = await listAllocationResources(db, slotId)
-  const bookingRows = await loadSlotBookingRows(db, slotId)
-  if (bookingRows.length === 0) {
+  const allBookingRows = await loadSlotBookingRows(db, slotId)
+  const offset = options.limit === undefined ? 0 : (options.offset ?? 0)
+  const pagination: SlotAllocationManifestPagination = {
+    limit: options.limit ?? null,
+    offset,
+    total: allBookingRows.length,
+  }
+
+  if (allBookingRows.length === 0) {
     return {
       slot: serializeSlot(slot),
       bookings: [],
       resources,
       sharingGroupLabels: {},
+      pagination,
       summary: {
         bookingCount: 0,
         travelerCount: 0,
@@ -183,6 +221,25 @@ export async function getSlotAllocationManifest(
     }
   }
 
+  // Counts are read over every booking on the departure before the page is
+  // cut, so a caller that pages sees the same headline numbers on page 3 as on
+  // page 1.
+  const summary = {
+    bookingCount: allBookingRows.length,
+    ...(await loadSlotTravelerCounts(
+      db,
+      allBookingRows.map((row) => row.id),
+    )),
+    bookingsByStatus: allBookingRows.reduce<Record<string, number>>((acc, row) => {
+      acc[row.status] = (acc[row.status] ?? 0) + 1
+      return acc
+    }, {}),
+  }
+
+  const bookingRows =
+    options.limit === undefined
+      ? allBookingRows
+      : allBookingRows.slice(offset, offset + options.limit)
   const bookingIds = bookingRows.map((row) => row.id)
   const travelerRows = await loadSlotTravelerRows(db, bookingIds)
   const bookingUnitRows = await loadSlotBookingUnitRows(db, slotId, bookingIds)
@@ -190,9 +247,10 @@ export async function getSlotAllocationManifest(
   const bookingById = new Map(bookingRows.map((row) => [row.id, row]))
   // Assign 1-based slot-local sequence by booking createdAt. The SQL above
   // already orders by `created_at` then `booking_number`, so iterating in
-  // array order is the same as iterating in chronological order.
+  // array order is the same as iterating in chronological order. Numbered off
+  // the *full* list so a booking keeps its chip number when the caller pages.
   const sequenceByBookingId = new Map<string, number>()
-  for (const [index, row] of bookingRows.entries()) {
+  for (const [index, row] of allBookingRows.entries()) {
     sequenceByBookingId.set(row.id, index + 1)
   }
   const travelersByBooking = new Map<string, AllocationManifestTraveler[]>()
@@ -231,11 +289,11 @@ export async function getSlotAllocationManifest(
   }
 
   const bookings = bookingRows.map(
-    (row, index): AllocationManifestBooking => ({
+    (row): AllocationManifestBooking => ({
       id: row.id,
       bookingNumber: row.booking_number,
       status: row.status,
-      bookingSequence: index + 1,
+      bookingSequence: sequenceByBookingId.get(row.id) ?? 0,
       paymentStatus: derivePaymentStatus(row),
       contactFirstName: row.contact_first_name,
       contactLastName: row.contact_last_name,
@@ -262,23 +320,8 @@ export async function getSlotAllocationManifest(
     bookings,
     resources,
     sharingGroupLabels: sharingGroupLabelMap,
-    summary: bookings.reduce(
-      (acc, booking) => {
-        acc.bookingCount += 1
-        acc.travelerCount += booking.travelers.length
-        acc.leadTravelerCount += booking.travelers.filter(
-          (traveler) => traveler.isLeadTraveler,
-        ).length
-        acc.bookingsByStatus[booking.status] = (acc.bookingsByStatus[booking.status] ?? 0) + 1
-        return acc
-      },
-      {
-        bookingCount: 0,
-        travelerCount: 0,
-        leadTravelerCount: 0,
-        bookingsByStatus: {} as Record<string, number>,
-      },
-    ),
+    pagination,
+    summary,
   }
 }
 
@@ -514,8 +557,8 @@ async function assertTravelerBelongsToSlot(db: SqlExecutor, slotId: string, trav
     JOIN bookings b ON b.id = bt.booking_id
     WHERE bt.id = ${travelerId}
       AND ba.availability_slot_id = ${slotId}
-      AND b.status IN (${activeBookingStatusesForSlotSql()})
-      AND ba.status IN ('held', 'confirmed', 'fulfilled')
+      AND b.status IN (${activeBookingStatusesSql()})
+      AND ba.status IN (${activeBookingAllocationStatusesSql()})
     LIMIT 1
   `,
   )
@@ -536,8 +579,8 @@ async function assertSharingGroupBelongsToSlot(db: SqlExecutor, slotId: string, 
     JOIN bookings b ON b.id = bt.booking_id
     WHERE btd.sharing_group_id = ${groupId}
       AND ba.availability_slot_id = ${slotId}
-      AND b.status IN (${activeBookingStatusesForSlotSql()})
-      AND ba.status IN ('held', 'confirmed', 'fulfilled')
+      AND b.status IN (${activeBookingStatusesSql()})
+      AND ba.status IN (${activeBookingAllocationStatusesSql()})
     LIMIT 1
   `,
   )

--- a/packages/operations/src/availability/service-departure-capacity.ts
+++ b/packages/operations/src/availability/service-departure-capacity.ts
@@ -31,8 +31,7 @@
  * worse than one that matches the manifest.
  */
 
-import { availabilitySlots } from "@voyant-travel/availability/schema"
-import { eq, sql } from "drizzle-orm"
+import { sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import { activeBookingAllocationStatusesSql, activeBookingStatusesSql } from "./booking-statuses.js"
@@ -41,6 +40,7 @@ import {
   type SlotResourceAvailability,
 } from "./service-allocation-resource-capacity.js"
 import { executeRows } from "./service-allocation-sql.js"
+import { getSlotById } from "./service-core.js"
 import { countSlotHolds, type SlotHoldCounts } from "./service-holds.js"
 
 /** Allocation rows split by what they still do to the slot's inventory. */
@@ -179,16 +179,7 @@ export async function getDepartureCapacityCounters(
   slotId: string,
   now: Date = new Date(),
 ): Promise<DepartureCapacityCounters | null> {
-  const [slot] = await db
-    .select({
-      id: availabilitySlots.id,
-      unlimited: availabilitySlots.unlimited,
-      initialPax: availabilitySlots.initialPax,
-      remainingPax: availabilitySlots.remainingPax,
-    })
-    .from(availabilitySlots)
-    .where(eq(availabilitySlots.id, slotId))
-    .limit(1)
+  const slot = await getSlotById(db, slotId)
 
   if (!slot) return null
 

--- a/packages/operations/src/availability/service-departure-capacity.ts
+++ b/packages/operations/src/availability/service-departure-capacity.ts
@@ -1,0 +1,401 @@
+/**
+ * Per-departure capacity census.
+ *
+ * An operated Departure is an `availability_slots` row bound to an immutable
+ * Product Version. Everything that consumes its capacity is written somewhere
+ * else — `availability_holds` while a cart is open, `booking_allocations` once
+ * a booking exists, `booking_travelers` once names are entered, and
+ * `allocation_resources` once the operator has laid out rooms or seats. The
+ * slot itself carries only two write-once-ish counters (`initial_pax`,
+ * `remaining_pax`) that nothing recomputes.
+ *
+ * This module counts all of it in one place so the workspace can put the
+ * stored counter next to the derived one and let the operator see when they
+ * disagree, rather than silently trusting either. Nothing here writes: a
+ * disagreement is reported (see `service-departure-issues.ts`), never
+ * repaired.
+ *
+ * Join path: `booking_allocations.availability_slot_id` is the canonical
+ * slot↔booking edge for the workspace. See
+ * `docs/architecture/operated-departure-logistics.md` for why, and for the two
+ * other edges that coexist in the codebase.
+ *
+ * Known attribution limit: `bookings.pax` and `booking_travelers` are
+ * booking-level, not departure-level. A single booking that touches two
+ * departures contributes its whole pax count and its whole traveler list to
+ * both. This matches how the existing allocation manifest already counts, so
+ * the workspace's counters and its rows agree; splitting a booking across
+ * departures needs a per-allocation pax figure, which
+ * `booking_allocations.quantity` could carry but nothing currently populates
+ * consistently. Not silently corrected here — a counter that guessed would be
+ * worse than one that matches the manifest.
+ */
+
+import { availabilitySlots } from "@voyant-travel/availability/schema"
+import { eq, sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import { activeBookingAllocationStatusesSql, activeBookingStatusesSql } from "./booking-statuses.js"
+import {
+  getSlotResourceAvailability,
+  type SlotResourceAvailability,
+} from "./service-allocation-resource-capacity.js"
+import { executeRows } from "./service-allocation-sql.js"
+import { countSlotHolds, type SlotHoldCounts } from "./service-holds.js"
+
+/** Allocation rows split by what they still do to the slot's inventory. */
+export interface DepartureAllocationCounters {
+  /** `status = 'held'` — a claim that has not been confirmed yet. */
+  held: number
+  /** `status = 'confirmed'`. */
+  confirmed: number
+  /** `status = 'fulfilled'` — the departure ran and this booking travelled. */
+  fulfilled: number
+  /**
+   * `status = 'held'` whose `hold_expires_at` has passed. These still count as
+   * consumption everywhere in the read model, which is exactly the problem:
+   * the seat is neither sellable nor sold. Detection only — releasing them is
+   * issue #4067's job.
+   */
+  staleHeld: number
+  /** `status = 'released'`. */
+  released: number
+  /** `status = 'expired'`. */
+  expired: number
+  /** `status = 'cancelled'`. */
+  cancelled: number
+  /** held + confirmed + fulfilled — the rows that still consume capacity. */
+  active: number
+  /** released + expired + cancelled — the rows that gave the seat back. */
+  inactive: number
+}
+
+export interface DepartureBookingCounters {
+  /** Bookings with a live allocation on this slot and a live booking status. */
+  active: number
+  /**
+   * Bookings whose allocation still points at this slot while the booking
+   * itself is cancelled. Every read model filters these out, so they are
+   * invisible until something counts them.
+   */
+  cancelledWithLiveAllocation: number
+  /** `Σ bookings.pax` over the active bookings — what was sold. */
+  expectedPax: number
+  /** Active booking count broken down by `bookings.status`. */
+  byStatus: Record<string, number>
+}
+
+export interface DepartureTravelerCounters {
+  /** `booking_travelers` rows entered against the active bookings. */
+  entered: number
+  /** Of those, how many are flagged as their booking's lead traveler. */
+  lead: number
+  /** Of those, how many hold at least one resource assignment. */
+  assigned: number
+  /** `entered - assigned`. */
+  unassigned: number
+  /**
+   * `expectedPax - entered`. Positive means names are still missing; negative
+   * means more travelers were entered than were sold.
+   */
+  missing: number
+}
+
+export interface DepartureResourceCounters {
+  /** Every `allocation_resources` row on the slot, parents included. */
+  total: number
+  /**
+   * Resources that actually seat a traveler — a `vehicle` whose
+   * `vehicle_seat` children are also rows would otherwise be counted twice.
+   */
+  seating: number
+  /** Σ capacity over the seating resources. */
+  capacity: number
+  /** Σ distinct assigned travelers over the seating resources. */
+  assigned: number
+  /** Σ remaining headroom over the seating resources. */
+  available: number
+  /** Seating resources whose assigned count exceeds their capacity. */
+  overCapacity: number
+}
+
+export interface DepartureCapacityCounters {
+  slotId: string
+  unlimited: boolean
+  /** `availability_slots.initial_pax` — the authored capacity. */
+  initialPax: number | null
+  /**
+   * The capacity the departure can actually seat: `initialPax`, lowered to the
+   * seating resources' total capacity when the operator has laid out fewer
+   * beds/seats than they authored pax. `null` when the slot is unlimited or
+   * has no authored capacity and no resources.
+   */
+  effectivePax: number | null
+  /** `availability_slots.remaining_pax` — the stored counter, as persisted. */
+  remainingPax: number | null
+  /**
+   * `initialPax` less what the other tables say is consumed (sold pax plus
+   * live hold pax). `null` when there is nothing to subtract from. Compared
+   * against `remainingPax` to detect counter drift.
+   */
+  derivedRemainingPax: number | null
+  /** `expectedPax` + live hold pax — what the derived remaining subtracts. */
+  derivedConsumedPax: number
+  holds: SlotHoldCounts
+  allocations: DepartureAllocationCounters
+  bookings: DepartureBookingCounters
+  travelers: DepartureTravelerCounters
+  resources: DepartureResourceCounters
+  /** The per-resource rows the resource counters roll up, in render order. */
+  resourceBreakdown: SlotResourceAvailability[]
+}
+
+interface AllocationStatusRow {
+  status: string
+  allocation_count: number
+  stale_held_count: number
+}
+
+interface BookingStatusRow {
+  status: string
+  booking_count: number
+  pax: number
+}
+
+interface TravelerCountRow {
+  entered: number
+  lead: number
+  assigned: number
+}
+
+/**
+ * Count everything that bears on one departure's capacity.
+ *
+ * Returns `null` when the slot does not exist, matching the other per-slot
+ * read models in this package.
+ */
+export async function getDepartureCapacityCounters(
+  db: PostgresJsDatabase,
+  slotId: string,
+  now: Date = new Date(),
+): Promise<DepartureCapacityCounters | null> {
+  const [slot] = await db
+    .select({
+      id: availabilitySlots.id,
+      unlimited: availabilitySlots.unlimited,
+      initialPax: availabilitySlots.initialPax,
+      remainingPax: availabilitySlots.remainingPax,
+    })
+    .from(availabilitySlots)
+    .where(eq(availabilitySlots.id, slotId))
+    .limit(1)
+
+  if (!slot) return null
+
+  const [allocationRows, bookingRows, travelerRows, holds, resourceBreakdown] = await Promise.all([
+    loadAllocationStatusRows(db, slotId, now),
+    loadBookingStatusRows(db, slotId),
+    loadTravelerCounts(db, slotId),
+    countSlotHolds(db, slotId, now),
+    getSlotResourceAvailability(db, slotId),
+  ])
+
+  const allocations = rollUpAllocations(allocationRows)
+  const bookings = rollUpBookings(bookingRows)
+  const travelers = rollUpTravelers(travelerRows[0], bookings.expectedPax)
+  const resources = rollUpResources(resourceBreakdown)
+
+  const derivedConsumedPax = bookings.expectedPax + holds.activePax
+  const initialPax = slot.initialPax ?? null
+
+  return {
+    slotId: slot.id,
+    unlimited: slot.unlimited,
+    initialPax,
+    effectivePax: deriveEffectivePax(slot.unlimited, initialPax, resources),
+    remainingPax: slot.remainingPax ?? null,
+    derivedRemainingPax:
+      slot.unlimited || initialPax === null ? null : initialPax - derivedConsumedPax,
+    derivedConsumedPax,
+    holds,
+    allocations,
+    bookings,
+    travelers,
+    resources,
+    resourceBreakdown,
+  }
+}
+
+function deriveEffectivePax(
+  unlimited: boolean,
+  initialPax: number | null,
+  resources: DepartureResourceCounters,
+): number | null {
+  if (unlimited) return null
+  if (resources.seating === 0) return initialPax
+  if (initialPax === null) return resources.capacity
+  return Math.min(initialPax, resources.capacity)
+}
+
+async function loadAllocationStatusRows(
+  db: PostgresJsDatabase,
+  slotId: string,
+  now: Date,
+): Promise<AllocationStatusRow[]> {
+  return executeRows<AllocationStatusRow>(
+    db,
+    sql`
+      SELECT
+        ba.status,
+        COUNT(*)::int AS allocation_count,
+        COUNT(*) FILTER (
+          WHERE ba.status = 'held'
+            AND ba.hold_expires_at IS NOT NULL
+            AND ba.hold_expires_at < ${now.toISOString()}::timestamptz
+        )::int AS stale_held_count
+      FROM booking_allocations ba
+      WHERE ba.availability_slot_id = ${slotId}
+      GROUP BY ba.status
+    `,
+  )
+}
+
+/**
+ * Bookings reachable from this slot through a *live* allocation, grouped by
+ * booking status. Deliberately unfiltered on `bookings.status` so a cancelled
+ * booking still holding an allocation shows up instead of vanishing.
+ *
+ * `EXISTS` rather than a join so a booking with two allocations on the same
+ * slot cannot double its `pax` into the sum.
+ */
+async function loadBookingStatusRows(
+  db: PostgresJsDatabase,
+  slotId: string,
+): Promise<BookingStatusRow[]> {
+  return executeRows<BookingStatusRow>(
+    db,
+    sql`
+      SELECT
+        b.status,
+        COUNT(*)::int AS booking_count,
+        COALESCE(SUM(b.pax), 0)::int AS pax
+      FROM bookings b
+      WHERE EXISTS (
+        SELECT 1
+        FROM booking_allocations ba
+        WHERE ba.booking_id = b.id
+          AND ba.availability_slot_id = ${slotId}
+          AND ba.status IN (${activeBookingAllocationStatusesSql()})
+      )
+      GROUP BY b.status
+    `,
+  )
+}
+
+/**
+ * Traveler records entered against the departure's live bookings, and how many
+ * of them hold a resource assignment. Not filtered by `participant_type` so
+ * this stays the same population `getSlotAllocationManifest` renders.
+ */
+async function loadTravelerCounts(
+  db: PostgresJsDatabase,
+  slotId: string,
+): Promise<TravelerCountRow[]> {
+  return executeRows<TravelerCountRow>(
+    db,
+    sql`
+      SELECT
+        COUNT(*)::int AS entered,
+        COUNT(*) FILTER (WHERE btd.is_lead_traveler)::int AS lead,
+        COUNT(*) FILTER (
+          WHERE btd.allocations IS NOT NULL AND btd.allocations <> '{}'::jsonb
+        )::int AS assigned
+      FROM booking_travelers bt
+      JOIN bookings b ON b.id = bt.booking_id
+      LEFT JOIN booking_traveler_travel_details btd ON btd.traveler_id = bt.id
+      WHERE b.status IN (${activeBookingStatusesSql()})
+        AND EXISTS (
+          SELECT 1
+          FROM booking_allocations ba
+          WHERE ba.booking_id = b.id
+            AND ba.availability_slot_id = ${slotId}
+            AND ba.status IN (${activeBookingAllocationStatusesSql()})
+        )
+    `,
+  )
+}
+
+function rollUpAllocations(rows: readonly AllocationStatusRow[]): DepartureAllocationCounters {
+  const byStatus = new Map(rows.map((row) => [row.status, row.allocation_count]))
+  const count = (status: string) => byStatus.get(status) ?? 0
+  const held = count("held")
+  const confirmed = count("confirmed")
+  const fulfilled = count("fulfilled")
+  const released = count("released")
+  const expired = count("expired")
+  const cancelled = count("cancelled")
+
+  return {
+    held,
+    confirmed,
+    fulfilled,
+    staleHeld: rows.reduce((total, row) => total + row.stale_held_count, 0),
+    released,
+    expired,
+    cancelled,
+    active: held + confirmed + fulfilled,
+    inactive: released + expired + cancelled,
+  }
+}
+
+function rollUpBookings(rows: readonly BookingStatusRow[]): DepartureBookingCounters {
+  const byStatus: Record<string, number> = {}
+  let active = 0
+  let expectedPax = 0
+  let cancelledWithLiveAllocation = 0
+
+  for (const row of rows) {
+    if (row.status === "cancelled") {
+      cancelledWithLiveAllocation += row.booking_count
+      continue
+    }
+    byStatus[row.status] = (byStatus[row.status] ?? 0) + row.booking_count
+    active += row.booking_count
+    expectedPax += row.pax
+  }
+
+  return { active, cancelledWithLiveAllocation, expectedPax, byStatus }
+}
+
+function rollUpTravelers(
+  row: TravelerCountRow | undefined,
+  expectedPax: number,
+): DepartureTravelerCounters {
+  const entered = row?.entered ?? 0
+  const assigned = row?.assigned ?? 0
+  return {
+    entered,
+    lead: row?.lead ?? 0,
+    assigned,
+    unassigned: Math.max(0, entered - assigned),
+    missing: expectedPax - entered,
+  }
+}
+
+function rollUpResources(
+  breakdown: readonly SlotResourceAvailability[],
+): DepartureResourceCounters {
+  const parentIds = new Set(
+    breakdown.flatMap((resource) => (resource.parentId ? [resource.parentId] : [])),
+  )
+  const seating = breakdown.filter((resource) => !parentIds.has(resource.id))
+
+  return {
+    total: breakdown.length,
+    seating: seating.length,
+    capacity: seating.reduce((sum, resource) => sum + resource.capacity, 0),
+    assigned: seating.reduce((sum, resource) => sum + resource.assigned, 0),
+    available: seating.reduce((sum, resource) => sum + resource.available, 0),
+    overCapacity: seating.filter((resource) => resource.assigned > resource.capacity).length,
+  }
+}

--- a/packages/operations/src/availability/service-departure-issues.ts
+++ b/packages/operations/src/availability/service-departure-issues.ts
@@ -1,0 +1,355 @@
+/**
+ * Departure attention issues — the typed vocabulary for "something about this
+ * departure disagrees with itself".
+ *
+ * Modelled on `@voyant-travel/inventory`'s product readiness evaluator: the
+ * rules are pure over facts a loader has already gathered, so they stay cheap
+ * to unit-test and identical across every transport, and every issue carries a
+ * **stable machine code** the UI translates. Never rename a code — the
+ * operator UI, the Tool transport, and anything that stores an issue key off
+ * these. Add a new code instead.
+ *
+ * Two severities:
+ *
+ *   - `critical` — the departure's capacity is wrong in a way that lets it
+ *     oversell or physically overfill. Someone has to intervene before it
+ *     runs.
+ *   - `warning` — the departure will operate, but a reconciliation the
+ *     operator owns is outstanding (names missing, seats unassigned, a stale
+ *     hold nobody released).
+ *
+ * Deliberately no `href`. Navigation is the UI's, and the same issue is
+ * rendered from three different places in the workspace.
+ *
+ * Detection only. Nothing here repairs anything — in particular, stale
+ * `booking_allocations` are reported, never released; that is issue #4067's
+ * territory.
+ */
+
+import { sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import { activeBookingAllocationStatusesSql } from "./booking-statuses.js"
+import { executeRows } from "./service-allocation-sql.js"
+import {
+  type DepartureCapacityCounters,
+  getDepartureCapacityCounters,
+} from "./service-departure-capacity.js"
+
+export type DepartureIssueSeverity = "critical" | "warning"
+
+/**
+ * Stable departure issue codes. Never rename one; add a new code instead.
+ */
+export type DepartureIssueCode =
+  /** `booking_allocations` still `held` whose `hold_expires_at` has passed. */
+  | "stale_held_allocation"
+  /** A live allocation on this slot whose booking is cancelled. */
+  | "allocation_on_cancelled_booking"
+  /** `availability_holds` past `expires_at` that were never released. */
+  | "expired_hold_not_released"
+  /** Fewer traveler records entered than `Σ bookings.pax`. */
+  | "travelers_missing_for_booked_pax"
+  /** More traveler records entered than `Σ bookings.pax`. */
+  | "travelers_exceed_booked_pax"
+  /** Stored `remaining_pax` disagrees with derived consumption. */
+  | "remaining_pax_drift"
+  /** Derived consumption exceeds the authored capacity. */
+  | "capacity_oversold"
+  /** A resource holds more travelers than its capacity. */
+  | "resource_over_capacity"
+  /** Travelers with no resource assignment on a departure that has resources. */
+  | "travelers_unassigned"
+  /** Travelers to seat, but no `allocation_resources` laid out. */
+  | "allocation_resources_missing"
+  /** The slot was never bound to an immutable Product Version. */
+  | "departure_not_version_bound"
+
+export type DepartureIssueSubjectType =
+  | "departure"
+  | "booking"
+  | "booking_allocation"
+  | "availability_hold"
+  | "allocation_resource"
+
+export interface DepartureIssue {
+  code: DepartureIssueCode
+  severity: DepartureIssueSeverity
+  subjectType: DepartureIssueSubjectType
+  /** Id of the row the issue is about; the slot id for departure-level issues. */
+  subjectId: string
+  /** How many rows of `subjectType` this issue covers. */
+  count: number
+  /** English fallback for consumers with no message catalogue. */
+  message: string
+}
+
+/** How many individually-identified subjects one code will name before it rolls up. */
+const SUBJECT_SAMPLE_LIMIT = 50
+
+/** The facts the evaluator needs. Assembled by `loadDepartureIssueSubjects`. */
+export interface DepartureIssueInput {
+  slotId: string
+  /** `availability_slots.product_version_id`; null on legacy or never-published rows. */
+  productVersionId: string | null
+  counters: DepartureCapacityCounters
+  /** Ids of `held` allocations past `hold_expires_at`, capped for boundedness. */
+  staleHeldAllocationIds: readonly string[]
+  /** Ids of cancelled bookings still holding a live allocation, capped. */
+  cancelledBookingIds: readonly string[]
+}
+
+/**
+ * Evaluate every rule against already-loaded facts. Pure: same facts in, same
+ * issues out, in a stable order (critical first, then code order).
+ */
+export function evaluateDepartureIssues(input: DepartureIssueInput): DepartureIssue[] {
+  const { counters } = input
+  const issues: DepartureIssue[] = []
+
+  const departureIssue = (
+    code: DepartureIssueCode,
+    severity: DepartureIssueSeverity,
+    count: number,
+    message: string,
+  ) => {
+    issues.push({
+      code,
+      severity,
+      subjectType: "departure",
+      subjectId: input.slotId,
+      count,
+      message,
+    })
+  }
+
+  for (const allocationId of input.staleHeldAllocationIds) {
+    issues.push({
+      code: "stale_held_allocation",
+      severity: "warning",
+      subjectType: "booking_allocation",
+      subjectId: allocationId,
+      count: 1,
+      message: "Allocation is still held past its hold expiry and is holding a seat nobody owns.",
+    })
+  }
+  // The sample is capped; report whatever it did not name as one rolled-up row
+  // so a departure with hundreds of stale holds still returns a bounded body.
+  const unnamedStale = counters.allocations.staleHeld - input.staleHeldAllocationIds.length
+  if (unnamedStale > 0) {
+    departureIssue(
+      "stale_held_allocation",
+      "warning",
+      unnamedStale,
+      "Further allocations are still held past their hold expiry.",
+    )
+  }
+
+  for (const bookingId of input.cancelledBookingIds) {
+    issues.push({
+      code: "allocation_on_cancelled_booking",
+      severity: "warning",
+      subjectType: "booking",
+      subjectId: bookingId,
+      count: 1,
+      message: "Booking is cancelled but still holds a live allocation on this departure.",
+    })
+  }
+  const unnamedCancelled =
+    counters.bookings.cancelledWithLiveAllocation - input.cancelledBookingIds.length
+  if (unnamedCancelled > 0) {
+    departureIssue(
+      "allocation_on_cancelled_booking",
+      "warning",
+      unnamedCancelled,
+      "Further cancelled bookings still hold a live allocation on this departure.",
+    )
+  }
+
+  if (counters.holds.expired > 0) {
+    departureIssue(
+      "expired_hold_not_released",
+      "warning",
+      counters.holds.expired,
+      "Checkout holds have expired without being released, so their pax are still deducted.",
+    )
+  }
+
+  if (counters.travelers.missing > 0) {
+    departureIssue(
+      "travelers_missing_for_booked_pax",
+      "warning",
+      counters.travelers.missing,
+      "Fewer traveler records have been entered than the bookings sold pax for.",
+    )
+  } else if (counters.travelers.missing < 0) {
+    departureIssue(
+      "travelers_exceed_booked_pax",
+      "warning",
+      -counters.travelers.missing,
+      "More traveler records have been entered than the bookings sold pax for.",
+    )
+  }
+
+  if (
+    counters.remainingPax !== null &&
+    counters.derivedRemainingPax !== null &&
+    counters.remainingPax !== counters.derivedRemainingPax
+  ) {
+    departureIssue(
+      "remaining_pax_drift",
+      "warning",
+      Math.abs(counters.remainingPax - counters.derivedRemainingPax),
+      "The stored remaining-pax counter disagrees with what the bookings and holds consume.",
+    )
+  }
+
+  if (counters.derivedRemainingPax !== null && counters.derivedRemainingPax < 0) {
+    departureIssue(
+      "capacity_oversold",
+      "critical",
+      -counters.derivedRemainingPax,
+      "Bookings and live holds consume more pax than the departure's authored capacity.",
+    )
+  }
+
+  for (const resource of counters.resourceBreakdown) {
+    if (resource.assigned <= resource.capacity) continue
+    issues.push({
+      code: "resource_over_capacity",
+      severity: "critical",
+      subjectType: "allocation_resource",
+      subjectId: resource.id,
+      count: resource.assigned - resource.capacity,
+      message: "More travelers are assigned to this resource than it can hold.",
+    })
+  }
+
+  if (counters.resources.seating === 0 && counters.travelers.entered > 0) {
+    departureIssue(
+      "allocation_resources_missing",
+      "warning",
+      counters.travelers.entered,
+      "Travelers are booked on this departure but no rooms or seats have been laid out.",
+    )
+  } else if (counters.travelers.unassigned > 0) {
+    departureIssue(
+      "travelers_unassigned",
+      "warning",
+      counters.travelers.unassigned,
+      "Travelers on this departure have not been assigned to a room or seat.",
+    )
+  }
+
+  if (!input.productVersionId) {
+    departureIssue(
+      "departure_not_version_bound",
+      "warning",
+      1,
+      "This departure is not bound to a published Product Version, so what it sells can drift.",
+    )
+  }
+
+  return issues.sort(
+    (a, b) =>
+      severityRank(a.severity) - severityRank(b.severity) ||
+      a.code.localeCompare(b.code) ||
+      a.subjectId.localeCompare(b.subjectId),
+  )
+}
+
+function severityRank(severity: DepartureIssueSeverity): number {
+  return severity === "critical" ? 0 : 1
+}
+
+interface DepartureIssueSubjects {
+  staleHeldAllocationIds: string[]
+  cancelledBookingIds: string[]
+}
+
+/**
+ * Load the individually-identified subjects the evaluator names. Both queries
+ * are capped so the issue list stays bounded no matter how badly a departure
+ * has drifted; the counters carry the true totals.
+ */
+export async function loadDepartureIssueSubjects(
+  db: PostgresJsDatabase,
+  slotId: string,
+  now: Date = new Date(),
+): Promise<DepartureIssueSubjects> {
+  const [staleRows, cancelledRows] = await Promise.all([
+    executeRows<{ id: string }>(
+      db,
+      sql`
+        SELECT ba.id
+        FROM booking_allocations ba
+        WHERE ba.availability_slot_id = ${slotId}
+          AND ba.status = 'held'
+          AND ba.hold_expires_at IS NOT NULL
+          AND ba.hold_expires_at < ${now.toISOString()}::timestamptz
+        ORDER BY ba.hold_expires_at
+        LIMIT ${SUBJECT_SAMPLE_LIMIT}
+      `,
+    ),
+    executeRows<{ id: string }>(
+      db,
+      sql`
+        SELECT DISTINCT b.id
+        FROM bookings b
+        JOIN booking_allocations ba ON ba.booking_id = b.id
+        WHERE ba.availability_slot_id = ${slotId}
+          AND ba.status IN (${activeBookingAllocationStatusesSql()})
+          AND b.status = 'cancelled'
+        ORDER BY b.id
+        LIMIT ${SUBJECT_SAMPLE_LIMIT}
+      `,
+    ),
+  ])
+
+  return {
+    staleHeldAllocationIds: staleRows.map((row) => row.id),
+    cancelledBookingIds: cancelledRows.map((row) => row.id),
+  }
+}
+
+/**
+ * Convenience loader + evaluator for callers that hold nothing yet. Returns
+ * `null` when the slot does not exist.
+ */
+export async function getDepartureIssues(
+  db: PostgresJsDatabase,
+  slotId: string,
+  options: {
+    now?: Date
+    counters?: DepartureCapacityCounters
+    productVersionId?: string | null
+  } = {},
+): Promise<DepartureIssue[] | null> {
+  const now = options.now ?? new Date()
+  const counters = options.counters ?? (await getDepartureCapacityCounters(db, slotId, now))
+  if (!counters) return null
+
+  const productVersionId =
+    options.productVersionId !== undefined
+      ? options.productVersionId
+      : await loadProductVersionId(db, slotId)
+  const subjects = await loadDepartureIssueSubjects(db, slotId, now)
+
+  return evaluateDepartureIssues({ slotId, productVersionId, counters, ...subjects })
+}
+
+async function loadProductVersionId(
+  db: PostgresJsDatabase,
+  slotId: string,
+): Promise<string | null> {
+  const rows = await executeRows<{ product_version_id: string | null }>(
+    db,
+    sql`
+      SELECT product_version_id
+      FROM availability_slots
+      WHERE id = ${slotId}
+      LIMIT 1
+    `,
+  )
+  return rows[0]?.product_version_id ?? null
+}

--- a/packages/operations/src/availability/service-departure-summary.ts
+++ b/packages/operations/src/availability/service-departure-summary.ts
@@ -1,0 +1,328 @@
+/**
+ * The one bounded envelope for an operated Departure.
+ *
+ * A departure is currently reconstructed by an operator from four screens that
+ * each hold a slice of it: the slot row for capacity, the allocation manifest
+ * for who is coming, the extras manifest for what they bought, and Finance for
+ * whether it made money. Nothing puts the four next to each other, so nothing
+ * notices when they disagree.
+ *
+ * This module **composes** those existing truths and computes none of them:
+ *
+ *   - capacity, holds, allocations and traveler completeness come from
+ *     `service-departure-capacity.ts`
+ *   - attention issues come from `service-departure-issues.ts`
+ *   - settlement comes from `derivePaidAmountCents`, the same helper the
+ *     allocation chips colour themselves with
+ *   - money comes from Finance's `getDepartureProfitability` across the
+ *     optional runtime port — Operations never recomputes revenue or cost
+ *   - the extras rollup comes from Bookings' own slot extras manifest
+ *
+ * Bounded on purpose. Every field here is a scalar, a small record, or a
+ * capped list, so paging the manifest (see `getSlotAllocationManifest`) can
+ * never change a headline number: the counters are computed by aggregate over
+ * the whole departure, not by counting what a page happened to return.
+ */
+
+import { type AvailabilitySlot, availabilitySlots } from "@voyant-travel/availability/schema"
+import type {
+  FinanceDepartureProfitabilityReport,
+  FinanceDepartureProfitabilityRow,
+} from "@voyant-travel/finance-contracts/runtime-port"
+import { eq } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import { readDepartureProfitabilityReport } from "./departure-profitability-runtime.js"
+import {
+  type BookingRow,
+  derivePaidAmountCents,
+  loadSlotBookingRows,
+} from "./service-allocation-manifest-queries.js"
+import {
+  type DepartureCapacityCounters,
+  getDepartureCapacityCounters,
+} from "./service-departure-capacity.js"
+import {
+  type DepartureIssue,
+  evaluateDepartureIssues,
+  loadDepartureIssueSubjects,
+} from "./service-departure-issues.js"
+
+/** Slot + Product Version identity — what this departure *is*. */
+export interface DepartureIdentity {
+  id: string
+  productId: string
+  /**
+   * The immutable Product Version this departure was materialized from. Null
+   * on legacy rows and on products that were never published (#4032).
+   */
+  productVersionId: string | null
+  itineraryId: string | null
+  optionId: string | null
+  facilityId: string | null
+  status: AvailabilitySlot["status"]
+  dateLocal: string
+  startsAt: string
+  endsAt: string | null
+  timezone: string
+  notes: string | null
+}
+
+export interface DepartureBookingQuantities {
+  /** Bookings with a live allocation and a live booking status. */
+  count: number
+  byStatus: Record<string, number>
+  /** `Σ bookings.pax` — what was sold. */
+  expectedPax: number
+  /**
+   * Currency the sell/settlement totals are quoted in, or `null` when the
+   * departure's bookings disagree. Amounts are never summed across currencies.
+   */
+  currency: string | null
+  /** `Σ sell_amount_cents`, or `null` when the currency is mixed. */
+  soldAmountCents: number | null
+  /** `Σ derivePaidAmountCents(booking)`, or `null` when the currency is mixed. */
+  paidAmountCents: number | null
+  /** `soldAmountCents - paidAmountCents`, or `null` when the currency is mixed. */
+  outstandingAmountCents: number | null
+}
+
+export interface DepartureExtrasRollup {
+  /** Extras offered on this departure's product. */
+  offered: number
+  /** Extras at least one traveler selected. */
+  withSelections: number
+  /** Σ selected travelers across all extras (one traveler can appear twice). */
+  selectedTravelerCount: number
+  /** Σ units the guide has to carry. */
+  totalQuantity: number
+  /** Σ selections still awaiting on-trip collection. */
+  outstandingCollectionCount: number
+  /** Extras where every selected traveler is marked fulfilled. */
+  fulfilledExtraCount: number
+}
+
+/** One currency's P&L line, exactly as Finance reported it. */
+export interface DepartureFinanceLine {
+  currency: string
+  revenueCents: number
+  actualCostCents: number
+  plannedCostCents: number
+  profitCents: number
+  marginPercent: number | null
+  varianceCents: number
+}
+
+export interface DepartureFinanceHeadline {
+  /** Per-currency lines. Never summed across currencies. */
+  perCurrency: DepartureFinanceLine[]
+  /** Finance's single-currency rollup in the operator's accounting base. */
+  base: DepartureFinanceLine | null
+  /** Source currencies Finance could not convert into the base rollup. */
+  unconvertibleCurrencies: string[]
+}
+
+export interface DepartureOperationsReadiness {
+  issues: DepartureIssue[]
+  criticalCount: number
+  warningCount: number
+  /** True when nothing needs the operator's attention. */
+  clear: boolean
+}
+
+export interface DepartureSummary {
+  departure: DepartureIdentity
+  capacity: DepartureCapacityCounters
+  bookings: DepartureBookingQuantities
+  travelers: DepartureCapacityCounters["travelers"]
+  allocation: DepartureCapacityCounters["resources"]
+  operations: DepartureOperationsReadiness
+  /** `null` when the Extras module is not deployed or the read failed. */
+  extras: DepartureExtrasRollup | null
+  /** `null` when no Finance provider is bound in this deployment. */
+  finance: DepartureFinanceHeadline | null
+}
+
+export interface GetDepartureSummaryOptions {
+  /** Evaluation instant; injectable so a suite can age a hold deterministically. */
+  now?: Date
+}
+
+/**
+ * Compose one departure's summary. Returns `null` when the slot does not
+ * exist, matching the other per-slot read models in this package.
+ */
+export async function getDepartureSummary(
+  db: PostgresJsDatabase,
+  slotId: string,
+  options: GetDepartureSummaryOptions = {},
+): Promise<DepartureSummary | null> {
+  const now = options.now ?? new Date()
+
+  const [slot] = await db
+    .select()
+    .from(availabilitySlots)
+    .where(eq(availabilitySlots.id, slotId))
+    .limit(1)
+
+  if (!slot) return null
+
+  const counters = await getDepartureCapacityCounters(db, slotId, now)
+  if (!counters) return null
+
+  const [subjects, bookingRows, extras, profitability] = await Promise.all([
+    loadDepartureIssueSubjects(db, slotId, now),
+    loadSlotBookingRows(db, slotId),
+    loadExtrasRollup(db, slotId),
+    readDepartureProfitabilityReport(db, { departureId: slotId }),
+  ])
+
+  const issues = evaluateDepartureIssues({
+    slotId,
+    productVersionId: slot.productVersionId,
+    counters,
+    ...subjects,
+  })
+
+  return {
+    departure: {
+      id: slot.id,
+      productId: slot.productId,
+      productVersionId: slot.productVersionId,
+      itineraryId: slot.itineraryId,
+      optionId: slot.optionId,
+      facilityId: slot.facilityId,
+      status: slot.status,
+      dateLocal: slot.dateLocal,
+      startsAt: slot.startsAt.toISOString(),
+      endsAt: slot.endsAt ? slot.endsAt.toISOString() : null,
+      timezone: slot.timezone,
+      notes: slot.notes,
+    },
+    capacity: counters,
+    bookings: rollUpBookingQuantities(counters, bookingRows),
+    travelers: counters.travelers,
+    allocation: counters.resources,
+    operations: {
+      issues,
+      criticalCount: issues.filter((issue) => issue.severity === "critical").length,
+      warningCount: issues.filter((issue) => issue.severity === "warning").length,
+      clear: issues.length === 0,
+    },
+    extras,
+    finance: profitability ? rollUpFinance(slotId, profitability) : null,
+  }
+}
+
+/**
+ * Booking money for the departure. Uses `derivePaidAmountCents` — the same
+ * settlement rule the allocation chips colour themselves with — rather than
+ * inventing a second answer to "how much has this booking actually paid".
+ *
+ * Totals collapse to `null` the moment the departure's bookings disagree on
+ * currency, because there is no honest single number to show; the per-booking
+ * rows in the manifest still carry their own.
+ */
+function rollUpBookingQuantities(
+  counters: DepartureCapacityCounters,
+  bookingRows: readonly BookingRow[],
+): DepartureBookingQuantities {
+  const currencies = new Set(
+    bookingRows.flatMap((row) => (row.sell_currency ? [row.sell_currency] : [])),
+  )
+  const currency = currencies.size === 1 ? ([...currencies][0] ?? null) : null
+
+  if (!currency) {
+    return {
+      count: counters.bookings.active,
+      byStatus: counters.bookings.byStatus,
+      expectedPax: counters.bookings.expectedPax,
+      currency: null,
+      soldAmountCents: null,
+      paidAmountCents: null,
+      outstandingAmountCents: null,
+    }
+  }
+
+  const soldAmountCents = bookingRows.reduce((sum, row) => sum + (row.sell_amount_cents ?? 0), 0)
+  const paidAmountCents = bookingRows.reduce((sum, row) => sum + derivePaidAmountCents(row), 0)
+
+  return {
+    count: counters.bookings.active,
+    byStatus: counters.bookings.byStatus,
+    expectedPax: counters.bookings.expectedPax,
+    currency,
+    soldAmountCents,
+    paidAmountCents,
+    outstandingAmountCents: soldAmountCents - paidAmountCents,
+  }
+}
+
+/**
+ * Reduce Finance's departure report to this departure's lines. Finance already
+ * filtered by `departureId`, but the report is a list shape shared with the
+ * range report, so the id filter is re-applied rather than assumed.
+ */
+function rollUpFinance(
+  slotId: string,
+  report: FinanceDepartureProfitabilityReport,
+): DepartureFinanceHeadline {
+  const toLine = (row: FinanceDepartureProfitabilityRow): DepartureFinanceLine => ({
+    currency: row.currency,
+    revenueCents: row.revenueCents,
+    actualCostCents: row.actualCostCents,
+    plannedCostCents: row.plannedCostCents,
+    profitCents: row.profitCents,
+    marginPercent: row.marginPercent,
+    varianceCents: row.varianceCents,
+  })
+
+  const baseRows = (report.base?.rows ?? []).filter((row) => row.departureId === slotId)
+
+  return {
+    perCurrency: report.rows.filter((row) => row.departureId === slotId).map(toLine),
+    base: baseRows[0] ? toLine(baseRows[0]) : null,
+    unconvertibleCurrencies: report.base?.unconvertibleCurrencies ?? [],
+  }
+}
+
+/**
+ * Extras headline, read from Bookings' own slot extras manifest so the numbers
+ * are the ones the extras screen shows.
+ *
+ * Imported dynamically: `@voyant-travel/bookings/extras` is a module barrel
+ * that also carries the extras route bundle, and a departure summary must not
+ * drag Hono routes into every static import closure that touches this service.
+ * The same `await import` is what lets a deployment without the Extras tables
+ * report `null` instead of failing the whole summary.
+ */
+async function loadExtrasRollup(
+  db: PostgresJsDatabase,
+  slotId: string,
+): Promise<DepartureExtrasRollup | null> {
+  type ExtrasModule = typeof import("@voyant-travel/bookings/extras")
+  let manifest: Awaited<ReturnType<ExtrasModule["bookingsExtrasService"]["getSlotExtraManifest"]>>
+  try {
+    const { bookingsExtrasService } = await import("@voyant-travel/bookings/extras")
+    manifest = await bookingsExtrasService.getSlotExtraManifest(db, slotId)
+  } catch {
+    return null
+  }
+  if (manifest.status !== "ok") return null
+
+  const summaries = manifest.data.summaries
+  return {
+    offered: summaries.length,
+    withSelections: summaries.filter((summary) => summary.selectedTravelerCount > 0).length,
+    selectedTravelerCount: summaries.reduce(
+      (sum, summary) => sum + summary.selectedTravelerCount,
+      0,
+    ),
+    totalQuantity: summaries.reduce((sum, summary) => sum + summary.totalQuantity, 0),
+    outstandingCollectionCount: summaries.reduce(
+      (sum, summary) => sum + summary.outstandingCollectionCount,
+      0,
+    ),
+    fulfilledExtraCount: summaries.filter((summary) => summary.fulfillmentComplete).length,
+  }
+}

--- a/packages/operations/src/availability/service-departure-summary.ts
+++ b/packages/operations/src/availability/service-departure-summary.ts
@@ -24,12 +24,11 @@
  * the whole departure, not by counting what a page happened to return.
  */
 
-import { type AvailabilitySlot, availabilitySlots } from "@voyant-travel/availability/schema"
+import type { AvailabilitySlot } from "@voyant-travel/availability/schema"
 import type {
   FinanceDepartureProfitabilityReport,
   FinanceDepartureProfitabilityRow,
 } from "@voyant-travel/finance-contracts/runtime-port"
-import { eq } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import { readDepartureProfitabilityReport } from "./departure-profitability-runtime.js"
@@ -38,6 +37,7 @@ import {
   derivePaidAmountCents,
   loadSlotBookingRows,
 } from "./service-allocation-manifest-queries.js"
+import { getSlotById } from "./service-core.js"
 import {
   type DepartureCapacityCounters,
   getDepartureCapacityCounters,
@@ -159,11 +159,7 @@ export async function getDepartureSummary(
 ): Promise<DepartureSummary | null> {
   const now = options.now ?? new Date()
 
-  const [slot] = await db
-    .select()
-    .from(availabilitySlots)
-    .where(eq(availabilitySlots.id, slotId))
-    .limit(1)
+  const slot = await getSlotById(db, slotId)
 
   if (!slot) return null
 

--- a/packages/operations/src/availability/service-holds.ts
+++ b/packages/operations/src/availability/service-holds.ts
@@ -381,6 +381,67 @@ export async function earliestOutstandingHoldExpiry(
 }
 
 /**
+ * Per-slot hold census.
+ *
+ * The hold table is otherwise only ever read by token or by draft — the
+ * checkout knows which hold it owns. A departure workspace asks the opposite
+ * question: how much of this slot's `remaining_pax` is currently spoken for by
+ * carts nobody has committed, and how much of it is being held by holds the
+ * reaper should already have released.
+ *
+ * `expired` is deliberately separate from `released`: an expired-but-unreleased
+ * hold is still decremented out of `remaining_pax`, so it is capacity the
+ * operator cannot sell and cannot see. Releasing them is the reaper's job
+ * (#4067); this only counts them.
+ */
+export interface SlotHoldCounts {
+  /** Live holds still inside their TTL. */
+  active: number
+  /** Pax still decremented out of `remaining_pax` by those live holds. */
+  activePax: number
+  /** Past `expires_at`, never released — capacity the reaper still owes back. */
+  expired: number
+  /** Pax held by those expired holds. */
+  expiredPax: number
+  /** Holds the reaper or a cancelled checkout gave back. */
+  released: number
+  /** Holds a completed checkout turned into a booking. */
+  converted: number
+}
+
+export async function countSlotHolds(
+  db: PostgresJsDatabase,
+  slotId: string,
+  now: Date = new Date(),
+): Promise<SlotHoldCounts> {
+  // agent-quality: raw-sql reviewed -- owner: availability; dynamic SQL interpolation uses Drizzle parameter binding or vetted SQL identifiers.
+  const outstanding = sql`${availabilityHolds.releasedAt} is null and ${availabilityHolds.convertedAt} is null`
+  // postgres.js binds a JS `Date` as a raw string parameter and throws
+  // `ERR_INVALID_ARG_TYPE`; hand it an ISO literal with an explicit cast.
+  const nowIso = now.toISOString()
+  const [row] = await db
+    .select({
+      active: sql<number>`count(*) filter (where ${outstanding} and ${availabilityHolds.expiresAt} >= ${nowIso}::timestamptz)::int`,
+      activePax: sql<number>`coalesce(sum(${availabilityHolds.paxCount}) filter (where ${outstanding} and ${availabilityHolds.expiresAt} >= ${nowIso}::timestamptz), 0)::int`,
+      expired: sql<number>`count(*) filter (where ${outstanding} and ${availabilityHolds.expiresAt} < ${nowIso}::timestamptz)::int`,
+      expiredPax: sql<number>`coalesce(sum(${availabilityHolds.paxCount}) filter (where ${outstanding} and ${availabilityHolds.expiresAt} < ${nowIso}::timestamptz), 0)::int`,
+      released: sql<number>`count(*) filter (where ${availabilityHolds.releasedAt} is not null)::int`,
+      converted: sql<number>`count(*) filter (where ${availabilityHolds.convertedAt} is not null)::int`,
+    })
+    .from(availabilityHolds)
+    .where(eq(availabilityHolds.slotId, slotId))
+
+  return {
+    active: row?.active ?? 0,
+    activePax: row?.activePax ?? 0,
+    expired: row?.expired ?? 0,
+    expiredPax: row?.expiredPax ?? 0,
+    released: row?.released ?? 0,
+    converted: row?.converted ?? 0,
+  }
+}
+
+/**
  * Looks up the hold(s) for a draft id. Multiple holds per draft
  * are possible (e.g. a multi-day product touching several slots);
  * the journey reaper releases them all at once.

--- a/packages/operations/src/availability/service-unit-availability.ts
+++ b/packages/operations/src/availability/service-unit-availability.ts
@@ -1,7 +1,7 @@
 import { availabilitySlots } from "@voyant-travel/availability/schema"
 import { and, asc, eq, inArray, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
-import { ACTIVE_BOOKING_STATUSES_FOR_SLOT } from "./booking-statuses.js"
+import { ACTIVE_BOOKING_STATUSES } from "./booking-statuses.js"
 import { bookingItemsRef, bookingsRef } from "./bookings-ref.js"
 import { optionUnitsRef } from "./option-units-ref.js"
 
@@ -53,7 +53,7 @@ export async function getSlotUnitAvailability(
     .innerJoin(bookingsRef, eq(bookingsRef.id, bookingItemsRef.bookingId))
     .where(
       and(
-        inArray(bookingsRef.status, [...ACTIVE_BOOKING_STATUSES_FOR_SLOT]),
+        inArray(bookingsRef.status, [...ACTIVE_BOOKING_STATUSES]),
         // agent-quality: raw-sql reviewed -- owner: availability; dynamic SQL interpolation uses Drizzle parameter binding or vetted SQL identifiers.
         sql`${bookingItemsRef.optionUnitId} IS NOT NULL`,
         // agent-quality: raw-sql reviewed -- owner: availability; dynamic SQL interpolation uses Drizzle parameter binding or vetted SQL identifiers.

--- a/packages/operations/src/availability/service.ts
+++ b/packages/operations/src/availability/service.ts
@@ -21,6 +21,9 @@ import {
   updateCloseout,
   updateSlot,
 } from "./service-core.js"
+import { getDepartureCapacityCounters } from "./service-departure-capacity.js"
+import { getDepartureIssues } from "./service-departure-issues.js"
+import { getDepartureSummary } from "./service-departure-summary.js"
 import { getAvailabilityOverview } from "./service-overview.js"
 import {
   createCustomPickupArea,
@@ -75,6 +78,9 @@ import { getSlotUnitAvailability } from "./service-unit-availability.js"
 
 export const availabilityService = {
   getSlotAllocationManifest,
+  getDepartureSummary,
+  getDepartureCapacityCounters,
+  getDepartureIssues,
   listAllocationResources,
   createAllocationResource,
   updateAllocationResource,

--- a/packages/operations/src/availability/validation.ts
+++ b/packages/operations/src/availability/validation.ts
@@ -339,6 +339,19 @@ export const materializeOpenSlotsSchema = z.object({
   optionId: z.string().optional(),
 })
 
+/**
+ * Paging for the slot allocation manifest's **booking** axis.
+ *
+ * `limit` is optional on purpose: omitting it returns every booking, which is
+ * what this route did before it could page, so no existing caller changes
+ * behaviour. The manifest's `summary` counters are whole-departure regardless
+ * of the page — see `SlotAllocationManifestPagination`.
+ */
+export const allocationManifestQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(200).optional(),
+  offset: z.coerce.number().int().min(0).default(0),
+})
+
 export const allocationAuditLogQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(100).default(50),
 })

--- a/packages/operations/src/index.ts
+++ b/packages/operations/src/index.ts
@@ -4,8 +4,10 @@ import {
 } from "@voyant-travel/bookings/runtime-port"
 import type { Module } from "@voyant-travel/core"
 import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
+import { financeDepartureProfitabilityRuntimePort } from "@voyant-travel/finance-contracts/runtime-port"
 import type { ApiModule } from "@voyant-travel/hono/module"
 
+import { configureDepartureProfitabilityReader } from "./availability/departure-profitability-runtime.js"
 import { availabilityLinkable } from "./availability/index.js"
 import { placesLinkable } from "./places/index.js"
 import { createOperationsAdminRoutes, operationsAdminRoutes } from "./routes.js"
@@ -31,13 +33,26 @@ export const operationsApiModule: ApiModule = {
 export const operationsApiModules = [operationsApiModule] as const
 
 export const createOperationsVoyantRuntime = defineGraphRuntimeFactory(
-  async ({ getPort, getPorts }) => ({
-    module: operationsModule,
-    adminRoutes: createOperationsAdminRoutes({
-      projection: await getPort(bookingActionProjectionRuntimePort),
-      sources: await getPorts(bookingActionSourceRuntimePort),
-    }),
-  }),
+  async ({ getPort, getPorts, hasPort }) => {
+    // Finance is optional: `getPort` throws on an unbound optional port, so the
+    // presence check has to come first. Binding the reader here keeps the money
+    // Finance's and the availability routes free of a Finance dependency — see
+    // `availability/departure-profitability-runtime.ts`.
+    const profitability = hasPort(financeDepartureProfitabilityRuntimePort)
+      ? await getPort(financeDepartureProfitabilityRuntimePort)
+      : undefined
+    configureDepartureProfitabilityReader(
+      profitability ? (db, query) => profitability.getDepartureProfitability(db, query) : undefined,
+    )
+
+    return {
+      module: operationsModule,
+      adminRoutes: createOperationsAdminRoutes({
+        projection: await getPort(bookingActionProjectionRuntimePort),
+        sources: await getPorts(bookingActionSourceRuntimePort),
+      }),
+    }
+  },
 )
 
 // Only the request side is package API. Binding the channel is deployment

--- a/packages/operations/src/voyant.ts
+++ b/packages/operations/src/voyant.ts
@@ -4,6 +4,7 @@ import {
 } from "@voyant-travel/bookings/runtime-port"
 import { catalogOperationsRuntimeExtensionPort } from "@voyant-travel/catalog/ports"
 import { defineModule, providePort, requirePort } from "@voyant-travel/core/project"
+import { financeDepartureProfitabilityRuntimePort } from "@voyant-travel/finance-contracts/runtime-port"
 
 import { operationsExpiredHoldsJobRuntimePort } from "./expired-holds-job-runtime-port.js"
 
@@ -52,6 +53,10 @@ export const operationsVoyantModule = defineModule({
     requirePort(operationsExpiredHoldsJobRuntimePort),
     requirePort(bookingActionProjectionRuntimePort),
     requirePort(bookingActionSourceRuntimePort, { optional: true, cardinality: "many" }),
+    // The departure workspace shows a headline P&L it must not compute. Optional
+    // because a deployment without Finance still operates departures; it just
+    // shows no money.
+    requirePort(financeDepartureProfitabilityRuntimePort, { optional: true }),
   ],
   jobs: [
     {

--- a/packages/operations/tests/availability/integration/departure-summary.test.ts
+++ b/packages/operations/tests/availability/integration/departure-summary.test.ts
@@ -1,0 +1,274 @@
+import { availabilitySlots } from "@voyant-travel/availability/schema"
+import { newId } from "@voyant-travel/db/lib/typeid"
+import { cleanupTestDb, createTestDb } from "@voyant-travel/db/test-utils"
+import { sql } from "drizzle-orm"
+import { beforeAll, beforeEach, describe, expect, it } from "vitest"
+import { products } from "../../../../inventory/src/schema.js"
+import { getSlotAllocationManifest } from "../../../src/availability/service-allocation.js"
+import { getDepartureCapacityCounters } from "../../../src/availability/service-departure-capacity.js"
+import {
+  type DepartureIssueCode,
+  getDepartureIssues,
+} from "../../../src/availability/service-departure-issues.js"
+import { getDepartureSummary } from "../../../src/availability/service-departure-summary.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+/**
+ * The reconciliation the departure workspace exists for: a departure whose
+ * booked pax and entered travelers disagree, and which is carrying an
+ * allocation that expired without anyone releasing it. Both are asserted by
+ * their stable issue code, and both are asserted to clear once repaired — a
+ * detector that never goes quiet is as useless as one that never fires.
+ */
+describe.skipIf(!DB_AVAILABLE)("departure summary (integration)", () => {
+  // biome-ignore lint/suspicious/noExplicitAny: drizzle test client -- owner: availability; matches the sibling availability suites.
+  let db: any
+  let productId: string
+  let productVersionId: string
+  let slotId: string
+
+  beforeAll(() => {
+    db = createTestDb()
+  })
+
+  beforeEach(async () => {
+    await cleanupTestDb(db)
+    productId = newId("products")
+    productVersionId = newId("product_versions")
+    slotId = newId("availability_slots")
+    await db.insert(products).values({
+      id: productId,
+      name: "Carpathian Ridge Trek",
+      sellCurrency: "EUR",
+      bookingMode: "date",
+    })
+    await db.insert(availabilitySlots).values({
+      id: slotId,
+      productId,
+      productVersionId,
+      dateLocal: "2026-09-14",
+      startsAt: new Date("2026-09-14T06:00:00Z"),
+      timezone: "UTC",
+      status: "open",
+      unlimited: false,
+      initialPax: 12,
+      remainingPax: 12,
+    })
+  })
+
+  async function seedBooking(input: {
+    pax: number
+    travelerCount: number
+    status?: "confirmed" | "in_progress" | "completed" | "cancelled"
+    allocationStatus?: "held" | "confirmed" | "fulfilled" | "released"
+    /** ISO instant; postgres.js rejects a bound `Date`, so seeds pass a string. */
+    holdExpiresAt?: string | null
+    sellAmountCents?: number
+    resourceId?: string
+  }) {
+    const bookingId = newId("bookings")
+    const bookingItemId = newId("booking_items")
+    const allocationId = newId("booking_allocations")
+    await db.execute(sql`
+      INSERT INTO bookings (id, booking_number, status, sell_currency, pax, sell_amount_cents)
+      VALUES (
+        ${bookingId},
+        ${`B${bookingId.slice(-6)}`},
+        ${input.status ?? "confirmed"},
+        'EUR',
+        ${input.pax},
+        ${input.sellAmountCents ?? 0}
+      )
+    `)
+    await db.execute(sql`
+      INSERT INTO booking_items (id, booking_id, title, status, quantity, sell_currency, product_id, availability_slot_id)
+      VALUES (${bookingItemId}, ${bookingId}, 'Departure seat', 'confirmed', ${input.pax}, 'EUR', ${productId}, ${slotId})
+    `)
+    await db.execute(sql`
+      INSERT INTO booking_allocations (
+        id, booking_id, booking_item_id, product_id, availability_slot_id,
+        quantity, allocation_type, status, hold_expires_at
+      )
+      VALUES (
+        ${allocationId}, ${bookingId}, ${bookingItemId}, ${productId}, ${slotId},
+        ${input.pax}, 'unit', ${input.allocationStatus ?? "confirmed"},
+        ${input.holdExpiresAt ?? null}::timestamptz
+      )
+    `)
+
+    const travelerIds: string[] = []
+    for (let index = 0; index < input.travelerCount; index += 1) {
+      const travelerId = newId("booking_travelers")
+      travelerIds.push(travelerId)
+      await db.execute(sql`
+        INSERT INTO booking_travelers (id, booking_id, participant_type, first_name, last_name)
+        VALUES (${travelerId}, ${bookingId}, 'traveler', 'Ana', ${`Pop${index}`})
+      `)
+      if (input.resourceId) {
+        await db.execute(sql`
+          INSERT INTO booking_traveler_travel_details (traveler_id, allocations)
+          VALUES (${travelerId}, ${JSON.stringify({ room: input.resourceId })}::jsonb)
+        `)
+      }
+    }
+
+    return { bookingId, allocationId, travelerIds }
+  }
+
+  function codesFor(issues: ReadonlyArray<{ code: DepartureIssueCode }>) {
+    return issues.map((issue) => issue.code)
+  }
+
+  it("flags booked pax without travelers and an allocation held past its expiry", async () => {
+    // Four seats sold, only one name entered.
+    await seedBooking({ pax: 4, travelerCount: 1, sellAmountCents: 400_00 })
+    // A second booking whose hold lapsed a day ago and was never released.
+    const stale = await seedBooking({
+      pax: 2,
+      travelerCount: 2,
+      allocationStatus: "held",
+      holdExpiresAt: "2026-09-13T06:00:00Z",
+      sellAmountCents: 200_00,
+    })
+
+    const now = new Date("2026-09-14T05:00:00Z")
+    const counters = await getDepartureCapacityCounters(db, slotId, now)
+    expect(counters?.bookings.expectedPax).toBe(6)
+    expect(counters?.travelers.entered).toBe(3)
+    expect(counters?.travelers.missing).toBe(3)
+    expect(counters?.allocations.held).toBe(1)
+    expect(counters?.allocations.confirmed).toBe(1)
+    expect(counters?.allocations.staleHeld).toBe(1)
+    // 12 authored − 6 sold; nothing is on a live checkout hold.
+    expect(counters?.derivedRemainingPax).toBe(6)
+    expect(counters?.remainingPax).toBe(12)
+
+    const issues = await getDepartureIssues(db, slotId, { now, counters: counters ?? undefined })
+    expect(codesFor(issues ?? [])).toContain("travelers_missing_for_booked_pax")
+    expect(codesFor(issues ?? [])).toContain("stale_held_allocation")
+    // The stale row is named, not just counted, so the UI can link to it.
+    expect((issues ?? []).find((issue) => issue.code === "stale_held_allocation")).toMatchObject({
+      severity: "warning",
+      subjectType: "booking_allocation",
+      subjectId: stale.allocationId,
+      count: 1,
+    })
+    // The stored counter never moved, so the drift is reported too.
+    expect(codesFor(issues ?? [])).toContain("remaining_pax_drift")
+  })
+
+  it("clears both issues once the travelers are entered and the hold is confirmed", async () => {
+    const shortBooking = await seedBooking({ pax: 4, travelerCount: 1, sellAmountCents: 400_00 })
+    const stale = await seedBooking({
+      pax: 2,
+      travelerCount: 2,
+      allocationStatus: "held",
+      holdExpiresAt: "2026-09-13T06:00:00Z",
+      sellAmountCents: 200_00,
+    })
+
+    const now = new Date("2026-09-14T05:00:00Z")
+    // Repair 1: enter the three missing names.
+    for (let index = 0; index < 3; index += 1) {
+      await db.execute(sql`
+        INSERT INTO booking_travelers (id, booking_id, participant_type, first_name, last_name)
+        VALUES (
+          ${newId("booking_travelers")}, ${shortBooking.bookingId}, 'traveler', 'Ion', ${`Ionescu${index}`}
+        )
+      `)
+    }
+    // Repair 2: confirm the lapsed hold.
+    await db.execute(sql`
+      UPDATE booking_allocations
+      SET status = 'confirmed', hold_expires_at = NULL
+      WHERE id = ${stale.allocationId}
+    `)
+    // Repair 3: reconcile the stored counter with what is actually consumed.
+    await db.execute(sql`
+      UPDATE availability_slots SET remaining_pax = 6 WHERE id = ${slotId}
+    `)
+
+    const issues = await getDepartureIssues(db, slotId, { now })
+    const codes = codesFor(issues ?? [])
+    expect(codes).not.toContain("travelers_missing_for_booked_pax")
+    expect(codes).not.toContain("stale_held_allocation")
+    expect(codes).not.toContain("remaining_pax_drift")
+  })
+
+  it("reports allocations left behind on a cancelled booking", async () => {
+    const cancelled = await seedBooking({ pax: 2, travelerCount: 2, status: "cancelled" })
+
+    const issues = await getDepartureIssues(db, slotId)
+    expect(issues?.find((issue) => issue.code === "allocation_on_cancelled_booking")).toMatchObject(
+      {
+        subjectType: "booking",
+        subjectId: cancelled.bookingId,
+        count: 1,
+      },
+    )
+    // The cancelled booking must not be counted as demand.
+    const counters = await getDepartureCapacityCounters(db, slotId)
+    expect(counters?.bookings.active).toBe(0)
+    expect(counters?.bookings.cancelledWithLiveAllocation).toBe(1)
+    expect(counters?.bookings.expectedPax).toBe(0)
+  })
+
+  it("composes one bounded envelope carrying the Product Version identity", async () => {
+    await seedBooking({ pax: 2, travelerCount: 2, sellAmountCents: 200_00 })
+
+    const summary = await getDepartureSummary(db, slotId)
+    expect(summary?.departure.productVersionId).toBe(productVersionId)
+    expect(summary?.departure.productId).toBe(productId)
+    expect(summary?.bookings.count).toBe(1)
+    expect(summary?.bookings.expectedPax).toBe(2)
+    expect(summary?.bookings.currency).toBe("EUR")
+    expect(summary?.bookings.soldAmountCents).toBe(200_00)
+    expect(summary?.bookings.paidAmountCents).toBe(0)
+    expect(summary?.bookings.outstandingAmountCents).toBe(200_00)
+    expect(summary?.travelers.entered).toBe(2)
+    // No Finance provider is bound in a package-level suite.
+    expect(summary?.finance).toBeNull()
+    expect(summary?.operations.issues.length).toBeGreaterThan(0)
+  })
+
+  it("keeps the manifest's headline counters stable while paging", async () => {
+    for (let index = 0; index < 3; index += 1) {
+      await seedBooking({ pax: 1, travelerCount: 2, sellAmountCents: 100_00 })
+    }
+
+    const whole = await getSlotAllocationManifest(db, slotId)
+    expect(whole?.bookings).toHaveLength(3)
+    expect(whole?.pagination).toEqual({ limit: null, offset: 0, total: 3 })
+    expect(whole?.summary.bookingCount).toBe(3)
+    expect(whole?.summary.travelerCount).toBe(6)
+
+    const page = await getSlotAllocationManifest(db, slotId, { limit: 1, offset: 1 })
+    expect(page?.bookings).toHaveLength(1)
+    expect(page?.pagination).toEqual({ limit: 1, offset: 1, total: 3 })
+    // The point of the change: the page shows one booking, the counters still
+    // describe the whole departure.
+    expect(page?.summary.bookingCount).toBe(3)
+    expect(page?.summary.travelerCount).toBe(6)
+    // Chip numbering is departure-local, so page 2's booking is still #2.
+    expect(page?.bookings[0]?.bookingSequence).toBe(2)
+    expect(page?.bookings[0]?.id).toBe(whole?.bookings[1]?.id)
+  })
+
+  it("reports a resource holding more travelers than it can seat", async () => {
+    const resourceId = newId("allocation_resources")
+    await db.execute(sql`
+      INSERT INTO allocation_resources (id, slot_id, kind, label, capacity, sort_order, flags)
+      VALUES (${resourceId}, ${slotId}, 'room', 'DBL 1', 1, 0, '{}'::jsonb)
+    `)
+    await seedBooking({ pax: 2, travelerCount: 2, resourceId })
+
+    const issues = await getDepartureIssues(db, slotId)
+    expect(issues?.find((issue) => issue.code === "resource_over_capacity")).toMatchObject({
+      severity: "critical",
+      subjectType: "allocation_resource",
+      subjectId: resourceId,
+      count: 1,
+    })
+  })
+})

--- a/packages/operations/tests/unit/voyant-manifest.test.ts
+++ b/packages/operations/tests/unit/voyant-manifest.test.ts
@@ -24,6 +24,9 @@ describe("operations deployment manifest", () => {
           optional: true,
           cardinality: "many",
         },
+        // Optional: a deployment without Finance still operates departures, it
+        // just shows no money on them.
+        { id: "finance.departure-profitability.runtime", optional: true },
       ],
       jobs: [
         {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,7 +249,7 @@ importers:
         version: 1.6.0(@date-fns/tz@1.4.1)(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@better-auth/api-key':
         specifier: 1.6.23
-        version: 1.6.23(1ac6a98f3eafa8cc5361cfcd8d9e497a)
+        version: 1.6.23(4cc07405e1e664eaf96048bc4329d318)
       '@fontsource-variable/inter-tight':
         specifier: ^5.2.7
         version: 5.2.7
@@ -4139,6 +4139,9 @@ importers:
       '@voyant-travel/db':
         specifier: workspace:^
         version: link:../db
+      '@voyant-travel/finance-contracts':
+        specifier: workspace:^
+        version: link:../finance-contracts
       '@voyant-travel/hono':
         specifier: workspace:^
         version: link:../hono
@@ -13163,6 +13166,14 @@ snapshots:
   '@better-auth/api-key@1.6.23(1ac6a98f3eafa8cc5361cfcd8d9e497a)':
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0)
+      '@better-auth/utils': 0.4.2
+      better-auth: 1.6.23(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.3)(rollup@4.60.2)(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9))(mongodb@7.1.0(socks@2.8.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.11)(vitest@4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)))(vue@3.5.39(typescript@6.0.3))
+      better-call: 1.3.7(zod@4.4.3)
+      zod: 4.4.3
+
+  '@better-auth/api-key@1.6.23(4cc07405e1e664eaf96048bc4329d318)':
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
       better-auth: 1.6.23(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.3)(rollup@4.60.2)(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9))(mongodb@7.1.0(socks@2.8.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.11)(vitest@4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)))(vue@3.5.39(typescript@6.0.3))
       better-call: 1.3.7(zod@4.4.3)


### PR DESCRIPTION
## Why

This is the **backend half** of #4033. An operator opening a departure had no single place that explained it: capacity, booking quantities, traveler completeness, allocation state, extras and money each came from a separate fetch and were reconciled in the browser, and nothing detected the mismatches that matter before the day of operation.

The workspace UI restructure (Overview / Travelers / Allocation / Operations / Financials / Activity, URL-addressable tabs, empty-state next actions, deep links) is a **follow-up PR** — this one is deliberately server-side only so it can be reviewed on its own.

## What changed

**Composed summary (AC1).** `GET /slots/{id}/summary` returns one bounded envelope combining slot + Product Version identity, capacity counters, booking quantities, traveler completeness, allocation rollup, operations readiness, extras and the finance headline. It composes existing truths and computes none of them.

**Capacity counters (AC3).** Held / confirmed / fulfilled allocations are now split rather than collapsed into one bucket; released, expired and cancelled claims are counted separately; expected pax and entered traveler records are distinct figures. `getSlotResourceAvailability` was already written and exported but had **no production caller** — it does now.

**Typed attention issues (AC4).** Eleven stable codes with severity, modelled on the existing `ProductReadinessCode` convention: stale held allocations, allocations on cancelled bookings, unreleased expired holds, traveler gaps both ways, remaining-pax drift, oversell, resource over-capacity, unassigned travelers, missing allocation setup, unbound departure. The evaluator is pure; its loader caps named subjects at 50 and rolls up the remainder. No hrefs in the domain layer — the UI owns navigation.

**One lifecycle vocabulary (AC5).** The active booking and allocation status lists had been copy-pasted into six packages in three shapes (array, `Set`, `||` chain). They collapse to one declaration in `bookings-contracts`, with the type-level pin against the Drizzle enum in `bookings` and the Drizzle `sql` builders left in the runtime packages. `docs/architecture/operated-departure-logistics.md` now documents the canonical slot↔booking join (`booking_allocations`) and marks the other two edges legacy/Finance.

**Pagination (AC2).** The allocation and extras manifests returned every booking, traveler and resource unbounded. Both are paginated; headline counters moved to the summary so paging never changes them.

**`productVersionId`** is exposed end-to-end — it was persisted and validated but omitted from the read model.

## Deliberately out of scope

- No reaper for expired `booking_allocations` — staleness is **detected** as a typed issue; releasing is #4067's territory.
- `availability_slots.remaining_resources` is fixed separately in #4161.
- Finance's join path and its narrower status list are untouched.

## Reviewer notes — please read

- **`packages/operations/openapi/admin/operations.json` is stale.** It gains a path, a query param, and `productVersionId` on every slot schema. There appears to be no per-package emitter (unlike catalog/media/finance); regenerating seems to need the operator app build. `check-operator-openapi-authority.mjs` validates ownership, not content, so **CI will not catch this** — it should be regenerated before merge.
- **Finance is reached through a module-level bound reader.** The port itself is a proper graph runtime port, but the last hop into the route is a module-level `configure…()` binding mirroring `hold-expiry-wake.ts`, because the availability routes are module-level constants mounted on two surfaces and there is no single construction site to thread an option through. Documented in the new file's docblock.
- **`readDepartureProfitabilityReport` currently swallows Finance errors** with a bare `catch` so a Finance outage cannot blank the whole workspace. The intent is right but there is no diagnostic — worth a log before merge.
- **`.github/workflows/ci.yml` gains one line.** The `db-lanes/integration` job runs an explicit per-file allowlist; without it the new suite would never run.
- **Booking-level pax attribution is a known limit**, documented in `service-departure-capacity.ts`: `bookings.pax` and `booking_travelers` are booking-level, so a booking spanning two departures contributes fully to both. This matches how the existing manifest already counts, so counters and rows agree; splitting it needs a populated `booking_allocations.quantity`.
- **postgres.js rejects a bound `Date`** (`ERR_INVALID_ARG_TYPE`) — three raw-SQL sites needed `${iso}::timestamptz`.
- All six touched packages are `private: true`, so no changeset.

## Verification

- `pnpm -F @voyant-travel/operations test` — 270 passed, 375 skipped (50 files)
- New integration suite `departure-summary.test.ts` against real Postgres — 6 passed; `slot-resource-availability` re-run as a regression check on the manifest change — 9 passed
- `pnpm exec biome check .` from the root — clean for every touched file
- **`typecheck` did not complete locally.** This machine was thrashing (swap 37.8/38.9 GB) under concurrent worktrees — the documented local `tsc` failure mode for this repo. One earlier run did surface a real `TS2305` cascade caused by a stale `bookings-contracts/dist`; that is resolved (`dep-paths.json` resolves consumers to built `.d.ts`, so the package must be built before dependents typecheck). **Relying on CI `build-graph`.**

Part of #4033