### PR TITLE
Audit and clean up allocation mutations inside their transaction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,6 +370,8 @@ jobs:
                 tests/availability/integration/auto-allocate-concurrency.test.ts
               pnpm --filter @voyant-travel/operations exec vitest run \
                 tests/availability/integration/departure-summary.test.ts
+              pnpm --filter @voyant-travel/operations exec vitest run \
+                tests/availability/integration/allocation-audit-atomicity.test.ts
               pnpm --filter @voyant-travel/legal exec vitest run \
                 tests/integration/contract-lifecycle-command.test.ts
               pnpm --filter @voyant-travel/notifications exec vitest run \

--- a/packages/operations/src/availability/service-allocation-automation.ts
+++ b/packages/operations/src/availability/service-allocation-automation.ts
@@ -59,18 +59,26 @@ export async function autoMaterializeAllocationResources(
   input: AllocationAutomationInput,
   options: AllocationMutationOptions = {},
 ): Promise<AllocationAutomationResult> {
-  const result = await db.transaction(async (tx) =>
-    autoMaterializeAllocationResourcesLocked(tx as PostgresJsDatabase, slotId, input),
-  )
-
-  if ((result.created ?? 0) > 0) {
-    await recordAllocationAudit(db, {
+  const result = await db.transaction(async (tx) => {
+    const materialized = await autoMaterializeAllocationResourcesLocked(
+      tx as PostgresJsDatabase,
       slotId,
-      action: "resources.materialize",
-      actorId: options.actorId ?? null,
-      after: { kind: result.kind, created: result.created ?? 0 },
-    })
-  }
+      input,
+    )
+
+    // Audit inside the transaction so the materialised resources and
+    // their record commit or roll back together.
+    if ((materialized.created ?? 0) > 0) {
+      await recordAllocationAudit(tx, {
+        slotId,
+        action: "resources.materialize",
+        actorId: options.actorId ?? null,
+        after: { kind: materialized.kind, created: materialized.created ?? 0 },
+      })
+    }
+
+    return materialized
+  })
 
   return result
 }
@@ -253,14 +261,17 @@ export async function autoAllocateSlotResources(
       await assertPlannedResourcesWithinCapacity(scoped, slotId, kind, resourceIds)
     }
 
-    return planned
-  })
+    // Audit inside the transaction so the applied plan and its record
+    // commit or roll back together — PR #4139 moved planning and writing
+    // in here but left the audit outside.
+    await recordAllocationAudit(tx, {
+      slotId,
+      action: "auto-allocate",
+      actorId: options.actorId ?? null,
+      after: { kind, assigned: planned.assignments.length, skipped: planned.skipped },
+    })
 
-  await recordAllocationAudit(db, {
-    slotId,
-    action: "auto-allocate",
-    actorId: options.actorId ?? null,
-    after: { kind, assigned: plan.assignments.length, skipped: plan.skipped },
+    return planned
   })
 
   return { kind, assigned: plan.assignments.length, skipped: plan.skipped }

--- a/packages/operations/src/availability/service-allocation-resource-capacity.ts
+++ b/packages/operations/src/availability/service-allocation-resource-capacity.ts
@@ -281,10 +281,7 @@ export async function countResourceOccupants(
   return rows[0]?.count ?? 0
 }
 
