### PR TITLE
Retire a dead Redis fallback, and document two that must stay

### DIFF
--- a/.changeset/brave-pandas-shave.md
+++ b/.changeset/brave-pandas-shave.md
@@ -1,0 +1,15 @@
+---
+"@voyant-travel/db": patch
+---
+
+Backfill unassigned member permission sets with the full access they already
+resolve to.
+
+`user_profiles.permissions` is nullable, and null means "no admin has assigned a
+scope set yet"; the staff-access resolver reads that as `["*"]`. The migration
+writes that same value down explicitly, so nothing changes behaviour today. It
+is groundwork: a fail-closed resolver cannot ship until the existing nulls are
+gone, and the backfill has to be deployed and verified first.
+
+It is not sufficient on its own — the signup path still inserts a profile
+without permissions, so a fresh deployment's first owner is created null again.

--- a/.changeset/tidy-moons-repeat.md
+++ b/.changeset/tidy-moons-repeat.md
@@ -1,0 +1,15 @@
+---
+"@voyant-travel/framework": minor
+---
+
+Require an explicit Redis binding on the Node runtime deployment.
+
+`VoyantNodeRuntimeDeployment.redis` is now required, and the runtime no longer
+infers Redis isolation and network from the deprecated `deployment.mode`. A host
+that composes a deployment knows which Redis it bound and must say so; a caller
+that cannot state the binding is a caller whose Redis safety posture nobody has
+decided.
+
+The generated Node runtime entry now resolves the binding its recorded mode has
+always implied, so generated artifacts keep their exact posture. No deployment
+changes behaviour.

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -114,8 +114,15 @@ export interface DisableSignupWhenUsersExistOptions {
    * with only other explicit surfaces can still be created by customer-facing
    * auth plugins such as phone OTP.
    *
-   * Defaults to ["admin"]. Users without an explicit surfaces array are
-   * treated as admin users for backward compatibility.
+   * Defaults to ["admin"]. A create payload without an explicit surfaces array
+   * is treated as an admin signup, which is the fail-closed reading and not a
+   * compatibility shim: `surfaces` is a transient property of the create
+   * payload, never a column on the user table, and it is only ever set by
+   * `customerSignupSurfaces` stamping on a customer-facing signup endpoint.
+   * Every admin signup path — email/password, email OTP, social — therefore
+   * arrives here with no surfaces, so this default is what makes the guard
+   * engage at all. Defaulting the other way would open self-registration on
+   * every deployment.
    */
   surfaces?: readonly string[]
 }
@@ -178,6 +185,9 @@ function signupBlockAppliesToUser(
     return blockedSurfaces.includes(surfaces.trim())
   }
 
+  // No declared surface reads as an admin signup. This is the guard's main
+  // path, not a fallback: nothing persists `surfaces`, so only a customer
+  // signup endpoint with `customerSignupSurfaces` configured ever declares one.
   return blockedSurfaces.includes("admin")
 }
 

--- a/packages/auth/tests/unit/staff-access.test.ts
+++ b/packages/auth/tests/unit/staff-access.test.ts
@@ -102,4 +102,37 @@ describe("resolveStaffAccess", () => {
       }),
     ).resolves.toEqual({ organizationId: null, scopes: ["catalog:read"] })
   })
