### PR TITLE
fix(bookings): stop the v1 status cutover on payment effects only

### DIFF
--- a/.changeset/eighty-pears-shake.md
+++ b/.changeset/eighty-pears-shake.md
@@ -1,0 +1,10 @@
+---
+"@voyant-travel/bookings": patch
+---
+
+Stop the Booking v1 status cutover from refusing to run on abandoned checkouts
+that never charged. The guard now trips only on a recorded payment
+authorization, capture, or payment — or on a checkout still inside its provider
+window — instead of on any historical provider session identifier. A session
+that only carries provider identifiers is kept as the record that a checkout was
+opened, rather than blocking a migration that no operator action could unblock.

--- a/packages/bookings/migrations/20260802200000_booking_v1_status_cutover.sql
+++ b/packages/bookings/migrations/20260802200000_booking_v1_status_cutover.sql
@@ -279,12 +279,22 @@ BEGIN
         ON payment_session."booking_id" = classification."booking_id"
       WHERE classification."classification" = 'abandoned_attempt'
         AND (
-          payment_session."status" IN ('requires_redirect', 'processing')
-          OR payment_session."provider_session_id" IS NOT NULL
-          OR payment_session."provider_payment_id" IS NOT NULL
-          OR payment_session."payment_authorization_id" IS NOT NULL
+          -- A recorded authorization, capture, or payment is money that moved.
+          -- Only these are effects an operator can actually reconcile.
+          payment_session."payment_authorization_id" IS NOT NULL
           OR payment_session."payment_capture_id" IS NOT NULL
           OR payment_session."payment_id" IS NOT NULL
+          -- A checkout still inside its provider window may yet settle, so the
+          -- migration must not delete the Booking underneath it. Past that
+          -- window an unsettled session is an abandoned attempt by definition,
+          -- which is exactly how the classifier already labelled the Booking.
+          OR (
+            payment_session."status" IN ('requires_redirect', 'processing')
+            AND coalesce(
+              payment_session."expires_at",
+              payment_session."updated_at" + interval '24 hours'
+            ) > now()
+          )
         )
       ORDER BY classification."booking_id"
       LIMIT 1
@@ -478,7 +488,11 @@ END $$;
 --> statement-breakpoint
 
 -- Remove harmless Finance attempt state before deleting the abandoned Booking.
--- External or settled payment evidence was preserved or rejected above.
+-- Settled payment evidence was preserved as a commitment, and unreconciled
+-- payment effects were rejected above. A session that only carries provider
+-- identifiers is deliberately left in place: it is the sole record that this
+-- deployment opened a checkout with the provider, so it keeps its `booking_id`
+-- and survives the Booking it names rather than being erased or blanked.
 DO $$
 BEGIN
   IF to_regclass('public.payment_sessions') IS NOT NULL THEN

