### PR TITLE
Prove the shared Product model across every experience family

### DIFF
--- a/.changeset/acceptance-tracer-schedule-term.md
+++ b/.changeset/acceptance-tracer-schedule-term.md
@@ -1,0 +1,31 @@
+---
+"@voyant-travel/inventory": minor
+"@voyant-travel/inventory-react": minor
+"@voyant-travel/products-contracts": minor
+"@voyant-travel/admin-contracts": minor
+---
+
+feat(inventory): resolve one operator-facing schedule term (Session/Occurrence/Departure)
+
+The same Product/Departure model runs sixty-minute recurring Sessions and
+multi-day Departures, so the operator needs to *see* the right noun without the
+domain forking under it. This adds a single resolver that decides the noun once
+and a localized label the UI reads.
+
+- **One decision, in one place.** `resolveScheduleTerm` maps a Product's
+  already-resolved duration to a `session | occurrence | departure` token: an
+  explicit sub-day duration is a **Session** (the 60-minute whale-watch Boat
+  Tour, a timed Activity, a scheduled transfer), an explicit full-day-or-longer
+  duration or an itinerary-derived day span is a **Departure** (a Day Tour, a
+  Multi-day Tour), and an unresolved duration — a single Event date or an
+  opening-hours Attraction Admission — is an **Occurrence**. It reads no mutable
+  Product truth to decide.
+- **Every surface agrees.** `resolveProductClassification` now carries
+  `scheduleTerm`, so the product list/detail read paths, the catalog-plane
+  projection, and the legacy Catalog search document all emit it from the same
+  resolver. The classification schemas in `products-contracts`,
+  `admin-contracts` and the `inventory-react` mirror gain the field.
+- **Presentation only.** A Session, an Occurrence and a Departure are the same
+  `availability_slots` row bound to the same Product Version. The operator UI
+  maps the token to a localized label (`common.scheduleTermLabels`, en + ro) and
+  the product list renders the plural under the family; the domain never forks.

--- a/.changeset/legacy-compat-and-acceptance-metrics.md
+++ b/.changeset/legacy-compat-and-acceptance-metrics.md
@@ -1,0 +1,24 @@
+---
+"@voyant-travel/core": minor
+"@voyant-travel/operations": minor
+---
+
+feat: compatibility redirects with usage counting and acceptance dashboard metrics
+
+Instrument the transitional surfaces so their removal can later be gated on
+evidence rather than assumption. Nothing is deleted here.
+
+- **Compatibility redirects (`@voyant-travel/core`).** `resolveLegacyRedirect`
+  maps the four superseded deep-link families — Extras, scheduled Catalog,
+  Product detail, and operator Availability — to their canonical successors for
+  the measured compatibility period. `resolveAndCountLegacyRedirect` resolves
+  and counts a hit in one call for a route middleware, and never fails the
+  redirect if the counter does.
+- **Usage counting.** `LegacyPathUsageStore` counts hits per stable route key;
+  the in-memory store seeds every known key at zero so "usage is zero" is an
+  explicit, checkable fact for the release review rather than a missing row.
+- **Acceptance metrics (`@voyant-travel/operations`).**
+  `computeAcceptanceMetrics` reports readiness failures, reconciliation drift,
+  unassigned travelers, missing costs, legacy-path usage, and rollup
+  disagreement over injectable providers. Every field is a count or a
+  route-keyed usage row — no traveler PII is read or emitted.

--- a/.changeset/legacy-family-review-queue.md
+++ b/.changeset/legacy-family-review-queue.md
@@ -1,0 +1,29 @@
+---
+"@voyant-travel/inventory": minor
+"@voyant-travel/products-contracts": minor
+---
+
+feat(inventory): conservatively backfill legacy families and expose an operator-review queue
+
+Ambiguous legacy Products must be resolved by a human, not guessed. This adds
+the queue that makes them discoverable and a migration that only classifies what
+is unambiguous.
+
+- **Discoverable review queue.** The product list read accepts
+  `classificationReview=pending | missing_family | unresolved_duration`. The
+  predicates are expressed as row-level SQL that mirrors
+  `resolveProductClassification` exactly (missing/dangling family; no explicit
+  duration and no dated default-itinerary day), so the queue and the rendered
+  review badge never disagree.
+- **Conservative backfill migration.** A product with authored itinerary days
+  but no family is unambiguously a Tour; the migration assigns the standard
+  `tour` family to exactly those rows. It never overwrites an existing family,
+  only fires on a strong positive signal, joins to the seeded family (so a
+  deployment without it is a no-op), and is idempotent. Duration is not
+  materialized — the resolver derives itinerary-derived duration live.
+- **Ambiguous rows are left alone.** A product with neither a family nor a
+  resolvable duration is untouched and surfaces in the review queue rather than
+  being guessed.
+- Migration-test coverage over a representative beta dataset that includes
+  ambiguous rows proves no Product disappears, no capacity claim (availability
+  slot) is lost, and only the unambiguous rows are classified.

--- a/.changeset/product-authoring-nav.md
+++ b/.changeset/product-authoring-nav.md
@@ -1,0 +1,14 @@
+---
+"@voyant-travel/inventory-react": minor
+---
+
+feat(inventory-react): organize Product authoring around seven deep-linkable groups
+
+Product authoring is reorganized around seven ordered groups — Overview &
+readiness, Content, Plan, Options & pricing, Availability, Distribution and
+History. `ProductAuthoringNav` renders them as a sticky, contextual deep-link
+navigation, and each group on the detail page anchors to a stable id
+(`/products/:id#authoring-plan`) so a link can land the operator directly on a
+concern. The grouping is presentation only — the section components are
+unchanged, just gathered under a stable, ordered set of headings, with en + ro
+labels.

--- a/.changeset/wire-legacy-redirects-and-acceptance-metrics.md
+++ b/.changeset/wire-legacy-redirects-and-acceptance-metrics.md
@@ -1,0 +1,35 @@
+---
+"@voyant-travel/core": minor
+"@voyant-travel/hono": minor
+"@voyant-travel/operations": minor
+---
+
+feat: serve the compatibility redirects and the acceptance metrics
+
+The redirect table and the metrics aggregator were built and unit-tested but
+nothing called either, so the redirects redirected nothing and the usage counter
+read zero because no request could ever reach it — the one reading that would
+have licensed deleting the surfaces it exists to protect. Both are now wired to
+a request.
+
+- **`legacyRedirects` (`@voyant-travel/hono/middleware/legacy-redirects`)** is
+  the HTTP edge for `resolveAndCountLegacyRedirect`: a superseded deep link
+  answers `308` to its canonical successor, carries its query string across, and
+  records the hit. It is mounted unconditionally by `serveAdminHost`, ahead of
+  static serving and auth — the only seam that sees these origin-root UI paths —
+  and deliberately not by the framework app, where a storefront's `/catalog/*`
+  content would collide with the compatibility table.
+- **`getLegacyPathUsageStore` / `setLegacyPathUsageStore`
+  (`@voyant-travel/core`)** bind one usage store per process, so the counter the
+  middleware writes is the counter the dashboard reads. A multi-process
+  deployment binds a durable store; until it does, "usage is zero" is only that
+  process's zero.
+- **`GET /v1/admin/operations/acceptance/aggregates`** serves
+  `computeAcceptanceMetrics` over `createAcceptanceMetricsProviders`, following
+  the existing `/aggregates` dashboard convention. Readiness failures,
+  reconciliation drift and unassigned travelers are single raw-SQL counts; the
+  two money signals come from the departure-profitability port that already
+  backs the departure workspace, and the envelope reports whether that provider
+  was bound so an unmeasured zero is not read as a measured one. The response is
+  uncached: legacy-path usage gates a deletion review and must not answer from a
+  snapshot. No traveler column is projected by any statement.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,6 +362,8 @@ jobs:
                 tests/integration/promotion-created-command.test.ts
               pnpm --filter @voyant-travel/cruises exec vitest run \
                 tests/integration/created-target-tools.test.ts
+              pnpm --filter @voyant-travel/inventory exec vitest run \
+                tests/integration/conservative-family-backfill.test.ts
               pnpm --filter @voyant-travel/finance exec vitest run \
                 tests/integration/booking-create.test.ts
               pnpm --filter @voyant-travel/finance exec vitest run \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,6 +385,8 @@ jobs:
               pnpm --filter @voyant-travel/operations exec vitest run \
                 tests/availability/integration/departure-summary.test.ts
               pnpm --filter @voyant-travel/operations exec vitest run \
+                tests/availability/integration/experience-families-tracer.test.ts
+              pnpm --filter @voyant-travel/operations exec vitest run \
                 tests/availability/integration/allocation-audit-atomicity.test.ts
               pnpm --filter @voyant-travel/operations exec vitest run \
                 tests/availability/integration/rooming-constraints.test.ts

--- a/docs/architecture/catalog-architecture.md
+++ b/docs/architecture/catalog-architecture.md
@@ -270,6 +270,26 @@ elsewhere in this document, e.g. §3.3, §8.2) is contextual vocabulary, not a
 `<= 1-day` family — a product casually called an "excursion" still carries
 whichever family and subtype actually apply, most often Tour.
 
+The same shared resolver also derives an operator-facing **schedule term**
+(`scheduleTerm`: `session` \| `occurrence` \| `departure`) from the resolved
+duration alone, so the choice is made once and every surface agrees:
+
+- an explicit sub-day duration is a **Session** (the sixty-minute whale-watch
+  Boat Tour, a timed Activity, a scheduled transfer);
+- an explicit full-day-or-longer duration, or an itinerary-derived day span, is
+  a **Departure** (a Day Tour, a Multi-day Tour);
+- an unresolved duration — a single Event date or an opening-hours Attraction
+  Admission — is an **Occurrence**.
+
+`scheduleTerm` is a **presentation** token, not a domain fork: a Session, an
+Occurrence and a Departure are the same immutable `availability_slots` row bound
+to the same Product Version, operated through the same Departure workspace. The
+operator UI (`@voyant-travel/inventory-react`) maps the token to a localized
+label (`common.scheduleTermLabels`, en + ro) so the same product reads as
+"Sessions" or "Departures" per its behaviour and the operator's locale, while
+one implementation underneath (`resolveScheduleTerm` in
+`@voyant-travel/inventory`) never reads mutable Product truth to decide it.
+
 ## 4. The field-policy contract
 
 The field-policy registry is the load-bearing schema decision of this architecture. Every field on every CatalogEntry, in every vertical, is declared with a row in a per-vertical policy file. The contract has 12 attributes (one path identifier plus 11 governance attributes).

--- a/docs/architecture/product-model-acceptance-and-retirement.md
+++ b/docs/architecture/product-model-acceptance-and-retirement.md
@@ -79,6 +79,20 @@ zero" a fact a release review can check** rather than an assumption. The
 redirects and the counter are **built and instrumented only**; they are not
 deleted here.
 
+**Where this runs.** `legacyRedirects`
+(`@voyant-travel/hono/middleware/legacy-redirects`) is the HTTP edge, mounted
+unconditionally by `serveAdminHost` ahead of static serving and auth. That is
+the only seam that sees these paths: they are UI deep links at the origin root,
+and the admin host routes only `/api/*` into the composed framework app, so a
+superseded bookmark would otherwise reach the SSR handler and render a not-found
+page. It is deliberately **not** mounted in `mountApp`: a storefront deployment
+serves `/catalog/*slug` as real published content at the origin root, and
+redirecting it there would break a live public URL to repair an operator
+bookmark. The writer (the middleware) and the reader (the dashboard below) share
+one store through `get`/`setLegacyPathUsageStore` in `@voyant-travel/core`;
+a multi-process deployment must bind a durable store there before serving, or
+the reported zero is only one process's zero.
+
 ## Acceptance dashboard metrics (no PII)
 
 `computeAcceptanceMetrics` (`@voyant-travel/operations`) reports six health
@@ -86,6 +100,23 @@ signals over injectable providers: readiness failures, reconciliation drift,
 unassigned travelers, missing costs, legacy-path usage, and rollup
 disagreement. Every field is a **count** or a route-keyed usage row — no
 traveler name, email, booking reference, or any other PII is read or emitted.
+
+It is served at `GET /v1/admin/operations/acceptance/aggregates`, following the
+same `/aggregates` convention as the availability dashboard read-models, with
+two deliberate differences: the response is `no-store` (legacy-path usage gates
+a deletion review and must not answer from a snapshot), and the envelope carries
+a `meta.financeProviderBound` flag so an unmeasured `0` for the two money
+signals is not mistaken for a measured one.
+
+`createAcceptanceMetricsProviders` binds the providers. Readiness failures,
+reconciliation drift and unassigned travelers are single fleet-wide raw-SQL
+counts — raw SQL because the tables belong to other modules and the
+`operations->availability` reach-in budget is exhausted. Missing costs and
+rollup disagreement are read from the departure-profitability port that already
+backs the departure workspace, because money is Finance's and Operations must
+not recompute it. The readiness mirror expresses the **blocking** rules of
+`evaluateProductReadiness`; Inventory owns that evaluator, so a new blocking
+rule there must be reflected here or this count silently understates.
 
 ## The deletion gate (out of scope here)
 

