### PR TITLE
Drop the repo-level node-options that broke db-integration on main

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,15 +1,15 @@
 @voyant-travel:registry=https://registry.npmjs.org
 
-# Node's default old-space ceiling on a 64-bit host is 4288 MB, which several
-# packages exceed when tsc runs cold: operations peaks at 4.96 GB checking and
-# 5.35 GB emitting declarations, and inventory (3.65 GB), commerce (3.56 GB) and
-# distribution (3.02 GB) sit close enough that widening their typecheck project
-# to cover tests pushes them over. CI already raises this at the workflow level,
-# so without a repo default the failure is local-only: `pnpm -F <pkg> build`
-# dies with exit 134 and no `error TS` to explain it.
+# Do NOT add `node-options` here to raise the default heap ceiling repo-wide.
+# pnpm applies that config by SETTING NODE_OPTIONS in the script environment,
+# which REPLACES rather than extends any value the caller already exported. CI
+# relies on that value: seven jobs in ci.yml set NODE_OPTIONS at job level, two
+# of them carrying `--conditions=development`, and the db-integration lane runs
+# `NODE_OPTIONS="--conditions=development --import=tsx …" pnpm --filter operator
+# db:migrate`. With a `node-options` line here that command sees only
+# `--max-old-space-size=…`, tsx never loads, and `voyant migrate` dies on
+# `Cannot find module …/operator-distribution.js imported from …/project.ts`.
 #
-# A package needing more still declares it inline — an explicit NODE_OPTIONS in
-# the script overrides what pnpm inherits from here (framework and runtime use
-# 14336). A package needing less need not say anything: this is a ceiling, not
-# an allocation.
-node-options=--max-old-space-size=8192
+# A package that needs more than Node's 4288 MB default declares it inline in
+# its own script — an explicit NODE_OPTIONS there is applied innermost and does
+# win. See operations, finance, framework, runtime and voyant-connect-adapter.

--- a/packages/finance/package.json
+++ b/packages/finance/package.json
@@ -38,10 +38,10 @@
     "./self-service-booking-source": "./src/self-service-booking-source.ts"
   },
   "scripts": {
-    "typecheck": "tsc -p tsconfig.typecheck.json",
+    "typecheck": "NODE_OPTIONS=--max-old-space-size=8192 tsc -p tsconfig.typecheck.json",
     "lint": "biome check src/",
     "test": "vitest run",
-    "build": "tsc -p tsconfig.build.json",
+    "build": "NODE_OPTIONS=--max-old-space-size=8192 tsc -p tsconfig.build.json",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
     "generate:openapi": "node --import tsx scripts/generate-travel-credit-openapi.ts && biome format --write openapi/storefront/finance.json",

--- a/packages/operations/package.json
+++ b/packages/operations/package.json
@@ -20,10 +20,10 @@
     "./booking-actions-job": "./src/booking-actions/job.ts"
   },
   "scripts": {
-    "typecheck": "tsc -p tsconfig.typecheck.json",
+    "typecheck": "NODE_OPTIONS=--max-old-space-size=8192 tsc -p tsconfig.typecheck.json",
     "lint": "biome check src/",
     "test": "vitest run --passWithNoTests",
-    "build": "tsc -p tsconfig.build.json",
+    "build": "NODE_OPTIONS=--max-old-space-size=8192 tsc -p tsconfig.build.json",
     "clean": "rm -rf dist tsconfig*.tsbuildinfo",
     "prepack": "pnpm run build",
     "db:generate": "drizzle-kit generate --config=drizzle.migrations.config.ts --name=operations_baseline && node ../../scripts/migrations/guard-create-type.mjs ./migrations && node ../../scripts/migrations/ensure-extensions.mjs ./migrations",

--- a/packages/voyant-connect-adapter/package.json
+++ b/packages/voyant-connect-adapter/package.json
@@ -27,10 +27,10 @@
     "dist"
   ],
   "scripts": {
-    "typecheck": "tsc -p tsconfig.typecheck.json",
+    "typecheck": "NODE_OPTIONS=--max-old-space-size=8192 tsc -p tsconfig.typecheck.json",
     "lint": "biome check src/",
     "test": "vitest run --passWithNoTests",
-    "build": "pnpm run clean && tsc -p tsconfig.build.json",
+    "build": "pnpm run clean && NODE_OPTIONS=--max-old-space-size=8192 tsc -p tsconfig.build.json",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm --workspace-concurrency=1 --filter @voyant-travel/voyant-connect-adapter... run build"
   },


### PR DESCRIPTION
**main is red on `db-integration`. This fixes it.** #4252 merged while its own CI was still running, and the heap half of it was wrong.

## What broke

pnpm applies `.npmrc` `node-options` by **setting** `NODE_OPTIONS` in the script environment, which **replaces** rather than extends a value the caller already exported. The db-integration lane runs:

```
NODE_OPTIONS="--conditions=development --import=tsx --max-old-space-size=8192" \
  pnpm --filter operator db:migrate
```

With the `node-options` line present, that command sees only `--max-old-space-size=8192`. `tsx` never loads, so a `.js` specifier imported from a `.ts` file cannot resolve:

```
voyant migrate: Cannot find module '…/packages/framework/src/operator-distribution.js'
                imported from '…/packages/framework/src/project.ts'
```

The blast radius was wider than the one red lane: **seven jobs in `ci.yml` set `NODE_OPTIONS` at job level, two of them carrying `--conditions=development`**, plus `release.yml`. All of them were having their value silently replaced. db-integration is simply where it was fatal rather than merely degrading.

## Why I missed it

I probed the wrong direction. I verified that an inline `NODE_OPTIONS` **inside a package script** still wins — it does, applied innermost — and concluded overrides were safe. I never tested `NODE_OPTIONS` exported **around** a `pnpm` invocation, which is the case CI actually uses, and that one loses.

## Verification — A/B against the failing command

| `.npmrc` | result |
|---|---|
| with `node-options` | `Cannot find module …/operator-distribution.js` — CI's exact error, reproduced locally |
| without it (this PR) | resolution succeeds; proceeds to `DATABASE_URL or DATABASE_URL_DIRECT is required` |

CI supplies `DATABASE_URL`, so the lane clears.

Also confirmed the environment is intact end to end: a script invoked through pnpm now sees the full `"--conditions=development --import=tsx --max-old-space-size=8192"` rather than a truncated value.

## What this PR does

- Removes the `node-options` line.
- Restores the three per-package flags (`finance`, `operations`, `voyant-connect-adapter`) — verified **byte-identical** to their pre-#4252 state.
- Leaves a comment in `.npmrc` recording the mechanism, so this is not retried. #4243 recommended a repo-level default in good faith; the finding is that `.npmrc` cannot deliver one safely here.

**The ratchet half of #4252 is untouched and stays** — `verify:typecheck-coverage` passed CI on that PR, along with `architecture`, `build-graph`, `tests`, `checks` and `quality-graph`.

## Follow-up

The heap problem #4223 raised is real and now has no repo-level answer: a package needing more than Node's 4288 MB declares it inline, as `operations`, `finance`, `framework`, `runtime` and `voyant-connect-adapter` do. Anything that widens a heavy package's typecheck under #4244 — `inventory` (3.65 GB), `commerce` (3.56 GB), `distribution` (3.02 GB) — must add the flag in that package's own scripts.
