### PR TITLE
fix(starters): pin the TanStack router and start family coherently

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,11 @@ jobs:
             exit 1
           fi
 
+      # Starter packaging derives the TanStack pin set from the workspace's
+      # resolved install, so the store must exist before packaging (#4233).
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Package starter archives
         run: pnpm package:starters -- --version "$RELEASE_VERSION" --out-dir .release/starters
 

--- a/scripts/package-starters.mjs
+++ b/scripts/package-starters.mjs
@@ -13,6 +13,35 @@ import { dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+
+// The TanStack router + Start toolchain ships as one coupled release train: the
+// Start hydration harness (@tanstack/start-client-core) reads router internals
+// off the router that @tanstack/react-router / @tanstack/router-core build, so
+// the two halves must come from the same era. A packaged starter pins only
+// @tanstack/react-router (runtimeDependencyCoordinates), and the isolated
+// consumer install has no lockfile, so the rest of the family floats to whatever
+// is `latest` on npm at install time. When the float crosses an upstream rename
+// (e.g. router store `matchesId` -> `ids` between start-client-core 1.170.14 and
+// 1.170.15), the floated harness reads a field the pinned router never built and
+// hydration throws `Cannot read properties of undefined (reading 'get')`.
+// Pinning the whole family to the workspace-resolved (coherent) versions keeps
+// the halves from splitting. Add a new family member here in one line; its
+// version is derived from the workspace install below. Refs #4233.
+const TANSTACK_ROUTER_START_FAMILY = [
+  "@tanstack/react-router",
+  "@tanstack/router-core",
+  "@tanstack/router-plugin",
+  "@tanstack/router-generator",
+  "@tanstack/router-utils",
+  "@tanstack/react-start",
+  "@tanstack/react-start-client",
+  "@tanstack/react-start-server",
+  "@tanstack/start-client-core",
+  "@tanstack/start-server-core",
+  "@tanstack/start-plugin-core",
+  "@tanstack/history",
+]
+
 const args = parseArgs(process.argv.slice(2))
 const version = resolveVersion(args.version)
 const outDir = resolve(repoRoot, args.outDir ?? ".release/starters")
@@ -74,6 +103,7 @@ function stageMinimalOperatorStarter(stagingTemplate, localLinks) {
           : standardNodeStarter.developmentDependencyCoordinates[name],
       ]),
     ),
