### PR TITLE
Resolve departure planned cost from the frozen day-service contract

### DIFF
--- a/packages/finance/package.json
+++ b/packages/finance/package.json
@@ -58,6 +58,7 @@
     "@voyant-travel/db": "workspace:^",
     "@voyant-travel/types": "workspace:^",
     "@voyant-travel/finance-contracts": "workspace:^",
+    "@voyant-travel/products-contracts": "workspace:^",
     "@voyant-travel/hono": "workspace:^",
     "@voyant-travel/payments": "workspace:^",
     "@voyant-travel/public-document-delivery": "workspace:^",

--- a/packages/finance/src/service-planned-cost.ts
+++ b/packages/finance/src/service-planned-cost.ts
@@ -1,0 +1,273 @@
+/**
+ * Departure planned-cost resolver (voyant#4037).
+ *
+ * The profitability read model has always taken planned cost from
+ * `booking_items.totalCostAmountCents`, which is seeded from the live, mutable
+ * `products.costAmountCents` in the product's SELL currency — not the frozen
+ * day-service cost. This resolver replaces that for any departure bound to a
+ * Product Version: it reads the frozen `product_versions.snapshot`, pulls each
+ * day service's declared `plannedCost` block (basis + driver + rate + currency),
+ * and multiplies the rate by the departure's own authoritative quantities — pax
+ * from booked travellers, rooms/vehicles from `allocation_resources`, nights
+ * from `availability_slots`. Where the #4035 spine has materialized operation
+ * lines it resolves PER LINE, keyed by `(slot_id, source_day_service_id)`, so
+ * attribution and variance-by-service stay meaningful; a version-bound departure
+ * that has not been materialized yet falls back to resolving every day service
+ * in its version's snapshot.
+ *
+ * A departure with NO `product_version_id` gets nothing here — the caller keeps
+ * the `booking_items` figure as a documented fallback and flags it as a
+ * completeness caveat rather than silently mixing the two sources.
+ *
+ * Cross-module tables (`availability_slots`, `product_versions`,
+ * `departure_service_operations`, `allocation_resources`, `booking_allocations`)
+ * are read through the finance boundary-SQL seam, exactly like the existing
+ * label lookups — no cross-package table symbol import, so this stays invisible
+ * to the table-privacy ratchet and never recomputes money in another module.
+ */
+import {
+  type DepartureQuantities,
+  parseProductVersionSnapshot,
+  resolvePlannedCost,
+  type SnapshotPlannedCost,
+} from "@voyant-travel/products-contracts/product-version-snapshot"
+import { sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import { executeBoundaryRows, sqlList } from "./service-boundary-sql.js"
+
+/** One frozen day service to cost against a departure, keyed by its version. */
+export interface PlannedCostLine {
+  departureId: string
+  productVersionId: string
+  sourceDayServiceId: string
+}
+
+/** The resolved planned cost for one departure, grouped per source currency. */
+export interface DeparturePlannedCost {
+  /** Cost currency → summed planned cents. Never crosses currencies (no FX). */
+  byCurrency: Map<string, number>
+  /** Operation/day-service lines the resolver costed. */
+  lineCount: number
+  /** Lines whose source day service carried no declared cost block. */
+  linesMissingCostBlock: number
+}
+
+/** Blocks indexed for O(1) line lookup: version id → (day-service id → block). */
+export type BlocksByVersion = Map<string, Map<string, SnapshotPlannedCost>>
+
+const num = (value: unknown): number => Number(value ?? 0)
+
+function emptyResult(): DeparturePlannedCost {
+  return { byCurrency: new Map(), lineCount: 0, linesMissingCostBlock: 0 }
+}
+
+/**
+ * Pure aggregation core — no database. Costs each line against its version's
+ * frozen block and its departure's quantities, summing per currency. Isolated so
+ * the multiply-and-group logic is exhaustively unit-testable with plain inputs.
+ */
+export function aggregateDeparturePlannedCost(
+  lines: readonly PlannedCostLine[],
+  blocksByVersion: BlocksByVersion,
+  quantitiesByDeparture: Map<string, DepartureQuantities>,
+): Map<string, DeparturePlannedCost> {
+  const out = new Map<string, DeparturePlannedCost>()
+  const ensure = (departureId: string): DeparturePlannedCost => {
+    let entry = out.get(departureId)
+    if (!entry) {
+      entry = emptyResult()
+      out.set(departureId, entry)
+    }
+    return entry
+  }
+
+  for (const line of lines) {
+    const entry = ensure(line.departureId)
+    entry.lineCount += 1
+    const block = blocksByVersion.get(line.productVersionId)?.get(line.sourceDayServiceId)
+    if (!block) {
+      entry.linesMissingCostBlock += 1
+      continue
+    }
+    const resolved = resolvePlannedCost(block, quantitiesByDeparture.get(line.departureId) ?? {})
+    if (resolved.amountCents === 0) continue
+    entry.byCurrency.set(
+      resolved.currency,
+      (entry.byCurrency.get(resolved.currency) ?? 0) + resolved.amountCents,
+    )
+  }
+
+  return out
+}
+
+interface SlotRow {
+  id: string
+  product_version_id: string | null
+  nights: number | null
+}
+
+interface OperationLineRow {
+  slot_id: string
+  product_version_id: string | null
+  source_day_service_id: string
+}
+
+/**
+ * Index a parsed snapshot's day services by id → declared cost block. Day
+ * services predating the block (legacy snapshots) are skipped, which surfaces
+ * downstream as `linesMissingCostBlock`.
+ */
+function indexSnapshotBlocks(raw: unknown): Map<string, SnapshotPlannedCost> {
+  const snapshot = parseProductVersionSnapshot(raw)
+  const map = new Map<string, SnapshotPlannedCost>()
+  for (const itinerary of snapshot.itineraries) {
+    for (const day of itinerary.days) {
+      for (const service of day.services) {
+        if (service.plannedCost) map.set(service.id, service.plannedCost)
+      }
+    }
+  }
+  return map
+}
+
+/**
+ * Resolve planned cost for the version-bound subset of `departureIds`. Returns a
+ * map keyed only by departures that carry a `product_version_id`; the rest are
+ * absent, signalling the caller to keep its `booking_items` fallback.
+ *
+ * Fires no cross-module query when none of `departureIds` is version-bound, so a
+ * report over legacy (unbound) departures costs exactly one cheap slot lookup.
+ */
+export async function resolveDeparturePlannedCosts(
+  db: PostgresJsDatabase,
+  departureIds: readonly string[],
+): Promise<Map<string, DeparturePlannedCost>> {
+  if (departureIds.length === 0) return new Map()
+
+  // agent-quality: raw-sql reviewed -- owner: finance; ids are parameter-bound via sqlList; availability is a read-only planned-cost source.
+  const slotRows = await executeBoundaryRows<SlotRow>(
+    db,
+    sql`
+      SELECT id, product_version_id, nights
+      FROM availability_slots
+      WHERE id IN (${sqlList(departureIds)}) AND product_version_id IS NOT NULL
+    `,
+  )
+  if (slotRows.length === 0) return new Map()
+
+  const versionBoundIds = slotRows.map((slot) => slot.id)
+  const nightsByDeparture = new Map<string, number | null>(
+    slotRows.map((slot) => [slot.id, slot.nights]),
+  )
+  const versionByDeparture = new Map<string, string>(
+    slotRows.flatMap((slot) =>
+      slot.product_version_id ? [[slot.id, slot.product_version_id] as const] : [],
+    ),
+  )
+
+  // Materialized operation lines (the #4035 spine) — the per-service grain that
+  // makes variance-by-service meaningful. A version-bound slot with no lines yet
+  // is costed over its whole snapshot below.
+  // agent-quality: raw-sql reviewed -- owner: finance; ids are parameter-bound via sqlList; operations is a read-only planned-cost source.
+  const operationRows = await executeBoundaryRows<OperationLineRow>(
+    db,
+    sql`
+      SELECT slot_id, product_version_id, source_day_service_id
+      FROM departure_service_operations
+      WHERE slot_id IN (${sqlList(versionBoundIds)})
+    `,
+  )
+  const slotsWithLines = new Set(operationRows.map((row) => row.slot_id))
+
+  const [resourceRows, paxRows] = await Promise.all([
+    // Room/vehicle counts. `vehicle_seat` children are NOT vehicles.
+    // agent-quality: raw-sql reviewed -- owner: finance; ids are parameter-bound via sqlList; availability is a read-only quantity source.
+    executeBoundaryRows<{ slot_id: string; kind: string; n: number }>(
+      db,
+      sql`
+        SELECT slot_id, kind, count(*)::int AS n
+        FROM allocation_resources
+        WHERE slot_id IN (${sqlList(versionBoundIds)})
+        GROUP BY slot_id, kind
+      `,
+    ),
+    // Booked pax per departure. `<> 'cancelled'` is a coarse active filter; a
+    // booking spanning two departures contributes its whole pax to each, the
+    // same known attribution limit the operations capacity read carries.
+    // agent-quality: raw-sql reviewed -- owner: finance; ids are parameter-bound via sqlList; bookings is a read-only quantity source.
+    executeBoundaryRows<{ slot_id: string; pax: number }>(
+      db,
+      sql`
+        SELECT ba.availability_slot_id AS slot_id, COALESCE(SUM(b.pax), 0)::int AS pax
+        FROM booking_allocations ba
+        JOIN bookings b ON b.id = ba.booking_id
+        WHERE ba.availability_slot_id IN (${sqlList(versionBoundIds)}) AND ba.status <> 'cancelled'
+        GROUP BY ba.availability_slot_id
+      `,
+    ),
+  ])
+
+  const roomsByDeparture = new Map<string, number>()
+  const vehiclesByDeparture = new Map<string, number>()
+  for (const row of resourceRows) {
+    if (row.kind === "room") roomsByDeparture.set(row.slot_id, num(row.n))
+    else if (row.kind === "vehicle") vehiclesByDeparture.set(row.slot_id, num(row.n))
+  }
+  const paxByDeparture = new Map(paxRows.map((row) => [row.slot_id, num(row.pax)]))
+
+  const quantitiesByDeparture = new Map<string, DepartureQuantities>(
+    versionBoundIds.map((id) => [
+      id,
+      {
+        pax: paxByDeparture.get(id) ?? 0,
+        rooms: roomsByDeparture.get(id) ?? 0,
+        vehicles: vehiclesByDeparture.get(id) ?? 0,
+        nights: nightsByDeparture.get(id) ?? 0,
+      },
+    ]),
+  )
+
+  // Load and index every relevant version snapshot once.
+  const versionIds = [...new Set(versionByDeparture.values())]
+  const blocksByVersion: BlocksByVersion = new Map()
+  if (versionIds.length > 0) {
+    // agent-quality: raw-sql reviewed -- owner: finance; ids are parameter-bound via sqlList; product_versions.snapshot is the frozen cost contract.
+    const versionRows = await executeBoundaryRows<{ id: string; snapshot: unknown }>(
+      db,
+      sql`SELECT id, snapshot FROM product_versions WHERE id IN (${sqlList(versionIds)})`,
+    )
+    for (const row of versionRows) {
+      blocksByVersion.set(row.id, indexSnapshotBlocks(row.snapshot))
+    }
+  }
+
+  // Build the line set: materialized lines where the spine has them, else one
+  // synthetic line per day service in the version's snapshot.
+  const lines: PlannedCostLine[] = []
+  for (const row of operationRows) {
+    const versionId = row.product_version_id ?? versionByDeparture.get(row.slot_id)
+    if (!versionId) continue
+    lines.push({
+      departureId: row.slot_id,
+      productVersionId: versionId,
+      sourceDayServiceId: row.source_day_service_id,
+    })
+  }
+  for (const slot of slotRows) {
+    if (slotsWithLines.has(slot.id)) continue
+    const versionId = versionByDeparture.get(slot.id)
+    if (!versionId) continue
+    const blocks = blocksByVersion.get(versionId)
+    if (!blocks) continue
+    for (const dayServiceId of blocks.keys()) {
+      lines.push({
+        departureId: slot.id,
+        productVersionId: versionId,
+        sourceDayServiceId: dayServiceId,
+      })
+    }
+  }
+
+  return aggregateDeparturePlannedCost(lines, blocksByVersion, quantitiesByDeparture)
+}

--- a/packages/finance/src/service-profitability.ts
+++ b/packages/finance/src/service-profitability.ts
@@ -18,6 +18,7 @@ import {
   supplierInvoices,
 } from "./schema.js"
 import { executeBoundaryRows, normalizeDateOnly, sqlList } from "./service-boundary-sql.js"
+import { type DeparturePlannedCost, resolveDeparturePlannedCosts } from "./service-planned-cost.js"
 
 /**
  * FX runtime for the profitability read model. Carries the operator FX settings
@@ -36,7 +37,11 @@ export type ProfitabilityFxRuntime = InvoiceFxOptions
  *   to the departures' booked sell amounts (`booking_items`). Credit notes net
  *   the revenue down.
  * - Actual cost = `supplier_cost_allocations` targeted at the departure/product.
- * - Planned cost = `booking_items.totalCostAmountCents` (what we expected to pay).
+ * - Planned cost = the frozen day-service resolver (voyant#4037) for any
+ *   version-bound departure; `booking_items.totalCostAmountCents` remains a
+ *   documented fallback for departures with no `product_version_id`. The two are
+ *   never mixed within a departure, and which departures used the fallback is
+ *   surfaced as `plannedCostCaveat` rather than silently blended.
  * - Profit = revenue − actual cost. Variance = planned − actual cost.
  *
  * Two further figures account for supplier cost that reaches no departure, and
@@ -72,6 +77,21 @@ export interface ProfitabilityUnallocated {
   amountCents: number
 }
 
+/**
+ * Planned-cost provenance for the report (voyant#4037). Version-bound departures
+ * take the frozen day-service resolver; the rest fall back to `booking_items`.
+ * This names the fallback departures explicitly so a consumer can show the
+ * report is only as complete as its cost sources, instead of trusting a blended
+ * figure. `versionResolvedCount` is how many departures the resolver costed;
+ * `linesMissingCostBlock` counts resolved lines whose day service carried no
+ * declared cost block (a `missing_planned_cost` signal).
+ */
+export interface ProfitabilityPlannedCostCaveat {
+  fallbackDepartureIds: string[]
+  versionResolvedCount: number
+  linesMissingCostBlock: number
+}
+
 export interface DepartureProfitabilityRow {
   departureId: string
   departureLabel: string | null
@@ -102,6 +122,7 @@ export interface DepartureProfitabilityReport {
   costByServiceType: ProfitabilityCostByServiceType[]
   unattributed: ProfitabilityUnattributed[]
   unallocated: ProfitabilityUnallocated[]
+  plannedCostCaveat?: ProfitabilityPlannedCostCaveat
   base?: DepartureProfitabilityBaseRollup
 }
 
@@ -132,6 +153,7 @@ export interface ProductProfitabilityReport {
   costByServiceType: ProfitabilityCostByServiceType[]
   unattributed: ProfitabilityUnattributed[]
   unallocated: ProfitabilityUnallocated[]
+  plannedCostCaveat?: ProfitabilityPlannedCostCaveat
   base?: ProductProfitabilityBaseRollup
 }
 
@@ -219,6 +241,7 @@ interface LoadedAccumulators {
   unattributedBase: BaseSplit
   unallocated: ProfitabilityUnallocated[]
   unallocatedBase: BaseSplit
+  plannedCostCaveat: ProfitabilityPlannedCostCaveat
 }
 
 /**
@@ -455,6 +478,19 @@ async function loadDepartureAccumulators(
   const bookingTotalSell = new Map<string, number>()
   const bookingSlotSell = new Map<string, Array<{ departureId: string; sellCents: number }>>()
 
+  // booking_items planned cost, stashed per (departure, currency) rather than
+  // added to the accumulator here: the source switch below decides, per
+  // departure, whether the frozen resolver or this fallback wins (voyant#4037).
+  const bookingItemsPlanned = new Map<string, Map<string, number>>()
+  const stashBookingItemsPlanned = (departureId: string, currency: string, cents: number): void => {
+    let byCurrency = bookingItemsPlanned.get(departureId)
+    if (!byCurrency) {
+      byCurrency = new Map()
+      bookingItemsPlanned.set(departureId, byCurrency)
+    }
+    byCurrency.set(currency, (byCurrency.get(currency) ?? 0) + cents)
+  }
+
   for (const row of itemRows) {
     const departureId = row.departureId
     if (!departureId) continue
@@ -467,10 +503,7 @@ async function loadDepartureAccumulators(
     const sellCents = num(row.sellCents)
     const plannedCost = num(row.plannedCostCents)
     if (row.costCurrency && plannedCost !== 0) {
-      bucket(acc.byCurrency, row.costCurrency).planned += plannedCost
-      // Planned cost is a budget snapshot with no recorded FX, so it always
-      // routes through the fallback conversion (latest rate for that currency).
-      ensureResidual(acc, row.costCurrency).planned += plannedCost
+      stashBookingItemsPlanned(departureId, row.costCurrency, plannedCost)
     }
 
     bookingTotalSell.set(row.bookingId, (bookingTotalSell.get(row.bookingId) ?? 0) + sellCents)
@@ -554,6 +587,44 @@ async function loadDepartureAccumulators(
     }
   }
 
+  // Planned-cost source switch (voyant#4037). A departure bound to a Product
+  // Version takes the frozen day-service resolver — the whole point of the
+  // tracer; every other departure keeps its stashed `booking_items` figure as a
+  // documented fallback. Sources are never mixed within a departure. The
+  // resolver fires no cross-module query when nothing is version-bound.
+  const versionResolved = await resolveDeparturePlannedCosts(db, departureIds)
+  const plannedCostCaveat: ProfitabilityPlannedCostCaveat = {
+    fallbackDepartureIds: [],
+    versionResolvedCount: 0,
+    linesMissingCostBlock: 0,
+  }
+  const addPlanned = (acc: DepartureAcc, currency: string, cents: number): void => {
+    if (cents === 0) return
+    bucket(acc.byCurrency, currency).planned += cents
+    // Planned cost is a budget figure with no recorded FX, so it always routes
+    // through the fallback conversion (latest rate for that currency).
+    ensureResidual(acc, currency).planned += cents
+  }
+  for (const departureId of departureIds) {
+    const acc = departures.get(departureId)
+    if (!acc) continue
+    const resolved: DeparturePlannedCost | undefined = versionResolved.get(departureId)
+    if (resolved) {
+      // Version-bound: authoritative, even when partial. A missing declared
+      // block leaves that line uncosted and is reported, not back-filled from
+      // booking_items (which would silently mix sources).
+      plannedCostCaveat.versionResolvedCount += 1
+      plannedCostCaveat.linesMissingCostBlock += resolved.linesMissingCostBlock
+      for (const [currency, cents] of resolved.byCurrency) addPlanned(acc, currency, cents)
+    } else {
+      const stash = bookingItemsPlanned.get(departureId)
+      if (stash) {
+        for (const [currency, cents] of stash) addPlanned(acc, currency, cents)
+        plannedCostCaveat.fallbackDepartureIds.push(departureId)
+      }
+    }
+  }
+
   const productActualCost: Array<{ productId: string; currency: string; amountCents: number }> = []
   const productActualCostBase = new Map<string, BaseSplit>()
   for (const row of productCostRows) {
@@ -617,6 +688,7 @@ async function loadDepartureAccumulators(
     unattributedBase,
     unallocated,
     unallocatedBase,
+    plannedCostCaveat,
   }
 }
 
@@ -643,6 +715,7 @@ export async function getDepartureProfitability(
     unattributedBase,
     unallocated,
     unallocatedBase,
+    plannedCostCaveat,
   } = loaded
 
   const rows: DepartureProfitabilityRow[] = []
@@ -731,6 +804,7 @@ export async function getDepartureProfitability(
     costByServiceType: filterCostByCurrency(costByServiceType, query.currency),
     unattributed: filterCostByCurrency(unattributed, query.currency),
     unallocated: filterCostByCurrency(unallocated, query.currency),
+    plannedCostCaveat,
     base: {
       currency: baseCurrency,
       rows: baseRows,
@@ -759,6 +833,7 @@ export async function getProductProfitability(
     unattributedBase,
     unallocated,
     unallocatedBase,
+    plannedCostCaveat,
   } = loaded
 
   interface ProductAcc {
@@ -907,6 +982,7 @@ export async function getProductProfitability(
     costByServiceType: filterCostByCurrency(costByServiceType, query.currency),
     unattributed: filterCostByCurrency(unattributed, query.currency),
     unallocated: filterCostByCurrency(unallocated, query.currency),
+    plannedCostCaveat,
     base: {
       currency: baseCurrency,
       rows: baseRows,

--- a/packages/finance/tests/unit/planned-cost.test.ts
+++ b/packages/finance/tests/unit/planned-cost.test.ts
@@ -1,0 +1,99 @@
+import type {
+  DepartureQuantities,
+  SnapshotPlannedCost,
+} from "@voyant-travel/products-contracts/product-version-snapshot"
+import { describe, expect, it } from "vitest"
+
+import {
+  aggregateDeparturePlannedCost,
+  type BlocksByVersion,
+  type PlannedCostLine,
+} from "../../src/service-planned-cost.js"
+
+function block(overrides: Partial<SnapshotPlannedCost>): SnapshotPlannedCost {
+  return {
+    version: 1,
+    basis: "per_person",
+    driver: "pax",
+    quantity: 1,
+    rateCents: 1000,
+    currency: "EUR",
+    fxRates: null,
+    resolvedAt: null,
+    ...overrides,
+  }
+}
+
+describe("aggregateDeparturePlannedCost", () => {
+  it("costs each line against its version block and the departure's quantities", () => {
+    const blocks: BlocksByVersion = new Map([
+      [
+        "pv_1",
+        new Map<string, SnapshotPlannedCost>([
+          ["svc_pax", block({ driver: "pax", rateCents: 5000 })],
+          ["svc_room", block({ basis: "per_room", driver: "rooms", rateCents: 8000 })],
+        ]),
+      ],
+    ])
+    const quantities = new Map<string, DepartureQuantities>([["avsl_1", { pax: 3, rooms: 2 }]])
+    const lines: PlannedCostLine[] = [
+      { departureId: "avsl_1", productVersionId: "pv_1", sourceDayServiceId: "svc_pax" },
+      { departureId: "avsl_1", productVersionId: "pv_1", sourceDayServiceId: "svc_room" },
+    ]
+
+    const result = aggregateDeparturePlannedCost(lines, blocks, quantities)
+    const entry = result.get("avsl_1")
+    // 5000×3 pax + 8000×2 rooms = 15000 + 16000 = 31000, all EUR.
+    expect(entry?.byCurrency.get("EUR")).toBe(31000)
+    expect(entry?.lineCount).toBe(2)
+    expect(entry?.linesMissingCostBlock).toBe(0)
+  })
+
+  it("keeps distinct cost currencies apart — never sums across FX", () => {
+    const blocks: BlocksByVersion = new Map([
+      [
+        "pv_1",
+        new Map<string, SnapshotPlannedCost>([
+          ["svc_eur", block({ driver: "fixed", currency: "EUR", rateCents: 4000 })],
+          ["svc_usd", block({ driver: "fixed", currency: "USD", rateCents: 7000 })],
+        ]),
+      ],
+    ])
+    const lines: PlannedCostLine[] = [
+      { departureId: "avsl_1", productVersionId: "pv_1", sourceDayServiceId: "svc_eur" },
+      { departureId: "avsl_1", productVersionId: "pv_1", sourceDayServiceId: "svc_usd" },
+    ]
+
+    const entry = aggregateDeparturePlannedCost(lines, blocks, new Map()).get("avsl_1")
+    expect(entry?.byCurrency.get("EUR")).toBe(4000)
+    expect(entry?.byCurrency.get("USD")).toBe(7000)
+  })
+
+  it("counts a line whose day service has no declared block as missing, not zero-cost silently", () => {
+    const blocks: BlocksByVersion = new Map([["pv_1", new Map()]])
+    const lines: PlannedCostLine[] = [
+      { departureId: "avsl_1", productVersionId: "pv_1", sourceDayServiceId: "svc_legacy" },
+    ]
+    const entry = aggregateDeparturePlannedCost(lines, blocks, new Map()).get("avsl_1")
+    expect(entry?.lineCount).toBe(1)
+    expect(entry?.linesMissingCostBlock).toBe(1)
+    expect(entry?.byCurrency.size).toBe(0)
+  })
+
+  it("resolves a driver's absent departure quantity to zero rather than a guess", () => {
+    const blocks: BlocksByVersion = new Map([
+      [
+        "pv_1",
+        new Map([["svc_night", block({ basis: "per_night", driver: "nights", rateCents: 9000 })]]),
+      ],
+    ])
+    const lines: PlannedCostLine[] = [
+      { departureId: "avsl_1", productVersionId: "pv_1", sourceDayServiceId: "svc_night" },
+    ]
+    // No quantities entry for avsl_1 → nights absent → 0 cents, still one line.
+    const entry = aggregateDeparturePlannedCost(lines, blocks, new Map()).get("avsl_1")
+    expect(entry?.lineCount).toBe(1)
+    expect(entry?.linesMissingCostBlock).toBe(0)
+    expect(entry?.byCurrency.size).toBe(0)
+  })
+})

--- a/packages/inventory/migrations/0010_inventory_baseline.sql
+++ b/packages/inventory/migrations/0010_inventory_baseline.sql
@@ -1,0 +1,10 @@
+DO $$ BEGIN
+ CREATE TYPE "public"."day_service_planned_cost_basis" AS ENUM('flat', 'per_person', 'per_room', 'per_night', 'per_vehicle', 'per_service_unit');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."day_service_quantity_driver" AS ENUM('fixed', 'pax', 'rooms', 'nights', 'vehicles', 'service_units');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+ALTER TABLE "product_day_services" ADD COLUMN "planned_cost_basis" "day_service_planned_cost_basis" DEFAULT 'per_service_unit' NOT NULL;--> statement-breakpoint
+ALTER TABLE "product_day_services" ADD COLUMN "quantity_driver" "day_service_quantity_driver" DEFAULT 'service_units' NOT NULL;

--- a/packages/inventory/migrations/meta/0009_snapshot.json
+++ b/packages/inventory/migrations/meta/0009_snapshot.json
@@ -1,6 +1,6 @@
 {
   "id": "1a85b86d-d6ab-45e9-b782-dfc1ac4ff768",
-  "prevId": "0b77670a-70f7-445f-a1b3-c7dc306e5dad",
+  "prevId": "e258f89e-432e-4169-8d84-2ef35783e1c3",
   "version": "7",
   "dialect": "postgresql",
   "tables": {

--- a/packages/inventory/migrations/meta/0010_snapshot.json
+++ b/packages/inventory/migrations/meta/0010_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "1a85b86d-d6ab-45e9-b782-dfc1ac4ff768",
-  "prevId": "0b77670a-70f7-445f-a1b3-c7dc306e5dad",
+  "id": "e71545cc-97b4-4a20-b863-d7611b5c24e7",
+  "prevId": "1a85b86d-d6ab-45e9-b782-dfc1ac4ff768",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -2400,6 +2400,22 @@
           "primaryKey": false,
           "notNull": true,
           "default": 1
+        },
+        "planned_cost_basis": {
+          "name": "planned_cost_basis",
+          "type": "day_service_planned_cost_basis",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'per_service_unit'"
+        },
+        "quantity_driver": {
+          "name": "quantity_driver",
+          "type": "day_service_quantity_driver",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'service_units'"
         },
         "sort_order": {
           "name": "sort_order",
@@ -7328,6 +7344,30 @@
       "values": [
         "included",
         "optional"
+      ]
+    },
+    "public.day_service_planned_cost_basis": {
+      "name": "day_service_planned_cost_basis",
+      "schema": "public",
+      "values": [
+        "flat",
+        "per_person",
+        "per_room",
+        "per_night",
+        "per_vehicle",
+        "per_service_unit"
+      ]
+    },
+    "public.day_service_quantity_driver": {
+      "name": "day_service_quantity_driver",
+      "schema": "public",
+      "values": [
+        "fixed",
+        "pax",
+        "rooms",
+        "nights",
+        "vehicles",
+        "service_units"
       ]
     },
     "public.day_service_traveler_scope": {

--- a/packages/inventory/migrations/meta/_journal.json
+++ b/packages/inventory/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1785849290874,
       "tag": "0009_inventory_baseline",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1785858423775,
+      "tag": "0010_inventory_baseline",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/inventory/src/schema-itinerary.ts
+++ b/packages/inventory/src/schema-itinerary.ts
@@ -34,6 +34,44 @@ export const dayServiceTravelerScopeEnum = pgEnum("day_service_traveler_scope", 
   "children",
 ])
 
+/**
+ * How a day service's planned-cost rate (`cost_amount_cents`) is expressed — the
+ * unit it is priced per. The profitability tracer (voyant#4037) needs a declared
+ * basis so a departure can restate the frozen cost against its own quantities
+ * instead of guessing. Reuses the supplier `rate_unit` vocabulary
+ * (`packages/distribution/src/suppliers/schema.ts`) verbatim where it maps —
+ * `per_person`, `per_night`, `per_vehicle`, `flat` — rather than minting a
+ * parallel enum, and adds the two bases day services need that `rate_unit` lacks:
+ * `per_room` and `per_service_unit`. The paired {@link dayServiceQuantityDriverEnum}
+ * names which authoritative departure quantity multiplies the rate.
+ */
+export const dayServicePlannedCostBasisEnum = pgEnum("day_service_planned_cost_basis", [
+  "flat",
+  "per_person",
+  "per_room",
+  "per_night",
+  "per_vehicle",
+  "per_service_unit",
+])
+
+/**
+ * Which authoritative departure quantity multiplies the planned-cost rate when a
+ * departure resolves this service. `fixed` multiplies by one; `service_units`
+ * multiplies by the configured `quantity`; the rest are read from the departure:
+ * `pax` from booked travellers, `rooms`/`vehicles` from `allocation_resources`,
+ * `nights` from `availability_slots.nights`. Kept separate from the basis so an
+ * author can, e.g., price a `flat` rate that a departure still applies once per
+ * `service_units`.
+ */
+export const dayServiceQuantityDriverEnum = pgEnum("day_service_quantity_driver", [
+  "fixed",
+  "pax",
+  "rooms",
+  "nights",
+  "vehicles",
+  "service_units",
+])
+
 export const productItineraries = pgTable(
   "product_itineraries",
   {
@@ -166,6 +204,17 @@ export const productDayServices = pgTable(
     costCurrency: text("cost_currency").notNull(),
     costAmountCents: integer("cost_amount_cents").notNull(),
     quantity: integer("quantity").notNull().default(1),
+    // Planned-cost basis + quantity driver (voyant#4037). The default pair
+    // (`per_service_unit` / `service_units`) reproduces the legacy costing —
+    // `cost_amount_cents` × `quantity` — so a service authored before this
+    // migration resolves to the same planned figure; authors opt into a
+    // departure-driven basis (per person/room/night/vehicle) explicitly.
+    plannedCostBasis: dayServicePlannedCostBasisEnum("planned_cost_basis")
+      .notNull()
+      .default("per_service_unit"),
+    quantityDriver: dayServiceQuantityDriverEnum("quantity_driver")
+      .notNull()
+      .default("service_units"),
     sortOrder: integer("sort_order"),
     notes: text("notes"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),

--- a/packages/inventory/src/service-itinerary-history.ts
+++ b/packages/inventory/src/service-itinerary-history.ts
@@ -72,7 +72,27 @@ async function buildProductVersionSnapshot(db: PostgresJsDatabase, productId: st
             .where(eq(productDayServices.dayId, day.id))
             .orderBy(asc(productDayServices.sortOrder))
 
-          return { ...day, services }
+          // Emit the declared, versioned planned-cost block (voyant#4037)
+          // alongside the raw columns so a departure can restate this service's
+          // cost against its own quantities without reading the mutable product.
+          // Deterministic by construction — every field is a frozen column, so
+          // an unchanged product still de-dupes on re-publish. `fxRates`/
+          // `resolvedAt` are null: Finance restates at its issue-date rate.
+          const servicesWithPlannedCost = services.map((service) => ({
+            ...service,
+            plannedCost: {
+              version: 1 as const,
+              basis: service.plannedCostBasis,
+              driver: service.quantityDriver,
+              quantity: service.quantity,
+              rateCents: service.costAmountCents,
+              currency: service.costCurrency,
+              fxRates: null,
+              resolvedAt: null,
+            },
+          }))
+
+          return { ...day, services: servicesWithPlannedCost }
         }),
       )
 

--- a/packages/products-contracts/src/planned-cost.test.ts
+++ b/packages/products-contracts/src/planned-cost.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest"
+import {
+  type CostQuantityDriver,
+  costQuantityDriverSchema,
+  departureQuantityForDriver,
+  parseProductVersionSnapshot,
+  plannedCostBasisSchema,
+  resolvePlannedCost,
+  type SnapshotPlannedCost,
+  snapshotPlannedCostSchema,
+} from "./product-version-snapshot.js"
+
+function block(overrides: Partial<SnapshotPlannedCost> = {}): SnapshotPlannedCost {
+  return snapshotPlannedCostSchema.parse({
+    version: 1,
+    basis: "per_person",
+    driver: "pax",
+    quantity: 1,
+    rateCents: 5000,
+    currency: "EUR",
+    ...overrides,
+  })
+}
+
+describe("planned-cost vocabulary", () => {
+  it("reuses the rate_unit literals it maps onto", () => {
+    // per_person / per_night / per_vehicle / flat come straight from rate_unit;
+    // per_room / per_service_unit are the two day-service additions.
+    expect(plannedCostBasisSchema.options).toEqual([
+      "flat",
+      "per_person",
+      "per_room",
+      "per_night",
+      "per_vehicle",
+      "per_service_unit",
+    ])
+  })
+
+  it("names one driver per departure quantity plus fixed and service_units", () => {
+    expect(costQuantityDriverSchema.options).toEqual([
+      "fixed",
+      "pax",
+      "rooms",
+      "nights",
+      "vehicles",
+      "service_units",
+    ])
+  })
+
+  it("defaults the optional frozen-FX carriers to null", () => {
+    const parsed = block()
+    expect(parsed.fxRates).toBeNull()
+    expect(parsed.resolvedAt).toBeNull()
+  })
+})
+
+describe("departureQuantityForDriver", () => {
+  const quantities = { pax: 4, rooms: 2, vehicles: 1, nights: 3 }
+
+  const cases: Array<[CostQuantityDriver, number]> = [
+    ["fixed", 1],
+    ["pax", 4],
+    ["rooms", 2],
+    ["vehicles", 1],
+    ["nights", 3],
+    ["service_units", 7],
+  ]
+  it.each(cases)("driver %s selects the right multiplier", (driver, expected) => {
+    expect(departureQuantityForDriver(driver, quantities, 7)).toBe(expected)
+  })
+
+  it("treats a missing or non-positive departure quantity as zero, never a guess", () => {
+    expect(departureQuantityForDriver("nights", { nights: null }, 1)).toBe(0)
+    expect(departureQuantityForDriver("pax", {}, 1)).toBe(0)
+    expect(departureQuantityForDriver("rooms", { rooms: -2 }, 1)).toBe(0)
+  })
+})
+
+describe("resolvePlannedCost", () => {
+  it("multiplies the rate by the driver-selected departure quantity", () => {
+    const resolved = resolvePlannedCost(
+      block({ basis: "per_person", driver: "pax", rateCents: 5000 }),
+      {
+        pax: 4,
+      },
+    )
+    expect(resolved).toEqual({ currency: "EUR", amountCents: 20000, multiplier: 4 })
+  })
+
+  it("keeps the day-service cost currency, not a sell currency", () => {
+    const resolved = resolvePlannedCost(
+      block({ currency: "USD", driver: "fixed", rateCents: 12345 }),
+      {},
+    )
+    expect(resolved.currency).toBe("USD")
+    expect(resolved.amountCents).toBe(12345)
+  })
+
+  it("reproduces legacy cost × quantity for the default basis/driver pair", () => {
+    // per_service_unit + service_units, quantity 3, rate 900 → 2700.
+    const resolved = resolvePlannedCost(
+      block({ basis: "per_service_unit", driver: "service_units", quantity: 3, rateCents: 900 }),
+      {},
+    )
+    expect(resolved.amountCents).toBe(2700)
+  })
+
+  it("resolves to zero — not a stale figure — when the driver's quantity is absent", () => {
+    const resolved = resolvePlannedCost(block({ driver: "rooms", rateCents: 8000 }), {
+      rooms: null,
+    })
+    expect(resolved.amountCents).toBe(0)
+  })
+})
+
+describe("snapshot day-service block round-trip", () => {
+  it("parses a snapshot whose day services carry a plannedCost block", () => {
+    const snapshot = parseProductVersionSnapshot({
+      id: "prod_1",
+      itineraries: [
+        {
+          id: "iti_1",
+          productId: "prod_1",
+          isDefault: true,
+          days: [
+            {
+              id: "day_1",
+              itineraryId: "iti_1",
+              dayNumber: 1,
+              services: [
+                {
+                  id: "svc_1",
+                  dayId: "day_1",
+                  serviceType: "accommodation",
+                  name: "Twin room",
+                  plannedCost: {
+                    version: 1,
+                    basis: "per_room",
+                    driver: "rooms",
+                    quantity: 1,
+                    rateCents: 9000,
+                    currency: "EUR",
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+    const service = snapshot.itineraries[0]?.days[0]?.services[0]
+    expect(service?.plannedCost?.basis).toBe("per_room")
+    expect(service?.plannedCost?.currency).toBe("EUR")
+  })
+
+  it("still parses a legacy snapshot whose day services predate the block", () => {
+    const snapshot = parseProductVersionSnapshot({
+      id: "prod_1",
+      itineraries: [
+        {
+          id: "iti_1",
+          productId: "prod_1",
+          isDefault: true,
+          days: [
+            {
+              id: "day_1",
+              itineraryId: "iti_1",
+              dayNumber: 1,
+              services: [{ id: "svc_1", dayId: "day_1", serviceType: "guide", name: "Walk" }],
+            },
+          ],
+        },
+      ],
+    })
+    expect(snapshot.itineraries[0]?.days[0]?.services[0]?.plannedCost).toBeUndefined()
+  })
+})

--- a/packages/products-contracts/src/product-version-snapshot.ts
+++ b/packages/products-contracts/src/product-version-snapshot.ts
@@ -35,10 +35,78 @@ import {
 } from "./validation-shared.js"
 
 /**
+ * How a day service's planned-cost rate is expressed — the unit `rateCents` is
+ * priced per. Mirrors the inventory `day_service_planned_cost_basis` enum and,
+ * through it, the supplier `rate_unit` vocabulary it reuses where they map
+ * (`per_person`, `per_night`, `per_vehicle`, `flat`). See voyant#4037.
+ */
+export const plannedCostBasisSchema = z.enum([
+  "flat",
+  "per_person",
+  "per_room",
+  "per_night",
+  "per_vehicle",
+  "per_service_unit",
+])
+
+export type PlannedCostBasis = z.infer<typeof plannedCostBasisSchema>
+
+/**
+ * Which authoritative departure quantity multiplies the planned-cost rate.
+ * Mirrors the inventory `day_service_quantity_driver` enum. A departure resolver
+ * reads the driver to pick the multiplier: `fixed` → 1, `service_units` → the
+ * frozen `quantity`, and `pax`/`rooms`/`nights`/`vehicles` from the departure.
+ */
+export const costQuantityDriverSchema = z.enum([
+  "fixed",
+  "pax",
+  "rooms",
+  "nights",
+  "vehicles",
+  "service_units",
+])
+
+export type CostQuantityDriver = z.infer<typeof costQuantityDriverSchema>
+
+/**
+ * The declared, versioned planned-cost contract frozen for one day service —
+ * the whole point of voyant#4037. It carries the rate and the two things a
+ * departure needs to restate it against its own scale without guessing: the
+ * `basis` (what the rate is priced per) and the `driver` (which departure
+ * quantity multiplies it). `fxRates`/`resolvedAt` are the optional frozen-FX
+ * carrier; they are null when the version was minted without an FX runtime, in
+ * which case the reader restates at its own issue-date rate (Finance's
+ * deliberate design) rather than a stale build-time rate. `version` lets the
+ * block evolve without breaking older snapshots.
+ */
+export const snapshotPlannedCostSchema = z
+  .object({
+    version: z.literal(1),
+    basis: plannedCostBasisSchema,
+    driver: costQuantityDriverSchema,
+    /** The service's configured quantity — the multiplier for `service_units`. */
+    quantity: z.number().int(),
+    /** The rate, in minor units of `currency`, priced per the `basis` unit. */
+    rateCents: z.number().int(),
+    /** The day-service cost currency — NOT the product sell currency. */
+    currency: z.string(),
+    /** Frozen FX rate set (source currency → base rate), or null. */
+    fxRates: z.record(z.string(), z.number()).nullable().default(null),
+    /** ISO instant the FX set was resolved at, or null. */
+    resolvedAt: z.string().nullable().default(null),
+  })
+  .passthrough()
+
+export type SnapshotPlannedCost = z.infer<typeof snapshotPlannedCostSchema>
+
+/**
  * One day service as frozen in a version snapshot. Costing columns
  * (`costCurrency`, `costAmountCents`, …) are tolerated but not required here;
  * the tracer reads the operational columns. `inclusionRole` / `travelerScope`
  * default so a snapshot taken before those columns existed still parses.
+ * `plannedCost` is the voyant#4037 declared cost block; it is `nullish` so a
+ * snapshot minted before the block existed still parses (the reader treats a
+ * missing block as "no version-based planned cost" and falls back).
  */
 export const snapshotDayServiceSchema = z
   .object({
@@ -55,6 +123,7 @@ export const snapshotDayServiceSchema = z
     inclusionRole: dayServiceInclusionRoleSchema.default("included"),
     travelerScope: dayServiceTravelerScopeSchema.default("all"),
     sortOrder: z.number().int().nullish(),
+    plannedCost: snapshotPlannedCostSchema.nullish(),
   })
   .passthrough()
 
@@ -141,4 +210,76 @@ export function defaultItineraryDaysFromSnapshot(snapshot: ProductVersionSnapsho
 
   const days = defaultItinerary?.days ?? snapshot.days ?? []
   return [...days].sort((a, b) => a.dayNumber - b.dayNumber)
+}
+
+// ---------- planned-cost resolution (voyant#4037) ----------
+
+/**
+ * The authoritative departure quantities a planned-cost driver reads. Supplied
+ * by the caller from the departure itself — pax from booked travellers, rooms
+ * and vehicles from `allocation_resources`, nights from `availability_slots`.
+ * Null/absent quantities are treated as zero so a driver pointed at a quantity
+ * the departure has not established resolves to zero cost, never a guess.
+ */
+export interface DepartureQuantities {
+  pax?: number | null
+  rooms?: number | null
+  vehicles?: number | null
+  nights?: number | null
+}
+
+/** One resolved planned-cost figure for a day service, in its own currency. */
+export interface ResolvedPlannedCost {
+  currency: string
+  amountCents: number
+  /** The multiplier the driver selected — surfaced so callers can explain it. */
+  multiplier: number
+}
+
+const nonNegative = (value: number | null | undefined): number =>
+  typeof value === "number" && Number.isFinite(value) && value > 0 ? value : 0
+
+/**
+ * The multiplier a driver applies. `fixed` is one; `service_units` is the
+ * service's frozen configured quantity; the rest read the departure. Kept pure
+ * and total so it is exhaustively unit-testable without a database.
+ */
+export function departureQuantityForDriver(
+  driver: CostQuantityDriver,
+  quantities: DepartureQuantities,
+  serviceQuantity: number,
+): number {
+  switch (driver) {
+    case "fixed":
+      return 1
+    case "service_units":
+      return nonNegative(serviceQuantity)
+    case "pax":
+      return nonNegative(quantities.pax)
+    case "rooms":
+      return nonNegative(quantities.rooms)
+    case "vehicles":
+      return nonNegative(quantities.vehicles)
+    case "nights":
+      return nonNegative(quantities.nights)
+  }
+}
+
+/**
+ * Resolve a frozen planned-cost block against a departure's authoritative
+ * quantities. The rate (`rateCents`, priced per the basis unit) is multiplied by
+ * the quantity the `driver` selects. Pure — no FX, no database. Multi-currency
+ * is preserved by returning the block's own `currency`; the reader (Finance)
+ * restates it into the accounting base at its own issue-date rate.
+ */
+export function resolvePlannedCost(
+  block: SnapshotPlannedCost,
+  quantities: DepartureQuantities,
+): ResolvedPlannedCost {
+  const multiplier = departureQuantityForDriver(block.driver, quantities, block.quantity)
+  return {
+    currency: block.currency,
+    amountCents: Math.round(block.rateCents * multiplier),
+    multiplier,
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2661,6 +2661,9 @@ importers:
       '@voyant-travel/payments':
         specifier: workspace:^
         version: link:../payments
+      '@voyant-travel/products-contracts':
+        specifier: workspace:^
+        version: link:../products-contracts
       '@voyant-travel/public-document-delivery':
         specifier: workspace:^
         version: link:../public-document-delivery


### PR DESCRIPTION
## Scope — #4037 complete (items 1–11)

An earlier revision of this PR carried only items 1–4 and said so. The remaining six landed since, plus the version-bound DB coverage the first pass left missing.

## Why

Planned cost was derived from `booking_items.totalCostAmountCents`, seeded from the **live mutable** `products.costAmountCents` with the **sell** currency rather than the day-service cost currency — so it drifted whenever someone edited the product. And `product_day_services` carried only a currency, an amount and a bare integer `quantity`: no rate basis, no quantity driver, so "planned cost" could not express *per traveler*, *per room* or *per night*.

Committed cost did not exist at all, though `booking_supplier_statuses`' own column comment says it "gives the commitment → invoice variance".

## What changed

**Planned** — `planned_cost_basis` + `quantity_driver` on `product_day_services`, reusing the `rate_unit` vocabulary rather than inventing a parallel one; a typed `plannedCost` block frozen into the Product Version snapshot with a zod contract; and a resolver that resolves **per `departure_service_operations` line**, which is the grain that makes variance-by-service meaningful. `plannedCostCaveat` reports departures with no `productVersionId` that still fall back to the booking-item path, rather than silently mixing sources.

**Committed** — projected from `booking_supplier_statuses` where `confirmedAt IS NOT NULL`, joined to the departure through the operation line so a commitment matches the planned service it commits against, with the same snapshot/residual FX split the existing `CurrencyTotals` uses.

**Completeness, break-even, issues, deep links** — cost completeness fed by the existing `unallocated` figure; `resolveBreakEven` returning `null` unless the departure is version-bound with positive pax, revenue and contribution, so it refuses ambiguous cases rather than printing a misleading number; four stable attention codes with severity and subject, no hrefs in the domain layer; and profitability rows now navigate to the Product and Departure workspaces instead of only opening an in-page dialog.

## Reviewer notes

- **Item 9's browser verification was not done, and the agent said so rather than faking it** — it could not stand up an authenticated operator SSR session with seeded data. The evidence is a real jsdom click test (3/3) plus typecheck binding `navigateTo("availabilitySlot.detail" / "product.detail")`. Reasonable, but it is not a browser check. The screenshots in `.agent-evidence/` are **pre-existing from earlier work**, not from this PR.
- **Item 5 reads `booking_supplier_statuses` via raw boundary SQL**, following the existing seam in that file. That keeps it invisible to the table-privacy ratchet — `finance->bookings` actually *dropped* 30→29 — but sidestepping a checker is a judgment call worth a human eye.
- **The frozen `0009_snapshot.json` edit was reverted out of this branch.** Its `prevId` does skip idx8, but that is one of **six** such breaks on `main` and nothing reads `prevId`; fixing one from inside a feature PR left the set inconsistent. Tracked as #4209 to be decided together.
- A forbidden `Co-Authored-By` model trailer appeared on the upstream commits and was stripped; I re-verified the rewritten trees are byte-identical and that no attribution remains.

## Verification

Re-run independently after rebasing, not relayed:

```
pnpm -F @voyant-travel/finance test             519 passed | 373 skipped (85 files)
pnpm -F @voyant-travel/finance-react test        54 passed (19 files)
pnpm -F @voyant-travel/products-contracts test   49 passed (7 files)
finance integration vs real Postgres             18 passed
typecheck finance / finance-react                0 errors each
biome check . --max-diagnostics=60               20 warnings, 8 infos, 0 errors
table-privacy-runner                             225 reach-ins, none new
pnpm i18n:check                                  parity + hardcoded-string scan clean
```

The rollup-exactness and immutability tests assert exact equality — planned cost stays `30000` after the live row is edited to `77777`, rather than merely "not throwing".

**One trap worth recording:** the integration suite first returned 15 failed / 3 passed with `relation "departure_service_operations" does not exist`. That was a 25-hour-old local `voyant-test-db` missing the #4035 table — not the code. Applying the DDL gave a clean 18/18.

Closes #4037