### PR TITLE
Count cross-module writes apart from reads in table privacy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,22 +65,38 @@ Three run as ratchets, holding a line rather than demanding it be clean today:
 baselines may only shrink.** Regenerate one only when tightening it; never to
 make a failure go away.
 
-`verify:table-privacy` carries **225 reach-ins across 37 module pairs**, and
-that is recorded as **debt with a target, not an acceptable steady state**
+`verify:table-privacy` carries **190 reach-ins across 35 module pairs**, recorded
+as **debt with a target, not an acceptable steady state**
 ([#4273](https://github.com/voyant-travel/voyant/issues/4273)). `bookings` is
 reached into by 8 modules; that coupling is why "modules are separately
 shippable" is not true of this repo.
 
-**The mechanism for paying it down is consolidation — merging modules — not
-extracting service calls.** ADR-0016 decision 7 is explicit that there are no
-ports for business modules, so replacing a direct table read with a service hop
-is the ADR-0007 refactor under a new name and is not wanted. Merging
-`availability` into `operations` alone removes ~41 reach-ins, which is more than
-any plausible refactor of the same seams
-([#4271](https://github.com/voyant-travel/voyant/issues/4271)).
+**48 of those 190 are cross-module WRITES**, counted separately in the baseline's
+`writePairs`. The split is not cosmetic — the remedies differ:
 
-So: do not add a pair, do not "fix" a pair with an indirection layer, and expect
-the number to fall in steps when modules merge rather than continuously.
+| | remedy |
+|---|---|
+| read | the owning module's service, **or** a local `*Ref` mirror |
+| **write** | the owning module's service, and nothing else |
+
+A `*Ref` mirror is a read-only partial view by construction, so it is not
+available for a write, and a write bypasses whatever the owner does on its own
+writes — revision bumps, validation, events. Reads are debt to pay down; **writes
+should reach zero.**
+
+**On the mechanism.** An earlier revision of this section said the way to pay this
+down is consolidation rather than service calls. That was right for
+`availability`, which was schema-only with its services already in `operations` —
+there was no module there, only a schema split from its owner. It is **wrong for
+real modules**: `finance` and `bookings` are 87k and 51k lines with their own
+route surfaces, and merging them is not on the table. For those the answer is the
+one this checker's own doc gives — the owning module's service, or a mirror.
+ADR-0016 decision 7 rules out *ports* for business modules; it does not rule out
+calling a sibling's service in-process.
+
+So: do not add a pair, do not "fix" one with an indirection layer, never add a
+write, and expect reads to fall through a mix of mirrors, service calls, and the
+occasional consolidation where a package turns out not to be a module at all.
 
 `verify:typecheck-coverage` enforces that every test file is typechecked by some
 CI job. A package whose tsconfig includes only `src/**` gets no typecheck job at

--- a/scripts/checks/schema/table-privacy-baseline.json
+++ b/scripts/checks/schema/table-privacy-baseline.json
@@ -2,7 +2,13 @@
   "$comment": [
     "Cross-module table reach-ins, by importer->owner. ADR-0016 decision 6.",
     "A pair may shrink, never grow; a new pair fails. Regenerate with --update-baseline",
-    "ONLY when tightening. Foundation packages (db, core, utils, types, schema-kit) are exempt."
+    "ONLY when tightening. Foundation packages (db, core, utils, types, schema-kit) are exempt.",
+    "",
+    "`writePairs` counts the subset that MUTATE another module's tables. A read has",
+    "two answers — the owner's service, or a local *Ref mirror. A write has one: a",
+    "mirror is read-only by construction. Writes bypass whatever the owner does on",
+    "its own writes (revision bumps, validation, events), so they should reach zero",
+    "rather than merely stop growing."
   ],
   "pairs": {
     "accommodations->bookings": 2,
@@ -40,5 +46,16 @@
     "storefront->legal": 2,
     "storefront->relationships": 3,
     "trips->inventory": 2
+  },
+  "writePairs": {
+    "apps->custom-fields": 2,
+    "commerce->bookings": 2,
+    "commerce->finance": 2,
+    "finance->bookings": 12,
+    "inventory->commerce": 16,
+    "inventory->operations": 4,
+    "legal->bookings": 5,
+    "relationships->identity": 4,
+    "storefront->relationships": 1
   }
 }

--- a/scripts/checks/schema/table-privacy-runner.ts
+++ b/scripts/checks/schema/table-privacy-runner.ts
@@ -8,9 +8,12 @@ import { collectSourceFiles, stripComments } from "./source-scan.ts"
 import {
   type Baseline,
   checkAgainstBaseline,
+  checkWritesAgainstBaseline,
   countReachIns,
+  countWriteReachIns,
   type ImportSite,
   improvements,
+  type WriteSite,
 } from "./table-privacy.ts"
 
 const here = dirname(fileURLToPath(import.meta.url))
@@ -48,19 +51,57 @@ function main(): void {
     }
   }
 
+  // A write only counts when the mutated binding was IMPORTED into this file —
+  // a same-named local table is not a reach-in.
+  const writeSites: WriteSite[] = []
+  for (const [file, text] of stripped) {
+    const importer = file.split("/")[1]
+    const imported = new Set<string>()
+    for (const match of text.matchAll(
+      /import\s+\{([^{}]*?)\}\s*from\s*"@voyant-travel\/[^"]+"/gs,
+    )) {
+      for (const raw of match[1].split(",")) {
+        const name = raw.trim()
+        if (name === "" || name.startsWith("type ")) continue
+        writeSitesPush(imported, name)
+      }
+    }
+    const names: string[] = []
+    for (const match of text.matchAll(/\.(?:update|insert|delete)\(\s*(\w+)\s*[),]/g)) {
+      if (imported.has(match[1] as string)) names.push(match[1] as string)
+    }
+    if (names.length > 0) writeSites.push({ importer, names })
+  }
+
   const counts = countReachIns(sites, { owners })
-  const baseline = JSON.parse(readFileSync(baselinePath, "utf8")).pairs as Baseline
+  const writeCounts = countWriteReachIns(writeSites, { owners })
+  const manifest = JSON.parse(readFileSync(baselinePath, "utf8"))
+  const baseline = manifest.pairs as Baseline
+  const writeBaseline = (manifest.writePairs ?? {}) as Baseline
 
   if (process.argv.includes("--update-baseline")) {
     writeFileSync(
       baselinePath,
-      `${JSON.stringify({ $comment: BASELINE_COMMENT, pairs: Object.fromEntries([...counts].sort()) }, null, 2)}\n`,
+      `${JSON.stringify(
+        {
+          $comment: BASELINE_COMMENT,
+          pairs: Object.fromEntries([...counts].sort()),
+          writePairs: Object.fromEntries([...writeCounts].sort()),
+        },
+        null,
+        2,
+      )}\n`,
     )
-    console.log(`table-privacy: baseline rewritten with ${counts.size} pairs`)
+    console.log(
+      `table-privacy: baseline rewritten with ${counts.size} pairs, ${writeCounts.size} write pairs`,
+    )
     return
   }
 
-  const violations = checkAgainstBaseline(counts, baseline)
+  const violations = [
+    ...checkWritesAgainstBaseline(writeCounts, writeBaseline),
+    ...checkAgainstBaseline(counts, baseline),
+  ]
   if (violations.length > 0) {
     console.error("Table privacy check failed.\n")
     for (const violation of violations) console.error(`  - ${violation}`)
@@ -73,13 +114,34 @@ function main(): void {
     console.log("table-privacy: these pairs improved — tighten the baseline:")
     for (const line of better) console.log(`  - ${line}`)
   }
-  console.log(`verify:table-privacy: ${total} reach-ins across ${counts.size} pairs, none new.`)
+  const writeTotal = [...writeCounts.values()].reduce((sum, n) => sum + n, 0)
+  console.log(
+    `verify:table-privacy: ${total} reach-ins across ${counts.size} pairs, none new. ` +
+      `Of those, ${writeTotal} are cross-module WRITES across ${writeCounts.size} pairs — ` +
+      "these have no mirror answer and should reach zero.",
+  )
 }
 
 const BASELINE_COMMENT = [
   "Cross-module table reach-ins, by importer->owner. ADR-0016 decision 6.",
   "A pair may shrink, never grow; a new pair fails. Regenerate with --update-baseline",
   "ONLY when tightening. Foundation packages (db, core, utils, types, schema-kit) are exempt.",
+  "",
+  "`writePairs` counts the subset that MUTATE another module's tables. A read has",
+  "two answers — the owner's service, or a local *Ref mirror. A write has one: a",
+  "mirror is read-only by construction. Writes bypass whatever the owner does on",
+  "its own writes (revision bumps, validation, events), so they should reach zero",
+  "rather than merely stop growing.",
 ]
+
+/** Adds an import binding, stripping an `x as y` alias to its local name. */
+function writeSitesPush(into: Set<string>, specifier: string): void {
+  into.add(
+    specifier
+      .split(/\s+as\s+/)
+      .pop()
+      ?.trim() ?? specifier,
+  )
+}
 
 main()

--- a/scripts/checks/schema/table-privacy.ts
+++ b/scripts/checks/schema/table-privacy.ts
@@ -30,6 +30,67 @@ export interface ImportSite {
 
 export type Baseline = Readonly<Record<string, number>>
 
+/**
+ * A cross-module WRITE: `.update(x)` / `.insert(x)` / `.delete(x)` where `x` is
+ * another module's table.
+ *
+ * The reach-in count flattens a read and a write into the same unit, and they
+ * are not the same thing. A read has two sanctioned answers — the owning
+ * module's service, or a local `*Ref` mirror. A write has only one: a mirror is
+ * a read-only partial view by construction, so writing through it is not
+ * available. A cross-module write mutates another module's aggregate directly,
+ * bypassing whatever the owner does on its own writes — revision bumps,
+ * validation, events.
+ *
+ * That difference is worth measuring separately, and the target is different
+ * too: reads are debt to pay down, writes should reach zero.
+ */
+export interface WriteSite {
+  /** Package directory name performing the write. */
+  importer: string
+  /** Table const names mutated in this file, from imported bindings only. */
+  names: readonly string[]
+}
+
+export function countWriteReachIns(sites: readonly WriteSite[], ownership: TableOwnership) {
+  const counts = new Map<string, number>()
+  for (const site of sites) {
+    for (const name of site.names) {
+      const owner = ownership.owners.get(name)
+      if (owner === undefined) continue
+      if (name.endsWith("Ref")) continue
+      if (owner === site.importer) continue
+      if (FOUNDATION_PACKAGES.has(owner)) continue
+      const key = `${site.importer}->${owner}`
+      counts.set(key, (counts.get(key) ?? 0) + 1)
+    }
+  }
+  return counts
+}
+
+/** Write violations name the remedy, which is narrower than for a read. */
+export function checkWritesAgainstBaseline(
+  counts: ReadonlyMap<string, number>,
+  baseline: Baseline,
+) {
+  const violations: string[] = []
+  for (const [pair, count] of [...counts].sort()) {
+    const allowed = baseline[pair]
+    if (allowed === undefined) {
+      violations.push(
+        `${pair}: ${count} cross-module WRITE(s) in a pair with no baseline. A module may not ` +
+          `mutate another module's tables — call the owning module's service. A *Ref mirror is ` +
+          `read-only and is not an option here.`,
+      )
+    } else if (count > allowed) {
+      violations.push(
+        `${pair}: ${count} cross-module writes, baseline allows ${allowed}. This number may only fall.`,
+      )
+    }
+  }
+  return violations
+}
+
 export function countReachIns(sites: readonly ImportSite[], ownership: TableOwnership) {
   const counts = new Map<string, number>()
   for (const site of sites) {

--- a/scripts/tests/table-privacy.test.mjs
+++ b/scripts/tests/table-privacy.test.mjs
@@ -3,7 +3,9 @@ import test from "node:test"
 
 import {
   checkAgainstBaseline,
+  checkWritesAgainstBaseline,
   countReachIns,
+  countWriteReachIns,
   improvements,
 } from "../checks/schema/table-privacy.ts"
 
@@ -54,4 +56,57 @@ test("a pair at or below its baseline passes", () => {
 test("an improved pair is reported so the baseline can be tightened", () => {
   const better = improvements(new Map([["finance->bookings", 29]]), { "finance->bookings": 30 })
   assert.match(better[0], /now 29, baseline still 30/)
+})
+
+// ---- cross-module writes ----------------------------------------------------
+//
+// A write is a strictly worse reach-in than a read: a *Ref mirror is read-only
+// by construction, so the mirror answer is unavailable, and the write bypasses
+// whatever the owner does on its own writes. These assert it is measured apart.
+
+test("a write into another module's table is counted", () => {
+  const counts = countWriteReachIns([{ importer: "finance", names: ["bookings"] }], ownership)
+  assert.equal(counts.get("finance->bookings"), 1)
+})
+
+test("a module writing its own table is not a reach-in", () => {
+  assert.equal(
+    countWriteReachIns([{ importer: "bookings", names: ["bookings"] }], ownership).size,
+    0,
+  )
+})
+
+test("writing a local *Ref mirror is not a reach-in", () => {
+  // The mirror IS the sanctioned escape hatch for reads; it must not be counted
+  // as a write reach-in just because it appears in a mutating position.
+  assert.equal(
+    countWriteReachIns([{ importer: "finance", names: ["bookingsRef"] }], ownership).size,
+    0,
+  )
+})
+
+test("a foundation table is exempt", () => {
+  assert.equal(countWriteReachIns([{ importer: "finance", names: ["users"] }], ownership).size, 0)
+})
+
+test("a write pair with no baseline fails, and names the remedy", () => {
+  const counts = countWriteReachIns([{ importer: "legal", names: ["bookings"] }], ownership)
+  const violations = checkWritesAgainstBaseline(counts, {})
+  assert.equal(violations.length, 1)
+  assert.match(violations[0], /may not mutate/)
+  // The remedy differs from a read's, so the message must not offer a mirror.
+  assert.match(violations[0], /mirror is read-only and is not an option/)
+})
+
+test("a write pair that grew fails", () => {
+  const counts = countWriteReachIns(
+    [{ importer: "finance", names: ["bookings", "bookingItems"] }],
+    ownership,
+  )
+  assert.equal(checkWritesAgainstBaseline(counts, { "finance->bookings": 1 }).length, 1)
+})
+
+test("a write pair at or below its baseline passes", () => {
+  const counts = countWriteReachIns([{ importer: "finance", names: ["bookings"] }], ownership)
+  assert.deepEqual(checkWritesAgainstBaseline(counts, { "finance->bookings": 2 }), [])
 })


### PR DESCRIPTION
Part of #4266. Came out of surveying the two largest remaining pairs for consolidation.

## The finding

I went to merge `finance→bookings` (29) and `inventory↔commerce` (25) the way `availability` was merged. Neither is that kind of move — finance and bookings are **87k and 51k lines** with their own route surfaces; inventory and commerce are 70k and 29k. These are real modules.

What the survey turned up instead is that **the reach-in count is measuring two different problems as one**:

| | remedy |
|---|---|
| read | the owning module's service, **or** a local `*Ref` mirror |
| **write** | the owning module's service, and nothing else |

A mirror is a read-only partial view by construction, so it is not available for a write. And a write mutates another module's aggregate directly, bypassing whatever the owner does on its own writes — revision bumps, validation, events.

**48 of the 190 reach-ins are writes, across 9 pairs:**

```
16  inventory->commerce         4  relationships->identity
12  finance->bookings           2  apps->custom-fields
 5  legal->bookings             2  commerce->bookings
 4  inventory->operations       2  commerce->finance
                                1  storefront->relationships
```

Concretely: **inventory writes ten commerce-owned pricing tables** (`departurePriceOverrides`, `optionPriceRules`, `pricingCategories`, and seven more). **finance writes** `bookings.internalNotes`, `customerPaymentPolicy`, `sellAmountCents`, `priceOverride`, and bumps `bookings.revision` itself in four places — while bookings bumps that same column in its own runtime contributor.

48 with a plausible **zero** is a far sharper goal than 190 without one.

## What this changes

`writePairs` is seeded at today's counts and ratcheted identically: a pair may shrink, never grow, a new pair fails. The read baseline is **byte-identical** (190 / 35), so this adds a dimension rather than loosening anything.

A write only counts when the mutated binding was imported from another `@voyant-travel` package — a same-named local table is not a reach-in, and a `*Ref` mirror in a mutating position is not either. Both are asserted.

## AGENTS.md correction

This section is one I wrote earlier today, and it is wrong for exactly these two pairs. It said the mechanism is *consolidation, not service calls*. That held for `availability` — schema-only, services already in `operations`, no module there at all — but not for real modules.

ADR-0016 decision 7 rules out **ports** for business modules; it does not rule out calling a sibling's service in-process, and this checker's own doc has said *service or mirror* all along. Also refreshes the stale 225/37 figures to 190/35 after #4281.

## Verification

```
table-privacy        190 reach-ins / 35 pairs; 48 writes / 9 pairs
table-privacy tests  15 pass  (7 new, incl. mirror-in-write-position and foundation exemption)
vacuity              a 13th finance->bookings write goes red:
                     "13 cross-module writes, baseline allows 12"
ref-mirrors OK  cross-package-fk OK  tracked-tree-scan OK
biome  21 warnings, 0 errors
```

Scripts and docs only — no changeset.