### PR TITLE
fix(public-surface): record who stands on the surface and what replaces what

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ rules as data rather than code:
 | `verify:graph-conformance` | what a package contributes to the resolved graph | `scripts/checks/graph/graph-conformance.json` |
 | `verify:symbol-policy` | where a symbol may and may not appear | `scripts/checks/symbols/symbol-policy.json` |
 | `verify:retired-surfaces` | deleted paths stay deleted | `scripts/checks/regression/retired-paths.json` |
+| `verify:public-surface` | what may be published, who outside this repo depends on it, and what a withdrawn package's successor is | `scripts/checks/manifests/public-surface.json` |
 
 Two run as ratchets, holding a line rather than demanding it be clean today:
 `verify:table-privacy` (cross-module table reach-ins) and

--- a/scripts/checks/manifests/public-surface-runner.ts
+++ b/scripts/checks/manifests/public-surface-runner.ts
@@ -8,6 +8,7 @@ import {
   checkPublicSurface,
   formatSurfaceViolations,
   type SurfaceManifest,
+  type SurfaceRegistry,
 } from "./public-surface.ts"
 
 const here = dirname(fileURLToPath(import.meta.url))
@@ -28,22 +29,32 @@ function main(): void {
   const allowlistFile = JSON.parse(readFileSync(allowlistPath, "utf8")) as {
     extensionSurface: string[]
     connectContractSurface: string[]
-  }
+  } & SurfaceRegistry
   const allowlist = [...allowlistFile.extensionSurface, ...allowlistFile.connectContractSurface]
+  const registry: SurfaceRegistry = {
+    consumers: allowlistFile.consumers,
+    withdrawn: allowlistFile.withdrawn,
+  }
 
-  const report = checkPublicSurface(manifests, allowlist)
+  const report = checkPublicSurface(manifests, allowlist, registry)
   const violations = formatSurfaceViolations(report)
 
   if (violations.length > 0) {
     console.error("Public npm surface check failed.\n")
     for (const violation of violations) console.error(`  - ${violation}`)
-    console.error("\nSee issue #4059 for what this surface is and why it is closed.")
+    console.error(
+      "\nSee issue #4059 for what this surface is and why it is closed, " +
+        "and #4159 for who is standing on it.",
+    )
     process.exit(1)
   }
 
+  const consumerCount = Object.keys(registry.consumers ?? {}).length
+  const withdrawnCount = Object.keys(registry.withdrawn ?? {}).length
   console.log(
     `verify:public-surface: ${allowlist.length} packages on the public surface, ` +
-      `closure is ${report.closureSize} — closed.`,
+      `closure is ${report.closureSize} — closed. ${consumerCount} recorded consumers, ` +
+      `${withdrawnCount} withdrawn packages.`,
   )
 }
 

--- a/scripts/checks/manifests/public-surface.json
+++ b/scripts/checks/manifests/public-surface.json
@@ -5,7 +5,11 @@
     "The dependency closure of this list must EQUAL this list; verify:public-surface enforces that.",
     "Adding an entry widens what external developers may depend on. Do it deliberately.",
     "This is not yet a publish gate: ~95 other packages are still published until the",
