### PR TITLE
Stop advertising a never-maintained counter as availability

### DIFF
--- a/.changeset/storefront-remaining-capacity-unknown.md
+++ b/.changeset/storefront-remaining-capacity-unknown.md
@@ -1,0 +1,23 @@
+---
+"@voyant-travel/storefront": patch
+"@voyant-travel/availability": patch
+---
+
+Stop advertising the never-maintained `remaining_resources` as live availability.
+
+`availability_slots.remaining_resources` can be seeded once when a slot is
+created and is then explicitly stripped on every update. Nothing anywhere
+decrements it as bookings, holds, amendments or refunds land, so its value only
+ever drifts upward relative to the truth. The storefront read it as a fallback
+whenever `remaining_pax` was unset, publishing a stale count on the public
+departure list, the product availability summary, and the price-preview
+allocation — a number that could only overstate what was left to sell.
+
+Storefront departures now derive capacity through a single
+`resolveDepartureCapacity` seam that reads only `remaining_pax`, the projection
+the platform actually maintains. When `remaining_pax` is unset the remaining
+capacity is reported as unknown (`null`) instead of a fabricated integer.
+Unknown degrades safely: `buildAvailabilityState` still derives `sold_out` only
+from an explicit `remaining === 0`, so an unknown count is neither presented as
+sold out nor as a concrete number of seats left. The column is marked deprecated
+on the schema and is no longer read by the storefront at all.