+    pnpm: { overrides: tanstackRouterStartOverrides() },
   })
   writeFileSync(
     join(stagingTemplate, "voyant.config.ts"),
@@ -118,6 +148,38 @@ function workspacePackageDirectory(name) {
 function workspacePackageVersion(name) {
   const packageDirectory = workspacePackageDirectory(name)
   return readJson(join(packageDirectory, "package.json")).version
+}
+
+// Exact-pin the coupled TanStack router + Start family to the single coherent
+// set the workspace already resolved, so a lockfile-less consumer install cannot
+// float half of it. Versions come from one source (the workspace install), so
+// the two halves can never drift apart the way #4233 did.
+function tanstackRouterStartOverrides() {
+  return Object.fromEntries(
+    TANSTACK_ROUTER_START_FAMILY.map((name) => [name, workspaceInstalledVersion(name)]),
+  )
+}
+
+function workspaceInstalledVersion(name) {
+  const store = join(repoRoot, "node_modules", ".pnpm")
+  const prefix = `${name.replace("/", "+")}@`
+  const versions = new Set()
+  for (const entry of readdirSync(store)) {
+    if (!entry.startsWith(prefix)) continue
+    // `.pnpm` dirs are `<name>@<version>[_<peer-hash>]`; take the version token.
+    const version = entry.slice(prefix.length).split("_", 1)[0]
+    if (/^\d/.test(version)) versions.add(version)
+  }
+  if (versions.size !== 1) {
+    throw new Error(
+      `Cannot coherently pin ${name}: workspace resolves ${
+        versions.size === 0
+          ? "no versions"
+          : `${versions.size} versions (${[...versions].join(", ")})`
+      }. Install the workspace before packaging starters, and reconcile the TanStack family to one release train.`,
+    )
+  }
+  return [...versions][0]
 }
 
 function readJson(path) {

--- a/scripts/tests/minimal-starter-acceptance.FINDINGS.md
+++ b/scripts/tests/minimal-starter-acceptance.FINDINGS.md
@@ -2,121 +2,172 @@
 
 ## Summary
 
-The reported `pageerror: Cannot read properties of undefined (reading 'get')`
-hydration failure is **not caused by the repo diff** between the last-passing
-commit `9a10fa57a` and the "failing" release commit `d738daf55`. That diff is
-`@voyant-travel/*` version fields + CHANGELOGs only, none of which affect the
-runtime graph. Both commits **pass** the acceptance test in a clean local build
-(evidence below).
+`pageerror: Cannot read properties of undefined (reading 'get')` at hydration is
+**reproduced**. The crash is `router.stores.ids.get()` in TanStack Start's
+`hydrateStart`, where `router.stores.ids` is `undefined`.
 
-The real trigger is external: a floating install of the **TanStack Start
-toolchain** in the test's isolated starter app, which pulls in a *second* copy
-of `@tanstack/react-router` / `@tanstack/router-core` alongside the copy the
-starter pins. Two `router-core` module instances in one client bundle means the
-router context registry created by one instance is invisible to a hook from the
-other → `.get` on an undefined context at hydration.
+Root cause: the packaged starter pins `@tanstack/react-router` (via
+`standard-node-starter.json` coordinates) and Vite dedupes the client to that
+copy, but it lets the rest of the **TanStack Start toolchain float freely** in
+the test's isolated app install. When the float crosses an upstream release that
+**renamed the router store field `matchesId` → `ids`**, the floated hydration
+harness (`@tanstack/start-client-core`) reads `router.stores.ids` off a router
+that the pinned/deduped `@tanstack/router-core` built with the *old* field name.
+Field is undefined → `.get()` throws → hydration never completes → the probe
+never sets `hydrated` → `waitForFunction` times out.
 
-## Evidence
+The "version-only repo diff" between the passing and failing commits is a red
+herring: the trigger is an external npm publish that landed in the CI window.
 
-Clean full `pnpm build`, then `node --test scripts/tests/minimal-starter-acceptance.test.mjs`:
+## The actual stack (deliverable #1)
 
-- `d738daf55` (HEAD, the "failing" commit): **5/5 pass**, incl. "hydrates the
-  production client bundle without browser errors".
-- `9a10fa57a` (last passing commit): **5/5 pass**.
+`voyant develop` (unminified) — names the module + symbol + line directly:
 
-So the failure does not reproduce from either commit's source in the current
-environment. On a passing `start`-mode run the test asserts `browserErrors`
-deep-equals `[]` (test line ~588), so the `pageerror` is *not* passive noise —
-when it appears it is a real hydration crash, it is simply intermittent on top
-of the duplicate-install condition.
+```
+pageerror: Cannot read properties of undefined (reading 'get')
+TypeError: Cannot read properties of undefined (reading 'get')
+    at hydrateStart (.../@tanstack+start-client-core@1.170.15/node_modules/@tanstack/start-client-core/dist/esm/client/hydrateStart.js:27:25)
+```
+Vite dev source link resolves the frame to
+`@tanstack/start-client-core/src/client/hydrateStart.ts:55:25`:
 
-### The duplicate
+```ts
+// hydrateStart.ts:55
+if (!router.stores.ids.get().length) {   // <-- router.stores.ids is undefined
+  await hydrate(router)
+}
+```
 
-In the installed starter `node_modules` (retained via `VOYANT_KEEP_ARTIFACTS=1`):
+`voyant start` (production, minified) — same call, confirmed by the built chunk:
 
-| package | copies |
+```
+pageerror: Cannot read properties of undefined (reading 'get')
+    at nn (http://127.0.0.1:<port>/assets/index-x-lM0s1k.js:1:23782)
+```
+`index-x-lM0s1k.js` contains, verbatim:
+`...serializationAdapters:t}),e.stores.ids.get().length||await Ce(e)`
+(`e` = router, `Ce` = `hydrate`) — the minified `hydrateStart`. Production and
+dev crash at the identical `router.stores.ids.get()` line. (No `.map` is emitted
+for the production client bundle, so the frame was mapped by grepping the chunk.)
+
+## Why `router.stores.ids` is undefined — the field rename
+
+`@tanstack/start-client-core` `hydrateStart` across the pass/crash boundary:
+
+| start-client-core | hydrateStart line 27 (dist) |
 |---|---|
-| `react`, `react-dom`, `@tanstack/react-query` | 1 each (fine) |
-| `@tanstack/react-router` | **2** — `1.170.17` and `1.170.18` |
-| `@tanstack/router-core` | **2** — `1.171.14` and `1.171.15` |
+| `1.170.14` (passing float) | `if (!router.stores.matchesId.get().length) await hydrate(router)` |
+| `1.170.15` (crashing float) | `if (!router.stores.ids.get().length) await hydrate(router)` |
 
-Resolution map:
+The router the app builds is the Vite-deduped `@tanstack/react-router@1.170.17`
+→ `@tanstack/router-core@1.171.14`, whose `router.stores` has **`matchesId`, not
+`ids`** (router-core grew a dedicated `stores.js` exposing `ids` only by
+`1.171.16`). So:
 
-- app root `@tanstack/react-router@1.170.17` → `router-core@1.171.14`  (= starter coordinate)
-- `@tanstack/react-start@1.168.34`, `@tanstack/react-start-client@1.168.16`,
-  `@tanstack/router-plugin@1.168.23` → `@tanstack/react-router@1.170.18` → `router-core@1.171.15`
+- `start-client-core@1.170.14` reads `router.stores.matchesId` → present on the
+  `1.171.14` router → **works**.
+- `start-client-core@1.170.15` reads `router.stores.ids` → **undefined** on the
+  `1.171.14` router → **throws**.
 
-The toolchain packages **hard-pin** their router:
-`react-start-client@1.168.16` declares `@tanstack/react-router: "1.170.18"`
-(exact) and `@tanstack/router-core: "1.171.15"` (exact); `router-plugin` needs
-`^1.170.18`. `1.170.17` does **not** satisfy `^1.170.18`, so pnpm is *forced* to
-keep both — this is a guaranteed two-copy install, not a dedupe accident.
+Duplication alone is not sufficient to crash (my first run had two router-core
+copies, `1.171.14` + `1.171.15`, and passed). The crash needs the harness to
+adopt the renamed `ids` field while the pinned/deduped router still exposes
+`matchesId`.
 
-### Why the version float, and why CI bisected to a repo commit
+## Corrected timeline (supersedes the earlier 1.168.16 claim)
 
-- The workspace's committed lockfile pins `@tanstack/react-start-client@1.168.15`,
-  whose router pin is `1.170.17` / `1.171.14` — consistent with the starter
-  coordinate. In-repo, everything is single-copy.
-- The acceptance test installs the starter app with `--ignore-workspace` and
-  `--config.frozen-lockfile=false` and **no app lockfile**, so it ignores the
-  workspace pin and re-resolves the toolchain to the newest matching release —
-  `react-start-client@1.168.16`, which hard-pins the newer `1.170.18` router.
-- `1.168.16` is an upstream npm publish. It landed between the last passing CI
-  run and the "failing" one, so CI's bisection window straddles the npm publish,
-  not a repo change. Any commit re-run after that publish would fail the same way;
-  any commit re-run before it would pass.
+`@tanstack/react-start-client` hard-pins its router/harness versions:
 
-### Why Vite doesn't save it deterministically
+| react-start-client | react-router | router-core | start-client-core | published (UTC) |
+|---|---|---|---|---|
+| 1.168.15 | 1.170.17 | 1.171.14 | 1.170.13/14 | 2026-07-01 |
+| 1.168.16 | 1.170.18 | 1.171.15 | **1.170.14** (`matchesId`) | 2026-07-13 |
+| 1.168.17 | 1.170.19 | 1.171.16 | **1.170.15** (`ids`) | **2026-08-04T20:35:44Z** |
 
-`packages/vite-config/src/index.ts` dedupes `@tanstack/react-router` for the
-client build (`VOYANT_DEDUPE_DEPENDENCIES`, line ~340) but **not**
-`@tanstack/router-core`. `@tanstack/react-start` is force-bundled into the client
-(`noExternal`, `TANSTACK_START_BUNDLED_PACKAGES`) and imports `router-core`
-directly, so react-start drags `router-core@1.171.15` into the bundle while the
-deduped `react-router` brings `router-core@1.171.14`. The router context
-singleton lives in `router-core`, so the two instances split it. Whether this
-crashes at hydration depends on chunk/hoist order, which is why it is
-intermittent locally but reproduced in CI.
+CI bisection window (UTC): `9a10fa57a` committed `2026-08-04T20:15:47Z` (PASSED),
+`d738daf55` committed `2026-08-04T20:32:12Z` (FAILED). `1.168.16` was already
+`latest` three weeks before the passing run, so it cannot be the trigger. The
+publish that straddles the window is **`1.168.17`, ~3 minutes after the release
+commit** — its `start-client-core@1.170.15` is the first with the `ids` rename.
+That is why the repo diff is version fields only, yet main fails reproducibly:
+the failing edge is an upstream npm publish, not a source change.
 
-## Recommended fix (not applied — see below)
+My earlier local run could not reproduce because pnpm served **stale registry
+metadata** and installed `react-start-client@1.168.16` (→ `start-client-core@1.170.14`,
+still `matchesId`), i.e. the pre-failure float state — which is also why it
+passed with the duplicate pair present.
 
-Options, most durable first:
+## Reproduction (what I did)
 
-1. **Stop the isolated app install from floating the TanStack Start toolchain.**
-   Emit `pnpm.overrides` (or exact deps) in the generated starter
-   (`scripts/package-starters.mjs` / `standard-node-starter.json`) pinning the
-   whole Start toolchain (`@tanstack/react-start*`, `@tanstack/router-plugin`,
-   `@tanstack/router-core`, `@tanstack/router-generator`, `@tanstack/router-utils`,
-   `@tanstack/react-router`) to the workspace-locked versions, so a fresh install
-   cannot jump to a newer react-start that hard-pins a newer router. This removes
-   the two-copy install entirely.
-2. **Dedupe `@tanstack/router-core` (and `@tanstack/history`) in the client
-   bundle** the same way `@tanstack/react-router` already is, so a split install
-   still collapses to one router runtime in the bundle. Lower blast radius but
-   only masks the duplicate install rather than preventing it, and the
-   `resolvableAppRootDependencies` gate would need to allow transitive-only
-   singletons.
-3. Keep the starter coordinate in lockstep with react-start's router pin. This is
-   tail-chasing (the float will drift again) and is *not* recommended as the
-   primary fix.
+Naturally floated (not forced): cleared pnpm's registry metadata cache
+(`rm -rf ~/.cache/pnpm/metadata ~/.cache/pnpm/metadata-v1.3
+~/.cache/pnpm/metadata-ff-v1.3 ~/.cache/pnpm/v11/metadata`), then ran the test
+unchanged. The isolated app install (`--prefer-offline`, no app lockfile) then
+floated `@tanstack/react-start` to `1.168.36` → `react-start-client@1.168.17` →
+`start-client-core@1.170.15`. Verified the installed versions before trusting the
+result; no `pnpm.overrides` were used to force the toolchain. Result: **5/5
+subtests fail**, both `start` and `develop`, with the stack above.
 
-### Why no code fix is committed here
+Because `1.168.17` is now `latest`, a plain `node --test
+scripts/tests/minimal-starter-acceptance.test.mjs` on a fresh-metadata machine
+now reproduces the CI failure.
 
-The task is to find the actual cause; a fix only if clear-cut. The actual cause
-is an external npm publish, and the crash could not be reproduced locally (both
-commits pass), so no candidate fix can be *verified against the failure*. Option
-1 is the correct durable fix and its effect (a single `react-router` /
-`router-core` copy in the install) is verifiable, but it is a starter-generation
-design change that should be reviewed and owned by the runtime team rather than
-slipped in under an unreproducible failure. The diagnosis + evidence is the
-deliverable.
+## Duplicate set in the crashing (1.168.17) install (deliverable #5)
+
+All under `<app>/node_modules/.pnpm/`:
+
+| package | versions present |
+|---|---|
+| `@tanstack/react-router` | `1.170.17` (app pin, Vite-deduped for client) **and** `1.170.19` (toolchain) |
+| `@tanstack/router-core` | `1.171.14` (from react-router 1.170.17) **and** `1.171.16` (from react-router 1.170.19) |
+| `@tanstack/start-client-core` | `1.170.15` (single — the hydration harness) |
+| `@tanstack/react-start` | `1.168.36` (single) |
+| `@tanstack/react-start-client` | `1.168.17` (single) |
+| `@tanstack/history` | `1.162.0` (single) |
+
+`react`, `react-dom`, `@tanstack/react-query` are single copies (fine). No
+`@voyant-travel/*` package is duplicated — the test's `pnpm.overrides` pin those
+to `file:` archives regardless of version, so the earlier "@voyant duplicate"
+hypothesis is disproved.
+
+## Recommended fix (not applied — see rationale)
+
+The defect is that the starter pins `@tanstack/react-router` but lets the
+TanStack Start hydration toolchain (`@tanstack/react-start*`,
+`@tanstack/start-client-core`, `@tanstack/router-core`, …) float independently,
+so a floated harness runs against a pinned, older router with a different store
+field name. Fix by pinning the **whole `@tanstack/*` router+start family
+coherently** so the harness and the router always come from one release train:
+
+1. **(recommended, durable)** In `scripts/package-starters.mjs`, emit
+   `pnpm.overrides` for the entire TanStack router/start family
+   (`@tanstack/react-router`, `@tanstack/router-core`, `@tanstack/router-plugin`,
+   `@tanstack/router-generator`, `@tanstack/router-utils`,
+   `@tanstack/react-start`, `@tanstack/react-start-client`,
+   `@tanstack/react-start-server`, `@tanstack/react-start-rsc`,
+   `@tanstack/start-client-core`, `@tanstack/start-server-core`,
+   `@tanstack/history`) locked to the versions the workspace lockfile resolves
+   (the coherent set the release was built and tested against). Derive them from
+   the workspace so the coordinate can't drift out of the family again. This
+   removes the split install entirely; its effect (single copy per package,
+   matching harness/router) is verifiable with the reproduction above.
+2. Alternatively, bump the starter `@tanstack/react-router` coordinate so the app
+   router is built by the same release train the toolchain floats to (e.g.
+   `1.170.19` → router-core `1.171.16`, which has `ids`). This is tail-chasing:
+   the float will drift again on the next TanStack publish.
+
+### Why not committed here
+
+Per the task ("fix only if clear-cut"; "a precise diagnosis with evidence is
+worth more than a speculative fix"), and because option 1 is a starter-generation
+design change that pins a dozen third-party versions and should be owned/reviewed
+by the runtime team, the deliverable is the verified diagnosis + a reproduction
+recipe so any candidate fix can be checked. Option 2 is a stop-gap, not a fix.
 
 ## Instrumentation left on the branch (in the test file)
 
-- `page.on("pageerror")` now records `error.stack` alongside `error.message`, so
-  the next time this reproduces the stack frame (and thus the offending module)
-  is captured instead of just the message.
+- `page.on("pageerror")` records `error.stack` alongside `error.message` — this is
+  what surfaced the `hydrateStart` frame above.
 - `VOYANT_KEEP_ARTIFACTS=1` retains the packed/installed/built fixture at
-  `$TMPDIR/voyant-minimal-starter-acceptance-keep` instead of deleting it, so the
-  installed `node_modules` can be inspected for duplicate copies. Default runs are
-  unchanged.
+  `$TMPDIR/voyant-minimal-starter-acceptance-keep` for `node_modules` inspection.
+  Default runs are unchanged.

--- a/scripts/tests/minimal-starter-acceptance.FINDINGS.md
+++ b/scripts/tests/minimal-starter-acceptance.FINDINGS.md
@@ -130,39 +130,62 @@ All under `<app>/node_modules/.pnpm/`:
 to `file:` archives regardless of version, so the earlier "@voyant duplicate"
 hypothesis is disproved.
 
-## Recommended fix (not applied — see rationale)
+## Fix applied
 
-The defect is that the starter pins `@tanstack/react-router` but lets the
-TanStack Start hydration toolchain (`@tanstack/react-start*`,
-`@tanstack/start-client-core`, `@tanstack/router-core`, …) float independently,
-so a floated harness runs against a pinned, older router with a different store
-field name. Fix by pinning the **whole `@tanstack/*` router+start family
-coherently** so the harness and the router always come from one release train:
+`scripts/package-starters.mjs` now emits `pnpm.overrides` in the generated
+starter `package.json` pinning the **whole `@tanstack/*` router + Start family**
+to one coherent release train, so a lockfile-less consumer install can no longer
+float half the family past the other:
 
-1. **(recommended, durable)** In `scripts/package-starters.mjs`, emit
-   `pnpm.overrides` for the entire TanStack router/start family
-   (`@tanstack/react-router`, `@tanstack/router-core`, `@tanstack/router-plugin`,
-   `@tanstack/router-generator`, `@tanstack/router-utils`,
-   `@tanstack/react-start`, `@tanstack/react-start-client`,
-   `@tanstack/react-start-server`, `@tanstack/react-start-rsc`,
-   `@tanstack/start-client-core`, `@tanstack/start-server-core`,
-   `@tanstack/history`) locked to the versions the workspace lockfile resolves
-   (the coherent set the release was built and tested against). Derive them from
-   the workspace so the coordinate can't drift out of the family again. This
-   removes the split install entirely; its effect (single copy per package,
-   matching harness/router) is verifiable with the reproduction above.
-2. Alternatively, bump the starter `@tanstack/react-router` coordinate so the app
-   router is built by the same release train the toolchain floats to (e.g.
-   `1.170.19` → router-core `1.171.16`, which has `ids`). This is tail-chasing:
-   the float will drift again on the next TanStack publish.
+```
+@tanstack/react-router 1.170.17   @tanstack/router-core 1.171.14
+@tanstack/router-plugin 1.168.19  @tanstack/router-generator 1.167.18
+@tanstack/router-utils 1.162.2    @tanstack/react-start 1.168.27
+@tanstack/react-start-client 1.168.15  @tanstack/react-start-server 1.167.21
+@tanstack/start-client-core 1.170.13   @tanstack/start-server-core 1.169.16
+@tanstack/start-plugin-core 1.171.19   @tanstack/history 1.162.0
+```
 
-### Why not committed here
+**Single source of truth:** the family *names* are one list
+(`TANSTACK_ROUTER_START_FAMILY`) and every *version* is derived from the
+workspace's own resolved install (`node_modules/.pnpm`, asserting exactly one
+version per package). The workspace is already a coherent `matchesId`-era set
+(react-router 1.170.17 → router-core 1.171.14 → start-client-core 1.170.13), so
+the emitted pins can never split the two halves. Adding a new family member later
+is a one-line addition to that array; its version resolves automatically. Chose
+this over a static block in `standard-node-starter.json` because a hand-listed
+version block is exactly the kind of thing that drifts out of sync with the
+workspace it must match.
 
-Per the task ("fix only if clear-cut"; "a precise diagnosis with evidence is
-worth more than a speculative fix"), and because option 1 is a starter-generation
-design change that pins a dozen third-party versions and should be owned/reviewed
-by the runtime team, the deliverable is the verified diagnosis + a reproduction
-recipe so any candidate fix can be checked. Option 2 is a stop-gap, not a fix.
+**No product code changed.** In particular `@tanstack/router-core` was **not**
+added to `VOYANT_DEDUPE_DEPENDENCIES` in `packages/vite-config/src/index.ts`: the
+overrides make the install contain a single `router-core` copy (verified below),
+so a dedupe entry would be redundant — added only if evidence showed the split
+survived, which it does not.
+
+The harness merge holds in practice: the acceptance harness
+(`minimal-starter-acceptance.test.mjs:371-379`) spreads its `file:` overrides on
+top of `packageJson.pnpm?.overrides`, so the starter-emitted TanStack pins
+survive — the installed app `package.json` carries both the 12 TanStack pins and
+the ~110 `file:` overrides.
+
+### Verification (clean pnpm metadata → today's registry, where 1.168.17 is `latest`)
+
+- `node --test scripts/tests/minimal-starter-acceptance.test.mjs` — **run 1: 5/5 pass**
+  (`FIX_RUN1_EXIT=0`); **run 2: 5/5 pass** (`FIX_RUN2_EXIT=0`). Zero `pageerror`
+  lines in either log. The `start`-mode subtest "hydrates the production client
+  bundle without browser errors" passing *is* the empty-`browserErrors` assertion
+  (test line ~588).
+- Installed family in the passing fixture is a single, coherent set — one
+  `react-router` (1.170.17), one `router-core` (1.171.14), `start-client-core`
+  1.170.13 from the same train. The harness now reads `router.stores.matchesId`,
+  the field the pinned router-core actually builds.
+- Control (same clean metadata, **without** the fix): floats to
+  `react-start-client@1.168.17` → `start-client-core@1.170.15` and fails 5/5 with
+  the `router.stores.ids.get()` crash — the reproduction documented above.
+
+Rejected: bumping `@tanstack/react-router` to `1.170.19` alone. It re-couples for
+exactly one upstream publish, then drifts again.
 
 ## Instrumentation left on the branch (in the test file)
 

--- a/scripts/tests/minimal-starter-acceptance.FINDINGS.md
+++ b/scripts/tests/minimal-starter-acceptance.FINDINGS.md
@@ -1,0 +1,122 @@
+# packaged-acceptance hydration failure — diagnosis (issue #4233)
+
+## Summary
+
+The reported `pageerror: Cannot read properties of undefined (reading 'get')`
+hydration failure is **not caused by the repo diff** between the last-passing
+commit `9a10fa57a` and the "failing" release commit `d738daf55`. That diff is
+`@voyant-travel/*` version fields + CHANGELOGs only, none of which affect the
+runtime graph. Both commits **pass** the acceptance test in a clean local build
+(evidence below).
+
+The real trigger is external: a floating install of the **TanStack Start
+toolchain** in the test's isolated starter app, which pulls in a *second* copy
+of `@tanstack/react-router` / `@tanstack/router-core` alongside the copy the
+starter pins. Two `router-core` module instances in one client bundle means the
+router context registry created by one instance is invisible to a hook from the
+other → `.get` on an undefined context at hydration.
+
+## Evidence
+
+Clean full `pnpm build`, then `node --test scripts/tests/minimal-starter-acceptance.test.mjs`:
+
+- `d738daf55` (HEAD, the "failing" commit): **5/5 pass**, incl. "hydrates the
+  production client bundle without browser errors".
+- `9a10fa57a` (last passing commit): **5/5 pass**.
+
+So the failure does not reproduce from either commit's source in the current
+environment. On a passing `start`-mode run the test asserts `browserErrors`
+deep-equals `[]` (test line ~588), so the `pageerror` is *not* passive noise —
+when it appears it is a real hydration crash, it is simply intermittent on top
+of the duplicate-install condition.
+
+### The duplicate
+
+In the installed starter `node_modules` (retained via `VOYANT_KEEP_ARTIFACTS=1`):
+
+| package | copies |
+|---|---|
+| `react`, `react-dom`, `@tanstack/react-query` | 1 each (fine) |
+| `@tanstack/react-router` | **2** — `1.170.17` and `1.170.18` |
+| `@tanstack/router-core` | **2** — `1.171.14` and `1.171.15` |
+
+Resolution map:
+
+- app root `@tanstack/react-router@1.170.17` → `router-core@1.171.14`  (= starter coordinate)
+- `@tanstack/react-start@1.168.34`, `@tanstack/react-start-client@1.168.16`,
+  `@tanstack/router-plugin@1.168.23` → `@tanstack/react-router@1.170.18` → `router-core@1.171.15`
+
+The toolchain packages **hard-pin** their router:
+`react-start-client@1.168.16` declares `@tanstack/react-router: "1.170.18"`
+(exact) and `@tanstack/router-core: "1.171.15"` (exact); `router-plugin` needs
+`^1.170.18`. `1.170.17` does **not** satisfy `^1.170.18`, so pnpm is *forced* to
+keep both — this is a guaranteed two-copy install, not a dedupe accident.
+
+### Why the version float, and why CI bisected to a repo commit
+
+- The workspace's committed lockfile pins `@tanstack/react-start-client@1.168.15`,
+  whose router pin is `1.170.17` / `1.171.14` — consistent with the starter
+  coordinate. In-repo, everything is single-copy.
+- The acceptance test installs the starter app with `--ignore-workspace` and
+  `--config.frozen-lockfile=false` and **no app lockfile**, so it ignores the
+  workspace pin and re-resolves the toolchain to the newest matching release —
+  `react-start-client@1.168.16`, which hard-pins the newer `1.170.18` router.
+- `1.168.16` is an upstream npm publish. It landed between the last passing CI
+  run and the "failing" one, so CI's bisection window straddles the npm publish,
+  not a repo change. Any commit re-run after that publish would fail the same way;
+  any commit re-run before it would pass.
+
+### Why Vite doesn't save it deterministically
+
+`packages/vite-config/src/index.ts` dedupes `@tanstack/react-router` for the
+client build (`VOYANT_DEDUPE_DEPENDENCIES`, line ~340) but **not**
+`@tanstack/router-core`. `@tanstack/react-start` is force-bundled into the client
+(`noExternal`, `TANSTACK_START_BUNDLED_PACKAGES`) and imports `router-core`
+directly, so react-start drags `router-core@1.171.15` into the bundle while the
+deduped `react-router` brings `router-core@1.171.14`. The router context
+singleton lives in `router-core`, so the two instances split it. Whether this
+crashes at hydration depends on chunk/hoist order, which is why it is
+intermittent locally but reproduced in CI.
+
+## Recommended fix (not applied — see below)
+
+Options, most durable first:
+
+1. **Stop the isolated app install from floating the TanStack Start toolchain.**
+   Emit `pnpm.overrides` (or exact deps) in the generated starter
+   (`scripts/package-starters.mjs` / `standard-node-starter.json`) pinning the
+   whole Start toolchain (`@tanstack/react-start*`, `@tanstack/router-plugin`,
+   `@tanstack/router-core`, `@tanstack/router-generator`, `@tanstack/router-utils`,
+   `@tanstack/react-router`) to the workspace-locked versions, so a fresh install
+   cannot jump to a newer react-start that hard-pins a newer router. This removes
+   the two-copy install entirely.
+2. **Dedupe `@tanstack/router-core` (and `@tanstack/history`) in the client
+   bundle** the same way `@tanstack/react-router` already is, so a split install
+   still collapses to one router runtime in the bundle. Lower blast radius but
+   only masks the duplicate install rather than preventing it, and the
+   `resolvableAppRootDependencies` gate would need to allow transitive-only
+   singletons.
+3. Keep the starter coordinate in lockstep with react-start's router pin. This is
+   tail-chasing (the float will drift again) and is *not* recommended as the
+   primary fix.
+
+### Why no code fix is committed here
+
+The task is to find the actual cause; a fix only if clear-cut. The actual cause
+is an external npm publish, and the crash could not be reproduced locally (both
+commits pass), so no candidate fix can be *verified against the failure*. Option
+1 is the correct durable fix and its effect (a single `react-router` /
+`router-core` copy in the install) is verifiable, but it is a starter-generation
+design change that should be reviewed and owned by the runtime team rather than
+slipped in under an unreproducible failure. The diagnosis + evidence is the
+deliverable.
+
+## Instrumentation left on the branch (in the test file)
+
+- `page.on("pageerror")` now records `error.stack` alongside `error.message`, so
+  the next time this reproduces the stack frame (and thus the offending module)
+  is captured instead of just the message.
+- `VOYANT_KEEP_ARTIFACTS=1` retains the packed/installed/built fixture at
+  `$TMPDIR/voyant-minimal-starter-acceptance-keep` instead of deleting it, so the
+  installed `node_modules` can be inspected for duplicate copies. Default runs are
+  unchanged.

--- a/scripts/tests/minimal-starter-acceptance.test.mjs
+++ b/scripts/tests/minimal-starter-acceptance.test.mjs
@@ -30,7 +30,15 @@ const frontendSingletonRoots = [
 test("packaged minimal starter serves project API and SSR routes", {
   timeout: 420_000,
 }, async (t) => {
-  const root = mkdtempSync(join(tmpdir(), "voyant-minimal-starter-acceptance-"))
+  const keepArtifacts = process.env.VOYANT_KEEP_ARTIFACTS === "1"
+  const keepRoot = join(tmpdir(), "voyant-minimal-starter-acceptance-keep")
+  if (keepArtifacts) {
+    rmSync(keepRoot, { recursive: true, force: true })
+    mkdirSync(keepRoot, { recursive: true })
+  }
+  const root = keepArtifacts
+    ? keepRoot
+    : mkdtempSync(join(tmpdir(), "voyant-minimal-starter-acceptance-"))
   const out = join(root, "out")
   const app = join(root, "app")
   try {
@@ -197,7 +205,8 @@ test("packaged minimal starter serves project API and SSR routes", {
       await assertVoyantServerMode(app, "develop", modeTest)
     })
   } finally {
-    rmSync(root, { recursive: true, force: true })
+    if (!keepArtifacts) rmSync(root, { recursive: true, force: true })
+    else console.log(`VOYANT_KEEP_ARTIFACTS: retained fixture at ${root}`)
   }
 })
 
@@ -553,7 +562,9 @@ async function assertBrowserHydration(app, port, t, serverOutput, { hmr }) {
   page.on("console", (message) => {
     if (message.type() === "error") browserErrors.push(`console: ${message.text()}`)
   })
-  page.on("pageerror", (error) => browserErrors.push(`pageerror: ${error.message}`))
+  page.on("pageerror", (error) =>
+    browserErrors.push(`pageerror: ${error.message}\n${error.stack ?? "(no stack)"}`),
+  )
   page.on("requestfailed", (request) => {
     browserErrors.push(
       `requestfailed: ${request.url()} (${request.failure()?.errorText ?? "unknown error"})`,


### PR DESCRIPTION
Fixes #4233 — `packaged-acceptance` has been red on `main` for every PR since `d738daf556`.

## It was never a repo regression

`@tanstack/react-start-client@1.168.17` was published `2026-08-04T20:35:44Z` — **three minutes after** the release commit CI blamed, and after the last passing run. A diff containing nothing but `version` fields appeared to break running code because the diff did not; the registry did.

The break is an upstream rename `router.stores.matchesId` → `router.stores.ids`:

```
TypeError: Cannot read properties of undefined (reading 'get')
    at hydrateStart (@tanstack/start-client-core/dist/esm/client/hydrateStart.js:27:25)
```

Confirmed in the published tarballs: `start-client-core` **1.170.14** calls `matchesId.get()`, **1.170.15** calls `ids.get()`; `router-core` **1.171.14** defines `matchesId` only, **1.171.16** defines `ids`.

The starter pinned `@tanstack/react-router` but the acceptance harness installs the isolated app with `--ignore-workspace --config.frozen-lockfile=false` and no lockfile, so **the Start toolchain floated to `latest` while the router stayed pinned**. Floated client, pinned core, missing field.

## The fix

`scripts/package-starters.mjs` now emits `pnpm.overrides` into the generated starter pinning the whole 12-package TanStack router + start family, every version derived from the workspaces own resolved install. A name-only list is the single source of truth, so adding a member later is one line.

It fails loudly rather than splitting silently:

```js
if (versions.size !== 1) {
  throw new Error(`Cannot coherently pin ${name}: workspace resolves ${…} versions …`)
}
```

Bumping only `@tanstack/react-router` to `1.170.19` would have worked today and drifted again on the next upstream publish.

**`@tanstack/router-core` was deliberately NOT added to `VOYANT_DEDUPE_DEPENDENCIES`** — with the overrides the install carries a single `router-core` copy, so the entry is redundant. No product code changes.

## Verification

| run | tests | pass | fail | pageerror |
|---|---|---|---|---|
| fix, run 1 | 5 | 5 | 0 | 0 |
| fix, run 2 | 5 | 5 | 0 | 0 |
| **control, no fix** | 5 | **0** | **5** | 4 |

Both fix runs started from a **cleared pnpm metadata cache**, so they resolved against todays registry with `1.168.17` as `latest` — the exact condition that fails. The passing subtest is the `assert.deepEqual(browserErrors, [], …)` case, so hydration is healthy rather than merely fast. Installed family in the passing fixture is single-copy: `react-router 1.170.17`, `router-core 1.171.14`, `start-client-core 1.170.13`.

## Second commit: the release lane would have thrown

Packaging now hard-depends on a resolved workspace install. `release-assets` in `release.yml` went checkout → pnpm setup → node setup → validate → **package**, with no `pnpm install`, so `package:starters` would have failed there. Added the install step. Verified locally that packaging with the store present emits 12 coherent pins.

## Known, pre-existing, not fixed here

`scripts/tests/package-starters.test.mjs` fails on pristine `main` — it hardcodes expected workspace versions (`framework 0.63.2` vs todays `0.75.7`) that drift with every release. It is reached only through `verify:minimal-starter`, which **no workflow invokes**, so it has been failing unnoticed. Out of scope here; filed separately.