--- a/packages/bookings/tests/unit/booking-v1-status-cutover-data.test.ts
+++ b/packages/bookings/tests/unit/booking-v1-status-cutover-data.test.ts
@@ -18,6 +18,26 @@ const migrations = [
 const readMigration = (filename: (typeof migrations)[number]) =>
   readFileSync(new URL(filename, migrationDirectory), "utf8")
 
+/**
+ * Finance is an optional deployment module, so the cutover only reaches
+ * `payment_sessions` when the table exists. Model the columns the guard reads.
+ */
+const paymentSessionsTable = `
+  CREATE TABLE "payment_sessions" (
+    "id" text PRIMARY KEY NOT NULL,
+    "booking_id" text,
+    "status" text NOT NULL,
+    "provider_session_id" text,
+    "provider_payment_id" text,
+    "payment_authorization_id" text,
+    "payment_capture_id" text,
+    "payment_id" text,
+    "expires_at" timestamp with time zone,
+    "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+    "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+  );
+`
+
 describe("Booking v1 status cutover data migration", () => {
   let client: PGlite | undefined
 
@@ -175,6 +195,132 @@ describe("Booking v1 status cutover data migration", () => {
       ORDER BY column_name
     `)
     expect(bookingColumns.rows).toEqual([{ columnDefault: null, columnName: "status" }])
+  })
+
+  it("removes attempts whose checkout was opened but never charged", async () => {
+    client = new PGlite()
+    for (const migration of migrations.slice(0, -1)) {
+      await client.exec(readMigration(migration))
+    }
+
+    await client.exec(`
+      ${paymentSessionsTable}
+
+      INSERT INTO "bookings" (
+        "id", "booking_number", "status", "sell_currency"
+      ) VALUES
+        ('booking_redirected', 'BOOK-REDIRECTED', 'draft', 'EUR'),
+        ('booking_expired_session', 'BOOK-EXPIRED-SESSION', 'draft', 'EUR');
+
+      INSERT INTO "payment_sessions" (
+        "id",
+        "booking_id",
+        "status",
+        "provider_session_id",
+        "provider_payment_id",
+        "expires_at",
+        "updated_at"
+      ) VALUES
+        (
+          'pmss_stale_redirect',
+          'booking_redirected',
+          'requires_redirect',
+          'provider-session-stale',
+          NULL,
+          now() - interval '30 days',
+          now() - interval '30 days'
+        ),
+        (
+          'pmss_expired',
+          'booking_expired_session',
+          'expired',
+          'provider-session-expired',
+          'provider-payment-expired',
+          now() - interval '60 days',
+          now() - interval '60 days'
+        );
+    `)
+
+    await client.exec(readMigration("20260802200000_booking_v1_status_cutover.sql"))
+
+    const bookings = await client.query<{ id: string }>(`
+      SELECT "id" FROM "bookings" ORDER BY "id"
+    `)
+    expect(bookings.rows).toEqual([])
+
+    // The provider link is the only record that a checkout was opened, so it
+    // outlives the Booking rather than being deleted or blanked.
+    const sessions = await client.query<{ bookingId: string; id: string }>(`
+      SELECT "id", "booking_id" AS "bookingId"
+      FROM "payment_sessions"
+      ORDER BY "id"
+    `)
+    expect(sessions.rows).toEqual([
+      { bookingId: "booking_expired_session", id: "pmss_expired" },
+      { bookingId: "booking_redirected", id: "pmss_stale_redirect" },
+    ])
+  })
+
+  it("fails before mutation when an attempt carries a real payment effect", async () => {
+    client = new PGlite()
+    for (const migration of migrations.slice(0, -1)) {
+      await client.exec(readMigration(migration))
+    }
+
+    await client.exec(`
+      ${paymentSessionsTable}
+
+      INSERT INTO "bookings" (
+        "id", "booking_number", "status", "sell_currency"
+      ) VALUES ('booking_charged', 'BOOK-CHARGED', 'draft', 'EUR');
+
+      INSERT INTO "payment_sessions" (
+        "id", "booking_id", "status", "payment_id"
+      ) VALUES ('pmss_charged', 'booking_charged', 'failed', 'pay_recorded');
+    `)
+
+    await expect(
+      client.exec(readMigration("20260802200000_booking_v1_status_cutover.sql")),
+    ).rejects.toThrow(/unresolved external payment effect/)
+
+    const booking = await client.query<{ status: string }>(`
+      SELECT "status"::text AS "status" FROM "bookings" WHERE "id" = 'booking_charged'
+    `)
+    expect(booking.rows).toEqual([{ status: "draft" }])
+  })
+
+  it("fails before mutation when an attempt has a checkout still in flight", async () => {
+    client = new PGlite()
+    for (const migration of migrations.slice(0, -1)) {
+      await client.exec(readMigration(migration))
+    }
+
+    await client.exec(`
+      ${paymentSessionsTable}
+
+      INSERT INTO "bookings" (
+        "id", "booking_number", "status", "sell_currency"
+      ) VALUES ('booking_in_flight', 'BOOK-IN-FLIGHT', 'draft', 'EUR');
+
+      INSERT INTO "payment_sessions" (
+        "id", "booking_id", "status", "provider_session_id", "expires_at"
+      ) VALUES (
+        'pmss_in_flight',
+        'booking_in_flight',
+        'processing',
+        'provider-session-live',
+        now() + interval '20 minutes'
+      );
+    `)
+
+    await expect(
+      client.exec(readMigration("20260802200000_booking_v1_status_cutover.sql")),
+    ).rejects.toThrow(/unresolved external payment effect/)
+
+    const booking = await client.query<{ status: string }>(`
+      SELECT "status"::text AS "status" FROM "bookings" WHERE "id" = 'booking_in_flight'
+    `)
+    expect(booking.rows).toEqual([{ status: "draft" }])
   })
 
   it("fails before mutation when an attempt has an ambiguous supplier effect", async () => {

--- a/packages/bookings/tests/unit/booking-v1-status-cutover-migration.test.ts
+++ b/packages/bookings/tests/unit/booking-v1-status-cutover-migration.test.ts
@@ -39,6 +39,22 @@ describe("Booking v1 status cutover migration", () => {
     expect(migration).toContain(`WHEN slot."status" = 'sold_out' THEN 'open'`)
   })
 
+  it("stops only on payment effects, not on opening a checkout", () => {
+    for (const startedButUncharged of [
+      'OR payment_session."provider_session_id" IS NOT NULL',
+      'OR payment_session."provider_payment_id" IS NOT NULL',
+    ]) {
+      expect(migration).not.toContain(startedButUncharged)
+    }
+    for (const effect of [
+      'payment_session."payment_authorization_id" IS NOT NULL',
+      'OR payment_session."payment_capture_id" IS NOT NULL',
+      'OR payment_session."payment_id" IS NOT NULL',
+    ]) {
+      expect(migration).toContain(effect)
+    }
+  })
+
   it("preserves real finance and legal records", () => {
     for (const evidence of [
       "invoice_record",


### PR DESCRIPTION
Closes #4196.

## Problem

`20260802200000_booking_v1_status_cutover` refused to migrate any deployment that had ever created a payment provider session for a Booking that was later abandoned, even when no money moved:

```sql
payment_session."status" IN ('requires_redirect', 'processing')
OR payment_session."provider_session_id" IS NOT NULL
OR payment_session."provider_payment_id" IS NOT NULL
OR ...
```

Creating a provider session is the first thing checkout does, so any storefront that has ever had a shopper click through to a payment page and close the tab accumulates these rows permanently. The hint told operators to "reconcile the payment session", but an unconfirmed PaymentIntent has no external effect to reconcile — the only way to satisfy the predicate was to null the provider identifiers, destroying the audit trail in order to work around a check.

## Change

The guard now trips only on evidence that a payment effect exists:

- `payment_authorization_id`, `payment_capture_id`, or `payment_id` is set — money moved and there is something to reconcile.
- **or** the session is `requires_redirect`/`processing` and is still inside its provider window (`expires_at`, falling back to 24h after `updated_at` when the provider declared none) — it may yet settle, so the migration must not delete the Booking underneath it.

Past that window, an unsettled session is an abandoned attempt by definition, which is exactly how the classifier already labelled the Booking.

The follow-on cleanup is deliberately left alone: a session carrying only provider identifiers now survives the guard and is **not** deleted or blanked. It keeps its `booking_id` and outlives the Booking it names, since it is the only record that this deployment opened a checkout with the provider.

## Verification

`packages/bookings/tests/unit/booking-v1-status-cutover-data.test.ts` runs the real migration chain on PGlite. Three new cases:

- a stale `requires_redirect` session and an `expired` session, both carrying provider identifiers and no payment effect → migration completes, Bookings are removed, both session rows are retained. Confirmed this case **fails against `main`** with the exact error from the issue.
- a session with `payment_id` set → still fails closed before any mutation.
- a `processing` session with `expires_at` in the future → still fails closed before any mutation.

Also run: `verify:booking-v1-lifecycle-contract`, `verify:migration-cutline` (frozen, unchanged), `verify:migration-boundaries`, bookings typecheck, biome. `verify:migration-replay-parity` skips locally without `TEST_DATABASE_URL`; CI covers it.