### PR TITLE
Typecheck packages/operations at all, and its tests with it

### DIFF
--- a/packages/operations/package.json
+++ b/packages/operations/package.json
@@ -20,11 +20,11 @@
     "./booking-actions-job": "./src/booking-actions/job.ts"
   },
   "scripts": {
-    "typecheck": "tsc -p tsconfig.typecheck.json",
+    "typecheck": "NODE_OPTIONS=--max-old-space-size=8192 tsc -p tsconfig.typecheck.json",
     "lint": "biome check src/",
     "test": "vitest run --passWithNoTests",
-    "build": "tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "build": "NODE_OPTIONS=--max-old-space-size=8192 tsc -p tsconfig.build.json",
+    "clean": "rm -rf dist tsconfig*.tsbuildinfo",
     "prepack": "pnpm run build",
     "db:generate": "drizzle-kit generate --config=drizzle.migrations.config.ts --name=operations_baseline && node ../../scripts/migrations/guard-create-type.mjs ./migrations && node ../../scripts/migrations/ensure-extensions.mjs ./migrations",
     "generate:openapi": "tsx scripts/generate-openapi.ts",

--- a/packages/operations/tests/availability/integration/materialize-template-defaults.test.ts
+++ b/packages/operations/tests/availability/integration/materialize-template-defaults.test.ts
@@ -19,8 +19,7 @@ import {
 const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
 
 describe.skipIf(!DB_AVAILABLE)("materialize template defaults (integration)", () => {
-  // biome-ignore lint/suspicious/noExplicitAny: owner: availability; createTestDb returns a driver-specific drizzle test client
-  let db: any
+  let db: ReturnType<typeof createTestDb>
   let productId: string
   let optionId: string
 
@@ -86,10 +85,9 @@ describe.skipIf(!DB_AVAILABLE)("materialize template defaults (integration)", ()
 
     const result = await materializeSlotResourcesFromTemplateDefaults(db, slotId)
     expect(result.created).toBe(25)
-    const rooms = await db.execute(sql`
+    const rows = await db.execute<{ label: string; capacity: number; kind: string }>(sql`
       SELECT label, capacity, kind FROM allocation_resources WHERE slot_id = ${slotId} ORDER BY sort_order
     `)
-    const rows = rooms as Array<{ label: string; capacity: number; kind: string }>
     expect(rows.filter((r) => r.kind === "room_sgl")).toHaveLength(5)
     expect(rows.filter((r) => r.kind === "room_dbl")).toHaveLength(20)
   })

--- a/packages/operations/tests/availability/integration/slot-events.test.ts
+++ b/packages/operations/tests/availability/integration/slot-events.test.ts
@@ -59,6 +59,8 @@ describe.skipIf(!DB_AVAILABLE)("availability slot events", () => {
         timezone: "UTC",
         status: "open",
         unlimited: false,
+        pastCutoff: false,
+        tooEarly: false,
         remainingPax: 5,
       },
       { eventBus: bus },

--- a/packages/operations/tests/availability/integration/slot-option-validation.test.ts
+++ b/packages/operations/tests/availability/integration/slot-option-validation.test.ts
@@ -5,19 +5,17 @@ import { RequestValidationError } from "@voyant-travel/hono"
 import { eq } from "drizzle-orm"
 import { beforeEach, describe, expect, it } from "vitest"
 import { productOptions, products } from "../../../../inventory/src/schema.js"
-import {
-  createRule,
-  createSlot,
-  updateRule,
-  updateSlot,
-} from "../../../src/availability/service-core.js"
+import { createSlot, updateSlot } from "../../../src/availability/service-core.js"
+import { createRule, updateRule } from "../../../src/availability/service-rules.js"
 
 const TEST_DATABASE_URL = process.env.TEST_DATABASE_URL
 const DB_AVAILABLE = !!TEST_DATABASE_URL
 
 const db = DB_AVAILABLE ? createTestDb() : (null as never)
 
-async function seedProduct(name: string, bookingMode = "date") {
+type ProductBookingMode = NonNullable<(typeof products.$inferInsert)["bookingMode"]>
+
+async function seedProduct(name: string, bookingMode: ProductBookingMode = "date") {
   const productId = newId("products")
   await db.insert(products).values({
     id: productId,
@@ -40,12 +38,22 @@ async function seedOption(productId: string, name: string) {
   return optionId
 }
 
-function slotInput(productId: string, overrides: Partial<Parameters<typeof createSlot>[1]> = {}) {
+type CreateSlotInput = Parameters<typeof createSlot>[1]
+
+// `createSlot` takes the *parsed* insert payload, so the schema defaults the
+// route layer fills in have to be supplied explicitly here. These four match
+// both the zod defaults and the column defaults, so a seeded slot is identical
+// to one created through the API.
+function slotInput(productId: string, overrides: Partial<CreateSlotInput> = {}): CreateSlotInput {
   return {
     productId,
     dateLocal: "2026-09-10",
     startsAt: "2026-09-10T09:00:00.000Z",
     timezone: "Europe/London",
+    status: "open",
+    unlimited: false,
+    pastCutoff: false,
+    tooEarly: false,
     ...overrides,
   }
 }
@@ -96,6 +104,8 @@ describe.skipIf(!DB_AVAILABLE)("availability slot option validation", () => {
       endsAt: "2026-10-14T15:00:00.000Z",
       timezone: "Europe/Bucharest",
       status: "open",
+      pastCutoff: false,
+      tooEarly: false,
       unlimited: false,
       initialPax: 20,
       remainingPax: 17,
@@ -265,6 +275,7 @@ describe.skipIf(!DB_AVAILABLE)("availability slot option validation", () => {
         active: false,
       })
       .returning()
+    if (!inactiveRule) throw new Error("failed to seed inactive availability rule")
 
     await expect(updateRule(db, inactiveRule.id, { active: true })).rejects.toBeInstanceOf(
       RequestValidationError,
@@ -280,6 +291,7 @@ describe.skipIf(!DB_AVAILABLE)("availability slot option validation", () => {
         timezone: "UTC",
         recurrenceRule: "NOT_A_RULE",
         maxCapacity: 10,
+        active: true,
       }),
     ).rejects.toBeInstanceOf(RequestValidationError)
 
@@ -289,6 +301,7 @@ describe.skipIf(!DB_AVAILABLE)("availability slot option validation", () => {
         timezone: "UTC",
         recurrenceRule: "FREQ=WEEKLY;INTERVAL=1",
         maxCapacity: 10,
+        active: true,
       }),
     ).rejects.toBeInstanceOf(RequestValidationError)
   })

--- a/packages/operations/tests/availability/unit/public-surface.test.ts
+++ b/packages/operations/tests/availability/unit/public-surface.test.ts
@@ -20,6 +20,11 @@ describe("availability public surface", () => {
       bookings: [],
       resources: [],
       sharingGroupLabels: {},
+      pagination: {
+        limit: null,
+        offset: 0,
+        total: 0,
+      },
       summary: {
         bookingCount: 0,
         travelerCount: 0,

--- a/packages/operations/tests/availability/unit/routes-core-contract.test.ts
+++ b/packages/operations/tests/availability/unit/routes-core-contract.test.ts
@@ -110,6 +110,7 @@ const ruleRow: InferSelectModel<typeof availabilityRules> = {
 const slotRow: InferSelectModel<typeof availabilitySlots> & { endDateLocal: string | null } = {
   id: "availability_slots_00000000000000000000",
   productId: "products_00000000000000000000000000",
+  productVersionId: null,
   itineraryId: null,
   optionId: null,
   facilityId: null,

--- a/packages/operations/tests/ground/integration/routes-checkpoints.test.ts
+++ b/packages/operations/tests/ground/integration/routes-checkpoints.test.ts
@@ -44,7 +44,14 @@ describe.skipIf(!DB_AVAILABLE)("Ground routes", () => {
     const { bookings } = await import("@voyant-travel/bookings/schema")
     const [row] = await db
       .insert(bookings)
-      .values({ bookingNumber: `BK-${nextSeq()}`, sellCurrency: "USD", ...overrides })
+      .values({
+        bookingNumber: `BK-${nextSeq()}`,
+        sellCurrency: "USD",
+        // `bookings.status` is NOT NULL and lost its database default in the
+        // v1 status cutover, so a seeded booking has to name its own status.
+        status: "confirmed" as const,
+        ...overrides,
+      })
       .returning()
     return row!
   }

--- a/packages/operations/tests/ground/integration/routes-dispatch-events.test.ts
+++ b/packages/operations/tests/ground/integration/routes-dispatch-events.test.ts
@@ -44,7 +44,14 @@ describe.skipIf(!DB_AVAILABLE)("Ground routes", () => {
     const { bookings } = await import("@voyant-travel/bookings/schema")
     const [row] = await db
       .insert(bookings)
-      .values({ bookingNumber: `BK-${nextSeq()}`, sellCurrency: "USD", ...overrides })
+      .values({
+        bookingNumber: `BK-${nextSeq()}`,
+        sellCurrency: "USD",
+        // `bookings.status` is NOT NULL and lost its database default in the
+        // v1 status cutover, so a seeded booking has to name its own status.
+        status: "confirmed" as const,
+        ...overrides,
+      })
       .returning()
     return row!
   }

--- a/packages/operations/tests/ground/integration/routes-driver-shifts-incidents.test.ts
+++ b/packages/operations/tests/ground/integration/routes-driver-shifts-incidents.test.ts
@@ -53,7 +53,14 @@ describe.skipIf(!DB_AVAILABLE)("Ground routes", () => {
     const { bookings } = await import("@voyant-travel/bookings/schema")
     const [row] = await db
       .insert(bookings)
-      .values({ bookingNumber: `BK-${nextSeq()}`, sellCurrency: "USD", ...overrides })
+      .values({
+        bookingNumber: `BK-${nextSeq()}`,
+        sellCurrency: "USD",
+        // `bookings.status` is NOT NULL and lost its database default in the
+        // v1 status cutover, so a seeded booking has to name its own status.
+        status: "confirmed" as const,
+        ...overrides,
+      })
       .returning()
     return row!
   }

--- a/packages/operations/tests/ground/integration/routes.test.ts
+++ b/packages/operations/tests/ground/integration/routes.test.ts
@@ -53,7 +53,14 @@ describe.skipIf(!DB_AVAILABLE)("Ground routes", () => {
     const { bookings } = await import("@voyant-travel/bookings/schema")
     const [row] = await db
       .insert(bookings)
-      .values({ bookingNumber: `BK-${nextSeq()}`, sellCurrency: "USD", ...overrides })
+      .values({
+        bookingNumber: `BK-${nextSeq()}`,
+        sellCurrency: "USD",
+        // `bookings.status` is NOT NULL and lost its database default in the
+        // v1 status cutover, so a seeded booking has to name its own status.
+        status: "confirmed" as const,
+        ...overrides,
+      })
       .returning()
     return row!
   }

--- a/packages/operations/tests/tools.test.ts
+++ b/packages/operations/tests/tools.test.ts
@@ -9,6 +9,7 @@ import {
   getOperatorDashboardSummaryTool,
   materializeDepartureRoomBlockTool,
   type OperationsToolServices,
+  type OperatorDashboardToolContext,
   operationsTools,
   rebuildBookingActionsTool,
   releaseDepartureRoomBlockTool,
@@ -726,107 +727,108 @@ describe("Operations dashboard Tool", () => {
     const calls: Array<{ service: string; query: unknown }> = []
     const registry = createToolRegistry()
     registry.register(getOperatorDashboardSummaryTool)
+    // The composed dashboard read pulls sibling-domain aggregate services off
+    // the context, so the fixture has to be the dashboard's own context type
+    // rather than the bare `ToolContext` every other tool here takes.
+    const dashboardContext: OperatorDashboardToolContext = {
+      ...contextWith({
+        async getAvailabilityAggregates(query) {
+          calls.push({ service: "operations", query })
+          return {
+            total: 4,
+            countsByStatus: [
+              { status: "open", count: 3 },
+              { status: "closed", count: 1 },
+              { status: "sold_out", count: 0 },
+              { status: "cancelled", count: 0 },
+            ],
+            upcomingSlots: 3,
+            upcomingPax: 42,
+            monthlyDepartures: [{ yearMonth: "2026-07", count: 4 }],
+          }
+        },
+      }),
+      bookings: {
+        async getBookingAggregates(query: unknown) {
+          calls.push({ service: "bookings", query })
+          return {
+            total: 7,
+            totalPax: 18,
+            countsByStatus: [
+              { status: "confirmed", count: 2 },
+              { status: "in_progress", count: 1 },
+              { status: "cancelled", count: 1 },
+            ],
+            monthlyCounts: [{ yearMonth: "2026-07", count: 7 }],
+            monthlyRevenue: [{ yearMonth: "2026-07", currency: "EUR", sellAmountCents: 250_000 }],
+            upcomingDepartures: { count: 1, items: [] },
+          }
+        },
+      },
+      inventory: {
+        async getProductAggregates(query: unknown) {
+          calls.push({ service: "inventory", query })
+          return {
+            total: 9,
+            countsByStatus: [
+              { status: "draft", count: 2 },
+              { status: "active", count: 7 },
+              { status: "archived", count: 0 },
+            ],
+            active: 7,
+            publicActive: 6,
+            monthlyCreatedCounts: [{ yearMonth: "2026-07", count: 2 }],
+          }
+        },
+      },
+      distribution: {
+        async getSupplierAggregates(query: unknown) {
+          calls.push({ service: "distribution", query })
+          return {
+            total: 5,
+            countsByStatus: [{ status: "active", count: 4 }],
+            countsByType: [{ type: "hotel", count: 3 }],
+            active: 4,
+          }
+        },
+      },
+      finance: {
+        async getFinanceAggregates(query: unknown) {
+          calls.push({ service: "finance", query })
+          return {
+            total: 3,
+            countsByStatus: [{ status: "issued", count: 2 }],
+            counts: {
+              invoices: { issued: 2, paid: 1, void: 0, overdue: 1 },
+              proformas: { issued: 0, converted: 0, void: 0 },
+              paymentSessions: { pending: 0, paid: 1, failed: 0 },
+            },
+            totals: [
+              {
+                currency: "EUR",
+                invoiced: 210_000,
+                collected: 150_000,
+                outstanding: 60_000,
+                refunded: 0,
+              },
+            ],
+            monthlyRevenue: [
+              { yearMonth: "2026-06", currency: "EUR", totalCents: 90_000 },
+              { yearMonth: "2026-07", currency: "EUR", totalCents: 120_000 },
+            ],
+            monthlyInvoiceCounts: [{ yearMonth: "2026-07", count: 2 }],
+            outstanding: [{ currency: "EUR", balanceDueCents: 60_000, count: 1 }],
+            overdue: [{ currency: "EUR", balanceDueCents: 20_000, count: 1 }],
+            outstandingTopN: [],
+          }
+        },
+      },
+    }
+
     const result = await registry.dispatch<{
       kpis: Record<string, unknown>
       alerts: unknown[]
-    }>(
-      "get_operator_dashboard_summary",
-      { range: "this-month" },
-      {
-        ...contextWith({
-          async getAvailabilityAggregates(query) {
-            calls.push({ service: "operations", query })
-            return {
-              total: 4,
-              countsByStatus: [
-                { status: "open", count: 3 },
-                { status: "closed", count: 1 },
-                { status: "sold_out", count: 0 },
-                { status: "cancelled", count: 0 },
-              ],
-              upcomingSlots: 3,
-              upcomingPax: 42,
-              monthlyDepartures: [{ yearMonth: "2026-07", count: 4 }],
-            }
-          },
-        }),
-        bookings: {
-          async getBookingAggregates(query: unknown) {
-            calls.push({ service: "bookings", query })
-            return {
-              total: 7,
-              totalPax: 18,
-              countsByStatus: [
-                { status: "confirmed", count: 2 },
-                { status: "in_progress", count: 1 },
-                { status: "cancelled", count: 1 },
-              ],
-              monthlyCounts: [{ yearMonth: "2026-07", count: 7 }],
-              monthlyRevenue: [{ yearMonth: "2026-07", currency: "EUR", sellAmountCents: 250_000 }],
-              upcomingDepartures: { count: 1, items: [] },
-            }
-          },
-        },
-        inventory: {
-          async getProductAggregates(query: unknown) {
-            calls.push({ service: "inventory", query })
-            return {
-              total: 9,
-              countsByStatus: [
-                { status: "draft", count: 2 },
-                { status: "active", count: 7 },
-                { status: "archived", count: 0 },
-              ],
-              active: 7,
-              publicActive: 6,
-              monthlyCreatedCounts: [{ yearMonth: "2026-07", count: 2 }],
-            }
-          },
-        },
-        distribution: {
-          async getSupplierAggregates(query: unknown) {
-            calls.push({ service: "distribution", query })
-            return {
-              total: 5,
-              countsByStatus: [{ status: "active", count: 4 }],
-              countsByType: [{ type: "hotel", count: 3 }],
-              active: 4,
-            }
-          },
-        },
-        finance: {
-          async getFinanceAggregates(query: unknown) {
-            calls.push({ service: "finance", query })
-            return {
-              total: 3,
-              countsByStatus: [{ status: "issued", count: 2 }],
-              counts: {
-                invoices: { issued: 2, paid: 1, void: 0, overdue: 1 },
-                proformas: { issued: 0, converted: 0, void: 0 },
-                paymentSessions: { pending: 0, paid: 1, failed: 0 },
-              },
-              totals: [
-                {
-                  currency: "EUR",
-                  invoiced: 210_000,
-                  collected: 150_000,
-                  outstanding: 60_000,
-                  refunded: 0,
-                },
-              ],
-              monthlyRevenue: [
-                { yearMonth: "2026-06", currency: "EUR", totalCents: 90_000 },
-                { yearMonth: "2026-07", currency: "EUR", totalCents: 120_000 },
-              ],
-              monthlyInvoiceCounts: [{ yearMonth: "2026-07", count: 2 }],
-              outstanding: [{ currency: "EUR", balanceDueCents: 60_000, count: 1 }],
-              overdue: [{ currency: "EUR", balanceDueCents: 20_000, count: 1 }],
-              outstandingTopN: [],
-            }
-          },
-        },
-      },
-    )
+    }>("get_operator_dashboard_summary", { range: "this-month" }, dashboardContext)
 
     expect(calls.map(({ service }) => service).sort()).toEqual([
       "bookings",

--- a/packages/operations/tests/unit/acceptance-routes.test.ts
+++ b/packages/operations/tests/unit/acceptance-routes.test.ts
@@ -8,6 +8,7 @@ import {
   configureDepartureProfitabilityReader,
   resetDepartureProfitabilityReader,
 } from "../../src/availability/departure-profitability-runtime.js"
+import type { Env } from "../../src/availability/routes-shared.js"
 import { operationsAdminRoutes } from "../../src/routes.js"
 
 /**
@@ -42,7 +43,7 @@ function scriptedDb(counts: { readiness: number; drift: number; unassigned: numb
 }
 
 function mount(db: PostgresJsDatabase) {
-  const app = new Hono()
+  const app = new Hono<Env>()
   app.use("*", async (c, next) => {
     c.set("db", db)
     return next()

--- a/packages/operations/tests/unit/mcp-runtime-departure.test.ts
+++ b/packages/operations/tests/unit/mcp-runtime-departure.test.ts
@@ -10,7 +10,30 @@ vi.mock("@voyant-travel/action-ledger/created-command", () => ({
 import { availabilityService } from "../../src/availability/service.js"
 import { AvailabilitySlotRevisionConflictError } from "../../src/availability/service-core.js"
 import { voyantToolContextContribution } from "../../src/mcp-runtime.js"
-import { CREATE_DEPARTURE_HANDLER_POLICY } from "../../src/tools.js"
+import { CREATE_DEPARTURE_HANDLER_POLICY, type OperationsToolServices } from "../../src/tools.js"
+
+/**
+ * `ToolContextContribution.contribute` is declared as `Record<string, unknown>`
+ * so the tools package needs no dependency on its contributors. That erases the
+ * shape every contributor actually returns, so the Operations runtime has to be
+ * named here before the tests can exercise it.
+ */
+async function contributeOperations(
+  vars: Record<string, unknown>,
+  resources: Record<string, unknown> = {},
+): Promise<OperationsToolServices> {
+  const contribution = (await voyantToolContextContribution.contribute({
+    request: {
+      var: vars,
+      get: (key: string) => vars[key],
+      req: { header: () => null },
+    } as never,
+    context: { db: {} } as never,
+    resources,
+  })) as { operations?: OperationsToolServices }
+  if (!contribution.operations) throw new Error("missing Operations runtime")
+  return contribution.operations
+}
 
 afterEach(() => {
   vi.restoreAllMocks()
@@ -44,24 +67,13 @@ describe("departure created-target runtime", () => {
       }
     })
     const emit = vi.fn().mockResolvedValue(undefined)
-    const contribution = await voyantToolContextContribution.contribute({
-      request: {
-        var: {
-          actor: "staff",
-          callerType: "agent",
-          agentId: "agent_1",
-          organizationId: "org_1",
-          eventBus: { emit },
-        },
-        get(key: string) {
-          return this.var[key as keyof typeof this.var]
-        },
-        req: { header: () => null },
-      } as never,
-      context: { db: {} } as never,
-      resources: {},
+    const operations = await contributeOperations({
+      actor: "staff",
+      callerType: "agent",
+      agentId: "agent_1",
+      organizationId: "org_1",
+      eventBus: { emit },
     })
-    if (!contribution.operations) throw new Error("missing Operations runtime")
     const input = {
       productId: "prod_1",
       dateLocal: "2026-10-12",
@@ -69,6 +81,8 @@ describe("departure created-target runtime", () => {
       timezone: "Europe/Bucharest",
       status: "open" as const,
       unlimited: false,
+      pastCutoff: false,
+      tooEarly: false,
       idempotencyKey: "bucharest-2026-10-12-v1",
     }
     const admitted = {
@@ -76,11 +90,11 @@ describe("departure created-target runtime", () => {
       invocation: { idempotencyKey: input.idempotencyKey },
     } as unknown as ToolHandlerActionPolicyContext
 
-    await expect(contribution.operations.createDeparture(input, admitted)).resolves.toMatchObject({
+    await expect(operations.createDeparture(input, admitted)).resolves.toMatchObject({
       replayed: false,
       departure: { id: "avsl_1" },
     })
-    await expect(contribution.operations.createDeparture(input, admitted)).resolves.toMatchObject({
+    await expect(operations.createDeparture(input, admitted)).resolves.toMatchObject({
       replayed: true,
       departure: { id: "avsl_1" },
     })
@@ -108,26 +122,15 @@ describe("departure created-target runtime", () => {
     vi.spyOn(availabilityService, "updateSlot").mockRejectedValue(
       new AvailabilitySlotRevisionConflictError("2026-07-28T12:00:00.000Z", current as never),
     )
-    const contribution = await voyantToolContextContribution.contribute({
-      request: {
-        var: {
-          actor: "staff",
-          callerType: "agent",
-          agentId: "agent_1",
-          organizationId: "org_1",
-        },
-        get(key: string) {
-          return this.var[key as keyof typeof this.var]
-        },
-        req: { header: () => null },
-      } as never,
-      context: { db: {} } as never,
-      resources: {},
+    const operations = await contributeOperations({
+      actor: "staff",
+      callerType: "agent",
+      agentId: "agent_1",
+      organizationId: "org_1",
     })
-    if (!contribution.operations) throw new Error("missing Operations runtime")
 
     await expect(
-      contribution.operations.updateDeparture("avsl_1", {
+      operations.updateDeparture("avsl_1", {
         updatedAt: "2026-07-28T12:00:00.000Z",
         notes: "Stale edit",
       }),
@@ -156,26 +159,18 @@ describe("departure created-target runtime", () => {
       unchanged: 3,
       invalidated: 0,
     })
-    const contribution = await voyantToolContextContribution.contribute({
-      request: {
-        var: { actor: "staff" },
-        get(key: string) {
-          return this.var[key as keyof typeof this.var]
-        },
-        req: { header: () => null },
-      } as never,
-      context: { db: {} } as never,
-      resources: {
+    const operations = await contributeOperations(
+      { actor: "staff" },
+      {
         "bookings.booking-action-projection.runtime": {
           create: vi.fn(),
           synchronize,
         },
         "bookings.booking-action-source.runtime": [sourceA, sourceB],
       },
-    })
-    if (!contribution.operations) throw new Error("missing Operations runtime")
+    )
 
-    await expect(contribution.operations.rebuildBookingActions()).resolves.toMatchObject({
+    await expect(operations.rebuildBookingActions()).resolves.toMatchObject({
       mode: "rebuild",
       providers: 2,
     })

--- a/packages/operations/tsconfig.build.json
+++ b/packages/operations/tsconfig.build.json
@@ -1,3 +1,15 @@
 {
-  "extends": ["./tsconfig.json", "../typescript-config/dep-paths.json"]
+  "extends": [
+    "@voyant-travel/voyant-typescript-config/base.json",
+    "../typescript-config/dep-paths.json"
+  ],
+  "compilerOptions": {
+    "composite": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"]
 }

--- a/packages/operations/tsconfig.json
+++ b/packages/operations/tsconfig.json
@@ -2,11 +2,9 @@
   "extends": "@voyant-travel/voyant-typescript-config/base.json",
   "compilerOptions": {
     "composite": false,
-    "outDir": "dist",
-    "rootDir": "src",
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "types": ["node"]
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "tests/**/*"]
 }


### PR DESCRIPTION
## The headline: this package had no typecheck job in CI

`scripts/run-ci-typechecks.mjs` selects via `classifyTypecheck`, which **skips any package whose typecheck project covers the same files as its build**. `packages/operations` classified `{required: false, reason: "build-covers-typecheck"}` — so `pnpm -F @voyant-travel/operations typecheck` was **never run in CI**, for tests *or* src.

Confirmed by differential:

```
# on origin/main          # on this branch
@voyant-travel/operations-react       @voyant-travel/operations
                                      @voyant-travel/operations-react
```

It now classifies `typecheck-covers-additional-files` with 65 files. (`operations-react` was always checked because its tests are co-located under `src/`.)

## The tsconfig split, and why the obvious edit doesn't work

Not a widened `tsconfig.typecheck.json` — that produces **24 `TS6059` errors**, because `rootDir: "src"` is inherited and 23 operations tests import sibling packages by relative path (`../../../../inventory/src/schema.js`). Those reach-ins work around a **cycle** — `@voyant-travel/inventory` depends on `@voyant-travel/operations` — so declaring the dependency isn't available.

Instead, follow the split `bookings-react` and `charters-react` already use:

- **`tsconfig.json`** — shared/editor project. Drops `outDir`/`rootDir` (emit geometry, not a checking concern), includes `["src/**/*", "tests/**/*"]`.
- **`tsconfig.build.json`** — stands alone, re-declares `outDir`/`rootDir`/`include: ["src/**/*"]`. **Tests never reach `dist`.**
- **`tsconfig.typecheck.json`** — unchanged; inherits the wider include, adds `noEmit`.

Bonus: the typecheck `.tsbuildinfo` stops being written into `dist/`.

## 47 type errors — and 59 tests that were actually broken

Verified by running the 12 touched files against a real Postgres on **baseline vs patched**. Baseline: 5 files fail, **59 tests red**. Patched: 12 files, 169 tests, all green.

**Real bugs, not fixtures:**
- Four `tests/ground/integration/*` `seedBooking` helpers omitted `bookings.status`, which is `NOT NULL` and **lost its database default** in `20260802200000_booking_v1_status_cutover.sql`. `overrides: Record<string, unknown>` hid it from the compiler → `57 × PostgresError: null value in column "status"`.
- `slot-option-validation.test.ts` imported `createRule`/`updateRule` from `service-core.js`; they live in `service-rules.js`. Vite's SSR transform yields `undefined` rather than throwing, so the file collected fine and died only with a database → `2 × TypeError: createRule is not a function`.

**None of those files are on CI's integration allow-list**, which is exactly why 59 failing tests sat undetected.

**Stale fixtures** (the #4036 pattern): a manifest that gained `pagination`, slots that gained `productVersionId` (#4032), and service inputs that are `z.infer` — the schema's **output** — so a direct caller must pass the fields `.default()` would have filled.

**Fixtures typed too loosely to check anything:** `let db: any` with a `biome-ignore` (typing it exposed 10 `TS7006`s and a bogus `RowList → Array<{…}>` cast), a `bookingMode` inferred as `string` rather than the enum, a bare `new Hono()` making `c.set("db", …)` `never`, and a `contribute()` return narrowing to `{}`.

**No `as any`, no `@ts-expect-error`, no production type loosened to make a test compile.**

## Heap flag (#4223) — measured, not guessed

Cold `tsc --diagnostics` across **all 110 packages** after a full build. Node's default ceiling here is **4288 MB**:

| package | peak heap | flag today |
|---|---|---|
| **operations** | **4.96 GB** | added here |
| inventory | 3.65 GB | none |
| commerce | 3.56 GB | none |
| distribution | 3.02 GB | none |
| finance | 2.82 GB | has one |

`operations` is the **only** package over the ceiling. It needs the flag for `build` too — src-only compile is **5.35 GB**, since declaration emit costs more than checking — so it was over the limit before this change as well.

**On sharing the flag: recommended, not done here.** CI already sets `--max-old-space-size=12288` at the workflow level, so this is a *local-only* failure; the per-package copies exist so `pnpm -F <pkg> build` works on a laptop. The right shape is one repo-level default (`node-options` in the root `.npmrc`), which is a repo-wide behavioural change and belongs in its own PR.

## The same gap exists in 47 more packages

All classified `build-covers-typecheck` — **no typecheck job in CI**, 784 test files between them. Worst first: `finance` (85), `bookings` (81), `inventory` (81), `hono` (37), `distribution` (36), `cruises` (34), `legal` (32), `storefront` (31), `admin` (30)… Not fixed here; one PR each.

## Verification

```
pnpm -F @voyant-travel/operations typecheck   exit 0, no error TS, no exit 134
pnpm -F @voyant-travel/operations test        334 passed | 430 skipped (63 files)
pnpm exec biome check . --max-diagnostics=60  21 warnings, 8 infos, 0 errors
table-privacy-runner                          225 reach-ins, none new
verify:openapi                                up to date
pnpm verify:architecture                      exit 0
pnpm build                                    113/113
```

## Reviewer notes

- **Biome is 21 warnings on current main, not 20.** All 29 diagnostics enumerated; none is in a file this diff touches.
- **Pre-existing, untouched:** `tests/places/integration/*` and `tests/resources/integration/*` fail against a real DB with `expected 404 to be 201` (21 assertions). They typecheck clean, no shared fixture changed, and they run in no CI lane. Worth its own issue.
- **`docker-compose.test.yml`'s `tmpfs` mount has no `size:`**, so it defaults to 64 MB and Postgres dies with `No space left on device` partway through the suite. Had to run disk-backed. Real papercut for local runs.
- `packages/operations` is `private: true` — no changeset.

Closes #4222
Closes #4223