### PR TITLE
fix(storefronts): scope storefronts to the deployment, not to an absent organization

### DIFF
--- a/.changeset/storefronts-deployment-scope.md
+++ b/.changeset/storefronts-deployment-scope.md
@@ -1,0 +1,27 @@
+---
+"@voyant-travel/auth": patch
+"@voyant-travel/auth-react": patch
+"@voyant-travel/db": patch
+---
+
+Make the Storefronts admin surface reachable again.
+
+Storefronts were scoped to a Better Auth operator organization, but the operator
+auth realm never creates one — the `organization` plugin is wired for the
+customer realm only. So `organization` is empty on every deployment: reads
+filtered to nothing, writes failed the `organization_id` foreign key, and the
+route rejected the session outright with "No active operator organization." A
+tenant could neither create a storefront nor read its keys.
+
+A self-host deployment is the tenant boundary (`docs/adr/0001-tenant-scoping.md`),
+so a storefront now belongs to the deployment: `organization_id` is dropped from
+`storefronts`, `storefront_api_keys`, and `storefront_customer_auth_credentials`,
+the slug is unique per deployment, and `StorefrontDto.organizationId` is gone
+from the admin contract. Authorization is unchanged — the `/v1/admin/*` staff
+guard and the `storefronts:*` scopes.
+
+Also stops rejecting a trusted origin that carries a path. The env allowlist is
+built from `APP_URL`, which is documented and shipped as the API base
+(`http://host:3300/api`); an origin check only ever compares origins, so the path
+is narrowed away instead of throwing. Rejecting it made every public catalog read
+answer 500 with "customer auth trusted origin must be an absolute HTTP(S) origin".

