### PR TITLE
Commit supplier statuses from the frozen Product Version

### DIFF
--- a/.changeset/frozen-supplier-commitments.md
+++ b/.changeset/frozen-supplier-commitments.md
@@ -1,0 +1,11 @@
+---
+"@voyant-travel/products-contracts": patch
+---
+
+Declare a day service's own `costCurrency` / `costAmountCents` on the product
+version snapshot reader.
+
+They were already written into `product_versions.snapshot` and reachable only
+through `passthrough()`. Typing them lets a reader take the frozen commitment
+figures without re-deriving the blob's shape, and keeps them explicitly distinct
+from the driver-scaled `plannedCost` block, which answers a different question.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,6 +368,8 @@ jobs:
                 tests/integration/profitability.test.ts
               pnpm --filter @voyant-travel/bookings exec vitest run \
                 tests/integration/booking-amendments.test.ts
+              pnpm --filter @voyant-travel/bookings exec vitest run \
+                tests/integration/frozen-supplier-statuses.test.ts
               pnpm --filter @voyant-travel/operations exec vitest run \
                 tests/availability/integration/auto-allocate-concurrency.test.ts
               pnpm --filter @voyant-travel/operations exec vitest run \

--- a/packages/bookings/package.json
+++ b/packages/bookings/package.json
@@ -58,6 +58,7 @@
     "@voyant-travel/db": "workspace:^",
     "@voyant-travel/types": "workspace:^",
     "@voyant-travel/hono": "workspace:^",
+    "@voyant-travel/products-contracts": "workspace:^",
     "@voyant-travel/reporting-contracts": "workspace:^",
     "@voyant-travel/utils": "workspace:^",
     "drizzle-orm": "catalog:",