--- a/packages/availability/src/schema-core.ts
+++ b/packages/availability/src/schema-core.ts
@@ -141,6 +141,17 @@ export const availabilitySlots = pgTable(
     remainingPax: integer("remaining_pax"),
     initialPickups: integer("initial_pickups"),
     remainingPickups: integer("remaining_pickups"),
+    /**
+     * @deprecated Never maintained — do not read as availability (#4161).
+     *
+     * This column can be seeded once when a slot is created and is then
+     * explicitly stripped on every update. No booking, hold, amendment or
+     * refund flow decrements it, so its value only ever drifts upward relative
+     * to the truth. `remainingPax` is the maintained remaining-capacity
+     * projection; use that (and treat its absence as *unknown*, not as a
+     * number of seats). Retained for now so existing rows and admin read
+     * models keep working; slated for removal.
+     */
     remainingResources: integer("remaining_resources"),
     pastCutoff: boolean("past_cutoff").notNull().default(false),
     tooEarly: boolean("too_early").notNull().default(false),

--- a/packages/storefront/src/service-boundary-sql.ts
+++ b/packages/storefront/src/service-boundary-sql.ts
@@ -23,7 +23,6 @@ export interface StorefrontSlotRow {
   unlimited: boolean
   initialPax: number | null
   remainingPax: number | null
-  remainingResources: number | null
   pastCutoff: boolean
   tooEarly: boolean
   nights: number | null
@@ -94,7 +93,6 @@ type StorefrontSlotDbRow = {
   unlimited: boolean
   initial_pax: number | string | null
   remaining_pax: number | string | null
-  remaining_resources: number | string | null
   past_cutoff: boolean
   too_early: boolean
   nights: number | string | null
@@ -184,7 +182,6 @@ function mapSlot(row: StorefrontSlotDbRow): StorefrontSlotRow {
     unlimited: row.unlimited,
     initialPax: toNumber(row.initial_pax),
     remainingPax: toNumber(row.remaining_pax),
-    remainingResources: toNumber(row.remaining_resources),
     pastCutoff: row.past_cutoff,
     tooEarly: row.too_early,
     nights: toNumber(row.nights),
@@ -277,7 +274,6 @@ export async function listStorefrontSlots(
         s.unlimited,
         s.initial_pax,
         s.remaining_pax,
-        s.remaining_resources,
         s.past_cutoff,
         s.too_early,
         s.nights,

--- a/packages/storefront/src/service-departures-core.ts
+++ b/packages/storefront/src/service-departures-core.ts
@@ -41,6 +41,35 @@ export function normalizeLocalDate(value: Date | string | null | undefined) {
   return String(value).slice(0, 10)
 }
 
+/**
+ * Customer-facing capacity/remaining pair for one departure slot.
+ *
+ * `remaining_pax` is the only remaining-capacity projection the platform
+ * actually maintains: booking, hold, amendment and refund flows update it
+ * atomically, and `updateSlot` recomputes it on capacity changes.
+ *
+ * `remaining_resources` is NOT maintained. It can be seeded once when a slot
+ * is created and is then explicitly stripped on every update, with no writer
+ * anywhere that decrements it as bookings land. Using it as a fallback for
+ * `remaining_pax` therefore advertises a number that can only ever be equal to
+ * or higher than the truth — an overselling path (#4161). It is deliberately
+ * not read here.
+ *
+ * When `remaining_pax` is unset the remaining capacity is genuinely *unknown*,
+ * and we surface `null` for it. Downstream, `buildAvailabilityState` only
+ * derives `sold_out` from an explicit `remaining === 0`, so unknown degrades to
+ * "not known to be sold out" rather than a fabricated count, and storefront UI
+ * renders it as a placeholder rather than a number of seats left.
+ */
+export function resolveDepartureCapacity(
+  slot: Pick<SlotRow, "unlimited" | "initialPax" | "remainingPax">,
+): { capacity: number | null; remaining: number | null } {
+  return {
+    capacity: slot.unlimited ? null : (slot.initialPax ?? slot.remainingPax ?? null),
+    remaining: slot.remainingPax ?? null,
+  }
+}
+
 export function buildResourceManifest(resources: SlotResourceAvailability[]) {
   if (resources.length === 0) return null
   const totals = new Map<string, { capacity: number; assigned: number; available: number }>()

--- a/packages/storefront/src/service-departures-price-preview.ts
+++ b/packages/storefront/src/service-departures-price-preview.ts
@@ -10,6 +10,7 @@ import {
   listSlots,
   normalizeIso,
   normalizeLocalDate,
+  resolveDepartureCapacity,
 } from "./service-departures-core.js"
 import {
   buildOfferPreview,
@@ -472,6 +473,7 @@ export async function previewStorefrontDeparturePrice(
   const basePrice = Number((subtotal - extrasTotal).toFixed(2))
   const slotResources = await getStorefrontSlotResourceAvailability(db, slot.id)
   const resourceManifest = buildResourceManifest(slotResources)
+  const { capacity: slotCapacity, remaining: slotRemaining } = resolveDepartureCapacity(slot)
 
   return {
     departureId: slot.id,
@@ -495,13 +497,13 @@ export async function previewStorefrontDeparturePrice(
         status: buildDepartureStatus(slot, context),
         availabilityState: buildAvailabilityState({
           status: buildDepartureStatus(slot, context),
-          remaining: slot.remainingPax ?? slot.remainingResources ?? null,
-          capacity: slot.unlimited ? null : (slot.initialPax ?? slot.remainingPax ?? null),
+          remaining: slotRemaining,
+          capacity: slotCapacity,
           pastCutoff: slot.pastCutoff,
           tooEarly: slot.tooEarly,
         }),
-        capacity: slot.unlimited ? null : (slot.initialPax ?? slot.remainingPax ?? null),
-        remaining: slot.remainingPax ?? slot.remainingResources ?? null,
+        capacity: slotCapacity,
+        remaining: slotRemaining,
         pastCutoff: slot.pastCutoff,
         tooEarly: slot.tooEarly,
         resourceManifest,

--- a/packages/storefront/src/service-departures.ts
+++ b/packages/storefront/src/service-departures.ts
@@ -15,6 +15,7 @@ import {
   listSlots,
   normalizeIso,
   normalizeLocalDate,
+  resolveDepartureCapacity,
   type SlotResourceAvailability,
   type SlotRow,
   summarizeProductAvailability,
@@ -46,6 +47,7 @@ async function buildDeparture(
   const context = await resolvePricingContext(db, slot.productId, slot.optionId, slot.id)
   const itineraryId = slot.itineraryId ?? defaultItineraryByProduct.get(slot.productId) ?? null
   const resources = resourceAvailability ?? []
+  const { capacity, remaining } = resolveDepartureCapacity(slot)
 
   return {
     id: slot.id,
@@ -66,8 +68,8 @@ async function buildDeparture(
             durationMinutes: slot.durationMinutes,
           },
     meetingPoint: meetingPointByProduct?.get(slot.productId) ?? null,
-    capacity: slot.unlimited ? null : (slot.initialPax ?? slot.remainingPax ?? null),
-    remaining: slot.remainingPax ?? slot.remainingResources ?? null,
+    capacity,
+    remaining,
     departureStatus: buildDepartureStatus(slot, context),
     nights: slot.nights,
     days: slot.days,

--- a/packages/storefront/tests/integration/departures-remaining-capacity.test.ts
+++ b/packages/storefront/tests/integration/departures-remaining-capacity.test.ts
@@ -1,0 +1,187 @@
+import { optionPriceRules, optionUnitPriceRules, priceCatalogs } from "@voyant-travel/commerce"
+import { cleanupTestDb, createTestDb } from "@voyant-travel/db/test-utils"
+import { optionUnits, productOptions, products } from "@voyant-travel/inventory/schema"
+import { availabilitySlots } from "@voyant-travel/operations"
+import { Hono } from "hono"
+import { beforeEach, describe, expect, it } from "vitest"
+
+import { createStorefrontPublicRoutes } from "../../src/routes-public.js"
+
+const TEST_DATABASE_URL = process.env.TEST_DATABASE_URL
+const DB_AVAILABLE = !!TEST_DATABASE_URL
+
+const db = DB_AVAILABLE ? createTestDb() : (null as never)
+
+const app = new Hono()
+  .use("*", async (c, next) => {
+    c.set("db" as never, db)
+    c.set(
+      "storefrontChannel" as never,
+      {
+        storefrontId: "sf_bound",
+        channelId: "chan_bound",
+        channelStatus: "active",
+      } as never,
+    )
+    await next()
+  })
+  .route(
+    "/",
+    createStorefrontPublicRoutes({
+      publication: { isProductPublished: async () => true },
+    }),
+  )
+
+/**
+ * Seed a published product with one priced option and a single open departure
+ * whose `remaining_pax` is unset while `remaining_resources` still carries a
+ * stale seeded number.
+ */
+async function seedStaleResourceDeparture(suffix: string) {
+  const [product] = await db
+    .insert(products)
+    .values({
+      name: `Danube Delta ${suffix}`,
+      status: "active",
+      activated: true,
+      visibility: "public",
+      sellCurrency: "EUR",
+    })
+    .returning()
+  const [option] = await db
+    .insert(productOptions)
+    .values({ productId: product.id, name: "Standard", status: "active", isDefault: true })
+    .returning()
+  const [unit] = await db
+    .insert(optionUnits)
+    .values({
+      optionId: option.id,
+      name: "Adult",
+      unitType: "person",
+      isHidden: false,
+    })
+    .returning()
+  const [catalog] = await db
+    .insert(priceCatalogs)
+    .values({
+      code: `PUBLIC-EUR-${suffix}`,
+      name: "Public EUR",
+      currencyCode: "EUR",
+      catalogType: "public",
+      isDefault: true,
+      active: true,
+    })
+    .returning()
+  const [rule] = await db
+    .insert(optionPriceRules)
+    .values({
+      productId: product.id,
+      optionId: option.id,
+      priceCatalogId: catalog.id,
+      name: "Public rate",
+      pricingMode: "per_person",
+      isDefault: true,
+      active: true,
+    })
+    .returning()
+  await db.insert(optionUnitPriceRules).values({
+    optionPriceRuleId: rule.id,
+    optionId: option.id,
+    unitId: unit.id,
+    pricingMode: "per_person",
+    sellAmountCents: 50000,
+    active: true,
+  })
+  const [slot] = await db
+    .insert(availabilitySlots)
+    .values({
+      productId: product.id,
+      optionId: option.id,
+      dateLocal: "2026-09-10",
+      startsAt: new Date("2026-09-10T06:00:00.000Z"),
+      endsAt: new Date("2026-09-10T10:00:00.000Z"),
+      timezone: "Europe/Bucharest",
+      status: "open",
+      initialPax: 20,
+      // The maintained projection is unset...
+      remainingPax: null,
+      // ...while this seeded-once column still holds a number nothing ever
+      // decrements.
+      remainingResources: 6,
+    })
+    .returning()
+
+  return { product, option, slot }
+}
+
+// Regression for #4161. `availability_slots.remaining_resources` is settable at
+// slot creation and then explicitly stripped on every update, with no writer
+// anywhere that decrements it as bookings land. The storefront used to fall
+// back to it whenever `remaining_pax` was unset, publishing a number that can
+// only ever overstate availability — an overselling path. Unset remaining
+// capacity must now surface as unknown (`null`).
+describe.skipIf(!DB_AVAILABLE)("public departures ignore stale remaining_resources", () => {
+  beforeEach(async () => {
+    await cleanupTestDb(db)
+  })
+
+  it("does not advertise remaining_resources on the departure list", async () => {
+    const { product, slot } = await seedStaleResourceDeparture("list")
+
+    const res = await app.request(`/products/${product.id}/departures`)
+    expect(res.status).toBe(200)
+
+    const body = (await res.json()) as {
+      data: Array<{ id: string; capacity: number | null; remaining: number | null }>
+    }
+    const departure = body.data.find((row) => row.id === slot.id)
+    expect(departure).toBeDefined()
+    expect(departure?.remaining).toBeNull()
+    expect(departure?.capacity).toBe(20)
+  }, 30000)
+
+  it("renders unknown remaining as available rather than sold out", async () => {
+    const { product, slot } = await seedStaleResourceDeparture("summary")
+
+    const res = await app.request(`/products/${product.id}/availability`)
+    expect(res.status).toBe(200)
+
+    const body = (await res.json()) as {
+      data: {
+        availabilityState: string
+        counts: { soldOut: number; available: number }
+        departures: Array<{ id: string; availabilityState: string; remaining: number | null }>
+      }
+    }
+    const departure = body.data.departures.find((row) => row.id === slot.id)
+    expect(departure).toBeDefined()
+    expect(departure?.remaining).toBeNull()
+    // Unknown must degrade to "not known to be sold out", never to sold_out.
+    expect(departure?.availabilityState).toBe("available")
+    expect(body.data.availabilityState).toBe("available")
+    expect(body.data.counts.soldOut).toBe(0)
+    expect(body.data.counts.available).toBe(1)
+  }, 30000)
+
+  it("does not advertise remaining_resources on the price preview allocation", async () => {
+    const { slot } = await seedStaleResourceDeparture("preview")
+
+    const res = await app.request(`/departures/${slot.id}/price`, {
+      method: "POST",
+      body: JSON.stringify({ pax: { adults: 1, children: 0, infants: 0 } }),
+      headers: { "content-type": "application/json" },
+    })
+    expect(res.status).toBe(200)
+
+    const body = (await res.json()) as {
+      data: {
+        allocation: {
+          slot: { capacity: number | null; remaining: number | null; availabilityState: string }
+        }
+      }
+    }
+    expect(body.data.allocation.slot.remaining).toBeNull()
+    expect(body.data.allocation.slot.capacity).toBe(20)
+    expect(body.data.allocation.slot.availabilityState).toBe("available")
+  }, 30000)
+})

--- a/packages/storefront/tests/unit/service-departures-capacity.test.ts
+++ b/packages/storefront/tests/unit/service-departures-capacity.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildAvailabilityState,
+  resolveDepartureCapacity,
+  type SlotRow,
+} from "../../src/service-departures-core.js"
+
+type CapacityInput = Pick<SlotRow, "unlimited" | "initialPax" | "remainingPax">
+
+function slot(data: Partial<CapacityInput> = {}): CapacityInput {
+  return {
+    unlimited: data.unlimited ?? false,
+    initialPax: data.initialPax ?? null,
+    remainingPax: data.remainingPax ?? null,
+  }
+}
+
+describe("resolveDepartureCapacity", () => {
+  it("reports the maintained remaining_pax projection", () => {
+    expect(resolveDepartureCapacity(slot({ initialPax: 24, remainingPax: 12 }))).toEqual({
+      capacity: 24,
+      remaining: 12,
+    })
+  })
+
+  it("reports unknown remaining when remaining_pax is unset (#4161)", () => {
+    // `remaining_resources` used to be the fallback here. It has no writer, so
+    // it can only ever overstate availability; an unset `remaining_pax` must
+    // surface as unknown instead.
+    expect(resolveDepartureCapacity(slot({ initialPax: 24, remainingPax: null }))).toEqual({
+      capacity: 24,
+      remaining: null,
+    })
+  })
+
+  it("keeps unlimited departures uncapped and without a remaining count", () => {
+    expect(
+      resolveDepartureCapacity(slot({ unlimited: true, initialPax: 24, remainingPax: null })),
+    ).toEqual({ capacity: null, remaining: null })
+  })
+
+  it("ignores any extra slot fields it is handed", () => {
+    // Guards against the fix being undone by widening the input again: passing
+    // a stale `remainingResources` through must not change the result.
+    const stale = { ...slot({ initialPax: 10 }), remainingResources: 6 }
+    expect(resolveDepartureCapacity(stale)).toEqual({ capacity: 10, remaining: null })
+  })
+})
+
+describe("buildAvailabilityState with unknown remaining", () => {
+  it("does not render unknown remaining as sold out", () => {
+    expect(
+      buildAvailabilityState({
+        status: "open",
+        remaining: null,
+        capacity: 24,
+        pastCutoff: false,
+        tooEarly: false,
+      }),
+    ).toBe("available")
+  })
+
+  it("still derives sold_out from an explicit zero remaining", () => {
+    expect(
+      buildAvailabilityState({
+        status: "open",
+        remaining: 0,
+        capacity: 24,
+        pastCutoff: false,
+        tooEarly: false,
+      }),
+    ).toBe("sold_out")
+  })
+
+  it("keeps a persisted sold_out status authoritative when remaining is unknown", () => {
+    expect(
+      buildAvailabilityState({
+        status: "sold_out",
+        remaining: null,
+        capacity: 24,
+        pastCutoff: false,
+        tooEarly: false,
+      }),
+    ).toBe("sold_out")
+  })
+})


### PR DESCRIPTION
## Why

`availability_slots.remaining_resources` has **no writer anywhere in the repo**. It can be seeded once at slot creation and is then explicitly stripped on every update as a "service-owned projection" — but no service owns it. Nothing in booking, hold, amendment or refund ever decrements it.

The storefront nevertheless fell back to it whenever `remaining_pax` was absent, in three places: the departure list, the availability summary, and the price preview. Because the value only ever drifts upward relative to the truth, it could only ever **overstate** what was left — an overselling path, not a display bug.

The failure shape is worse than "stale": `remaining_pax` is `NULL` precisely when a slot is **unlimited**, so an unlimited departure could render "6 left".

## Premise verified before changing anything

Swept `packages/`, `apps/`, `examples/` and all SQL under `packages/*/migrations/`. Every reference is a column definition, a DTO passthrough, an accept-on-create input, the strip-on-update, an i18n label, or a test fixture.

Two pieces of positive evidence beyond the grep:
- `packages/operations/tests/availability/integration/slot-events.test.ts:230-278` writes `remainingResources: 0` via raw drizzle and then asserts `updateSlot` leaves it at `0` — the suite itself documents that the service never owns the value.
- By contrast `remaining_pax` has real writers: `service-amendments.ts:1428,1458`, `sagas/refund-booking.ts:184,228`, `service-core.ts:1360`.

## What changed

- New `resolveDepartureCapacity(slot)` seam in `service-departures-core.ts`, reading `remainingPax` only; all three call sites use it.
- `service-boundary-sql.ts` drops the column from the SELECT, the DB row type, `StorefrontSlotRow` and the mapper — the storefront no longer reads it at all. Nothing outside storefront consumes that type.
- The column is marked `@deprecated` and **left in place**. No migration. Removing it is a separate decision and is not needed to close the overselling path.

Zero diff inside `packages/operations/src/availability/`, so no conflict with the #4033 branch.

## `null` degrades safely — verified, not assumed

- `buildDepartureStatus` never reads `remaining`.
- `buildAvailabilityState` derives sold-out only from `capacity != null && remaining === 0`, so `null` → available, i.e. "not known to be sold out". A persisted `status: "sold_out"` still wins.
- `capacity` was never derived from `remainingResources`, so it is unchanged.
- Downstream UI: `isDepartureBookable` treats `null` as bookable and the availability cell renders `—`. Neither "sold out" nor a fabricated number.

## Reviewer notes

1. **`GET /v1/public/products/:id/availability` still emits `remainingResources`** — `packages/commerce/src/pricing/service-public.ts` selects it and returns it verbatim on a **customer-facing** route. Nothing in-repo consumes the field, but an external storefront could. Left alone deliberately: it is outside `packages/storefront/`, and removing a field from a public response is a contract change deserving its own decision. **Highest-priority follow-up.**
2. Departure documents are cached 15 min, so cached payloads can carry the old number until TTL expiry or the next `availability.slot.changed` invalidation.

## Verification

- `pnpm -F @voyant-travel/storefront test` (CI-equivalent, no `TEST_DATABASE_URL`) — 138 passed, 32 skipped
- New unit tests 7 passed; new integration tests 3 passed against a real Postgres
- **The integration test was proven to catch the regression**: temporarily restoring the `?? remainingResources` fallback produced `AssertionError: expected 6 to be null`, then reverted
- `pnpm -F @voyant-travel/availability typecheck` / `test` — both clean
- `pnpm exec biome check .` from the root — no fixes applied; `git status` shows only the 8 intended files
- **`pnpm -F @voyant-travel/storefront typecheck` OOMs, and this is pre-existing.** `Ineffective mark-compacts near heap limit`, exit 134, **no `error TS` diagnostics**, at a 5.6 GB heap. Confirmed by reverting the `src` edits on a clean Sprite and re-running to an identical `134`. CI passes it with `--max-old-space-size=12288`. **CI `build-graph` is authoritative for this gate.**

Closes #4161