### PR TITLE
fix(framework-migrations): accept both generations of the Booking v1 status cutover

### DIFF
--- a/.changeset/olive-eels-clap.md
+++ b/.changeset/olive-eels-clap.md
@@ -1,0 +1,26 @@
+---
+"@voyant-travel/framework-migrations": patch
+---
+
+Record the two generations of the Booking v1 status cutover as equivalent, so
+already-current deployments can take operator 0.3.0.
+
+The payment-effect guard in
+`bookings/20260802200000_booking_v1_status_cutover` was narrowed in place, which
+changed the migration's content hash without a companion equivalence entry. Any
+deployment that had applied the original tripped `MigrationImmutabilityError`
+and could go no further — everything ordered after `bookings` in the collector
+plan was unreachable, and because each migration commits in its own transaction
+a failed run left the schema partly advanced.
+
+The equivalence is sound without an adoption increment, unlike the quotes →
+proposals pairs. The guard only raises; it never writes. The narrowed predicate
+is a strict subset of the original, so a database that recorded the original
+matched zero rows against it and matches zero against the subset, and every
+other statement in the file is byte-identical. The class of deployment the edit
+was written for is exactly the class the original aborted on, so it never
+recorded a ledger row to diverge from.
+
+The closure is symmetric, so a rolled-back image shipping the original bytes
+against a ledger written by the corrected one is accepted too. An unrelated hash
+for this migration still fails.

--- a/docs/architecture/migration-collector-d2.md
+++ b/docs/architecture/migration-collector-d2.md
@@ -289,6 +289,38 @@ PostgreSQL 18 as well as 16 — 18 is the only version on which the NOT NULL
 constraint names exist to be compared — and reports which of the two it saw so a
 green run is not read as coverage it does not have.
 
+## Editing an already-applied migration (voyant#4247)
+
+The rename above is the elaborate case. The ordinary one is a bug fix to a
+migration that has already shipped, and it has a rule of its own: **the edit and
+its equivalence entry are one change**. An edit landing without the entry does
+not fail where it is written — it fails later, on exactly the deployments that
+were already current, and everything after the edited migration in collector
+order becomes unreachable.
+
+The payment-effect guard in `bookings/20260802200000_booking_v1_status_cutover`
+shipped that way (#4199 fixed real damage; #4247 is its missing companion). Two
+things generalise from it:
+
+- **Both directions of the split are affected populations.** Once an edit ships,
+  some deployments hold the old hash and some the new. Reverting the file
+  strands the second group exactly as the edit stranded the first, so "restore
+  the original and ship a new increment" still needs the equivalence entry — it
+  is not the cheaper escape it looks like. `equivalenceClosure` is symmetric for
+  this reason.
+- **Not every equivalence needs a companion increment.** The rename ones do,
+  because equivalence marks a migration applied and something must still perform
+  the rename. A guard that only ever *raises* leaves nothing unfinished, and
+  narrowing its predicate is sound on its own: a database that recorded the
+  original had zero rows matching it, so it has zero matching the subset. State
+  the containment argument in the comment beside the hashes — that argument, not
+  the size of the diff, is what makes an entry legitimate.
+
+A partial run is the reason this is worth stating loudly. Each migration commits
+in its own transaction, so a run that fails at the gate leaves the schema
+advanced up to that point and the retry starts from a different schema than the
+attempt before it.
+
 ## References
 
 - `docs/architecture/migration-collector-d1.md` — the collector primitive + ledger D.2 reuses; the `assertSchemaAtBaseline` parity pattern.

--- a/packages/framework-migrations/src/collector.test.ts
+++ b/packages/framework-migrations/src/collector.test.ts
@@ -220,6 +220,129 @@ describe("migration hash compatibility", () => {
     ).rejects.toBeInstanceOf(MigrationImmutabilityError)
   })
 
