### PR TITLE
fix(operator-standard): sign in to the admin realm, not the realm-less surface

### DIFF
--- a/.changeset/lucky-hoops-repeat.md
+++ b/.changeset/lucky-hoops-repeat.md
@@ -1,0 +1,20 @@
+---
+"@voyant-travel/operator-standard": patch
+"@voyant-travel/auth-react": patch
+---
+
+Fix operator admin sign-in posting to the wrong auth realm.
+
+The admin shell scoped its auth fetcher to the `/auth/admin` Better Auth realm,
+but then rendered `VoyantAvailabilityProvider` in its child-provider list. Every
+`Voyant<Domain>Provider` is an alias of the one `VoyantReactProvider`, so that
+replaced the shell's `{ baseUrl, fetcher }` for the whole tree and every
+auth-react call fell back to the realm-less `/api/auth/*` surface — sign-in,
+sign-up, and password reset all 404'd. The provider is redundant (domain hooks
+read the shell's context directly) and is gone; a `verify:symbol-policy` rule
+keeps any provider alias out of the operator shell.
+
+`createAuthBasePathFetcher` now takes `sharedPaths`, so the paths the deployment
+serves itself — `/auth/me`, `/auth/status`, `/auth/bootstrap-status`,
+`/auth/api-tokens`, `/auth/organization/list-members` — stay on the shared
+prefix instead of being rewritten onto the realm.

--- a/apps/operator/scripts/seed-demo.mjs
+++ b/apps/operator/scripts/seed-demo.mjs
@@ -7,8 +7,8 @@
  * against real data.
  *
  * Plain Node ESM. No new dependencies: uses global `fetch` and a hand-rolled
- * cookie jar. `better-auth/crypto` (already a transitive dep of the operator)
- * is used only to (re)set the admin password when a login attempt fails.
+ * cookie jar. `better-auth/crypto` and `pg` (both already operator dependencies)
+ * are used only to (re)set the admin password when a login attempt fails.
  *
  * Usage (from apps/operator):
  *   node scripts/seed-demo.mjs
@@ -24,7 +24,7 @@
  * Auth model: the admin realm is local Better Auth. If the configured
  * email/password cannot sign in, and the reset fallback is enabled, the script
  * hashes SEED_ADMIN_PASSWORD with Better Auth's scrypt and writes it to the
- * `credential` account row via `docker exec voyant-ui-pg psql`, then retries.
+ * `credential` account row over DATABASE_URL, then retries.
  *
  * Safe to re-run: every entity is looked up by a stable marker (name / tag /
  * number) before it is created, so a second run reuses existing records.
@@ -32,7 +32,6 @@
  * The API is mounted under `/api/v1/admin/*` (the SSR app owns `/v1/*`).
  */
 
-import { execFileSync } from "node:child_process"
 import { readFileSync } from "node:fs"
 import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
