### PR TITLE
Let a Tool declare the admin writes it fronts

### DIFF
--- a/.changeset/tool-declared-admin-write-coverage.md
+++ b/.changeset/tool-declared-admin-write-coverage.md
@@ -1,0 +1,17 @@
+---
+"@voyant-travel/graph-contracts": patch
+---
+
+feat(graph-contracts): let a Tool declare the admin write endpoints it fronts
+
+`VoyantGraphToolDeclaration` gains an optional `adminWrites`, the list of admin
+OpenAPI paths a Tool is the agent surface for.
+
+Admin write coverage is otherwise inferred from a Tool's name, and that
+inference reads the resource's trailing noun. Two resources whose noun is the
+same word are therefore indistinguishable: `attach_departure_fleet_resource`,
+which links an existing fleet record to one departure, also satisfied
+`/v1/admin/operations/resources` — create, rename and delete of the coach
+itself. Where the colliding word *is* the noun there is no name that avoids it,
+so the Tool states its endpoints instead. A declaration is exhaustive: a Tool
+that declares covers the resources behind those paths and no others.

--- a/packages/graph-contracts/src/facets.ts
+++ b/packages/graph-contracts/src/facets.ts
@@ -352,6 +352,20 @@ export interface VoyantGraphToolDeclaration extends VoyantGraphFacetEntity {
   requiredScopes?: readonly string[]
   context?: readonly string[]
   risk?: "low" | "medium" | "high" | "critical"
+  /**
+   * The admin write endpoints this Tool is the agent surface for, written
+   * exactly as the paths appear in the owning module's admin OpenAPI document.
+   *
+   * Admin write coverage is otherwise inferred from the Tool's name, which
+   * matches a resource on its trailing noun. That inference cannot separate two
+   * resources whose noun is the same word: `/operations/resources` is the fleet
+   * record for a coach, while `/operations/availability/slots/{id}/allocation/
+   * fleet-resources` attaches an existing one to a departure, and a Tool named
+   * for the second satisfied the first. Declaring the paths replaces the
+   * inference for this Tool — it covers these endpoints and nothing else — so
+   * add every endpoint the Tool genuinely fronts, not only the narrowest one.
+   */
+  adminWrites?: readonly string[]
 }
 
 export interface VoyantGraphWebhookDeclaration extends VoyantGraphFacetEntity {

--- a/packages/operations/src/voyant.ts
+++ b/packages/operations/src/voyant.ts
@@ -293,6 +293,16 @@ export const operationsVoyantModule = defineModule({
       requiredScopes: ["operations:write"],
       context: ["operations"],
       risk: "medium",
+      // Attaching writes the departure's allocation-resource container as well
+      // as the fleet link, so both endpoints are this Tool's surface. Declared
+      // rather than inferred because the fleet *record* at
+      // `/v1/admin/operations/resources` shares the noun `resource` and this
+      // Tool cannot create, rename or delete a coach — leaving it to the name
+      // match reported that global CRUD as covered.
+      adminWrites: [
+        "/v1/admin/operations/availability/slots/{id}/allocation/fleet-resources",
+        "/v1/admin/operations/availability/slots/{id}/allocation/resources",
+      ],
     },
     {
       id: "@voyant-travel/operations#tool.detach-departure-fleet-resource",
@@ -309,6 +319,12 @@ export const operationsVoyantModule = defineModule({
       requiredScopes: ["operations:write"],
       context: ["operations"],
       risk: "high",
+      // Detaching removes the departure's allocation-resource container along
+      // with the fleet link; it does not touch the fleet record itself.
+      adminWrites: [
+        "/v1/admin/operations/availability/slots/{id}/allocation/fleet-resources/{fleetResourceId}",
+        "/v1/admin/operations/availability/slots/{id}/allocation/resources/{resourceId}",
+      ],
     },
     {
       id: "@voyant-travel/operations#tool.list-departure-fleet-resources",

--- a/scripts/agent-write-coverage-baseline.json
+++ b/scripts/agent-write-coverage-baseline.json
@@ -19,7 +19,7 @@
   "@voyant-travel/mice": 14,
   "@voyant-travel/navigation-preferences": 1,
   "@voyant-travel/notifications": 12,
-  "@voyant-travel/operations": 91,
+  "@voyant-travel/operations": 92,
   "@voyant-travel/operator-settings": 3,
   "@voyant-travel/proposals": 11,
   "@voyant-travel/realtime": 1,

--- a/scripts/check-agent-write-coverage.ts
+++ b/scripts/check-agent-write-coverage.ts
@@ -158,6 +158,8 @@ async function loadWorkspaceModules(root: string) {
             requiredScopes: Array.isArray(tool.requiredScopes)
               ? tool.requiredScopes.map(String)
               : [],
+            // Declared admin paths win over name matching for this Tool.
+            adminWrites: Array.isArray(tool.adminWrites) ? tool.adminWrites.map(String) : undefined,
           })
         }
       }

--- a/scripts/lib/agent-write-coverage.mjs
+++ b/scripts/lib/agent-write-coverage.mjs
@@ -12,6 +12,14 @@
  * would force a Tool for every incidental PATCH, and route shape is not a
  * capability boundary. What matters is that a resource an operator can create
  * or modify is reachable at all.
+ *
+ * A Tool is matched to a resource by name unless its manifest declaration lists
+ * the admin paths it fronts. Name matching reads the resource's trailing noun,
+ * so two resources whose noun is the same word are indistinguishable: an
+ * operations Tool named for a departure's `fleet-resources` attachment also
+ * satisfied `/operations/resources`, the fleet record itself, and hid genuine
+ * fleet CRUD. `adminWrites` on the Tool declaration replaces the inference for
+ * that Tool, which is the only way out when the colliding word *is* the noun.
  */
 
 const WRITE_METHODS = new Set(["post", "patch", "put", "delete"])
@@ -73,8 +81,10 @@ const ACTION_SEGMENTS = new Set([
 /**
  * Inspect admin write coverage across modules.
  *
- * @param modules Array of `{ packageName, unitId, tools: [{ id, name, risk }],
- *   adminWriteOperations: [{ method, path }] }`.
+ * @param modules Array of `{ packageName, unitId, tools: [{ id, name, risk,
+ *   requiredScopes, adminWrites }], adminWriteOperations: [{ method, path }] }`.
+ *   `adminWrites` is the Tool's own list of admin paths; when present it
+ *   replaces name matching for that Tool.
  * @param options.allowlist Map of `resourceKey` -> `{ rationale }` for
  *   resources that deliberately have no Tool.
  */
@@ -94,17 +104,38 @@ export function inspectAgentWriteCoverage(modules, options = {}) {
       resources.set(key, entry)
     }
 
+    const moduleTools = dedupeByName(module.tools ?? []).map((tool) => ({
+      name: tool.name,
+      write: isWriteTool(tool),
+      tokens: tokenize(tool.name),
+      declared: declaredResourceKeys(tool),
+    }))
+
+    for (const tool of moduleTools) {
+      if (!tool.declared) continue
+      if (!tool.write) {
+        diagnostics.push(
+          `${module.unitId}: ${tool.name} declares adminWrites but asks for no write scope — a read Tool covers no write resource, so the declaration is inert`,
+        )
+        continue
+      }
+      for (const [path, key] of tool.declared) {
+        if (key !== undefined && resources.has(key)) continue
+        diagnostics.push(
+          `${module.unitId}: ${tool.name} declares adminWrites ${path}, which is not an admin write operation in this module's OpenAPI documents — fix the path or drop it`,
+        )
+      }
+    }
+
     // Only write-capable Tools can cover a write resource. Counting reads was
     // the first version of this check, and it declared notification templates
     // "covered" by list/get — the precise gap it exists to catch.
-    const toolTokens = dedupeByName(module.tools ?? [])
-      .filter((tool) => isWriteTool(tool))
-      .map((tool) => ({ name: tool.name, tokens: tokenize(tool.name) }))
+    const toolMatchers = moduleTools.filter((tool) => tool.write)
 
     for (const resource of [...resources.values()].sort((a, b) => a.key.localeCompare(b.key))) {
       const allowKey = `${module.unitId}:${resource.key}`
       const allowed = allowlist.get(allowKey)
-      const covering = toolTokens.filter((tool) => coversResource(tool.tokens, resource.key))
+      const covering = toolMatchers.filter((tool) => coversResource(tool, resource.key))
 
       if (allowed) {
         usedAllowlistKeys.add(allowKey)
@@ -236,7 +267,24 @@ function dedupeByName(tools) {
   return [...seen.values()]
 }
 
-function coversResource(toolTokens, key) {
+/**
+ * Resource keys a Tool declaration names outright, or `undefined` when it
+ * declares nothing and coverage falls back to its name.
+ *
+ * @returns Map of declared admin path -> resource key.
+ */
+function declaredResourceKeys(tool) {
+  const paths = tool.adminWrites
+  if (!Array.isArray(paths) || paths.length === 0) return undefined
+  return new Map(paths.map((path) => [path, resourceKey(String(path))]))
+}
+
+function coversResource(tool, key) {
+  // A declaration is exhaustive: the Tool covers the resources behind the paths
+  // it names and no others. Falling back to the name for anything it left out
+  // would reinstate the collision the declaration exists to settle.
+  if (tool.declared) return [...tool.declared.values()].includes(key)
+
   // The resource's own noun is the last segment; a Tool covers the resource
   // when it names that noun. `/proposal/product` needs a Tool about products, not
   // merely one about proposals, or add_proposal_product's absence would hide behind
@@ -244,7 +292,7 @@ function coversResource(toolTokens, key) {
   const segments = key.split("/")
   const noun = segments[segments.length - 1]
   const nounTokens = noun.split("-").map(singularize).filter(Boolean)
-  return nounTokens.every((token) => toolTokens.includes(token))
+  return nounTokens.every((token) => tool.tokens.includes(token))
 }
 
 function tokenize(name) {

--- a/scripts/tests/check-agent-write-coverage.test.mjs
+++ b/scripts/tests/check-agent-write-coverage.test.mjs
@@ -128,6 +128,124 @@ describe("agent write coverage", () => {
     )
   })
 
+  it("does not let a Tool for a qualified noun cover the bare noun it contains", () => {
+    // `fleet-resource` and `resource` are different entities that share a noun:
+    // one is a departure's attachment, the other the fleet record itself.
+    // Name matching reads the trailing noun and cannot tell them apart, so the
+    // attach Tool declares the endpoints it fronts and the global fleet CRUD
+    // stays visible as the gap it is.
+    const operations = [
+      { method: "post", path: "/v1/admin/operations/resources" },
+      { method: "patch", path: "/v1/admin/operations/resources/{id}" },
+      {
+        method: "post",
+        path: "/v1/admin/operations/availability/slots/{id}/allocation/fleet-resources",
+      },
+    ]
+    const declaring = {
+      ...writeTool("attach_departure_fleet_resource", "operations:write"),
+      adminWrites: ["/v1/admin/operations/availability/slots/{id}/allocation/fleet-resources"],
+    }
+
+    const { rows, diagnostics } = inspectAgentWriteCoverage([
+      {
+        packageName: "@voyant-travel/operations",
+        unitId: "@voyant-travel/operations",
+        tools: [declaring],
+        adminWriteOperations: operations,
+      },
+    ])
+    assert.deepEqual(diagnostics, [])
+    assert.deepEqual(
+      rows.map(({ resource, posture }) => [resource, posture]),
+      [
+        ["operation/availability/slot/allocation/fleet-resource", "covered"],
+        ["operation/resource", "uncovered"],
+      ],
+    )
+
+    // Without the declaration the same Tool name aliases both — the behaviour
+    // this replaces.
+    const inferred = inspectAgentWriteCoverage([
+      {
+        packageName: "@voyant-travel/operations",
+        unitId: "@voyant-travel/operations",
+        tools: [writeTool("attach_departure_fleet_resource", "operations:write")],
+        adminWriteOperations: operations,
+      },
+    ])
+    assert.deepEqual(
+      inferred.rows.map(({ resource, posture }) => [resource, posture]),
+      [
+        ["operation/availability/slot/allocation/fleet-resource", "covered"],
+        ["operation/resource", "covered"],
+      ],
+    )
+  })
+
+  it("treats a declaration as the Tool's whole write surface", () => {
+    // A declared Tool stops matching by name entirely: listing one endpoint and
+    // silently keeping the name match for the rest would put the collision back.
+    const { rows } = inspectAgentWriteCoverage([
+      {
+        packageName: "@voyant-travel/proposals",
+        unitId: "@voyant-travel/proposals",
+        tools: [
+          {
+            ...writeTool("add_proposal_product"),
+            adminWrites: ["/v1/admin/proposals/proposals/{id}/products"],
+          },
+          writeTool("create_proposal"),
+        ],
+        adminWriteOperations: operations,
+      },
+    ])
+    assert.deepEqual(
+      rows.map(({ resource, tools }) => [resource, tools]),
+      [
+        ["proposal", ["create_proposal"]],
+        ["proposal/product", ["add_proposal_product"]],
+      ],
+    )
+  })
+
+  it("rejects a declaration that names no admin write operation", () => {
+    const { diagnostics } = inspectAgentWriteCoverage([
+      {
+        packageName: "@voyant-travel/proposals",
+        unitId: "@voyant-travel/proposals",
+        tools: [
+          {
+            ...writeTool("add_proposal_product"),
+            adminWrites: ["/v1/admin/proposals/proposals/{id}/line-items"],
+          },
+        ],
+        adminWriteOperations: operations,
+      },
+    ])
+    assert.equal(diagnostics.length, 1)
+    assert.match(diagnostics[0], /add_proposal_product declares adminWrites/)
+    assert.match(diagnostics[0], /line-items/)
+  })
+
+  it("rejects a declaration on a Tool that asks for no write scope", () => {
+    const { diagnostics } = inspectAgentWriteCoverage([
+      {
+        packageName: "@voyant-travel/proposals",
+        unitId: "@voyant-travel/proposals",
+        tools: [
+          {
+            ...readTool("list_proposal_products"),
+            adminWrites: ["/v1/admin/proposals/proposals/{id}/products"],
+          },
+        ],
+        adminWriteOperations: operations,
+      },
+    ])
+    assert.equal(diagnostics.length, 1)
+    assert.match(diagnostics[0], /asks for no write scope/)
+  })
+
   it("rejects an allowlist entry that is stale or unexplained", () => {
     const modules = [
       {


### PR DESCRIPTION
## Why

`coversResource()` matched a Tool to an admin write resource by the key's **trailing noun**. `operation/resource` tokenises to `["resource"]`, which is a subset of `attach_departure_fleet_resource`'s tokens — so the fleet-attach Tool silently "covered" create/rename/delete of the **global fleet record**, which it cannot do. It takes an existing `resourceId` and links it to a departure.

The gap was real, and the ratchet had stopped tracking it. Closes #4217.

## Why not match on the full resource key

That was the suggested fix. It was **measured, not assumed, and it does not work**: requiring every segment's tokens to appear in the Tool name flips **52 rows covered→uncovered across 12 modules** — `catalog/booking-session` would need a Tool naming "catalog", `relationship/organization/note` one naming "relationship". That is a broken check, not a stricter one.

A "most-specific-noun-wins" rule was also tried: it breaks an existing pinned case (`proposal/product` shadowed by `proposal/proposal-product`), flips 7 rows, and would have uncovered `operation/availability/slot/allocation/resource` too.

The decisive fact: `operation/resource` and `operation/availability/slot/allocation/resource` have an **identical noun string**. No rule that reads the Tool's *name* can separate them.

## The fix

`VoyantGraphToolDeclaration` gains an optional `adminWrites?: readonly string[]` — the admin OpenAPI paths the Tool fronts.

- **A declaration is exhaustive.** A declaring Tool covers those paths' resources and nothing else; partial declaration plus a name fallback would reinstate the collision.
- **Two fail-loud diagnostics:** a declared path that is not an admin write operation in that module's OpenAPI ("fix the path or drop it"), and a declaration on a Tool with no write scope (inert). The first makes it self-maintaining — rename a route and the checker complains rather than the declaration rotting.
- `attach_/detach_departure_fleet_resource` declare both the `allocation/fleet-resources` path **and** `allocation/resources`, because attach writes the departure's allocation-resource container and detach removes it.

## Impact — exactly one row

| key | before | after |
|---|---|---|
| `@voyant-travel/operations` `operation/resource` | covered by the fleet Tools | **uncovered** |

Totals 106/445 → **105/446**. Baseline `@voyant-travel/operations` **91 → 92**.

**The baseline goes UP because the checker was undercounting — this is not a ratchet bump.** `operation/resource` is `POST/PATCH/DELETE /v1/admin/operations/resources`: create/rename/delete of the fleet record. It was never covered; the bug hid it.

Still covered, correctly: `.../allocation/fleet-resource`, `.../allocation/resource` (its POST/DELETE legs — its PATCH is still not agent-reachable, which per-resource matching does not model), `.../allocation/traveler`.

## The sweep found two more of the same bug

215 shadowing key-pairs exist; 23 share a covering Tool. Twenty-one are benign (two routes onto one entity, or the bare key independently covered). **Two are the same defect and are still miscounted** — not fixed here, since each needs its module owner's judgement and each raises a baseline:

1. **`commerce`** — `sellability/policy` (`/v1/admin/sellability/policies`) is counted covered *solely* by `create_/update_cancellation_policy`, which front `/v1/admin/pricing/cancellation-policies`. Different entity. Fix would take commerce 28 → 29.
2. **`bookings`** — `booking/traveler` and `booking/item/traveler` are counted covered *solely* by `preview_traveler_correction_amendment` / `preview_traveler_roster_change_amendment`, which are **previews**, aliasing via the noun `traveler`. Likely 14 → 16.

Both are now fixable with the mechanism this PR adds. I'd suggest a follow-up issue rather than widening this one.

## Verification

Four new tests, **proven to fail against the pre-fix library** (`git show HEAD:scripts/lib/agent-write-coverage.mjs`):

```
✖ does not let a Tool for a qualified noun cover the bare noun it contains
✖ treats a declaration as the Tool's whole write surface
✖ rejects a declaration that names no admin write operation
✖ rejects a declaration on a Tool that asks for no write scope
ℹ pass 12  ℹ fail 4
```

After the fix: `ℹ tests 16 ℹ pass 16 ℹ fail 0`. The aliasing test asserts both halves — with the declaration `operation/resource` is uncovered; without it the same Tool name still aliases both, pinning that the *declaration* settles it, not a heuristic.

Mid-fix, before correcting the baseline, the checker failed exactly as intended: `92 admin write resource(s) have no Tool, above the baseline of 91`.

```
verify:agent-tool-coverage             OK (54 modules, 310 Tools)
verify:first-party-tool-output-schemas OK
verify:graph-conformance               OK (3 packages conform)
verify:deployment-graph                OK — adminWrites does not alter generated artifacts
verify:symbol-policy                   OK
graph-contracts typecheck              exit 0
operations tests                       334 passed
biome check .                          21 warnings, 8 infos, 0 errors
```

## Reviewer notes

- **The exhaustive-declaration rule has a trade:** adding `adminWrites` to a Tool that currently name-covers several resources will drop the undeclared ones. That fails loudly at the ratchet, which is intended.
- `pnpm -F @voyant-travel/operations typecheck` dies locally at exit 134 with zero `error TS` lines — the unbuilt-dist heap death (#4223), not a type error. The declaration shape was proven to compile via a standalone `tsc --noEmit --strict` probe and by confirming `adminWrites?: readonly string[]` lands in the built `dist/facets.d.ts`.
- Changeset is a patch on `@voyant-travel/graph-contracts` (published); `operations` is private.

Closes #4217