### PR TITLE
Deny the retired plugin graph kind instead of warning

### DIFF
--- a/docs/architecture/module-provider-plugin-taxonomy.md
+++ b/docs/architecture/module-provider-plugin-taxonomy.md
@@ -178,31 +178,33 @@ Rule:
 If the package customizes an existing module rather than defining a new
 capability, it is an extension.
 
-### 6. Plugins are deprecated graph-unit debt
+### 6. The plugin graph kind is retired in this repository
 
-`package.json#voyant.kind: "plugin"` and `voyant.plugin.v1` manifests remain
-recognized for backward compatibility only. New executable npm packages must
-declare their actual deployment role: module, extension, adapter, or provider.
+**No workspace package declares `voyant.kind: "plugin"`.** The migration
+described below is complete, and `pnpm verify:deprecated-graph-kinds` is now a
+**denial**: a workspace package under `packages/`, `apps/`, or `examples/` that
+declares the kind fails `verify:architecture`. It is no longer warn-only.
 
-Historical plugin packages must migrate to their correct target:
+Historical plugin packages migrated to their correct target:
 
-- payment, search, and storage integrations become adapters or providers
-- CRM, accounting, and remote-sync integrations become remote apps when they
+- payment, search, and storage integrations became adapters or providers
+- CRM, accounting, and remote-sync integrations became remote apps where they
   can operate through scoped APIs, events, webhooks, app-owned custom fields,
   and remote admin UI
-- SmartBill migration is tracked by `voyant#3443`
-- Payload and Sanity CMS package migrations remain open taxonomy debt
 
-The terminal state deletes the plugin graph kind after the remaining packages
-migrate. Until then, `pnpm verify:deprecated-graph-kinds` runs as a warn-only
-architecture check and prints `[deprecated-kind]` lines for workspace packages
-that still declare `voyant.kind: "plugin"`. The check exits 0 and must not fail
-CI.
+What remains, deliberately:
+
+- `VoyantGraphUnitKind` in `@voyant-travel/graph-contracts` still includes
+  `"plugin"`, and the `voyant.plugin.v1` lowering path still resolves. That is
+  for **external** packages that have not migrated — deleting the kind from the
+  graph contract is a separate, breaking change, not part of this rule.
+- Authored `plugins` entries in a deployment config remain legacy compatibility
+  inputs for those external packages.
 
 Rule:
 
-Do not introduce new plugin graph units. Keep existing plugin declarations only
-where required for compatibility while migration work is active.
+Do not introduce plugin graph units. A new executable npm package declares its
+actual deployment role: module, extension, adapter, or provider.
 
 Package-owned extensions remain extension contributions in the resolved graph.
 They do not become plugins merely because the runtime lowers them to an

--- a/scripts/check-deprecated-graph-kinds.mjs
+++ b/scripts/check-deprecated-graph-kinds.mjs
@@ -2,9 +2,21 @@ import { existsSync, readdirSync, readFileSync } from "node:fs"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
 
-const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+// RFC #3395 retired "plugin" as a classification. Every workspace package has
+// migrated to its actual deployment role, so this check is a denial rather than
+// the warn-only nudge it was during the migration: a workspace package may not
+// declare voyant.kind "plugin" again.
+//
+// The graph runtime still *recognizes* the kind — `VoyantGraphUnitKind` and the
+// `voyant.plugin.v1` lowering path stay for external packages that have not
+// migrated. This check governs what lives in this repository.
+const defaultRepoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
 const workspaceRoots = ["packages", "apps", "examples"]
