### PR TITLE
feat(catalog): carry Booking Requirements through the v1 session quote seam

### DIFF
--- a/.changeset/booking-requirements-session-seam.md
+++ b/.changeset/booking-requirements-session-seam.md
@@ -1,0 +1,34 @@
+---
+"@voyant-travel/catalog-contracts": minor
+"@voyant-travel/catalog": minor
+"@voyant-travel/accommodations": minor
+"@voyant-travel/cruises": minor
+"@voyant-travel/inventory": minor
+"@voyant-travel/trips": minor
+---
+
+Carry Booking Requirements through the v1 Booking Session lifecycle. The
+descriptor a host renders the wizard from now survives the quote seam instead
+of being discarded on the way through it.
+
+- `bookingSessionRecordV1` gains an optional `requirements` — present whenever
+  the Session is `active` and its target resolves, absent for terminal or
+  purged Sessions. A host can render the Configure step before it can quote.
+- `bookingQuoteRecordV1.requirements` is required: a Quote always has a
+  resolvable target.
+- The `quote_unavailable` lifecycle rejection gains an optional
+  `requirements`, so a priced-out or sold-out target still renders a correct
+  wizard.
+- `OwnedBookingHandler` gains a required `computeRequirements(ctx, request)`.
+  Each vertical's `computeQuote` now derives its descriptor through that same
+  method — one derivation, so what a host renders and what a Commit validates
+  against cannot drift.
+- `ComputeQuoteResult.shape` is renamed to `ComputeQuoteResult.requirements`.
+  `quoteResponseV1.shape` and `QuoteEntityResult.shape` on the beta quote path
+  are unchanged.
+- `BookingSessionModulePorts`, `BookingSessionCompositeLeafRuntime` and
+  `BookingSessionCompositeHandler` gain `composeRequirements`, so trip-composite
+  targets publish requirements too.
+- `booking_session_quotes` gains a `requirements` jsonb column. Quotes carry a
+  10-minute TTL and are not commitments, so the migration expires in-flight
+  Quotes rather than backfilling a fabricated descriptor.

--- a/packages/accommodations/src/booking-engine/handler.ts
+++ b/packages/accommodations/src/booking-engine/handler.ts
@@ -20,6 +20,7 @@ import type {
   ComputeQuoteRequest,
   ComputeQuoteResult,
   ComputeQuotesRequest,
+  ComputeRequirementsResult,
   OwnedBookingHandler,
   OwnedHandlerContext,
 } from "@voyant-travel/catalog/booking-engine"
