### PR TITLE
fix(release): verify the published surface against the commit, not the working tree

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,6 +229,12 @@ jobs:
       # A failed publish is exactly when the surface is split between what
       # shipped and what did not, so this must still run and say which. Running
       # it last keeps a broken surface from also blocking the release PR.
+      #
+      # Safe in that position because the gate reads manifests out of the
+      # commit, not the working directory: the release-PR step above runs
+      # `pnpm version-packages`, which rewrites every releasable version on disk
+      # to what the *pending* PR will publish. Keep it commit-scoped if this
+      # moves.
       - name: Verify the published surface installs
         if: ${{ !cancelled() }}
         run: pnpm verify:published-surface

--- a/scripts/lib/published-surface.mjs
+++ b/scripts/lib/published-surface.mjs
@@ -48,6 +48,27 @@ export function parseAttempts(argv) {
   return attempts
 }
 
+export const DEFAULT_TREE = "HEAD"
+
+/**
+ * Which commit the gate speaks for. Defaults to the checked-out commit; a
+ * commit-ish is accepted so a release can be re-verified after the fact.
+ *
+ * Parsed with the explicit index check `parseAttempts` explains, and validated
+ * so a flag with no value reads as an error rather than silently checking a
+ * tree named `--keep`.
+ */
+export function parseTree(argv) {
+  const index = argv.indexOf("--tree")
+  if (index === -1) return DEFAULT_TREE
+
+  const tree = argv[index + 1]
+  if (!tree || tree.startsWith("--")) {
+    throw new Error(`--tree requires a commit-ish, received "${tree ?? ""}"`)
+  }
+  return tree
+}
+
 export const REGISTRY = "https://registry.npmjs.org"
 
 /**
@@ -90,6 +111,36 @@ const DEPENDENCY_FIELDS = ["dependencies", "peerDependencies", "optionalDependen
 
 /** Node resolution conditions, most specific first, as a consumer would hit them. */
 const IMPORT_CONDITIONS = ["import", "node", "default", "require"]
