### PR TITLE
feat(mcp): narrow a query descriptor to one resource on describe_tool

### DIFF
--- a/.changeset/mcp-narrowed-describe.md
+++ b/.changeset/mcp-narrowed-describe.md
@@ -1,0 +1,28 @@
+---
+"@voyant-travel/mcp": minor
+---
+
+`describe_tool` accepts an optional `resource`, narrowing a `<domain>_query`
+descriptor to one branch instead of the union of every resource's input schema.
+
+Collapsing the 133 reads into 24 query tools (#3984) moved the discovery bill
+rather than removing it: a query descriptor advertises every member's schema, so
+an agent that wants one resource still pays for all of them. On the selected
+operator graph `bookings_query` cost 20,573 bytes across 22 branches. Narrowed it
+costs 1,811 — a 91% cut, 74% across all 24 query tools, and 52% over the six
+real-surface discovery journeys the eval harness drives.
+
+It needs no extra round trip: `search_tools` already returns the query tool's
+description, which names every resource, so the agent can name its branch before
+it describes anything. `resource` is optional and omitting it still returns the
+full union, so an existing client is unaffected.
+
+An unknown `resource` now fails with `NOT_FOUND` and the valid resource names as
+`candidates`, rather than falling through to a branchless `{ resource: string }`
+schema that reads as a valid answer.
+
+Also fixes the meta-tool error envelope, which was a near-copy of the dispatch
+one and dropped `candidates`, `didYouMean`, `meta` and `contractVersion` — so
+every `search_tools` / `describe_tool` / `call_tool` failure lost the actionable
+fields #3947 added, on exactly the calls an agent makes while still finding its
+way around. Both paths now build the envelope from one function.

--- a/apps/operator/tests/agent-journey-real-surface.test.ts
+++ b/apps/operator/tests/agent-journey-real-surface.test.ts
@@ -121,6 +121,13 @@ interface DiscoveryJourney {
   id: string
   query: string
   tool: string
+  /**
+   * The resource this journey actually wants. `search_tools` already returns the
+   * query tool's description, which names every resource, so an agent can pass
+   * this to `describe_tool` and be advertised ONE branch instead of the union —
+   * no extra round trip. Measured here so the saving is pinned on the real graph.
+   */
+  resource: string
 }
 
 // After the layered read projection (voyant#3932) the flat `get_*`/`list_*` reads
@@ -130,12 +137,22 @@ interface DiscoveryJourney {
 // tool (products/product/product-content all live in `inventory_query`), which is
 // exactly the clustering that cuts the discovery bill.
 const JOURNEYS: DiscoveryJourney[] = [
-  { id: "discover-products", query: "products", tool: "inventory_query" },
-  { id: "discover-product", query: "product", tool: "inventory_query" },
-  { id: "discover-product-content", query: "product content", tool: "inventory_query" },
-  { id: "discover-bookings", query: "bookings", tool: "bookings_query" },
-  { id: "discover-booking", query: "booking", tool: "bookings_query" },
-  { id: "discover-departures", query: "departures", tool: "operations_query" },
+  { id: "discover-products", query: "products", tool: "inventory_query", resource: "products" },
+  { id: "discover-product", query: "product", tool: "inventory_query", resource: "product" },
+  {
+    id: "discover-product-content",
+    query: "product content",
+    tool: "inventory_query",
+    resource: "product_content",
+  },
+  { id: "discover-bookings", query: "bookings", tool: "bookings_query", resource: "bookings" },
+  { id: "discover-booking", query: "booking", tool: "bookings_query", resource: "booking" },
+  {
+    id: "discover-departures",
+    query: "departures",
+    tool: "operations_query",
+    resource: "departures",
+  },
 ]
 
 interface DiscoveryScore {
@@ -146,6 +163,8 @@ interface DiscoveryScore {
   described: boolean
   calls: number
   tokenEstimate: number
+  /** The same journey describing only `journey.resource` — same call count. */
+  narrowedTokenEstimate: number
 }
 
 async function runDiscovery(app: Hono, journey: DiscoveryJourney): Promise<DiscoveryScore> {
@@ -155,32 +174,52 @@ async function runDiscovery(app: Hono, journey: DiscoveryJourney): Promise<Disco
   const descriptor = (describe.result as { structuredContent?: { inputSchema?: unknown } })
     ?.structuredContent
   const described = describe.result?.isError !== true && descriptor?.inputSchema != null
+
+  // Same two calls, one argument different. Anything that makes this path error
+  // or return no schema must fail the journey, or the comparison is measuring a
+  // broken call against a working one.
+  const narrowed = await callTool(app, "describe_tool", {
+    name: journey.tool,
+    resource: journey.resource,
+  })
+  const narrowedDescriptor = (narrowed.result as { structuredContent?: { inputSchema?: unknown } })
+    ?.structuredContent
+  const narrowedDescribed =
+    narrowed.result?.isError !== true && narrowedDescriptor?.inputSchema != null
+
   return {
     id: journey.id,
     tool: journey.tool,
-    completed: found && described,
+    completed: found && described && narrowedDescribed,
     found,
-    described,
+    described: described && narrowedDescribed,
     calls: 2,
     tokenEstimate: Math.round((search.bytes + describe.bytes) / BYTES_PER_TOKEN),
+    narrowedTokenEstimate: Math.round((search.bytes + narrowed.bytes) / BYTES_PER_TOKEN),
   }
 }
 
 function formatReport(scores: readonly DiscoveryScore[]): string {
   const lines = [
     "agent journey eval — real-surface discovery (voyant#3936)",
-    "  columns: completed | tool | calls | ~tokens (search + describe, resp bytes/4)",
+    "  columns: completed | tool | calls | ~tokens broad → narrowed (resp bytes/4)",
   ]
   for (const s of scores) {
+    const cut =
+      s.tokenEstimate > 0 ? Math.round((1 - s.narrowedTokenEstimate / s.tokenEstimate) * 100) : 0
     lines.push(
       `  ${s.completed ? "✓" : "✗"} ${s.tool.padEnd(22)} ` +
-        `calls=${s.calls} ~tokens=${String(s.tokenEstimate).padStart(5)}` +
+        `calls=${s.calls} ~tokens=${String(s.tokenEstimate).padStart(5)} → ` +
+        `${String(s.narrowedTokenEstimate).padStart(5)} (-${cut}%)` +
         (s.completed ? "" : ` [found=${s.found} described=${s.described}]`),
     )
   }
   const total = scores.reduce((sum, s) => sum + s.tokenEstimate, 0)
+  const narrowedTotal = scores.reduce((sum, s) => sum + s.narrowedTokenEstimate, 0)
   lines.push(
-    `  TOTAL discovery ~tokens=${total} completed=${scores.filter((s) => s.completed).length}/${scores.length}`,
+    `  TOTAL discovery ~tokens=${total} → ${narrowedTotal} ` +
+      `(-${Math.round((1 - narrowedTotal / total) * 100)}%) ` +
+      `completed=${scores.filter((s) => s.completed).length}/${scores.length}`,
   )
   return lines.join("\n")
 }
@@ -242,5 +281,31 @@ describe("agent journey eval — real selected-graph surface", () => {
       `real-surface discovery cost ${total} tokens exceeded ceiling ${DISCOVERY_TOKEN_CEILING} — ` +
         "read the printed report; this is what the read projection (W8) should cut.",
     ).toBeLessThanOrEqual(DISCOVERY_TOKEN_CEILING)
+  })
+
+  it("makes a narrowed describe materially cheaper than the full union", () => {
+    // The saving is the whole reason `resource` exists on describe_tool, and it is
+    // the kind of property that rots quietly: adding a resource to a domain makes
+    // the union grow and the narrowed branch stay flat, so the gap should only
+    // widen. Assert the FLOOR, not the measurement, so ordinary schema edits pass.
+    //
+    // Measured on the selected graph: 38,587 → 18,659 tokens across the six
+    // journeys (-52%). Per-journey cuts run 36–71% rather than the 91% the
+    // `bookings_query` DESCRIPTOR alone sees (20,573 → 1,811 bytes), because each
+    // journey also pays an unchanged `search_tools` call — that half of the bill
+    // is untouched by this and is the next thing worth attacking.
+    //
+    // A 30% floor leaves room for a domain whose query tool has one resource
+    // (nothing to narrow) to enter the set without failing this.
+    const total = scores.reduce((sum, s) => sum + s.tokenEstimate, 0)
+    const narrowedTotal = scores.reduce((sum, s) => sum + s.narrowedTokenEstimate, 0)
+    const cut = 1 - narrowedTotal / total
+
+    expect(
+      cut,
+      `narrowed describe saved only ${Math.round(cut * 100)}% (${total} → ${narrowedTotal} tokens). ` +
+        "Either the union stopped carrying per-resource schemas, or narrowing stopped " +
+        "pruning them — read the printed report.",
+    ).toBeGreaterThan(0.3)
   })
 })