+
+  // The two states below are the reason local member permissions cannot be made
+  // fail-closed in one release: real deployments hold rows in both, and both
+  // currently read as full access. Pin them so that a change to the fallback has
+  // to be a deliberate edit to these expectations rather than a silent lockout.
+  it.each([
+    { label: "an unassigned permission set", rows: [{ permissions: null }] },
+    { label: "no profile row at all", rows: [] },
+  ])("resolves local staff with $label to full access", async ({ rows }) => {
+    const database = databaseReturning(rows)
+
+    await expect(
+      resolveStaffAccess({
+        accessCatalog: ACCESS_CATALOG,
+        authMode: "local",
+        db: database.db as never,
+        userId: "user_staff_1",
+      }),
+    ).resolves.toEqual({ organizationId: null, scopes: ["*"] })
+  })
+
+  it("preserves an explicitly empty local scope set instead of reading it as full access", async () => {
+    const database = databaseReturning([{ permissions: [] }])
+
+    await expect(
+      resolveStaffAccess({
+        accessCatalog: ACCESS_CATALOG,
+        authMode: "local",
+        db: database.db as never,
+        userId: "user_staff_1",
+      }),
+    ).resolves.toEqual({ organizationId: null, scopes: [] })
+  })
 })

--- a/packages/db/migrations/20260805000000_backfill_unassigned_member_permissions.sql
+++ b/packages/db/migrations/20260805000000_backfill_unassigned_member_permissions.sql
@@ -1,0 +1,44 @@
+-- Give every unassigned member the permission set it already resolves to.
+--
+-- `user_profiles.permissions` is nullable, and `null` means "no admin has
+-- assigned a scope set yet". `resolveStaffAccess` reads that as full access
+-- (`["*"]`) so that deployments provisioned before member RBAC keep working.
+-- This backfill writes that same `["*"]` down explicitly.
+--
+-- IT CHANGES NO BEHAVIOUR. Every row it touches resolved to `["*"]` before and
+-- resolves to `["*"]` after; it only moves the value from the resolver's
+-- fallback into the column. It exists so that a LATER release can make the
+-- resolver fail closed (and the column NOT NULL) without locking existing
+-- members out of their own deployment.
+--
+-- THIS ALONE DOES NOT MAKE THE COLUMN SAFE TO REQUIRE. Two gaps remain, and
+-- both must be closed before any fail-closed change:
+--
+--   1. Nothing on the write side sets `permissions` at signup.
+--      `provisionCurrentUserProfile` inserts a profile without it, so the
+--      bootstrap owner of every new deployment is created null again the
+--      moment this migration has run.
+--   2. `resolveStaffAccess` also falls back when there is no `user_profiles`
+--      row at all (`profile?.permissions ?? …`), which no `UPDATE` can reach.
+--
+-- Deliberately `["*"]` and not the catalog-expanded admin preset: local mode
+-- has never expanded the wildcard, and resources marked `explicit-resource`
+-- (team, bookings PII, apps) are NOT satisfied by a bare `*`. Expanding here
+-- would be a privilege increase, not a migration.
+--
+-- Guarded on the column's existence and shape, and on `IS NULL`, so a re-run
+-- and a database that never had the column are both no-ops.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = 'public'
+       AND table_name = 'user_profiles'
+       AND column_name = 'permissions'
+       AND data_type = 'jsonb'
+  ) THEN
+    UPDATE "user_profiles"
+       SET "permissions" = '["*"]'::jsonb
+     WHERE "permissions" IS NULL;
+  END IF;
+END $$;

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1785801960000,
       "tag": "20260804000600_proposal_permission_resource",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1785888000000,