+
+/**
+ * Manifest paths the workspace globs cover, chosen from a listing of a
+ * *committed* tree rather than from the working directory.
+ *
+ * The release job runs `pnpm version-packages` before this gate, which rewrites
+ * every releasable package.json on disk to the version the pending release PR
+ * will carry. Reading those files made the gate wait for versions that only
+ * publish once that PR merges, so it failed on every push to `main` that
+ * carried a releasable changeset — naming five healthy packages as missing from
+ * the registry. The commit is what `main` actually says is published, and it is
+ * the one view no later step in the job can perturb.
+ *
+ * `pnpm-workspace.yaml` globs one level (`packages/*`), so a manifest qualifies
+ * when it sits exactly one directory below a globbed root.
+ */
+export function workspaceManifestPaths(workspacePatterns, treePaths) {
+  const directories = workspacePatterns
+    .filter((pattern) => pattern.endsWith("/*"))
+    .map((pattern) => pattern.slice(0, -2))
+
+  const covered = (candidate) =>
+    directories.some(
+      (directory) =>
+        candidate.startsWith(`${directory}/`) &&
+        candidate.slice(directory.length + 1).split("/").length === 2,
+    )
+
+  return treePaths.filter((path) => path.endsWith("/package.json") && covered(path)).sort()
+}
 
 export function selectPublishedPackages(manifests) {
   return manifests

--- a/scripts/tests/published-surface.test.mjs
+++ b/scripts/tests/published-surface.test.mjs
@@ -3,14 +3,19 @@ import { test } from "node:test"
 
 import {
   DEFAULT_ATTEMPTS,
+  DEFAULT_TREE,
   expandExportPattern,
   importProbeSpecifiers,
   parseAttempts,
+  parseTree,
   registryHasVersion,
   selectPublishedPackages,
   unappliedPublishConfigViolations,
   unresolvedProtocolViolations,
+  workspaceManifestPaths,
 } from "../lib/published-surface.mjs"
+
+const WORKSPACE_PATTERNS = ["packages/*", "apps/*", "examples/*"]
 
 function registryResponse({ status = 200, statusText = "OK", body = {} }) {
   return async () => ({
@@ -92,6 +97,71 @@ test("refuses to call a registry failure an unpublished version", async () => {
       },
     }),
     /ECONNRESET/,
+  )
+})
+
+test("defaults to the checked-out commit when no tree is named", () => {
+  assert.equal(parseTree(["/usr/bin/node", "/repo/scripts/verify.mjs"]), DEFAULT_TREE)
+})
+
+test("reads an explicit tree", () => {
+  assert.equal(
+    parseTree(["/usr/bin/node", "/repo/scripts/verify.mjs", "--tree", "origin/main"]),
+    "origin/main",
+  )
+})
+
+test("refuses a tree flag carrying no commit-ish", () => {
+  for (const argv of [["--tree"], ["--tree", "--keep"]]) {
+    assert.throws(
+      () => parseTree(["/usr/bin/node", "/repo/scripts/verify.mjs", ...argv]),
+      /--tree requires a commit-ish/,
+    )
+  }
+})
+
+test("takes manifests from the commit, not from the working directory", () => {
+  // The defect this replaced: `pnpm version-packages` runs before this gate in
+  // the release job and rewrites every releasable package.json on disk, so a
+  // disk read asked the registry for versions that only publish once the
+  // pending release PR merges.
+  assert.deepEqual(
+    workspaceManifestPaths(WORKSPACE_PATTERNS, [
+      "packages/catalog-contracts/package.json",
+      "apps/operator/package.json",
+      "examples/storefront/package.json",
+    ]),
+    [
+      "apps/operator/package.json",
+      "examples/storefront/package.json",
+      "packages/catalog-contracts/package.json",
+    ],
+  )
+})
+
+test("covers only the one level the workspace globs reach", () => {
+  assert.deepEqual(
+    workspaceManifestPaths(WORKSPACE_PATTERNS, [
+      "package.json",
+      "packages/package.json",
+      "packages/ui/package.json",
+      "packages/plugins/legacy/package.json",
+      "packages/ui/src/fixtures/package.json",
+      "docs/package.json",
+    ]),
+    ["packages/ui/package.json"],
+  )
+})
+
+test("ignores everything in the tree that is not a manifest", () => {
+  assert.deepEqual(
+    workspaceManifestPaths(WORKSPACE_PATTERNS, [
+      "packages/ui/package.json",
+      "packages/ui/tsconfig.json",
+      "packages/ui/src/index.ts",
+      "packages/ui/my-package.json",
+    ]),
+    ["packages/ui/package.json"],
   )
 })
 

--- a/scripts/verify-published-surface.mjs
+++ b/scripts/verify-published-surface.mjs
@@ -5,12 +5,14 @@
  *
  * This runs *after* publish, because it asks a question only the registry can
  * answer: can an outside consumer install what we just shipped and import it?
- * It installs every non-private workspace package at the version in the
- * repository into a scratch directory and exercises each declared entry point.
+ * It installs every non-private workspace package at the version the checked-out
+ * commit declares into a scratch directory and exercises each declared entry
+ * point.
  *
  * Usage: node scripts/verify-published-surface.mjs [--keep] [--attempts <n>]
+ *        node scripts/verify-published-surface.mjs [--tree <commit-ish>]
  */
-import { execFile } from "node:child_process"
+import { execFile, execFileSync } from "node:child_process"
 import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
@@ -23,37 +25,40 @@ import {
   formatMissingVersion,
   importProbeSpecifiers,
   parseAttempts,
+  parseTree,
   REGISTRY,
   registryHasVersion,
   selectPublishedPackages,
   unappliedPublishConfigViolations,
   unresolvedProtocolViolations,
+  workspaceManifestPaths,
 } from "./lib/published-surface.mjs"
 
 const execFileAsync = promisify(execFile)
 
 const KEEP = process.argv.includes("--keep")
 const ATTEMPTS = parseAttempts(process.argv)
+const TREE = parseTree(process.argv)
 /** The registry is read-your-writes only eventually; a fresh publish can 404 briefly. */
 const RETRY_DELAY_MS = 10_000
 
