### PR TITLE
Stop the product cost roll-up adding minor units across currencies

### DIFF
--- a/.changeset/product-cost-rollup-mixed-currencies.md
+++ b/.changeset/product-cost-rollup-mixed-currencies.md
@@ -1,0 +1,32 @@
+---
+"@voyant-travel/inventory": minor
+"@voyant-travel/finance": minor
+---
+
+Stop the product cost roll-up adding minor units across currencies.
+
+`product_day_services.cost_currency` is a required per-row column, so a single
+itinerary routinely mixes currencies — EUR coach hire next to TRY hotel nights
+on the same Turkish tour. The roll-up behind `products.cost_amount_cents` summed
+those rows with no `GROUP BY` and no FX, producing an integer that belonged to
+no currency, and then derived `products.margin_percent` from it against a sell
+amount quoted in a third.
+
+The roll-up now totals each source currency separately and restates every
+non-sell currency into the product's sell currency — which is what the column
+already meant to its consumers, since the operator product page formats it with
+`sellCurrency` — through the same FX resolution finance uses for invoices.
+Following the profitability read model, a source currency with no resolvable
+rate is reported rather than guessed at; because a single scalar cannot say
+"everything except the lira", the total and the margin are withheld (`null`)
+instead of under-reporting cost and over-reporting margin.
+
+`POST /v1/admin/products/{id}/recalculate` now answers with the sell `currency`,
+the per-source-currency subtotals it was built from, and the currencies it could
+not convert. `costAmountCents` and `marginPercent` are nullable in that
+response. `margin_percent` is also null, rather than `0`, for a product with no
+sell amount — a product that is not priced has no margin.
+
+`resolveFxMoneyBaseAmount` is now exported from `@voyant-travel/finance` so
+modules outside finance can restate an amount without reimplementing rate
+lookup.

--- a/packages/finance/src/index.ts
+++ b/packages/finance/src/index.ts
@@ -344,6 +344,11 @@ export {
   type StoredDocumentReference,
 } from "./document-download.js"
 export {
+  type FxMoneyInput,
+  type ResolveFxMoneyBaseAmountOptions,
+  resolveFxMoneyBaseAmount,
+} from "./fx-money.js"
+export {
   createInvoiceFxApiExtension,
   createInvoiceFxRoutes,
   createVoyantDataFxExchangeRateResolver,

--- a/packages/inventory/openapi/admin/products.json
+++ b/packages/inventory/openapi/admin/products.json
@@ -18145,14 +18145,44 @@
                     "data": {
                       "type": "object",
                       "properties": {
+                        "currency": {
+                          "type": "string"
+                        },
                         "costAmountCents": {
-                          "type": "integer"
+                          "type": ["integer", "null"]
                         },
                         "marginPercent": {
-                          "type": "integer"
+                          "type": ["integer", "null"]
+                        },
+                        "byCurrency": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "currency": {
+                                "type": "string"
+                              },
+                              "amountCents": {
+                                "type": "integer"
+                              }
+                            },
+                            "required": ["currency", "amountCents"]
+                          }
+                        },
+                        "unconvertibleCurrencies": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
                         }
                       },
-                      "required": ["costAmountCents", "marginPercent"]
+                      "required": [
+                        "currency",
+                        "costAmountCents",
+                        "marginPercent",
+                        "byCurrency",
+                        "unconvertibleCurrencies"
+                      ]
                     }
                   },
                   "required": ["data"]

