### PR TITLE
Name the amendment schema through zod's own registry

### DIFF
--- a/packages/bookings/src/routes-amendments.ts
+++ b/packages/bookings/src/routes-amendments.ts
@@ -30,7 +30,26 @@ const errorSchema = z.object({
   bookingItemId: z.string().optional(),
   reason: z.string().optional(),
 })
-const bookingAmendmentOpenApiSchema = bookingAmendmentSchema.openapi("BookingAmendment")
+/**
+ * Named through zod's own registry, not `.openapi()`.
+ *
+ * `.openapi()` is grafted on by `extendZodWithOpenApi`, which assigns to
+ * `ZodType.prototype` when `@hono/zod-openapi` is first imported. Zod v4 copies
+ * its methods onto each instance at construction time, so that graft only ever
+ * reaches schemas built *after* that import. `bookingAmendmentSchema` is built
+ * by `@voyant-travel/bookings-contracts`, which depends on `zod` alone
+ * (ADR-0002) and is therefore constructed first whenever an importer reaches
+ * the contracts package before it reaches Hono — leaving the schema without the
+ * method and throwing `bookingAmendmentSchema.openapi is not a function`.
+ *
+ * Whether that happened was pure import-order luck: it broke
+ * `@voyant-travel/storefront`'s unit suite while every Bookings entrypoint kept
+ * working. `.meta({ id })` is native zod v4 and writes to the same
+ * `z.globalRegistry` the OpenAPI generator reads, so it produces an identical
+ * `#/components/schemas/BookingAmendment` reference with no ordering
+ * requirement at all. Do not "simplify" this back to `.openapi()`.
+ */
+const bookingAmendmentOpenApiSchema = bookingAmendmentSchema.meta({ id: "BookingAmendment" })
 const amendmentDataSchema = z.object({ data: bookingAmendmentOpenApiSchema })
 const amendmentListDataSchema = z.object({ data: z.array(bookingAmendmentOpenApiSchema) })
 const amendmentOkDataSchema = z