+const git = (args) => execFileSync("git", args, { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 })
+
+const readFromTree = (file) => git(["show", `${TREE}:${file}`])
+
+/**
+ * The manifests as `TREE` committed them, not as they sit on disk. See
+ * `workspaceManifestPaths` for why the working directory is the wrong source:
+ * the release job rewrites every releasable version before this gate runs.
+ */
 function workspaceManifests() {
-  const workspace = parseYaml(fs.readFileSync("pnpm-workspace.yaml", "utf8"))
-  const directories = (workspace.packages ?? [])
+  const patterns = parseYaml(readFromTree("pnpm-workspace.yaml")).packages ?? []
+  const roots = patterns
     .filter((pattern) => pattern.endsWith("/*"))
     .map((pattern) => pattern.slice(0, -2))
 
-  const manifests = []
-  for (const directory of directories) {
-    if (!fs.existsSync(directory)) continue
-    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
-      if (!entry.isDirectory()) continue
-      const file = path.join(directory, entry.name, "package.json")
-      if (!fs.existsSync(file)) continue
-      manifests.push(JSON.parse(fs.readFileSync(file, "utf8")))
-    }
-  }
-  return manifests
+  const treePaths = git(["ls-tree", "-r", "--name-only", TREE, "--", ...roots]).split("\n")
+  return workspaceManifestPaths(patterns, treePaths).map((file) => JSON.parse(readFromTree(file)))
 }
 
 /**
@@ -226,7 +231,10 @@ async function main() {
     return
   }
 
-  console.log(`verify:published-surface: ${packages.length} publishable packages.`)
+  console.log(
+    `verify:published-surface: ${packages.length} publishable packages at ` +
+      `${TREE} (${git(["rev-parse", "--short", TREE]).trim()}).`,
+  )
 
   const unpublished = await awaitRegistry(packages)
   if (unpublished.length > 0) {


### PR DESCRIPTION
The `release` workflow has been red on every push to `main` that carries a releasable changeset — [run 30922164653](https://github.com/voyant-travel/voyant/actions/runs/30922164653) and the two before it. It reports five healthy packages as missing from npm:

```
- @voyant-travel/accommodations-contracts@0.105.17 is the version in the repository
  and is not on the registry. A first publish of a new package name fails with E404
  until npm Trusted Publishers is configured for it — see #4048 and #4086.
  ... catalog-contracts@0.120.0, cruises-contracts@0.105.19,
      flights-contracts@0.104.20, products-contracts@0.108.9
```

## Diagnosis

Those versions exist nowhere but the runner's working tree. `origin/main` says 0.105.16 / 0.119.0 / 0.105.18 / 0.104.19 / 0.108.8, and so does npm — they match exactly.

The step order explains it. Every publish step in that run was **skipped** (nothing pending). Then `Create or update Release PR` ran `pnpm version-packages`, which rewrites every releasable `package.json` **on disk** to the version the pending release PR will carry. Then the gate ran, and `workspaceManifests()` read those mutated files. So it waited for versions that only publish once that PR merges, retried 6×, and failed.

That is unconditional for any `main` push with a releasable changeset touching a public package. It passed on `chore: release packages (#4194)` only because the changesets were already consumed there, so the version step was skipped and disk matched npm. The E404/Trusted-Publishers hint is a red herring — none of these are first publishes.

## Change

Read the manifests out of the commit rather than the working directory.

That is what the step's own comment says it asks — "can an outside consumer install what **main says** is published" — and it is the one view no later step in the job can perturb. `git ls-tree` enumerates the manifests the workspace globs cover and `git show` reads each one.

The step keeps its position and its `!cancelled()` guard, so both properties its comment argues for survive: a failed publish still reports which half of the surface shipped, and a broken surface still cannot block release-PR creation. I added a note there so the coupling is visible to whoever moves it next.

`--tree <commit-ish>` re-verifies a past release.

## Verification

Reproduced end-to-end on `9b9e8ac855`, the exact commit that failed in CI:

1. `pnpm version-packages` — bumps the tree to `0.105.17` / `0.120.0` / `0.105.19` / `0.104.20` / `0.108.9`, the same five versions from the failing log.
2. Pre-fix script on that tree → fails with byte-identical output to CI.
3. This branch's script on the same tree → **passes**: installs all 14 published packages from npm and exercises 172 entry points.

Still fails closed: committing `catalog-contracts@99.99.99` and rerunning reports it as not on the registry, so the gate has not been weakened into a no-op.

`pnpm verify:published-surface` (tests + gate) exits 0 on this branch. Five new unit tests cover `--tree` parsing and the manifest-path selection, including that it reaches exactly one level below each globbed root.