--- a/apps/operator/tests/selected-graph-mcp-tool-surface.test.ts
+++ b/apps/operator/tests/selected-graph-mcp-tool-surface.test.ts
@@ -203,6 +203,61 @@ describe("selected-graph MCP tool surface cost", () => {
     expect(unnamed).toEqual([])
   })
 
+  it("registers every staff-audience tool the selected graph declares", async () => {
+    // voyant#3682 acceptance (3): compose the published tool metadata with the
+    // graph manifest and prove MCP discovery registers every admitted tool.
+    //
+    // The defect that issue reported is already fixed — `create_booking_extra`
+    // now declares graph risk `high` against its `sensitive` tier. Two things
+    // were checked before writing this, by reintroducing each break and watching
+    // it fail, so nobody re-derives them:
+    //
+    //   - tier/risk mismatch → `assertCompatibleRisk` THROWS during registration,
+    //     the mount fails, and every test in this file goes red. Loud.
+    //   - a scope no access resource declares → the graph BUILD fails with
+    //     VOYANT_GRAPH_UNKNOWN_REFERENCE. Loud, and earlier still.
+    //
+    // So this is not a guard against a live bug; it pins the RESULT those two
+    // checks currently produce. The assertion above is a floor of 200 against
+    // ~270 actual, which would absorb a drop of dozens in silence. Any filtering
+    // introduced later between registration and the served index — a scope
+    // intersection, a narrowed audience, a projection that stops emitting a
+    // domain — shrinks the surface without tripping a floor. Assert by NAME.
+    const { app } = await mountSelectedGraphMcp()
+    const manifest = (await (await app.request("/manifest", {}, TEST_ENV, TEST_CTX)).json()) as {
+      tools: Array<{ name?: string }>
+    }
+    const registered = new Set(manifest.tools.map(({ name }) => name))
+
+    const runtime = createGeneratedGraphRuntime()
+    const declared: string[] = []
+    for (const tool of runtime.tools) {
+      const definition = await tool.load<{
+        name: string
+        audience?: { allowed?: readonly string[] }
+      }>()
+      const name = tool.name ?? definition.name
+      // The manifest is composed for a STAFF key. Customer-portal tools are
+      // declared for the customer audience and are correctly absent here — the
+      // audience filter is the point, not a gap. An undeclared audience defaults
+      // to every grant audience, so it stays in scope. Anything else missing is a
+      // registration failure.
+      const allowed = definition.audience?.allowed
+      if (allowed !== undefined && !allowed.includes("staff")) continue
+      declared.push(name)
+    }
+
+    const missing = declared.filter((name) => !registered.has(name)).sort()
+    expect(
+      missing,
+      `${missing.length} staff tool(s) the graph declares never reached the MCP manifest. ` +
+        "These registered without error and were then filtered out of the served index — " +
+        "check requiredScopes against the access catalog, action availability.status, and " +
+        "the audience policy on each name above.",
+    ).toEqual([])
+    expect(declared.length).toBeGreaterThan(200)
+  })
+
   it("bounds the AGGREGATE describe schema of the collapsed read surface", async () => {
     // Progressive disclosure made the long tail invisible to `tools/list`, which
     // is the point — but unbounded per-tool schema growth would then show up

--- a/packages/mcp/src/dispatch.ts
+++ b/packages/mcp/src/dispatch.ts
@@ -105,28 +105,42 @@ export async function dispatchToResult(
       ...(shaped.meta ? { _meta: shaped.meta } : {}),
     }
   } catch (err) {
-    // Normalize any thrown value into a ToolError so the envelope always carries
-    // the actionable fields. An unknown throw maps to PROVIDER_ERROR (terminal),
-    // the safe-for-writes default — a blind retry of an unknown failure could
-    // duplicate a write. `toToolError` recognises a ToolError raised by another
-    // loaded copy of @voyant-travel/tools, so a duplicated install does not
-    // strip its code and remediation here (voyant#4115).
-    const toolError = toToolError(err)
-    const error = {
-      contractVersion: TOOL_CONTRACT_VERSION,
-      code: toolError.code,
-      message: toolError.message,
-      retryable: toolError.retryable,
-      nextSteps: toolError.nextSteps,
-      ...(toolError.candidates ? { candidates: toolError.candidates } : {}),
-      ...(toolError.didYouMean ? { didYouMean: toolError.didYouMean } : {}),
-      ...(toolError.meta ? { meta: toolError.meta } : {}),
-    }
-    return {
-      isError: true,
-      content: [{ type: "text", text: `[${toolError.code}] ${toolError.message}` }],
-      _meta: { "voyant.travel/error": error },
-    }
+    return toErrorResult(err)
+  }
+}
+
+/**
+ * The single MCP error envelope. Every actionable field voyant#3947 added has to
+ * survive here or it is dead weight at the throw site.
+ *
+ * This lives in one place because it did not used to: the meta-tool layer had its
+ * own copy that carried only `code`, `message`, `retryable` and `nextSteps`, so
+ * `candidates`, `didYouMean`, `meta` and `contractVersion` were silently dropped
+ * from every `search_tools` / `describe_tool` / `call_tool` failure — the exact
+ * errors an agent hits while it is still trying to find its way around.
+ */
+export function toErrorResult(err: unknown): CallToolResult {
+  // Normalize any thrown value into a ToolError so the envelope always carries
+  // the actionable fields. An unknown throw maps to PROVIDER_ERROR (terminal),
+  // the safe-for-writes default — a blind retry of an unknown failure could
+  // duplicate a write. `toToolError` recognises a ToolError raised by another
+  // loaded copy of @voyant-travel/tools, so a duplicated install does not
+  // strip its code and remediation here (voyant#4115).
+  const toolError = toToolError(err)
+  const error = {
+    contractVersion: TOOL_CONTRACT_VERSION,
+    code: toolError.code,
+    message: toolError.message,
+    retryable: toolError.retryable,
+    nextSteps: toolError.nextSteps,
+    ...(toolError.candidates ? { candidates: toolError.candidates } : {}),
+    ...(toolError.didYouMean ? { didYouMean: toolError.didYouMean } : {}),
+    ...(toolError.meta ? { meta: toolError.meta } : {}),
+  }
+  return {
+    isError: true,
+    content: [{ type: "text", text: `[${toolError.code}] ${toolError.message}` }],
+    _meta: { "voyant.travel/error": error },
   }
 }
 