--- a/docs/architecture/product-model-acceptance-and-retirement.md
+++ b/docs/architecture/product-model-acceptance-and-retirement.md
@@ -1,0 +1,96 @@
+# Product-model acceptance and retirement
+
+This document records the lifecycle rules that carry the unified Product /
+Departure model (RFC #4027) across every experience family and retire the
+transitional beta surfaces safely. The domain rules for families, subtype, and
+duration live in [`catalog-architecture.md` §3.3.2](./catalog-architecture.md);
+this document covers what happens around the edges: terminology, legacy
+migration, compatibility, metrics, and the deletion gate.
+
+## One model, many families
+
+A Tour, an Activity, an Attraction Admission, an Event and a Transportation
+Transfer are the **same** aggregate: one Product, an immutable Product Version,
+`availability_slots` bound to that Version, the Departure workspace, Travelers,
+allocation, operations, and Finance. There is no per-family scheduling engine.
+The `experience-families-tracer` integration suite in `@voyant-travel/operations`
+proves this end to end — including the 60-minute whale-watch Boat Tour running
+as recurring timed **Sessions** (several occurrences a day, each bound to one
+frozen Version, with a meeting point, capacity and a manifest) and **no
+itinerary days**.
+
+## Operator-facing schedule term
+
+`resolveScheduleTerm` (`@voyant-travel/inventory`) derives one presentation token
+— `session | occurrence | departure` — from the resolved Product duration, and
+the operator UI localizes it (`common.scheduleTermLabels`, en + ro). It is a
+label, not a domain fork: the underlying row is the same
+`availability_slots` departure regardless of the noun shown. See
+[`catalog-architecture.md` §3.3.2](./catalog-architecture.md).
+
+## Conservative legacy migration and the review queue
+
+Legacy classification is migrated **conservatively — ambiguous rows are never
+guessed**:
+
+- The `20260804120000_conservative_family_backfill` migration assigns the
+  standard `tour` family only to Products that have authored itinerary days but
+  no family (an unambiguous positive signal). It never overwrites an existing
+  family and is idempotent.
+- Duration is not materialized: the shared resolver derives itinerary-derived
+  duration live, and a Product with neither an explicit duration nor an
+  itinerary stays `unresolved`.
+- Any Product with no family, or an unresolved duration, surfaces in the
+  **operator classification-review queue**: the product list read accepts
+  `classificationReview=pending | missing_family | unresolved_duration`, whose
+  SQL predicates mirror `resolveProductClassification` exactly so the queue and
+  the rendered review badge never disagree. The operator resolves each row by
+  assigning a family or authoring a duration.
+
+The `conservative-family-backfill` migration test runs the real migration SQL
+against Postgres over a beta-shaped fixture that deliberately includes ambiguous
+rows, and proves no Product disappears and no capacity claim (availability slot)
+is lost.
+
+## Legacy Slots are Version-bound
+
+Every new departure binds `availability_slots.product_version_id` to an immutable
+Version, so an operated departure reads frozen truth, not mutable Product state.
+Legacy slots with no Version are reported (the departure summary carries a null
+`productVersionId`) rather than silently reading mutable Product truth.
+
+## Compatibility redirects and usage counting
+
+Four families of first-party deep link were superseded. During the measured
+compatibility period each resolves to its canonical successor
+(`resolveLegacyRedirect` in `@voyant-travel/core`) instead of breaking:
+
+| Legacy family | Example legacy path | Canonical successor |
+|---|---|---|
+| Extras | `/extras/:id` | `/products/options/:id` |
+| Scheduled Catalog | `/catalog/scheduled/:id` | `/products/:id` |
+| Product detail | `/product/:id` | `/products/:id` |
+| Operator Availability | `/availability/slots/:id` | `/operations/departures/:id` |
+
+Every hit is counted against a stable key (`LegacyPathUsageStore`), seeded so
+every known key reports even at zero — a route absent from the report means "no
+such route", which is not the same as "zero usage". This makes **"usage is
+zero" a fact a release review can check** rather than an assumption. The
+redirects and the counter are **built and instrumented only**; they are not
+deleted here.
+
+## Acceptance dashboard metrics (no PII)
+
+`computeAcceptanceMetrics` (`@voyant-travel/operations`) reports six health
+signals over injectable providers: readiness failures, reconciliation drift,
+unassigned travelers, missing costs, legacy-path usage, and rollup
+disagreement. Every field is a **count** or a route-keyed usage row — no
+traveler name, email, booking reference, or any other PII is read or emitted.
+
+## The deletion gate (out of scope here)
+
+Transitional routes, projections, flags and redirects are **not** deleted as
+part of this work. Deletion is gated on: first-party callers migrated, measured
+**zero** legacy-path usage, the canonical browser scenarios passing, and a human
+release review approving the removal. Build and instrument now; remove in a
+later, evidence-backed change.

--- a/packages/accommodations/tsconfig.build.json
+++ b/packages/accommodations/tsconfig.build.json
@@ -1180,6 +1180,9 @@
       "@voyant-travel/hono/middleware/error-boundary": [
         "../hono/dist/middleware/error-boundary.d.ts"
       ],
+      "@voyant-travel/hono/middleware/legacy-redirects": [
+        "../hono/dist/middleware/legacy-redirects.d.ts"
+      ],
       "@voyant-travel/hono/middleware/logger": ["../hono/dist/middleware/logger.d.ts"],
       "@voyant-travel/hono/middleware/rate-limit": ["../hono/dist/middleware/rate-limit.d.ts"],
       "@voyant-travel/hono/middleware/require-actor": [

--- a/packages/accommodations/tsconfig.typecheck.json
+++ b/packages/accommodations/tsconfig.typecheck.json
@@ -1181,6 +1181,9 @@
       "@voyant-travel/hono/middleware/error-boundary": [
         "../hono/dist/middleware/error-boundary.d.ts"
       ],
+      "@voyant-travel/hono/middleware/legacy-redirects": [
+        "../hono/dist/middleware/legacy-redirects.d.ts"
+      ],
       "@voyant-travel/hono/middleware/logger": ["../hono/dist/middleware/logger.d.ts"],
       "@voyant-travel/hono/middleware/rate-limit": ["../hono/dist/middleware/rate-limit.d.ts"],
       "@voyant-travel/hono/middleware/require-actor": [

--- a/packages/admin-contracts/src/products.ts
+++ b/packages/admin-contracts/src/products.ts
@@ -25,6 +25,7 @@ const productClassificationSummarySchema = z.object({
   durationMinutes: z.number().int().nullable(),
   durationDays: z.number().int().nullable(),
   durationProvenance: z.enum(["explicit", "itinerary-derived", "unresolved"]),
+  scheduleTerm: z.enum(["session", "occurrence", "departure"]),
   reviewRequired: z.boolean(),
   reviewReasons: z.array(z.enum(["missing_family", "unresolved_duration"])),
 })

--- a/packages/admin-host/src/serve.ts
+++ b/packages/admin-host/src/serve.ts
@@ -1,4 +1,8 @@
 import { serveStatic } from "@hono/node-server/serve-static"
+import {
+  type LegacyRedirectsOptions,
+  legacyRedirects,
+} from "@voyant-travel/hono/middleware/legacy-redirects"
 import { securityHeaders } from "@voyant-travel/hono/middleware/security-headers"
 import type { ExecutionContext } from "hono"
 import { Hono } from "hono"
@@ -21,6 +25,14 @@ export interface ServeAdminHostOptions<Env extends object> {
    * bindings, and the execution context.
    */
   app: (request: Request, env: Env, ctx: ExecutionContext) => Response | Promise<Response>
+  /**
+   * Where compatibility-redirect hits are counted. Defaults to the process-wide
+   * binding in `@voyant-travel/core`, which is the store the acceptance
+   * dashboard reads back — so the counter is wired by construction and a host
+   * cannot accidentally serve redirects nobody is counting. Pass one only in a
+   * test, or when the host owns a durable store it has not bound globally.
+   */
+  legacyPathUsage?: LegacyRedirectsOptions["store"]
 }
 
 /**
@@ -35,6 +47,10 @@ export interface ServeAdminHostOptions<Env extends object> {
  * This packages the static-host + fall-through that admin hosts (the operator
  * starter and hosted admin deployments, voyant#3044) previously held
  * inline as a `web` Hono app.
+ *
+ * It also carries the compatibility redirects for the deep links the unified
+ * Product/Departure model superseded (voyant#4038) — see the mount below for
+ * why they belong here and nowhere else.
  */
 export function serveAdminHost<Env extends object = Record<string, unknown>>(
   options: ServeAdminHostOptions<Env>,
@@ -52,6 +68,15 @@ export function serveAdminHost<Env extends object = Record<string, unknown>>(
       stripeConnect: { pathPrefixes: ["/"], documentResponsesOnly: true },
     }),
   )
+  // Compatibility redirects for the deep-link families the unified
+  // Product/Departure model superseded (voyant#4038). This is the only seam
+  // that sees them: they are origin-root UI paths, so they never reach the
+  // composed API app, and the SSR fall-through below would answer a superseded
+  // bookmark with a not-found page. Mounted ahead of static serving and of the
+  // API/SSR fall-through, and unconditionally — a redirect layer that a host
+  // has to opt into is a redirect layer that eventually nobody opts into, and
+  // an uncounted hit is indistinguishable from no hit at all.
+  web.use("*", legacyRedirects({ store: options.legacyPathUsage }))
   web.use("*", serveStatic({ root: options.clientAssetsDir }))
   web.all("*", (c) => options.app(c.req.raw, c.env, c.executionCtx))
   return web

--- a/packages/admin-host/tests/serve.test.ts
+++ b/packages/admin-host/tests/serve.test.ts
@@ -21,6 +21,24 @@ const ctx: ExecutionContext = {
   props: undefined,
 }
 
+/**
+ * Minimal usage store. Hand-rolled rather than imported so this test asserts the
+ * host actually records something, not that a particular store implementation
+ * works — that is covered where the store lives.
+ */
+function recordingStore() {
+  const hits: { key: string; at: string }[] = []
+  return {
+    hits,
+    store: {
+      record(key: string, at: Date) {
+        hits.push({ key, at: at.toISOString() })
+      },
+      snapshot: () => [],
+    },
+  }
+}
+
 describe("serveAdminHost", () => {
   it("serves built client assets", async () => {
     const clientAssetsDir = createAssetsDir()
@@ -92,5 +110,60 @@ describe("serveAdminHost", () => {
       expect(response.headers.get("cross-origin-opener-policy")).toBe("same-origin")
       expect(response.headers.get("content-security-policy")).not.toContain("stripe.com")
     }
+  })
+})
+
+describe("serveAdminHost compatibility redirects", () => {
+  it("redirects a superseded deep link and counts the hit before the app ever sees it", async () => {
+    const clientAssetsDir = createAssetsDir()
+    const { hits, store } = recordingStore()
+    let appCalls = 0
+    const web = serveAdminHost({
+      clientAssetsDir,
+      legacyPathUsage: store,
+      app: () => {
+        appCalls += 1
+        return new Response("SSR NOT-FOUND", { status: 404 })
+      },
+    })
+
+    const response = await web.request("/availability/slots/avsl_1?tab=manifest", {}, {}, ctx)
+
+    expect(response.status).toBe(308)
+    expect(response.headers.get("location")).toBe("/operations/availability/avsl_1?tab=manifest")
+    expect(hits).toEqual([{ key: "availability.slot", at: hits[0]?.at }])
+    // The SSR handler would have rendered a not-found page for this bookmark.
+    expect(appCalls).toBe(0)
+  })
+
+  it("leaves the canonical successor alone", async () => {
+    const clientAssetsDir = createAssetsDir()
+    const { hits, store } = recordingStore()
+    const web = serveAdminHost({
+      clientAssetsDir,
+      legacyPathUsage: store,
+      app: () => new Response("APP", { status: 200 }),
+    })
+
+    const response = await web.request("/operations/availability/avsl_1", {}, {}, ctx)
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe("APP")
+    expect(hits).toEqual([])
+  })
+
+  it("does not intercept the API surface", async () => {
+    const clientAssetsDir = createAssetsDir()
+    const { hits, store } = recordingStore()
+    const web = serveAdminHost({
+      clientAssetsDir,
+      legacyPathUsage: store,
+      app: () => Response.json({ ok: true }),
+    })
+
+    const response = await web.request("/api/v1/admin/products/prod_9", {}, {}, ctx)
+
+    expect(response.status).toBe(200)
+    expect(hits).toEqual([])
   })
 })

--- a/packages/catalog/tsconfig.build.json
+++ b/packages/catalog/tsconfig.build.json
@@ -1134,6 +1134,9 @@
       "@voyant-travel/hono/middleware/error-boundary": [
         "../hono/dist/middleware/error-boundary.d.ts"
       ],
+      "@voyant-travel/hono/middleware/legacy-redirects": [
+        "../hono/dist/middleware/legacy-redirects.d.ts"
+      ],
       "@voyant-travel/hono/middleware/logger": ["../hono/dist/middleware/logger.d.ts"],
       "@voyant-travel/hono/middleware/rate-limit": ["../hono/dist/middleware/rate-limit.d.ts"],
       "@voyant-travel/hono/middleware/require-actor": [

--- a/packages/catalog/tsconfig.typecheck.json
+++ b/packages/catalog/tsconfig.typecheck.json
@@ -1135,6 +1135,9 @@
       "@voyant-travel/hono/middleware/error-boundary": [
         "../hono/dist/middleware/error-boundary.d.ts"
       ],
+      "@voyant-travel/hono/middleware/legacy-redirects": [
+        "../hono/dist/middleware/legacy-redirects.d.ts"
+      ],
       "@voyant-travel/hono/middleware/logger": ["../hono/dist/middleware/logger.d.ts"],
       "@voyant-travel/hono/middleware/rate-limit": ["../hono/dist/middleware/rate-limit.d.ts"],
       "@voyant-travel/hono/middleware/require-actor": [

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -1140,6 +1140,9 @@
       "@voyant-travel/hono/middleware/error-boundary": [
         "../hono/dist/middleware/error-boundary.d.ts"
       ],
+      "@voyant-travel/hono/middleware/legacy-redirects": [
+        "../hono/dist/middleware/legacy-redirects.d.ts"
+      ],
       "@voyant-travel/hono/middleware/logger": ["../hono/dist/middleware/logger.d.ts"],
       "@voyant-travel/hono/middleware/rate-limit": ["../hono/dist/middleware/rate-limit.d.ts"],
       "@voyant-travel/hono/middleware/require-actor": [

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -1134,6 +1134,9 @@
       "@voyant-travel/hono/middleware/error-boundary": [
         "../hono/dist/middleware/error-boundary.d.ts"
       ],
+      "@voyant-travel/hono/middleware/legacy-redirects": [
+        "../hono/dist/middleware/legacy-redirects.d.ts"
+      ],
       "@voyant-travel/hono/middleware/logger": ["../hono/dist/middleware/logger.d.ts"],
       "@voyant-travel/hono/middleware/rate-limit": ["../hono/dist/middleware/rate-limit.d.ts"],
       "@voyant-travel/hono/middleware/require-actor": [

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -53,6 +53,18 @@ export type {
 export { createEventBus, generateEventId } from "./events.js"
 export { hooks } from "./hooks.js"
 export type {
+  LegacyPathUsageRow,
+  LegacyPathUsageStore,
+  LegacyRedirect,
+  LegacyRouteFamily,
+} from "./legacy-compat.js"
+export {
+  InMemoryLegacyPathUsageStore,
+  LEGACY_REDIRECT_KEYS,
+  resolveAndCountLegacyRedirect,
+  resolveLegacyRedirect,
+} from "./legacy-compat.js"
+export type {
   LinkableDefinition,
   LinkCardinality,
   LinkDefinition,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -59,10 +59,13 @@ export type {
   LegacyRouteFamily,
 } from "./legacy-compat.js"
 export {
+  getLegacyPathUsageStore,
   InMemoryLegacyPathUsageStore,
   LEGACY_REDIRECT_KEYS,
+  resetLegacyPathUsageStore,
   resolveAndCountLegacyRedirect,
   resolveLegacyRedirect,
+  setLegacyPathUsageStore,
 } from "./legacy-compat.js"
 export type {
   LinkableDefinition,

--- a/packages/core/src/legacy-compat.ts
+++ b/packages/core/src/legacy-compat.ts
@@ -52,18 +52,28 @@ interface LegacyRedirectRule {
  */
 const LEGACY_REDIRECT_RULES: readonly LegacyRedirectRule[] = [
   // Extras were a standalone beta surface; they are Product-owned Options now.
+  //
+  // There is no `/products/options` route and there never was: Options are an
+  // authoring group *inside* Product detail, anchored as `#authoring-options`
+  // (see `authoringGroupDeepLink` in @voyant-travel/inventory-react). The old
+  // target matched `/products/$id` with `id = "options"`, so it turned one
+  // not-found page into another — invisible while nothing called this table.
+  //
+  // A legacy extras id is not a product id, so the detail rule cannot resolve
+  // the anchor without a lookup this layer has no business doing. It lands on
+  // the Product index, which is where an operator can find the owning Product.
   {
     key: "extras.detail",
     family: "extras",
     pattern: /^\/extras\/([^/]+)\/?$/,
-    to: (m) => `/products/options/${m[1]}`,
+    to: () => "/products",
     status: 308,
   },
   {
     key: "extras.index",
     family: "extras",
     pattern: /^\/extras\/?$/,
-    to: () => "/products/options",
+    to: () => "/products",
     status: 308,
   },
   // The scheduled Catalog browse surface is the Product catalog now.
@@ -90,11 +100,17 @@ const LEGACY_REDIRECT_RULES: readonly LegacyRedirectRule[] = [
     status: 308,
   },
   // Operator Availability deep link → the Departure workspace on the slot.
+  //
+  // The workspace is `/operations/availability/$id` — the route is declared as
+  // `${basePath}/$id` with `basePath = "/operations/availability"` in
+  // @voyant-travel/operations-react's admin route contribution. There is no
+  // `/operations/departures` route; "Departures" is the operator-facing *label*
+  // for that surface, not its path.
   {
     key: "availability.slot",
     family: "availability",
     pattern: /^\/availability\/slots\/([^/]+)\/?$/,
-    to: (m) => `/operations/departures/${m[1]}`,
+    to: (m) => `/operations/availability/${m[1]}`,
     status: 308,
   },
 ]
@@ -167,6 +183,47 @@ export class InMemoryLegacyPathUsageStore implements LegacyPathUsageStore {
       lastSeenAt: value.lastSeenAt,
     }))
   }
+}
+
+/**
+ * The process-wide usage binding both ends of the compatibility layer resolve.
+ *
+ * The writer is the request boundary (a redirect middleware on the host that
+ * serves the deep links) and the reader is the acceptance dashboard (an admin
+ * route inside `@voyant-travel/operations`). Those two are composed by packages
+ * that cannot import each other — the serving seam knows nothing about a
+ * module's routes, and a module cannot reach the host — so without a binding
+ * they would each hold their own store and the dashboard would report a zero
+ * the redirects never had a chance to increment. That is the exact failure this
+ * whole module exists to prevent, so the binding lives here, next to the
+ * interface it satisfies.
+ *
+ * Defaults to an in-memory store: correct for the single-process Node operator
+ * deployment, and enough for tests. Anything multi-process must bind a durable
+ * implementation with {@link setLegacyPathUsageStore} before serving its first
+ * request — until it does, "usage is zero" is only *this* process's zero, which
+ * is not the fleet-wide fact a release review needs.
+ */
+let boundLegacyPathUsageStore: LegacyPathUsageStore = new InMemoryLegacyPathUsageStore()
+
+/** The store the redirect middleware records into and the dashboard reads. */
+export function getLegacyPathUsageStore(): LegacyPathUsageStore {
+  return boundLegacyPathUsageStore
+}
+
+/**
+ * Bind the deployment's durable usage store. Call once, before the first
+ * request; both the middleware and the dashboard resolve the store per call, so
+ * a later rebind is honoured but silently discards whatever the default store
+ * already counted.
+ */
+export function setLegacyPathUsageStore(store: LegacyPathUsageStore): void {
+  boundLegacyPathUsageStore = store
+}
+
+/** Test seam: restore the in-memory default so a suite cannot leak into the next. */
+export function resetLegacyPathUsageStore(): void {
+  boundLegacyPathUsageStore = new InMemoryLegacyPathUsageStore()
 }
 
 export interface LegacyRedirectOutcome {

--- a/packages/core/src/legacy-compat.ts
+++ b/packages/core/src/legacy-compat.ts
@@ -1,0 +1,195 @@
+/**
+ * Compatibility redirects for superseded deep links, plus the usage counting
+ * that turns "is anyone still hitting the old URL?" from an assumption into a
+ * fact someone can check.
+ *
+ * The unified Product / Departure model retired four families of first-party
+ * deep link. Rather than break bookmarks, older emails and cached search
+ * results during the measured compatibility period, each legacy path resolves
+ * to its canonical successor here, and every hit is counted against a stable
+ * key. The redirects are **built and instrumented** — they are NOT deleted.
+ * Removal is gated on measured-zero usage plus a human release review (see
+ * voyant#4038); this module is what makes the "zero" measurable.
+ *
+ * Nothing in here reads a database or a request body, so it is safe to import
+ * from any layer. A route middleware resolves the redirect and records the hit
+ * against a `LegacyPathUsageStore`; the operator dashboard reads the store's
+ * snapshot back as the `legacy-path usage` metric (no PII — only route keys and
+ * counts are ever recorded).
+ */
+
+/** The four superseded deep-link families this compatibility layer covers. */
+export type LegacyRouteFamily = "extras" | "catalog" | "product" | "availability"
+
+export interface LegacyRedirect {
+  /** Stable key the usage counter and the release review track. Never reuse. */
+  key: string
+  family: LegacyRouteFamily
+  /** The canonical path the legacy link now resolves to. */
+  to: string
+  /**
+   * HTTP status for the redirect. `308` (permanent, method-preserving) for a
+   * straight rename; superseded surfaces use `308` so proxies and clients cache
+   * the successor for the compatibility window.
+   */
+  status: 301 | 308
+}
+
+interface LegacyRedirectRule {
+  key: string
+  family: LegacyRouteFamily
+  /** Matches a legacy pathname, capturing the id segment where present. */
+  pattern: RegExp
+  /** Builds the canonical path from the regex match. */
+  to: (match: RegExpMatchArray) => string
+  status: 301 | 308
+}
+
+/**
+ * The compatibility table. One rule per superseded first-party deep link.
+ * Ordered most-specific-first so a nested legacy path never matches a broader
+ * rule ahead of its own.
+ */
+const LEGACY_REDIRECT_RULES: readonly LegacyRedirectRule[] = [
+  // Extras were a standalone beta surface; they are Product-owned Options now.
+  {
+    key: "extras.detail",
+    family: "extras",
+    pattern: /^\/extras\/([^/]+)\/?$/,
+    to: (m) => `/products/options/${m[1]}`,
+    status: 308,
+  },
+  {
+    key: "extras.index",
+    family: "extras",
+    pattern: /^\/extras\/?$/,
+    to: () => "/products/options",
+    status: 308,
+  },
+  // The scheduled Catalog browse surface is the Product catalog now.
+  {
+    key: "catalog.scheduled.detail",
+    family: "catalog",
+    pattern: /^\/catalog\/scheduled\/([^/]+)\/?$/,
+    to: (m) => `/products/${m[1]}`,
+    status: 308,
+  },
+  {
+    key: "catalog.scheduled.index",
+    family: "catalog",
+    pattern: /^\/catalog\/scheduled\/?$/,
+    to: () => "/products",
+    status: 308,
+  },
+  // Legacy Product detail path (singular) → the canonical plural resource.
+  {
+    key: "product.detail",
+    family: "product",
+    pattern: /^\/product\/([^/]+)\/?$/,
+    to: (m) => `/products/${m[1]}`,
+    status: 308,
+  },
+  // Operator Availability deep link → the Departure workspace on the slot.
+  {
+    key: "availability.slot",
+    family: "availability",
+    pattern: /^\/availability\/slots\/([^/]+)\/?$/,
+    to: (m) => `/operations/departures/${m[1]}`,
+    status: 308,
+  },
+]
+
+/** Every stable redirect key, e.g. for seeding a usage report at zero. */
+export const LEGACY_REDIRECT_KEYS: readonly string[] = LEGACY_REDIRECT_RULES.map((r) => r.key)
+
+/**
+ * Resolve a legacy pathname to its canonical successor, or `null` when the path
+ * is not a superseded one. Query strings and fragments are ignored — pass the
+ * pathname only.
+ */
+export function resolveLegacyRedirect(pathname: string): LegacyRedirect | null {
+  for (const rule of LEGACY_REDIRECT_RULES) {
+    const match = pathname.match(rule.pattern)
+    if (match) {
+      return { key: rule.key, family: rule.family, to: rule.to(match), status: rule.status }
+    }
+  }
+  return null
+}
+
+/** One row of legacy-path usage. Carries a route key and a count — never PII. */
+export interface LegacyPathUsageRow {
+  key: string
+  family: LegacyRouteFamily
+  hits: number
+  /** ISO instant of the most recent hit, or null when never hit. */
+  lastSeenAt: string | null
+}
+
+/**
+ * The usage-counting seam. A deployment binds a durable implementation (shared
+ * across the fleet) so "usage is zero" is a fleet-wide fact; the in-memory
+ * default below is enough for a single process and for tests.
+ */
+export interface LegacyPathUsageStore {
+  record(key: string, at: Date): void | Promise<void>
+  snapshot(): LegacyPathUsageRow[] | Promise<LegacyPathUsageRow[]>
+}
+
+const FAMILY_BY_KEY = new Map<string, LegacyRouteFamily>(
+  LEGACY_REDIRECT_RULES.map((r) => [r.key, r.family]),
+)
+
+/**
+ * In-memory usage store, seeded so every known key reports even before its
+ * first hit — a key absent from the report reads as "no such route", which is
+ * not the same as "zero usage". A release review needs the explicit zero.
+ */
+export class InMemoryLegacyPathUsageStore implements LegacyPathUsageStore {
+  private readonly counts = new Map<string, { hits: number; lastSeenAt: string | null }>()
+
+  constructor() {
+    for (const key of LEGACY_REDIRECT_KEYS) {
+      this.counts.set(key, { hits: 0, lastSeenAt: null })
+    }
+  }
+
+  record(key: string, at: Date): void {
+    const current = this.counts.get(key) ?? { hits: 0, lastSeenAt: null }
+    this.counts.set(key, { hits: current.hits + 1, lastSeenAt: at.toISOString() })
+  }
+
+  snapshot(): LegacyPathUsageRow[] {
+    return [...this.counts.entries()].map(([key, value]) => ({
+      key,
+      family: FAMILY_BY_KEY.get(key) ?? "product",
+      hits: value.hits,
+      lastSeenAt: value.lastSeenAt,
+    }))
+  }
+}
+
+export interface LegacyRedirectOutcome {
+  redirect: LegacyRedirect
+}
+
+/**
+ * Resolve a redirect for a pathname AND count the hit in one call, for a route
+ * middleware to use. Returns the redirect (so the caller issues the response)
+ * or `null` to fall through to normal routing. Recording failures are swallowed
+ * — a compatibility redirect must never fail because its counter did.
+ */
+export async function resolveAndCountLegacyRedirect(
+  store: LegacyPathUsageStore,
+  pathname: string,
+  now: Date,
+): Promise<LegacyRedirect | null> {
+  const redirect = resolveLegacyRedirect(pathname)
+  if (!redirect) return null
+  try {
+    await store.record(redirect.key, now)
+  } catch {
+    // Counting is best-effort; never block the redirect on it.
+  }
+  return redirect
+}

--- a/packages/core/tests/legacy-compat.test.ts
+++ b/packages/core/tests/legacy-compat.test.ts
@@ -11,10 +11,10 @@ describe("resolveLegacyRedirect", () => {
   it("redirects each superseded family to its canonical successor", () => {
     expect(resolveLegacyRedirect("/extras/opt_123")).toMatchObject({
       family: "extras",
-      to: "/products/options/opt_123",
+      to: "/products",
       status: 308,
     })
-    expect(resolveLegacyRedirect("/extras")).toMatchObject({ to: "/products/options" })
+    expect(resolveLegacyRedirect("/extras")).toMatchObject({ to: "/products" })
     expect(resolveLegacyRedirect("/catalog/scheduled/prod_9")).toMatchObject({
       family: "catalog",
       to: "/products/prod_9",
@@ -26,7 +26,7 @@ describe("resolveLegacyRedirect", () => {
     })
     expect(resolveLegacyRedirect("/availability/slots/avsl_1")).toMatchObject({
       family: "availability",
-      to: "/operations/departures/avsl_1",
+      to: "/operations/availability/avsl_1",
     })
   })
 
@@ -36,7 +36,7 @@ describe("resolveLegacyRedirect", () => {
 
   it("returns null for a path that is not superseded", () => {
     expect(resolveLegacyRedirect("/products/prod_9")).toBeNull()
-    expect(resolveLegacyRedirect("/operations/departures/avsl_1")).toBeNull()
+    expect(resolveLegacyRedirect("/operations/availability/avsl_1")).toBeNull()
     expect(resolveLegacyRedirect("/")).toBeNull()
   })
 })
@@ -65,7 +65,7 @@ describe("resolveAndCountLegacyRedirect", () => {
     const now = new Date("2026-08-04T12:00:00Z")
 
     const hit = await resolveAndCountLegacyRedirect(store, "/extras/opt_1", now)
-    expect(hit?.to).toBe("/products/options/opt_1")
+    expect(hit?.to).toBe("/products")
     expect(store.snapshot().find((r) => r.key === "extras.detail")?.hits).toBe(1)
 
     const miss = await resolveAndCountLegacyRedirect(store, "/products/opt_1", now)

--- a/packages/core/tests/legacy-compat.test.ts
+++ b/packages/core/tests/legacy-compat.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  InMemoryLegacyPathUsageStore,
+  LEGACY_REDIRECT_KEYS,
+  resolveAndCountLegacyRedirect,
+  resolveLegacyRedirect,
+} from "../src/legacy-compat.js"
+
+describe("resolveLegacyRedirect", () => {
+  it("redirects each superseded family to its canonical successor", () => {
+    expect(resolveLegacyRedirect("/extras/opt_123")).toMatchObject({
+      family: "extras",
+      to: "/products/options/opt_123",
+      status: 308,
+    })
+    expect(resolveLegacyRedirect("/extras")).toMatchObject({ to: "/products/options" })
+    expect(resolveLegacyRedirect("/catalog/scheduled/prod_9")).toMatchObject({
+      family: "catalog",
+      to: "/products/prod_9",
+    })
+    expect(resolveLegacyRedirect("/catalog/scheduled")).toMatchObject({ to: "/products" })
+    expect(resolveLegacyRedirect("/product/prod_9")).toMatchObject({
+      family: "product",
+      to: "/products/prod_9",
+    })
+    expect(resolveLegacyRedirect("/availability/slots/avsl_1")).toMatchObject({
+      family: "availability",
+      to: "/operations/departures/avsl_1",
+    })
+  })
+
+  it("tolerates a trailing slash", () => {
+    expect(resolveLegacyRedirect("/product/prod_9/")).toMatchObject({ to: "/products/prod_9" })
+  })
+
+  it("returns null for a path that is not superseded", () => {
+    expect(resolveLegacyRedirect("/products/prod_9")).toBeNull()
+    expect(resolveLegacyRedirect("/operations/departures/avsl_1")).toBeNull()
+    expect(resolveLegacyRedirect("/")).toBeNull()
+  })
+})
+
+describe("InMemoryLegacyPathUsageStore", () => {
+  it("seeds every known key at zero so 'no usage' is explicit, not missing", () => {
+    const store = new InMemoryLegacyPathUsageStore()
+    const snapshot = store.snapshot()
+    expect(snapshot.map((r) => r.key).sort()).toEqual([...LEGACY_REDIRECT_KEYS].sort())
+    expect(snapshot.every((r) => r.hits === 0 && r.lastSeenAt === null)).toBe(true)
+  })
+
+  it("counts hits per key and stamps the last-seen instant", () => {
+    const store = new InMemoryLegacyPathUsageStore()
+    store.record("product.detail", new Date("2026-08-04T10:00:00Z"))
+    store.record("product.detail", new Date("2026-08-04T11:00:00Z"))
+    const row = store.snapshot().find((r) => r.key === "product.detail")
+    expect(row?.hits).toBe(2)
+    expect(row?.lastSeenAt).toBe("2026-08-04T11:00:00.000Z")
+  })
+})
+
+describe("resolveAndCountLegacyRedirect", () => {
+  it("resolves and records a hit in one call, and leaves non-legacy paths alone", async () => {
+    const store = new InMemoryLegacyPathUsageStore()
+    const now = new Date("2026-08-04T12:00:00Z")
+
+    const hit = await resolveAndCountLegacyRedirect(store, "/extras/opt_1", now)
+    expect(hit?.to).toBe("/products/options/opt_1")
+    expect(store.snapshot().find((r) => r.key === "extras.detail")?.hits).toBe(1)
+
+    const miss = await resolveAndCountLegacyRedirect(store, "/products/opt_1", now)
+    expect(miss).toBeNull()
+  })
+
+  it("never throws when the store's record fails — the redirect still resolves", async () => {
+    const flakyStore = {
+      record() {
+        throw new Error("counter down")
+      },
+      snapshot() {
+        return []
+      },
+    }
+    const hit = await resolveAndCountLegacyRedirect(flakyStore, "/product/prod_9", new Date())
+    expect(hit?.to).toBe("/products/prod_9")
+  })
+})

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -1185,6 +1185,9 @@
       "@voyant-travel/hono/middleware/error-boundary": [
         "../hono/dist/middleware/error-boundary.d.ts"
       ],
+      "@voyant-travel/hono/middleware/legacy-redirects": [
+        "../hono/dist/middleware/legacy-redirects.d.ts"
+      ],
       "@voyant-travel/hono/middleware/logger": ["../hono/dist/middleware/logger.d.ts"],
       "@voyant-travel/hono/middleware/rate-limit": ["../hono/dist/middleware/rate-limit.d.ts"],
       "@voyant-travel/hono/middleware/require-actor": [

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -1186,6 +1186,9 @@
       "@voyant-travel/hono/middleware/error-boundary": [
         "../hono/dist/middleware/error-boundary.d.ts"
       ],
+      "@voyant-travel/hono/middleware/legacy-redirects": [
+        "../hono/dist/middleware/legacy-redirects.d.ts"
+      ],
       "@voyant-travel/hono/middleware/logger": ["../hono/dist/middleware/logger.d.ts"],
       "@voyant-travel/hono/middleware/rate-limit": ["../hono/dist/middleware/rate-limit.d.ts"],
       "@voyant-travel/hono/middleware/require-actor": [

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -1189,6 +1189,9 @@
       "@voyant-travel/hono/middleware/error-boundary": [
         "../hono/dist/middleware/error-boundary.d.ts"
       ],
+      "@voyant-travel/hono/middleware/legacy-redirects": [
+        "../hono/dist/middleware/legacy-redirects.d.ts"
+      ],
       "@voyant-travel/hono/middleware/logger": ["../hono/dist/middleware/logger.d.ts"],
       "@voyant-travel/hono/middleware/rate-limit": ["../hono/dist/middleware/rate-limit.d.ts"],
       "@voyant-travel/hono/middleware/require-actor": [

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -1190,6 +1190,9 @@
       "@voyant-travel/hono/middleware/error-boundary": [
         "../hono/dist/middleware/error-boundary.d.ts"
       ],
+      "@voyant-travel/hono/middleware/legacy-redirects": [
+        "../hono/dist/middleware/legacy-redirects.d.ts"
+      ],
       "@voyant-travel/hono/middleware/logger": ["../hono/dist/middleware/logger.d.ts"],
       "@voyant-travel/hono/middleware/rate-limit": ["../hono/dist/middleware/rate-limit.d.ts"],
       "@voyant-travel/hono/middleware/require-actor": [

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -1221,6 +1221,9 @@
       "@voyant-travel/hono/middleware/error-boundary": [
         "../hono/dist/middleware/error-boundary.d.ts"
       ],
+      "@voyant-travel/hono/middleware/legacy-redirects": [
+        "../hono/dist/middleware/legacy-redirects.d.ts"
+      ],
       "@voyant-travel/hono/middleware/logger": ["../hono/dist/middleware/logger.d.ts"],
       "@voyant-travel/hono/middleware/rate-limit": ["../hono/dist/middleware/rate-limit.d.ts"],
       "@voyant-travel/hono/middleware/require-actor": [

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -1216,6 +1216,9 @@
       "@voyant-travel/hono/middleware/error-boundary": [
         "../hono/dist/middleware/error-boundary.d.ts"
       ],
+      "@voyant-travel/hono/middleware/legacy-redirects": [
+        "../hono/dist/middleware/legacy-redirects.d.ts"
+      ],
       "@voyant-travel/hono/middleware/logger": ["../hono/dist/middleware/logger.d.ts"],
       "@voyant-travel/hono/middleware/rate-limit": ["../hono/dist/middleware/rate-limit.d.ts"],
       "@voyant-travel/hono/middleware/require-actor": [

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -1223,6 +1223,9 @@
       "@voyant-travel/hono/middleware/error-boundary": [
         "../hono/dist/middleware/error-boundary.d.ts"
       ],
+      "@voyant-travel/hono/middleware/legacy-redirects": [
+        "../hono/dist/middleware/legacy-redirects.d.ts"
+      ],
       "@voyant-travel/hono/middleware/logger": ["../hono/dist/middleware/logger.d.ts"],
       "@voyant-travel/hono/middleware/rate-limit": ["../hono/dist/middleware/rate-limit.d.ts"],
       "@voyant-travel/hono/middleware/require-actor": [

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -1224,6 +1224,9 @@
       "@voyant-travel/hono/middleware/error-boundary": [
         "../hono/dist/middleware/error-boundary.d.ts"
       ],
+      "@voyant-travel/hono/middleware/legacy-redirects": [
+        "../hono/dist/middleware/legacy-redirects.d.ts"
+      ],
       "@voyant-travel/hono/middleware/logger": ["../hono/dist/middleware/logger.d.ts"],
       "@voyant-travel/hono/middleware/rate-limit": ["../hono/dist/middleware/rate-limit.d.ts"],
       "@voyant-travel/hono/middleware/require-actor": [

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -24,6 +24,7 @@
     "./middleware/require-actor": "./src/middleware/require-actor.ts",
     "./middleware/require-permission": "./src/middleware/require-permission.ts",
     "./middleware/security-headers": "./src/middleware/security-headers.ts",
+    "./middleware/legacy-redirects": "./src/middleware/legacy-redirects.ts",
     "./middleware/logger": "./src/middleware/logger.ts",
     "./auth": "./src/auth/index.ts",
     "./auth/session-jwt": "./src/auth/session-jwt.ts",
@@ -172,6 +173,11 @@
         "types": "./dist/middleware/security-headers.d.ts",
         "import": "./dist/middleware/security-headers.js",
         "default": "./dist/middleware/security-headers.js"
+      },
+      "./middleware/legacy-redirects": {
+        "types": "./dist/middleware/legacy-redirects.d.ts",
+        "import": "./dist/middleware/legacy-redirects.js",
+        "default": "./dist/middleware/legacy-redirects.js"
       },
       "./middleware/logger": {
         "types": "./dist/middleware/logger.d.ts",

--- a/packages/hono/src/middleware/index.ts
+++ b/packages/hono/src/middleware/index.ts
@@ -18,6 +18,7 @@ export {
   idempotencyKey,
   purgeExpiredIdempotencyKeys,
 } from "./idempotency-key.js"
+export { type LegacyRedirectsOptions, legacyRedirects } from "./legacy-redirects.js"
 export { consoleLoggerProvider, logger } from "./logger.js"
 export {
   type PublicCacheOptions,

--- a/packages/hono/src/middleware/legacy-redirects.ts
+++ b/packages/hono/src/middleware/legacy-redirects.ts
@@ -1,0 +1,75 @@
+/**
+ * Compatibility-redirect middleware for the four superseded first-party deep
+ * link families (voyant#4038).
+ *
+ * The table, the successors and the usage counter all live in
+ * `@voyant-travel/core`'s `legacy-compat` module; this is the HTTP edge that
+ * makes them do something. One request in, one `308` out, one hit recorded —
+ * so the "measured zero" the deletion gate waits for is measured against real
+ * traffic rather than assumed.
+ *
+ * ## Where this is mounted, and where it deliberately is not
+ *
+ * Mounted by `serveAdminHost` (`@voyant-travel/admin-host`), which is the only
+ * seam that sees these paths: the four legacy families are UI deep links at the
+ * origin root (`/extras/:id`, `/catalog/scheduled/:id`, `/product/:id`,
+ * `/availability/slots/:id`), and the operator host routes only `/api/*` into
+ * the composed Hono API app. A bookmark to `/product/prod_9` never reaches
+ * `mountApp`; it reaches the SSR handler, which renders a not-found page.
+ *
+ * It is deliberately NOT registered in `mountApp` alongside `cors` /
+ * `securityHeaders`. A storefront deployment mounts the framework app at the
+ * origin root and serves `/catalog/*slug` as real CMS content — auto-redirecting
+ * `/catalog/scheduled/...` there would break a live public URL to fix an
+ * operator bookmark. The compatibility table is scoped to first-party operator
+ * surfaces, so its mounting is too.
+ *
+ * ## Ordering
+ *
+ * Mount before static-asset serving and before auth. A superseded bookmark must
+ * answer identically to a logged-out browser and a logged-in one; making the
+ * redirect conditional on a session would under-count exactly the traffic the
+ * gate is trying to see.
+ */
+
+import {
+  getLegacyPathUsageStore,
+  type LegacyPathUsageStore,
+  resolveAndCountLegacyRedirect,
+} from "@voyant-travel/core"
+import type { MiddlewareHandler } from "hono"
+
+export interface LegacyRedirectsOptions {
+  /**
+   * Where hits are counted. Defaults to the process-wide binding from
+   * `@voyant-travel/core`, which is the same store the acceptance dashboard
+   * reads — pass one explicitly only in a test, or when a host owns a durable
+   * store it has not bound globally.
+   */
+  store?: LegacyPathUsageStore
+  /** Clock seam. Defaults to `Date`. */
+  now?: () => Date
+}
+
+/**
+ * Resolve a superseded deep link to its canonical successor, count the hit, and
+ * answer with the redirect. Requests that are not superseded fall straight
+ * through, so this is safe to mount on `*`.
+ *
+ * The query string is carried over verbatim and the fragment never reaches the
+ * server, which is why `resolveLegacyRedirect` takes a pathname only. The
+ * status comes from the table (`308`, method-preserving) rather than from here.
+ */
+export function legacyRedirects(options: LegacyRedirectsOptions = {}): MiddlewareHandler {
+  const clock = options.now ?? (() => new Date())
+  return async (c, next) => {
+    const url = new URL(c.req.url)
+    const redirect = await resolveAndCountLegacyRedirect(
+      options.store ?? getLegacyPathUsageStore(),
+      url.pathname,
+      clock(),
+    )
+    if (!redirect) return next()
+    return c.redirect(`${redirect.to}${url.search}`, redirect.status)
+  }
+}

--- a/packages/hono/tests/unit/legacy-redirects.test.ts
+++ b/packages/hono/tests/unit/legacy-redirects.test.ts
@@ -1,0 +1,94 @@
+import {
+  getLegacyPathUsageStore,
+  InMemoryLegacyPathUsageStore,
+  resetLegacyPathUsageStore,
+} from "@voyant-travel/core"
+import { Hono } from "hono"
+import { afterEach, describe, expect, it } from "vitest"
+
+import { legacyRedirects } from "../../src/middleware/legacy-redirects.js"
+
+/**
+ * Exercises the middleware as an HTTP edge, not as a wrapper around the pure
+ * resolver: a real request in, a real `Location` header out, and the counter
+ * moved. The resolver's own table is covered in `@voyant-travel/core`.
+ */
+function appWith(store?: InMemoryLegacyPathUsageStore) {
+  const app = new Hono()
+  app.use("*", legacyRedirects(store ? { store } : {}))
+  app.all("*", (c) => c.text("FELL THROUGH", 200))
+  return app
+}
+
+afterEach(() => {
+  resetLegacyPathUsageStore()
+})
+
+describe("legacyRedirects", () => {
+  it("redirects each superseded family and counts the hit", async () => {
+    const store = new InMemoryLegacyPathUsageStore()
+    const app = appWith(store)
+
+    const cases: [string, string, string][] = [
+      ["/extras/opt_1", "/products", "extras.detail"],
+      ["/catalog/scheduled/prod_9", "/products/prod_9", "catalog.scheduled.detail"],
+      ["/product/prod_9", "/products/prod_9", "product.detail"],
+      ["/availability/slots/avsl_1", "/operations/availability/avsl_1", "availability.slot"],
+    ]
+
+    for (const [from, to, key] of cases) {
+      const response = await app.request(from)
+      expect(response.status).toBe(308)
+      expect(response.headers.get("location")).toBe(to)
+      expect(store.snapshot().find((row) => row.key === key)?.hits).toBe(1)
+    }
+  })
+
+  it("carries the query string onto the successor", async () => {
+    const response = await appWith(new InMemoryLegacyPathUsageStore()).request(
+      "/product/prod_9?tab=pricing&from=email",
+    )
+
+    expect(response.headers.get("location")).toBe("/products/prod_9?tab=pricing&from=email")
+  })
+
+  it("falls through for a path that is not superseded, and counts nothing", async () => {
+    const store = new InMemoryLegacyPathUsageStore()
+
+    const response = await appWith(store).request("/products/prod_9")
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe("FELL THROUGH")
+    expect(store.snapshot().every((row) => row.hits === 0)).toBe(true)
+  })
+
+  it("records into the process-wide store when the host binds none", async () => {
+    const response = await appWith().request("/extras")
+
+    expect(response.status).toBe(308)
+    expect(response.headers.get("location")).toBe("/products")
+    const snapshot = await getLegacyPathUsageStore().snapshot()
+    expect(snapshot.find((row) => row.key === "extras.index")?.hits).toBe(1)
+  })
+
+  it("still redirects when the counter throws", async () => {
+    const app = new Hono()
+    app.use(
+      "*",
+      legacyRedirects({
+        store: {
+          record() {
+            throw new Error("counter down")
+          },
+          snapshot: () => [],
+        },
+      }),
+    )
+    app.all("*", (c) => c.text("FELL THROUGH", 200))
+
+    const response = await app.request("/product/prod_9")
+
+    expect(response.status).toBe(308)
+    expect(response.headers.get("location")).toBe("/products/prod_9")
+  })
+})

--- a/packages/inventory-react/src/components/product-detail/product-authoring-nav-view.tsx
+++ b/packages/inventory-react/src/components/product-detail/product-authoring-nav-view.tsx
@@ -1,0 +1,65 @@
+"use client"
+
+import * as React from "react"
+
+import { useProductsUiI18nOrDefault } from "../../i18n/index.js"
+import {
+  authoringGroupAnchorId,
+  authoringGroupFromHash,
+  PRODUCT_AUTHORING_GROUP_IDS,
+  type ProductAuthoringGroupId,
+} from "./product-authoring-nav.js"
+
+export interface ProductAuthoringNavProps {
+  /** Product id, so each group is a shareable contextual deep link. */
+  productId: string
+}
+
+/**
+ * The Product authoring group navigation — seven ordered, deep-linkable groups
+ * (Overview & readiness → History). Each item is an anchor to the group's
+ * in-page section id, so it works as an on-page jump and as a shareable deep
+ * link (`/products/:id#authoring-plan`). The active group is derived from the
+ * location hash, with no router dependency.
+ */
+export function ProductAuthoringNav({ productId }: ProductAuthoringNavProps) {
+  const { messages } = useProductsUiI18nOrDefault()
+  const nav = messages.productAuthoringNav
+  const [active, setActive] = React.useState<ProductAuthoringGroupId | null>(null)
+
+  React.useEffect(() => {
+    const sync = () =>
+      setActive(authoringGroupFromHash(typeof window === "undefined" ? null : window.location.hash))
+    sync()
+    if (typeof window === "undefined") return
+    window.addEventListener("hashchange", sync)
+    return () => window.removeEventListener("hashchange", sync)
+  }, [])
+
+  return (
+    <nav
+      aria-label={nav.label}
+      className="sticky top-0 z-10 -mx-1 flex flex-wrap gap-1 overflow-x-auto border-b bg-background/95 px-1 py-2 backdrop-blur"
+    >
+      {PRODUCT_AUTHORING_GROUP_IDS.map((id) => {
+        const anchor = authoringGroupAnchorId(id)
+        const isActive = active === id
+        return (
+          <a
+            key={id}
+            href={`#${anchor}`}
+            aria-current={isActive ? "true" : undefined}
+            data-product-id={productId}
+            className={
+              isActive
+                ? "rounded-md bg-secondary px-3 py-1.5 font-medium text-secondary-foreground text-sm"
+                : "rounded-md px-3 py-1.5 text-muted-foreground text-sm hover:bg-muted hover:text-foreground"
+            }
+          >
+            {nav.groups[id]}
+          </a>
+        )
+      })}
+    </nav>
+  )
+}

--- a/packages/inventory-react/src/components/product-detail/product-authoring-nav.test.ts
+++ b/packages/inventory-react/src/components/product-detail/product-authoring-nav.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  authoringGroupAnchorId,
+  authoringGroupDeepLink,
+  authoringGroupFromHash,
+  PRODUCT_AUTHORING_GROUP_IDS,
+} from "./product-authoring-nav.js"
+
+describe("product authoring navigation", () => {
+  it("declares the seven groups in canonical order", () => {
+    expect([...PRODUCT_AUTHORING_GROUP_IDS]).toEqual([
+      "overview",
+      "content",
+      "plan",
+      "options",
+      "availability",
+      "distribution",
+      "history",
+    ])
+  })
+
+  it("derives a stable anchor id and a contextual deep link per group", () => {
+    expect(authoringGroupAnchorId("plan")).toBe("authoring-plan")
+    expect(authoringGroupDeepLink("prod_9", "options")).toBe("/products/prod_9#authoring-options")
+  })
+
+  it("round-trips a hash back to its group and ignores unknown hashes", () => {
+    for (const id of PRODUCT_AUTHORING_GROUP_IDS) {
+      expect(authoringGroupFromHash(`#${authoringGroupAnchorId(id)}`)).toBe(id)
+    }
+    expect(authoringGroupFromHash("#authoring-nope")).toBeNull()
+    expect(authoringGroupFromHash("")).toBeNull()
+    expect(authoringGroupFromHash(null)).toBeNull()
+  })
+})

--- a/packages/inventory-react/src/components/product-detail/product-authoring-nav.ts
+++ b/packages/inventory-react/src/components/product-detail/product-authoring-nav.ts
@@ -1,0 +1,57 @@
+/**
+ * The Product authoring information architecture (voyant#4038).
+ *
+ * Product authoring is organized around seven ordered groups — Overview &
+ * readiness, Content, Plan, Options & pricing, Availability, Distribution and
+ * History — each addressable by a stable in-page anchor so the operator (and a
+ * deep link from elsewhere) can jump straight to a concern. The grouping is a
+ * presentation concern: the underlying section components are unchanged, they
+ * are just gathered under a stable, ordered set of headings.
+ *
+ * This module is the single source of truth for the group order, the stable
+ * ids, and the anchor/deep-link derivation, so the nav and the detail page can
+ * never drift on either the set or the ordering.
+ */
+
+/** The seven authoring groups, in canonical display order. */
+export type ProductAuthoringGroupId =
+  | "overview"
+  | "content"
+  | "plan"
+  | "options"
+  | "availability"
+  | "distribution"
+  | "history"
+
+export const PRODUCT_AUTHORING_GROUP_IDS = [
+  "overview",
+  "content",
+  "plan",
+  "options",
+  "availability",
+  "distribution",
+  "history",
+] as const satisfies readonly ProductAuthoringGroupId[]
+
+/** The in-page element id an authoring group anchors to. */
+export function authoringGroupAnchorId(id: ProductAuthoringGroupId): string {
+  return `authoring-${id}`
+}
+
+/** A contextual deep link to a Product authoring group. */
+export function authoringGroupDeepLink(productId: string, id: ProductAuthoringGroupId): string {
+  return `/products/${productId}#${authoringGroupAnchorId(id)}`
+}
+
+/**
+ * Resolve the active authoring group from a location hash (`#authoring-plan` →
+ * `plan`), or null when the hash names no known group.
+ */
+export function authoringGroupFromHash(
+  hash: string | null | undefined,
+): ProductAuthoringGroupId | null {
+  if (!hash) return null
+  const bare = hash.replace(/^#/, "")
+  const match = PRODUCT_AUTHORING_GROUP_IDS.find((id) => authoringGroupAnchorId(id) === bare)
+  return match ?? null
+}

--- a/packages/inventory-react/src/components/product-detail/product-detail-page.tsx
+++ b/packages/inventory-react/src/components/product-detail/product-detail-page.tsx
@@ -11,6 +11,8 @@ import {
   useProductLocale,
 } from "./host.js"
 import { ProductActivitySection } from "./product-activity-section.js"
+import { authoringGroupAnchorId } from "./product-authoring-nav.js"
+import { ProductAuthoringNav } from "./product-authoring-nav-view.js"
 import { DepartureDialog } from "./product-departure-dialog.js"
 import { DeparturePricingOverrideDialog } from "./product-departure-pricing-override-dialog.js"
 import { ProductDialog } from "./product-detail-dialog.js"
@@ -116,126 +118,165 @@ export function ProductDetailPage({ id }: { id: string }) {
         }}
       />
 
+      {/* Authoring is organized around seven ordered, deep-linkable groups:
+          Overview & readiness, Content, Plan, Options & pricing, Availability,
+          Distribution, History. `ProductAuthoringNav` renders the contextual
+          deep links; each group below anchors to its stable id. */}
+      <ProductAuthoringNav productId={id} />
+
       {/* Content — two-column layout */}
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
         {/* ── Left column (main) ── */}
         <div className="flex min-w-0 flex-col gap-6">
-          <ProductDetailsSection product={product} onEdit={dialogs.edit.openNow} />
+          <section
+            id={authoringGroupAnchorId("overview")}
+            className="flex scroll-mt-16 flex-col gap-6"
+          >
+            <ProductDetailsSection product={product} onEdit={dialogs.edit.openNow} />
+          </section>
 
-          <ProductSeoSharingSection
-            product={product}
-            media={galleryMedia}
-            isUploading={mutations.uploadMedia.isPending}
-            isSavingImage={mutations.setOpenGraph.isPending}
-            onUpload={async (file) => {
-              const result = await mutations.uploadMedia.mutateAsync({ file })
-              return result.data
-            }}
-            onSetOpenGraph={(mediaId) => mutations.setOpenGraph.mutateAsync(mediaId)}
-          />
-
-          <ProductMediaSection
-            productId={id}
-            media={galleryMedia}
-            isUploading={mutations.uploadMedia.isPending}
-            onUpload={(file) => mutations.uploadMedia.mutate({ file })}
-            onSelectFromLibrary={(assets) => mutations.addMediaFromLibrary.mutate({ assets })}
-            onSetCover={(mediaId) => mutations.setCover.mutate(mediaId)}
-            onDelete={async (mediaId) => {
-              if (
-                await confirmDialog({
-                  description: productMessages.deleteMediaConfirm,
-                  destructive: true,
-                })
-              ) {
-                mutations.deleteMedia.mutate(mediaId)
-              }
-            }}
-          />
-
-          <ProductDeparturesSection
-            slots={slots}
-            itineraryNameById={itineraryNameById}
-            slotIdsWithOverrides={slotIdsWithOverrides}
-            onCreate={dialogs.departure.openNew}
-            onEdit={dialogs.departure.openEdit}
-            onOverridePrice={dialogs.departureOverride.openEdit}
-            onManageAvailability={(slot) => navigate.toAvailability(slot.id)}
-            onDelete={async (slotId) => {
-              if (
-                await confirmDialog({
-                  description: productMessages.deleteDepartureConfirm,
-                  destructive: true,
-                })
-              ) {
-                mutations.deleteSlot.mutate(slotId)
-              }
-            }}
-          />
-
-          <ProductSchedulesSection
-            rules={rules}
-            onCreate={dialogs.schedule.openNew}
-            onEdit={dialogs.schedule.openEdit}
-            onDelete={async (ruleId) => {
-              if (
-                await confirmDialog({
-                  description: productMessages.deleteScheduleConfirm,
-                  destructive: true,
-                })
-              ) {
-                mutations.deleteRule.mutate(ruleId)
-              }
-            }}
-          />
-
-          <ProductDetailItinerarySection productId={id} />
-
-          <ProductEditorialOverlaySection productId={id} />
-
-          <ProductsUiMessagesProvider locale={resolvedLocale}>
-            <ProductOptionsSection
-              productId={id}
-              renderOptionDetails={(option) => (
-                <PricingPanel
-                  productId={id}
-                  optionId={option.id}
-                  optionName={option.name}
-                  productCurrency={product.sellCurrency}
-                  layout={deriveOptionPricingLayout(product.bookingMode)}
-                  extras={renderOptionExtras?.(id, option.id)}
-                />
-              )}
+          <section
+            id={authoringGroupAnchorId("content")}
+            className="flex scroll-mt-16 flex-col gap-6"
+          >
+            <ProductSeoSharingSection
+              product={product}
+              media={galleryMedia}
+              isUploading={mutations.uploadMedia.isPending}
+              isSavingImage={mutations.setOpenGraph.isPending}
+              onUpload={async (file) => {
+                const result = await mutations.uploadMedia.mutateAsync({ file })
+                return result.data
+              }}
+              onSetOpenGraph={(mediaId) => mutations.setOpenGraph.mutateAsync(mediaId)}
             />
-          </ProductsUiMessagesProvider>
 
-          <ProductPaymentPolicySection product={product} onSuccess={invalidateProduct} />
-          <ProductMarketRulesSection productId={id} />
+            <ProductMediaSection
+              productId={id}
+              media={galleryMedia}
+              isUploading={mutations.uploadMedia.isPending}
+              onUpload={(file) => mutations.uploadMedia.mutate({ file })}
+              onSelectFromLibrary={(assets) => mutations.addMediaFromLibrary.mutate({ assets })}
+              onSetCover={(mediaId) => mutations.setCover.mutate(mediaId)}
+              onDelete={async (mediaId) => {
+                if (
+                  await confirmDialog({
+                    description: productMessages.deleteMediaConfirm,
+                    destructive: true,
+                  })
+                ) {
+                  mutations.deleteMedia.mutate(mediaId)
+                }
+              }}
+            />
+
+            <ProductEditorialOverlaySection productId={id} />
+          </section>
+
+          <section id={authoringGroupAnchorId("plan")} className="flex scroll-mt-16 flex-col gap-6">
+            <ProductDetailItinerarySection productId={id} />
+          </section>
+
+          <section
+            id={authoringGroupAnchorId("options")}
+            className="flex scroll-mt-16 flex-col gap-6"
+          >
+            <ProductsUiMessagesProvider locale={resolvedLocale}>
+              <ProductOptionsSection
+                productId={id}
+                renderOptionDetails={(option) => (
+                  <PricingPanel
+                    productId={id}
+                    optionId={option.id}
+                    optionName={option.name}
+                    productCurrency={product.sellCurrency}
+                    layout={deriveOptionPricingLayout(product.bookingMode)}
+                    extras={renderOptionExtras?.(id, option.id)}
+                  />
+                )}
+              />
+            </ProductsUiMessagesProvider>
+
+            <ProductPaymentPolicySection product={product} onSuccess={invalidateProduct} />
+            <ProductMarketRulesSection productId={id} />
+          </section>
+
+          <section
+            id={authoringGroupAnchorId("availability")}
+            className="flex scroll-mt-16 flex-col gap-6"
+          >
+            <ProductDeparturesSection
+              slots={slots}
+              itineraryNameById={itineraryNameById}
+              slotIdsWithOverrides={slotIdsWithOverrides}
+              onCreate={dialogs.departure.openNew}
+              onEdit={dialogs.departure.openEdit}
+              onOverridePrice={dialogs.departureOverride.openEdit}
+              onManageAvailability={(slot) => navigate.toAvailability(slot.id)}
+              onDelete={async (slotId) => {
+                if (
+                  await confirmDialog({
+                    description: productMessages.deleteDepartureConfirm,
+                    destructive: true,
+                  })
+                ) {
+                  mutations.deleteSlot.mutate(slotId)
+                }
+              }}
+            />
+
+            <ProductSchedulesSection
+              rules={rules}
+              onCreate={dialogs.schedule.openNew}
+              onEdit={dialogs.schedule.openEdit}
+              onDelete={async (ruleId) => {
+                if (
+                  await confirmDialog({
+                    description: productMessages.deleteScheduleConfirm,
+                    destructive: true,
+                  })
+                ) {
+                  mutations.deleteRule.mutate(ruleId)
+                }
+              }}
+            />
+          </section>
         </div>
 
         {/* ── Right column (sidebar) ── */}
         <div className="flex flex-col gap-6">
-          <ProductChannelsSection
-            allChannels={channels}
-            mappings={mappings}
-            onAddChannel={(channelId) => mutations.addChannelMapping.mutate(channelId)}
-            onRemoveChannel={(mappingId) => mutations.removeChannelMapping.mutate(mappingId)}
-          />
+          <section
+            id={authoringGroupAnchorId("distribution")}
+            className="flex scroll-mt-16 flex-col gap-6"
+          >
+            <ProductChannelsSection
+              allChannels={channels}
+              mappings={mappings}
+              onAddChannel={(channelId) => mutations.addChannelMapping.mutate(channelId)}
+              onRemoveChannel={(mappingId) => mutations.removeChannelMapping.mutate(mappingId)}
+            />
 
-          <ProductOrganizeSection product={product} onEdit={dialogs.edit.openNow} />
+            <ProductOrganizeSection product={product} onEdit={dialogs.edit.openNow} />
 
-          <ProductBrochureSection
-            brochure={brochure}
-            isGenerating={mutations.generateBrochure.isPending}
-            generateError={
-              mutations.generateBrochure.error
-                ? mutations.generateBrochure.error.message || productMessages.brochureGenerateFailed
-                : null
-            }
-            onGenerate={() => mutations.generateBrochure.mutate()}
-          />
+            <ProductBrochureSection
+              brochure={brochure}
+              isGenerating={mutations.generateBrochure.isPending}
+              generateError={
+                mutations.generateBrochure.error
+                  ? mutations.generateBrochure.error.message ||
+                    productMessages.brochureGenerateFailed
+                  : null
+              }
+              onGenerate={() => mutations.generateBrochure.mutate()}
+            />
+          </section>
 
-          <ProductActivitySection productId={id} />
+          <section
+            id={authoringGroupAnchorId("history")}
+            className="flex scroll-mt-16 flex-col gap-6"
+          >
+            <ProductActivitySection productId={id} />
+          </section>
         </div>
       </div>
 

--- a/packages/inventory-react/src/components/product-list.tsx
+++ b/packages/inventory-react/src/components/product-list.tsx
@@ -631,26 +631,36 @@ export function ProductList({ pageSize = 25, onSelectProduct }: ProductListProps
                     )}
                   </TableCell>
                   <TableCell>
-                    <div className="flex items-center gap-1.5">
-                      <span>
-                        {product.classification?.familyName ??
-                          product.productTypeName ??
-                          productMessages.noValue}
-                      </span>
-                      {product.classification?.reviewRequired ? (
-                        <Badge
-                          variant="outline"
-                          className="border-amber-400 text-amber-700 text-xs dark:text-amber-300"
-                          title={product.classification.reviewReasons
-                            .map((reason) =>
-                              reason === "missing_family"
-                                ? productMessages.reviewMissingFamily
-                                : productMessages.reviewMissingDuration,
-                            )
-                            .join("; ")}
-                        >
-                          {productMessages.reviewBadge}
-                        </Badge>
+                    <div className="flex flex-col gap-0.5">
+                      <div className="flex items-center gap-1.5">
+                        <span>
+                          {product.classification?.familyName ??
+                            product.productTypeName ??
+                            productMessages.noValue}
+                        </span>
+                        {product.classification?.reviewRequired ? (
+                          <Badge
+                            variant="outline"
+                            className="border-amber-400 text-amber-700 text-xs dark:text-amber-300"
+                            title={product.classification.reviewReasons
+                              .map((reason) =>
+                                reason === "missing_family"
+                                  ? productMessages.reviewMissingFamily
+                                  : productMessages.reviewMissingDuration,
+                              )
+                              .join("; ")}
+                          >
+                            {productMessages.reviewBadge}
+                          </Badge>
+                        ) : null}
+                      </div>
+                      {product.classification?.scheduleTerm ? (
+                        <span className="text-muted-foreground text-xs">
+                          {
+                            messages.common.scheduleTermLabels[product.classification.scheduleTerm]
+                              .plural
+                          }
+                        </span>
                       ) : null}
                     </div>
                   </TableCell>

--- a/packages/inventory-react/src/i18n/en-core.ts
+++ b/packages/inventory-react/src/i18n/en-core.ts
@@ -68,6 +68,11 @@ export const productsUiCoreEn = {
       private: "Private",
       hidden: "Hidden",
     },
+    scheduleTermLabels: {
+      session: { singular: "Session", plural: "Sessions" },
+      occurrence: { singular: "Occurrence", plural: "Occurrences" },
+      departure: { singular: "Departure", plural: "Departures" },
+    },
   },
   comboboxes: {
     product: {

--- a/packages/inventory-react/src/i18n/en-core.ts
+++ b/packages/inventory-react/src/i18n/en-core.ts
@@ -111,6 +111,18 @@ export const productsUiCoreEn = {
     title: "Products",
     description: "Manage the products you sell.",
   },
+  productAuthoringNav: {
+    label: "Product authoring sections",
+    groups: {
+      overview: "Overview & readiness",
+      content: "Content",
+      plan: "Plan",
+      options: "Options & pricing",
+      availability: "Availability",
+      distribution: "Distribution",
+      history: "History",
+    },
+  },
   productDetailPage: {
     actions: {
       back: "Back",

--- a/packages/inventory-react/src/i18n/messages-core.ts
+++ b/packages/inventory-react/src/i18n/messages-core.ts
@@ -41,6 +41,16 @@ export type ProductsUiCoreMessages = {
     productBookingModeBasis: Record<ProductBookingMode, string>
     productCapacityModeLabels: Record<ProductCapacityMode, string>
     productVisibilityLabels: Record<ProductVisibility, string>
+    /**
+     * Operator-facing schedule term labels (Session / Occurrence / Departure).
+     * One localized label per resolved `scheduleTerm` token; the token itself is
+     * resolved once in `@voyant-travel/inventory` (`resolveScheduleTerm`).
+     */
+    scheduleTermLabels: {
+      session: { singular: string; plural: string }
+      occurrence: { singular: string; plural: string }
+      departure: { singular: string; plural: string }
+    }
   }
   comboboxes: {
     product: {

--- a/packages/inventory-react/src/i18n/messages-core.ts
+++ b/packages/inventory-react/src/i18n/messages-core.ts
@@ -89,6 +89,19 @@ export type ProductsUiCoreMessages = {
     title: string
     description: string
   }
+  productAuthoringNav: {
+    /** Accessible label for the authoring group navigation landmark. */
+    label: string
+    groups: {
+      overview: string
+      content: string
+      plan: string
+      options: string
+      availability: string
+      distribution: string
+      history: string
+    }
+  }
   productDetailPage: {
     actions: {
       back: string

--- a/packages/inventory-react/src/i18n/ro-core.ts
+++ b/packages/inventory-react/src/i18n/ro-core.ts
@@ -67,6 +67,11 @@ export const productsUiCoreRo = {
       private: "Privat",
       hidden: "Ascuns",
     },
+    scheduleTermLabels: {
+      session: { singular: "Sesiune", plural: "Sesiuni" },
+      occurrence: { singular: "Apariție", plural: "Apariții" },
+      departure: { singular: "Plecare", plural: "Plecări" },
+    },
   },
   comboboxes: {
     product: {

--- a/packages/inventory-react/src/i18n/ro-core.ts
+++ b/packages/inventory-react/src/i18n/ro-core.ts
@@ -110,6 +110,18 @@ export const productsUiCoreRo = {
     title: "Produse",
     description: "Administreaza produsele pe care le vinzi.",
   },
+  productAuthoringNav: {
+    label: "Secțiuni de configurare a produsului",
+    groups: {
+      overview: "Prezentare și pregătire",
+      content: "Conținut",
+      plan: "Plan",
+      options: "Opțiuni și prețuri",
+      availability: "Disponibilitate",
+      distribution: "Distribuție",
+      history: "Istoric",
+    },
+  },
   productDetailPage: {
     actions: {
       back: "Inapoi",

--- a/packages/inventory-react/src/schemas.ts
+++ b/packages/inventory-react/src/schemas.ts
@@ -51,6 +51,7 @@ export const productClassificationSchema = z.object({
   durationMinutes: z.number().int().nullable(),
   durationDays: z.number().int().nullable(),
   durationProvenance: z.enum(["explicit", "itinerary-derived", "unresolved"]),
+  scheduleTerm: z.enum(["session", "occurrence", "departure"]),
   reviewRequired: z.boolean(),
   reviewReasons: z.array(z.enum(["missing_family", "unresolved_duration"])),
 })

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -1239,6 +1239,9 @@
       "@voyant-travel/hono/middleware/error-boundary": [
         "../hono/dist/middleware/error-boundary.d.ts"
       ],
+      "@voyant-travel/hono/middleware/legacy-redirects": [
+        "../hono/dist/middleware/legacy-redirects.d.ts"
+      ],
       "@voyant-travel/hono/middleware/logger": ["../hono/dist/middleware/logger.d.ts"],
       "@voyant-travel/hono/middleware/rate-limit": ["../hono/dist/middleware/rate-limit.d.ts"],
       "@voyant-travel/hono/middleware/require-actor": [

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -1234,6 +1234,9 @@
       "@voyant-travel/hono/middleware/error-boundary": [
         "../hono/dist/middleware/error-boundary.d.ts"
       ],
+      "@voyant-travel/hono/middleware/legacy-redirects": [
+        "../hono/dist/middleware/legacy-redirects.d.ts"
+      ],
       "@voyant-travel/hono/middleware/logger": ["../hono/dist/middleware/logger.d.ts"],
       "@voyant-travel/hono/middleware/rate-limit": ["../hono/dist/middleware/rate-limit.d.ts"],
       "@voyant-travel/hono/middleware/require-actor": [

--- a/packages/inventory/migrations/20260804120000_conservative_family_backfill.sql
+++ b/packages/inventory/migrations/20260804120000_conservative_family_backfill.sql
@@ -1,0 +1,34 @@
+-- Conservative legacy family backfill.
+--
+-- A legacy product with authored itinerary days but no family assigned is
+-- unambiguously a Tour: within `products`, an itinerary of dated days is the
+-- Tour shape (Attraction Admissions, Events and Transfers do not carry one).
+-- Assign the standard `tour` family to exactly those rows.
+--
+-- This is deliberately conservative:
+--   * it only touches rows where `product_type_id IS NULL`, so an existing
+--     family (standard or operator-authored) is never overwritten;
+--   * it only assigns on a strong POSITIVE signal (>= 1 dated itinerary day);
+--   * it joins to the seeded `tour` family, so on a deployment without it the
+--     statement matches nothing rather than nulling a family out;
+--   * it is idempotent — a second run finds the rows already classified.
+--
+-- Rows WITHOUT that positive signal (no family AND no itinerary) are left
+-- untouched on purpose. They are genuinely ambiguous and must surface in the
+-- operator classification-review queue (`?classificationReview=pending`) to be
+-- resolved by a human, never silently guessed. Duration is not materialized
+-- here: the shared resolver derives itinerary-derived duration live, and a row
+-- with neither an explicit duration nor an itinerary stays `unresolved` and
+-- likewise enters the review queue.
+UPDATE "products" AS p
+SET "product_type_id" = t.id
+FROM "product_types" AS t
+WHERE t.code = 'tour'
+  AND p."product_type_id" IS NULL
+  AND EXISTS (
+    SELECT 1
+    FROM "product_days" pd
+    JOIN "product_itineraries" pi ON pi.id = pd.itinerary_id
+    WHERE pi.product_id = p.id
+      AND pd.day_number >= 1
+  );

--- a/packages/inventory/migrations/meta/_journal.json
+++ b/packages/inventory/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1785858423775,
       "tag": "0010_inventory_baseline",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1785931200000,
+      "tag": "20260804120000_conservative_family_backfill",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/inventory/src/classification-review-query.ts
+++ b/packages/inventory/src/classification-review-query.ts
@@ -1,0 +1,83 @@
+/**
+ * SQL predicates for the operator classification-review queue.
+ *
+ * The review *state* (`reviewRequired` / `reviewReasons`) is computed in one
+ * place — `resolveProductClassification` — from the resolved family and
+ * duration. That resolver runs per-row in JS after a read, which is fine for
+ * rendering a badge but cannot drive a paginated, counted list. This module
+ * expresses the SAME two review reasons as row-level SQL predicates so the
+ * product list read can surface the ambiguous rows as a discoverable queue
+ * without a second, drifting definition of "needs review".
+ *
+ * Both predicates are deliberately conservative and mirror the resolver exactly:
+ *
+ *   - `missing_family` — the product has no family, or a dangling family FK.
+ *     Same as `resolveProductClassification` seeing `family: null`.
+ *   - `unresolved_duration` — no explicit `duration_minutes` AND the default (or
+ *     first) itinerary has no dated days. Same as `resolveProductDuration`
+ *     falling through to `unresolved`; the default-itinerary subquery matches
+ *     the `itineraryDurationDays` subquery the list read already feeds the
+ *     resolver (`is_default DESC, sort_order ASC` + `max(day_number)`).
+ *
+ * Ambiguous rows are never guessed — they simply become selectable. An operator
+ * resolves them by assigning a family or authoring a duration.
+ */
+
+import { type SQL, sql } from "drizzle-orm"
+
+import { productDays, productItineraries, products, productTypes } from "./schema.js"
+
+/** Products with no family assigned, or a family FK that resolves to nothing. */
+export function missingFamilyPredicate(): SQL {
+  // agent-quality: raw-sql reviewed -- owner: inventory; references vetted table identifiers only.
+  return sql`(
+    ${products.productTypeId} is null
+    or not exists (
+      select 1 from ${productTypes}
+      where ${productTypes.id} = ${products.productTypeId}
+    )
+  )`
+}
+
+/**
+ * Products whose duration cannot be resolved: no explicit `duration_minutes` and
+ * the default (or first) itinerary carries no dated day. Uses the same
+ * default-itinerary selection the list read's `itineraryDurationDays` subquery
+ * uses, so the queue and the rendered badge never disagree.
+ */
+export function unresolvedDurationPredicate(): SQL {
+  // agent-quality: raw-sql reviewed -- owner: inventory; references vetted table identifiers only.
+  return sql`(
+    ${products.durationMinutes} is null
+    and coalesce((
+      select max(${productDays.dayNumber})
+      from ${productDays}
+      where ${productDays.itineraryId} = (
+        select ${productItineraries.id}
+        from ${productItineraries}
+        where ${productItineraries.productId} = ${products.id}
+        order by ${productItineraries.isDefault} desc, ${productItineraries.sortOrder} asc
+        limit 1
+      )
+    ), 0) < 1
+  )`
+}
+
+/** The three review-queue filter modes accepted by the product list read. */
+export type ClassificationReviewFilter = "pending" | "missing_family" | "unresolved_duration"
+
+/**
+ * The predicate for a review-queue filter mode. `pending` returns any row that
+ * needs review (either reason); the reason-specific modes narrow to one.
+ */
+export function classificationReviewPredicate(filter: ClassificationReviewFilter): SQL {
+  switch (filter) {
+    case "missing_family":
+      return missingFamilyPredicate()
+    case "unresolved_duration":
+      return unresolvedDurationPredicate()
+    default:
+      // agent-quality: raw-sql reviewed -- owner: inventory; composed from vetted predicates.
+      return sql`(${missingFamilyPredicate()} or ${unresolvedDurationPredicate()})`
+  }
+}

--- a/packages/inventory/src/classification.ts
+++ b/packages/inventory/src/classification.ts
@@ -144,6 +144,61 @@ export function resolveProductDuration(input: ResolveDurationInput): ResolvedDur
 /** Reasons a product needs classification review. */
 export type ClassificationReviewReason = "missing_family" | "unresolved_duration"
 
+/**
+ * The operator-facing schedule term a Product's occurrences are named by.
+ * Purely a *presentation* token: one implementation resolves it here, and the
+ * operator UI maps the token to a localized label (Session / Occurrence /
+ * Departure). It never forks the domain — a departure, a session and an
+ * occurrence are the same `availability_slots` row underneath.
+ *
+ *   - `session`    — a timed, sub-day occurrence that repeats through the day
+ *                    (the 60-minute whale-watch Boat Tour, a timed Activity, a
+ *                    scheduled transfer).
+ *   - `departure`  — a day-spanning occurrence (a Day Tour, a Multi-day Tour).
+ *   - `occurrence` — a single dated happening or open admission with no
+ *                    authored duration (an Event date, an opening-hours
+ *                    Attraction Admission).
+ */
+export type ScheduleTerm = "session" | "occurrence" | "departure"
+
+export const SCHEDULE_TERMS: readonly ScheduleTerm[] = ["session", "occurrence", "departure"]
+
+export interface ResolveScheduleTermInput {
+  durationMinutes: number | null
+  durationDays: number | null
+  durationProvenance: DurationProvenance
+}
+
+/**
+ * Resolve the operator-facing schedule term from a Product's *resolved
+ * duration* — the single, locale-independent decision. The operator UI turns
+ * the returned token into a Session / Occurrence / Departure label per locale;
+ * this function is the one place the choice is made.
+ *
+ * Keyed on duration shape, which is genuine Product behaviour and already
+ * resolved by `resolveProductDuration`, so it needs no availability read and
+ * never reads mutable Product truth:
+ *
+ *   - an explicit sub-day duration is a timed, repeatable **session**;
+ *   - an explicit full-day-or-longer duration, or an itinerary-derived day
+ *     span, is a **departure**;
+ *   - an unresolved duration (a single date / open admission) is an
+ *     **occurrence**.
+ *
+ * Family never overrides the term: a Tour that runs sixty-minute sessions is
+ * still shown as running Sessions, and a Tour that spans days runs Departures —
+ * exactly as the duration says.
+ */
+export function resolveScheduleTerm(input: ResolveScheduleTermInput): ScheduleTerm {
+  if (input.durationProvenance === "explicit" && input.durationMinutes != null) {
+    return input.durationMinutes < MINUTES_PER_DAY ? "session" : "departure"
+  }
+  if (input.durationProvenance === "itinerary-derived") {
+    return "departure"
+  }
+  return "occurrence"
+}
+
 export interface ResolvedProductClassification {
   /** Stable family code (e.g. `tour`), or null when unclassified/dangling. */
   familyCode: string | null
@@ -154,6 +209,11 @@ export interface ResolvedProductClassification {
   durationMinutes: number | null
   durationDays: number | null
   durationProvenance: DurationProvenance
+  /**
+   * Operator-facing schedule term token (Session / Occurrence / Departure).
+   * Derived from the resolved duration; the UI localizes it. One implementation.
+   */
+  scheduleTerm: ScheduleTerm
   /** True when the product should surface an actionable review warning. */
   reviewRequired: boolean
   reviewReasons: ClassificationReviewReason[]
@@ -192,6 +252,11 @@ export function resolveProductClassification(
     durationMinutes: duration.minutes,
     durationDays: duration.days,
     durationProvenance: duration.provenance,
+    scheduleTerm: resolveScheduleTerm({
+      durationMinutes: duration.minutes,
+      durationDays: duration.days,
+      durationProvenance: duration.provenance,
+    }),
     reviewRequired: reviewReasons.length > 0,
     reviewReasons,
   }

--- a/packages/inventory/src/service-catalog-plane.ts
+++ b/packages/inventory/src/service-catalog-plane.ts
@@ -645,6 +645,7 @@ async function projectProductClassification(
     ["durationMinutes", classification.durationMinutes],
     ["durationDays", classification.durationDays],
     ["durationProvenance", classification.durationProvenance],
+    ["scheduleTerm", classification.scheduleTerm],
     ["classificationReviewRequired", classification.reviewRequired],
     ["classificationReviewReasons", classification.reviewReasons],
   ])

--- a/packages/inventory/src/service-catalog.ts
+++ b/packages/inventory/src/service-catalog.ts
@@ -1044,6 +1044,7 @@ export const catalogProductsService = {
           durationMinutes: classification.durationMinutes,
           durationDays: classification.durationDays,
           durationProvenance: classification.durationProvenance,
+          scheduleTerm: classification.scheduleTerm,
           reviewRequired: classification.reviewRequired,
           reviewReasons: classification.reviewReasons,
           categoryIds: product.categories.map((category) => category.id),

--- a/packages/inventory/src/service-core.ts
+++ b/packages/inventory/src/service-core.ts
@@ -4,6 +4,7 @@ import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { z } from "zod"
 import { nextDepartureAt, upcomingDepartureExists } from "./availability-slot-access.js"
 import { resolveProductClassification } from "./classification.js"
+import { classificationReviewPredicate } from "./classification-review-query.js"
 import type { ProductReadinessIssue } from "./readiness.js"
 import {
   productCategoryProducts,
@@ -203,6 +204,13 @@ export const coreProductsService = {
 
     if (query.productSubtypeCode) {
       conditions.push(eq(products.productSubtypeCode, query.productSubtypeCode))
+    }
+
+    if (query.classificationReview) {
+      // Operator review queue: surface rows with an unresolved family and/or
+      // duration using the SAME semantics `resolveProductClassification` derives
+      // the review badge from, so the queue and the badge never disagree.
+      conditions.push(classificationReviewPredicate(query.classificationReview))
     }
 
     if (query.contractTemplateId) {

--- a/packages/inventory/tests/integration/conservative-family-backfill.test.ts
+++ b/packages/inventory/tests/integration/conservative-family-backfill.test.ts
@@ -1,0 +1,206 @@
+// Migration coverage for the conservative legacy family backfill (voyant#4038)
+// against a real Postgres instance. Proves — over a representative beta dataset
+// that deliberately includes AMBIGUOUS rows — that the migration:
+//   * never drops a Product (count is invariant);
+//   * never loses a genuine capacity claim (availability slots survive);
+//   * only assigns `tour` on the strong positive signal (itinerary days);
+//   * leaves genuinely ambiguous rows unclassified so they surface in the
+//     operator classification-review queue rather than being guessed.
+//
+// The migration is data-only, so it re-runs safely against the freshly seeded
+// fixture here (cleanupTestDb truncates data, not schema). The raw SQL is read
+// straight from the committed migration file so this test exercises the exact
+// statement a deployment applies, not a paraphrase of it.
+import { readFile } from "node:fs/promises"
+import { cleanupTestDb, createTestDb } from "@voyant-travel/db/test-utils"
+import { availabilitySlots } from "@voyant-travel/operations"
+import { sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { STANDARD_PRODUCT_FAMILIES } from "../../src/classification.js"
+import { productDays, productItineraries, products, productTypes } from "../../src/schema.js"
+import { coreProductsService } from "../../src/service-core.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+const BACKFILL_SQL_URL = new URL(
+  "../../migrations/20260804120000_conservative_family_backfill.sql",
+  import.meta.url,
+)
+
+const TOUR = STANDARD_PRODUCT_FAMILIES.find((f) => f.code === "tour")!
+const ACTIVITY = STANDARD_PRODUCT_FAMILIES.find((f) => f.code === "activity")!
+
+describe.skipIf(!DB_AVAILABLE)("Conservative legacy family backfill (integration)", () => {
+  let db: PostgresJsDatabase
+
+  beforeAll(() => {
+    db = createTestDb()
+  })
+
+  beforeEach(async () => {
+    await cleanupTestDb(db)
+    // Seed the two standard families the migration and fixture reference. The
+    // seed migration inserts these, but cleanupTestDb truncates them, so the
+    // fixture re-seeds with the same deterministic ids.
+    await db.insert(productTypes).values([
+      { id: TOUR.id, name: TOUR.name, code: TOUR.code, active: true },
+      { id: ACTIVITY.id, name: ACTIVITY.name, code: ACTIVITY.code, active: true },
+    ])
+  })
+
+  async function seedProduct(overrides: Partial<typeof products.$inferInsert>) {
+    const [product] = await db
+      .insert(products)
+      .values({ name: "Beta product", sellCurrency: "EUR", status: "active", ...overrides })
+      .returning()
+    if (!product) throw new Error("failed to seed product")
+    return product
+  }
+
+  async function seedItineraryDay(productId: string, dayNumber: number) {
+    const [itinerary] = await db
+      .insert(productItineraries)
+      .values({ productId, name: "Main", isDefault: true })
+      .returning()
+    if (!itinerary) throw new Error("failed to seed itinerary")
+    await db.insert(productDays).values({ itineraryId: itinerary.id, dayNumber })
+  }
+
+  async function runBackfillMigration() {
+    const migration = await readFile(BACKFILL_SQL_URL, "utf8")
+    await db.execute(sql.raw(migration))
+  }
+
+  it("backfills only the unambiguous rows and keeps every ambiguous row for review", async () => {
+    // A — already a Tour, with an itinerary. Must stay Tour, untouched.
+    const alreadyTour = await seedProduct({ name: "Istanbul Multi-day", productTypeId: TOUR.id })
+    await seedItineraryDay(alreadyTour.id, 3)
+
+    // B — NO family but HAS an itinerary of dated days: unambiguously a Tour.
+    const legacyTour = await seedProduct({ name: "Bulgaria Day Tour", productTypeId: null })
+    await seedItineraryDay(legacyTour.id, 1)
+
+    // C — NO family, NO itinerary, NO explicit duration: genuinely ambiguous.
+    const ambiguous = await seedProduct({ name: "Legacy mystery", productTypeId: null })
+
+    // D — NO family but an explicit sub-day duration (a timed thing). Duration
+    // resolves, but the family is still missing, so it must remain in the queue
+    // and must NOT be guessed as a Tour (it has no itinerary).
+    const timedNoFamily = await seedProduct({
+      name: "Legacy timed",
+      productTypeId: null,
+      durationMinutes: 90,
+    })
+
+    // E — fully classified Activity. Must be untouched and absent from the queue.
+    const activity = await seedProduct({
+      name: "Cooking class",
+      productTypeId: ACTIVITY.id,
+      durationMinutes: 120,
+    })
+
+    // F — a Tour with a live capacity claim (an open availability slot). The
+    // migration must not disturb the slot.
+    await db.insert(availabilitySlots).values({
+      productId: alreadyTour.id,
+      dateLocal: "2035-06-01",
+      startsAt: new Date("2035-06-01T09:00:00Z"),
+      timezone: "UTC",
+      status: "open",
+    })
+
+    const [{ count: beforeCount }] = (await db.execute(
+      sql`select count(*)::int as count from products`,
+    )) as unknown as [{ count: number }]
+    const [{ count: slotsBefore }] = (await db.execute(
+      sql`select count(*)::int as count from availability_slots`,
+    )) as unknown as [{ count: number }]
+
+    await runBackfillMigration()
+
+    // No Product silently disappears; no capacity claim is lost.
+    const [{ count: afterCount }] = (await db.execute(
+      sql`select count(*)::int as count from products`,
+    )) as unknown as [{ count: number }]
+    const [{ count: slotsAfter }] = (await db.execute(
+      sql`select count(*)::int as count from availability_slots`,
+    )) as unknown as [{ count: number }]
+    expect(afterCount).toBe(beforeCount)
+    expect(slotsAfter).toBe(slotsBefore)
+
+    const familyOf = async (id: string) => {
+      const [row] = (await db.execute(
+        sql`select product_type_id from products where id = ${id}`,
+      )) as unknown as [{ product_type_id: string | null }]
+      return row.product_type_id
+    }
+
+    // B was backfilled to Tour; A and E untouched; C and D left NULL.
+    expect(await familyOf(legacyTour.id)).toBe(TOUR.id)
+    expect(await familyOf(alreadyTour.id)).toBe(TOUR.id)
+    expect(await familyOf(activity.id)).toBe(ACTIVITY.id)
+    expect(await familyOf(ambiguous.id)).toBeNull()
+    expect(await familyOf(timedNoFamily.id)).toBeNull()
+
+    // The review queue surfaces exactly the two still-ambiguous rows.
+    const pending = await coreProductsService.listProducts(db, {
+      classificationReview: "pending",
+      sortBy: "createdAt",
+      sortDir: "desc",
+      limit: 50,
+      offset: 0,
+    })
+    const pendingIds = new Set(pending.data.map((p) => p.id))
+    expect(pendingIds).toEqual(new Set([ambiguous.id, timedNoFamily.id]))
+    expect(pending.total).toBe(2)
+
+    // `missing_family` narrows to the two family-less rows; `unresolved_duration`
+    // narrows to just the row with neither a duration nor an itinerary.
+    const missingFamily = await coreProductsService.listProducts(db, {
+      classificationReview: "missing_family",
+      sortBy: "createdAt",
+      sortDir: "desc",
+      limit: 50,
+      offset: 0,
+    })
+    expect(new Set(missingFamily.data.map((p) => p.id))).toEqual(
+      new Set([ambiguous.id, timedNoFamily.id]),
+    )
+
+    const unresolvedDuration = await coreProductsService.listProducts(db, {
+      classificationReview: "unresolved_duration",
+      sortBy: "createdAt",
+      sortDir: "desc",
+      limit: 50,
+      offset: 0,
+    })
+    expect(new Set(unresolvedDuration.data.map((p) => p.id))).toEqual(new Set([ambiguous.id]))
+
+    // Every ambiguous row still carries its resolved review reasons in the read
+    // model, so the queue row can explain itself.
+    const ambiguousRow = pending.data.find((p) => p.id === ambiguous.id)
+    expect(ambiguousRow?.classification.reviewReasons).toEqual([
+      "missing_family",
+      "unresolved_duration",
+    ])
+  })
+
+  it("is idempotent — a second run changes nothing", async () => {
+    const legacyTour = await seedProduct({ name: "Legacy tour", productTypeId: null })
+    await seedItineraryDay(legacyTour.id, 2)
+
+    await runBackfillMigration()
+    const [firstRow] = (await db.execute(
+      sql`select product_type_id from products where id = ${legacyTour.id}`,
+    )) as unknown as [{ product_type_id: string | null }]
+    expect(firstRow.product_type_id).toBe(TOUR.id)
+
+    await runBackfillMigration()
+    const [secondRow] = (await db.execute(
+      sql`select product_type_id from products where id = ${legacyTour.id}`,
+    )) as unknown as [{ product_type_id: string | null }]
+    expect(secondRow.product_type_id).toBe(TOUR.id)
+  })
+})

--- a/packages/inventory/tests/unit/classification-schedule-term.test.ts
+++ b/packages/inventory/tests/unit/classification-schedule-term.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  resolveProductClassification,
+  resolveScheduleTerm,
+  SCHEDULE_TERMS,
+} from "../../src/classification.js"
+
+describe("resolveScheduleTerm", () => {
+  it("names a timed sub-day explicit duration a Session (the 60-minute Boat Tour)", () => {
+    expect(
+      resolveScheduleTerm({
+        durationMinutes: 60,
+        durationDays: 1,
+        durationProvenance: "explicit",
+      }),
+    ).toBe("session")
+  })
+
+  it("names a timed Activity (120 minutes) a Session", () => {
+    expect(
+      resolveScheduleTerm({
+        durationMinutes: 120,
+        durationDays: 1,
+        durationProvenance: "explicit",
+      }),
+    ).toBe("session")
+  })
+
+  it("names an explicit full-day-or-longer duration a Departure", () => {
+    expect(
+      resolveScheduleTerm({
+        durationMinutes: 1440,
+        durationDays: 1,
+        durationProvenance: "explicit",
+      }),
+    ).toBe("departure")
+    expect(
+      resolveScheduleTerm({
+        durationMinutes: 2880,
+        durationDays: 2,
+        durationProvenance: "explicit",
+      }),
+    ).toBe("departure")
+  })
+
+  it("names an itinerary-derived day span a Departure (Day Tour, Multi-day Tour)", () => {
+    expect(
+      resolveScheduleTerm({
+        durationMinutes: null,
+        durationDays: 1,
+        durationProvenance: "itinerary-derived",
+      }),
+    ).toBe("departure")
+    expect(
+      resolveScheduleTerm({
+        durationMinutes: null,
+        durationDays: 3,
+        durationProvenance: "itinerary-derived",
+      }),
+    ).toBe("departure")
+  })
+
+  it("names an unresolved duration an Occurrence (Event date, opening-hours Admission)", () => {
+    expect(
+      resolveScheduleTerm({
+        durationMinutes: null,
+        durationDays: null,
+        durationProvenance: "unresolved",
+      }),
+    ).toBe("occurrence")
+  })
+
+  it("only ever returns one of the three known tokens", () => {
+    for (const provenance of ["explicit", "itinerary-derived", "unresolved"] as const) {
+      const term = resolveScheduleTerm({
+        durationMinutes: provenance === "explicit" ? 90 : null,
+        durationDays: provenance === "itinerary-derived" ? 2 : null,
+        durationProvenance: provenance,
+      })
+      expect(SCHEDULE_TERMS).toContain(term)
+    }
+  })
+})
+
+describe("resolveProductClassification attaches the schedule term", () => {
+  it("resolves a Boat Tour family=tour + 60-minute duration to a Session", () => {
+    const classification = resolveProductClassification({
+      family: { code: "tour", name: "Tour" },
+      subtypeCode: "boat-tour",
+      durationMinutes: 60,
+      itineraryDurationDays: null,
+    })
+    expect(classification.familyCode).toBe("tour")
+    expect(classification.scheduleTerm).toBe("session")
+    expect(classification.reviewRequired).toBe(false)
+  })
+
+  it("resolves a Multi-day Tour to a Departure", () => {
+    const classification = resolveProductClassification({
+      family: { code: "tour", name: "Tour" },
+      subtypeCode: "multi-day-tour",
+      durationMinutes: null,
+      itineraryDurationDays: 3,
+    })
+    expect(classification.scheduleTerm).toBe("departure")
+  })
+
+  it("resolves an unclassified, undurated legacy row to an Occurrence and flags review", () => {
+    const classification = resolveProductClassification({
+      family: null,
+      subtypeCode: null,
+      durationMinutes: null,
+      itineraryDurationDays: null,
+    })
+    expect(classification.scheduleTerm).toBe("occurrence")
+    expect(classification.reviewRequired).toBe(true)
+    expect(classification.reviewReasons).toEqual(["missing_family", "unresolved_duration"])
+  })
+})

--- a/packages/inventory/tsconfig.build.json
+++ b/packages/inventory/tsconfig.build.json
@@ -1233,6 +1233,9 @@
       "@voyant-travel/hono/middleware/error-boundary": [
         "../hono/dist/middleware/error-boundary.d.ts"
       ],
+      "@voyant-travel/hono/middleware/legacy-redirects": [
+        "../hono/dist/middleware/legacy-redirects.d.ts"
+      ],
       "@voyant-travel/hono/middleware/logger": ["../hono/dist/middleware/logger.d.ts"],
       "@voyant-travel/hono/middleware/rate-limit": ["../hono/dist/middleware/rate-limit.d.ts"],
       "@voyant-travel/hono/middleware/require-actor": [

--- a/packages/inventory/tsconfig.typecheck.json
+++ b/packages/inventory/tsconfig.typecheck.json
@@ -1234,6 +1234,9 @@
       "@voyant-travel/hono/middleware/error-boundary": [
         "../hono/dist/middleware/error-boundary.d.ts"
       ],
+      "@voyant-travel/hono/middleware/legacy-redirects": [
+        "../hono/dist/middleware/legacy-redirects.d.ts"
+      ],
       "@voyant-travel/hono/middleware/logger": ["../hono/dist/middleware/logger.d.ts"],
       "@voyant-travel/hono/middleware/rate-limit": ["../hono/dist/middleware/rate-limit.d.ts"],
       "@voyant-travel/hono/middleware/require-actor": [

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -1239,6 +1239,9 @@
       "@voyant-travel/hono/middleware/error-boundary": [
         "../hono/dist/middleware/error-boundary.d.ts"
       ],
+      "@voyant-travel/hono/middleware/legacy-redirects": [
+        "../hono/dist/middleware/legacy-redirects.d.ts"
+      ],
       "@voyant-travel/hono/middleware/logger": ["../hono/dist/middleware/logger.d.ts"],
       "@voyant-travel/hono/middleware/rate-limit": ["../hono/dist/middleware/rate-limit.d.ts"],
       "@voyant-travel/hono/middleware/require-actor": [

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -1234,6 +1234,9 @@
       "@voyant-travel/hono/middleware/error-boundary": [
         "../hono/dist/middleware/error-boundary.d.ts"
       ],
+      "@voyant-travel/hono/middleware/legacy-redirects": [
+        "../hono/dist/middleware/legacy-redirects.d.ts"
+      ],
       "@voyant-travel/hono/middleware/logger": ["../hono/dist/middleware/logger.d.ts"],
       "@voyant-travel/hono/middleware/rate-limit": ["../hono/dist/middleware/rate-limit.d.ts"],
       "@voyant-travel/hono/middleware/require-actor": [

--- a/packages/operations/openapi/admin/operations.json
+++ b/packages/operations/openapi/admin/operations.json
@@ -6499,6 +6499,39 @@
                               "capacity": {
                                 "type": "integer"
                               },
+                              "occupancyMin": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "roomTypeId": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "bedConfiguration": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "accessible": {
+                                "type": "boolean"
+                              },
+                              "minAge": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "maxAge": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
                               "flags": {
                                 "type": "object",
                                 "additionalProperties": {}
@@ -6527,6 +6560,12 @@
                               "refId",
                               "label",
                               "capacity",
+                              "occupancyMin",
+                              "roomTypeId",
+                              "bedConfiguration",
+                              "accessible",
+                              "minAge",
+                              "maxAge",
                               "flags",
                               "parentId",
                               "sortOrder",
@@ -6681,6 +6720,47 @@
                     "type": "integer",
                     "minimum": 1
                   },
+                  "occupancyMin": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "minimum": 1
+                  },
+                  "roomTypeId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "minLength": 1
+                  },
+                  "bedConfiguration": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "minLength": 1,
+                    "maxLength": 160
+                  },
+                  "accessible": {
+                    "type": "boolean"
+                  },
+                  "minAge": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "minimum": 0,
+                    "maximum": 120
+                  },
+                  "maxAge": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "minimum": 0,
+                    "maximum": 120
+                  },
                   "flags": {
                     "type": "object",
                     "additionalProperties": {},
@@ -6746,6 +6826,39 @@
                         "capacity": {
                           "type": "integer"
                         },
+                        "occupancyMin": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "roomTypeId": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "bedConfiguration": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "accessible": {
+                          "type": "boolean"
+                        },
+                        "minAge": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "maxAge": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
                         "flags": {
                           "type": "object",
                           "additionalProperties": {}
@@ -6774,6 +6887,12 @@
                         "refId",
                         "label",
                         "capacity",
+                        "occupancyMin",
+                        "roomTypeId",
+                        "bedConfiguration",
+                        "accessible",
+                        "minAge",
+                        "maxAge",
                         "flags",
                         "parentId",
                         "sortOrder",
@@ -6924,6 +7043,47 @@
                     "type": "integer",
                     "minimum": 1
                   },
+                  "occupancyMin": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "minimum": 1
+                  },
+                  "roomTypeId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "minLength": 1
+                  },
+                  "bedConfiguration": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "minLength": 1,
+                    "maxLength": 160
+                  },
+                  "accessible": {
+                    "type": "boolean"
+                  },
+                  "minAge": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "minimum": 0,
+                    "maximum": 120
+                  },
+                  "maxAge": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "minimum": 0,
+                    "maximum": 120
+                  },
                   "flags": {
                     "type": "object",
                     "additionalProperties": {},
@@ -6990,6 +7150,39 @@
                         "capacity": {
                           "type": "integer"
                         },
+                        "occupancyMin": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "roomTypeId": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "bedConfiguration": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "accessible": {
+                          "type": "boolean"
+                        },
+                        "minAge": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "maxAge": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
                         "flags": {
                           "type": "object",
                           "additionalProperties": {}
@@ -7018,6 +7211,12 @@
                         "refId",
                         "label",
                         "capacity",
+                        "occupancyMin",
+                        "roomTypeId",
+                        "bedConfiguration",
+                        "accessible",
+                        "minAge",
+                        "maxAge",
                         "flags",
                         "parentId",
                         "sortOrder",
@@ -7311,6 +7510,19 @@
                       "string",
                       "null"
                     ]
+                  },
+                  "override": {
+                    "type": "object",
+                    "properties": {
+                      "reason": {
+                        "type": "string",
+                        "minLength": 3,
+                        "maxLength": 500
+                      }
+                    },
+                    "required": [
+                      "reason"
+                    ]
                   }
                 },
                 "required": [
@@ -7343,12 +7555,71 @@
                             "string",
                             "null"
                           ]
+                        },
+                        "violations": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string"
+                              },
+                              "severity": {
+                                "type": "string",
+                                "enum": [
+                                  "blocking",
+                                  "advisory"
+                                ]
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "expected": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "actual": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "travelerIds": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "severity",
+                              "message"
+                            ]
+                          }
                         }
                       },
                       "required": [
                         "travelerId",
                         "kind",
-                        "resourceId"
+                        "resourceId",
+                        "violations"
                       ]
                     }
                   },
@@ -7438,6 +7709,186 @@
         },
         "operationId": "patchAdminOperationsAvailabilitySlotsByIdAllocationTravelersByTravelerId",
         "summary": "PATCH /v1/admin/operations/availability/slots/{id}/allocation/travelers/{travelerId}",
+        "tags": [
+          "operations"
+        ],
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
+      }
+    },
+    "/v1/admin/operations/availability/slots/{id}/allocation/travelers/{travelerId}/rooming-preferences": {
+      "patch": {
+        "description": "Set the traveler's bed preference and booked room type. A field the caller omits keeps its stored value; an explicit `null` clears it.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "travelerId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "bedPreference": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "enum": [
+                      "single",
+                      "twin",
+                      "double",
+                      "no-preference",
+                      null
+                    ]
+                  },
+                  "roomTypeId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "minLength": 1
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The traveler's resolved rooming preferences",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "travelerId": {
+                          "type": "string"
+                        },
+                        "bedPreference": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "roomTypeId": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "travelerId",
+                        "bedPreference",
+                        "roomTypeId"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid_request, or an allocation invariant was violated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "detail": {}
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The slot, traveler, resource, sharing group, or template was not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "detail": {}
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Resource over capacity, a revision precondition failed, or the fleet resource is double-booked",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "detail": {}
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "The allocation operation could not be completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "detail": {}
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "patchAdminOperationsAvailabilitySlotsByIdAllocationTravelersByTravelerIdRoomingPreferences",
+        "summary": "PATCH /v1/admin/operations/availability/slots/{id}/allocation/travelers/{travelerId}/rooming-preferences",
         "tags": [
           "operations"
         ],
@@ -8352,6 +8803,85 @@
                         "skipped": {
                           "type": "integer"
                         },
+                        "unplaced": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "groupKey": {
+                                "type": "string"
+                              },
+                              "sharingGroupId": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "travelerIds": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "reason": {
+                                "type": "string",
+                                "enum": [
+                                  "no_resources",
+                                  "no_capacity"
+                                ]
+                              },
+                              "largestFreeCapacity": {
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "groupKey",
+                              "sharingGroupId",
+                              "travelerIds",
+                              "reason",
+                              "largestFreeCapacity"
+                            ]
+                          }
+                        },
+                        "compromises": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "groupKey": {
+                                "type": "string"
+                              },
+                              "sharingGroupId": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "travelerIds": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "resourceId": {
+                                "type": "string"
+                              },
+                              "relaxed": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "required": [
+                              "groupKey",
+                              "sharingGroupId",
+                              "travelerIds",
+                              "resourceId",
+                              "relaxed"
+                            ]
+                          }
+                        },
                         "created": {
                           "type": "integer"
                         },
@@ -8393,6 +8923,39 @@
                               "capacity": {
                                 "type": "integer"
                               },
+                              "occupancyMin": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "roomTypeId": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "bedConfiguration": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "accessible": {
+                                "type": "boolean"
+                              },
+                              "minAge": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "maxAge": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
                               "flags": {
                                 "type": "object",
                                 "additionalProperties": {}
@@ -8421,6 +8984,12 @@
                               "refId",
                               "label",
                               "capacity",
+                              "occupancyMin",
+                              "roomTypeId",
+                              "bedConfiguration",
+                              "accessible",
+                              "minAge",
+                              "maxAge",
                               "flags",
                               "parentId",
                               "sortOrder",
@@ -8708,6 +9277,85 @@
                         "skipped": {
                           "type": "integer"
                         },
+                        "unplaced": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "groupKey": {
+                                "type": "string"
+                              },
+                              "sharingGroupId": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "travelerIds": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "reason": {
+                                "type": "string",
+                                "enum": [
+                                  "no_resources",
+                                  "no_capacity"
+                                ]
+                              },
+                              "largestFreeCapacity": {
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "groupKey",
+                              "sharingGroupId",
+                              "travelerIds",
+                              "reason",
+                              "largestFreeCapacity"
+                            ]
+                          }
+                        },
+                        "compromises": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "groupKey": {
+                                "type": "string"
+                              },
+                              "sharingGroupId": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "travelerIds": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "resourceId": {
+                                "type": "string"
+                              },
+                              "relaxed": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "required": [
+                              "groupKey",
+                              "sharingGroupId",
+                              "travelerIds",
+                              "resourceId",
+                              "relaxed"
+                            ]
+                          }
+                        },
                         "created": {
                           "type": "integer"
                         },
@@ -8749,6 +9397,39 @@
                               "capacity": {
                                 "type": "integer"
                               },
+                              "occupancyMin": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "roomTypeId": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "bedConfiguration": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "accessible": {
+                                "type": "boolean"
+                              },
+                              "minAge": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "maxAge": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
                               "flags": {
                                 "type": "object",
                                 "additionalProperties": {}
@@ -8777,6 +9458,12 @@
                               "refId",
                               "label",
                               "capacity",
+                              "occupancyMin",
+                              "roomTypeId",
+                              "bedConfiguration",
+                              "accessible",
+                              "minAge",
+                              "maxAge",
                               "flags",
                               "parentId",
                               "sortOrder",
@@ -8884,6 +9571,463 @@
         "x-voyant-surface": "admin"
       }
     },
+    "/v1/admin/operations/availability/slots/{id}/allocation/room-blocks/materialize": {
+      "post": {
+        "description": "Materialise room positions from a contracted room block and take the matching nightly pickup. Idempotent at (kind, block) granularity: a repeat creates nothing and takes no second pickup. Omit `rooms` to take the block's whole remaining hold for the departure's nights.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "blockId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "rooms": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 500
+                  },
+                  "namePattern": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 160,
+                    "default": "Room {sequence}"
+                  },
+                  "kind": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 80,
+                    "default": "room"
+                  }
+                },
+                "required": [
+                  "blockId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The positions created and the rooms taken off the block",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "blockId": {
+                          "type": "string"
+                        },
+                        "kind": {
+                          "type": "string"
+                        },
+                        "created": {
+                          "type": "integer"
+                        },
+                        "skippedExisting": {
+                          "type": "integer"
+                        },
+                        "roomsPickedUp": {
+                          "type": "integer"
+                        },
+                        "pickupId": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "remainingAfter": {
+                          "type": "integer"
+                        },
+                        "resources": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "slotId": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "refType": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "refId": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "label": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "capacity": {
+                                "type": "integer"
+                              },
+                              "occupancyMin": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "roomTypeId": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "bedConfiguration": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "accessible": {
+                                "type": "boolean"
+                              },
+                              "minAge": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "maxAge": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "flags": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              },
+                              "parentId": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "sortOrder": {
+                                "type": "integer"
+                              },
+                              "createdAt": {
+                                "type": "string"
+                              },
+                              "updatedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "slotId",
+                              "kind",
+                              "refType",
+                              "refId",
+                              "label",
+                              "capacity",
+                              "occupancyMin",
+                              "roomTypeId",
+                              "bedConfiguration",
+                              "accessible",
+                              "minAge",
+                              "maxAge",
+                              "flags",
+                              "parentId",
+                              "sortOrder",
+                              "createdAt",
+                              "updatedAt"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "blockId",
+                        "kind",
+                        "created",
+                        "skippedExisting",
+                        "roomsPickedUp",
+                        "pickupId",
+                        "remainingAfter",
+                        "resources"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid_request, or an allocation invariant was violated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "detail": {}
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The slot, traveler, resource, sharing group, or template was not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "detail": {}
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Resource over capacity, a revision precondition failed, or the fleet resource is double-booked",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "detail": {}
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "The allocation operation could not be completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "detail": {}
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postAdminOperationsAvailabilitySlotsByIdAllocationRoomBlocksMaterialize",
+        "summary": "POST /v1/admin/operations/availability/slots/{id}/allocation/room-blocks/materialize",
+        "tags": [
+          "operations"
+        ],
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
+      }
+    },
+    "/v1/admin/operations/availability/slots/{id}/allocation/room-blocks/{blockId}": {
+      "delete": {
+        "description": "Give the departure's block rooms back: remove the positions, clear the traveler allocations that pointed at them, and reverse the pickup so another departure can draw the same rooms.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "blockId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 80,
+              "default": "room"
+            },
+            "required": false,
+            "name": "kind",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The positions removed and the rooms handed back",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "blockId": {
+                          "type": "string"
+                        },
+                        "kind": {
+                          "type": "string"
+                        },
+                        "removed": {
+                          "type": "integer"
+                        },
+                        "roomsReleased": {
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "blockId",
+                        "kind",
+                        "removed",
+                        "roomsReleased"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid_request, or an allocation invariant was violated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "detail": {}
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The slot, traveler, resource, sharing group, or template was not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "detail": {}
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Resource over capacity, a revision precondition failed, or the fleet resource is double-booked",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "detail": {}
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "The allocation operation could not be completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "detail": {}
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "deleteAdminOperationsAvailabilitySlotsByIdAllocationRoomBlocksByBlockId",
+        "summary": "DELETE /v1/admin/operations/availability/slots/{id}/allocation/room-blocks/{blockId}",
+        "tags": [
+          "operations"
+        ],
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
+      }
+    },
     "/v1/admin/operations/availability/products/{productId}/allocation/resource-templates": {
       "get": {
         "parameters": [
@@ -8965,6 +10109,45 @@
                                 "capacity": {
                                   "type": "integer"
                                 },
+                                "occupancyMin": {
+                                  "type": [
+                                    "integer",
+                                    "null"
+                                  ]
+                                },
+                                "occupancyMax": {
+                                  "type": [
+                                    "integer",
+                                    "null"
+                                  ]
+                                },
+                                "minAge": {
+                                  "type": [
+                                    "integer",
+                                    "null"
+                                  ]
+                                },
+                                "maxAge": {
+                                  "type": [
+                                    "integer",
+                                    "null"
+                                  ]
+                                },
+                                "roomTypeId": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "bedConfiguration": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "accessible": {
+                                  "type": "boolean"
+                                },
                                 "namePattern": {
                                   "type": "string"
                                 },
@@ -8998,6 +10181,13 @@
                                 "refType",
                                 "refId",
                                 "capacity",
+                                "occupancyMin",
+                                "occupancyMax",
+                                "minAge",
+                                "maxAge",
+                                "roomTypeId",
+                                "bedConfiguration",
+                                "accessible",
                                 "namePattern",
                                 "layout",
                                 "defaultCount",
@@ -9076,6 +10266,54 @@
                   "capacity": {
                     "type": "integer",
                     "minimum": 1
+                  },
+                  "occupancyMin": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "minimum": 1
+                  },
+                  "occupancyMax": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "minimum": 1
+                  },
+                  "minAge": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "minimum": 0,
+                    "maximum": 120
+                  },
+                  "maxAge": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "minimum": 0,
+                    "maximum": 120
+                  },
+                  "roomTypeId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "minLength": 1
+                  },
+                  "bedConfiguration": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "minLength": 1,
+                    "maxLength": 160
+                  },
+                  "accessible": {
+                    "type": "boolean"
                   },
                   "namePattern": {
                     "type": "string",
@@ -9159,6 +10397,45 @@
                         "capacity": {
                           "type": "integer"
                         },
+                        "occupancyMin": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "occupancyMax": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "minAge": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "maxAge": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "roomTypeId": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "bedConfiguration": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "accessible": {
+                          "type": "boolean"
+                        },
                         "namePattern": {
                           "type": "string"
                         },
@@ -9192,6 +10469,13 @@
                         "refType",
                         "refId",
                         "capacity",
+                        "occupancyMin",
+                        "occupancyMax",
+                        "minAge",
+                        "maxAge",
+                        "roomTypeId",
+                        "bedConfiguration",
+                        "accessible",
                         "namePattern",
                         "layout",
                         "defaultCount",
@@ -9645,6 +10929,39 @@
                           "capacity": {
                             "type": "integer"
                           },
+                          "occupancyMin": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          },
+                          "roomTypeId": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "bedConfiguration": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "accessible": {
+                            "type": "boolean"
+                          },
+                          "minAge": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          },
+                          "maxAge": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          },
                           "flags": {
                             "type": "object",
                             "additionalProperties": {}
@@ -9673,6 +10990,12 @@
                           "refId",
                           "label",
                           "capacity",
+                          "occupancyMin",
+                          "roomTypeId",
+                          "bedConfiguration",
+                          "accessible",
+                          "minAge",
+                          "maxAge",
                           "flags",
                           "parentId",
                           "sortOrder",
@@ -9806,6 +11129,39 @@
                             "capacity": {
                               "type": "integer"
                             },
+                            "occupancyMin": {
+                              "type": [
+                                "integer",
+                                "null"
+                              ]
+                            },
+                            "roomTypeId": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "bedConfiguration": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "accessible": {
+                              "type": "boolean"
+                            },
+                            "minAge": {
+                              "type": [
+                                "integer",
+                                "null"
+                              ]
+                            },
+                            "maxAge": {
+                              "type": [
+                                "integer",
+                                "null"
+                              ]
+                            },
                             "flags": {
                               "type": "object",
                               "additionalProperties": {}
@@ -9834,6 +11190,12 @@
                             "refId",
                             "label",
                             "capacity",
+                            "occupancyMin",
+                            "roomTypeId",
+                            "bedConfiguration",
+                            "accessible",
+                            "minAge",
+                            "maxAge",
                             "flags",
                             "parentId",
                             "sortOrder",
@@ -10171,6 +11533,19 @@
                     },
                     "minItems": 1,
                     "maxItems": 200
+                  },
+                  "override": {
+                    "type": "object",
+                    "properties": {
+                      "reason": {
+                        "type": "string",
+                        "minLength": 3,
+                        "maxLength": 500
+                      }
+                    },
+                    "required": [
+                      "reason"
+                    ]
                   }
                 },
                 "required": [
@@ -10209,6 +11584,64 @@
                           "items": {
                             "type": "string"
                           }
+                        },
+                        "violations": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string"
+                              },
+                              "severity": {
+                                "type": "string",
+                                "enum": [
+                                  "blocking",
+                                  "advisory"
+                                ]
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "expected": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "actual": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "travelerIds": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "severity",
+                              "message"
+                            ]
+                          }
                         }
                       },
                       "required": [
@@ -10216,7 +11649,8 @@
                         "assigned",
                         "unassigned",
                         "unchanged",
-                        "travelerIds"
+                        "travelerIds",
+                        "violations"
                       ]
                     }
                   },