+      "tag": "20260805000000_backfill_unassigned_member_permissions",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/framework/src/deployment-artifacts.test.ts
+++ b/packages/framework/src/deployment-artifacts.test.ts
@@ -506,6 +506,10 @@ describe("deployment graph artifacts", () => {
     expect(source).toContain("startVoyantNodeRuntime")
     expect(source).not.toContain("profileSnapshotPath:")
     expect(source).toContain("const deployment = resolveGeneratedRuntimeDeployment()")
+    // The runtime takes an explicit Redis binding and infers nothing from mode,
+    // so the generated deployment has to state one.
+    expect(source).toContain('{ isolation: "shared", network: "untrusted" }')
+    expect(source).toContain('{ isolation: "dedicated", network: "trusted" }')
     expect(source).toContain("deployment,")
     expect(source).toContain("deploymentRequirements: resolveGeneratedDeploymentRequirements()")
     expect(source).toContain('from "./graph-runtime.generated.js"')

--- a/packages/framework/src/deployment-artifacts.ts
+++ b/packages/framework/src/deployment-artifacts.ts
@@ -864,6 +864,13 @@ export function resolveGeneratedRuntimeDeployment(): VoyantNodeRuntimeDeployment
   return {
     mode: candidate.mode,
     providers,
+    // The graph artifact records \`mode\`, not the concrete Redis binding. The
+    // runtime takes an explicit binding and does not infer one, so the artifact
+    // states the posture its mode has always implied.
+    redis:
+      candidate.mode === "managed-cloud"
+        ? { isolation: "shared", network: "untrusted" }
+        : { isolation: "dedicated", network: "trusted" },
     ...(candidate.responseCache === undefined
       ? {}
       : { responseCache: generatedResponseCachePosture(candidate.responseCache) }),

--- a/packages/framework/src/node-runtime.test.ts
+++ b/packages/framework/src/node-runtime.test.ts
@@ -169,6 +169,11 @@ const BASE_PROVIDERS = {
   payments: "none",
 } satisfies VoyantDeploymentProviders
 
+/** The binding a managed-cloud deployment has always bound: one Redis, many tenants. */
+const SHARED_UNTRUSTED_REDIS = { isolation: "shared", network: "untrusted" } as const
+/** The binding a self-hosted deployment has always bound: its own Redis, private network. */
+const DEDICATED_TRUSTED_REDIS = { isolation: "dedicated", network: "trusted" } as const
+
 afterEach(() => {
   redisOperations.length = 0
   tcpRedisConnections.length = 0
@@ -430,7 +435,11 @@ describe("loadVoyantNodeRuntime Redis URL validation", () => {
           wakeup: true,
         },
       ],
-      deployment: { mode: "self-hosted", providers: BASE_PROVIDERS },
+      deployment: {
+        mode: "self-hosted",
+        providers: BASE_PROVIDERS,
+        redis: DEDICATED_TRUSTED_REDIS,
+      },
       deploymentRequirements: { resources: [] },
       runtimePorts: {
         [outboxRuntimePort.id]: {
@@ -464,7 +473,7 @@ describe("loadVoyantNodeRuntime Redis URL validation", () => {
     const runtime = await loadVoyantNodeRuntime({
       graphRuntime: emptyGraphRuntime(providers),
       jobs: [],
-      deployment: { mode: "self-hosted", providers },
+      deployment: { mode: "self-hosted", providers, redis: DEDICATED_TRUSTED_REDIS },
       deploymentRequirements: { resources: [] },
       env: { ORIGIN_TRUST_SECRET: "secret" },
     })
@@ -489,7 +498,7 @@ describe("loadVoyantNodeRuntime Redis URL validation", () => {
       loadVoyantNodeRuntime({
         graphRuntime: emptyGraphRuntime(providers),
         jobs: [],
-        deployment: { mode: "managed-cloud", providers },
+        deployment: { mode: "managed-cloud", providers, redis: SHARED_UNTRUSTED_REDIS },
         deploymentRequirements: { resources: [] },
         env: {
           REDIS_URL: "https://example.upstash.io?token=test-token",
@@ -509,7 +518,7 @@ describe("loadVoyantNodeRuntime Redis URL validation", () => {
       loadVoyantNodeRuntime({
         graphRuntime: emptyGraphRuntime(providers),
         jobs: [],
-        deployment: { mode: "managed-cloud", providers },
+        deployment: { mode: "managed-cloud", providers, redis: SHARED_UNTRUSTED_REDIS },
         deploymentRequirements: { resources: [] },
         env: {
           REDIS_URL: "http://example.upstash.io?token=test-token",
@@ -536,7 +545,7 @@ describe("loadVoyantNodeRuntime Redis URL validation", () => {
       loadVoyantNodeRuntime({
         graphRuntime: emptyGraphRuntime(providers),
         jobs: [],
-        deployment: { mode: "managed-cloud", providers },
+        deployment: { mode: "managed-cloud", providers, redis: SHARED_UNTRUSTED_REDIS },
         deploymentRequirements: { resources: [] },
         env: {
           REDIS_URL: redisUrl,
@@ -550,7 +559,7 @@ describe("loadVoyantNodeRuntime Redis URL validation", () => {
       loadVoyantNodeRuntime({
         graphRuntime: emptyGraphRuntime(providers),
         jobs: [],
-        deployment: { mode: "managed-cloud", providers },
+        deployment: { mode: "managed-cloud", providers, redis: SHARED_UNTRUSTED_REDIS },
         deploymentRequirements: { resources: [] },
         env: {
           REDIS_URL: redisUrl,
@@ -572,7 +581,7 @@ describe("loadVoyantNodeRuntime Redis URL validation", () => {
       loadVoyantNodeRuntime({
         graphRuntime: emptyGraphRuntime(providers),
         jobs: [],
-        deployment: { mode: "managed-cloud", providers },
+        deployment: { mode: "managed-cloud", providers, redis: SHARED_UNTRUSTED_REDIS },
         deploymentRequirements: { resources: [] },
         env: {
           REDIS_URL: "https://example.upstash.io?token=test-token",
@@ -603,7 +612,7 @@ describe("loadVoyantNodeRuntime Redis URL validation", () => {
       loadVoyantNodeRuntime({
         graphRuntime: emptyGraphRuntime(providers),
         jobs: [],
-        deployment: { mode: "managed-cloud", providers },
+        deployment: { mode: "managed-cloud", providers, redis: SHARED_UNTRUSTED_REDIS },
         deploymentRequirements: { resources: [] },
         env: {
           REDIS_URL: redisUrl,
@@ -630,7 +639,7 @@ describe("loadVoyantNodeRuntime Redis URL validation", () => {
       loadVoyantNodeRuntime({
         graphRuntime: emptyGraphRuntime(providers),
         jobs: [],
-        deployment: { mode: "self-hosted", providers },
+        deployment: { mode: "self-hosted", providers, redis: DEDICATED_TRUSTED_REDIS },
         deploymentRequirements: { resources: [] },
         env: { ORIGIN_TRUST_SECRET: "secret" },
       }),
@@ -654,7 +663,7 @@ describe("loadVoyantNodeRuntime Redis URL validation", () => {
       loadVoyantNodeRuntime({
         graphRuntime: emptyGraphRuntime(providers),
         jobs: [],
-        deployment: { mode: "self-hosted", providers },
+        deployment: { mode: "self-hosted", providers, redis: DEDICATED_TRUSTED_REDIS },
         deploymentRequirements: { resources: [] },
         env: {
           REDIS_URL: redisUrl,
@@ -709,7 +718,7 @@ describe("loadVoyantNodeRuntime Redis URL validation", () => {
     ).rejects.toThrow(/a Redis binding on an untrusted network requires rediss:\/\//)
   })
 
-  it("does not infer Redis constraints from mode when the binding declares them", async () => {
+  it("reads Redis constraints from the binding, never from the deployment mode", async () => {
     const providers = {
       ...BASE_PROVIDERS,
       adminAuth: "better-auth",

--- a/packages/framework/src/node-runtime.ts
+++ b/packages/framework/src/node-runtime.ts
@@ -204,8 +204,14 @@ export interface VoyantNodeRuntimeDeployment {
   mode?: VoyantDeploymentMode
   providers: Readonly<Record<string, string>> &
     Partial<Pick<VoyantDeploymentProviders, "scheduledJobs">>
-  /** Explicit properties of the concrete Redis binding selected at boot. */
-  redis?: VoyantRedisBindingConstraints
+  /**
+   * Explicit properties of the concrete Redis binding selected at boot.
+   *
+   * Required: the host that composes a deployment knows which Redis it bound,
+   * and the runtime must not guess. A caller that cannot state the binding is
+   * a caller whose Redis safety posture nobody has decided.
+   */
+  redis: VoyantRedisBindingConstraints
   /** How shared public responses reach requesters. Absent reads as no edge tier. */
   responseCache?: VoyantResponseCachePosture
 }
@@ -376,7 +382,7 @@ export async function loadVoyantNodeRuntime(
   assertVoyantNodeRuntimeSupport({
     providers: options.deployment.providers,
     providerPlan,
-    redis: resolveRedisBindingConstraints(options.deployment),
+    redis: options.deployment.redis,
     requirements,
     env,
     hasAuthIntegration: Boolean(auth),
@@ -798,18 +804,6 @@ function reportVoyantNodeDeploymentPosture(input: VoyantNodeDeploymentPostureInp
   for (const report of voyantNodeDeploymentPostureReports(input)) {
     console.warn(`[node-runtime] ${report}`)
   }
-}
-
-function resolveRedisBindingConstraints(
-  deployment: VoyantNodeRuntimeDeployment,
-): VoyantRedisBindingConstraints {
-  if (deployment.redis) return deployment.redis
-  // Generated runtimes before the runtime-binding contract carried only mode.
-  // Preserve their exact safety posture while keeping all new policy on the
-  // binding itself.
-  return deployment.mode === "managed-cloud"
-    ? { isolation: "shared", network: "untrusted" }
-    : { isolation: "dedicated", network: "trusted" }
 }
 
 function nodeRuntimeEnvIssues(

--- a/packages/framework/src/runtime-host-options.test.ts
+++ b/packages/framework/src/runtime-host-options.test.ts
@@ -194,7 +194,11 @@ describe("deployment host options", () => {
     await loadVoyantNodeRuntime({
       graphRuntime: runtimeWithUnits({ "@acme/bookings": factory }),
       jobs: [],
-      deployment: { mode: "self-hosted", providers: NODE_PROVIDERS },
+      deployment: {
+        mode: "self-hosted",
+        providers: NODE_PROVIDERS,
+        redis: { isolation: "dedicated", network: "trusted" },
+      },
       deploymentRequirements: { resources: [] },
       hostOptions: { "@acme/bookings": { resolveMonthlyBookingLimit: () => 25 } },
     })


### PR DESCRIPTION
Three legacy fallbacks reviewed. **One was dead and is removed. Two are load-bearing — and the comments describing them were wrong in ways that invited deletion.**

## 1. `framework` Redis fallback — dead, removed

`resolveRedisBindingConstraints` fell back to `deployment.mode` when `deployment.redis` was absent, for runtimes generated before the binding contract.

**Proof it was dead.** One caller. Only two things construct a `VoyantNodeRuntimeDeployment`:
- `packages/runtime/src/index.ts:405` — the real boot path, passing `redis` from `resolveRuntimeDeploymentBindings`, whose return type declares it **non-optional**.
- The generated Node entry from `buildNodeRuntimeEntry`, which emitted no `redis` — but that is **not a product boot path**. Its only caller is `scripts/check-deployment-graph.ts`, which string-asserts the emitted text, and the operator's `runtime-entry.generated.ts` is in `RETIRED_OPERATOR_GENERATED_FILES` with a checker asserting it stays deleted. The live app boots from `project-runtime.generated.ts`.

`redis` is now **required**; the fallback is gone; the generated entry states the binding its recorded `mode` always implied, so its posture is unchanged.

⚠️ **The identical mapping is still live one layer up** — `deployment-bindings.ts::legacyRedisConstraints(generated.mode)`. Generated project runtimes carry no `redis`, so with `VOYANT_DEPLOYMENT_BINDINGS_JSON` unset the posture is still derived from `mode`. Removing that needs a graph-artifact change. The `@deprecated` note is now true of `VoyantNodeRuntimeDeployment.mode`; it is **not** yet true of the generated-bindings `mode`.

## 2. `auth` `surfaces` — the comment was backwards. **This is fail-CLOSED.**

The comment said users without `surfaces` are treated as admin *"for backward compatibility"*, which reads as a compat shim to delete.

It is the opposite:

- `surfaces` is **not a column** on the admin `user` table.
- No production code declares it as a better-auth `additionalField`.
- **No production caller passes `customerSignupSurfaces`** — only `server.ts` and tests reference it; the single admin builder passes neither.

So `user?.surfaces` is **always undefined in production**, control always reaches `return blockedSurfaces.includes("admin")`, and that returning `true` is **the only reason the single-tenant "Sign-up is disabled" guard ever fires** — for email/password, email OTP and social sign-up alike.

**Defaulting the other way would open self-registration on every live deployment.** The phone-OTP plugin the comment names is not registered anywhere in this repo.

Not removed. Comments corrected to say this is the guard's main path and the fail-closed reading — specifically so the next reader does not delete it.

## 3. `db` `permissions: null` ⇒ full access — behaviour not flipped; inert backfill added

New migration sets `permissions = '["*"]'` where null, guarded on the column existing and being `jsonb`. **Every row it touches resolved to `["*"]` before and after — inert until the resolver changes.**

Deliberately the bare wildcard, not the catalog-expanded admin preset: local mode has never expanded `*`, and `explicit-resource` resources (`team`, bookings PII, `apps`) are **not** satisfied by it. Expanding would be a privilege increase wearing a migration's clothes.

**The safe sequence is three steps, not two.** Two findings make a plain backfill insufficient:

1. `provisionCurrentUserProfile` never sets `permissions`, so **null regenerates** for every bootstrap owner and cloud-mirrored user after the backfill runs. Null is not a legacy population.
2. `staff-access.ts:89` is `profile?.permissions ?? FULL_ACCESS_SCOPES`, so **two** states collapse to full access: null, *and* no `user_profiles` row at all. **No `UPDATE` can reach the second.**

| step | |
|---|---|
| **R1** | this backfill + make the provision path write an explicit set + decide what a missing profile row means. All behaviour-preserving. |
| **verify** | `SELECT count(*) FROM user_profiles WHERE permissions IS NULL` = 0 on each production database, and still 0 after a new signup |
| **R2** | only then: `NOT NULL` and drop the `??`. `VOYANT_RBAC_ENFORCE=off` is the rollback lever. |

**The fallback had zero test coverage.** Deleting `?? FULL_ACCESS_SCOPES` would have passed the entire suite while locking every existing member out. Tests now pin null → `["*"]`, no-row → `["*"]`, explicit `[]` → `[]`.

## Verification

```
framework            400 passed (40 files)
runtime              104 passed (12 files)
auth                 266 passed | 19 skipped (33 files)
db                   129 passed | 93 skipped (22 files)
framework-migrations 152 passed | 24 skipped (12 files)

biome check .        21 warnings, 8 infos, 0 errors — measured on origin/main
                     in a throwaway worktree and on the branch; identical
table-privacy        225 reach-ins, none new
typecheck            framework / runtime / auth / db — 0 errors each
verify:architecture  exit 0
```

**The migration was executed against real Postgres 17**, not reviewed: nulls → `["*"]`, explicit `[]` (deny-all) preserved, explicit lists preserved, second run a no-op, and a no-op where the column is absent. Then the DB-backed check `verify:architecture` skips without a database:

```
verify-migration-replay-parity: OK — every upgrade path == package-owned replay
```

`cutline.generated.json` untouched; the migration is a post-cutline increment that executes on every database, per the D.2 rules. Both changesets are on `private: true` packages, so they record the interface change without triggering a publish.