### PR TITLE
feat(catalog): add a non-binding Offer Preview read

### DIFF
--- a/.changeset/offer-preview-non-binding-read.md
+++ b/.changeset/offer-preview-non-binding-read.md
@@ -1,0 +1,45 @@
+---
+"@voyant-travel/catalog-contracts": minor
+"@voyant-travel/catalog": minor
+---
+
+Add a non-binding Offer Preview read.
+
+Storefront detail pages — product, accommodation, cruise — have to show a live
+price and render the right configuration controls *before* any Booking Session
+exists. Beta served that with `POST /catalog/quote`, which v1 deleted, and the
+only v1 replacement was to open a Session. That is the wrong trade: Sessions are
+persisted, revisioned, capability-bearing, expiring rows that a sweep has to
+reap, and a shopper nudging a pax stepper is not yet an attempt to book. One
+Session per keystroke floods `booking_sessions` at real traffic.
+
+`POST /v1/{admin,public}/catalog/offers/preview` answers the same question
+statelessly. `offerPreviewRequestV1` takes the Session create target union, the
+Session commercial scope and the public selection schema;
+`offerPreviewResultV1` returns `binding: false`, `available`, the Booking
+Requirements, and `pricing` only when there is a price.
+
+`requirements` is required and `pricing` is the optional half, which is the
+load-bearing part of the shape: a sold-out or unpriced target must still render
+a wizard, or the shopper cannot change the selection that made it unavailable.
+
+Four structural invariants keep this from becoming beta's `/quote` under a new
+name. It mints no identifier — no `id`, `quoteId` or token, so nothing can be
+presented later as authority. It persists nothing: the preview is handed only
+`normalizeSelection`, `composeRequirements` and `composeQuote`, never the
+repository, so it cannot write a Session, Quote, Hold, operation claim or audit
+row. It says `binding: false` explicitly. And because it has no id at all, the
+result is not assignable where `commitBookingSessionV1` or `placeBookingHoldV1`
+require a `quoteId` — asserted in `preview-contracts.test.ts` so a later field
+addition cannot quietly undo it.
+
+The preview reuses the same `composeRequirements` / `composeQuote` ports the
+Session lifecycle uses, over an ephemeral in-memory session-shaped value, rather
+than adding a third derivation path — the price a detail page shows and the
+price the wizard quotes come from one place. Quoting audience is derived from
+the caller's `actorKind` exactly as on the Session path, so a storefront visitor
+cannot preview at staff or partner price tiers, and the public route sits behind
+the same active-storefront-channel admission as the public Session routes.
+
+`composeQuote` now falls back to the module's read connection when there is no
+open Session transaction, matching what `composeRequirements` already did.

--- a/packages/accommodations/tsconfig.build.json
+++ b/packages/accommodations/tsconfig.build.json
@@ -371,6 +371,9 @@
       "@voyant-travel/catalog-contracts/booking-engine/lifecycle-conformance": [
         "../catalog-contracts/dist/booking-engine/lifecycle-conformance.d.ts"
       ],
+      "@voyant-travel/catalog-contracts/booking-engine/preview-contracts": [
+        "../catalog-contracts/dist/booking-engine/preview-contracts.d.ts"
+      ],
       "@voyant-travel/catalog-contracts/booking-engine/pricing-contracts": [
         "../catalog-contracts/dist/booking-engine/pricing-contracts.d.ts"
       ],

--- a/packages/accommodations/tsconfig.typecheck.json
+++ b/packages/accommodations/tsconfig.typecheck.json
@@ -372,6 +372,9 @@
       "@voyant-travel/catalog-contracts/booking-engine/lifecycle-conformance": [
         "../catalog-contracts/dist/booking-engine/lifecycle-conformance.d.ts"
       ],
+      "@voyant-travel/catalog-contracts/booking-engine/preview-contracts": [
+        "../catalog-contracts/dist/booking-engine/preview-contracts.d.ts"
+      ],
       "@voyant-travel/catalog-contracts/booking-engine/pricing-contracts": [
         "../catalog-contracts/dist/booking-engine/pricing-contracts.d.ts"
       ],

--- a/packages/catalog-contracts/package.json
+++ b/packages/catalog-contracts/package.json
@@ -21,6 +21,7 @@
     "./booking-engine/requirements-contracts": "./src/booking-engine/requirements-contracts.ts",
     "./booking-engine/requirements-defaults": "./src/booking-engine/requirements-defaults.ts",
     "./booking-engine/selection-contracts": "./src/booking-engine/selection-contracts.ts",
+    "./booking-engine/preview-contracts": "./src/booking-engine/preview-contracts.ts",
     "./booking-engine/pricing-contracts": "./src/booking-engine/pricing-contracts.ts",
     "./booking-engine/lifecycle-conformance": "./src/booking-engine/lifecycle-conformance.ts",
     "./booking-engine/session-contracts": "./src/booking-engine/session-contracts.ts",
@@ -121,6 +122,11 @@
         "types": "./dist/booking-engine/selection-contracts.d.ts",
         "import": "./dist/booking-engine/selection-contracts.js",
         "default": "./dist/booking-engine/selection-contracts.js"
+      },
+      "./booking-engine/preview-contracts": {
+        "types": "./dist/booking-engine/preview-contracts.d.ts",
+        "import": "./dist/booking-engine/preview-contracts.js",
+        "default": "./dist/booking-engine/preview-contracts.js"
       },
       "./booking-engine/pricing-contracts": {
         "types": "./dist/booking-engine/pricing-contracts.d.ts",

--- a/packages/catalog-contracts/src/booking-engine/contracts.ts
+++ b/packages/catalog-contracts/src/booking-engine/contracts.ts
@@ -2,6 +2,7 @@
 
 export * from "./engine-contracts.js"
 export * from "./lifecycle-conformance.js"
+export * from "./preview-contracts.js"
 export * from "./pricing-contracts.js"
 export * from "./requirements-contracts.js"
 export * from "./selection-contracts.js"

--- a/packages/catalog-contracts/src/booking-engine/preview-contracts.test.ts
+++ b/packages/catalog-contracts/src/booking-engine/preview-contracts.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  offerPreviewOutcomeV1,
+  offerPreviewRequestV1,
+  offerPreviewResultV1,
+} from "./preview-contracts.js"
+import {
+  DEFAULT_PAX_BANDS,
+  DEFAULT_PAYMENT_INTENTS,
+  defaultBookingFields,
+  defaultRequirementsFlags,
+  defaultTravelerFields,
+  paxBandsAllowedTotalFrom,
+} from "./requirements-defaults.js"
+import { commitBookingSessionV1, placeBookingHoldV1 } from "./session-contracts.js"
+
+const REQUIREMENTS = {
+  ...defaultRequirementsFlags(),
+  paxBands: [...DEFAULT_PAX_BANDS],
+  paxBandsAllowedTotal: paxBandsAllowedTotalFrom(DEFAULT_PAX_BANDS),
+  travelerFields: [...defaultTravelerFields()],
+  bookingFields: [...defaultBookingFields()],
+  paymentIntents: [...DEFAULT_PAYMENT_INTENTS],
+}
+
+function previewResult(overrides: Record<string, unknown> = {}) {
+  return offerPreviewResultV1.parse({
+    binding: false,
+    available: false,
+    requirements: REQUIREMENTS,
+    ...overrides,
+  })
+}
+
+describe("offerPreviewResultV1", () => {
+  /**
+   * Invariant 1 + 4 (voyant#4188). A preview mints no identifier, so its
+   * result is structurally not assignable anywhere a `quoteId` is required.
+   * Asserted on the schema rather than on one sample response so that a field
+   * added later cannot quietly reopen the path back to beta's `/quote`.
+   */
+  it("declares no identifier of any kind", () => {
+    const keys = Object.keys(offerPreviewResultV1.shape)
+
+    for (const forbidden of ["id", "quoteId", "token", "sessionId", "holdId"]) {
+      expect(keys).not.toContain(forbidden)
+    }
+    expect(keys.some((key) => /^(id|.*(Id|Token|token))$/.test(key))).toBe(false)
+  })
+
+  it("strips an identifier a caller or a future field tries to smuggle through", () => {
+    const parsed = previewResult({ id: "bsqu_1", quoteId: "bsqu_1", token: "t" }) as Record<
+      string,
+      unknown
+    >
+
+    expect(parsed.id).toBeUndefined()
+    expect(parsed.quoteId).toBeUndefined()
+    expect(parsed.token).toBeUndefined()
+  })
+
+  it("cannot satisfy the commands that consume a Quote", () => {
+    expect(
+      commitBookingSessionV1.safeParse({ ...previewResult(), expectedRevision: 1 }).success,
+    ).toBe(false)
+    expect(placeBookingHoldV1.safeParse({ ...previewResult(), expectedRevision: 1 }).success).toBe(
+      false,
+    )
+  })
+
+  it("is always non-binding", () => {
+    expect(offerPreviewResultV1.safeParse({ ...previewResult(), binding: true }).success).toBe(
+      false,
+    )
+    expect(previewResult().binding).toBe(false)
+  })
+
+  it("keeps requirements required and pricing optional", () => {
+    expect(previewResult().pricing).toBeUndefined()
+    expect(
+      offerPreviewResultV1.safeParse({ binding: false, available: true, pricing: undefined })
+        .success,
+    ).toBe(false)
+  })
+})
+
+describe("offerPreviewRequestV1", () => {
+  it("takes only the targets a Booking Session can be opened against", () => {
+    expect(
+      offerPreviewRequestV1.safeParse({
+        target: { kind: "product", productId: "prod_1" },
+        scope: { locale: "en", market: "default" },
+      }).success,
+    ).toBe(true)
+    expect(
+      offerPreviewRequestV1.safeParse({
+        target: { kind: "trip_snapshot", tripSnapshotId: "t_1", tripEnvelopeId: "e_1" },
+        scope: { locale: "en", market: "default" },
+      }).success,
+    ).toBe(false)
+  })
+
+  it("has no audience on the wire — it is derived from the caller's actor kind", () => {
+    const parsed = offerPreviewRequestV1.parse({
+      target: { kind: "product", productId: "prod_1" },
+      scope: { locale: "en", market: "default", audience: "staff" },
+    })
+
+    expect(Object.keys(parsed.scope)).not.toContain("audience")
+  })
+})
+
+describe("offerPreviewOutcomeV1", () => {
+  it("carries rejections in the body, like the Session outcome union", () => {
+    expect(
+      offerPreviewOutcomeV1.safeParse({
+        kind: "rejected",
+        error: {
+          kind: "quote_unavailable",
+          reason: "target_not_found",
+          nextAction: "select_alternative_inventory",
+        },
+      }).success,
+    ).toBe(true)
+  })
+})

--- a/packages/catalog-contracts/src/booking-engine/preview-contracts.ts
+++ b/packages/catalog-contracts/src/booking-engine/preview-contracts.ts
@@ -1,0 +1,95 @@
+/**
+ * Offer Preview V1 — a stateless, non-binding read of what a target would
+ * cost and what booking it would require.
+ *
+ * A storefront detail page has to show a live price and render the right
+ * configuration controls *before* the shopper has done anything that looks
+ * like booking. Moving a pax stepper is not an attempt to book, so it must not
+ * mint a Booking Session: Sessions are persisted, revisioned,
+ * capability-bearing, expiring rows that a sweep has to reap, and one per
+ * keystroke floods `booking_sessions` at real traffic.
+ *
+ * This is deliberately NOT beta's `POST /catalog/quote` under a new name. Four
+ * structural invariants keep it from drifting back into one:
+ *
+ * 1. It mints no identifier — the result carries no `id`, no `quoteId`, no
+ *    token of any kind, so there is nothing to present later as authority.
+ * 2. It persists nothing — no Session row, no Quote row, no capability cookie.
+ * 3. It says `binding: false` explicitly rather than leaving it to be inferred.
+ * 4. Because it has no id at all, the result is not assignable anywhere a
+ *    `quoteId` is required (`commitBookingSessionV1`, `placeBookingHoldV1`).
+ *    `preview-contracts.test.ts` asserts the absence of those keys so a future
+ *    field addition cannot quietly undo it.
+ *
+ * A fifth property follows: for a given `(target, scope, selection)` the read
+ * is deterministic and therefore cacheable.
+ */
+
+import { z } from "zod"
+import { pricingBreakdownV1 } from "./pricing-contracts.js"
+import { bookingRequirementsV1 } from "./requirements-contracts.js"
+import { bookingSelectionPublicV1 } from "./selection-contracts.js"
+import {
+  bookingQuoteUnavailableReasonV1,
+  bookingSessionLifecycleErrorV1,
+  bookingSessionScopeV1,
+  createBookingSessionTargetV1,
+} from "./session-contracts.js"
+
+/**
+ * What a detail page asks about.
+ *
+ * The target union, the commercial scope and the public selection schema are
+ * the same ones the Session create path takes — a preview that could describe
+ * a target the Session plane cannot open would be quoting something the
+ * shopper can never buy.
+ *
+ * There is no `audience` here for the same reason `bookingSessionScopeV1` has
+ * none: audience selects staff/partner price tiers and staff-visible content,
+ * so it is derived server-side from the caller's `actorKind`. Accepting it on
+ * the wire would let any storefront visitor ask for staff pricing by name.
+ */
+export const offerPreviewRequestV1 = z.object({
+  target: createBookingSessionTargetV1,
+  scope: bookingSessionScopeV1,
+  selection: bookingSelectionPublicV1.optional(),
+})
+export type OfferPreviewRequestV1 = z.input<typeof offerPreviewRequestV1>
+
+/**
+ * The non-binding result.
+ *
+ * `requirements` is REQUIRED, and that is the load-bearing part of the shape:
+ * a detail page must be able to draw its pax steppers, date pickers and option
+ * lists even when the target is sold out or unpriced. Requirements that
+ * evaporated with the price would leave the shopper unable to change the very
+ * selection that made it unavailable.
+ *
+ * `pricing` is what is optional. `available: false` plus `unavailableReason`
+ * says why there is no number to show.
+ */
+export const offerPreviewResultV1 = z.object({
+  /** Never true. A preview confers no price protection and no capacity. */
+  binding: z.literal(false),
+  available: z.boolean(),
+  requirements: bookingRequirementsV1,
+  pricing: pricingBreakdownV1.optional(),
+  unavailableReason: bookingQuoteUnavailableReasonV1.optional(),
+})
+export type OfferPreviewResultV1 = z.infer<typeof offerPreviewResultV1>
+
+/**
+ * Preview outcome, shaped like `bookingSessionOutcomeV1`: rejections are
+ * carried in the 200 body rather than as transport errors, so a host reads one
+ * discriminated union instead of branching on status codes.
+ *
+ * Rejections reuse `bookingSessionLifecycleErrorV1` rather than declaring a
+ * parallel error vocabulary — a preview can only fail the ways a Session read
+ * of the same target fails (`not_authorized`, `invalid_selection`,
+ * `quote_unavailable`).
+ */
+export const offerPreviewOutcomeV1 = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("offer_preview"), preview: offerPreviewResultV1 }),
+  z.object({ kind: z.literal("rejected"), error: bookingSessionLifecycleErrorV1 }),
+])
+export type OfferPreviewOutcomeV1 = z.infer<typeof offerPreviewOutcomeV1>

--- a/packages/catalog-contracts/src/booking-engine/selection-contracts.ts
+++ b/packages/catalog-contracts/src/booking-engine/selection-contracts.ts
@@ -243,10 +243,6 @@ export const bookingSelectionPublicV1 = z.object({
    * the booking and visible to ops; treat as untrusted input.
    */
   customerNotes: z.string().optional(),
-
-  // Engine-controlled — written when /quote returns
-  quoteId: z.string().optional(),
-  quoteExpiresAt: z.string().optional(),
 })
 export type BookingSelectionPublicV1 = z.infer<typeof bookingSelectionPublicV1>
 

--- a/packages/catalog-contracts/src/booking-engine/session-contracts.ts
+++ b/packages/catalog-contracts/src/booking-engine/session-contracts.ts
@@ -165,6 +165,7 @@ export const createBookingSessionTargetV1 = z.discriminatedUnion("kind", [
     })
     .strict(),
 ])