@@ -10364,6 +11798,93 @@
                         "skipped": {
                           "type": "integer"
                         },
+                        "unplaced": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "groupKey": {
+                                "type": "string"
+                              },
+                              "sharingGroupId": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "travelerIds": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "reason": {
+                                "type": "string",
+                                "enum": [
+                                  "no_resources",
+                                  "no_capacity"
+                                ]
+                              },
+                              "largestFreeCapacity": {
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "groupKey",
+                              "sharingGroupId",
+                              "travelerIds",
+                              "reason",
+                              "largestFreeCapacity"
+                            ]
+                          }
+                        },
+                        "compromises": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "groupKey": {
+                                "type": "string"
+                              },
+                              "sharingGroupId": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "travelerIds": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "resourceId": {
+                                "type": "string"
+                              },
+                              "relaxed": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string",
+                                  "enum": [
+                                    "bed_preference",
+                                    "room_type",
+                                    "option",
+                                    "option_unit",
+                                    "age_band",
+                                    "accessibility"
+                                  ]
+                                }
+                              }
+                            },
+                            "required": [
+                              "groupKey",
+                              "sharingGroupId",
+                              "travelerIds",
+                              "resourceId",
+                              "relaxed"
+                            ]
+                          }
+                        },
                         "entries": {
                           "type": "array",
                           "items": {
@@ -10458,6 +11979,8 @@
                         "kind",
                         "assigned",
                         "skipped",
+                        "unplaced",
+                        "compromises",
                         "entries",
                         "violations"
                       ]
@@ -43566,6 +45089,133 @@
         },
         "operationId": "postAdminOperationsSpaceBlocksByIdRelease",
         "summary": "POST /v1/admin/operations/space-blocks/{id}/release",