--- a/packages/bookings/tests/unit/amendment-openapi-naming.test.ts
+++ b/packages/bookings/tests/unit/amendment-openapi-naming.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Guards the OpenAPI naming of a contracts-owned schema against import order.
+ *
+ * `bookingAmendmentSchema` is built by `@voyant-travel/bookings-contracts`,
+ * which depends on `zod` alone (ADR-0002). `.openapi()` is not part of zod — it
+ * is grafted onto `ZodType.prototype` by `extendZodWithOpenApi` when
+ * `@hono/zod-openapi` is first imported. Zod v4 copies its methods onto each
+ * instance at construction time, so that graft only reaches schemas built after
+ * the import, and calling `.openapi()` on a contracts schema throws
+ * `bookingAmendmentSchema.openapi is not a function` whenever an importer
+ * reaches the contracts package first.
+ *
+ * That is exactly what happened: every Bookings entrypoint kept working while
+ * `@voyant-travel/storefront`'s unit suite failed to collect at all, because
+ * its import graph happened to evaluate the contracts package first.
+ *
+ * This test pins the behaviour rather than the mechanism — a schema constructed
+ * before Hono is imported must still yield a named `#/components/schemas/...`
+ * reference. It deliberately imports plain `zod` first to reproduce the hostile
+ * order.
+ */
+
+import { describe, expect, it } from "vitest"
+import { z as plainZod } from "zod"
+
+// Constructed BEFORE @hono/zod-openapi is imported, mirroring how a contracts
+// package's schemas are built. Do not move this below the import.
+const foreignSchema = plainZod.object({ id: plainZod.string() })
+
+describe("OpenAPI naming for contracts-owned schemas", () => {
+  it("names a schema built before @hono/zod-openapi loads", async () => {
+    const { OpenAPIHono, createRoute, z } = await import("@hono/zod-openapi")
+
+    // `.meta({ id })` is native zod v4 and writes to the same `z.globalRegistry`
+    // the generator reads, so it needs no prototype graft.
+    const named = foreignSchema.meta({ id: "ForeignNamedSchema" })
+
+    const app = new OpenAPIHono()
+    app.openapi(
+      createRoute({
+        method: "get",
+        path: "/thing",
+        responses: {
+          200: {
+            description: "ok",
+            content: { "application/json": { schema: z.object({ data: named }) } },
+          },
+        },
+      }),
+      (c) => c.json({ data: { id: "x" } }),
+    )
+    app.doc("/doc", { openapi: "3.0.0", info: { title: "t", version: "1" } })
+
+    const doc = await (await app.request("/doc")).json()
+
+    expect(Object.keys(doc.components?.schemas ?? {})).toContain("ForeignNamedSchema")
+    expect(
+      doc.paths["/thing"].get.responses["200"].content["application/json"].schema.properties.data
+        .$ref,
+    ).toBe("#/components/schemas/ForeignNamedSchema")
+  })
+
+  it("confirms the prototype graft does not reach a pre-built instance", async () => {
+    // The failure mode itself. If a future zod/zod-to-openapi pairing ever makes
+    // this false, `.openapi()` on a contracts schema becomes safe again and this
+    // whole workaround can be revisited.
+    await import("@hono/zod-openapi")
+    expect(
+      (foreignSchema as unknown as { openapi?: unknown }).openapi,
+      "a schema built before the import should still lack .openapi()",
+    ).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Why

`packages/storefront`'s unit suite could not collect **at all** on `main`:

```
TypeError: bookingAmendmentSchema.openapi is not a function
  ❯ packages/bookings/src/routes-amendments.ts:33
```

Because the husky `pre-push` hook runs the repo suite, this blocked **every push that didn't pass `--no-verify`**.

## Root cause

`.openapi()` is not part of zod. `extendZodWithOpenApi` assigns it to `ZodType.prototype` when `@hono/zod-openapi` is first imported:

```js
zod.ZodType.prototype.openapi = function (...args) { ... }
```

But **zod v4 copies its methods onto each instance at construction time**, so a prototype graft applied later never reaches an already-built schema. Demonstrated directly:

```
plain zod BEFORE hono:                undefined
plain zod AFTER hono (new instance):  function
plain zod AFTER hono (old instance):  undefined   ← the bug
```

`bookingAmendmentSchema` is built by `@voyant-travel/bookings-contracts`, which depends on `zod` alone (ADR-0002). So whenever an importer reaches the contracts package before it reaches Hono, the schema is already constructed and has no `.openapi()`.

Whether that happened was **pure import-order luck**. Every Bookings entrypoint kept working — which is why this survived — and only storefront's import graph evaluated the contracts package first, surfacing the failure far from its cause.

Worth noting this is not a duplicate-zod problem: there is exactly one `zod@4.4.3` in the store and both packages resolve to it.

## The fix

Use zod v4's native `.meta({ id })`, which writes to the same `z.globalRegistry` the OpenAPI generator reads and needs no prototype graft.

**Verified end to end that the generated document is unchanged.** A schema constructed *before* the Hono import, named via `.meta`, still yields:

```
components: [ 'BookingAmendment' ]
ref used:   {"data":{"$ref":"#/components/schemas/BookingAmendment"}}
```

— identical to what `.openapi("BookingAmendment")` produced.

This was the **only** place in the repo calling `.openapi()` on a contracts-owned schema; a sweep of every file importing from a `*-contracts` package found no other instance. The other `.openapi()` calls in this file are on schemas built with Hono's own `z` and are unaffected.

## Regression guard

`packages/bookings/tests/unit/amendment-openapi-naming.test.ts` pins the **behaviour**, not the mechanism: a schema built before Hono loads must still produce a named component and `$ref`. Its second case asserts the prototype graft genuinely does not reach a pre-built instance — so if a future zod / zod-to-openapi pairing makes that false, this workaround can be revisited deliberately rather than by accident.

## Verification

```
pnpm -F @voyant-travel/storefront exec vitest run tests/unit/service-departures.test.ts
 Test Files  1 passed (1)      Tests  1 passed (1)      # was failing to collect

pnpm -F @voyant-travel/bookings test
 Test Files  55 passed | 15 skipped (70)
      Tests  458 passed | 158 skipped (616)

pnpm -F @voyant-travel/bookings exec vitest run tests/unit/amendment-openapi-naming.test.ts
 Test Files  1 passed (1)      Tests  2 passed (2)

node scripts/check-retail-openapi-authority.mjs
check-retail-openapi-authority: OK (26 package-owned API bundles)

pnpm exec biome check .
Checked 6541 files. No fixes applied. 20 warnings, 8 infos (all pre-existing).
```

`check-deployment-graph-openapi-coverage.mjs` was not run to completion — it requires `apps/operator/.voyant/deployment-graph.generated.json`, a build artifact absent from a fresh worktree. Unrelated to this change.

No changeset — `@voyant-travel/bookings` is `private: true`.

Found while verifying #4033 in the browser; reported by the lab job on #4164.