--- a/packages/mcp/src/meta-tools.ts
+++ b/packages/mcp/src/meta-tools.ts
@@ -24,16 +24,16 @@ import {
   ToolError,
   type ToolManifestEntry,
   type ToolRegistry,
-  toToolError,
 } from "@voyant-travel/tools"
 import type { AccessCatalog, ApiKeyPermissions } from "@voyant-travel/types/api-keys"
 import { isAuthorized } from "./authorization.js"
-import { dispatchToResult } from "./dispatch.js"
+import { dispatchToResult, toErrorResult } from "./dispatch.js"
 import { isRecord } from "./guards.js"
 import type { McpCaller, McpCallOutcome, McpObserver } from "./observability.js"
 import {
   advertiseQueryTool,
   dispatchQueryTool,
+  hasQueryResource,
   queryToolDescription,
   type ReadProjection,
   toolDomain,
@@ -299,11 +299,23 @@ function registerDescribeTool({
       description:
         "Return the full input schema, output contract, and metadata for one tool " +
         "by name. Use the names returned by search_tools. For a `<domain>_query` tool " +
-        "the input schema is a discriminated union on `resource`.",
-      inputSchema: z.object({ name: z.string().trim().min(1) }),
+        "the input schema is a discriminated union on `resource` — pass `resource` " +
+        "here to get just that branch, which is far cheaper than the whole union.",
+      inputSchema: z.object({
+        name: z.string().trim().min(1),
+        resource: z
+          .string()
+          .trim()
+          .min(1)
+          .optional()
+          .describe(
+            "For a `<domain>_query` tool: narrow the returned input schema to this " +
+              "one resource. The resource names are listed in the tool's description.",
+          ),
+      }),
       annotations: { readOnlyHint: true, openWorldHint: false },
     },
-    (args) => describeTool(registry, surface, projection, args.name),
+    (args) => describeTool(registry, surface, projection, args.name, args.resource),
   )
 }
 