-    "first-party repos have a build path (#4059 item 4)."
+    "first-party repos have a build path (#4059 item 4).",
+    "",
+    "`consumers` and `withdrawn` are the other half — who is standing on this surface,",
+    "and what a reader should move to when something leaves it. See #4159 and the",
+    "header of public-surface.ts."
   ],
   "extensionSurface": [
     "@voyant-travel/admin-extension-sdk",
@@ -32,5 +36,228 @@
     "supplier; a supplier-sold tour or package is a Product. The Connect source",
     "verticals are accommodations, charters, cruises, flights, and products.",
     "See connect#106."
-  ]
+  ],
+  "$consumers": [
+    "Repositories outside this one that install packages this one publishes,",
+    "audited 2026-08-04 for #4159. `consumes` is what each declares in the",
+    "@voyant-travel scope, including names this repository does not own —",
+    "connect-provider-sdk, connect-sdk, data-sdk, cloud-sdk, cli and max-embed",
+    "live in sibling repos and are recorded for inventory, not checked here.",
+    "",
+    "Taking a package named here off the allowlist fails the check, naming the",
+    "repository whose build it breaks. Record it under `withdrawn` to proceed."
+  ],
+  "consumers": {
+    "voyant-travel/hisky-connector": {
+      "consumes": ["@voyant-travel/connect-provider-sdk", "@voyant-travel/flights-contracts"]
+    },
+    "voyant-travel/tui-connector": {
+      "consumes": [
+        "@voyant-travel/connect-provider-sdk",
+        "@voyant-travel/connect-sdk",
+        "@voyant-travel/data-sdk"
+      ]
+    },
+    "voyant-travel/uniworld-connector": {
+      "consumes": ["@voyant-travel/connect-provider-sdk", "@voyant-travel/data-sdk"]
+    },
+    "voyant-travel/viking-connector": {
+      "consumes": ["@voyant-travel/connect-provider-sdk", "@voyant-travel/data-sdk"]
+    },
+    "voyant-travel/silversea-connector": {
+      "consumes": ["@voyant-travel/connect-provider-sdk", "@voyant-travel/data-sdk"]
+    },
+    "voyant-travel/connect": {
+      "consumes": ["@voyant-travel/catalog-contracts", "@voyant-travel/flights-contracts"]
+    },
+    "voyant-travel/algolia-adapter": {
+      "consumes": ["@voyant-travel/catalog-contracts", "@voyant-travel/graph-contracts"]
+    },
+    "voyant-travel/netopia-adapter": {
+      "consumes": [
+        "@voyant-travel/core",
+        "@voyant-travel/finance",
+        "@voyant-travel/hono",
+        "@voyant-travel/notifications",
+        "@voyant-travel/payments",
+        "@voyant-travel/utils"
+      ]
+    },
+    "voyant-travel/plugin-smartbill": {
+      "consumes": [
+        "@voyant-travel/bookings",
+        "@voyant-travel/core",
+        "@voyant-travel/finance",
+        "@voyant-travel/finance-react",
+        "@voyant-travel/hono",
+        "@voyant-travel/identity",
+        "@voyant-travel/operator-settings",
+        "@voyant-travel/relationships",
+        "@voyant-travel/storage",
+        "@voyant-travel/ui",
+        "@voyant-travel/utils"
+      ]
+    },
+    "voyant-travel/plugin-payload-cms": {
+      "consumes": ["@voyant-travel/core", "@voyant-travel/utils"]
+    },
+    "voyant-travel/cli": {
+      "consumes": ["@voyant-travel/cloud-sdk", "@voyant-travel/core", "@voyant-travel/framework"]
+    },
+    "voyant-travel/platform": {
+      "consumes": [
+        "@voyant-travel/admin-extension-sdk",
+        "@voyant-travel/app-manifest",
+        "@voyant-travel/apps",
+        "@voyant-travel/cloud-sdk",
+        "@voyant-travel/flights",
+        "@voyant-travel/i18n",
+        "@voyant-travel/max-embed",
+        "@voyant-travel/notifications",
+        "@voyant-travel/storefront",
+        "@voyant-travel/storefront-react",
+        "@voyant-travel/tools",
+        "@voyant-travel/trips",
+        "@voyant-travel/types",
+        "@voyant-travel/ui",
+        "@voyant-travel/vite-config"
+      ]
+    },
+    "pxmstudio/voyant-smartbill-app": {
+      "consumes": [
+        "@voyant-travel/admin-extension-sdk",
+        "@voyant-travel/app-manifest",
+        "@voyant-travel/ui"
+      ]
+    }
+  },
+  "$withdrawn": [
+    "Packages that were on the public surface and are not any more. Marking a",
+    "package private here does not unpublish it — the last version keeps",
+    "resolving forever — so the failure is silent and lands on whoever pinned it.",
+    "This is what those readers have instead of an npm deprecation notice.",
+    "",
+    "An entry must stay true: the package must really be private, must not also",
+    "be on the allowlist, and a successor this repository owns must really be",
+    "published. `successor: null` is allowed and requires a reason.",
+    "",
+    "There is deliberately no `pms` consumer — that product was cancelled",
+    "2026-07-30 and its pins are not a build to migrate."
+  ],
+  "withdrawn": {
+    "@voyant-travel/flights": {
+      "successor": "@voyant-travel/flights-contracts",
+      "consumers": ["voyant-travel/hisky-connector", "voyant-travel/platform"],
+      "reason": "A connector needs the payload types, not the runtime module. ADR-0022 section 3: contracts packages are an authoring convenience, and a connector's compatibility axis is the worker protocol date. hisky-connector migrated 2026-08-01."
+    },
+    "@voyant-travel/apps": {
+      "successor": "@voyant-travel/app-manifest",
+      "consumers": ["pxmstudio/voyant-smartbill-app", "voyant-travel/platform"],
+      "reason": "#4059 split the publisher-facing manifest contract out of the host-side runtime module. compileAppManifest, appManifestSchema and canonicalJsonStringify moved verbatim; the release digest is unchanged."
+    },
+    "@voyant-travel/bookings": {
+      "successor": null,
+      "consumers": ["voyant-travel/plugin-smartbill"],
+      "reason": "No successor. plugin-smartbill builds in process against the operator's runtime modules and needs a build path — #4059 item 4."
+    },
+    "@voyant-travel/core": {
+      "successor": null,
+      "consumers": [
+        "voyant-travel/cli",
+        "voyant-travel/netopia-adapter",
+        "voyant-travel/plugin-payload-cms",
+        "voyant-travel/plugin-smartbill"
+      ],
+      "reason": "No successor. Four repos build in process against it and need a build path — #4059 item 4."
+    },
+    "@voyant-travel/finance": {
+      "successor": null,
+      "consumers": ["voyant-travel/netopia-adapter", "voyant-travel/plugin-smartbill"],
+      "reason": "No successor. See #4059 item 4."
+    },
+    "@voyant-travel/finance-react": {
+      "successor": null,
+      "consumers": ["voyant-travel/plugin-smartbill"],
+      "reason": "No successor. See #4059 item 4."
+    },
+    "@voyant-travel/framework": {
+      "successor": null,
+      "consumers": ["voyant-travel/cli"],
+      "reason": "No successor. The CLI resolves the framework to scaffold and inspect a deployment; under the image model that relationship is unsettled — #4059 item 4."
+    },
+    "@voyant-travel/hono": {
+      "successor": null,
+      "consumers": ["voyant-travel/netopia-adapter", "voyant-travel/plugin-smartbill"],
+      "reason": "No successor. See #4059 item 4."
+    },
+    "@voyant-travel/i18n": {
+      "successor": null,
+      "consumers": ["voyant-travel/platform"],
+      "reason": "No successor. Platform is first-party and still resolves an npm copy of the framework; platform#1622 is the fix."
+    },
+    "@voyant-travel/identity": {
+      "successor": null,
+      "consumers": ["voyant-travel/plugin-smartbill"],
+      "reason": "No successor. See #4059 item 4."
+    },
+    "@voyant-travel/notifications": {
+      "successor": null,
+      "consumers": ["voyant-travel/netopia-adapter", "voyant-travel/platform"],
+      "reason": "No successor. See #4059 item 4."
+    },
+    "@voyant-travel/operator-settings": {
+      "successor": null,
+      "consumers": ["voyant-travel/plugin-smartbill"],
+      "reason": "No successor. See #4059 item 4."
+    },
+    "@voyant-travel/relationships": {
+      "successor": null,
+      "consumers": ["voyant-travel/plugin-smartbill"],
+      "reason": "No successor. See #4059 item 4."
+    },
+    "@voyant-travel/storage": {
+      "successor": null,
+      "consumers": ["voyant-travel/plugin-smartbill"],
+      "reason": "No successor. See #4059 item 4."
+    },
+    "@voyant-travel/storefront": {
+      "successor": null,
+      "consumers": ["voyant-travel/platform"],
+      "reason": "No successor. Platform is first-party; see platform#1622."
+    },
+    "@voyant-travel/storefront-react": {
+      "successor": null,
+      "consumers": ["voyant-travel/platform"],
+      "reason": "No successor. Platform is first-party; see platform#1622."
+    },
+    "@voyant-travel/tools": {
+      "successor": null,
+      "consumers": ["voyant-travel/platform"],
+      "reason": "No successor. Platform is first-party; see platform#1622."
+    },
+    "@voyant-travel/trips": {
+      "successor": null,
+      "consumers": ["voyant-travel/platform"],
+      "reason": "No successor. Platform is first-party; see platform#1622."
+    },
+    "@voyant-travel/types": {
+      "successor": null,
+      "consumers": ["voyant-travel/platform"],
+      "reason": "No successor. Platform is first-party; see platform#1622."
+    },
+    "@voyant-travel/utils": {
+      "successor": null,
+      "consumers": [
+        "voyant-travel/netopia-adapter",
+        "voyant-travel/plugin-payload-cms",
+        "voyant-travel/plugin-smartbill"
+      ],
+      "reason": "No successor. See #4059 item 4."
+    },
+    "@voyant-travel/vite-config": {
+      "successor": null,
+      "consumers": ["voyant-travel/platform"],
+      "reason": "No successor. Platform is first-party; see platform#1622."
+    }
+  }
 }