-export async function clearTravelerAllocationsForResource(
-  db: PostgresJsDatabase,
-  resourceId: string,
-) {
+export async function clearTravelerAllocationsForResource(db: SqlExecutor, resourceId: string) {
   await db.execute(sql`
     UPDATE booking_traveler_travel_details btd
     SET allocations = COALESCE((

--- a/packages/operations/src/availability/service-allocation-resource-crud.ts
+++ b/packages/operations/src/availability/service-allocation-resource-crud.ts
@@ -71,21 +71,23 @@ export async function createAllocationResource(
         sortOrder: input.sortOrder ?? 0,
       })
       .returning()
+    if (created) {
+      // Audit inside the transaction so the resource and its record
+      // commit or roll back together.
+      await recordAllocationAudit(tx, {
+        slotId,
+        action: "resource.create",
+        actorId: options.actorId ?? null,
+        resourceId: created.id,
+        after: {
+          kind: created.kind,
+          label: created.label,
+          capacity: created.capacity,
+        },
+      })
+    }
     return created ?? null
   })
-  if (row) {
-    await recordAllocationAudit(db, {
-      slotId,
-      action: "resource.create",
-      actorId: options.actorId ?? null,
-      resourceId: row.id,
-      after: {
-        kind: row.kind,
-        label: row.label,
-        capacity: row.capacity,
-      },
-    })
-  }
   return row
 }
 
@@ -178,28 +180,29 @@ export async function updateAllocationResource(
       .set({ ...input, updatedAt: new Date() })
       .where(and(eq(allocationResources.id, resourceId), eq(allocationResources.slotId, slotId)))
       .returning()
-    return row ? { existing, row } : null
-  })
-  if (result) {
-    await recordAllocationAudit(db, {
+    if (!row) return null
+    // Audit inside the transaction so the update and its record commit
+    // or roll back together.
+    await recordAllocationAudit(tx, {
       slotId,
       action: "resource.update",
       actorId: options.actorId ?? null,
-      resourceId: result.row.id,
+      resourceId: row.id,
       before: {
-        label: result.existing.label,
-        capacity: result.existing.capacity,
-        flags: result.existing.flags,
-        sortOrder: result.existing.sortOrder,
+        label: existing.label,
+        capacity: existing.capacity,
+        flags: existing.flags,
+        sortOrder: existing.sortOrder,
       },
       after: {
-        label: result.row.label,
-        capacity: result.row.capacity,
-        flags: result.row.flags,
-        sortOrder: result.row.sortOrder,
+        label: row.label,
+        capacity: row.capacity,
+        flags: row.flags,
+        sortOrder: row.sortOrder,
       },
     })
-  }
+    return { existing, row }
+  })
   return result?.row ?? null
 }
 
@@ -240,22 +243,27 @@ export async function deleteAllocationResource(
         label: allocationResources.label,
         capacity: allocationResources.capacity,
       })
+    if (deleted) {
+      // Clear the dangling traveler references and audit inside the
+      // transaction so the row deletion, the cleanup, and the record
+      // commit or roll back together. Otherwise a failed cleanup leaves
+      // `booking_traveler_travel_details.allocations` pointing at a
+      // deleted resource id, and the rooming CSV stops reconciling.
+      await clearTravelerAllocationsForResource(tx, resourceId)
+      await recordAllocationAudit(tx, {
+        slotId,
+        action: "resource.delete",
+        actorId: options.actorId ?? null,
+        resourceId: deleted.id,
+        before: {
+          kind: deleted.kind,
+          label: deleted.label,
+          capacity: deleted.capacity,
+        },
+      })
+    }
     return deleted ?? null
   })
-  if (row) {
-    await clearTravelerAllocationsForResource(db, resourceId)
-    await recordAllocationAudit(db, {
-      slotId,
-      action: "resource.delete",
-      actorId: options.actorId ?? null,
-      resourceId: row.id,
-      before: {
-        kind: row.kind,
-        label: row.label,
-        capacity: row.capacity,
-      },
-    })
-  }
   return row
 }
 

--- a/packages/operations/src/availability/service-allocation.ts
+++ b/packages/operations/src/availability/service-allocation.ts
@@ -1,3 +1,9 @@
+// agent-quality: file-size exception -- owner: availability. This module
+// pairs the slot allocation manifest read with every traveler/sharing-group
+// mutation that must stay in step with it, and they share private slot/
+// traveler helpers below. It was already over the limit before #4164 wrapped
+// the mutations' audit writes in their transactions; splitting the manifest
+// read out is a separate refactor, not part of this bug fix.
 import {
   type allocationResources,
   availabilitySlots,
@@ -338,10 +344,9 @@ export async function assignTravelerAllocation(
       400,
     )
   }
-  let beforeResourceId: string | null = null
   await db.transaction(async (tx) => {
     await assertTravelerBelongsToSlot(tx, slotId, travelerId)
-    beforeResourceId = await getTravelerAllocation(tx, travelerId, input.kind)
+    const beforeResourceId = await getTravelerAllocation(tx, travelerId, input.kind)
 
     if (input.resourceId) {
       const [resource] = await executeRows<{
@@ -396,14 +401,18 @@ export async function assignTravelerAllocation(
         WHERE traveler_id = ${travelerId}
       `)
     }
-  })
-  await recordAllocationAudit(db, {
-    slotId,
-    action: input.resourceId ? "traveler.assign" : "traveler.unassign",
-    actorId: options.actorId ?? null,
-    travelerId,
-    before: { kind: input.kind, resourceId: beforeResourceId },
-    after: { kind: input.kind, resourceId: input.resourceId },
+
+    // Audit inside the transaction so a failed audit insert rolls the
+    // assignment back rather than committing an unrecorded move.
+    // `beforeResourceId` was captured above, before the write.
+    await recordAllocationAudit(tx, {
+      slotId,
+      action: input.resourceId ? "traveler.assign" : "traveler.unassign",
+      actorId: options.actorId ?? null,
+      travelerId,
+      before: { kind: input.kind, resourceId: beforeResourceId },
+      after: { kind: input.kind, resourceId: input.resourceId },
+    })
   })
 
   return { travelerId, kind: input.kind, resourceId: input.resourceId }