--- a/packages/inventory/src/routes-maintenance.ts
+++ b/packages/inventory/src/routes-maintenance.ts
@@ -4,10 +4,14 @@
  * parent app's middleware chain).
  *
  * Migrated to `@hono/zod-openapi` for the OpenAPI admin backfill (voyant#2114 —
- * inventory core sub-batch). The recalculate response is the rolled-up
- * `{ costAmountCents, marginPercent }` (both integer cents/percent — §17). Its
- * `.openapi()` operation propagates up through the parent `productRoutes`
- * registry.
+ * inventory core sub-batch). Its `.openapi()` operation propagates up through
+ * the parent `productRoutes` registry.
+ *
+ * The response reports the roll-up in the product's sell `currency` (integer
+ * cents/percent — §17) alongside the per-source-currency subtotals it was built
+ * from. `costAmountCents` and `marginPercent` are null when a source currency
+ * had no resolvable FX rate; the currencies concerned are named in
+ * `unconvertibleCurrencies` rather than folded in at a guessed rate (#4162).
  */
 
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
@@ -19,8 +23,11 @@ import { productsService } from "./service.js"
 const errorResponseSchema = z.object({ error: z.string() })
 
 const recalculateResultSchema = z.object({
-  costAmountCents: z.number().int(),
-  marginPercent: z.number().int(),
+  currency: z.string(),
+  costAmountCents: z.number().int().nullable(),
+  marginPercent: z.number().int().nullable(),
+  byCurrency: z.array(z.object({ currency: z.string(), amountCents: z.number().int() })),
+  unconvertibleCurrencies: z.array(z.string()),
 })
 
 const recalculateProductRoute = createRoute({

--- a/packages/inventory/src/service-itinerary-history.ts
+++ b/packages/inventory/src/service-itinerary-history.ts
@@ -11,42 +11,11 @@ import {
   products,
   productVersions,
 } from "./schema.js"
+import { type ProductCostFxOptions, recalculateProductCost } from "./service-product-cost.js"
 import type { insertProductNoteSchema, insertVersionSchema } from "./validation.js"
 
 type CreateVersionInput = z.infer<typeof insertVersionSchema>
 type CreateProductNoteInput = z.infer<typeof insertProductNoteSchema>
-
-async function recalculateProductCost(db: PostgresJsDatabase, productId: string) {
-  const [result] = await db
-    .select({
-      totalCost: sql<number>`coalesce(sum(${productDayServices.costAmountCents} * ${productDayServices.quantity}), 0)::int`,
-    })
-    .from(productDayServices)
-    .innerJoin(productDays, eq(productDayServices.dayId, productDays.id))
-    .innerJoin(productItineraries, eq(productDays.itineraryId, productItineraries.id))
-    .where(eq(productItineraries.productId, productId))
-
-  const costAmountCents = result?.totalCost ?? 0
-
-  const [product] = await db
-    .select({ sellAmountCents: products.sellAmountCents })
-    .from(products)
-    .where(eq(products.id, productId))
-    .limit(1)
-
-  const sellAmountCents = product?.sellAmountCents ?? 0
-  const marginPercent =
-    sellAmountCents > 0
-      ? Math.round(((sellAmountCents - costAmountCents) / sellAmountCents) * 100)
-      : 0
-
-  await db
-    .update(products)
-    .set({ costAmountCents, marginPercent, updatedAt: new Date() })
-    .where(eq(products.id, productId))
-
-  return { costAmountCents, marginPercent }
-}
 
 /**
  * The frozen shape a Product Version stores: the product row plus the options,
@@ -208,17 +177,12 @@ export const itineraryHistoryProductsService = {
     return row
   },
 
-  async recalculate(db: PostgresJsDatabase, productId: string) {
-    const [product] = await db
-      .select({ id: products.id })
-      .from(products)
-      .where(eq(products.id, productId))
-      .limit(1)
-
-    if (!product) {
-      return null
-    }
-
-    return recalculateProductCost(db, productId)
+  /**
+   * Recompute the product's rolled-up itinerary cost and margin. `options`
+   * carries the FX runtime used to restate non-sell-currency service costs; with
+   * none supplied the roll-up falls back to persisted `exchange_rates`.
+   */
+  recalculate(db: PostgresJsDatabase, productId: string, options: ProductCostFxOptions = {}) {
+    return recalculateProductCost(db, productId, options)
   },
 }

--- a/packages/inventory/src/service-itinerary.ts
+++ b/packages/inventory/src/service-itinerary.ts
@@ -12,6 +12,7 @@ import {
   assertItineraryDayNumberAvailable,
   mapItineraryDayNumberWriteError,
 } from "./service-itinerary-validation.js"
+import { recalculateProductCost } from "./service-product-cost.js"
 import type {
   insertDaySchema,
   insertDayServiceSchema,
@@ -27,38 +28,6 @@ type CreateDayInput = z.infer<typeof insertDaySchema>
 type UpdateDayInput = z.infer<typeof updateDaySchema>
 type CreateDayServiceInput = z.infer<typeof insertDayServiceSchema>
 type UpdateDayServiceInput = z.infer<typeof updateDayServiceSchema>
-
-async function recalculateProductCost(db: PostgresJsDatabase, productId: string) {
-  const [result] = await db
-    .select({
-      totalCost: sql<number>`coalesce(sum(${productDayServices.costAmountCents} * ${productDayServices.quantity}), 0)::int`,
-    })
-    .from(productDayServices)
-    .innerJoin(productDays, eq(productDayServices.dayId, productDays.id))
-    .innerJoin(productItineraries, eq(productDays.itineraryId, productItineraries.id))
-    .where(eq(productItineraries.productId, productId))
-
-  const costAmountCents = result?.totalCost ?? 0
-
-  const [product] = await db
-    .select({ sellAmountCents: products.sellAmountCents })
-    .from(products)
-    .where(eq(products.id, productId))
-    .limit(1)
-
-  const sellAmountCents = product?.sellAmountCents ?? 0
-  const marginPercent =
-    sellAmountCents > 0
-      ? Math.round(((sellAmountCents - costAmountCents) / sellAmountCents) * 100)
-      : 0
-
-  await db
-    .update(products)
-    .set({ costAmountCents, marginPercent, updatedAt: new Date() })
-    .where(eq(products.id, productId))
-
-  return { costAmountCents, marginPercent }
-}
 
 async function ensureProductExists(db: PostgresJsDatabase, productId: string) {
   const [product] = await db

--- a/packages/inventory/src/service-product-cost.ts
+++ b/packages/inventory/src/service-product-cost.ts
@@ -1,0 +1,225 @@
+/**
+ * Product cost roll-up — the single owner of `products.cost_amount_cents` and
+ * `products.margin_percent` (voyant#4162).
+ *
+ * `product_day_services.cost_currency` is a required per-row column, so one
+ * itinerary routinely mixes currencies: EUR coach hire next to TRY hotel nights
+ * on the same Turkish tour. The roll-up therefore groups by source currency and
+ * never adds minor units across currencies.
+ *
+ * The stored scalar is denominated in the product's **sell currency**. That is
+ * what the column already means to its consumers — the operator product page
+ * formats `costAmountCents` with `product.sellCurrency`, and `marginPercent` is
+ * derived against `products.sell_amount_cents`, which is quoted in that same
+ * currency. Every non-sell source currency is converted through the same FX
+ * machinery finance uses for invoices (`resolveFxMoneyBaseAmount`: persisted
+ * `exchange_rates` first, then the caller's runtime resolver).
+ *
+ * Following the profitability read model's precedent, a source currency with no
+ * resolvable rate is reported in `unconvertibleCurrencies` rather than guessed
+ * at. Unlike that read model, a single scalar column cannot say "everything
+ * except the Turkish lira", so the total is withheld (`null`) instead of
+ * silently under-reporting cost and over-reporting margin. `margin_percent`
+ * follows it to `null`, because a margin is only meaningful when both sides are
+ * known and in the same currency.
+ */
+
+import {
+  type FxMoneyInput,
+  type InvoiceFxOptions,
+  resolveFxMoneyBaseAmount,
+} from "@voyant-travel/finance"
+import { eq, sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import { productDayServices, productDays, productItineraries, products } from "./schema.js"
+
+/** Cost booked in one source currency. Only ever summed within that currency. */
+export interface ProductCostCurrencySubtotal {
+  currency: string
+  amountCents: number
+}
+
+export interface ProductCostRollup {
+  /** Currency `costAmountCents` is denominated in — the product's sell currency. */
+  currency: string
+  /**
+   * Total itinerary cost in `currency`, or `null` when at least one source
+   * currency had no resolvable rate into it.
+   */
+  costAmountCents: number | null
+  /** Margin against the sell amount, or `null` when either side is unknown. */
+  marginPercent: number | null
+  /** Per-source-currency subtotals, in currency order. Never collapsed blindly. */
+  byCurrency: ProductCostCurrencySubtotal[]
+  /** Source currencies with no resolvable FX rate into `currency`. */
+  unconvertibleCurrencies: string[]
+}
+
+/** FX runtime for the roll-up — the same options finance threads into invoices. */
+export type ProductCostFxOptions = InvoiceFxOptions
+
+export interface CollapsedProductCost {
+  totalCents: number | null
+  unconvertibleCurrencies: string[]
+}
+
+function normalizeCurrency(value: string | null | undefined): string {
+  return value?.trim().toUpperCase() ?? ""
+}
+
+/**
+ * Group raw service costs by source currency. Currency codes are normalized so
+ * a row stored as `eur` lands in the same bucket as `EUR` instead of becoming a
+ * second, separately-unconvertible currency.
+ */
+export function sumCostByCurrency(
+  rows: Iterable<{ currency: string | null | undefined; amountCents: number }>,
+): ProductCostCurrencySubtotal[] {
+  const totals = new Map<string, number>()
+  for (const row of rows) {
+    const currency = normalizeCurrency(row.currency)
+    totals.set(currency, (totals.get(currency) ?? 0) + row.amountCents)
+  }
+  return [...totals]
+    .map(([currency, amountCents]) => ({ currency, amountCents }))
+    .sort((a, b) => a.currency.localeCompare(b.currency))
+}
+
+/**
+ * Collapse per-currency subtotals into one figure in `targetCurrency`.
+ *
+ * `convert` returns the subtotal restated in `targetCurrency`, or `null` when no
+ * rate is available. A zero subtotal never needs a rate, so it cannot make the
+ * roll-up unconvertible. Any other currency without a rate withholds the total
+ * outright — an under-counted cost reads as a healthy margin, which is worse
+ * than no number at all.
+ */
+export async function collapseCostToCurrency(
+  subtotals: readonly ProductCostCurrencySubtotal[],
+  targetCurrency: string,
+  convert: (subtotal: ProductCostCurrencySubtotal) => Promise<number | null> | number | null,
+): Promise<CollapsedProductCost> {
+  let total = 0
+  const unconvertibleCurrencies: string[] = []
+
+  for (const subtotal of subtotals) {
+    if (subtotal.amountCents === 0) continue
+    if (targetCurrency !== "" && subtotal.currency === targetCurrency) {
+      total += subtotal.amountCents
+      continue
+    }
+
+    const converted =
+      targetCurrency === "" || subtotal.currency === "" ? null : await convert(subtotal)
+    if (converted == null) {
+      unconvertibleCurrencies.push(subtotal.currency)
+      continue
+    }
+    total += converted
+  }
+
+  return {
+    totalCents: unconvertibleCurrencies.length > 0 ? null : Math.round(total),
+    unconvertibleCurrencies,
+  }
+}
+
+/**
+ * Margin of a known cost against a known sell amount, both in the sell currency.
+ * `null` whenever either side is unknown — a product with no sell price has no
+ * margin, and reporting `0` there reads as "sold at cost".
+ */
+export function computeMarginPercent(
+  sellAmountCents: number | null | undefined,
+  costAmountCents: number | null,
+): number | null {
+  if (costAmountCents == null) return null
+  if (sellAmountCents == null || sellAmountCents <= 0) return null
+  return Math.round(((sellAmountCents - costAmountCents) / sellAmountCents) * 100)
+}
+
+/**
+ * Recompute and persist `products.cost_amount_cents` / `products.margin_percent`
+ * from the product's itinerary day services. Returns `null` when the product
+ * does not exist.
+ */
+export async function recalculateProductCost(
+  db: PostgresJsDatabase,
+  productId: string,
+  options: ProductCostFxOptions = {},
+): Promise<ProductCostRollup | null> {
+  const [product] = await db
+    .select({ sellCurrency: products.sellCurrency, sellAmountCents: products.sellAmountCents })
+    .from(products)
+    .where(eq(products.id, productId))
+    .limit(1)
+
+  if (!product) {
+    return null
+  }
+
+  const currency = normalizeCurrency(product.sellCurrency)
+
+  const rows = await db
+    .select({
+      currency: productDayServices.costCurrency,
+      // Cast before multiplying: an int4 product overflows long before a
+      // realistic itinerary total does. Read back through Number(), since
+      // postgres-js hands int8 over as a string.
+      // agent-quality: raw-sql reviewed -- owner: inventory; dynamic SQL interpolation uses Drizzle parameter binding or vetted SQL identifiers.
+      amountCents: sql<number>`coalesce(sum(${productDayServices.costAmountCents}::bigint * ${productDayServices.quantity}), 0)`,
+    })
+    .from(productDayServices)
+    .innerJoin(productDays, eq(productDayServices.dayId, productDays.id))
+    .innerJoin(productItineraries, eq(productDays.itineraryId, productItineraries.id))
+    .where(eq(productItineraries.productId, productId))
+    .groupBy(productDayServices.costCurrency)
+
+  const byCurrency = sumCostByCurrency(
+    rows.map((row) => ({ currency: row.currency, amountCents: Number(row.amountCents ?? 0) })),
+  )
+
+  const { totalCents, unconvertibleCurrencies } = await collapseCostToCurrency(
+    byCurrency,
+    currency,
+    async (subtotal) => {
+      // Annotated as `FxMoneyInput` so the resolved base amount and base
+      // currency come back on the result type, as finance's own callers do.
+      const input: FxMoneyInput = {
+        amountCents: subtotal.amountCents,
+        currency: subtotal.currency,
+      }
+      try {
+        const converted = await resolveFxMoneyBaseAmount(db, input, {
+          ...options,
+          targetBaseCurrency: currency,
+        })
+        return converted.baseCurrency === currency && converted.baseAmountCents != null
+          ? converted.baseAmountCents
+          : null
+      } catch {
+        // This roll-up runs inside the day-service write path, so a rate lookup
+        // that cannot even be attempted — a deployment carrying no
+        // `exchange_rates` table, say — must not fail the save. An
+        // unreachable rate is an unresolved rate: reported, never guessed.
+        return null
+      }
+    },
+  )
+
+  const marginPercent = computeMarginPercent(product.sellAmountCents, totalCents)
+
+  await db
+    .update(products)
+    .set({ costAmountCents: totalCents, marginPercent, updatedAt: new Date() })
+    .where(eq(products.id, productId))
+
+  return {
+    currency,
+    costAmountCents: totalCents,
+    marginPercent,
+    byCurrency,
+    unconvertibleCurrencies,
+  }
+}

--- a/packages/inventory/tests/admin/unit/routes-core-contract.test.ts
+++ b/packages/inventory/tests/admin/unit/routes-core-contract.test.ts
@@ -87,6 +87,17 @@ const productWithTypeSchema = productSchema.extend({
   productType: z.object({ id: z.string(), name: z.string(), code: z.string() }).nullable(),
 })
 
+// Mirrors `recalculateResultSchema` in `routes-maintenance.ts`. The total and
+// margin are nullable because a source currency with no resolvable FX rate is
+// named in `unconvertibleCurrencies` instead of being folded in (voyant#4162).
+const recalculateResultSchema = z.object({
+  currency: z.string(),
+  costAmountCents: z.number().int().nullable(),
+  marginPercent: z.number().int().nullable(),
+  byCurrency: z.array(z.object({ currency: z.string(), amountCents: z.number().int() })),
+  unconvertibleCurrencies: z.array(z.string()),
+})
+
 const productCategorySchema = z.object({
   id: z.string(),
   parentId: z.string().nullable(),
@@ -224,12 +235,32 @@ describe("inventory core single-entity response contracts", () => {
   })
 
   it("the recalculate { data } envelope satisfies the declared OpenAPI schema", () => {
-    const parsed = z
-      .object({
-        data: z.object({ costAmountCents: z.number().int(), marginPercent: z.number().int() }),
-      })
-      .safeParse({ data: { costAmountCents: 80000, marginPercent: 33 } })
-    expect(parsed.success).toBe(true)
+    const parsed = z.object({ data: recalculateResultSchema }).safeParse({
+      data: {
+        currency: "EUR",
+        costAmountCents: 80000,
+        marginPercent: 33,
+        byCurrency: [{ currency: "EUR", amountCents: 80000 }],
+        unconvertibleCurrencies: [],
+      },
+    })
+    expect(parsed.success ? null : parsed.error.toString()).toBeNull()
+  })
+
+  it("the recalculate { data } envelope carries a withheld total for an unconvertible currency", () => {
+    const parsed = z.object({ data: recalculateResultSchema }).safeParse({
+      data: {
+        currency: "EUR",
+        costAmountCents: null,
+        marginPercent: null,
+        byCurrency: [
+          { currency: "EUR", amountCents: 30000 },
+          { currency: "TRY", amountCents: 500000 },
+        ],
+        unconvertibleCurrencies: ["TRY"],
+      },
+    })
+    expect(parsed.success ? null : parsed.error.toString()).toBeNull()
   })
 
   it("the success envelope satisfies the declared OpenAPI schema", () => {

--- a/packages/inventory/tests/integration/routes.test.ts
+++ b/packages/inventory/tests/integration/routes.test.ts
@@ -320,6 +320,80 @@ describe.skipIf(!DB_AVAILABLE)("Product routes", () => {
     const { data } = await recalcRes.json()
     expect(data.costAmountCents).toBe(0)
     expect(data.marginPercent).toBe(100)
+    expect(data.currency).toBe("EUR")
+    expect(data.byCurrency).toEqual([])
+    expect(data.unconvertibleCurrencies).toEqual([])
+  })
+
+  it("totals a mixed-currency itinerary per currency instead of adding minor units", async () => {
+    const createRes = await app.request("/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Turkey Grand Tour",
+        sellCurrency: "EUR",
+        sellAmountCents: 200000,
+      }),
+    })
+    const { data: product } = await createRes.json()
+
+    const itineraryRes = await app.request(`/${product.id}/itineraries`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Main" }),
+    })
+    const { data: itinerary } = await itineraryRes.json()
+
+    const dayRes = await app.request(`/${product.id}/itineraries/${itinerary.id}/days`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ dayNumber: 1, title: "Istanbul", location: "Istanbul" }),
+    })
+    const { data: day } = await dayRes.json()
+
+    // EUR coach hire (2 × 150.00) alongside TRY hotel nights (3 × 5,000.00).
+    for (const service of [
+      { serviceType: "transfer", name: "Coach", costCurrency: "EUR", cost: 15000, quantity: 2 },
+      {
+        serviceType: "accommodation",
+        name: "Hotel",
+        costCurrency: "TRY",
+        cost: 500000,
+        quantity: 3,
+      },
+    ]) {
+      await app.request(`/${product.id}/days/${day.id}/services`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          serviceType: service.serviceType,
+          name: service.name,
+          costCurrency: service.costCurrency,
+          costAmountCents: service.cost,
+          quantity: service.quantity,
+        }),
+      })
+    }
+
+    const recalcRes = await app.request(`/${product.id}/recalculate`, { method: "POST" })
+    expect(recalcRes.status).toBe(200)
+    const { data } = await recalcRes.json()
+
+    // Grouped by source currency by the database, not flattened into one integer.
+    expect(data.currency).toBe("EUR")
+    expect(data.byCurrency).toEqual([
+      { currency: "EUR", amountCents: 30000 },
+      { currency: "TRY", amountCents: 1500000 },
+    ])
+    // Whatever the deployment's FX data allows, the answer is never the naive
+    // sum of euro cents and kuruş.
+    expect(data.costAmountCents).not.toBe(1530000)
+    if (data.unconvertibleCurrencies.includes("TRY")) {
+      expect(data.costAmountCents).toBeNull()
+      expect(data.marginPercent).toBeNull()
+    } else {
+      expect(data.costAmountCents).toBeGreaterThan(30000)
+    }
   })
 
   it("creates and lists structured product features", async () => {

--- a/packages/inventory/tests/unit/product-cost-rollup.test.ts
+++ b/packages/inventory/tests/unit/product-cost-rollup.test.ts
@@ -1,0 +1,332 @@
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+/**
+ * Mixed-currency product cost roll-up (voyant#4162).
+ *
+ * `product_day_services.cost_currency` is per row, so a Turkish tour holds EUR
+ * coach hire next to TRY hotel nights. The roll-up used to `sum()` those minor
+ * units into one integer and derive a margin from it, producing a number that
+ * belonged to no currency at all. These tests pin the replacement: total per
+ * source currency, restate into the product's sell currency through finance's
+ * FX machinery, and withhold the figure when a rate is missing.
+ */
+
+const { resolveFxMoneyBaseAmount } = vi.hoisted(() => ({
+  resolveFxMoneyBaseAmount: vi.fn(),
+}))
+
+vi.mock("@voyant-travel/finance", () => ({ resolveFxMoneyBaseAmount }))
+
+const { recalculateProductCost, collapseCostToCurrency } = await import(
+  "../../src/service-product-cost.js"
+)
+
+/** Stand-in for the persisted `exchange_rates` lookup finance performs. */
+function fxRates(rates: Record<string, number>) {
+  return async (
+    _db: unknown,
+    input: { amountCents: number; currency: string },
+    options: { targetBaseCurrency?: string | null },
+  ) => {
+    const rate = rates[input.currency]
+    if (rate === undefined) {
+      // Finance's shape for "no resolvable rate": the base amount stays unset
+      // rather than being filled in at a guessed rate.
+      return { ...input, baseCurrency: null, baseAmountCents: null, fxRateSetId: null }
+    }
+    return {
+      ...input,
+      baseCurrency: options.targetBaseCurrency ?? null,
+      baseAmountCents: Math.round(input.amountCents * rate),
+      fxRateSetId: "fxrs_test",
+    }
+  }
+}
+
+function fakeProductCostDb(options: {
+  product: { sellCurrency: string; sellAmountCents: number | null } | null
+  services: Array<{ currency: string; amountCents: number }>
+}): { db: PostgresJsDatabase; updateSets: Array<Record<string, unknown>> } {
+  const updateSets: Array<Record<string, unknown>> = []
+
+  // Every builder step returns the same awaitable, so the stub answers both the
+  // `.from().where().limit()` product lookup and the grouped `.innerJoin()` roll-up.
+  const chain = (rows: unknown[]) => {
+    const builder = Promise.resolve(rows) as Promise<unknown[]> &
+      Record<string, () => Promise<unknown[]>>
+    for (const step of ["from", "innerJoin", "where", "limit", "groupBy", "orderBy"]) {
+      builder[step] = () => builder
+    }
+    return builder
+  }
+
+  const db = {
+    select: (fields: Record<string, unknown>) =>
+      "sellCurrency" in fields
+        ? chain(options.product ? [options.product] : [])
+        : // postgres-js hands int8 back as a string — mirror that so the roll-up
+          // is forced to coerce rather than relying on a JS number.
+          chain(
+            options.services.map((service) => ({
+              currency: service.currency,
+              amountCents: String(service.amountCents),
+            })),
+          ),
+    update: () => ({
+      set: (values: Record<string, unknown>) => {
+        updateSets.push(values)
+        return { where: async () => [] }
+      },
+    }),
+  } as never
+
+  return { db, updateSets }
+}
+
+beforeEach(() => {
+  resolveFxMoneyBaseAmount.mockReset()
+})
+
+describe("recalculateProductCost", () => {
+  it("leaves a single-currency product on its own currency without consulting FX", async () => {
+    const { db, updateSets } = fakeProductCostDb({
+      product: { sellCurrency: "EUR", sellAmountCents: 100_000 },
+      services: [{ currency: "EUR", amountCents: 40_000 }],
+    })
+
+    const result = await recalculateProductCost(db, "prod_1")
+
+    expect(result).toEqual({
+      currency: "EUR",
+      costAmountCents: 40_000,
+      marginPercent: 60,
+      byCurrency: [{ currency: "EUR", amountCents: 40_000 }],
+      unconvertibleCurrencies: [],
+    })
+    expect(resolveFxMoneyBaseAmount).not.toHaveBeenCalled()
+    expect(updateSets).toEqual([
+      expect.objectContaining({ costAmountCents: 40_000, marginPercent: 60 }),
+    ])
+  })
+
+  it("never adds minor units across currencies — it converts into the sell currency first", async () => {
+    resolveFxMoneyBaseAmount.mockImplementation(fxRates({ TRY: 0.028 }))
+    const { db, updateSets } = fakeProductCostDb({
+      product: { sellCurrency: "EUR", sellAmountCents: 100_000 },
+      services: [
+        { currency: "EUR", amountCents: 30_000 },
+        { currency: "TRY", amountCents: 500_000 },
+      ],
+    })
+
+    const result = await recalculateProductCost(db, "prod_1")
+
+    // The old roll-up returned 530_000: EUR cents plus TRY kuruş, a figure in no
+    // currency at all, which then read as a -430% margin.
+    expect(result?.costAmountCents).not.toBe(530_000)
+    expect(result?.costAmountCents).toBe(44_000) // 30_000 EUR + 500_000 TRY × 0.028
+    expect(result?.currency).toBe("EUR")
+    expect(result?.marginPercent).toBe(56)
+    expect(result?.byCurrency).toEqual([
+      { currency: "EUR", amountCents: 30_000 },
+      { currency: "TRY", amountCents: 500_000 },
+    ])
+    expect(result?.unconvertibleCurrencies).toEqual([])
+    expect(updateSets).toEqual([
+      expect.objectContaining({ costAmountCents: 44_000, marginPercent: 56 }),
+    ])
+
+    // The conversion target is the product's sell currency, so cost and sell are
+    // in the same currency by the time a margin is taken.
+    expect(resolveFxMoneyBaseAmount).toHaveBeenCalledTimes(1)
+    expect(resolveFxMoneyBaseAmount.mock.calls[0]?.[2]).toMatchObject({
+      targetBaseCurrency: "EUR",
+    })
+  })
+
+  it("withholds the total and the margin when a source currency has no resolvable rate", async () => {
+    resolveFxMoneyBaseAmount.mockImplementation(fxRates({}))
+    const { db, updateSets } = fakeProductCostDb({
+      product: { sellCurrency: "EUR", sellAmountCents: 100_000 },
+      services: [
+        { currency: "EUR", amountCents: 30_000 },
+        { currency: "TRY", amountCents: 500_000 },
+      ],
+    })
+
+    const result = await recalculateProductCost(db, "prod_1")
+
+    expect(result?.costAmountCents).toBeNull()
+    expect(result?.marginPercent).toBeNull()
+    expect(result?.unconvertibleCurrencies).toEqual(["TRY"])
+    // Reported, not guessed: no fallback rate of 1, and no partial total that
+    // would silently under-report cost and over-report margin.
+    expect(result?.byCurrency).toEqual([
+      { currency: "EUR", amountCents: 30_000 },
+      { currency: "TRY", amountCents: 500_000 },
+    ])
+    expect(updateSets).toEqual([
+      expect.objectContaining({ costAmountCents: null, marginPercent: null }),
+    ])
+  })
+
+  it("does not derive a margin from a cost and a sell amount in different currencies", async () => {
+    resolveFxMoneyBaseAmount.mockImplementation(fxRates({}))
+    const { db } = fakeProductCostDb({
+      product: { sellCurrency: "EUR", sellAmountCents: 100_000 },
+      services: [{ currency: "TRY", amountCents: 500_000 }],
+    })
+
+    const unconverted = await recalculateProductCost(db, "prod_1")
+
+    // 500_000 kuruş against 100_000 euro cents would have read as a -400% margin.
+    expect(unconverted?.costAmountCents).toBeNull()
+    expect(unconverted?.marginPercent).toBeNull()
+
+    resolveFxMoneyBaseAmount.mockImplementation(fxRates({ TRY: 0.028 }))
+    const converted = await recalculateProductCost(
+      fakeProductCostDb({
+        product: { sellCurrency: "EUR", sellAmountCents: 100_000 },
+        services: [{ currency: "TRY", amountCents: 500_000 }],
+      }).db,
+      "prod_1",
+    )
+
+    expect(converted?.costAmountCents).toBe(14_000)
+    expect(converted?.marginPercent).toBe(86)
+  })
+
+  it("treats a rate resolved into some other currency as unresolvable", async () => {
+    // Finance falls back to the configured accounting base when no target is
+    // usable. A RON figure is not a EUR figure, so it must not be summed in.
+    resolveFxMoneyBaseAmount.mockImplementation(async (_db, input) => ({
+      ...input,
+      baseCurrency: "RON",
+      baseAmountCents: 999,
+      fxRateSetId: "fxrs_test",
+    }))
+    const { db } = fakeProductCostDb({
+      product: { sellCurrency: "EUR", sellAmountCents: 100_000 },
+      services: [{ currency: "TRY", amountCents: 500_000 }],
+    })
+
+    const result = await recalculateProductCost(db, "prod_1")
+
+    expect(result?.costAmountCents).toBeNull()
+    expect(result?.unconvertibleCurrencies).toEqual(["TRY"])
+  })
+
+  it("keeps the day-service write path alive when the rate lookup itself fails", async () => {
+    // The roll-up runs on every day-service save. A deployment with no
+    // `exchange_rates` table must get an unconvertible currency back, not a
+    // failed save.
+    resolveFxMoneyBaseAmount.mockRejectedValue(
+      new Error('relation "exchange_rates" does not exist'),
+    )
+    const { db, updateSets } = fakeProductCostDb({
+      product: { sellCurrency: "EUR", sellAmountCents: 100_000 },
+      services: [{ currency: "TRY", amountCents: 500_000 }],
+    })
+
+    const result = await recalculateProductCost(db, "prod_1")
+
+    expect(result?.costAmountCents).toBeNull()
+    expect(result?.unconvertibleCurrencies).toEqual(["TRY"])
+    expect(updateSets).toEqual([
+      expect.objectContaining({ costAmountCents: null, marginPercent: null }),
+    ])
+  })
+
+  it("merges differently-cased currency codes instead of reporting one as unconvertible", async () => {
+    const { db } = fakeProductCostDb({
+      product: { sellCurrency: "eur", sellAmountCents: 100_000 },
+      services: [
+        { currency: "eur", amountCents: 30_000 },
+        { currency: "EUR", amountCents: 10_000 },
+      ],
+    })
+
+    const result = await recalculateProductCost(db, "prod_1")
+
+    expect(result).toMatchObject({
+      currency: "EUR",
+      costAmountCents: 40_000,
+      byCurrency: [{ currency: "EUR", amountCents: 40_000 }],
+      unconvertibleCurrencies: [],
+    })
+    expect(resolveFxMoneyBaseAmount).not.toHaveBeenCalled()
+  })
+
+  it("has no margin when the product carries no sell amount", async () => {
+    const { db, updateSets } = fakeProductCostDb({
+      product: { sellCurrency: "EUR", sellAmountCents: null },
+      services: [{ currency: "EUR", amountCents: 40_000 }],
+    })
+
+    const result = await recalculateProductCost(db, "prod_1")
+
+    expect(result).toMatchObject({ costAmountCents: 40_000, marginPercent: null })
+    expect(updateSets).toEqual([
+      expect.objectContaining({ costAmountCents: 40_000, marginPercent: null }),
+    ])
+  })
+
+  it("rolls up to zero for a product with no itinerary services", async () => {
+    const { db } = fakeProductCostDb({
+      product: { sellCurrency: "EUR", sellAmountCents: 100_000 },
+      services: [],
+    })
+
+    await expect(recalculateProductCost(db, "prod_1")).resolves.toMatchObject({
+      costAmountCents: 0,
+      marginPercent: 100,
+      byCurrency: [],
+    })
+  })
+
+  it("returns null and writes nothing when the product does not exist", async () => {
+    const { db, updateSets } = fakeProductCostDb({ product: null, services: [] })
+
+    await expect(recalculateProductCost(db, "prod_missing")).resolves.toBeNull()
+    expect(updateSets).toEqual([])
+  })
+})
+
+describe("collapseCostToCurrency", () => {
+  it("does not need a rate for a currency that contributes nothing", async () => {
+    const result = await collapseCostToCurrency(
+      [
+        { currency: "EUR", amountCents: 30_000 },
+        { currency: "TRY", amountCents: 0 },
+      ],
+      "EUR",
+      () => null,
+    )
+
+    expect(result).toEqual({ totalCents: 30_000, unconvertibleCurrencies: [] })
+  })
+
+  it("reports every unconvertible currency, not just the first", async () => {
+    const result = await collapseCostToCurrency(
+      [
+        { currency: "GBP", amountCents: 1000 },
+        { currency: "TRY", amountCents: 500_000 },
+      ],
+      "EUR",
+      () => null,
+    )
+
+    expect(result).toEqual({ totalCents: null, unconvertibleCurrencies: ["GBP", "TRY"] })
+  })
+
+  it("cannot denominate anything when the product has no sell currency", async () => {
+    const result = await collapseCostToCurrency(
+      [{ currency: "EUR", amountCents: 30_000 }],
+      "",
+      () => expect.unreachable("a missing target currency must not be converted into"),
+    )
+
+    expect(result).toEqual({ totalCents: null, unconvertibleCurrencies: ["EUR"] })
+  })
+})

--- a/packages/inventory/tests/unit/recalculate.test.ts
+++ b/packages/inventory/tests/unit/recalculate.test.ts
@@ -1,51 +1,74 @@
 import { describe, expect, it } from "vitest"
 
+import { computeMarginPercent, sumCostByCurrency } from "../../src/service-product-cost.js"
+
 /**
- * Unit tests for the margin computation logic.
- * The formula is: marginPercent = round(((sell - cost) / sell) * 100)
+ * Unit tests for the two pure halves of the product cost roll-up: totalling
+ * service costs per source currency, and deriving the margin once the cost is
+ * known in the sell currency. These used to re-implement both formulas locally,
+ * which let the real ones drift (voyant#4162) — they now drive the exported
+ * helpers.
  */
 
-function computeMarginPercent(sellAmountCents: number, costAmountCents: number): number {
-  if (sellAmountCents <= 0) return 0
-  return Math.round(((sellAmountCents - costAmountCents) / sellAmountCents) * 100)
-}
-
-function sumServiceCosts(services: { costAmountCents: number; quantity: number }[]): number {
-  return services.reduce((sum, s) => sum + s.costAmountCents * s.quantity, 0)
-}
-
 describe("Product cost recalculation", () => {
-  describe("sumServiceCosts", () => {
-    it("returns 0 for empty services", () => {
-      expect(sumServiceCosts([])).toBe(0)
+  describe("sumCostByCurrency", () => {
+    it("returns no subtotals for empty services", () => {
+      expect(sumCostByCurrency([])).toEqual([])
     })
 
-    it("sums single service cost", () => {
-      expect(sumServiceCosts([{ costAmountCents: 5000, quantity: 1 }])).toBe(5000)
+    it("sums a single service cost", () => {
+      expect(sumCostByCurrency([{ currency: "EUR", amountCents: 5000 }])).toEqual([
+        { currency: "EUR", amountCents: 5000 },
+      ])
     })
 
-    it("multiplies cost by quantity", () => {
-      expect(sumServiceCosts([{ costAmountCents: 5000, quantity: 3 }])).toBe(15000)
-    })
-
-    it("sums multiple services", () => {
+    it("sums multiple services in the same currency", () => {
       expect(
-        sumServiceCosts([
-          { costAmountCents: 5000, quantity: 1 },
-          { costAmountCents: 3000, quantity: 2 },
-          { costAmountCents: 1000, quantity: 1 },
+        sumCostByCurrency([
+          { currency: "EUR", amountCents: 5000 },
+          { currency: "EUR", amountCents: 6000 },
+          { currency: "EUR", amountCents: 1000 },
         ]),
-      ).toBe(12000)
+      ).toEqual([{ currency: "EUR", amountCents: 12000 }])
+    })
+
+    it("keeps different currencies apart instead of adding their minor units", () => {
+      expect(
+        sumCostByCurrency([
+          { currency: "EUR", amountCents: 5000 },
+          { currency: "TRY", amountCents: 500_000 },
+        ]),
+      ).toEqual([
+        { currency: "EUR", amountCents: 5000 },
+        { currency: "TRY", amountCents: 500_000 },
+      ])
+    })
+
+    it("normalizes currency codes so one currency is not counted as two", () => {
+      expect(
+        sumCostByCurrency([
+          { currency: "eur", amountCents: 5000 },
+          { currency: " EUR ", amountCents: 3000 },
+        ]),
+      ).toEqual([{ currency: "EUR", amountCents: 8000 }])
     })
   })
 
   describe("computeMarginPercent", () => {
-    it("returns 0 when sell amount is 0", () => {
-      expect(computeMarginPercent(0, 5000)).toBe(0)
+    it("has no margin when the sell amount is 0", () => {
+      expect(computeMarginPercent(0, 5000)).toBeNull()
     })
 
-    it("returns 0 when sell amount is negative", () => {
-      expect(computeMarginPercent(-1000, 5000)).toBe(0)
+    it("has no margin when the sell amount is negative", () => {
+      expect(computeMarginPercent(-1000, 5000)).toBeNull()
+    })
+
+    it("has no margin when the product carries no sell amount", () => {
+      expect(computeMarginPercent(null, 5000)).toBeNull()
+    })
+
+    it("has no margin when the cost could not be resolved", () => {
+      expect(computeMarginPercent(10000, null)).toBeNull()
     })
 
     it("computes 100% margin when cost is 0", () => {


### PR DESCRIPTION
## Why

`product_day_services.cost_currency` is a **required per-row** column, so a single itinerary routinely mixes currencies — EUR coach hire next to TRY hotel nights on the same Turkish tour.

`recalculateProductCost` summed those rows with no `GROUP BY cost_currency` and no FX:

```ts
sum(${productDayServices.costAmountCents} * ${productDayServices.quantity})::int
```

The result went into `products.cost_amount_cents` — an integer belonging to no currency — and `products.margin_percent` was then derived from it against `sell_amount_cents`, quoted in a possibly third currency. Both values are operator-visible and feed product-level profitability. The roll-up was also duplicated in two files.

## The decision: convert into the **sell** currency

Not finance's accounting base. The code decided this:

- `packages/inventory-react/src/components/product-detail-page.tsx:407` already formats `costAmountCents` with `product.sellCurrency` — the column *means* "cents in the sell currency" to its only display consumer.
- `margin_percent` is taken against `sell_amount_cents`. Converting to the accounting base would have left the margin cross-currency — the other half of the same bug.

So: `GROUP BY cost_currency` → per-currency subtotals → each non-sell currency restated via `resolveFxMoneyBaseAmount` (persisted `exchange_rates` first, then the caller's resolver) → summed. Margin is taken only once both sides are in one currency.

**Unresolvable rates are withheld, not guessed.** Finance's profitability model excludes them and reports `unconvertibleCurrencies`; a single scalar column cannot say "everything except the lira", so a partial total would silently under-report cost and over-report margin. `cost_amount_cents` and `margin_percent` are set to `null` and the offending currencies are named in the response. **Both columns were already nullable — no migration**, and existing consumers already type them nullable.

Two deliberate secondary changes:
- **`margin_percent` is now `null`, not `0`, when a product has no sell amount.** "0% margin" on an unpriced product is a lie, and this leaves one encoding of "unknown" rather than two.
- **The FX lookup cannot fail the write path it runs inside.** This roll-up executes during `createDayService`/`updateDayService`/`deleteDayService`; a deployment with no `exchange_rates` table would otherwise throw on every itinerary edit. A throw is treated as unconvertible — reported, never guessed, never fails the save.

Also: the `* quantity` product is cast `::bigint`; an int4 product overflows long before a realistic itinerary total does.

## Reviewer notes

1. **Behaviour change for existing data, by design.** An operator with all-EUR services, a RON `sell_currency`, and no `exchange_rates` rows goes from a wrong number to `null` on the next recalc. Intended, but user-visible.
2. **`POST /v1/admin/products/{id}/recalculate` is wider and now nullable** — gains `currency`, `byCurrency`, `unconvertibleCurrencies`. Nothing in the repo calls this endpoint.
3. **`openapi/admin/products.json` was hand-edited, not regenerated.** Running the generator produced 177 insertions of which only 33 were this change — **main's checked-in artifact is already stale** (a `severity` enum on readiness warnings plus a 134-line block), and no CI job regenerates and diffs it. Only the relevant hunk was applied rather than smuggling unrelated drift into this PR. Worth its own fix.
4. **`resolveFxMoneyBaseAmount` is now public on `@voyant-travel/finance`** via `index.ts` — no new subpath, so no `publishConfig`/dep-paths/dist-config edits.
5. `packages/inventory/src/authoring/builder.ts:85` still lets a spec set `costAmountCents`/`marginPercent` directly. That is author-supplied input in the sell currency, consistent with this interpretation; left alone.

## Verification

- `pnpm -F @voyant-travel/inventory test` — 581 passed, 58 skipped (85 files)
- `pnpm -F @voyant-travel/finance test` — 501 passed, 363 skipped (82 files)
- New coverage proves: mixed EUR+TRY no longer yields the nonsense scalar; a rate resolved into some *other* currency is rejected rather than summed; the unresolvable path returns `null` + `["TRY"]` and persists nulls; a lookup that *throws* does not break the write path; zero-amount currencies never withhold a total; `eur`/`EUR` merge. Plus a DB-gated integration test running the real `GROUP BY` SQL.
- `pnpm exec biome check .` from the root — no fixes applied; `git status` shows only the intended files
- `npx tsx scripts/checks/schema/table-privacy-runner.ts` — **none new**
- `check-agent-code-quality --changed` — 0 errors; the one warning is pre-existing and 30 lines better than before
- **Typecheck not obtained locally.** Worth recording the root cause: no package has a built `dist/`, so `tsconfig.typecheck.json`'s `paths` (pointing at `../<pkg>/dist/*.d.ts`) all miss and tsc compiles the entire workspace *source* graph. Finance survives it only because its own script sets `--max-old-space-size=8192`; inventory's does not. Not a signal about this change — **CI `build-graph` is authoritative.**

Closes #4162