--- a/packages/bookings/src/availability-ref.ts
+++ b/packages/bookings/src/availability-ref.ts
@@ -19,6 +19,14 @@ export const availabilitySlotsRef = pgTable("availability_slots", {
   facilityId: text("facility_id"),
   availabilityRuleId: typeIdRef("availability_rule_id"),
   startTimeId: typeIdRef("start_time_id"),
+  /**
+   * The immutable Product Version this departure was materialized against
+   * (RFC #4027). Null for legacy departures and for slots generated before a
+   * product was ever published. Bookings reads it so proposal→booking
+   * conversion seeds supplier commitments from the frozen snapshot rather than
+   * the live, mutable product (voyant#4189).
+   */
+  productVersionId: text("product_version_id"),
   dateLocal: date("date_local").notNull(),
   startsAt: timestamp("starts_at", { withTimezone: true }).notNull(),
   endsAt: timestamp("ends_at", { withTimezone: true }),

--- a/packages/bookings/src/convert-day-services.ts
+++ b/packages/bookings/src/convert-day-services.ts
@@ -1,0 +1,275 @@
+/**
+ * Frozen day-service resolution for proposal→booking conversion (voyant#4189).
+ *
+ * `booking_supplier_statuses` is the operator's record of which supplier
+ * services a booking commits to. Conversion used to seed it from the LIVE,
+ * mutable `product_day_services`, keyed on `product.id`. That defeats the
+ * immutable Product Version RFC #4027 established precisely so a later Product
+ * edit cannot silently mutate an already-sold Departure: edit a day service
+ * after conversion and the committed supplier statuses correspond to no version
+ * at all — not the one sold, not necessarily the current one — so the same
+ * product edit produced different commitments depending only on WHEN conversion
+ * happened.
+ *
+ * This resolver reads the frozen `product_versions.snapshot` for any conversion
+ * whose departure is version-bound, and keeps the live read only where there is
+ * no version to read. Three things are deliberate:
+ *
+ *   1. It decodes through the SHARED reader
+ *      (`@voyant-travel/products-contracts/product-version-snapshot`, built by
+ *      voyant#4035, whose own docblock names this consumer). There is exactly
+ *      one parser for that blob; this file adds none.
+ *
+ *   2. It freezes the SAME figures the live read took — the day service's own
+ *      `costCurrency` / `costAmountCents` — not the driver-scaled #4037
+ *      `plannedCost` block. Those answer different questions: a commitment is a
+ *      flat amount owed to a supplier, whereas planned cost is a budget Finance
+ *      restates against a departure's own pax/rooms/nights. Swapping one for the
+ *      other here would change committed booking economics under the cover of a
+ *      freezing fix.
+ *
+ *   3. The fallback is REPORTED, never silent. Every resolution returns a
+ *      `ConvertDayServiceProvenance` naming the source, the version (when any),
+ *      and why it fell back — the same discipline `plannedCostCaveat` applies to
+ *      planned cost in `packages/finance/src/service-profitability.ts`. The
+ *      converter stamps it onto the booking so a reviewer can tell a
+ *      version-backed commitment from a legacy one after the fact.
+ *
+ * `product_versions` is read through a local `*Ref` mirror rather than an
+ * Inventory import: bookings is a retail-spine package and may not depend on the
+ * Inventory authoring runtime (scripts/check-retail-spine-closure.mjs). The
+ * mirror pins the table; the contracts reader pins the blob's shape.
+ */
+import {
+  defaultItineraryDaysFromSnapshot,
+  parseProductVersionSnapshot,
+  type SnapshotDayService,
+} from "@voyant-travel/products-contracts/product-version-snapshot"
+import { and, asc, eq, sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import {
+  productDayServicesRef,
+  productDaysRef,
+  productItinerariesRef,
+  productVersionsRef,
+} from "./products-ref.js"
+
+/** One supplier commitment to seed onto `booking_supplier_statuses`. */
+export interface ConvertDayService {
+  supplierServiceId: string | null
+  name: string
+  costCurrency: string
+  costAmountCents: number
+}
+
+/** Which source the day services were read from. */
+export type ConvertDayServiceSource = "product_version" | "live_product"
+
+/**
+ * Why a conversion could not use a frozen Version. Each value is a distinct
+ * operational situation, kept separate so the fallback rate can be read as
+ * "legacy data" vs "unbound departure" rather than one undifferentiated blob.
+ */
+export type ConvertDayServiceFallbackReason =
+  /** No departure was selected at all — nothing carries a version reference. */
+  | "no_departure_selected"
+  /** The departure exists but predates version binding (`product_version_id` is null). */
+  | "departure_not_version_bound"
+  /** The departure names a version whose row is gone, or belongs to another product. */
+  | "product_version_missing"
+
+/**
+ * The recorded account of where a booking's supplier commitments came from.
+ * Modelled on `ProfitabilityPlannedCostCaveat`: a fallback is a fact about the
+ * data, so it is surfaced rather than papered over.
+ */
+export interface ConvertDayServiceProvenance {
+  source: ConvertDayServiceSource
+  /** The frozen Version the commitments were read from, when there was one. */
+  productVersionId: string | null
+  /** The departure the version was resolved through, when one was selected. */
+  availabilitySlotId: string | null
+  /** Null exactly when `source` is `product_version`. */
+  fallbackReason: ConvertDayServiceFallbackReason | null
+  /** Commitments seeded. */
+  serviceCount: number
+  /**
+   * Frozen services dropped because the snapshot carried no cost columns —
+   * `booking_supplier_statuses` requires both, so such a service cannot become a
+   * commitment. Counted rather than defaulted to zero, which would invent a
+   * free supplier service.
+   */
+  servicesMissingCost: number
+}
+
+export interface ConvertDayServiceResolution {
+  dayServices: ConvertDayService[]
+  provenance: ConvertDayServiceProvenance
+}
+
+/** The departure fields this resolver needs; supplied by the caller. */
+export interface ConvertDeparture {
+  id: string
+  productVersionId: string | null
+}
+
+/**
+ * Order commitments the way the live query did: globally by `sortOrder` then id,
+ * with absent `sortOrder` last (Postgres `ORDER BY ... ASC` puts NULLs last).
+ * Preserved verbatim so this change is about WHICH source is read, never about
+ * the order commitments land in.
+ */
+function bySortOrderThenId(a: SnapshotDayService, b: SnapshotDayService): number {
+  const left = a.sortOrder ?? Number.MAX_SAFE_INTEGER
+  const right = b.sortOrder ?? Number.MAX_SAFE_INTEGER
+  if (left !== right) return left - right
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0
+}
+
+/**
+ * The live, mutable read — the pre-#4189 behaviour, unchanged. Reached only when
+ * there is no frozen Version to read, and always reported as such.
+ */
+async function readLiveDayServices(
+  db: PostgresJsDatabase,
+  productId: string,
+): Promise<ConvertDayService[]> {
+  // product_days is keyed by itinerary_id (products re-parented days onto
+  // product_itineraries), so the per-product lookup joins through the itinerary.
+  const days = await db
+    .select({ id: productDaysRef.id })
+    .from(productDaysRef)
+    .innerJoin(productItinerariesRef, eq(productDaysRef.itineraryId, productItinerariesRef.id))
+    .where(eq(productItinerariesRef.productId, productId))
+    .orderBy(asc(productDaysRef.dayNumber))
+
+  if (days.length === 0) return []
+
+  return db
+    .select({
+      supplierServiceId: productDayServicesRef.supplierServiceId,
+      name: productDayServicesRef.name,
+      costCurrency: productDayServicesRef.costCurrency,
+      costAmountCents: productDayServicesRef.costAmountCents,
+    })
+    .from(productDayServicesRef)
+    .where(
+      // agent-quality: raw-sql reviewed -- owner: bookings; dynamic SQL interpolation uses Drizzle parameter binding or vetted SQL identifiers.
+      sql`${productDayServicesRef.dayId} IN (
+        SELECT ${productDaysRef.id}
+        FROM ${productDaysRef}
+        INNER JOIN ${productItinerariesRef}
+          ON ${productDaysRef.itineraryId} = ${productItinerariesRef.id}
+        WHERE ${productItinerariesRef.productId} = ${productId}
+      )`,
+    )
+    .orderBy(asc(productDayServicesRef.sortOrder), asc(productDayServicesRef.id))
+}
+
+function fallback(
+  dayServices: ConvertDayService[],
+  reason: ConvertDayServiceFallbackReason,
+  departure: ConvertDeparture | null,
+): ConvertDayServiceResolution {
+  return {
+    dayServices,
+    provenance: {
+      source: "live_product",
+      productVersionId: null,
+      availabilitySlotId: departure?.id ?? null,
+      fallbackReason: reason,
+      serviceCount: dayServices.length,
+      servicesMissingCost: 0,
+    },
+  }
+}
+
+/**
+ * Resolve the supplier commitments a conversion should seed.
+ *
+ * Prefers the frozen `product_versions.snapshot` reached through the selected
+ * departure's `product_version_id`; falls back to the live product only when
+ * there is no version to read, and says so in the returned provenance.
+ *
+ * ONE departure is consulted, because a conversion targets at most one: the
+ * convert command carries a single top-level `slotId` and its `itemLines` carry
+ * no per-line departure reference (see `convertProductSchema` in
+ * `@voyant-travel/bookings-contracts`). A booking can come to span several
+ * departures later, through amendments or group merges, but it cannot be
+ * CREATED spanning them — so there is no multi-departure ambiguity to resolve at
+ * this seam, and inventing a rule for one would be speculative.
+ */
+export async function resolveConvertDayServices(
+  db: PostgresJsDatabase,
+  input: { productId: string; departure: ConvertDeparture | null },
+): Promise<ConvertDayServiceResolution> {
+  const { productId, departure } = input
+
+  if (!departure) {
+    return fallback(await readLiveDayServices(db, productId), "no_departure_selected", null)
+  }
+  if (!departure.productVersionId) {
+    return fallback(
+      await readLiveDayServices(db, productId),
+      "departure_not_version_bound",
+      departure,
+    )
+  }
+
+  // Match the product too: a departure pointing at another product's version is
+  // corrupt data, and seeding a booking from it would be worse than falling back.
+  const [version] = await db
+    .select({ snapshot: productVersionsRef.snapshot })
+    .from(productVersionsRef)
+    .where(
+      and(
+        eq(productVersionsRef.id, departure.productVersionId),
+        eq(productVersionsRef.productId, productId),
+      ),
+    )
+    .limit(1)
+
+  if (!version) {
+    return fallback(await readLiveDayServices(db, productId), "product_version_missing", departure)
+  }
+
+  // Parses loudly: an unreadable snapshot throws rather than yielding an empty
+  // commitment set, which would silently book a departure with no supplier
+  // obligations at all.
+  const snapshot = parseProductVersionSnapshot(version.snapshot)
+
+  // The DEFAULT itinerary is the one a departure operates (the same choice
+  // voyant#4035's materializer makes). The live fallback above still reads every
+  // itinerary, so unbound conversions keep their existing behaviour exactly.
+  const frozenServices = defaultItineraryDaysFromSnapshot(snapshot)
+    .flatMap((day) => day.services)
+    .sort(bySortOrderThenId)
+
+  const dayServices: ConvertDayService[] = []
+  let servicesMissingCost = 0
+  for (const service of frozenServices) {
+    if (service.costCurrency == null || service.costAmountCents == null) {
+      servicesMissingCost += 1
+      continue
+    }
+    dayServices.push({
+      supplierServiceId: service.supplierServiceId ?? null,
+      name: service.name,
+      costCurrency: service.costCurrency,
+      costAmountCents: service.costAmountCents,
+    })
+  }
+
+  return {
+    dayServices,
+    provenance: {
+      source: "product_version",
+      productVersionId: departure.productVersionId,
+      availabilitySlotId: departure.id,
+      fallbackReason: null,
+      serviceCount: dayServices.length,
+      servicesMissingCost,
+    },
+  }
+}

--- a/packages/bookings/src/products-ref.ts
+++ b/packages/bookings/src/products-ref.ts
@@ -1,5 +1,14 @@
 import { typeId, typeIdRef } from "@voyant-travel/db/lib/typeid-column"
-import { boolean, date, integer, pgTable, primaryKey, text, timestamp } from "drizzle-orm/pg-core"
+import {
+  boolean,
+  date,
+  integer,
+  jsonb,
+  pgTable,
+  primaryKey,
+  text,
+  timestamp,
+} from "drizzle-orm/pg-core"
 
 export const productsRef = pgTable("products", {
   id: typeId("products").primaryKey(),
@@ -96,6 +105,24 @@ export const productDayServicesRef = pgTable("product_day_services", {
   sortOrder: integer("sort_order"),
   notes: text("notes"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+})
+
+/**
+ * DELIBERATE local mirror of `product_versions` (owned by
+ * `@voyant-travel/inventory`). Bookings reads only the frozen `snapshot` blob,
+ * and only to seed supplier commitments at conversion (voyant#4189) — the
+ * immutable Product Version, not the live product, is what a sold departure
+ * committed to. Mirrored rather than imported because bookings is a retail-spine
+ * package and must not take a runtime dependency on the Inventory authoring
+ * runtime (enforced by scripts/check-retail-spine-closure.mjs). The blob is
+ * decoded through the shared `@voyant-travel/products-contracts` reader, so the
+ * SHAPE of the snapshot is still a contract, not a local guess.
+ */
+export const productVersionsRef = pgTable("product_versions", {
+  id: typeId("product_versions").primaryKey(),
+  productId: typeIdRef("product_id").notNull(),
+  versionNumber: integer("version_number").notNull(),
+  snapshot: jsonb("snapshot").notNull(),
 })
 
 export const productTicketSettingsRef = pgTable("product_ticket_settings", {

--- a/packages/bookings/src/service-core.ts
+++ b/packages/bookings/src/service-core.ts
@@ -44,6 +44,12 @@ import {
   assertMonthlyBookingLimitAvailable,
   BookingMonthlyLimitReachedError,
 } from "./booking-plan-limit.js"
+import {
+  type ConvertDayService,
+  type ConvertDayServiceProvenance,
+  type ConvertDeparture,
+  resolveConvertDayServices,
+} from "./convert-day-services.js"
 import { exchangeRatesRef } from "./markets-ref.js"
 import {
   applyTravelDetailSnapshot,
@@ -56,9 +62,6 @@ import {
   bookingProductDetailsRef,
   optionUnitsRef,
   productCategoryProductsRef,
-  productDayServicesRef,
-  productDaysRef,
-  productItinerariesRef,
   productOptionsRef,
   productsRef,
   productTicketSettingsRef,
@@ -321,12 +324,16 @@ export interface ConvertProductData {
     endsAt: Date | null
     timezone: string
   } | null
-  dayServices: Array<{
-    supplierServiceId: string | null
-    name: string
-    costCurrency: string
-    costAmountCents: number
-  }>
+  dayServices: ConvertDayService[]
+  /**
+   * Where `dayServices` came from — the frozen Product Version the departure was
+   * sold against, or the live product as a reported fallback (voyant#4189).
+   * Optional so the existing callers that hand-build `ConvertProductData` (tests
+   * and the sourced-commitment path) are unchanged; when absent the converter
+   * records the commitments as being of unknown provenance rather than assuming
+   * they were frozen.
+   */
+  dayServiceProvenance?: ConvertDayServiceProvenance
   units: Array<{
     id: string
     optionId: string
@@ -902,39 +909,6 @@ async function getConvertProductData(
     option = defaultOption ?? null
   }
 
-  // product_days is keyed by itinerary_id (products re-parented days onto
-  // product_itineraries); getConvertProductData joins through the itinerary
-  // ref so the per-product day lookup still works for converts that want to
-  // seed booking supplier statuses from the product's day services.
-  const days = await db
-    .select({ id: productDaysRef.id, dayNumber: productDaysRef.dayNumber })
-    .from(productDaysRef)
-    .innerJoin(productItinerariesRef, eq(productDaysRef.itineraryId, productItinerariesRef.id))
-    .where(eq(productItinerariesRef.productId, product.id))
-    .orderBy(asc(productDaysRef.dayNumber))
-
-  const dayServices = days.length
-    ? await db
-        .select({
-          supplierServiceId: productDayServicesRef.supplierServiceId,
-          name: productDayServicesRef.name,
-          costCurrency: productDayServicesRef.costCurrency,
-          costAmountCents: productDayServicesRef.costAmountCents,
-        })
-        .from(productDayServicesRef)
-        .where(
-          // agent-quality: raw-sql reviewed -- owner: bookings; dynamic SQL interpolation uses Drizzle parameter binding or vetted SQL identifiers.
-          sql`${productDayServicesRef.dayId} IN (
-            SELECT ${productDaysRef.id}
-            FROM ${productDaysRef}
-            INNER JOIN ${productItinerariesRef}
-              ON ${productDaysRef.itineraryId} = ${productItinerariesRef.id}
-            WHERE ${productItinerariesRef.productId} = ${product.id}
-          )`,
-        )
-        .orderBy(asc(productDayServicesRef.sortOrder), asc(productDayServicesRef.id))
-    : []
-
   let units: OptionUnitReference[] = []
   if (requestedUnitIds.length > 0) {
     const unitRows = await db
@@ -958,7 +932,12 @@ async function getConvertProductData(
       .orderBy(asc(optionUnitsRef.sortOrder), asc(optionUnitsRef.createdAt))
   }
 
+  // The departure is resolved BEFORE the day services, because it is what
+  // carries the frozen Product Version the commitments must come from
+  // (voyant#4189). Ordering matters: the day-service read is now a function of
+  // the selected departure, not of the live product alone.
   let slot: ConvertProductData["slot"] = null
+  let departure: ConvertDeparture | null = null
   if (data.slotId) {
     const [selectedSlot] = await db
       .select()
@@ -995,7 +974,18 @@ async function getConvertProductData(
       endsAt: selectedSlot.endsAt,
       timezone: selectedSlot.timezone,
     }
+    departure = {
+      id: selectedSlot.id,
+      productVersionId: selectedSlot.productVersionId,
+    }
   }
+
+  // Supplier commitments come from the frozen Version the departure was sold
+  // against wherever there is one; the live product is only a reported fallback.
+  const { dayServices, provenance: dayServiceProvenance } = await resolveConvertDayServices(db, {
+    productId: product.id,
+    departure,
+  })
 
   return {
     product: {
@@ -1013,6 +1003,7 @@ async function getConvertProductData(
     option: option ? { id: option.id, name: option.name } : null,
     slot,
     dayServices,
+    dayServiceProvenance,
     units: units.map((unit) => ({
       id: unit.id,
       optionId: unit.optionId,
@@ -2384,7 +2375,7 @@ const bookingsServiceInternal = {
     userId?: string,
     options: { availabilityHoldToken?: string; monthlyBookingLimit?: number | null } = {},
   ) {
-    const { product, option, slot, dayServices, units } = productData
+    const { product, option, slot, dayServices, dayServiceProvenance, units } = productData
 
     // Slot dates win over product dates so scheduled/recurring products don't
     // land with null dates. endsAt is a timestamp; fall back to the slot's
@@ -2811,6 +2802,22 @@ const bookingsServiceInternal = {
         productName: product.name,
         optionId: option?.id ?? null,
         slotId: slot?.id ?? null,
+        // Where this booking's supplier commitments came from (voyant#4189).
+        // Recorded on the conversion audit row so a reviewer can tell, after the
+        // fact, whether a booking's `booking_supplier_statuses` are backed by a
+        // frozen Product Version or by the live product — and, when they are
+        // not, exactly why. A silent fallback would be indistinguishable from a
+        // version-backed commitment, which is the failure mode RFC #4027 exists
+        // to prevent. `unknown` covers callers that build `ConvertProductData`
+        // themselves and therefore vouch for nothing.
+        supplierCommitmentProvenance: dayServiceProvenance ?? {
+          source: "unknown",
+          productVersionId: null,
+          availabilitySlotId: slot?.id ?? null,
+          fallbackReason: "provenance_not_supplied",
+          serviceCount: dayServices.length,
+          servicesMissingCost: 0,
+        },
         ...(convertedHold
           ? {
               availabilityHoldId: convertedHold.id,

--- a/packages/bookings/tests/integration/frozen-supplier-statuses.test.ts
+++ b/packages/bookings/tests/integration/frozen-supplier-statuses.test.ts
@@ -1,0 +1,450 @@
+/**
+ * Supplier commitments are frozen at the Product Version (voyant#4189).
+ *
+ * `booking_supplier_statuses` used to be seeded from the LIVE, mutable
+ * `product_day_services`, so editing a day service after conversion left an
+ * already-sold booking committed to services matching no version at all. RFC
+ * #4027 minted the immutable Product Version precisely to stop that.
+ *
+ * The test that matters is the one that MUTATES. A suite that converts and
+ * asserts the rows look right proves only that some read happened; it passes
+ * just as happily against the live product. So this suite edits the live
+ * `product_day_services` row — name, cost amount, AND cost currency — between
+ * conversions, and asserts that a conversion performed AFTER the edit still
+ * commits the frozen figures. That is the only assertion that can tell a frozen
+ * read from a live one.
+ *
+ * Conversion is driven through the real command seam
+ * (`settleBookingCreateDomain` behind an authentic action-ledger mutation
+ * lease), not by calling the internal converter directly — the lease is a
+ * security boundary and a test that bypassed it would prove less than it claims.
+ */
+import { executeAdmittedCreatedTargetCommand } from "@voyant-travel/action-ledger"
+import { newId } from "@voyant-travel/db/lib/typeid"
+import {
+  createToolRegistry,
+  defineTool,
+  type ToolHandlerActionPolicyContext,
+} from "@voyant-travel/tools"
+import { asc, eq } from "drizzle-orm"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+import { z } from "zod"
+import {
+  optionUnits,
+  productDayServices,
+  productDays,
+  productItineraries,
+  productOptions,
+  products,
+  productVersions,
+} from "../../../inventory/src/schema.js"
+import { itineraryHistoryProductsService } from "../../../inventory/src/service-itinerary-history.js"
+import { availabilitySlotsRef } from "../../src/availability-ref.js"
+import { settleBookingCreateDomain } from "../../src/booking-create-command-domain.js"
+import { bookingActivityLog, bookingSupplierStatuses } from "../../src/schema.js"
+
+const DB_AVAILABLE = Boolean(process.env.TEST_DATABASE_URL)
+
+/**
+ * A locally declared handler policy that mints an AUTHENTIC lease. It pins the
+ * command-target facts `settleBookingCreateDomain` compares, and its own action
+ * identity is passed back through the `actionName` option, so nothing here
+ * weakens the seam — it exercises it.
+ */
+const TEST_BOOKING_CREATE_ACTION = "@voyant-travel/bookings#test.action.frozen-supplier-statuses"
+const TEST_BOOKING_CREATE_POLICY = {
+  capabilityId: TEST_BOOKING_CREATE_ACTION,
+  capabilityVersion: "v1",
+  canonicalName: "create_booking_frozen_supplier_statuses_probe",
+  actionPolicy: {
+    id: TEST_BOOKING_CREATE_ACTION,
+    capabilityId: TEST_BOOKING_CREATE_ACTION,
+    version: "v1",
+    kind: "execute",
+    targetType: "booking",
+    targetLifecycle: "created",
+    ledger: "required",
+    approval: "never",
+    risk: "high",
+    reversible: false,
+    allowedActorTypes: ["staff"],
+    createdTarget: {
+      commandTargetType: "finance_booking_create_command",
+      resultReferenceType: "booking",
+      durability: "handler-command-claim-v1",
+    },
+  },
+} as const
+
+async function mintAdmission(idempotencyKey: string): Promise<ToolHandlerActionPolicyContext> {
+  let admitted: ToolHandlerActionPolicyContext | undefined
+  const registry = createToolRegistry()
+  registry.register(
+    defineTool({
+      owner: "@voyant-travel/bookings",
+      capabilityId: TEST_BOOKING_CREATE_POLICY.capabilityId,
+      capabilityVersion: TEST_BOOKING_CREATE_POLICY.capabilityVersion,
+      name: TEST_BOOKING_CREATE_POLICY.canonicalName,
+      description: "Mint an authentic booking-create admission for integration coverage.",
+      inputSchema: z.object({}),
+      outputSchema: z.object({ ok: z.literal(true) }),
+      requiredScopes: [],
+      audience: { source: "grant", allowed: ["staff"] },
+      tier: "destructive",
+      riskPolicy: {
+        destructive: true,
+        reversible: false,
+        dryRunSupported: false,
+        confirmationRequired: true,
+        sideEffects: ["data-write", "external-booking", "payment"],
+      },
+      actionPolicyEnforcement: "handler",
+      async handler(_args, context) {
+        admitted = context.handlerActionPolicy
+        return { ok: true as const }
+      },
+    }),
+    { actionPolicy: TEST_BOOKING_CREATE_POLICY.actionPolicy },
+  )
+  await registry.dispatch(
+    TEST_BOOKING_CREATE_POLICY.canonicalName,
+    {},
+    {
+      db: {},
+      actor: "staff",
+      audience: "staff",
+      tenantId: "tenant_bookings_frozen_supplier_statuses",
+      resolverScope: {
+        locale: "en-GB",
+        audience: "staff",
+        market: "default",
+        actor: "staff",
+      },
+      handlerActionPolicy: {
+        ...TEST_BOOKING_CREATE_POLICY,
+        actionPolicy: {
+          ...TEST_BOOKING_CREATE_POLICY.actionPolicy,
+          enforcement: "handler",
+          invocation: {
+            controlField: "_voyant",
+            requiredFields: ["confirmed", "idempotencyKey"],
+            optionalFields: ["reasonCode", "approvalId", "idempotencyFingerprint"],
+            fingerprintAlgorithm: "action-ledger-command-v1",
+          },
+        },
+        invocation: { confirmed: true, idempotencyKey },
+      },
+    },
+  )
+  if (!admitted) throw new Error("Tool registry did not mint the booking-create admission")
+  return admitted
+}
+
+describe.skipIf(!DB_AVAILABLE)(
+  "booking supplier statuses are frozen at the Product Version",
+  () => {
+    let db: ReturnType<typeof import("@voyant-travel/db/test-utils").createTestDb>
+    let sequence = 0
+
+    beforeAll(async () => {
+      const { cleanupTestDb, createTestDb } = await import("@voyant-travel/db/test-utils")
+      db = createTestDb()
+      await cleanupTestDb(db)
+    })
+
+    beforeEach(async () => {
+      const { cleanupTestDb } = await import("@voyant-travel/db/test-utils")
+      await cleanupTestDb(db)
+    })
+
+    afterAll(async () => {
+      const { closeTestDb } = await import("@voyant-travel/db/test-utils")
+      await closeTestDb()
+    })
+
+    /**
+     * A one-day product with two priced day services, frozen as version 1, plus a
+     * departure. `bindVersion` decides whether the departure is version-bound —
+     * the single axis every assertion below turns on.
+     */
+    async function seed(options: { bindVersion: boolean }) {
+      const ids = {
+        productId: newId("products"),
+        optionId: newId("product_options"),
+        unitId: newId("option_units"),
+        itineraryId: newId("product_itineraries"),
+        dayId: newId("product_days"),
+        serviceA: newId("product_day_services"),
+        serviceB: newId("product_day_services"),
+        versionId: newId("product_versions"),
+        slotId: newId("availability_slots"),
+      }
+
+      await db.insert(products).values({
+        id: ids.productId,
+        name: "Danube Delta Escape",
+        sellCurrency: "EUR",
+        sellAmountCents: 90_000,
+        costAmountCents: 40_000,
+        bookingMode: "date",
+      })
+      await db.insert(productOptions).values({
+        id: ids.optionId,
+        productId: ids.productId,
+        name: "Standard",
+        status: "active",
+        isDefault: true,
+        sortOrder: 0,
+      })
+      // Exactly one required unit, so conversion resolves a line without the
+      // caller having to supply explicit `itemLines`.
+      await db.insert(optionUnits).values({
+        id: ids.unitId,
+        optionId: ids.optionId,
+        name: "Adult",
+        unitType: "person",
+        isRequired: true,
+        minQuantity: 1,
+        sortOrder: 0,
+      })
+      await db.insert(productItineraries).values({
+        id: ids.itineraryId,
+        productId: ids.productId,
+        name: "Default",
+        isDefault: true,
+        sortOrder: 0,
+      })
+      await db.insert(productDays).values({
+        id: ids.dayId,
+        itineraryId: ids.itineraryId,
+        dayNumber: 1,
+        title: "Arrival",
+      })
+      await db.insert(productDayServices).values([
+        {
+          id: ids.serviceA,
+          dayId: ids.dayId,
+          serviceType: "accommodation",
+          name: "Pelican Lodge — half board",
+          supplierServiceId: "svc_lodge",
+          costCurrency: "EUR",
+          costAmountCents: 25_000,
+          quantity: 1,
+          sortOrder: 0,
+        },
+        {
+          id: ids.serviceB,
+          dayId: ids.dayId,
+          serviceType: "experience",
+          name: "Sunrise boat safari",
+          supplierServiceId: "svc_boat",
+          costCurrency: "EUR",
+          costAmountCents: 15_000,
+          quantity: 1,
+          sortOrder: 1,
+        },
+      ])
+
+      const snapshot = await itineraryHistoryProductsService.buildSnapshot(db, ids.productId)
+      await db.insert(productVersions).values({
+        id: ids.versionId,
+        productId: ids.productId,
+        versionNumber: 1,
+        snapshot,
+        authorId: "tester",
+      })
+
+      const now = new Date()
+      await db.insert(availabilitySlotsRef).values({
+        id: ids.slotId,
+        productId: ids.productId,
+        optionId: ids.optionId,
+        productVersionId: options.bindVersion ? ids.versionId : null,
+        dateLocal: "2026-09-14",
+        startsAt: new Date("2026-09-14T06:00:00.000Z"),
+        endsAt: null,
+        timezone: "Europe/Bucharest",
+        status: "open",
+        unlimited: false,
+        initialPax: 20,
+        remainingPax: 20,
+        pastCutoff: false,
+        tooEarly: false,
+        createdAt: now,
+        updatedAt: now,
+      })
+
+      return ids
+    }
+
+    async function convert(ids: Awaited<ReturnType<typeof seed>>) {
+      sequence += 1
+      const commandKey = `bookings-frozen-supplier-statuses-${sequence}`
+      const admitted = await mintAdmission(commandKey)
+      const input = {
+        productId: ids.productId,
+        optionId: ids.optionId,
+        slotId: ids.slotId,
+        bookingNumber: `BK-FROZEN-${String(sequence).padStart(6, "0")}`,
+        pax: 2,
+      }
+
+      const result = await executeAdmittedCreatedTargetCommand(
+        {
+          db,
+          context: {
+            userId: "user_bookings_frozen_supplier_statuses",
+            callerType: "session",
+            actor: "staff",
+            organizationId: "tenant_bookings_frozen_supplier_statuses",
+          },
+          admitted,
+          commandTargetType: "finance_booking_create_command",
+          canonicalTargetType: "booking",
+          resultReferenceType: "booking",
+          commandInput: input,
+          evaluatedRisk: "high",
+        },
+        {
+          async create(tx, lease) {
+            const booking = await settleBookingCreateDomain(
+              lease,
+              tx,
+              commandKey,
+              input,
+              "tester",
+              {
+                actionName: TEST_BOOKING_CREATE_ACTION,
+                actionVersion: "v1",
+              },
+            )
+            if (!booking) throw new Error("conversion returned no booking")
+            return { value: booking, targetId: booking.id }
+          },
+          async replay() {
+            throw new Error("conversion unexpectedly replayed")
+          },
+        },
+      )
+
+      return result.value
+    }
+
+    const commitmentsOf = async (bookingId: string) =>
+      db
+        .select({
+          supplierServiceId: bookingSupplierStatuses.supplierServiceId,
+          serviceName: bookingSupplierStatuses.serviceName,
+          costCurrency: bookingSupplierStatuses.costCurrency,
+          costAmountCents: bookingSupplierStatuses.costAmountCents,
+        })
+        .from(bookingSupplierStatuses)
+        .where(eq(bookingSupplierStatuses.bookingId, bookingId))
+        .orderBy(asc(bookingSupplierStatuses.createdAt), asc(bookingSupplierStatuses.id))
+
+    const provenanceOf = async (bookingId: string) => {
+      const [row] = await db
+        .select({ metadata: bookingActivityLog.metadata })
+        .from(bookingActivityLog)
+        .where(eq(bookingActivityLog.bookingId, bookingId))
+      return (row?.metadata as Record<string, unknown> | null)?.supplierCommitmentProvenance as
+        | Record<string, unknown>
+        | undefined
+    }
+
+    const FROZEN = [
+      {
+        supplierServiceId: "svc_lodge",
+        serviceName: "Pelican Lodge — half board",
+        costCurrency: "EUR",
+        costAmountCents: 25_000,
+      },
+      {
+        supplierServiceId: "svc_boat",
+        serviceName: "Sunrise boat safari",
+        costCurrency: "EUR",
+        costAmountCents: 15_000,
+      },
+    ]
+
+    it("commits the frozen Version's day services, and a later Product edit changes nothing", async () => {
+      const ids = await seed({ bindVersion: true })
+
+      const first = await convert(ids)
+      expect(await commitmentsOf(first.id)).toEqual(FROZEN)
+      expect(await provenanceOf(first.id)).toMatchObject({
+        source: "product_version",
+        productVersionId: ids.versionId,
+        availabilitySlotId: ids.slotId,
+        fallbackReason: null,
+        serviceCount: 2,
+        servicesMissingCost: 0,
+      })
+
+      // The operator now edits the LIVE product: a different supplier service, a
+      // different price, and a different currency. Under publish this would mint
+      // version 2; the departure stays bound to version 1.
+      await db
+        .update(productDayServices)
+        .set({
+          name: "MUTATED — budget hostel",
+          supplierServiceId: "svc_hostel",
+          costCurrency: "USD",
+          costAmountCents: 1_000,
+        })
+        .where(eq(productDayServices.id, ids.serviceA))
+      await db
+        .update(productDayServices)
+        .set({
+          name: "MUTATED — cancelled safari",
+          costCurrency: "RON",
+          costAmountCents: 999,
+        })
+        .where(eq(productDayServices.id, ids.serviceB))
+
+      // The commitments already written are untouched.
+      expect(await commitmentsOf(first.id)).toEqual(FROZEN)
+
+      // And — the assertion that actually distinguishes a frozen read from a live
+      // one — a conversion run AFTER the edit still commits the frozen figures.
+      const second = await convert(ids)
+      expect(await commitmentsOf(second.id)).toEqual(FROZEN)
+      expect(await provenanceOf(second.id)).toMatchObject({
+        source: "product_version",
+        productVersionId: ids.versionId,
+      })
+    })
+
+    it("falls back to the live product for an unbound departure, and records that it did", async () => {
+      const ids = await seed({ bindVersion: false })
+
+      await db
+        .update(productDayServices)
+        .set({ name: "Live name", costCurrency: "USD", costAmountCents: 4_200 })
+        .where(eq(productDayServices.id, ids.serviceA))
+
+      const booking = await convert(ids)
+
+      // A departure with no `product_version_id` has no frozen source to read, so
+      // the live product remains the documented fallback — unchanged behaviour.
+      expect(await commitmentsOf(booking.id)).toEqual([
+        {
+          supplierServiceId: "svc_lodge",
+          serviceName: "Live name",
+          costCurrency: "USD",
+          costAmountCents: 4_200,
+        },
+        FROZEN[1],
+      ])
+
+      // The point of the fallback contract: it is never silent.
+      expect(await provenanceOf(booking.id)).toMatchObject({
+        source: "live_product",
+        productVersionId: null,
+        availabilitySlotId: ids.slotId,
+        fallbackReason: "departure_not_version_bound",
+        serviceCount: 2,
+      })
+    })
+  },
+)

--- a/packages/products-contracts/src/product-version-snapshot.ts
+++ b/packages/products-contracts/src/product-version-snapshot.ts
@@ -100,13 +100,20 @@ export const snapshotPlannedCostSchema = z
 export type SnapshotPlannedCost = z.infer<typeof snapshotPlannedCostSchema>
 
 /**
- * One day service as frozen in a version snapshot. Costing columns
- * (`costCurrency`, `costAmountCents`, …) are tolerated but not required here;
- * the tracer reads the operational columns. `inclusionRole` / `travelerScope`
- * default so a snapshot taken before those columns existed still parses.
- * `plannedCost` is the voyant#4037 declared cost block; it is `nullish` so a
- * snapshot minted before the block existed still parses (the reader treats a
- * missing block as "no version-based planned cost" and falls back).
+ * One day service as frozen in a version snapshot. `inclusionRole` /
+ * `travelerScope` default so a snapshot taken before those columns existed still
+ * parses. `plannedCost` is the voyant#4037 declared cost block; it is `nullish`
+ * so a snapshot minted before the block existed still parses (the reader treats
+ * a missing block as "no version-based planned cost" and falls back).
+ *
+ * `costCurrency` / `costAmountCents` are the day service's OWN cost columns,
+ * frozen verbatim from `product_day_services`. They are deliberately distinct
+ * from `plannedCost`: these are the flat, unscaled commitment figures the
+ * booking converter (voyant#4189) writes onto `booking_supplier_statuses`,
+ * whereas `plannedCost` is the driver-scaled budget block Finance restates
+ * against a departure's own quantities. Both are declared because they answer
+ * different questions and a reader must not silently substitute one for the
+ * other. They are `nullish` so a snapshot predating either still parses.
  */
 export const snapshotDayServiceSchema = z
   .object({
@@ -123,6 +130,8 @@ export const snapshotDayServiceSchema = z
     inclusionRole: dayServiceInclusionRoleSchema.default("included"),
     travelerScope: dayServiceTravelerScopeSchema.default("all"),
     sortOrder: z.number().int().nullish(),
+    costCurrency: z.string().nullish(),
+    costAmountCents: z.number().int().nullish(),
     plannedCost: snapshotPlannedCostSchema.nullish(),
   })
   .passthrough()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1526,6 +1526,9 @@ importers:
       '@voyant-travel/hono':
         specifier: workspace:^
         version: link:../hono
+      '@voyant-travel/products-contracts':
+        specifier: workspace:^
+        version: link:../products-contracts
       '@voyant-travel/reporting-contracts':
         specifier: workspace:^
         version: link:../reporting-contracts


### PR DESCRIPTION
## Why

`booking_supplier_statuses` records which supplier services a booking commits to. It was seeded at proposal→booking conversion from the **live** `product_day_services`, keyed on `product.id` — nothing consulted `product_versions.snapshot`.

So editing a day service after conversion left an already-committed booking corresponding to **no version**: not the one sold, not necessarily the current one. The same product edit produced different commitments depending only on *when* conversion happened. That is exactly what the immutable Version from #4030/#4032 exists to prevent, and it was the last place in the RFC still reading live product truth for a committed record.

## What changed

Conversion resolves day services through the departure's `availability_slots.product_version_id`, parsing the snapshot with the shared reader in `@voyant-travel/products-contracts` — not a second parser.

Bookings with no bound Version keep the live read, and **that fallback is recorded rather than silent**: provenance (source, version id, slot id, reason, service count, services missing cost) is stamped onto the existing `booking_converted` audit row. No migration — it is jsonb-queryable on a surface that already exists. This follows the `plannedCostCaveat` precedent from #4037. Callers that hand-build the conversion payload record `unknown` rather than falsely claiming a frozen read.

## Decisions worth reviewing

- **The closure question resolved itself.** `@voyant-travel/products-contracts` is already a dependency of `finance` and `commerce`, both retail-spine roots, so the edge was inside the closure and is not in `forbiddenPackages`. `product_versions` is reached through a local `*Ref` mirror per the `availability-ref.ts` precedent, so the table-privacy ratchet is untouched. `verify:retail-spine-closure` passes.
- **A conversion cannot span departures**, so no multi-departure rule was invented. `convertProductSchema` carries one top-level `slotId` and its item lines carry no per-line departure reference; every item inherits that slot. A booking can come to span departures later via amendments, but not at creation. Documented in the resolver's docblock.
- **Behaviour change:** the frozen path reads the **default itinerary**, matching #4035's materializer — it is what a departure operates. The live fallback still reads every itinerary, so unbound conversions are byte-identical to before.
- **Deliberately did not switch to `plannedCost`.** The frozen `costCurrency`/`costAmountCents` are the same figures the live read took. #4037's `plannedCost` block is driver-scaled *budget*, not a flat supplier commitment — swapping it in here would change committed booking economics under cover of a freezing fix.

## The test is load-bearing, and was verified by breaking it

It drives the real command seam (`settleBookingCreateDomain` behind an authentic action-ledger lease) rather than calling the internal converter, and it asserts that a conversion run **after** the live edit still commits frozen figures — asserting that already-written rows are unchanged proves nothing, since nothing rewrites them.

With the fix disabled it fails on exactly the right thing:

```
+     "serviceName": "MUTATED — budget hostel",
+     "serviceName": "MUTATED — cancelled safari",
```

## Not fixed here, and why

`booking_items.totalCostAmountCents` is likewise seeded from the live `products.costAmountCents`, with `costCurrency` taken from the **sell** currency. Both halves are out of scope rather than overlooked:

- #4037 chose to supersede that value at *read* time and `service-planned-cost.ts` documents it as the fallback for departures with no `product_version_id` — changing the write would alter the fallback the profitability report depends on.
- The currency half is not cheaply fixable either: `products` has `costAmountCents` with **no cost-currency column**, so the sell currency is the only one available, and substituting a day-service cost currency would be wrong since services can differ in currency.

Sites: `service-core.ts` around `:2617/:2624` and `:2644/:2646`. Worth its own issue.

## Verification

```
frozen-supplier-statuses.test.ts (real Postgres)   2 passed
@voyant-travel/bookings                          464 passed | 160 skipped (72 files)
@voyant-travel/products-contracts                 49 passed (7 files)
@voyant-travel/finance                           519 passed | 373 skipped (85 files)
@voyant-travel/operations                        321 passed | 424 skipped (60 files)
@voyant-travel/inventory                         581 passed |  58 skipped (85 files)
operations departure-service-operations (#4035)    3 passed (real Postgres)

biome check . --max-diagnostics=60    20 warnings, 8 infos, 0 errors (matches clean main)
table-privacy-runner                  225 reach-ins, none new
verify:retail-spine-closure           Verified retail spine package closure.
typecheck  bookings / finance / products-contracts / commerce / admin-contracts — 0 errors each
```

`operations` and `inventory` typecheck returned 134 with **zero `error TS` lines** — OOM under local load, not type errors (see #4223). CI `build-graph` is authoritative.

Closes #4189