### PR TITLE
Guard the draft cutover on the column it reads, and prove migration order robustness

### DIFF
--- a/docs/architecture/schema-discipline.md
+++ b/docs/architecture/schema-discipline.md
@@ -191,4 +191,33 @@ Rules:
   resolvability, schema parity, generated-manifest freshness, duplicate prefixes
   (vs the baseline), and that every link table is in the latest snapshot.
 
+### Source order between independent packages is not a contract
+
+Migration sources apply deps-first over `voyant.requiresSchemas`. Sources with
+**no declared edge between them** are ordered by an arbitrary tie-break, and that
+tie-break is not stable — it changes when a package is added, renamed, or
+absorbed into another.
+
+So a migration that reads another package's table must not rely on that package
+having run. Two rules follow:
+
+- **Declare the dependency** in `requiresSchemas` when your schema genuinely
+  needs another package's tables to exist first. That is what orders the plan.
+- **Guard on the column, not the table**, when you cannot declare it — for
+  example when the target sits outside your package's allowed dependency set.
+  The frozen framework bundle materialises many tables *without* the columns
+  later increments add, so `to_regclass('public.x') IS NOT NULL` is not evidence
+  that `x.some_column` exists.
+
+PL/pgSQL parses a statement only when its branch is reached, so an unreached arm
+may safely reference a column that does not exist. That is what makes a
+column-existence branch work where a single static statement would fail.
+
+`verify:migration-replay-parity` replays the upgrade path a second time against a
+**different valid topological order**, with the tie-break between independent
+sources reversed. A migration that depends on an undeclared ordering fails there
+immediately, rather than the next time someone moves a package. See
+[#4279](https://github.com/voyant-travel/voyant/issues/4279), which was latent on
+`main` for exactly as long as `availability` happened to sort before `catalog`.
+
 Generated project artifacts live only under `.voyant/` and are disposable.

--- a/packages/catalog/migrations/20260802190000_booking_v1_beta_draft_cutover.sql
+++ b/packages/catalog/migrations/20260802190000_booking_v1_beta_draft_cutover.sql
@@ -36,7 +36,18 @@ BEGIN
       HINT = 'Restore or reconcile the Booking before rerunning; the migration will not guess whether a commitment exists.';
   END IF;
 
-  IF to_regclass('public.availability_holds') IS NOT NULL THEN
+  -- The hold-conversion columns arrive with a later increment than the frozen
+  -- framework bundle that materialises availability_holds, so the table can
+  -- exist without them. No hold can have been converted before those columns
+  -- exist, so the probe is vacuously false and skipping it is exact.
+  IF to_regclass('public.availability_holds') IS NOT NULL
+     AND EXISTS (
+       SELECT 1 FROM "information_schema"."columns"
+       WHERE "table_schema" = 'public'
+         AND "table_name" = 'availability_holds'
+         AND "column_name" = 'converted_at'
+     )
+  THEN
     EXECUTE $query$
       SELECT EXISTS (
         SELECT 1
@@ -89,12 +100,31 @@ BEGIN
     RAISE EXCEPTION 'Booking v1 draft cutover found availability_holds without availability_slots.';
   END IF;
 
-  INSERT INTO "booking_v1_legacy_holds_to_release" ("id", "slot_id", "pax_count")
-  SELECT hold."id", hold."slot_id", hold."pax_count"
-  FROM "availability_holds" hold
-  JOIN "booking_drafts" draft ON draft."id" = hold."draft_id"
-  WHERE hold."released_at" IS NULL
-    AND hold."converted_at" IS NULL;
+  -- This selects which legacy holds get RELEASED, so it must not be skipped when
+  -- converted_at is absent — that would leave them held forever. Without the
+  -- column no hold can be converted, so `converted_at IS NULL` is true for every
+  -- row and dropping the term selects exactly the same set. PL/pgSQL parses a
+  -- branch only when it is reached, so the unreached arm never resolves the
+  -- missing column.
+  IF EXISTS (
+    SELECT 1 FROM "information_schema"."columns"
+    WHERE "table_schema" = 'public'
+      AND "table_name" = 'availability_holds'
+      AND "column_name" = 'converted_at'
+  ) THEN
+    INSERT INTO "booking_v1_legacy_holds_to_release" ("id", "slot_id", "pax_count")
+    SELECT hold."id", hold."slot_id", hold."pax_count"
+    FROM "availability_holds" hold
+    JOIN "booking_drafts" draft ON draft."id" = hold."draft_id"
+    WHERE hold."released_at" IS NULL
+      AND hold."converted_at" IS NULL;
+  ELSE
+    INSERT INTO "booking_v1_legacy_holds_to_release" ("id", "slot_id", "pax_count")
+    SELECT hold."id", hold."slot_id", hold."pax_count"
+    FROM "availability_holds" hold
+    JOIN "booking_drafts" draft ON draft."id" = hold."draft_id"
+    WHERE hold."released_at" IS NULL;
+  END IF;
 END $$;
 --> statement-breakpoint
 DO $$

--- a/packages/framework-migrations/src/collector.test.ts
+++ b/packages/framework-migrations/src/collector.test.ts
@@ -103,6 +103,75 @@ describe("compatibility preflight migrations", () => {
 })
 
 describe("migration hash compatibility", () => {
+  it("accepts the catalog draft-cutover guard widening as equivalent (#4279)", async () => {
+    // The real migration file, so the registered hash cannot drift from the bytes
+    // it claims to describe — the failure mode an inline fixture would hide.
+    const sql = readFileSync(
+      new URL(
+        "../../catalog/migrations/20260802190000_booking_v1_beta_draft_cutover.sql",
+        import.meta.url,
+      ),
+      "utf8",
+    )
+    const client: MigrationClient = {
+      async query(query: string) {
+        if (query.includes(`SELECT "content_hash"`)) {
+          // A database that applied the ORIGINAL, table-only guard.
+          return {
+            rows: [
+              { content_hash: "fb264e967dd9b6c2220e65c71c05fe83b0c1be3b64ca642d82999bf65bbe51f5" },
+            ],
+          }
+        }
+        return { rows: [] }
+      },
+    }
+
+    const result = await applyMigrations(
+      client,
+      [
+        {
+          name: "catalog",
+          priority: 0,
+          migrations: [{ tag: "20260802190000_booking_v1_beta_draft_cutover", sql }],
+        },
+      ],
+      ledgerOpts,
+    )
+    expect(result).toEqual({ executed: [], baselined: [] })
+  })
+
+  it("still rejects genuinely changed SQL under the same tag", async () => {
+    // Equivalence is registered per (source, tag, contentHash). Registering one
+    // must not turn the tag into a hole the immutability gate ignores.
+    const client: MigrationClient = {
+      async query(query: string) {
+        if (query.includes(`SELECT "content_hash"`)) {
+          return {
+            rows: [
+              { content_hash: "fb264e967dd9b6c2220e65c71c05fe83b0c1be3b64ca642d82999bf65bbe51f5" },
+            ],
+          }
+        }
+        return { rows: [] }
+      },
+    }
+
+    await expect(
+      applyMigrations(
+        client,
+        [
+          {
+            name: "catalog",
+            priority: 0,
+            migrations: [{ tag: "20260802190000_booking_v1_beta_draft_cutover", sql: "SELECT 1;" }],
+          },
+        ],
+        ledgerOpts,
+      ),
+    ).rejects.toBeInstanceOf(MigrationImmutabilityError)
+  })
+
   it("accepts the db cloud-auth scopes idempotency rewrite as equivalent", async () => {
     const queries: string[] = []
     const client: MigrationClient = {

--- a/packages/framework-migrations/src/collector.ts
+++ b/packages/framework-migrations/src/collector.ts
@@ -276,6 +276,37 @@ function equivalenceClosure(
   return hashes.map((hash) => [`${key}/${hash}`, new Set(hashes.filter((other) => other !== hash))])
 }
 
+// `catalog/20260802190000_booking_v1_beta_draft_cutover`: two guards were widened
+// from "the availability_holds TABLE exists" to "the table exists AND carries
+// converted_at" (#4279). The frozen framework bundle materialises
+// availability_holds WITHOUT the hold-conversion columns — an `availability`
+// increment adds them — so on a database holding the bundle but not yet that
+// increment, the original guards passed and then resolved a column that was not
+// there. It only ever worked because "availability" sorts before "catalog" among
+// sources with no declared dependency between them; nothing declared the order.
+//
+// Equivalence is sound here without a companion increment.
+//
+//   • On any database where the ORIGINAL applied, converted_at existed — it
+//     resolves the column unconditionally, so absent it the migration ERRORED and
+//     recorded no ledger row. The widened guards therefore take the same branch
+//     the original took, over the same rows.
+//   • The probe guard is read-only; it computes has_ambiguous_conversion, which is
+//     vacuously false with no conversion columns.
+//   • The hold-selection guard is NOT a skip, deliberately: it chooses which legacy
+//     holds are released. Without converted_at no hold can be converted, so
+//     `converted_at IS NULL` holds for every row and the shortened predicate
+//     selects exactly the same set. Skipping it instead would leave those holds
+//     unreleased — a divergence, not an equivalence.
+//
+// Both generations therefore reach the same end state on any database where either
+// applied. Every other statement in the file is byte-identical.
+const CATALOG_BOOKING_V1_DRAFT_CUTOVER_HASHES = [
+  // original: guarded on to_regclass('public.availability_holds') alone.
+  "fb264e967dd9b6c2220e65c71c05fe83b0c1be3b64ca642d82999bf65bbe51f5",
+  // widened to require the converted_at column too (#4279).
+  "c0ae3e358e5238b0056724c6134cbbc35d25544ede9f838876e6bc90601ec26e",
+] as const
 const EQUIVALENT_MIGRATION_HASHES = new Map<string, ReadonlySet<string>>([
   ...equivalenceClosure("db/0001_db_baseline", DB_0001_HASHES),
   ...equivalenceClosure("framework/0004_framework_baseline", FRAMEWORK_0004_HASHES),
@@ -283,6 +314,10 @@ const EQUIVALENT_MIGRATION_HASHES = new Map<string, ReadonlySet<string>>([
   ...equivalenceClosure(
     "bookings/20260802200000_booking_v1_status_cutover",
     BOOKING_V1_STATUS_CUTOVER_HASHES,
+  ),
+  ...equivalenceClosure(
+    "catalog/20260802190000_booking_v1_beta_draft_cutover",
+    CATALOG_BOOKING_V1_DRAFT_CUTOVER_HASHES,
   ),
   ...PROPOSAL_RENAME_EDITED_HASHES.flatMap(([key, hashes]) => equivalenceClosure(key, hashes)),
 ])

--- a/scripts/verify-migration-replay-parity.mjs
+++ b/scripts/verify-migration-replay-parity.mjs
@@ -124,6 +124,54 @@ function discoverPackageSources() {
   return sources
 }
 
+/**
+ * A SECOND VALID topological order over the same sources, tie-broken the other way.
+ *
+ * The migration plan orders sources deps-first over `voyant.requiresSchemas`, and
+ * breaks ties between independent sources by plan order (effectively alphabetical).
+ * That tie-break is arbitrary, so a migration may depend on it WITHOUT declaring
+ * anything — and it keeps working until someone moves a package and the tie-break
+ * lands differently.
+ *
+ * That is not hypothetical: `catalog`'s booking-v1 draft cutover reads
+ * `availability_holds.converted_at`, a column an `availability` increment adds, and
+ * was correct only because "availability" sorts before "catalog" (voyant#4279).
+ * Absorbing availability into operations moved it after and broke the upgrade path.
+ *
+ * Replaying against a different valid order turns "we find out when we move a
+ * package" into "we find out now", for every source at once.
+ */
+function alternateSourceOrder(sources) {
+  const byName = new Map(sources.map((s) => [s.name, s]))
+  const deps = new Map()
+  for (const source of sources) {
+    const manifestPath = join(ROOT, "packages", source.name, "package.json")
+    const declared = existsSync(manifestPath)
+      ? (JSON.parse(readFileSync(manifestPath, "utf8")).voyant?.requiresSchemas ?? [])
+      : []
+    deps.set(
+      source.name,
+      new Set(declared.map((n) => n.replace(/^@[^/]+\//, "")).filter((n) => byName.has(n))),
+    )
+  }
+
+  // Kahn, taking the LAST ready source each round — the reverse of the plan's
+  // tie-break. Declared edges are still honoured, so this order is just as valid.
+  const remaining = new Set(sources.map((s) => s.name))
+  const ordered = []
+  while (remaining.size > 0) {
+    const ready = [...remaining].filter((name) =>
+      [...deps.get(name)].every((dep) => !remaining.has(dep)),
+    )
+    if (ready.length === 0) break // cycle: leave the rest in plan order
+    const pick = ready[ready.length - 1]
+    remaining.delete(pick)
+    ordered.push(byName.get(pick))
+  }
+  for (const name of remaining) ordered.push(byName.get(name))
+  return ordered
+}
+
 async function applyFolders(client, folders) {
   for (const folder of folders) {
     for (const stmt of loadFolder(folder)) {
@@ -289,10 +337,35 @@ async function main() {
       })
     })
 
+    // Order robustness: the same upgrade path, replayed against a DIFFERENT valid
+    // topological order. Any migration that depends on the plan's arbitrary
+    // tie-break between independent sources fails here rather than the next time
+    // a package moves.
+    const alternate = alternateSourceOrder(packageSources)
+    const reordered = alternate.map((s) => s.name).join(", ")
+    const alternateFp = await withFreshDb(admin, "voyant_replay_alt_order", async () => {
+      const cutline = loadCutline()
+      console.log(`  sources: alternate valid order — ${reordered}`)
+      return onDb("voyant_replay_alt_order", async (c) => {
+        await applyFolders(c, [FRAMEWORK_BUNDLE])
+        await applyFolders(c, [LEGACY_DEPLOYMENT_MIGRATIONS])
+        for (const source of alternate) {
+          if (!source.hasMigrations) {
+            throw new Error(`schema source ${source.name} has no migrations folder`)
+          }
+          for (const stmt of loadFolderAfterCutline(source.migrationsDir, source.name, cutline)) {
+            await c.query(stmt)
+          }
+        }
+        return fingerprint(c)
+      })
+    })
+
     const sections = ["columns", "enums", "indexes", "constraints"]
     const lanes = [
       { label: "upgrade path", fingerprint: newFp },
       { label: "pre-rename history", fingerprint: preRenameFp },
+      { label: "alternate source order", fingerprint: alternateFp },
     ]
     let ok = true
     for (const lane of lanes) {


### PR DESCRIPTION
Closes #4279. Unblocks #4271.

## The bug, which is live on `main` today

`catalog/20260802190000_booking_v1_beta_draft_cutover` reads `availability_holds.converted_at` while guarding only on the **table** existing:

```sql
IF to_regclass('public.availability_holds') IS NOT NULL THEN
  ... hold."converted_at" IS NOT NULL ...
```

The frozen framework bundle materialises `availability_holds` **without** the hold-conversion columns — an `availability` increment adds them. So on a database holding the bundle but not yet that increment, the guard passes and then resolves a column that is not there.

It has never fired because `availability` sorts before `catalog` among sources with no declared dependency between them. **Nothing declares that order**, and the tie-break moves whenever a package is added, renamed, or absorbed.

Declaring the dependency is not available: `catalog` is a retail-spine root, `requiresSchemas` edges are constructed non-optional, and the spine gate forbids catalog reaching operated Operations runtime.

## The two guards are not the same shape

| guard | with the column absent |
|---|---|
| **probe** — computes `has_ambiguous_conversion` | read-only, vacuously false → **skip is exact** |
| **hold selection** — chooses which legacy holds are **released** | **must not skip**, or they stay held forever |

For the second, no hold can be converted without the column, so `converted_at IS NULL` holds for every row and the shortened predicate selects exactly the same set. The two branches are written out side by side so the reviewable question is "are these the same set", not "is this string-built SQL correct".

PL/pgSQL parses a branch only when reached, so the unreached arm never resolves the missing column — verified directly against Postgres before relying on it:

```
NOTICE:  UNREACHED branch did not fail -> parsing is deferred
ERROR:   column t.missing_col does not exist        (only when reached)
```

## Equivalence

`CATALOG_BOOKING_V1_DRAFT_CUTOVER_HASHES`, sound **without** a companion increment: the original resolves the column unconditionally, so on any database where it applied the column existed and the widened guards take the same branch over the same rows; where it did not exist the original errored and recorded no ledger row. Precedent: `BOOKING_V1_STATUS_CUTOVER_HASHES` (#4247).

## The general fix — the half that matters long-term

`verify:migration-replay-parity` now replays the upgrade path against a **different valid topological order**: declared `requiresSchemas` edges honoured, the tie-break between independent sources reversed.

It catches this bug **on unmodified `main`**, which is the proof it works:

```
sources: alternate valid order — ... catalog, bookings, legal, distribution, availability, operations, ...
verify-migration-replay-parity ERROR: column hold.converted_at does not exist
```

After the fix, all three lanes agree:

```
OK  upgrade path            5694 columns, 1465 enums, 2208 indexes, 961 constraints
OK  pre-rename history      5694 / 1465 / 2208 / 961
OK  alternate source order  5694 / 1465 / 2208 / 961
```

This is what makes the remaining module merges safe rather than lucky — every one of them reshuffles source order for a dozen packages.

## Tests

- The equivalence test reads the **real migration file**, so the registered hash cannot drift from the bytes it claims to describe.
- Registering an equivalence must not turn the tag into a hole: genuinely changed SQL under the same tag still raises `MigrationImmutabilityError`.

## Verification

```
replay-parity (3 lanes)  OK
union                    PASS
cutline                  OK (frozen — 23 sources)
migration-boundaries     OK
retail-spine-closure     OK
framework-migrations     94 pass
biome                    21 warnings, 0 errors (baseline)
```

Docs: `schema-discipline.md` gains a short section on why source order between independent packages is not a contract, and the guard-on-the-column rule that follows.

No changeset — `framework-migrations` and `catalog` are both private.