### PR TITLE
Attach a fleet resource to a departure and project its conflicts

### DIFF
--- a/.changeset/coach-tracer-departure-resources.md
+++ b/.changeset/coach-tracer-departure-resources.md
@@ -1,0 +1,43 @@
+---
+"@voyant-travel/operations": minor
+"@voyant-travel/operations-react": patch
+---
+
+feat(operations): attach a Resource to a departure, materialize seats, allocate atomically
+
+A coach could not be pointed at the departure it operates, could not be laid out
+before the first sale, and the plan's conflicts were computed nowhere the server
+could see.
+
+- **A departure can attach a fleet `resources` record.** `allocation_resources`
+  gains a `"resource"` ref producer that writes the departure's container and
+  the cross-departure `resource_slot_assignments` commitment in one transaction,
+  adopting an assignment the Resources admin already made rather than
+  duplicating it, and refusing a coach already committed to an overlapping
+  departure. `docs/architecture/operated-departure-logistics.md` records which
+  table is authoritative for what.
+- **`vehicle_seat` templates materialize.** `default_count` counts vehicles and
+  each one gets its full seat map, so an empty coach can be drawn before the
+  departure has sold a seat. Previously only the pax-derived path created seats,
+  which needed bookings to already exist.
+- **Idempotency parity.** Both materialisation paths now skip existing resources
+  at `(kind, ref)` granularity and report `skippedExisting`. The pax-derived
+  path used to raise `409 Resources already exist`; a retried request is now a
+  visible no-op.
+- **`POST /slots/{id}/allocation/auto-allocate/preview`** returns the plan
+  without writing it, and is the first production caller of
+  `validateSlotAllocationCapacity`.
+- **`POST /slots/{id}/allocation/travelers/assignments`** places a set of
+  travelers in one transaction, so a sharing group can no longer land
+  half-placed. Per-traveler `expectedResourceId` is an optimistic-concurrency
+  precondition.
+- **`GET /slots/{id}/allocation/conflicts`** is a server-side projection with
+  stable codes covering unassigned, over-capacity, duplicate, inaccessible,
+  incompatible, oversubscribed group and split group, so UI, CSV and print
+  agree. The unused client-side `buildValidationIssues` / `ValidationSummary`
+  are removed.
+- **Seat exports are reachable.** `export-rooming-list` takes a `kind`, and the
+  filename union gains `seating`.
+- **Retry and revision safety.** Allocation mutations accept an
+  `Idempotency-Key`, resource update/delete and fleet detach accept
+  `expectedUpdatedAt`, and the new legs append action-ledger mutation entries.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,6 +369,14 @@ jobs:
               pnpm --filter @voyant-travel/operations exec vitest run \
                 tests/availability/integration/auto-allocate-concurrency.test.ts
               pnpm --filter @voyant-travel/operations exec vitest run \
+                tests/availability/integration/allocation-assignment-concurrency.test.ts
+              pnpm --filter @voyant-travel/operations exec vitest run \
+                tests/availability/integration/allocation-routes.test.ts
+              pnpm --filter @voyant-travel/operations exec vitest run \
+                tests/availability/integration/allocation-departure-resources.test.ts
+              pnpm --filter @voyant-travel/operations exec vitest run \
+                tests/availability/integration/materialize-template-defaults.test.ts
+              pnpm --filter @voyant-travel/operations exec vitest run \
                 tests/availability/integration/departure-summary.test.ts
               pnpm --filter @voyant-travel/operations exec vitest run \
                 tests/availability/integration/allocation-audit-atomicity.test.ts

--- a/docs/architecture/operated-departure-logistics.md
+++ b/docs/architecture/operated-departure-logistics.md
@@ -97,6 +97,74 @@ would change behaviour. It stays a distinct, locally-documented vocabulary.
 The admin route bundle is mounted behind the operator application's existing
 authenticated admin boundary. Mutation audit entries retain the acting user ID.
 
+## Attaching a fleet resource: which table is authoritative
+
+An allocation resource may carry `refType = "resource"` with `refId` pointing at
+a `resources` row, which is how a departure says "this is the coach that
+operates it". Two tables then describe the same coach, and they answer different
+questions:
+
+| Table | Authoritative for | Scope |
+|---|---|---|
+| `allocation_resources` (`ref_type = "resource"`) | **what this departure operates** — the container travelers are assigned against, its capacity, its child seats | one slot |
+| `resource_slot_assignments` | **fleet commitment across departures** — is this coach already promised elsewhere, and since when | every slot |
+
+Neither is a copy of the other, and neither is optional:
+
+- Every read the departure workspace does — manifest, exports, capacity
+  counters, the conflicts projection — goes through `allocation_resources`. A
+  departure never has to consult the Resources module to render or validate its
+  plan.
+- Only `resource_slot_assignments` spans departures, so it is the only table
+  that can detect a double-booking. `allocation_resources` is slot-scoped by
+  construction and can never see a clash.
+
+There is exactly **one write path** (`service-allocation-resource-link.ts`).
+Attaching writes both rows in one transaction, having first consulted the fleet
+ledger as the conflict oracle; detaching removes the container and releases the
+commitment. A live `resource_slot_assignments` row the Resources admin section
+already created for the same (slot, resource) is **adopted**, not duplicated,
+and its id is recorded on the allocation resource's `flags.resourceAssignmentId`.
+That reconciliation is what stops a coach being held twice through two unrelated
+tables.
+
+An attach is idempotent: re-attaching the same resource returns the existing
+link rather than raising, matching the materialisation paths.
+
+## Materialising a layout, and what "already done" means
+
+Both materialisation paths — pax-derived (`autoMaterializeAllocationResources`)
+and template-default (`materializeSlotResourcesFromTemplateDefaults`) — agree on
+**skip-existing at `(kind, ref_id)` granularity**. Materialising is a
+converge-to-this-layout operation, so running it twice leaves the same rows and
+reports `created: 0, skippedExisting: n`. The pax-derived path used to raise
+`409 Resources already exist` instead; skipping is the only rule of the two that
+is safe to retry, and the per-`(kind, ref)` granularity is what lets a second
+room type materialise later without the whole `room` kind counting as done.
+
+Replacing an existing layout stays an explicit operator action: delete the
+resources, then materialise again.
+
+`vehicle_seat` templates materialise from their `default_count` too, which
+counts **vehicles**; the seat count comes from the template's layout. An
+operator can therefore draw a coach before the departure has sold a single seat.
+
+## Allocation conflicts are a server projection
+
+"What is wrong with this plan" is answered once, server-side
+(`service-allocation-conflicts.ts`), so the workspace UI, the CSV export and the
+printed manifest cannot disagree. The rules are pure over already-loaded facts
+and every conflict carries a stable machine code:
+`traveler_unassigned`, `resource_over_capacity`, `duplicate_assignment`,
+`inaccessible_assignment`, `incompatible_assignment`,
+`oversubscribed_sharing_group`, `split_sharing_group`. Never rename a code; add
+a new one. Detection only — nothing there repairs anything.
+
+Departure-level drift (stale holds, oversold capacity, missing travelers) stays
+in `service-departure-issues.ts`. The two projections are complementary: one
+asks "does this departure's bookkeeping agree with itself", the other asks "can
+this rooming or seating plan actually be operated".
+
 ## Deliberately deferred planner work
 
 This shared primitive supports real rooming, vehicle, and seat assignment now.
@@ -109,8 +177,9 @@ Rich specialist planning remains additive UI over the same data:
   allocation map;
 - crew qualifications, shifts, duty-time limits, and supplier contracting;
 - vehicle registration, depot, route-leg, and maintenance constraints;
-- automatic conflict detection across departures for shared fleet and staff.
+- automatic conflict detection across departures for shared fleet and staff
+  beyond the overlapping-window check the attach path already performs.
 
 Those features should link resources through `refType`/`refId` to their owning
 fleet, people, supplier, or facility records instead of copying those entities
-into availability.
+into availability — the `"resource"` ref above is the first of them.