@@ -416,22 +425,26 @@ export async function updateTravelerSharingGroup(
   input: UpdateTravelerSharingGroupInput,
   options: AllocationMutationOptions = {},
 ) {
-  await assertTravelerBelongsToSlot(db, slotId, travelerId)
-  const beforeSharingGroupId = await getTravelerSharingGroup(db, travelerId)
-  await db.execute(sql`
-    INSERT INTO booking_traveler_travel_details (traveler_id, sharing_group_id)
-    VALUES (${travelerId}, ${input.sharingGroupId})
-    ON CONFLICT (traveler_id) DO UPDATE SET
-      sharing_group_id = ${input.sharingGroupId},
-      updated_at = now()
-  `)
-  await recordAllocationAudit(db, {
-    slotId,
-    action: input.sharingGroupId ? "traveler.sharing-group.set" : "traveler.sharing-group.clear",
-    actorId: options.actorId ?? null,
-    travelerId,
-    before: { sharingGroupId: beforeSharingGroupId },
-    after: { sharingGroupId: input.sharingGroupId },
+  await db.transaction(async (tx) => {
+    await assertTravelerBelongsToSlot(tx, slotId, travelerId)
+    const beforeSharingGroupId = await getTravelerSharingGroup(tx, travelerId)
+    await tx.execute(sql`
+      INSERT INTO booking_traveler_travel_details (traveler_id, sharing_group_id)
+      VALUES (${travelerId}, ${input.sharingGroupId})
+      ON CONFLICT (traveler_id) DO UPDATE SET
+        sharing_group_id = ${input.sharingGroupId},
+        updated_at = now()
+    `)
+    // Audit inside the transaction so the sharing-group change and its
+    // record commit or roll back together.
+    await recordAllocationAudit(tx, {
+      slotId,
+      action: input.sharingGroupId ? "traveler.sharing-group.set" : "traveler.sharing-group.clear",
+      actorId: options.actorId ?? null,
+      travelerId,
+      before: { sharingGroupId: beforeSharingGroupId },
+      after: { sharingGroupId: input.sharingGroupId },
+    })
   })
 
   return { travelerId, sharingGroupId: input.sharingGroupId }
@@ -443,24 +456,28 @@ export async function pairSharingGroup(
   input: PairSharingGroupInput,
   options: AllocationMutationOptions = {},
 ) {
-  for (const travelerId of input.travelerIds) {
-    await assertTravelerBelongsToSlot(db, slotId, travelerId)
-  }
-
   const sharingGroupId = input.sharingGroupId ?? globalThis.crypto.randomUUID()
-  await db.execute(sql`
-    INSERT INTO booking_traveler_travel_details (traveler_id, sharing_group_id)
-    SELECT id, ${sharingGroupId}
-    FROM unnest(${sqlTextArray(input.travelerIds)}) AS u(id)
-    ON CONFLICT (traveler_id) DO UPDATE SET
-      sharing_group_id = EXCLUDED.sharing_group_id,
-      updated_at = now()
-  `)
-  await recordAllocationAudit(db, {
-    slotId,
-    action: "traveler.sharing-group.set",
-    actorId: options.actorId ?? null,
-    after: { sharingGroupId, travelerIds: input.travelerIds },
+  await db.transaction(async (tx) => {
+    for (const travelerId of input.travelerIds) {
+      await assertTravelerBelongsToSlot(tx, slotId, travelerId)
+    }
+
+    await tx.execute(sql`
+      INSERT INTO booking_traveler_travel_details (traveler_id, sharing_group_id)
+      SELECT id, ${sharingGroupId}
+      FROM unnest(${sqlTextArray(input.travelerIds)}) AS u(id)
+      ON CONFLICT (traveler_id) DO UPDATE SET
+        sharing_group_id = EXCLUDED.sharing_group_id,
+        updated_at = now()
+    `)
+    // Audit inside the transaction so the pairing and its record commit
+    // or roll back together.
+    await recordAllocationAudit(tx, {
+      slotId,
+      action: "traveler.sharing-group.set",
+      actorId: options.actorId ?? null,
+      after: { sharingGroupId, travelerIds: input.travelerIds },
+    })
   })
 
   return { sharingGroupId, travelerIds: input.travelerIds }
@@ -473,20 +490,25 @@ export async function updateSharingGroupLabel(
   input: UpdateSharingGroupLabelInput,
   options: AllocationMutationOptions = {},
 ) {
-  await assertSharingGroupBelongsToSlot(db, slotId, groupId)
-  const [row] = await db
-    .insert(sharingGroupLabels)
-    .values({ groupId, label: input.label })
-    .onConflictDoUpdate({
-      target: sharingGroupLabels.groupId,
-      set: { label: input.label, updatedAt: new Date() },
+  const row = await db.transaction(async (tx) => {
+    await assertSharingGroupBelongsToSlot(tx, slotId, groupId)
+    const [inserted] = await tx
+      .insert(sharingGroupLabels)
+      .values({ groupId, label: input.label })
+      .onConflictDoUpdate({
+        target: sharingGroupLabels.groupId,
+        set: { label: input.label, updatedAt: new Date() },
+      })
+      .returning()
+    // Audit inside the transaction so the label change and its record
+    // commit or roll back together.
+    await recordAllocationAudit(tx, {
+      slotId,
+      action: "sharing-group.label.update",
+      actorId: options.actorId ?? null,
+      after: { sharingGroupId: groupId, label: inserted?.label ?? input.label },
     })
-    .returning()
-  await recordAllocationAudit(db, {
-    slotId,
-    action: "sharing-group.label.update",
-    actorId: options.actorId ?? null,
-    after: { sharingGroupId: groupId, label: row?.label ?? input.label },
+    return inserted
   })
   return row ?? { groupId, label: input.label, createdAt: new Date(), updatedAt: new Date() }
 }
@@ -497,19 +519,24 @@ export async function deleteSharingGroupLabel(
   groupId: string,
   options: AllocationMutationOptions = {},
 ) {
-  await assertSharingGroupBelongsToSlot(db, slotId, groupId)
-  const [row] = await db
-    .delete(sharingGroupLabels)
-    .where(eq(sharingGroupLabels.groupId, groupId))
-    .returning()
-  if (row) {
-    await recordAllocationAudit(db, {
-      slotId,
-      action: "sharing-group.label.clear",
-      actorId: options.actorId ?? null,
-      before: { sharingGroupId: groupId, label: row.label },
-    })
-  }
+  const row = await db.transaction(async (tx) => {
+    await assertSharingGroupBelongsToSlot(tx, slotId, groupId)
+    const [deleted] = await tx
+      .delete(sharingGroupLabels)
+      .where(eq(sharingGroupLabels.groupId, groupId))
+      .returning()
+    if (deleted) {
+      // Audit inside the transaction so the label removal and its record
+      // commit or roll back together.
+      await recordAllocationAudit(tx, {
+        slotId,
+        action: "sharing-group.label.clear",
+        actorId: options.actorId ?? null,
+        before: { sharingGroupId: groupId, label: deleted.label },
+      })
+    }
+    return deleted
+  })
   return row ?? null
 }
 

--- a/packages/operations/tests/availability/integration/allocation-audit-atomicity.test.ts
+++ b/packages/operations/tests/availability/integration/allocation-audit-atomicity.test.ts
@@ -1,0 +1,206 @@
+import { allocationResources, availabilitySlots } from "@voyant-travel/availability/schema"
+import { createDbClient } from "@voyant-travel/db"
+import { newId } from "@voyant-travel/db/lib/typeid"
+import { cleanupTestDb } from "@voyant-travel/db/test-utils"
+import { sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest"
+import { products } from "../../../../inventory/src/schema.js"
+import { assignTravelerAllocation } from "../../../src/availability/service-allocation.js"
+import { deleteAllocationResource } from "../../../src/availability/service-allocation-resource-crud.js"
+
+const DB_AVAILABLE = Boolean(process.env.TEST_DATABASE_URL)
+
+type ClosableTestDb = PostgresJsDatabase & {
+  $client: { end(options?: { timeout?: number | null }): Promise<unknown> }
+}
+
+function connect(): ClosableTestDb {
+  return createDbClient(process.env.TEST_DATABASE_URL as string, {
+    adapter: "node",
+    nodeMaxConnections: 4,
+    timeouts: { statementMs: false, queryMs: false, connectMs: false },
+  }) as ClosableTestDb
+}
+
+// A BEFORE INSERT trigger that always raises, so every attempt to write
+// `allocation_audit_log` fails from inside whatever transaction is running.
+// The trigger and its function are created outside any transaction, so a
+// mutation that rolls back does not remove them; each test drops them itself.
+async function installFailingAuditTrigger(db: PostgresJsDatabase) {
+  await db.execute(sql`
+    CREATE OR REPLACE FUNCTION voyant_test_fail_allocation_audit() RETURNS trigger AS $$
+    BEGIN
+      RAISE EXCEPTION 'forced allocation audit failure';
+    END;
+    $$ LANGUAGE plpgsql
+  `)
+  await db.execute(sql`
+    CREATE TRIGGER voyant_test_fail_allocation_audit_trigger
+    BEFORE INSERT ON allocation_audit_log
+    FOR EACH ROW EXECUTE FUNCTION voyant_test_fail_allocation_audit()
+  `)
+}
+
+async function removeFailingAuditTrigger(db: PostgresJsDatabase) {
+  await db.execute(
+    sql`DROP TRIGGER IF EXISTS voyant_test_fail_allocation_audit_trigger ON allocation_audit_log`,
+  )
+  await db.execute(sql`DROP FUNCTION IF EXISTS voyant_test_fail_allocation_audit()`)
+}
+
+describe.skipIf(!DB_AVAILABLE)("allocation audit atomicity (integration)", () => {
+  let db: ClosableTestDb
+  let productId: string
+  let slotId: string
+
+  beforeAll(() => {
+    db = connect()
+  })
+
+  afterAll(async () => {
+    await db.$client.end({ timeout: 0 })
+  })
+
+  beforeEach(async () => {
+    await cleanupTestDb(db)
+    productId = newId("products")
+    slotId = newId("availability_slots")
+    await db.insert(products).values({
+      id: productId,
+      name: "Transylvania Coach Tour",
+      sellCurrency: "EUR",
+      bookingMode: "date",
+    })
+    await db.insert(availabilitySlots).values({
+      id: slotId,
+      productId,
+      dateLocal: "2026-06-01",
+      startsAt: new Date("2026-06-01T08:00:00Z"),
+      timezone: "UTC",
+      status: "open",
+      unlimited: false,
+      initialPax: 20,
+      remainingPax: 20,
+    })
+  })
+
+  // The trigger lives outside the schema TRUNCATE, so drop it after every
+  // test rather than relying on cleanup to remove it.
+  afterEach(async () => {
+    await removeFailingAuditTrigger(db)
+  })
+
+  async function seedRoom(label: string, capacity: number) {
+    const id = newId("allocation_resources")
+    await db.insert(allocationResources).values({
+      id,
+      slotId,
+      kind: "room",
+      label,
+      capacity,
+      sortOrder: 1,
+      flags: {},
+    })
+    return id
+  }
+
+  async function seedTraveler(allocations?: Record<string, string>) {
+    const bookingId = newId("bookings")
+    const bookingItemId = newId("booking_items")
+    const travelerId = newId("booking_travelers")
+    await db.execute(sql`
+      INSERT INTO bookings (id, booking_number, status, sell_currency, pax)
+      VALUES (${bookingId}, ${`AUDIT-${bookingId.slice(-6)}`}, 'confirmed', 'EUR', 1)
+    `)
+    await db.execute(sql`
+      INSERT INTO booking_items (id, booking_id, title, status, quantity, sell_currency, product_id, availability_slot_id)
+      VALUES (${bookingItemId}, ${bookingId}, 'Coach seat', 'confirmed', 1, 'EUR', ${productId}, ${slotId})
+    `)
+    await db.execute(sql`
+      INSERT INTO booking_allocations (id, booking_id, booking_item_id, product_id, availability_slot_id, quantity, allocation_type, status)
+      VALUES (${newId("booking_allocations")}, ${bookingId}, ${bookingItemId}, ${productId}, ${slotId}, 1, 'unit', 'confirmed')
+    `)
+    await db.execute(sql`
+      INSERT INTO booking_travelers (id, booking_id, participant_type, first_name, last_name)
+      VALUES (${travelerId}, ${bookingId}, 'traveler', 'Test', 'Traveler')
+    `)
+    if (allocations) {
+      await db.execute(sql`
+        INSERT INTO booking_traveler_travel_details (traveler_id, allocations)
+        VALUES (${travelerId}, ${JSON.stringify(allocations)}::jsonb)
+      `)
+    }
+    return travelerId
+  }
+
+  async function travelerRoom(travelerId: string): Promise<string | null> {
+    const [row] = await db.execute<{ room: string | null }>(sql`
+      SELECT allocations ->> 'room' AS room
+      FROM booking_traveler_travel_details
+      WHERE traveler_id = ${travelerId}
+    `)
+    return row?.room ?? null
+  }
+
+  async function auditCount(): Promise<number> {
+    const [row] = await db.execute<{ count: number }>(
+      sql`SELECT COUNT(*)::int AS count FROM allocation_audit_log WHERE slot_id = ${slotId}`,
+    )
+    return row?.count ?? 0
+  }
+
+  async function resourceExists(resourceId: string): Promise<boolean> {
+    const [row] = await db.execute<{ count: number }>(
+      sql`SELECT COUNT(*)::int AS count FROM allocation_resources WHERE id = ${resourceId}`,
+    )
+    return (row?.count ?? 0) > 0
+  }
+
+  it("rolls the traveler assignment back when its audit insert fails", async () => {
+    const roomId = await seedRoom("DBL 1", 2)
+    const travelerId = await seedTraveler()
+
+    await installFailingAuditTrigger(db)
+    await expect(
+      assignTravelerAllocation(db, slotId, travelerId, { kind: "room", resourceId: roomId }),
+    ).rejects.toThrow(/allocation_audit_log/)
+
+    // The audit failed inside the transaction, so the assignment must not
+    // have persisted and no audit row can exist.
+    expect(await travelerRoom(travelerId)).toBeNull()
+    expect(await auditCount()).toBe(0)
+
+    // With the audit path healthy again, the same mutation commits together
+    // with exactly one audit row.
+    await removeFailingAuditTrigger(db)
+    await assignTravelerAllocation(db, slotId, travelerId, { kind: "room", resourceId: roomId })
+    expect(await travelerRoom(travelerId)).toBe(roomId)
+    expect(await auditCount()).toBe(1)
+  })
+
+  it("rolls the resource deletion and its cleanup back when the audit insert fails", async () => {
+    const roomId = await seedRoom("DBL 1", 2)
+    const travelerId = await seedTraveler({ room: roomId })
+
+    await installFailingAuditTrigger(db)
+    await expect(deleteAllocationResource(db, slotId, roomId)).rejects.toThrow(
+      /allocation_audit_log/,
+    )
+
+    // Deletion, the dangling-reference cleanup, and the audit share one
+    // transaction: the row must survive and still be referenced.
+    expect(await resourceExists(roomId)).toBe(true)
+    expect(await travelerRoom(travelerId)).toBe(roomId)
+    expect(await auditCount()).toBe(0)
+
+    // Healthy path: the resource is gone, the traveler no longer references
+    // it, and a single audit row records the delete.
+    await removeFailingAuditTrigger(db)
+    const deleted = await deleteAllocationResource(db, slotId, roomId)
+    expect(deleted?.id).toBe(roomId)
+    expect(await resourceExists(roomId)).toBe(false)
+    expect(await travelerRoom(travelerId)).toBeNull()
+    expect(await auditCount()).toBe(1)
+  })
+})


### PR DESCRIPTION
## Why

Allocation mutations performed their audit write — and, on delete, a data-cleanup step — **after** their transaction had committed, on the unscoped `db` handle.

`allocation_audit_log` is the only record of who moved a traveler or changed a resource, so a mutation whose audit insert failed was committed and invisible. Worse, if `clearTravelerAllocationsForResource` did not run, `booking_traveler_travel_details.allocations` still referenced a deleted `allocation_resources` id — the UI degrades to "unallocated", but the rooming CSV counts those travelers under an id that no longer resolves, so exported totals stop reconciling.

Several tracers under #4027 list "assignment mutations are audited" as an acceptance criterion; that cannot hold while the audit write can fail independently of the mutation.

Note this is a different class of problem from the auto-allocation race fixed in #4139 — that moved *planning and writing* under one lock but left the trailing audit call outside the transaction.

## What changed

`recordAllocationAudit(tx, ...)` and `clearTravelerAllocationsForResource(tx, ...)` now run inside each mutation's transaction.

It went beyond the three sites originally identified, also covering `pairSharingGroup`, `updateSharingGroupLabel`, `deleteSharingGroupLabel` and `autoMaterializeAllocationResources` — and it wrapped `updateTravelerSharingGroup`/`pairSharingGroup` in transactions they previously lacked.

Both ordering hazards are handled: `beforeResourceId` is captured inside the transaction before the write, and return values are unchanged (`deleted?.id` is explicitly asserted).

## Reviewer notes

- **It took a file-size exemption rather than splitting.** `service-allocation.ts` grew 610 → 637 lines with an `// agent-quality: file-size exception` comment. Verified: the file was **already** over the 600-line limit at the base commit, and the exemption comment is an established convention in this repo. Defensible for a bug fix, but it is a gate exemption, not a fix. **No ratchet baseline was regenerated.**
- The new integration test uses a `BEFORE INSERT` trigger that always raises, so it is a real regression test — under the old code the mutation would have committed before the audit threw.
- Added to the `db-lanes/integration` per-file allowlist in `.github/workflows/ci.yml`, which runs an explicit list; without it the suite would never execute in CI.
- No changeset — `@voyant-travel/operations` is `private: true`.

## Verification

The remote agent produced no report, so every result below was re-run independently rather than relayed:

```
pnpm -F @voyant-travel/operations test
 Test Files  24 passed | 27 skipped (51)
      Tests  270 passed | 377 skipped (647)

pnpm exec biome check .
Checked 6526 files. No fixes applied. 20 warnings, 8 infos (all pre-existing).
git status clean afterwards.

npx tsx scripts/checks/schema/table-privacy-runner.ts
verify:table-privacy: 225 reach-ins across 37 pairs, none new.
```

The new suite was **skipped** in the agent's own run (no `TEST_DATABASE_URL`), leaving the central claim unproven, so it was re-run against a real Postgres:

```
✓ rolls the traveler assignment back when its audit insert fails
✓ rolls the resource deletion and its cleanup back when the audit insert fails
 Test Files  1 passed (1)     Tests  2 passed (2)
```

**Typecheck was not run** — the documented local OOM caveat (unbuilt `dist` makes tsc compile the whole workspace source graph). CI `build-graph` is authoritative.

## Unrelated: a live breakage on main

Surfaced while pushing — the `pre-push` hook fails on `main` itself:

```
FAIL packages/storefront tests/unit/service-departures.test.ts
TypeError: bookingAmendmentSchema.openapi is not a function
  ❯ packages/bookings/src/routes-amendments.ts:33:62
```

Not caused by this change (the diff touches only `packages/operations` and the CI allowlist), but it will block anyone's `git push` through the hook until fixed.

Closes #4164