### PR TITLE
Turn the slot detail page into a departure workspace

### DIFF
--- a/.changeset/departure-tracer-workspace.md
+++ b/.changeset/departure-tracer-workspace.md
@@ -1,0 +1,30 @@
+---
+"@voyant-travel/operations-react": minor
+"@voyant-travel/finance-react": patch
+"@voyant-travel/i18n": minor
+---
+
+feat(operations): reconcile a departure in one workspace
+
+The availability slot detail page becomes the departure workspace. It reads its
+headline from the composed `GET /slots/{id}/summary` envelope instead of
+re-summing the allocation manifest in the browser, so a paged manifest can no
+longer move a counter, and Finance's own P&L replaces the client-side revenue
+roll-up (`aggregateSlotFinancials` and `KpiStrip` are deprecated but still
+exported).
+
+- Six sections — Overview, Travelers, Allocation, Operations, Financials,
+  Activity — replace the old six tabs. Extras, Pickup and Closeouts are
+  sections inside Operations; Meta is the identity block inside Overview.
+- The selected section is URL-addressable (`?tab=`), so it survives a reload
+  and is linkable.
+- Every section renders when empty, each with its next authorized action.
+  Pickup and Closeouts previously disappeared entirely.
+- The typed departure issues render with severity, grouped, localized per
+  `DepartureIssueCode`, each linking to its subject where one exists.
+- Allocation resources' persisted `refType`/`refId` now resolve to a
+  destination (resource, supplier, product), and Financials links to Finance's
+  profitability report through a new `financeProfitability.report` destination.
+- Fixes the allocation audit log resolving `allocation_resources` ids against
+  the global operations resource pool, which always missed and rendered a raw
+  id.

--- a/packages/finance-react/src/admin/index.tsx
+++ b/packages/finance-react/src/admin/index.tsx
@@ -127,6 +127,13 @@ declare module "@voyant-travel/admin" {
     "supplierInvoice.list": Record<string, never>
     /** A supplier invoice's detail page. */
     "supplierInvoice.detail": { supplierInvoiceId: string }
+    /**
+     * The departure/product profitability report. Declared here because this
+     * package owns the route, and also declared by
+     * `@voyant-travel/operations-react` — the departure workspace links out to
+     * it rather than recomputing revenue.
+     */
+    "financeProfitability.report": Record<string, never>
   }
 }
 
@@ -370,6 +377,9 @@ export function createFinanceAdminExtension(
         id: "finance-profitability",
         path: `${basePath}/profitability`,
         title: profitability,
+        // Route-backed destination (RFC §4.7): the key resolves by pure path
+        // interpolation of this route, so the host's resolver is generated.
+        destination: "financeProfitability.report",
         ssr: "data-only",
         page: () => import("./pages/profitability.js"),
         // Dynamic import on purpose — see the invoices index loader above.

--- a/packages/i18n/src/admin/availability/en-part-2.ts
+++ b/packages/i18n/src/admin/availability/en-part-2.ts
@@ -162,6 +162,220 @@ export const adminAvailabilityMessagesEnPart2 = {
         "auto-allocate": "Auto-allocate",
       },
     },
+    /**
+     * The departure workspace (issue #4033): one screen where capacity,
+     * Bookings and Travelers are reconciled against each other. Six sections,
+     * each addressable by `?tab=`.
+     */
+    departure: {
+      tabs: {
+        overview: "Overview",
+        travelers: "Travelers",
+        allocation: "Allocation",
+        operations: "Operations",
+        financials: "Financials",
+        activity: "Activity",
+      },
+      overview: {
+        capacityTitle: "Capacity",
+        authoredPaxLabel: "Authored pax",
+        effectivePaxLabel: "Seatable pax",
+        storedRemainingLabel: "Stored remaining",
+        derivedRemainingLabel: "Derived remaining",
+        consumedPaxLabel: "Consumed pax",
+        unlimitedLabel: "Unlimited",
+        driftHint:
+          "The stored counter and the derived one disagree. Reconcile the bookings and holds below.",
+        bookingsTitle: "Bookings",
+        activeBookingsLabel: "Active bookings",
+        soldPaxLabel: "Sold pax",
+        cancelledWithAllocationLabel: "Cancelled, still allocated",
+        holdsTitle: "Checkout holds",
+        holdsActiveLabel: "Live",
+        holdsExpiredLabel: "Expired",
+        holdsPaxLabel: "Pax held",
+        identityTitle: "Identity",
+        productVersionLabel: "Product version",
+        notVersionBound: "Not bound to a published version",
+        extrasTitle: "Extras",
+        extrasOfferedLabel: "Offered",
+        extrasSelectedLabel: "Selected by travelers",
+        extrasOutstandingLabel: "Still to collect",
+        extrasUnavailable: "Extras are not deployed on this operator.",
+        editAction: "Edit departure",
+      },
+      travelers: {
+        title: "Traveler roster",
+        enteredLabel: "Names entered",
+        leadLabel: "Lead travelers",
+        seatedLabel: "Seated",
+        unseatedLabel: "Not seated",
+        missingLabel: "Names still missing",
+        excessLabel: "Names beyond sold pax",
+        columnTraveler: "Traveler",
+        columnBooking: "Booking",
+        columnStatus: "Status",
+        columnSeat: "Seat / room",
+        seatedBadge: "Seated",
+        unseatedBadge: "Not seated",
+        leadBadge: "Lead",
+        emptyTitle: "Nobody is booked on this departure yet",
+        emptyDescription:
+          "Travelers appear here the moment a booking is allocated to this departure.",
+        emptyAction: "Create a booking",
+        openBookingAction: "Open booking",
+      },
+      operations: {
+        title: "Operations",
+        description: "Everything that has to be squared away before this departure runs.",
+        pickupTitle: "Pickup",
+        pickupEmptyTitle: "No pickup points on this departure",
+        pickupEmptyDescription:
+          "Add a pickup point so the driver knows where to collect travelers.",
+        pickupEmptyAction: "Add a pickup point",
+        pickupPointUnknown: "Pickup point no longer available",
+        closeoutsTitle: "Closeouts",
+        closeoutsEmptyTitle: "This departure is open for sale",
+        closeoutsEmptyDescription:
+          "Close the date when it must stop selling — a guide is unavailable, or the supplier pulled the allotment.",
+        closeoutsEmptyAction: "Close this date",
+        extrasTitle: "Extras",
+        extrasEmptyTitle: "No extras are offered on this departure",
+        extrasEmptyDescription:
+          "Extras are configured on the product, then sold against every departure of it.",
+        extrasEmptyAction: "Configure extras on the product",
+      },
+      financials: {
+        title: "Profitability",
+        description: "Finance's own figures for this departure. Operations never recomputes them.",
+        columnCurrency: "Currency",
+        columnRevenue: "Revenue",
+        columnPlannedCost: "Planned cost",
+        columnActualCost: "Actual cost",
+        columnVariance: "Variance",
+        columnProfit: "Profit",
+        columnMargin: "Margin",
+        baseTitle: "Accounting base",
+        unconvertibleTitle: "Not converted into the base",
+        unconvertibleDescription:
+          "Finance had no rate for these currencies, so their lines are missing from the base rollup: {currencies}",
+        settlementTitle: "Settlement",
+        settlementSoldLabel: "Sold",
+        settlementPaidLabel: "Paid",
+        settlementOutstandingLabel: "Outstanding",
+        mixedCurrenciesHint:
+          "Bookings on this departure disagree on currency — totals are per booking.",
+        emptyTitle: "Finance has no lines for this departure yet",
+        emptyDescription:
+          "Revenue and cost appear once invoices and supplier costs are attributed to it.",
+        unavailableTitle: "Profitability is unavailable",
+        unavailableDescription:
+          "No Finance provider is bound to this deployment, so this departure has no revenue or cost figures. The settlement below comes from the bookings themselves.",
+        openReportAction: "Open the profitability report",
+      },
+      activity: {
+        emptyTitle: "Nothing has happened on this departure yet",
+        emptyDescription:
+          "Resource changes and traveler assignments are recorded here as they are made.",
+        emptyAction: "Go to Allocation",
+      },
+      resources: {
+        title: "Resources",
+        description: "Every room, seat or cabin laid out on this departure.",
+        columnResource: "Resource",
+        columnCapacity: "Capacity",
+        columnAssigned: "Assigned",
+        columnAvailable: "Available",
+        overCapacityBadge: "Over capacity",
+        emptyTitle: "No rooms or seats are laid out yet",
+        emptyDescription:
+          "Generate the inventory this product configures, or add a resource by hand.",
+      },
+      links: {
+        openResource: "Open resource",
+        openSupplier: "Open supplier",
+        openProduct: "Open product",
+        openBooking: "Open booking",
+        openFinanceReport: "Open the profitability report",
+        goToSection: "Go to {section}",
+      },
+      issues: {
+        title: "Needs attention",
+        summary: "{critical} critical · {warning} to reconcile",
+        criticalGroup: "Critical — fix before this departure runs",
+        warningGroup: "To reconcile",
+        criticalBadge: "Critical",
+        warningBadge: "Warning",
+        affectedLabel: "{count} affected",
+        clearTitle: "Nothing needs attention",
+        clearDescription:
+          "Capacity, bookings and travelers agree with each other on this departure.",
+        clearAction: "Review the roster",
+        /**
+         * One entry per `DepartureIssueCode`. The server also ships an English
+         * `message`, but that is a fallback for consumers with no catalogue —
+         * the workspace renders these, and falls back only for a code it does
+         * not know yet.
+         */
+        codes: {
+          stale_held_allocation: {
+            title: "Allocation held past its expiry",
+            description:
+              "A held allocation is past its hold expiry and is still consuming a seat nobody owns. Confirm the booking or release the allocation.",
+          },
+          allocation_on_cancelled_booking: {
+            title: "Cancelled booking still allocated",
+            description:
+              "A cancelled booking still holds a live allocation on this departure, so its seat never came back. Release the allocation.",
+          },
+          expired_hold_not_released: {
+            title: "Expired checkout hold not released",
+            description:
+              "A checkout hold expired without being released, so its pax are still deducted from what can be sold.",
+          },
+          travelers_missing_for_booked_pax: {
+            title: "Traveler names missing",
+            description:
+              "Fewer traveler records have been entered than the bookings sold pax for. Enter the missing names on their bookings.",
+          },
+          travelers_exceed_booked_pax: {
+            title: "More travelers than pax sold",
+            description:
+              "More traveler records have been entered than the bookings sold pax for. Correct the pax count or remove the extra travelers.",
+          },
+          remaining_pax_drift: {
+            title: "Remaining-pax counter has drifted",
+            description:
+              "The stored remaining-pax counter disagrees with what the bookings and live holds actually consume.",
+          },
+          capacity_oversold: {
+            title: "Departure is oversold",
+            description:
+              "Bookings and live holds consume more pax than this departure's authored capacity. Raise the capacity or move a booking.",
+          },
+          resource_over_capacity: {
+            title: "Resource is over capacity",
+            description:
+              "More travelers are assigned to this resource than it can hold. Reseat the overflow or raise the resource's capacity.",
+          },
+          travelers_unassigned: {
+            title: "Travelers are not seated",
+            description:
+              "Travelers on this departure have not been assigned to a room or seat. Assign them in Allocation.",
+          },
+          allocation_resources_missing: {
+            title: "No rooms or seats laid out",
+            description:
+              "Travelers are booked on this departure but nothing has been laid out to seat them. Generate the inventory in Allocation.",
+          },
+          departure_not_version_bound: {
+            title: "Departure is not version-bound",
+            description:
+              "This departure is not bound to a published Product Version, so what it sells can drift from what was authored.",
+          },
+        },
+      },
+    },
     duration: {
       nightSingular: "1 night",
       nightsPlural: "{count} nights",

--- a/packages/i18n/src/admin/availability/ro-part-2.ts
+++ b/packages/i18n/src/admin/availability/ro-part-2.ts
@@ -164,6 +164,207 @@ export const adminAvailabilityMessagesRoPart2 = {
         "auto-allocate": "Auto-alocare",
       },
     },
+    departure: {
+      tabs: {
+        overview: "Sumar",
+        travelers: "Calatori",
+        allocation: "Alocare",
+        operations: "Operatiuni",
+        financials: "Financiar",
+        activity: "Activitate",
+      },
+      overview: {
+        capacityTitle: "Capacitate",
+        authoredPaxLabel: "Pax configurati",
+        effectivePaxLabel: "Pax care pot fi cazati",
+        storedRemainingLabel: "Ramasi (stocat)",
+        derivedRemainingLabel: "Ramasi (calculat)",
+        consumedPaxLabel: "Pax consumati",
+        unlimitedLabel: "Nelimitat",
+        driftHint:
+          "Contorul stocat difera de cel calculat. Reconciliaza rezervarile si rezervarile temporare de mai jos.",
+        bookingsTitle: "Rezervari",
+        activeBookingsLabel: "Rezervari active",
+        soldPaxLabel: "Pax vanduti",
+        cancelledWithAllocationLabel: "Anulate, inca alocate",
+        holdsTitle: "Rezervari temporare",
+        holdsActiveLabel: "Active",
+        holdsExpiredLabel: "Expirate",
+        holdsPaxLabel: "Pax blocati",
+        identityTitle: "Identitate",
+        productVersionLabel: "Versiune produs",
+        notVersionBound: "Nelegata de o versiune publicata",
+        extrasTitle: "Extra",
+        extrasOfferedLabel: "Oferite",
+        extrasSelectedLabel: "Alese de calatori",
+        extrasOutstandingLabel: "De colectat",
+        extrasUnavailable: "Modulul Extra nu este instalat la acest operator.",
+        editAction: "Editeaza plecarea",
+      },
+      travelers: {
+        title: "Lista calatorilor",
+        enteredLabel: "Nume introduse",
+        leadLabel: "Calatori principali",
+        seatedLabel: "Cazati",
+        unseatedLabel: "Necazati",
+        missingLabel: "Nume lipsa",
+        excessLabel: "Nume peste pax vanduti",
+        columnTraveler: "Calator",
+        columnBooking: "Rezervare",
+        columnStatus: "Status",
+        columnSeat: "Loc / camera",
+        seatedBadge: "Cazat",
+        unseatedBadge: "Necazat",
+        leadBadge: "Principal",
+        emptyTitle: "Nimeni nu este rezervat pe aceasta plecare",
+        emptyDescription:
+          "Calatorii apar aici imediat ce o rezervare este alocata acestei plecari.",
+        emptyAction: "Creeaza o rezervare",
+        openBookingAction: "Deschide rezervarea",
+      },
+      operations: {
+        title: "Operatiuni",
+        description: "Tot ce trebuie rezolvat inainte ca aceasta plecare sa aiba loc.",
+        pickupTitle: "Pickup",
+        pickupEmptyTitle: "Niciun punct de pickup pe aceasta plecare",
+        pickupEmptyDescription:
+          "Adauga un punct de pickup ca soferul sa stie de unde ia calatorii.",
+        pickupEmptyAction: "Adauga un punct de pickup",
+        pickupPointUnknown: "Punctul de pickup nu mai este disponibil",
+        closeoutsTitle: "Closeout-uri",
+        closeoutsEmptyTitle: "Aceasta plecare este deschisa la vanzare",
+        closeoutsEmptyDescription:
+          "Inchide data cand trebuie oprita vanzarea — ghidul nu este disponibil sau furnizorul a retras alotmentul.",
+        closeoutsEmptyAction: "Inchide aceasta data",
+        extrasTitle: "Extra",
+        extrasEmptyTitle: "Nu sunt oferite extra pe aceasta plecare",
+        extrasEmptyDescription:
+          "Serviciile extra se configureaza pe produs, apoi se vand pe fiecare plecare a lui.",
+        extrasEmptyAction: "Configureaza extra pe produs",
+      },
+      financials: {
+        title: "Profitabilitate",
+        description: "Cifrele proprii ale modulului Financiar. Operatiunile nu le recalculeaza.",
+        columnCurrency: "Moneda",
+        columnRevenue: "Venit",
+        columnPlannedCost: "Cost planificat",
+        columnActualCost: "Cost real",
+        columnVariance: "Diferenta",
+        columnProfit: "Profit",
+        columnMargin: "Marja",
+        baseTitle: "Moneda contabila",
+        unconvertibleTitle: "Neconvertite in moneda contabila",
+        unconvertibleDescription:
+          "Modulul Financiar nu a avut curs pentru aceste monede, deci liniile lor lipsesc din total: {currencies}",
+        settlementTitle: "Incasari",
+        settlementSoldLabel: "Vandut",
+        settlementPaidLabel: "Incasat",
+        settlementOutstandingLabel: "De incasat",
+        mixedCurrenciesHint:
+          "Rezervarile de pe aceasta plecare au monede diferite — totalurile raman pe rezervare.",
+        emptyTitle: "Modulul Financiar nu are inca linii pentru aceasta plecare",
+        emptyDescription:
+          "Venitul si costul apar dupa ce facturile si costurile de la furnizori sunt atribuite plecarii.",
+        unavailableTitle: "Profitabilitatea nu este disponibila",
+        unavailableDescription:
+          "Niciun furnizor Financiar nu este conectat la acest deployment, deci plecarea nu are cifre de venit sau cost. Incasarile de mai jos vin din rezervari.",
+        openReportAction: "Deschide raportul de profitabilitate",
+      },
+      activity: {
+        emptyTitle: "Nu s-a intamplat nimic inca pe aceasta plecare",
+        emptyDescription:
+          "Modificarile de resurse si alocarile de calatori se inregistreaza aici pe masura ce sunt facute.",
+        emptyAction: "Mergi la Alocare",
+      },
+      resources: {
+        title: "Resurse",
+        description: "Fiecare camera, loc sau cabina pregatita pe aceasta plecare.",
+        columnResource: "Resursa",
+        columnCapacity: "Capacitate",
+        columnAssigned: "Alocate",
+        columnAvailable: "Disponibile",
+        overCapacityBadge: "Peste capacitate",
+        emptyTitle: "Nicio camera sau loc nu este pregatit inca",
+        emptyDescription: "Genereaza inventarul configurat pe produs sau adauga o resursa manual.",
+      },
+      links: {
+        openResource: "Deschide resursa",
+        openSupplier: "Deschide furnizorul",
+        openProduct: "Deschide produsul",
+        openBooking: "Deschide rezervarea",
+        openFinanceReport: "Deschide raportul de profitabilitate",
+        goToSection: "Mergi la {section}",
+      },
+      issues: {
+        title: "Necesita atentie",
+        summary: "{critical} critice · {warning} de reconciliat",
+        criticalGroup: "Critic — rezolva inainte ca plecarea sa aiba loc",
+        warningGroup: "De reconciliat",
+        criticalBadge: "Critic",
+        warningBadge: "Avertisment",
+        affectedLabel: "{count} afectate",
+        clearTitle: "Nimic nu necesita atentie",
+        clearDescription: "Capacitatea, rezervarile si calatorii sunt in acord pe aceasta plecare.",
+        clearAction: "Vezi lista calatorilor",
+        codes: {
+          stale_held_allocation: {
+            title: "Alocare blocata dupa expirare",
+            description:
+              "O alocare temporara a depasit termenul de expirare si inca ocupa un loc care nu apartine nimanui. Confirma rezervarea sau elibereaza alocarea.",
+          },
+          allocation_on_cancelled_booking: {
+            title: "Rezervare anulata inca alocata",
+            description:
+              "O rezervare anulata inca detine o alocare activa pe aceasta plecare, deci locul nu a fost eliberat. Elibereaza alocarea.",
+          },
+          expired_hold_not_released: {
+            title: "Rezervare temporara expirata, neeliberata",
+            description:
+              "O rezervare temporara a expirat fara sa fie eliberata, deci pax-ii ei sunt in continuare scazuti din ce se poate vinde.",
+          },
+          travelers_missing_for_booked_pax: {
+            title: "Lipsesc nume de calatori",
+            description:
+              "S-au introdus mai putini calatori decat pax-ii vanduti de rezervari. Completeaza numele lipsa pe rezervarile lor.",
+          },
+          travelers_exceed_booked_pax: {
+            title: "Mai multi calatori decat pax vanduti",
+            description:
+              "S-au introdus mai multi calatori decat pax-ii vanduti de rezervari. Corecteaza numarul de pax sau sterge calatorii in plus.",
+          },
+          remaining_pax_drift: {
+            title: "Contorul de pax ramasi a derivat",
+            description:
+              "Contorul stocat de pax ramasi difera de ce consuma efectiv rezervarile si rezervarile temporare active.",
+          },
+          capacity_oversold: {
+            title: "Plecare suprarezervata",
+            description:
+              "Rezervarile si rezervarile temporare active consuma mai multi pax decat capacitatea configurata. Creste capacitatea sau muta o rezervare.",
+          },
+          resource_over_capacity: {
+            title: "Resursa peste capacitate",
+            description:
+              "Sunt alocati mai multi calatori acestei resurse decat poate primi. Realoca surplusul sau creste capacitatea resursei.",
+          },
+          travelers_unassigned: {
+            title: "Calatori necazati",
+            description:
+              "Calatori de pe aceasta plecare nu au fost alocati unei camere sau unui loc. Aloca-i in Alocare.",
+          },
+          allocation_resources_missing: {
+            title: "Nicio camera sau loc pregatit",
+            description:
+              "Exista calatori rezervati pe aceasta plecare, dar nu s-a pregatit nimic pentru a-i caza. Genereaza inventarul in Alocare.",
+          },
+          departure_not_version_bound: {
+            title: "Plecare nelegata de o versiune",
+            description:
+              "Aceasta plecare nu este legata de o versiune publicata a produsului, deci ce vinde poate devia de la ce a fost configurat.",
+          },
+        },
+      },
+    },
     duration: {
       nightSingular: "1 noapte",
       nightsPlural: "{count} nopti",

--- a/packages/operations-react/src/admin.ts
+++ b/packages/operations-react/src/admin.ts
@@ -78,6 +78,8 @@ declare module "@voyant-travel/admin" {
     "product.detail": { productId: string }
     /** An availability slot's detail page. */
     "availabilitySlot.detail": { slotId: string }
+    /** Finance's departure profitability report (bound by finance-react). */
+    "financeProfitability.report": Record<string, never>
   }
 }
 