@@ -120,16 +119,30 @@ function readDatabaseUrl() {
 }
 
 async function resetAdminPassword() {
+  const databaseUrl = readDatabaseUrl()
+  if (!databaseUrl) {
+    throw new Error(
+      "auth: password reset needs DATABASE_URL (exported, or set in apps/operator/.env).",
+    )
+  }
   const { hashPassword } = await import("better-auth/crypto")
-  const hash = await hashPassword(ADMIN_PASSWORD)
-  // Parse the pg container/db from DATABASE_URL for the psql fallback.
-  const dbUrl = readDatabaseUrl()
-  const dbName = dbUrl ? new URL(dbUrl).pathname.replace(/^\//, "") || "voyant" : "voyant"
-  const dbUser = dbUrl ? decodeURIComponent(new URL(dbUrl).username) || "voyant" : "voyant"
-  const sql = `UPDATE account SET password='${hash}', updated_at=now() FROM "user" u WHERE account.user_id=u.id AND account.provider_id='credential' AND u.email='${ADMIN_EMAIL}';`
-  execFileSync("docker", ["exec", "voyant-ui-pg", "psql", "-U", dbUser, dbName, "-c", sql], {
-    stdio: "pipe",
-  })
+  const { default: pg } = await import("pg")
+  // Connect over the wire from DATABASE_URL — the database is not assumed to be
+  // a container, let alone one with a particular name.
+  const client = new pg.Client({ connectionString: databaseUrl })
+  await client.connect()
+  try {
+    await client.query(
+      `UPDATE account SET password = $1, updated_at = now()
+         FROM "user" u
+        WHERE account.user_id = u.id
+          AND account.provider_id = 'credential'
+          AND u.email = $2`,
+      [await hashPassword(ADMIN_PASSWORD), ADMIN_EMAIL],
+    )
+  } finally {
+    await client.end()
+  }
 }
 
 async function authenticate() {

--- a/packages/auth-react/src/client.test.ts
+++ b/packages/auth-react/src/client.test.ts
@@ -32,4 +32,50 @@ describe("createAuthBasePathFetcher", () => {
     )
     expect(fetcher).toHaveBeenNthCalledWith(4, "https://admin.example/api/auth/status", undefined)
   })
+
+  it("leaves shared deployment-owned auth paths on the default prefix", async () => {
+    const fetcher = vi.fn(async () => new Response(null, { status: 204 }))
+    const adminFetcher = createAuthBasePathFetcher(fetcher, {
+      baseUrl: "https://operator.example/api",
+      authBasePath: "/auth/admin",
+      sharedPaths: ["/me", "/status", "/api-tokens", "/organization/list-members"],
+    })
+
+    const calls = [
+      // Shared: the deployment serves these itself, off the realm prefix.
+      ["https://operator.example/api/auth/status", "https://operator.example/api/auth/status"],
+      ["https://operator.example/api/auth/me", "https://operator.example/api/auth/me"],
+      [
+        "https://operator.example/api/auth/api-tokens?limit=25",
+        "https://operator.example/api/auth/api-tokens?limit=25",
+      ],
+      [
+        "https://operator.example/api/auth/api-tokens/key_1/rotate",
+        "https://operator.example/api/auth/api-tokens/key_1/rotate",
+      ],
+      [
+        "https://operator.example/api/auth/organization/list-members",
+        "https://operator.example/api/auth/organization/list-members",
+      ],
+      // Realm-scoped: Better Auth handles these under /auth/admin.
+      [
+        "https://operator.example/api/auth/sign-in/email",
+        "https://operator.example/api/auth/admin/sign-in/email",
+      ],
+      // A sibling of a shared path is not itself shared.
+      [
+        "https://operator.example/api/auth/organization/invite-member",
+        "https://operator.example/api/auth/admin/organization/invite-member",
+      ],
+      // A shared path is matched whole, not as a string prefix.
+      [
+        "https://operator.example/api/auth/status-report",
+        "https://operator.example/api/auth/admin/status-report",
+      ],
+    ] as const
+
+    for (const [requested] of calls) await adminFetcher(requested)
+
+    expect(fetcher.mock.calls.map((call) => call[0])).toEqual(calls.map(([, target]) => target))
+  })
 })

--- a/packages/auth-react/src/client.test.ts
+++ b/packages/auth-react/src/client.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest"
 