+  // The v1 status cutover's payment-effect guard was narrowed in place (#4199),
+  // stranding every deployment that had already applied the original. The
+  // original bytes are reconstructed from the shipped file by undoing that edit,
+  // so the pinned hashes below fail loudly if either generation drifts again.
+  const currentBookingCutover = readFileSync(
+    new URL(
+      "../../bookings/migrations/20260802200000_booking_v1_status_cutover.sql",
+      import.meta.url,
+    ),
+    "utf8",
+  )
+  const narrowedGuard = `          -- A recorded authorization, capture, or payment is money that moved.
+          -- Only these are effects an operator can actually reconcile.
+          payment_session."payment_authorization_id" IS NOT NULL
+          OR payment_session."payment_capture_id" IS NOT NULL
+          OR payment_session."payment_id" IS NOT NULL
+          -- A checkout still inside its provider window may yet settle, so the
+          -- migration must not delete the Booking underneath it. Past that
+          -- window an unsettled session is an abandoned attempt by definition,
+          -- which is exactly how the classifier already labelled the Booking.
+          OR (
+            payment_session."status" IN ('requires_redirect', 'processing')
+            AND coalesce(
+              payment_session."expires_at",
+              payment_session."updated_at" + interval '24 hours'
+            ) > now()
+          )
+`
+  const originalGuard = `          payment_session."status" IN ('requires_redirect', 'processing')
+          OR payment_session."provider_session_id" IS NOT NULL
+          OR payment_session."provider_payment_id" IS NOT NULL
+          OR payment_session."payment_authorization_id" IS NOT NULL
+          OR payment_session."payment_capture_id" IS NOT NULL
+          OR payment_session."payment_id" IS NOT NULL
+`
+  const narrowedCleanupNote = `-- Settled payment evidence was preserved as a commitment, and unreconciled
+-- payment effects were rejected above. A session that only carries provider
+-- identifiers is deliberately left in place: it is the sole record that this
+-- deployment opened a checkout with the provider, so it keeps its \`booking_id\`
+-- and survives the Booking it names rather than being erased or blanked.
+`
+  const originalCleanupNote = `-- External or settled payment evidence was preserved or rejected above.
+`
+  const originalBookingCutover = currentBookingCutover
+    .replace(narrowedGuard, originalGuard)
+    .replace(narrowedCleanupNote, originalCleanupNote)
+
+  const bookingCutoverHashes = {
+    original: "f1d9f275271c117792ddb0a9f13a41b48f65b4fc60a4a752d06f42bd132437da",
+    narrowed: "1651c727ee4d02c269c4f104695a3c871999ab49cbefc9b7af3ec676a3211be4",
+  } as const
+
+  it("reconstructs the pre-#4199 cutover bytes from the shipped migration", () => {
+    expect(currentBookingCutover).toContain(narrowedGuard)
+    expect(currentBookingCutover).toContain(narrowedCleanupNote)
+    expect(originalBookingCutover).not.toBe(currentBookingCutover)
+  })
+
+  it.each([
+    {
+      direction: "original ledger to narrowed migration",
+      sql: currentBookingCutover,
+      expectedCurrentHash: bookingCutoverHashes.narrowed,
+      ledgerHash: bookingCutoverHashes.original,
+    },
+    {
+      direction: "narrowed ledger to original migration",
+      sql: originalBookingCutover,
+      expectedCurrentHash: bookingCutoverHashes.original,
+      ledgerHash: bookingCutoverHashes.narrowed,
+    },
+  ])("accepts the booking v1 status cutover guard narrowing from $direction", async (testCase) => {
+    const queries: string[] = []
+    const client: MigrationClient = {
+      async query(sql: string) {
+        queries.push(sql)
+        if (sql.includes(`SELECT "content_hash"`)) {
+          return { rows: [{ content_hash: testCase.ledgerHash, source: "bookings" }] }
+        }
+        return { rows: [] }
+      },
+    }
+    const source: MigrationSource = {
+      name: "bookings",
+      priority: 0,
+      migrations: [{ tag: "20260802200000_booking_v1_status_cutover", sql: testCase.sql }],
+    }
+
+    expect(planMigrations([source])[0]?.contentHash).toBe(testCase.expectedCurrentHash)
+    await expect(applyMigrations(client, [source], ledgerOpts)).resolves.toEqual({
+      executed: [],
+      baselined: [],
+    })
+    expect(queries).not.toContain("BEGIN")
+  })
+
+  it("still rejects an unrelated hash for the booking v1 status cutover", async () => {
+    const client: MigrationClient = {
+      async query(sql: string) {
+        if (sql.includes(`SELECT "content_hash"`)) {
+          return { rows: [{ content_hash: "unrelated-hash", source: "bookings" }] }
+        }
+        return { rows: [] }
+      },
+    }
+
+    await expect(
+      applyMigrations(
+        client,
+        [
+          {
+            name: "bookings",
+            priority: 0,
+            migrations: [
+              { tag: "20260802200000_booking_v1_status_cutover", sql: currentBookingCutover },
+            ],
+          },
+        ],
+        ledgerOpts,
+      ),
+    ).rejects.toBeInstanceOf(MigrationImmutabilityError)
+  })
+
   const relationshipsBaseline = readFileSync(
     new URL("../../relationships/migrations/0000_relationships_baseline.sql", import.meta.url),
     "utf8",

--- a/packages/framework-migrations/src/collector.ts
+++ b/packages/framework-migrations/src/collector.ts
@@ -174,6 +174,29 @@ const ACTION_LEDGER_0000_HASHES = [
   "d63e6a73b58f985888e258b318255eba5181db307438b25f3d262350f837b2ce",
   "2c1f05738aedd395ffdecc7d5000144a41e6af7e7a85b85563302e89bb1f4f6c",
 ] as const
+// `bookings/20260802200000_booking_v1_status_cutover`: the payment-effect guard
+// was NARROWED in place (#4199). The original tripped on any provider-linked
+// payment session — including a checkout that was merely opened — which no
+// operator action could clear; the current one trips on a recorded
+// authorization, capture or payment, or on a checkout still inside its provider
+// expiry window.
+//
+// Equivalence is sound here without a companion increment, unlike the rename
+// pairs below. The guard is abort-only: it raises, it never writes. The current
+// predicate is a strict subset of the original, so a database that recorded the
+// original necessarily had ZERO rows matching it and therefore zero matching the
+// narrowed one — the two generations reach the same end state on any database
+// where either applied. Every other statement in the file is byte-identical.
+//
+// The class the edit was written for (provider-linked sessions with no payment
+// effect) is exactly the class that made the ORIGINAL abort, so it never
+// recorded a ledger row to diverge from. See voyant#4247.
+const BOOKING_V1_STATUS_CUTOVER_HASHES = [
+  // original: any provider identifier or in-flight status trips the guard.
+  "f1d9f275271c117792ddb0a9f13a41b48f65b4fc60a4a752d06f42bd132437da",
+  // narrowed to settled payment effects plus unexpired checkouts (#4199).
+  "1651c727ee4d02c269c4f104695a3c871999ab49cbefc9b7af3ec676a3211be4",
+] as const
 // The quotes → proposals module rename (#4004) followed the new vocabulary into
 // eight already-shipped migrations owned by OTHER sources, renaming the shared
 // objects they declare: `booking_origins.proposal_version_id` and its index and
@@ -257,6 +280,10 @@ const EQUIVALENT_MIGRATION_HASHES = new Map<string, ReadonlySet<string>>([
   ...equivalenceClosure("db/0001_db_baseline", DB_0001_HASHES),
   ...equivalenceClosure("framework/0004_framework_baseline", FRAMEWORK_0004_HASHES),
   ...equivalenceClosure("action-ledger/0000_action_ledger_baseline", ACTION_LEDGER_0000_HASHES),
+  ...equivalenceClosure(
+    "bookings/20260802200000_booking_v1_status_cutover",
+    BOOKING_V1_STATUS_CUTOVER_HASHES,
+  ),
   ...PROPOSAL_RENAME_EDITED_HASHES.flatMap(([key, hashes]) => equivalenceClosure(key, hashes)),
 ])
 


### PR DESCRIPTION
Closes #4247.

`bookings/20260802200000_booking_v1_status_cutover` was edited in place by #4199 to narrow its payment-effect guard. That changed the file's content hash without a companion equivalence entry, so every deployment that had already applied the original hit `MigrationImmutabilityError` and stopped there — everything ordered after `bookings` in the collector plan unreachable, and the schema left partly advanced because each migration commits in its own transaction.

Both hashes in the issue reproduce exactly from git:

```
558e652e49^  f1d9f275271c117792ddb0a9f13a41b48f65b4fc60a4a752d06f42bd132437da
HEAD         1651c727ee4d02c269c4f104695a3c871999ab49cbefc9b7af3ec676a3211be4
```

## Option 1, and why option 2 is not actually the safer one

The issue offers a choice: add the equivalence entry, or restore the original file and ship the guard change as a new migration.

Option 2 does not avoid the problem — it moves it. Once the edit shipped, the population split: some ledgers hold `f1d9f275…`, some hold `1651c727…`. Reverting the file strands the second group exactly as the edit stranded the first, so it needs the same equivalence entry *plus* a new increment. `equivalenceClosure` is already symmetric, which covers both directions in one entry.

## Why this equivalence needs no companion increment

The quotes → proposals equivalences are gated on a companion (#4143, #4172) because equivalence marks a migration *applied*, so without an increment the renames never run and the database keeps `quote_*` objects while the application queries `proposal_*`.

Nothing is left unfinished here:

- the guard is abort-only — it `RAISE`s, it never writes;
- the narrowed predicate is a strict subset of the original (`auth OR capture OR payment` were all in the original; `status IN (…) AND not expired` ⊂ `status IN (…)`), so a database that recorded the original matched zero rows against it and matches zero against the subset;
- every other statement in the file is byte-identical — the second hunk of #4199 is comment-only.

The class the edit was written for (provider-linked sessions with no payment effect) is exactly the class that made the **original** abort, so it never recorded a ledger row that could diverge.

## Tests

`collector.test.ts` reconstructs the pre-#4199 bytes by undoing the edit against the shipped file and pins both hashes, following the action-ledger pattern. Removing the equivalence entry fails the two acceptance tests; an unrelated hash for this migration still raises `MigrationImmutabilityError`.

## Docs

A new section in `migration-collector-d2.md` states the general rule the incident exposes — an in-place edit and its equivalence entry are one change — and records the distinction between an equivalence that needs a companion increment and one that does not, so the next author has the containment argument rather than the precedent alone.

## Verification

- `pnpm --filter @voyant-travel/framework-migrations test` — 80 passed, 12 skipped (the skips need `TEST_DATABASE_URL`)
- `pnpm -F @voyant-travel/framework-migrations... typecheck`, `build` — clean
- `pnpm exec biome check .` — 0 errors; changed files clean
- `pnpm verify:migration-boundaries`, `pnpm verify:migration-cutline` — OK (cutline still frozen; this tag is a post-cutline increment and is not in the bundle)