+export type CreateBookingSessionTargetV1 = z.infer<typeof createBookingSessionTargetV1>
 
 export const createBookingSessionV1 = z.object({
   idempotencyKey: z.string().min(8).max(128),
@@ -295,6 +296,21 @@ export const renewBookingSessionV1 = z.object({
 })
 export type RenewBookingSessionV1 = z.input<typeof renewBookingSessionV1>
 
+/**
+ * Why a target could not be priced. Named rather than inlined because the
+ * stateless Offer Preview reports the same set (`offerPreviewResultV1`) — a
+ * preview and a Session Quote of the same target must fail for the same
+ * reasons under the same names.
+ */
+export const bookingQuoteUnavailableReasonV1 = z.enum([
+  "target_not_found",
+  "target_not_bookable",
+  "price_unavailable",
+  "policy_unavailable",
+  "selection_unavailable",
+])
+export type BookingQuoteUnavailableReasonV1 = z.infer<typeof bookingQuoteUnavailableReasonV1>
+
 export const bookingSessionLifecycleErrorV1 = z.discriminatedUnion("kind", [
   z.object({
     kind: z.literal("revision_conflict"),
@@ -324,13 +340,7 @@ export const bookingSessionLifecycleErrorV1 = z.discriminatedUnion("kind", [
      * itself failed to resolve.
      */
     requirements: bookingRequirementsV1.optional(),
-    reason: z.enum([
-      "target_not_found",
-      "target_not_bookable",
-      "price_unavailable",
-      "policy_unavailable",
-      "selection_unavailable",
-    ]),
+    reason: bookingQuoteUnavailableReasonV1,
     nextAction: z.enum(["select_alternative_inventory", "contact_operator", "update_selection"]),
   }),
   z.object({

--- a/packages/catalog/openapi/admin/catalog-booking.json
+++ b/packages/catalog/openapi/admin/catalog-booking.json
@@ -10608,6 +10608,2017 @@
           }
         ]
       },
+      "OfferPreviewOutcomeV1": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": ["offer_preview"]
+              },
+              "preview": {
+                "type": "object",
+                "properties": {
+                  "binding": {
+                    "type": "boolean",
+                    "enum": [false]
+                  },
+                  "available": {
+                    "type": "boolean"
+                  },
+                  "requirements": {
+                    "type": "object",
+                    "properties": {
+                      "showsConfigure": {
+                        "type": "boolean"
+                      },
+                      "showsBilling": {
+                        "type": "boolean"
+                      },
+                      "showsTravelers": {
+                        "type": "boolean"
+                      },
+                      "showsAccommodation": {
+                        "type": "boolean"
+                      },
+                      "showsAddons": {
+                        "type": "boolean"
+                      },
+                      "showsPayment": {
+                        "type": "boolean"
+                      },
+                      "showsReview": {
+                        "type": "boolean",
+                        "enum": [true]
+                      },
+                      "configureSubSteps": {
+                        "type": "array",
+                        "items": {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "enum": ["departure"]
+                                },
+                                "required": {
+                                  "type": "boolean",
+                                  "enum": [true]
+                                }
+                              },
+                              "required": ["kind", "required"]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "enum": ["product-option"]
+                                },
+                                "options": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "code": {
+                                        "type": ["string", "null"]
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "description": {
+                                        "type": ["string", "null"]
+                                      },
+                                      "isDefault": {
+                                        "type": "boolean"
+                                      },
+                                      "units": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "id": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "description": {
+                                              "type": ["string", "null"]
+                                            },
+                                            "unitType": {
+                                              "type": ["string", "null"]
+                                            },
+                                            "minQuantity": {
+                                              "type": ["integer", "null"],
+                                              "minimum": 0
+                                            },
+                                            "maxQuantity": {
+                                              "type": ["integer", "null"],
+                                              "minimum": 0
+                                            }
+                                          },
+                                          "required": ["id", "name"]
+                                        }
+                                      }
+                                    },
+                                    "required": ["id", "name"]
+                                  }
+                                }
+                              },
+                              "required": ["kind", "options"]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "enum": ["option-units"]
+                                }
+                              },
+                              "required": ["kind"]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "enum": ["cabin-category"]
+                                },
+                                "categories": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "code": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "capacityMin": {
+                                        "type": "integer",
+                                        "minimum": 0
+                                      },
+                                      "capacityMax": {
+                                        "type": "integer",
+                                        "minimum": 0
+                                      },
+                                      "description": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": ["id", "name"]
+                                  }
+                                }
+                              },
+                              "required": ["kind", "categories"]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "enum": ["cabin-number"]
+                                },
+                                "perCategory": {
+                                  "type": "object",
+                                  "additionalProperties": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "id": {
+                                          "type": "string"
+                                        },
+                                        "code": {
+                                          "type": "string"
+                                        },
+                                        "label": {
+                                          "type": "string"
+                                        },
+                                        "capacity": {
+                                          "type": "integer",
+                                          "minimum": 0
+                                        },
+                                        "hasAccessibilityFeatures": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": ["id", "label"]
+                                    }
+                                  }
+                                }
+                              },
+                              "required": ["kind", "perCategory"]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "enum": ["date-range"]
+                                },
+                                "minNights": {
+                                  "type": "integer",
+                                  "exclusiveMinimum": 0
+                                },
+                                "maxNights": {
+                                  "type": "integer",
+                                  "exclusiveMinimum": 0
+                                }
+                              },
+                              "required": ["kind", "minNights", "maxNights"]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "enum": ["occupancy"]
+                                },
+                                "bands": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "code": {
+                                        "type": "string"
+                                      },
+                                      "label": {
+                                        "type": "string"
+                                      },
+                                      "minAge": {
+                                        "type": "integer",
+                                        "minimum": 0
+                                      },
+                                      "maxAge": {
+                                        "type": "integer",
+                                        "minimum": 0
+                                      },
+                                      "minCount": {
+                                        "type": "integer",
+                                        "minimum": 0
+                                      },
+                                      "maxCount": {
+                                        "type": "integer",
+                                        "minimum": 0
+                                      }
+                                    },
+                                    "required": ["code", "label", "minCount", "maxCount"]
+                                  }
+                                }
+                              },
+                              "required": ["kind", "bands"]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "enum": ["air-arrangement"]
+                                },
+                                "required": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": ["kind"]
+                            }
+                          ]
+                        }
+                      },
+                      "paxBands": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "code": {
+                              "type": "string"
+                            },
+                            "label": {
+                              "type": "string"
+                            },
+                            "minAge": {
+                              "type": "integer",
+                              "minimum": 0
+                            },
+                            "maxAge": {
+                              "type": "integer",
+                              "minimum": 0
+                            },
+                            "minCount": {
+                              "type": "integer",
+                              "minimum": 0
+                            },
+                            "maxCount": {
+                              "type": "integer",
+                              "minimum": 0
+                            }
+                          },
+                          "required": ["code", "label", "minCount", "maxCount"]
+                        }
+                      },
+                      "paxBandsAllowedTotal": {
+                        "type": "object",
+                        "properties": {
+                          "min": {
+                            "type": "integer"
+                          },
+                          "max": {
+                            "type": "integer"
+                          }
+                        },
+                        "required": ["min", "max"]
+                      },
+                      "paxBandDependencies": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "dependentCode": {
+                              "type": "string"
+                            },
+                            "masterCode": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": ["requires", "limits_per_master", "limits_sum", "excludes"]
+                            },
+                            "maxPerMaster": {
+                              "type": "integer",
+                              "minimum": 0
+                            },
+                            "maxDependentSum": {
+                              "type": "integer",
+                              "minimum": 0
+                            }
+                          },
+                          "required": ["dependentCode", "masterCode", "type"]
+                        }
+                      },
+                      "travelerFields": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "label": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            },
+                            "required": {
+                              "type": "boolean"
+                            },
+                            "options": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "string"
+                                  },
+                                  "label": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["value", "label"]
+                              }
+                            },
+                            "appliesToBands": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "required": ["key", "label", "type", "required"]
+                        }
+                      },
+                      "bookingFields": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "label": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            },
+                            "required": {
+                              "type": "boolean"
+                            },
+                            "group": {
+                              "type": "string",
+                              "enum": ["billing", "company", "preferences"]
+                            }
+                          },
+                          "required": ["key", "label", "type", "required", "group"]
+                        }
+                      },
+                      "accommodation": {
+                        "type": "object",
+                        "properties": {
+                          "roomOptions": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "description": {
+                                  "type": ["string", "null"]
+                                },
+                                "capacity": {
+                                  "type": ["integer", "null"],
+                                  "minimum": 0
+                                },
+                                "baseRateHint": {
+                                  "type": ["number", "null"]
+                                },
+                                "ratePlans": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "description": {
+                                        "type": ["string", "null"]
+                                      },
+                                      "chargeFrequency": {
+                                        "type": "string",
+                                        "enum": ["per_night", "per_stay"]
+                                      },
+                                      "cancellationPolicy": {
+                                        "type": ["string", "null"]
+                                      },
+                                      "inclusions": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "currency": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": ["id", "name"]
+                                  }
+                                }
+                              },
+                              "required": ["id", "name"]
+                            }
+                          },
+                          "sharedRoomAllowed": {
+                            "type": "boolean"
+                          },
+                          "subSteps": {
+                            "type": "array",
+                            "items": {
+                              "oneOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "kind": {
+                                      "type": "string",
+                                      "enum": ["rooms"]
+                                    },
+                                    "options": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "id": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "description": {
+                                            "type": ["string", "null"]
+                                          },
+                                          "capacity": {
+                                            "type": ["integer", "null"],
+                                            "minimum": 0
+                                          },
+                                          "baseRateHint": {
+                                            "type": ["number", "null"]
+                                          },
+                                          "ratePlans": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "id": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "description": {
+                                                  "type": ["string", "null"]
+                                                },
+                                                "chargeFrequency": {
+                                                  "type": "string",
+                                                  "enum": ["per_night", "per_stay"]
+                                                },
+                                                "cancellationPolicy": {
+                                                  "type": ["string", "null"]
+                                                },
+                                                "inclusions": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "currency": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": ["id", "name"]
+                                            }
+                                          }
+                                        },
+                                        "required": ["id", "name"]
+                                      }
+                                    },
+                                    "sharedRoomAllowed": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": ["kind", "options", "sharedRoomAllowed"]
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "kind": {
+                                      "type": "string",
+                                      "enum": ["extensions"]
+                                    },
+                                    "options": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "id": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "city": {
+                                            "type": ["string", "null"]
+                                          },
+                                          "side": {
+                                            "type": "string",
+                                            "enum": ["pre", "post"]
+                                          },
+                                          "nights": {
+                                            "type": ["integer", "null"],
+                                            "minimum": 0
+                                          },
+                                          "pricePerPersonHint": {
+                                            "type": ["number", "null"]
+                                          }
+                                        },
+                                        "required": ["id", "name", "side"]
+                                      }
+                                    },
+                                    "allowsPre": {
+                                      "type": "boolean"
+                                    },
+                                    "allowsPost": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": ["kind", "options", "allowsPre", "allowsPost"]
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        "required": ["sharedRoomAllowed"]
+                      },
+                      "addons": {
+                        "type": "object",
+                        "properties": {
+                          "catalog": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "description": {
+                                  "type": ["string", "null"]
+                                },
+                                "kind": {
+                                  "type": "string",
+                                  "enum": ["extras", "excursions", "insurance"]
+                                },
+                                "groupKey": {
+                                  "type": ["string", "null"]
+                                },
+                                "pricingMode": {
+                                  "type": ["string", "null"]
+                                },
+                                "unitAmountCents": {
+                                  "type": ["integer", "null"]
+                                },
+                                "currency": {
+                                  "type": ["string", "null"]
+                                },
+                                "pricedPerPerson": {
+                                  "type": ["boolean", "null"]
+                                },
+                                "selectionType": {
+                                  "type": ["string", "null"],
+                                  "enum": [
+                                    "optional",
+                                    "required",
+                                    "default_selected",
+                                    "unavailable",
+                                    null
+                                  ]
+                                },
+                                "minQuantity": {
+                                  "type": ["integer", "null"],
+                                  "minimum": 0
+                                },
+                                "maxQuantity": {
+                                  "type": ["integer", "null"],
+                                  "minimum": 0
+                                },
+                                "defaultQuantity": {
+                                  "type": ["integer", "null"],
+                                  "minimum": 0
+                                }
+                              },
+                              "required": ["id", "name", "kind"]
+                            }
+                          },
+                          "groups": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "enum": ["extras", "excursions", "insurance"]
+                                },
+                                "label": {
+                                  "type": "string"
+                                },
+                                "groupBy": {
+                                  "type": "string",
+                                  "enum": ["port", "day"]
+                                },
+                                "perGuestSelection": {
+                                  "type": "boolean"
+                                },
+                                "items": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "description": {
+                                        "type": ["string", "null"]
+                                      },
+                                      "kind": {
+                                        "type": "string",
+                                        "enum": ["extras", "excursions", "insurance"]
+                                      },
+                                      "groupKey": {
+                                        "type": ["string", "null"]
+                                      },
+                                      "pricingMode": {
+                                        "type": ["string", "null"]
+                                      },
+                                      "unitAmountCents": {
+                                        "type": ["integer", "null"]
+                                      },
+                                      "currency": {
+                                        "type": ["string", "null"]
+                                      },
+                                      "pricedPerPerson": {
+                                        "type": ["boolean", "null"]
+                                      },
+                                      "selectionType": {
+                                        "type": ["string", "null"],
+                                        "enum": [
+                                          "optional",
+                                          "required",
+                                          "default_selected",
+                                          "unavailable",
+                                          null
+                                        ]
+                                      },
+                                      "minQuantity": {
+                                        "type": ["integer", "null"],
+                                        "minimum": 0
+                                      },
+                                      "maxQuantity": {
+                                        "type": ["integer", "null"],
+                                        "minimum": 0
+                                      },
+                                      "defaultQuantity": {
+                                        "type": ["integer", "null"],
+                                        "minimum": 0
+                                      }
+                                    },
+                                    "required": ["id", "name", "kind"]
+                                  }
+                                }
+                              },
+                              "required": ["kind", "label", "perGuestSelection", "items"]
+                            }
+                          }
+                        }
+                      },
+                      "paymentIntents": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "enum": ["hold", "card", "bank_transfer", "ticket_on_credit", "inquiry"]
+                        }
+                      }
+                    },
+                    "required": [
+                      "showsConfigure",
+                      "showsBilling",
+                      "showsTravelers",
+                      "showsAccommodation",
+                      "showsAddons",
+                      "showsPayment",
+                      "showsReview",
+                      "paxBands",
+                      "paxBandsAllowedTotal",
+                      "travelerFields",
+                      "bookingFields",
+                      "paymentIntents"
+                    ]
+                  },
+                  "pricing": {
+                    "type": "object",
+                    "properties": {
+                      "currency": {
+                        "type": "string",
+                        "minLength": 3,
+                        "maxLength": 3
+                      },
+                      "lines": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "kind": {
+                              "type": "string",
+                              "enum": [
+                                "base",
+                                "addon",
+                                "accommodation",
+                                "supplement",
+                                "discount",
+                                "fee"
+                              ]
+                            },
+                            "label": {
+                              "type": "string"
+                            },
+                            "quantity": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "unitAmount": {
+                              "type": "integer"
+                            },
+                            "totalAmount": {
+                              "type": "integer"
+                            },
+                            "taxIncluded": {
+                              "type": "boolean"
+                            },
+                            "pricingBasis": {
+                              "type": "string",
+                              "enum": ["per_person", "per_unit", "per_booking"]
+                            },
+                            "componentId": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "authority": {
+                              "type": "string",
+                              "enum": ["booking_quote", "accepted_proposal_manual"]
+                            }
+                          },
+                          "required": ["kind", "label", "unitAmount", "totalAmount"]
+                        }
+                      },
+                      "taxes": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "code": {
+                              "type": "string"
+                            },
+                            "label": {
+                              "type": "string"
+                            },
+                            "rate": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "amount": {
+                              "type": "integer"
+                            },
+                            "base": {
+                              "type": "integer"
+                            },
+                            "includedInPrice": {
+                              "type": "boolean"
+                            },
+                            "scope": {
+                              "type": "string",
+                              "enum": ["included", "excluded", "withheld"]
+                            },
+                            "componentId": {
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "required": ["code", "label", "rate", "amount", "base"]
+                        }
+                      },
+                      "subtotal": {
+                        "type": "integer"
+                      },
+                      "taxTotal": {
+                        "type": "integer"
+                      },
+                      "total": {
+                        "type": "integer"
+                      },
+                      "policyEvidence": {
+                        "type": "object",
+                        "properties": {
+                          "cancellation": {},
+                          "bookingTerms": {}
+                        }
+                      },
+                      "componentPolicies": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "cancellation": {},
+                            "bookingTerms": {},
+                            "componentId": {
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "required": ["componentId"]
+                        }
+                      }
+                    },
+                    "required": ["currency", "lines", "taxes", "subtotal", "taxTotal", "total"]
+                  },
+                  "unavailableReason": {
+                    "type": "string",
+                    "enum": [
+                      "target_not_found",
+                      "target_not_bookable",
+                      "price_unavailable",
+                      "policy_unavailable",
+                      "selection_unavailable"
+                    ]
+                  }
+                },
+                "required": ["binding", "available", "requirements"]
+              }
+            },
+            "required": ["kind", "preview"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": ["rejected"]
+              },
+              "error": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": ["revision_conflict"]
+                      },
+                      "expectedRevision": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0
+                      },
+                      "actualRevision": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0
+                      },
+                      "actualState": {
+                        "type": "string",
+                        "enum": [
+                          "active",
+                          "supplier_pending",
+                          "component_pending",
+                          "consumed",
+                          "expired",
+                          "abandoned"
+                        ]
+                      }
+                    },
+                    "required": ["kind", "expectedRevision", "actualRevision", "actualState"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": ["session_expired"]
+                      }
+                    },
+                    "required": ["kind"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": ["session_consumed"]
+                      }
+                    },
+                    "required": ["kind"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": ["capability_required"]
+                      }
+                    },
+                    "required": ["kind"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": ["capability_scope_required"]
+                      },
+                      "action": {
+                        "type": "string",
+                        "enum": [
+                          "read",
+                          "update",
+                          "quote",
+                          "hold",
+                          "commit",
+                          "abandon",
+                          "adopt",
+                          "renew"
+                        ]
+                      }
+                    },
+                    "required": ["kind", "action"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": ["not_authorized"]
+                      }
+                    },
+                    "required": ["kind"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": ["idempotency_conflict"]
+                      }
+                    },
+                    "required": ["kind"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": ["supplier_operation_active"]
+                      },
+                      "nextAction": {
+                        "type": "string",
+                        "enum": ["reconcile_supplier_operation"]
+                      }
+                    },
+                    "required": ["kind", "nextAction"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": ["quote_unavailable"]
+                      },
+                      "requirements": {
+                        "type": "object",
+                        "properties": {
+                          "showsConfigure": {
+                            "type": "boolean"
+                          },
+                          "showsBilling": {
+                            "type": "boolean"
+                          },
+                          "showsTravelers": {
+                            "type": "boolean"
+                          },
+                          "showsAccommodation": {
+                            "type": "boolean"
+                          },
+                          "showsAddons": {
+                            "type": "boolean"
+                          },
+                          "showsPayment": {
+                            "type": "boolean"
+                          },
+                          "showsReview": {
+                            "type": "boolean",
+                            "enum": [true]
+                          },
+                          "configureSubSteps": {
+                            "type": "array",
+                            "items": {
+                              "oneOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "kind": {
+                                      "type": "string",
+                                      "enum": ["departure"]
+                                    },
+                                    "required": {
+                                      "type": "boolean",
+                                      "enum": [true]
+                                    }
+                                  },
+                                  "required": ["kind", "required"]
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "kind": {
+                                      "type": "string",
+                                      "enum": ["product-option"]
+                                    },
+                                    "options": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "id": {
+                                            "type": "string"
+                                          },
+                                          "code": {
+                                            "type": ["string", "null"]
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "description": {
+                                            "type": ["string", "null"]
+                                          },
+                                          "isDefault": {
+                                            "type": "boolean"
+                                          },
+                                          "units": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "id": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "description": {
+                                                  "type": ["string", "null"]
+                                                },
+                                                "unitType": {
+                                                  "type": ["string", "null"]
+                                                },
+                                                "minQuantity": {
+                                                  "type": ["integer", "null"],
+                                                  "minimum": 0
+                                                },
+                                                "maxQuantity": {
+                                                  "type": ["integer", "null"],
+                                                  "minimum": 0
+                                                }
+                                              },
+                                              "required": ["id", "name"]
+                                            }
+                                          }
+                                        },
+                                        "required": ["id", "name"]
+                                      }
+                                    }
+                                  },
+                                  "required": ["kind", "options"]
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "kind": {
+                                      "type": "string",
+                                      "enum": ["option-units"]
+                                    }
+                                  },
+                                  "required": ["kind"]
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "kind": {
+                                      "type": "string",
+                                      "enum": ["cabin-category"]
+                                    },
+                                    "categories": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "id": {
+                                            "type": "string"
+                                          },
+                                          "code": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          },
+                                          "capacityMin": {
+                                            "type": "integer",
+                                            "minimum": 0
+                                          },
+                                          "capacityMax": {
+                                            "type": "integer",
+                                            "minimum": 0
+                                          },
+                                          "description": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": ["id", "name"]
+                                      }
+                                    }
+                                  },
+                                  "required": ["kind", "categories"]
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "kind": {
+                                      "type": "string",
+                                      "enum": ["cabin-number"]
+                                    },
+                                    "perCategory": {
+                                      "type": "object",
+                                      "additionalProperties": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "id": {
+                                              "type": "string"
+                                            },
+                                            "code": {
+                                              "type": "string"
+                                            },
+                                            "label": {
+                                              "type": "string"
+                                            },
+                                            "capacity": {
+                                              "type": "integer",
+                                              "minimum": 0
+                                            },
+                                            "hasAccessibilityFeatures": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": ["id", "label"]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "required": ["kind", "perCategory"]
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "kind": {
+                                      "type": "string",
+                                      "enum": ["date-range"]
+                                    },
+                                    "minNights": {
+                                      "type": "integer",
+                                      "exclusiveMinimum": 0
+                                    },
+                                    "maxNights": {
+                                      "type": "integer",
+                                      "exclusiveMinimum": 0
+                                    }
+                                  },
+                                  "required": ["kind", "minNights", "maxNights"]
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "kind": {
+                                      "type": "string",
+                                      "enum": ["occupancy"]
+                                    },
+                                    "bands": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "code": {
+                                            "type": "string"
+                                          },
+                                          "label": {
+                                            "type": "string"
+                                          },
+                                          "minAge": {
+                                            "type": "integer",
+                                            "minimum": 0
+                                          },
+                                          "maxAge": {
+                                            "type": "integer",
+                                            "minimum": 0
+                                          },
+                                          "minCount": {
+                                            "type": "integer",
+                                            "minimum": 0
+                                          },
+                                          "maxCount": {
+                                            "type": "integer",
+                                            "minimum": 0
+                                          }
+                                        },
+                                        "required": ["code", "label", "minCount", "maxCount"]
+                                      }
+                                    }
+                                  },
+                                  "required": ["kind", "bands"]
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "kind": {
+                                      "type": "string",
+                                      "enum": ["air-arrangement"]
+                                    },
+                                    "required": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": ["kind"]
+                                }
+                              ]
+                            }
+                          },
+                          "paxBands": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "code": {
+                                  "type": "string"
+                                },
+                                "label": {
+                                  "type": "string"
+                                },
+                                "minAge": {
+                                  "type": "integer",
+                                  "minimum": 0
+                                },
+                                "maxAge": {
+                                  "type": "integer",
+                                  "minimum": 0
+                                },
+                                "minCount": {
+                                  "type": "integer",
+                                  "minimum": 0
+                                },
+                                "maxCount": {
+                                  "type": "integer",
+                                  "minimum": 0
+                                }
+                              },
+                              "required": ["code", "label", "minCount", "maxCount"]
+                            }
+                          },
+                          "paxBandsAllowedTotal": {
+                            "type": "object",
+                            "properties": {
+                              "min": {
+                                "type": "integer"
+                              },
+                              "max": {
+                                "type": "integer"
+                              }
+                            },
+                            "required": ["min", "max"]
+                          },
+                          "paxBandDependencies": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "dependentCode": {
+                                  "type": "string"
+                                },
+                                "masterCode": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "requires",
+                                    "limits_per_master",
+                                    "limits_sum",
+                                    "excludes"
+                                  ]
+                                },
+                                "maxPerMaster": {
+                                  "type": "integer",
+                                  "minimum": 0
+                                },
+                                "maxDependentSum": {
+                                  "type": "integer",
+                                  "minimum": 0
+                                }
+                              },
+                              "required": ["dependentCode", "masterCode", "type"]
+                            }
+                          },
+                          "travelerFields": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "label": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                },
+                                "required": {
+                                  "type": "boolean"
+                                },
+                                "options": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "value": {
+                                        "type": "string"
+                                      },
+                                      "label": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": ["value", "label"]
+                                  }
+                                },
+                                "appliesToBands": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "required": ["key", "label", "type", "required"]
+                            }
+                          },
+                          "bookingFields": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "label": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                },
+                                "required": {
+                                  "type": "boolean"
+                                },
+                                "group": {
+                                  "type": "string",
+                                  "enum": ["billing", "company", "preferences"]
+                                }
+                              },
+                              "required": ["key", "label", "type", "required", "group"]
+                            }
+                          },
+                          "accommodation": {
+                            "type": "object",
+                            "properties": {
+                              "roomOptions": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "description": {
+                                      "type": ["string", "null"]
+                                    },
+                                    "capacity": {
+                                      "type": ["integer", "null"],
+                                      "minimum": 0
+                                    },
+                                    "baseRateHint": {
+                                      "type": ["number", "null"]
+                                    },
+                                    "ratePlans": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "id": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "description": {
+                                            "type": ["string", "null"]
+                                          },
+                                          "chargeFrequency": {
+                                            "type": "string",
+                                            "enum": ["per_night", "per_stay"]
+                                          },
+                                          "cancellationPolicy": {
+                                            "type": ["string", "null"]
+                                          },
+                                          "inclusions": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "currency": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": ["id", "name"]
+                                      }
+                                    }
+                                  },
+                                  "required": ["id", "name"]
+                                }
+                              },
+                              "sharedRoomAllowed": {
+                                "type": "boolean"
+                              },
+                              "subSteps": {
+                                "type": "array",
+                                "items": {
+                                  "oneOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["rooms"]
+                                        },
+                                        "options": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "id": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "description": {
+                                                "type": ["string", "null"]
+                                              },
+                                              "capacity": {
+                                                "type": ["integer", "null"],
+                                                "minimum": 0
+                                              },
+                                              "baseRateHint": {
+                                                "type": ["number", "null"]
+                                              },
+                                              "ratePlans": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "id": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "description": {
+                                                      "type": ["string", "null"]
+                                                    },
+                                                    "chargeFrequency": {
+                                                      "type": "string",
+                                                      "enum": ["per_night", "per_stay"]
+                                                    },
+                                                    "cancellationPolicy": {
+                                                      "type": ["string", "null"]
+                                                    },
+                                                    "inclusions": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "currency": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": ["id", "name"]
+                                                }
+                                              }
+                                            },
+                                            "required": ["id", "name"]
+                                          }
+                                        },
+                                        "sharedRoomAllowed": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": ["kind", "options", "sharedRoomAllowed"]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["extensions"]
+                                        },
+                                        "options": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "id": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "city": {
+                                                "type": ["string", "null"]
+                                              },
+                                              "side": {
+                                                "type": "string",
+                                                "enum": ["pre", "post"]
+                                              },
+                                              "nights": {
+                                                "type": ["integer", "null"],
+                                                "minimum": 0
+                                              },
+                                              "pricePerPersonHint": {
+                                                "type": ["number", "null"]
+                                              }
+                                            },
+                                            "required": ["id", "name", "side"]
+                                          }
+                                        },
+                                        "allowsPre": {
+                                          "type": "boolean"
+                                        },
+                                        "allowsPost": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": ["kind", "options", "allowsPre", "allowsPost"]
+                                    }
+                                  ]
+                                }
+                              }
+                            },
+                            "required": ["sharedRoomAllowed"]
+                          },
+                          "addons": {
+                            "type": "object",
+                            "properties": {
+                              "catalog": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "description": {
+                                      "type": ["string", "null"]
+                                    },
+                                    "kind": {
+                                      "type": "string",
+                                      "enum": ["extras", "excursions", "insurance"]
+                                    },
+                                    "groupKey": {
+                                      "type": ["string", "null"]
+                                    },
+                                    "pricingMode": {
+                                      "type": ["string", "null"]
+                                    },
+                                    "unitAmountCents": {
+                                      "type": ["integer", "null"]
+                                    },
+                                    "currency": {
+                                      "type": ["string", "null"]
+                                    },
+                                    "pricedPerPerson": {
+                                      "type": ["boolean", "null"]
+                                    },
+                                    "selectionType": {
+                                      "type": ["string", "null"],
+                                      "enum": [
+                                        "optional",
+                                        "required",
+                                        "default_selected",
+                                        "unavailable",
+                                        null
+                                      ]
+                                    },
+                                    "minQuantity": {
+                                      "type": ["integer", "null"],
+                                      "minimum": 0
+                                    },
+                                    "maxQuantity": {
+                                      "type": ["integer", "null"],
+                                      "minimum": 0
+                                    },
+                                    "defaultQuantity": {
+                                      "type": ["integer", "null"],
+                                      "minimum": 0
+                                    }
+                                  },
+                                  "required": ["id", "name", "kind"]
+                                }
+                              },
+                              "groups": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "kind": {
+                                      "type": "string",
+                                      "enum": ["extras", "excursions", "insurance"]
+                                    },
+                                    "label": {
+                                      "type": "string"
+                                    },
+                                    "groupBy": {
+                                      "type": "string",
+                                      "enum": ["port", "day"]
+                                    },
+                                    "perGuestSelection": {
+                                      "type": "boolean"
+                                    },
+                                    "items": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "id": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "description": {
+                                            "type": ["string", "null"]
+                                          },
+                                          "kind": {
+                                            "type": "string",
+                                            "enum": ["extras", "excursions", "insurance"]
+                                          },
+                                          "groupKey": {
+                                            "type": ["string", "null"]
+                                          },
+                                          "pricingMode": {
+                                            "type": ["string", "null"]
+                                          },
+                                          "unitAmountCents": {
+                                            "type": ["integer", "null"]
+                                          },
+                                          "currency": {
+                                            "type": ["string", "null"]
+                                          },
+                                          "pricedPerPerson": {
+                                            "type": ["boolean", "null"]
+                                          },
+                                          "selectionType": {
+                                            "type": ["string", "null"],
+                                            "enum": [
+                                              "optional",
+                                              "required",
+                                              "default_selected",
+                                              "unavailable",
+                                              null
+                                            ]
+                                          },
+                                          "minQuantity": {
+                                            "type": ["integer", "null"],
+                                            "minimum": 0
+                                          },
+                                          "maxQuantity": {
+                                            "type": ["integer", "null"],
+                                            "minimum": 0
+                                          },
+                                          "defaultQuantity": {
+                                            "type": ["integer", "null"],
+                                            "minimum": 0
+                                          }
+                                        },
+                                        "required": ["id", "name", "kind"]
+                                      }
+                                    }
+                                  },
+                                  "required": ["kind", "label", "perGuestSelection", "items"]
+                                }
+                              }
+                            }
+                          },
+                          "paymentIntents": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "enum": [
+                                "hold",
+                                "card",
+                                "bank_transfer",
+                                "ticket_on_credit",
+                                "inquiry"
+                              ]
+                            }
+                          }
+                        },
+                        "required": [
+                          "showsConfigure",
+                          "showsBilling",
+                          "showsTravelers",
+                          "showsAccommodation",
+                          "showsAddons",
+                          "showsPayment",
+                          "showsReview",
+                          "paxBands",
+                          "paxBandsAllowedTotal",
+                          "travelerFields",
+                          "bookingFields",
+                          "paymentIntents"
+                        ]
+                      },
+                      "reason": {
+                        "type": "string",
+                        "enum": [
+                          "target_not_found",
+                          "target_not_bookable",
+                          "price_unavailable",
+                          "policy_unavailable",
+                          "selection_unavailable"
+                        ]
+                      },
+                      "nextAction": {
+                        "type": "string",
+                        "enum": [
+                          "select_alternative_inventory",
+                          "contact_operator",
+                          "update_selection"
+                        ]
+                      }
+                    },
+                    "required": ["kind", "reason", "nextAction"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": ["commit_rejected"]
+                      },
+                      "reason": {
+                        "type": "string",
+                        "enum": [
+                          "entity_not_found",
+                          "entity_not_bookable",
+                          "incomplete_draft",
+                          "price_changed"
+                        ]
+                      },
+                      "nextAction": {
+                        "type": "string",
+                        "enum": [
+                          "select_alternative_inventory",
+                          "update_selection",
+                          "request_fresh_quote"
+                        ]
+                      }
+                    },
+                    "required": ["kind", "reason", "nextAction"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": ["invalid_selection"]
+                      },
+                      "reason": {
+                        "type": "string",
+                        "enum": ["unsupported_target", "forbidden_field"]
+                      },
+                      "path": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "required": ["kind", "reason"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": ["renewal_not_allowed"]
+                      },
+                      "reason": {
+                        "type": "string",
+                        "enum": [
+                          "session_not_active",
+                          "extension_too_large",
+                          "absolute_lifetime_exceeded"
+                        ]
+                      }
+                    },
+                    "required": ["kind", "reason"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": ["quote_required"]
+                      },
+                      "nextAction": {
+                        "type": "string",
+                        "enum": ["request_fresh_quote"]
+                      }
+                    },
+                    "required": ["kind", "nextAction"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": ["quote_expired", "quote_superseded"]
+                      },
+                      "nextAction": {
+                        "type": "string",
+                        "enum": ["request_fresh_quote"]
+                      }
+                    },
+                    "required": ["kind", "nextAction"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": ["hold_required", "hold_expired", "availability_changed"]
+                      },
+                      "nextAction": {
+                        "type": "string",
+                        "enum": ["request_new_hold"]
+                      }
+                    },
+                    "required": ["kind", "nextAction"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": ["hold_quantity_mismatch"]
+                      },
+                      "requestedQuantity": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0
+                      },
+                      "expectedQuantity": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0
+                      },
+                      "nextAction": {
+                        "type": "string",
+                        "enum": ["request_new_hold"]
+                      }
+                    },
+                    "required": ["kind", "requestedQuantity", "expectedQuantity", "nextAction"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": ["commit_already_consumed"]
+                      },
+                      "nextAction": {
+                        "type": "string",
+                        "enum": ["return_idempotent_result"]
+                      }
+                    },
+                    "required": ["kind", "nextAction"]
+                  }
+                ]
+              }
+            },
+            "required": ["kind", "error"]
+          }
+        ]
+      },
       "SupplierOperationRecordV1": {
         "type": "object",
         "properties": {
@@ -11592,6 +13603,511 @@
           },
           "403": {
             "description": "Active storefront channel context is required for public booking sessions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/admin/catalog/offers/preview": {
+      "post": {
+        "x-voyant-api-id": "@voyant-travel/catalog#booking-engine.api.admin",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "target": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "enum": ["product"]
+                          },
+                          "productId": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "required": ["kind", "productId"],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "enum": ["catalog_item"]
+                          },
+                          "catalogItemId": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "required": ["kind", "catalogItemId"],
+                        "additionalProperties": false
+                      }
+                    ]
+                  },
+                  "scope": {
+                    "type": "object",
+                    "properties": {
+                      "locale": {
+                        "type": "string",
+                        "minLength": 2
+                      },
+                      "market": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "currency": {
+                        "type": "string",
+                        "minLength": 3,
+                        "maxLength": 3
+                      }
+                    },
+                    "required": ["locale", "market"]
+                  },
+                  "selection": {
+                    "type": "object",
+                    "properties": {
+                      "configure": {
+                        "type": "object",
+                        "properties": {
+                          "departureSlotId": {
+                            "type": "string"
+                          },
+                          "departureDate": {
+                            "type": "string"
+                          },
+                          "departureTime": {
+                            "type": "string"
+                          },
+                          "pax": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "integer",
+                              "minimum": 0
+                            },
+                            "default": {}
+                          },
+                          "variantId": {
+                            "type": "string"
+                          },
+                          "optionSelections": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "optionId": {
+                                  "type": "string"
+                                },
+                                "optionName": {
+                                  "type": "string"
+                                },
+                                "optionUnitId": {
+                                  "type": "string"
+                                },
+                                "optionUnitName": {
+                                  "type": "string"
+                                },
+                                "quantity": {
+                                  "type": "integer",
+                                  "minimum": 0
+                                }
+                              },
+                              "required": ["optionId", "quantity"]
+                            }
+                          },
+                          "cabinCategoryId": {
+                            "type": "string"
+                          },
+                          "cabinNumberId": {
+                            "type": "string"
+                          },
+                          "roomTypeId": {
+                            "type": "string"
+                          },
+                          "ratePlanId": {
+                            "type": "string"
+                          },
+                          "board": {
+                            "type": "string"
+                          },
+                          "dateRange": {
+                            "type": "object",
+                            "properties": {
+                              "checkIn": {
+                                "type": "string"
+                              },
+                              "checkOut": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["checkIn", "checkOut"]
+                          },
+                          "airArrangement": {
+                            "type": "string",
+                            "enum": ["cruise_line", "independent", "none"]
+                          }
+                        },
+                        "default": {
+                          "pax": {}
+                        }
+                      },
+                      "billing": {
+                        "type": "object",
+                        "properties": {
+                          "buyerType": {
+                            "type": "string",
+                            "enum": ["B2C", "B2B"],
+                            "default": "B2C"
+                          },
+                          "organizationId": {
+                            "type": "string"
+                          },
+                          "contact": {
+                            "type": "object",
+                            "properties": {
+                              "firstName": {
+                                "type": "string",
+                                "default": ""
+                              },
+                              "lastName": {
+                                "type": "string",
+                                "default": ""
+                              },
+                              "email": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                    "enum": [""]
+                                  },
+                                  {
+                                    "type": "string",
+                                    "format": "email"
+                                  }
+                                ],
+                                "default": ""
+                              },
+                              "phone": {
+                                "type": "string"
+                              },
+                              "personId": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "address": {
+                            "type": "object",
+                            "properties": {
+                              "line1": {
+                                "type": "string"
+                              },
+                              "line2": {
+                                "type": "string"
+                              },
+                              "city": {
+                                "type": "string"
+                              },
+                              "postal": {
+                                "type": "string"
+                              },
+                              "country": {
+                                "type": "string"
+                              }
+                            },
+                            "default": {}
+                          },
+                          "company": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "vatId": {
+                                "type": "string"
+                              },
+                              "registrationNumber": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["name"]
+                          },
+                          "saveAsDefault": {
+                            "type": "boolean"
+                          }
+                        },
+                        "default": {
+                          "buyerType": "B2C",
+                          "contact": {
+                            "firstName": "",
+                            "lastName": "",
+                            "email": ""
+                          },
+                          "address": {}
+                        },
+                        "required": ["contact"]
+                      },
+                      "travelers": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "rowId": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "firstName": {
+                              "type": "string",
+                              "minLength": 1,
+                              "maxLength": 255
+                            },
+                            "lastName": {
+                              "type": "string",
+                              "minLength": 1,
+                              "maxLength": 255
+                            },
+                            "email": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "enum": [""]
+                                },
+                                {
+                                  "type": "string",
+                                  "format": "email"
+                                }
+                              ]
+                            },
+                            "phone": {
+                              "type": "string",
+                              "maxLength": 50
+                            },
+                            "personId": {
+                              "type": "string"
+                            },
+                            "band": {
+                              "type": "string",
+                              "minLength": 1,
+                              "maxLength": 128,
+                              "default": "adult"
+                            },
+                            "dateOfBirth": {
+                              "type": "string"
+                            },
+                            "documents": {
+                              "type": "object",
+                              "additionalProperties": {}
+                            },
+                            "preferredLanguage": {
+                              "type": "string",
+                              "maxLength": 35
+                            },
+                            "specialRequests": {
+                              "type": "string"
+                            },
+                            "isPrimary": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": ["firstName", "lastName"]
+                        },
+                        "default": []
+                      },
+                      "accommodation": {
+                        "type": "object",
+                        "properties": {
+                          "rooms": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "optionUnitId": {
+                                  "type": "string"
+                                },
+                                "quantity": {
+                                  "type": "integer",
+                                  "minimum": 1
+                                },
+                                "ratePlanId": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["optionUnitId", "quantity"]
+                            }
+                          },
+                          "travelerAssignments": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "default": {}
+                          },
+                          "sharedRoom": {
+                            "type": "object",
+                            "properties": {
+                              "mode": {
+                                "type": "string",
+                                "enum": ["create", "join"]
+                              },
+                              "groupId": {
+                                "type": "string"
+                              },
+                              "label": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["mode"]
+                          }
+                        },
+                        "required": ["rooms"]
+                      },
+                      "addons": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "extraId": {
+                              "type": "string"
+                            },
+                            "quantity": {
+                              "type": "integer",
+                              "minimum": 1
+                            }
+                          },
+                          "required": ["extraId", "quantity"]
+                        },
+                        "default": []
+                      },
+                      "payment": {
+                        "type": "object",
+                        "properties": {
+                          "intent": {
+                            "type": "string",
+                            "enum": [
+                              "hold",
+                              "card",
+                              "bank_transfer",
+                              "ticket_on_credit",
+                              "inquiry"
+                            ],
+                            "default": "hold"
+                          },
+                          "schedule": {}
+                        },
+                        "default": {
+                          "intent": "hold"
+                        }
+                      },
+                      "paymentSchedules": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "scheduleType": {
+                              "type": "string",
+                              "enum": ["deposit", "installment", "balance", "hold", "other"]
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": ["pending", "due", "paid", "waived", "cancelled", "expired"]
+                            },
+                            "dueDate": {
+                              "type": "string"
+                            },
+                            "currency": {
+                              "type": "string",
+                              "minLength": 3,
+                              "maxLength": 3
+                            },
+                            "amountCents": {
+                              "type": "integer",
+                              "minimum": 0
+                            },
+                            "notes": {
+                              "type": ["string", "null"]
+                            }
+                          },
+                          "required": [
+                            "scheduleType",
+                            "status",
+                            "dueDate",
+                            "currency",
+                            "amountCents"
+                          ]
+                        }
+                      },
+                      "promotionCode": {
+                        "type": "string"
+                      },
+                      "customerNotes": {
+                        "type": "string"
+                      },
+                      "quoteId": {
+                        "type": "string"
+                      },
+                      "quoteExpiresAt": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "required": ["target", "scope"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Non-binding Offer Preview — no identifier, nothing persisted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OfferPreviewOutcomeV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Active storefront channel context is required for public offer previews",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/catalog/openapi/storefront/catalog-booking.json
+++ b/packages/catalog/openapi/storefront/catalog-booking.json
@@ -10608,6 +10608,2017 @@
           }
         ]
       },