-import { createAuthBasePathFetcher } from "./client.js"
+import { createAuthBasePathFetcher, type VoyantFetcher } from "./client.js"
 
 describe("createAuthBasePathFetcher", () => {
   it("routes only auth calls under the configured API base URL to the selected realm", async () => {
@@ -34,7 +34,9 @@ describe("createAuthBasePathFetcher", () => {
   })
 
   it("leaves shared deployment-owned auth paths on the default prefix", async () => {
-    const fetcher = vi.fn(async () => new Response(null, { status: 204 }))
+    // Typed parameters so `mock.calls[n][0]` is the requested URL rather than an
+    // element of an empty tuple.
+    const fetcher = vi.fn<VoyantFetcher>(async () => new Response(null, { status: 204 }))
     const adminFetcher = createAuthBasePathFetcher(fetcher, {
       baseUrl: "https://operator.example/api",
       authBasePath: "/auth/admin",

--- a/packages/auth-react/src/client.ts
+++ b/packages/auth-react/src/client.ts
@@ -14,6 +14,19 @@ function normalizePath(value: string): string {
   return trimTrailingSlash(path)
 }
 
+export interface AuthBasePathFetcherOptions {
+  baseUrl: string
+  authBasePath: string
+  /**
+   * Paths under `/auth` that are served by the deployment itself rather than by
+   * the realm's Better Auth handler, so they keep the shared prefix. Given
+   * `/status`, both `/auth/status` and `/auth/status?x=1` pass through, and so
+   * does any nested path such as `/auth/api-tokens/key_1/rotate` for
+   * `/api-tokens`.
+   */
+  sharedPaths?: readonly string[]
+}
+
 /**
  * Routes auth-react requests to a specific auth realm without changing other API calls.
  * The replacement is deliberately scoped to the configured API base URL so a customer
@@ -21,21 +34,24 @@ function normalizePath(value: string): string {
  */
 export function createAuthBasePathFetcher(
   fetcher: VoyantFetcher,
-  options: { baseUrl: string; authBasePath: string },
+  options: AuthBasePathFetcherOptions,
 ): VoyantFetcher {
   const baseUrl = trimTrailingSlash(options.baseUrl)
   const defaultAuthBaseUrl = `${baseUrl}/auth`
   const realmAuthBaseUrl = `${baseUrl}${normalizePath(options.authBasePath)}`
+  const sharedPaths = (options.sharedPaths ?? []).map(normalizePath)
 
   return (url, init) => {
     const isDefaultAuthRequest =
       url === defaultAuthBaseUrl ||
       url.startsWith(`${defaultAuthBaseUrl}/`) ||
       url.startsWith(`${defaultAuthBaseUrl}?`)
-    const target = isDefaultAuthRequest
-      ? `${realmAuthBaseUrl}${url.slice(defaultAuthBaseUrl.length)}`
-      : url
-    return fetcher(target, init)
+    if (!isDefaultAuthRequest) return fetcher(url, init)
+
+    const rest = url.slice(defaultAuthBaseUrl.length)
+    const path = trimTrailingSlash(rest.split(/[?#]/)[0] ?? "")
+    const isShared = sharedPaths.some((shared) => path === shared || path.startsWith(`${shared}/`))
+    return fetcher(isShared ? url : `${realmAuthBaseUrl}${rest}`, init)
   }
 }
 

--- a/packages/operator-standard/src/standard-frontend.tsx
+++ b/packages/operator-standard/src/standard-frontend.tsx
@@ -39,7 +39,6 @@ import type {
   FinancePublicRouteRuntime,
 } from "@voyant-travel/finance-react/public-routes"
 import { ProductDetailPageProducts } from "@voyant-travel/inventory-react/storefront"
-import { VoyantAvailabilityProvider } from "@voyant-travel/operations-react/availability/provider"
 import type {
   createProposalsPublicRouteContribution,
   ProposalsPublicRouteRuntime,
@@ -111,6 +110,22 @@ export interface StandardOperatorFrontend {
     workspaceRoute: AnyRoute
   }): ReturnType<typeof createAdminRouter<TRouteTree>>
 }
+
+/**
+ * Admin auth paths the deployment serves itself instead of handing to the admin
+ * realm's Better Auth handler. Unlike the customer realm — which mounts its own
+ * facades under `/auth/customer/*` — these stay on the shared `/auth/*` prefix,
+ * so the realm rewrite below must leave them alone or they 404.
+ *
+ * Mounted by `createOperatorAuthNodeRuntime` in `@voyant-travel/auth`.
+ */
+const ADMIN_SHARED_AUTH_PATHS = [
+  "/me",
+  "/status",
+  "/bootstrap-status",
+  "/api-tokens",
+  "/organization/list-members",
+] as const
 
 class ApiError extends Error {
   constructor(
@@ -338,12 +353,12 @@ export function createStandardOperatorFrontend(
 ): StandardOperatorFrontend {
   const presentation = createAdminHostPresentation(options)
   const runtime = createPresentationRuntime(presentation, options.presentations)
-  const AvailabilityProvider: AdminChildProvider = ({ children }) => (
-    <VoyantAvailabilityProvider baseUrl={getAdminApiUrl()} fetcher={adminFetcher}>
-      {children}
-    </VoyantAvailabilityProvider>
-  )
-  const providers = [TooltipProvider, AvailabilityProvider] satisfies readonly AdminChildProvider[]
+  // Every `Voyant<Domain>Provider` is an alias of the one `VoyantReactProvider`,
+  // so they all write the same React context. Re-rendering one below the shell
+  // would replace the shell's `{ baseUrl, fetcher }` for the entire tree — the
+  // admin realm scoping below included. Domain hooks read the shell's context
+  // directly, so nothing here re-provides it.
+  const providers = [TooltipProvider] satisfies readonly AdminChildProvider[]
 
   function Providers({ children, queryClient }: { children: ReactNode; queryClient: QueryClient }) {
     const baseUrl = getAdminApiUrl()
@@ -353,7 +368,12 @@ export function createStandardOperatorFrontend(
     // realm — mirroring the storefront's `/auth/customer` rewrite. Non-auth URLs
     // pass through unchanged, so domain data hooks are unaffected.
     const adminAuthFetcher = useMemo(
-      () => createAuthBasePathFetcher(adminFetcher, { baseUrl, authBasePath: "/auth/admin" }),
+      () =>
+        createAuthBasePathFetcher(adminFetcher, {
+          baseUrl,
+          authBasePath: "/auth/admin",
+          sharedPaths: ADMIN_SHARED_AUTH_PATHS,
+        }),
       [baseUrl],
     )
     return (

--- a/scripts/checks/symbols/symbol-policy.json
+++ b/scripts/checks/symbols/symbol-policy.json
@@ -12,6 +12,49 @@
         "loadFlightAdminRoutes": ["packages/runtime/src/deployment-resources.ts"],
         "loadFlightsRuntime": ["packages/runtime/src/deployment-resources.ts"]
       }
+    },
+    "operator-admin-shell-context": {
+      "$comment": [
+        "Every Voyant<Domain>Provider is an alias of the one VoyantReactProvider,",
+        "so rendering one below the operator admin shell replaces the shell's",
+        "{ baseUrl, fetcher } for the whole tree — including the admin Better Auth",
+        "realm scoping, which silently 404s every auth-react call. Domain hooks read",
+        "the shell's context directly and need no re-provider. See issue #4182."
+      ],
+      "absentFrom": {
+        "VoyantActionLedgerProvider": ["packages/operator-standard/src/standard-frontend.tsx"],
+        "VoyantAuthProvider": ["packages/operator-standard/src/standard-frontend.tsx"],
+        "VoyantAvailabilityProvider": ["packages/operator-standard/src/standard-frontend.tsx"],
+        "VoyantBookingRequirementsProvider": [
+          "packages/operator-standard/src/standard-frontend.tsx"
+        ],
+        "VoyantBookingsProvider": ["packages/operator-standard/src/standard-frontend.tsx"],
+        "VoyantCatalogProvider": ["packages/operator-standard/src/standard-frontend.tsx"],
+        "VoyantChartersProvider": ["packages/operator-standard/src/standard-frontend.tsx"],
+        "VoyantCruisesProvider": ["packages/operator-standard/src/standard-frontend.tsx"],
+        "VoyantCustomerPortalProvider": ["packages/operator-standard/src/standard-frontend.tsx"],
+        "VoyantDistributionProvider": ["packages/operator-standard/src/standard-frontend.tsx"],
+        "VoyantExternalRefsProvider": ["packages/operator-standard/src/standard-frontend.tsx"],
+        "VoyantExtrasProvider": ["packages/operator-standard/src/standard-frontend.tsx"],
+        "VoyantFacilitiesProvider": ["packages/operator-standard/src/standard-frontend.tsx"],
+        "VoyantFinanceProvider": ["packages/operator-standard/src/standard-frontend.tsx"],
+        "VoyantFlightsProvider": ["packages/operator-standard/src/standard-frontend.tsx"],
+        "VoyantGroundProvider": ["packages/operator-standard/src/standard-frontend.tsx"],
+        "VoyantIdentityProvider": ["packages/operator-standard/src/standard-frontend.tsx"],
+        "VoyantLegalProvider": ["packages/operator-standard/src/standard-frontend.tsx"],
+        "VoyantMarketsProvider": ["packages/operator-standard/src/standard-frontend.tsx"],
+        "VoyantMediaProvider": ["packages/operator-standard/src/standard-frontend.tsx"],
+        "VoyantNotificationsProvider": ["packages/operator-standard/src/standard-frontend.tsx"],
+        "VoyantPricingProvider": ["packages/operator-standard/src/standard-frontend.tsx"],
+        "VoyantProductsProvider": ["packages/operator-standard/src/standard-frontend.tsx"],
+        "VoyantPromotionsProvider": ["packages/operator-standard/src/standard-frontend.tsx"],
+        "VoyantProvider": ["packages/operator-standard/src/standard-frontend.tsx"],
+        "VoyantResourcesProvider": ["packages/operator-standard/src/standard-frontend.tsx"],
+        "VoyantSellabilityProvider": ["packages/operator-standard/src/standard-frontend.tsx"],
+        "VoyantStorefrontProvider": ["packages/operator-standard/src/standard-frontend.tsx"],
+        "VoyantSuppliersProvider": ["packages/operator-standard/src/standard-frontend.tsx"],
+        "VoyantTripsProvider": ["packages/operator-standard/src/standard-frontend.tsx"]
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes #4182.

## What was wrong

Operator admin sign-in POSTed to `/api/auth/sign-in/email`, which is not mounted, so the form failed with **"Voyant API error: 404"**. It blocks a fresh self-hosted or local setup entirely; deployed operators mostly use the Voyant Cloud admin-auth broker, so the local email/password path is rarely exercised.

The issue guessed at `createAuthClient({ baseURL: ".../auth/admin" })` losing its path suffix. That client is fine — Better Auth 1.6.23 keeps a `baseURL` that already has a path, and the sign-in form does not use it anyway. `SignInPage` uses the auth-react `useSignIn` hook, which reads `{ baseUrl, fetcher }` off the shared React context. The giveaway is the message itself: `Voyant API error: 404` is auth-react's own error string, not Better Auth's.

## Root cause

`Providers` in `standard-frontend.tsx` scoped the shared admin fetcher to the `/auth/admin` realm (#3604), then passed `AvailabilityProvider` in the shell's `providers` list:

```tsx
const AvailabilityProvider = ({ children }) => (
  <VoyantAvailabilityProvider baseUrl={getAdminApiUrl()} fetcher={adminFetcher}>…</VoyantAvailabilityProvider>
)
```

Every `Voyant<Domain>Provider` is a re-export alias of the one `VoyantReactProvider`, so it writes the *same* React context. `OperatorAdminShellProvider` renders the provider list **below** its own `VoyantReactProvider`, so the availability provider replaced the shell's `{ baseUrl, fetcher }` for the entire tree — putting the raw `adminFetcher` back and sending every auth-react call to the realm-less `/auth/*` surface. The realm scoping added in #3604 never took effect.

## The fix

- **Drop the redundant provider.** Domain hooks read the shell's context directly; the shell already provides the same `baseUrl` and a fetcher that passes non-auth URLs through unchanged, so this is a no-op for availability and restores realm scoping.
- **Add a `verify:symbol-policy` rule** (`operator-admin-shell-context`) keeping all 30 provider aliases out of `standard-frontend.tsx`, so this cannot silently come back. Confirmed it fails when the import is restored.
- **Scope the rewrite to the realm's Better Auth surface.** Rewriting all of `/auth/*` broke the other direction: `/auth/status`, `/auth/me`, `/auth/bootstrap-status`, `/auth/api-tokens`, and `/auth/organization/list-members` are served by the deployment itself and have no `/auth/admin` counterpart. `createAuthBasePathFetcher` takes a `sharedPaths` option so those keep the shared prefix. The customer realm, which mounts its own facades under `/auth/customer/*`, is unchanged.

## Adjacent papercuts from the issue

- `seed-demo.mjs` no longer hardcodes `docker exec voyant-ui-pg`; the password-reset fallback connects over `DATABASE_URL` with a parameterised update, so it works against any Postgres (and stops interpolating the hash into SQL).
- The bare `403` for an unverified admin was a symptom of this bug, not a separate one — with the realm fixed, `SignInPage` renders "Your email address has not been verified" plus a resend action. Verified below.

## Verification

Local operator (`voyant develop`) against a seeded database, driven through a real browser.

Before — reproduced the report exactly:
```
POST 404 http://localhost:3310/api/auth/sign-in/email
card: "Voyant API error: 404"
```

After — sign-in succeeds and lands on the workspace, and the shared paths stay put:
```
POST 200 /api/auth/admin/sign-in/email
GET  200 /api/auth/status
GET  200 /api/auth/admin/get-session
GET  200 /api/auth/me
GET  200 /api/auth/api-tokens?limit=25&sortBy=createdAt&sortDirection=desc
```

With `email_verified` flipped to `false` (and restored after):
```
POST 403 /api/auth/admin/sign-in/email
card: "Your email address has not been verified. Please check your inbox or resend the verification code."  [Resend verification code]
```

Also run: `biome check .` clean, `pnpm verify:architecture` green, `@voyant-travel/auth-react` (68) and `@voyant-travel/operator-standard` (19) suites pass, `auth-react` builds (real `tsc`).