-const targetByPackage = new Map([["@voyant-travel/plugin-smartbill", "remote app"]])
+
+// `--root <dir>` scans somewhere other than this repository. Only the vacuity
+// test uses it, so the checker can be proven to still go red without dropping
+// probe files into a real workspace package.
+const repoRoot = parseRootFlag(process.argv.slice(2)) ?? defaultRepoRoot
 
 const deprecated = []
 for (const root of workspaceRoots) {
@@ -18,11 +30,27 @@ if (deprecated.length === 0) {
   console.log('[deprecated-kind] OK: no workspace packages declare voyant.kind "plugin".')
 } else {
   for (const entry of deprecated) {
-    const target = targetByPackage.get(entry.name) ?? inferTarget(entry.name)
-    console.log(
-      `[deprecated-kind] ${entry.name} declares voyant.kind "plugin" in ${entry.relativePath}; RFC target: ${target}.`,
+    console.error(
+      `[deprecated-kind] ${entry.name} declares voyant.kind "plugin" in ${entry.relativePath}; ` +
+        `declare its actual deployment role instead: ${inferTarget(entry.name)}.`,
     )
   }
+  console.error(
+    "[deprecated-kind] See docs/architecture/module-provider-plugin-taxonomy.md section 6.",
+  )
+  process.exitCode = 1
+}
+
+/** Returns the `--root` value, or undefined when the flag is absent or unpaired. */
+function parseRootFlag(argv) {
+  const index = argv.indexOf("--root")
+  if (index === -1) return undefined
+  const value = argv[index + 1]
+  if (value === undefined || value.startsWith("--")) {
+    console.error("[deprecated-kind] --root requires a directory argument.")
+    process.exit(2)
+  }
+  return path.resolve(value)
 }
 
 function collectDeprecatedPluginPackages(directory, result) {

--- a/scripts/tests/check-deprecated-graph-kinds.test.mjs
+++ b/scripts/tests/check-deprecated-graph-kinds.test.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict"
+import { execFileSync } from "node:child_process"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import test from "node:test"
+
+/**
+ * Guards the deprecated-kind checker against going vacuous.
+ *
+ * RFC #3395 retired "plugin" as a classification and every workspace package
+ * has migrated, so this checker now passes trivially. A checker that passes
+ * because there is nothing to find is indistinguishable from one that passes
+ * because it stopped looking — these tests assert it can still go red.
+ */
+
+const repoRoot = process.cwd()
+const CHECKER = path.join(repoRoot, "scripts", "check-deprecated-graph-kinds.mjs")
+
+function runChecker(extraArgs = []) {
+  try {
+    const stdout = execFileSync(process.execPath, [CHECKER, ...extraArgs], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: "pipe",
+    })
+    return { code: 0, output: stdout }
+  } catch (error) {
+    return {
+      code: error.status ?? 1,
+      output: `${error.stdout ?? ""}${error.stderr ?? ""}`,
+    }
+  }
+}
+
+/** Builds a throwaway workspace so no probe file lands in a real package. */
+function withWorkspace(packages, assertion) {
+  const root = mkdtempSync(path.join(tmpdir(), "deprecated-kind-"))
+  try {
+    for (const [name, manifest] of Object.entries(packages)) {
+      const directory = path.join(root, "packages", name)
+      mkdirSync(directory, { recursive: true })
+      writeFileSync(path.join(directory, "package.json"), JSON.stringify(manifest, null, 2))
+    }
+    assertion(runChecker(["--root", root]))
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+}
+
+test("the real workspace declares no plugin graph kinds", () => {
+  const result = runChecker()
+  assert.equal(result.code, 0, result.output)
+  assert.match(result.output, /no workspace packages declare voyant\.kind "plugin"/)
+})
+
+test('a package declaring voyant.kind "plugin" fails the check', () => {
+  withWorkspace(
+    { "plugin-example": { name: "@voyant-travel/plugin-example", voyant: { kind: "plugin" } } },
+    (result) => {
+      assert.equal(result.code, 1, result.output)
+      assert.match(result.output, /@voyant-travel\/plugin-example declares voyant\.kind "plugin"/)
+    },
+  )
+})
+
+test("packages declaring a migrated kind pass", () => {
+  withWorkspace(
+    {
+      "netopia-adapter": { name: "@voyant-travel/netopia-adapter", voyant: { kind: "adapter" } },
+      bookings: { name: "@voyant-travel/bookings", voyant: { kind: "module" } },
+    },
+    (result) => {
+      assert.equal(result.code, 0, result.output)
+    },
+  )
+})
+
+test("the suggested target reflects the package's role", () => {
+  withWorkspace(
+    { "plugin-smartbill": { name: "@voyant-travel/plugin-smartbill", voyant: { kind: "plugin" } } },
+    (result) => {
+      assert.equal(result.code, 1, result.output)
+      assert.match(result.output, /remote app/)
+    },
+  )
+})
+
+test("--root without a directory argument is rejected rather than silently ignored", () => {
+  const result = runChecker(["--root"])
+  assert.equal(result.code, 2, result.output)
+  assert.match(result.output, /--root requires a directory argument/)
+})


### PR DESCRIPTION
Closes #4268. Part of #4266.

The plugin classification was retired by RFC #3395 and the migration is complete — payment, search and storage integrations moved to adapters and providers; CRM, accounting and remote-sync integrations moved to apps. Zero workspace packages declare `voyant.kind: "plugin"`:

```sh
grep -rn '"kind"[[:space:]]*:[[:space:]]*"plugin"' --include=package.json . | grep -v node_modules
# (no output)
```

`verify:deprecated-graph-kinds` was warn-only for the duration of that migration and exited 0 unconditionally, so nothing prevented the kind being reintroduced.

## Changes

- **The check now fails.** Exit 1 on any workspace package declaring the kind, with the taxonomy doc and the package's likely target role in the message.
- **Dropped the stale `plugin-smartbill` entry** from `targetByPackage` — it no longer declares the kind, and `inferTarget` already derives "remote app" from the name.
- **Added `--root`** so the vacuity test scans a temp workspace instead of dropping probe manifests into a real package (stray probes have been committed as fake violations before).
- **Added `scripts/tests/check-deprecated-graph-kinds.test.mjs`** — 5 tests. A checker that passes because there is nothing to find is indistinguishable from one that stopped looking, so this asserts it still goes red, and that the unpaired `--root` flag is rejected rather than silently reading the wrong argv slot.
- **Updated `module-provider-plugin-taxonomy.md` §6** to record the terminal state as reached.

## Deliberately not changed

`VoyantGraphUnitKind` in `graph-contracts` still includes `"plugin"` and the `voyant.plugin.v1` lowering path still resolves. Those exist for **external** packages that have not migrated; removing them is a breaking change to a published contract and separate work.

## Verification

```
pnpm verify:deprecated-graph-kinds   # OK: no workspace packages declare voyant.kind "plugin"
node --test scripts/tests/check-deprecated-graph-kinds.test.mjs   # 5 pass, 0 fail
```

No published package changed, so no changeset.