+        "tags": [
+          "operations"
+        ],
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
+      }
+    },
+    "/v1/admin/operations/acceptance/aggregates": {
+      "get": {
+        "description": "Acceptance dashboard metrics for the unified Product/Departure rollout: readiness failures, reconciliation drift, unassigned travelers, missing costs, compatibility redirect (legacy-path) usage, and rollup disagreement. Every field is a count or a route-keyed usage row — no traveler identity is read or emitted. Served uncached: legacy-path usage gates a deletion review and must not answer from a snapshot.",
+        "responses": {
+          "200": {
+            "description": "Acceptance dashboard metrics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "readinessFailures": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "reconciliationDrift": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "unassignedTravelers": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "missingCosts": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "rollupDisagreement": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "legacyPathUsage": {
+                          "type": "object",
+                          "properties": {
+                            "totalHits": {
+                              "type": "integer",
+                              "minimum": 0
+                            },
+                            "allZero": {
+                              "type": "boolean"
+                            },
+                            "byKey": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "family": {
+                                    "type": "string",
+                                    "enum": [
+                                      "extras",
+                                      "catalog",
+                                      "product",
+                                      "availability"
+                                    ]
+                                  },
+                                  "hits": {
+                                    "type": "integer",
+                                    "minimum": 0
+                                  },
+                                  "lastSeenAt": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "family",
+                                  "hits",
+                                  "lastSeenAt"
+                                ]
+                              }
+                            }
+                          },
+                          "required": [
+                            "totalHits",
+                            "allZero",
+                            "byKey"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "readinessFailures",
+                        "reconciliationDrift",
+                        "unassignedTravelers",
+                        "missingCosts",
+                        "rollupDisagreement",
+                        "legacyPathUsage"
+                      ]
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "financeProviderBound": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "financeProviderBound"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "meta"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "getAdminOperationsAcceptanceAggregates",
+        "summary": "GET /v1/admin/operations/acceptance/aggregates",
         "tags": [
           "operations"
         ],

--- a/packages/operations/src/acceptance-metrics-providers.ts
+++ b/packages/operations/src/acceptance-metrics-providers.ts
@@ -1,0 +1,381 @@
+/**
+ * The deployment-side bindings for {@link AcceptanceMetricsProviders} — what
+ * turns the pure aggregator in `acceptance-metrics.ts` into a number the
+ * operator and the release review can actually look at (voyant#4038).
+ *
+ * ## Why raw SQL
+ *
+ * Every count here spans the whole fleet of departures, so none of them can be
+ * built out of the per-departure read models (`getDepartureCapacityCounters`
+ * and friends) without N round trips. They are written as one statement each,
+ * against table names as string literals, exactly as
+ * `service-allocation-room-block.ts` documents: `availability_slots`,
+ * `availability_holds`, `booking_*` and the `product*` tables are owned by
+ * other modules, a module's tables are private (ADR-0016 decision 6), and the
+ * `operations->availability` reach-in ratchet has no headroom. Naming a table
+ * const would spend budget that does not exist; naming a table in SQL spends
+ * none.
+ *
+ * ## PII
+ *
+ * Every statement selects `COUNT(*)`. No traveler, booking or contact column is
+ * ever projected — not filtered out downstream, never read in the first place.
+ * That is the property the metrics contract promises, and it is enforced here
+ * by construction rather than by review.
+ *
+ * ## Fidelity, stated plainly
+ *
+ * Three of the five counts mirror logic that is authored elsewhere, and a
+ * mirror that silently drifts is worse than no metric:
+ *
+ *   - **reconciliation drift** mirrors the `remaining_pax_drift` rule in
+ *     `availability/service-departure-issues.ts` over the derivation in
+ *     `availability/service-departure-capacity.ts`. Same predicate, evaluated
+ *     set-wide instead of per slot.
+ *   - **unassigned travelers** mirrors `loadTravelerCounts`' `entered - assigned`
+ *     over the same population the allocation manifest renders.
+ *   - **readiness failures** mirrors the *blocking* rules of
+ *     `evaluateProductReadiness` (`@voyant-travel/inventory`). All eight blocking
+ *     codes are expressed; the warning-severity rules are deliberately not,
+ *     because warnings do not stop a publish. The three facts that evaluator
+ *     takes from a deployment-supplied resolver (meeting point, allocation
+ *     template, active channel count) are warnings, so their absence here costs
+ *     nothing. Inventory owns that evaluator: if a blocking rule is added there,
+ *     it must be added here too, or this number quietly understates.
+ *
+ * Money is Finance's and Operations must not recompute it, so **missing costs**
+ * and **rollup disagreement** are read from the departure-profitability report
+ * through the port that already backs the departure workspace. A deployment
+ * assembled without Finance binds nothing and both report `0` — "not measured"
+ * and "measured zero" are indistinguishable in an `int`, which is a real limit
+ * of the metrics contract and is why the endpoint reports the binding alongside
+ * the counts.
+ */
+
+import type { LegacyPathUsageRow } from "@voyant-travel/core"
+import { getLegacyPathUsageStore } from "@voyant-travel/core"
+import type { FinanceDepartureProfitabilityRow } from "@voyant-travel/finance-contracts/runtime-port"
+import { sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import type { AcceptanceMetricsProviders } from "./acceptance-metrics.js"
+import {
+  activeBookingAllocationStatusesSql,
+  activeBookingStatusesSql,
+} from "./availability/booking-statuses.js"
+import {
+  hasDepartureProfitabilityReader,
+  readDepartureProfitabilityReport,
+} from "./availability/departure-profitability-runtime.js"
+import { executeRows } from "./availability/service-allocation-sql.js"
+
+/** Minutes in a day — mirrors `MINUTES_PER_DAY` in inventory's classification. */
+const MINUTES_PER_DAY = 1440
+
+/**
+ * Booking modes whose supply is resolved at quote time, so they are never asked
+ * for a future dated departure. Mirrors `DYNAMIC_BOOKING_MODES` in inventory's
+ * `readiness.ts`.
+ */
+const DYNAMIC_BOOKING_MODES = ["open", "stay"] as const
+
+export interface AcceptanceMetricsProviderOptions {
+  /**
+   * Legacy-path usage source. Defaults to the process-wide binding in
+   * `@voyant-travel/core` — the same store the compatibility-redirect
+   * middleware records into, which is what makes the reported zero the zero the
+   * redirects produced rather than an unrelated empty store.
+   */
+  legacyPathUsage?: () => LegacyPathUsageRow[] | Promise<LegacyPathUsageRow[]>
+  /** Clock seam for the time-bounded predicates. Defaults to `Date`. */
+  now?: () => Date
+}
+
+async function countScalar(db: PostgresJsDatabase, query: ReturnType<typeof sql>): Promise<number> {
+  const rows = await executeRows<{ count: number }>(db, query)
+  return rows[0]?.count ?? 0
+}
+
+/**
+ * Departures whose stored `remaining_pax` disagrees with what their bookings
+ * and live holds actually consume. Skips unlimited departures and departures
+ * with no authored capacity — neither has a derived counter to disagree with.
+ */
+export async function countReconciliationDrift(db: PostgresJsDatabase, now: Date): Promise<number> {
+  const nowIso = now.toISOString()
+  return countScalar(
+    db,
+    sql`
+      SELECT COUNT(*)::int AS count
+      FROM availability_slots s
+      WHERE s.unlimited = false
+        AND s.initial_pax IS NOT NULL
+        AND s.remaining_pax IS NOT NULL
+        AND s.remaining_pax <> (
+          s.initial_pax
+          - COALESCE((
+              SELECT SUM(b.pax)
+              FROM bookings b
+              WHERE b.status <> 'cancelled'
+                AND EXISTS (
+                  SELECT 1
+                  FROM booking_allocations ba
+                  WHERE ba.booking_id = b.id
+                    AND ba.availability_slot_id = s.id
+                    AND ba.status IN (${activeBookingAllocationStatusesSql()})
+                )
+            ), 0)
+          - COALESCE((
+              SELECT SUM(h.pax_count)
+              FROM availability_holds h
+              WHERE h.slot_id = s.id
+                AND h.released_at IS NULL
+                AND h.converted_at IS NULL
+                AND h.expires_at >= ${nowIso}::timestamptz
+            ), 0)
+        )
+    `,
+  )
+}
+
+/**
+ * Traveler records on live bookings that hold a live allocation to a departure
+ * and carry no resource assignment. A count of rows — no traveler is named,
+ * projected, or joined for identity.
+ */
+export async function countUnassignedTravelers(db: PostgresJsDatabase): Promise<number> {
+  return countScalar(
+    db,
+    sql`
+      SELECT COUNT(*)::int AS count
+      FROM booking_travelers bt
+      JOIN bookings b ON b.id = bt.booking_id
+      LEFT JOIN booking_traveler_travel_details btd ON btd.traveler_id = bt.id
+      WHERE b.status IN (${activeBookingStatusesSql()})
+        AND (btd.allocations IS NULL OR btd.allocations = '{}'::jsonb)
+        AND EXISTS (
+          SELECT 1
+          FROM booking_allocations ba
+          WHERE ba.booking_id = b.id
+            AND ba.availability_slot_id IS NOT NULL
+            AND ba.status IN (${activeBookingAllocationStatusesSql()})
+        )
+    `,
+  )
+}
+
+/**
+ * Live products that would be refused publication.
+ *
+ * Scoped to `products.status = 'active'` on purpose: a draft that is not yet
+ * ready is the normal state of authoring, not a rollout defect, and counting
+ * drafts would bury the signal. Every disjunct below is one `blocking` rule
+ * from `evaluateProductReadiness`, in the same order, with the same predicate.
+ * The default option and default itinerary are resolved with the same
+ * `is_default` + `sort_order, created_at` ordering the readiness loader uses, so
+ * a product with two rows flagged default resolves to the same one here.
+ */
+export async function countReadinessFailures(db: PostgresJsDatabase): Promise<number> {
+  const dynamicModes = sql.join(
+    // agent-quality: raw-sql reviewed -- owner: operations; dynamic SQL interpolation uses Drizzle parameter binding or vetted SQL identifiers.
+    DYNAMIC_BOOKING_MODES.map((mode) => sql`${mode}`),
+    sql`, `,
+  )
+  return countScalar(
+    db,
+    sql`
+      WITH candidate AS (
+        SELECT p.id, p.booking_mode, p.duration_minutes, p.sell_amount_cents
+        FROM products p
+        WHERE p.status = 'active'
+      ),
+      default_option AS (
+        SELECT DISTINCT ON (o.product_id) o.product_id, o.id, o.status
+        FROM product_options o
+        WHERE o.is_default = true
+        ORDER BY o.product_id, o.sort_order ASC, o.created_at ASC
+      ),
+      default_itinerary AS (
+        SELECT DISTINCT ON (i.product_id) i.product_id, i.id
+        FROM product_itineraries i
+        WHERE i.is_default = true
+        ORDER BY i.product_id, i.sort_order ASC, i.created_at ASC
+      ),
+      itinerary_days AS (
+        SELECT
+          d.itinerary_id,
+          COUNT(*)::int AS day_count,
+          COUNT(DISTINCT d.day_number)::int AS distinct_day_count,
+          MIN(d.day_number)::int AS first_day,
+          MAX(d.day_number)::int AS last_day
+        FROM product_days d
+        GROUP BY d.itinerary_id
+      )
+      SELECT COUNT(*)::int AS count
+      FROM candidate c
+      LEFT JOIN default_option o ON o.product_id = c.id
+      LEFT JOIN default_itinerary it ON it.product_id = c.id
+      LEFT JOIN itinerary_days d ON d.itinerary_id = it.id
+      WHERE
+        -- no_future_open_departure
+        (
+          c.booking_mode NOT IN (${dynamicModes})
+          AND NOT EXISTS (
+            SELECT 1
+            FROM availability_slots s
+            WHERE s.product_id = c.id
+              AND s.status = 'open'
+              AND s.starts_at >= now()
+          )
+        )
+        -- missing_default_option / default_option_not_active
+        OR o.id IS NULL
+        OR o.status <> 'active'
+        -- no_option_units
+        OR NOT EXISTS (SELECT 1 FROM option_units u WHERE u.option_id = o.id)
+        -- no_price
+        OR (
+          COALESCE(c.sell_amount_cents, 0) <= 0
+          AND NOT EXISTS (
+            SELECT 1 FROM product_pax_pricing_tiers t WHERE t.product_id = c.id
+          )
+        )
+        -- missing_itinerary / empty_itinerary / non_consecutive_itinerary_days,
+        -- evaluated only for products that owe a day-by-day plan.
+        OR (
+          (
+            c.booking_mode = 'itinerary'
+            OR COALESCE(c.duration_minutes, 0) > ${MINUTES_PER_DAY}
+          )
+          AND (
+            it.id IS NULL
+            OR d.day_count IS NULL
+            OR d.first_day <> 1
+            OR d.last_day <> d.day_count
+            OR d.distinct_day_count <> d.day_count
+          )
+        )
+    `,
+  )
+}
+
+/** Departures grouped by id, with their per-currency and base-rollup rows. */
+interface DepartureRollup {
+  rows: FinanceDepartureProfitabilityRow[]
+  baseRows: FinanceDepartureProfitabilityRow[]
+}
+
+function groupByDeparture(
+  rows: readonly FinanceDepartureProfitabilityRow[],
+  baseRows: readonly FinanceDepartureProfitabilityRow[],
+): Map<string, DepartureRollup> {
+  const grouped = new Map<string, DepartureRollup>()
+  const entry = (departureId: string) => {
+    const existing = grouped.get(departureId)
+    if (existing) return existing
+    const created: DepartureRollup = { rows: [], baseRows: [] }
+    grouped.set(departureId, created)
+    return created
+  }
+  for (const row of rows) entry(row.departureId).rows.push(row)
+  for (const row of baseRows) entry(row.departureId).baseRows.push(row)
+  return grouped
+}
+
+/**
+ * The two Finance-derived counts, read in one pass so the profitability report
+ * is loaded once rather than twice. Returns zeros when no Finance provider is
+ * bound — see the module docblock.
+ */
+async function readFinanceCounts(
+  db: PostgresJsDatabase,
+): Promise<{ missingCosts: number; rollupDisagreement: number }> {
+  if (!hasDepartureProfitabilityReader()) return { missingCosts: 0, rollupDisagreement: 0 }
+  const report = await readDepartureProfitabilityReport(db, {})
+  if (!report) return { missingCosts: 0, rollupDisagreement: 0 }
+
+  const base = report.base
+  const grouped = groupByDeparture(report.rows, base?.rows ?? [])
+  const unconvertible = new Set(base?.unconvertibleCurrencies ?? [])
+
+  let missingCosts = 0
+  let rollupDisagreement = 0
+
+  for (const rollup of grouped.values()) {
+    if (rollup.rows.length > 0) {
+      const plannedCents = rollup.rows.reduce((sum, row) => sum + row.plannedCostCents, 0)
+      if (plannedCents === 0) missingCosts += 1
+    }
+
+    // Nothing to disagree with when Finance produced no base rollup at all.
+    if (!base) continue
+    if (rollup.rows.length === 0) continue
+
+    // A source currency the rollup could not convert means the base row is
+    // knowably short of the per-currency rows it claims to summarize.
+    if (rollup.rows.some((row) => unconvertible.has(row.currency))) {
+      rollupDisagreement += 1
+      continue
+    }
+    // A departure with per-currency rows and no base row is unrepresented.
+    if (rollup.baseRows.length === 0) {
+      rollupDisagreement += 1
+      continue
+    }
+    // When every row is already in the base currency no FX is involved, so the
+    // two views must agree exactly. Anything else needs rates we do not hold
+    // here, and comparing it would manufacture false disagreement.
+    if (!rollup.rows.every((row) => row.currency === base.currency)) continue
+    const summed = rollup.rows.reduce(
+      (totals, row) => ({
+        revenueCents: totals.revenueCents + row.revenueCents,
+        actualCostCents: totals.actualCostCents + row.actualCostCents,
+        plannedCostCents: totals.plannedCostCents + row.plannedCostCents,
+      }),
+      { revenueCents: 0, actualCostCents: 0, plannedCostCents: 0 },
+    )
+    const baseTotals = rollup.baseRows.reduce(
+      (totals, row) => ({
+        revenueCents: totals.revenueCents + row.revenueCents,
+        actualCostCents: totals.actualCostCents + row.actualCostCents,
+        plannedCostCents: totals.plannedCostCents + row.plannedCostCents,
+      }),
+      { revenueCents: 0, actualCostCents: 0, plannedCostCents: 0 },
+    )
+    if (
+      summed.revenueCents !== baseTotals.revenueCents ||
+      summed.actualCostCents !== baseTotals.actualCostCents ||
+      summed.plannedCostCents !== baseTotals.plannedCostCents
+    ) {
+      rollupDisagreement += 1
+    }
+  }
+
+  return { missingCosts, rollupDisagreement }
+}
+
+/**
+ * Bind the acceptance metrics to a request's database handle.
+ *
+ * The Finance-derived pair share one report read, so they are memoized per
+ * provider set: `computeAcceptanceMetrics` calls both concurrently and neither
+ * should pay for the other's round trip.
+ */
+export function createAcceptanceMetricsProviders(
+  db: PostgresJsDatabase,
+  options: AcceptanceMetricsProviderOptions = {},
+): AcceptanceMetricsProviders {
+  const now = options.now ?? (() => new Date())
+  const readUsage = options.legacyPathUsage ?? (() => getLegacyPathUsageStore().snapshot())
+  let financeCounts: ReturnType<typeof readFinanceCounts> | undefined
+  const finance = () => (financeCounts ??= readFinanceCounts(db))
+
+  return {
+    countReadinessFailures: () => countReadinessFailures(db),
+    countReconciliationDrift: () => countReconciliationDrift(db, now()),
+    countUnassignedTravelers: () => countUnassignedTravelers(db),
+    countMissingCosts: async () => (await finance()).missingCosts,
+    countRollupDisagreements: async () => (await finance()).rollupDisagreement,
+    legacyPathUsage: async () => readUsage(),
+  }
+}

--- a/packages/operations/src/acceptance-metrics.ts
+++ b/packages/operations/src/acceptance-metrics.ts
@@ -1,0 +1,109 @@
+/**
+ * Acceptance dashboard metrics for the unified Product/Departure rollout
+ * (voyant#4038). Six health signals the operator and the release review both
+ * watch while the transitional surfaces are still live:
+ *
+ *   - readiness failures        — Products that cannot publish;
+ *   - reconciliation drift      — Departures whose stored counters disagree with
+ *                                 what their bookings/travelers actually say;
+ *   - unassigned travelers      — booked travelers with no resource allocation;
+ *   - missing costs             — operated Departures with no planned cost;
+ *   - legacy-path usage         — hits on the compatibility redirects, per key;
+ *   - rollup disagreement       — Departures where the per-currency P&L and the
+ *                                 base-currency rollup disagree.
+ *
+ * Every metric is a COUNT or a route-keyed usage row. No traveler name, email,
+ * booking reference or any other PII is read or emitted — a dashboard is a
+ * fleet-wide health surface, not a person finder. The aggregator is pure over an
+ * injectable provider set so it unit-tests without a database and each real
+ * source is bound at the deployment boundary, exactly like the existing operator
+ * dashboard services.
+ */
+
+import type { LegacyPathUsageRow } from "@voyant-travel/core"
+import { z } from "zod"
+
+/**
+ * The data sources the metrics aggregate over. Each returns a scalar count (or,
+ * for legacy usage, route-keyed rows) so nothing PII-bearing can leak through
+ * the seam. A deployment binds real implementations; a test binds fakes.
+ */
+export interface AcceptanceMetricsProviders {
+  /** Products that fail publish readiness. */
+  countReadinessFailures(): Promise<number>
+  /** Departures whose stored counters drift from their bookings/travelers. */
+  countReconciliationDrift(): Promise<number>
+  /** Booked travelers with no resource allocation. */
+  countUnassignedTravelers(): Promise<number>
+  /** Operated Departures with no planned cost recorded. */
+  countMissingCosts(): Promise<number>
+  /** Departures whose per-currency and base-currency rollups disagree. */
+  countRollupDisagreements(): Promise<number>
+  /** Compatibility-redirect usage rows (route keys + counts, never PII). */
+  legacyPathUsage(): Promise<LegacyPathUsageRow[]>
+}
+
+export const legacyPathUsageRowSchema = z.object({
+  key: z.string(),
+  family: z.enum(["extras", "catalog", "product", "availability"]),
+  hits: z.number().int().min(0),
+  lastSeenAt: z.string().nullable(),
+})
+
+export const acceptanceMetricsSchema = z.object({
+  readinessFailures: z.number().int().min(0),
+  reconciliationDrift: z.number().int().min(0),
+  unassignedTravelers: z.number().int().min(0),
+  missingCosts: z.number().int().min(0),
+  rollupDisagreement: z.number().int().min(0),
+  legacyPathUsage: z.object({
+    /** Σ hits across every compatibility redirect — the "is it zero yet?" number. */
+    totalHits: z.number().int().min(0),
+    /** True only when every legacy redirect has zero recorded hits. */
+    allZero: z.boolean(),
+    byKey: z.array(legacyPathUsageRowSchema),
+  }),
+})
+
+export type AcceptanceMetrics = z.infer<typeof acceptanceMetricsSchema>
+
+/**
+ * Compute the acceptance metrics from the bound providers. Runs the independent
+ * reads concurrently; every field is a count or a keyed count, so the result is
+ * safe to render on any dashboard without a PII review.
+ */
+export async function computeAcceptanceMetrics(
+  providers: AcceptanceMetricsProviders,
+): Promise<AcceptanceMetrics> {
+  const [
+    readinessFailures,
+    reconciliationDrift,
+    unassignedTravelers,
+    missingCosts,
+    rollupDisagreement,
+    usage,
+  ] = await Promise.all([
+    providers.countReadinessFailures(),
+    providers.countReconciliationDrift(),
+    providers.countUnassignedTravelers(),
+    providers.countMissingCosts(),
+    providers.countRollupDisagreements(),
+    providers.legacyPathUsage(),
+  ])
+
+  const byKey = [...usage].sort((a, b) => a.key.localeCompare(b.key))
+  const totalHits = byKey.reduce((sum, row) => sum + row.hits, 0)
+
+  return {
+    readinessFailures,
+    reconciliationDrift,
+    unassignedTravelers,
+    missingCosts,
+    rollupDisagreement,
+    legacyPathUsage: {
+      totalHits,
+      allZero: totalHits === 0,
+      byKey,
+    },
+  }
+}

--- a/packages/operations/src/acceptance-routes.ts
+++ b/packages/operations/src/acceptance-routes.ts
@@ -1,0 +1,74 @@
+/**
+ * The acceptance dashboard read-model: `GET /v1/admin/operations/acceptance/aggregates`.
+ *
+ * Follows the `/aggregates` convention the availability dashboard already
+ * established (`availability/routes-core.ts`) — an `OpenAPIHono` sub-chain, one
+ * `createRoute` per leg, a `{ data }` envelope — so the operator dashboard
+ * reaches these six signals through the same shape as every other aggregate it
+ * renders.
+ *
+ * Two deliberate departures from that convention:
+ *
+ *   - **No read-through snapshot and no `max-age`.** The availability
+ *     aggregates are cached for 60s because they are a KPI tile. Legacy-path
+ *     usage is the input to a *deletion gate*: someone asks "is it zero yet?",
+ *     clicks the superseded link to check the redirect still works, and reloads.
+ *     A cached zero would answer the question wrong at exactly the moment it
+ *     matters, so this leg is `no-store`.
+ *   - **A `meta` sibling next to `data`.** `acceptanceMetricsSchema` is all
+ *     counts, and an unbound Finance provider reports `0` for missing costs and
+ *     rollup disagreement — indistinguishable from a measured zero. Rather than
+ *     widen the PII-free metrics contract to carry provenance, the envelope
+ *     says whether Finance was bound for this read.
+ */
+
+import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
+import { openApiValidationHook } from "@voyant-travel/hono"
+
+import { acceptanceMetricsSchema, computeAcceptanceMetrics } from "./acceptance-metrics.js"
+import { createAcceptanceMetricsProviders } from "./acceptance-metrics-providers.js"
+import { hasDepartureProfitabilityReader } from "./availability/departure-profitability-runtime.js"
+import type { Env } from "./availability/routes-shared.js"
+
+const acceptanceMetricsMetaSchema = z.object({
+  /**
+   * False when this deployment binds no Finance profitability provider, in
+   * which case `missingCosts` and `rollupDisagreement` are `0` because nothing
+   * measured them — not because they were measured at zero.
+   */
+  financeProviderBound: z.boolean(),
+})
+
+const getAcceptanceAggregatesRoute = createRoute({
+  method: "get",
+  path: "/acceptance/aggregates",
+  description:
+    "Acceptance dashboard metrics for the unified Product/Departure rollout: readiness " +
+    "failures, reconciliation drift, unassigned travelers, missing costs, compatibility " +
+    "redirect (legacy-path) usage, and rollup disagreement. Every field is a count or a " +
+    "route-keyed usage row — no traveler identity is read or emitted. Served uncached: " +
+    "legacy-path usage gates a deletion review and must not answer from a snapshot.",
+  responses: {
+    200: {
+      description: "Acceptance dashboard metrics",
+      content: {
+        "application/json": {
+          schema: z.object({
+            data: acceptanceMetricsSchema,
+            meta: acceptanceMetricsMetaSchema,
+          }),
+        },
+      },
+    },
+  },
+})
+
+export const acceptanceAdminRoutes = new OpenAPIHono<Env>({
+  defaultHook: openApiValidationHook,
+}).openapi(getAcceptanceAggregatesRoute, async (c) => {
+  c.header("Cache-Control", "private, no-store")
+  const data = await computeAcceptanceMetrics(createAcceptanceMetricsProviders(c.get("db")))
+  return c.json({ data, meta: { financeProviderBound: hasDepartureProfitabilityReader() } }, 200)
+})
+
+export type AcceptanceAdminRoutes = typeof acceptanceAdminRoutes

--- a/packages/operations/src/index.ts
+++ b/packages/operations/src/index.ts
@@ -57,6 +57,15 @@ export const createOperationsVoyantRuntime = defineGraphRuntimeFactory(
 
 // Only the request side is package API. Binding the channel is deployment
 // wiring and stays with the runtime contributor.
+export type {
+  AcceptanceMetrics,
+  AcceptanceMetricsProviders,
+} from "./acceptance-metrics.js"
+export {
+  acceptanceMetricsSchema,
+  computeAcceptanceMetrics,
+  legacyPathUsageRowSchema,
+} from "./acceptance-metrics.js"
 export {
   OPERATIONS_EXPIRED_HOLDS_JOB_ID,
   requestAvailabilityHoldExpiryWake,

--- a/packages/operations/src/index.ts
+++ b/packages/operations/src/index.ts
@@ -66,6 +66,10 @@ export {
   computeAcceptanceMetrics,
   legacyPathUsageRowSchema,
 } from "./acceptance-metrics.js"
+export type { AcceptanceMetricsProviderOptions } from "./acceptance-metrics-providers.js"
+export { createAcceptanceMetricsProviders } from "./acceptance-metrics-providers.js"
+export type { AcceptanceAdminRoutes } from "./acceptance-routes.js"
+export { acceptanceAdminRoutes } from "./acceptance-routes.js"
 export {
   OPERATIONS_EXPIRED_HOLDS_JOB_ID,
   requestAvailabilityHoldExpiryWake,

--- a/packages/operations/src/routes.ts
+++ b/packages/operations/src/routes.ts
@@ -2,6 +2,7 @@ import { OpenAPIHono } from "@hono/zod-openapi"
 import { openApiValidationHook } from "@voyant-travel/hono"
 import { Hono } from "hono"
 
+import { acceptanceAdminRoutes } from "./acceptance-routes.js"
 import { availabilityAdminRoutes, availabilityRoutes } from "./availability/routes.js"
 import {
   type BookingActionRoutesOptions,
@@ -31,6 +32,7 @@ operationsAdminRoutes.route("/availability", availabilityAdminRoutes)
 operationsAdminRoutes.route("/", resourcesRoutes)
 operationsAdminRoutes.route("/", groundRoutes)
 operationsAdminRoutes.route("/", facilitiesRoutes)
+operationsAdminRoutes.route("/", acceptanceAdminRoutes)
 
 export function createOperationsAdminRoutes(options?: BookingActionRoutesOptions) {
   const routes = new OpenAPIHono({ defaultHook: openApiValidationHook })
@@ -38,6 +40,7 @@ export function createOperationsAdminRoutes(options?: BookingActionRoutesOptions
     .route("/", resourcesRoutes)
     .route("/", groundRoutes)
     .route("/", facilitiesRoutes)
+    .route("/", acceptanceAdminRoutes)
   return options ? routes.route("/", createBookingActionAdminRoutes(options)) : routes
 }
 

--- a/packages/operations/tests/availability/integration/experience-families-tracer.test.ts
+++ b/packages/operations/tests/availability/integration/experience-families-tracer.test.ts
@@ -1,0 +1,340 @@
+// Acceptance tracer (voyant#4038): the SAME Product / Product Version / Slot /
+// Departure workspace / Traveler / allocation foundations carry every canonical
+// experience family — recurring timed Sessions and single Occurrences alike —
+// with NO separate scheduling aggregate.
+//
+//   * item 1 — the 60-minute whale-watch Boat Tour runs as recurring timed
+//     Sessions (several occurrences a day, each bound to the same frozen Version,
+//     with a meeting point, capacity and a manifest) and NO itinerary days;
+//   * item 3 — a participatory Activity, an opening-hours Attraction Admission,
+//     an Event and a Transportation/Transfer each complete
+//     create → availability → booking/manifest through the same
+//     `getDepartureSummary` workspace read.
+//
+// The point is proving they need no separate engine: every case is asserted
+// against the one shared summary, and the operator-facing schedule term is the
+// one resolver deciding Session vs Occurrence vs Departure from Product
+// behaviour.
+import { availabilitySlots } from "@voyant-travel/availability/schema"
+import { newId } from "@voyant-travel/db/lib/typeid"
+import { cleanupTestDb, createTestDb } from "@voyant-travel/db/test-utils"
+import { sql } from "drizzle-orm"
+import { beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import {
+  resolveProductClassification,
+  type ScheduleTerm,
+} from "../../../../inventory/src/classification.js"
+import { products, productTypes } from "../../../../inventory/src/schema.js"
+import { getSlotAllocationManifest } from "../../../src/availability/service-allocation.js"
+import { getDepartureSummary } from "../../../src/availability/service-departure-summary.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+interface FamilySeed {
+  familyCode: string
+  familyName: string
+  subtypeCode: string | null
+  durationMinutes: number | null
+  /** Itinerary-derived day count, for the multi-day comparison only. */
+  itineraryDurationDays: number | null
+}
+
+describe.skipIf(!DB_AVAILABLE)("experience families tracer (integration)", () => {
+  // biome-ignore lint/suspicious/noExplicitAny: drizzle test client -- owner: operations; matches the sibling availability suites.
+  let db: any
+
+  beforeAll(() => {
+    db = createTestDb()
+  })
+
+  beforeEach(async () => {
+    await cleanupTestDb(db)
+  })
+
+  async function seedFamily(seed: FamilySeed): Promise<string> {
+    const typeId = newId("product_types")
+    await db.insert(productTypes).values({
+      id: typeId,
+      name: seed.familyName,
+      code: seed.familyCode,
+      active: true,
+    })
+    return typeId
+  }
+
+  async function seedProduct(input: {
+    name: string
+    productTypeId: string
+    subtypeCode: string | null
+    durationMinutes: number | null
+  }): Promise<string> {
+    const productId = newId("products")
+    await db.insert(products).values({
+      id: productId,
+      name: input.name,
+      sellCurrency: "EUR",
+      bookingMode: "date_time",
+      productTypeId: input.productTypeId,
+      productSubtypeCode: input.subtypeCode,
+      durationMinutes: input.durationMinutes,
+    })
+    return productId
+  }
+
+  /** One timed occurrence bound to a frozen Product Version; no itinerary. */
+  async function seedSession(input: {
+    productId: string
+    productVersionId: string
+    startsAt: string
+    durationMinutes: number | null
+    meetingPoint?: string
+    unlimited?: boolean
+    pax?: number
+  }): Promise<string> {
+    const slotId = newId("availability_slots")
+    const starts = new Date(input.startsAt)
+    const ends = input.durationMinutes
+      ? new Date(starts.getTime() + input.durationMinutes * 60_000)
+      : null
+    await db.insert(availabilitySlots).values({
+      id: slotId,
+      productId: input.productId,
+      productVersionId: input.productVersionId,
+      itineraryId: null,
+      dateLocal: input.startsAt.slice(0, 10),
+      startsAt: starts,
+      endsAt: ends,
+      timezone: "UTC",
+      status: "open",
+      unlimited: input.unlimited ?? false,
+      initialPax: input.unlimited ? null : (input.pax ?? 12),
+      remainingPax: input.unlimited ? null : (input.pax ?? 12),
+      notes: input.meetingPoint ?? null,
+    })
+    return slotId
+  }
+
+  async function seedBooking(input: {
+    productId: string
+    slotId: string
+    pax: number
+    travelerCount: number
+    sellAmountCents: number
+  }): Promise<void> {
+    const bookingId = newId("bookings")
+    const bookingItemId = newId("booking_items")
+    const allocationId = newId("booking_allocations")
+    await db.execute(sql`
+      INSERT INTO bookings (id, booking_number, status, sell_currency, pax, sell_amount_cents)
+      VALUES (${bookingId}, ${`B${bookingId.slice(-6)}`}, 'confirmed', 'EUR', ${input.pax}, ${input.sellAmountCents})
+    `)
+    await db.execute(sql`
+      INSERT INTO booking_items (id, booking_id, title, status, quantity, sell_currency, product_id, availability_slot_id)
+      VALUES (${bookingItemId}, ${bookingId}, 'Seat', 'confirmed', ${input.pax}, 'EUR', ${input.productId}, ${input.slotId})
+    `)
+    await db.execute(sql`
+      INSERT INTO booking_allocations (
+        id, booking_id, booking_item_id, product_id, availability_slot_id,
+        quantity, allocation_type, status, hold_expires_at
+      )
+      VALUES (${allocationId}, ${bookingId}, ${bookingItemId}, ${input.productId}, ${input.slotId}, ${input.pax}, 'unit', 'confirmed', null::timestamptz)
+    `)
+    for (let index = 0; index < input.travelerCount; index += 1) {
+      await db.execute(sql`
+        INSERT INTO booking_travelers (id, booking_id, participant_type, first_name, last_name)
+        VALUES (${newId("booking_travelers")}, ${bookingId}, 'traveler', 'Ana', ${`Pop${index}`})
+      `)
+    }
+  }
+
+  function scheduleTermFor(seed: FamilySeed): ScheduleTerm {
+    return resolveProductClassification({
+      family: { code: seed.familyCode, name: seed.familyName },
+      subtypeCode: seed.subtypeCode,
+      durationMinutes: seed.durationMinutes,
+      itineraryDurationDays: seed.itineraryDurationDays,
+    }).scheduleTerm
+  }
+
+  it("runs the 60-minute Boat Tour as recurring timed Sessions with a meeting point and no itinerary days", async () => {
+    const seed: FamilySeed = {
+      familyCode: "tour",
+      familyName: "Tour",
+      subtypeCode: "boat-tour",
+      durationMinutes: 60,
+      itineraryDurationDays: null,
+    }
+    // The one resolver names it a Session — not a Departure — from its behaviour.
+    expect(scheduleTermFor(seed)).toBe("session")
+
+    const typeId = await seedFamily(seed)
+    const productId = await seedProduct({
+      name: "Whale-watch Boat Tour",
+      productTypeId: typeId,
+      subtypeCode: "boat-tour",
+      durationMinutes: 60,
+    })
+    const versionId = newId("product_versions")
+
+    // Three 60-minute occurrences on the same day, all bound to one frozen
+    // Version — the recurring-Sessions shape, with a meeting point.
+    const nineAm = await seedSession({
+      productId,
+      productVersionId: versionId,
+      startsAt: "2026-07-01T09:00:00Z",
+      durationMinutes: 60,
+      meetingPoint: "Meet at Pier 3, 15 minutes before departure",
+      pax: 20,
+    })
+    const tenAm = await seedSession({
+      productId,
+      productVersionId: versionId,
+      startsAt: "2026-07-01T10:00:00Z",
+      durationMinutes: 60,
+      meetingPoint: "Meet at Pier 3, 15 minutes before departure",
+      pax: 20,
+    })
+    await seedSession({
+      productId,
+      productVersionId: versionId,
+      startsAt: "2026-07-01T11:00:00Z",
+      durationMinutes: 60,
+      meetingPoint: "Meet at Pier 3, 15 minutes before departure",
+      pax: 20,
+    })
+
+    // Several timed occurrences share the day and the Version — no parallel
+    // scheduling aggregate, just Slots.
+    const [{ count: sameDay }] = (await db.execute(
+      sql`select count(*)::int as count from availability_slots where product_id = ${productId} and date_local = '2026-07-01'`,
+    )) as unknown as [{ count: number }]
+    expect(sameDay).toBe(3)
+
+    await seedBooking({
+      productId,
+      slotId: nineAm,
+      pax: 4,
+      travelerCount: 4,
+      sellAmountCents: 4 * 45_00,
+    })
+
+    const summary = await getDepartureSummary(db, nineAm)
+    expect(summary).not.toBeNull()
+    // Same Departure workspace read: capacity, bookings, travelers, manifest.
+    expect(summary?.departure.productVersionId).toBe(versionId)
+    expect(summary?.departure.itineraryId).toBeNull() // no itinerary days
+    expect(summary?.departure.notes).toContain("Pier 3") // meeting point carried
+    expect(summary?.bookings.count).toBe(1)
+    expect(summary?.bookings.expectedPax).toBe(4)
+    expect(summary?.bookings.soldAmountCents).toBe(4 * 45_00)
+    expect(summary?.travelers.entered).toBe(4)
+
+    // The manifest is the same allocation manifest every departure uses.
+    const manifest = await getSlotAllocationManifest(db, nineAm)
+    expect(manifest).not.toBeNull()
+
+    // The 10:00 Session is an independent departure on the same Product/Version.
+    const other = await getDepartureSummary(db, tenAm)
+    expect(other?.departure.itineraryId).toBeNull()
+    expect(other?.bookings.count).toBe(0)
+  })
+
+  const smokeFamilies: Array<
+    FamilySeed & { name: string; expected: ScheduleTerm; unlimited?: boolean }
+  > = [
+    {
+      name: "Sunrise Kayak Session",
+      familyCode: "activity",
+      familyName: "Activity",
+      subtypeCode: "kayak",
+      durationMinutes: 120,
+      itineraryDurationDays: null,
+      expected: "session",
+    },
+    {
+      name: "Museum Admission",
+      familyCode: "attraction",
+      familyName: "Attraction",
+      subtypeCode: "admission",
+      durationMinutes: null,
+      itineraryDurationDays: null,
+      expected: "occurrence",
+      unlimited: true,
+    },
+    {
+      name: "Jazz Festival Night",
+      familyCode: "event",
+      familyName: "Event",
+      subtypeCode: null,
+      durationMinutes: null,
+      itineraryDurationDays: null,
+      expected: "occurrence",
+    },
+    {
+      name: "Airport Transfer",
+      familyCode: "transportation",
+      familyName: "Transportation",
+      subtypeCode: "transfer",
+      durationMinutes: 90,
+      itineraryDurationDays: null,
+      expected: "session",
+    },
+  ]
+
+  it.each(
+    smokeFamilies,
+  )("completes create → availability → booking/manifest for $familyName ($expected) with no separate aggregate", async (seed) => {
+    expect(scheduleTermFor(seed)).toBe(seed.expected)
+
+    const typeId = await seedFamily(seed)
+    const productId = await seedProduct({
+      name: seed.name,
+      productTypeId: typeId,
+      subtypeCode: seed.subtypeCode,
+      durationMinutes: seed.durationMinutes,
+    })
+    const versionId = newId("product_versions")
+    const slotId = await seedSession({
+      productId,
+      productVersionId: versionId,
+      startsAt: "2026-08-20T08:00:00Z",
+      durationMinutes: seed.durationMinutes,
+      unlimited: seed.unlimited,
+      pax: 30,
+    })
+
+    await seedBooking({
+      productId,
+      slotId,
+      pax: 2,
+      travelerCount: 2,
+      sellAmountCents: 2 * 30_00,
+    })
+
+    const summary = await getDepartureSummary(db, slotId)
+    expect(summary).not.toBeNull()
+    expect(summary?.departure.itineraryId).toBeNull()
+    expect(summary?.departure.productVersionId).toBe(versionId)
+    expect(summary?.bookings.count).toBe(1)
+    expect(summary?.bookings.expectedPax).toBe(2)
+    expect(summary?.travelers.entered).toBe(2)
+
+    const manifest = await getSlotAllocationManifest(db, slotId)
+    expect(manifest).not.toBeNull()
+  })
+
+  it("names a day-spanning Tour a Departure — the same resolver, different behaviour", async () => {
+    // Contrast: an itinerary-derived multi-day Tour is a Departure, proving the
+    // term follows behaviour, not family.
+    expect(
+      scheduleTermFor({
+        familyCode: "tour",
+        familyName: "Tour",
+        subtypeCode: "multi-day-tour",
+        durationMinutes: null,
+        itineraryDurationDays: 3,
+      }),
+    ).toBe("departure")
+  })
+})

--- a/packages/operations/tests/unit/acceptance-metrics.test.ts
+++ b/packages/operations/tests/unit/acceptance-metrics.test.ts
@@ -1,0 +1,87 @@
+import { InMemoryLegacyPathUsageStore } from "@voyant-travel/core"
+import { describe, expect, it } from "vitest"
+
+import {
+  type AcceptanceMetricsProviders,
+  acceptanceMetricsSchema,
+  computeAcceptanceMetrics,
+} from "../../src/acceptance-metrics.js"
+
+function providers(
+  overrides: Partial<AcceptanceMetricsProviders> = {},
+): AcceptanceMetricsProviders {
+  const store = new InMemoryLegacyPathUsageStore()
+  return {
+    countReadinessFailures: async () => 0,
+    countReconciliationDrift: async () => 0,
+    countUnassignedTravelers: async () => 0,
+    countMissingCosts: async () => 0,
+    countRollupDisagreements: async () => 0,
+    legacyPathUsage: async () => store.snapshot(),
+    ...overrides,
+  }
+}
+
+describe("computeAcceptanceMetrics", () => {
+  it("aggregates every provider count and validates against the schema", async () => {
+    const metrics = await computeAcceptanceMetrics(
+      providers({
+        countReadinessFailures: async () => 3,
+        countReconciliationDrift: async () => 2,
+        countUnassignedTravelers: async () => 5,
+        countMissingCosts: async () => 1,
+        countRollupDisagreements: async () => 4,
+      }),
+    )
+
+    expect(metrics.readinessFailures).toBe(3)
+    expect(metrics.reconciliationDrift).toBe(2)
+    expect(metrics.unassignedTravelers).toBe(5)
+    expect(metrics.missingCosts).toBe(1)
+    expect(metrics.rollupDisagreement).toBe(4)
+    // Never throws — the shape is exactly what the dashboard contract promises.
+    expect(() => acceptanceMetricsSchema.parse(metrics)).not.toThrow()
+  })
+
+  it("reports legacy-path usage as zero when nothing has hit the redirects", async () => {
+    const metrics = await computeAcceptanceMetrics(providers())
+    expect(metrics.legacyPathUsage.totalHits).toBe(0)
+    expect(metrics.legacyPathUsage.allZero).toBe(true)
+    // Every known key is present at zero — an explicit, checkable zero.
+    expect(metrics.legacyPathUsage.byKey.length).toBeGreaterThan(0)
+    expect(metrics.legacyPathUsage.byKey.every((r) => r.hits === 0)).toBe(true)
+  })
+
+  it("surfaces recorded legacy-path hits and flips allZero off", async () => {
+    const store = new InMemoryLegacyPathUsageStore()
+    store.record("product.detail", new Date("2026-08-04T10:00:00Z"))
+    store.record("extras.detail", new Date("2026-08-04T10:05:00Z"))
+
+    const metrics = await computeAcceptanceMetrics(
+      providers({ legacyPathUsage: async () => store.snapshot() }),
+    )
+    expect(metrics.legacyPathUsage.totalHits).toBe(2)
+    expect(metrics.legacyPathUsage.allZero).toBe(false)
+    expect(metrics.legacyPathUsage.byKey.find((r) => r.key === "product.detail")?.hits).toBe(1)
+  })
+
+  it("emits only counts and route keys — no PII fields", async () => {
+    const metrics = await computeAcceptanceMetrics(
+      providers({ countUnassignedTravelers: async () => 9 }),
+    )
+    const serialized = JSON.stringify(metrics)
+    // The metric is a count; no traveler identity ever rides along.
+    expect(serialized).not.toMatch(/email|firstName|lastName|traveler_id|bookingNumber/i)
+    const keys = Object.keys(metrics)
+    expect(keys.sort()).toEqual(
+      [
+        "legacyPathUsage",
+        "missingCosts",
+        "readinessFailures",
+        "reconciliationDrift",
+        "rollupDisagreement",
+        "unassignedTravelers",
+      ].sort(),
+    )
+  })
+})

--- a/packages/operations/tests/unit/acceptance-routes.test.ts
+++ b/packages/operations/tests/unit/acceptance-routes.test.ts
@@ -1,0 +1,167 @@
+import { InMemoryLegacyPathUsageStore, setLegacyPathUsageStore } from "@voyant-travel/core"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { Hono } from "hono"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import { acceptanceMetricsSchema } from "../../src/acceptance-metrics.js"
+import {
+  configureDepartureProfitabilityReader,
+  resetDepartureProfitabilityReader,
+} from "../../src/availability/departure-profitability-runtime.js"
+import { operationsAdminRoutes } from "../../src/routes.js"
+
+/**
+ * Wiring test for `GET /v1/admin/operations/acceptance/aggregates`.
+ *
+ * The aggregator itself is unit-tested in `acceptance-metrics.test.ts`; what is
+ * proved here is that the route exists on the mounted admin surface, resolves
+ * its providers from the request's database handle, and serializes the shape the
+ * contract declares. The database is a scripted `execute()` — the providers are
+ * raw SQL, so that is the whole surface they need — and the counts are keyed off
+ * the statement text so each provider's own query is asserted to have run.
+ */
+
+interface ScriptedDb {
+  db: PostgresJsDatabase
+  statements: string[]
+}
+
+function scriptedDb(counts: { readiness: number; drift: number; unassigned: number }): ScriptedDb {
+  const statements: string[] = []
+  const execute = async (query: { toString?: () => string } | unknown) => {
+    // Drizzle's SQL object carries the fragment list; the queryChunks text is
+    // enough to tell the three statements apart without a real dialect.
+    const text = JSON.stringify(query)
+    statements.push(text)
+    if (text.includes("products p")) return [{ count: counts.readiness }]
+    if (text.includes("availability_slots s")) return [{ count: counts.drift }]
+    if (text.includes("booking_travelers bt")) return [{ count: counts.unassigned }]
+    return []
+  }
+  return { db: { execute } as unknown as PostgresJsDatabase, statements }
+}
+
+function mount(db: PostgresJsDatabase) {
+  const app = new Hono()
+  app.use("*", async (c, next) => {
+    c.set("db", db)
+    return next()
+  })
+  app.route("/", operationsAdminRoutes)
+  return app
+}
+
+beforeEach(() => {
+  setLegacyPathUsageStore(new InMemoryLegacyPathUsageStore())
+})
+
+afterEach(() => {
+  resetDepartureProfitabilityReader()
+})
+
+describe("GET /acceptance/aggregates", () => {
+  it("serves the computed metrics from the request's database handle", async () => {
+    const { db, statements } = scriptedDb({ readiness: 3, drift: 2, unassigned: 5 })
+
+    const response = await mount(db).request("/acceptance/aggregates")
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as { data: unknown; meta: unknown }
+    const metrics = acceptanceMetricsSchema.parse(body.data)
+    expect(metrics.readinessFailures).toBe(3)
+    expect(metrics.reconciliationDrift).toBe(2)
+    expect(metrics.unassignedTravelers).toBe(5)
+    // Every provider's own statement actually ran against the request handle.
+    expect(statements).toHaveLength(3)
+    expect(body.meta).toEqual({ financeProviderBound: false })
+  })
+
+  it("is served uncached — a gate metric must not answer from a snapshot", async () => {
+    const { db } = scriptedDb({ readiness: 0, drift: 0, unassigned: 0 })
+
+    const response = await mount(db).request("/acceptance/aggregates")
+
+    expect(response.headers.get("cache-control")).toBe("private, no-store")
+  })
+
+  it("reports legacy-path usage from the store the redirect middleware records into", async () => {
+    const store = new InMemoryLegacyPathUsageStore()
+    store.record("product.detail", new Date("2026-08-04T10:00:00Z"))
+    store.record("extras.detail", new Date("2026-08-04T10:05:00Z"))
+    store.record("extras.detail", new Date("2026-08-04T10:06:00Z"))
+    setLegacyPathUsageStore(store)
+    const { db } = scriptedDb({ readiness: 0, drift: 0, unassigned: 0 })
+
+    const response = await mount(db).request("/acceptance/aggregates")
+
+    const metrics = acceptanceMetricsSchema.parse(
+      ((await response.json()) as { data: unknown }).data,
+    )
+    expect(metrics.legacyPathUsage.totalHits).toBe(3)
+    expect(metrics.legacyPathUsage.allZero).toBe(false)
+    expect(metrics.legacyPathUsage.byKey.find((row) => row.key === "extras.detail")?.hits).toBe(2)
+    // Keys that were never hit still report, explicitly, at zero.
+    expect(
+      metrics.legacyPathUsage.byKey.find((row) => row.key === "catalog.scheduled.index"),
+    ).toEqual({ key: "catalog.scheduled.index", family: "catalog", hits: 0, lastSeenAt: null })
+  })
+
+  it("derives the money counts from the bound Finance provider and says it was bound", async () => {
+    const { db } = scriptedDb({ readiness: 0, drift: 0, unassigned: 0 })
+    configureDepartureProfitabilityReader(async () => ({
+      rows: [
+        // No planned cost recorded at all.
+        row("avsl_1", "EUR", { planned: 0, actual: 100, revenue: 500 }),
+        // Planned cost present, and its base row disagrees with it.
+        row("avsl_2", "EUR", { planned: 400, actual: 400, revenue: 900 }),
+        // Priced in a currency the rollup could not convert.
+        row("avsl_3", "JPY", { planned: 700, actual: 700, revenue: 1000 }),
+      ],
+      base: {
+        currency: "EUR",
+        unconvertibleCurrencies: ["JPY"],
+        rows: [
+          row("avsl_1", "EUR", { planned: 0, actual: 100, revenue: 500 }),
+          row("avsl_2", "EUR", { planned: 400, actual: 400, revenue: 111 }),
+          row("avsl_3", "EUR", { planned: 0, actual: 0, revenue: 0 }),
+        ],
+      },
+    }))
+
+    const response = await mount(db).request("/acceptance/aggregates")
+    const body = (await response.json()) as { data: unknown; meta: unknown }
+    const metrics = acceptanceMetricsSchema.parse(body.data)
+
+    expect(metrics.missingCosts).toBe(1)
+    expect(metrics.rollupDisagreement).toBe(2)
+    expect(body.meta).toEqual({ financeProviderBound: true })
+  })
+
+  it("emits no PII — the serialized body is counts and route keys only", async () => {
+    const { db } = scriptedDb({ readiness: 1, drift: 1, unassigned: 7 })
+
+    const response = await mount(db).request("/acceptance/aggregates")
+
+    const serialized = JSON.stringify(((await response.json()) as { data: unknown }).data)
+    expect(serialized).not.toMatch(/email|firstName|lastName|traveler_id|bookingNumber/i)
+  })
+})
+
+function row(
+  departureId: string,
+  currency: string,
+  amounts: { planned: number; actual: number; revenue: number },
+) {
+  return {
+    departureId,
+    productId: null,
+    departureDate: null,
+    currency,
+    revenueCents: amounts.revenue,
+    actualCostCents: amounts.actual,
+    plannedCostCents: amounts.planned,
+    profitCents: amounts.revenue - amounts.actual,
+    marginPercent: null,
+    varianceCents: amounts.planned - amounts.actual,
+  }
+}

--- a/packages/products-contracts/src/validation-catalog.ts
+++ b/packages/products-contracts/src/validation-catalog.ts
@@ -4,7 +4,7 @@ import {
   publicCatalogProductDetailSchema,
   publicCatalogProductSummarySchema,
 } from "./validation-public.js"
-import { languageTagSchema } from "./validation-shared.js"
+import { languageTagSchema, scheduleTermSchema } from "./validation-shared.js"
 
 export const localizedCatalogProductSummarySchema = publicCatalogProductSummarySchema
 export const localizedCatalogProductDetailSchema = publicCatalogProductDetailSchema
@@ -37,6 +37,9 @@ export const catalogSearchDocumentSchema = z.object({
   durationMinutes: z.number().int().nullable(),
   durationDays: z.number().int().nullable(),
   durationProvenance: z.enum(["explicit", "itinerary-derived", "unresolved"]),
+  // Operator-facing schedule term (Session / Occurrence / Departure), derived
+  // from the resolved duration. Denormalized so catalog views can facet on it.
+  scheduleTerm: scheduleTermSchema,
   // Actionable review state for unresolved legacy classification/duration.
   reviewRequired: z.boolean(),
   reviewReasons: z.array(z.enum(["missing_family", "unresolved_duration"])),

--- a/packages/products-contracts/src/validation-core.ts
+++ b/packages/products-contracts/src/validation-core.ts
@@ -7,6 +7,7 @@ import {
   productOptionStatusSchema,
   productStatusSchema,
   productVisibilitySchema,
+  scheduleTermSchema,
   typeIdSchema,
   z,
 } from "./validation-shared.js"
@@ -187,6 +188,7 @@ export const productClassificationSchema = z.object({
   durationMinutes: z.number().int().nullable(),
   durationDays: z.number().int().nullable(),
   durationProvenance: z.enum(["explicit", "itinerary-derived", "unresolved"]),
+  scheduleTerm: scheduleTermSchema,
   reviewRequired: z.boolean(),
   reviewReasons: z.array(z.enum(["missing_family", "unresolved_duration"])),
 })

--- a/packages/products-contracts/src/validation-core.ts
+++ b/packages/products-contracts/src/validation-core.ts
@@ -220,6 +220,12 @@ export const productListQuerySchema = z.object({
   familyCode: z.string().optional(),
   /** Facet on the Product subtype stable code (e.g. `boat-tour`). */
   productSubtypeCode: z.string().optional(),
+  /**
+   * Operator classification-review queue filter. `pending` returns every row
+   * that needs review; the reason-specific values narrow to one reason. Ambiguous
+   * legacy rows surface here rather than being silently guessed.
+   */
+  classificationReview: z.enum(["pending", "missing_family", "unresolved_duration"]).optional(),
   contractTemplateId: typeIdSchema("contract_templates").optional(),
   taxClassId: z.string().optional(),
   categoryId: z.string().optional(),

--- a/packages/products-contracts/src/validation-shared.ts
+++ b/packages/products-contracts/src/validation-shared.ts
@@ -26,6 +26,12 @@ export const productBookingModeSchema = z.enum([
 export const productCapacityModeSchema = z.enum(["free_sale", "limited", "on_request"])
 export const productVisibilitySchema = z.enum(["public", "private", "hidden"])
 export const productActivationModeSchema = z.enum(["manual", "scheduled", "channel_controlled"])
+/**
+ * Operator-facing schedule term token — Session / Occurrence / Departure. A
+ * presentation classification derived from the resolved Product duration; the
+ * operator UI localizes it. See `resolveScheduleTerm` in `@voyant-travel/inventory`.
+ */
+export const scheduleTermSchema = z.enum(["session", "occurrence", "departure"])
 export const productTicketFulfillmentSchema = z.enum([
   "none",
   "per_booking",

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -1232,6 +1232,9 @@
       "@voyant-travel/hono/middleware/error-boundary": [
         "../hono/dist/middleware/error-boundary.d.ts"
       ],
+      "@voyant-travel/hono/middleware/legacy-redirects": [
+        "../hono/dist/middleware/legacy-redirects.d.ts"
+      ],
       "@voyant-travel/hono/middleware/logger": ["../hono/dist/middleware/logger.d.ts"],
       "@voyant-travel/hono/middleware/rate-limit": ["../hono/dist/middleware/rate-limit.d.ts"],
       "@voyant-travel/hono/middleware/require-actor": [


### PR DESCRIPTION
## Scope — everything in #4038 except the deletion step

Items 1–9 are implemented. **Deleting** the transitional routes, projections and flags is deliberately excluded: #4038's own criteria gate that on measured-zero usage plus a human release review. This PR builds and *instruments* them so that gate can actually be evaluated.

## What landed

- **Recurring timed Sessions** for the Boat Tour on the same Product / Version / Slot / workspace / allocation / Finance foundations — no parallel scheduling aggregate.
- **One schedule term, three labels.** Session / Occurrence / Departure resolved by Product behaviour and locale over a single implementation.
- **Smoke paths for four more families** — participatory Activity, Attraction Admission, Event, Transfer.
- **Product authoring** reorganized into seven deep-linkable groups.
- **Conservative family backfill** — only `product_type_id IS NULL`, only on a positive `product_days` signal, idempotent, joining the seeded `tour` family so it no-ops if absent. Ambiguous rows are deliberately untouched and go to an operator-review queue.
- **Compatibility redirects with usage counting**, and **acceptance dashboard metrics**.

## The wiring gap, and why it mattered

The redirects and metrics originally landed as exported, unit-tested functions with **zero production call sites**. Every gate was green — a pure function has no integration surface to fail.

That was worst for the usage counter: #4038 deletes superseded surfaces once usage is *measured at zero*, and a counter nothing calls reads zero **trivially**. It would have licensed exactly the deletion it exists to gate.

Now wired:
- `legacyRedirects()` middleware in `serveAdminHost` — the only layer that sees these paths, since the runtime routes just `/api/*` into the composed app. Deliberately **not** in `mountApp`, where a storefront serves `/catalog/*slug` as real published content and an auto-redirect would break a live public URL to fix an operator bookmark. Mounted unconditionally, because opt-in is how this became dead code.
- `GET /v1/admin/operations/acceptance/aggregates`, with **no snapshot cache** and `no-store` — a cached zero answers a deletion-gating question wrong at the moment it matters — plus `meta.financeProviderBound` so an *unmeasured* zero is not read as a measured one.

## Three redirect targets pointed at routes that do not exist

Wiring made this observable. All three redirected one not-found page into another:

| key | was | now |
|---|---|---|
| `availability.slot` | `/operations/departures/:id` | `/operations/availability/:id` |
| `extras.detail` | `/products/options/:id` | `/products` |
| `extras.index` | `/products/options` | `/products` |

`/operations/departures` is the operator-facing **label**, not the path. And there is no `/products/options` route — Options are an authoring group inside Product detail, so the old target matched `/products/$id` with `id = "options"`. A legacy extras id is not a product id, so those rules land on the Product index rather than guessing an anchor this layer cannot resolve.

**The tests asserted the broken targets** and would have locked them in.

## Browser and live-system verification

Driven against a real operator on a fresh database (34 migrations, 450 tables), not fixtures.

**The core RFC promise holds.** A version-bound Istanbul departure materialized three operation lines from the frozen snapshot (correct consecutive dates, `planned` status, constrained `inclusion_role`/`traveler_scope`). Editing the **live** day service to `"MUTATED — luxury limo transfer"` at 99999 cents left the departure reading `"Airport transfer"`. Later Product edits cannot silently mutate a sold departure — verified end to end.

**All five families resolve through one `getDepartureSummary`** (HTTP 200 each): Boat Tour, Day Tour, Multi-day Tour, Pottery Workshop, Castle Admission. No separate aggregates.

**Typed issues discriminate correctly.** Five departures created while their products were drafts each report `warning: departure_not_version_bound`; the one created post-publish reports clear.

**Redirects verified over real HTTP** — all five families return `308` with the query string preserved — and in the browser, where `/availability/slots/:id?tab=operations` lands on a fully rendered workspace ("Istanbul Multi-day Tour · 2026-09-19", 6 nights, Europe/Istanbul, all six sections). Screenshot in `.agent-evidence/`.

**Readiness gates fired for real** rather than being bypassed: publish was blocked by `no_option_units` on all five, and by `empty_itinerary` on the multi-day tour until an itinerary existed.

## Gates

```
@voyant-travel/core        166 passed (13 files)
@voyant-travel/hono        353 passed (37 files)
@voyant-travel/operations  330 passed | 430 skipped (63 files)
@voyant-travel/admin-host   14 passed (4 files)
biome check . --max-diagnostics=60   20 warnings, 8 infos, 0 errors (matches clean main)
table-privacy-runner                 225 reach-ins, none new
verify:openapi                       up to date
i18n:check                           parity + hardcoded-string scan clean
typecheck  core / hono / admin-host / operations — 0 errors each
```

## Reviewer notes

- **The usage store is per-process.** Correct for the single-process Node operator; anything multi-process must bind a durable store via `setLegacyPathUsageStore` or "usage is zero" is only one process's zero. Documented in the core docblock, the changeset and the architecture doc.
- **The readiness-failures metric is a SQL mirror of an evaluator Inventory owns.** All eight blocking rules are expressed; if Inventory adds one, this count silently understates until mirrored. Operations cannot depend on `@voyant-travel/inventory` (the dependency runs the other way), and a port would mean touching `graph-conformance.json` plus both manifests.
- The `operations.json` diff carries pre-existing drift from #4216 along with ~50 lines of its own; regenerating is mandatory now that `--check` is in `verify:architecture`.
- The remote job hand-patched lab1's shared test DB on :5436 to work around a pre-existing bookings migration drift, so that database is no longer pristine for other jobs.

Part of #4038 — deletion step deliberately excluded, pending your release review.