--- a/packages/operations-react/src/availability/allocation/components/slot-allocation-model.ts
+++ b/packages/operations-react/src/availability/allocation/components/slot-allocation-model.ts
@@ -49,11 +49,6 @@ export function deriveAllocationKinds({
   return kinds
 }
 
-export type ValidationIssue = {
-  id: string
-  label: string
-}
-
 export function collectOccupants(
   travelers: AllocationManifestTraveler[],
   resources: AllocationResource[],
@@ -113,65 +108,6 @@ export function collectVehicleOccupants(
   }
 
   return { byResource, byTravelerId, unallocated }
-}
-
-export function buildValidationIssues({
-  travelers,
-  resources,
-  occupants,
-  kind,
-  messages,
-}: {
-  travelers: AllocationManifestTraveler[]
-  resources: AllocationResource[]
-  occupants: AllocationOccupants
-  kind: string
-  messages: AllocationUiMessages
-}) {
-  const issues: ValidationIssue[] = []
-
-  if (occupants.unallocated.length > 0) {
-    issues.push({
-      id: "unallocated",
-      label: `${occupants.unallocated.length} ${messages.validationUnallocated}`,
-    })
-  }
-
-  for (const resource of resources) {
-    const count = occupants.byResource.get(resource.id)?.length ?? 0
-    if (count > resource.capacity) {
-      issues.push({
-        id: `over-capacity:${resource.id}`,
-        label: `${resource.label ?? kindLabel(kind, messages)} ${messages.validationOverCapacity}`,
-      })
-    }
-  }
-
-  for (const splitGroup of splitSharingGroups(travelers, kind)) {
-    issues.push({
-      id: `split:${splitGroup}`,
-      label: `${messages.validationSplitGroup}: ${splitGroup}`,
-    })
-  }
-
-  return issues
-}
-
-export function splitSharingGroups(travelers: AllocationManifestTraveler[], kind: string) {
-  const allocationsByGroup = new Map<string, Set<string>>()
-  for (const traveler of travelers) {
-    const groupId = traveler.sharingGroupId
-    if (!groupId) continue
-    const allocations = allocationsByGroup.get(groupId) ?? new Set<string>()
-    allocations.add(traveler.allocations[kind] ?? "unallocated")
-    allocationsByGroup.set(groupId, allocations)
-  }
-
-  const split: string[] = []
-  for (const [groupId, allocations] of allocationsByGroup) {
-    if (allocations.size > 1) split.push(groupId)
-  }
-  return split
 }
 
 export interface VehicleSeatGroup {

--- a/packages/operations-react/src/availability/allocation/components/slot-allocation-shared.tsx
+++ b/packages/operations-react/src/availability/allocation/components/slot-allocation-shared.tsx
@@ -7,11 +7,11 @@ import type {
   AllocationResource,
 } from "@voyant-travel/operations-react/availability"
 import { Badge, Card, CardContent, CardHeader, CardTitle, cn } from "@voyant-travel/ui/components"
-import { Accessibility, CircleAlert, Crown, History, UtensilsCrossed } from "lucide-react"
+import { Accessibility, Crown, History, UtensilsCrossed } from "lucide-react"
 import type { ReactNode } from "react"
 
 import { useAllocationUiI18nOrDefault, useAllocationUiMessagesOrDefault } from "../i18n/index.js"
-import { flagString, type ValidationIssue } from "./slot-allocation-model.js"
+import { flagString } from "./slot-allocation-model.js"
 
 /**
  * Passive grouping container used by the unallocated column and other
@@ -110,50 +110,6 @@ export function TravelerTile({
         </div>
       </div>
       {renderActions ? <div className="shrink-0">{renderActions(traveler)}</div> : null}
-    </div>
-  )
-}
-
-export function ValidationSummary({
-  issues,
-  resources,
-  unallocatedCount,
-}: {
-  issues: ValidationIssue[]
-  resources: AllocationResource[]
-  unallocatedCount: number
-}) {
-  const messages = useAllocationUiMessagesOrDefault()
-
-  if (issues.length === 0) {
-    return (
-      <div className="flex flex-wrap items-center gap-2 rounded-md border bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
-        <Badge variant="outline">{messages.validationClear}</Badge>
-        <span>
-          {resources.length} {messages.resources.toLowerCase()} · {unallocatedCount}{" "}
-          {messages.unallocated.toLowerCase()}
-        </span>
-      </div>
-    )
-  }
-
-  return (
-    <div className="rounded-md border border-amber-300/60 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-200">
-      <div className="flex items-center gap-2 font-medium">
-        <CircleAlert className="size-4" aria-hidden="true" />
-        {messages.validationTitle}
-      </div>
-      <div className="mt-2 flex flex-wrap gap-2">
-        {issues.map((issue) => (
-          <Badge
-            key={issue.id}
-            variant="outline"
-            className="border-amber-300 bg-background/70 text-amber-900 dark:border-amber-500/40 dark:bg-amber-500/15 dark:text-amber-100"
-          >
-            {issue.label}
-          </Badge>
-        ))}
-      </div>
     </div>
   )
 }

--- a/packages/operations/src/availability/index.ts
+++ b/packages/operations/src/availability/index.ts
@@ -98,14 +98,44 @@ export {
   validateSlotAllocationCapacity,
 } from "./service-allocation.js"
 export {
+  type AssignTravelerAllocationsBatchInput,
+  type AssignTravelerAllocationsBatchResult,
+  assignTravelerAllocationsBatch,
+  type BatchAllocationAssignment,
+} from "./service-allocation-assignment-batch.js"
+export {
+  type AllocationPlanEntry,
+  type AllocationPlanPreview,
   type MaterializeSlotResourcesFromTemplatesOptions,
   materializeSlotResourcesFromTemplateDefaults,
+  previewAutoAllocateSlotResources,
 } from "./service-allocation-automation.js"
 export {
+  type AllocationConflict,
+  type AllocationConflictCode,
+  type AllocationConflictInput,
+  type AllocationConflictResource,
+  type AllocationConflictSeverity,
+  type AllocationConflictSubjectType,
+  evaluateAllocationConflicts,
+  getSlotAllocationConflicts,
+} from "./service-allocation-conflicts.js"
+export {
+  type AllocationExportPrefix,
   allocationExportFilename,
+  allocationExportPrefixForKind,
   buildAllocationPassengersCsv,
   buildAllocationRoomingCsv,
 } from "./service-allocation-exports.js"
+export {
+  type AttachDepartureResourceInput,
+  attachDepartureResource,
+  type DepartureResourceLink,
+  type DepartureResourceRow,
+  type DetachDepartureResourceOptions,
+  detachDepartureResource,
+  listDepartureResourceLinks,
+} from "./service-allocation-resource-link.js"
 export {
   type DepartureAllocationCounters,
   type DepartureBookingCounters,

--- a/packages/operations/src/availability/routes-allocation-planning.ts
+++ b/packages/operations/src/availability/routes-allocation-planning.ts
@@ -262,7 +262,7 @@ const conflictsRoute = createRoute({
 
 // --- ledger plumbing --------------------------------------------------------
 
-const LEDGER_ACTION_VERSION = 1
+const LEDGER_ACTION_VERSION = "v1"
 
 function actionLedgerContext(c: Context<Env>): ActionLedgerRequestContextValues {
   const vars = c.var as Record<string, unknown>

--- a/packages/operations/src/availability/routes-allocation-planning.ts
+++ b/packages/operations/src/availability/routes-allocation-planning.ts
@@ -1,0 +1,413 @@
+/**
+ * Departure-planning allocation routes: attaching a fleet `resources` record to
+ * a departure, placing a whole set of travelers atomically, previewing an
+ * auto-allocation before it writes, and the server-side conflicts projection.
+ *
+ * Its own `OpenAPIHono` sub-chain composed onto `availabilityAllocationRoutes`,
+ * per the per-family pattern documented in `routes-allocation.ts`.
+ *
+ * ## Retry safety
+ *
+ * Every mutating leg here mounts the framework's `Idempotency-Key` middleware.
+ * A retried `POST` with the same key replays the stored response instead of
+ * re-running the command — which is what a dropped connection on auto-allocate
+ * needs, because re-planning a departure that has since been half-assigned is
+ * not the same operation twice. The header stays optional so existing clients
+ * keep working; supplying it is what buys the guarantee.
+ *
+ * Every mutating leg also appends an action-ledger mutation entry, so a
+ * departure's fleet and seating changes are visible in the same admission trail
+ * as every other operator command, alongside the domain-specific
+ * `allocation_audit_log` row the services write inside their transaction.
+ */
+
+import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
+import {
+  type ActionLedgerRequestContextValues,
+  appendActionLedgerMutation,
+} from "@voyant-travel/action-ledger"
+import { idempotencyKey, openApiValidationHook } from "@voyant-travel/hono"
+import type { Context } from "hono"
+
+import {
+  allocationErrorResponses,
+  allocationResourceSchema,
+  errorResponseSchema,
+  handleAllocationRouteError,
+  slotIdParamSchema,
+} from "./routes-allocation-shared.js"
+import type { Env } from "./routes-shared.js"
+import { assignTravelerAllocationsBatch } from "./service-allocation-assignment-batch.js"
+import { previewAutoAllocateSlotResources } from "./service-allocation-automation.js"
+import { getSlotAllocationConflicts } from "./service-allocation-conflicts.js"
+import {
+  attachDepartureResource,
+  detachDepartureResource,
+  listDepartureResourceLinks,
+} from "./service-allocation-resource-link.js"
+import {
+  allocationKindQuerySchema,
+  attachDepartureResourceSchema,
+  batchAssignTravelerAllocationsSchema,
+  detachDepartureResourceQuerySchema,
+} from "./validation.js"
+
+const fleetResourceParamSchema = z.object({ id: z.string(), fleetResourceId: z.string() })
+
+const departureResourceLinkSchema = z.object({
+  resource: allocationResourceSchema,
+  assignmentId: z.string(),
+  created: z.boolean(),
+})
+
+const allocationConflictSchema = z.object({
+  code: z.string(),
+  severity: z.enum(["critical", "warning"]),
+  kind: z.string(),
+  subjectType: z.enum(["traveler", "allocation_resource", "sharing_group", "departure"]),
+  subjectId: z.string(),
+  count: z.number().int(),
+  travelerIds: z.array(z.string()),
+  resourceIds: z.array(z.string()),
+  message: z.string(),
+})
+
+const allocationPlanPreviewSchema = z.object({
+  kind: z.string(),
+  assigned: z.number().int(),
+  skipped: z.number().int(),
+  entries: z.array(
+    z.object({
+      travelerId: z.string(),
+      travelerName: z.string(),
+      bookingId: z.string(),
+      bookingNumber: z.string(),
+      sharingGroupId: z.string().nullable(),
+      resourceId: z.string(),
+      resourceLabel: z.string().nullable(),
+      currentResourceId: z.string().nullable(),
+      unchanged: z.boolean(),
+    }),
+  ),
+  violations: z.array(
+    z.object({
+      slotId: z.string(),
+      resourceId: z.string(),
+      kind: z.string(),
+      capacity: z.number().int(),
+      existingAssigned: z.number().int(),
+      requested: z.number().int(),
+    }),
+  ),
+})
+
+const batchAssignResultSchema = z.object({
+  kind: z.string(),
+  assigned: z.number().int(),
+  unassigned: z.number().int(),
+  unchanged: z.number().int(),
+  travelerIds: z.array(z.string()),
+})
+
+// --- route definitions ------------------------------------------------------
+
+const listFleetResourcesRoute = createRoute({
+  method: "get",
+  path: "/slots/{id}/allocation/fleet-resources",
+  description:
+    "Fleet `resources` records attached to this departure — the `allocation_resources` " +
+    "rows whose `refType` is `resource`.",
+  request: { params: slotIdParamSchema },
+  responses: {
+    200: {
+      description: "The departure's attached fleet resources",
+      content: {
+        "application/json": { schema: z.object({ data: z.array(allocationResourceSchema) }) },
+      },
+    },
+  },
+})
+
+const attachFleetResourceRoute = createRoute({
+  method: "post",
+  path: "/slots/{id}/allocation/fleet-resources",
+  description:
+    "Attach a fleet `resources` record (a coach, a boat, a room) to this departure. " +
+    "Writes the departure's `allocation_resources` container and the cross-departure " +
+    "`resource_slot_assignments` commitment in one transaction, adopting an existing " +
+    "live assignment rather than duplicating it. Rejects a resource already committed " +
+    "to an overlapping departure. Re-attaching the same resource is a no-op.",
+  request: {
+    params: slotIdParamSchema,
+    body: {
+      required: true,
+      content: { "application/json": { schema: attachDepartureResourceSchema } },
+    },
+  },
+  responses: {
+    201: {
+      description: "The attached resource and its fleet commitment",
+      content: { "application/json": { schema: z.object({ data: departureResourceLinkSchema }) } },
+    },
+    400: allocationErrorResponses[400],
+    404: allocationErrorResponses[404],
+    409: allocationErrorResponses[409],
+    500: allocationErrorResponses[500],
+  },
+})
+
+const detachFleetResourceRoute = createRoute({
+  method: "delete",
+  path: "/slots/{id}/allocation/fleet-resources/{fleetResourceId}",
+  description:
+    "Detach a fleet resource from this departure: remove its container (and, with " +
+    "`cascade`, its seats), clear the traveler allocations that pointed at them, and " +
+    "release the fleet commitment.",
+  request: { params: fleetResourceParamSchema, query: detachDepartureResourceQuerySchema },
+  responses: {
+    200: {
+      description: "The removed allocation resources and the released assignment",
+      content: {
+        "application/json": {
+          schema: z.object({
+            data: z.object({
+              removedResourceIds: z.array(z.string()),
+              assignmentId: z.string().nullable(),
+            }),
+          }),
+        },
+      },
+    },
+    400: allocationErrorResponses[400],
+    404: allocationErrorResponses[404],
+    409: allocationErrorResponses[409],
+    500: allocationErrorResponses[500],
+  },
+})
+
+const batchAssignRoute = createRoute({
+  method: "post",
+  path: "/slots/{id}/allocation/travelers/assignments",
+  description:
+    "Place a set of travelers in one transaction. Either every assignment lands or " +
+    "none does, so a sharing group can never end up half-placed. Per-traveler " +
+    "`expectedResourceId` is an optimistic-concurrency precondition.",
+  request: {
+    params: slotIdParamSchema,
+    body: {
+      required: true,
+      content: { "application/json": { schema: batchAssignTravelerAllocationsSchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "Counts of what the batch assigned, unassigned, and left unchanged",
+      content: { "application/json": { schema: z.object({ data: batchAssignResultSchema }) } },
+    },
+    400: allocationErrorResponses[400],
+    404: allocationErrorResponses[404],
+    409: allocationErrorResponses[409],
+    500: allocationErrorResponses[500],
+  },
+})
+
+const previewAutoAllocateRoute = createRoute({
+  method: "post",
+  path: "/slots/{id}/allocation/auto-allocate/preview",
+  description:
+    "Compute the auto-allocation plan without writing it. Returns the traveler→resource " +
+    "entries the commit would produce, which of them change anything, and any capacity " +
+    "violations the plan would create.",
+  request: {
+    params: slotIdParamSchema,
+    body: {
+      required: true,
+      content: { "application/json": { schema: allocationKindQuerySchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "The uncommitted allocation plan",
+      content: { "application/json": { schema: z.object({ data: allocationPlanPreviewSchema }) } },
+    },
+    400: allocationErrorResponses[400],
+    404: allocationErrorResponses[404],
+    409: allocationErrorResponses[409],
+    500: allocationErrorResponses[500],
+  },
+})
+
+const conflictsRoute = createRoute({
+  method: "get",
+  path: "/slots/{id}/allocation/conflicts",
+  description:
+    "The departure's allocation conflicts for one resource kind: unassigned travelers, " +
+    "over-capacity and duplicated resources, inaccessible and incompatible placements, " +
+    "and oversubscribed or split sharing groups. Codes are stable; the UI, the CSV " +
+    "export and the printed manifest all read this one projection.",
+  request: { params: slotIdParamSchema, query: allocationKindQuerySchema },
+  responses: {
+    200: {
+      description: "The departure's allocation conflicts, critical first",
+      content: {
+        "application/json": { schema: z.object({ data: z.array(allocationConflictSchema) }) },
+      },
+    },
+    404: {
+      description: "Availability slot not found",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+// --- ledger plumbing --------------------------------------------------------
+
+const LEDGER_ACTION_VERSION = 1
+
+function actionLedgerContext(c: Context<Env>): ActionLedgerRequestContextValues {
+  const vars = c.var as Record<string, unknown>
+  return {
+    userId: (vars.userId as string | undefined) ?? null,
+    agentId: (vars.agentId as string | undefined) ?? null,
+    workflowPrincipalId: null,
+    principalSubtype: null,
+    sessionId: (vars.sessionId as string | undefined) ?? null,
+    apiTokenId: ((vars.apiTokenId ?? vars.apiKeyId) as string | undefined) ?? null,
+    callerType: (vars.callerType as ActionLedgerRequestContextValues["callerType"]) ?? null,
+    actor: (vars.actor as ActionLedgerRequestContextValues["actor"]) ?? null,
+    isInternalRequest: (vars.isInternalRequest as boolean | undefined) ?? false,
+    organizationId: (vars.organizationId as string | undefined) ?? null,
+    workflowRunId: null,
+    workflowStepId: null,
+    correlationId: c.req.header("x-correlation-id") ?? c.req.header("x-request-id") ?? null,
+  }
+}
+
+/**
+ * Record the mutation in the action ledger. Best-effort: the departure change
+ * has already committed by the time this runs, so a ledger outage must not turn
+ * a successful placement into a 500. The transactional
+ * `allocation_audit_log` row is the durable domain record.
+ */
+async function appendAllocationLedgerEntry(
+  c: Context<Env>,
+  input: { actionName: string; slotId: string; summary: string },
+) {
+  try {
+    await appendActionLedgerMutation(c.get("db"), {
+      context: actionLedgerContext(c),
+      actionName: input.actionName,
+      actionVersion: LEDGER_ACTION_VERSION,
+      actionKind: "update",
+      evaluatedRisk: "medium",
+      targetType: "departure",
+      targetId: input.slotId,
+      routeOrToolName: `${c.req.method} ${new URL(c.req.url).pathname}`,
+      authorizationSource: "operations.route",
+      mutationDetail: { summary: input.summary, reversalKind: "none" },
+    })
+  } catch {
+    // Intentional: see the docblock. Logging is the deployment's job.
+  }
+}
+
+// --- handlers ---------------------------------------------------------------
+
+export const availabilityAllocationPlanningRoutes = new OpenAPIHono<Env>({
+  defaultHook: openApiValidationHook,
+})
+
+// Retry protection for the mutating legs only; the reads below are naturally
+// idempotent and must not consume a key.
+availabilityAllocationPlanningRoutes.use(
+  "/slots/:id/allocation/fleet-resources",
+  idempotencyKey({ scope: "operations.allocation.fleet-resource.attach" }),
+)
+availabilityAllocationPlanningRoutes.use(
+  "/slots/:id/allocation/travelers/assignments",
+  idempotencyKey({ scope: "operations.allocation.travelers.assign-batch" }),
+)
+
+availabilityAllocationPlanningRoutes
+  .openapi(listFleetResourcesRoute, async (c) => {
+    const data = await listDepartureResourceLinks(c.get("db"), c.req.valid("param").id)
+    return c.json({ data }, 200)
+  })
+  .openapi(attachFleetResourceRoute, async (c) => {
+    try {
+      const slotId = c.req.valid("param").id
+      const body = c.req.valid("json")
+      const data = await attachDepartureResource(c.get("db"), slotId, body, {
+        actorId: c.get("userId") ?? null,
+      })
+      await appendAllocationLedgerEntry(c, {
+        actionName: "operations.allocation.fleet-resource.attach",
+        slotId,
+        summary: data.created
+          ? `Attached resource ${body.resourceId} to departure ${slotId}`
+          : `Resource ${body.resourceId} was already attached to departure ${slotId}`,
+      })
+      return c.json({ data }, 201)
+    } catch (error) {
+      return handleAllocationRouteError(c, error)
+    }
+  })
+  .openapi(detachFleetResourceRoute, async (c) => {
+    try {
+      const params = c.req.valid("param")
+      const query = c.req.valid("query")
+      const data = await detachDepartureResource(c.get("db"), params.id, params.fleetResourceId, {
+        actorId: c.get("userId") ?? null,
+        ...(query.expectedUpdatedAt !== undefined
+          ? { expectedUpdatedAt: query.expectedUpdatedAt }
+          : {}),
+        ...(query.cascade !== undefined ? { cascade: query.cascade } : {}),
+      })
+      if (!data) return c.json({ error: "Resource is not attached to this departure" }, 404)
+      await appendAllocationLedgerEntry(c, {
+        actionName: "operations.allocation.fleet-resource.detach",
+        slotId: params.id,
+        summary: `Detached resource ${params.fleetResourceId} from departure ${params.id}`,
+      })
+      return c.json({ data }, 200)
+    } catch (error) {
+      return handleAllocationRouteError(c, error)
+    }
+  })
+  .openapi(batchAssignRoute, async (c) => {
+    try {
+      const slotId = c.req.valid("param").id
+      const body = c.req.valid("json")
+      const data = await assignTravelerAllocationsBatch(c.get("db"), slotId, body, {
+        actorId: c.get("userId") ?? null,
+      })
+      await appendAllocationLedgerEntry(c, {
+        actionName: "operations.allocation.travelers.assign-batch",
+        slotId,
+        summary: `Placed ${data.assigned} and cleared ${data.unassigned} ${body.kind} assignments on departure ${slotId}`,
+      })
+      return c.json({ data }, 200)
+    } catch (error) {
+      return handleAllocationRouteError(c, error)
+    }
+  })
+  .openapi(previewAutoAllocateRoute, async (c) => {
+    try {
+      const data = await previewAutoAllocateSlotResources(
+        c.get("db"),
+        c.req.valid("param").id,
+        c.req.valid("json"),
+      )
+      return c.json({ data }, 200)
+    } catch (error) {
+      return handleAllocationRouteError(c, error)
+    }
+  })
+  .openapi(conflictsRoute, async (c) => {
+    const data = await getSlotAllocationConflicts(c.get("db"), c.req.valid("param").id, {
+      kind: c.req.valid("query").kind,
+    })
+    return data ? c.json({ data }, 200) : c.json({ error: "Availability slot not found" }, 404)
+  })
+
+export type AvailabilityAllocationPlanningRoutes = typeof availabilityAllocationPlanningRoutes

--- a/packages/operations/src/availability/routes-allocation-shared.ts
+++ b/packages/operations/src/availability/routes-allocation-shared.ts
@@ -1,0 +1,93 @@
+/**
+ * Response schemas and error plumbing shared by the allocation route families.
+ *
+ * Extracted from `routes-allocation.ts` when the departure-resource, batch
+ * assignment, conflicts and plan-preview legs arrived: they are their own
+ * `OpenAPIHono` sub-chain (the established per-family pattern in this bundle)
+ * and need the same error union and resource schema.
+ */
+
+import { z } from "@hono/zod-openapi"
+import type { Context } from "hono"
+
+import type { Env } from "./routes-shared.js"
+import { AllocationServiceError } from "./service-allocation.js"
+
+export const errorResponseSchema = z.object({ error: z.string() })
+/** Allocation service errors serialize `error` + an optional `detail` payload. */
+export const allocationErrorSchema = z.object({
+  error: z.string(),
+  detail: z.unknown().optional(),
+})
+export const isoTimestamp = z.string()
+/** Resource `flags` is an untyped jsonb record. */
+export const flagsSchema = z.record(z.string(), z.unknown())
+
+export const slotIdParamSchema = z.object({ id: z.string() })
+
+// §17: `allocation_resources.$inferSelect` — timestamps serialize to strings.
+export const allocationResourceSchema = z.object({
+  id: z.string(),
+  slotId: z.string(),
+  kind: z.string(),
+  refType: z.string().nullable(),
+  refId: z.string().nullable(),
+  label: z.string().nullable(),
+  capacity: z.number().int(),
+  flags: flagsSchema,
+  parentId: z.string().nullable(),
+  sortOrder: z.number().int(),
+  createdAt: isoTimestamp,
+  updatedAt: isoTimestamp,
+})
+
+/**
+ * Map an `AllocationServiceError` to its HTTP status (anything else re-throws to
+ * the boundary). Returns `c.json(...)` — a typed response — so the `.openapi()`
+ * handlers' declared 4xx schemas accept it. The status is narrowed to the
+ * literal union the allocation routes actually declare (400/404/409/500) so the
+ * shared helper's return composes with each leg's typed response union.
+ */
+export function handleAllocationRouteError(c: Context<Env>, error: unknown) {
+  if (error instanceof AllocationServiceError) {
+    return c.json(
+      {
+        error: error.message,
+        ...(error.detail ? { detail: error.detail } : {}),
+      },
+      error.status as 400 | 404 | 409 | 500,
+    )
+  }
+  throw error
+}
+
+/** One `application/json` error response entry keyed by an explicit status. */
+export const errResponse = (description: string) => ({
+  description,
+  content: { "application/json": { schema: allocationErrorSchema } },
+})
+
+/**
+ * The error statuses `handleAllocationRouteError` can emit (an
+ * `AllocationServiceError` maps to 400/404/409/500). Every leg that funnels
+ * errors through that shared helper declares this full set inline (a spread
+ * collapses the literal status keys `createRoute` needs) so the helper's typed
+ * response union is a subset of each route's declared responses. `400` doubles
+ * as the request-body validation failure surfaced by `openApiValidationHook`.
+ */
+export const allocationErrorResponses = {
+  400: errResponse("invalid_request, or an allocation invariant was violated"),
+  404: errResponse("The slot, traveler, resource, sharing group, or template was not found"),
+  409: errResponse(
+    "Resource over capacity, a revision precondition failed, or the fleet resource is double-booked",
+  ),
+  500: errResponse("The allocation operation could not be completed"),
+}
+
+/** Serialize a CSV body as a `text/csv` attachment via the typed `c.body(...)`. */
+export function csvResponse(c: Context<Env>, csv: string, filename: string) {
+  return c.body(csv, 200, {
+    "Content-Type": "text/csv; charset=utf-8",
+    "Content-Disposition": `attachment; filename="${filename}"`,
+  })
+}

--- a/packages/operations/src/availability/routes-allocation.ts
+++ b/packages/operations/src/availability/routes-allocation.ts
@@ -28,12 +28,21 @@
  */
 
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
-import { openApiValidationHook } from "@voyant-travel/hono"
-import type { Context } from "hono"
+import { idempotencyKey, openApiValidationHook } from "@voyant-travel/hono"
 
+import { availabilityAllocationPlanningRoutes } from "./routes-allocation-planning.js"
+import {
+  allocationErrorResponses,
+  allocationResourceSchema,
+  csvResponse,
+  errorResponseSchema,
+  flagsSchema,
+  handleAllocationRouteError,
+  isoTimestamp,
+  slotIdParamSchema,
+} from "./routes-allocation-shared.js"
 import type { Env } from "./routes-shared.js"
 import {
-  AllocationServiceError,
   assignTravelerAllocation,
   createAllocationResource,
   deleteAllocationResource,
@@ -56,14 +65,17 @@ import {
 } from "./service-allocation-automation.js"
 import {
   allocationExportFilename,
+  allocationExportPrefixForKind,
   buildAllocationPassengersCsv,
   buildAllocationRoomingCsv,
 } from "./service-allocation-exports.js"
 import {
   allocationAuditLogQuerySchema,
   allocationAutomationSchema,
+  allocationKindQuerySchema,
   allocationManifestQuerySchema,
   assignTravelerAllocationSchema,
+  deleteAllocationResourceQuerySchema,
   insertAllocationResourceSchema,
   materializeOpenSlotsSchema,
   pairSharingGroupSchema,
@@ -75,38 +87,15 @@ import {
 
 // --- shared response schemas ------------------------------------------------
 
-const errorResponseSchema = z.object({ error: z.string() })
-/** Allocation service errors serialize `error` + an optional `detail` payload. */
-const allocationErrorSchema = z.object({ error: z.string(), detail: z.unknown().optional() })
-const isoTimestamp = z.string()
-/** Resource `flags` is an untyped jsonb record. */
-const flagsSchema = z.record(z.string(), z.unknown())
-
-const slotIdParamSchema = z.object({ id: z.string() })
 const slotResourceParamSchema = z.object({ id: z.string(), resourceId: z.string() })
 const slotTravelerParamSchema = z.object({ id: z.string(), travelerId: z.string() })
 const slotGroupParamSchema = z.object({ id: z.string(), groupId: z.string() })
 const productIdParamSchema = z.object({ productId: z.string() })
+const allocationExportQuerySchema = allocationKindQuerySchema
 const templateParamSchema = z.object({
   productId: z.string(),
   optionId: z.string(),
   kind: z.string(),
-})
-
-// §17: `allocation_resources.$inferSelect` — timestamps serialize to strings.
-const allocationResourceSchema = z.object({
-  id: z.string(),
-  slotId: z.string(),
-  kind: z.string(),
-  refType: z.string().nullable(),
-  refId: z.string().nullable(),
-  label: z.string().nullable(),
-  capacity: z.number().int(),
-  flags: flagsSchema,
-  parentId: z.string().nullable(),
-  sortOrder: z.number().int(),
-  createdAt: isoTimestamp,
-  updatedAt: isoTimestamp,
 })
 
 /** Trimmed `returning()` projection from delete (id/kind/label/capacity only). */
@@ -226,6 +215,8 @@ const allocationAutomationResultSchema = z.object({
   assigned: z.number().int().optional(),
   skipped: z.number().int().optional(),
   created: z.number().int().optional(),
+  /** Template groups already materialised on this slot and left alone. */
+  skippedExisting: z.number().int().optional(),
   resources: z.array(allocationResourceSchema).optional(),
 })
 
@@ -254,55 +245,6 @@ const productOptionResourceTemplatesSchema = z.object({
   sortOrder: z.number().int(),
   templates: z.array(resourceTemplateSchema),
 })
-
-/**
- * Map an `AllocationServiceError` to its HTTP status (anything else re-throws to
- * the boundary). Returns `c.json(...)` — a typed response — so the `.openapi()`
- * handlers' declared 4xx schemas accept it. The status is narrowed to the
- * literal union the allocation routes actually declare (400/404/409/500) so the
- * shared helper's return composes with each leg's typed response union.
- */
-function handleAllocationRouteError(c: Context<Env>, error: unknown) {
-  if (error instanceof AllocationServiceError) {
-    return c.json(
-      {
-        error: error.message,
-        ...(error.detail ? { detail: error.detail } : {}),
-      },
-      error.status as 400 | 404 | 409 | 500,
-    )
-  }
-  throw error
-}
-
-/** One `application/json` error response entry keyed by an explicit status. */
-const errResponse = (description: string) => ({
-  description,
-  content: { "application/json": { schema: allocationErrorSchema } },
-})
-
-/**
- * The error statuses `handleAllocationRouteError` can emit (an
- * `AllocationServiceError` maps to 400/404/409/500). Every leg that funnels
- * errors through that shared helper declares this full set inline (a spread
- * collapses the literal status keys `createRoute` needs) so the helper's typed
- * response union is a subset of each route's declared responses. `400` doubles
- * as the request-body validation failure surfaced by `openApiValidationHook`.
- */
-const allocationErrorResponses = {
-  400: errResponse("invalid_request, or an allocation invariant was violated"),
-  404: errResponse("The slot, traveler, resource, sharing group, or template was not found"),
-  409: errResponse("Resource over capacity, or resources already exist for this kind"),
-  500: errResponse("The allocation operation could not be completed"),
-}
-
-/** Serialize a CSV body as a `text/csv` attachment via the typed `c.body(...)`. */
-function csvResponse(c: Context<Env>, csv: string, filename: string) {
-  return c.body(csv, 200, {
-    "Content-Type": "text/csv; charset=utf-8",
-    "Content-Disposition": `attachment; filename="${filename}"`,
-  })
-}
 
 // --- slot allocation manifest + resources -----------------------------------
 
@@ -373,7 +315,7 @@ const updateResourceRoute = createRoute({
 const deleteResourceRoute = createRoute({
   method: "delete",
   path: "/slots/{id}/allocation/resources/{resourceId}",
-  request: { params: slotResourceParamSchema },
+  request: { params: slotResourceParamSchema, query: deleteAllocationResourceQuerySchema },
   responses: {
     200: {
       description: "The deleted allocation resource (id/kind/label/capacity)",
@@ -434,8 +376,10 @@ const slotResourceRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidation
   .openapi(deleteResourceRoute, async (c) => {
     try {
       const params = c.req.valid("param")
+      const { expectedUpdatedAt } = c.req.valid("query")
       const row = await deleteAllocationResource(c.get("db"), params.id, params.resourceId, {
         actorId: c.get("userId") ?? null,
+        ...(expectedUpdatedAt !== undefined ? { expectedUpdatedAt } : {}),
       })
       return row
         ? c.json({ data: row }, 200)
@@ -656,10 +600,14 @@ const exportPassengersRoute = createRoute({
 const exportRoomingRoute = createRoute({
   method: "get",
   path: "/slots/{id}/allocation/export-rooming-list",
-  request: { params: slotIdParamSchema },
+  description:
+    "Resource-occupancy CSV for one allocation kind. `kind=vehicle_seat` produces the " +
+    "coach seating manifest; the default `room` produces the rooming list. The CSV " +
+    "builder always took a kind — until now the route never let a caller name one.",
+  request: { params: slotIdParamSchema, query: allocationExportQuerySchema },
   responses: {
     200: {
-      description: "Rooming-list CSV (text/csv attachment)",
+      description: "Rooming-list or seating-manifest CSV (text/csv attachment)",
       content: { "text/csv": { schema: z.string() } },
     },
     404: {
@@ -690,10 +638,11 @@ const slotAuditExportRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidat
   .openapi(exportRoomingRoute, async (c) => {
     const manifest = await getSlotAllocationManifest(c.get("db"), c.req.valid("param").id)
     if (!manifest) return c.json({ error: "Availability slot not found" }, 404)
+    const { kind } = c.req.valid("query")
     return csvResponse(
       c,
-      buildAllocationRoomingCsv(manifest),
-      allocationExportFilename(manifest, "rooming"),
+      buildAllocationRoomingCsv(manifest, kind),
+      allocationExportFilename(manifest, allocationExportPrefixForKind(kind)),
     )
   })
 
@@ -702,6 +651,11 @@ const slotAuditExportRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidat
 const autoMaterializeRoute = createRoute({
   method: "post",
   path: "/slots/{id}/allocation/auto-materialize",
+  description:
+    "Materialise resources for this kind from the option's templates, sized to the pax " +
+    "already booked. Idempotent: template groups that already have resources on this " +
+    "slot are skipped and reported in `skippedExisting`, so a retry is a no-op rather " +
+    "than a 409.",
   request: {
     params: slotIdParamSchema,
     body: {
@@ -726,13 +680,21 @@ const autoMaterializeRoute = createRoute({
 const materializeTemplatesRoute = createRoute({
   method: "post",
   path: "/slots/{id}/allocation/materialize-templates",
+  description:
+    "Lay this departure out from its option's template `default_count`s, before any " +
+    "sale. `vehicle_seat` templates count vehicles and draw each one's full seat map.",
   request: { params: slotIdParamSchema },
   responses: {
     200: {
       description: "The count of resources materialised from the slot's template defaults",
       content: {
         "application/json": {
-          schema: z.object({ data: z.object({ created: z.number().int() }) }),
+          schema: z.object({
+            data: z.object({
+              created: z.number().int(),
+              skippedExisting: z.number().int(),
+            }),
+          }),
         },
       },
     },
@@ -768,6 +730,20 @@ const autoAllocateRoute = createRoute({
 })
 
 const slotAutomationRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidationHook })
+
+// Auto-allocate re-plans from live state, so a retry after a dropped connection
+// is *not* the same operation twice. An `Idempotency-Key` makes it replayable;
+// the header stays optional so existing clients are unaffected.
+slotAutomationRoutes.use(
+  "/slots/:id/allocation/auto-allocate",
+  idempotencyKey({ scope: "operations.allocation.auto-allocate" }),
+)
+slotAutomationRoutes.use(
+  "/slots/:id/allocation/auto-materialize",
+  idempotencyKey({ scope: "operations.allocation.auto-materialize" }),
+)
+
+slotAutomationRoutes
   .openapi(autoMaterializeRoute, async (c) => {
     try {
       const data = await autoMaterializeAllocationResources(
@@ -787,7 +763,10 @@ const slotAutomationRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidati
         c.get("db"),
         c.req.valid("param").id,
       )
-      return c.json({ data: { created: result.created } }, 200)
+      return c.json(
+        { data: { created: result.created, skippedExisting: result.skippedExisting } },
+        200,
+      )
     } catch (error) {
       return handleAllocationRouteError(c, error)
     }
@@ -963,3 +942,4 @@ export const availabilityAllocationRoutes = new OpenAPIHono<Env>({
   .route("/", slotAuditExportRoutes)
   .route("/", slotAutomationRoutes)
   .route("/", templateRoutes)
+  .route("/", availabilityAllocationPlanningRoutes)

--- a/packages/operations/src/availability/service-allocation-assignment-batch.ts
+++ b/packages/operations/src/availability/service-allocation-assignment-batch.ts
@@ -1,0 +1,271 @@
+/**
+ * Batch traveler↔resource assignment.
+ *
+ * The per-traveler `PATCH .../travelers/{travelerId}` leg is one traveler per
+ * request per transaction, so moving a sharing group of four meant four
+ * requests: any of them could fail and leave a family half-placed, and the
+ * capacity guard saw each move in isolation. This places a whole set inside one
+ * transaction behind the same `FOR UPDATE` over the kind's resources that
+ * auto-allocate takes, so a batch and an auto-allocate can never interleave.
+ *
+ * `validateSlotAllocationCapacity` runs *after* the writes and inside the same
+ * transaction: it excludes the travelers being re-planned from the existing
+ * count, so running it post-write is what lets a batch that frees a bed and
+ * fills it in the same call pass, while a batch that oversells rolls back whole.
+ */
+
+import { sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import { activeBookingAllocationStatusesSql, activeBookingStatusesSql } from "./booking-statuses.js"
+import type { AllocationMutationOptions } from "./service-allocation.js"
+import { recordAllocationAudit } from "./service-allocation-audit.js"
+import { AllocationServiceError } from "./service-allocation-errors.js"
+import {
+  type PlannedAllocation,
+  validateSlotAllocationCapacity,
+} from "./service-allocation-resource-capacity.js"
+import { executeRows, sqlTextArray } from "./service-allocation-sql.js"
+
+export interface BatchAllocationAssignment {
+  travelerId: string
+  /** Target resource, or `null` to unassign the traveler from this kind. */
+  resourceId: string | null
+  /**
+   * Optimistic-concurrency precondition: the resource the caller believed this
+   * traveler held. Omit to skip the check; pass `null` to require the traveler
+   * to be currently unassigned. A mismatch rejects the whole batch with 409.
+   */
+  expectedResourceId?: string | null
+}
+
+export interface AssignTravelerAllocationsBatchInput {
+  kind: string
+  assignments: BatchAllocationAssignment[]
+}
+
+export interface AssignTravelerAllocationsBatchResult {
+  kind: string
+  assigned: number
+  unassigned: number
+  /** Assignments whose target already matched — written anyway, counted here. */
+  unchanged: number
+  travelerIds: string[]
+}
+
+export async function assignTravelerAllocationsBatch(
+  db: PostgresJsDatabase,
+  slotId: string,
+  input: AssignTravelerAllocationsBatchInput,
+  options: AllocationMutationOptions = {},
+): Promise<AssignTravelerAllocationsBatchResult> {
+  const { kind, assignments } = input
+  if (assignments.length === 0) {
+    throw new AllocationServiceError("A batch assignment needs at least one traveler", 400)
+  }
+  const travelerIds = assignments.map((assignment) => assignment.travelerId)
+  if (new Set(travelerIds).size !== travelerIds.length) {
+    throw new AllocationServiceError("A traveler may appear only once in a batch", 400)
+  }
+  if (kind === "vehicle" && assignments.some((assignment) => assignment.resourceId !== null)) {
+    throw new AllocationServiceError(
+      "Vehicles are parent resources; assign travelers to vehicle seats instead",
+      400,
+    )
+  }
+
+  return db.transaction(async (tx) => {
+    const scoped = tx as PostgresJsDatabase
+
+    // Same lock statement `autoAllocateSlotResources` takes, so a batch and an
+    // auto-allocate serialize against each other rather than racing.
+    await scoped.execute(sql`
+      SELECT id
+      FROM allocation_resources
+      WHERE slot_id = ${slotId} AND kind = ${kind}
+      FOR UPDATE
+    `)
+
+    await assertTravelersBelongToSlot(scoped, slotId, travelerIds)
+    const targetResourceIds = [
+      ...new Set(
+        assignments.flatMap((assignment) => (assignment.resourceId ? [assignment.resourceId] : [])),
+      ),
+    ]
+    await assertResourcesBelongToSlot(scoped, slotId, kind, targetResourceIds)
+
+    const before = await loadCurrentAllocations(scoped, travelerIds, kind)
+    assertExpectedResourceIds(assignments, before)
+
+    await scoped.execute(sql`
+      INSERT INTO booking_traveler_travel_details (traveler_id)
+      SELECT id FROM unnest(${sqlTextArray(travelerIds)}) AS u(id)
+      ON CONFLICT (traveler_id) DO NOTHING
+    `)
+
+    const assigned = assignments.filter(
+      (assignment): assignment is BatchAllocationAssignment & { resourceId: string } =>
+        assignment.resourceId !== null,
+    )
+    const cleared = assignments.filter((assignment) => assignment.resourceId === null)
+
+    if (assigned.length > 0) {
+      await scoped.execute(sql`
+        UPDATE booking_traveler_travel_details btd
+        SET allocations =
+              COALESCE(btd.allocations, '{}'::jsonb)
+              || jsonb_build_object(${kind}::text, plan.resource_id::text),
+            updated_at = now()
+        FROM unnest(
+          ${sqlTextArray(assigned.map((assignment) => assignment.travelerId))},
+          ${sqlTextArray(assigned.map((assignment) => assignment.resourceId))}
+        ) AS plan(traveler_id, resource_id)
+        WHERE btd.traveler_id = plan.traveler_id
+      `)
+    }
+    if (cleared.length > 0) {
+      await scoped.execute(sql`
+        UPDATE booking_traveler_travel_details
+        SET allocations = COALESCE(allocations, '{}'::jsonb) - ${kind}::text,
+            updated_at = now()
+        WHERE traveler_id = ANY(${sqlTextArray(cleared.map((assignment) => assignment.travelerId))})
+      `)
+    }
+
+    const planned: PlannedAllocation[] = assigned.map((assignment) => ({
+      travelerId: assignment.travelerId,
+      kind,
+      resourceId: assignment.resourceId,
+    }))
+    const violations = await validateSlotAllocationCapacity(scoped, slotId, planned)
+    if (violations.length > 0) {
+      throw new AllocationServiceError("Resource over capacity", 409, { kind, violations })
+    }
+
+    // Audit inside the transaction: a rolled-back batch must not leave an entry
+    // claiming the family was moved.
+    await recordAllocationAudit(scoped, {
+      slotId,
+      action: "traveler.assign.batch",
+      actorId: options.actorId ?? null,
+      before: {
+        kind,
+        assignments: assignments.map((assignment) => ({
+          travelerId: assignment.travelerId,
+          resourceId: before.get(assignment.travelerId) ?? null,
+        })),
+      },
+      after: {
+        kind,
+        assignments: assignments.map((assignment) => ({
+          travelerId: assignment.travelerId,
+          resourceId: assignment.resourceId,
+        })),
+      },
+    })
+
+    const unchanged = assignments.filter(
+      (assignment) => (before.get(assignment.travelerId) ?? null) === assignment.resourceId,
+    ).length
+
+    return {
+      kind,
+      assigned: assigned.length,
+      unassigned: cleared.length,
+      unchanged,
+      travelerIds,
+    }
+  })
+}
+
+async function assertTravelersBelongToSlot(
+  db: PostgresJsDatabase,
+  slotId: string,
+  travelerIds: readonly string[],
+): Promise<void> {
+  const rows = await executeRows<{ id: string }>(
+    db,
+    sql`
+      SELECT DISTINCT bt.id
+      FROM booking_travelers bt
+      JOIN booking_allocations ba ON ba.booking_id = bt.booking_id
+      JOIN bookings b ON b.id = bt.booking_id
+      WHERE bt.id = ANY(${sqlTextArray([...travelerIds])})
+        AND ba.availability_slot_id = ${slotId}
+        AND b.status IN (${activeBookingStatusesSql()})
+        AND ba.status IN (${activeBookingAllocationStatusesSql()})
+    `,
+  )
+  const found = new Set(rows.map((row) => row.id))
+  const missing = travelerIds.filter((id) => !found.has(id))
+  if (missing.length > 0) {
+    throw new AllocationServiceError("Traveler not found for this slot", 404, {
+      travelerIds: missing,
+    })
+  }
+}
+
+async function assertResourcesBelongToSlot(
+  db: PostgresJsDatabase,
+  slotId: string,
+  kind: string,
+  resourceIds: readonly string[],
+): Promise<void> {
+  if (resourceIds.length === 0) return
+  const rows = await executeRows<{ id: string }>(
+    db,
+    sql`
+      SELECT id
+      FROM allocation_resources
+      WHERE slot_id = ${slotId}
+        AND kind = ${kind}
+        AND id = ANY(${sqlTextArray([...resourceIds])})
+    `,
+  )
+  const found = new Set(rows.map((row) => row.id))
+  const missing = resourceIds.filter((id) => !found.has(id))
+  if (missing.length > 0) {
+    throw new AllocationServiceError("Resource not found for this slot/kind", 404, {
+      resourceIds: missing,
+    })
+  }
+}
+
+async function loadCurrentAllocations(
+  db: PostgresJsDatabase,
+  travelerIds: readonly string[],
+  kind: string,
+): Promise<Map<string, string | null>> {
+  const rows = await executeRows<{ traveler_id: string; resource_id: string | null }>(
+    db,
+    sql`
+      SELECT traveler_id, allocations ->> ${kind} AS resource_id
+      FROM booking_traveler_travel_details
+      WHERE traveler_id = ANY(${sqlTextArray([...travelerIds])})
+    `,
+  )
+  return new Map(rows.map((row) => [row.traveler_id, row.resource_id]))
+}
+
+function assertExpectedResourceIds(
+  assignments: readonly BatchAllocationAssignment[],
+  before: ReadonlyMap<string, string | null>,
+): void {
+  const conflicts = assignments.flatMap((assignment) => {
+    if (assignment.expectedResourceId === undefined) return []
+    const current = before.get(assignment.travelerId) ?? null
+    if (current === assignment.expectedResourceId) return []
+    return [
+      {
+        travelerId: assignment.travelerId,
+        expectedResourceId: assignment.expectedResourceId,
+        currentResourceId: current,
+      },
+    ]
+  })
+  if (conflicts.length === 0) return
+  throw new AllocationServiceError("Traveler allocation changed after it was read", 409, {
+    reason: "revision_conflict",
+    conflicts,
+  })
+}

--- a/packages/operations/src/availability/service-allocation-auto-allocate.ts
+++ b/packages/operations/src/availability/service-allocation-auto-allocate.ts
@@ -1,0 +1,322 @@
+/**
+ * Auto-allocation: turning a departure's travelers and resources into a plan,
+ * previewing it, and committing it.
+ *
+ * Split out of `service-allocation-automation.ts`, which now owns
+ * materialisation only. The two halves share nothing but the allocator.
+ */
+
+import type { AllocationResource } from "@voyant-travel/availability/schema"
+import { sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import type { z } from "zod"
+
+import {
+  type AllocatorResource,
+  type AllocatorTraveler,
+  planRoomAllocation,
+  planVehicleSeatAllocation,
+} from "./auto-allocator.js"
+import { activeBookingAllocationStatusesSql, activeBookingStatusesSql } from "./booking-statuses.js"
+import {
+  type AllocationMutationOptions,
+  getSlotAllocationManifest,
+  recordAllocationAudit,
+  type SlotAllocationManifest,
+} from "./service-allocation.js"
+import { AllocationServiceError } from "./service-allocation-errors.js"
+import {
+  type ResourceCapacityViolation,
+  validateSlotAllocationCapacity,
+} from "./service-allocation-resource-capacity.js"
+import { executeRows, sqlTextArray } from "./service-allocation-sql.js"
+import type { allocationAutomationSchema } from "./validation.js"
+
+export type AllocationAutomationInput = z.infer<typeof allocationAutomationSchema>
+
+export interface AllocationAutomationResult {
+  kind: string
+  assigned?: number
+  skipped?: number
+  created?: number
+  /**
+   * Template groups that already had resources on this slot and were left
+   * alone. Both materialisation paths report it, so a retry is visibly a
+   * no-op rather than an error.
+   */
+  skippedExisting?: number
+  resources?: AllocationResource[]
+}
+
+export interface AllocationPlanEntry {
+  travelerId: string
+  travelerName: string
+  bookingId: string
+  bookingNumber: string
+  sharingGroupId: string | null
+  resourceId: string
+  resourceLabel: string | null
+  /** The resource the traveler holds today; `null` when unassigned. */
+  currentResourceId: string | null
+  /** `true` when the plan would leave the traveler exactly where they are. */
+  unchanged: boolean
+}
+
+export interface AllocationPlanPreview {
+  kind: string
+  assigned: number
+  skipped: number
+  /** Entries the plan would write, in allocator order. */
+  entries: AllocationPlanEntry[]
+  /**
+   * Capacity violations the plan would create. Always empty in practice — the
+   * plan is computed under the same lock the writer takes — but returned so a
+   * caller can render the backstop rather than trusting it silently.
+   */
+  violations: ResourceCapacityViolation[]
+}
+
+/**
+ * Dry-run auto-allocation: compute the plan and hand it back **without
+ * writing**. The transaction is opened so `validateSlotAllocationCapacity`'s
+ * `FOR UPDATE` spans the whole check, and it commits having changed nothing.
+ *
+ * This is the first production caller of `validateSlotAllocationCapacity`,
+ * which shipped exported and unused.
+ */
+export async function previewAutoAllocateSlotResources(
+  db: PostgresJsDatabase,
+  slotId: string,
+  input: AllocationAutomationInput,
+): Promise<AllocationPlanPreview> {
+  const kind = input.kind ?? "room"
+
+  return db.transaction(async (tx) => {
+    const scoped = tx as PostgresJsDatabase
+    const manifest = await getSlotAllocationManifest(scoped, slotId)
+    if (!manifest) throw new AllocationServiceError("Availability slot not found", 404)
+
+    const resources = manifest.resources.filter((resource) => resource.kind === kind)
+    if (resources.length === 0) {
+      throw new AllocationServiceError("No resources for this allocation kind", 400, { kind })
+    }
+
+    const travelers = toAllocatorTravelers(manifest, kind)
+    const planned =
+      kind === "vehicle_seat"
+        ? planVehicleSeatAllocation(travelers, resources.map(toAllocatorResource))
+        : planRoomAllocation(travelers, resources.map(toAllocatorResource))
+
+    const resourceLabelById = new Map(resources.map((resource) => [resource.id, resource.label]))
+    const travelerById = new Map(
+      manifest.bookings.flatMap((booking) =>
+        booking.travelers.map((traveler) => [traveler.id, { traveler, booking }] as const),
+      ),
+    )
+
+    const entries = planned.assignments.flatMap((assignment): AllocationPlanEntry[] => {
+      const found = travelerById.get(assignment.travelerId)
+      if (!found) return []
+      const currentResourceId = found.traveler.allocations[kind] ?? null
+      return [
+        {
+          travelerId: assignment.travelerId,
+          travelerName: found.traveler.fullName,
+          bookingId: found.booking.id,
+          bookingNumber: found.booking.bookingNumber,
+          sharingGroupId: found.traveler.sharingGroupId,
+          resourceId: assignment.resourceId,
+          resourceLabel: resourceLabelById.get(assignment.resourceId) ?? null,
+          currentResourceId,
+          unchanged: currentResourceId === assignment.resourceId,
+        },
+      ]
+    })
+
+    const violations = await validateSlotAllocationCapacity(
+      scoped,
+      slotId,
+      planned.assignments.map((assignment) => ({ ...assignment, kind })),
+    )
+
+    return {
+      kind,
+      assigned: planned.assignments.length,
+      skipped: planned.skipped,
+      entries,
+      violations,
+    }
+  })
+}
+
+export async function autoAllocateSlotResources(
+  db: PostgresJsDatabase,
+  slotId: string,
+  input: AllocationAutomationInput,
+  options: AllocationMutationOptions = {},
+): Promise<AllocationAutomationResult> {
+  const kind = input.kind ?? "room"
+
+  // The capacity invariant lives in the *decision*, not in the write, so the
+  // manifest read, the plan and the upsert all sit inside one transaction
+  // behind the same `FOR UPDATE` over the slot's resources of this kind.
+  // Planning from a snapshot taken before the lock let a manual assignment
+  // (or a second auto-allocate) land in between; the plan was then applied
+  // verbatim and could push a resource past its capacity with no conflict
+  // raised. Serialising the writes alone never serialised the decision.
+  const plan = await db.transaction(async (tx) => {
+    const scoped = tx as PostgresJsDatabase
+
+    await scoped.execute(sql`
+      SELECT id
+      FROM allocation_resources
+      WHERE slot_id = ${slotId} AND kind = ${kind}
+      FOR UPDATE
+    `)
+
+    const manifest = await getSlotAllocationManifest(scoped, slotId)
+    if (!manifest) throw new AllocationServiceError("Availability slot not found", 404)
+
+    const resources = manifest.resources.filter((resource) => resource.kind === kind)
+    if (resources.length === 0) {
+      throw new AllocationServiceError("No resources for this allocation kind", 400, { kind })
+    }
+
+    const travelers = toAllocatorTravelers(manifest, kind)
+    const allocatorResources = resources.map(toAllocatorResource)
+    const planned =
+      kind === "vehicle_seat"
+        ? planVehicleSeatAllocation(travelers, allocatorResources)
+        : planRoomAllocation(travelers, allocatorResources)
+
+    if (planned.assignments.length > 0) {
+      const travelerIds = planned.assignments.map((assignment) => assignment.travelerId)
+      const resourceIds = planned.assignments.map((assignment) => assignment.resourceId)
+      await scoped.execute(sql`
+        INSERT INTO booking_traveler_travel_details (traveler_id, allocations)
+        SELECT
+          row.traveler_id,
+          jsonb_build_object(${kind}::text, row.resource_id::text)
+        FROM unnest(${sqlTextArray(travelerIds)}, ${sqlTextArray(resourceIds)}) AS row(traveler_id, resource_id)
+        ON CONFLICT (traveler_id) DO UPDATE SET
+          allocations =
+            COALESCE(booking_traveler_travel_details.allocations, '{}'::jsonb)
+            || EXCLUDED.allocations,
+          updated_at = now()
+      `)
+      await assertPlannedResourcesWithinCapacity(scoped, slotId, kind, resourceIds)
+    }
+
+    // Audit inside the transaction. A rolled-back allocation must not leave a
+    // record claiming travelers were placed, and an audit insert that fails
+    // must take the allocation with it — see #4164.
+    await recordAllocationAudit(scoped, {
+      slotId,
+      action: "auto-allocate",
+      actorId: options.actorId ?? null,
+      after: { kind, assigned: planned.assignments.length, skipped: planned.skipped },
+    })
+
+    return planned
+  })
+
+  return { kind, assigned: plan.assignments.length, skipped: plan.skipped }
+}
+
+/**
+ * Post-write invariant check for the resources an auto-allocate plan
+ * touched. Re-planning under the lock already keeps the plan inside
+ * capacity, so this is a backstop against an allocator regression rather
+ * than the primary guard -- it runs inside the writing transaction, so a
+ * violation rolls the whole plan back instead of shipping an oversold slot.
+ * One aggregate query over the planned resources only: an unrelated
+ * resource that was already over capacity must not block the operator.
+ */
+async function assertPlannedResourcesWithinCapacity(
+  db: PostgresJsDatabase,
+  slotId: string,
+  kind: string,
+  resourceIds: string[],
+): Promise<void> {
+  const overflowing = await executeRows<{
+    id: string
+    label: string | null
+    capacity: number
+    assigned: number
+  }>(
+    db,
+    sql`
+      SELECT ar.id, ar.label, ar.capacity, usage.assigned
+      FROM allocation_resources ar
+      JOIN LATERAL (
+        SELECT COUNT(DISTINCT btd.traveler_id)::int AS assigned
+        FROM booking_traveler_travel_details btd
+        JOIN booking_travelers bt ON bt.id = btd.traveler_id
+        JOIN booking_allocations ba ON ba.booking_id = bt.booking_id
+        JOIN bookings b ON b.id = bt.booking_id
+        WHERE btd.allocations ->> ar.kind = ar.id
+          AND ba.availability_slot_id = ar.slot_id
+          AND b.status IN (${activeBookingStatusesSql()})
+          AND ba.status IN (${activeBookingAllocationStatusesSql()})
+      ) usage ON true
+      WHERE ar.slot_id = ${slotId}
+        AND ar.kind = ${kind}
+        AND ar.id = ANY(${sqlTextArray([...new Set(resourceIds)])})
+        AND usage.assigned > ar.capacity
+    `,
+  )
+
+  if (overflowing.length === 0) return
+
+  throw new AllocationServiceError("Resource over capacity", 409, {
+    kind,
+    resources: overflowing.map((resource) => ({
+      id: resource.id,
+      label: resource.label,
+      capacity: resource.capacity,
+      assigned: resource.assigned,
+    })),
+  })
+}
+
+function toAllocatorTravelers(manifest: SlotAllocationManifest, kind: string): AllocatorTraveler[] {
+  const travelers: AllocatorTraveler[] = []
+  for (const booking of manifest.bookings) {
+    for (const traveler of booking.travelers) {
+      travelers.push({
+        id: traveler.id,
+        bookingId: booking.id,
+        bookingStatus: booking.status,
+        isLeadTraveler: traveler.isLeadTraveler,
+        sharingGroupId: traveler.sharingGroupId,
+        hasAccessibilityNeeds: traveler.hasAccessibilityNeeds,
+        existingAllocationId: traveler.allocations[kind] ?? null,
+        optionId: traveler.optionId,
+        optionUnitId: traveler.optionUnitId,
+        optionUnitCode: traveler.optionUnitCode,
+      })
+    }
+  }
+  return travelers
+}
+
+function toAllocatorResource(resource: AllocationResource): AllocatorResource {
+  return {
+    id: resource.id,
+    kind: resource.kind,
+    capacity: resource.capacity,
+    flags: resource.flags ?? {},
+    parentId: resource.parentId,
+    refType: resource.refType,
+    refId: resource.refId,
+    label: resource.label,
+    row: typeof resource.flags?.row === "number" ? resource.flags.row : undefined,
+    column: typeof resource.flags?.column === "string" ? resource.flags.column : undefined,
+    position:
+      resource.flags?.position === "window" ||
+      resource.flags?.position === "aisle" ||
+      resource.flags?.position === "middle"
+        ? resource.flags.position
+        : undefined,
+  }
+}

--- a/packages/operations/src/availability/service-allocation-automation.ts
+++ b/packages/operations/src/availability/service-allocation-automation.ts
@@ -6,30 +6,28 @@ import {
 } from "@voyant-travel/availability/schema"
 import { and, eq, inArray, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
-import type { z } from "zod"
-import {
-  type AllocatorResource,
-  type AllocatorTraveler,
-  planRoomAllocation,
-  planVehicleSeatAllocation,
-} from "./auto-allocator.js"
 import { activeBookingAllocationStatusesSql, activeBookingStatusesSql } from "./booking-statuses.js"
-import {
-  type AllocationMutationOptions,
-  getSlotAllocationManifest,
-  recordAllocationAudit,
-  type SlotAllocationManifest,
-} from "./service-allocation.js"
+import { type AllocationMutationOptions, recordAllocationAudit } from "./service-allocation.js"
+import type {
+  AllocationAutomationInput,
+  AllocationAutomationResult,
+} from "./service-allocation-auto-allocate.js"
 import { AllocationServiceError } from "./service-allocation-errors.js"
-import { executeRows, sqlTextArray } from "./service-allocation-sql.js"
+import { executeRows } from "./service-allocation-sql.js"
 import {
   type AutoMaterializeRow,
   materializeVehicleSeatGroupInTransaction,
   renderNamePattern,
 } from "./service-allocation-vehicle-materialization.js"
-import type { allocationAutomationSchema } from "./validation.js"
 
-export type AllocationAutomationInput = z.infer<typeof allocationAutomationSchema>
+export {
+  type AllocationAutomationInput,
+  type AllocationAutomationResult,
+  type AllocationPlanEntry,
+  type AllocationPlanPreview,
+  autoAllocateSlotResources,
+  previewAutoAllocateSlotResources,
+} from "./service-allocation-auto-allocate.js"
 export type {
   ProductOptionResourceTemplates,
   ResourceTemplate,
@@ -45,42 +43,74 @@ export {
   positionFromCells,
 } from "./service-allocation-vehicle-materialization.js"
 
-export interface AllocationAutomationResult {
-  kind: string
-  assigned?: number
-  skipped?: number
-  created?: number
-  resources?: AllocationResource[]
-}
-
+/**
+ * ## Idempotency
+ *
+ * This used to raise `409 Resources already exist` the moment the slot held a
+ * single resource of the requested kind, while
+ * {@link materializeSlotResourcesFromTemplateDefaults} silently skipped. Two
+ * routes over the same table disagreed on what "already done" means, and a
+ * retried request — the normal outcome of a dropped connection — surfaced as an
+ * error the operator had to interpret.
+ *
+ * Both paths now agree on **skip-existing at (kind, ref) granularity**:
+ * materialising is a converge-to-this-layout operation, so calling it twice
+ * leaves the same rows and reports `created: 0, skippedExisting: n`. Skipping
+ * was chosen over erroring because it is the only one of the two that is safe
+ * to retry, and because per-(kind, ref) granularity lets a second room type
+ * materialise later without the whole kind being considered done — the coarser
+ * "any row of this kind exists" rule blocked exactly that.
+ *
+ * Replacing an existing layout stays an explicit operator action: delete the
+ * resources, then materialise again.
+ */
 export async function autoMaterializeAllocationResources(
   db: PostgresJsDatabase,
   slotId: string,
   input: AllocationAutomationInput,
   options: AllocationMutationOptions = {},
 ): Promise<AllocationAutomationResult> {
-  const result = await db.transaction(async (tx) => {
-    const materialized = await autoMaterializeAllocationResourcesLocked(
-      tx as PostgresJsDatabase,
-      slotId,
-      input,
-    )
-
-    // Audit inside the transaction so the materialised resources and
-    // their record commit or roll back together.
-    if ((materialized.created ?? 0) > 0) {
-      await recordAllocationAudit(tx, {
+  return db.transaction(async (tx) => {
+    const scoped = tx as PostgresJsDatabase
+    const result = await autoMaterializeAllocationResourcesLocked(scoped, slotId, input)
+    if ((result.created ?? 0) > 0) {
+      // Inside the transaction: a rolled-back materialisation must not leave an
+      // audit entry claiming rooms were laid out.
+      await recordAllocationAudit(scoped, {
         slotId,
         action: "resources.materialize",
         actorId: options.actorId ?? null,
-        after: { kind: materialized.kind, created: materialized.created ?? 0 },
+        after: {
+          kind: result.kind,
+          created: result.created ?? 0,
+          skippedExisting: result.skippedExisting ?? 0,
+        },
       })
     }
-
-    return materialized
+    return result
   })
+}
 
-  return result
+/**
+ * Existing `(kind, ref_id)` pairs on a slot. Both materialisation paths key
+ * their skip decision on the pair they are about to write, so a template that
+ * targets a second option unit still materialises while the first is left
+ * alone.
+ */
+async function loadExistingResourceKeys(
+  db: PostgresJsDatabase,
+  slotId: string,
+): Promise<Set<string>> {
+  const rows = await executeRows<{ kind: string; ref_id: string | null }>(
+    db,
+    // agent-quality: raw-sql reviewed -- owner: availability; dynamic SQL interpolation uses Drizzle parameter binding or vetted SQL identifiers.
+    sql`SELECT DISTINCT kind, ref_id FROM allocation_resources WHERE slot_id = ${slotId}`,
+  )
+  return new Set(rows.map((row) => resourceKey(row.kind, row.ref_id)))
+}
+
+function resourceKey(kind: string, refId: string | null | undefined): string {
+  return `${kind}::${refId ?? ""}`
 }
 
 async function autoMaterializeAllocationResourcesLocked(
@@ -97,19 +127,7 @@ async function autoMaterializeAllocationResourcesLocked(
     .limit(1)
   if (!slot) throw new AllocationServiceError("Availability slot not found", 404)
 
-  const existing = await executeRows<{ count: number }>(
-    db,
-    sql`
-      SELECT COUNT(*)::int AS count
-      FROM allocation_resources
-      WHERE slot_id = ${slotId} AND kind = ${kind}
-    `,
-  )
-  if ((existing[0]?.count ?? 0) > 0) {
-    throw new AllocationServiceError("Resources already exist", 409, {
-      detail: "Delete existing resources before re-materializing, or add new ones manually.",
-    })
-  }
+  const existingKeys = await loadExistingResourceKeys(db, slotId)
 
   const groups = await executeRows<AutoMaterializeRow>(
     db,
@@ -153,12 +171,17 @@ async function autoMaterializeAllocationResourcesLocked(
     `,
   )
 
-  if (groups.length === 0) return { kind, created: 0, resources: [] }
+  if (groups.length === 0) return { kind, created: 0, skippedExisting: 0, resources: [] }
 
   const created: AllocationResource[] = []
   let sequence = 0
+  let skippedExisting = 0
   for (const group of groups) {
     if (kind === "vehicle_seat") {
+      if (existingKeys.has(resourceKey(kind, group.ref_id))) {
+        skippedExisting += 1
+        continue
+      }
       const vehicleResources = await materializeVehicleSeatGroupInTransaction(
         db,
         slotId,
@@ -167,18 +190,24 @@ async function autoMaterializeAllocationResourcesLocked(
       )
       sequence += vehicleResources.vehicleCount
       created.push(...vehicleResources.resources)
+      existingKeys.add(resourceKey(kind, group.ref_id))
+      continue
+    }
+
+    // Default the resource's ref to its materializing option so the UI
+    // can badge each row with the option name (e.g. Standard double).
+    // Templates that explicitly set ref_type/ref_id (e.g. pointing at a
+    // hotel inventory row) keep their own values.
+    const resolvedRefType = group.ref_type ?? "option"
+    const resolvedRefId = group.ref_id ?? group.option_id
+    if (existingKeys.has(resourceKey(kind, resolvedRefId))) {
+      skippedExisting += 1
       continue
     }
 
     const unitsNeeded = Math.max(1, Math.ceil(group.pax_count / Math.max(1, group.capacity)))
     for (let index = 0; index < unitsNeeded; index++) {
       sequence += 1
-      // Default the resource's ref to its materializing option so the UI
-      // can badge each row with the option name (e.g. Standard double).
-      // Templates that explicitly set ref_type/ref_id (e.g. pointing at a
-      // hotel inventory row) keep their own values.
-      const resolvedRefType = group.ref_type ?? "option"
-      const resolvedRefId = group.ref_id ?? group.option_id
       const [row] = await db
         .insert(allocationResources)
         .values({
@@ -198,139 +227,10 @@ async function autoMaterializeAllocationResourcesLocked(
         .returning()
       if (row) created.push(row)
     }
+    existingKeys.add(resourceKey(kind, resolvedRefId))
   }
 
-  return { kind, created: created.length, resources: created }
-}
-
-export async function autoAllocateSlotResources(
-  db: PostgresJsDatabase,
-  slotId: string,
-  input: AllocationAutomationInput,
-  options: AllocationMutationOptions = {},
-): Promise<AllocationAutomationResult> {
-  const kind = input.kind ?? "room"
-
-  // The capacity invariant lives in the *decision*, not in the write, so the
-  // manifest read, the plan and the upsert all sit inside one transaction
-  // behind the same `FOR UPDATE` over the slot's resources of this kind.
-  // Planning from a snapshot taken before the lock let a manual assignment
-  // (or a second auto-allocate) land in between; the plan was then applied
-  // verbatim and could push a resource past its capacity with no conflict
-  // raised. Serialising the writes alone never serialised the decision.
-  const plan = await db.transaction(async (tx) => {
-    const scoped = tx as PostgresJsDatabase
-
-    await scoped.execute(sql`
-      SELECT id
-      FROM allocation_resources
-      WHERE slot_id = ${slotId} AND kind = ${kind}
-      FOR UPDATE
-    `)
-
-    const manifest = await getSlotAllocationManifest(scoped, slotId)
-    if (!manifest) throw new AllocationServiceError("Availability slot not found", 404)
-
-    const resources = manifest.resources.filter((resource) => resource.kind === kind)
-    if (resources.length === 0) {
-      throw new AllocationServiceError("No resources for this allocation kind", 400, { kind })
-    }
-
-    const travelers = toAllocatorTravelers(manifest, kind)
-    const allocatorResources = resources.map(toAllocatorResource)
-    const planned =
-      kind === "vehicle_seat"
-        ? planVehicleSeatAllocation(travelers, allocatorResources)
-        : planRoomAllocation(travelers, allocatorResources)
-
-    if (planned.assignments.length > 0) {
-      const travelerIds = planned.assignments.map((assignment) => assignment.travelerId)
-      const resourceIds = planned.assignments.map((assignment) => assignment.resourceId)
-      await scoped.execute(sql`
-        INSERT INTO booking_traveler_travel_details (traveler_id, allocations)
-        SELECT
-          row.traveler_id,
-          jsonb_build_object(${kind}::text, row.resource_id::text)
-        FROM unnest(${sqlTextArray(travelerIds)}, ${sqlTextArray(resourceIds)}) AS row(traveler_id, resource_id)
-        ON CONFLICT (traveler_id) DO UPDATE SET
-          allocations =
-            COALESCE(booking_traveler_travel_details.allocations, '{}'::jsonb)
-            || EXCLUDED.allocations,
-          updated_at = now()
-      `)
-      await assertPlannedResourcesWithinCapacity(scoped, slotId, kind, resourceIds)
-    }
-
-    // Audit inside the transaction so the applied plan and its record
-    // commit or roll back together — PR #4139 moved planning and writing
-    // in here but left the audit outside.
-    await recordAllocationAudit(tx, {
-      slotId,
-      action: "auto-allocate",
-      actorId: options.actorId ?? null,
-      after: { kind, assigned: planned.assignments.length, skipped: planned.skipped },
-    })
-
-    return planned
-  })
-
-  return { kind, assigned: plan.assignments.length, skipped: plan.skipped }
-}
-
-/**
- * Post-write invariant check for the resources an auto-allocate plan
- * touched. Re-planning under the lock already keeps the plan inside
- * capacity, so this is a backstop against an allocator regression rather
- * than the primary guard -- it runs inside the writing transaction, so a
- * violation rolls the whole plan back instead of shipping an oversold slot.
- * One aggregate query over the planned resources only: an unrelated
- * resource that was already over capacity must not block the operator.
- */
-async function assertPlannedResourcesWithinCapacity(
-  db: PostgresJsDatabase,
-  slotId: string,
-  kind: string,
-  resourceIds: string[],
-): Promise<void> {
-  const overflowing = await executeRows<{
-    id: string
-    label: string | null
-    capacity: number
-    assigned: number
-  }>(
-    db,
-    sql`
-      SELECT ar.id, ar.label, ar.capacity, usage.assigned
-      FROM allocation_resources ar
-      JOIN LATERAL (
-        SELECT COUNT(DISTINCT btd.traveler_id)::int AS assigned
-        FROM booking_traveler_travel_details btd
-        JOIN booking_travelers bt ON bt.id = btd.traveler_id
-        JOIN booking_allocations ba ON ba.booking_id = bt.booking_id
-        JOIN bookings b ON b.id = bt.booking_id
-        WHERE btd.allocations ->> ar.kind = ar.id
-          AND ba.availability_slot_id = ar.slot_id
-          AND b.status IN (${activeBookingStatusesSql()})
-          AND ba.status IN (${activeBookingAllocationStatusesSql()})
-      ) usage ON true
-      WHERE ar.slot_id = ${slotId}
-        AND ar.kind = ${kind}
-        AND ar.id = ANY(${sqlTextArray([...new Set(resourceIds)])})
-        AND usage.assigned > ar.capacity
-    `,
-  )
-
-  if (overflowing.length === 0) return
-
-  throw new AllocationServiceError("Resource over capacity", 409, {
-    kind,
-    resources: overflowing.map((resource) => ({
-      id: resource.id,
-      label: resource.label,
-      capacity: resource.capacity,
-      assigned: resource.assigned,
-    })),
-  })
+  return { kind, created: created.length, skippedExisting, resources: created }
 }
 
 export interface MaterializeSlotResourcesFromTemplatesOptions {
@@ -362,15 +262,32 @@ export interface MaterializeSlotResourcesFromTemplatesOptions {
  * `default_count` are skipped — operators handle those via the admin
  * materialise route once pax is known.
  *
- * Vehicle-seat layouts are out of scope here; use the existing
- * `autoMaterializeAllocationResources` path for those once the slot
- * has bookings (it knows pax-per-option).
+ * `vehicle_seat` templates are materialised here too: `default_count` is read
+ * as the number of *vehicles* to lay out, and each one gets its full seat map
+ * from the template's `flags.layoutSpec` (or `layout` + `capacity`). Before
+ * this, the only path that created seats was the pax-derived one, so a coach
+ * with an empty seat map could not be drawn until the departure had already
+ * been sold — the operator had to hand-create fifty seats or sell blind.
+ *
+ * Runs inside a transaction that holds the slot row lock, because vehicle-seat
+ * layouts write a parent and its children and must not interleave with a
+ * concurrent materialisation of the same slot.
  */
 export async function materializeSlotResourcesFromTemplateDefaults(
   db: PostgresJsDatabase,
   slotId: string,
   opts: MaterializeSlotResourcesFromTemplatesOptions = {},
-): Promise<{ created: number; resources: AllocationResource[] }> {
+): Promise<{ created: number; skippedExisting: number; resources: AllocationResource[] }> {
+  return db.transaction(async (tx) =>
+    materializeSlotResourcesFromTemplateDefaultsLocked(tx as PostgresJsDatabase, slotId, opts),
+  )
+}
+
+async function materializeSlotResourcesFromTemplateDefaultsLocked(
+  db: PostgresJsDatabase,
+  slotId: string,
+  opts: MaterializeSlotResourcesFromTemplatesOptions,
+): Promise<{ created: number; skippedExisting: number; resources: AllocationResource[] }> {
   const [slot] = await db
     .select({
       id: availabilitySlots.id,
@@ -379,8 +296,9 @@ export async function materializeSlotResourcesFromTemplateDefaults(
     })
     .from(availabilitySlots)
     .where(eq(availabilitySlots.id, slotId))
+    .for("update")
     .limit(1)
-  if (!slot) return { created: 0, resources: [] }
+  if (!slot) return { created: 0, skippedExisting: 0, resources: [] }
 
   // Resolve which option(s) supply templates. An explicit `opts.optionId`
   // wins (used when back-filling a product-level slot on behalf of one
@@ -399,7 +317,7 @@ export async function materializeSlotResourcesFromTemplateDefaults(
     )
     optionIds = optionRows.map((row) => row.id)
   }
-  if (optionIds.length === 0) return { created: 0, resources: [] }
+  if (optionIds.length === 0) return { created: 0, skippedExisting: 0, resources: [] }
 
   const templateConditions = [inArray(productOptionResourceTemplates.productOptionId, optionIds)]
   if (opts.kind) {
@@ -412,29 +330,55 @@ export async function materializeSlotResourcesFromTemplateDefaults(
     .where(and(...templateConditions))
     .orderBy(productOptionResourceTemplates.kind, productOptionResourceTemplates.createdAt)
 
-  if (templates.length === 0) return { created: 0, resources: [] }
+  if (templates.length === 0) return { created: 0, skippedExisting: 0, resources: [] }
 
   const skipExisting = opts.skipExisting !== false
-  const existing = skipExisting
-    ? await executeRows<{ kind: string; ref_id: string | null }>(
-        db,
-        // agent-quality: raw-sql reviewed -- owner: availability; dynamic SQL interpolation uses Drizzle parameter binding or vetted SQL identifiers.
-        sql`SELECT DISTINCT kind, ref_id FROM allocation_resources WHERE slot_id = ${slotId}`,
-      )
-    : []
   // Key by (kind, ref) — not kind alone — so a second room type (another
   // option_unit, same kind="room") still materializes when re-applying, rather
-  // than the whole "room" kind being skipped once one room exists.
-  const templateKey = (kind: string, refId: string | null) => `${kind}::${refId ?? ""}`
-  const existingKeys = new Set(existing.map((row) => templateKey(row.kind, row.ref_id)))
+  // than the whole "room" kind being skipped once one room exists. Shared with
+  // `autoMaterializeAllocationResources`, which now skips on the same rule.
+  const existingKeys = skipExisting ? await loadExistingResourceKeys(db, slotId) : new Set<string>()
 
   const resources: AllocationResource[] = []
   let sequence = 0
+  let skippedExisting = 0
 
   for (const template of templates) {
     if (template.defaultCount == null || template.defaultCount <= 0) continue
-    if (template.kind === "vehicle_seat") continue
-    if (skipExisting && existingKeys.has(templateKey(template.kind, template.refId))) continue
+    const key = resourceKey(template.kind, template.refId)
+    if (skipExisting && existingKeys.has(key)) {
+      skippedExisting += 1
+      continue
+    }
+
+    if (template.kind === "vehicle_seat") {
+      // `default_count` counts vehicles here, not seats: the seat count comes
+      // from the layout. `pax_count` is irrelevant — that is the whole point of
+      // laying a coach out before the first sale.
+      const group: AutoMaterializeRow = {
+        option_id: template.productOptionId,
+        pax_count: 0,
+        vehicle_count: template.defaultCount,
+        capacity: template.capacity,
+        name_pattern: template.namePattern,
+        ref_type: template.refType,
+        ref_id: template.refId,
+        layout: template.layout,
+        flags: template.flags ?? {},
+        option_name: null,
+        sort_order: null,
+      }
+      const vehicleResources = await materializeVehicleSeatGroupInTransaction(
+        db,
+        slotId,
+        group,
+        sequence,
+      )
+      sequence += vehicleResources.vehicleCount
+      resources.push(...vehicleResources.resources)
+      existingKeys.add(key)
+      continue
+    }
 
     for (let index = 0; index < template.defaultCount; index++) {
       sequence += 1
@@ -456,9 +400,10 @@ export async function materializeSlotResourcesFromTemplateDefaults(
         .returning()
       if (row) resources.push(row)
     }
+    existingKeys.add(key)
   }
 
-  return { created: resources.length, resources }
+  return { created: resources.length, skippedExisting, resources }
 }
 
 /**
@@ -499,46 +444,4 @@ export async function materializeOpenSlotsFromTemplateDefaults(
   }
 
   return { slots: slots.length, created }
-}
-
-function toAllocatorTravelers(manifest: SlotAllocationManifest, kind: string): AllocatorTraveler[] {
-  const travelers: AllocatorTraveler[] = []
-  for (const booking of manifest.bookings) {
-    for (const traveler of booking.travelers) {
-      travelers.push({
-        id: traveler.id,
-        bookingId: booking.id,
-        bookingStatus: booking.status,
-        isLeadTraveler: traveler.isLeadTraveler,
-        sharingGroupId: traveler.sharingGroupId,
-        hasAccessibilityNeeds: traveler.hasAccessibilityNeeds,
-        existingAllocationId: traveler.allocations[kind] ?? null,
-        optionId: traveler.optionId,
-        optionUnitId: traveler.optionUnitId,
-        optionUnitCode: traveler.optionUnitCode,
-      })
-    }
-  }
-  return travelers
-}
-
-function toAllocatorResource(resource: AllocationResource): AllocatorResource {
-  return {
-    id: resource.id,
-    kind: resource.kind,
-    capacity: resource.capacity,
-    flags: resource.flags ?? {},
-    parentId: resource.parentId,
-    refType: resource.refType,
-    refId: resource.refId,
-    label: resource.label,
-    row: typeof resource.flags?.row === "number" ? resource.flags.row : undefined,
-    column: typeof resource.flags?.column === "string" ? resource.flags.column : undefined,
-    position:
-      resource.flags?.position === "window" ||
-      resource.flags?.position === "aisle" ||
-      resource.flags?.position === "middle"
-        ? resource.flags.position
-        : undefined,
-  }
 }

--- a/packages/operations/src/availability/service-allocation-conflicts.ts
+++ b/packages/operations/src/availability/service-allocation-conflicts.ts
@@ -1,0 +1,388 @@
+/**
+ * Allocation conflicts — the one server-side answer to "what is wrong with this
+ * departure's rooming / seating plan".
+ *
+ * Modelled on `service-departure-issues.ts`: the rules are **pure** over facts a
+ * loader already gathered, every conflict carries a **stable machine code** the
+ * UI translates, and nothing here repairs anything. Building it server-side is
+ * the point — the workspace UI, the CSV export and the printed manifest were
+ * each free to invent their own notion of "conflict", and the only client-side
+ * implementation that existed (`buildValidationIssues` in `operations-react`)
+ * had zero call sites and covered three of the seven cases.
+ *
+ * Never rename a code; add a new one.
+ *
+ * Severities follow the departure-issues convention:
+ *   - `critical` — the plan cannot physically be operated as it stands.
+ *   - `warning`  — the plan will operate, but a reconciliation is outstanding.
+ */
+
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import { isActiveBookingStatus } from "./booking-statuses.js"
+import {
+  type AllocationManifestTraveler,
+  getSlotAllocationManifest,
+  type SlotAllocationManifest,
+} from "./service-allocation.js"
+
+export type AllocationConflictSeverity = "critical" | "warning"
+
+/** Stable allocation-conflict codes. Never rename one; add a new code instead. */
+export type AllocationConflictCode =
+  /** A traveler on a live booking holds no resource of this kind. */
+  | "traveler_unassigned"
+  /** A resource with capacity > 1 holds more travelers than it can. */
+  | "resource_over_capacity"
+  /** A capacity-1 resource (a seat) is held by more than one traveler. */
+  | "duplicate_assignment"
+  /** A traveler who flagged accessibility needs sits in a resource not marked accessible. */
+  | "inaccessible_assignment"
+  /** A traveler sits in a resource belonging to an option or unit they did not buy. */
+  | "incompatible_assignment"
+  /** A sharing group is larger than the resource it can be placed in. */
+  | "oversubscribed_sharing_group"
+  /** A sharing group's members are spread across more than one resource. */
+  | "split_sharing_group"
+
+export type AllocationConflictSubjectType =
+  | "traveler"
+  | "allocation_resource"
+  | "sharing_group"
+  | "departure"
+
+export interface AllocationConflict {
+  code: AllocationConflictCode
+  severity: AllocationConflictSeverity
+  /** Resource kind the conflict was evaluated for ("room", "vehicle_seat", …). */
+  kind: string
+  subjectType: AllocationConflictSubjectType
+  /** Id of the row the conflict is about; the slot id for departure-level rollups. */
+  subjectId: string
+  /** How many rows of `subjectType` this conflict covers. */
+  count: number
+  /** Travelers implicated, capped. Empty for departure-level rollups. */
+  travelerIds: string[]
+  /** Resources implicated, capped. */
+  resourceIds: string[]
+  /** English fallback for consumers with no message catalogue. */
+  message: string
+}
+
+/** How many individually-named subjects one code emits before it rolls up. */
+const SUBJECT_SAMPLE_LIMIT = 100
+
+/** Flag keys that mark a resource as usable by a traveler with accessibility needs. */
+const ACCESSIBLE_FLAG_KEYS = ["accessible", "accessibilityNeeded", "wheelchairAccessible"] as const
+
+export interface AllocationConflictResource {
+  id: string
+  kind: string
+  capacity: number
+  label: string | null
+  refType: string | null
+  refId: string | null
+  parentId: string | null
+  flags: Record<string, unknown>
+}
+
+export interface AllocationConflictInput {
+  slotId: string
+  kind: string
+  /** Travelers on live bookings only. The caller filters; the evaluator does not. */
+  travelers: readonly AllocationManifestTraveler[]
+  /** Every resource on the slot, of every kind. Filtering to `kind` is the evaluator's job. */
+  resources: readonly AllocationConflictResource[]
+}
+
+/**
+ * Evaluate every rule against already-loaded facts. Pure: same facts in, same
+ * conflicts out, in a stable order (critical first, then code, then subject).
+ */
+export function evaluateAllocationConflicts(input: AllocationConflictInput): AllocationConflict[] {
+  const { kind, slotId } = input
+  const kindResources = input.resources.filter((resource) => resource.kind === kind)
+  const resourceById = new Map(kindResources.map((resource) => [resource.id, resource]))
+  const conflicts: AllocationConflict[] = []
+
+  const occupants = new Map<string, AllocationManifestTraveler[]>()
+  const unassigned: AllocationManifestTraveler[] = []
+  for (const traveler of input.travelers) {
+    const resourceId = traveler.allocations[kind]
+    const resource = resourceId ? resourceById.get(resourceId) : undefined
+    if (!resource) {
+      unassigned.push(traveler)
+      continue
+    }
+    const list = occupants.get(resource.id) ?? []
+    list.push(traveler)
+    occupants.set(resource.id, list)
+  }
+
+  pushTravelerConflicts(conflicts, {
+    code: "traveler_unassigned",
+    severity: "warning",
+    kind,
+    slotId,
+    travelers: unassigned,
+    message: "Traveler has not been assigned a place on this departure.",
+    rollupMessage: "Further travelers have not been assigned a place on this departure.",
+  })
+
+  for (const resource of kindResources) {
+    const held = occupants.get(resource.id) ?? []
+    if (held.length <= resource.capacity) continue
+    // Capacity-1 containers (a seat) get their own code: "two people in seat 12A"
+    // is a different operator conversation from "a triple holds four". The two
+    // codes are deliberately disjoint so a consumer can render either alone.
+    const duplicate = resource.capacity === 1
+    conflicts.push({
+      code: duplicate ? "duplicate_assignment" : "resource_over_capacity",
+      severity: "critical",
+      kind,
+      subjectType: "allocation_resource",
+      subjectId: resource.id,
+      count: held.length - resource.capacity,
+      travelerIds: held.slice(0, SUBJECT_SAMPLE_LIMIT).map((traveler) => traveler.id),
+      resourceIds: [resource.id],
+      message: duplicate
+        ? "More than one traveler holds this seat."
+        : "More travelers are assigned to this resource than it can hold.",
+    })
+  }
+
+  const inaccessible: AllocationManifestTraveler[] = []
+  const incompatible: AllocationManifestTraveler[] = []
+  const inaccessibleResourceIds = new Set<string>()
+  const incompatibleResourceIds = new Set<string>()
+  for (const [resourceId, held] of occupants) {
+    const resource = resourceById.get(resourceId)
+    if (!resource) continue
+    for (const traveler of held) {
+      if (traveler.hasAccessibilityNeeds && !isAccessibleResource(resource)) {
+        inaccessible.push(traveler)
+        inaccessibleResourceIds.add(resourceId)
+      }
+      if (isIncompatibleAssignment(traveler, resource)) {
+        incompatible.push(traveler)
+        incompatibleResourceIds.add(resourceId)
+      }
+    }
+  }
+
+  pushTravelerConflicts(conflicts, {
+    code: "inaccessible_assignment",
+    severity: "warning",
+    kind,
+    slotId,
+    travelers: inaccessible,
+    resourceIds: [...inaccessibleResourceIds],
+    message:
+      "Traveler flagged accessibility needs but is placed in a resource not marked accessible.",
+    rollupMessage:
+      "Further travelers flagged accessibility needs but are placed in resources not marked accessible.",
+  })
+  pushTravelerConflicts(conflicts, {
+    code: "incompatible_assignment",
+    severity: "critical",
+    kind,
+    slotId,
+    travelers: incompatible,
+    resourceIds: [...incompatibleResourceIds],
+    message: "Traveler is placed in a resource belonging to an option or unit they did not buy.",
+    rollupMessage:
+      "Further travelers are placed in resources belonging to options or units they did not buy.",
+  })
+
+  const largestCapacity = kindResources.reduce(
+    (largest, resource) => Math.max(largest, resource.capacity),
+    0,
+  )
+  for (const group of sharingGroups(input.travelers, kind)) {
+    // A group is oversubscribed when it cannot fit where it sits, or — when it
+    // has not been placed yet — cannot fit anywhere on this departure.
+    const target = group.placedResourceIds.length === 1 ? group.placedResourceIds[0] : null
+    const targetCapacity = target
+      ? (resourceById.get(target)?.capacity ?? 0)
+      : group.placedResourceIds.length === 0
+        ? largestCapacity
+        : null
+    if (
+      targetCapacity !== null &&
+      kindResources.length > 0 &&
+      group.travelerIds.length > targetCapacity
+    ) {
+      conflicts.push({
+        code: "oversubscribed_sharing_group",
+        severity: "critical",
+        kind,
+        subjectType: "sharing_group",
+        subjectId: group.id,
+        count: group.travelerIds.length - targetCapacity,
+        travelerIds: group.travelerIds.slice(0, SUBJECT_SAMPLE_LIMIT),
+        resourceIds: target ? [target] : [],
+        message: "This sharing group has more members than the resource it can be placed in holds.",
+      })
+    }
+
+    if (group.distinctPlacements > 1) {
+      conflicts.push({
+        code: "split_sharing_group",
+        severity: "warning",
+        kind,
+        subjectType: "sharing_group",
+        subjectId: group.id,
+        count: group.distinctPlacements,
+        travelerIds: group.travelerIds.slice(0, SUBJECT_SAMPLE_LIMIT),
+        resourceIds: group.placedResourceIds,
+        message: "This sharing group's members are split across more than one resource.",
+      })
+    }
+  }
+
+  return conflicts.sort(
+    (a, b) =>
+      severityRank(a.severity) - severityRank(b.severity) ||
+      a.code.localeCompare(b.code) ||
+      a.subjectId.localeCompare(b.subjectId),
+  )
+}
+
+interface TravelerConflictSpec {
+  code: AllocationConflictCode
+  severity: AllocationConflictSeverity
+  kind: string
+  slotId: string
+  travelers: readonly AllocationManifestTraveler[]
+  resourceIds?: readonly string[]
+  message: string
+  rollupMessage: string
+}
+
+/**
+ * Emit one row per traveler up to the sample cap, then a single departure-level
+ * rollup for the remainder, so a 400-pax coach still returns a bounded body.
+ */
+function pushTravelerConflicts(conflicts: AllocationConflict[], spec: TravelerConflictSpec): void {
+  for (const traveler of spec.travelers.slice(0, SUBJECT_SAMPLE_LIMIT)) {
+    conflicts.push({
+      code: spec.code,
+      severity: spec.severity,
+      kind: spec.kind,
+      subjectType: "traveler",
+      subjectId: traveler.id,
+      count: 1,
+      travelerIds: [traveler.id],
+      resourceIds: spec.resourceIds ? [...spec.resourceIds] : [],
+      message: spec.message,
+    })
+  }
+  const unnamed = spec.travelers.length - SUBJECT_SAMPLE_LIMIT
+  if (unnamed > 0) {
+    conflicts.push({
+      code: spec.code,
+      severity: spec.severity,
+      kind: spec.kind,
+      subjectType: "departure",
+      subjectId: spec.slotId,
+      count: unnamed,
+      travelerIds: [],
+      resourceIds: [],
+      message: spec.rollupMessage,
+    })
+  }
+}
+
+interface SharingGroupFacts {
+  id: string
+  travelerIds: string[]
+  /** Distinct resources the group's placed members occupy. */
+  placedResourceIds: string[]
+  /** Distinct placements including "not placed", so a half-placed family counts as split. */
+  distinctPlacements: number
+}
+
+function sharingGroups(
+  travelers: readonly AllocationManifestTraveler[],
+  kind: string,
+): SharingGroupFacts[] {
+  const byGroup = new Map<string, { travelerIds: string[]; placements: Set<string> }>()
+  for (const traveler of travelers) {
+    const groupId = traveler.sharingGroupId
+    if (!groupId) continue
+    const bucket = byGroup.get(groupId) ?? { travelerIds: [], placements: new Set<string>() }
+    bucket.travelerIds.push(traveler.id)
+    bucket.placements.add(traveler.allocations[kind] ?? "")
+    byGroup.set(groupId, bucket)
+  }
+  return [...byGroup]
+    .map(([id, bucket]) => ({
+      id,
+      travelerIds: bucket.travelerIds,
+      placedResourceIds: [...bucket.placements].filter(Boolean),
+      distinctPlacements: bucket.placements.size,
+    }))
+    .sort((a, b) => a.id.localeCompare(b.id))
+}
+
+function isAccessibleResource(resource: AllocationConflictResource): boolean {
+  return ACCESSIBLE_FLAG_KEYS.some((key) => resource.flags[key] === true)
+}
+
+/**
+ * A resource that names the option unit or product option it was materialised
+ * for may only hold travelers who bought that unit/option. Resources with no
+ * such ref hold anyone — most departures never key their rooms by unit.
+ */
+function isIncompatibleAssignment(
+  traveler: AllocationManifestTraveler,
+  resource: AllocationConflictResource,
+): boolean {
+  if (resource.refType === "option_unit" && resource.refId && traveler.optionUnitId) {
+    if (resource.refId !== traveler.optionUnitId) return true
+  }
+  const templateOptionId = resource.flags.templateOptionId
+  if (typeof templateOptionId === "string" && traveler.optionId) {
+    if (templateOptionId !== traveler.optionId) return true
+  }
+  return false
+}
+
+function severityRank(severity: AllocationConflictSeverity): number {
+  return severity === "critical" ? 0 : 1
+}
+
+/**
+ * Load the departure's manifest and evaluate conflicts for one resource kind.
+ * Returns `null` when the slot does not exist.
+ *
+ * Only travelers on live bookings are considered — a cancelled booking's
+ * traveler is not a rooming problem, it is a booking problem, and
+ * `service-departure-issues.ts` already reports it.
+ */
+export async function getSlotAllocationConflicts(
+  db: PostgresJsDatabase,
+  slotId: string,
+  options: { kind?: string; manifest?: SlotAllocationManifest } = {},
+): Promise<AllocationConflict[] | null> {
+  const kind = options.kind ?? "room"
+  const manifest = options.manifest ?? (await getSlotAllocationManifest(db, slotId))
+  if (!manifest) return null
+  return evaluateAllocationConflicts({
+    slotId,
+    kind,
+    travelers: manifest.bookings.flatMap((booking) =>
+      isActiveBookingStatus(booking.status) ? booking.travelers : [],
+    ),
+    resources: manifest.resources.map((resource) => ({
+      id: resource.id,
+      kind: resource.kind,
+      capacity: resource.capacity,
+      label: resource.label,
+      refType: resource.refType,
+      refId: resource.refId,
+      parentId: resource.parentId,
+      flags: resource.flags ?? {},
+    })),
+  })
+}

--- a/packages/operations/src/availability/service-allocation-exports.ts
+++ b/packages/operations/src/availability/service-allocation-exports.ts
@@ -94,12 +94,28 @@ export function buildAllocationRoomingCsv(manifest: SlotAllocationManifest, kind
   return csvDocument(rows)
 }
 
+/**
+ * Export filenames. `seating` was unreachable before: `buildAllocationRoomingCsv`
+ * has always taken a `kind`, but the route declared no `kind` parameter and this
+ * union had no name for a seat manifest, so a coach's seating list could not be
+ * downloaded at all.
+ */
+export type AllocationExportPrefix = "passengers" | "rooming" | "seating"
+
 export function allocationExportFilename(
   manifest: SlotAllocationManifest,
-  prefix: "passengers" | "rooming",
+  prefix: AllocationExportPrefix,
 ): string {
   const slug = manifest.slot.productId?.slice(0, 8) ?? "departure"
   return `${prefix}-${slug}-${manifest.slot.id}.csv`
+}
+
+/**
+ * Which export a resource kind belongs to. Seat-shaped kinds print as a seating
+ * manifest; everything else prints as a rooming list.
+ */
+export function allocationExportPrefixForKind(kind: string): AllocationExportPrefix {
+  return kind === "vehicle_seat" || kind === "flight_seat" ? "seating" : "rooming"
 }
 
 function csvDocument(rows: Array<Array<string | number | boolean | null | undefined>>) {

--- a/packages/operations/src/availability/service-allocation-resource-crud.ts
+++ b/packages/operations/src/availability/service-allocation-resource-crud.ts
@@ -95,9 +95,12 @@ export async function updateAllocationResource(
   db: PostgresJsDatabase,
   slotId: string,
   resourceId: string,
-  input: UpdateAllocationResourceInput,
+  patch: UpdateAllocationResourceInput,
   options: AllocationMutationOptions = {},
 ) {
+  // `expectedUpdatedAt` is a precondition, never a column: strip it before the
+  // patch reaches `set()`.
+  const { expectedUpdatedAt, ...input } = patch
   const result = await db.transaction(async (tx) => {
     const transactionalDb = tx as PostgresJsDatabase
     const [existing] = await tx
@@ -109,12 +112,14 @@ export async function updateAllocationResource(
         flags: allocationResources.flags,
         sortOrder: allocationResources.sortOrder,
         parentId: allocationResources.parentId,
+        updatedAt: allocationResources.updatedAt,
       })
       .from(allocationResources)
       .where(and(eq(allocationResources.id, resourceId), eq(allocationResources.slotId, slotId)))
       .for("update")
       .limit(1)
     if (!existing) return null
+    assertAllocationResourceRevision(existing.updatedAt, expectedUpdatedAt, resourceId)
 
     if (existing.kind === "vehicle_seat" && input.capacity !== undefined && input.capacity !== 1) {
       throw new AllocationServiceError("A vehicle seat must have capacity 1", 400)
@@ -206,22 +211,28 @@ export async function updateAllocationResource(
   return result?.row ?? null
 }
 
+export interface DeleteAllocationResourceOptions extends AllocationMutationOptions {
+  /** Optimistic-concurrency precondition; see `updateAllocationResourceSchema`. */
+  expectedUpdatedAt?: string
+}
+
 export async function deleteAllocationResource(
   db: PostgresJsDatabase,
   slotId: string,
   resourceId: string,
-  options: AllocationMutationOptions = {},
+  options: DeleteAllocationResourceOptions = {},
 ) {
   const row = await db.transaction(async (tx) => {
     // Locking the parent candidate serializes deletion with seat creation,
     // which locks the same row before checking and inserting child seats.
     const [existing] = await tx
-      .select({ id: allocationResources.id })
+      .select({ id: allocationResources.id, updatedAt: allocationResources.updatedAt })
       .from(allocationResources)
       .where(and(eq(allocationResources.id, resourceId), eq(allocationResources.slotId, slotId)))
       .for("update")
       .limit(1)
     if (!existing) return null
+    assertAllocationResourceRevision(existing.updatedAt, options.expectedUpdatedAt, resourceId)
 
     const [child] = await tx
       .select({ id: allocationResources.id })
@@ -265,6 +276,34 @@ export async function deleteAllocationResource(
     return deleted ?? null
   })
   return row
+}
+
+/**
+ * Optimistic concurrency for allocation resources, mirroring the departure's own
+ * `expectedUpdatedAt` precondition in `service-core.ts`. Omitting the
+ * precondition keeps the previous last-write-wins behaviour, so existing callers
+ * are unaffected.
+ */
+function assertAllocationResourceRevision(
+  currentUpdatedAt: Date,
+  expectedUpdatedAt: string | undefined,
+  resourceId: string,
+) {
+  if (expectedUpdatedAt === undefined) return
+  const expected = new Date(expectedUpdatedAt)
+  if (Number.isNaN(expected.getTime())) {
+    throw new AllocationServiceError("expectedUpdatedAt must be a valid instant", 400, {
+      expectedUpdatedAt,
+    })
+  }
+  if (expected.getTime() !== currentUpdatedAt.getTime()) {
+    throw new AllocationServiceError("Allocation resource changed after it was read", 409, {
+      reason: "revision_conflict",
+      resourceId,
+      expectedUpdatedAt,
+      currentUpdatedAt: currentUpdatedAt.toISOString(),
+    })
+  }
 }
 
 async function assertValidResourceParent(

--- a/packages/operations/src/availability/service-allocation-resource-link.ts
+++ b/packages/operations/src/availability/service-allocation-resource-link.ts
@@ -1,0 +1,556 @@
+/**
+ * Attach a global fleet `resources` row to one departure.
+ *
+ * Until now `allocation_resources.ref_type` only ever carried `"option"` or
+ * `"option_unit"`, so a coach that exists as a `resources` record could never be
+ * pointed at the departure it actually operates. The departure workspace and the
+ * Resources admin section each had their own idea of "the coach on this
+ * departure" and nothing reconciled them.
+ *
+ * ## Authority
+ *
+ * The two tables answer different questions and both stay, with one write path:
+ *
+ *   - **`allocation_resources` (`ref_type = "resource"`) is authoritative for
+ *     what the departure operates.** It is slot-scoped, carries the capacity
+ *     travelers are assigned against, parents the seats, and is what every
+ *     manifest, export, conflict and capacity counter already reads. A departure
+ *     never has to consult the Resources module to render or validate its plan.
+ *   - **`resource_slot_assignments` is authoritative for fleet commitment across
+ *     departures.** It is the only table that spans slots, so it is the only one
+ *     that can answer "is this coach already committed to an overlapping
+ *     departure". `allocation_resources` is slot-scoped by construction and can
+ *     never see a clash.
+ *
+ * A coach therefore cannot be attached twice, because both rows are written and
+ * released together inside one transaction, and the fleet ledger is consulted as
+ * the conflict oracle *before* the allocation resource is created. An assignment
+ * the Resources admin already made for this slot is **adopted**, not duplicated:
+ * a live `resource_slot_assignments` row for the same (slot, resource) is reused
+ * and its id recorded on the allocation resource's `flags.resourceAssignmentId`.
+ *
+ * `docs/architecture/operated-departure-logistics.md` records the decision.
+ */
+
+import { newId } from "@voyant-travel/db/lib/typeid"
+import { sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import type { AllocationMutationOptions } from "./service-allocation.js"
+import { recordAllocationAudit } from "./service-allocation-audit.js"
+import { AllocationServiceError } from "./service-allocation-errors.js"
+import { clearTravelerAllocationsForResource } from "./service-allocation-resource-capacity.js"
+import { executeRows, sqlTextArray } from "./service-allocation-sql.js"
+
+/** Fleet-assignment statuses that still hold the resource for a departure. */
+const LIVE_ASSIGNMENT_STATUSES = ["reserved", "assigned"] as const
+
+/**
+ * Default departure-workspace kind for each `resources.kind`. Kinds absent here
+ * (guide, equipment, other) are not traveler-assignable containers, so the
+ * caller must name the workspace kind explicitly.
+ */
+const WORKSPACE_KIND_BY_RESOURCE_KIND: Readonly<Record<string, string>> = {
+  vehicle: "vehicle",
+  boat: "vehicle",
+  room: "room",
+}
+
+export interface AttachDepartureResourceInput {
+  /** `resources.id` of the fleet record to attach. */
+  resourceId: string
+  /**
+   * Departure-workspace kind for the created `allocation_resources` row.
+   * Defaults from the fleet record's own kind; required for kinds that have no
+   * default (guide, equipment, other).
+   */
+  kind?: string
+  /**
+   * Capacity of the departure container. Defaults to the fleet record's
+   * `capacity`; required when the fleet record does not declare one.
+   */
+  capacity?: number
+  /** Label override. Defaults to the fleet record's name (and code, if set). */
+  label?: string | null
+  flags?: Record<string, unknown>
+  sortOrder?: number
+  notes?: string | null
+}
+
+export interface DepartureResourceLink {
+  /** The `allocation_resources` row the departure operates. */
+  resource: DepartureResourceRow
+  /** The `resource_slot_assignments` row holding the fleet commitment. */
+  assignmentId: string
+  /** `false` when an identical link already existed and was returned as-is. */
+  created: boolean
+}
+
+export interface DepartureResourceRow {
+  id: string
+  slotId: string
+  kind: string
+  refType: string | null
+  refId: string | null
+  label: string | null
+  capacity: number
+  flags: Record<string, unknown>
+  parentId: string | null
+  sortOrder: number
+  createdAt: string
+  updatedAt: string
+}
+
+interface AllocationResourceSqlRow {
+  id: string
+  slot_id: string
+  kind: string
+  ref_type: string | null
+  ref_id: string | null
+  label: string | null
+  capacity: number
+  flags: Record<string, unknown> | null
+  parent_id: string | null
+  sort_order: number
+  created_at: string | Date
+  updated_at: string | Date
+}
+
+function toDepartureResourceRow(row: AllocationResourceSqlRow): DepartureResourceRow {
+  return {
+    id: row.id,
+    slotId: row.slot_id,
+    kind: row.kind,
+    refType: row.ref_type,
+    refId: row.ref_id,
+    label: row.label,
+    capacity: row.capacity,
+    flags: row.flags ?? {},
+    parentId: row.parent_id,
+    sortOrder: row.sort_order,
+    createdAt: new Date(row.created_at).toISOString(),
+    updatedAt: new Date(row.updated_at).toISOString(),
+  }
+}
+
+const ALLOCATION_RESOURCE_COLUMNS = sql`
+  id, slot_id, kind, ref_type, ref_id, label, capacity, flags, parent_id, sort_order,
+  created_at, updated_at
+`
+
+/**
+ * Attach a fleet resource to a departure.
+ *
+ * Idempotent: re-attaching the same resource to the same departure returns the
+ * existing link with `created: false` rather than raising, which is the same
+ * "already there is success" rule the materialisation paths follow.
+ */
+export async function attachDepartureResource(
+  db: PostgresJsDatabase,
+  slotId: string,
+  input: AttachDepartureResourceInput,
+  options: AllocationMutationOptions = {},
+): Promise<DepartureResourceLink> {
+  return db.transaction(async (tx) => {
+    const scoped = tx as PostgresJsDatabase
+    const slot = await lockSlot(scoped, slotId)
+    const resource = await loadFleetResource(scoped, input.resourceId)
+
+    const existing = await findLinkedAllocationResource(scoped, slotId, input.resourceId)
+    if (existing) {
+      const assignmentId =
+        typeof existing.flags.resourceAssignmentId === "string"
+          ? existing.flags.resourceAssignmentId
+          : await ensureFleetAssignment(scoped, slotId, input.resourceId, options.actorId ?? null)
+      return { resource: existing, assignmentId, created: false }
+    }
+
+    const kind = input.kind ?? WORKSPACE_KIND_BY_RESOURCE_KIND[resource.kind]
+    if (!kind) {
+      throw new AllocationServiceError(
+        "This resource kind has no default departure kind; name one explicitly",
+        400,
+        { resourceKind: resource.kind },
+      )
+    }
+    const capacity = input.capacity ?? resource.capacity
+    if (capacity == null || capacity < 1) {
+      throw new AllocationServiceError(
+        "The resource declares no capacity; supply one when attaching it",
+        400,
+        { resourceId: input.resourceId },
+      )
+    }
+
+    await assertNoOverlappingCommitment(scoped, {
+      slotId,
+      resourceId: input.resourceId,
+      startsAt: slot.starts_at,
+      endsAt: slot.ends_at,
+    })
+
+    const assignmentId = await ensureFleetAssignment(
+      scoped,
+      slotId,
+      input.resourceId,
+      options.actorId ?? null,
+      input.notes ?? null,
+    )
+
+    const label = input.label ?? defaultResourceLabel(resource)
+    const flags = {
+      ...(input.flags ?? {}),
+      resourceAssignmentId: assignmentId,
+      resourceKind: resource.kind,
+      ...(resource.code ? { resourceCode: resource.code } : {}),
+    }
+    const rows = await executeRows<AllocationResourceSqlRow>(
+      scoped,
+      sql`
+        INSERT INTO allocation_resources
+          (id, slot_id, kind, ref_type, ref_id, label, capacity, flags, sort_order)
+        VALUES (
+          ${newId("allocation_resources")},
+          ${slotId},
+          ${kind},
+          'resource',
+          ${input.resourceId},
+          ${label},
+          ${capacity},
+          ${JSON.stringify(flags)}::jsonb,
+          ${input.sortOrder ?? 0}
+        )
+        RETURNING ${ALLOCATION_RESOURCE_COLUMNS}
+      `,
+    )
+    const created = rows[0]
+    if (!created) throw new AllocationServiceError("Resource attach failed", 500)
+
+    // Audit inside the transaction: a rolled-back attach must not leave an
+    // entry claiming the coach is on the departure.
+    await recordAllocationAudit(scoped, {
+      slotId,
+      action: "resource.attach",
+      actorId: options.actorId ?? null,
+      resourceId: created.id,
+      after: {
+        fleetResourceId: input.resourceId,
+        assignmentId,
+        kind,
+        capacity,
+        label,
+      },
+    })
+
+    return { resource: toDepartureResourceRow(created), assignmentId, created: true }
+  })
+}
+
+export interface DetachDepartureResourceOptions extends AllocationMutationOptions {
+  /**
+   * Optimistic-concurrency precondition: the `updatedAt` the caller read. A
+   * mismatch rejects with 409 rather than detaching a coach someone else
+   * reconfigured in the meantime.
+   */
+  expectedUpdatedAt?: string
+  /**
+   * Delete the resource's children (a coach's seats) too. Without it a coach
+   * that has been laid out is refused, matching manual resource deletion.
+   */
+  cascade?: boolean
+}
+
+/**
+ * Detach a fleet resource from a departure: remove the `allocation_resources`
+ * row (and, with `cascade`, its seats), clear traveler allocations that pointed
+ * at them, and release the fleet commitment so the coach is free again.
+ */
+export async function detachDepartureResource(
+  db: PostgresJsDatabase,
+  slotId: string,
+  resourceId: string,
+  options: DetachDepartureResourceOptions = {},
+): Promise<{ removedResourceIds: string[]; assignmentId: string | null } | null> {
+  return db.transaction(async (tx) => {
+    const scoped = tx as PostgresJsDatabase
+    await lockSlot(scoped, slotId)
+
+    const link = await findLinkedAllocationResource(scoped, slotId, resourceId)
+    if (!link) return null
+    assertExpectedUpdatedAt(link.updatedAt, options.expectedUpdatedAt, link.id)
+
+    const children = await executeRows<{ id: string }>(
+      scoped,
+      sql`
+        SELECT id FROM allocation_resources
+        WHERE slot_id = ${slotId} AND parent_id = ${link.id}
+        ORDER BY sort_order, created_at
+      `,
+    )
+    if (children.length > 0 && !options.cascade) {
+      throw new AllocationServiceError(
+        "Remove child resources before detaching their parent",
+        409,
+        { childCount: children.length },
+      )
+    }
+
+    const removedResourceIds = [...children.map((child) => child.id), link.id]
+    for (const removedId of removedResourceIds) {
+      await clearTravelerAllocationsForResource(scoped, removedId)
+    }
+    await scoped.execute(sql`
+      DELETE FROM allocation_resources
+      WHERE slot_id = ${slotId} AND id = ANY(${sqlTextArray(removedResourceIds)})
+    `)
+
+    const assignmentId =
+      typeof link.flags.resourceAssignmentId === "string" ? link.flags.resourceAssignmentId : null
+    await scoped.execute(sql`
+      UPDATE resource_slot_assignments
+      SET status = 'released', released_at = now()
+      WHERE slot_id = ${slotId}
+        AND resource_id = ${resourceId}
+        AND status IN (${liveAssignmentStatusesSql()})
+    `)
+
+    await recordAllocationAudit(scoped, {
+      slotId,
+      action: "resource.detach",
+      actorId: options.actorId ?? null,
+      resourceId: link.id,
+      before: {
+        fleetResourceId: resourceId,
+        assignmentId,
+        kind: link.kind,
+        capacity: link.capacity,
+        label: link.label,
+        removedChildCount: children.length,
+      },
+    })
+
+    return { removedResourceIds, assignmentId }
+  })
+}
+
+/** Every fleet resource currently attached to a departure. */
+export async function listDepartureResourceLinks(
+  db: PostgresJsDatabase,
+  slotId: string,
+): Promise<DepartureResourceRow[]> {
+  const rows = await executeRows<AllocationResourceSqlRow>(
+    db,
+    sql`
+      SELECT ${ALLOCATION_RESOURCE_COLUMNS}
+      FROM allocation_resources
+      WHERE slot_id = ${slotId} AND ref_type = 'resource'
+      ORDER BY kind, sort_order, created_at
+    `,
+  )
+  return rows.map(toDepartureResourceRow)
+}
+
+function assertExpectedUpdatedAt(
+  currentUpdatedAt: string,
+  expectedUpdatedAt: string | undefined,
+  resourceId: string,
+): void {
+  if (expectedUpdatedAt === undefined) return
+  const expected = new Date(expectedUpdatedAt)
+  if (Number.isNaN(expected.getTime())) {
+    throw new AllocationServiceError("expectedUpdatedAt must be a valid instant", 400, {
+      expectedUpdatedAt,
+    })
+  }
+  if (expected.getTime() !== new Date(currentUpdatedAt).getTime()) {
+    throw new AllocationServiceError("Allocation resource changed after it was read", 409, {
+      reason: "revision_conflict",
+      resourceId,
+      expectedUpdatedAt,
+      currentUpdatedAt,
+    })
+  }
+}
+
+function liveAssignmentStatusesSql() {
+  return sql.join(
+    // agent-quality: raw-sql reviewed -- owner: availability; each status is a bound parameter from a frozen literal tuple, never caller input.
+    LIVE_ASSIGNMENT_STATUSES.map((status) => sql`${status}`),
+    sql.raw(", "),
+  )
+}
+
+interface SlotRow {
+  id: string
+  starts_at: string | Date
+  ends_at: string | Date | null
+}
+
+async function lockSlot(db: PostgresJsDatabase, slotId: string): Promise<SlotRow> {
+  const rows = await executeRows<SlotRow>(
+    db,
+    sql`
+      SELECT id, starts_at, ends_at
+      FROM availability_slots
+      WHERE id = ${slotId}
+      FOR UPDATE
+    `,
+  )
+  const slot = rows[0]
+  if (!slot) throw new AllocationServiceError("Availability slot not found", 404)
+  return slot
+}
+
+interface FleetResourceRow {
+  id: string
+  kind: string
+  name: string
+  code: string | null
+  capacity: number | null
+  active: boolean
+}
+
+async function loadFleetResource(
+  db: PostgresJsDatabase,
+  resourceId: string,
+): Promise<FleetResourceRow> {
+  const rows = await executeRows<FleetResourceRow>(
+    db,
+    sql`
+      SELECT id, kind::text AS kind, name, code, capacity, active
+      FROM resources
+      WHERE id = ${resourceId}
+      LIMIT 1
+    `,
+  )
+  const resource = rows[0]
+  if (!resource) throw new AllocationServiceError("Resource not found", 404)
+  if (!resource.active) {
+    throw new AllocationServiceError("Resource is inactive and cannot be attached", 400, {
+      resourceId,
+    })
+  }
+  return resource
+}
+
+function defaultResourceLabel(resource: FleetResourceRow): string {
+  return resource.code ? `${resource.name} (${resource.code})` : resource.name
+}
+
+async function findLinkedAllocationResource(
+  db: PostgresJsDatabase,
+  slotId: string,
+  resourceId: string,
+): Promise<DepartureResourceRow | null> {
+  const rows = await executeRows<AllocationResourceSqlRow>(
+    db,
+    sql`
+      SELECT ${ALLOCATION_RESOURCE_COLUMNS}
+      FROM allocation_resources
+      WHERE slot_id = ${slotId} AND ref_type = 'resource' AND ref_id = ${resourceId}
+      ORDER BY created_at
+      LIMIT 1
+    `,
+  )
+  return rows[0] ? toDepartureResourceRow(rows[0]) : null
+}
+
+/**
+ * The fleet ledger is the conflict oracle. A live assignment on any *other*
+ * departure whose operating window overlaps this one means the coach is already
+ * committed; `allocation_resources` is slot-scoped and can never see that.
+ *
+ * A slot without `ends_at` is treated as instantaneous — it still collides with
+ * a multi-day departure that spans it, which is the case that matters.
+ */
+async function assertNoOverlappingCommitment(
+  db: PostgresJsDatabase,
+  input: {
+    slotId: string
+    resourceId: string
+    startsAt: string | Date
+    endsAt: string | Date | null
+  },
+): Promise<void> {
+  const startsAt = new Date(input.startsAt).toISOString()
+  const endsAt = new Date(input.endsAt ?? input.startsAt).toISOString()
+  const conflicts = await executeRows<{
+    assignment_id: string
+    slot_id: string
+    starts_at: string | Date
+    ends_at: string | Date | null
+  }>(
+    db,
+    sql`
+      SELECT rsa.id AS assignment_id, rsa.slot_id, s.starts_at, s.ends_at
+      FROM resource_slot_assignments rsa
+      JOIN availability_slots s ON s.id = rsa.slot_id
+      WHERE rsa.resource_id = ${input.resourceId}
+        AND rsa.slot_id <> ${input.slotId}
+        AND rsa.status IN (${liveAssignmentStatusesSql()})
+        AND tstzrange(s.starts_at, COALESCE(s.ends_at, s.starts_at), '[]')
+            && tstzrange(${startsAt}::timestamptz, ${endsAt}::timestamptz, '[]')
+      ORDER BY s.starts_at
+      LIMIT 1
+    `,
+  )
+  const conflict = conflicts[0]
+  if (!conflict) return
+  throw new AllocationServiceError(
+    "Resource is already committed to an overlapping departure",
+    409,
+    {
+      reason: "resource_double_booked",
+      resourceId: input.resourceId,
+      conflictingSlotId: conflict.slot_id,
+      conflictingAssignmentId: conflict.assignment_id,
+    },
+  )
+}
+
+/**
+ * Adopt the departure's existing live fleet assignment, or open one. Adoption is
+ * what keeps the Resources admin section and the departure workspace from
+ * producing two commitments for the same coach on the same departure.
+ */
+async function ensureFleetAssignment(
+  db: PostgresJsDatabase,
+  slotId: string,
+  resourceId: string,
+  actorId: string | null,
+  notes: string | null = null,
+): Promise<string> {
+  const existing = await executeRows<{ id: string }>(
+    db,
+    sql`
+      SELECT id
+      FROM resource_slot_assignments
+      WHERE slot_id = ${slotId}
+        AND resource_id = ${resourceId}
+        AND status IN (${liveAssignmentStatusesSql()})
+      ORDER BY assigned_at
+      LIMIT 1
+      FOR UPDATE
+    `,
+  )
+  const adopted = existing[0]
+  if (adopted) return adopted.id
+
+  const inserted = await executeRows<{ id: string }>(
+    db,
+    sql`
+      INSERT INTO resource_slot_assignments (id, slot_id, resource_id, status, assigned_by, notes)
+      VALUES (
+        ${newId("resource_slot_assignments")},
+        ${slotId},
+        ${resourceId},
+        'assigned',
+        ${actorId},
+        ${notes}
+      )
+      RETURNING id
+    `,
+  )
+  const row = inserted[0]
+  if (!row) throw new AllocationServiceError("Fleet assignment could not be opened", 500)
+  return row.id
+}

--- a/packages/operations/src/availability/service-allocation-vehicle-materialization.ts
+++ b/packages/operations/src/availability/service-allocation-vehicle-materialization.ts
@@ -15,6 +15,22 @@ export interface AutoMaterializeRow {
   flags: Record<string, unknown> | null
   option_name: string | null
   sort_order: number | null
+  /**
+   * Explicit number of vehicles to lay out, overriding the pax-derived count.
+   * Template-default materialisation supplies this so an operator can draw a
+   * coach *before* the first sale, when `pax_count` is zero and the derived
+   * count would be meaningless.
+   */
+  vehicle_count?: number | null
+}
+
+/**
+ * How many vehicles this group needs: the explicit `vehicle_count` when the
+ * caller knows it (template defaults), otherwise derived from pax.
+ */
+function resolveVehicleCount(group: AutoMaterializeRow, seatsPerVehicle: number): number {
+  if (group.vehicle_count != null) return Math.max(0, group.vehicle_count)
+  return Math.max(1, Math.ceil(group.pax_count / Math.max(1, seatsPerVehicle)))
 }
 
 /**
@@ -36,7 +52,7 @@ export async function materializeVehicleSeatGroupInTransaction(
 
   const layout = group.layout ?? "2-2"
   const seatsPerRow = parseLayoutSeatsPerRow(layout)
-  const vehiclesNeeded = Math.max(1, Math.ceil(group.pax_count / Math.max(1, group.capacity)))
+  const vehiclesNeeded = resolveVehicleCount(group, group.capacity)
   const resources: AllocationResource[] = []
   let sequence = startingSequence
 
@@ -126,7 +142,7 @@ async function materializeVehicleSeatGroupFromSpec(
   )
   if (seatsPerVehicle === 0) return { resources: [], vehicleCount: 0 }
 
-  const vehiclesNeeded = Math.max(1, Math.ceil(group.pax_count / seatsPerVehicle))
+  const vehiclesNeeded = resolveVehicleCount(group, seatsPerVehicle)
   const resources: AllocationResource[] = []
   let sequence = startingSequence
 

--- a/packages/operations/src/availability/validation.ts
+++ b/packages/operations/src/availability/validation.ts
@@ -290,13 +290,78 @@ export const insertAllocationResourceSchema = allocationResourceCoreSchema.super
     }
   },
 )
+/**
+ * `expectedUpdatedAt` is the optimistic-concurrency precondition: the
+ * `updatedAt` the caller read. Supplying it rejects a patch computed against a
+ * resource somebody else has since re-shaped (a coach whose capacity was
+ * lowered under you) with 409 instead of silently overwriting.
+ */
 export const updateAllocationResourceSchema = allocationResourceCoreSchema
   .omit({ kind: true })
-  .strict()
   .partial()
-  .refine((value) => Object.keys(value).length > 0, {
+  .extend({ expectedUpdatedAt: isoDateTimeSchema.optional() })
+  .strict()
+  .refine((value) => Object.keys(value).some((key) => key !== "expectedUpdatedAt"), {
     message: "Patch payload is required",
   })
+
+export const deleteAllocationResourceQuerySchema = z.object({
+  expectedUpdatedAt: isoDateTimeSchema.optional(),
+})
+
+/**
+ * Attach an existing fleet `resources` record to a departure. `kind` and
+ * `capacity` default from the fleet record; name them when it does not carry
+ * one (a `guide`/`equipment` resource, or a coach with no declared capacity).
+ */
+export const attachDepartureResourceSchema = z.object({
+  resourceId: z.string().trim().min(1),
+  kind: allocationResourceKindSchema.optional(),
+  capacity: z.number().int().min(1).optional(),
+  label: z.string().trim().min(1).max(160).nullable().optional(),
+  flags: allocationResourceFlagsSchema.default({}),
+  sortOrder: z.number().int().default(0),
+  notes: z.string().trim().max(500).nullable().optional(),
+})
+
+export const detachDepartureResourceQuerySchema = z.object({
+  expectedUpdatedAt: isoDateTimeSchema.optional(),
+  /** Remove the attached resource's children (a coach's seats) with it. */
+  cascade: booleanQueryParam.optional(),
+})
+
+/**
+ * Place a whole set of travelers in one transaction. `expectedResourceId` is
+ * the per-traveler optimistic-concurrency precondition — omit it to write
+ * unconditionally, pass `null` to require the traveler to be unassigned.
+ */
+export const batchAssignTravelerAllocationsSchema = z
+  .object({
+    kind: allocationResourceKindSchema,
+    assignments: z
+      .array(
+        z.object({
+          travelerId: z.string().trim().min(1),
+          resourceId: z.string().trim().min(1).nullable(),
+          expectedResourceId: z.string().trim().min(1).nullable().optional(),
+        }),
+      )
+      .min(1)
+      .max(200),
+  })
+  .refine(
+    (value) =>
+      value.kind !== "vehicle" ||
+      value.assignments.every((assignment) => assignment.resourceId === null),
+    {
+      path: ["kind"],
+      message: "Vehicles are parent resources; assign travelers to vehicle seats instead",
+    },
+  )
+
+export const allocationKindQuerySchema = z.object({
+  kind: allocationResourceKindSchema.default("room"),
+})
 
 export const assignTravelerAllocationSchema = z
   .object({

--- a/packages/operations/tests/availability/integration/allocation-assignment-concurrency.test.ts
+++ b/packages/operations/tests/availability/integration/allocation-assignment-concurrency.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Batch assignment under concurrency.
+ *
+ * The per-traveler leg was already serialized by a `FOR UPDATE` on the target
+ * resource, but a *batch* has to hold the whole kind: two batches that each fit
+ * on their own can oversell a room between them, and a batch that races an
+ * auto-allocate can do the same. Both take the same
+ * `SELECT ... WHERE kind = ... FOR UPDATE` statement, so the decision — not
+ * just the write — is serialized.
+ */
+
+import { allocationResources, availabilitySlots } from "@voyant-travel/availability/schema"
+import { createDbClient } from "@voyant-travel/db"
+import { newId } from "@voyant-travel/db/lib/typeid"
+import { cleanupTestDb } from "@voyant-travel/db/test-utils"
+import { sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { products } from "../../../../inventory/src/schema.js"
+import { assignTravelerAllocationsBatch } from "../../../src/availability/service-allocation-assignment-batch.js"
+import { autoAllocateSlotResources } from "../../../src/availability/service-allocation-automation.js"
+
+const DB_AVAILABLE = Boolean(process.env.TEST_DATABASE_URL)
+
+type ClosableTestDb = PostgresJsDatabase & {
+  $client: { end(options?: { timeout?: number | null }): Promise<unknown> }
+}
+
+function connect(maxConnections: number): ClosableTestDb {
+  return createDbClient(process.env.TEST_DATABASE_URL as string, {
+    adapter: "node",
+    nodeMaxConnections: maxConnections,
+    timeouts: { statementMs: false, queryMs: false, connectMs: false },
+  }) as ClosableTestDb
+}
+
+describe.skipIf(!DB_AVAILABLE)("batch assignment concurrency (integration)", () => {
+  let db: ClosableTestDb
+  let productId: string
+  let slotId: string
+
+  beforeAll(async () => {
+    db = connect(6)
+    await cleanupTestDb(db)
+    productId = newId("products")
+    await db.insert(products).values({
+      id: productId,
+      name: "Transylvania Coach Tour",
+      sellCurrency: "EUR",
+      bookingMode: "date",
+    })
+  }, 120000)
+
+  afterAll(async () => {
+    await db.$client.end({ timeout: 0 })
+  })
+
+  beforeEach(async () => {
+    slotId = newId("availability_slots")
+    await db.insert(availabilitySlots).values({
+      id: slotId,
+      productId,
+      dateLocal: "2026-06-01",
+      startsAt: new Date("2026-06-01T08:00:00Z"),
+      timezone: "UTC",
+      status: "open",
+      unlimited: false,
+      initialPax: 20,
+      remainingPax: 20,
+    })
+  })
+
+  async function seedRoom(label: string, capacity: number, sortOrder: number) {
+    const id = newId("allocation_resources")
+    await db.insert(allocationResources).values({
+      id,
+      slotId,
+      kind: "room",
+      label,
+      capacity,
+      sortOrder,
+      flags: {},
+    })
+    return id
+  }
+
+  async function seedBooking(bookingNumber: string, travelerIds: string[]) {
+    const bookingId = newId("bookings")
+    const bookingItemId = newId("booking_items")
+    await db.execute(sql`
+      INSERT INTO bookings (id, booking_number, status, sell_currency, pax)
+      VALUES (${bookingId}, ${bookingNumber}, 'confirmed', 'EUR', ${travelerIds.length})
+    `)
+    await db.execute(sql`
+      INSERT INTO booking_items
+        (id, booking_id, title, status, quantity, sell_currency, product_id, availability_slot_id)
+      VALUES (${bookingItemId}, ${bookingId}, 'Coach seat', 'confirmed', ${travelerIds.length},
+              'EUR', ${productId}, ${slotId})
+    `)
+    await db.execute(sql`
+      INSERT INTO booking_allocations
+        (id, booking_id, booking_item_id, product_id, availability_slot_id, quantity, allocation_type, status)
+      VALUES (${newId("booking_allocations")}, ${bookingId}, ${bookingItemId}, ${productId},
+              ${slotId}, ${travelerIds.length}, 'unit', 'confirmed')
+    `)
+    for (const travelerId of travelerIds) {
+      await db.execute(sql`
+        INSERT INTO booking_travelers (id, booking_id, participant_type, first_name, last_name)
+        VALUES (${travelerId}, ${bookingId}, 'traveler', 'Test', ${travelerId.slice(-4)})
+      `)
+    }
+    return bookingId
+  }
+
+  async function roomOccupancy(roomId: string) {
+    const rows = await db.execute<{ assigned: number }>(sql`
+      SELECT COUNT(DISTINCT btd.traveler_id)::int AS assigned
+      FROM booking_traveler_travel_details btd
+      JOIN booking_travelers bt ON bt.id = btd.traveler_id
+      JOIN booking_allocations ba ON ba.booking_id = bt.booking_id
+      WHERE btd.allocations ->> 'room' = ${roomId}
+        AND ba.availability_slot_id = ${slotId}
+    `)
+    return [...rows][0]?.assigned ?? 0
+  }
+
+  it("lets only one of two competing batches fill the last bed", async () => {
+    const room = await seedRoom("DBL 1", 2, 1)
+    const pairA = [newId("booking_travelers"), newId("booking_travelers")]
+    const pairB = [newId("booking_travelers"), newId("booking_travelers")]
+    await seedBooking("BATCH-CONC-A", pairA)
+    await seedBooking("BATCH-CONC-B", pairB)
+
+    const batch = (travelerIds: string[]) =>
+      assignTravelerAllocationsBatch(db, slotId, {
+        kind: "room",
+        assignments: travelerIds.map((travelerId) => ({ travelerId, resourceId: room })),
+      })
+
+    const outcomes = await Promise.allSettled([batch(pairA), batch(pairB)])
+    expect(outcomes.filter((outcome) => outcome.status === "fulfilled")).toHaveLength(1)
+    expect(outcomes.filter((outcome) => outcome.status === "rejected")).toHaveLength(1)
+    expect(await roomOccupancy(room)).toBe(2)
+  })
+
+  it("never oversells when a batch races an auto-allocate", async () => {
+    const roomA = await seedRoom("DBL 1", 2, 1)
+    const roomB = await seedRoom("DBL 2", 2, 2)
+    const pairA = [newId("booking_travelers"), newId("booking_travelers")]
+    const pairB = [newId("booking_travelers"), newId("booking_travelers")]
+    await seedBooking("BATCH-RACE-A", pairA)
+    await seedBooking("BATCH-RACE-B", pairB)
+
+    await Promise.allSettled([
+      assignTravelerAllocationsBatch(db, slotId, {
+        kind: "room",
+        assignments: pairA.map((travelerId) => ({ travelerId, resourceId: roomA })),
+      }),
+      autoAllocateSlotResources(db, slotId, { kind: "room" }),
+    ])
+
+    for (const room of [roomA, roomB]) {
+      expect.soft(await roomOccupancy(room)).toBeLessThanOrEqual(2)
+    }
+  })
+
+  it("rolls the whole batch back when one traveler does not fit", async () => {
+    const single = await seedRoom("SGL", 1, 1)
+    const pair = [newId("booking_travelers"), newId("booking_travelers")]
+    await seedBooking("BATCH-ATOMIC", pair)
+
+    await expect(
+      assignTravelerAllocationsBatch(db, slotId, {
+        kind: "room",
+        assignments: pair.map((travelerId) => ({ travelerId, resourceId: single })),
+      }),
+    ).rejects.toMatchObject({ status: 409 })
+
+    expect(await roomOccupancy(single)).toBe(0)
+  })
+
+  it("frees and refills a bed in the same batch", async () => {
+    const room = await seedRoom("DBL 1", 2, 1)
+    const seated = [newId("booking_travelers"), newId("booking_travelers")]
+    const waiting = [newId("booking_travelers")]
+    await seedBooking("BATCH-SWAP-A", seated)
+    await seedBooking("BATCH-SWAP-B", waiting)
+
+    await assignTravelerAllocationsBatch(db, slotId, {
+      kind: "room",
+      assignments: seated.map((travelerId) => ({ travelerId, resourceId: room })),
+    })
+    expect(await roomOccupancy(room)).toBe(2)
+
+    // Full room; the swap only fits because the capacity check runs after both
+    // writes land inside the one transaction.
+    const result = await assignTravelerAllocationsBatch(db, slotId, {
+      kind: "room",
+      assignments: [
+        { travelerId: seated[0] as string, resourceId: null },
+        { travelerId: waiting[0] as string, resourceId: room },
+      ],
+    })
+    expect(result.assigned).toBe(1)
+    expect(result.unassigned).toBe(1)
+    expect(await roomOccupancy(room)).toBe(2)
+  })
+})

--- a/packages/operations/tests/availability/integration/allocation-departure-resources.test.ts
+++ b/packages/operations/tests/availability/integration/allocation-departure-resources.test.ts
@@ -6,13 +6,13 @@ import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { beforeAll, beforeEach, describe, expect, it } from "vitest"
 
 import { products } from "../../../../inventory/src/schema.js"
-import { resources, resourceSlotAssignments } from "../../../src/resources/schema.js"
 import { AllocationServiceError } from "../../../src/availability/service-allocation.js"
 import {
   attachDepartureResource,
   detachDepartureResource,
   listDepartureResourceLinks,
 } from "../../../src/availability/service-allocation-resource-link.js"
+import { resourceSlotAssignments, resources } from "../../../src/resources/schema.js"
 
 const DB_AVAILABLE = Boolean(process.env.TEST_DATABASE_URL)
 
@@ -80,9 +80,14 @@ describe.skipIf(!DB_AVAILABLE)("departure fleet-resource link (integration)", ()
   })
 
   it("attaches a fleet resource as an allocation resource and opens its fleet commitment", async () => {
-    const link = await attachDepartureResource(db, slotId, { resourceId: coachId }, {
-      actorId: "usr_test",
-    })
+    const link = await attachDepartureResource(
+      db,
+      slotId,
+      { resourceId: coachId },
+      {
+        actorId: "usr_test",
+      },
+    )
 
     expect(link.created).toBe(true)
     expect(link.resource.kind).toBe("vehicle")

--- a/packages/operations/tests/availability/integration/allocation-departure-resources.test.ts
+++ b/packages/operations/tests/availability/integration/allocation-departure-resources.test.ts
@@ -1,0 +1,260 @@
+import { allocationResources, availabilitySlots } from "@voyant-travel/availability/schema"
+import { newId } from "@voyant-travel/db/lib/typeid"
+import { cleanupTestDb, createTestDb } from "@voyant-travel/db/test-utils"
+import { and, eq, sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { products } from "../../../../inventory/src/schema.js"
+import { resources, resourceSlotAssignments } from "../../../src/resources/schema.js"
+import { AllocationServiceError } from "../../../src/availability/service-allocation.js"
+import {
+  attachDepartureResource,
+  detachDepartureResource,
+  listDepartureResourceLinks,
+} from "../../../src/availability/service-allocation-resource-link.js"
+
+const DB_AVAILABLE = Boolean(process.env.TEST_DATABASE_URL)
+
+describe.skipIf(!DB_AVAILABLE)("departure fleet-resource link (integration)", () => {
+  let db: PostgresJsDatabase
+  let productId: string
+  let slotId: string
+  let otherSlotId: string
+  let coachId: string
+
+  // One TRUNCATE for the file. `cleanupTestDb` truncates the whole ~500-table
+  // schema and can take tens of seconds; each test gets its own departure,
+  // resource and ids instead so they cannot see each other's rows.
+  beforeAll(async () => {
+    db = createTestDb() as PostgresJsDatabase
+    await cleanupTestDb(db)
+    productId = newId("products")
+    await db.insert(products).values({
+      id: productId,
+      name: "Transylvania Coach Tour",
+      sellCurrency: "EUR",
+      bookingMode: "date",
+    })
+  }, 120000)
+
+  beforeEach(async () => {
+    slotId = newId("availability_slots")
+    otherSlotId = newId("availability_slots")
+    coachId = newId("resources")
+
+    await db.insert(availabilitySlots).values([
+      {
+        id: slotId,
+        productId,
+        dateLocal: "2026-06-01",
+        startsAt: new Date("2026-06-01T08:00:00Z"),
+        endsAt: new Date("2026-06-03T18:00:00Z"),
+        timezone: "UTC",
+        status: "open",
+        unlimited: false,
+        initialPax: 50,
+        remainingPax: 50,
+      },
+      {
+        id: otherSlotId,
+        productId,
+        dateLocal: "2026-06-02",
+        startsAt: new Date("2026-06-02T08:00:00Z"),
+        endsAt: new Date("2026-06-04T18:00:00Z"),
+        timezone: "UTC",
+        status: "open",
+        unlimited: false,
+        initialPax: 50,
+        remainingPax: 50,
+      },
+    ])
+    await db.insert(resources).values({
+      id: coachId,
+      kind: "vehicle",
+      name: "Setra S 517",
+      code: "B-123-XYZ",
+      capacity: 49,
+      active: true,
+    })
+  })
+
+  it("attaches a fleet resource as an allocation resource and opens its fleet commitment", async () => {
+    const link = await attachDepartureResource(db, slotId, { resourceId: coachId }, {
+      actorId: "usr_test",
+    })
+
+    expect(link.created).toBe(true)
+    expect(link.resource.kind).toBe("vehicle")
+    expect(link.resource.refType).toBe("resource")
+    expect(link.resource.refId).toBe(coachId)
+    expect(link.resource.capacity).toBe(49)
+    expect(link.resource.label).toBe("Setra S 517 (B-123-XYZ)")
+    expect(link.resource.flags.resourceAssignmentId).toBe(link.assignmentId)
+
+    const assignments = await db
+      .select()
+      .from(resourceSlotAssignments)
+      .where(eq(resourceSlotAssignments.slotId, slotId))
+    expect(assignments).toHaveLength(1)
+    expect(assignments[0]?.resourceId).toBe(coachId)
+    expect(assignments[0]?.status).toBe("assigned")
+    expect(assignments[0]?.assignedBy).toBe("usr_test")
+
+    const audit = await db.execute<{ action: string; actor_id: string | null }>(sql`
+      SELECT action, actor_id FROM allocation_audit_log WHERE slot_id = ${slotId}
+    `)
+    expect([...audit].map((row) => row.action)).toContain("resource.attach")
+  })
+
+  it("is idempotent: re-attaching returns the existing link without a second commitment", async () => {
+    const first = await attachDepartureResource(db, slotId, { resourceId: coachId })
+    const second = await attachDepartureResource(db, slotId, { resourceId: coachId })
+
+    expect(second.created).toBe(false)
+    expect(second.resource.id).toBe(first.resource.id)
+    expect(second.assignmentId).toBe(first.assignmentId)
+
+    const links = await listDepartureResourceLinks(db, slotId)
+    expect(links).toHaveLength(1)
+    const assignments = await db
+      .select()
+      .from(resourceSlotAssignments)
+      .where(eq(resourceSlotAssignments.slotId, slotId))
+    expect(assignments).toHaveLength(1)
+  })
+
+  // The whole point of the authority decision: `resource_slot_assignments` is
+  // the only table that spans departures, so it is the only one that can see a
+  // coach already committed elsewhere. `allocation_resources` is slot-scoped.
+  it("refuses a coach already committed to an overlapping departure", async () => {
+    await attachDepartureResource(db, otherSlotId, { resourceId: coachId })
+
+    await expect(attachDepartureResource(db, slotId, { resourceId: coachId })).rejects.toThrow(
+      /already committed to an overlapping departure/,
+    )
+
+    const links = await listDepartureResourceLinks(db, slotId)
+    expect(links).toEqual([])
+  })
+
+  it("allows a coach whose other commitment was released", async () => {
+    await attachDepartureResource(db, otherSlotId, { resourceId: coachId })
+    await detachDepartureResource(db, otherSlotId, coachId)
+
+    const link = await attachDepartureResource(db, slotId, { resourceId: coachId })
+    expect(link.created).toBe(true)
+  })
+
+  // Reconciliation: the Resources admin section may already have committed the
+  // coach to this departure. Adopting that row is what stops the same coach
+  // being held twice through two unrelated tables.
+  it("adopts an assignment the Resources admin already made for this departure", async () => {
+    const existingAssignmentId = newId("resource_slot_assignments")
+    await db.insert(resourceSlotAssignments).values({
+      id: existingAssignmentId,
+      slotId,
+      resourceId: coachId,
+      status: "reserved",
+    })
+
+    const link = await attachDepartureResource(db, slotId, { resourceId: coachId })
+    expect(link.assignmentId).toBe(existingAssignmentId)
+
+    const assignments = await db
+      .select()
+      .from(resourceSlotAssignments)
+      .where(eq(resourceSlotAssignments.slotId, slotId))
+    expect(assignments).toHaveLength(1)
+  })
+
+  it("requires an explicit kind and capacity for a resource that declares neither", async () => {
+    const guideId = newId("resources")
+    await db.insert(resources).values({ id: guideId, kind: "guide", name: "Ana", active: true })
+
+    await expect(attachDepartureResource(db, slotId, { resourceId: guideId })).rejects.toThrow(
+      /no default departure kind/,
+    )
+    await expect(
+      attachDepartureResource(db, slotId, { resourceId: guideId, kind: "guide" }),
+    ).rejects.toThrow(/declares no capacity/)
+
+    const link = await attachDepartureResource(db, slotId, {
+      resourceId: guideId,
+      kind: "guide",
+      capacity: 1,
+    })
+    expect(link.resource.kind).toBe("guide")
+  })
+
+  it("refuses an inactive resource", async () => {
+    await db.update(resources).set({ active: false }).where(eq(resources.id, coachId))
+    await expect(attachDepartureResource(db, slotId, { resourceId: coachId })).rejects.toThrow(
+      /inactive/,
+    )
+  })
+
+  it("refuses to detach a laid-out coach without cascade, then removes its seats with it", async () => {
+    const link = await attachDepartureResource(db, slotId, { resourceId: coachId })
+    const seatId = newId("allocation_resources")
+    await db.insert(allocationResources).values({
+      id: seatId,
+      slotId,
+      kind: "vehicle_seat",
+      label: "1A",
+      capacity: 1,
+      parentId: link.resource.id,
+      flags: {},
+    })
+
+    await expect(detachDepartureResource(db, slotId, coachId)).rejects.toThrow(
+      /Remove child resources/,
+    )
+
+    const detached = await detachDepartureResource(db, slotId, coachId, { cascade: true })
+    expect(detached?.removedResourceIds).toEqual([seatId, link.resource.id])
+
+    const remaining = await db
+      .select()
+      .from(allocationResources)
+      .where(eq(allocationResources.slotId, slotId))
+    expect(remaining).toEqual([])
+
+    const [assignment] = await db
+      .select()
+      .from(resourceSlotAssignments)
+      .where(
+        and(
+          eq(resourceSlotAssignments.slotId, slotId),
+          eq(resourceSlotAssignments.resourceId, coachId),
+        ),
+      )
+    expect(assignment?.status).toBe("released")
+    expect(assignment?.releasedAt).toBeTruthy()
+  })
+
+  it("enforces the optimistic-concurrency precondition on detach", async () => {
+    const link = await attachDepartureResource(db, slotId, { resourceId: coachId })
+
+    await expect(
+      detachDepartureResource(db, slotId, coachId, {
+        expectedUpdatedAt: new Date("2020-01-01T00:00:00Z").toISOString(),
+      }),
+    ).rejects.toMatchObject({ status: 409 })
+
+    const ok = await detachDepartureResource(db, slotId, coachId, {
+      expectedUpdatedAt: link.resource.updatedAt,
+    })
+    expect(ok?.removedResourceIds).toEqual([link.resource.id])
+  })
+
+  it("returns null when detaching a resource that was never attached", async () => {
+    expect(await detachDepartureResource(db, slotId, coachId)).toBeNull()
+  })
+
+  it("raises a 404-shaped error for an unknown slot", async () => {
+    await expect(
+      attachDepartureResource(db, newId("availability_slots"), { resourceId: coachId }),
+    ).rejects.toBeInstanceOf(AllocationServiceError)
+  })
+})

--- a/packages/operations/tests/availability/integration/allocation-routes.test.ts
+++ b/packages/operations/tests/availability/integration/allocation-routes.test.ts
@@ -257,9 +257,7 @@ describe.skipIf(!DB_AVAILABLE)("Availability allocation routes", () => {
       "traveler_unassigned",
     ])
 
-    const missing = await app.request(
-      `/slots/${newId("availability_slots")}/allocation/conflicts`,
-    )
+    const missing = await app.request(`/slots/${newId("availability_slots")}/allocation/conflicts`)
     expect(missing.status).toBe(404)
   })
 
@@ -273,10 +271,10 @@ describe.skipIf(!DB_AVAILABLE)("Availability allocation routes", () => {
       capacity: 1,
       parentId: coach.id,
     })
-    const assigned = await app.request(
-      `/slots/${slotId}/allocation/travelers/${travelerIds[0]}`,
-      { method: "PATCH", ...json({ kind: "vehicle_seat", resourceId: seat.id }) },
-    )
+    const assigned = await app.request(`/slots/${slotId}/allocation/travelers/${travelerIds[0]}`, {
+      method: "PATCH",
+      ...json({ kind: "vehicle_seat", resourceId: seat.id }),
+    })
     expect(assigned.status).toBe(200)
 
     const res = await app.request(
@@ -311,17 +309,15 @@ describe.skipIf(!DB_AVAILABLE)("Availability allocation routes", () => {
     const listed = await app.request(`/slots/${slotId}/allocation/fleet-resources`)
     expect((await listed.json()).data).toHaveLength(1)
 
-    const detach = await app.request(
-      `/slots/${slotId}/allocation/fleet-resources/${coachId}`,
-      { method: "DELETE" },
-    )
+    const detach = await app.request(`/slots/${slotId}/allocation/fleet-resources/${coachId}`, {
+      method: "DELETE",
+    })
     expect(detach.status).toBe(200)
     expect((await detach.json()).data.removedResourceIds).toHaveLength(1)
 
-    const missing = await app.request(
-      `/slots/${slotId}/allocation/fleet-resources/${coachId}`,
-      { method: "DELETE" },
-    )
+    const missing = await app.request(`/slots/${slotId}/allocation/fleet-resources/${coachId}`, {
+      method: "DELETE",
+    })
     expect(missing.status).toBe(404)
   })
 

--- a/packages/operations/tests/availability/integration/allocation-routes.test.ts
+++ b/packages/operations/tests/availability/integration/allocation-routes.test.ts
@@ -1,0 +1,371 @@
+/**
+ * Allocation admin-route coverage. The pre-existing `routes.test.ts` has zero
+ * occurrences of "allocation": every leg of the departure-workspace surface —
+ * manifest, resources, assignment, exports, automations — was only ever
+ * exercised through its service functions.
+ */
+
+import { availabilitySlots } from "@voyant-travel/availability/schema"
+import { newId } from "@voyant-travel/db/lib/typeid"
+import { cleanupTestDb, createTestDb } from "@voyant-travel/db/test-utils"
+import { sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { Hono } from "hono"
+import { beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { productOptions, products } from "../../../../inventory/src/schema.js"
+import { availabilityAdminRoutes } from "../../../src/availability/routes.js"
+import { resources } from "../../../src/resources/schema.js"
+
+const DB_AVAILABLE = Boolean(process.env.TEST_DATABASE_URL)
+
+const json = (body: Record<string, unknown>) => ({
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify(body),
+})
+
+describe.skipIf(!DB_AVAILABLE)("Availability allocation routes", () => {
+  let db: PostgresJsDatabase
+  let app: Hono
+  let productId: string
+  let optionId: string
+  let slotId: string
+
+  // One TRUNCATE for the file, not one per test: `cleanupTestDb` truncates the
+  // whole ~500-table schema and takes tens of seconds on a cold Postgres, which
+  // blows the 60s hook timeout. Each test gets its own departure instead, so
+  // they cannot see each other's rows.
+  beforeAll(async () => {
+    db = createTestDb() as PostgresJsDatabase
+    app = new Hono()
+    app.use("*", async (c, next) => {
+      c.set("db" as never, db)
+      c.set("userId" as never, "usr_test")
+      await next()
+    })
+    app.route("/", availabilityAdminRoutes)
+
+    await cleanupTestDb(db)
+    productId = newId("products")
+    optionId = newId("product_options")
+    await db.insert(products).values({
+      id: productId,
+      name: "Transylvania Coach Tour",
+      sellCurrency: "EUR",
+      bookingMode: "date",
+    })
+    await db.insert(productOptions).values({
+      id: optionId,
+      productId,
+      name: "Standard",
+      status: "active",
+      sortOrder: 0,
+    })
+  }, 120000)
+
+  beforeEach(async () => {
+    slotId = newId("availability_slots")
+    await db.insert(availabilitySlots).values({
+      id: slotId,
+      productId,
+      optionId,
+      dateLocal: "2026-06-01",
+      startsAt: new Date("2026-06-01T08:00:00Z"),
+      endsAt: new Date("2026-06-03T18:00:00Z"),
+      timezone: "UTC",
+      status: "open",
+      unlimited: false,
+      initialPax: 20,
+      remainingPax: 20,
+    })
+  })
+
+  async function seedBooking(bookingNumber: string, travelerIds: string[]) {
+    const bookingId = newId("bookings")
+    const bookingItemId = newId("booking_items")
+    await db.execute(sql`
+      INSERT INTO bookings (id, booking_number, status, sell_currency, pax)
+      VALUES (${bookingId}, ${bookingNumber}, 'confirmed', 'EUR', ${travelerIds.length})
+    `)
+    await db.execute(sql`
+      INSERT INTO booking_items
+        (id, booking_id, title, status, quantity, sell_currency, product_id, option_id, availability_slot_id)
+      VALUES (${bookingItemId}, ${bookingId}, 'Coach seat', 'confirmed', ${travelerIds.length},
+              'EUR', ${productId}, ${optionId}, ${slotId})
+    `)
+    await db.execute(sql`
+      INSERT INTO booking_allocations
+        (id, booking_id, booking_item_id, product_id, availability_slot_id, quantity, allocation_type, status)
+      VALUES (${newId("booking_allocations")}, ${bookingId}, ${bookingItemId}, ${productId},
+              ${slotId}, ${travelerIds.length}, 'unit', 'confirmed')
+    `)
+    for (const travelerId of travelerIds) {
+      await db.execute(sql`
+        INSERT INTO booking_travelers (id, booking_id, participant_type, first_name, last_name)
+        VALUES (${travelerId}, ${bookingId}, 'traveler', 'Test', ${travelerId.slice(-4)})
+      `)
+    }
+    return bookingId
+  }
+
+  async function createResource(body: Record<string, unknown>) {
+    const res = await app.request(`/slots/${slotId}/allocation/resources`, {
+      method: "POST",
+      ...json(body),
+    })
+    expect(res.status).toBe(201)
+    return (await res.json()).data as {
+      id: string
+      updatedAt: string
+      capacity: number
+      kind: string
+    }
+  }
+
+  it("serves the manifest with its resources", async () => {
+    await createResource({ kind: "room", label: "DBL 1", capacity: 2 })
+    const res = await app.request(`/slots/${slotId}/allocation`)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data.resources).toHaveLength(1)
+    expect(body.data.summary.bookingCount).toBe(0)
+  })
+
+  it("enforces the expectedUpdatedAt precondition on resource update and delete", async () => {
+    const room = await createResource({ kind: "room", label: "DBL 1", capacity: 2 })
+
+    const stale = await app.request(`/slots/${slotId}/allocation/resources/${room.id}`, {
+      method: "PATCH",
+      ...json({ capacity: 3, expectedUpdatedAt: "2020-01-01T00:00:00.000Z" }),
+    })
+    expect(stale.status).toBe(409)
+    expect((await stale.json()).detail.reason).toBe("revision_conflict")
+
+    const fresh = await app.request(`/slots/${slotId}/allocation/resources/${room.id}`, {
+      method: "PATCH",
+      ...json({ capacity: 3, expectedUpdatedAt: room.updatedAt }),
+    })
+    expect(fresh.status).toBe(200)
+    expect((await fresh.json()).data.capacity).toBe(3)
+
+    const staleDelete = await app.request(
+      `/slots/${slotId}/allocation/resources/${room.id}?expectedUpdatedAt=${encodeURIComponent(room.updatedAt)}`,
+      { method: "DELETE" },
+    )
+    expect(staleDelete.status).toBe(409)
+  })
+
+  it("places a whole sharing group atomically, or none of it", async () => {
+    const travelerIds = [newId("booking_travelers"), newId("booking_travelers")]
+    await seedBooking("ALLOC-ROUTE-1", travelerIds)
+    const twin = await createResource({ kind: "room", label: "TWIN", capacity: 2 })
+    const single = await createResource({ kind: "room", label: "SGL", capacity: 1 })
+
+    const overflow = await app.request(`/slots/${slotId}/allocation/travelers/assignments`, {
+      method: "POST",
+      ...json({
+        kind: "room",
+        assignments: travelerIds.map((travelerId) => ({ travelerId, resourceId: single.id })),
+      }),
+    })
+    expect(overflow.status).toBe(409)
+
+    // Nothing landed: the rejected batch rolled back whole.
+    const afterFailure = await app.request(`/slots/${slotId}/allocation`)
+    const failureBody = await afterFailure.json()
+    for (const booking of failureBody.data.bookings) {
+      for (const traveler of booking.travelers) {
+        expect(traveler.allocations.room).toBeUndefined()
+      }
+    }
+
+    const ok = await app.request(`/slots/${slotId}/allocation/travelers/assignments`, {
+      method: "POST",
+      ...json({
+        kind: "room",
+        assignments: travelerIds.map((travelerId) => ({
+          travelerId,
+          resourceId: twin.id,
+          expectedResourceId: null,
+        })),
+      }),
+    })
+    expect(ok.status).toBe(200)
+    expect((await ok.json()).data.assigned).toBe(2)
+  })
+
+  it("rejects a batch whose optimistic precondition no longer holds", async () => {
+    const travelerIds = [newId("booking_travelers")]
+    await seedBooking("ALLOC-ROUTE-2", travelerIds)
+    const twin = await createResource({ kind: "room", label: "TWIN", capacity: 2 })
+
+    const res = await app.request(`/slots/${slotId}/allocation/travelers/assignments`, {
+      method: "POST",
+      ...json({
+        kind: "room",
+        assignments: [
+          { travelerId: travelerIds[0], resourceId: twin.id, expectedResourceId: "avr_other" },
+        ],
+      }),
+    })
+    expect(res.status).toBe(409)
+    expect((await res.json()).detail.reason).toBe("revision_conflict")
+  })
+
+  it("previews an auto-allocation without writing it", async () => {
+    const travelerIds = [newId("booking_travelers"), newId("booking_travelers")]
+    await seedBooking("ALLOC-ROUTE-3", travelerIds)
+    await createResource({ kind: "room", label: "DBL 1", capacity: 2 })
+
+    const preview = await app.request(`/slots/${slotId}/allocation/auto-allocate/preview`, {
+      method: "POST",
+      ...json({ kind: "room" }),
+    })
+    expect(preview.status).toBe(200)
+    const plan = (await preview.json()).data
+    expect(plan.assigned).toBe(2)
+    expect(plan.violations).toEqual([])
+    expect(plan.entries.every((entry: { unchanged: boolean }) => entry.unchanged === false)).toBe(
+      true,
+    )
+
+    const manifest = await (await app.request(`/slots/${slotId}/allocation`)).json()
+    for (const booking of manifest.data.bookings) {
+      for (const traveler of booking.travelers) {
+        expect(traveler.allocations.room).toBeUndefined()
+      }
+    }
+
+    const committed = await app.request(`/slots/${slotId}/allocation/auto-allocate`, {
+      method: "POST",
+      ...json({ kind: "room" }),
+    })
+    expect(committed.status).toBe(200)
+    expect((await committed.json()).data.assigned).toBe(2)
+  })
+
+  it("projects allocation conflicts for the requested kind", async () => {
+    const travelerIds = [newId("booking_travelers"), newId("booking_travelers")]
+    await seedBooking("ALLOC-ROUTE-4", travelerIds)
+    await createResource({ kind: "room", label: "SGL", capacity: 1 })
+
+    const res = await app.request(`/slots/${slotId}/allocation/conflicts?kind=room`)
+    expect(res.status).toBe(200)
+    const conflicts = (await res.json()).data as Array<{ code: string; subjectId: string }>
+    expect(conflicts.map((conflict) => conflict.code)).toEqual([
+      "traveler_unassigned",
+      "traveler_unassigned",
+    ])
+
+    const missing = await app.request(
+      `/slots/${newId("availability_slots")}/allocation/conflicts`,
+    )
+    expect(missing.status).toBe(404)
+  })
+
+  it("exports a seating manifest, which the route could not reach before", async () => {
+    const travelerIds = [newId("booking_travelers")]
+    await seedBooking("ALLOC-ROUTE-5", travelerIds)
+    const coach = await createResource({ kind: "vehicle", label: "Coach 1", capacity: 4 })
+    const seat = await createResource({
+      kind: "vehicle_seat",
+      label: "1A",
+      capacity: 1,
+      parentId: coach.id,
+    })
+    const assigned = await app.request(
+      `/slots/${slotId}/allocation/travelers/${travelerIds[0]}`,
+      { method: "PATCH", ...json({ kind: "vehicle_seat", resourceId: seat.id }) },
+    )
+    expect(assigned.status).toBe(200)
+
+    const res = await app.request(
+      `/slots/${slotId}/allocation/export-rooming-list?kind=vehicle_seat`,
+    )
+    expect(res.status).toBe(200)
+    expect(res.headers.get("Content-Disposition")).toContain(`seating-`)
+    const csv = await res.text()
+    expect(csv).toContain("1A")
+
+    const rooming = await app.request(`/slots/${slotId}/allocation/export-rooming-list`)
+    expect(rooming.headers.get("Content-Disposition")).toContain("rooming-")
+  })
+
+  it("attaches and detaches a fleet resource over HTTP", async () => {
+    const coachId = newId("resources")
+    await db.insert(resources).values({
+      id: coachId,
+      kind: "vehicle",
+      name: "Setra S 517",
+      capacity: 49,
+      active: true,
+    })
+
+    const attach = await app.request(`/slots/${slotId}/allocation/fleet-resources`, {
+      method: "POST",
+      ...json({ resourceId: coachId }),
+    })
+    expect(attach.status).toBe(201)
+    expect((await attach.json()).data.created).toBe(true)
+
+    const listed = await app.request(`/slots/${slotId}/allocation/fleet-resources`)
+    expect((await listed.json()).data).toHaveLength(1)
+
+    const detach = await app.request(
+      `/slots/${slotId}/allocation/fleet-resources/${coachId}`,
+      { method: "DELETE" },
+    )
+    expect(detach.status).toBe(200)
+    expect((await detach.json()).data.removedResourceIds).toHaveLength(1)
+
+    const missing = await app.request(
+      `/slots/${slotId}/allocation/fleet-resources/${coachId}`,
+      { method: "DELETE" },
+    )
+    expect(missing.status).toBe(404)
+  })
+
+  it("replays a retried auto-allocate carrying the same Idempotency-Key", async () => {
+    const travelerIds = [newId("booking_travelers"), newId("booking_travelers")]
+    await seedBooking("ALLOC-ROUTE-6", travelerIds)
+    await createResource({ kind: "room", label: "DBL 1", capacity: 2 })
+
+    const request = () =>
+      app.request(`/slots/${slotId}/allocation/auto-allocate`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "Idempotency-Key": "retry-1" },
+        body: JSON.stringify({ kind: "room" }),
+      })
+
+    const first = await request()
+    expect(first.status).toBe(200)
+    const second = await request()
+    expect(second.status).toBe(200)
+    expect(second.headers.get("Idempotency-Replayed")).toBe("true")
+
+    const audit = await db.execute<{ action: string }>(sql`
+      SELECT action FROM allocation_audit_log WHERE slot_id = ${slotId} AND action = 'auto-allocate'
+    `)
+    expect([...audit]).toHaveLength(1)
+  })
+
+  it("reports skipped groups instead of 409 when materialising twice", async () => {
+    await db.execute(sql`
+      INSERT INTO product_option_resource_templates
+        (id, product_option_id, kind, capacity, name_pattern, default_count)
+      VALUES (${newId("product_option_resource_templates")}, ${optionId}, 'room', 2, 'DBL {sequence}', 3)
+    `)
+
+    const first = await app.request(`/slots/${slotId}/allocation/materialize-templates`, {
+      method: "POST",
+    })
+    expect(first.status).toBe(200)
+    expect((await first.json()).data).toEqual({ created: 3, skippedExisting: 0 })
+
+    const second = await app.request(`/slots/${slotId}/allocation/materialize-templates`, {
+      method: "POST",
+    })
+    expect(second.status).toBe(200)
+    expect((await second.json()).data).toEqual({ created: 0, skippedExisting: 1 })
+  })
+})

--- a/packages/operations/tests/availability/integration/materialize-template-defaults.test.ts
+++ b/packages/operations/tests/availability/integration/materialize-template-defaults.test.ts
@@ -257,10 +257,7 @@ describe.skipIf(!DB_AVAILABLE)("materialize template defaults (integration)", ()
       defaultCount: 1,
       flags: {
         layoutSpec: {
-          rows: [
-            { cells: ["seat", "aisle", "seat"] },
-            { cells: ["void", "aisle", "seat"] },
-          ],
+          rows: [{ cells: ["seat", "aisle", "seat"] }, { cells: ["void", "aisle", "seat"] }],
         },
       },
     })

--- a/packages/operations/tests/availability/integration/materialize-template-defaults.test.ts
+++ b/packages/operations/tests/availability/integration/materialize-template-defaults.test.ts
@@ -174,12 +174,16 @@ describe.skipIf(!DB_AVAILABLE)("materialize template defaults (integration)", ()
       status: "confirmed",
     })
 
-    const outcomes = await Promise.allSettled([
+    // Idempotency parity (#4034): the pax-derived path used to 409 on the
+    // second call while the template-default path silently skipped. Both now
+    // skip, so a retried request is a visible no-op instead of an error the
+    // operator has to interpret.
+    const outcomes = await Promise.all([
       autoMaterializeAllocationResources(db, slotId, { kind: "vehicle_seat" }),
       autoMaterializeAllocationResources(db, slotId, { kind: "vehicle_seat" }),
     ])
-    expect(outcomes.filter((outcome) => outcome.status === "fulfilled")).toHaveLength(1)
-    expect(outcomes.filter((outcome) => outcome.status === "rejected")).toHaveLength(1)
+    expect(outcomes.filter((outcome) => (outcome.created ?? 0) > 0)).toHaveLength(1)
+    expect(outcomes.filter((outcome) => (outcome.skippedExisting ?? 0) > 0)).toHaveLength(1)
 
     const rows = await db
       .select()
@@ -192,6 +196,99 @@ describe.skipIf(!DB_AVAILABLE)("materialize template defaults (integration)", ()
     expect(seats.every((seat) => seat.capacity === 1 && seat.parentId === vehicles[0]?.id)).toBe(
       true,
     )
+  })
+
+  // #4034: a coach could not be laid out before the first sale. The only path
+  // that created seats derived its vehicle count from booked pax, so an empty
+  // departure produced nothing and the operator had to hand-create every seat.
+  it("lays a coach out from its template default before any booking exists", async () => {
+    await db.insert(productOptionResourceTemplates).values({
+      productOptionId: optionId,
+      kind: "vehicle_seat",
+      capacity: 6,
+      namePattern: "Coach {sequence}",
+      layout: "2-1",
+      defaultCount: 2,
+    })
+
+    const slotId = newId("availability_slots")
+    await db.insert(availabilitySlots).values({
+      id: slotId,
+      productId,
+      optionId,
+      dateLocal: "2026-06-01",
+      startsAt: new Date("2026-06-01T08:00:00Z"),
+      timezone: "UTC",
+      status: "open",
+      unlimited: false,
+      initialPax: 12,
+      remainingPax: 12,
+    })
+
+    const result = await materializeSlotResourcesFromTemplateDefaults(db, slotId)
+    // default_count counts vehicles; the seat count comes from the layout.
+    expect(result.created).toBe(2 + 12)
+
+    const rows = await db
+      .select()
+      .from(allocationResources)
+      .where(eq(allocationResources.slotId, slotId))
+    const vehicles = rows.filter((row) => row.kind === "vehicle")
+    const seats = rows.filter((row) => row.kind === "vehicle_seat")
+    expect(vehicles).toHaveLength(2)
+    expect(seats).toHaveLength(12)
+    expect(seats.every((seat) => seat.capacity === 1)).toBe(true)
+    expect(new Set(seats.map((seat) => seat.parentId))).toEqual(
+      new Set(vehicles.map((vehicle) => vehicle.id)),
+    )
+
+    // ...and re-running is a no-op, not a duplicate coach.
+    const again = await materializeSlotResourcesFromTemplateDefaults(db, slotId)
+    expect(again.created).toBe(0)
+    expect(again.skippedExisting).toBe(1)
+  })
+
+  it("draws a seat map from a template layoutSpec", async () => {
+    await db.insert(productOptionResourceTemplates).values({
+      productOptionId: optionId,
+      kind: "vehicle_seat",
+      capacity: 3,
+      namePattern: "Minibus {sequence}",
+      defaultCount: 1,
+      flags: {
+        layoutSpec: {
+          rows: [
+            { cells: ["seat", "aisle", "seat"] },
+            { cells: ["void", "aisle", "seat"] },
+          ],
+        },
+      },
+    })
+
+    const slotId = newId("availability_slots")
+    await db.insert(availabilitySlots).values({
+      id: slotId,
+      productId,
+      optionId,
+      dateLocal: "2026-06-01",
+      startsAt: new Date("2026-06-01T08:00:00Z"),
+      timezone: "UTC",
+      status: "open",
+      unlimited: false,
+      initialPax: 3,
+      remainingPax: 3,
+    })
+
+    const result = await materializeSlotResourcesFromTemplateDefaults(db, slotId)
+    expect(result.created).toBe(1 + 3)
+
+    const rows = await db
+      .select()
+      .from(allocationResources)
+      .where(eq(allocationResources.slotId, slotId))
+    const vehicle = rows.find((row) => row.kind === "vehicle")
+    expect(vehicle?.capacity).toBe(3)
+    expect(rows.filter((row) => row.kind === "vehicle_seat")).toHaveLength(3)
   })
 
   it("auto-materializes during generateAvailabilitySlots", async () => {

--- a/packages/operations/tests/unit/allocation-conflicts.test.ts
+++ b/packages/operations/tests/unit/allocation-conflicts.test.ts
@@ -116,10 +116,7 @@ describe("evaluateAllocationConflicts", () => {
         traveler("t1", { allocations: { room: "r1" }, hasAccessibilityNeeds: true }),
         traveler("t2", { allocations: { room: "r2" }, hasAccessibilityNeeds: true }),
       ],
-      resources: [
-        resource("r1"),
-        resource("r2", { flags: { accessibilityNeeded: true } }),
-      ],
+      resources: [resource("r1"), resource("r2", { flags: { accessibilityNeeded: true } })],
     })
     expect(codes(conflicts)).toEqual(["inaccessible_assignment"])
     expect(conflicts[0]?.subjectId).toBe("t1")

--- a/packages/operations/tests/unit/allocation-conflicts.test.ts
+++ b/packages/operations/tests/unit/allocation-conflicts.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from "vitest"
+
+import type { AllocationManifestTraveler } from "../../src/availability/service-allocation.js"
+import {
+  type AllocationConflictResource,
+  evaluateAllocationConflicts,
+} from "../../src/availability/service-allocation-conflicts.js"
+
+const SLOT_ID = "avsl_conflicts"
+
+function traveler(
+  id: string,
+  overrides: Partial<AllocationManifestTraveler> = {},
+): AllocationManifestTraveler {
+  return {
+    id,
+    bookingId: overrides.bookingId ?? `bk_${id}`,
+    bookingNumber: overrides.bookingNumber ?? `BK-${id}`,
+    bookingStatus: overrides.bookingStatus ?? "confirmed",
+    bookingSequence: overrides.bookingSequence ?? 1,
+    paymentStatus: overrides.paymentStatus ?? "unpaid",
+    firstName: overrides.firstName ?? "Test",
+    lastName: overrides.lastName ?? id,
+    fullName: overrides.fullName ?? `Test ${id}`,
+    email: null,
+    phone: null,
+    isLeadTraveler: overrides.isLeadTraveler ?? false,
+    isPrimary: overrides.isPrimary ?? false,
+    sharingGroupId: overrides.sharingGroupId ?? null,
+    optionId: overrides.optionId ?? null,
+    optionUnitId: overrides.optionUnitId ?? null,
+    optionUnitCode: overrides.optionUnitCode ?? null,
+    roomTypeId: null,
+    bedPreference: null,
+    allocations: overrides.allocations ?? {},
+    travelerCategory: null,
+    participantType: overrides.participantType ?? "traveler",
+    hasAccessibilityNeeds: overrides.hasAccessibilityNeeds ?? false,
+    hasDietaryRequirements: overrides.hasDietaryRequirements ?? false,
+  }
+}
+
+function resource(
+  id: string,
+  overrides: Partial<AllocationConflictResource> = {},
+): AllocationConflictResource {
+  return {
+    id,
+    kind: overrides.kind ?? "room",
+    capacity: overrides.capacity ?? 2,
+    label: overrides.label ?? id,
+    refType: overrides.refType ?? null,
+    refId: overrides.refId ?? null,
+    parentId: overrides.parentId ?? null,
+    flags: overrides.flags ?? {},
+  }
+}
+
+function codes(conflicts: ReturnType<typeof evaluateAllocationConflicts>) {
+  return conflicts.map((conflict) => conflict.code)
+}
+
+describe("evaluateAllocationConflicts", () => {
+  it("reports a traveler holding no resource of this kind", () => {
+    const conflicts = evaluateAllocationConflicts({
+      slotId: SLOT_ID,
+      kind: "room",
+      travelers: [traveler("t1")],
+      resources: [resource("r1")],
+    })
+    expect(codes(conflicts)).toEqual(["traveler_unassigned"])
+    expect(conflicts[0]?.subjectId).toBe("t1")
+  })
+
+  it("treats an allocation pointing at a resource that is not on the slot as unassigned", () => {
+    const conflicts = evaluateAllocationConflicts({
+      slotId: SLOT_ID,
+      kind: "room",
+      travelers: [traveler("t1", { allocations: { room: "r_missing" } })],
+      resources: [resource("r1")],
+    })
+    expect(codes(conflicts)).toEqual(["traveler_unassigned"])
+  })
+
+  it("separates over-capacity from a duplicated capacity-1 seat", () => {
+    const roomConflicts = evaluateAllocationConflicts({
+      slotId: SLOT_ID,
+      kind: "room",
+      travelers: [
+        traveler("t1", { allocations: { room: "r1" } }),
+        traveler("t2", { allocations: { room: "r1" } }),
+        traveler("t3", { allocations: { room: "r1" } }),
+      ],
+      resources: [resource("r1", { capacity: 2 })],
+    })
+    expect(codes(roomConflicts)).toEqual(["resource_over_capacity"])
+    expect(roomConflicts[0]?.count).toBe(1)
+
+    const seatConflicts = evaluateAllocationConflicts({
+      slotId: SLOT_ID,
+      kind: "vehicle_seat",
+      travelers: [
+        traveler("t1", { allocations: { vehicle_seat: "s1" } }),
+        traveler("t2", { allocations: { vehicle_seat: "s1" } }),
+      ],
+      resources: [resource("s1", { kind: "vehicle_seat", capacity: 1 })],
+    })
+    expect(codes(seatConflicts)).toEqual(["duplicate_assignment"])
+  })
+
+  it("flags an accessibility-needing traveler placed in a resource that is not marked accessible", () => {
+    const conflicts = evaluateAllocationConflicts({
+      slotId: SLOT_ID,
+      kind: "room",
+      travelers: [
+        traveler("t1", { allocations: { room: "r1" }, hasAccessibilityNeeds: true }),
+        traveler("t2", { allocations: { room: "r2" }, hasAccessibilityNeeds: true }),
+      ],
+      resources: [
+        resource("r1"),
+        resource("r2", { flags: { accessibilityNeeded: true } }),
+      ],
+    })
+    expect(codes(conflicts)).toEqual(["inaccessible_assignment"])
+    expect(conflicts[0]?.subjectId).toBe("t1")
+  })
+
+  it("flags a traveler placed in a unit or option they did not buy", () => {
+    const conflicts = evaluateAllocationConflicts({
+      slotId: SLOT_ID,
+      kind: "room",
+      travelers: [
+        traveler("t1", {
+          allocations: { room: "r1" },
+          optionUnitId: "ou_double",
+        }),
+        traveler("t2", { allocations: { room: "r2" }, optionId: "opt_a" }),
+      ],
+      resources: [
+        resource("r1", { refType: "option_unit", refId: "ou_single" }),
+        resource("r2", { flags: { templateOptionId: "opt_a" } }),
+      ],
+    })
+    expect(codes(conflicts)).toEqual(["incompatible_assignment"])
+    expect(conflicts[0]?.subjectId).toBe("t1")
+  })
+
+  it("reports a sharing group larger than the resource it sits in", () => {
+    const conflicts = evaluateAllocationConflicts({
+      slotId: SLOT_ID,
+      kind: "room",
+      travelers: [
+        traveler("t1", { sharingGroupId: "sg1", allocations: { room: "r1" } }),
+        traveler("t2", { sharingGroupId: "sg1", allocations: { room: "r1" } }),
+        traveler("t3", { sharingGroupId: "sg1", allocations: { room: "r1" } }),
+      ],
+      resources: [resource("r1", { capacity: 2 })],
+    })
+    expect(codes(conflicts)).toEqual(["oversubscribed_sharing_group", "resource_over_capacity"])
+  })
+
+  it("reports an unplaced sharing group that cannot fit anywhere on the departure", () => {
+    const conflicts = evaluateAllocationConflicts({
+      slotId: SLOT_ID,
+      kind: "room",
+      travelers: [
+        traveler("t1", { sharingGroupId: "sg1" }),
+        traveler("t2", { sharingGroupId: "sg1" }),
+        traveler("t3", { sharingGroupId: "sg1" }),
+      ],
+      resources: [resource("r1", { capacity: 2 })],
+    })
+    expect(codes(conflicts)).toContain("oversubscribed_sharing_group")
+  })
+
+  it("reports a split sharing group, but not one that is merely unplaced", () => {
+    const split = evaluateAllocationConflicts({
+      slotId: SLOT_ID,
+      kind: "room",
+      travelers: [
+        traveler("t1", { sharingGroupId: "sg1", allocations: { room: "r1" } }),
+        traveler("t2", { sharingGroupId: "sg1", allocations: { room: "r2" } }),
+      ],
+      resources: [resource("r1"), resource("r2")],
+    })
+    expect(codes(split)).toContain("split_sharing_group")
+
+    const unplaced = evaluateAllocationConflicts({
+      slotId: SLOT_ID,
+      kind: "room",
+      travelers: [
+        traveler("t1", { sharingGroupId: "sg1" }),
+        traveler("t2", { sharingGroupId: "sg1" }),
+      ],
+      resources: [resource("r1")],
+    })
+    expect(codes(unplaced)).not.toContain("split_sharing_group")
+  })
+
+  it("counts a half-placed family as split", () => {
+    const conflicts = evaluateAllocationConflicts({
+      slotId: SLOT_ID,
+      kind: "room",
+      travelers: [
+        traveler("t1", { sharingGroupId: "sg1", allocations: { room: "r1" } }),
+        traveler("t2", { sharingGroupId: "sg1" }),
+      ],
+      resources: [resource("r1")],
+    })
+    expect(codes(conflicts)).toContain("split_sharing_group")
+  })
+
+  it("returns critical conflicts before warnings", () => {
+    const conflicts = evaluateAllocationConflicts({
+      slotId: SLOT_ID,
+      kind: "room",
+      travelers: [
+        traveler("t1", { allocations: { room: "r1" } }),
+        traveler("t2", { allocations: { room: "r1" } }),
+        traveler("t3", { allocations: { room: "r1" } }),
+        traveler("t4"),
+      ],
+      resources: [resource("r1", { capacity: 2 })],
+    })
+    expect(conflicts.map((conflict) => conflict.severity)).toEqual(["critical", "warning"])
+  })
+
+  it("rolls up beyond the per-code sample cap so the body stays bounded", () => {
+    const travelers = Array.from({ length: 130 }, (_, index) => traveler(`t${index}`))
+    const conflicts = evaluateAllocationConflicts({
+      slotId: SLOT_ID,
+      kind: "room",
+      travelers,
+      resources: [resource("r1")],
+    })
+    expect(conflicts).toHaveLength(101)
+    const rollup = conflicts.find((conflict) => conflict.subjectType === "departure")
+    expect(rollup?.subjectId).toBe(SLOT_ID)
+    expect(rollup?.count).toBe(30)
+  })
+
+  it("evaluates only the requested kind", () => {
+    const conflicts = evaluateAllocationConflicts({
+      slotId: SLOT_ID,
+      kind: "vehicle_seat",
+      travelers: [traveler("t1", { allocations: { room: "r1", vehicle_seat: "s1" } })],
+      resources: [resource("r1"), resource("s1", { kind: "vehicle_seat", capacity: 1 })],
+    })
+    expect(conflicts).toEqual([])
+  })
+})


### PR DESCRIPTION
## Why

This is the **server half** of #4034; the UI is a follow-up.

A departure could already materialise seats and place travelers in them, but nothing connected those seats to the **actual coach operating the trip**. `allocation_resources.ref_type` only ever held `"option"` or `"option_unit"`; a vehicle reached a departure through the parallel, unlinked `resource_slot_assignments` aggregate, only from the Resources admin section, with no path back from a seat to the vehicle carrying it.

## The authority decision

Both tables stay, answering different questions, with **one write path**:

| Table | Authoritative for | Why it must be |
|---|---|---|
| `allocation_resources` (`ref_type = "resource"`) | what this departure **operates** — the container travelers are assigned against, its capacity, its seats | every manifest, export, capacity and conflict read already goes through it, so a departure never consults the Resources module to render or validate its plan |
| `resource_slot_assignments` | fleet **commitment across departures** | it is the only table that spans slots, so it is the only one that can detect a double-booking; `allocation_resources` is slot-scoped by construction and can never see a clash |

`attachDepartureResource` writes both in one transaction, consulting the fleet ledger as the conflict oracle first (rejecting a resource with a live assignment on an overlapping window elsewhere). A `resource_slot_assignments` row the Resources admin already created for the same (slot, resource) is **adopted, not duplicated**. Recorded in `docs/architecture/operated-departure-logistics.md`.

## Also in this PR

- **A coach can be laid out before anything is sold.** Template materialisation skipped `vehicle_seat` outright, and the only path that created seats required bookings to already exist on the slot — so an operator had to hand-build every seat of an unsold departure.
- **Idempotency parity.** The two materialisation paths disagreed: one skipped existing rows, the other raised `409`. Both now skip, keyed on `(kind, ref_id)` so a second room type still materialises while the first is left alone. ⚠️ **Behaviour change** for anything relying on the 409; replacing a layout stays explicit (delete, then materialise).
- **Dry-run auto-allocation** returning the plan without writing.
- **Batch assignment.** Moving a sharing group previously meant N requests in N transactions, so a family could land half-placed.
- **Conflicts as a server projection** so the workspace, CSV and any future print view cannot disagree: unassigned, over-capacity, duplicate, inaccessible, incompatible, oversubscribed and split sharing groups. Accessibility was previously only an auto-allocator *sort key* and was never checked on manual assignment. The client-side `buildValidationIssues`/`ValidationSummary` this supersedes had **zero call sites** and are deleted.
- **Seat export.** The CSV builder already took a `kind`, but the route declared no parameter and the filename union admitted only `passengers`/`rooming`, so `vehicle_seat` was unreachable over HTTP.

## Reviewer notes

- **This branch was cut before #4181 merged, and rebasing surfaced a real regression I fixed.** #4034 moves `autoAllocateSlotResources` into a new file; the moved copy carried the *old* post-commit `recordAllocationAudit(db, …)`, which would have silently reverted #4181 for that path. The audit now runs inside the transaction, and the other five sites #4181 fixed were verified intact after the rebase.
- **Full action-ledger admission is not wired.** `executeAdmittedCreatedTargetCommand` requires a `ToolHandlerActionPolicyContext` from an admitted Tool invocation — `createDeparture` gets one because it *is* a Tool. Allocation has no Tool surface, so that would be its own PR. Used the HTTP-boundary equivalents instead: `idempotencyKey()` middleware (replay verified by test), `appendActionLedgerMutation`, and `expectedUpdatedAt`/`expectedResourceId` optimistic concurrency. The transactional `allocation_audit_log` row remains the durable record.
- **`packages/operations/openapi/admin/operations.json` is stale** — it lacks the 5 new paths. There is no `generate:openapi` script in `packages/operations`, and no CI job regenerates and diffs it, so nothing catches this. Same gap flagged on #4176.
- **`service-allocation-automation.ts` was split** (738 lines, over the 600-line hard fail) into materialisation + `service-allocation-auto-allocate.ts`. Public exports unchanged.
- **i18n keys for the deleted `ValidationSummary` were left in place** — they are fields of the public `AllocationUiMessages` type, so removing them is breaking. The follow-up UI PR should map the new conflict codes and retire them together.
- **Batch capacity validation runs after the writes, inside the transaction.** That is what lets a batch which frees a bed and refills it in the same call pass (covered by a test) while an overselling batch rolls back whole.
- **Pre-existing, untouched:** `tests/availability/integration/routes.test.ts` fails 6/40 locally — it inserts `booking_items` without the NOT NULL `status`. That file is not in the CI allowlist, so it has never run in CI.

## Verification

Re-run **after** the rebase onto current main:

```
pnpm -F @voyant-travel/operations test        282 passed | 404 skipped (55 files)
pnpm -F @voyant-travel/operations-react test   62 passed (12 files)

# integration, each its own vitest invocation against a real Postgres
allocation-routes                  10 passed
allocation-departure-resources     11 passed
allocation-assignment-concurrency   4 passed
auto-allocate-concurrency           1 passed   (pre-existing #4139 guard, still green)

npx tsx scripts/checks/schema/table-privacy-runner.ts
verify:table-privacy: 225 reach-ins across 37 pairs, none new.
```

`operations->availability` stayed at its baseline of 35 — every new source file uses raw SQL via `executeRows` rather than importing an availability table.

`pnpm exec biome check .` reports 5 errors, **all pre-existing in packages this PR does not touch** (`accommodations`, `auth`, `catalog`, plus a `biome.json` deprecation); zero in `packages/operations`.

`check-agent-code-quality --changed`: 0 errors, 2 file-size warnings.

All 4 new integration files added to the `db-lanes/integration` allowlist in `.github/workflows/ci.yml`, which runs an explicit per-file list.

**No local typecheck** — the documented OOM (unbuilt `dist` makes tsc compile the whole workspace). CI `build-graph` is authoritative.

Part of #4034