@@ -312,24 +324,42 @@ function describeTool(
   surface: AuthorizedSurface,
   projection: ReadProjection,
   name: string,
+  resource?: string,
 ): CallToolResult {
   const queryTool = projection.queryToolFor(name)
   if (queryTool) {
+    // Fail closed on an unknown resource rather than advertising an empty union,
+    // and hand back the valid names so the retry is one step, not a re-discovery.
+    if (resource !== undefined && !hasQueryResource(queryTool, resource)) {
+      return errorResult(
+        new ToolError(
+          `${name} has no resource "${resource}".`,
+          "NOT_FOUND",
+          undefined,
+          undefined,
+          // `candidates` is the 5th `details` arg, not `meta` — only the former
+          // reaches the MCP error envelope (dispatch.ts lifts it out of the
+          // ToolError, not out of meta).
+          { candidates: queryTool.resources.map((member) => member.resource) },
+        ),
+      )
+    }
     try {
-      const descriptor = advertiseQueryTool(registry, queryTool)
+      const descriptor = advertiseQueryTool(registry, queryTool, resource)
       // A query tool's descriptor is the union of every resource's schema — the
       // largest describe payload on the surface. Carry it once, in
       // `structuredContent`, and keep the human-readable `content` channel a short
       // pointer rather than a second pretty-printed copy (voyant#3932); the doubled
       // copy was the single biggest line in the discovery bill.
       const resources = queryTool.resources.map((member) => member.resource).join(", ")
+      const text =
+        resource === undefined
+          ? `${queryTool.name}: set "resource" to one of ${resources}. Full schema in ` +
+            `structuredContent — re-describe with {"resource": "<one of these>"} for just ` +
+            "that resource's schema."
+          : `${queryTool.name} resource "${resource}": schema in structuredContent.`
       return {
-        content: [
-          {
-            type: "text",
-            text: `${queryTool.name}: set "resource" to one of ${resources}. Full schema in structuredContent.`,
-          },
-        ],
+        content: [{ type: "text", text }],
         structuredContent: descriptor,
       }
     } catch (err) {
@@ -449,20 +479,9 @@ function unknownToolResult(name: string): CallToolResult {
   )
 }
 
-function errorResult(err: unknown): CallToolResult {
-  // Recognises a ToolError from another loaded copy of @voyant-travel/tools so
-  // a duplicated install cannot flatten its code into PROVIDER_ERROR.
-  const toolError = toToolError(err)
-  return {
-    isError: true,
-    content: [{ type: "text", text: `[${toolError.code}] ${toolError.message}` }],
-    _meta: {
-      [DISPATCH_ERROR_META_KEY]: {
-        code: toolError.code,
-        message: toolError.message,
-        retryable: toolError.retryable,
-        nextSteps: toolError.nextSteps,
-      },
-    },
-  }
-}
+/**
+ * Meta-tool failures use the SAME envelope as dispatch. This used to be a
+ * near-copy that dropped `candidates`, `didYouMean`, `meta` and
+ * `contractVersion` — see {@link toErrorResult}.
+ */
+const errorResult = toErrorResult

--- a/packages/mcp/src/read-projection.ts
+++ b/packages/mcp/src/read-projection.ts
@@ -131,9 +131,14 @@ export function buildReadProjection(surface: AuthorizedSurface): ReadProjection 
  * projected input fields. The registry still validates the untouched domain
  * schema at dispatch, so this is a discovery projection, not the parse contract.
  */
-export function queryToolInputSchema(registry: ToolRegistry, queryTool: QueryTool): z.ZodType {
+export function queryToolInputSchema(
+  registry: ToolRegistry,
+  queryTool: QueryTool,
+  resource?: string,
+): z.ZodType {
   const branches: z.ZodObject[] = []
   for (const member of queryTool.resources) {
+    if (resource !== undefined && member.resource !== resource) continue
     const def = registry.get(member.entry.name)
     if (!def) continue
     const memberObject = toMcpInputSchema(
@@ -153,14 +158,33 @@ export function queryToolInputSchema(registry: ToolRegistry, queryTool: QueryToo
   return z.discriminatedUnion("resource", branches as [z.ZodObject, z.ZodObject, ...z.ZodObject[]])
 }
 
-/** A one-line, resource-listing description so keyword `search_tools` still matches. */
-export function queryToolDescription(queryTool: QueryTool): string {
+/**
+ * A one-line, resource-listing description so keyword `search_tools` still matches.
+ *
+ * Listing every resource here is what makes narrowed `describe_tool` free: this
+ * string reaches the agent through `search_tools`, so it already knows the
+ * resource names before it describes anything.
+ */
+export function queryToolDescription(queryTool: QueryTool, resource?: string): string {
   const resources = queryTool.resources.map((member) => member.resource).join(", ")
+  if (resource !== undefined) {
+    return (
+      `Query ${queryTool.domain} read data for resource "${resource}". The input ` +
+      `schema below is narrowed to this resource; pass "resource": "${resource}" ` +
+      `alongside its arguments. Other resources: ${resources}.`
+    )
+  }
   return (
     `Query ${queryTool.domain} read data. Set "resource" to the record you want and ` +
     `supply that resource's own arguments (this tool's input schema is a discriminated ` +
-    `union on "resource"). Resources: ${resources}.`
+    `union on "resource"). Resources: ${resources}. Pass "resource" to describe_tool ` +
+    `to get just that resource's schema instead of all ${queryTool.resources.length}.`
   )
+}
+
+/** True when `resource` names a member of this query tool. */
+export function hasQueryResource(queryTool: QueryTool, resource: string): boolean {
+  return queryTool.resources.some((member) => member.resource === resource)
 }
 
 /**
@@ -181,18 +205,33 @@ const QUERY_OUTPUT_SCHEMA = {
  * The descriptor `describe_tool` returns for a query tool — the discovery view an
  * agent needs to call it: the union input schema, a permissive output note,
  * read-only annotations, and per-resource scope metadata.
+ *
+ * `resource` NARROWS the advertised input schema to that one branch. Collapsing
+ * the reads moved the discovery bill rather than removing it: a query tool's
+ * descriptor is the union of every member's input schema, so `bookings_query`
+ * costs 15,766 bytes across 22 branches while an agent reads exactly one of them.
+ * That is the eager-serialization problem voyant#3927 solved for `tools/list`,
+ * recurring one layer down.
+ *
+ * Narrowing needs no extra round trip because {@link queryToolDescription} — which
+ * `search_tools` already returns — names every resource. So the agent that found
+ * the tool can already name the branch it wants. Measured on the selected operator
+ * graph: `bookings_query` 15,766 → 1,513 bytes, and 104,207 → ~24,000 across all
+ * 24 query tools. Omitting `resource` still returns the full union, so an existing
+ * client keeps working.
  */
 export function advertiseQueryTool(
   registry: ToolRegistry,
   queryTool: QueryTool,
+  resource?: string,
 ): Record<string, unknown> {
-  const inputSchema = z.toJSONSchema(queryToolInputSchema(registry, queryTool), {
+  const inputSchema = z.toJSONSchema(queryToolInputSchema(registry, queryTool, resource), {
     io: "input",
     unrepresentable: "any",
   })
   return {
     name: queryTool.name,
-    description: queryToolDescription(queryTool),
+    description: queryToolDescription(queryTool, resource),
     inputSchema,
     outputSchema: QUERY_OUTPUT_SCHEMA,
     annotations: { readOnlyHint: true, openWorldHint: false },
@@ -202,11 +241,16 @@ export function advertiseQueryTool(
         kind: "read-query",
         domain: queryTool.domain,
         tier: "read",
-        resources: queryTool.resources.map((member) => ({
-          resource: member.resource,
-          capabilityId: member.entry.capabilityId,
-          requiredScopes: member.entry.requiredScopes,
-        })),
+        // Narrowed describe carries only the selected resource's scope metadata.
+        // Advertising all 22 capabilityId/requiredScopes tuples alongside a
+        // one-branch schema would put most of the cost straight back.
+        resources: queryTool.resources
+          .filter((member) => resource === undefined || member.resource === resource)
+          .map((member) => ({
+            resource: member.resource,
+            capabilityId: member.entry.capabilityId,
+            requiredScopes: member.entry.requiredScopes,
+          })),
       },
     },
   }

--- a/packages/mcp/tests/agent-journey-eval.test.ts
+++ b/packages/mcp/tests/agent-journey-eval.test.ts
@@ -289,6 +289,33 @@ const SCENARIOS: JourneyScenario[] = [
       productList(prior[2]).length > 0,
   },
   {
+    // The SAME journey as above, describing only the resource it actually wants.
+    // Kept as a separate scenario rather than replacing the broad one so the
+    // report shows both costs side by side on every run — that delta is the whole
+    // argument for the narrowed describe, and it disappears if only one survives.
+    //
+    // `search_tools` already returns the query tool's description, which names
+    // every resource, so naming one here costs no extra round trip. On the seeded
+    // fixture the saving is modest (few resources, small schemas); on the real
+    // selected graph `bookings_query` goes 20,573 → 1,811 bytes.
+    id: "discover-then-read-products-narrowed",
+    title: "search_tools → describe_tool(resource: products) → inventory_query",
+    drive(prior) {
+      if (prior.length === 0) return { tool: "search_tools", args: { query: "product" } }
+      if (prior.length === 1)
+        return {
+          tool: "describe_tool",
+          args: { name: "inventory_query", resource: "products" },
+        }
+      if (prior.length === 2) return { tool: "inventory_query", args: { resource: "products" } }
+      return null
+    },
+    completed: (prior) =>
+      searchHit(prior[0], "inventory_query") &&
+      describedName(prior[1]) === "inventory_query" &&
+      productList(prior[2]).length > 0,
+  },
+  {
     // Find a product, then read its composed content by the id just discovered.
     id: "find-product-read-content",
     title: "search_tools → inventory_query(products) → inventory_query(product_content)",
@@ -383,20 +410,41 @@ const SCENARIOS: JourneyScenario[] = [
  * When you intentionally change the surface, re-run, read the printed report,
  * and move the measured baseline in the comment plus the ceiling if needed.
  *
- * Measured estimates at authoring (response bytes ÷ 4). The describe_tool step
- * dominates the discovery journeys — it pays a tool's full input schema once,
- * which is exactly the per-tool cost the aggregate ratchet in the operator
- * starter bounds. The guide journey pays the `voyant_guide` prose instead.
- *   discover-then-read-products   calls=3  ~tokens≈1789
- *   find-product-read-content     calls=3  ~tokens≈425
- *   list-bookings-with-filter     calls=3  ~tokens≈1092
- *   guide-then-act                calls=3  ~tokens≈872
- *   recover-from-bad-input        calls=3  ~tokens≈422
+ * Measured estimates (response bytes ÷ 4). The describe_tool step dominates the
+ * discovery journeys — it pays a tool's full input schema once, which is exactly
+ * the per-tool cost the aggregate ratchet in the operator application bounds. The
+ * guide journey pays the `voyant_guide` prose instead.
+ *
+ * RE-RECORDED 2026-08-05. The authoring numbers were taken before the layered
+ * read projection (voyant#3932, PR #3984) and the live-client payload fixes
+ * (PR #3990) landed, and nobody moved them afterwards — so the ceilings had
+ * drifted to ~2.5x the real cost and would not have caught a doubling. Three
+ * journeys got materially cheaper; none got more expensive:
+ *
+ *   journey                          calls  was    now    ceiling
+ *   discover-then-read-products        3    1789   1186    1_800
+ *   discover-then-read-products-narrow 3      —     926    1_400
+ *   find-product-read-content          3     425    568      850
+ *   list-bookings-with-filter          3    1092    724    1_100
+ *   guide-then-act                     3     872    845    1_300
+ *   recover-from-bad-input             3     422    422      650
+ *
+ * `find-product-read-content` rose 425 → 568 because the projection returns a
+ * richer content envelope; that is the intended trade and not a regression. The
+ * un-narrowed journeys each rose ~90 tokens against the previous re-recording
+ * because a query tool's description now advertises the narrowed path — a fixed
+ * cost paid once per describe, which the narrowed journey more than repays.
+ *
+ * The two `discover-then-read-products*` rows are the same journey with and
+ * without a `resource` on `describe_tool`: 1186 → 926 here, and 20,573 → 1,811
+ * BYTES on the real `bookings_query` (22 resources vs the fixture's 2). Keep both
+ * so the delta stays visible. Ceilings are ~1.5x the measurement.
  */
 const BASELINES: Record<string, { calls: number; maxTokens: number }> = {
-  "discover-then-read-products": { calls: 3, maxTokens: 2_700 },
-  "find-product-read-content": { calls: 3, maxTokens: 650 },
-  "list-bookings-with-filter": { calls: 3, maxTokens: 1_650 },
+  "discover-then-read-products": { calls: 3, maxTokens: 1_800 },
+  "discover-then-read-products-narrowed": { calls: 3, maxTokens: 1_400 },
+  "find-product-read-content": { calls: 3, maxTokens: 850 },
+  "list-bookings-with-filter": { calls: 3, maxTokens: 1_100 },
   "guide-then-act": { calls: 3, maxTokens: 1_300 },
   "recover-from-bad-input": { calls: 3, maxTokens: 650 },
 }

--- a/packages/mcp/tests/server.test.ts
+++ b/packages/mcp/tests/server.test.ts
@@ -125,9 +125,16 @@ async function listedNames(app: Hono): Promise<string[]> {
 async function describeTool(
   app: Hono,
   name: string,
+  resource?: string,
 ): Promise<{ result?: Record<string, unknown>; structuredContent?: Record<string, unknown> }> {
   const res = await readRpc(
-    await app.request("/", rpc("tools/call", { name: "describe_tool", arguments: { name } })),
+    await app.request(
+      "/",
+      rpc("tools/call", {
+        name: "describe_tool",
+        arguments: resource === undefined ? { name } : { name, resource },
+      }),
+    ),
   )
   const result = res.result as { structuredContent?: Record<string, unknown> } | undefined
   return { result, structuredContent: result?.structuredContent }
@@ -1245,6 +1252,74 @@ describe("createMcpApiRoutes", () => {
     )
     expect(bothExposed).toContain("echoes")
     expect(bothExposed).toContain("sensitive_record")
+  })
+
+  it("narrows a query descriptor to one resource when describe_tool is given one", () => {
+    // Collapsing the reads (voyant#3932) moved the discovery bill rather than
+    // removing it: a query descriptor is the union of every member's input schema,
+    // so an agent that wants ONE resource still pays for all of them. Measured on
+    // the selected operator graph, `bookings_query` cost 20,573 bytes across 22
+    // branches; narrowed it costs 1,811 — a 91% cut, and 74% across all 24 query
+    // tools. This is the tier-0 argument of voyant#3927 applied one layer down.
+    return (async () => {
+      const app = appWithScopes(["products:read", "secrets:read"])
+      const full = (await describeTool(app, "test_query")).structuredContent as {
+        inputSchema?: { oneOf?: unknown[] }
+        _meta?: { "voyant.travel/tool"?: { resources?: Array<{ resource: string }> } }
+      }
+      // Both resources are present, and the union carries a branch per resource.
+      expect(full.inputSchema?.oneOf).toHaveLength(2)
+
+      const narrowed = (await describeTool(app, "test_query", "echoes")).structuredContent as {
+        inputSchema?: { oneOf?: unknown[]; properties?: Record<string, unknown> }
+        _meta?: { "voyant.travel/tool"?: { resources?: Array<{ resource: string }> } }
+      }
+      // A single branch collapses out of the union into a plain object schema.
+      expect(narrowed.inputSchema?.oneOf).toBeUndefined()
+      expect(narrowed.inputSchema?.properties).toHaveProperty("resource")
+      // The scope metadata narrows with it — leaving all N tuples in place would
+      // put most of the saving straight back.
+      const exposed = (narrowed._meta?.["voyant.travel/tool"]?.resources ?? []).map(
+        ({ resource }) => resource,
+      )
+      expect(exposed).toEqual(["echoes"])
+
+      expect(JSON.stringify(narrowed).length).toBeLessThan(JSON.stringify(full).length)
+    })()
+  })
+
+  it("rejects an unknown describe_tool resource with the valid names", async () => {
+    // Failing closed matters more here than usual: an unknown resource used to
+    // fall through to a branchless `{ resource: string }` schema, which reads as a
+    // valid answer and tells the agent nothing. Return the candidates so the retry
+    // is one step rather than a re-discovery.
+    const app = appWithScopes(["products:read", "secrets:read"])
+    const res = await readRpc(
+      await app.request(
+        "/",
+        rpc("tools/call", {
+          name: "describe_tool",
+          arguments: { name: "test_query", resource: "echos" },
+        }),
+      ),
+    )
+    expect((res.result as { isError?: boolean })?.isError).toBe(true)
+    const body = JSON.stringify(res.result)
+    expect(body).toContain("echoes")
+    expect(body).toContain("NOT_FOUND")
+  })
+
+  it("still describes an unnarrowed query tool for a client that sends no resource", async () => {
+    // `resource` is additive. A client written against the pre-narrowing contract
+    // must keep getting the full union rather than an error or an empty schema.
+    const app = appWithScopes(["products:read", "secrets:read"])
+    const described = (await describeTool(app, "test_query")).structuredContent as {
+      inputSchema?: { oneOf?: unknown[] }
+      description?: string
+    }
+    expect(described.inputSchema?.oneOf).toHaveLength(2)
+    // And the description tells the agent the cheaper path exists.
+    expect(described.description).toContain("resource")
   })
 
   it("discovers and invokes a sensitive Tool only with its explicit grant", async () => {


### PR DESCRIPTION
Continues the #3921 tool-surface work. Four related pieces.

## 1. `describe_tool(name, resource)` — narrowed query descriptors

Collapsing the 133 reads into 24 `<domain>_query` tools (#3984) **moved** the
discovery bill rather than removing it. A query descriptor advertises the union
of every member's input schema, so an agent that wants one resource pays for all.

| | full | narrowed | cut |
|---|---|---|---|
| `bookings_query` (22 resources) | 20,573 B | 1,811 B | **91%** |
| all 24 query tools | 141,646 B | 37,069 B | **74%** |
| 6 real discovery journeys | 38,587 tok | 18,659 tok | **52%** |

**No extra round trip** — `search_tools` already returns the description naming
every resource. `resource` is optional; omitting it returns the full union.

## 2. Meta-tool errors were dropping their actionable fields

`errorResult` in `meta-tools.ts` was a near-copy of the dispatch envelope
carrying only `code`, `message`, `retryable`, `nextSteps` — so `candidates`,
`didYouMean`, `meta` and `contractVersion` were silently dropped from **every**
`search_tools` / `describe_tool` / `call_tool` failure, exactly the calls an
agent makes while still finding its way. Both paths now build the envelope from
one function.

## 3. An opt-in live-client eval

The scripted lane stays the CI gate — a journey needing a live key gets disabled
the first week the key rotates. But a scripted driver is handed the tool name,
the resource, and the argument shape, so it cannot fail the way a real agent
fails, and every remaining #3921 claim is a claim about **prose**.

Skipped without a key. Talks to the HTTP API with `fetch` rather than adding an
SDK dependency to a published package. Tier-0 tools are derived from the live
`tools/list`, so a regression to eager loading pays the same bill a real client
would.

It immediately validated (1): both tested models pass `resource` to
`describe_tool` **unprompted**, which is the one claim the scripted tests cannot
settle.

## 4. …and it found a real defect

Asked for a seeded product **by name**, both models searched the tool catalog,
matched nothing, and told the user there were *"no available records for a Kyoto
Cherry Blossom Tour in the system"*. The record was right there. A zero-hit
search returned a bare `{ total: 0, tools: [] }`, and nothing contradicted the
reading that the DATA does not exist — a discovery miss became a confident false
statement about the operator's catalog.

A no-hit search now falls back to the per-domain query tools. The smaller model
went from 9 calls and budget exhaustion to 3.

**Three richer variants were tried first and did not work** (advisory `noMatch`
block, `exactMatch: false` flag, worked example) — every version that led with
the miss was read as a refusal. They are recorded in the code so nobody retries
them. Prose in the response is not the lever; usable tools in `tools` are.

**The gap is not closed.** Neither model reaches the query tool from a
record-name search, so that scenario is kept in `KNOWN_GAPS`, asserted to keep
failing, so fixing the surface turns it red and prompts promotion instead of the
eval quietly ceasing to exercise the bug. Current read: it belongs to the guide
layer (W7) — server `instructions` should establish "records live behind
`<domain>_query`" *before* the first call.

Also fixes the seeded `list_products`, which carried only `status` while the real
tool has a `search` filter — unfaithful on exactly the axis this journey
exercises.

## Also

- #3682's outstanding acceptance item: the manifest assertion was a floor of 200
  against ~270, so a tool dropping out failed nothing. Now asserted by name.
  (The defect itself was already fixed; both known mismatches are loud — verified
  by reintroducing each.)
- Stale eval baselines re-recorded — they predated #3984/#3990 and had drifted to
  ~2.5x real cost.

## Verification

- `packages/mcp`: 86 tests pass (13 files), live lane green on both models
- `apps/operator` MCP surface + journey tests: 9 pass
- `tsc -p tsconfig.build.json` clean; `biome check` 0 errors (1 warning,
  byte-identical on `main`)
