### PR TITLE
fix(tools): classify every PROVIDER_ERROR site, and suggest near-match tool names

### DIFF
--- a/packages/bookings/src/requirements/mcp-runtime.ts
+++ b/packages/bookings/src/requirements/mcp-runtime.ts
@@ -30,9 +30,18 @@ export function contributeBookingRequirementsToolContext(input: {
       | ServiceFunction
       | undefined
     if (typeof candidate !== "function") {
+      // voyant#3950: terminal, and deliberately so — `operation` comes from the
+      // Tool definition, not from the caller, so no retry and no input change can
+      // make this resolve. MISSING_SERVICE says that; PROVIDER_ERROR implied a
+      // provider that might recover. The valid operations are already in hand, so
+      // list them as candidates rather than making the operator go read the
+      // service to find out what it does support.
       throw new ToolError(
         `Unsupported booking requirements operation: ${operation}`,
-        "PROVIDER_ERROR",
+        "MISSING_SERVICE",
+        undefined,
+        undefined,
+        { candidates: supportedOperations() },
       )
     }
     if (operation.startsWith("list") || operation.startsWith("create")) {
@@ -45,12 +54,28 @@ export function contributeBookingRequirementsToolContext(input: {
       const { id, ...data } = args
       return candidate(db as never, String(id) as never, data as never)
     }
+    // voyant#3950: reached when the operation EXISTS but its verb prefix is not
+    // one this dispatcher knows how to shape arguments for. That is a server-side
+    // defect rather than a missing binding, so PROVIDER_ERROR (terminal, "report
+    // it to the operator") is the honest code — classified explicitly here rather
+    // than inherited from a default nobody revisited.
     throw new ToolError(
       `Unsupported booking requirements operation: ${operation}`,
       "PROVIDER_ERROR",
     )
   }
   return { bookingRequirements: { execute } }
+}
+
+/**
+ * The booking-requirements operations this runtime can dispatch — the function
+ * keys the service exposes. Used as `candidates` on an unsupported-operation
+ * failure, where the set is already in memory and costs no extra query.
+ */
+function supportedOperations(): string[] {
+  return Object.keys(bookingRequirementsService)
+    .filter((key) => typeof Reflect.get(bookingRequirementsService, key) === "function")
+    .sort()
 }
 
 async function requiredInventoryRuntime(value: unknown): Promise<BookingsInventoryRuntime> {

--- a/packages/catalog/src/mcp-runtime.ts
+++ b/packages/catalog/src/mcp-runtime.ts
@@ -30,9 +30,13 @@ export const voyantToolContextContribution = defineToolContextContribution({
       async search({ slice, request }) {
         const indexer = runtime.indexer
         if (!indexer) {
+          // voyant#3950: an unwired indexer is a deployment gap, not a provider
+          // failing. Both codes are terminal, but MISSING_SERVICE's remediation
+          // names the actual fix — ask the operator to wire the binding — where
+          // PROVIDER_ERROR pointed the agent at correcting its request.
           throw new ToolError(
             "Catalog search indexer is not configured for this deployment.",
-            "PROVIDER_ERROR",
+            "MISSING_SERVICE",
           )
         }
         if (request.mode === "keyword") return indexer.search(slice, request)

--- a/packages/operations/src/allocation-tool-errors.ts
+++ b/packages/operations/src/allocation-tool-errors.ts
@@ -1,0 +1,35 @@
+/**
+ * Status → Tool error code mapping for the allocation service (voyant#3950).
+ *
+ * Internal: `src/mcp-runtime.ts` is this package's public `./tools` subpath, so
+ * the mapping lives here instead, where a test can import it directly without
+ * making it supported package API.
+ */
+import type { ToolErrorCode } from "@voyant-travel/tools"
+
+/**
+ * Map an allocation service HTTP status onto a Tool error code.
+ *
+ * The code decides `retryable`, and an agent that cannot tell "retry" from
+ * "stop" does both, wrongly. A transient failure reported as terminal makes it
+ * abandon work that would have succeeded on a second attempt; a terminal failure
+ * reported as retryable makes it hammer a request that can never succeed — and
+ * on an allocation write, a wrong retry risks a duplicate placement.
+ *
+ * So the transient statuses are named explicitly rather than folded into a
+ * 4xx/5xx split, which is what the previous mapping did:
+ *
+ * - 408 / 429 are 4xx but retryable — a timeout and a rate limit both clear on
+ *   their own. Classifying them as `INVALID_INPUT` told the agent to go fix an
+ *   input that was never wrong, so it would rewrite a correct request instead of
+ *   waiting and repeating it.
+ * - 502 / 503 / 504 are the upstream being unavailable rather than rejecting.
+ * - A plain 500 stays terminal: it is an unhandled server fault, and repeating
+ *   an allocation write against one is not obviously safe.
+ */
+export function allocationToolErrorCode(status: number): ToolErrorCode {
+  if (status === 404) return "NOT_FOUND"
+  if (status === 408 || status === 429) return "PROVIDER_UNAVAILABLE"
+  if (status === 502 || status === 503 || status === 504) return "PROVIDER_UNAVAILABLE"
+  return status >= 400 && status < 500 ? "INVALID_INPUT" : "PROVIDER_ERROR"
+}

--- a/packages/operations/src/mcp-runtime.ts
+++ b/packages/operations/src/mcp-runtime.ts
@@ -8,10 +8,11 @@ import {
 } from "@voyant-travel/bookings/runtime-port"
 import type { EventBus } from "@voyant-travel/core"
 import type { AnyDrizzleDb } from "@voyant-travel/db"
-import type { ToolErrorCode, ToolHandlerActionPolicyContext } from "@voyant-travel/tools"
+import type { ToolHandlerActionPolicyContext } from "@voyant-travel/tools"
 import { defineToolContextContribution, requireService, ToolError } from "@voyant-travel/tools"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
+import { allocationToolErrorCode } from "./allocation-tool-errors.js"
 import { availabilityService } from "./availability/service.js"
 import {
   type AssignTravelerAllocationsBatchInput,
@@ -258,11 +259,6 @@ async function withAllocationToolErrors<T>(run: () => Promise<T>): Promise<T> {
       { cause: error },
     )
   }
-}
-
-function allocationToolErrorCode(status: number): ToolErrorCode {
-  if (status === 404) return "NOT_FOUND"
-  return status >= 400 && status < 500 ? "INVALID_INPUT" : "PROVIDER_ERROR"
 }
 
 function jsonSafeValue(value: unknown): unknown {

--- a/packages/operations/tests/unit/allocation-tool-errors.test.ts
+++ b/packages/operations/tests/unit/allocation-tool-errors.test.ts
@@ -1,0 +1,53 @@
+/**
+ * voyant#3950: the allocation status → Tool error code mapping.
+ *
+ * This is worth a direct test because the code is what sets `retryable`, and the
+ * consequence of getting it wrong is asymmetric and invisible: an agent told a
+ * transient failure is terminal silently abandons work that would have
+ * succeeded, and nothing in the transcript says why.
+ */
+import { TOOL_ERROR_DEFAULTS } from "@voyant-travel/tools"
+import { describe, expect, it } from "vitest"
+
+import { allocationToolErrorCode } from "../../src/allocation-tool-errors.js"
+
+/** Whether the code this status maps to tells the caller a retry may succeed. */
+const retryable = (status: number) => TOOL_ERROR_DEFAULTS[allocationToolErrorCode(status)].retryable
+
+describe("allocationToolErrorCode", () => {
+  it("maps a missing record to NOT_FOUND", () => {
+    expect(allocationToolErrorCode(404)).toBe("NOT_FOUND")
+  })
+
+  it("treats a timeout and a rate limit as retryable despite being 4xx", () => {
+    // The regression this fixes: both fell into the 4xx branch and came back as
+    // INVALID_INPUT, which tells an agent to go correct an input that was never
+    // wrong. It would rewrite a correct request rather than wait and repeat it.
+    for (const status of [408, 429]) {
+      expect(allocationToolErrorCode(status), `status ${status}`).toBe("PROVIDER_UNAVAILABLE")
+      expect(retryable(status), `status ${status} should be retryable`).toBe(true)
+    }
+  })
+
+  it("treats an unavailable upstream as retryable", () => {
+    for (const status of [502, 503, 504]) {
+      expect(allocationToolErrorCode(status), `status ${status}`).toBe("PROVIDER_UNAVAILABLE")
+      expect(retryable(status), `status ${status} should be retryable`).toBe(true)
+    }
+  })
+
+  it("keeps a plain 500 terminal", () => {
+    // Deliberate: an unhandled server fault is not known to be transient, and
+    // these wrap allocation WRITES where a wrong retry risks a duplicate
+    // placement. Terminal is the safe default when we cannot characterise it.
+    expect(allocationToolErrorCode(500)).toBe("PROVIDER_ERROR")
+    expect(retryable(500)).toBe(false)
+  })
+
+  it("keeps ordinary client errors terminal input errors", () => {
+    for (const status of [400, 403, 409, 422]) {
+      expect(allocationToolErrorCode(status), `status ${status}`).toBe("INVALID_INPUT")
+      expect(retryable(status), `status ${status} should be terminal`).toBe(false)
+    }
+  })
+})

--- a/packages/tools/src/near-matches.ts
+++ b/packages/tools/src/near-matches.ts
@@ -1,0 +1,101 @@
+/**
+ * Near-match suggestion for name-shaped arguments (voyant#3950).
+ *
+ * `ToolError` has carried `candidates` and `didYouMean` since voyant#3947, but
+ * nothing populated them, so both were dead. The one place a candidate set is
+ * genuinely free is a lookup against a registry that is already in memory —
+ * a tool name, a resource name, an operation name — which is also where an agent
+ * fails most often, because it types the name from memory or from a description.
+ */
+
+/**
+ * Damerau-Levenshtein distance, capped: returns `max + 1` as soon as the true
+ * distance is known to exceed `max`.
+ *
+ * The cap is what makes this safe to run against a few hundred names on an error
+ * path. A short row is cheap, and the early exit skips the rest of a name that
+ * has already diverged too far to suggest.
+ *
+ * Transpositions count as one edit, not two, because the mistakes this exists to
+ * catch are typing mistakes: `get_bokoing` should reach `get_booking`.
+ */
+export function boundedEditDistance(left: string, right: string, max: number): number {
+  if (left === right) return 0
+  if (Math.abs(left.length - right.length) > max) return max + 1
+
+  let previous = Array.from({ length: right.length + 1 }, (_, i) => i)
+  let beforePrevious: number[] = []
+
+  for (let i = 1; i <= left.length; i += 1) {
+    const current = [i, ...Array.from<number>({ length: right.length }).fill(0)]
+    let rowMin = current[0] as number
+    for (let j = 1; j <= right.length; j += 1) {
+      const cost = left[i - 1] === right[j - 1] ? 0 : 1
+      let value = Math.min(
+        (current[j - 1] as number) + 1,
+        (previous[j] as number) + 1,
+        (previous[j - 1] as number) + cost,
+      )
+      if (
+        i > 1 &&
+        j > 1 &&
+        left[i - 1] === right[j - 2] &&
+        left[i - 2] === right[j - 1] &&
+        beforePrevious.length > 0
+      ) {
+        value = Math.min(value, (beforePrevious[j - 2] as number) + 1)
+      }
+      current[j] = value
+      if (value < rowMin) rowMin = value
+    }
+    // Every later row is >= this row's minimum, so once the whole row exceeds
+    // the cap the final distance does too.
+    if (rowMin > max) return max + 1
+    beforePrevious = previous
+    previous = current
+  }
+  return previous[right.length] as number
+}
+
+/** How close a name must be to be worth suggesting, scaled to its length. */
+function toleranceFor(name: string): number {
+  if (name.length <= 4) return 1
+  if (name.length <= 8) return 2
+  return 3
+}
+
+export interface NearMatches {
+  /** Names close enough to suggest, nearest first. Empty when nothing is close. */
+  candidates: string[]
+  /** The single nearest name, when one is clearly closest. */
+  didYouMean?: string
+}
+
+/**
+ * Find the names closest to `name` among `known`.
+ *
+ * Returns at most `limit` because the point is a suggestion an agent can act on,
+ * not a directory listing — dumping every registered name into an error is what
+ * this replaces, and it costs more context than it saves.
+ *
+ * `didYouMean` is set only when the nearest match is strictly nearer than the
+ * runner-up. Two equally-close names mean we do not actually know which was
+ * intended, and asserting one would send the agent confidently to the wrong tool.
+ */
+export function findNearMatches(name: string, known: Iterable<string>, limit = 5): NearMatches {
+  const tolerance = toleranceFor(name)
+  const scored: Array<{ name: string; distance: number }> = []
+  for (const candidate of known) {
+    if (candidate === name) continue
+    const distance = boundedEditDistance(name, candidate, tolerance)
+    if (distance <= tolerance) scored.push({ name: candidate, distance })
+  }
+  scored.sort((a, b) => a.distance - b.distance || a.name.localeCompare(b.name))
+
+  const candidates = scored.slice(0, limit).map(({ name: n }) => n)
+  const nearest = scored[0]
+  const runnerUp = scored[1]
+  const unambiguous =
+    nearest !== undefined && (runnerUp === undefined || runnerUp.distance > nearest.distance)
+  return unambiguous ? { candidates, didYouMean: nearest.name } : { candidates }
+}

--- a/packages/tools/src/registry.ts
+++ b/packages/tools/src/registry.ts
@@ -9,6 +9,7 @@ import {
   firstHandlerActionPolicyIdentityMismatch,
   mintHandlerActionPolicyContext,
 } from "./handler-action-policy.js"
+import { findNearMatches } from "./near-matches.js"
 import { warnOnDuplicateToolsPackageInstance } from "./package-instance.js"
 import {
   type AnyToolDefinition,
@@ -317,11 +318,32 @@ function parseToolInput(
   return input.data
 }
 
+/**
+ * voyant#3950: an unregistered tool name is where `candidates` earns its keep.
+ *
+ * This used to inline EVERY registered name into the message — ~270 of them on
+ * the operator graph, as one unstructured comma-joined string. That is a
+ * directory listing charged to the agent's context at the exact moment it is
+ * already lost, and it buries the one name it probably meant.
+ *
+ * Near matches instead: a handful of structured `candidates` the transport can
+ * present or cap, plus `didYouMean` when one name is unambiguously nearest.
+ * When nothing is close the message says how to enumerate rather than
+ * enumerating — discovery is a tool call, not an error payload.
+ */
 function unknownToolError(name: string, knownNames: Iterable<string>): ToolError {
+  const { candidates, didYouMean } = findNearMatches(name, knownNames)
+  const suffix = didYouMean
+    ? ` Did you mean "${didYouMean}"?`
+    : candidates.length > 0
+      ? ` Close matches: ${candidates.join(", ")}.`
+      : " Use the discovery tools to list what this deployment serves."
   return new ToolError(
-    `Tool "${name}" is not registered. Known tools: ${Array.from(knownNames).join(", ") || "(none)"}`,
+    `Tool "${name}" is not registered.${suffix}`,
     "NOT_FOUND",
     { name },
+    undefined,
+    { ...(candidates.length > 0 ? { candidates } : {}), ...(didYouMean ? { didYouMean } : {}) },
   )
 }
 

--- a/packages/tools/src/registry.ts
+++ b/packages/tools/src/registry.ts
@@ -340,6 +340,12 @@ async function executeTool(
     // PROVIDER_ERROR whose raw text reaches the caller (voyant#4115).
     if (isToolError(err)) throw toToolError(err)
     const message = err instanceof Error ? err.message : String(err)
+    // voyant#3950: PROVIDER_ERROR (terminal) is the deliberate classification for
+    // an UNRECOGNIZED throw, not a default nobody revisited. We know nothing about
+    // what failed here, and this wrapper covers writes as well as reads — telling
+    // an agent to retry a write whose outcome we cannot characterise is how you
+    // get a duplicate booking. A handler that knows its failure is transient
+    // should throw PROVIDER_UNAVAILABLE itself; `isToolError` above preserves it.
     throw new ToolError(`Tool "${name}" failed: ${message}`, "PROVIDER_ERROR", undefined, {
       cause: err,
     })

--- a/packages/tools/tests/near-matches.test.ts
+++ b/packages/tools/tests/near-matches.test.ts
@@ -1,0 +1,63 @@
+/**
+ * voyant#3950: near-match suggestions for an unregistered tool name.
+ *
+ * The behaviour worth pinning is not "finds close names" but the two judgement
+ * calls around it — that an ambiguous nearest match does NOT become a confident
+ * `didYouMean`, and that a name with nothing close returns nothing rather than
+ * the whole registry.
+ */
+import { describe, expect, it } from "vitest"
+
+import { boundedEditDistance, findNearMatches } from "../src/near-matches.js"
+
+describe("boundedEditDistance", () => {
+  it("counts a transposition as one edit", () => {
+    // The mistakes this exists to catch are typing mistakes, and treating a
+    // swap as two edits pushes the name it should have found out of tolerance.
+    expect(boundedEditDistance("get_bokoing", "get_booking", 3)).toBe(1)
+  })
+
+  it("stops early instead of computing a distance it will not use", () => {
+    // The contract is only "greater than max", not the true distance.
+    expect(boundedEditDistance("aaaaaaaa", "zzzzzzzz", 2)).toBeGreaterThan(2)
+  })
+
+  it("is zero for an exact match", () => {
+    expect(boundedEditDistance("list_bookings", "list_bookings", 3)).toBe(0)
+  })
+})
+
+describe("findNearMatches", () => {
+  const KNOWN = ["list_bookings", "get_booking", "create_booking", "list_products", "get_product"]
+
+  it("suggests the intended name for a typo", () => {
+    const { candidates, didYouMean } = findNearMatches("get_bokoing", KNOWN)
+    expect(didYouMean).toBe("get_booking")
+    expect(candidates).toContain("get_booking")
+  })
+
+  it("withholds didYouMean when two names are equally close", () => {
+    // "get_bookings" is one edit from `get_booking` (drop the s) and one from
+    // `list_bookings` is not — construct a genuine tie instead.
+    const tie = findNearMatches("xat", ["cat", "bat"])
+    expect(tie.didYouMean).toBeUndefined()
+    // Both still offered — the agent picks, rather than being sent confidently
+    // to whichever happened to sort first.
+    expect(tie.candidates).toEqual(["bat", "cat"])
+  })
+
+  it("returns nothing when no name is close", () => {
+    // The failure mode being replaced: dumping every registered name into the
+    // error. Nothing close must mean nothing returned, not everything returned.
+    expect(findNearMatches("completely_unrelated_zzz", KNOWN)).toEqual({ candidates: [] })
+  })
+
+  it("caps how many candidates it offers", () => {
+    const many = Array.from({ length: 40 }, (_, i) => `get_thing${i}`)
+    expect(findNearMatches("get_thing", many, 5).candidates).toHaveLength(5)
+  })
+
+  it("never suggests the name that was asked for", () => {
+    expect(findNearMatches("get_booking", KNOWN).candidates).not.toContain("get_booking")
+  })
+})

--- a/packages/tools/tests/registry.test.ts
+++ b/packages/tools/tests/registry.test.ts
@@ -145,6 +145,35 @@ describe("createToolRegistry", () => {
     })
   })
 
+  it("suggests the intended tool when the name is a near miss", async () => {
+    // voyant#3950: this error used to inline every registered name into its
+    // message — a directory listing charged to the agent's context at the moment
+    // it is already lost. Structured candidates instead, so the transport can
+    // present them and the one likely name is not buried.
+    const registry = createToolRegistry()
+    registry.register(echoTool)
+
+    await expect(registry.dispatch("ecoh", {}, ctx)).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      candidates: ["echo"],
+      didYouMean: "echo",
+    })
+  })
+
+  it("does not enumerate the registry when nothing is close", async () => {
+    const registry = createToolRegistry()
+    registry.register(echoTool)
+
+    const error = await registry
+      .dispatch("completely_unrelated_zzz", {}, ctx)
+      .then(() => undefined)
+      .catch((err: ToolError) => err)
+
+    expect(error?.code).toBe("NOT_FOUND")
+    expect(error?.candidates).toBeUndefined()
+    expect(error?.message).not.toContain("echo")
+  })
+
   it("throws INVALID_INPUT when args fail the input schema", async () => {
     const registry = createToolRegistry()
     registry.register(echoTool)


### PR DESCRIPTION
Closes acceptance item 2 of #3950 and the part of item 1 that is actually free.

## The real defect

`packages/operations` `allocationToolErrorCode` folded every status into a
4xx/5xx split:

| status | was | now | why |
|---|---|---|---|
| 408, 429 | `INVALID_INPUT` (terminal) | `PROVIDER_UNAVAILABLE` | told the agent to fix an input that was never wrong; it should wait and repeat |
| 502, 503, 504 | `PROVIDER_ERROR` (terminal) | `PROVIDER_UNAVAILABLE` | agent abandoned work a retry would have completed |
| 500 | `PROVIDER_ERROR` | unchanged | deliberate — unhandled fault, and these wrap allocation **writes** where a wrong retry risks a duplicate placement |

The mapping moved to an internal module because `src/mcp-runtime.ts` is the
package's public `./tools` subpath, and this should be testable without becoming
supported API.

## Wrong code, not wrong retryability

An unwired catalog indexer and an unresolvable booking-requirements operation are
deployment gaps, not providers failing. Both terminal either way, but
`MISSING_SERVICE`'s remediation names the actual fix where `PROVIDER_ERROR`
pointed the agent at correcting its request. The booking-requirements site also
now returns the supported operation names as `candidates` — already in memory.

The generic wrapper in `tools/registry.ts` stays `PROVIDER_ERROR`, with the
reasoning recorded rather than inherited.

## `unknownToolError` was actively harmful

It inlined **every registered name** into the message — ~270 on the operator
graph, one comma-joined string. A directory listing charged to the agent's
context at the moment it is already lost, burying the one name it probably meant.

Now near-match `candidates` plus `didYouMean`, via a capped Damerau-Levenshtein
(a transposition costs one edit, so `get_bokoing` reaches `get_booking`), run
only on the error path. Two judgement calls are test-pinned because they are what
makes it useful rather than clever:

- an **ambiguous** nearest match yields no `didYouMean` — asserting one sends the
  agent confidently to the wrong tool;
- nothing close returns **nothing**, not a fallback to enumerating.

## On acceptance item 1

I audited all 69 `NOT_FOUND` sites (69 now, not 63). Essentially **none** is the
"list-then-find, candidates already in hand" pattern the issue assumes — they are
uniformly `getX(id) → null` straight against a service, so populating candidates
means an extra error-path query, which the issue says to skip. Detail and a
suggested re-scope are in [this comment](https://github.com/voyant-travel/voyant/issues/3950#issuecomment-5189059780).

## Verification

- `packages/tools` 81 tests, `packages/operations` new mapping test 5 tests, `packages/bookings` 341 unit tests — all pass
- `pnpm -F @voyant-travel/operations... build` clean (full dep chain, 0 `error TS`)
- `biome check` clean on changed files

All four touched packages are `private: true` post-#4098, so no changeset.