@@ -88,22 +89,44 @@ export interface CreateAccommodationBookingHandlerOptions {
 export function createAccommodationBookingHandler(
   options: CreateAccommodationBookingHandlerOptions,
 ): OwnedBookingHandler {
+  /**
+   * The single derivation of a property's Booking Requirements. Both
+   * `computeRequirements` and `computeQuote` come through here, so the
+   * descriptor a host renders is the descriptor a Commit later validates
+   * against — one code path, not two (voyant#4113).
+   */
+  async function deriveRequirements(ctx: OwnedHandlerContext, request: ComputeQuoteRequest) {
+    const content = await options.loadContent(ctx, request.entityId)
+    if (!content) return { status: "unavailable" as const, reason: "property_not_found" }
+    const requirements: BookingRequirements = buildAccommodationRequirements(content, {
+      minNights: options.defaultMinNights,
+      maxNights: options.defaultMaxNights,
+    })
+    return { status: "available" as const, content, requirements }
+  }
+
   return {
     entityModule: "accommodations",
+
+    async computeRequirements(
+      ctx: OwnedHandlerContext,
+      request: ComputeQuoteRequest,
+    ): Promise<ComputeRequirementsResult> {
+      const derived = await deriveRequirements(ctx, request)
+      return derived.status === "available"
+        ? { requirements: derived.requirements }
+        : { unavailable: true, reason: derived.reason }
+    },
 
     async computeQuote(
       ctx: OwnedHandlerContext,
       request: ComputeQuoteRequest,
     ): Promise<ComputeQuoteResult> {
-      const content = await options.loadContent(ctx, request.entityId)
-      if (!content) {
-        return { available: false, invalidReason: "property_not_found" }
+      const derived = await deriveRequirements(ctx, request)
+      if (derived.status === "unavailable") {
+        return { available: false, invalidReason: derived.reason }
       }
-
-      const shape: BookingRequirements = buildAccommodationRequirements(content, {
-        minNights: options.defaultMinNights,
-        maxNights: options.defaultMaxNights,
-      })
+      const shape = derived.requirements
 
       const draft = (request.draft ?? {}) as DraftLike
       const quoteInput = quoteInputFromDraft(draft, request.scope.currency)
@@ -114,7 +137,7 @@ export function createAccommodationBookingHandler(
         available: quote?.status === "ok" ? quote.available : true,
         invalidReason: quoteInvalidReason(quote),
         pricing,
-        shape,
+        requirements: shape,
       }
     },
 
@@ -163,7 +186,7 @@ export function createAccommodationBookingHandler(
             available: quote?.status === "ok" ? quote.available : !invalidReason,
             invalidReason: invalidReason ?? quoteInvalidReason(quote),
             pricing: quote?.status === "ok" ? pricingFromOwnedStayQuote(quote) : undefined,
-            shape,
+            requirements: shape,
           },
         }
       })

--- a/packages/bookings-react/tests/unit/manual-booking-session-client.test.ts
+++ b/packages/bookings-react/tests/unit/manual-booking-session-client.test.ts
@@ -5,6 +5,21 @@ import {
   type ManualBookingSessionContinuation,
 } from "../../src/manual-booking-session-client.js"
 
+const REQUIREMENTS = {
+  showsConfigure: true,
+  showsBilling: true,
+  showsTravelers: true,
+  showsAccommodation: false,
+  showsAddons: false,
+  showsPayment: true,
+  showsReview: true,
+  paxBands: [{ code: "adult", label: "Adult", minCount: 1, maxCount: 8 }],
+  paxBandsAllowedTotal: { min: 1, max: 8 },
+  travelerFields: [],
+  bookingFields: [],
+  paymentIntents: ["card"],
+}
+
 function json(body: unknown) {
   return Response.json(body)
 }
@@ -231,6 +246,7 @@ function quote() {
       sessionId: "bses_1",
       sessionRevision: 1,
       state: "active",
+      requirements: REQUIREMENTS,
       pricing: {
         currency: "EUR",
         lines: [],

--- a/packages/catalog-contracts/src/booking-engine/session-contracts.ts
+++ b/packages/catalog-contracts/src/booking-engine/session-contracts.ts
@@ -1,6 +1,6 @@
 import { z } from "zod"
 
-import { pricingBreakdownV1 } from "./draft-contracts.js"
+import { bookingRequirementsV1, pricingBreakdownV1 } from "./draft-contracts.js"
 import { bookingLifecycleCommitOutcomeV1 } from "./lifecycle-conformance.js"
 
 export const bookingSessionActorKindV1 = z.enum(["anonymous", "customer", "staff", "partner"])
@@ -76,6 +76,19 @@ export const bookingSessionRecordV1 = z.object({
   actorKind: bookingSessionActorKindV1,
   state: bookingSessionStateV1,
   revision: z.number().int().positive(),
+  /**
+   * Server-owned Booking Requirements for this Session's target — what a
+   * booking of it requires, and therefore which wizard steps a host renders.
+   *
+   * It rides the Session and not only the Quote because a host must draw the
+   * Configure step *before* it can quote: requirements on the Quote alone
+   * would leave it needing a price to render its first screen.
+   *
+   * Rule: present whenever the Session is `active` and its target resolves;
+   * absent for terminal (`consumed` / `expired` / `abandoned`) or purged
+   * Sessions, whose target is no longer re-derived.
+   */
+  requirements: bookingRequirementsV1.optional(),
   expiresAt: z.string().datetime(),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
@@ -151,6 +164,12 @@ export const bookingQuoteRecordV1 = z.object({
   sessionId: z.string().min(1),
   sessionRevision: z.number().int().positive(),
   state: bookingSessionQuoteLifecycleStateV1,
+  /**
+   * The Booking Requirements this price was computed against. Required —
+   * a Quote always has a resolvable target, and the requirements a host
+   * renders must be the same derivation the Commit later validates.
+   */
+  requirements: bookingRequirementsV1,
   pricing: pricingBreakdownV1,
   quotedAt: z.string().datetime(),
   expiresAt: z.string().datetime(),
@@ -236,6 +255,13 @@ export const bookingSessionLifecycleErrorV1 = z.discriminatedUnion("kind", [
   }),
   z.object({
     kind: z.literal("quote_unavailable"),
+    /**
+     * Requirements survive unavailability: a priced-out or sold-out target
+     * must still render a correct wizard so the buyer can change the
+     * selection that made it unavailable. Absent only when the target
+     * itself failed to resolve.
+     */
+    requirements: bookingRequirementsV1.optional(),
     reason: z.enum([
       "target_not_found",
       "target_not_bookable",

--- a/packages/catalog/migrations/20260804120000_booking_session_quote_requirements.sql
+++ b/packages/catalog/migrations/20260804120000_booking_session_quote_requirements.sql
@@ -1,0 +1,12 @@
+-- A Quote now carries the Booking Requirements its price was computed against,
+-- so a host renders and a Commit validates against one derivation rather than
+-- two. Existing rows have no descriptor to backfill and no honest one to
+-- invent. A Quote carries a 10-minute TTL and is not a commitment, so expire
+-- the in-flight ones instead: the buyer re-quotes and gets a real descriptor.
+UPDATE booking_session_quotes SET state = 'expired' WHERE state = 'active';
+--> statement-breakpoint
+ALTER TABLE booking_session_quotes ADD COLUMN requirements jsonb NOT NULL DEFAULT '{}'::jsonb;
+--> statement-breakpoint
+-- The default exists only to backfill the expired rows above. New Quotes must
+-- supply a real descriptor, so drop it once the column is populated.
+ALTER TABLE booking_session_quotes ALTER COLUMN requirements DROP DEFAULT;

--- a/packages/catalog/migrations/meta/_journal.json
+++ b/packages/catalog/migrations/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1785686400000,
       "tag": "20260802190000_booking_v1_beta_draft_cutover",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1785834000000,
+      "tag": "20260804120000_booking_session_quote_requirements",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/catalog/src/booking-engine/index.ts
+++ b/packages/catalog/src/booking-engine/index.ts
@@ -144,6 +144,7 @@ export {
   type ComputeQuoteRequest,
   type ComputeQuoteResult,
   type ComputeQuotesRequest,
+  type ComputeRequirementsResult,
   createOwnedBookingHandlerRegistry,
   type DeriveSelfServiceCommandRequest,
   type DeriveSelfServiceCommandResult,
@@ -243,6 +244,8 @@ export {
   type CommitSourcedBookingInput,
   type CommitSourcedBookingResult,
   type ComposeBookingQuoteInput,
+  type ComposeBookingQuoteResult,
+  type ComposeBookingRequirementsResult,
   type CompositeBookingCommitment,
   createBookingSessionModule,
 } from "./sessions-service.js"

--- a/packages/catalog/src/booking-engine/owned-handler.test.ts
+++ b/packages/catalog/src/booking-engine/owned-handler.test.ts
@@ -15,6 +15,9 @@ function stubHandler(entityModule: string): OwnedBookingHandler {
     async computeQuote(_ctx: OwnedHandlerContext, _req: ComputeQuoteRequest) {
       return { available: true }
     },
+    async computeRequirements(_ctx: OwnedHandlerContext, _req: ComputeQuoteRequest) {
+      return { unavailable: true as const }
+    },
   }
 }
 
@@ -57,6 +60,9 @@ describe("OwnedBookingHandlerRegistry", () => {
       async computeQuote(_ctx, req) {
         captured.push(req)
         return { available: true, pricing: undefined }
+      },
+      async computeRequirements() {
+        return { unavailable: true as const }
       },
     })
 

--- a/packages/catalog/src/booking-engine/owned-handler.ts
+++ b/packages/catalog/src/booking-engine/owned-handler.ts
@@ -72,14 +72,25 @@ export interface ComputeQuoteResult {
   invalidReason?: string
   pricing?: PricingBasis
   /**
-   * Per-quote journey descriptor. Owned handlers return this when
-   * they have enough context (always, for products in Phase A; the
-   * journey falls back to defaults when omitted).
+   * Per-quote journey descriptor, produced by this handler's
+   * `computeRequirements`. Present whenever the target resolved —
+   * including when pricing failed, so an unavailable target still
+   * renders a correct wizard. Absent only when the target itself
+   * could not be resolved.
    */
-  shape?: BookingRequirements
+  requirements?: BookingRequirements
   /** Echoed back into `catalog_quotes.upstream_payload` for audit. */
   upstreamPayload?: Record<string, unknown>
 }
+
+/**
+ * Outcome of the requirements-only derivation. Either the target resolved and
+ * has a renderable descriptor, or it did not resolve at all — `reason` mirrors
+ * `ComputeQuoteResult.invalidReason` so callers classify both the same way.
+ */
+export type ComputeRequirementsResult =
+  | { requirements: BookingRequirements }
+  | { unavailable: true; reason?: string }
 
 export interface ComputeQuoteBatchSelection {
   selectionId: string
@@ -185,8 +196,22 @@ export interface OwnedBookingHandler {
   readonly holdReleaseGraceMs?: number
 
   /**
+   * Derive what a booking of this row requires, without pricing it.
+   *
+   * The engine calls this on every outcome that publishes a Session record,
+   * so a host can render the Configure step before it can quote. `computeQuote`
+   * must call this same method rather than building its own descriptor: the
+   * requirements a host renders and the requirements a Commit later validates
+   * against have to be one derivation, not two (voyant#4113).
+   */
+  computeRequirements(
+    ctx: OwnedHandlerContext,
+    request: ComputeQuoteRequest,
+  ): Promise<ComputeRequirementsResult>
+
+  /**
    * Live-quote an owned row for a draft. The engine calls this on
-   * every meaningful input change. Returns shape + pricing +
+   * every meaningful input change. Returns requirements + pricing +
    * availability.
    *
    * Implementations should be idempotent — the same input must

--- a/packages/catalog/src/booking-engine/quote.ts
+++ b/packages/catalog/src/booking-engine/quote.ts
@@ -326,7 +326,7 @@ async function computeRawQuote(
     failedReason = result.invalidReason
     pricing = result.pricing
     upstreamPayload = result.upstreamPayload
-    ownedShape = result.shape
+    ownedShape = result.requirements
   } else {
     const adapter = request.sourceConnectionId
       ? (deps.registry.resolveByConnection(request.sourceConnectionId) ??
@@ -503,7 +503,7 @@ function rawFromOwnedResult(result: ComputeQuoteResult): RawQuoteComputation {
     failedReason: result.invalidReason,
     pricing: result.pricing,
     upstreamPayload: result.upstreamPayload,
-    ownedShape: result.shape,
+    ownedShape: result.requirements,
   }
 }
 

--- a/packages/catalog/src/booking-engine/sessions-drizzle.ts
+++ b/packages/catalog/src/booking-engine/sessions-drizzle.ts
@@ -3,7 +3,7 @@ import { newId } from "@voyant-travel/db/lib/typeid"
 import { and, eq, inArray, isNull, lte, notExists, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
-import type { PricingBreakdownV1 } from "./contracts.js"
+import type { BookingRequirementsV1, PricingBreakdownV1 } from "./contracts.js"
 import {
   bookingSessionAuditEventsTable,
   bookingSessionCommitsTable,
@@ -227,6 +227,7 @@ export function createDrizzleBookingSessionRepository(
           sessionId: record.sessionId,
           sessionRevision: record.sessionRevision,
           state: record.state,
+          requirements: record.requirements,
           pricing: record.pricing,
           priceFingerprint: record.priceFingerprint,
           quotedAt: record.quotedAt,
@@ -237,6 +238,7 @@ export function createDrizzleBookingSessionRepository(
           target: bookingSessionQuotesTable.id,
           set: {
             state: record.state,
+            requirements: record.requirements,
             pricing: record.pricing,
             priceFingerprint: record.priceFingerprint,
             expiresAt: record.expiresAt,
@@ -491,6 +493,7 @@ function mapQuote(row: SelectBookingSessionQuote): BookingQuoteInternalRecord {
     sessionId: row.sessionId,
     sessionRevision: row.sessionRevision,
     state: row.state as BookingQuoteInternalRecord["state"],
+    requirements: row.requirements as BookingRequirementsV1,
     pricing: row.pricing as PricingBreakdownV1,
     priceFingerprint: row.priceFingerprint,
     quotedAt: row.quotedAt,

--- a/packages/catalog/src/booking-engine/sessions-memory.ts
+++ b/packages/catalog/src/booking-engine/sessions-memory.ts
@@ -1,5 +1,14 @@
+import {
+  DEFAULT_PAX_BANDS,
+  DEFAULT_PAYMENT_INTENTS,
+  defaultBookingFields,
+  defaultRequirementsFlags,
+  defaultTravelerFields,
+  paxBandsAllowedTotalFrom,
+} from "@voyant-travel/catalog-contracts/booking-engine/requirements"
 import { newId } from "@voyant-travel/db/lib/typeid"
 
+import type { BookingRequirementsV1 } from "./contracts.js"
 import type {
   BookingCommitInternalRecord,
   BookingHoldInternalRecord,
@@ -220,10 +229,26 @@ export function createInMemoryBookingSessionRepository(): InMemoryBookingSession
   return repository
 }
 
+/**
+ * A minimal renderable descriptor for in-memory fixtures. It stands in for a
+ * vertical's derivation so the Session plane can be exercised without one — it
+ * is not a fallback any production path may use.
+ */
+export function inMemoryBookingRequirements(): BookingRequirementsV1 {
+  return {
+    ...defaultRequirementsFlags(),
+    paxBands: [...DEFAULT_PAX_BANDS],
+    paxBandsAllowedTotal: paxBandsAllowedTotalFrom(DEFAULT_PAX_BANDS),
+    travelerFields: [...defaultTravelerFields()],
+    bookingFields: [...defaultBookingFields()],
+    paymentIntents: [...DEFAULT_PAYMENT_INTENTS],
+  } as BookingRequirementsV1
+}
+
 export interface InMemoryOwnedInventoryPorts
   extends Pick<
     BookingSessionModulePorts,
-    "placeCapacityHold" | "releaseCapacityHold" | "commitOwnedBooking"
+    "composeRequirements" | "placeCapacityHold" | "releaseCapacityHold" | "commitOwnedBooking"
   > {
   setCapacity(capacityKey: string, quantity: number): void
   hasActiveHold(holdId: string): boolean
@@ -242,6 +267,9 @@ export function createInMemoryOwnedInventoryPorts(): InMemoryOwnedInventoryPorts
     allocationIds,
     setCapacity(capacityKey, quantity) {
       capacities.set(capacityKey, quantity)
+    },
+    async composeRequirements() {
+      return { status: "available", requirements: inMemoryBookingRequirements() }
     },
     hasActiveHold(holdId) {
       return activeHolds.has(holdId)
@@ -306,6 +334,7 @@ function cloneAudit(record: BookingSessionAuditRecord): BookingSessionAuditRecor
 function cloneQuote(record: BookingQuoteInternalRecord): BookingQuoteInternalRecord {
   return {
     ...record,
+    requirements: structuredClone(record.requirements),
     pricing: structuredClone(record.pricing),
     quotedAt: new Date(record.quotedAt),
     expiresAt: new Date(record.expiresAt),

--- a/packages/catalog/src/booking-engine/sessions-production.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-production.test.ts
@@ -38,6 +38,8 @@ vi.mock("@voyant-travel/finance", async (importOriginal) => ({
   },
 }))
 
+import type { BookingRequirements } from "@voyant-travel/catalog-contracts/booking-engine/requirements"
+import { defaultRequirementsFlags } from "@voyant-travel/catalog-contracts/booking-engine/requirements"
 import type { OwnedBookingHandler } from "./owned-handler.js"
 import { createOwnedBookingHandlerRegistry } from "./owned-handler.js"
 import { createSourceAdapterRegistry } from "./registry.js"
@@ -53,6 +55,19 @@ const STOREFRONT_ACCESS = {
   storefront: { storefrontId: "sf_public", channelId: "chan_public" },
 } as const
 const TEST_CAPABILITY = `bcap_${"a".repeat(43)}`
+
+/** Stand-in for a vertical's derivation; only its identity matters here. */
+const HANDLER_REQUIREMENTS: BookingRequirements = {
+  ...defaultRequirementsFlags(),
+  paxBands: [{ code: "adult", label: "Adult", minCount: 1, maxCount: 8 }],
+  paxBandsAllowedTotal: { min: 1, max: 8 },
+  travelerFields: [],
+  bookingFields: [],
+  paymentIntents: ["card"],
+}
+const HANDLER_REQUIREMENTS_PORT: OwnedBookingHandler["computeRequirements"] = async () => ({
+  requirements: HANDLER_REQUIREMENTS,
+})
 
 function createProductionHarness(handler: OwnedBookingHandler) {
   const repository = createInMemoryBookingSessionRepository()
@@ -500,6 +515,7 @@ describe("production Booking Session ports", () => {
     }
     const { module } = createProductionHarness({
       entityModule: "products",
+      computeRequirements: HANDLER_REQUIREMENTS_PORT,
       async computeQuote() {
         return {
           available: true,
@@ -528,6 +544,7 @@ describe("production Booking Session ports", () => {
   it("returns a typed rejection when an owned target cannot be quoted", async () => {
     const { module } = createProductionHarness({
       entityModule: "products",
+      computeRequirements: HANDLER_REQUIREMENTS_PORT,
       async computeQuote() {
         return { available: false, invalidReason: "product_not_found" }
       },
@@ -550,10 +567,58 @@ describe("production Booking Session ports", () => {
     })
   })
 
+  it("still returns renderable Requirements when a resolvable target cannot be priced", async () => {
+    // The load-bearing case: the target resolved and the wizard is correct,
+    // only the price is missing. Dropping the descriptor here is what forced
+    // hosts to invent one (voyant#4113).
+    const { module } = createProductionHarness({
+      entityModule: "products",
+      computeRequirements: HANDLER_REQUIREMENTS_PORT,
+      async computeQuote() {
+        return {
+          available: false,
+          invalidReason: "no_sell_amount_configured",
+          requirements: HANDLER_REQUIREMENTS,
+        }
+      },
+    })
+    const { created, access } = await createAnonymousSession(module)
+
+    const quoted = await module.quoteSession(
+      created.session.id,
+      { expectedRevision: created.session.revision, idempotencyKey: "quote_unpriceable" },
+      access,
+    )
+
+    expect(quoted).toEqual({
+      kind: "rejected",
+      error: {
+        kind: "quote_unavailable",
+        requirements: HANDLER_REQUIREMENTS,
+        reason: "price_unavailable",
+        nextAction: "contact_operator",
+      },
+    })
+  })
+
+  it("publishes Requirements on the Session record before any Quote exists", async () => {
+    const { module } = createProductionHarness({
+      entityModule: "products",
+      computeRequirements: HANDLER_REQUIREMENTS_PORT,
+      async computeQuote() {
+        return { available: false, invalidReason: "no_sell_amount_configured" }
+      },
+    })
+    const { created } = await createAnonymousSession(module)
+
+    expect(created.session.requirements).toEqual(HANDLER_REQUIREMENTS)
+  })
+
   it("rejects a hold quantity that disagrees with the normalized selection", async () => {
     let placeHoldCalls = 0
     const { module } = createProductionHarness({
       entityModule: "products",
+      computeRequirements: HANDLER_REQUIREMENTS_PORT,
       async computeQuote() {
         return {
           available: true,
@@ -607,6 +672,7 @@ describe("production Booking Session ports", () => {
   it("returns a typed actionable rejection for an incomplete commit", async () => {
     const { module } = createProductionHarness({
       entityModule: "products",
+      computeRequirements: HANDLER_REQUIREMENTS_PORT,
       async computeQuote() {
         return {
           available: true,
@@ -674,6 +740,7 @@ function createCommittableProductionModule(command: Record<string, unknown> = {}
   const handlers = createOwnedBookingHandlerRegistry()
   handlers.register({
     entityModule: "products",
+    computeRequirements: HANDLER_REQUIREMENTS_PORT,
     async computeQuote() {
       return {
         available: true,

--- a/packages/catalog/src/booking-engine/sessions-production.ts
+++ b/packages/catalog/src/booking-engine/sessions-production.ts
@@ -3,7 +3,16 @@ import {
   createSourcedBookingCommitment,
   type SourcedBookingTravelerInput,
 } from "@voyant-travel/bookings/service-sourced-commitment"
-import { paxBandBaseCode } from "@voyant-travel/catalog-contracts/booking-engine/requirements"
+import type { BookingRequirements } from "@voyant-travel/catalog-contracts/booking-engine/requirements"
+import {
+  DEFAULT_PAX_BANDS,
+  DEFAULT_PAYMENT_INTENTS,
+  defaultBookingFields,
+  defaultRequirementsFlags,
+  defaultTravelerFields,
+  paxBandBaseCode,
+  paxBandsAllowedTotalFrom,
+} from "@voyant-travel/catalog-contracts/booking-engine/requirements"
 import type { AnyDrizzleDb } from "@voyant-travel/db"
 import {
   allocateBookingNumber,
@@ -20,8 +29,13 @@ import { catalogSourcedEntriesTable } from "../schema-sourced-entries.js"
 import { captureSnapshot } from "../services/snapshot-service.js"
 import type { PricingBasis } from "../snapshot/schema.js"
 import { bookingAllocationsRef, bookingsRef } from "./bookings-ref.js"
+import type { BookingRequirementsV1 } from "./contracts.js"
 import { pricingBreakdownV1 } from "./contracts.js"
-import type { OwnedBookingHandlerRegistry, SelfServiceBillingParty } from "./owned-handler.js"
+import type {
+  ComputeQuoteRequest,
+  OwnedBookingHandlerRegistry,
+  SelfServiceBillingParty,
+} from "./owned-handler.js"
 import { engineParametersFromSelection } from "./quote-support.js"
 import type { SourceAdapterRegistry } from "./registry.js"
 import type { ProductionBookingSessionPaymentDeps } from "./sessions-payment-production.js"
@@ -34,6 +48,7 @@ import {
   type BookingSessionRepository,
   type CommitOwnedBookingInput,
   type CommitSourcedBookingInput,
+  type ComposeBookingRequirementsResult,
   createBookingSessionModule,
   InvalidBookingSessionSelectionError,
 } from "./sessions-service.js"
@@ -76,6 +91,20 @@ export function createProductionBookingSessionModule(
       repository: deps.repository,
       normalizeSelection: async ({ selection, target, access }) =>
         normalizeBookingSelection(target, selection, access),
+      composeRequirements: async (input) => {
+        const { session } = input
+        if (session.target.kind === "trip_snapshot") {
+          const handler = await deps.resolveCompositeHandler?.()
+          return (
+            (handler ? await handler.composeRequirements({ ...input, leaf }) : undefined) ?? {
+              status: "unavailable",
+              reason: "target_not_bookable",
+              nextAction: "contact_operator",
+            }
+          )
+        }
+        return leaf.composeRequirements(input)
+      },
       composeQuote: async (input) => {
         const { session } = input
         if (session.target.kind === "trip_snapshot") {
@@ -129,8 +158,44 @@ export function createProductionBookingSessionModule(
 function createProductionCompositeLeafRuntime(
   deps: ProductionBookingSessionModuleDeps,
 ): BookingSessionCompositeLeafRuntime {
+  const composeRequirements: BookingSessionCompositeLeafRuntime["composeRequirements"] = async ({
+    session,
+    tx,
+  }) => {
+    // Session creation runs before a Session row exists, so there is no
+    // open Session transaction to borrow. Requirements derivation only
+    // reads, so falling back to the module's connection is safe.
+    const db = (tx as PostgresJsDatabase | undefined) ?? deps.db
+    if (session.target.kind === "catalog_item") {
+      const sourced = await resolveSourcedTarget(db, session)
+      return sourced
+        ? { status: "available", requirements: sourcedBookingRequirements() }
+        : unavailableRequirementsResult("product_not_found")
+    }
+    if (session.target.kind === "trip_snapshot") {
+      return unavailableRequirementsResult("unsupported_target")
+    }
+    const handlers = await deps.resolveOwnedHandlers()
+    const handler = handlers.resolve(entityModuleForSession(session.target))
+    if (!handler) {
+      return {
+        status: "unavailable",
+        reason: "target_not_bookable",
+        nextAction: "select_alternative_inventory",
+      }
+    }
+    const result = await handler.computeRequirements(
+      { db, adapterContext: {} as never },
+      ownedComputeRequest(handler.entityModule, session),
+    )
+    return "requirements" in result
+      ? { status: "available", requirements: requirementsForSession(result.requirements) }
+      : unavailableRequirementsResult(result.reason)
+  }
+
   return {
-    async composeQuote({ session, tx }) {
+    composeRequirements,
+    async composeQuote({ session, now, tx }) {
       if (session.target.kind === "catalog_item") {
         return composeSourcedQuote(deps, session, tx as PostgresJsDatabase)
       }
@@ -148,22 +213,28 @@ function createProductionCompositeLeafRuntime(
       }
       const result = await handler.computeQuote(
         { db: tx as PostgresJsDatabase, adapterContext: {} as never },
-        {
-          entityModule: handler.entityModule,
-          entityId: entityIdForSession(session.target),
-          draft: session.statePayload,
-          parameters: engineParametersFromSelection(undefined, session.statePayload, {
-            entityModule: handler.entityModule,
-            sourceKind: "owned",
-          }),
-          scope: { locale: "en", audience: "customer", market: "default" },
-        },
+        ownedComputeRequest(handler.entityModule, session),
       )
+      // The handler builds the descriptor unconditionally, precisely so a
+      // pricing failure cannot collapse it. Carry it through both exits.
+      const requirements = result.requirements
+        ? requirementsForSession(result.requirements)
+        : undefined
       if (!result.available || !result.pricing) {
-        return unavailableQuoteResult(result.invalidReason)
+        return { ...unavailableQuoteResult(result.invalidReason), requirements }
       }
+      // A priced target always has a resolvable descriptor. Ask the same
+      // derivation directly rather than dropping a good quote if a handler
+      // omitted it from its quote result.
+      let quoted = requirements
+      if (!quoted) {
+        const resolved = await composeRequirements({ session, now, tx })
+        if (resolved.status === "available") quoted = resolved.requirements
+      }
+      if (!quoted) return unavailableQuoteResult(result.invalidReason)
       return {
         status: "quoted",
+        requirements: quoted,
         pricing: pricingBreakdownFromBasis(result.pricing, result.upstreamPayload),
       }
     },
@@ -216,10 +287,12 @@ async function composeSourcedQuote(
 ) {
   const sourced = await resolveSourcedTarget(tx, session)
   if (!sourced) return unavailableQuoteResult("product_not_found")
+  // The target resolved, so every exit below can still render a wizard.
+  const requirements = sourcedBookingRequirements()
   const registry = await deps.resolveSourceRegistry()
   const adapter = registry.resolveByConnection(sourced.sourceConnectionId)
   if (!adapter?.capabilities.supportsLiveResolution || !adapter.liveResolve) {
-    return unavailableQuoteResult("no_sell_amount_configured")
+    return { ...unavailableQuoteResult("no_sell_amount_configured"), requirements }
   }
   const result = await adapter.liveResolve(
     { connection_id: sourced.sourceConnectionId },
@@ -232,12 +305,12 @@ async function composeSourcedQuote(
   )
   const liveValues = result.values[sourced.entityId]
   if (result.failed?.[sourced.entityId] || !liveValues) {
-    return unavailableQuoteResult("selection_unavailable")
+    return { ...unavailableQuoteResult("selection_unavailable"), requirements }
   }
   const pricing = pricingBreakdownFromLiveValues(liveValues)
   return pricing
-    ? { status: "quoted" as const, pricing }
-    : unavailableQuoteResult("no_sell_amount_configured")
+    ? { status: "quoted" as const, requirements, pricing }
+    : { ...unavailableQuoteResult("no_sell_amount_configured"), requirements }
 }
 
 async function commitSourcedBooking(
@@ -728,6 +801,59 @@ function policyEvidenceFromValues(values?: Record<string, unknown>) {
     ...(cancellation !== undefined ? { cancellation } : {}),
     ...(bookingTerms !== undefined ? { bookingTerms } : {}),
   }
+}
+
+function ownedComputeRequest(
+  entityModule: string,
+  session: CommitOwnedBookingInput["session"],
+): ComputeQuoteRequest {
+  return {
+    entityModule,
+    entityId: entityIdForSession(session.target),
+    draft: session.statePayload,
+    parameters: engineParametersFromSelection(undefined, session.statePayload, {
+      entityModule,
+      sourceKind: "owned",
+    }),
+    scope: { locale: "en", audience: "customer", market: "default" },
+  }
+}
+
+/**
+ * The hand-written `BookingRequirements` interface and the Zod-inferred
+ * `BookingRequirementsV1` describe the same descriptor; the interface declares
+ * `ReadonlyArray` where the schema infers mutable arrays. Narrow once here,
+ * where vertical output crosses into the Session plane, rather than at every
+ * point that publishes a descriptor.
+ */
+function requirementsForSession(requirements: BookingRequirements): BookingRequirementsV1 {
+  return requirements as unknown as BookingRequirementsV1
+}
+
+/**
+ * Baseline descriptor for a sourced (`catalog_item`) target. The source
+ * adapter contract has no requirements primitive yet, so a sourced row gets
+ * the engine defaults: one Configure occupancy sub-step over the canonical
+ * pax bands, the standard traveler + billing fields, and the full payment
+ * intent set the deployment's capabilities then narrow.
+ */
+function sourcedBookingRequirements(): BookingRequirementsV1 {
+  return requirementsForSession({
+    ...defaultRequirementsFlags(),
+    configureSubSteps: [{ kind: "occupancy", bands: DEFAULT_PAX_BANDS }],
+    paxBands: DEFAULT_PAX_BANDS,
+    paxBandsAllowedTotal: paxBandsAllowedTotalFrom(DEFAULT_PAX_BANDS),
+    travelerFields: defaultTravelerFields(),
+    bookingFields: defaultBookingFields(),
+    paymentIntents: DEFAULT_PAYMENT_INTENTS,
+  })
+}
+
+function unavailableRequirementsResult(
+  invalidReason: string | undefined,
+): ComposeBookingRequirementsResult {
+  const { reason, nextAction } = unavailableQuoteResult(invalidReason)
+  return { status: "unavailable", reason, nextAction }
 }
 
 function unavailableQuoteResult(invalidReason: string | undefined) {

--- a/packages/catalog/src/booking-engine/sessions-routes.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-routes.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest"
 import {
   createInMemoryBookingSessionRepository,
   createInMemoryOwnedInventoryPorts,
+  inMemoryBookingRequirements,
 } from "./sessions-memory.js"
 import { createBookingSessionRoutes } from "./sessions-routes.js"
 import { createBookingSessionModule } from "./sessions-service.js"
@@ -70,8 +71,10 @@ function createApp(
     ports: {
       repository,
       normalizeSelection: async ({ selection }) => selection,
+      composeRequirements: inventory.composeRequirements,
       composeQuote: async () => ({
         status: "quoted",
+        requirements: inMemoryBookingRequirements(),
         pricing: {
           currency: "EUR",
           lines: [],

--- a/packages/catalog/src/booking-engine/sessions-schema.ts
+++ b/packages/catalog/src/booking-engine/sessions-schema.ts
@@ -135,6 +135,8 @@ export const bookingSessionQuotesTable = pgTable(
       .references(() => bookingSessionsTable.id, { onDelete: "cascade" }),
     sessionRevision: integer("session_revision").notNull(),
     state: text("state").notNull(),
+    /** Booking Requirements this price was computed against. */
+    requirements: jsonb("requirements").$type<Record<string, unknown>>().notNull(),
     pricing: jsonb("pricing").$type<Record<string, unknown>>().notNull(),
     priceFingerprint: text("price_fingerprint").notNull(),
     quotedAt: timestamp("quoted_at", { withTimezone: true }).notNull(),

--- a/packages/catalog/src/booking-engine/sessions-service.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-service.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest"
 import {
   createInMemoryBookingSessionRepository,
   createInMemoryOwnedInventoryPorts,
+  inMemoryBookingRequirements,
 } from "./sessions-memory.js"
 import {
   type BookingSessionPaymentPorts,
@@ -68,7 +69,12 @@ function createHarness(
     ports: {
       repository,
       normalizeSelection: async ({ selection }) => selection,
-      composeQuote: async () => ({ status: "quoted", pricing: price }),
+      composeRequirements: inventory.composeRequirements,
+      composeQuote: async () => ({
+        status: "quoted",
+        requirements: inMemoryBookingRequirements(),
+        pricing: price,
+      }),
       placeCapacityHold: inventory.placeCapacityHold,
       releaseCapacityHold: inventory.releaseCapacityHold,
       commitOwnedBooking: inventory.commitOwnedBooking,
@@ -1011,7 +1017,12 @@ describe("Booking Session v1 owned tracer", () => {
       ports: {
         repository,
         normalizeSelection: async ({ selection }) => selection,
-        composeQuote: async () => ({ status: "quoted", pricing: BASE_PRICING }),
+        composeRequirements: inventory.composeRequirements,
+        composeQuote: async () => ({
+          status: "quoted",
+          requirements: inMemoryBookingRequirements(),
+          pricing: BASE_PRICING,
+        }),
         placeCapacityHold: inventory.placeCapacityHold,
         releaseCapacityHold: inventory.releaseCapacityHold,
         commitOwnedBooking: async (input) =>
@@ -1407,7 +1418,15 @@ describe("Booking Session v1 sourced continuation", () => {
       ports: {
         repository,
         normalizeSelection: async ({ selection }) => selection,
-        composeQuote: async () => ({ status: "quoted", pricing: BASE_PRICING }),
+        composeRequirements: async () => ({
+          status: "available",
+          requirements: inMemoryBookingRequirements(),
+        }),
+        composeQuote: async () => ({
+          status: "quoted",
+          requirements: inMemoryBookingRequirements(),
+          pricing: BASE_PRICING,
+        }),
         placeCapacityHold: async () => "unavailable",
         releaseCapacityHold: async () => {},
         commitOwnedBooking: async () => {

--- a/packages/catalog/src/booking-engine/sessions-service.ts
+++ b/packages/catalog/src/booking-engine/sessions-service.ts
@@ -20,7 +20,11 @@ import type {
   UpdateBookingSessionV1,
 } from "@voyant-travel/catalog-contracts/booking-engine/session-contracts"
 import { newId } from "@voyant-travel/db/lib/typeid"
-import type { BookingLifecycleCommitOutcomeV1, PricingBreakdownV1 } from "./contracts.js"
+import type {
+  BookingLifecycleCommitOutcomeV1,
+  BookingRequirementsV1,
+  PricingBreakdownV1,
+} from "./contracts.js"
 
 const DEFAULT_SESSION_TTL_MS = 24 * 60 * 60 * 1000
 const DEFAULT_QUOTE_TTL_MS = 10 * 60 * 1000
@@ -65,6 +69,8 @@ export interface BookingQuoteInternalRecord {
   sessionId: string
   sessionRevision: number
   state: "active" | "superseded" | "consumed" | "expired"
+  /** The descriptor this price was computed against. See `composeRequirements`. */
+  requirements: BookingRequirementsV1
   pricing: PricingBreakdownV1
   priceFingerprint: string
   quotedAt: Date
@@ -193,12 +199,46 @@ export type BookingSessionQuoteUnavailableReason =
   | "policy_unavailable"
   | "selection_unavailable"
 
+export type BookingSessionQuoteUnavailableNextAction =
+  | "select_alternative_inventory"
+  | "contact_operator"
+  | "update_selection"
+
 export type ComposeBookingQuoteResult =
-  | { status: "quoted"; pricing: PricingBreakdownV1 }
+  | {
+      status: "quoted"
+      /**
+       * The descriptor the price was computed against. Required on the quoted
+       * branch — a target that priced necessarily resolved.
+       */
+      requirements: BookingRequirementsV1
+      pricing: PricingBreakdownV1
+    }
+  | {
+      status: "unavailable"
+      /**
+       * Carried through unavailability so a priced-out or sold-out target
+       * still renders a correct wizard. Absent only when the target itself
+       * did not resolve.
+       */
+      requirements?: BookingRequirementsV1
+      reason: BookingSessionQuoteUnavailableReason
+      nextAction: BookingSessionQuoteUnavailableNextAction
+    }
+
+/**
+ * Requirements derivation, split out of quoting so a host can render the
+ * Configure step before it has a price. Implementations must delegate to the
+ * same per-vertical derivation `composeQuote` uses — one code path, so the
+ * requirements a host renders and the requirements a Commit validates against
+ * cannot drift (voyant#4113).
+ */
+export type ComposeBookingRequirementsResult =
+  | { status: "available"; requirements: BookingRequirementsV1 }
   | {
       status: "unavailable"
       reason: BookingSessionQuoteUnavailableReason
-      nextAction: "select_alternative_inventory" | "contact_operator" | "update_selection"
+      nextAction: BookingSessionQuoteUnavailableNextAction
     }
 
 export type PlaceBookingCapacityHoldResult =
@@ -275,6 +315,7 @@ export type CommitCompositeBookingResult =
     >
 
 export interface BookingSessionCompositeLeafRuntime {
+  composeRequirements(input: ComposeBookingQuoteInput): Promise<ComposeBookingRequirementsResult>
   composeQuote(input: ComposeBookingQuoteInput): Promise<ComposeBookingQuoteResult>
   placeCapacityHold(input: {
     session: BookingSessionInternalRecord
@@ -302,6 +343,9 @@ export interface BookingSessionCompositeLeafRuntime {
 }
 
 export interface BookingSessionCompositeHandler {
+  composeRequirements(
+    input: ComposeBookingQuoteInput & { leaf: BookingSessionCompositeLeafRuntime },
+  ): Promise<ComposeBookingRequirementsResult>
   composeQuote(
     input: ComposeBookingQuoteInput & { leaf: BookingSessionCompositeLeafRuntime },
   ): Promise<ComposeBookingQuoteResult>
@@ -395,6 +439,17 @@ export interface BookingSessionModulePorts {
     access: BookingSessionAccessContext
     now: Date
   }): Promise<Record<string, unknown>>
+  /**
+   * Derive the target's Booking Requirements without pricing it. Called on
+   * every outcome that publishes a Session record, so a host can render the
+   * Configure step before it quotes.
+   *
+   * `tx` is the caller's Session transaction where one is open; Session
+   * creation runs before a Session row exists, so implementations must accept
+   * a nullish `tx` and fall back to their own read connection. The derivation
+   * is read-only either way.
+   */
+  composeRequirements(input: ComposeBookingQuoteInput): Promise<ComposeBookingRequirementsResult>
   composeQuote(input: ComposeBookingQuoteInput): Promise<ComposeBookingQuoteResult>
   placeCapacityHold(input: {
     session: BookingSessionInternalRecord
@@ -520,6 +575,22 @@ export function createBookingSessionModule(
 
   const loadSession = (sessionId: string) => repository.getSession(sessionId)
 
+  /**
+   * Resolve the descriptor a host renders this Session from. Terminal and
+   * purged Sessions have no target left to re-derive, and an unresolvable
+   * target is not a reason to fail the Session operation itself — both omit
+   * the field rather than rejecting.
+   */
+  async function sessionRequirements(
+    session: BookingSessionInternalRecord,
+    at: Date,
+    tx?: unknown,
+  ): Promise<BookingRequirementsV1 | undefined> {
+    if (session.state !== "active" || session.purgedAt) return undefined
+    const resolved = await options.ports.composeRequirements({ session, now: at, tx })
+    return resolved.status === "available" ? resolved.requirements : undefined
+  }
+
   function rejectRevision(
     expectedRevision: number,
     session: BookingSessionInternalRecord,
@@ -580,7 +651,10 @@ export function createBookingSessionModule(
       if (existing.createRequestFingerprint !== createRequestFingerprint) {
         return idempotencyConflict()
       }
-      return { kind: "session_created", session: serializeSession(existing) }
+      return {
+        kind: "session_created",
+        session: serializeSession(existing, await sessionRequirements(existing, at)),
+      }
     }
     let statePayload: Record<string, unknown>
     try {
@@ -619,9 +693,15 @@ export function createBookingSessionModule(
       if (created.createRequestFingerprint !== createRequestFingerprint) {
         return idempotencyConflict()
       }
-      return { kind: "session_created", session: serializeSession(created) }
+      return {
+        kind: "session_created",
+        session: serializeSession(created, await sessionRequirements(created, at)),
+      }
     }
-    return { kind: "session_created", session: serializeSession(session) }
+    return {
+      kind: "session_created",
+      session: serializeSession(session, await sessionRequirements(session, at)),
+    }
   }
 
   return {
@@ -665,7 +745,11 @@ export function createBookingSessionModule(
         })
         return {
           kind: "session_resumed",
-          session: serializeSessionView(session, access),
+          session: serializeSessionView(
+            session,
+            access,
+            await sessionRequirements(session, at, tx),
+          ),
         }
       })
     },
@@ -719,7 +803,11 @@ export function createBookingSessionModule(
         await appendSessionAudit(repository, session, "adopt", access, at)
         const outcome: BookingSessionOutcomeV1 = {
           kind: "session_adopted",
-          session: serializeSessionView(session, access),
+          session: serializeSessionView(
+            session,
+            access,
+            await sessionRequirements(session, at, tx),
+          ),
         }
         await repository.completeOperation({ id: claim.id, outcome })
         return outcome
@@ -829,7 +917,7 @@ export function createBookingSessionModule(
         await appendSessionAudit(repository, session, "update", access, at)
         const outcome: BookingSessionOutcomeV1 = {
           kind: "session_updated",
-          session: serializeSession(session),
+          session: serializeSession(session, await sessionRequirements(session, at, tx)),
         }
         await repository.completeOperation({ id: claim.id, outcome })
         return outcome
@@ -867,12 +955,13 @@ export function createBookingSessionModule(
         if (composed.status === "unavailable") {
           return completeAndReturn(repository, claim.id, quoteUnavailable(composed))
         }
-        const { pricing } = composed
+        const { pricing, requirements } = composed
         const quote: BookingQuoteInternalRecord = {
           id: newId("booking_session_quotes"),
           sessionId,
           sessionRevision: session.revision,
           state: "active",
+          requirements,
           pricing,
           priceFingerprint: await stableFingerprint(pricing),
           quotedAt: at,
@@ -884,7 +973,9 @@ export function createBookingSessionModule(
         })
         const outcome: BookingSessionOutcomeV1 = {
           kind: "quote_created",
-          session: serializeSession(session),
+          // The compose call already derived requirements for this target;
+          // publish those rather than re-deriving them for the record.
+          session: serializeSession(session, requirements),
           quote: serializeQuote(quote),
         }
         await repository.completeOperation({ id: claim.id, outcome })
@@ -1824,6 +1915,9 @@ function quoteUnavailable(
     kind: "rejected",
     error: {
       kind: "quote_unavailable",
+      // A target that priced out or sold out still has a renderable wizard.
+      // Dropping the descriptor here is what forced hosts to invent one.
+      ...(result.requirements ? { requirements: result.requirements } : {}),
       reason: result.reason,
       nextAction: result.nextAction,
     },
@@ -2092,7 +2186,10 @@ function capacityKeyForTarget(target: BookingSessionTargetV1): string {
   throw new Error("Booking Session target does not identify capacity")
 }
 
-function serializeSession(session: BookingSessionInternalRecord): BookingSessionRecordV1 {
+function serializeSession(
+  session: BookingSessionInternalRecord,
+  requirements?: BookingRequirementsV1,
+): BookingSessionRecordV1 {
   return {
     id: session.id,
     target: session.target,
@@ -2100,6 +2197,7 @@ function serializeSession(session: BookingSessionInternalRecord): BookingSession
     actorKind: session.actorKind,
     state: session.state,
     revision: session.revision,
+    ...(requirements ? { requirements } : {}),
     expiresAt: session.expiresAt.toISOString(),
     createdAt: session.createdAt.toISOString(),
     updatedAt: session.updatedAt.toISOString(),
@@ -2109,8 +2207,9 @@ function serializeSession(session: BookingSessionInternalRecord): BookingSession
 function serializeSessionView(
   session: BookingSessionInternalRecord,
   access: BookingSessionAccessContext,
+  requirements?: BookingRequirementsV1,
 ): BookingSessionViewV1 {
-  const record = serializeSession(session)
+  const record = serializeSession(session, requirements)
   if (access.actorKind === "staff") {
     return { ...record, redaction: "selection_omitted" }
   }
@@ -2123,6 +2222,7 @@ function serializeQuote(quote: BookingQuoteInternalRecord): BookingQuoteRecordV1
     sessionId: quote.sessionId,
     sessionRevision: quote.sessionRevision,
     state: quote.state,
+    requirements: quote.requirements,
     pricing: quote.pricing,
     quotedAt: quote.quotedAt.toISOString(),
     expiresAt: quote.expiresAt.toISOString(),

--- a/packages/catalog/tests/integration/booking-sessions-v1.test.ts
+++ b/packages/catalog/tests/integration/booking-sessions-v1.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../../src/booking-engine/bookings-ref.js"
 import { createSourceAdapterRegistry } from "../../src/booking-engine/registry.js"
 import { createDrizzleBookingSessionRepository } from "../../src/booking-engine/sessions-drizzle.js"
+import { inMemoryBookingRequirements } from "../../src/booking-engine/sessions-memory.js"
 import {
   bookingSessionAuditEventsTable,
   bookingSessionCommitsTable,
@@ -40,6 +41,7 @@ const ACCESS = {
   capability: "bcap_postgres_booking_session_capability_1234567890",
   storefront: { storefrontId: "sf_pg", channelId: "chan_pg" },
 }
+const REQUIREMENTS = inMemoryBookingRequirements()
 const PRICING = {
   currency: "EUR",
   lines: [],
@@ -206,7 +208,12 @@ describe.skipIf(!DB_AVAILABLE)("Booking Session v1 PostgreSQL invariants", () =>
       ports: {
         repository: sessions,
         normalizeSelection: async ({ selection }) => selection,
-        composeQuote: async () => ({ status: "quoted", pricing: PRICING }),
+        composeRequirements: async () => ({ status: "available", requirements: REQUIREMENTS }),
+        composeQuote: async () => ({
+          status: "quoted",
+          requirements: REQUIREMENTS,
+          pricing: PRICING,
+        }),
         placeCapacityHold: async () => "unavailable",
         releaseCapacityHold: async () => {},
         commitOwnedBooking: async () => {
@@ -457,7 +464,12 @@ function createModule(
     ports: {
       repository,
       normalizeSelection: async ({ selection }) => structuredClone(selection),
-      composeQuote: async () => ({ status: "quoted", pricing: PRICING }),
+      composeRequirements: async () => ({ status: "available", requirements: REQUIREMENTS }),
+      composeQuote: async () => ({
+        status: "quoted",
+        requirements: REQUIREMENTS,
+        pricing: PRICING,
+      }),
       placeCapacityHold: async () => "held",
       releaseCapacityHold: async () => {},
       commitOwnedBooking,

--- a/packages/cruises/src/booking-engine/handler.ts
+++ b/packages/cruises/src/booking-engine/handler.ts
@@ -20,6 +20,7 @@ import type {
   BookingRequirements,
   ComputeQuoteRequest,
   ComputeQuoteResult,
+  ComputeRequirementsResult,
   OwnedBookingHandler,
   OwnedHandlerContext,
 } from "@voyant-travel/catalog/booking-engine"
@@ -98,6 +99,22 @@ export interface CreateCruiseBookingHandlerOptions extends CruiseHandlerLoaders 
 export function createCruiseBookingHandler(
   options: CreateCruiseBookingHandlerOptions,
 ): OwnedBookingHandler {
+  /**
+   * The single derivation of a cruise's Booking Requirements. Both
+   * `computeRequirements` and `computeQuote` come through here, so the
+   * descriptor a host renders is the descriptor a Commit later validates
+   * against — one code path, not two (voyant#4113).
+   */
+  async function deriveRequirements(ctx: OwnedHandlerContext, request: ComputeQuoteRequest) {
+    const content = await options.loadContent(ctx, request.entityId)
+    if (!content) return { status: "unavailable" as const, reason: "cruise_not_found" }
+    const requirements: BookingRequirements = buildCruiseRequirements(content, {
+      forceCabinNumberSubStep: options.forceCabinNumberSubStep,
+      includeInsurance: options.includeInsurance,
+    })
+    return { status: "available" as const, content, requirements }
+  }
+
   return {
     entityModule: "cruises",
     // Cruise lines commonly hold cabin capacity for 24h after a
@@ -106,19 +123,26 @@ export function createCruiseBookingHandler(
     // by replacing the handler at boot.
     holdReleaseGraceMs: 24 * 60 * 60 * 1000,
 
+    async computeRequirements(
+      ctx: OwnedHandlerContext,
+      request: ComputeQuoteRequest,
+    ): Promise<ComputeRequirementsResult> {
+      const derived = await deriveRequirements(ctx, request)
+      return derived.status === "available"
+        ? { requirements: derived.requirements }
+        : { unavailable: true, reason: derived.reason }
+    },
+
     async computeQuote(
       ctx: OwnedHandlerContext,
       request: ComputeQuoteRequest,
     ): Promise<ComputeQuoteResult> {
-      const content = await options.loadContent(ctx, request.entityId)
-      if (!content) {
-        return { available: false, invalidReason: "cruise_not_found" }
+      const derived = await deriveRequirements(ctx, request)
+      if (derived.status === "unavailable") {
+        return { available: false, invalidReason: derived.reason }
       }
-
-      const shape: BookingRequirements = buildCruiseRequirements(content, {
-        forceCabinNumberSubStep: options.forceCabinNumberSubStep,
-        includeInsurance: options.includeInsurance,
-      })
+      const { content } = derived
+      const shape = derived.requirements
 
       const draft = (request.draft ?? {}) as DraftLike
       const sailingId = draft.configure?.departureSlotId
@@ -129,7 +153,7 @@ export function createCruiseBookingHandler(
       // user picks all three, return shape only — the wizard
       // renders the steps and waits.
       if (!sailingId || !cabinCategoryId || paxCount <= 0) {
-        return { available: true, shape }
+        return { available: true, requirements: shape }
       }
 
       const price = await options.loadPrice(ctx, {
@@ -143,7 +167,7 @@ export function createCruiseBookingHandler(
         return {
           available: false,
           invalidReason: "no_price_for_occupancy",
-          shape,
+          requirements: shape,
         }
       }
 
@@ -152,7 +176,7 @@ export function createCruiseBookingHandler(
 
       return {
         available: true,
-        shape,
+        requirements: shape,
         pricing: {
           base_amount: totalCents,
           taxes: 0,

--- a/packages/inventory/src/booking-engine/handler.ts
+++ b/packages/inventory/src/booking-engine/handler.ts
@@ -24,6 +24,7 @@ import {
   type BookingRequirements,
   type ComputeQuoteRequest,
   type ComputeQuoteResult,
+  type ComputeRequirementsResult,
   DEFAULT_PAX_BANDS,
   DEFAULT_PAYMENT_INTENTS,
   defaultBookingFields,
@@ -510,41 +511,23 @@ function bookingTravelerCategory(band: string | undefined): "adult" | "child" | 
 export function createProductsBookingHandler(
   options: CreateProductsBookingHandlerOptions,
 ): OwnedBookingHandler {
-  return {
-    entityModule: "products",
-
-    async computeQuote(
-      ctx: OwnedHandlerContext,
-      request: ComputeQuoteRequest,
-    ): Promise<ComputeQuoteResult> {
-      const product = await loadProduct(ctx.db, request.entityId)
-      if (!product) {
-        return { available: false, invalidReason: "product_not_found" }
-      }
-      if (product.status !== "active" && product.status !== "draft") {
-        return {
-          available: false,
-          invalidReason: `product_status_${product.status}`,
-        }
-      }
-
-      const draft = (request.draft ?? {}) as DraftLike
-      const optionId = draft.configure?.variantId
-      const optionSelections = normalizeOptionSelections(draft.configure?.optionSelections)
-      const slotId = draft.configure?.departureSlotId
-
-      // Concurrent enrichment + slot-date lookup. The slot date is
-      // needed before we can call loadResolvedOptionPrice, so it
-      // joins this batch.
-      const [
-        travelerFields,
-        addonCatalog,
-        productOptionCatalog,
-        paxBands,
-        paxBandDependencies,
-        taxRate,
-        slotDate,
-      ] = await Promise.all([
+  /**
+   * The single derivation of a product's Booking Requirements. Both
+   * `computeRequirements` and `computeQuote` come through here, so the
+   * descriptor a host renders is the descriptor a Commit later validates
+   * against — one code path, not two (voyant#4113).
+   *
+   * The raw catalogs come back alongside it because pricing needs the same
+   * addon and option rows and must not read them a second time.
+   */
+  async function deriveRequirements(ctx: OwnedHandlerContext, request: ComputeQuoteRequest) {
+    const product = await loadProduct(ctx.db, request.entityId)
+    if (!product) return { status: "unavailable" as const, reason: "product_not_found" }
+    if (product.status !== "active" && product.status !== "draft") {
+      return { status: "unavailable" as const, reason: `product_status_${product.status}` }
+    }
+    const [travelerFields, addonCatalog, productOptions, paxBands, paxBandDependencies] =
+      await Promise.all([
         safeLoad("loadTravelerFields", options.loadTravelerFields?.(ctx, request.entityId)),
         safeLoad("loadAddonCatalog", options.loadAddonCatalog?.(ctx, request.entityId)),
         safeLoad("loadProductOptions", options.loadProductOptions?.(ctx, request.entityId)),
@@ -553,6 +536,59 @@ export function createProductsBookingHandler(
           "loadPaxBandDependencies",
           options.loadPaxBandDependencies?.(ctx, request.entityId),
         ),
+      ])
+    return {
+      status: "available" as const,
+      product,
+      addonCatalog,
+      productOptions,
+      requirements: buildOwnedProductRequirements({
+        travelerFields,
+        addonCatalog,
+        productOptions,
+        paxBands,
+        paxBandDependencies,
+      }),
+    }
+  }
+
+  return {
+    entityModule: "products",
+
+    async computeRequirements(
+      ctx: OwnedHandlerContext,
+      request: ComputeQuoteRequest,
+    ): Promise<ComputeRequirementsResult> {
+      const derived = await deriveRequirements(ctx, request)
+      return derived.status === "available"
+        ? { requirements: derived.requirements }
+        : { unavailable: true, reason: derived.reason }
+    },
+
+    async computeQuote(
+      ctx: OwnedHandlerContext,
+      request: ComputeQuoteRequest,
+    ): Promise<ComputeQuoteResult> {
+      // The journey descriptor never depends on pricing — derive it first
+      // so the wizard always renders the right steps, bands, options, extras
+      // and units. Pricing is best-effort below: a failure returns the
+      // requirements with no price rather than 500ing the quote (which would
+      // collapse them to the bare default).
+      const derived = await deriveRequirements(ctx, request)
+      if (derived.status === "unavailable") {
+        return { available: false, invalidReason: derived.reason }
+      }
+      const { product, addonCatalog, productOptions: productOptionCatalog } = derived
+      const shape = derived.requirements
+
+      const draft = (request.draft ?? {}) as DraftLike
+      const optionId = draft.configure?.variantId
+      const optionSelections = normalizeOptionSelections(draft.configure?.optionSelections)
+      const slotId = draft.configure?.departureSlotId
+
+      // The slot date is needed before we can call loadResolvedOptionPrice,
+      // so it shares this batch with the tax-rate lookup.
+      const [taxRate, slotDate] = await Promise.all([
         safeLoad(
           "loadTaxRate",
           options.loadTaxRate?.(ctx, {
@@ -567,19 +603,6 @@ export function createProductsBookingHandler(
             )
           : Promise.resolve(draft.configure?.departureDate ?? null),
       ])
-
-      // The journey descriptor never depends on pricing — build it
-      // unconditionally so the wizard always renders the right steps,
-      // bands, options, extras and units. Pricing is best-effort: a
-      // failure here returns the shape with no price rather than 500ing
-      // the quote (which would collapse the shape to the bare default).
-      const shape = buildOwnedProductRequirements({
-        travelerFields,
-        addonCatalog,
-        productOptions: productOptionCatalog,
-        paxBands,
-        paxBandDependencies,
-      })
 
       let available = false
       let pricing: ComputeQuoteResult["pricing"]
@@ -691,7 +714,7 @@ export function createProductsBookingHandler(
           : undefined
       } catch (error) {
         console.warn(
-          "[products/booking-engine] pricing failed; returning shape without a price",
+          "[products/booking-engine] pricing failed; returning requirements without a price",
           error,
         )
         available = false
@@ -702,7 +725,7 @@ export function createProductsBookingHandler(
         available,
         invalidReason: available ? undefined : "no_sell_amount_configured",
         pricing,
-        shape,
+        requirements: shape,
       }
     },
 

--- a/packages/inventory/tests/unit/pax-band-tiers.test.ts
+++ b/packages/inventory/tests/unit/pax-band-tiers.test.ts
@@ -103,7 +103,7 @@ describe("quoting and committing a product with two child tiers", () => {
 
     const quote = await computeQuote(handler, draft({ adult: 1 }))
 
-    expect(quote.shape?.paxBands.map((band) => band.code)).toEqual([
+    expect(quote.requirements?.paxBands.map((band) => band.code)).toEqual([
       "adult",
       "child",
       "child:pc_c2",

--- a/packages/storefront-sdk/tests/unit/booking-session-v1.test.ts
+++ b/packages/storefront-sdk/tests/unit/booking-session-v1.test.ts
@@ -2,6 +2,21 @@ import { describe, expect, it } from "vitest"
 
 import { createVoyantStorefrontClient } from "../../src/index.js"
 
+const REQUIREMENTS = {
+  showsConfigure: true,
+  showsBilling: true,
+  showsTravelers: true,
+  showsAccommodation: false,
+  showsAddons: false,
+  showsPayment: true,
+  showsReview: true,
+  paxBands: [{ code: "adult", label: "Adult", minCount: 1, maxCount: 8 }],
+  paxBandsAllowedTotal: { min: 1, max: 8 },
+  travelerFields: [],
+  bookingFields: [],
+  paymentIntents: ["card"],
+}
+
 describe("Booking Session v1 SDK", () => {
   it("returns a payment continuation and resumes Commit on the same typed route", async () => {
     let commitAttempts = 0
@@ -23,6 +38,7 @@ describe("Booking Session v1 SDK", () => {
             sessionId: "bses_demo",
             sessionRevision: 1,
             state: "active",
+            requirements: REQUIREMENTS,
             pricing: {
               currency: "EUR",
               lines: [],
@@ -169,6 +185,7 @@ describe("Booking Session v1 SDK", () => {
             sessionId: "bses_demo",
             sessionRevision: 2,
             state: "active",
+            requirements: REQUIREMENTS,
             pricing: {
               currency: "EUR",
               lines: [],

--- a/packages/trips/src/booking-session-composite-handler.ts
+++ b/packages/trips/src/booking-session-composite-handler.ts
@@ -2,11 +2,20 @@ import { bookingsService, setAcceptedProposalBookingOrigin } from "@voyant-trave
 import type {
   BookingHoldInternalRecord,
   BookingQuoteInternalRecord,
+  BookingRequirementsV1,
   BookingSessionCompositeHandler,
   BookingSessionInternalRecord,
   CompositeBookingCommitment,
   PricingBreakdownV1,
 } from "@voyant-travel/catalog/booking-engine"
+import {
+  DEFAULT_PAX_BANDS,
+  DEFAULT_PAYMENT_INTENTS,
+  defaultBookingFields,
+  defaultRequirementsFlags,
+  defaultTravelerFields,
+  paxBandsAllowedTotalFrom,
+} from "@voyant-travel/catalog-contracts/booking-engine/requirements"
 import type { BookingSessionTargetV1 } from "@voyant-travel/catalog-contracts/booking-engine/session-contracts"
 import { eq } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
@@ -51,18 +60,83 @@ export function createTripBookingSessionCompositeHandler(
     recordComponentCommit: (input) => recordComponentCommit(input),
     ...overrides,
   }
+  const composeRequirements: BookingSessionCompositeHandler["composeRequirements"] = async (
+    input,
+  ) => {
+    {
+      const database = input.tx as PostgresJsDatabase
+      const snapshot = await loadTargetSnapshot(database, input.session, persistence.loadSnapshot)
+      const components = frozenComponents(snapshot)
+
+      // A Trip Snapshot froze its own configuration when the proposal was
+      // accepted, so the trip-level wizard has nothing left to configure or
+      // to add on to. What it still needs is the union of the components'
+      // traveler and booking field requirements, which is what the Travelers
+      // and Billing steps render. Component requirements come from the same
+      // leaf derivation the components' own quotes use.
+      const travelerFields = new Map<string, BookingRequirementsV1["travelerFields"][number]>()
+      const bookingFields = new Map<string, BookingRequirementsV1["bookingFields"][number]>()
+      let paxBands: BookingRequirementsV1["paxBands"] | undefined
+      let paxBandsAllowedTotal: BookingRequirementsV1["paxBandsAllowedTotal"] | undefined
+
+      for (const component of components.values()) {
+        if (!isCatalogBackedTripComponent(component)) continue
+        const resolved = await input.leaf.composeRequirements({
+          session: childSession(input.session, component),
+          now: input.now,
+          tx: input.tx,
+        })
+        if (resolved.status === "unavailable") return resolved
+        for (const field of resolved.requirements.travelerFields) {
+          if (!travelerFields.has(field.key)) travelerFields.set(field.key, field)
+        }
+        for (const field of resolved.requirements.bookingFields) {
+          if (!bookingFields.has(field.key)) bookingFields.set(field.key, field)
+        }
+        // Party size is one decision across the whole trip. The first
+        // catalog-backed component's bands stand for it; a per-component
+        // reconciliation belongs with selection validation, not here.
+        paxBands ??= resolved.requirements.paxBands
+        paxBandsAllowedTotal ??= resolved.requirements.paxBandsAllowedTotal
+      }
+
+      return {
+        status: "available",
+        requirements: {
+          ...defaultRequirementsFlags(),
+          showsConfigure: false,
+          showsAccommodation: false,
+          showsAddons: false,
+          paxBands: paxBands ?? [...DEFAULT_PAX_BANDS],
+          paxBandsAllowedTotal: paxBandsAllowedTotal ?? paxBandsAllowedTotalFrom(DEFAULT_PAX_BANDS),
+          travelerFields:
+            travelerFields.size > 0 ? [...travelerFields.values()] : defaultTravelerFields(),
+          bookingFields:
+            bookingFields.size > 0 ? [...bookingFields.values()] : defaultBookingFields(),
+          paymentIntents: [...DEFAULT_PAYMENT_INTENTS],
+        } as BookingRequirementsV1,
+      }
+    }
+  }
+
   return {
+    composeRequirements,
+
     async composeQuote(input) {
       const database = input.tx as PostgresJsDatabase
       const snapshot = await loadTargetSnapshot(database, input.session, persistence.loadSnapshot)
       const components = frozenComponents(snapshot)
+      // Derived up front so every exit below — priced or not — publishes the
+      // trip's own requirements rather than a component's or none at all.
+      const derived = await composeRequirements(input)
+      const requirements = derived.status === "available" ? derived.requirements : undefined
       const lines: PricingBreakdownV1["lines"] = []
       const taxes: PricingBreakdownV1["taxes"] = []
       const componentPolicies: NonNullable<PricingBreakdownV1["componentPolicies"]> = []
 
       for (const proposalLine of snapshot.proposal.lines) {
         const component = components.get(proposalLine.componentId)
-        if (!component) return unavailable("selection_unavailable")
+        if (!component) return { ...unavailable("selection_unavailable"), requirements }
         if (!isCatalogBackedTripComponent(component)) {
           lines.push({
             kind: "base",
@@ -93,10 +167,19 @@ export function createTripBookingSessionCompositeHandler(
           now: input.now,
           tx: input.tx,
         })
-        if (quoted.status === "unavailable") return quoted
+        // The component's own descriptor is not the trip's; republish the
+        // trip-level one so the host renders the journey it is actually in.
+        if (quoted.status === "unavailable") {
+          return {
+            status: "unavailable",
+            requirements,
+            reason: quoted.reason,
+            nextAction: quoted.nextAction,
+          }
+        }
         const acceptedPolicy = acceptedPolicyEvidence(component)
         if (!hasRequiredPolicyEvidence(acceptedPolicy, quoted.pricing.policyEvidence)) {
-          return unavailable("policy_unavailable")
+          return { ...unavailable("policy_unavailable"), requirements }
         }
         if (quoted.pricing.policyEvidence) {
           componentPolicies.push({ componentId: component.id, ...quoted.pricing.policyEvidence })
@@ -117,7 +200,8 @@ export function createTripBookingSessionCompositeHandler(
       }
 
       const pricing = aggregatePricing(snapshot.currency, lines, taxes, componentPolicies)
-      return { status: "quoted", pricing }
+      if (!requirements) return unavailable("selection_unavailable")
+      return { status: "quoted", requirements, pricing }
     },
 
     async placeCapacityHold(input) {

--- a/packages/trips/tests/booking-session-composite-handler.test.ts
+++ b/packages/trips/tests/booking-session-composite-handler.test.ts
@@ -1,10 +1,19 @@
 import type {
   BookingHoldInternalRecord,
   BookingQuoteInternalRecord,
+  BookingRequirementsV1,
   BookingSessionCompositeLeafRuntime,
   BookingSessionInternalRecord,
   PricingBreakdownV1,
 } from "@voyant-travel/catalog/booking-engine"
+import {
+  DEFAULT_PAX_BANDS,
+  DEFAULT_PAYMENT_INTENTS,
+  defaultBookingFields,
+  defaultRequirementsFlags,
+  defaultTravelerFields,
+  paxBandsAllowedTotalFrom,
+} from "@voyant-travel/catalog-contracts/booking-engine/requirements"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { describe, expect, it, vi } from "vitest"
 
@@ -15,6 +24,14 @@ import {
 import type { TripComponent, TripSnapshot } from "../src/schema.js"
 
 const NOW = new Date("2026-08-02T10:00:00.000Z")
+const LEAF_REQUIREMENTS = {
+  ...defaultRequirementsFlags(),
+  paxBands: [...DEFAULT_PAX_BANDS],
+  paxBandsAllowedTotal: paxBandsAllowedTotalFrom(DEFAULT_PAX_BANDS),
+  travelerFields: [...defaultTravelerFields()],
+  bookingFields: [...defaultBookingFields()],
+  paymentIntents: [...DEFAULT_PAYMENT_INTENTS],
+} as BookingRequirementsV1
 const ACCESS = {
   actorKind: "staff" as const,
   principalId: "staff_1",
@@ -198,6 +215,7 @@ describe("accepted Proposal Version Booking Session composite", () => {
     const leaf = leafRuntime()
     leaf.composeQuote = async ({ session }) => ({
       status: "quoted",
+      requirements: LEAF_REQUIREMENTS,
       pricing: pricing(entityId(session) === "prod_first" ? 12_000 : 10_000),
     })
     const quote = await createQuote(handler, state.session, leaf, state.db)
@@ -261,6 +279,9 @@ describe("accepted Proposal Version Booking Session composite", () => {
       }),
     ).resolves.toEqual({
       status: "unavailable",
+      // The trip's own descriptor survives the policy failure so the host
+      // still renders the journey it is in.
+      requirements: expect.objectContaining({ showsConfigure: false }),
       reason: "policy_unavailable",
       nextAction: "contact_operator",
     })
@@ -336,11 +357,16 @@ function leafRuntime(
   } = {},
 ): BookingSessionCompositeLeafRuntime {
   return {
+    composeRequirements: async () =>
+      options.unavailable
+        ? { status: "unavailable", reason: "selection_unavailable", nextAction: "update_selection" }
+        : { status: "available", requirements: LEAF_REQUIREMENTS },
     composeQuote: async () =>
       options.unavailable
         ? { status: "unavailable", reason: "selection_unavailable", nextAction: "update_selection" }
         : {
             status: "quoted",
+            requirements: LEAF_REQUIREMENTS,
             pricing: pricing(options.quoteTotal ?? 11_000, options.policyEvidence),
           },
     placeCapacityHold: options.placeCapacityHold ?? (async () => "held"),
@@ -383,6 +409,7 @@ async function createQuote(
     sessionId: session.id,
     sessionRevision: session.revision,
     state: "active",
+    requirements: result.requirements,
     pricing: result.pricing,
     priceFingerprint: "aggregate_quote",
     quotedAt: NOW,


### PR DESCRIPTION
Second step of #4188, on top of #4191.

The v1 Session lifecycle produced the journey requirements descriptor and then discarded it. `inventory/src/booking-engine/handler.ts` builds it unconditionally — with a comment stating that a pricing failure must NOT collapse it — and `sessions-production.ts` threw it away twice: once on the `!result.available || !result.pricing` early return, once by returning only `{ status: "quoted", pricing }`. The port could not carry it either, so no host could render a wizard.

## What changes

- **One derivation.** `OwnedBookingHandler` gains a required `computeRequirements`. Each vertical derives the descriptor once and both the quote path and the requirements path read that one derivation. This is what structurally closes the #4113 class — descriptor and commit derivation stop being two hand-written sources of truth about what a booking requires.
- **Requirements ride the session record, not only the quote.** A host renders Configure *before* it can quote, so `bookingSessionRecordV1` carries them (optional; present while `active` and the target resolves). `bookingQuoteRecordV1.requirements` is required.
- **Requirements survive unavailability.** `quote_unavailable` carries them, restoring the behaviour the inventory handler was written for.
- **Persistence.** `booking_session_quotes.requirements jsonb NOT NULL`. The migration expires in-flight quotes rather than backfilling a fake descriptor — a quote has a 10-minute TTL and is not a commitment, so the buyer re-quotes and gets a real one. Executed against Postgres, not just reviewed: `UPDATE 1`, column `NOT NULL` with no residual default, constraint rejects a null insert.

## Reviewer attention

1. **Two requirement type families.** `BookingRequirements` (interface, `ReadonlyArray`) is what verticals return; `BookingRequirementsV1` (`z.infer`, mutable arrays) is what the contract needs, and neither is assignable to the other. Narrowed once at the boundary in `sessions-production.ts` via a documented cast. Unifying them is a larger job than this phase.
2. **`createSessionRecord` has no transaction.** It runs before a Session row exists, so `composeRequirements` falls back to `deps.db` there. Derivation is read-only so this is safe, but it is a genuine exception to "every session path runs inside `withSessionTransaction`".
3. **`computeQuote` does not literally call `computeRequirements`** — the descriptor loads are also pricing inputs, so calling it literally would double the DB reads. Each vertical has a private `deriveRequirements` returning descriptor + raw loads; both public methods read it. Still exactly one derivation, but not the literal shape.
4. **Trip-composite descriptor is a judgement call.** A Trip Snapshot froze its configuration at acceptance, so configure/accommodation/addons steps are off and traveler/booking fields are unioned first-wins; `paxBands` comes from the first catalog-backed component. Commented in place — worth a second opinion.
5. **Sourced (`catalog_item`) targets get a generic baseline descriptor.** The source-adapter contract has no requirements primitive yet; per-adapter derivation is a later phase.

Scope, `bookingSelectionV1`, the offer-preview read, fingerprint enforcement, and the client rewrite are later phases of #4188.