--- a/scripts/checks/manifests/public-surface.ts
+++ b/scripts/checks/manifests/public-surface.ts
@@ -19,6 +19,29 @@
  * giving the first-party repos (netopia-adapter, connect, hisky-connector,
  * algolia-adapter, plugin-smartbill) a build path — #4059 item 4. What this
  * stops is the allowlist rotting before that lands.
+ *
+ * ## Withdrawal, and who it lands on — #4159
+ *
+ * Contracting a surface has a second failure the closure rule does not see:
+ * someone outside this repository is already depending on what gets withdrawn.
+ * `hisky-connector` pinned `@voyant-travel/flights` after it went private;
+ * `voyant-smartbill-app` pinned `@voyant-travel/apps` after it was split. Both
+ * kept installing, because marking a package private here does not unpublish it
+ * — it freezes it. The break is silent and in the future: no version will ever
+ * supersede the one they resolve, and npm names no successor.
+ *
+ * So the allowlist carries two more sections, and this file checks them:
+ *
+ * - `consumers` — repositories outside this one that install from the surface,
+ *   and what they declare. Taking a package they name off the allowlist fails
+ *   here, naming the repository, instead of in their next install.
+ * - `withdrawn` — packages that used to be on the surface, each pointing at the
+ *   successor a reader should move to. This is what an external reader has
+ *   instead of a deprecation notice, so entries must stay true: a withdrawn
+ *   package must really be private, and a successor must really be published.
+ *
+ * Neither section can be derived from this repository, which is the point —
+ * they are the record of what the contraction is standing on.
  */
 
 export interface SurfaceManifest {
@@ -26,6 +49,27 @@ export interface SurfaceManifest {
   private?: boolean
   dependencies?: Record<string, string>
   peerDependencies?: Record<string, string>
+}
+
+/** A repository outside this one that installs from the public surface. */
+export interface ConsumerRecord {
+  /** Everything scoped `@voyant-travel/` that the repository declares. */
+  consumes: string[]
+}
+
+/** A package that used to be on the public surface and no longer is. */
+export interface WithdrawalRecord {
+  /** The package a reader should move to, or `null` when there is not one yet. */
+  successor: string | null
+  /** Required when `successor` is null: why there is nothing to point at. */
+  reason?: string
+  /** Repositories known to have depended on it when it was withdrawn. */
+  consumers?: string[]
+}
+
+export interface SurfaceRegistry {
+  consumers?: Record<string, ConsumerRecord>
+  withdrawn?: Record<string, WithdrawalRecord>
 }
 
 export interface SurfaceReport {
@@ -37,6 +81,12 @@ export interface SurfaceReport {
   missing: string[]
   /** Allowlist entries that are marked private and so cannot be published. */
   unpublishable: string[]
+  /** A recorded consumer installs a package of ours that is no longer published. */
+  stranded: { repository: string; dependency: string }[]
+  /** A withdrawal record that no longer describes reality. */
+  staleWithdrawals: { package: string; why: string }[]
+  /** A withdrawal that points at a successor which is itself not published. */
+  danglingSuccessors: { package: string; successor: string }[]
   closureSize: number
 }
 
@@ -52,6 +102,7 @@ function workspaceDependencies(manifest: SurfaceManifest): string[] {
 export function checkPublicSurface(
   manifests: readonly SurfaceManifest[],
   allowlist: readonly string[],
+  registry: SurfaceRegistry = {},
 ): SurfaceReport {
   const byName = new Map(manifests.map((manifest) => [manifest.name, manifest]))
   const allowed = new Set(allowlist)
@@ -86,7 +137,62 @@ export function checkPublicSurface(
     .map((manifest) => manifest.name)
     .sort()
 
-  return { escapes, missing, unpublishable, unlisted, closureSize: seen.size }
+  // A recorded consumer is a repository we know installs from this surface. Only
+  // the names this repository owns are checkable: a connector's dependency on
+  // `connect-provider-sdk` is the connect repo's business, not ours. Withdrawing
+  // a package a consumer names is what produced #4159, so it fails here rather
+  // than in that repository's next install.
+  const withdrawn = registry.withdrawn ?? {}
+  const stranded: SurfaceReport["stranded"] = []
+  for (const [repository, record] of Object.entries(registry.consumers ?? {})) {
+    for (const dependency of record.consumes) {
+      if (!byName.has(dependency)) continue
+      if (allowed.has(dependency)) continue
+      // Recording the withdrawal is the way to do this deliberately: the entry
+      // names a successor, or says why there is not one. What fails here is
+      // withdrawing without saying anything.
+      if (dependency in withdrawn) continue
+      stranded.push({ repository, dependency })
+    }
+  }
+
+  // The withdrawal record is what a reader outside this repository has instead
+  // of an npm deprecation notice, so it has to stay true. An entry that no
+  // longer describes a withdrawn package is worse than no entry.
+  const staleWithdrawals: SurfaceReport["staleWithdrawals"] = []
+  const danglingSuccessors: SurfaceReport["danglingSuccessors"] = []
+  for (const [name, record] of Object.entries(withdrawn)) {
+    if (!byName.has(name)) {
+      staleWithdrawals.push({ package: name, why: "no such package in this repository" })
+    } else if (byName.get(name)?.private !== true) {
+      staleWithdrawals.push({ package: name, why: "the package is publishable again" })
+    }
+    if (allowed.has(name)) {
+      staleWithdrawals.push({ package: name, why: "it is also on the allowlist" })
+    }
+    if (record.successor === null) {
+      if (!record.reason?.trim()) {
+        staleWithdrawals.push({ package: name, why: "no successor and no reason given" })
+      }
+      continue
+    }
+    // A successor this repository does not own cannot be checked here; one it
+    // does own must still be published, or the pointer leads nowhere.
+    if (byName.has(record.successor) && !allowed.has(record.successor)) {
+      danglingSuccessors.push({ package: name, successor: record.successor })
+    }
+  }
+
+  return {
+    escapes,
+    missing,
+    unpublishable,
+    unlisted,
+    stranded,
+    staleWithdrawals,
+    danglingSuccessors,
+    closureSize: seen.size,
+  }
 }
 
 export function formatSurfaceViolations(report: SurfaceReport): string[] {
@@ -110,6 +216,27 @@ export function formatSurfaceViolations(report: SurfaceReport): string[] {
         `Publishing ${leak.package} would drag ${leak.dependency} — and its own closure — ` +
         `back onto npm. Either extract the contract ${leak.package} actually needs, or add ` +
         `${leak.dependency} to the allowlist deliberately.`,
+    )
+  }
+  for (const { repository, dependency } of report.stranded) {
+    violations.push(
+      `${repository} declares ${dependency}, which this change takes off the public surface. ` +
+        `Nothing unpublishes on npm, so that repository keeps resolving a frozen version and ` +
+        `nothing will ever supersede it — this is #4159. Migrate it first, or record ` +
+        `${dependency} under \`withdrawn\` with the successor a reader should move to.`,
+    )
+  }
+  for (const { package: name, why } of report.staleWithdrawals) {
+    violations.push(
+      `${name}: recorded under \`withdrawn\` but ${why}. The withdrawal record is what an ` +
+        `external reader has instead of an npm deprecation notice; a wrong entry misdirects them.`,
+    )
+  }
+  for (const { package: name, successor } of report.danglingSuccessors) {
+    violations.push(
+      `${name} was withdrawn in favour of ${successor}, but ${successor} is not on the public ` +
+        `surface either. Point at something a reader can actually install, or set ` +
+        `\`successor: null\` with a reason.`,
     )
   }
   return violations

--- a/scripts/tests/public-surface.test.mjs
+++ b/scripts/tests/public-surface.test.mjs
@@ -98,3 +98,106 @@ test("a dependency cycle inside the allowlist terminates", () => {
   assert.deepEqual(report.escapes, [])
   assert.equal(report.closureSize, 2)
 })
+
+// Withdrawal — #4159. Marking a package private does not unpublish it, so a
+// consumer outside this repository keeps resolving a frozen version forever.
+
+const flights = { name: "@voyant-travel/flights", private: true }
+const flightsContracts = { name: "@voyant-travel/flights-contracts" }
+const hisky = { "voyant-travel/hisky-connector": { consumes: [flightsContracts.name] } }
+
+test("withdrawing a package a recorded consumer depends on is a violation", () => {
+  const report = checkPublicSurface([flights, flightsContracts], [], { consumers: hisky })
+  assert.deepEqual(report.stranded, [
+    { repository: "voyant-travel/hisky-connector", dependency: flightsContracts.name },
+  ])
+  assert.match(
+    formatSurfaceViolations(report).find((v) => v.includes("hisky-connector")),
+    /keeps resolving a frozen version/,
+  )
+})
+
+test("a consumer whose dependencies are all allowlisted is fine", () => {
+  const report = checkPublicSurface([flightsContracts], [flightsContracts.name], {
+    consumers: hisky,
+  })
+  assert.deepEqual(report.stranded, [])
+  assert.deepEqual(formatSurfaceViolations(report), [])
+})
+
+test("a consumer's dependency on a sibling repo's package is not ours to check", () => {
+  // connect-provider-sdk lives in the connect repo; no manifest for it here.
+  const report = checkPublicSurface([], [], {
+    consumers: {
+      "voyant-travel/hisky-connector": { consumes: ["@voyant-travel/connect-provider-sdk"] },
+    },
+  })
+  assert.deepEqual(report.stranded, [])
+})
+
+test("recording the withdrawal is how a package a consumer names may leave", () => {
+  const report = checkPublicSurface([flights, flightsContracts], [flightsContracts.name], {
+    consumers: { "voyant-travel/hisky-connector": { consumes: [flights.name] } },
+    withdrawn: { [flights.name]: { successor: flightsContracts.name } },
+  })
+  assert.deepEqual(report.stranded, [])
+  assert.deepEqual(formatSurfaceViolations(report), [])
+})
+
+test("a withdrawal pointing at a successor that is not published is a violation", () => {
+  const report = checkPublicSurface([flights, { ...flightsContracts, private: true }], [], {
+    withdrawn: { [flights.name]: { successor: flightsContracts.name } },
+  })
+  assert.deepEqual(report.danglingSuccessors, [
+    { package: flights.name, successor: flightsContracts.name },
+  ])
+  assert.match(formatSurfaceViolations(report).at(-1), /not on the public surface either/)
+})
+
+test("a withdrawal with no successor must say why", () => {
+  const bare = checkPublicSurface([flights], [], {
+    withdrawn: { [flights.name]: { successor: null } },
+  })
+  assert.deepEqual(bare.staleWithdrawals, [
+    { package: flights.name, why: "no successor and no reason given" },
+  ])
+
+  const explained = checkPublicSurface([flights], [], {
+    withdrawn: { [flights.name]: { successor: null, reason: "#4059 item 4" } },
+  })
+  assert.deepEqual(explained.staleWithdrawals, [])
+})
+
+test("a withdrawal record that stopped being true is a violation", () => {
+  const republished = checkPublicSurface([{ name: flights.name }], [], {
+    withdrawn: { [flights.name]: { successor: flightsContracts.name } },
+  })
+  assert.deepEqual(republished.staleWithdrawals, [
+    { package: flights.name, why: "the package is publishable again" },
+  ])
+
+  const absent = checkPublicSurface([], [], {
+    withdrawn: { "@voyant-travel/gone": { successor: null, reason: "x" } },
+  })
+  assert.deepEqual(absent.staleWithdrawals, [
+    { package: "@voyant-travel/gone", why: "no such package in this repository" },
+  ])
+})
+
+test("a package cannot be both withdrawn and on the allowlist", () => {
+  const report = checkPublicSurface([flightsContracts], [flightsContracts.name], {
+    withdrawn: { [flightsContracts.name]: { successor: null, reason: "x" } },
+  })
+  assert.ok(
+    report.staleWithdrawals.some((entry) => entry.why === "it is also on the allowlist"),
+    "expected the contradiction to be reported",
+  )
+})
+
+test("no registry means no new violations — the check is additive", () => {
+  const report = checkPublicSurface([flightsContracts], [flightsContracts.name])
+  assert.deepEqual(report.stranded, [])
+  assert.deepEqual(report.staleWithdrawals, [])
+  assert.deepEqual(report.danglingSuccessors, [])
+  assert.deepEqual(formatSurfaceViolations(report), [])
+})


### PR DESCRIPTION
Closes #4159.

The issue's first two boxes turned out to be already ticked, and checking the fourth turned up more than connectors. What is left is the thing that let it happen silently, so that is what this PR builds.

## What the audit found

**Checkbox 1 — what a connector imports for flight types — is answered.** `docs/adr/0022-connector-compatibility-axis.md` is on `main`. Decision 3: contracts packages stay published as an authoring convenience, `flights-contracts` is in `connectContractSurface`, and its version is explicitly *not* a compatibility claim — the axis is the worker protocol date.

**Checkbox 2 — hisky — was done before the issue was filed.** `hisky-connector@0775521a` (#9, 2026-08-01) replaced `@voyant-travel/flights` with `@voyant-travel/flights-contracts@^0.104.11`. The issue body was written from a stale read.

**Checkbox 3 — the `@voyantjs` connectors — is four repos, not three.** The issue missed `silversea-connector`, which is the *newest* of them (pushed 2026-07-31) and also on the retired scope. Unpacking both scopes and diffing the declared type surfaces showed the migration is a pure rename — every symbol they import exists in the successor, `./hosted-worker` unchanged, nothing removed in either direction. All four are migrated in sibling PRs, each green on `check-types` and its test suite:

- voyant-travel/silversea-connector#1
- voyant-travel/tui-connector#29
- voyant-travel/uniworld-connector#9
- voyant-travel/viking-connector#9

Worth noting `scripts/verify-package-tarballs.mjs` already fails a published tarball that references the legacy scope. The rule existed; it just had no reach into repos that consume us.

**Checkbox 4 — the audit — found seven consumers, none of them connectors.** Only 14 packages are still public; 103 are private. Registry-resolved dependencies on packages that are now private:

| Repo | Visibility | Private packages depended on |
|---|---|---|
| `plugin-smartbill` | **public, on npm** | bookings, core, finance, finance-react, hono, identity, operator-settings, relationships, storage, utils |
| `netopia-adapter` | **public, on npm** | core, finance, hono, notifications, utils |
| `cli` | **public, on npm** | core, framework |
| `plugin-payload-cms` | **public, on npm** | core, utils |
| `platform` | private, first-party | apps, flights, i18n, storefront(-react), types, tools, vite-config, notifications, trips |
| `pxmstudio/voyant-smartbill-app` | private | `apps` (devDep) — fixed in pxmstudio/voyant-smartbill-app#40 |
| `pms` | — | cancelled 2026-07-30; excluded deliberately |

Nothing is broken *today*. That is the trap: privating a package here does not unpublish it, so every one of these still installs. What is broken is the future — no version will ever supersede the one they resolve, and nothing names a successor.

## What this PR changes

`verify:public-surface` already enforced that the allowlist's dependency closure equals the allowlist. It had no notion of **who is standing on it**, so withdrawal was free. Two sections are added to `public-surface.json`, and the checker keeps them honest:

- **`consumers`** — the 13 repositories outside this one that install from the surface, and what each declares. Taking a package they name off the allowlist fails here, naming the repository, instead of at their next install. Names this repo does not own (`connect-provider-sdk`, `data-sdk`, `cloud-sdk`, `cli`, `max-embed`) are recorded for inventory and not checked — they are sibling repos' business.
- **`withdrawn`** — the 21 packages that have left, each pointing at the successor a reader should move to, or carrying an explicit reason there is not one. This is what an external reader has instead of an npm deprecation notice, so it has to stay true: a withdrawn package must really be private, must not also be allowlisted, and a successor this repo owns must really be published.

Recording a withdrawal is *how* a package a consumer names may leave — the gate is deliberateness, not permanence.

Two entries name a successor: `flights` → `flights-contracts` (ADR-0022), `apps` → `app-manifest` (#4059). The other 19 are the #4059 item 4 debt made visible rather than implied.

## Verification

Removing `flights-contracts` from the allowlist, the check now fails with:

```
- voyant-travel/hisky-connector declares @voyant-travel/flights-contracts, which this
  change takes off the public surface. Nothing unpublishes on npm, so that repository
  keeps resolving a frozen version and nothing will ever supersede it — this is #4159.
  Migrate it first, or record @voyant-travel/flights-contracts under `withdrawn` with
  the successor a reader should move to.
- voyant-travel/connect declares @voyant-travel/flights-contracts, which this change …
- @voyant-travel/flights was withdrawn in favour of @voyant-travel/flights-contracts,
  but @voyant-travel/flights-contracts is not on the public surface either. …
```

That is exactly the #4159 failure, caught at the commit that causes it.

- `pnpm verify:public-surface` — green; 19 unit tests (9 new invariants), runner green against `main`
- `biome check .` from the root — exit 0, warnings pre-existing and unrelated
- No changeset: `scripts/` and `AGENTS.md` only, no package touched

## Not in this PR

The four public repos — `netopia-adapter`, `plugin-smartbill`, `plugin-payload-cms`, `cli` — need a build path decision (monorepo absorption, private registry, or git dependencies). That is #4059 item 4 and is not mechanical. This PR records the debt where the next person to contract the surface will hit it.