--- a/packages/auth-react/src/storefronts-page.test.tsx
+++ b/packages/auth-react/src/storefronts-page.test.tsx
@@ -21,7 +21,6 @@ import { createStorefrontsAdminApi, type StorefrontsAdminApi } from "./storefron
 
 const STOREFRONT: StorefrontDto = {
   id: "storefront_1",
-  organizationId: "org_1",
   name: "Web store",
   slug: "web",
   hostingKind: "external",

--- a/packages/auth/src/node-runtime.ts
+++ b/packages/auth/src/node-runtime.ts
@@ -750,13 +750,22 @@ export function createOperatorAuthNodeRuntime<Env extends OperatorAuthNodeEnv>(
     // env allowlist so a cross-origin customer-auth call from any allowed
     // storefront origin is trusted by Better Auth (WORK: direct-client support).
     // Wildcard (`https://*.host`) entries pass through untouched — Better Auth
-    // matches them natively; every other entry must be a canonical origin.
-    const trustedOrigins = [...new Set([...context.trustedOrigins, ...getTrustedOrigins(env)])].map(
-      (origin) =>
-        isCustomerWildcardOrigin(origin)
-          ? origin
-          : requireCanonicalOrigin(origin, "customer auth trusted origin"),
-    )
+    // matches them natively; every other entry is narrowed to its origin.
+    //
+    // Narrowed, not rejected: the env allowlist is built from `APP_URL` /
+    // `DASH_BASE_URL` / `CORS_ALLOWLIST`, and `APP_URL` is documented (and
+    // shipped) as the API base — `http://host:3300/api`. An origin check only
+    // ever compares origins, so the trailing path carries no meaning here;
+    // throwing on it turned every public read into a 500 (voyant#4261).
+    const trustedOrigins = [
+      ...new Set(
+        [...context.trustedOrigins, ...getTrustedOrigins(env)].map((origin) =>
+          isCustomerWildcardOrigin(origin)
+            ? origin
+            : canonicalOriginOf(origin, "customer auth trusted origin"),
+        ),
+      ),
+    ]
     const invitationAcceptBaseURL = context.invitationAcceptBaseURL
       ? requireCanonicalOrigin(
           context.invitationAcceptBaseURL,
@@ -780,23 +789,33 @@ export function createOperatorAuthNodeRuntime<Env extends OperatorAuthNodeEnv>(
   }
 
   function requireCanonicalOrigin(value: string, label: string): string {
+    const parsed = parseHttpUrl(value, label)
+    if ((parsed.pathname !== "/" && parsed.pathname !== "") || parsed.search || parsed.hash) {
+      throw new Error(`${label} must be an absolute HTTP(S) origin`)
+    }
+    return parsed.origin
+  }
+
+  /**
+   * The origin of an absolute HTTP(S) URL. Unlike {@link requireCanonicalOrigin}
+   * this accepts a URL that carries a path/query/fragment and discards it, for
+   * the places where only the origin is ever compared.
+   */
+  function canonicalOriginOf(value: string, label: string): string {
+    return parseHttpUrl(value, label).origin
+  }
+
+  function parseHttpUrl(value: string, label: string): URL {
     let parsed: URL
     try {
       parsed = new URL(value)
     } catch {
       throw new Error(`${label} must be an absolute HTTP(S) origin`)
     }
-    if (
-      !["http:", "https:"].includes(parsed.protocol) ||
-      parsed.username ||
-      parsed.password ||
-      (parsed.pathname !== "/" && parsed.pathname !== "") ||
-      parsed.search ||
-      parsed.hash
-    ) {
+    if (!["http:", "https:"].includes(parsed.protocol) || parsed.username || parsed.password) {
       throw new Error(`${label} must be an absolute HTTP(S) origin`)
     }
-    return parsed.origin
+    return parsed
   }
 
   function requirePublicApiBaseUrl(value: string, baseURL: string): string {

--- a/packages/auth/src/storefront-admin-contracts.ts
+++ b/packages/auth/src/storefront-admin-contracts.ts
@@ -56,7 +56,6 @@ export const storefrontCustomerAccountPolicySchema = z
 export const storefrontSchema = z
   .object({
     id: z.string(),
-    organizationId: z.string(),
     name: z.string(),
     slug: z.string(),
     hostingKind: storefrontHostingKindSchema,

--- a/packages/auth/src/storefront-local-adapter.ts
+++ b/packages/auth/src/storefront-local-adapter.ts
@@ -1,8 +1,10 @@
 /**
  * Local storefront runtime provider — backs {@link storefrontRuntimePort} with
- * the deployment's own runtime DB (self-host). Mirrors the team-management
- * local adapter: every operator write is bounded to `context.organizationId`,
- * and request-time resolution (`resolveStorefrontByApiKey`) is org-agnostic.
+ * the deployment's own runtime DB (self-host). The deployment is the tenant
+ * boundary (docs/adr/0001-tenant-scoping.md), so storefronts are deployment-wide:
+ * operator writes are authorized by the `/v1/admin/*` staff guard and the
+ * `storefronts:*` scopes, and request-time resolution
+ * (`resolveStorefrontByApiKey`) selects by token.
  */
 import {
   type InsertStorefront,
@@ -50,7 +52,6 @@ export { isStorefrontOriginAllowed } from "./storefront-origins.js"
 function toStorefrontDto(row: SelectStorefront): StorefrontDto {
   return {
     id: row.id,
-    organizationId: row.organizationId,
     name: row.name,
     slug: row.slug,
     hostingKind: row.hostingKind,
@@ -98,20 +99,15 @@ export function createLocalStorefrontAdapter(options: {
 }): StorefrontRuntimeProvider {
   const { resolveCipher } = options
 
-  /** Load a storefront and prove it belongs to the acting organization. */
-  async function requireOwnedStorefront(
+  /** Load a storefront by id, or report it as missing. */
+  async function requireStorefront(
     context: StorefrontRequestContext,
     storefrontId: string,
   ): Promise<SelectStorefront> {
     const [row] = await context.db
       .select()
       .from(storefronts)
-      .where(
-        and(
-          eq(storefronts.id, storefrontId),
-          eq(storefronts.organizationId, context.organizationId),
-        ),
-      )
+      .where(eq(storefronts.id, storefrontId))
       .limit(1)
     if (!row) throw new StorefrontInputError("Storefront was not found.")
     return row
@@ -146,12 +142,7 @@ export function createLocalStorefrontAdapter(options: {
     const [row] = await context.db
       .update(storefronts)
       .set({ ...patch, updatedAt: new Date() })
-      .where(
-        and(
-          eq(storefronts.id, storefrontId),
-          eq(storefronts.organizationId, context.organizationId),
-        ),
-      )
+      .where(eq(storefronts.id, storefrontId))
       .returning()
     if (!row) throw new StorefrontInputError("Storefront was not found.")
     return toStorefrontDto(row)
@@ -166,13 +157,12 @@ export function createLocalStorefrontAdapter(options: {
     const rows = await context.db
       .select({ id: storefronts.id, allowedOrigins: storefronts.allowedOrigins })
       .from(storefronts)
-      .where(eq(storefronts.organizationId, context.organizationId))
     for (const row of rows) {
       if (storefrontId && row.id === storefrontId) continue
       for (const candidate of allowedOrigins) {
         if (row.allowedOrigins.some((existing) => originsOverlap(candidate, existing))) {
           throw new StorefrontInputError(
-            "Storefront allowed origin overlaps another storefront in this organization.",
+            "Storefront allowed origin overlaps another storefront in this deployment.",
           )
         }
       }
@@ -190,7 +180,6 @@ export function createLocalStorefrontAdapter(options: {
       .insert(storefrontApiKeys)
       .values({
         storefrontId: storefront.id,
-        organizationId: storefront.organizationId,
         kind,
         tokenHash: generated.tokenHash,
         tokenPreview: generated.tokenPreview,
@@ -203,16 +192,12 @@ export function createLocalStorefrontAdapter(options: {
 
   return {
     async listStorefronts(context) {
-      const rows = await context.db
-        .select()
-        .from(storefronts)
-        .where(eq(storefronts.organizationId, context.organizationId))
-        .orderBy(desc(storefronts.createdAt))
+      const rows = await context.db.select().from(storefronts).orderBy(desc(storefronts.createdAt))
       return rows.map(toStorefrontDto)
     },
 
     async getStorefront(context, storefrontId) {
-      return toStorefrontDto(await requireOwnedStorefront(context, storefrontId))
+      return toStorefrontDto(await requireStorefront(context, storefrontId))
     },
 
     async createStorefront(context, input) {
@@ -239,7 +224,6 @@ export function createLocalStorefrontAdapter(options: {
       const [row] = await context.db
         .insert(storefronts)
         .values({
-          organizationId: context.organizationId,
           name: input.name.trim(),
           slug,
           hostingKind: input.hostingKind,
@@ -255,7 +239,7 @@ export function createLocalStorefrontAdapter(options: {
     },
 
     async updateStorefront(context, storefrontId, patch) {
-      await requireOwnedStorefront(context, storefrontId)
+      await requireStorefront(context, storefrontId)
       const update: Partial<InsertStorefront> = {}
       if (patch.name !== undefined) update.name = patch.name.trim()
       if (patch.allowedOrigins !== undefined) {
@@ -274,19 +258,12 @@ export function createLocalStorefrontAdapter(options: {
     },
 
     async deleteStorefront(context, storefrontId) {
-      await requireOwnedStorefront(context, storefrontId)
-      await context.db
-        .delete(storefronts)
-        .where(
-          and(
-            eq(storefronts.id, storefrontId),
-            eq(storefronts.organizationId, context.organizationId),
-          ),
-        )
+      await requireStorefront(context, storefrontId)
+      await context.db.delete(storefronts).where(eq(storefronts.id, storefrontId))
     },
 
     async setAllowedOrigins(context, storefrontId, origins) {
-      await requireOwnedStorefront(context, storefrontId)
+      await requireStorefront(context, storefrontId)
       const allowedOrigins = normalizeStorefrontAllowedOrigins(origins)
       await assertNoOverlappingOrigins(context, storefrontId, allowedOrigins)
       return persistStorefrontPatch(context, storefrontId, {
@@ -295,7 +272,7 @@ export function createLocalStorefrontAdapter(options: {
     },
 
     async listApiKeys(context, storefrontId) {
-      await requireOwnedStorefront(context, storefrontId)
+      await requireStorefront(context, storefrontId)
       const rows = await context.db
         .select()
         .from(storefrontApiKeys)
@@ -305,12 +282,12 @@ export function createLocalStorefrontAdapter(options: {
     },
 
     async issueApiKey(context, storefrontId, kind, name) {
-      const storefront = await requireOwnedStorefront(context, storefrontId)
+      const storefront = await requireStorefront(context, storefrontId)
       return issueKeyRow(context, storefront, kind, name)
     },
 
     async rotateApiKey(context, storefrontId, keyId) {
-      const storefront = await requireOwnedStorefront(context, storefrontId)
+      const storefront = await requireStorefront(context, storefrontId)
       const [existing] = await context.db
         .select()
         .from(storefrontApiKeys)
@@ -327,7 +304,7 @@ export function createLocalStorefrontAdapter(options: {
     },
 
     async revokeApiKey(context, storefrontId, keyId) {
-      await requireOwnedStorefront(context, storefrontId)
+      await requireStorefront(context, storefrontId)
       await context.db
         .update(storefrontApiKeys)
         .set({ revokedAt: new Date(), updatedAt: new Date() })
@@ -405,21 +382,21 @@ export function createLocalStorefrontAdapter(options: {
     },
 
     async updateAccountPolicy(context, storefrontId, policy) {
-      await requireOwnedStorefront(context, storefrontId)
+      await requireStorefront(context, storefrontId)
       return persistStorefrontPatch(context, storefrontId, {
         accountPolicy: normalizeStorefrontCustomerAccountPolicy(policy),
       })
     },
 
     async updateMethods(context, storefrontId, methods) {
-      await requireOwnedStorefront(context, storefrontId)
+      await requireStorefront(context, storefrontId)
       const normalized = normalizeStorefrontCustomerAuthMethods(methods)
       await requireCredentialsForEnabledSocialMethods(context, storefrontId, normalized)
       return persistStorefrontPatch(context, storefrontId, { methods: normalized })
     },
 
     async listProviderCredentials(context, storefrontId) {
-      await requireOwnedStorefront(context, storefrontId)
+      await requireStorefront(context, storefrontId)
       const rows = await context.db
         .select()
         .from(storefrontCustomerAuthCredentials)
@@ -441,7 +418,7 @@ export function createLocalStorefrontAdapter(options: {
     },
 
     async putProviderCredential(context, storefrontId, provider, credentials) {
-      const storefront = await requireOwnedStorefront(context, storefrontId)
+      await requireStorefront(context, storefrontId)
       const bundle = validateStorefrontCredentialBundle(provider, credentials)
       const encrypted = await resolveCipher(context.bindings).encrypt(JSON.stringify(bundle))
       const [existing] = await context.db
@@ -463,14 +440,13 @@ export function createLocalStorefrontAdapter(options: {
       }
       await context.db.insert(storefrontCustomerAuthCredentials).values({
         storefrontId,
-        organizationId: storefront.organizationId,
         provider,
         encryptedCredentials: encrypted,
       })
     },
 
     async deleteProviderCredential(context, storefrontId, provider) {
-      await requireOwnedStorefront(context, storefrontId)
+      await requireStorefront(context, storefrontId)
       await context.db
         .delete(storefrontCustomerAuthCredentials)
         .where(

--- a/packages/auth/src/storefront-routes.ts
+++ b/packages/auth/src/storefront-routes.ts
@@ -25,7 +25,6 @@ type StorefrontEnv = {
   Bindings: Record<string, unknown>
   Variables: {
     userId?: string
-    organizationId?: string | null
     scopes?: string[] | null
     db: VoyantDb
     link?: StorefrontRequestContext["link"]
@@ -202,16 +201,15 @@ const clearChannelBindingRoute = storefrontRoute({
 })
 
 /**
- * Resolve the operator-scoped request context. The organization is derived from
- * the admin session — never a client parameter — so every write is bounded to
- * the acting operator's organization.
+ * Resolve the operator request context. The deployment is the tenant boundary
+ * (docs/adr/0001-tenant-scoping.md), so there is no organization to derive: the
+ * `/v1/admin/*` staff guard admits the caller and `storefronts:write` gates the
+ * writes.
  */
 function requestContext(c: StorefrontRouteContext): StorefrontRequestContext | Response {
   const userId = c.get("userId")
   if (!userId) return c.json({ error: "Unauthorized" }, 401)
-  const organizationId = c.get("organizationId")
-  if (!organizationId) return c.json({ error: "No active operator organization." }, 403)
-  return { bindings: c.env, db: c.get("db"), link: c.get("link"), organizationId }
+  return { bindings: c.env, db: c.get("db"), link: c.get("link") }
 }
 
 function canManageStorefronts(c: StorefrontRouteContext): boolean {
@@ -302,7 +300,6 @@ export function createStorefrontAdminRoutes(
 
   routes.openapi(capabilitiesRoute, (c) => {
     if (!c.get("userId")) return c.json({ error: "Unauthorized" }, 401)
-    if (!c.get("organizationId")) return c.json({ error: "No active operator organization." }, 403)
     const manageProviders = canManageStorefronts(c)
     return c.json({
       data: {

--- a/packages/auth/src/storefront-runtime-port.ts
+++ b/packages/auth/src/storefront-runtime-port.ts
@@ -11,7 +11,6 @@ import type { VoyantDb } from "@voyant-travel/hono"
 
 export interface StorefrontDto {
   id: string
-  organizationId: string
   name: string
   slug: string
   hostingKind: StorefrontHostingKind
@@ -80,18 +79,23 @@ export interface UpdateStorefrontInput {
   accountPolicy?: StorefrontCustomerAccountPolicy
 }
 
-/** Operator-scoped admin context: every write is bounded to one organization. */
+/**
+ * Operator admin context. The deployment is the tenant boundary
+ * (docs/adr/0001-tenant-scoping.md), so a storefront belongs to the deployment
+ * and there is no in-process organization scope to bound a write to — the
+ * operator actor guard on `/v1/admin/*` and the `storefronts:*` scopes are the
+ * authorization.
+ */
 export interface StorefrontRequestContext {
   bindings: Record<string, unknown>
   db: VoyantDb
   link?: LinkService
-  organizationId: string
 }
 
 /**
  * Request-time resolve context. Customer-auth resolution runs without an
- * operator user, so no organization scope is present — a token selects its
- * storefront globally, then the declared-origin check authorizes it.
+ * operator user — a token selects its storefront, then the declared-origin
+ * check authorizes it.
  */
 export interface StorefrontResolveContext {
   bindings: Record<string, unknown>

--- a/packages/auth/tests/integration/local-storefront.test.ts
+++ b/packages/auth/tests/integration/local-storefront.test.ts
@@ -1,7 +1,6 @@
 import { createDbClient } from "@voyant-travel/db"
 import type { KmsEnvelope } from "@voyant-travel/db/schema/iam"
 import { authOrganization, storefronts } from "@voyant-travel/db/schema/iam"
-import { eq } from "drizzle-orm"
 import { afterAll, beforeEach, describe, expect, it } from "vitest"
 import type { StorefrontCredentialCipher } from "../../src/storefront-credentials.js"
 import { createLocalStorefrontAdapter } from "../../src/storefront-local-adapter.js"
@@ -11,8 +10,6 @@ import type {
 } from "../../src/storefront-runtime-port.js"
 
 const TEST_DATABASE_URL = process.env.TEST_DATABASE_URL
-const ORG_ID = "org_storefront_test"
-const OTHER_ORG_ID = "org_storefront_test_other"
 
 // Deterministic in-memory cipher: base64 stands in for KMS ciphertext so the
 // round-trip (encrypt → store envelope → decrypt) is exercised end-to-end.
@@ -33,31 +30,19 @@ describe.skipIf(!TEST_DATABASE_URL)("local storefront adapter", () => {
     timeouts: { connectMs: false, queryMs: false, statementMs: false },
   })
   const adapter = createLocalStorefrontAdapter({ resolveCipher: () => testCipher })
-  const context: StorefrontRequestContext = { bindings: {}, db, organizationId: ORG_ID }
+  const context: StorefrontRequestContext = { bindings: {}, db }
   const resolveContext: StorefrontResolveContext = { bindings: {}, db }
 
+  // No organization fixture: the operator auth realm never creates one, so a
+  // real deployment runs with `organization` empty. Storefronts must work there
+  // (voyant#4261) — the emptiness is the point, not an omission.
   beforeEach(async () => {
-    await db.delete(authOrganization).where(eq(authOrganization.id, OTHER_ORG_ID))
-    await db.delete(authOrganization).where(eq(authOrganization.id, ORG_ID))
-    await db.insert(authOrganization).values([
-      {
-        id: ORG_ID,
-        name: "Test Operator",
-        slug: `test-operator-${ORG_ID}`,
-        createdAt: new Date(),
-      },
-      {
-        id: OTHER_ORG_ID,
-        name: "Other Test Operator",
-        slug: `test-operator-${OTHER_ORG_ID}`,
-        createdAt: new Date(),
-      },
-    ])
+    await db.delete(storefronts)
+    await db.delete(authOrganization)
   })
 
   afterAll(async () => {
-    await db.delete(authOrganization).where(eq(authOrganization.id, OTHER_ORG_ID))
-    await db.delete(authOrganization).where(eq(authOrganization.id, ORG_ID))
+    await db.delete(storefronts)
   })
 
   async function createShop() {
@@ -78,7 +63,6 @@ describe.skipIf(!TEST_DATABASE_URL)("local storefront adapter", () => {
 
   it("creates, reads, lists, and updates a storefront (origins/methods/policy)", async () => {
     const created = await createShop()
-    expect(created.organizationId).toBe(ORG_ID)
     expect(created.allowedOrigins).toEqual(["https://shop.example.com"])
 
     expect(await adapter.getStorefront(context, created.id)).toMatchObject({ id: created.id })
@@ -132,10 +116,9 @@ describe.skipIf(!TEST_DATABASE_URL)("local storefront adapter", () => {
     expect(await adapter.resolveStorefrontByApiKey(resolveContext, rotated.token)).toBeNull()
   })
 
-  it("rejects an origin with cross-organization exact and wildcard matches", async () => {
+  it("rejects an origin that exact- and wildcard-matches two storefronts", async () => {
     await createShop()
     await db.insert(storefronts).values({
-      organizationId: OTHER_ORG_ID,
       name: "Other Shop",
       slug: "other-shop",
       hostingKind: "external",
@@ -195,15 +178,29 @@ describe.skipIf(!TEST_DATABASE_URL)("local storefront adapter", () => {
     ).rejects.toThrow(/facebook/)
   })
 
-  it("scopes every read/write to the acting organization", async () => {
-    const shop = await createShop()
-    const otherOrgContext: StorefrontRequestContext = {
-      bindings: {},
-      db,
-      organizationId: "org_intruder",
-    }
-    await expect(adapter.getStorefront(otherOrgContext, shop.id)).rejects.toThrow(/not found/i)
-    expect(await adapter.listStorefronts(otherOrgContext)).toHaveLength(0)
+  it("reports an unknown storefront id as not found", async () => {
+    await createShop()
+    await expect(adapter.getStorefront(context, "storefronts_missing")).rejects.toThrow(
+      /not found/i,
+    )
+  })
+
+  // The regression this suite exists for: with `organization` empty — which is
+  // every operator deployment, because the admin realm has no organization
+  // plugin — creating and listing a storefront must still work. Scoping the
+  // storefront tables by `organization_id` made the insert fail its foreign key
+  // and the list return nothing (voyant#4261).
+  it("creates and lists a storefront with no operator organization in the database", async () => {
+    expect(await db.select().from(authOrganization)).toHaveLength(0)
+
+    const created = await createShop()
+    const listed = await adapter.listStorefronts(context)
+
+    expect(listed.map((row) => row.id)).toEqual([created.id])
+    const issued = await adapter.issueApiKey(context, created.id, "publishable", "web")
+    expect(
+      (await adapter.resolveStorefrontByApiKey(resolveContext, issued.token))?.storefront.id,
+    ).toBe(created.id)
   })
 
   it("deletes a storefront", async () => {

--- a/packages/auth/tests/unit/node-runtime.test.ts
+++ b/packages/auth/tests/unit/node-runtime.test.ts
@@ -344,11 +344,11 @@ describe("createOperatorAuthNodeRuntime", () => {
       },
     },
     {
-      label: "trusted origin with a path",
+      label: "trusted origin that is not an absolute HTTP(S) URL",
       context: {
         baseURL: "https://shop.example.com",
         publicApiBaseURL: "https://shop.example.com/api",
-        trustedOrigins: ["https://shop.example.com/path"],
+        trustedOrigins: ["shop.example.com"],
       },
     },
   ])("fails closed for a broker context with $label", async ({ context }) => {
@@ -373,6 +373,36 @@ describe("createOperatorAuthNodeRuntime", () => {
     )
 
     expect(response.status).toBe(500)
+  })
+
+  // `APP_URL` is documented (and shipped) as the API base — `http://host/api` —
+  // and it feeds the env trusted-origin allowlist. An origin check only compares
+  // origins, so the path is narrowed away rather than rejected; rejecting it
+  // turned every public read into a 500 (voyant#4261).
+  it("narrows a trusted origin that carries a path to its origin", async () => {
+    const runtime = createOperatorAuthNodeRuntime({
+      accessCatalog: { resources: [], presets: [] },
+      appName: "auth-test",
+      authMode: "voyant-cloud",
+      reporter: { captureException: vi.fn() },
+      resolveCustomerAuthContext: async () => ({
+        baseURL: "https://shop.example.com",
+        publicApiBaseURL: "https://shop.example.com/api",
+        trustedOrigins: ["https://shop.example.com/api", "https://shop.example.com"],
+        methods: { emailCode: true, emailPassword: true },
+      }),
+    })
+
+    const response = await runtime.handler.fetch(
+      new Request("https://runtime.internal/auth/customer/config"),
+      {
+        DATABASE_URL: "postgres://unused",
+        SESSION_CLAIMS_ADMIN_SECRET: "admin-session-claims-secret",
+      },
+      { waitUntil: vi.fn() } as never,
+    )
+
+    expect(response.status).toBe(200)
   })
 
   it("awaits managed customer auth context for public API session resolution", async () => {
@@ -506,7 +536,6 @@ describe("createOperatorAuthNodeRuntime", () => {
 describe("createOperatorAuthNodeRuntime storefront customer-auth failures", () => {
   const STOREFRONT: StorefrontDto = {
     id: "sf_1",
-    organizationId: "org_1",
     name: "Shop",
     slug: "shop",
     hostingKind: "external",
@@ -735,7 +764,6 @@ describe("isCustomerCorsSurface", () => {
 describe("createOperatorAuthNodeRuntime customer dynamic CORS", () => {
   const STOREFRONT: StorefrontDto = {
     id: "sf_cors",
-    organizationId: "org_1",
     name: "Shop",
     slug: "shop",
     hostingKind: "external",

--- a/packages/auth/tests/unit/storefront-admin-contracts.test.ts
+++ b/packages/auth/tests/unit/storefront-admin-contracts.test.ts
@@ -7,7 +7,6 @@ import {
 
 const STOREFRONT = {
   id: "storefront_1",
-  organizationId: "org_1",
   name: "Customer portal",
   slug: "customer-portal",
   hostingKind: "external",

--- a/packages/auth/tests/unit/storefront-customer-auth-resolver.test.ts
+++ b/packages/auth/tests/unit/storefront-customer-auth-resolver.test.ts
@@ -19,7 +19,6 @@ import type {
 
 const STOREFRONT: StorefrontDto = {
   id: "sf_1",
-  organizationId: "org_1",
   name: "Shop",
   slug: "shop",
   hostingKind: "external",

--- a/packages/auth/tests/unit/storefront-routes.test.ts
+++ b/packages/auth/tests/unit/storefront-routes.test.ts
@@ -13,7 +13,6 @@ import type {
 
 const STOREFRONT: StorefrontDto = {
   id: "storefront_1",
-  organizationId: "org_actor",
   name: "Web",
   slug: "web",
   hostingKind: "external",
@@ -95,7 +94,6 @@ function app(
   provider: StorefrontRuntimeProvider,
   options: {
     authenticated?: boolean
-    organizationId?: string | null
     scopes?: string[]
     businessAccounts?: boolean
     channelBinding?: StorefrontChannelBindingProvider | null
@@ -103,7 +101,6 @@ function app(
 ) {
   const {
     authenticated = true,
-    organizationId = "org_actor",
     scopes = ["storefronts:read", "storefronts:write"],
     businessAccounts = true,
     channelBinding = null,
@@ -112,14 +109,12 @@ function app(
     Bindings: Record<string, unknown>
     Variables: {
       userId?: string
-      organizationId?: string | null
       scopes?: string[] | null
       db: never
     }
   }>()
   hono.use("*", async (c, next) => {
     if (authenticated) c.set("userId", "user_actor")
-    c.set("organizationId", organizationId)
     c.set("scopes", scopes)
     c.set("db", {} as never)
     await next()
@@ -132,7 +127,11 @@ function app(
 }
 
 describe("storefront admin routes", () => {
-  it("lists storefronts scoped to the session organization", async () => {
+  // The operator auth realm has no organization plugin, so a self-host session
+  // never carries one. Demanding it here made every storefront request fail with
+  // "No active operator organization." and left the surface unreachable
+  // (voyant#4261). The deployment is the tenant boundary.
+  it("lists storefronts for a staff session that carries no organization", async () => {
     const provider = runtime()
     const response = await app(provider).request("/v1/admin/storefronts/storefronts")
 
@@ -141,8 +140,17 @@ describe("storefront admin routes", () => {
       data: [expect.objectContaining({ id: "storefront_1" })],
     })
     expect(provider.listStorefronts).toHaveBeenCalledWith(
-      expect.objectContaining({ organizationId: "org_actor" }),
+      expect.objectContaining({ db: expect.anything() }),
     )
+  })
+
+  it("reports capabilities for a staff session that carries no organization", async () => {
+    const response = await app(runtime()).request("/v1/admin/storefronts/capabilities")
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      data: { businessAccounts: true, manageProviders: true, channelBinding: false },
+    })
   })
 
   it("requires an authenticated user before calling the port", async () => {
@@ -152,16 +160,6 @@ describe("storefront admin routes", () => {
     )
 
     expect(response.status).toBe(401)
-    expect(provider.listStorefronts).not.toHaveBeenCalled()
-  })
-
-  it("rejects requests without an active operator organization", async () => {
-    const provider = runtime()
-    const response = await app(provider, { organizationId: null }).request(
-      "/v1/admin/storefronts/storefronts",
-    )
-
-    expect(response.status).toBe(403)
     expect(provider.listStorefronts).not.toHaveBeenCalled()
   })
 
@@ -236,7 +234,7 @@ describe("storefront admin routes", () => {
       data: [expect.objectContaining({ channelBinding: CHANNEL_BINDING })],
     })
     expect(binding.listStorefrontChannelBindings).toHaveBeenCalledWith(
-      expect.objectContaining({ organizationId: "org_actor" }),
+      expect.objectContaining({ db: expect.anything() }),
       [STOREFRONT.id],
     )
   })
@@ -255,7 +253,7 @@ describe("storefront admin routes", () => {
     expect(response.status).toBe(200)
     expect(await response.json()).toEqual({ data: CHANNEL_BINDING })
     expect(binding.setStorefrontChannelBinding).toHaveBeenCalledWith(
-      expect.objectContaining({ organizationId: "org_actor" }),
+      expect.objectContaining({ db: expect.anything() }),
       "storefront_1",
       { channelId: "channels_1" },
     )
@@ -307,7 +305,7 @@ describe("storefront admin routes", () => {
 
     expect(response.status).toBe(204)
     expect(provider.putProviderCredential).toHaveBeenCalledWith(
-      expect.objectContaining({ organizationId: "org_actor" }),
+      expect.objectContaining({ db: expect.anything() }),
       "storefront_1",
       "google",
       { clientId: "id", clientSecret: "secret" },

--- a/packages/db/migrations/20260805090000_storefront_deployment_scope.sql
+++ b/packages/db/migrations/20260805090000_storefront_deployment_scope.sql
@@ -1,0 +1,22 @@
+-- Storefronts belong to the deployment, not to an operator organization.
+--
+-- The operator auth realm never creates a Better Auth organization (the
+-- `organization` plugin is wired for the customer realm only), so `organization`
+-- is empty on every operator deployment. Scoping the storefront access model by
+-- `organization_id NOT NULL REFERENCES organization(id)` therefore made every
+-- insert fail its foreign key and every read filter to nothing, which is why the
+-- Storefronts admin surface could neither list nor create (voyant#4261).
+--
+-- A self-host deployment is the tenant boundary (docs/adr/0001-tenant-scoping.md),
+-- so the column carried no authorization meaning it could enforce. Drop it.
+ALTER TABLE "storefronts" DROP CONSTRAINT IF EXISTS "storefronts_organization_id_organization_id_fk";--> statement-breakpoint
+ALTER TABLE "storefront_api_keys" DROP CONSTRAINT IF EXISTS "storefront_api_keys_organization_id_organization_id_fk";--> statement-breakpoint
+ALTER TABLE "storefront_customer_auth_credentials" DROP CONSTRAINT IF EXISTS "storefront_customer_auth_credentials_organization_id_organization_id_fk";--> statement-breakpoint
+DROP INDEX IF EXISTS "storefronts_org_idx";--> statement-breakpoint
+DROP INDEX IF EXISTS "storefront_api_keys_org_idx";--> statement-breakpoint
+DROP INDEX IF EXISTS "storefront_customer_auth_credentials_org_idx";--> statement-breakpoint
+DROP INDEX IF EXISTS "storefronts_org_slug_unique";--> statement-breakpoint
+ALTER TABLE "storefronts" DROP COLUMN IF EXISTS "organization_id";--> statement-breakpoint
+ALTER TABLE "storefront_api_keys" DROP COLUMN IF EXISTS "organization_id";--> statement-breakpoint
+ALTER TABLE "storefront_customer_auth_credentials" DROP COLUMN IF EXISTS "organization_id";--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "storefronts_slug_unique" ON "storefronts" USING btree ("slug");

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1785888000000,
       "tag": "20260805000000_backfill_unassigned_member_permissions",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1785920400000,
+      "tag": "20260805090000_storefront_deployment_scope",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/iam/storefronts.ts
+++ b/packages/db/src/schema/iam/storefronts.ts
@@ -4,9 +4,11 @@
  * A storefront is the commerce-access identity for one frontend that talks to
  * this operator's public API and customer auth. Unlike the managed control
  * plane — where a storefront is scoped to a workload/environment — a self-host
- * deployment owns a single operator organization, so storefronts are scoped by
- * `organization_id` (the Better Auth operator org, `authOrganization`), the
- * same tenancy vocabulary the rest of the IAM schema uses.
+ * deployment IS the tenant boundary (ADR-0001), so a storefront belongs to the
+ * deployment rather than to a row-level owner. There is deliberately no
+ * `organization_id`: the operator realm never creates a Better Auth
+ * organization, so scoping storefronts by one made every write fail its foreign
+ * key and every read return nothing (voyant#4261).
  *
  * Access keys (`storefrontApiKeys`) and OAuth provider credentials
  * (`storefrontCustomerAuthCredentials`) hang off a storefront row. The keys are
@@ -17,7 +19,6 @@
 import { boolean, index, jsonb, pgTable, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core"
 
 import { typeId, typeIdRef } from "../../lib/typeid-column.js"
-import { authOrganization } from "./auth.js"
 import type { KmsEnvelope } from "./kms.js"
 
 export const STOREFRONT_CUSTOMER_AUTH_SOCIAL_PROVIDERS = ["google", "facebook", "apple"] as const
@@ -66,9 +67,6 @@ export const storefronts = pgTable(
   "storefronts",
   {
     id: typeId("storefronts"),
-    organizationId: typeIdRef("organization_id")
-      .notNull()
-      .references(() => authOrganization.id, { onDelete: "cascade" }),
     name: text("name").notNull(),
     slug: text("slug").notNull(),
     hostingKind: text("hosting_kind").$type<StorefrontHostingKind>().notNull().default("external"),
@@ -93,10 +91,7 @@ export const storefronts = pgTable(
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
-  (table) => [
-    uniqueIndex("storefronts_org_slug_unique").on(table.organizationId, table.slug),
-    index("storefronts_org_idx").on(table.organizationId),
-  ],
+  (table) => [uniqueIndex("storefronts_slug_unique").on(table.slug)],
 )
 
 /**
@@ -111,9 +106,6 @@ export const storefrontApiKeys = pgTable(
     storefrontId: typeIdRef("storefront_id")
       .notNull()
       .references(() => storefronts.id, { onDelete: "cascade" }),
-    organizationId: typeIdRef("organization_id")
-      .notNull()
-      .references(() => authOrganization.id, { onDelete: "cascade" }),
     kind: text("kind").$type<StorefrontApiKeyKind>().notNull(),
     tokenHash: text("token_hash").notNull(),
     tokenPreview: text("token_preview").notNull(),
@@ -126,7 +118,6 @@ export const storefrontApiKeys = pgTable(
   (table) => [
     uniqueIndex("storefront_api_keys_token_hash_unique").on(table.tokenHash),
     index("storefront_api_keys_storefront_idx").on(table.storefrontId),
-    index("storefront_api_keys_org_idx").on(table.organizationId),
   ],
 )
 
@@ -142,9 +133,6 @@ export const storefrontCustomerAuthCredentials = pgTable(
     storefrontId: typeIdRef("storefront_id")
       .notNull()
       .references(() => storefronts.id, { onDelete: "cascade" }),
-    organizationId: typeIdRef("organization_id")
-      .notNull()
-      .references(() => authOrganization.id, { onDelete: "cascade" }),
     provider: text("provider").$type<StorefrontCustomerAuthSocialProvider>().notNull(),
     encryptedCredentials: jsonb("encrypted_credentials").$type<KmsEnvelope>().notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
@@ -155,7 +143,6 @@ export const storefrontCustomerAuthCredentials = pgTable(
       table.storefrontId,
       table.provider,
     ),
-    index("storefront_customer_auth_credentials_org_idx").on(table.organizationId),
   ],
 )
 


### PR DESCRIPTION
Closes #4261.

## What was broken

`/v1/admin/storefronts/*` is the only admin surface that required an operator
organization on the session. The operator auth realm never creates one — the
Better Auth `organization` plugin is wired for the **customer** realm only
(`packages/auth/src/server.ts:613`) — so the `organization` table is empty on
every operator deployment. Two failures follow, and they are the same fault:

- **self-host** — `resolveStaffAccess` returns `organizationId: null` by design
  for local deployments (`packages/auth/src/staff-access.ts:88`), so
  `requestContext` rejected the request before reaching the port. Capabilities,
  list, and create all answered `403 "No active operator organization."`, which
  the page renders as "Storefronts unavailable / Couldn't load your storefronts".
- **managed** — it returns the *platform* organization id, which is not a row in
  this deployment's `organization` table, so the
  `storefronts_organization_id_organization_id_fk` foreign key rejected every
  insert. That is the `POST … -> 500` from the issue comment.

The reported `GET … -> 500` I could not reproduce; on the published image the
same request answers `403`. Both leave the surface unreachable, and both are
fixed here, but I'd rather flag the discrepancy than claim a repro I don't have.

Separately, and reproduced live: `APP_URL` ships as the API base
(`apps/operator/.env.example` → `http://localhost:3300/api`) and feeds the
customer-auth trusted-origin allowlist. `requireCanonicalOrigin` threw on the
`/api` path, so **every public catalog read answered 500**:

```
POST /v1/public/catalog/slots -> 500
err: 'customer auth trusted origin must be an absolute HTTP(S) origin'
  at requireCanonicalOrigin (.../auth/dist/node-runtime.js:504:19)
  at resolveCustomerAuthContext (.../auth/dist/node-runtime.js:469:101)
```

That is the second symptom in the issue body, and the seeded storefront's own
origins were never the problem — the offending entry came from `APP_URL`.

## The fix

A self-host deployment is the tenant boundary
(`docs/adr/0001-tenant-scoping.md`), and `packages/*` must not carry in-process
tenant scoping. The column enforced no authorization it could actually reach, so
storefronts now belong to the deployment:

- `organization_id` dropped from `storefronts`, `storefront_api_keys`, and
  `storefront_customer_auth_credentials`, with their FKs and org indexes
- the storefront slug is unique per deployment
- `StorefrontDto.organizationId` and `StorefrontRequestContext.organizationId`
  are gone; the origin-overlap check now spans the deployment
- authorization is unchanged — the `/v1/admin/*` staff guard plus the
  `storefronts:read` / `storefronts:write` scopes

Trusted origins are narrowed to their origin rather than rejected. A URL that is
not absolute HTTP(S), or that carries credentials, still fails closed;
`baseURL` and `invitationAcceptBaseURL` keep the strict check, since a path
changes their meaning.

## Verification

Against a **fresh Postgres with zero `organization` rows** — the production
condition — driving the real app over HTTP:

```
GET  /api/v1/admin/storefronts/capabilities            -> 200
GET  /api/v1/admin/storefronts/storefronts             -> 200 {"data":[]}
POST /api/v1/admin/storefronts/storefronts             -> 201  (slug local-engine)
POST /api/v1/admin/storefronts/storefronts/:id/keys    -> 201  (token shown once)
GET  /api/v1/admin/storefronts/storefronts/:id/keys    -> 200
POST /api/v1/public/catalog/slots  (Origin: :3600)     -> 403  (was 500)
```

The public read now fails closed at 403 instead of faulting, with `APP_URL`
still set to the path-bearing `http://localhost:3305/api`.

Also green: `verify-migration-replay-parity` (OK — every upgrade path equals the
package-owned replay), `verify-package-baseline --union` (PASS — 30 sources
apply together, 332 tables reconstitute the bundle), `verify:architecture`,
`@voyant-travel/auth` (267), `@voyant-travel/auth-react` (68),
`@voyant-travel/db` (129), and biome at the repo baseline.

`packages/auth/tests/integration/local-storefront.test.ts` runs in the CI
integration lane and now asserts the regression directly: it deletes every
`organization` row, then proves create → list → issue key → resolve by token.

## Not addressed

The slug field stripping hyphens, from the issue comment. That help text
("Lowercase letters, numbers, and hyphens.") exists neither in this repo's
source nor in the `operator:0.3.0` bundle, and `storefronts-page.tsx` stores the
slug verbatim with no hint text — so that dialog is the Voyant Cloud admin, not
this repo. Worth its own issue there.