--- a/packages/operations-react/src/availability/admin/admin-extension.test.ts
+++ b/packages/operations-react/src/availability/admin/admin-extension.test.ts
@@ -41,11 +41,26 @@ describe("createAvailabilityAdminExtension", () => {
     expect(slotDetail?.title).toBe("Disponibilitate")
   })
 
-  it("carries no search contracts (the pages keep their filters local)", () => {
+  it("carries a search contract only on the departure workspace", () => {
+    // The list pages keep their filters component-local. The slot detail page
+    // is the one route with a URL contract: its six workspace sections are
+    // addressable, so `?tab=` survives a reload and is linkable.
     const extension = createAvailabilityAdminExtension()
     for (const route of extension.routes ?? []) {
+      if (route.id === "availability-slot-detail") continue
       expect(route.validateSearch).toBeUndefined()
     }
+  })
+
+  it("round-trips the departure workspace tab through the route search contract", () => {
+    const extension = createAvailabilityAdminExtension()
+    const slotDetail = extension.routes?.find((route) => route.id === "availability-slot-detail")
+
+    expect(slotDetail?.validateSearch?.({ tab: "financials" })).toEqual({ tab: "financials" })
+    // Absent and unrecognized values both land on the overview rather than
+    // failing the route — a hand-edited or stale URL must still render.
+    expect(slotDetail?.validateSearch?.({})).toEqual({ tab: "overview" })
+    expect(slotDetail?.validateSearch?.({ tab: "not-a-section" })).toEqual({ tab: "overview" })
   })
 
   it("carries lazy page loaders instead of eager components", async () => {

--- a/packages/operations-react/src/availability/admin/index.tsx
+++ b/packages/operations-react/src/availability/admin/index.tsx
@@ -25,6 +25,8 @@ import {
   AvailabilitySlotDetailSkeleton,
   AvailabilityStartTimeDetailSkeleton,
 } from "../components/availability-skeletons.js"
+// Lean static: a zod object literal, no page or data-layer module behind it.
+import { departureWorkspaceSearchSchema } from "../departure-search-params.js"
 
 /**
  * Semantic destinations the availability admin surfaces navigate to
@@ -40,6 +42,13 @@ declare module "@voyant-travel/admin" {
     "availabilitySlot.list": Record<string, never>
     /** An availability start time's detail page. */
     "availabilityStartTime.detail": { startTimeId: string }
+    /**
+     * Finance's departure profitability report. Declared here (and bound to
+     * its route by `@voyant-travel/finance-react/admin`) because the departure
+     * workspace's Financials section links out to it — Operations renders
+     * Finance's figures but never owns the report.
+     */
+    "financeProfitability.report": Record<string, never>
   }
 }
 
@@ -94,10 +103,11 @@ export interface CreateAvailabilityAdminExtensionOptions {
  * `AdminRoutePageProps` via the default-exported wrappers in `./pages/`.
  * The index host's SSR loader binding is no longer app-side:
  * {@link ensureAvailabilityPageData} runs in the contribution's own loader
- * against the host runtime's cookie-forwarding fetcher. The pages keep
- * their filter state component-local, so there are no URL search contracts,
- * and every cross-route link resolves through the semantic destinations
- * declared above.
+ * against the host runtime's cookie-forwarding fetcher. The list pages keep
+ * their filter state component-local; the one URL search contract is the
+ * departure workspace's `?tab=` (see `departure-search-params.ts`), which
+ * makes a section of the slot detail page linkable. Every cross-route link
+ * resolves through the semantic destinations declared above.
  *
  * WIDGETS: none. {@link OptionResourceTemplatesPanel} (the per-option
  * resource templates editor the product editor embeds) ships from this
@@ -144,6 +154,11 @@ export function createAvailabilityAdminExtension(
         // Key declared by @voyant-travel/bookings-react/admin (bound type-only above).
         destination: "availabilitySlot.detail",
         destinationParams: { id: "slotId" },
+        // The departure workspace's six sections are URL-addressable
+        // (`?tab=financials`): the section survives a reload and is linkable
+        // into a ticket. Parsed here, so the page receives an already-narrowed
+        // value on `AdminRoutePageProps.search`.
+        validateSearch: (search) => departureWorkspaceSearchSchema.parse(search),
         page: () => import("./pages/availability-slot-detail-page.js"),
         loader: async ({ queryClient, runtime, params }: AdminRouteLoaderContext) => {
           const id = params.id

--- a/packages/operations-react/src/availability/admin/pages/availability-slot-detail-page.tsx
+++ b/packages/operations-react/src/availability/admin/pages/availability-slot-detail-page.tsx
@@ -1,5 +1,6 @@
 import type { AdminRoutePageProps } from "@voyant-travel/admin"
 
+import { parseDepartureWorkspaceTab } from "../../departure-search-params.js"
 import { AvailabilitySlotDetailHost } from "../slot-detail-host.js"
 
 /**
@@ -7,8 +8,25 @@ import { AvailabilitySlotDetailHost } from "../slot-detail-host.js"
  * the slot id off {@link AdminRoutePageProps} and binds it onto the packaged
  * host. Resolved lazily through the contribution's `page` loader so the
  * detail page lands in its own chunk.
+ *
+ * `search.tab` was already validated by the contribution's `validateSearch`
+ * (`departureWorkspaceSearchSchema`); it is re-narrowed here rather than cast,
+ * so a host that binds the page without that contract still lands on a real
+ * section instead of on `undefined`. Selecting a section patches the URL in
+ * place through `updateSearch`, which replaces rather than pushes — moving
+ * between sections is not history.
  */
 // fallow-ignore-next-line unused-export
-export default function AvailabilitySlotDetailRoutePage({ params }: AdminRoutePageProps) {
-  return <AvailabilitySlotDetailHost slotId={params.id ?? ""} />
+export default function AvailabilitySlotDetailRoutePage({
+  params,
+  search,
+  updateSearch,
+}: AdminRoutePageProps) {
+  return (
+    <AvailabilitySlotDetailHost
+      slotId={params.id ?? ""}
+      tab={parseDepartureWorkspaceTab(search.tab)}
+      onTabChange={(tab) => updateSearch((previous) => ({ ...previous, tab }))}
+    />
+  )
 }

--- a/packages/operations-react/src/availability/admin/slot-detail-host.tsx
+++ b/packages/operations-react/src/availability/admin/slot-detail-host.tsx
@@ -14,15 +14,24 @@ import {
 import { ProductQuickViewSheet } from "@voyant-travel/inventory-react/ui"
 import { lazy, Suspense, useState } from "react"
 import { SlotAllocationPage } from "../allocation/index.js"
-import { AvailabilitySlotDialog } from "../components/availability-dialogs.js"
+import {
+  AvailabilityCloseoutDialog,
+  AvailabilityPickupPointDialog,
+  AvailabilitySlotDialog,
+} from "../components/availability-dialogs.js"
 import {
   AvailabilitySlotDetailPage,
   getAvailabilitySlotDetailQueryOptions,
   getAvailabilitySlotProductQueryOptions,
 } from "../components/availability-slot-detail-page.js"
 import {
+  type CreateAvailabilityCloseoutInput,
+  type CreateAvailabilityPickupPointInput,
   type CreateAvailabilitySlotInput,
+  type DepartureWorkspaceTab,
   type UpdateAvailabilitySlotInput,
+  useAvailabilityCloseoutMutation,
+  useAvailabilityPickupPointMutation,
   useAvailabilitySlotMutation,
   useRules,
   useStartTimes,
@@ -38,6 +47,13 @@ const BookingQuickViewSheet = lazy(() =>
 export interface AvailabilitySlotDetailHostProps {
   /** The availability slot id (route param, bound by the host route file). */
   slotId: string
+  /**
+   * The workspace section, read from the route's `?tab=` search param. When
+   * omitted the workspace keeps the selection in component state.
+   */
+  tab?: DepartureWorkspaceTab
+  /** Patches `?tab=` in place (the route page passes `updateSearch`). */
+  onTabChange?: (tab: DepartureWorkspaceTab) => void
 }
 
 /**
@@ -63,13 +79,19 @@ export interface AvailabilitySlotDetailHostProps {
  * The SSR prefetch loader stays in the host route file (it runs outside the
  * React tree with the app's cookie-forwarding fetcher).
  */
-export function AvailabilitySlotDetailHost({ slotId }: AvailabilitySlotDetailHostProps) {
+export function AvailabilitySlotDetailHost({
+  slotId,
+  tab,
+  onTabChange,
+}: AvailabilitySlotDetailHostProps) {
   const messages = useOperatorAdminMessages()
   const extrasMessages = useExtrasUiMessagesOrDefault()
   const resolveHref = useAdminHref()
   const navigateTo = useAdminNavigate()
   const client = useVoyantAvailabilityContext()
   const slotMutation = useAvailabilitySlotMutation()
+  const pickupPointMutation = useAvailabilityPickupPointMutation()
+  const closeoutMutation = useAvailabilityCloseoutMutation()
   const slotQuery = useQuery(getAvailabilitySlotDetailQueryOptions(client, slotId))
   const slot = slotQuery.data?.data
   const productQuery = useQuery({
@@ -80,6 +102,11 @@ export function AvailabilitySlotDetailHost({ slotId }: AvailabilitySlotDetailHos
   const [bookingPreviewId, setBookingPreviewId] = useState<string | null>(null)
   const [productPreviewId, setProductPreviewId] = useState<string | null>(null)
   const [editDialogOpen, setEditDialogOpen] = useState(false)
+  // The next authorized action behind the Operations section's empty states
+  // (AC7): a departure with no pickup point and one with no closeout must both
+  // offer the way to create one, not just say they have none.
+  const [pickupDialogOpen, setPickupDialogOpen] = useState(false)
+  const [closeoutDialogOpen, setCloseoutDialogOpen] = useState(false)
   // Lazy-load rules + start times only when the edit dialog opens —
   // the slot detail view itself doesn't need them. Scope to the slot's
   // product so the dialog only suggests recurring rules / start times
@@ -105,12 +132,25 @@ export function AvailabilitySlotDetailHost({ slotId }: AvailabilitySlotDetailHos
     <>
       <AvailabilitySlotDetailPage
         id={slotId}
+        tab={tab}
+        onTabChange={onTabChange}
         onBack={() => navigateTo("availabilitySlot.list", {})}
         onDeleted={() => navigateTo("availabilitySlot.list", {})}
         onOpenProduct={(productId) => setProductPreviewId(productId)}
         onOpenStartTime={(startTimeId) =>
           navigateTo("availabilityStartTime.detail", { startTimeId })
         }
+        onOpenBooking={(bookingId) => setBookingPreviewId(bookingId)}
+        // AC8: the destinations an allocation resource's persisted
+        // `ref_type`/`ref_id` can point at, plus Finance's own report. All
+        // resolve through semantic keys — a packaged page never imports a host
+        // route tree.
+        onOpenResource={(resourceId) => navigateTo("resource.detail", { resourceId })}
+        onOpenSupplier={(supplierId) => navigateTo("supplier.detail", { supplierId })}
+        onOpenFinanceReport={() => navigateTo("financeProfitability.report", {})}
+        onCreateBooking={() => navigateTo("booking.create", { productId: slot?.productId, slotId })}
+        onAddPickupPoint={() => setPickupDialogOpen(true)}
+        onAddCloseout={() => setCloseoutDialogOpen(true)}
         onEdit={() => setEditDialogOpen(true)}
         renderAllocation={({ slotId: allocationSlotId }) => (
           <SlotAllocationPage
@@ -176,6 +216,41 @@ export function AvailabilitySlotDetailHost({ slotId }: AvailabilitySlotDetailHos
             void slotQuery.refetch()
           }}
         />
+      ) : null}
+
+      {slot && productQuery.data?.data ? (
+        <>
+          <AvailabilityPickupPointDialog
+            messages={messages.availability}
+            open={pickupDialogOpen}
+            onOpenChange={setPickupDialogOpen}
+            products={[productQuery.data.data]}
+            onSubmit={async (payload) => {
+              await pickupPointMutation.create.mutateAsync(
+                payload as CreateAvailabilityPickupPointInput,
+              )
+            }}
+            onSuccess={() => setPickupDialogOpen(false)}
+          />
+          <AvailabilityCloseoutDialog
+            messages={messages.availability}
+            open={closeoutDialogOpen}
+            onOpenChange={setCloseoutDialogOpen}
+            products={[productQuery.data.data]}
+            slots={[slot]}
+            onSubmit={async (payload) => {
+              // Default the closeout onto THIS departure: the operator opened
+              // it from the departure's own empty state, so the date and slot
+              // are not something they should have to re-pick.
+              await closeoutMutation.create.mutateAsync({
+                ...payload,
+                slotId: payload.slotId ?? slot.id,
+                dateLocal: payload.dateLocal || slot.dateLocal,
+              } as CreateAvailabilityCloseoutInput)
+            }}
+            onSuccess={() => setCloseoutDialogOpen(false)}
+          />
+        </>
       ) : null}
     </>
   )

--- a/packages/operations-react/src/availability/components/availability-slot-detail-activity.tsx
+++ b/packages/operations-react/src/availability/components/availability-slot-detail-activity.tsx
@@ -1,6 +1,14 @@
 "use client"
 
-import { Badge, Button } from "@voyant-travel/ui/components"
+import {
+  Badge,
+  Button,
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@voyant-travel/ui/components"
 import {
   Activity,
   History,
@@ -59,17 +67,37 @@ export function ActivityTimeline({
   assignments,
   auditEntries,
   resourceById,
+  allocationResourceById,
   bookingById,
   travelerById,
   formatDateTime: formatDateTimeFn,
+  emptyAction,
   i18n,
 }: {
   assignments: AvailabilitySlotAssignmentRow[]
   auditEntries: AllocationAuditLogEntry[]
+  /**
+   * The operations RESOURCE POOL (`/v1/admin/operations/resources`), keyed by
+   * `resources.id`. `slot_assignments.resource_id` points here.
+   */
   resourceById: Map<string, { id: string; name: string }>
+  /**
+   * This departure's `allocation_resources`, keyed by
+   * `allocation_resources.id`. The allocation AUDIT LOG points here — a
+   * different table from the pool above. Resolving audit entries against the
+   * pool always missed and rendered a raw typeid to the operator.
+   */
+  allocationResourceById?: Map<string, { id: string; name: string }>
   bookingById: Map<string, AllocationManifestBooking>
   travelerById: Map<string, { fullName: string; bookingNumber: string; bookingId: string }>
   formatDateTime: (value: string | Date) => string
+  /** Next action offered when the departure has no history yet (AC7). */
+  emptyAction?: {
+    title: string
+    description: string
+    actionLabel: string
+    onAction: () => void
+  }
   i18n: {
     title: string
     empty: string
@@ -85,13 +113,21 @@ export function ActivityTimeline({
   }
 }) {
   const [filter, setFilter] = useState<ActivityTimelineSource | "all">("all")
-  const resourceLabel = (id: string | null | undefined) =>
+  const poolResourceLabel = (id: string | null | undefined) =>
     (id ? resourceById.get(id)?.name : null) ?? id ?? i18n.unassignedResource
+  /**
+   * Audit entries name an `allocation_resources` row. Fall back to the pool
+   * only for a legacy entry that predates the split, then to the placeholder —
+   * never to the raw id, which reads as noise to an operator.
+   */
+  const allocationResourceLabel = (id: string | null | undefined) =>
+    (id ? (allocationResourceById?.get(id)?.name ?? resourceById.get(id)?.name) : null) ??
+    i18n.unassignedResource
 
   const events: ActivityTimelineEvent[] = []
   const nowIso = new Date().toISOString()
   for (const assignment of assignments) {
-    const resource = resourceLabel(assignment.resourceId)
+    const resource = poolResourceLabel(assignment.resourceId)
     const booking = bookingById.get(assignment.bookingId ?? "")
     // Active assignments don't carry a released timestamp. Sort them
     // alongside current activity using `now`, and flag the entry so
@@ -116,7 +152,7 @@ export function ActivityTimeline({
     })
   }
   for (const entry of auditEntries) {
-    const resource = entry.resourceId ? resourceLabel(entry.resourceId) : null
+    const resource = entry.resourceId ? allocationResourceLabel(entry.resourceId) : null
     const traveler = entry.travelerId ? travelerById.get(entry.travelerId) : null
     const detailParts: string[] = []
     if (traveler) detailParts.push(traveler.fullName)
@@ -169,9 +205,24 @@ export function ActivityTimeline({
       </div>
 
       {visible.length === 0 ? (
-        <div className="rounded-md border bg-background p-6 text-center">
-          <p className="text-sm text-muted-foreground">{i18n.empty}</p>
-        </div>
+        emptyAction ? (
+          <Empty data-slot="departure-activity-empty" className="border">
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <History aria-hidden="true" />
+              </EmptyMedia>
+              <EmptyTitle>{emptyAction.title}</EmptyTitle>
+              <EmptyDescription>{emptyAction.description}</EmptyDescription>
+            </EmptyHeader>
+            <Button variant="outline" onClick={emptyAction.onAction}>
+              {emptyAction.actionLabel}
+            </Button>
+          </Empty>
+        ) : (
+          <div className="rounded-md border bg-background p-6 text-center">
+            <p className="text-sm text-muted-foreground">{i18n.empty}</p>
+          </div>
+        )
       ) : (
         <div className="flex flex-col gap-2">
           {visible.map((event) => (

--- a/packages/operations-react/src/availability/components/availability-slot-detail-data.ts
+++ b/packages/operations-react/src/availability/components/availability-slot-detail-data.ts
@@ -1,0 +1,126 @@
+"use client"
+
+import type { QueryClient } from "@tanstack/react-query"
+
+import {
+  getDepartureSummaryQueryOptions,
+  getPickupPointsQueryOptions,
+  getProductQueryOptions,
+  getSlotAllocationQueryOptions,
+  getSlotAssignmentsQueryOptions,
+  getSlotCloseoutsQueryOptions,
+  getSlotPickupsQueryOptions,
+  getSlotQueryOptions,
+  getSlotResourcesQueryOptions,
+  type VoyantAvailabilityContextValue,
+} from "../index.js"
+
+/**
+ * The departure workspace's reads, in one place.
+ *
+ * Split out of the page module so the page stays a page. Everything here is
+ * re-exported from `availability-slot-detail-page.js`, which is the published
+ * entry hosts and the admin route loader already import from.
+ *
+ * Two kinds of read live side by side on purpose:
+ *
+ *   - the COMPOSED SUMMARY (`GET /slots/{id}/summary`), which carries every
+ *     headline figure as a whole-departure aggregate;
+ *   - the PAGINATED DETAIL (pickups, closeouts, assignments, resources, the
+ *     allocation manifest), which carries rows.
+ *
+ * The workspace never derives a headline from the second kind. That is the
+ * whole point of the envelope: paging the manifest cannot move a counter.
+ */
+
+export function getAvailabilitySlotDetailQueryOptions(
+  client: VoyantAvailabilityContextValue,
+  id: string | null | undefined,
+) {
+  return getSlotQueryOptions(client, id)
+}
+
+export function getAvailabilitySlotSummaryQueryOptions(
+  client: VoyantAvailabilityContextValue,
+  id: string | null | undefined,
+) {
+  return getDepartureSummaryQueryOptions(client, id)
+}
+
+export function getAvailabilitySlotProductQueryOptions(
+  client: VoyantAvailabilityContextValue,
+  productId: string | null | undefined,
+) {
+  return getProductQueryOptions(client, productId)
+}
+
+export function getAvailabilitySlotPickupsQueryOptions(
+  client: VoyantAvailabilityContextValue,
+  id: string | null | undefined,
+) {
+  return getSlotPickupsQueryOptions(client, id, { limit: 25, offset: 0 })
+}
+
+export function getAvailabilitySlotPickupPointsQueryOptions(
+  client: VoyantAvailabilityContextValue,
+  productId: string | null | undefined,
+) {
+  return getPickupPointsQueryOptions(client, {
+    productId: productId ?? undefined,
+    limit: 25,
+    offset: 0,
+  })
+}
+
+export function getAvailabilitySlotCloseoutsQueryOptions(
+  client: VoyantAvailabilityContextValue,
+  id: string | null | undefined,
+) {
+  return getSlotCloseoutsQueryOptions(client, id, { limit: 25, offset: 0 })
+}
+
+export function getAvailabilitySlotAssignmentsQueryOptions(
+  client: VoyantAvailabilityContextValue,
+  id: string | null | undefined,
+) {
+  return getSlotAssignmentsQueryOptions(client, id, { limit: 25, offset: 0 })
+}
+
+export function getAvailabilitySlotResourcesQueryOptions(client: VoyantAvailabilityContextValue) {
+  return getSlotResourcesQueryOptions(client, { limit: 25, offset: 0 })
+}
+
+export function getAvailabilitySlotAllocationQueryOptions(
+  client: VoyantAvailabilityContextValue,
+  id: string | null | undefined,
+) {
+  return getSlotAllocationQueryOptions(client, id)
+}
+
+export async function loadAvailabilitySlotDetailPage(
+  queryClient: QueryClient,
+  client: VoyantAvailabilityContextValue,
+  id: string,
+) {
+  const slotData = await queryClient.ensureQueryData(
+    getAvailabilitySlotDetailQueryOptions(client, id),
+  )
+
+  return Promise.all([
+    Promise.resolve(slotData),
+    // The composed envelope: every headline figure in the workspace comes from
+    // this one read, so it is prefetched alongside the slot itself.
+    queryClient.ensureQueryData(getAvailabilitySlotSummaryQueryOptions(client, id)),
+    queryClient.ensureQueryData(getAvailabilitySlotPickupsQueryOptions(client, id)),
+    queryClient.ensureQueryData(getAvailabilitySlotCloseoutsQueryOptions(client, id)),
+    queryClient.ensureQueryData(getAvailabilitySlotAssignmentsQueryOptions(client, id)),
+    queryClient.ensureQueryData(getAvailabilitySlotResourcesQueryOptions(client)),
+    queryClient.ensureQueryData(getAvailabilitySlotAllocationQueryOptions(client, id)),
+    queryClient.ensureQueryData(
+      getAvailabilitySlotProductQueryOptions(client, slotData.data.productId),
+    ),
+    queryClient.ensureQueryData(
+      getAvailabilitySlotPickupPointsQueryOptions(client, slotData.data.productId),
+    ),
+  ])
+}

--- a/packages/operations-react/src/availability/components/availability-slot-detail-financials.tsx
+++ b/packages/operations-react/src/availability/components/availability-slot-detail-financials.tsx
@@ -4,6 +4,13 @@ import { Badge, Card, CardContent, cn } from "@voyant-travel/ui/components"
 import type { ReactNode } from "react"
 import type { AllocationManifestBooking, AvailabilitySlotRow } from "../index.js"
 
+/**
+ * @deprecated Superseded by `DepartureHeadline`
+ * (`./departure-workspace-headline.js`), which reads the composed departure
+ * summary instead of re-summing the allocation manifest in the browser. Kept
+ * as a published export for consumers that already mount it; the departure
+ * workspace no longer uses it.
+ */
 export function KpiStrip({
   slot,
   rollup,
@@ -134,6 +141,15 @@ export interface SlotFinancialRollup {
 
 const FINANCIAL_BOOKING_STATUSES = new Set(["confirmed", "in_progress", "completed"])
 
+/**
+ * @deprecated Client-side settlement roll-up over whatever page of the
+ * allocation manifest happened to be loaded, using a paid-amount rule of its
+ * own. The departure summary (`GET /slots/{id}/summary`) now carries
+ * whole-departure figures computed with `derivePaidAmountCents` — the same
+ * rule the allocation chips colour themselves with — and Finance's own P&L
+ * next to them. Read `summary.bookings` / `summary.finance` instead. Kept as a
+ * published export only for consumers that already call it.
+ */
 export function aggregateSlotFinancials(
   bookings: ReadonlyArray<AllocationManifestBooking>,
   productCurrency: string | null,

--- a/packages/operations-react/src/availability/components/availability-slot-detail-meta.tsx
+++ b/packages/operations-react/src/availability/components/availability-slot-detail-meta.tsx
@@ -15,6 +15,7 @@ export function MetaTab({
   slot,
   productName,
   statusLabel,
+  productVersionId,
   onOpenProduct,
   onOpenStartTime,
   i18n: msg,
@@ -22,6 +23,14 @@ export function MetaTab({
   slot: AvailabilitySlotDetail
   productName: string | null
   statusLabel: string
+  /**
+   * The immutable Product Version this departure was materialized from
+   * (`availability_slots.product_version_id`, surfaced by the departure
+   * summary). `undefined` when the caller has no summary loaded; `null` on a
+   * departure that was never bound to a published version — which the issue
+   * list also reports as `departure_not_version_bound`.
+   */
+  productVersionId?: string | null
   onOpenProduct?: (productId: string) => void
   onOpenStartTime?: (startTimeId: string) => void
   i18n: {
@@ -33,6 +42,8 @@ export function MetaTab({
     createdLabel: string
     updatedLabel: string
     productLabel: string
+    productVersionLabel?: string
+    notVersionBoundLabel?: string
     statusLabel: string
     timezoneLabel: string
     noValue: string
@@ -81,6 +92,16 @@ export function MetaTab({
       ),
     },
   ]
+  if (productVersionId !== undefined && msg.productVersionLabel) {
+    rows.push({
+      label: msg.productVersionLabel,
+      value: productVersionId ? (
+        <span className="font-mono text-xs">{productVersionId}</span>
+      ) : (
+        <span className="text-muted-foreground">{msg.notVersionBoundLabel ?? msg.noValue}</span>
+      ),
+    })
+  }
   if (slot.availabilityRuleId) {
     rows.push({
       label: msg.ruleLabel,

--- a/packages/operations-react/src/availability/components/availability-slot-detail-page.test.tsx
+++ b/packages/operations-react/src/availability/components/availability-slot-detail-page.test.tsx
@@ -1,0 +1,438 @@
+// @vitest-environment jsdom
+
+import type * as ReactTypes from "react"
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import type { DepartureIssue, DepartureSummary } from "../index.js"
+import { AvailabilitySlotDetailPage } from "./availability-slot-detail-page.js"
+
+/**
+ * Departure workspace acceptance (issue #4033).
+ *
+ * The three things the redesign has to hold:
+ *   - every one of the six sections renders on an EMPTY departure, each with
+ *     its next authorized action (AC7) — the old Pickup and Closeouts tabs
+ *     vanished entirely when empty;
+ *   - the typed attention issues render with their severity and clear once
+ *     the underlying disagreement is repaired (AC4);
+ *   - the selected section round-trips through the URL contract (AC3).
+ */
+
+const EMPTY_SUMMARY: DepartureSummary = {
+  departure: {
+    id: "slot_1",
+    productId: "prod_1",
+    productVersionId: "pver_1",
+    itineraryId: null,
+    optionId: null,
+    facilityId: null,
+    status: "open",
+    dateLocal: "2026-09-01",
+    startsAt: "2026-09-01T06:00:00.000Z",
+    endsAt: null,
+    timezone: "Europe/Bucharest",
+    notes: null,
+  },
+  capacity: {
+    slotId: "slot_1",
+    unlimited: false,
+    initialPax: 20,
+    effectivePax: 20,
+    remainingPax: 20,
+    derivedRemainingPax: 20,
+    derivedConsumedPax: 0,
+    holds: { active: 0, activePax: 0, expired: 0, expiredPax: 0, released: 0, converted: 0 },
+    allocations: {
+      held: 0,
+      confirmed: 0,
+      fulfilled: 0,
+      staleHeld: 0,
+      released: 0,
+      expired: 0,
+      cancelled: 0,
+      active: 0,
+      inactive: 0,
+    },
+    bookings: { active: 0, cancelledWithLiveAllocation: 0, expectedPax: 0, byStatus: {} },
+    travelers: { entered: 0, lead: 0, assigned: 0, unassigned: 0, missing: 0 },
+    resources: { total: 0, seating: 0, capacity: 0, assigned: 0, available: 0, overCapacity: 0 },
+    resourceBreakdown: [],
+  },
+  bookings: {
+    count: 0,
+    byStatus: {},
+    expectedPax: 0,
+    currency: null,
+    soldAmountCents: null,
+    paidAmountCents: null,
+    outstandingAmountCents: null,
+  },
+  travelers: { entered: 0, lead: 0, assigned: 0, unassigned: 0, missing: 0 },
+  allocation: { total: 0, seating: 0, capacity: 0, assigned: 0, available: 0, overCapacity: 0 },
+  operations: { issues: [], criticalCount: 0, warningCount: 0, clear: true },
+  extras: null,
+  // No Finance provider is bound in this deployment — an explicit
+  // "unavailable", not a grid of zeros.
+  finance: null,
+}
+
+const OVERSOLD_ISSUE: DepartureIssue = {
+  code: "capacity_oversold",
+  severity: "critical",
+  subjectType: "departure",
+  subjectId: "slot_1",
+  count: 3,
+  message: "Bookings and live holds consume more pax than the departure's authored capacity.",
+}
+
+const UNSEATED_ISSUE: DepartureIssue = {
+  code: "travelers_unassigned",
+  severity: "warning",
+  subjectType: "departure",
+  subjectId: "slot_1",
+  count: 2,
+  message: "Travelers on this departure have not been assigned to a room or seat.",
+}
+
+const testState = vi.hoisted(() => ({
+  summary: null as unknown,
+  /** Captured from the mocked `Tabs`, so a trigger click can drive it. */
+  onValueChange: undefined as ((value: string) => void) | undefined,
+  activeTab: undefined as string | undefined,
+}))
+
+;(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: (options: { queryKey: readonly unknown[] }) => {
+    const kind = options.queryKey[0]
+    switch (kind) {
+      case "slot":
+        return {
+          isPending: false,
+          data: {
+            data: {
+              id: "slot_1",
+              productId: "prod_1",
+              itineraryId: null,
+              optionId: null,
+              facilityId: null,
+              availabilityRuleId: null,
+              startTimeId: null,
+              dateLocal: "2026-09-01",
+              startsAt: "2026-09-01T06:00:00.000Z",
+              endsAt: null,
+              timezone: "Europe/Bucharest",
+              status: "open",
+              unlimited: false,
+              initialPax: 20,
+              remainingPax: 20,
+              nights: null,
+              days: null,
+              notes: null,
+              initialPickups: null,
+              remainingPickups: null,
+              remainingResources: null,
+              pastCutoff: false,
+              tooEarly: false,
+              createdAt: "2026-08-01T00:00:00.000Z",
+              updatedAt: "2026-08-01T00:00:00.000Z",
+            },
+          },
+        }
+      case "summary":
+        return { isPending: false, data: { data: testState.summary } }
+      case "product":
+        return {
+          isPending: false,
+          data: { data: { id: "prod_1", name: "Danube Delta", sellCurrency: "EUR" } },
+        }
+      case "allocation":
+        return {
+          isPending: false,
+          data: { data: { bookings: [], resources: [], sharingGroupLabels: {} } },
+        }
+      default:
+        return { isPending: false, data: { data: [] } }
+    }
+  },
+}))
+
+vi.mock("../index.js", () => ({
+  getDepartureSummaryQueryOptions: () => ({ queryKey: ["summary"] }),
+  getPickupPointsQueryOptions: () => ({ queryKey: ["pickup-points"] }),
+  getProductQueryOptions: () => ({ queryKey: ["product"] }),
+  getSlotAllocationQueryOptions: () => ({ queryKey: ["allocation"] }),
+  getSlotAssignmentsQueryOptions: () => ({ queryKey: ["assignments"] }),
+  getSlotCloseoutsQueryOptions: () => ({ queryKey: ["closeouts"] }),
+  getSlotPickupsQueryOptions: () => ({ queryKey: ["pickups"] }),
+  getSlotQueryOptions: () => ({ queryKey: ["slot"] }),
+  getSlotResourcesQueryOptions: () => ({ queryKey: ["resources"] }),
+  defaultDepartureWorkspaceTab: "overview",
+  productNameById: () => new Map<string, string>(),
+  slotLocalEnd: () => null,
+  slotLocalStart: (slot: { dateLocal: string }) => ({ date: slot.dateLocal, time: "09:00" }),
+  slotStatusTone: {
+    open: "positive",
+    closed: "muted",
+    sold_out: "warning",
+    cancelled: "destructive",
+  },
+  useAvailabilitySlotMutation: () => ({
+    remove: { isPending: false, mutateAsync: vi.fn() },
+  }),
+  useSlotAllocationAuditLog: () => ({ data: { data: [] } }),
+  useVoyantAvailabilityContext: () => ({}),
+}))
+
+vi.mock("@voyant-travel/ui/components", () => {
+  const Passthrough = ({ children }: { children?: ReactTypes.ReactNode }) => <>{children}</>
+  const Block = ({ children }: { children?: ReactTypes.ReactNode }) => <div>{children}</div>
+
+  return {
+    Alert: Block,
+    AlertDescription: Block,
+    AlertTitle: Block,
+    AlertDialog: Passthrough,
+    AlertDialogAction: Block,
+    AlertDialogCancel: Block,
+    AlertDialogContent: Passthrough,
+    AlertDialogDescription: Block,
+    AlertDialogFooter: Passthrough,
+    AlertDialogHeader: Passthrough,
+    AlertDialogTitle: Block,
+    Badge: ({ children }: { children?: ReactTypes.ReactNode }) => <span>{children}</span>,
+    Button: ({ children, ...props }: ReactTypes.ButtonHTMLAttributes<HTMLButtonElement>) => (
+      <button type="button" {...props}>
+        {children}
+      </button>
+    ),
+    Card: Block,
+    CardContent: Block,
+    CardHeader: Block,
+    CardTitle: ({ children }: { children?: ReactTypes.ReactNode }) => <h2>{children}</h2>,
+    cn: (...classes: Array<string | null | false | undefined>) => classes.filter(Boolean).join(" "),
+    Empty: ({ children, ...props }: ReactTypes.HTMLAttributes<HTMLDivElement>) => (
+      <div {...props}>{children}</div>
+    ),
+    EmptyContent: Block,
+    EmptyDescription: Block,
+    EmptyHeader: Block,
+    EmptyMedia: Block,
+    EmptyTitle: Block,
+    Table: ({ children }: { children?: ReactTypes.ReactNode }) => <table>{children}</table>,
+    TableBody: ({ children }: { children?: ReactTypes.ReactNode }) => <tbody>{children}</tbody>,
+    TableCell: ({ children }: { children?: ReactTypes.ReactNode }) => <td>{children}</td>,
+    TableHead: ({ children }: { children?: ReactTypes.ReactNode }) => <th>{children}</th>,
+    TableHeader: ({ children }: { children?: ReactTypes.ReactNode }) => <thead>{children}</thead>,
+    TableRow: ({ children }: { children?: ReactTypes.ReactNode }) => <tr>{children}</tr>,
+    // Radix unmounts inactive tab panels; the mock renders every panel so one
+    // assertion can prove all six sections exist on an empty departure.
+    Tabs: ({
+      children,
+      value,
+      onValueChange,
+    }: {
+      children?: ReactTypes.ReactNode
+      value?: string
+      onValueChange?: (value: string) => void
+    }) => {
+      testState.onValueChange = onValueChange
+      testState.activeTab = value
+      return <div data-active-tab={value}>{children}</div>
+    },
+    TabsContent: Block,
+    TabsList: Block,
+    TabsTrigger: ({ children, value }: { children?: ReactTypes.ReactNode; value: string }) => (
+      <button
+        type="button"
+        data-tab-trigger={value}
+        onClick={() => testState.onValueChange?.(value)}
+      >
+        {children}
+      </button>
+    ),
+  }
+})
+
+describe("AvailabilitySlotDetailPage — the departure workspace", () => {
+  let container: HTMLDivElement | null = null
+  let root: Root | null = null
+
+  const render = (element: ReactTypes.ReactElement) => {
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+    act(() => root?.render(element))
+    return container
+  }
+
+  afterEach(() => {
+    if (root) act(() => root?.unmount())
+    container?.remove()
+    root = null
+    container = null
+    testState.summary = null
+    testState.onValueChange = undefined
+    testState.activeTab = undefined
+  })
+
+  it("renders all six sections on an empty departure, each with its next action", () => {
+    testState.summary = EMPTY_SUMMARY
+    const view = render(
+      <AvailabilitySlotDetailPage
+        id="slot_1"
+        // The Allocation section is the host's manager (SlotAllocationPage in
+        // the operator); its own empty state — "Add resource" / "Generate
+        // resources" — is covered by slot-allocation-page.test.tsx.
+        renderAllocation={() => <p>allocation-manager</p>}
+        renderExtras={() => <p>extras-manifest</p>}
+        onCreateBooking={() => undefined}
+        onAddPickupPoint={() => undefined}
+        onAddCloseout={() => undefined}
+        onOpenProduct={() => undefined}
+        onOpenFinanceReport={() => undefined}
+      />,
+    )
+
+    // All six section triggers exist, whether or not the section has rows.
+    for (const tab of [
+      "overview",
+      "travelers",
+      "allocation",
+      "operations",
+      "financials",
+      "activity",
+    ]) {
+      expect(view.querySelector(`[data-tab-trigger="${tab}"]`)).not.toBeNull()
+    }
+
+    const text = view.textContent ?? ""
+
+    // Overview — nothing to reconcile, with somewhere to go next.
+    expect(text).toContain("Nothing needs attention")
+    expect(text).toContain("Review the roster")
+    // Travelers.
+    expect(text).toContain("Nobody is booked on this departure yet")
+    expect(text).toContain("Create a booking")
+    // Allocation.
+    expect(text).toContain("allocation-manager")
+    // Operations — the two sections that used to disappear entirely.
+    expect(text).toContain("No pickup points on this departure")
+    expect(text).toContain("Add a pickup point")
+    expect(text).toContain("This departure is open for sale")
+    expect(text).toContain("Close this date")
+    expect(text).toContain("No extras are offered on this departure")
+    expect(text).toContain("Configure extras on the product")
+    // Financials — no Finance provider bound is an explicit state, not zeros.
+    expect(text).toContain("Profitability is unavailable")
+    expect(text).toContain("Open the profitability report")
+    // Activity.
+    expect(text).toContain("Nothing has happened on this departure yet")
+    expect(text).toContain("Go to Allocation")
+  })
+
+  it("renders typed issues with their severity and clears them after the repair", () => {
+    testState.summary = {
+      ...EMPTY_SUMMARY,
+      operations: {
+        issues: [OVERSOLD_ISSUE, UNSEATED_ISSUE],
+        criticalCount: 1,
+        warningCount: 1,
+        clear: false,
+      },
+    } satisfies DepartureSummary
+    const view = render(<AvailabilitySlotDetailPage id="slot_1" />)
+
+    const issues = [...view.querySelectorAll("[data-slot='departure-issue']")]
+    expect(issues).toHaveLength(2)
+    expect(issues.map((issue) => issue.getAttribute("data-severity"))).toEqual([
+      "critical",
+      "warning",
+    ])
+    expect(issues.map((issue) => issue.getAttribute("data-code"))).toEqual([
+      "capacity_oversold",
+      "travelers_unassigned",
+    ])
+
+    const text = view.textContent ?? ""
+    // The LOCALIZED copy for the code, not the server's English fallback.
+    expect(text).toContain("Departure is oversold")
+    expect(text).toContain("Travelers are not seated")
+    expect(text).not.toContain(OVERSOLD_ISSUE.message)
+    expect(text).toContain("Critical — fix before this departure runs")
+    expect(text).toContain("To reconcile")
+    expect(text).not.toContain("Nothing needs attention")
+
+    // Repair: the server now reports a clear departure.
+    testState.summary = EMPTY_SUMMARY
+    act(() => root?.render(<AvailabilitySlotDetailPage id="slot_1" />))
+
+    expect(view.querySelectorAll("[data-slot='departure-issue']")).toHaveLength(0)
+    expect(view.querySelector("[data-slot='departure-issues-clear']")).not.toBeNull()
+    expect(view.textContent).toContain("Nothing needs attention")
+  })
+
+  it("falls back to the server message for a code it has no catalogue entry for", () => {
+    testState.summary = {
+      ...EMPTY_SUMMARY,
+      operations: {
+        issues: [
+          {
+            code: "a_code_from_a_newer_server",
+            severity: "warning",
+            subjectType: "departure",
+            subjectId: "slot_1",
+            count: 1,
+            message: "Something this client has never heard of.",
+          },
+        ],
+        criticalCount: 0,
+        warningCount: 1,
+        clear: false,
+      },
+    } satisfies DepartureSummary
+    const view = render(<AvailabilitySlotDetailPage id="slot_1" />)
+
+    expect(view.textContent).toContain("Something this client has never heard of.")
+  })
+
+  it("round-trips the selected section through the tab contract", () => {
+    testState.summary = EMPTY_SUMMARY
+    const onTabChange = vi.fn()
+    const view = render(
+      <AvailabilitySlotDetailPage id="slot_1" tab="financials" onTabChange={onTabChange} />,
+    )
+
+    // The controlled value drives the workspace…
+    expect(view.querySelector("[data-active-tab]")?.getAttribute("data-active-tab")).toBe(
+      "financials",
+    )
+
+    // …and selecting another section reports it back for the URL to carry.
+    act(() => {
+      view.querySelector<HTMLButtonElement>('[data-tab-trigger="travelers"]')?.click()
+    })
+    expect(onTabChange).toHaveBeenCalledWith("travelers")
+  })
+
+  it("keeps the workspace uncontrolled when the host binds no tab contract", () => {
+    testState.summary = EMPTY_SUMMARY
+    const view = render(<AvailabilitySlotDetailPage id="slot_1" />)
+
+    expect(view.querySelector("[data-active-tab]")?.getAttribute("data-active-tab")).toBe(
+      "overview",
+    )
+
+    act(() => {
+      view.querySelector<HTMLButtonElement>('[data-tab-trigger="operations"]')?.click()
+    })
+    expect(view.querySelector("[data-active-tab]")?.getAttribute("data-active-tab")).toBe(
+      "operations",
+    )
+  })
+})

--- a/packages/operations-react/src/availability/components/availability-slot-detail-page.tsx
+++ b/packages/operations-react/src/availability/components/availability-slot-detail-page.tsx
@@ -1,18 +1,8 @@
 "use client"
 
-import type { QueryClient } from "@tanstack/react-query"
 import { useQuery } from "@tanstack/react-query"
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
   Badge,
-  Button,
   Card,
   CardContent,
   CardHeader,
@@ -23,34 +13,47 @@ import {
   TabsList,
   TabsTrigger,
 } from "@voyant-travel/ui/components"
-import { CalendarDays, Package, Pencil, Truck } from "lucide-react"
 import { type ReactNode, useState } from "react"
 import { useAvailabilityUiI18nOrDefault } from "../i18n/index.js"
 import {
-  getPickupPointsQueryOptions,
-  getProductQueryOptions,
-  getSlotAllocationQueryOptions,
-  getSlotAssignmentsQueryOptions,
-  getSlotCloseoutsQueryOptions,
-  getSlotPickupsQueryOptions,
-  getSlotQueryOptions,
-  getSlotResourcesQueryOptions,
-  slotStatusTone,
+  type DepartureIssue,
+  type DepartureWorkspaceTab,
+  defaultDepartureWorkspaceTab,
   useAvailabilitySlotMutation,
   useSlotAllocationAuditLog,
   useVoyantAvailabilityContext,
-  type VoyantAvailabilityContextValue,
 } from "../index.js"
 import { getSlotStatusLabel } from "./availability-columns.js"
 import { AvailabilitySlotDetailSkeleton } from "./availability-skeletons.js"
 import { ActivityTimeline } from "./availability-slot-detail-activity.js"
-import { aggregateSlotFinancials, KpiStrip } from "./availability-slot-detail-financials.js"
 import {
-  computeSlotNightsLabel,
-  formatSlotDateRange,
-  MetaTab,
-} from "./availability-slot-detail-meta.js"
-import { slotStatusToneClass } from "./slot-status-tone.js"
+  getAvailabilitySlotAllocationQueryOptions,
+  getAvailabilitySlotAssignmentsQueryOptions,
+  getAvailabilitySlotCloseoutsQueryOptions,
+  getAvailabilitySlotDetailQueryOptions,
+  getAvailabilitySlotPickupPointsQueryOptions,
+  getAvailabilitySlotPickupsQueryOptions,
+  getAvailabilitySlotProductQueryOptions,
+  getAvailabilitySlotResourcesQueryOptions,
+  getAvailabilitySlotSummaryQueryOptions,
+} from "./availability-slot-detail-data.js"
+import { computeSlotNightsLabel, formatSlotDateRange } from "./availability-slot-detail-meta.js"
+import {
+  type DepartureLinkTarget,
+  resolveAllocationResourceTarget,
+} from "./departure-deep-links.js"
+import type { DepartureIssueAction } from "./departure-issues.js"
+import { DepartureFinancialsSection } from "./departure-workspace-financials.js"
+import { DepartureWorkspaceHeader } from "./departure-workspace-header.js"
+import { DepartureHeadline } from "./departure-workspace-headline.js"
+import { DepartureOperationsSection } from "./departure-workspace-operations.js"
+import { DepartureOverviewSection } from "./departure-workspace-overview.js"
+import {
+  DepartureResourcesSection,
+  departureResourceLabel,
+  linkTargetLabel,
+} from "./departure-workspace-resources.js"
+import { DepartureTravelersSection } from "./departure-workspace-travelers.js"
 
 export interface AvailabilitySlotDetailPageProps {
   id: string
@@ -79,103 +82,80 @@ export interface AvailabilitySlotDetailPageProps {
    */
   headerActions?: ReactNode
   /**
-   * Content for the Allocation tab. Hosts mount their allocation
+   * Content for the Allocation section. Hosts mount their allocation
    * manager here (for example, `SlotAllocationPage` from
    * `@voyant-travel/operations-react/availability/allocation` in `embed` mode).
-   * When omitted, the tab shows a stub message instead.
+   * When omitted, the section shows a stub message instead.
    */
   renderAllocation?: (context: { slotId: string; productId: string | null }) => ReactNode
   /**
-   * Content for the Extras tab. Hosts that mount `@voyant-travel/bookings/extras` can
-   * render a slot-level operations manifest here without making
-   * availability-ui depend on booking extras UI.
+   * Content for the Extras section inside Operations. Hosts that mount
+   * `@voyant-travel/bookings/extras` can render a slot-level operations
+   * manifest here without making this package depend on booking extras UI.
    */
   renderExtras?: (context: { slotId: string; productId: string | null }) => ReactNode
+  /** Overrides the Extras section heading (Bookings owns that vocabulary). */
   extrasTabLabel?: ReactNode
+  /**
+   * The workspace section to show. Controlled by the host so the section is
+   * URL-addressable (`?tab=financials`); when omitted the workspace keeps the
+   * selection in component state and a reload lands back on Overview.
+   */
+  tab?: DepartureWorkspaceTab
+  onTabChange?: (tab: DepartureWorkspaceTab) => void
+  /** Opens a booking (quick view or detail). */
+  onOpenBooking?: (bookingId: string) => void
+  /** Opens a row in the operations resource pool. */
+  onOpenResource?: (resourceId: string) => void
+  /** Opens a supplier a resource is sourced from. */
+  onOpenSupplier?: (supplierId: string) => void
+  /** Opens Finance's departure profitability report. */
+  onOpenFinanceReport?: () => void
+  /** Next action for an empty roster: start a booking on this departure. */
+  onCreateBooking?: () => void
+  /** Next action for an empty Pickup section. */
+  onAddPickupPoint?: () => void
+  /** Next action for an empty Closeouts section. */
+  onAddCloseout?: () => void
 }
 
-export function getAvailabilitySlotDetailQueryOptions(
-  client: VoyantAvailabilityContextValue,
-  id: string | null | undefined,
-) {
-  return getSlotQueryOptions(client, id)
+export {
+  getAvailabilitySlotAllocationQueryOptions,
+  getAvailabilitySlotAssignmentsQueryOptions,
+  getAvailabilitySlotCloseoutsQueryOptions,
+  getAvailabilitySlotDetailQueryOptions,
+  getAvailabilitySlotPickupPointsQueryOptions,
+  getAvailabilitySlotPickupsQueryOptions,
+  getAvailabilitySlotProductQueryOptions,
+  getAvailabilitySlotResourcesQueryOptions,
+  getAvailabilitySlotSummaryQueryOptions,
+  loadAvailabilitySlotDetailPage,
+} from "./availability-slot-detail-data.js"
+
+/**
+ * Which section repairs which issue. Departure-level codes name no row, so the
+ * only useful navigation is the section that owns the fix; subject-bearing
+ * codes prefer the subject's own destination and fall back to this.
+ */
+const ISSUE_REPAIR_TAB: Record<string, DepartureWorkspaceTab> = {
+  allocation_on_cancelled_booking: "travelers",
+  allocation_resources_missing: "allocation",
+  resource_over_capacity: "allocation",
+  stale_held_allocation: "travelers",
+  travelers_exceed_booked_pax: "travelers",
+  travelers_missing_for_booked_pax: "travelers",
+  travelers_unassigned: "allocation",
 }
 
-export function getAvailabilitySlotProductQueryOptions(
-  client: VoyantAvailabilityContextValue,
-  productId: string | null | undefined,
-) {
-  return getProductQueryOptions(client, productId)
-}
-
-export function getAvailabilitySlotPickupsQueryOptions(
-  client: VoyantAvailabilityContextValue,
-  id: string | null | undefined,
-) {
-  return getSlotPickupsQueryOptions(client, id, { limit: 25, offset: 0 })
-}
-
-export function getAvailabilitySlotPickupPointsQueryOptions(
-  client: VoyantAvailabilityContextValue,
-  productId: string | null | undefined,
-) {
-  return getPickupPointsQueryOptions(client, {
-    productId: productId ?? undefined,
-    limit: 25,
-    offset: 0,
-  })
-}
-
-export function getAvailabilitySlotCloseoutsQueryOptions(
-  client: VoyantAvailabilityContextValue,
-  id: string | null | undefined,
-) {
-  return getSlotCloseoutsQueryOptions(client, id, { limit: 25, offset: 0 })
-}
-
-export function getAvailabilitySlotAssignmentsQueryOptions(
-  client: VoyantAvailabilityContextValue,
-  id: string | null | undefined,
-) {
-  return getSlotAssignmentsQueryOptions(client, id, { limit: 25, offset: 0 })
-}
-
-export function getAvailabilitySlotResourcesQueryOptions(client: VoyantAvailabilityContextValue) {
-  return getSlotResourcesQueryOptions(client, { limit: 25, offset: 0 })
-}
-
-export function getAvailabilitySlotAllocationQueryOptions(
-  client: VoyantAvailabilityContextValue,
-  id: string | null | undefined,
-) {
-  return getSlotAllocationQueryOptions(client, id)
-}
-
-export async function loadAvailabilitySlotDetailPage(
-  queryClient: QueryClient,
-  client: VoyantAvailabilityContextValue,
-  id: string,
-) {
-  const slotData = await queryClient.ensureQueryData(
-    getAvailabilitySlotDetailQueryOptions(client, id),
-  )
-
-  return Promise.all([
-    Promise.resolve(slotData),
-    queryClient.ensureQueryData(getAvailabilitySlotPickupsQueryOptions(client, id)),
-    queryClient.ensureQueryData(getAvailabilitySlotCloseoutsQueryOptions(client, id)),
-    queryClient.ensureQueryData(getAvailabilitySlotAssignmentsQueryOptions(client, id)),
-    queryClient.ensureQueryData(getAvailabilitySlotResourcesQueryOptions(client)),
-    queryClient.ensureQueryData(getAvailabilitySlotAllocationQueryOptions(client, id)),
-    queryClient.ensureQueryData(
-      getAvailabilitySlotProductQueryOptions(client, slotData.data.productId),
-    ),
-    queryClient.ensureQueryData(
-      getAvailabilitySlotPickupPointsQueryOptions(client, slotData.data.productId),
-    ),
-  ])
-}
-
+/**
+ * The departure workspace: capacity, Bookings and Travelers reconciled in one
+ * place (issue #4033).
+ *
+ * Six sections, every one of them rendered whether or not it has rows —
+ * Pickup and Closeouts used to disappear entirely when empty, which made "not
+ * set up" indistinguishable from "not applicable" and left the operator no way
+ * to act. Each empty section now carries its next authorized action instead.
+ */
 export function AvailabilitySlotDetailPage({
   id,
   className,
@@ -189,16 +169,36 @@ export function AvailabilitySlotDetailPage({
   renderAllocation,
   renderExtras,
   extrasTabLabel,
+  tab,
+  onTabChange,
+  onOpenBooking,
+  onOpenResource,
+  onOpenSupplier,
+  onOpenFinanceReport,
+  onCreateBooking,
+  onAddPickupPoint,
+  onAddCloseout,
 }: AvailabilitySlotDetailPageProps) {
   const client = useVoyantAvailabilityContext()
   const i18n = useAvailabilityUiI18nOrDefault()
   const messages = i18n.messages
   const detailMessages = messages.details
+  const departureMessages = detailMessages.departure
   const noValue = detailMessages.noValue
   const slotMutation = useAvailabilitySlotMutation()
-  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+  const [uncontrolledTab, setUncontrolledTab] = useState<DepartureWorkspaceTab>(
+    defaultDepartureWorkspaceTab,
+  )
+  const activeTab = tab ?? uncontrolledTab
+  const selectTab = (next: DepartureWorkspaceTab) => {
+    setUncontrolledTab(next)
+    onTabChange?.(next)
+  }
+
   const { data: slotData, isPending } = useQuery(getAvailabilitySlotDetailQueryOptions(client, id))
   const slot = slotData?.data
+  const summaryQuery = useQuery(getAvailabilitySlotSummaryQueryOptions(client, id))
+  const summary = summaryQuery.data?.data ?? null
   const productQuery = useQuery({
     ...getAvailabilitySlotProductQueryOptions(client, slot?.productId ?? ""),
     enabled: Boolean(slot?.productId),
@@ -229,8 +229,35 @@ export function AvailabilitySlotDetailPage({
   const pickupPointById = new Map(
     (pickupPointsQuery.data?.data ?? []).map((item) => [item.id, item]),
   )
-  const resourceById = new Map((resourcesQuery.data?.data ?? []).map((item) => [item.id, item]))
+  // The operations RESOURCE POOL (`/v1/admin/operations/resources`). Slot
+  // assignments reference these rows.
+  const poolResourceById = new Map((resourcesQuery.data?.data ?? []).map((item) => [item.id, item]))
   const allocationBookings = allocationQuery.data?.data.bookings ?? []
+  // This departure's own `allocation_resources`. The allocation AUDIT LOG
+  // references these — a different table from the pool above, which is why
+  // resolving audit entries against the pool always missed and rendered a raw
+  // id. The manifest is the primary source; the summary's breakdown backfills
+  // any row the manifest page did not carry.
+  const allocationResourceById = new Map<string, { id: string; name: string }>()
+  for (const resource of summary?.capacity.resourceBreakdown ?? []) {
+    allocationResourceById.set(resource.id, {
+      id: resource.id,
+      name: departureResourceLabel(resource),
+    })
+  }
+  for (const resource of allocationQuery.data?.data.resources ?? []) {
+    allocationResourceById.set(resource.id, {
+      id: resource.id,
+      name: departureResourceLabel(resource),
+    })
+  }
+  const resourceLabelById = new Map<string, string>()
+  for (const [resourceId, resource] of allocationResourceById) {
+    resourceLabelById.set(resourceId, resource.name)
+  }
+  const resourceBreakdownById = new Map(
+    (summary?.capacity.resourceBreakdown ?? []).map((resource) => [resource.id, resource]),
+  )
   const bookingById = new Map(allocationBookings.map((item) => [item.id, item]))
   const travelerById = new Map<
     string,
@@ -245,8 +272,6 @@ export function AvailabilitySlotDetailPage({
       })
     }
   }
-  const productSellCurrency = productQuery.data?.data.sellCurrency ?? null
-  const financialRollup = aggregateSlotFinancials(allocationBookings, productSellCurrency)
 
   const productName = productQuery.data?.data.name ?? null
   const productTypeName = productQuery.data?.data.productType?.name ?? null
@@ -264,135 +289,178 @@ export function AvailabilitySlotDetailPage({
   const closeoutRows = closeoutsQuery.data?.data ?? []
   const auditEntries = auditLogQuery.data?.data ?? []
 
+  const openLink = (target: DepartureLinkTarget) => {
+    switch (target.kind) {
+      case "resource":
+        onOpenResource?.(target.resourceId)
+        return
+      case "supplier":
+        onOpenSupplier?.(target.supplierId)
+        return
+      case "product":
+        onOpenProduct?.(target.productId)
+        return
+      case "booking":
+        onOpenBooking?.(target.bookingId)
+    }
+  }
+  const canOpenLink = (target: DepartureLinkTarget): boolean => {
+    switch (target.kind) {
+      case "resource":
+        return Boolean(onOpenResource)
+      case "supplier":
+        return Boolean(onOpenSupplier)
+      case "product":
+        return Boolean(onOpenProduct)
+      case "booking":
+        return Boolean(onOpenBooking)
+    }
+  }
+
+  const tabLabels: Record<DepartureWorkspaceTab, string> = departureMessages.tabs
+  const goToSection = (target: DepartureWorkspaceTab): DepartureIssueAction => ({
+    label: departureMessages.links.goToSection.replace("{section}", tabLabels[target]),
+    onSelect: () => selectTab(target),
+  })
+
+  const resolveIssueAction = (issue: DepartureIssue): DepartureIssueAction | null => {
+    if (issue.subjectType === "booking" && onOpenBooking) {
+      return {
+        label: departureMessages.links.openBooking,
+        onSelect: () => onOpenBooking(issue.subjectId),
+      }
+    }
+    if (issue.subjectType === "allocation_resource") {
+      const resource = resourceBreakdownById.get(issue.subjectId)
+      const target = resource
+        ? resolveAllocationResourceTarget(resource, { productId: slot.productId })
+        : null
+      if (target && canOpenLink(target)) {
+        return {
+          label: linkTargetLabel(target, departureMessages.links),
+          onSelect: () => openLink(target),
+        }
+      }
+    }
+    if (issue.code === "departure_not_version_bound" && onOpenProduct) {
+      return {
+        label: departureMessages.links.openProduct,
+        onSelect: () => onOpenProduct(slot.productId),
+      }
+    }
+    const repairTab = ISSUE_REPAIR_TAB[issue.code]
+    return repairTab ? goToSection(repairTab) : null
+  }
+
   const handleDelete = async () => {
     await slotMutation.remove.mutateAsync(slot.id)
-    setDeleteDialogOpen(false)
     onDeleted?.()
   }
 
-  const fallbackActions = headerActions ?? (
-    <div className="flex flex-wrap items-center gap-2">
-      {onEdit ? (
-        <Button variant="outline" onClick={onEdit}>
-          <Pencil data-icon="inline-start" aria-hidden="true" />
-          {detailMessages.editSlot}
-        </Button>
-      ) : null}
-      {slot.productId && onOpenProduct ? (
-        <Button variant="outline" onClick={() => onOpenProduct(slot.productId)}>
-          <Package data-icon="inline-start" aria-hidden="true" />
-          {detailMessages.openProduct}
-        </Button>
-      ) : null}
-      <Button
-        variant="destructive"
-        onClick={() => setDeleteDialogOpen(true)}
-        disabled={slotMutation.remove.isPending}
-      >
-        {detailMessages.delete}
-      </Button>
-      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>{detailMessages.slot.deleteConfirm}</AlertDialogTitle>
-            <AlertDialogDescription>{detailMessages.slot.deleteDescription}</AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>{detailMessages.slot.deleteCancel}</AlertDialogCancel>
-            <AlertDialogAction
-              variant="destructive"
-              onClick={() => void handleDelete()}
-              disabled={slotMutation.remove.isPending}
-            >
-              {detailMessages.slot.deleteConfirmAction}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </div>
-  )
+  const attentionCount =
+    (summary?.operations.criticalCount ?? 0) + (summary?.operations.warningCount ?? 0)
+  const logisticsCount = pickupRows.length + closeoutRows.length
 
   return (
     <div className={cn("flex flex-col gap-6", className)}>
       {breadcrumb ? <div className="text-sm">{breadcrumb}</div> : null}
 
-      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-3">
-            <h1 className="text-2xl font-bold tracking-tight">{titleText}</h1>
-            <Badge variant="outline" className={slotStatusToneClass[slotStatusTone[slot.status]]}>
-              {getSlotStatusLabel(slot.status, messages)}
-            </Badge>
-            {productTypeName ? <Badge variant="outline">{productTypeName}</Badge> : null}
-          </div>
-          <div className="mt-1 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-            <span>
-              {dateRangeLabel}
-              {nightsLabel ? ` · ${nightsLabel}` : null}
-            </span>
-            <Badge variant="outline">{slot.timezone}</Badge>
-          </div>
-          {flagBadges.length > 0 ? (
-            <div className="mt-2 flex flex-wrap items-center gap-2">
-              {flagBadges.map((label) => (
-                <Badge key={label} variant="secondary">
-                  {label}
-                </Badge>
-              ))}
-            </div>
-          ) : null}
-        </div>
-        {fallbackActions}
-      </div>
-
-      <KpiStrip
+      <DepartureWorkspaceHeader
         slot={slot}
-        rollup={financialRollup}
-        formatCurrency={i18n.formatCurrency}
-        i18nLabels={{
-          pax: detailMessages.slot.paxKpiLabel,
-          total: detailMessages.slot.totalKpiLabel,
-          paid: detailMessages.slot.paidKpiLabel,
-          outstanding: detailMessages.slot.outstandingKpiLabel,
-          mixedHint: detailMessages.slot.mixedCurrenciesHint,
-          noValue,
-        }}
+        titleText={titleText}
+        productTypeName={productTypeName}
+        dateRangeLabel={dateRangeLabel}
+        nightsLabel={nightsLabel}
+        flagBadges={flagBadges}
+        messages={messages}
+        headerActions={headerActions}
+        onEdit={onEdit}
+        onOpenProduct={onOpenProduct}
+        onDelete={handleDelete}
+        deletePending={slotMutation.remove.isPending}
       />
 
-      <Tabs defaultValue="allocation">
+      {summary ? (
+        <DepartureHeadline
+          summary={summary}
+          formatCurrency={i18n.formatCurrency}
+          messages={{
+            pax: detailMessages.slot.paxKpiLabel,
+            total: detailMessages.slot.totalKpiLabel,
+            paid: detailMessages.slot.paidKpiLabel,
+            outstanding: detailMessages.slot.outstandingKpiLabel,
+            mixedHint: detailMessages.slot.mixedCurrenciesHint,
+            noValue,
+          }}
+        />
+      ) : null}
+
+      <Tabs value={activeTab} onValueChange={(next) => selectTab(next as DepartureWorkspaceTab)}>
         <TabsList className="flex h-auto w-fit flex-wrap justify-start">
-          <TabsTrigger value="allocation">{detailMessages.tabs.allocation}</TabsTrigger>
-          {renderExtras ? (
-            <TabsTrigger value="extras">{extrasTabLabel ?? detailMessages.tabs.extras}</TabsTrigger>
-          ) : null}
-          {pickupRows.length > 0 ? (
-            <TabsTrigger value="pickup">
-              {detailMessages.tabs.pickup}
+          <TabsTrigger value="overview">
+            {tabLabels.overview}
+            {attentionCount > 0 ? (
               <Badge variant="outline" className="ml-1.5">
-                {pickupRows.length}
+                {attentionCount}
               </Badge>
-            </TabsTrigger>
-          ) : null}
-          {closeoutRows.length > 0 ? (
-            <TabsTrigger value="closeouts">
-              {detailMessages.tabs.closeouts}
+            ) : null}
+          </TabsTrigger>
+          <TabsTrigger value="travelers">
+            {tabLabels.travelers}
+            {summary && summary.travelers.entered > 0 ? (
               <Badge variant="outline" className="ml-1.5">
-                {closeoutRows.length}
+                {summary.travelers.entered}
               </Badge>
-            </TabsTrigger>
-          ) : null}
+            ) : null}
+          </TabsTrigger>
+          <TabsTrigger value="allocation">{tabLabels.allocation}</TabsTrigger>
+          <TabsTrigger value="operations">
+            {tabLabels.operations}
+            {logisticsCount > 0 ? (
+              <Badge variant="outline" className="ml-1.5">
+                {logisticsCount}
+              </Badge>
+            ) : null}
+          </TabsTrigger>
+          <TabsTrigger value="financials">{tabLabels.financials}</TabsTrigger>
           <TabsTrigger value="activity">
-            {detailMessages.tabs.activity}
+            {tabLabels.activity}
             {auditEntries.length > 0 ? (
               <Badge variant="outline" className="ml-1.5">
                 {auditEntries.length}
               </Badge>
             ) : null}
           </TabsTrigger>
-          <TabsTrigger value="meta">{detailMessages.tabs.meta}</TabsTrigger>
         </TabsList>
 
-        <TabsContent value="allocation" className="mt-4">
+        <TabsContent value="overview" className="mt-4">
+          <DepartureOverviewSection
+            summary={summary}
+            slot={slot}
+            productName={productName}
+            statusLabel={getSlotStatusLabel(slot.status, messages)}
+            messages={messages}
+            formatDateTime={i18n.formatDateTime}
+            onEdit={onEdit}
+            onClearIssues={() => selectTab("travelers")}
+            resolveIssueAction={resolveIssueAction}
+            onOpenProduct={onOpenProduct}
+            onOpenStartTime={onOpenStartTime}
+          />
+        </TabsContent>
+
+        <TabsContent value="travelers" className="mt-4">
+          <DepartureTravelersSection
+            summary={summary}
+            bookings={allocationBookings}
+            resourceLabelById={resourceLabelById}
+            messages={messages}
+            onCreateBooking={onCreateBooking}
+            onOpenBooking={onOpenBooking}
+          />
+        </TabsContent>
+
+        <TabsContent value="allocation" className="mt-4 flex flex-col gap-8">
           {renderAllocation ? (
             renderAllocation({ slotId: id, productId: slot.productId })
           ) : (
@@ -400,59 +468,43 @@ export function AvailabilitySlotDetailPage({
               {detailMessages.tabs.allocationUnwired}
             </p>
           )}
+          <DepartureResourcesSection
+            summary={summary}
+            messages={messages}
+            productId={slot.productId}
+            onOpenLink={openLink}
+          />
         </TabsContent>
 
-        {renderExtras ? (
-          <TabsContent value="extras" className="mt-4">
-            {renderExtras({ slotId: id, productId: slot.productId })}
-          </TabsContent>
-        ) : null}
+        <TabsContent value="operations" className="mt-4">
+          <DepartureOperationsSection
+            summary={summary}
+            pickupRows={pickupRows}
+            pickupPointById={pickupPointById}
+            closeoutRows={closeoutRows}
+            messages={messages}
+            renderExtras={
+              renderExtras
+                ? () => renderExtras({ slotId: id, productId: slot.productId })
+                : undefined
+            }
+            extrasTitle={extrasTabLabel}
+            onAddPickupPoint={onAddPickupPoint}
+            onAddCloseout={onAddCloseout}
+            onOpenProduct={onOpenProduct}
+            productId={slot.productId}
+          />
+        </TabsContent>
 
-        {pickupRows.length > 0 ? (
-          <TabsContent value="pickup" className="mt-4">
-            <div className="flex flex-col gap-3 text-sm">
-              {pickupRows.map((pickup) => {
-                const point = pickupPointById.get(pickup.pickupPointId)
-                return (
-                  <div key={pickup.id} className="rounded-md border p-3">
-                    <div className="flex items-center gap-2 font-medium">
-                      <Truck className="size-4" aria-hidden="true" />
-                      {point?.name ?? pickup.pickupPointId}
-                    </div>
-                    <div className="mt-1 text-muted-foreground">
-                      {point?.locationText ?? detailMessages.slot.noLocationText}
-                    </div>
-                    <div className="mt-2">
-                      {detailMessages.slot.initialLabel}: {pickup.initialCapacity ?? noValue} ·{" "}
-                      {detailMessages.slot.remainingLabel}: {pickup.remainingCapacity ?? noValue}
-                    </div>
-                  </div>
-                )
-              })}
-            </div>
-          </TabsContent>
-        ) : null}
-
-        {closeoutRows.length > 0 ? (
-          <TabsContent value="closeouts" className="mt-4">
-            <div className="flex flex-col gap-3 text-sm">
-              {closeoutRows.map((closeout) => (
-                <div key={closeout.id} className="rounded-md border p-3">
-                  <div className="flex items-center gap-2 font-medium">
-                    <CalendarDays className="size-4" aria-hidden="true" />
-                    {closeout.dateLocal}
-                  </div>
-                  <div className="mt-1 text-muted-foreground">
-                    {detailMessages.slot.createdByLabel}: {closeout.createdBy ?? noValue}
-                  </div>
-                  {closeout.reason ? (
-                    <div className="mt-2 whitespace-pre-wrap">{closeout.reason}</div>
-                  ) : null}
-                </div>
-              ))}
-            </div>
-          </TabsContent>
-        ) : null}
+        <TabsContent value="financials" className="mt-4">
+          <DepartureFinancialsSection
+            summary={summary}
+            messages={messages}
+            formatCurrency={i18n.formatCurrency}
+            formatNumber={i18n.formatNumber}
+            onOpenFinanceReport={onOpenFinanceReport}
+          />
+        </TabsContent>
 
         <TabsContent value="activity" className="mt-4 flex flex-col gap-4">
           {slot.notes ? (
@@ -468,10 +520,17 @@ export function AvailabilitySlotDetailPage({
           <ActivityTimeline
             assignments={assignmentRows}
             auditEntries={auditEntries}
-            resourceById={resourceById}
+            resourceById={poolResourceById}
+            allocationResourceById={allocationResourceById}
             bookingById={bookingById}
             travelerById={travelerById}
             formatDateTime={i18n.formatDateTime}
+            emptyAction={{
+              title: departureMessages.activity.emptyTitle,
+              description: departureMessages.activity.emptyDescription,
+              actionLabel: departureMessages.activity.emptyAction,
+              onAction: () => selectTab("allocation"),
+            }}
             i18n={{
               title: detailMessages.tabs.activity,
               empty: detailMessages.tabs.activityEmpty,
@@ -484,30 +543,6 @@ export function AvailabilitySlotDetailPage({
               auditActionLabels: detailMessages.tabs.auditActionLabels,
               ongoing: detailMessages.tabs.activityOngoing,
               noValue,
-            }}
-          />
-        </TabsContent>
-
-        <TabsContent value="meta" className="mt-4">
-          <MetaTab
-            slot={slot}
-            productName={productName}
-            statusLabel={getSlotStatusLabel(slot.status, messages)}
-            onOpenProduct={onOpenProduct}
-            onOpenStartTime={onOpenStartTime}
-            i18n={{
-              title: detailMessages.tabs.metaTitle,
-              slotIdLabel: detailMessages.tabs.metaSlotId,
-              ruleLabel: detailMessages.slot.ruleLabel,
-              startTimeLabel: detailMessages.slot.startTimeIdLabel,
-              endsAtLabel: detailMessages.slot.endsAtLabel,
-              createdLabel: detailMessages.createdLabel,
-              updatedLabel: detailMessages.updatedLabel,
-              productLabel: messages.productLabel,
-              statusLabel: messages.statusLabel,
-              timezoneLabel: messages.timezoneLabel,
-              noValue,
-              format: i18n.formatDateTime,
             }}
           />
         </TabsContent>

--- a/packages/operations-react/src/availability/components/departure-deep-links.ts
+++ b/packages/operations-react/src/availability/components/departure-deep-links.ts
@@ -1,0 +1,54 @@
+/**
+ * Where a departure's rows live outside Operations.
+ *
+ * `allocation_resources` has carried `ref_type` / `ref_id` since it was
+ * introduced — the materializer writes the option a room came from, and a
+ * template may point a row at a supplier's inventory or at a row in the
+ * operations resource pool — but nothing ever resolved that pair into a place
+ * the operator could go. This module is that resolution, kept as pure data so
+ * the page can map a target onto whichever navigation its host provides
+ * (packaged pages never import a host route tree).
+ */
+
+export type DepartureLinkTarget =
+  | { kind: "resource"; resourceId: string }
+  | { kind: "supplier"; supplierId: string }
+  | { kind: "product"; productId: string }
+  | { kind: "booking"; bookingId: string }
+
+export interface AllocationResourceRef {
+  refType: string | null
+  refId: string | null
+}
+
+/**
+ * Resolve an allocation resource's persisted reference to a destination.
+ *
+ * `option` / `option_unit` refs point at a product OPTION, which has no page
+ * of its own — the option is only reachable through the product editor, so
+ * those resolve to the departure's product rather than to nothing. Anything
+ * this codebase does not write (a bespoke template ref, a future kind) returns
+ * `null`: rendering a dead link is worse than rendering plain text.
+ */
+export function resolveAllocationResourceTarget(
+  resource: AllocationResourceRef,
+  context: { productId: string | null },
+): DepartureLinkTarget | null {
+  const { refType, refId } = resource
+
+  if (!refType) return null
+
+  switch (refType) {
+    case "resource":
+      return refId ? { kind: "resource", resourceId: refId } : null
+    case "supplier":
+      return refId ? { kind: "supplier", supplierId: refId } : null
+    case "product":
+      return refId ? { kind: "product", productId: refId } : null
+    case "option":
+    case "option_unit":
+      return context.productId ? { kind: "product", productId: context.productId } : null
+    default:
+      return null
+  }
+}

--- a/packages/operations-react/src/availability/components/departure-issues.tsx
+++ b/packages/operations-react/src/availability/components/departure-issues.tsx
@@ -1,0 +1,225 @@
+"use client"
+
+import {
+  Badge,
+  Button,
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@voyant-travel/ui/components"
+import { AlertTriangle, CheckCircle2, TriangleAlert } from "lucide-react"
+import type { DepartureIssue, DepartureIssueSeverity } from "../index.js"
+
+/**
+ * The UI half of the typed attention vocabulary (`service-departure-issues.ts`).
+ *
+ * The server ships a stable machine `code` plus an English `message`. The
+ * message is a fallback for consumers with no catalogue — a Tool transport, a
+ * webhook — NOT the string an operator reads. This component renders the
+ * localized entry for every code it knows and falls back to the server string
+ * only for a code a newer server invented, so a version skew degrades to
+ * English instead of to a blank row.
+ */
+
+export interface DepartureIssueCodeMessage {
+  title: string
+  description: string
+}
+
+export interface DepartureIssueMessages {
+  title: string
+  summary: string
+  criticalGroup: string
+  warningGroup: string
+  criticalBadge: string
+  warningBadge: string
+  affectedLabel: string
+  clearTitle: string
+  clearDescription: string
+  clearAction: string
+  codes: Record<string, DepartureIssueCodeMessage>
+}
+
+export interface DepartureIssueAction {
+  label: string
+  onSelect: () => void
+}
+
+const severityStyles: Record<DepartureIssueSeverity, { row: string; icon: string; badge: string }> =
+  {
+    critical: {
+      row: "border-red-500/40 bg-red-500/5",
+      icon: "text-red-600 dark:text-red-400",
+      badge: "border-transparent bg-red-500/10 text-red-600 dark:text-red-400",
+    },
+    warning: {
+      row: "border-yellow-500/40 bg-yellow-500/5",
+      icon: "text-yellow-700 dark:text-yellow-400",
+      badge: "border-transparent bg-yellow-500/10 text-yellow-700 dark:text-yellow-400",
+    },
+  }
+
+const severityIcons = {
+  critical: TriangleAlert,
+  warning: AlertTriangle,
+}
+
+/**
+ * Group the issues the way the operator triages them: everything that can
+ * oversell or overfill the departure first, then the reconciliations they own.
+ * The server already sorts by severity then code, so grouping preserves order.
+ */
+export function DepartureIssueList({
+  issues,
+  messages,
+  resolveAction,
+  onClearAction,
+}: {
+  issues: readonly DepartureIssue[]
+  messages: DepartureIssueMessages
+  resolveAction?: (issue: DepartureIssue) => DepartureIssueAction | null
+  /** Next action offered when nothing needs attention (AC7). */
+  onClearAction?: () => void
+}) {
+  const critical = issues.filter((issue) => issue.severity === "critical")
+  const warning = issues.filter((issue) => issue.severity === "warning")
+
+  if (issues.length === 0) {
+    return (
+      <Empty data-slot="departure-issues-clear" className="border">
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <CheckCircle2 aria-hidden="true" />
+          </EmptyMedia>
+          <EmptyTitle>{messages.clearTitle}</EmptyTitle>
+          <EmptyDescription>{messages.clearDescription}</EmptyDescription>
+        </EmptyHeader>
+        {onClearAction ? (
+          <Button variant="outline" onClick={onClearAction}>
+            {messages.clearAction}
+          </Button>
+        ) : null}
+      </Empty>
+    )
+  }
+
+  return (
+    <div data-slot="departure-issues" className="flex flex-col gap-4">
+      {critical.length > 0 ? (
+        <DepartureIssueGroup
+          heading={messages.criticalGroup}
+          issues={critical}
+          messages={messages}
+          resolveAction={resolveAction}
+        />
+      ) : null}
+      {warning.length > 0 ? (
+        <DepartureIssueGroup
+          heading={messages.warningGroup}
+          issues={warning}
+          messages={messages}
+          resolveAction={resolveAction}
+        />
+      ) : null}
+    </div>
+  )
+}
+
+function DepartureIssueGroup({
+  heading,
+  issues,
+  messages,
+  resolveAction,
+}: {
+  heading: string
+  issues: readonly DepartureIssue[]
+  messages: DepartureIssueMessages
+  resolveAction?: (issue: DepartureIssue) => DepartureIssueAction | null
+}) {
+  return (
+    <section className="flex flex-col gap-2">
+      <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {heading}
+      </h3>
+      <ul className="flex flex-col gap-2">
+        {issues.map((issue) => (
+          <DepartureIssueRow
+            key={`${issue.code}:${issue.subjectId}`}
+            issue={issue}
+            messages={messages}
+            action={resolveAction?.(issue) ?? null}
+          />
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+function DepartureIssueRow({
+  issue,
+  messages,
+  action,
+}: {
+  issue: DepartureIssue
+  messages: DepartureIssueMessages
+  action: DepartureIssueAction | null
+}) {
+  const styles = severityStyles[issue.severity]
+  const Icon = severityIcons[issue.severity]
+  const copy = messages.codes[issue.code]
+  // Unknown code: a server one release ahead. Render its English fallback
+  // rather than dropping a row the operator has to act on.
+  const title = copy?.title ?? issue.message
+  const description = copy?.description ?? null
+
+  return (
+    <li
+      data-slot="departure-issue"
+      data-severity={issue.severity}
+      data-code={issue.code}
+      className={`flex flex-wrap items-start gap-3 rounded-md border p-3 ${styles.row}`}
+    >
+      <Icon className={`mt-0.5 size-4 shrink-0 ${styles.icon}`} aria-hidden="true" />
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <p className="text-sm font-medium">{title}</p>
+          <Badge variant="outline" className={styles.badge}>
+            {issue.severity === "critical" ? messages.criticalBadge : messages.warningBadge}
+          </Badge>
+          {issue.count > 1 ? (
+            <Badge variant="outline">
+              {messages.affectedLabel.replace("{count}", String(issue.count))}
+            </Badge>
+          ) : null}
+        </div>
+        {description ? <p className="mt-1 text-sm text-muted-foreground">{description}</p> : null}
+      </div>
+      {action ? (
+        <Button variant="outline" size="sm" onClick={action.onSelect}>
+          {action.label}
+        </Button>
+      ) : null}
+    </li>
+  )
+}
+
+/** Compact severity counts for the workspace header / overview banner. */
+export function DepartureIssueSummary({
+  criticalCount,
+  warningCount,
+  messages,
+}: {
+  criticalCount: number
+  warningCount: number
+  messages: Pick<DepartureIssueMessages, "summary">
+}) {
+  return (
+    <span data-slot="departure-issue-summary" className="text-sm text-muted-foreground">
+      {messages.summary
+        .replace("{critical}", String(criticalCount))
+        .replace("{warning}", String(warningCount))}
+    </span>
+  )
+}

--- a/packages/operations-react/src/availability/components/departure-stat.tsx
+++ b/packages/operations-react/src/availability/components/departure-stat.tsx
@@ -1,0 +1,80 @@
+"use client"
+
+import { Card, CardContent, cn } from "@voyant-travel/ui/components"
+import type { ReactNode } from "react"
+
+/**
+ * The workspace's one number-with-a-label primitive. Every headline figure in
+ * the departure workspace comes from the composed summary, so they all render
+ * identically — a figure that looks different from its neighbours reads as a
+ * different KIND of number, which is exactly the confusion this workspace
+ * exists to remove.
+ */
+export function StatCard({
+  label,
+  children,
+  hint,
+  badge,
+  tone,
+}: {
+  label: string
+  children: ReactNode
+  hint?: ReactNode
+  badge?: ReactNode
+  /** `attention` tints the figure when it is the one that disagrees. */
+  tone?: "default" | "attention"
+}) {
+  return (
+    <Card data-slot="departure-stat" data-tone={tone ?? "default"}>
+      <CardContent className="flex flex-col gap-1">
+        <div className="text-xs font-medium text-muted-foreground">{label}</div>
+        <div className="flex flex-wrap items-center gap-2">
+          <div
+            className={cn(
+              "text-xl font-semibold tabular-nums leading-none",
+              tone === "attention" && "text-red-600 dark:text-red-400",
+            )}
+          >
+            {children}
+          </div>
+          {badge}
+        </div>
+        {hint ? <div className="text-xs text-muted-foreground">{hint}</div> : null}
+      </CardContent>
+    </Card>
+  )
+}
+
+export function StatGrid({ children, className }: { children: ReactNode; className?: string }) {
+  return <div className={cn("grid grid-cols-2 gap-4 sm:grid-cols-4", className)}>{children}</div>
+}
+
+/** Section shell: a heading, an optional description, and its content. */
+export function DepartureSection({
+  title,
+  description,
+  actions,
+  children,
+  slot,
+}: {
+  title: ReactNode
+  description?: ReactNode
+  actions?: ReactNode
+  children: ReactNode
+  slot?: string
+}) {
+  return (
+    <section data-slot={slot} className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h2 className="text-base font-semibold">{title}</h2>
+          {description ? (
+            <p className="mt-0.5 text-sm text-muted-foreground">{description}</p>
+          ) : null}
+        </div>
+        {actions}
+      </div>
+      {children}
+    </section>
+  )
+}

--- a/packages/operations-react/src/availability/components/departure-workspace-financials.tsx
+++ b/packages/operations-react/src/availability/components/departure-workspace-financials.tsx
@@ -1,0 +1,258 @@
+"use client"
+
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+  Button,
+  cn,
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@voyant-travel/ui/components"
+import { ExternalLink, TriangleAlert, Wallet } from "lucide-react"
+import type { AvailabilityUiMessages } from "../i18n/index.js"
+import type { DepartureFinanceLine, DepartureSummary } from "../index.js"
+import { DepartureSection, StatCard, StatGrid } from "./departure-stat.js"
+
+/**
+ * Financials: Finance's own P&L for the departure.
+ *
+ * This section used to sum `sellAmountCents` across the allocation manifest's
+ * bookings in the browser and call the result revenue. It was not revenue — it
+ * was what was sold, before credit notes, before supplier cost, before FX, and
+ * it silently tracked whichever page of the manifest was loaded. Finance owns
+ * those figures, the summary carries them across the optional runtime port,
+ * and Operations renders them without recomputing anything.
+ *
+ * `finance === null` means no Finance provider is bound to this deployment.
+ * That is a DIFFERENT fact from "this departure made nothing", so it renders as
+ * an explicit unavailable state rather than as a grid of zeros — the booking
+ * settlement figures stay visible underneath because they come from Bookings,
+ * not from Finance.
+ */
+export function DepartureFinancialsSection({
+  summary,
+  messages,
+  formatCurrency,
+  formatNumber,
+  onOpenFinanceReport,
+}: {
+  summary: DepartureSummary | null
+  messages: AvailabilityUiMessages
+  formatCurrency: (value: number, currency: string) => string
+  formatNumber: (value: number) => string
+  onOpenFinanceReport?: () => void
+}) {
+  const details = messages.details
+  const copy = details.departure.financials
+  const noValue = details.noValue
+  const finance = summary?.finance ?? null
+  const bookings = summary?.bookings ?? null
+
+  const openReport = onOpenFinanceReport ? (
+    <Button variant="outline" onClick={onOpenFinanceReport}>
+      <ExternalLink data-icon="inline-start" aria-hidden="true" />
+      {copy.openReportAction}
+    </Button>
+  ) : null
+
+  return (
+    <div className="flex flex-col gap-8">
+      <DepartureSection
+        slot="departure-financials"
+        title={copy.title}
+        description={copy.description}
+        actions={openReport}
+      >
+        {finance === null ? (
+          <Empty data-slot="departure-finance-unavailable" className="border">
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <Wallet aria-hidden="true" />
+              </EmptyMedia>
+              <EmptyTitle>{copy.unavailableTitle}</EmptyTitle>
+              <EmptyDescription>{copy.unavailableDescription}</EmptyDescription>
+            </EmptyHeader>
+            {openReport}
+          </Empty>
+        ) : finance.perCurrency.length === 0 && finance.base === null ? (
+          <Empty data-slot="departure-finance-empty" className="border">
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <Wallet aria-hidden="true" />
+              </EmptyMedia>
+              <EmptyTitle>{copy.emptyTitle}</EmptyTitle>
+              <EmptyDescription>{copy.emptyDescription}</EmptyDescription>
+            </EmptyHeader>
+            {openReport}
+          </Empty>
+        ) : (
+          <div className="flex flex-col gap-4">
+            {finance.base ? (
+              <div>
+                <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  {copy.baseTitle}
+                </h3>
+                <StatGrid className="sm:grid-cols-4">
+                  <StatCard label={copy.columnRevenue}>
+                    {formatCurrency(finance.base.revenueCents / 100, finance.base.currency)}
+                  </StatCard>
+                  <StatCard label={copy.columnActualCost}>
+                    {formatCurrency(finance.base.actualCostCents / 100, finance.base.currency)}
+                  </StatCard>
+                  <StatCard
+                    label={copy.columnProfit}
+                    tone={finance.base.profitCents < 0 ? "attention" : "default"}
+                  >
+                    {formatCurrency(finance.base.profitCents / 100, finance.base.currency)}
+                  </StatCard>
+                  <StatCard label={copy.columnMargin}>
+                    {finance.base.marginPercent === null
+                      ? noValue
+                      : `${formatNumber(finance.base.marginPercent)}%`}
+                  </StatCard>
+                </StatGrid>
+              </div>
+            ) : null}
+
+            {finance.perCurrency.length > 0 ? (
+              <div className="overflow-x-auto rounded-md border">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>{copy.columnCurrency}</TableHead>
+                      <TableHead>{copy.columnRevenue}</TableHead>
+                      <TableHead>{copy.columnPlannedCost}</TableHead>
+                      <TableHead>{copy.columnActualCost}</TableHead>
+                      <TableHead>{copy.columnVariance}</TableHead>
+                      <TableHead>{copy.columnProfit}</TableHead>
+                      <TableHead>{copy.columnMargin}</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {finance.perCurrency.map((line) => (
+                      <FinanceRow
+                        key={line.currency}
+                        line={line}
+                        formatCurrency={formatCurrency}
+                        formatNumber={formatNumber}
+                        noValue={noValue}
+                      />
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            ) : null}
+
+            {finance.unconvertibleCurrencies.length > 0 ? (
+              <Alert variant="destructive">
+                <TriangleAlert aria-hidden="true" />
+                <AlertTitle>{copy.unconvertibleTitle}</AlertTitle>
+                <AlertDescription>
+                  {copy.unconvertibleDescription.replace(
+                    "{currencies}",
+                    finance.unconvertibleCurrencies.join(", "),
+                  )}
+                </AlertDescription>
+              </Alert>
+            ) : null}
+          </div>
+        )}
+      </DepartureSection>
+
+      <DepartureSection slot="departure-settlement" title={copy.settlementTitle}>
+        <StatGrid className="sm:grid-cols-3">
+          <StatCard label={copy.settlementSoldLabel}>
+            {formatSettlement(
+              bookings?.soldAmountCents,
+              bookings?.currency,
+              formatCurrency,
+              noValue,
+            )}
+          </StatCard>
+          <StatCard label={copy.settlementPaidLabel}>
+            {formatSettlement(
+              bookings?.paidAmountCents,
+              bookings?.currency,
+              formatCurrency,
+              noValue,
+            )}
+          </StatCard>
+          <StatCard
+            label={copy.settlementOutstandingLabel}
+            tone={
+              bookings?.outstandingAmountCents && bookings.outstandingAmountCents > 0
+                ? "attention"
+                : "default"
+            }
+          >
+            {formatSettlement(
+              bookings?.outstandingAmountCents,
+              bookings?.currency,
+              formatCurrency,
+              noValue,
+            )}
+          </StatCard>
+        </StatGrid>
+        {bookings && bookings.currency === null && bookings.count > 0 ? (
+          <p className="text-sm text-muted-foreground">{copy.mixedCurrenciesHint}</p>
+        ) : null}
+      </DepartureSection>
+    </div>
+  )
+}
+
+function FinanceRow({
+  line,
+  formatCurrency,
+  formatNumber,
+  noValue,
+}: {
+  line: DepartureFinanceLine
+  formatCurrency: (value: number, currency: string) => string
+  formatNumber: (value: number) => string
+  noValue: string
+}) {
+  const money = (cents: number) => formatCurrency(cents / 100, line.currency)
+
+  return (
+    <TableRow>
+      <TableCell className="font-medium">{line.currency}</TableCell>
+      <TableCell className="tabular-nums">{money(line.revenueCents)}</TableCell>
+      <TableCell className="tabular-nums">{money(line.plannedCostCents)}</TableCell>
+      <TableCell className="tabular-nums">{money(line.actualCostCents)}</TableCell>
+      <TableCell
+        className={cn("tabular-nums", line.varianceCents > 0 && "text-red-600 dark:text-red-400")}
+      >
+        {money(line.varianceCents)}
+      </TableCell>
+      <TableCell
+        className={cn("tabular-nums", line.profitCents < 0 && "text-red-600 dark:text-red-400")}
+      >
+        {money(line.profitCents)}
+      </TableCell>
+      <TableCell className="tabular-nums">
+        {line.marginPercent === null ? noValue : `${formatNumber(line.marginPercent)}%`}
+      </TableCell>
+    </TableRow>
+  )
+}
+
+function formatSettlement(
+  cents: number | null | undefined,
+  currency: string | null | undefined,
+  formatCurrency: (value: number, currency: string) => string,
+  noValue: string,
+): string {
+  if (cents === null || cents === undefined || !currency) return noValue
+  return formatCurrency(cents / 100, currency)
+}

--- a/packages/operations-react/src/availability/components/departure-workspace-header.tsx
+++ b/packages/operations-react/src/availability/components/departure-workspace-header.tsx
@@ -1,0 +1,140 @@
+"use client"
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Badge,
+  Button,
+} from "@voyant-travel/ui/components"
+import { Package, Pencil } from "lucide-react"
+import { type ReactNode, useState } from "react"
+import type { AvailabilityUiMessages } from "../i18n/index.js"
+import { type AvailabilitySlotDetail, slotStatusTone } from "../index.js"
+import { getSlotStatusLabel } from "./availability-columns.js"
+import { slotStatusToneClass } from "./slot-status-tone.js"
+
+/**
+ * The workspace's identity line: what this departure is called, its status,
+ * when it runs, and the actions that apply to the departure as a whole (as
+ * opposed to the per-section actions inside the tabs).
+ *
+ * Split out of the page so the page stays a page. `headerActions` still lets a
+ * host render the same actions in its own inset top bar instead — in which
+ * case the in-page buttons, and the delete confirmation they own, are not
+ * rendered at all.
+ */
+export function DepartureWorkspaceHeader({
+  slot,
+  titleText,
+  productTypeName,
+  dateRangeLabel,
+  nightsLabel,
+  flagBadges,
+  messages,
+  headerActions,
+  onEdit,
+  onOpenProduct,
+  onDelete,
+  deletePending,
+}: {
+  slot: AvailabilitySlotDetail
+  titleText: string
+  productTypeName: string | null
+  dateRangeLabel: string
+  nightsLabel: string | null
+  flagBadges: readonly string[]
+  messages: AvailabilityUiMessages
+  headerActions?: ReactNode
+  onEdit?: () => void
+  onOpenProduct?: (productId: string) => void
+  onDelete: () => Promise<void>
+  deletePending: boolean
+}) {
+  const detailMessages = messages.details
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+
+  const handleDelete = async () => {
+    await onDelete()
+    setDeleteDialogOpen(false)
+  }
+
+  return (
+    <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-3">
+          <h1 className="text-2xl font-bold tracking-tight">{titleText}</h1>
+          <Badge variant="outline" className={slotStatusToneClass[slotStatusTone[slot.status]]}>
+            {getSlotStatusLabel(slot.status, messages)}
+          </Badge>
+          {productTypeName ? <Badge variant="outline">{productTypeName}</Badge> : null}
+        </div>
+        <div className="mt-1 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+          <span>
+            {dateRangeLabel}
+            {nightsLabel ? ` · ${nightsLabel}` : null}
+          </span>
+          <Badge variant="outline">{slot.timezone}</Badge>
+        </div>
+        {flagBadges.length > 0 ? (
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            {flagBadges.map((label) => (
+              <Badge key={label} variant="secondary">
+                {label}
+              </Badge>
+            ))}
+          </div>
+        ) : null}
+      </div>
+
+      {headerActions ?? (
+        <div className="flex flex-wrap items-center gap-2">
+          {onEdit ? (
+            <Button variant="outline" onClick={onEdit}>
+              <Pencil data-icon="inline-start" aria-hidden="true" />
+              {detailMessages.editSlot}
+            </Button>
+          ) : null}
+          {slot.productId && onOpenProduct ? (
+            <Button variant="outline" onClick={() => onOpenProduct(slot.productId)}>
+              <Package data-icon="inline-start" aria-hidden="true" />
+              {detailMessages.openProduct}
+            </Button>
+          ) : null}
+          <Button
+            variant="destructive"
+            onClick={() => setDeleteDialogOpen(true)}
+            disabled={deletePending}
+          >
+            {detailMessages.delete}
+          </Button>
+          <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>{detailMessages.slot.deleteConfirm}</AlertDialogTitle>
+                <AlertDialogDescription>
+                  {detailMessages.slot.deleteDescription}
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>{detailMessages.slot.deleteCancel}</AlertDialogCancel>
+                <AlertDialogAction
+                  variant="destructive"
+                  onClick={() => void handleDelete()}
+                  disabled={deletePending}
+                >
+                  {detailMessages.slot.deleteConfirmAction}
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/operations-react/src/availability/components/departure-workspace-headline.tsx
+++ b/packages/operations-react/src/availability/components/departure-workspace-headline.tsx
@@ -1,0 +1,117 @@
+"use client"
+
+import { Badge, cn } from "@voyant-travel/ui/components"
+import type { ReactNode } from "react"
+import type { DepartureSummary } from "../index.js"
+import { StatCard, StatGrid } from "./departure-stat.js"
+
+/**
+ * The four figures the operator checks first, all read from the ONE composed
+ * departure envelope.
+ *
+ * Previously these were computed in the browser by summing the allocation
+ * manifest's booking rows, which meant the headline silently tracked whatever
+ * page of the manifest happened to be loaded and used a settlement rule of its
+ * own. The summary's counters are whole-departure aggregates and its
+ * settlement is `derivePaidAmountCents` — the same rule the allocation chips
+ * colour themselves with — so the headline and the rows can no longer
+ * disagree.
+ */
+export interface DepartureHeadlineMessages {
+  pax: string
+  total: string
+  paid: string
+  outstanding: string
+  mixedHint: string
+  noValue: string
+}
+
+export function DepartureHeadline({
+  summary,
+  formatCurrency,
+  messages,
+}: {
+  summary: DepartureSummary
+  formatCurrency: (value: number, currency: string) => string
+  messages: DepartureHeadlineMessages
+}) {
+  const { capacity, bookings } = summary
+  const paxValue = capacity.unlimited
+    ? "∞"
+    : `${capacity.derivedRemainingPax ?? capacity.remainingPax ?? 0} / ${capacity.initialPax ?? 0}`
+  // The stored counter is authoritative for selling; the derived one is what
+  // the other tables actually consume. Showing the stored figure as a hint is
+  // how the drift becomes visible without a second screen.
+  const driftHint =
+    !capacity.unlimited &&
+    capacity.remainingPax !== null &&
+    capacity.derivedRemainingPax !== null &&
+    capacity.remainingPax !== capacity.derivedRemainingPax
+      ? String(capacity.remainingPax)
+      : undefined
+
+  const amount = (value: number | null): ReactNode => {
+    if (value === null || !bookings.currency) return messages.noValue
+    return formatCurrency(value / 100, bookings.currency)
+  }
+  const mixedHint =
+    bookings.currency === null && bookings.count > 0 ? messages.mixedHint : undefined
+
+  const paidPercent =
+    bookings.soldAmountCents && bookings.soldAmountCents > 0 && bookings.paidAmountCents !== null
+      ? Math.round((bookings.paidAmountCents / bookings.soldAmountCents) * 100)
+      : null
+  const outstandingPercent = paidPercent === null ? null : Math.max(0, 100 - paidPercent)
+
+  return (
+    <StatGrid>
+      <StatCard
+        label={messages.pax}
+        hint={driftHint}
+        tone={driftHint === undefined ? "default" : "attention"}
+      >
+        {paxValue}
+      </StatCard>
+      <StatCard label={messages.total} hint={mixedHint}>
+        {amount(bookings.soldAmountCents)}
+      </StatCard>
+      <StatCard
+        label={messages.paid}
+        hint={mixedHint}
+        badge={paidPercent === null ? null : <PercentBadge percent={paidPercent} kind="paid" />}
+      >
+        {amount(bookings.paidAmountCents)}
+      </StatCard>
+      <StatCard
+        label={messages.outstanding}
+        hint={mixedHint}
+        badge={
+          outstandingPercent === null ? null : (
+            <PercentBadge percent={outstandingPercent} kind="outstanding" />
+          )
+        }
+      >
+        {amount(bookings.outstandingAmountCents)}
+      </StatCard>
+    </StatGrid>
+  )
+}
+
+function PercentBadge({ percent, kind }: { percent: number; kind: "paid" | "outstanding" }) {
+  const good = kind === "paid" ? percent >= 100 : percent <= 0
+  const bad = kind === "paid" ? percent <= 0 : percent >= 100
+
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        "border-transparent",
+        good && "bg-green-500/10 text-green-600 dark:text-green-400",
+        bad && "bg-red-500/10 text-red-600 dark:text-red-400",
+        !good && !bad && "bg-yellow-500/10 text-yellow-700 dark:text-yellow-400",
+      )}
+    >
+      {`${percent}%`}
+    </Badge>
+  )
+}

--- a/packages/operations-react/src/availability/components/departure-workspace-operations.tsx
+++ b/packages/operations-react/src/availability/components/departure-workspace-operations.tsx
@@ -1,0 +1,190 @@
+"use client"
+
+import {
+  Button,
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@voyant-travel/ui/components"
+import { CalendarDays, CalendarX, Package, ShoppingBag, Truck } from "lucide-react"
+import type { ReactNode } from "react"
+import type { AvailabilityUiMessages } from "../i18n/index.js"
+import type {
+  AvailabilityCloseoutRow,
+  AvailabilityPickupPointRow,
+  AvailabilitySlotPickupRow,
+  DepartureSummary,
+} from "../index.js"
+import { DepartureSection } from "./departure-stat.js"
+
+/**
+ * Operations: everything that has to be squared away before the departure
+ * runs.
+ *
+ * Pickup, Closeouts and Extras used to be three top-level tabs, two of which
+ * VANISHED when they were empty — so "no pickup point has been set" and "this
+ * product has no pickups at all" looked identical, and neither offered a way
+ * to fix it. They are sections here instead, always rendered, each with the
+ * next authorized action attached to its empty state (AC7).
+ *
+ * They belong together because they are the same job: the day-of-departure
+ * logistics an operator owns. Pickup is where the driver collects, Closeouts
+ * is whether the date may still sell, and Extras is what the guide has to
+ * carry and collect.
+ */
+export function DepartureOperationsSection({
+  summary,
+  pickupRows,
+  pickupPointById,
+  closeoutRows,
+  messages,
+  renderExtras,
+  extrasTitle,
+  onAddPickupPoint,
+  onAddCloseout,
+  onOpenProduct,
+  productId,
+}: {
+  summary: DepartureSummary | null
+  pickupRows: ReadonlyArray<AvailabilitySlotPickupRow>
+  pickupPointById: ReadonlyMap<string, AvailabilityPickupPointRow>
+  closeoutRows: ReadonlyArray<AvailabilityCloseoutRow>
+  messages: AvailabilityUiMessages
+  renderExtras?: () => ReactNode
+  /** Host override for the Extras heading — Bookings owns that vocabulary. */
+  extrasTitle?: ReactNode
+  onAddPickupPoint?: () => void
+  onAddCloseout?: () => void
+  onOpenProduct?: (productId: string) => void
+  productId: string | null
+}) {
+  const details = messages.details
+  const copy = details.departure.operations
+  const noValue = details.noValue
+  const extras = summary?.extras ?? null
+
+  return (
+    <div className="flex flex-col gap-8">
+      <DepartureSection slot="departure-pickup" title={copy.pickupTitle}>
+        {pickupRows.length === 0 ? (
+          <SectionEmpty
+            slot="departure-pickup-empty"
+            icon={<Truck aria-hidden="true" />}
+            title={copy.pickupEmptyTitle}
+            description={copy.pickupEmptyDescription}
+            actionLabel={copy.pickupEmptyAction}
+            onAction={onAddPickupPoint}
+          />
+        ) : (
+          <div className="flex flex-col gap-3 text-sm">
+            {pickupRows.map((pickup) => {
+              const point = pickupPointById.get(pickup.pickupPointId)
+              return (
+                <div key={pickup.id} className="rounded-md border p-3">
+                  <div className="flex items-center gap-2 font-medium">
+                    <Truck className="size-4" aria-hidden="true" />
+                    {/* Never the raw pickup-point id: a row's visible label is
+                        a name, not an identifier. */}
+                    {point?.name ?? copy.pickupPointUnknown}
+                  </div>
+                  <div className="mt-1 text-muted-foreground">
+                    {point?.locationText ?? details.slot.noLocationText}
+                  </div>
+                  <div className="mt-2">
+                    {`${details.slot.initialLabel}: ${pickup.initialCapacity ?? noValue} · ${details.slot.remainingLabel}: ${pickup.remainingCapacity ?? noValue}`}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </DepartureSection>
+
+      <DepartureSection slot="departure-closeouts" title={copy.closeoutsTitle}>
+        {closeoutRows.length === 0 ? (
+          <SectionEmpty
+            slot="departure-closeouts-empty"
+            icon={<CalendarX aria-hidden="true" />}
+            title={copy.closeoutsEmptyTitle}
+            description={copy.closeoutsEmptyDescription}
+            actionLabel={copy.closeoutsEmptyAction}
+            onAction={onAddCloseout}
+          />
+        ) : (
+          <div className="flex flex-col gap-3 text-sm">
+            {closeoutRows.map((closeout) => (
+              <div key={closeout.id} className="rounded-md border p-3">
+                <div className="flex items-center gap-2 font-medium">
+                  <CalendarDays className="size-4" aria-hidden="true" />
+                  {closeout.dateLocal}
+                </div>
+                <div className="mt-1 text-muted-foreground">
+                  {`${details.slot.createdByLabel}: ${closeout.createdBy ?? noValue}`}
+                </div>
+                {closeout.reason ? (
+                  <div className="mt-2 whitespace-pre-wrap">{closeout.reason}</div>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        )}
+      </DepartureSection>
+
+      <DepartureSection slot="departure-extras" title={extrasTitle ?? copy.extrasTitle}>
+        {/* The extras manifest is Bookings' panel; availability only decides
+            whether there is anything for it to show. `extras === null` means
+            the module is not deployed, which reads the same to the operator as
+            "nothing is offered" — both need the product configured. */}
+        {renderExtras && extras && extras.offered > 0 ? (
+          renderExtras()
+        ) : (
+          <SectionEmpty
+            slot="departure-extras-empty"
+            icon={<ShoppingBag aria-hidden="true" />}
+            title={copy.extrasEmptyTitle}
+            description={copy.extrasEmptyDescription}
+            actionLabel={copy.extrasEmptyAction}
+            actionIcon={<Package data-icon="inline-start" aria-hidden="true" />}
+            onAction={productId && onOpenProduct ? () => onOpenProduct(productId) : undefined}
+          />
+        )}
+      </DepartureSection>
+    </div>
+  )
+}
+
+function SectionEmpty({
+  slot,
+  icon,
+  title,
+  description,
+  actionLabel,
+  actionIcon,
+  onAction,
+}: {
+  slot: string
+  icon: ReactNode
+  title: string
+  description: string
+  actionLabel: string
+  actionIcon?: ReactNode
+  onAction?: () => void
+}) {
+  return (
+    <Empty data-slot={slot} className="border">
+      <EmptyHeader>
+        <EmptyMedia variant="icon">{icon}</EmptyMedia>
+        <EmptyTitle>{title}</EmptyTitle>
+        <EmptyDescription>{description}</EmptyDescription>
+      </EmptyHeader>
+      {onAction ? (
+        <Button variant="outline" onClick={onAction}>
+          {actionIcon}
+          {actionLabel}
+        </Button>
+      ) : null}
+    </Empty>
+  )
+}

--- a/packages/operations-react/src/availability/components/departure-workspace-overview.tsx
+++ b/packages/operations-react/src/availability/components/departure-workspace-overview.tsx
@@ -1,0 +1,210 @@
+"use client"
+
+import { Badge, Button } from "@voyant-travel/ui/components"
+import { Pencil } from "lucide-react"
+import type { AvailabilityUiMessages } from "../i18n/index.js"
+import type { AvailabilitySlotDetail, DepartureIssue, DepartureSummary } from "../index.js"
+import { MetaTab } from "./availability-slot-detail-meta.js"
+import { type DepartureIssueAction, DepartureIssueList } from "./departure-issues.js"
+import { DepartureSection, StatCard, StatGrid } from "./departure-stat.js"
+
+/**
+ * Overview: what this departure IS, and whether its own numbers agree.
+ *
+ * The stored counter and the derived one sit next to each other on purpose —
+ * the reason this workspace exists is that four screens each held a slice of a
+ * departure and nothing noticed when they disagreed. The typed attention
+ * issues lead the section because clearing them is what the operator came for.
+ *
+ * Meta (identifiers + lifecycle) lands here rather than keeping a tab of its
+ * own: the slot id, its rule, its start time and its Product Version are the
+ * departure's identity, which is the question this section already answers.
+ */
+export function DepartureOverviewSection({
+  summary,
+  slot,
+  productName,
+  statusLabel,
+  messages,
+  formatDateTime,
+  onEdit,
+  onClearIssues,
+  resolveIssueAction,
+  onOpenProduct,
+  onOpenStartTime,
+}: {
+  /** `null` while the summary is still loading or its read failed. */
+  summary: DepartureSummary | null
+  slot: AvailabilitySlotDetail
+  productName: string | null
+  statusLabel: string
+  messages: AvailabilityUiMessages
+  formatDateTime: (value: string | Date) => string
+  onEdit?: () => void
+  onClearIssues?: () => void
+  resolveIssueAction?: (issue: DepartureIssue) => DepartureIssueAction | null
+  onOpenProduct?: (productId: string) => void
+  onOpenStartTime?: (startTimeId: string) => void
+}) {
+  const details = messages.details
+  const copy = details.departure
+  const overview = copy.overview
+  const noValue = details.noValue
+  const capacity = summary?.capacity ?? null
+  const bookings = summary?.bookings ?? null
+  const extras = summary?.extras ?? null
+
+  const paxDrift =
+    capacity !== null &&
+    !capacity.unlimited &&
+    capacity.remainingPax !== null &&
+    capacity.derivedRemainingPax !== null &&
+    capacity.remainingPax !== capacity.derivedRemainingPax
+
+  const figure = (value: number | null | undefined) =>
+    value === null || value === undefined ? noValue : String(value)
+
+  return (
+    <div className="flex flex-col gap-8">
+      <DepartureSection
+        slot="departure-attention"
+        title={copy.issues.title}
+        actions={
+          onEdit ? (
+            <Button variant="outline" onClick={onEdit}>
+              <Pencil data-icon="inline-start" aria-hidden="true" />
+              {overview.editAction}
+            </Button>
+          ) : null
+        }
+      >
+        <DepartureIssueList
+          issues={summary?.operations.issues ?? []}
+          messages={copy.issues}
+          resolveAction={resolveIssueAction}
+          onClearAction={onClearIssues}
+        />
+      </DepartureSection>
+
+      <DepartureSection slot="departure-capacity" title={overview.capacityTitle}>
+        <StatGrid className="sm:grid-cols-5">
+          <StatCard label={overview.authoredPaxLabel}>
+            {capacity?.unlimited ? overview.unlimitedLabel : figure(capacity?.initialPax)}
+          </StatCard>
+          <StatCard label={overview.effectivePaxLabel}>
+            {capacity?.unlimited ? overview.unlimitedLabel : figure(capacity?.effectivePax)}
+          </StatCard>
+          <StatCard label={overview.consumedPaxLabel}>
+            {figure(capacity?.derivedConsumedPax)}
+          </StatCard>
+          <StatCard label={overview.storedRemainingLabel} tone={paxDrift ? "attention" : "default"}>
+            {figure(capacity?.remainingPax)}
+          </StatCard>
+          <StatCard
+            label={overview.derivedRemainingLabel}
+            tone={paxDrift ? "attention" : "default"}
+            hint={paxDrift ? overview.driftHint : undefined}
+          >
+            {figure(capacity?.derivedRemainingPax)}
+          </StatCard>
+        </StatGrid>
+      </DepartureSection>
+
+      <DepartureSection slot="departure-bookings" title={overview.bookingsTitle}>
+        <StatGrid className="sm:grid-cols-3">
+          <StatCard label={overview.activeBookingsLabel}>{figure(bookings?.count)}</StatCard>
+          <StatCard label={overview.soldPaxLabel}>{figure(bookings?.expectedPax)}</StatCard>
+          <StatCard
+            label={overview.cancelledWithAllocationLabel}
+            tone={
+              capacity && capacity.bookings.cancelledWithLiveAllocation > 0
+                ? "attention"
+                : "default"
+            }
+          >
+            {figure(capacity?.bookings.cancelledWithLiveAllocation)}
+          </StatCard>
+        </StatGrid>
+        {bookings && Object.keys(bookings.byStatus).length > 0 ? (
+          <div className="flex flex-wrap items-center gap-2">
+            {Object.entries(bookings.byStatus).map(([status, count]) => (
+              <Badge key={status} variant="outline">
+                {`${getBookingStatusLabel(status)} · ${count}`}
+              </Badge>
+            ))}
+          </div>
+        ) : null}
+      </DepartureSection>
+
+      <DepartureSection slot="departure-holds" title={overview.holdsTitle}>
+        <StatGrid className="sm:grid-cols-3">
+          <StatCard label={overview.holdsActiveLabel}>{figure(capacity?.holds.active)}</StatCard>
+          <StatCard
+            label={overview.holdsExpiredLabel}
+            tone={capacity && capacity.holds.expired > 0 ? "attention" : "default"}
+          >
+            {figure(capacity?.holds.expired)}
+          </StatCard>
+          <StatCard label={overview.holdsPaxLabel}>{figure(capacity?.holds.activePax)}</StatCard>
+        </StatGrid>
+      </DepartureSection>
+
+      <DepartureSection slot="departure-extras-rollup" title={overview.extrasTitle}>
+        {extras ? (
+          <StatGrid className="sm:grid-cols-3">
+            <StatCard label={overview.extrasOfferedLabel}>{String(extras.offered)}</StatCard>
+            <StatCard label={overview.extrasSelectedLabel}>
+              {String(extras.selectedTravelerCount)}
+            </StatCard>
+            <StatCard
+              label={overview.extrasOutstandingLabel}
+              tone={extras.outstandingCollectionCount > 0 ? "attention" : "default"}
+            >
+              {String(extras.outstandingCollectionCount)}
+            </StatCard>
+          </StatGrid>
+        ) : (
+          <p className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+            {overview.extrasUnavailable}
+          </p>
+        )}
+      </DepartureSection>
+
+      <MetaTab
+        slot={slot}
+        productName={productName}
+        statusLabel={statusLabel}
+        productVersionId={summary ? summary.departure.productVersionId : undefined}
+        onOpenProduct={onOpenProduct}
+        onOpenStartTime={onOpenStartTime}
+        i18n={{
+          title: details.tabs.metaTitle,
+          slotIdLabel: details.tabs.metaSlotId,
+          ruleLabel: details.slot.ruleLabel,
+          startTimeLabel: details.slot.startTimeIdLabel,
+          endsAtLabel: details.slot.endsAtLabel,
+          createdLabel: details.createdLabel,
+          updatedLabel: details.updatedLabel,
+          productLabel: messages.productLabel,
+          productVersionLabel: overview.productVersionLabel,
+          notVersionBoundLabel: overview.notVersionBound,
+          statusLabel: messages.statusLabel,
+          timezoneLabel: messages.timezoneLabel,
+          noValue,
+          format: formatDateTime,
+        }}
+      />
+    </div>
+  )
+}
+
+/**
+ * Booking statuses are Bookings' vocabulary, not Availability's, and the
+ * departure summary reports whatever `bookings.status` values it found. This
+ * package deliberately does NOT keep a copy of that enum — a stale copy would
+ * silently mislabel a status Bookings added — so the raw key is humanized the
+ * same way the activity timeline humanizes an unmapped audit action.
+ */
+function getBookingStatusLabel(status: string): string {
+  return status.replace(/[._-]/g, " ")
+}

--- a/packages/operations-react/src/availability/components/departure-workspace-resources.tsx
+++ b/packages/operations-react/src/availability/components/departure-workspace-resources.tsx
@@ -1,0 +1,146 @@
+"use client"
+
+import {
+  Badge,
+  Button,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@voyant-travel/ui/components"
+import { ExternalLink } from "lucide-react"
+import type { AvailabilityUiMessages } from "../i18n/index.js"
+import type { DepartureResourceRow, DepartureSummary } from "../index.js"
+import {
+  type DepartureLinkTarget,
+  resolveAllocationResourceTarget,
+} from "./departure-deep-links.js"
+import { DepartureSection } from "./departure-stat.js"
+
+/**
+ * The whole-departure resource census, with every row's persisted reference
+ * resolved into somewhere the operator can go (AC8).
+ *
+ * The allocation manager below it is per-kind and interactive; this is the
+ * flat, complete list the summary computes, which is also the only place the
+ * `ref_type` / `ref_id` a template or the materializer wrote has ever been
+ * shown. Rows whose reference resolves to nothing render as plain labels — a
+ * dead link is worse than no link.
+ */
+export function DepartureResourcesSection({
+  summary,
+  messages,
+  productId,
+  onOpenLink,
+}: {
+  summary: DepartureSummary | null
+  messages: AvailabilityUiMessages
+  productId: string | null
+  onOpenLink?: (target: DepartureLinkTarget) => void
+}) {
+  const copy = messages.details.departure.resources
+  const links = messages.details.departure.links
+  const rows = summary?.capacity.resourceBreakdown ?? []
+
+  if (rows.length === 0) return null
+
+  return (
+    <DepartureSection slot="departure-resources" title={copy.title} description={copy.description}>
+      <div className="overflow-x-auto rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>{copy.columnResource}</TableHead>
+              <TableHead>{copy.columnCapacity}</TableHead>
+              <TableHead>{copy.columnAssigned}</TableHead>
+              <TableHead>{copy.columnAvailable}</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.map((resource) => (
+              <TableRow key={resource.id}>
+                <TableCell>
+                  <span className="flex flex-wrap items-center gap-2">
+                    <ResourceLabel
+                      resource={resource}
+                      productId={productId}
+                      linkLabels={links}
+                      onOpenLink={onOpenLink}
+                    />
+                    {resource.assigned > resource.capacity ? (
+                      <Badge
+                        variant="outline"
+                        className="border-transparent bg-red-500/10 text-red-600 dark:text-red-400"
+                      >
+                        {copy.overCapacityBadge}
+                      </Badge>
+                    ) : null}
+                  </span>
+                </TableCell>
+                <TableCell className="tabular-nums">{resource.capacity}</TableCell>
+                <TableCell className="tabular-nums">{resource.assigned}</TableCell>
+                <TableCell className="tabular-nums">{resource.available}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </DepartureSection>
+  )
+}
+
+/**
+ * A resource's operator-facing name. `allocation_resources.label` is what the
+ * materializer rendered from the template's name pattern ("Room 12"); the kind
+ * is the fallback so a row never shows its typeid as its name.
+ */
+export function departureResourceLabel(resource: { label: string | null; kind: string }): string {
+  return resource.label ?? resource.kind.replace(/[._-]/g, " ")
+}
+
+function ResourceLabel({
+  resource,
+  productId,
+  linkLabels,
+  onOpenLink,
+}: {
+  resource: DepartureResourceRow
+  productId: string | null
+  linkLabels: AvailabilityUiMessages["details"]["departure"]["links"]
+  onOpenLink?: (target: DepartureLinkTarget) => void
+}) {
+  const label = departureResourceLabel(resource)
+  const target = resolveAllocationResourceTarget(resource, { productId })
+
+  if (!target || !onOpenLink) return <span className="font-medium">{label}</span>
+
+  return (
+    <Button
+      variant="link"
+      className="h-auto p-0 font-medium"
+      onClick={() => onOpenLink(target)}
+      aria-label={linkTargetLabel(target, linkLabels)}
+    >
+      {label}
+      <ExternalLink className="ml-1 size-3" aria-hidden="true" />
+    </Button>
+  )
+}
+
+export function linkTargetLabel(
+  target: DepartureLinkTarget,
+  labels: AvailabilityUiMessages["details"]["departure"]["links"],
+): string {
+  switch (target.kind) {
+    case "resource":
+      return labels.openResource
+    case "supplier":
+      return labels.openSupplier
+    case "product":
+      return labels.openProduct
+    case "booking":
+      return labels.openBooking
+  }
+}

--- a/packages/operations-react/src/availability/components/departure-workspace-travelers.tsx
+++ b/packages/operations-react/src/availability/components/departure-workspace-travelers.tsx
@@ -1,0 +1,163 @@
+"use client"
+
+import {
+  Badge,
+  Button,
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@voyant-travel/ui/components"
+import { UserPlus, Users } from "lucide-react"
+import type { AvailabilityUiMessages } from "../i18n/index.js"
+import type { AllocationManifestBooking, DepartureSummary } from "../index.js"
+import { DepartureSection, StatCard, StatGrid } from "./departure-stat.js"
+
+/**
+ * Travelers: who is actually coming, and whether the names match what was
+ * sold.
+ *
+ * The counters are the summary's whole-departure aggregates; the rows are the
+ * allocation manifest's page. That split is deliberate — a paged manifest can
+ * never move a headline number (`service-departure-summary.ts`), so "3 names
+ * missing" stays true no matter how much of the roster is on screen.
+ */
+export function DepartureTravelersSection({
+  summary,
+  bookings,
+  resourceLabelById,
+  messages,
+  onCreateBooking,
+  onOpenBooking,
+}: {
+  summary: DepartureSummary | null
+  bookings: ReadonlyArray<AllocationManifestBooking>
+  /** Allocation resource id → its operator-facing label, for the seat column. */
+  resourceLabelById: ReadonlyMap<string, string>
+  messages: AvailabilityUiMessages
+  /** Next action when nobody is booked yet (AC7). */
+  onCreateBooking?: () => void
+  onOpenBooking?: (bookingId: string) => void
+}) {
+  const copy = messages.details.departure.travelers
+  const travelers = summary?.travelers ?? null
+  const rows = bookings.flatMap((booking) =>
+    booking.travelers.map((traveler) => ({ booking, traveler })),
+  )
+
+  return (
+    <div className="flex flex-col gap-6">
+      <DepartureSection slot="departure-traveler-counters" title={copy.title}>
+        <StatGrid className="sm:grid-cols-5">
+          <StatCard label={copy.enteredLabel}>{String(travelers?.entered ?? 0)}</StatCard>
+          <StatCard label={copy.leadLabel}>{String(travelers?.lead ?? 0)}</StatCard>
+          <StatCard label={copy.seatedLabel}>{String(travelers?.assigned ?? 0)}</StatCard>
+          <StatCard
+            label={copy.unseatedLabel}
+            tone={travelers && travelers.unassigned > 0 ? "attention" : "default"}
+          >
+            {String(travelers?.unassigned ?? 0)}
+          </StatCard>
+          {/* `missing` is signed: positive means names are outstanding, negative
+              means more travelers were entered than pax were sold. */}
+          <StatCard
+            label={travelers && travelers.missing < 0 ? copy.excessLabel : copy.missingLabel}
+            tone={travelers && travelers.missing !== 0 ? "attention" : "default"}
+          >
+            {String(Math.abs(travelers?.missing ?? 0))}
+          </StatCard>
+        </StatGrid>
+      </DepartureSection>
+
+      {rows.length === 0 ? (
+        <Empty data-slot="departure-travelers-empty" className="border">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <Users aria-hidden="true" />
+            </EmptyMedia>
+            <EmptyTitle>{copy.emptyTitle}</EmptyTitle>
+            <EmptyDescription>{copy.emptyDescription}</EmptyDescription>
+          </EmptyHeader>
+          {onCreateBooking ? (
+            <Button onClick={onCreateBooking}>
+              <UserPlus data-icon="inline-start" aria-hidden="true" />
+              {copy.emptyAction}
+            </Button>
+          ) : null}
+        </Empty>
+      ) : (
+        <div className="overflow-x-auto rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>{copy.columnTraveler}</TableHead>
+                <TableHead>{copy.columnBooking}</TableHead>
+                <TableHead>{copy.columnStatus}</TableHead>
+                <TableHead>{copy.columnSeat}</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.map(({ booking, traveler }) => {
+                const seats = Object.values(traveler.allocations)
+                  .map((resourceId) => resourceLabelById.get(resourceId) ?? null)
+                  .filter((label): label is string => Boolean(label))
+
+                return (
+                  <TableRow key={traveler.id}>
+                    <TableCell>
+                      <span className="flex flex-wrap items-center gap-2">
+                        <span className="font-medium">{traveler.fullName}</span>
+                        {traveler.isLeadTraveler ? (
+                          <Badge variant="secondary">{copy.leadBadge}</Badge>
+                        ) : null}
+                      </span>
+                    </TableCell>
+                    <TableCell>
+                      {onOpenBooking ? (
+                        <Button
+                          variant="link"
+                          className="h-auto p-0"
+                          onClick={() => onOpenBooking(booking.id)}
+                          aria-label={copy.openBookingAction}
+                        >
+                          {booking.bookingNumber}
+                        </Button>
+                      ) : (
+                        booking.bookingNumber
+                      )}
+                    </TableCell>
+                    <TableCell className="capitalize">
+                      {booking.status.replace(/[._-]/g, " ")}
+                    </TableCell>
+                    <TableCell>
+                      {seats.length > 0 ? (
+                        <span className="flex flex-wrap gap-1">
+                          {seats.map((label) => (
+                            <Badge key={label} variant="outline">
+                              {label}
+                            </Badge>
+                          ))}
+                        </span>
+                      ) : (
+                        <Badge variant="outline" className="text-muted-foreground">
+                          {copy.unseatedBadge}
+                        </Badge>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                )
+              })}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/operations-react/src/availability/departure-search-params.ts
+++ b/packages/operations-react/src/availability/departure-search-params.ts
@@ -1,0 +1,46 @@
+import { z } from "zod"
+
+/**
+ * The departure workspace's URL search contract.
+ *
+ * The workspace's six sections are addressable: `?tab=financials` is a link a
+ * reviewer can paste into a ticket and a reload keeps the operator where they
+ * were. Lives in the data layer (no router imports) so the admin route
+ * contribution can bind it to `validateSearch` while the page component parses
+ * the same contract — the pattern `@voyant-travel/catalog-react`'s
+ * `catalog-search-params.ts` already established.
+ */
+
+export const departureWorkspaceTabs = [
+  /** What this departure *is* + the capacity headline and its identifiers. */
+  "overview",
+  /** Who is coming: the traveler roster and its completeness. */
+  "travelers",
+  /** Rooms, seats and cabins, and who sits where. */
+  "allocation",
+  /** Everything that has to be squared away before it runs. */
+  "operations",
+  /** Finance's own P&L for the departure. */
+  "financials",
+  /** What changed, and who changed it. */
+  "activity",
+] as const
+
+export type DepartureWorkspaceTab = (typeof departureWorkspaceTabs)[number]
+
+export const defaultDepartureWorkspaceTab: DepartureWorkspaceTab = "overview"
+
+/**
+ * `.catch` rather than a bare enum: a stale or hand-edited `?tab=` must land
+ * the operator on the overview, never fail the route.
+ */
+export const departureWorkspaceSearchSchema = z.object({
+  tab: z.enum(departureWorkspaceTabs).catch(defaultDepartureWorkspaceTab),
+})
+
+export type DepartureWorkspaceSearchParams = z.infer<typeof departureWorkspaceSearchSchema>
+
+/** Narrow an unknown search value onto the tab union, defaulting on anything else. */
+export function parseDepartureWorkspaceTab(value: unknown): DepartureWorkspaceTab {
+  return departureWorkspaceSearchSchema.parse({ tab: value }).tab
+}

--- a/packages/operations-react/src/availability/departure-summary-schemas.ts
+++ b/packages/operations-react/src/availability/departure-summary-schemas.ts
@@ -1,0 +1,205 @@
+import { z } from "zod"
+
+// --- departure summary ------------------------------------------------------
+//
+// Mirror of `GET /slots/{id}/summary` (see `service-departure-summary.ts` in
+// @voyant-travel/operations). The workspace reads its headline from this ONE
+// envelope: every counter is whole-departure, so paging the allocation
+// manifest can never move a number here. Kept in sync with the server schema
+// by intent — operations-react can't depend on the server package.
+
+export const departureIssueSeveritySchema = z.enum(["critical", "warning"])
+export type DepartureIssueSeverity = z.infer<typeof departureIssueSeveritySchema>
+
+export const departureIssueSubjectTypeSchema = z.enum([
+  "departure",
+  "booking",
+  "booking_allocation",
+  "availability_hold",
+  "allocation_resource",
+])
+export type DepartureIssueSubjectType = z.infer<typeof departureIssueSubjectTypeSchema>
+
+/**
+ * The stable issue codes the server evaluates today. The wire field stays a
+ * plain string on purpose: a server one release ahead may emit a code this
+ * client has no catalogue entry for, and dropping the row would hide a real
+ * problem. Unknown codes render the server's English `message` fallback.
+ */
+export const departureIssueCodes = [
+  "allocation_on_cancelled_booking",
+  "allocation_resources_missing",
+  "capacity_oversold",
+  "departure_not_version_bound",
+  "expired_hold_not_released",
+  "remaining_pax_drift",
+  "resource_over_capacity",
+  "stale_held_allocation",
+  "travelers_exceed_booked_pax",
+  "travelers_missing_for_booked_pax",
+  "travelers_unassigned",
+] as const
+export type DepartureIssueCode = (typeof departureIssueCodes)[number]
+
+export const departureIssueSchema = z.object({
+  code: z.string(),
+  severity: departureIssueSeveritySchema,
+  subjectType: departureIssueSubjectTypeSchema,
+  subjectId: z.string(),
+  count: z.number().int(),
+  /** English fallback for consumers with no message catalogue. */
+  message: z.string(),
+})
+export type DepartureIssue = z.infer<typeof departureIssueSchema>
+
+const departureHoldCountersSchema = z.object({
+  active: z.number().int(),
+  activePax: z.number().int(),
+  expired: z.number().int(),
+  expiredPax: z.number().int(),
+  released: z.number().int(),
+  converted: z.number().int(),
+})
+
+const departureAllocationCountersSchema = z.object({
+  held: z.number().int(),
+  confirmed: z.number().int(),
+  fulfilled: z.number().int(),
+  staleHeld: z.number().int(),
+  released: z.number().int(),
+  expired: z.number().int(),
+  cancelled: z.number().int(),
+  active: z.number().int(),
+  inactive: z.number().int(),
+})
+
+export const departureTravelerCountersSchema = z.object({
+  entered: z.number().int(),
+  lead: z.number().int(),
+  assigned: z.number().int(),
+  unassigned: z.number().int(),
+  missing: z.number().int(),
+})
+export type DepartureTravelerCounters = z.infer<typeof departureTravelerCountersSchema>
+
+export const departureResourceCountersSchema = z.object({
+  total: z.number().int(),
+  seating: z.number().int(),
+  capacity: z.number().int(),
+  assigned: z.number().int(),
+  available: z.number().int(),
+  overCapacity: z.number().int(),
+})
+export type DepartureResourceCounters = z.infer<typeof departureResourceCountersSchema>
+
+export const departureResourceRowSchema = z.object({
+  id: z.string(),
+  slotId: z.string(),
+  kind: z.string(),
+  label: z.string().nullable(),
+  refType: z.string().nullable(),
+  refId: z.string().nullable(),
+  parentId: z.string().nullable(),
+  capacity: z.number().int(),
+  assigned: z.number().int(),
+  available: z.number().int(),
+  flags: z.record(z.string(), z.unknown()),
+  sortOrder: z.number().int(),
+})
+export type DepartureResourceRow = z.infer<typeof departureResourceRowSchema>
+
+export const departureCapacityCountersSchema = z.object({
+  slotId: z.string(),
+  unlimited: z.boolean(),
+  initialPax: z.number().int().nullable(),
+  effectivePax: z.number().int().nullable(),
+  remainingPax: z.number().int().nullable(),
+  derivedRemainingPax: z.number().int().nullable(),
+  derivedConsumedPax: z.number().int(),
+  holds: departureHoldCountersSchema,
+  allocations: departureAllocationCountersSchema,
+  bookings: z.object({
+    active: z.number().int(),
+    cancelledWithLiveAllocation: z.number().int(),
+    expectedPax: z.number().int(),
+    byStatus: z.record(z.string(), z.number().int()),
+  }),
+  travelers: departureTravelerCountersSchema,
+  resources: departureResourceCountersSchema,
+  resourceBreakdown: z.array(departureResourceRowSchema),
+})
+export type DepartureCapacityCounters = z.infer<typeof departureCapacityCountersSchema>
+
+export const departureFinanceLineSchema = z.object({
+  currency: z.string(),
+  revenueCents: z.number().int(),
+  actualCostCents: z.number().int(),
+  plannedCostCents: z.number().int(),
+  profitCents: z.number().int(),
+  marginPercent: z.number().nullable(),
+  varianceCents: z.number().int(),
+})
+export type DepartureFinanceLine = z.infer<typeof departureFinanceLineSchema>
+
+export const departureFinanceHeadlineSchema = z.object({
+  perCurrency: z.array(departureFinanceLineSchema),
+  base: departureFinanceLineSchema.nullable(),
+  unconvertibleCurrencies: z.array(z.string()),
+})
+export type DepartureFinanceHeadline = z.infer<typeof departureFinanceHeadlineSchema>
+
+export const departureExtrasRollupSchema = z.object({
+  offered: z.number().int(),
+  withSelections: z.number().int(),
+  selectedTravelerCount: z.number().int(),
+  totalQuantity: z.number().int(),
+  outstandingCollectionCount: z.number().int(),
+  fulfilledExtraCount: z.number().int(),
+})
+export type DepartureExtrasRollup = z.infer<typeof departureExtrasRollupSchema>
+
+export const departureSummarySchema = z.object({
+  departure: z.object({
+    id: z.string(),
+    productId: z.string(),
+    productVersionId: z.string().nullable(),
+    itineraryId: z.string().nullable(),
+    optionId: z.string().nullable(),
+    facilityId: z.string().nullable(),
+    status: z.enum(["open", "closed", "sold_out", "cancelled"]),
+    dateLocal: z.string(),
+    startsAt: z.string(),
+    endsAt: z.string().nullable(),
+    timezone: z.string(),
+    notes: z.string().nullable(),
+  }),
+  capacity: departureCapacityCountersSchema,
+  bookings: z.object({
+    count: z.number().int(),
+    byStatus: z.record(z.string(), z.number().int()),
+    expectedPax: z.number().int(),
+    /** `null` when the departure's bookings disagree on currency. */
+    currency: z.string().nullable(),
+    soldAmountCents: z.number().int().nullable(),
+    paidAmountCents: z.number().int().nullable(),
+    outstandingAmountCents: z.number().int().nullable(),
+  }),
+  travelers: departureTravelerCountersSchema,
+  allocation: departureResourceCountersSchema,
+  operations: z.object({
+    issues: z.array(departureIssueSchema),
+    criticalCount: z.number().int(),
+    warningCount: z.number().int(),
+    clear: z.boolean(),
+  }),
+  /** `null` when the Extras module is not deployed or the read failed. */
+  extras: departureExtrasRollupSchema.nullable(),
+  /** `null` when no Finance provider is bound in this deployment. */
+  finance: departureFinanceHeadlineSchema.nullable(),
+})
+export type DepartureSummary = z.infer<typeof departureSummarySchema>
+
+// Envelope declared inline rather than through `singleEnvelope`: `schemas.ts`
+// re-exports this module, and importing back into it would make the two
+// evaluate in a cycle.
+export const departureSummaryResponse = z.object({ data: departureSummarySchema })

--- a/packages/operations-react/src/availability/index.ts
+++ b/packages/operations-react/src/availability/index.ts
@@ -15,6 +15,14 @@ export {
   type VoyantFetcher,
 } from "./client.js"
 export * from "./constants.js"
+export {
+  type DepartureWorkspaceSearchParams,
+  type DepartureWorkspaceTab,
+  defaultDepartureWorkspaceTab,
+  departureWorkspaceSearchSchema,
+  departureWorkspaceTabs,
+  parseDepartureWorkspaceTab,
+} from "./departure-search-params.js"
 export * from "./hooks/index.js"
 export {
   useVoyantAvailabilityContext,
@@ -26,6 +34,7 @@ export { availabilityQueryKeys } from "./query-keys.js"
 export {
   getAvailabilityOverviewQueryOptions,
   getCloseoutsQueryOptions,
+  getDepartureSummaryQueryOptions,
   getPickupPointsQueryOptions,
   getProductQueryOptions,
   getProductResourceTemplatesQueryOptions,

--- a/packages/operations-react/src/availability/query-keys.ts
+++ b/packages/operations-react/src/availability/query-keys.ts
@@ -78,6 +78,9 @@ export const availabilityQueryKeys = {
     [...availabilityQueryKeys.pickupPoints(), "list", filters] as const,
 
   slotDetail: (id: string) => [...availabilityQueryKeys.slots(), "detail", id] as const,
+  /** The composed departure envelope (`GET /slots/{id}/summary`). */
+  departureSummary: (id: string) =>
+    [...availabilityQueryKeys.slots(), "departure-summary", id] as const,
   slotUnitAvailability: (id: string) =>
     [...availabilityQueryKeys.slots(), "unit-availability", id] as const,
   slotPickupsList: (filters: AvailabilitySlotDetailFilters) =>

--- a/packages/operations-react/src/availability/query-options.ts
+++ b/packages/operations-react/src/availability/query-options.ts
@@ -22,6 +22,7 @@ import {
   availabilitySlotSingleResponse,
   availabilityStartTimeListResponse,
   bookingSummaryListResponse,
+  departureSummaryResponse,
   productListResponse,
   productOptionResourceTemplatesListResponse,
   productSingleResponse,
@@ -222,6 +223,29 @@ export function getSlotUnitAvailabilityQueryOptions(
       return fetchWithValidation(
         `/v1/admin/operations/availability/slots/${slotId}/unit-availability`,
         slotUnitAvailabilityListResponse,
+        client,
+      )
+    },
+  })
+}
+
+/**
+ * The departure workspace's one headline read. Every counter in the envelope
+ * is computed by aggregate over the whole departure, so the workspace never
+ * has to reassemble a headline from the paginated detail lists (pickups,
+ * closeouts, resources, manifests) — those stay separate fetches.
+ */
+export function getDepartureSummaryQueryOptions(
+  client: FetchWithValidationOptions,
+  slotId: string | null | undefined,
+) {
+  return queryOptions({
+    queryKey: availabilityQueryKeys.departureSummary(slotId ?? ""),
+    queryFn: async () => {
+      if (!slotId) throw new Error("getDepartureSummaryQueryOptions requires a slotId")
+      return fetchWithValidation(
+        `/v1/admin/operations/availability/slots/${slotId}/summary`,
+        departureSummaryResponse,
         client,
       )
     },

--- a/packages/operations-react/src/availability/schemas.ts
+++ b/packages/operations-react/src/availability/schemas.ts
@@ -429,6 +429,8 @@ export const allocationAuditLogResponse = z.object({
   data: z.array(allocationAuditLogEntrySchema),
 })
 
+export * from "./departure-summary-schemas.js"
+
 export const slotUnitAvailabilityRecordSchema = z.object({
   optionUnitId: z.string(),
   unitName: z.string(),

--- a/packages/operations-react/src/availability/ui.ts
+++ b/packages/operations-react/src/availability/ui.ts
@@ -73,6 +73,7 @@ export {
   getAvailabilitySlotPickupsQueryOptions,
   getAvailabilitySlotProductQueryOptions,
   getAvailabilitySlotResourcesQueryOptions,
+  getAvailabilitySlotSummaryQueryOptions,
   loadAvailabilitySlotDetailPage,
 } from "./components/availability-slot-detail-page.js"
 export {
@@ -92,6 +93,18 @@ export {
   AvailabilityStartTimesTab,
   type AvailabilityTabMessages,
 } from "./components/availability-tabs.js"
+export {
+  type AllocationResourceRef,
+  type DepartureLinkTarget,
+  resolveAllocationResourceTarget,
+} from "./components/departure-deep-links.js"
+export {
+  type DepartureIssueAction,
+  type DepartureIssueCodeMessage,
+  DepartureIssueList,
+  type DepartureIssueMessages,
+  DepartureIssueSummary,
+} from "./components/departure-issues.js"
 export {
   type AvailabilityUiMessageOverrides,
   type AvailabilityUiMessages,


### PR DESCRIPTION
## Why

This is the **UI half** of #4033; the backend landed in #4176.

The slot detail page reassembled a departure from five separate fetches and left the operator to reconcile them. It now reads its headline from the composed `GET /slots/{id}/summary` envelope and presents six stable sections.

## Navigation — nothing was dropped

New tab set: **Overview / Travelers / Allocation / Operations / Financials / Activity**.

| Old tab | Now | Why |
|---|---|---|
| Pickup | Operations | Where the driver collects — day-of-departure logistics. |
| Closeouts | Operations | Whether the date may still sell; an operator override on this departure. Sits beside Pickup because both are "square this away before it runs". |
| Extras | Operations | What the guide carries and collects on the day. The rollup *also* appears on Overview because the summary carries it as a headline; the manifest panel itself is in Operations. |
| Meta | Overview | Slot id, rule, start time and now the **Product Version** are the departure's identity — the question Overview answers. A tab whose only content is a read-only identifier table did not earn a sixth slot. |

The old `details.tabs.*` i18n keys are retained and reused as section headings.

## What else changed

- **Every section renders when empty, with its next authorized action.** Pickup and Closeouts previously vanished entirely when they had no rows — exactly when an operator needs telling what to do about it.
- **The eleven typed attention issues** render grouped and severity-styled at the top of Overview, each linking to its subject, with the count badged on the tab. Every code has a localized title + description in **en and ro**; the server's `message` is only a fallback for consumers with no catalogue.
- **Financials reads Finance's own figures** (per-currency + base + `unconvertibleCurrencies`) instead of computing revenue in the browser from booking sell amounts, and states explicitly that money is unavailable when no Finance provider is bound rather than rendering zeros.
- **`?tab=` makes a section addressable** and survives reload. An unrecognized value lands on Overview via `.catch(...)` rather than failing the route.
- **Deep links** for Resource, Supplier and Finance added alongside the existing Product and Booking.
- **Bug fix:** the activity timeline resolved allocation-audit resource ids against the wrong table. `slot_assignments.resource_id` points at the operations resource *pool*; the audit log's `resourceId` points at `allocation_resources`. The lookup always missed and rendered a raw id. The timeline now takes both maps and falls back to a placeholder — **never to the id**.

## Reviewer notes

- **`packages/finance-react/src/admin/index.tsx` is touched** (outside the original scope). A Finance deep link needs a resolvable destination or `useAdminHref` falls back to `"#"` with a console warning. Two lines: declare `financeProfitability.report` and bind it to the existing `/finance/profitability` route. Verified no package with an exhaustive `satisfies AdminDestinationResolvers` can see the new key.
- **`aggregateSlotFinancials` and `KpiStrip` are kept and `@deprecated`, not deleted** — both are published exports via `availability/ui.ts`, so removing them would be a silent breaking change for external consumers.
- **Booking statuses are humanized, not translated.** Availability has no booking-status catalogue and one was not added: a copied enum drifts the moment Bookings adds a status. Same treatment the activity timeline already gives an unmapped audit action.
- **`schemas.ts` → `departure-summary-schemas.ts` is a one-way re-export on purpose.** The child declares its own envelope rather than importing `singleEnvelope` back, because `export *` would make the two evaluate in a TDZ cycle. Please don't "tidy" that.
- **Resource deep links resolve only refs this codebase actually writes** — `resource`, `supplier`, `product`, `option`/`option_unit`. Anything else renders as plain text; a dead link is worse than no link.
- Two files were split to stay under the 600-line pre-commit limit (`availability-slot-detail-data.ts`, `departure-workspace-header.tsx`, `departure-summary-schemas.ts`); the page went 704 → 556 and schemas 675 → 475.
- **Backend untouched** — no modifications under `packages/operations/src/availability/`.

## Verification

- `pnpm -F @voyant-travel/operations-react test` — 62 passed (12 files), re-run green after rebasing onto merged main
- `pnpm -F @voyant-travel/finance-react test` — 51 passed; `@voyant-travel/i18n` — 13 passed
- `pnpm i18n:check` — parity passed, 24 + 49 definition sets, hardcoded-string scan clean
- `pnpm exec biome check .` from the root — no fixes applied, `git status` clean of rewrites
- `npx tsx scripts/checks/schema/table-privacy-runner.ts` — **none new**
- `check-agent-code-quality` — zero errors in touched files
- **No local `typecheck`**: it OOMs here (exit 134, no `error TS`) because nothing is built, so tsc compiles the whole workspace source graph. **CI `build-graph` is authoritative** — types are otherwise unverified, since vitest transpiles without checking.

Part of #4033