+      "OfferPreviewOutcomeV1": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": ["offer_preview"]
+              },
+              "preview": {
+                "type": "object",
+                "properties": {
+                  "binding": {
+                    "type": "boolean",
+                    "enum": [false]
+                  },
+                  "available": {
+                    "type": "boolean"
+                  },
+                  "requirements": {
+                    "type": "object",
+                    "properties": {
+                      "showsConfigure": {
+                        "type": "boolean"
+                      },
+                      "showsBilling": {
+                        "type": "boolean"
+                      },
+                      "showsTravelers": {
+                        "type": "boolean"
+                      },
+                      "showsAccommodation": {
+                        "type": "boolean"
+                      },
+                      "showsAddons": {
+                        "type": "boolean"
+                      },
+                      "showsPayment": {
+                        "type": "boolean"
+                      },
+                      "showsReview": {
+                        "type": "boolean",
+                        "enum": [true]
+                      },
+                      "configureSubSteps": {
+                        "type": "array",
+                        "items": {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "enum": ["departure"]
+                                },
+                                "required": {
+                                  "type": "boolean",
+                                  "enum": [true]
+                                }
+                              },
+                              "required": ["kind", "required"]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "enum": ["product-option"]
+                                },
+                                "options": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "code": {
+                                        "type": ["string", "null"]
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "description": {
+                                        "type": ["string", "null"]
+                                      },
+                                      "isDefault": {
+                                        "type": "boolean"
+                                      },
+                                      "units": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "id": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "description": {
+                                              "type": ["string", "null"]
+                                            },
+                                            "unitType": {
+                                              "type": ["string", "null"]
+                                            },
+                                            "minQuantity": {
+                                              "type": ["integer", "null"],
+                                              "minimum": 0
+                                            },
+                                            "maxQuantity": {
+                                              "type": ["integer", "null"],
+                                              "minimum": 0
+                                            }
+                                          },
+                                          "required": ["id", "name"]
+                                        }
+                                      }
+                                    },
+                                    "required": ["id", "name"]
+                                  }
+                                }
+                              },
+                              "required": ["kind", "options"]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "enum": ["option-units"]
+                                }
+                              },
+                              "required": ["kind"]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "enum": ["cabin-category"]
+                                },
+                                "categories": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "code": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "capacityMin": {
+                                        "type": "integer",
+                                        "minimum": 0
+                                      },
+                                      "capacityMax": {
+                                        "type": "integer",
+                                        "minimum": 0
+                                      },
+                                      "description": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": ["id", "name"]
+                                  }
+                                }
+                              },
+                              "required": ["kind", "categories"]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "enum": ["cabin-number"]
+                                },
+                                "perCategory": {
+                                  "type": "object",
+                                  "additionalProperties": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "id": {
+                                          "type": "string"
+                                        },
+                                        "code": {
+                                          "type": "string"
+                                        },
+                                        "label": {
+                                          "type": "string"
+                                        },
+                                        "capacity": {
+                                          "type": "integer",
+                                          "minimum": 0
+                                        },
+                                        "hasAccessibilityFeatures": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": ["id", "label"]
+                                    }
+                                  }
+                                }
+                              },
+                              "required": ["kind", "perCategory"]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "enum": ["date-range"]
+                                },
+                                "minNights": {
+                                  "type": "integer",
+                                  "exclusiveMinimum": 0
+                                },
+                                "maxNights": {
+                                  "type": "integer",
+                                  "exclusiveMinimum": 0
+                                }
+                              },
+                              "required": ["kind", "minNights", "maxNights"]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "enum": ["occupancy"]
+                                },
+                                "bands": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "code": {
+                                        "type": "string"
+                                      },
+                                      "label": {
+                                        "type": "string"
+                                      },
+                                      "minAge": {
+                                        "type": "integer",
+                                        "minimum": 0
+                                      },
+                                      "maxAge": {
+                                        "type": "integer",
+                                        "minimum": 0
+                                      },
+                                      "minCount": {
+                                        "type": "integer",
+                                        "minimum": 0
+                                      },
+                                      "maxCount": {
+                                        "type": "integer",
+                                        "minimum": 0
+                                      }
+                                    },
+                                    "required": ["code", "label", "minCount", "maxCount"]
+                                  }
+                                }
+                              },
+                              "required": ["kind", "bands"]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "enum": ["air-arrangement"]
+                                },
+                                "required": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": ["kind"]
+                            }
+                          ]
+                        }
+                      },
+                      "paxBands": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "code": {
+                              "type": "string"
+                            },
+                            "label": {
+                              "type": "string"
+                            },
+                            "minAge": {
+                              "type": "integer",
+                              "minimum": 0
+                            },
+                            "maxAge": {
+                              "type": "integer",
+                              "minimum": 0
+                            },
+                            "minCount": {
+                              "type": "integer",
+                              "minimum": 0
+                            },
+                            "maxCount": {
+                              "type": "integer",
+                              "minimum": 0
+                            }
+                          },
+                          "required": ["code", "label", "minCount", "maxCount"]
+                        }
+                      },
+                      "paxBandsAllowedTotal": {
+                        "type": "object",
+                        "properties": {
+                          "min": {
+                            "type": "integer"
+                          },
+                          "max": {
+                            "type": "integer"
+                          }
+                        },
+                        "required": ["min", "max"]
+                      },
+                      "paxBandDependencies": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "dependentCode": {
+                              "type": "string"
+                            },
+                            "masterCode": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": ["requires", "limits_per_master", "limits_sum", "excludes"]
+                            },
+                            "maxPerMaster": {
+                              "type": "integer",
+                              "minimum": 0
+                            },
+                            "maxDependentSum": {
+                              "type": "integer",
+                              "minimum": 0
+                            }
+                          },
+                          "required": ["dependentCode", "masterCode", "type"]
+                        }
+                      },
+                      "travelerFields": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "label": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            },
+                            "required": {
+                              "type": "boolean"
+                            },
+                            "options": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "string"
+                                  },
+                                  "label": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": ["value", "label"]
+                              }
+                            },
+                            "appliesToBands": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "required": ["key", "label", "type", "required"]
+                        }
+                      },
+                      "bookingFields": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "label": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            },
+                            "required": {
+                              "type": "boolean"
+                            },
+                            "group": {
+                              "type": "string",
+                              "enum": ["billing", "company", "preferences"]
+                            }
+                          },
+                          "required": ["key", "label", "type", "required", "group"]
+                        }
+                      },
+                      "accommodation": {
+                        "type": "object",
+                        "properties": {
+                          "roomOptions": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "description": {
+                                  "type": ["string", "null"]
+                                },
+                                "capacity": {
+                                  "type": ["integer", "null"],
+                                  "minimum": 0
+                                },
+                                "baseRateHint": {
+                                  "type": ["number", "null"]
+                                },
+                                "ratePlans": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "description": {
+                                        "type": ["string", "null"]
+                                      },
+                                      "chargeFrequency": {
+                                        "type": "string",
+                                        "enum": ["per_night", "per_stay"]
+                                      },
+                                      "cancellationPolicy": {
+                                        "type": ["string", "null"]
+                                      },
+                                      "inclusions": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "currency": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": ["id", "name"]
+                                  }
+                                }
+                              },
+                              "required": ["id", "name"]
+                            }
+                          },
+                          "sharedRoomAllowed": {
+                            "type": "boolean"
+                          },
+                          "subSteps": {
+                            "type": "array",
+                            "items": {
+                              "oneOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "kind": {
+                                      "type": "string",
+                                      "enum": ["rooms"]
+                                    },
+                                    "options": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "id": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "description": {
+                                            "type": ["string", "null"]
+                                          },
+                                          "capacity": {
+                                            "type": ["integer", "null"],
+                                            "minimum": 0
+                                          },
+                                          "baseRateHint": {
+                                            "type": ["number", "null"]
+                                          },
+                                          "ratePlans": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "id": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "description": {
+                                                  "type": ["string", "null"]
+                                                },
+                                                "chargeFrequency": {
+                                                  "type": "string",
+                                                  "enum": ["per_night", "per_stay"]
+                                                },
+                                                "cancellationPolicy": {
+                                                  "type": ["string", "null"]
+                                                },
+                                                "inclusions": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "currency": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": ["id", "name"]
+                                            }
+                                          }
+                                        },
+                                        "required": ["id", "name"]
+                                      }
+                                    },
+                                    "sharedRoomAllowed": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": ["kind", "options", "sharedRoomAllowed"]
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "kind": {
+                                      "type": "string",
+                                      "enum": ["extensions"]
+                                    },
+                                    "options": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "id": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "city": {
+                                            "type": ["string", "null"]
+                                          },
+                                          "side": {
+                                            "type": "string",
+                                            "enum": ["pre", "post"]
+                                          },
+                                          "nights": {
+                                            "type": ["integer", "null"],
+                                            "minimum": 0
+                                          },
+                                          "pricePerPersonHint": {
+                                            "type": ["number", "null"]
+                                          }
+                                        },
+                                        "required": ["id", "name", "side"]
+                                      }
+                                    },
+                                    "allowsPre": {
+                                      "type": "boolean"
+                                    },
+                                    "allowsPost": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": ["kind", "options", "allowsPre", "allowsPost"]
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        "required": ["sharedRoomAllowed"]
+                      },
+                      "addons": {
+                        "type": "object",
+                        "properties": {
+                          "catalog": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "description": {
+                                  "type": ["string", "null"]
+                                },
+                                "kind": {
+                                  "type": "string",
+                                  "enum": ["extras", "excursions", "insurance"]
+                                },
+                                "groupKey": {
+                                  "type": ["string", "null"]
+                                },
+                                "pricingMode": {
+                                  "type": ["string", "null"]
+                                },
+                                "unitAmountCents": {
+                                  "type": ["integer", "null"]
+                                },
+                                "currency": {
+                                  "type": ["string", "null"]
+                                },
+                                "pricedPerPerson": {
+                                  "type": ["boolean", "null"]
+                                },
+                                "selectionType": {
+                                  "type": ["string", "null"],
+                                  "enum": [
+                                    "optional",
+                                    "required",
+                                    "default_selected",
+                                    "unavailable",
+                                    null
+                                  ]
+                                },
+                                "minQuantity": {
+                                  "type": ["integer", "null"],
+                                  "minimum": 0
+                                },
+                                "maxQuantity": {
+                                  "type": ["integer", "null"],
+                                  "minimum": 0
+                                },
+                                "defaultQuantity": {
+                                  "type": ["integer", "null"],
+                                  "minimum": 0
+                                }
+                              },
+                              "required": ["id", "name", "kind"]
+                            }
+                          },
+                          "groups": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "enum": ["extras", "excursions", "insurance"]
+                                },
+                                "label": {
+                                  "type": "string"
+                                },
+                                "groupBy": {
+                                  "type": "string",
+                                  "enum": ["port", "day"]
+                                },
+                                "perGuestSelection": {
+                                  "type": "boolean"
+                                },
+                                "items": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "description": {
+                                        "type": ["string", "null"]
+                                      },
+                                      "kind": {
+                                        "type": "string",
+                                        "enum": ["extras", "excursions", "insurance"]
+                                      },
+                                      "groupKey": {
+                                        "type": ["string", "null"]
+                                      },
+                                      "pricingMode": {
+                                        "type": ["string", "null"]
+                                      },
+                                      "unitAmountCents": {
+                                        "type": ["integer", "null"]
+                                      },
+                                      "currency": {
+                                        "type": ["string", "null"]
+                                      },
+                                      "pricedPerPerson": {
+                                        "type": ["boolean", "null"]
+                                      },
+                                      "selectionType": {
+                                        "type": ["string", "null"],
+                                        "enum": [
+                                          "optional",
+                                          "required",
+                                          "default_selected",
+                                          "unavailable",
+                                          null
+                                        ]
+                                      },
+                                      "minQuantity": {
+                                        "type": ["integer", "null"],
+                                        "minimum": 0
+                                      },
+                                      "maxQuantity": {
+                                        "type": ["integer", "null"],
+                                        "minimum": 0
+                                      },
+                                      "defaultQuantity": {
+                                        "type": ["integer", "null"],
+                                        "minimum": 0
+                                      }
+                                    },
+                                    "required": ["id", "name", "kind"]
+                                  }
+                                }
+                              },
+                              "required": ["kind", "label", "perGuestSelection", "items"]
+                            }
+                          }
+                        }
+                      },
+                      "paymentIntents": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "enum": ["hold", "card", "bank_transfer", "ticket_on_credit", "inquiry"]
+                        }
+                      }
+                    },
+                    "required": [
+                      "showsConfigure",
+                      "showsBilling",
+                      "showsTravelers",
+                      "showsAccommodation",
+                      "showsAddons",
+                      "showsPayment",
+                      "showsReview",
+                      "paxBands",
+                      "paxBandsAllowedTotal",
+                      "travelerFields",
+                      "bookingFields",
+                      "paymentIntents"
+                    ]
+                  },
+                  "pricing": {
+                    "type": "object",
+                    "properties": {
+                      "currency": {
+                        "type": "string",
+                        "minLength": 3,
+                        "maxLength": 3
+                      },
+                      "lines": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "kind": {
+                              "type": "string",
+                              "enum": [
+                                "base",
+                                "addon",
+                                "accommodation",
+                                "supplement",
+                                "discount",
+                                "fee"
+                              ]
+                            },
+                            "label": {
+                              "type": "string"
+                            },
+                            "quantity": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "unitAmount": {
+                              "type": "integer"
+                            },
+                            "totalAmount": {
+                              "type": "integer"
+                            },
+                            "taxIncluded": {
+                              "type": "boolean"
+                            },
+                            "pricingBasis": {
+                              "type": "string",
+                              "enum": ["per_person", "per_unit", "per_booking"]
+                            },
+                            "componentId": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "authority": {
+                              "type": "string",
+                              "enum": ["booking_quote", "accepted_proposal_manual"]
+                            }
+                          },
+                          "required": ["kind", "label", "unitAmount", "totalAmount"]
+                        }
+                      },
+                      "taxes": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "code": {
+                              "type": "string"
+                            },
+                            "label": {
+                              "type": "string"
+                            },
+                            "rate": {
+                              "type": "number",
+                              "minimum": 0
+                            },
+                            "amount": {
+                              "type": "integer"
+                            },
+                            "base": {
+                              "type": "integer"
+                            },
+                            "includedInPrice": {
+                              "type": "boolean"
+                            },
+                            "scope": {
+                              "type": "string",
+                              "enum": ["included", "excluded", "withheld"]
+                            },
+                            "componentId": {
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "required": ["code", "label", "rate", "amount", "base"]
+                        }
+                      },
+                      "subtotal": {
+                        "type": "integer"
+                      },
+                      "taxTotal": {
+                        "type": "integer"
+                      },
+                      "total": {
+                        "type": "integer"
+                      },
+                      "policyEvidence": {
+                        "type": "object",
+                        "properties": {
+                          "cancellation": {},
+                          "bookingTerms": {}
+                        }
+                      },
+                      "componentPolicies": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "cancellation": {},
+                            "bookingTerms": {},
+                            "componentId": {
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "required": ["componentId"]
+                        }
+                      }
+                    },
+                    "required": ["currency", "lines", "taxes", "subtotal", "taxTotal", "total"]
+                  },
+                  "unavailableReason": {
+                    "type": "string",
+                    "enum": [
+                      "target_not_found",
+                      "target_not_bookable",
+                      "price_unavailable",
+                      "policy_unavailable",
+                      "selection_unavailable"
+                    ]
+                  }
+                },
+                "required": ["binding", "available", "requirements"]
+              }
+            },
+            "required": ["kind", "preview"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": ["rejected"]
+              },
+              "error": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": ["revision_conflict"]
+                      },
+                      "expectedRevision": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0
+                      },
+                      "actualRevision": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0
+                      },
+                      "actualState": {
+                        "type": "string",
+                        "enum": [
+                          "active",
+                          "supplier_pending",
+                          "component_pending",
+                          "consumed",
+                          "expired",
+                          "abandoned"
+                        ]
+                      }
+                    },
+                    "required": ["kind", "expectedRevision", "actualRevision", "actualState"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": ["session_expired"]
+                      }
+                    },
+                    "required": ["kind"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": ["session_consumed"]
+                      }
+                    },
+                    "required": ["kind"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": ["capability_required"]
+                      }
+                    },
+                    "required": ["kind"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": ["capability_scope_required"]
+                      },
+                      "action": {
+                        "type": "string",
+                        "enum": [
+                          "read",
+                          "update",
+                          "quote",
+                          "hold",
+                          "commit",
+                          "abandon",
+                          "adopt",
+                          "renew"
+                        ]
+                      }
+                    },
+                    "required": ["kind", "action"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": ["not_authorized"]
+                      }
+                    },
+                    "required": ["kind"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": ["idempotency_conflict"]
+                      }
+                    },
+                    "required": ["kind"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": ["supplier_operation_active"]
+                      },
+                      "nextAction": {
+                        "type": "string",
+                        "enum": ["reconcile_supplier_operation"]
+                      }
+                    },
+                    "required": ["kind", "nextAction"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": ["quote_unavailable"]
+                      },
+                      "requirements": {
+                        "type": "object",
+                        "properties": {
+                          "showsConfigure": {
+                            "type": "boolean"
+                          },
+                          "showsBilling": {
+                            "type": "boolean"
+                          },
+                          "showsTravelers": {
+                            "type": "boolean"
+                          },
+                          "showsAccommodation": {
+                            "type": "boolean"
+                          },
+                          "showsAddons": {
+                            "type": "boolean"
+                          },
+                          "showsPayment": {
+                            "type": "boolean"
+                          },
+                          "showsReview": {
+                            "type": "boolean",
+                            "enum": [true]
+                          },
+                          "configureSubSteps": {
+                            "type": "array",
+                            "items": {
+                              "oneOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "kind": {
+                                      "type": "string",
+                                      "enum": ["departure"]
+                                    },
+                                    "required": {
+                                      "type": "boolean",
+                                      "enum": [true]
+                                    }
+                                  },
+                                  "required": ["kind", "required"]
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "kind": {
+                                      "type": "string",
+                                      "enum": ["product-option"]
+                                    },
+                                    "options": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "id": {
+                                            "type": "string"
+                                          },
+                                          "code": {
+                                            "type": ["string", "null"]
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "description": {
+                                            "type": ["string", "null"]
+                                          },
+                                          "isDefault": {
+                                            "type": "boolean"
+                                          },
+                                          "units": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "id": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "description": {
+                                                  "type": ["string", "null"]
+                                                },
+                                                "unitType": {
+                                                  "type": ["string", "null"]
+                                                },
+                                                "minQuantity": {
+                                                  "type": ["integer", "null"],
+                                                  "minimum": 0
+                                                },
+                                                "maxQuantity": {
+                                                  "type": ["integer", "null"],
+                                                  "minimum": 0
+                                                }
+                                              },
+                                              "required": ["id", "name"]
+                                            }
+                                          }
+                                        },
+                                        "required": ["id", "name"]
+                                      }
+                                    }
+                                  },
+                                  "required": ["kind", "options"]
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "kind": {
+                                      "type": "string",
+                                      "enum": ["option-units"]
+                                    }
+                                  },
+                                  "required": ["kind"]
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "kind": {
+                                      "type": "string",
+                                      "enum": ["cabin-category"]
+                                    },
+                                    "categories": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "id": {
+                                            "type": "string"
+                                          },
+                                          "code": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          },
+                                          "capacityMin": {
+                                            "type": "integer",
+                                            "minimum": 0
+                                          },
+                                          "capacityMax": {
+                                            "type": "integer",
+                                            "minimum": 0
+                                          },
+                                          "description": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": ["id", "name"]
+                                      }
+                                    }
+                                  },
+                                  "required": ["kind", "categories"]
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "kind": {
+                                      "type": "string",
+                                      "enum": ["cabin-number"]
+                                    },
+                                    "perCategory": {
+                                      "type": "object",
+                                      "additionalProperties": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "id": {
+                                              "type": "string"
+                                            },
+                                            "code": {
+                                              "type": "string"
+                                            },
+                                            "label": {
+                                              "type": "string"
+                                            },
+                                            "capacity": {
+                                              "type": "integer",
+                                              "minimum": 0
+                                            },
+                                            "hasAccessibilityFeatures": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": ["id", "label"]
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "required": ["kind", "perCategory"]
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "kind": {
+                                      "type": "string",
+                                      "enum": ["date-range"]
+                                    },
+                                    "minNights": {
+                                      "type": "integer",
+                                      "exclusiveMinimum": 0
+                                    },
+                                    "maxNights": {
+                                      "type": "integer",
+                                      "exclusiveMinimum": 0
+                                    }
+                                  },
+                                  "required": ["kind", "minNights", "maxNights"]
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "kind": {
+                                      "type": "string",
+                                      "enum": ["occupancy"]
+                                    },
+                                    "bands": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "code": {
+                                            "type": "string"
+                                          },
+                                          "label": {
+                                            "type": "string"
+                                          },
+                                          "minAge": {
+                                            "type": "integer",
+                                            "minimum": 0
+                                          },
+                                          "maxAge": {
+                                            "type": "integer",
+                                            "minimum": 0
+                                          },
+                                          "minCount": {
+                                            "type": "integer",
+                                            "minimum": 0
+                                          },
+                                          "maxCount": {
+                                            "type": "integer",
+                                            "minimum": 0
+                                          }
+                                        },
+                                        "required": ["code", "label", "minCount", "maxCount"]
+                                      }
+                                    }
+                                  },
+                                  "required": ["kind", "bands"]
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "kind": {
+                                      "type": "string",
+                                      "enum": ["air-arrangement"]
+                                    },
+                                    "required": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": ["kind"]
+                                }
+                              ]
+                            }
+                          },
+                          "paxBands": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "code": {
+                                  "type": "string"
+                                },
+                                "label": {
+                                  "type": "string"
+                                },
+                                "minAge": {
+                                  "type": "integer",
+                                  "minimum": 0
+                                },
+                                "maxAge": {
+                                  "type": "integer",
+                                  "minimum": 0
+                                },
+                                "minCount": {
+                                  "type": "integer",
+                                  "minimum": 0
+                                },
+                                "maxCount": {
+                                  "type": "integer",
+                                  "minimum": 0
+                                }
+                              },
+                              "required": ["code", "label", "minCount", "maxCount"]
+                            }
+                          },
+                          "paxBandsAllowedTotal": {
+                            "type": "object",
+                            "properties": {
+                              "min": {
+                                "type": "integer"
+                              },
+                              "max": {
+                                "type": "integer"
+                              }
+                            },
+                            "required": ["min", "max"]
+                          },
+                          "paxBandDependencies": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "dependentCode": {
+                                  "type": "string"
+                                },
+                                "masterCode": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "requires",
+                                    "limits_per_master",
+                                    "limits_sum",
+                                    "excludes"
+                                  ]
+                                },
+                                "maxPerMaster": {
+                                  "type": "integer",
+                                  "minimum": 0
+                                },
+                                "maxDependentSum": {
+                                  "type": "integer",
+                                  "minimum": 0
+                                }
+                              },
+                              "required": ["dependentCode", "masterCode", "type"]
+                            }
+                          },
+                          "travelerFields": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "label": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                },
+                                "required": {
+                                  "type": "boolean"
+                                },
+                                "options": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "value": {
+                                        "type": "string"
+                                      },
+                                      "label": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": ["value", "label"]
+                                  }
+                                },
+                                "appliesToBands": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "required": ["key", "label", "type", "required"]
+                            }
+                          },
+                          "bookingFields": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "label": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                },
+                                "required": {
+                                  "type": "boolean"
+                                },
+                                "group": {
+                                  "type": "string",
+                                  "enum": ["billing", "company", "preferences"]
+                                }
+                              },
+                              "required": ["key", "label", "type", "required", "group"]
+                            }
+                          },
+                          "accommodation": {
+                            "type": "object",
+                            "properties": {
+                              "roomOptions": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "description": {
+                                      "type": ["string", "null"]
+                                    },
+                                    "capacity": {
+                                      "type": ["integer", "null"],
+                                      "minimum": 0
+                                    },
+                                    "baseRateHint": {
+                                      "type": ["number", "null"]
+                                    },
+                                    "ratePlans": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "id": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "description": {
+                                            "type": ["string", "null"]
+                                          },
+                                          "chargeFrequency": {
+                                            "type": "string",
+                                            "enum": ["per_night", "per_stay"]
+                                          },
+                                          "cancellationPolicy": {
+                                            "type": ["string", "null"]
+                                          },
+                                          "inclusions": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "currency": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": ["id", "name"]
+                                      }
+                                    }
+                                  },
+                                  "required": ["id", "name"]
+                                }
+                              },
+                              "sharedRoomAllowed": {
+                                "type": "boolean"
+                              },
+                              "subSteps": {
+                                "type": "array",
+                                "items": {
+                                  "oneOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["rooms"]
+                                        },
+                                        "options": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "id": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "description": {
+                                                "type": ["string", "null"]
+                                              },
+                                              "capacity": {
+                                                "type": ["integer", "null"],
+                                                "minimum": 0
+                                              },
+                                              "baseRateHint": {
+                                                "type": ["number", "null"]
+                                              },
+                                              "ratePlans": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "id": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "description": {
+                                                      "type": ["string", "null"]
+                                                    },
+                                                    "chargeFrequency": {
+                                                      "type": "string",
+                                                      "enum": ["per_night", "per_stay"]
+                                                    },
+                                                    "cancellationPolicy": {
+                                                      "type": ["string", "null"]
+                                                    },
+                                                    "inclusions": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "currency": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": ["id", "name"]
+                                                }
+                                              }
+                                            },
+                                            "required": ["id", "name"]
+                                          }
+                                        },
+                                        "sharedRoomAllowed": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": ["kind", "options", "sharedRoomAllowed"]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": ["extensions"]
+                                        },
+                                        "options": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "id": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "city": {
+                                                "type": ["string", "null"]
+                                              },
+                                              "side": {
+                                                "type": "string",
+                                                "enum": ["pre", "post"]
+                                              },
+                                              "nights": {
+                                                "type": ["integer", "null"],
+                                                "minimum": 0
+                                              },
+                                              "pricePerPersonHint": {
+                                                "type": ["number", "null"]
+                                              }
+                                            },
+                                            "required": ["id", "name", "side"]
+                                          }
+                                        },
+                                        "allowsPre": {
+                                          "type": "boolean"
+                                        },
+                                        "allowsPost": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": ["kind", "options", "allowsPre", "allowsPost"]
+                                    }
+                                  ]
+                                }
+                              }
+                            },
+                            "required": ["sharedRoomAllowed"]
+                          },
+                          "addons": {
+                            "type": "object",
+                            "properties": {
+                              "catalog": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "description": {
+                                      "type": ["string", "null"]
+                                    },
+                                    "kind": {
+                                      "type": "string",
+                                      "enum": ["extras", "excursions", "insurance"]
+                                    },
+                                    "groupKey": {
+                                      "type": ["string", "null"]
+                                    },
+                                    "pricingMode": {
+                                      "type": ["string", "null"]
+                                    },
+                                    "unitAmountCents": {
+                                      "type": ["integer", "null"]
+                                    },
+                                    "currency": {
+                                      "type": ["string", "null"]
+                                    },
+                                    "pricedPerPerson": {
+                                      "type": ["boolean", "null"]
+                                    },
+                                    "selectionType": {
+                                      "type": ["string", "null"],
+                                      "enum": [
+                                        "optional",
+                                        "required",
+                                        "default_selected",
+                                        "unavailable",
+                                        null
+                                      ]
+                                    },
+                                    "minQuantity": {
+                                      "type": ["integer", "null"],
+                                      "minimum": 0
+                                    },
+                                    "maxQuantity": {
+                                      "type": ["integer", "null"],
+                                      "minimum": 0
+                                    },
+                                    "defaultQuantity": {
+                                      "type": ["integer", "null"],
+                                      "minimum": 0
+                                    }
+                                  },
+                                  "required": ["id", "name", "kind"]
+                                }
+                              },
+                              "groups": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "kind": {
+                                      "type": "string",
+                                      "enum": ["extras", "excursions", "insurance"]
+                                    },
+                                    "label": {
+                                      "type": "string"
+                                    },
+                                    "groupBy": {
+                                      "type": "string",
+                                      "enum": ["port", "day"]
+                                    },
+                                    "perGuestSelection": {
+                                      "type": "boolean"
+                                    },
+                                    "items": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "id": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "description": {
+                                            "type": ["string", "null"]
+                                          },
+                                          "kind": {
+                                            "type": "string",
+                                            "enum": ["extras", "excursions", "insurance"]
+                                          },
+                                          "groupKey": {
+                                            "type": ["string", "null"]
+                                          },
+                                          "pricingMode": {
+                                            "type": ["string", "null"]
+                                          },
+                                          "unitAmountCents": {
+                                            "type": ["integer", "null"]
+                                          },
+                                          "currency": {
+                                            "type": ["string", "null"]
+                                          },
+                                          "pricedPerPerson": {
+                                            "type": ["boolean", "null"]
+                                          },
+                                          "selectionType": {
+                                            "type": ["string", "null"],
+                                            "enum": [
+                                              "optional",
+                                              "required",
+                                              "default_selected",
+                                              "unavailable",
+                                              null
+                                            ]
+                                          },
+                                          "minQuantity": {
+                                            "type": ["integer", "null"],
+                                            "minimum": 0
+                                          },
+                                          "maxQuantity": {
+                                            "type": ["integer", "null"],
+                                            "minimum": 0
+                                          },
+                                          "defaultQuantity": {
+                                            "type": ["integer", "null"],
+                                            "minimum": 0
+                                          }
+                                        },
+                                        "required": ["id", "name", "kind"]
+                                      }
+                                    }
+                                  },
+                                  "required": ["kind", "label", "perGuestSelection", "items"]
+                                }
+                              }
+                            }
+                          },
+                          "paymentIntents": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "enum": [
+                                "hold",
+                                "card",
+                                "bank_transfer",
+                                "ticket_on_credit",
+                                "inquiry"
+                              ]
+                            }
+                          }
+                        },
+                        "required": [
+                          "showsConfigure",
+                          "showsBilling",
+                          "showsTravelers",
+                          "showsAccommodation",
+                          "showsAddons",
+                          "showsPayment",
+                          "showsReview",
+                          "paxBands",
+                          "paxBandsAllowedTotal",
+                          "travelerFields",
+                          "bookingFields",
+                          "paymentIntents"
+                        ]
+                      },
+                      "reason": {
+                        "type": "string",
+                        "enum": [
+                          "target_not_found",
+                          "target_not_bookable",
+                          "price_unavailable",
+                          "policy_unavailable",
+                          "selection_unavailable"
+                        ]
+                      },
+                      "nextAction": {
+                        "type": "string",
+                        "enum": [
+                          "select_alternative_inventory",
+                          "contact_operator",
+                          "update_selection"
+                        ]
+                      }
+                    },
+                    "required": ["kind", "reason", "nextAction"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": ["commit_rejected"]
+                      },
+                      "reason": {
+                        "type": "string",
+                        "enum": [
+                          "entity_not_found",
+                          "entity_not_bookable",
+                          "incomplete_draft",
+                          "price_changed"
+                        ]
+                      },
+                      "nextAction": {
+                        "type": "string",
+                        "enum": [
+                          "select_alternative_inventory",
+                          "update_selection",
+                          "request_fresh_quote"
+                        ]
+                      }
+                    },
+                    "required": ["kind", "reason", "nextAction"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": ["invalid_selection"]
+                      },
+                      "reason": {
+                        "type": "string",
+                        "enum": ["unsupported_target", "forbidden_field"]
+                      },
+                      "path": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "required": ["kind", "reason"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": ["renewal_not_allowed"]
+                      },
+                      "reason": {
+                        "type": "string",
+                        "enum": [
+                          "session_not_active",
+                          "extension_too_large",
+                          "absolute_lifetime_exceeded"
+                        ]
+                      }
+                    },
+                    "required": ["kind", "reason"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": ["quote_required"]
+                      },
+                      "nextAction": {
+                        "type": "string",
+                        "enum": ["request_fresh_quote"]
+                      }
+                    },
+                    "required": ["kind", "nextAction"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": ["quote_expired", "quote_superseded"]
+                      },
+                      "nextAction": {
+                        "type": "string",
+                        "enum": ["request_fresh_quote"]
+                      }
+                    },
+                    "required": ["kind", "nextAction"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": ["hold_required", "hold_expired", "availability_changed"]
+                      },
+                      "nextAction": {
+                        "type": "string",
+                        "enum": ["request_new_hold"]
+                      }
+                    },
+                    "required": ["kind", "nextAction"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": ["hold_quantity_mismatch"]
+                      },
+                      "requestedQuantity": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0
+                      },
+                      "expectedQuantity": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0
+                      },
+                      "nextAction": {
+                        "type": "string",
+                        "enum": ["request_new_hold"]
+                      }
+                    },
+                    "required": ["kind", "requestedQuantity", "expectedQuantity", "nextAction"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": ["commit_already_consumed"]
+                      },
+                      "nextAction": {
+                        "type": "string",
+                        "enum": ["return_idempotent_result"]
+                      }
+                    },
+                    "required": ["kind", "nextAction"]
+                  }
+                ]
+              }
+            },
+            "required": ["kind", "error"]
+          }
+        ]
+      },
       "SupplierOperationRecordV1": {
         "type": "object",
         "properties": {
@@ -11592,6 +13603,511 @@
           },
           "403": {
             "description": "Active storefront channel context is required for public booking sessions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/public/catalog/offers/preview": {
+      "post": {
+        "x-voyant-api-id": "@voyant-travel/catalog#booking-engine.api.public",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "target": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "enum": ["product"]
+                          },
+                          "productId": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "required": ["kind", "productId"],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "enum": ["catalog_item"]
+                          },
+                          "catalogItemId": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "required": ["kind", "catalogItemId"],
+                        "additionalProperties": false
+                      }
+                    ]
+                  },
+                  "scope": {
+                    "type": "object",
+                    "properties": {
+                      "locale": {
+                        "type": "string",
+                        "minLength": 2
+                      },
+                      "market": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "currency": {
+                        "type": "string",
+                        "minLength": 3,
+                        "maxLength": 3
+                      }
+                    },
+                    "required": ["locale", "market"]
+                  },
+                  "selection": {
+                    "type": "object",
+                    "properties": {
+                      "configure": {
+                        "type": "object",
+                        "properties": {
+                          "departureSlotId": {
+                            "type": "string"
+                          },
+                          "departureDate": {
+                            "type": "string"
+                          },
+                          "departureTime": {
+                            "type": "string"
+                          },
+                          "pax": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "integer",
+                              "minimum": 0
+                            },
+                            "default": {}
+                          },
+                          "variantId": {
+                            "type": "string"
+                          },
+                          "optionSelections": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "optionId": {
+                                  "type": "string"
+                                },
+                                "optionName": {
+                                  "type": "string"
+                                },
+                                "optionUnitId": {
+                                  "type": "string"
+                                },
+                                "optionUnitName": {
+                                  "type": "string"
+                                },
+                                "quantity": {
+                                  "type": "integer",
+                                  "minimum": 0
+                                }
+                              },
+                              "required": ["optionId", "quantity"]
+                            }
+                          },
+                          "cabinCategoryId": {
+                            "type": "string"
+                          },
+                          "cabinNumberId": {
+                            "type": "string"
+                          },
+                          "roomTypeId": {
+                            "type": "string"
+                          },
+                          "ratePlanId": {
+                            "type": "string"
+                          },
+                          "board": {
+                            "type": "string"
+                          },
+                          "dateRange": {
+                            "type": "object",
+                            "properties": {
+                              "checkIn": {
+                                "type": "string"
+                              },
+                              "checkOut": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["checkIn", "checkOut"]
+                          },
+                          "airArrangement": {
+                            "type": "string",
+                            "enum": ["cruise_line", "independent", "none"]
+                          }
+                        },
+                        "default": {
+                          "pax": {}
+                        }
+                      },
+                      "billing": {
+                        "type": "object",
+                        "properties": {
+                          "buyerType": {
+                            "type": "string",
+                            "enum": ["B2C", "B2B"],
+                            "default": "B2C"
+                          },
+                          "organizationId": {
+                            "type": "string"
+                          },
+                          "contact": {
+                            "type": "object",
+                            "properties": {
+                              "firstName": {
+                                "type": "string",
+                                "default": ""
+                              },
+                              "lastName": {
+                                "type": "string",
+                                "default": ""
+                              },
+                              "email": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                    "enum": [""]
+                                  },
+                                  {
+                                    "type": "string",
+                                    "format": "email"
+                                  }
+                                ],
+                                "default": ""
+                              },
+                              "phone": {
+                                "type": "string"
+                              },
+                              "personId": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "address": {
+                            "type": "object",
+                            "properties": {
+                              "line1": {
+                                "type": "string"
+                              },
+                              "line2": {
+                                "type": "string"
+                              },
+                              "city": {
+                                "type": "string"
+                              },
+                              "postal": {
+                                "type": "string"
+                              },
+                              "country": {
+                                "type": "string"
+                              }
+                            },
+                            "default": {}
+                          },
+                          "company": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "vatId": {
+                                "type": "string"
+                              },
+                              "registrationNumber": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["name"]
+                          },
+                          "saveAsDefault": {
+                            "type": "boolean"
+                          }
+                        },
+                        "default": {
+                          "buyerType": "B2C",
+                          "contact": {
+                            "firstName": "",
+                            "lastName": "",
+                            "email": ""
+                          },
+                          "address": {}
+                        },
+                        "required": ["contact"]
+                      },
+                      "travelers": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "rowId": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "firstName": {
+                              "type": "string",
+                              "minLength": 1,
+                              "maxLength": 255
+                            },
+                            "lastName": {
+                              "type": "string",
+                              "minLength": 1,
+                              "maxLength": 255
+                            },
+                            "email": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "enum": [""]
+                                },
+                                {
+                                  "type": "string",
+                                  "format": "email"
+                                }
+                              ]
+                            },
+                            "phone": {
+                              "type": "string",
+                              "maxLength": 50
+                            },
+                            "personId": {
+                              "type": "string"
+                            },
+                            "band": {
+                              "type": "string",
+                              "minLength": 1,
+                              "maxLength": 128,
+                              "default": "adult"
+                            },
+                            "dateOfBirth": {
+                              "type": "string"
+                            },
+                            "documents": {
+                              "type": "object",
+                              "additionalProperties": {}
+                            },
+                            "preferredLanguage": {
+                              "type": "string",
+                              "maxLength": 35
+                            },
+                            "specialRequests": {
+                              "type": "string"
+                            },
+                            "isPrimary": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": ["firstName", "lastName"]
+                        },
+                        "default": []
+                      },
+                      "accommodation": {
+                        "type": "object",
+                        "properties": {
+                          "rooms": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "optionUnitId": {
+                                  "type": "string"
+                                },
+                                "quantity": {
+                                  "type": "integer",
+                                  "minimum": 1
+                                },
+                                "ratePlanId": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": ["optionUnitId", "quantity"]
+                            }
+                          },
+                          "travelerAssignments": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "default": {}
+                          },
+                          "sharedRoom": {
+                            "type": "object",
+                            "properties": {
+                              "mode": {
+                                "type": "string",
+                                "enum": ["create", "join"]
+                              },
+                              "groupId": {
+                                "type": "string"
+                              },
+                              "label": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["mode"]
+                          }
+                        },
+                        "required": ["rooms"]
+                      },
+                      "addons": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "extraId": {
+                              "type": "string"
+                            },
+                            "quantity": {
+                              "type": "integer",
+                              "minimum": 1
+                            }
+                          },
+                          "required": ["extraId", "quantity"]
+                        },
+                        "default": []
+                      },
+                      "payment": {
+                        "type": "object",
+                        "properties": {
+                          "intent": {
+                            "type": "string",
+                            "enum": [
+                              "hold",
+                              "card",
+                              "bank_transfer",
+                              "ticket_on_credit",
+                              "inquiry"
+                            ],
+                            "default": "hold"
+                          },
+                          "schedule": {}
+                        },
+                        "default": {
+                          "intent": "hold"
+                        }
+                      },
+                      "paymentSchedules": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "scheduleType": {
+                              "type": "string",
+                              "enum": ["deposit", "installment", "balance", "hold", "other"]
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": ["pending", "due", "paid", "waived", "cancelled", "expired"]
+                            },
+                            "dueDate": {
+                              "type": "string"
+                            },
+                            "currency": {
+                              "type": "string",
+                              "minLength": 3,
+                              "maxLength": 3
+                            },
+                            "amountCents": {
+                              "type": "integer",
+                              "minimum": 0
+                            },
+                            "notes": {
+                              "type": ["string", "null"]
+                            }
+                          },
+                          "required": [
+                            "scheduleType",
+                            "status",
+                            "dueDate",
+                            "currency",
+                            "amountCents"
+                          ]
+                        }
+                      },
+                      "promotionCode": {
+                        "type": "string"
+                      },
+                      "customerNotes": {
+                        "type": "string"
+                      },
+                      "quoteId": {
+                        "type": "string"
+                      },
+                      "quoteExpiresAt": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "required": ["target", "scope"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Non-binding Offer Preview — no identifier, nothing persisted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OfferPreviewOutcomeV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Active storefront channel context is required for public offer previews",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/catalog/src/booking-engine/errors.ts
+++ b/packages/catalog/src/booking-engine/errors.ts
@@ -37,6 +37,24 @@ export type BookingEngineErrorCode =
   | typeof ORDER_NOT_FOUND
   | typeof ORDER_ALREADY_CANCELLED
 
+/**
+ * A selection payload the Booking Session plane refuses to derive from —
+ * either the target does not take a selection at all, or the payload carried a
+ * key only the engine or an operator may write.
+ *
+ * Lives here rather than beside the Session service because both the Session
+ * lifecycle and the stateless Offer Preview raise and recognise it, and a
+ * shared error class must not make those two modules import each other.
+ */
+export class InvalidBookingSessionSelectionError extends Error {
+  constructor(
+    readonly reason: "unsupported_target" | "forbidden_field",
+    readonly path?: string,
+  ) {
+    super(`booking_session_selection_${reason}${path ? `:${path}` : ""}`)
+  }
+}
+
 export class BookingEngineError extends Error {
   constructor(
     public readonly code: BookingEngineErrorCode,

--- a/packages/catalog/src/booking-engine/offer-preview.test.ts
+++ b/packages/catalog/src/booking-engine/offer-preview.test.ts
@@ -1,0 +1,346 @@
+import type { OfferPreviewRequestV1 } from "@voyant-travel/catalog-contracts/booking-engine/preview-contracts"
+import { bookingSessionAudienceForActorV1 } from "@voyant-travel/catalog-contracts/booking-engine/session-contracts"
+import { Hono } from "hono"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  createInMemoryBookingSessionRepository,
+  createInMemoryOwnedInventoryPorts,
+  inMemoryBookingRequirements,
+} from "./sessions-memory.js"
+import { createBookingSessionRoutes } from "./sessions-routes.js"
+import {
+  type BookingSessionModulePorts,
+  createBookingSessionModule,
+  InvalidBookingSessionSelectionError,
+} from "./sessions-service.js"
+
+const ACTIVE_STOREFRONT = {
+  storefrontId: "sf_public",
+  channelId: "chan_public",
+  channelStatus: "active",
+} as const
+
+const PRICING = {
+  currency: "EUR",
+  lines: [],
+  taxes: [],
+  subtotal: 10000,
+  taxTotal: 0,
+  total: 10000,
+} as const
+
+const REQUEST: OfferPreviewRequestV1 = {
+  target: { kind: "product", productId: "prod_owned_1" },
+  scope: { locale: "ro", market: "mkt_ro", currency: "RON" },
+  selection: { configure: { pax: { adult: 2 } } },
+}
+
+function createHarness(
+  overrides: Partial<Pick<BookingSessionModulePorts, "composeQuote" | "composeRequirements">> = {},
+) {
+  const repository = createInMemoryBookingSessionRepository()
+  const inventory = createInMemoryOwnedInventoryPorts()
+  inventory.setCapacity("product:prod_owned_1", 2)
+  const composeQuote = vi.fn<BookingSessionModulePorts["composeQuote"]>(async () => ({
+    status: "quoted" as const,
+    requirements: inMemoryBookingRequirements(),
+    pricing: { ...PRICING, lines: [], taxes: [] },
+  }))
+  const composeRequirements = vi.fn<BookingSessionModulePorts["composeRequirements"]>(
+    inventory.composeRequirements,
+  )
+  const module = createBookingSessionModule({
+    now: () => new Date("2026-08-01T12:00:00.000Z"),
+    ports: {
+      repository,
+      normalizeSelection: async ({ selection }) => selection,
+      composeRequirements: overrides.composeRequirements ?? composeRequirements,
+      composeQuote: overrides.composeQuote ?? composeQuote,
+      placeCapacityHold: inventory.placeCapacityHold,
+      releaseCapacityHold: inventory.releaseCapacityHold,
+      commitOwnedBooking: inventory.commitOwnedBooking,
+    },
+  })
+  return { composeQuote, composeRequirements, module, repository }
+}
+
+function createApp(harness: ReturnType<typeof createHarness>) {
+  const app = new Hono()
+  app.use("/v1/public/catalog/*", async (c, next) => {
+    c.set("storefrontChannel" as never, ACTIVE_STOREFRONT as never)
+    await next()
+  })
+  app.route(
+    "/v1/public/catalog",
+    createBookingSessionRoutes({ actorKind: "anonymous", resolveModule: () => harness.module }),
+  )
+  app.route(
+    "/v1/admin/catalog",
+    createBookingSessionRoutes({
+      actorKind: "staff",
+      resolveModule: () => harness.module,
+      resolveAccess: () => ({
+        actorKind: "staff",
+        principalId: "staff_1",
+        staffAuthority: { admitted: true, reason: "booking_support_case" },
+      }),
+    }),
+  )
+  return app
+}
+
+function repositoryRowCount(repository: ReturnType<typeof createInMemoryBookingSessionRepository>) {
+  return (
+    repository.sessions.size +
+    repository.quotes.size +
+    repository.holds.size +
+    repository.commits.size +
+    repository.operations.size +
+    repository.auditEvents.size
+  )
+}
+
+describe("Offer Preview", () => {
+  it("prices a target without opening a Booking Session", async () => {
+    const harness = createHarness()
+
+    const outcome = await harness.module.previewOffer(REQUEST, { actorKind: "anonymous" })
+
+    expect(outcome.kind).toBe("offer_preview")
+    if (outcome.kind !== "offer_preview") return
+    expect(outcome.preview.binding).toBe(false)
+    expect(outcome.preview.available).toBe(true)
+    expect(outcome.preview.pricing?.total).toBe(10000)
+    expect(outcome.preview.requirements).toBeDefined()
+  })
+
+  /**
+   * The load-bearing case: a sold-out or unpriced target still has to render a
+   * wizard, or the shopper cannot change the selection that made it
+   * unavailable.
+   */
+  it("returns requirements when pricing is unavailable", async () => {
+    const harness = createHarness({
+      composeQuote: async () => ({
+        status: "unavailable",
+        requirements: inMemoryBookingRequirements(),
+        reason: "selection_unavailable",
+        nextAction: "update_selection",
+      }),
+    })
+
+    const outcome = await harness.module.previewOffer(REQUEST, { actorKind: "anonymous" })
+
+    expect(outcome.kind).toBe("offer_preview")
+    if (outcome.kind !== "offer_preview") return
+    expect(outcome.preview.available).toBe(false)
+    expect(outcome.preview.pricing).toBeUndefined()
+    expect(outcome.preview.unavailableReason).toBe("selection_unavailable")
+    expect(outcome.preview.requirements.paxBands.length).toBeGreaterThan(0)
+  })
+
+  it("falls back to the requirements derivation when the quote dropped the descriptor", async () => {
+    const harness = createHarness({
+      composeQuote: async () => ({
+        status: "unavailable",
+        reason: "price_unavailable",
+        nextAction: "contact_operator",
+      }),
+    })
+
+    const outcome = await harness.module.previewOffer(REQUEST, { actorKind: "anonymous" })
+
+    expect(outcome.kind).toBe("offer_preview")
+    if (outcome.kind !== "offer_preview") return
+    expect(outcome.preview.requirements.paxBands.length).toBeGreaterThan(0)
+    expect(outcome.preview.unavailableReason).toBe("price_unavailable")
+  })
+
+  it("rejects only when the target itself does not resolve", async () => {
+    const harness = createHarness({
+      composeQuote: async () => ({
+        status: "unavailable",
+        reason: "target_not_found",
+        nextAction: "select_alternative_inventory",
+      }),
+      composeRequirements: async () => ({
+        status: "unavailable",
+        reason: "target_not_found",
+        nextAction: "select_alternative_inventory",
+      }),
+    })
+
+    const outcome = await harness.module.previewOffer(REQUEST, { actorKind: "anonymous" })
+
+    expect(outcome).toEqual({
+      kind: "rejected",
+      error: {
+        kind: "quote_unavailable",
+        reason: "target_not_found",
+        nextAction: "select_alternative_inventory",
+      },
+    })
+  })
+
+  /** Invariant 1 + 4 (voyant#4188), asserted on a real response. */
+  it("mints no identifier a caller could present as authority", async () => {
+    const harness = createHarness()
+
+    const outcome = await harness.module.previewOffer(REQUEST, { actorKind: "anonymous" })
+
+    if (outcome.kind !== "offer_preview") throw new Error("expected a preview")
+    for (const key of ["id", "quoteId", "sessionId", "holdId", "token"]) {
+      expect(outcome.preview).not.toHaveProperty(key)
+    }
+    expect(JSON.stringify(outcome.preview)).not.toMatch(/"(id|quoteId|sessionId|token)"/)
+  })
+
+  /** Invariant 2 (voyant#4188). */
+  it("persists nothing — no Session, Quote, Hold, operation or audit row", async () => {
+    const harness = createHarness()
+    expect(repositoryRowCount(harness.repository)).toBe(0)
+
+    for (let index = 0; index < 25; index += 1) {
+      await harness.module.previewOffer(REQUEST, { actorKind: "anonymous" })
+    }
+
+    expect(repositoryRowCount(harness.repository)).toBe(0)
+    expect(harness.repository.sessions.size).toBe(0)
+    expect(harness.repository.quotes.size).toBe(0)
+    expect(harness.repository.auditEvents.size).toBe(0)
+  })
+
+  it("is deterministic for the same target, scope and selection", async () => {
+    const harness = createHarness()
+
+    const first = await harness.module.previewOffer(REQUEST, { actorKind: "anonymous" })
+    const second = await harness.module.previewOffer(REQUEST, { actorKind: "anonymous" })
+
+    expect(first).toEqual(second)
+  })
+
+  describe("audience", () => {
+    it("derives customer audience for a public caller even when the body names staff", async () => {
+      const harness = createHarness()
+
+      await harness.module.previewOffer(
+        { ...REQUEST, scope: { ...REQUEST.scope, audience: "staff" } as never },
+        { actorKind: "anonymous" },
+      )
+
+      const session = harness.composeQuote.mock.calls[0]?.[0].session
+      expect(session?.actorKind).toBe("anonymous")
+      expect(bookingSessionAudienceForActorV1(session?.actorKind ?? "anonymous")).toBe("customer")
+      expect(session?.scope).not.toHaveProperty("audience")
+    })
+
+    it("keeps staff audience for a staff caller", async () => {
+      const harness = createHarness()
+
+      await harness.module.previewOffer(REQUEST, {
+        actorKind: "staff",
+        principalId: "staff_1",
+        staffAuthority: { admitted: true, reason: "booking_support_case" },
+      })
+
+      const session = harness.composeQuote.mock.calls[0]?.[0].session
+      expect(bookingSessionAudienceForActorV1(session?.actorKind ?? "anonymous")).toBe("staff")
+    })
+
+    it("refuses a named actor without a principal", async () => {
+      const harness = createHarness()
+
+      const outcome = await harness.module.previewOffer(REQUEST, { actorKind: "customer" })
+
+      expect(outcome).toEqual({ kind: "rejected", error: { kind: "not_authorized" } })
+      expect(harness.composeQuote).not.toHaveBeenCalled()
+    })
+  })
+
+  it("rejects a selection the Session plane would refuse", async () => {
+    const repository = createInMemoryBookingSessionRepository()
+    const inventory = createInMemoryOwnedInventoryPorts()
+    const module = createBookingSessionModule({
+      ports: {
+        repository,
+        normalizeSelection: async () => {
+          throw new InvalidBookingSessionSelectionError("forbidden_field", "selection.staffBooking")
+        },
+        composeRequirements: inventory.composeRequirements,
+        composeQuote: async () => ({
+          status: "quoted",
+          requirements: inMemoryBookingRequirements(),
+          pricing: { ...PRICING, lines: [], taxes: [] },
+        }),
+        placeCapacityHold: inventory.placeCapacityHold,
+        releaseCapacityHold: inventory.releaseCapacityHold,
+        commitOwnedBooking: inventory.commitOwnedBooking,
+      },
+    })
+
+    const outcome = await module.previewOffer(REQUEST, { actorKind: "anonymous" })
+
+    expect(outcome).toEqual({
+      kind: "rejected",
+      error: {
+        kind: "invalid_selection",
+        reason: "forbidden_field",
+        path: "selection.staffBooking",
+      },
+    })
+    expect(repositoryRowCount(repository)).toBe(0)
+  })
+})
+
+describe("POST /offers/preview", () => {
+  it("is mounted on the public surface behind the storefront-channel gate", async () => {
+    const harness = createHarness()
+    const app = createApp(harness)
+
+    const res = await app.request("/v1/public/catalog/offers/preview", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(REQUEST),
+    })
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { kind: string; preview: Record<string, unknown> }
+    expect(body.kind).toBe("offer_preview")
+    expect(body.preview.binding).toBe(false)
+    expect(body.preview).not.toHaveProperty("quoteId")
+    expect(repositoryRowCount(harness.repository)).toBe(0)
+  })
+
+  it("is refused without an active storefront channel", async () => {
+    const harness = createHarness()
+    const app = new Hono()
+    app.route(
+      "/v1/public/catalog",
+      createBookingSessionRoutes({ actorKind: "anonymous", resolveModule: () => harness.module }),
+    )
+
+    const res = await app.request("/v1/public/catalog/offers/preview", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(REQUEST),
+    })
+
+    expect(res.status).toBe(403)
+  })
+
+  it("is mounted on the admin surface too", async () => {
+    const harness = createHarness()
+    const app = createApp(harness)
+
+    const res = await app.request("/v1/admin/catalog/offers/preview", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(REQUEST),
+    })
+
+    expect(res.status).toBe(200)
+    const session = harness.composeQuote.mock.calls[0]?.[0].session
+    expect(session?.actorKind).toBe("staff")
+  })
+})

--- a/packages/catalog/src/booking-engine/offer-preview.ts
+++ b/packages/catalog/src/booking-engine/offer-preview.ts
@@ -19,11 +19,11 @@
  */
 
 import type {
-  BookingQuoteUnavailableReasonV1,
   OfferPreviewOutcomeV1,
   OfferPreviewRequestV1,
   OfferPreviewResultV1,
 } from "@voyant-travel/catalog-contracts/booking-engine/preview-contracts"
+import type { BookingQuoteUnavailableReasonV1 } from "@voyant-travel/catalog-contracts/booking-engine/session-contracts"
 
 import type { BookingRequirementsV1 } from "./contracts.js"
 import { InvalidBookingSessionSelectionError } from "./errors.js"

--- a/packages/catalog/src/booking-engine/offer-preview.ts
+++ b/packages/catalog/src/booking-engine/offer-preview.ts
@@ -1,0 +1,210 @@
+/**
+ * Offer Preview — the stateless read behind a storefront detail page.
+ *
+ * A shopper moving a pax stepper is not yet an attempt to book, so this path
+ * must not open a Booking Session: Sessions are persisted, revisioned,
+ * capability-bearing, expiring rows that a sweep has to reap, and one per
+ * keystroke floods `booking_sessions`.
+ *
+ * The preview therefore builds an ephemeral, in-memory session-shaped value,
+ * hands it to the SAME `composeRequirements` / `composeQuote` ports the
+ * Session lifecycle uses, and throws it away. It never touches the repository
+ * — there is deliberately no `BookingSessionRepository` in
+ * {@link OfferPreviewPorts}, so "persists nothing" is a property of the
+ * function's dependencies rather than a rule someone has to remember.
+ *
+ * Reusing the Session's ports is the point: a third derivation path is exactly
+ * how the price a detail page shows would come to disagree with the price the
+ * wizard quotes.
+ */
+
+import type {
+  BookingQuoteUnavailableReasonV1,
+  OfferPreviewOutcomeV1,
+  OfferPreviewRequestV1,
+  OfferPreviewResultV1,
+} from "@voyant-travel/catalog-contracts/booking-engine/preview-contracts"
+
+import type { BookingRequirementsV1 } from "./contracts.js"
+import { InvalidBookingSessionSelectionError } from "./errors.js"
+import type {
+  BookingSessionAccessContext,
+  BookingSessionInternalRecord,
+  BookingSessionModulePorts,
+} from "./sessions-service.js"
+
+/**
+ * Exactly the ports a preview may reach, and no more.
+ *
+ * Notably absent: `repository`. A preview cannot write a Session, a Quote, a
+ * Hold, an operation claim or an audit row because it is not given anything
+ * that could.
+ */
+export type OfferPreviewPorts = Pick<
+  BookingSessionModulePorts,
+  "normalizeSelection" | "composeRequirements" | "composeQuote"
+>
+
+/**
+ * The id on the ephemeral record.
+ *
+ * A constant rather than `newId(...)`: minting a typeid — even one that is
+ * discarded — would make this operation an identifier factory, and the whole
+ * point of a preview is that there is no identifier for a caller to present
+ * later as authority. Nothing downstream reads it; `composeRequirements` and
+ * `composeQuote` derive from the target, the selection, the scope and the
+ * actor kind only.
+ */
+const EPHEMERAL_PREVIEW_SESSION_ID = "offer-preview"
+
+/**
+ * Read what a target would cost and what booking it would require, without
+ * opening a Booking Session.
+ *
+ * `at` is passed in rather than read from the clock so a preview is
+ * deterministic for a given `(target, scope, selection)` and therefore
+ * cacheable.
+ */
+export async function previewOffer(
+  ports: OfferPreviewPorts,
+  input: OfferPreviewRequestV1,
+  access: BookingSessionAccessContext,
+  at: Date,
+): Promise<OfferPreviewOutcomeV1> {
+  if (access.actorKind !== "anonymous" && !access.principalId?.trim()) {
+    return { kind: "rejected", error: { kind: "not_authorized" } }
+  }
+
+  let statePayload: Record<string, unknown>
+  try {
+    // The same normalization the Session create path runs, so a public caller
+    // cannot smuggle a staff-only or engine-owned selection key into the
+    // derivation and price against it.
+    statePayload = await ports.normalizeSelection({
+      target: input.target,
+      selection: (input.selection ?? {}) as Record<string, unknown>,
+      access,
+      now: at,
+    })
+  } catch (error) {
+    if (error instanceof InvalidBookingSessionSelectionError) {
+      return {
+        kind: "rejected",
+        error: {
+          kind: "invalid_selection",
+          reason: error.reason,
+          ...(error.path ? { path: error.path } : {}),
+        },
+      }
+    }
+    throw error
+  }
+
+  const session = ephemeralPreviewSession(input, access, statePayload, at)
+
+  // No transaction: a preview has no Session row to lock, and both compose
+  // ports are read-only and accept a nullish `tx`.
+  const composed = await ports.composeQuote({ session, now: at, tx: undefined })
+  if (composed.status === "quoted") {
+    return {
+      kind: "offer_preview",
+      preview: previewResult(true, composed.requirements, { pricing: composed.pricing }),
+    }
+  }
+
+  // Unavailability must not collapse the wizard: a sold-out or unpriced target
+  // still has to render controls the shopper can change. `composeQuote` carries
+  // the descriptor through its unavailable exit whenever the target resolved;
+  // when it did not, ask the requirements derivation directly before giving up.
+  const requirements =
+    composed.requirements ?? (await deriveRequirements(ports, session, at)) ?? undefined
+  if (!requirements) {
+    return {
+      kind: "rejected",
+      error: {
+        kind: "quote_unavailable",
+        reason: composed.reason,
+        nextAction: composed.nextAction,
+      },
+    }
+  }
+  return {
+    kind: "offer_preview",
+    preview: previewResult(false, requirements, { unavailableReason: composed.reason }),
+  }
+}
+
+async function deriveRequirements(
+  ports: OfferPreviewPorts,
+  session: BookingSessionInternalRecord,
+  at: Date,
+): Promise<BookingRequirementsV1 | null> {
+  const resolved = await ports.composeRequirements({ session, now: at, tx: undefined })
+  return resolved.status === "available" ? resolved.requirements : null
+}
+
+/**
+ * Build the result.
+ *
+ * Written as one constructor so there is a single place the shape is decided,
+ * and so the "no identifier" invariant is visible: nothing here can attach an
+ * `id`, a `quoteId` or a token, because none is in scope.
+ */
+function previewResult(
+  available: boolean,
+  requirements: BookingRequirementsV1,
+  extra: {
+    pricing?: OfferPreviewResultV1["pricing"]
+    unavailableReason?: BookingQuoteUnavailableReasonV1
+  },
+): OfferPreviewResultV1 {
+  return {
+    binding: false,
+    available,
+    requirements,
+    ...(extra.pricing ? { pricing: extra.pricing } : {}),
+    ...(extra.unavailableReason ? { unavailableReason: extra.unavailableReason } : {}),
+  }
+}
+
+/**
+ * A session-shaped value that exists only for the duration of one call.
+ *
+ * `actorKind` is copied from the transport-resolved access context and never
+ * from the request body, because the compose ports derive the quoting audience
+ * from it (`bookingSessionAudienceForActorV1`). That is what stops a
+ * storefront visitor from previewing at staff or partner price tiers.
+ */
+function ephemeralPreviewSession(
+  input: OfferPreviewRequestV1,
+  access: BookingSessionAccessContext,
+  statePayload: Record<string, unknown>,
+  at: Date,
+): BookingSessionInternalRecord {
+  return {
+    id: EPHEMERAL_PREVIEW_SESSION_ID,
+    createIdempotencyKey: EPHEMERAL_PREVIEW_SESSION_ID,
+    createRequestFingerprint: EPHEMERAL_PREVIEW_SESSION_ID,
+    capabilityScopes: [],
+    target: input.target,
+    actorKind: access.actorKind,
+    ...(access.actorKind === "anonymous" ? {} : { ownerPrincipalId: access.principalId }),
+    ...(access.actorKind === "staff" || !access.storefront
+      ? {}
+      : { storefrontOrigin: access.storefront }),
+    // Rebuilt field by field rather than spread: the request schema already
+    // strips an `audience` the caller named, and reconstructing it here means
+    // a direct service caller cannot smuggle one in either.
+    scope: {
+      locale: input.scope.locale,
+      market: input.scope.market,
+      ...(input.scope.currency ? { currency: input.scope.currency } : {}),
+    },
+    state: "active",
+    revision: 1,
+    statePayload,
+    expiresAt: at,
+    createdAt: at,
+    updatedAt: at,
+  }
+}

--- a/packages/catalog/src/booking-engine/operator-routes.test.ts
+++ b/packages/catalog/src/booking-engine/operator-routes.test.ts
@@ -220,8 +220,8 @@ describe("mountCatalogBookingRoutes", () => {
 
     expect(descriptor.module).toEqual({ name: "catalog-booking" })
     expect(descriptor.publicPath).toBe("catalog")
-    expect(descriptor.anonymous).toEqual(["/booking-sessions"])
-    expect(descriptor.optionalCustomerAuth).toEqual(["/booking-sessions"])
+    expect(descriptor.anonymous).toEqual(["/booking-sessions", "/offers"])
+    expect(descriptor.optionalCustomerAuth).toEqual(["/booking-sessions", "/offers"])
     expect(descriptor.lazyRoutes?.paths).toBe(catalogBookingRoutePaths)
     expect(descriptor.transactionalPaths).toBe(catalogBookingTransactionalPaths)
 

--- a/packages/catalog/src/booking-engine/operator-routes.ts
+++ b/packages/catalog/src/booking-engine/operator-routes.ts
@@ -393,6 +393,7 @@ export const catalogBookingRoutePaths = [
   "/v1/admin/catalog/booking-sessions/:sessionId/hold",
   "/v1/admin/catalog/booking-sessions/:sessionId/abandon",
   "/v1/admin/catalog/booking-sessions/:sessionId/commit",
+  "/v1/admin/catalog/offers/preview",
   "/v1/admin/catalog/booking-sessions/maintenance/expire",
   "/v1/admin/catalog/booking-sessions/maintenance/purge",
   "/v1/admin/catalog/supplier-operations",
@@ -412,6 +413,7 @@ export const catalogBookingRoutePaths = [
   "/v1/public/catalog/booking-sessions/:sessionId/hold",
   "/v1/public/catalog/booking-sessions/:sessionId/abandon",
   "/v1/public/catalog/booking-sessions/:sessionId/commit",
+  "/v1/public/catalog/offers/preview",
   "/v1/public/catalog/slots",
 ] as const
 
@@ -514,8 +516,12 @@ export function createCatalogBookingEngineApiModule(
   return {
     module: { name: "catalog-booking" },
     publicPath: "catalog",
-    anonymous: ["/booking-sessions"],
-    optionalCustomerAuth: ["/booking-sessions"],
+    // `/offers/preview` is anonymous for the same reason `/booking-sessions`
+    // is: a shopper reads a price before they have any session at all. Its
+    // storefront-channel admission is enforced inside the route bundle, the
+    // same middleware the public Session routes sit behind.
+    anonymous: ["/booking-sessions", "/offers"],
+    optionalCustomerAuth: ["/booking-sessions", "/offers"],
     lazyRoutes: {
       paths: catalogBookingRoutePaths,
       load: async () => {

--- a/packages/catalog/src/booking-engine/sessions-production.ts
+++ b/packages/catalog/src/booking-engine/sessions-production.ts
@@ -201,8 +201,13 @@ function createProductionCompositeLeafRuntime(
   return {
     composeRequirements,
     async composeQuote({ session, now, tx }) {
+      // The stateless Offer Preview quotes without a Session row, so there is
+      // no open Session transaction to borrow. Quoting only reads, so falling
+      // back to the module's connection is safe — the same fallback
+      // `composeRequirements` already makes for Session creation.
+      const db = (tx as PostgresJsDatabase | undefined) ?? deps.db
       if (session.target.kind === "catalog_item") {
-        return composeSourcedQuote(deps, session, tx as PostgresJsDatabase)
+        return composeSourcedQuote(deps, session, db)
       }
       if (session.target.kind === "trip_snapshot") {
         return unavailableQuoteResult("unsupported_target")
@@ -217,7 +222,7 @@ function createProductionCompositeLeafRuntime(
         }
       }
       const result = await handler.computeQuote(
-        { db: tx as PostgresJsDatabase, adapterContext: {} as never },
+        { db, adapterContext: {} as never },
         ownedComputeRequest(handler.entityModule, session),
       )
       // The handler builds the descriptor unconditionally, precisely so a

--- a/packages/catalog/src/booking-engine/sessions-routes.ts
+++ b/packages/catalog/src/booking-engine/sessions-routes.ts
@@ -1,5 +1,9 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import {
+  offerPreviewOutcomeV1,
+  offerPreviewRequestV1,
+} from "@voyant-travel/catalog-contracts/booking-engine/preview-contracts"
+import {
   abandonBookingSessionV1,
   adoptBookingSessionV1,
   type BookingSessionActorKindV1,
@@ -48,6 +52,39 @@ const bookingSessionOutcomeOpenApiSchema = z
 const supplierOperationRecordOpenApiSchema = z
   .lazy(() => supplierOperationRecordV1)
   .openapi("SupplierOperationRecordV1")
+const offerPreviewOutcomeOpenApiSchema = z
+  .lazy(() => offerPreviewOutcomeV1)
+  .openapi("OfferPreviewOutcomeV1")
+
+/**
+ * The non-binding read a storefront detail page uses before any Booking
+ * Session exists. Deliberately not under `/booking-sessions`: it creates none,
+ * and nesting it there would invite a host to believe it had one.
+ */
+const previewOfferRoute = createRoute({
+  method: "post",
+  path: "/offers/preview",
+  request: {
+    body: {
+      required: true,
+      content: { "application/json": { schema: offerPreviewRequestV1 } },
+    },
+  },
+  responses: {
+    200: {
+      description: "Non-binding Offer Preview — no identifier, nothing persisted",
+      content: { "application/json": { schema: offerPreviewOutcomeOpenApiSchema } },
+    },
+    400: {
+      description: "Invalid request",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "Active storefront channel context is required for public offer previews",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
 
 const createSessionRoute = createRoute({
   method: "post",
@@ -499,6 +536,15 @@ export function createBookingSessionRoutes(options: BookingSessionRoutesOptions)
               c.req.valid("json"),
               resolveAccess(options, c),
             ),
+        ),
+      ),
+    )
+    .openapi(previewOfferRoute, async (c) =>
+      asRouteResponse(
+        c.json(
+          await options
+            .resolveModule(c)
+            .previewOffer(c.req.valid("json"), resolveAccess(options, c)),
         ),
       ),
     )

--- a/packages/catalog/src/booking-engine/sessions-service.ts
+++ b/packages/catalog/src/booking-engine/sessions-service.ts
@@ -1,4 +1,8 @@
 import type {
+  OfferPreviewOutcomeV1,
+  OfferPreviewRequestV1,
+} from "@voyant-travel/catalog-contracts/booking-engine/preview-contracts"
+import type {
   AbandonBookingSessionV1,
   AdoptBookingSessionV1,
   BookingHoldRecordV1,
@@ -27,6 +31,8 @@ import type {
   BookingRequirementsV1,
   PricingBreakdownV1,
 } from "./contracts.js"
+import { InvalidBookingSessionSelectionError } from "./errors.js"
+import { previewOffer } from "./offer-preview.js"
 
 const DEFAULT_SESSION_TTL_MS = 24 * 60 * 60 * 1000
 const DEFAULT_QUOTE_TTL_MS = 10 * 60 * 1000
@@ -458,6 +464,12 @@ export interface BookingSessionModulePorts {
    * is read-only either way.
    */
   composeRequirements(input: ComposeBookingQuoteInput): Promise<ComposeBookingRequirementsResult>
+  /**
+   * Price the target. Read-only, and — like `composeRequirements` — must
+   * accept a nullish `tx`: the stateless Offer Preview quotes an ephemeral
+   * session-shaped value that has no Session row and therefore no open Session
+   * transaction to borrow.
+   */
   composeQuote(input: ComposeBookingQuoteInput): Promise<ComposeBookingQuoteResult>
   placeCapacityHold(input: {
     session: BookingSessionInternalRecord
@@ -497,14 +509,13 @@ export interface BookingSessionModuleOptions {
   maxSessionLifetimeMs?: number
 }
 
-export class InvalidBookingSessionSelectionError extends Error {
-  constructor(
-    readonly reason: "unsupported_target" | "forbidden_field",
-    readonly path?: string,
-  ) {
-    super(`booking_session_selection_${reason}${path ? `:${path}` : ""}`)
-  }
-}
+/**
+ * Re-exported from `errors.js`, which is where it is now declared: the
+ * stateless Offer Preview has to recognise the same rejection, and importing
+ * it from here would put a runtime edge back from `offer-preview.ts` into this
+ * module, which imports `offer-preview.ts` in turn.
+ */
+export { InvalidBookingSessionSelectionError }
 
 export class BookingSessionCommitRejectedError extends Error {
   constructor(readonly reason: BookingSessionCommitRejectionReason) {
@@ -521,6 +532,16 @@ export interface BookingSessionModule {
     input: CreateBookingSessionV1,
     access: BookingSessionAccessContext,
   ): Promise<BookingSessionOutcomeV1>
+  /**
+   * Stateless, non-binding read of what a target would cost and what booking
+   * it would require. Mints no identifier and writes nothing — see
+   * `offer-preview.ts`. A storefront detail page uses this so that adjusting a
+   * pax stepper does not open a Session.
+   */
+  previewOffer(
+    input: OfferPreviewRequestV1,
+    access: BookingSessionAccessContext,
+  ): Promise<OfferPreviewOutcomeV1>
   resumeSession(
     sessionId: string,
     access: BookingSessionAccessContext,
@@ -722,6 +743,19 @@ export function createBookingSessionModule(
   return {
     createSession(input, access) {
       return createSessionRecord(input, access)
+    },
+
+    previewOffer(input, access) {
+      // Handed only the three derivation ports — no repository — so a preview
+      // is structurally incapable of writing a Session, Quote, Hold, operation
+      // claim or audit row.
+      const { normalizeSelection, composeRequirements, composeQuote } = options.ports
+      return previewOffer(
+        { normalizeSelection, composeRequirements, composeQuote },
+        input,
+        access,
+        now(),
+      )
     },
 
     createAcceptedProposalSession(input, access) {

--- a/packages/catalog/tsconfig.build.json
+++ b/packages/catalog/tsconfig.build.json
@@ -423,6 +423,9 @@
       "@voyant-travel/catalog-contracts/booking-engine/lifecycle-conformance": [
         "../catalog-contracts/dist/booking-engine/lifecycle-conformance.d.ts"
       ],
+      "@voyant-travel/catalog-contracts/booking-engine/preview-contracts": [
+        "../catalog-contracts/dist/booking-engine/preview-contracts.d.ts"
+      ],
       "@voyant-travel/catalog-contracts/booking-engine/pricing-contracts": [
         "../catalog-contracts/dist/booking-engine/pricing-contracts.d.ts"
       ],

--- a/packages/catalog/tsconfig.typecheck.json
+++ b/packages/catalog/tsconfig.typecheck.json
@@ -424,6 +424,9 @@
       "@voyant-travel/catalog-contracts/booking-engine/lifecycle-conformance": [
         "../catalog-contracts/dist/booking-engine/lifecycle-conformance.d.ts"
       ],
+      "@voyant-travel/catalog-contracts/booking-engine/preview-contracts": [
+        "../catalog-contracts/dist/booking-engine/preview-contracts.d.ts"
+      ],
       "@voyant-travel/catalog-contracts/booking-engine/pricing-contracts": [
         "../catalog-contracts/dist/booking-engine/pricing-contracts.d.ts"
       ],

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -431,6 +431,9 @@
       "@voyant-travel/catalog-contracts/booking-engine/lifecycle-conformance": [
         "../catalog-contracts/dist/booking-engine/lifecycle-conformance.d.ts"
       ],
+      "@voyant-travel/catalog-contracts/booking-engine/preview-contracts": [
+        "../catalog-contracts/dist/booking-engine/preview-contracts.d.ts"
+      ],
       "@voyant-travel/catalog-contracts/booking-engine/pricing-contracts": [
         "../catalog-contracts/dist/booking-engine/pricing-contracts.d.ts"
       ],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -425,6 +425,9 @@
       "@voyant-travel/catalog-contracts/booking-engine/lifecycle-conformance": [
         "../catalog-contracts/dist/booking-engine/lifecycle-conformance.d.ts"
       ],
+      "@voyant-travel/catalog-contracts/booking-engine/preview-contracts": [
+        "../catalog-contracts/dist/booking-engine/preview-contracts.d.ts"
+      ],
       "@voyant-travel/catalog-contracts/booking-engine/pricing-contracts": [
         "../catalog-contracts/dist/booking-engine/pricing-contracts.d.ts"
       ],

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -424,6 +424,9 @@
       "@voyant-travel/catalog-contracts/booking-engine/lifecycle-conformance": [
         "../catalog-contracts/dist/booking-engine/lifecycle-conformance.d.ts"
       ],
+      "@voyant-travel/catalog-contracts/booking-engine/preview-contracts": [
+        "../catalog-contracts/dist/booking-engine/preview-contracts.d.ts"
+      ],
       "@voyant-travel/catalog-contracts/booking-engine/pricing-contracts": [
         "../catalog-contracts/dist/booking-engine/pricing-contracts.d.ts"
       ],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -425,6 +425,9 @@
       "@voyant-travel/catalog-contracts/booking-engine/lifecycle-conformance": [
         "../catalog-contracts/dist/booking-engine/lifecycle-conformance.d.ts"
       ],
+      "@voyant-travel/catalog-contracts/booking-engine/preview-contracts": [
+        "../catalog-contracts/dist/booking-engine/preview-contracts.d.ts"
+      ],
       "@voyant-travel/catalog-contracts/booking-engine/pricing-contracts": [
         "../catalog-contracts/dist/booking-engine/pricing-contracts.d.ts"
       ],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -424,6 +424,9 @@
       "@voyant-travel/catalog-contracts/booking-engine/lifecycle-conformance": [
         "../catalog-contracts/dist/booking-engine/lifecycle-conformance.d.ts"
       ],
+      "@voyant-travel/catalog-contracts/booking-engine/preview-contracts": [
+        "../catalog-contracts/dist/booking-engine/preview-contracts.d.ts"
+      ],
       "@voyant-travel/catalog-contracts/booking-engine/pricing-contracts": [
         "../catalog-contracts/dist/booking-engine/pricing-contracts.d.ts"
       ],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -425,6 +425,9 @@
       "@voyant-travel/catalog-contracts/booking-engine/lifecycle-conformance": [
         "../catalog-contracts/dist/booking-engine/lifecycle-conformance.d.ts"
       ],
+      "@voyant-travel/catalog-contracts/booking-engine/preview-contracts": [
+        "../catalog-contracts/dist/booking-engine/preview-contracts.d.ts"
+      ],
       "@voyant-travel/catalog-contracts/booking-engine/pricing-contracts": [
         "../catalog-contracts/dist/booking-engine/pricing-contracts.d.ts"
       ],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -430,6 +430,9 @@
       "@voyant-travel/catalog-contracts/booking-engine/lifecycle-conformance": [
         "../catalog-contracts/dist/booking-engine/lifecycle-conformance.d.ts"
       ],
+      "@voyant-travel/catalog-contracts/booking-engine/preview-contracts": [
+        "../catalog-contracts/dist/booking-engine/preview-contracts.d.ts"
+      ],
       "@voyant-travel/catalog-contracts/booking-engine/pricing-contracts": [
         "../catalog-contracts/dist/booking-engine/pricing-contracts.d.ts"
       ],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -425,6 +425,9 @@
       "@voyant-travel/catalog-contracts/booking-engine/lifecycle-conformance": [
         "../catalog-contracts/dist/booking-engine/lifecycle-conformance.d.ts"
       ],
+      "@voyant-travel/catalog-contracts/booking-engine/preview-contracts": [
+        "../catalog-contracts/dist/booking-engine/preview-contracts.d.ts"
+      ],
       "@voyant-travel/catalog-contracts/booking-engine/pricing-contracts": [
         "../catalog-contracts/dist/booking-engine/pricing-contracts.d.ts"
       ],

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -424,6 +424,9 @@
       "@voyant-travel/catalog-contracts/booking-engine/lifecycle-conformance": [
         "../catalog-contracts/dist/booking-engine/lifecycle-conformance.d.ts"
       ],
+      "@voyant-travel/catalog-contracts/booking-engine/preview-contracts": [
+        "../catalog-contracts/dist/booking-engine/preview-contracts.d.ts"
+      ],
       "@voyant-travel/catalog-contracts/booking-engine/pricing-contracts": [
         "../catalog-contracts/dist/booking-engine/pricing-contracts.d.ts"
       ],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -425,6 +425,9 @@
       "@voyant-travel/catalog-contracts/booking-engine/lifecycle-conformance": [
         "../catalog-contracts/dist/booking-engine/lifecycle-conformance.d.ts"
       ],
+      "@voyant-travel/catalog-contracts/booking-engine/preview-contracts": [
+        "../catalog-contracts/dist/booking-engine/preview-contracts.d.ts"
+      ],
       "@voyant-travel/catalog-contracts/booking-engine/pricing-contracts": [
         "../catalog-contracts/dist/booking-engine/pricing-contracts.d.ts"
       ],

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -430,6 +430,9 @@
       "@voyant-travel/catalog-contracts/booking-engine/lifecycle-conformance": [
         "../catalog-contracts/dist/booking-engine/lifecycle-conformance.d.ts"
       ],
+      "@voyant-travel/catalog-contracts/booking-engine/preview-contracts": [
+        "../catalog-contracts/dist/booking-engine/preview-contracts.d.ts"
+      ],
       "@voyant-travel/catalog-contracts/booking-engine/pricing-contracts": [
         "../catalog-contracts/dist/booking-engine/pricing-contracts.d.ts"
       ],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -425,6 +425,9 @@
       "@voyant-travel/catalog-contracts/booking-engine/lifecycle-conformance": [
         "../catalog-contracts/dist/booking-engine/lifecycle-conformance.d.ts"
       ],
+      "@voyant-travel/catalog-contracts/booking-engine/preview-contracts": [
+        "../catalog-contracts/dist/booking-engine/preview-contracts.d.ts"
+      ],
       "@voyant-travel/catalog-contracts/booking-engine/pricing-contracts": [
         "../catalog-contracts/dist/booking-engine/pricing-contracts.d.ts"
       ],

--- a/packages/inventory/tsconfig.build.json
+++ b/packages/inventory/tsconfig.build.json
@@ -424,6 +424,9 @@
       "@voyant-travel/catalog-contracts/booking-engine/lifecycle-conformance": [
         "../catalog-contracts/dist/booking-engine/lifecycle-conformance.d.ts"
       ],
+      "@voyant-travel/catalog-contracts/booking-engine/preview-contracts": [
+        "../catalog-contracts/dist/booking-engine/preview-contracts.d.ts"
+      ],
       "@voyant-travel/catalog-contracts/booking-engine/pricing-contracts": [
         "../catalog-contracts/dist/booking-engine/pricing-contracts.d.ts"
       ],

--- a/packages/inventory/tsconfig.typecheck.json
+++ b/packages/inventory/tsconfig.typecheck.json
@@ -425,6 +425,9 @@
       "@voyant-travel/catalog-contracts/booking-engine/lifecycle-conformance": [
         "../catalog-contracts/dist/booking-engine/lifecycle-conformance.d.ts"
       ],
+      "@voyant-travel/catalog-contracts/booking-engine/preview-contracts": [
+        "../catalog-contracts/dist/booking-engine/preview-contracts.d.ts"
+      ],
       "@voyant-travel/catalog-contracts/booking-engine/pricing-contracts": [
         "../catalog-contracts/dist/booking-engine/pricing-contracts.d.ts"
       ],

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -430,6 +430,9 @@
       "@voyant-travel/catalog-contracts/booking-engine/lifecycle-conformance": [
         "../catalog-contracts/dist/booking-engine/lifecycle-conformance.d.ts"
       ],
+      "@voyant-travel/catalog-contracts/booking-engine/preview-contracts": [
+        "../catalog-contracts/dist/booking-engine/preview-contracts.d.ts"
+      ],
       "@voyant-travel/catalog-contracts/booking-engine/pricing-contracts": [
         "../catalog-contracts/dist/booking-engine/pricing-contracts.d.ts"
       ],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -425,6 +425,9 @@
       "@voyant-travel/catalog-contracts/booking-engine/lifecycle-conformance": [
         "../catalog-contracts/dist/booking-engine/lifecycle-conformance.d.ts"
       ],
+      "@voyant-travel/catalog-contracts/booking-engine/preview-contracts": [
+        "../catalog-contracts/dist/booking-engine/preview-contracts.d.ts"
+      ],
       "@voyant-travel/catalog-contracts/booking-engine/pricing-contracts": [
         "../catalog-contracts/dist/booking-engine/pricing-contracts.d.ts"
       ],

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -423,6 +423,9 @@
       "@voyant-travel/catalog-contracts/booking-engine/lifecycle-conformance": [
         "../catalog-contracts/dist/booking-engine/lifecycle-conformance.d.ts"
       ],
+      "@voyant-travel/catalog-contracts/booking-engine/preview-contracts": [
+        "../catalog-contracts/dist/booking-engine/preview-contracts.d.ts"
+      ],
       "@voyant-travel/catalog-contracts/booking-engine/pricing-contracts": [
         "../catalog-contracts/dist/booking-engine/pricing-contracts.d.ts"
       ],

--- a/scripts/check-agent-write-coverage.ts
+++ b/scripts/check-agent-write-coverage.ts
@@ -38,6 +38,13 @@ const ALLOWLIST = new Map<string, { rationale: string }>([
     },
   ],
   [
+    "@voyant-travel/catalog:catalog/offer",
+    {
+      rationale:
+        "Offer Preview is POST-shaped because its input is a nested selection, but it is a read: it mints no identifier and persists nothing, enforced by its port type rather than by convention. An agent that wants a priced, bindable offer opens a Booking Session and quotes it, which is already a Tool.",
+    },
+  ],
+  [
     "@voyant-travel/auth:storefront/channel-binding",
     {
       rationale:


### PR DESCRIPTION
Phase 3 of #4188, on top of #4191/#4193/#4195/#4201.

Storefront detail pages need a live price and the right configuration controls **before any Booking Session exists** — a shopper moving a pax stepper is not an attempt to book. Beta served this with `POST /catalog/quote`, which v1 deleted. Creating a Session per keystroke is not the answer: Sessions are persisted, revisioned, capability-bearing, expiring rows a sweep must reap.

`POST /v1/{admin,public}/catalog/offers/preview` returns `{ binding: false, available, requirements, pricing? }`. `requirements` is required — the point is that a detail page renders correct controls even when the price is unavailable.

## The invariants that keep this from being beta `/quote` again

1. **No identifier** — no `id`, `quoteId`, or token. Asserted against `offerPreviewResultV1.shape` keys plus a regex catch-all, so a future field addition cannot quietly break it; a spread preview is also asserted to fail `commitBookingSessionV1` and `placeBookingHoldV1`.
2. **Persists nothing** — enforced structurally, not by discipline: `OfferPreviewPorts` is a `Pick<>` that does not include the repository, so persistence is out of scope by construction. A test runs 25 previews and asserts sessions + quotes + holds + commits + operations + audit events total 0.
3. **`binding: z.literal(false)`** — `binding: true` fails to parse.
4. **No audience escalation** — a caller naming `audience: "staff"` is asserted to reach the compose port as `anonymous`.
5. Deterministic for `(target, scope, selection)`, so it is cacheable.

Reuses the same `composeQuote` / `composeRequirements` ports as the Session lifecycle — no third derivation path. Public surface inherits the sibling routes' `activeStorefront` admission verbatim.

## Reviewer attention

1. **A `rejected` arm was necessary.** `requirements` is required, but `composeRequirements` genuinely cannot produce one when the target does not resolve at all (`target_not_found`). Rather than making requirements optional or inventing a descriptor for a nonexistent product, the outcome is a discriminated union mirroring `bookingSessionOutcomeV1`, which the sibling routes already return.
2. **`composeQuote` gained the nullish-`tx` handling `composeRequirements` already documented.** A preview has no Session row and so no transaction; the sibling port at `sessions-production.ts:166` already handled this and `composeQuote` at :203 cast unconditionally. Now consistent.
3. **`InvalidBookingSessionSelectionError` moved to `errors.ts`** (re-exported from its old home) to break a real `sessions-service → offer-preview → sessions-service` runtime cycle.
4. **Second commit deletes two dead fields.** `bookingSelectionPublicV1` carried `quoteId`/`quoteExpiresAt` commented "Engine-controlled — written when `/quote` returns". That route is gone, nothing reads or writes them (verified across every client package — the `quoteId` uses in `manual-booking-session-client.ts` are correct `/hold` and `/commit` request bodies), and leaving them let a caller PATCH a `quoteId` into a schema whose entire point is default-deny.

Requirements fingerprinting and `selection_incomplete` enforcement are a sibling branch; the client rewrite is the phase after.