### PR TITLE
feat(payments): make the checkout handoff a union, not a url with a label

### DIFF
--- a/.changeset/payment-embedded-checkout-handoff.md
+++ b/.changeset/payment-embedded-checkout-handoff.md
@@ -1,0 +1,51 @@
+---
+"@voyant-travel/payments": minor
+"@voyant-travel/finance": patch
+"@voyant-travel/operator-settings": patch
+---
+
+`PaymentInitiationResult.checkout` is a discriminated union with a `redirect` arm
+and an `embedded` arm, so the port can express an in-page payment.
+
+`PaymentHostedCheckout` was a `url` with a label: `kind` was
+`"hosted_checkout" | "redirect"`, `url` was required, and both values mean "send
+the shopper somewhere else". A provider that supports in-page payment (Stripe
+Elements, Adyen Drop-in, Braintree Hosted Fields) hands back a per-session client
+secret plus a publishable key and the page mounts the form itself — there was no
+arm of the union that could carry that, so no adapter could offer it and the
+shopper was redirected off the storefront at the last step of the funnel.
+
+The union is now:
+
+- `PaymentRedirectCheckout` — `kind: "hosted_checkout" | "redirect"`, `url`
+  required. Today's behaviour, unchanged.
+- `PaymentEmbeddedCheckout` — `kind: "embedded"`, carrying the opaque
+  `clientSecret`, the `publishableKey`, and an optional `providerAccountId` for
+  platform-scoped providers. No `url`. The runtime forwards these and never
+  learns what the front end does with them.
+
+Both arms keep `expiresAt`.
+
+The two sides negotiate, so gaining an arm never takes one away. An adapter
+advertises `capabilities.embeddedCheckout`; a caller declares
+`PaymentInitiationInput.acceptedCheckoutHandoffs`, the arms it can render in
+preference order. **Omitting it means `["redirect"]`** — a caller that has not
+opted in is never handed a form it cannot mount. `embeddedCheckout` is optional
+and absent means `false`, so an existing redirect adapter needs no change.
+
+New helpers: `isRedirectPaymentCheckout`, `isEmbeddedPaymentCheckout`,
+`paymentCheckoutHandoff`, `paymentCheckoutRedirectUrl`,
+`supportedPaymentCheckoutHandoffs`, `acceptedPaymentCheckoutHandoffs`, and
+`negotiatePaymentCheckoutHandoff`.
+
+The conformance kit covers both arms and the downgrade. An adapter declaring
+`embeddedCheckout` must return a well-formed `embedded` arm to a caller that
+accepts one, supplied through the new `embeddedInitiation` fixture, and *every*
+adapter is now probed with a redirect-only caller — a storefront that only knows
+how to redirect must not break when an adapter gains in-page support.
+
+Finance is a redirect-only caller: `startPaymentAdapterCardPayment` and
+`applyPaymentAdapterInitiationResult` read the URL through
+`paymentCheckoutRedirectUrl(...)` rather than `checkout?.url`, and never request
+the embedded arm. Persisting an embedded handoff so a storefront can mount a form
+is follow-on work, not part of the port.

--- a/docs/architecture/payment-adapter-boundary.md
+++ b/docs/architecture/payment-adapter-boundary.md
@@ -44,7 +44,7 @@ matching provider facets for a concrete selected adapter.
 
 - the runtime adapter port;
 - declared processor capabilities;
-- hosted checkout / redirect initiation;
+- hosted checkout / redirect / embedded initiation (see below);
 - authorize, capture, void, refund, and status operation contracts;
 - callback signature verification and canonical event mapping;
 - idempotency and retry expectations;
@@ -59,6 +59,46 @@ matching provider facets for a concrete selected adapter.
   connection may be made the active default, and the authoritative registry
   enforces that gate. The default/self-host registry is read-only for activation
   and fails closed.
+
+## Checkout handoff
+
+`PaymentInitiationResult.checkout` is a discriminated union over how the shopper
+reaches the processor, not a URL with a label:
+
+| arm | `kind` | carries |
+|---|---|---|
+| redirect | `hosted_checkout`, `redirect` | `url` — the shopper leaves the storefront |
+| embedded | `embedded` | `clientSecret`, `publishableKey`, optional `providerAccountId` — the page mounts the provider's own form |
+
+Both arms carry an optional `expiresAt`. The embedded arm exists because
+in-page providers (Stripe Elements, Adyen Drop-in, Braintree Hosted Fields) hand
+back a per-session credential plus a publishable identifier, and a union that
+requires a `url` cannot express that — the shopper gets redirected off the
+storefront at the last step of the funnel no matter which adapter is configured.
+The runtime forwards those credentials opaquely and never learns what the front
+end does with them.
+
+The two sides negotiate, so gaining an arm never takes one away:
+
+- an adapter advertises `capabilities.embeddedCheckout` alongside the existing
+  `hostedCheckout` / `redirectCheckout` flags. It is optional, and absent means
+  `false`, so an adapter written against the earlier contract keeps its meaning;
+- a caller declares `PaymentInitiationInput.acceptedCheckoutHandoffs` — the arms
+  it can render, most-preferred first. **Omitting it means `["redirect"]`**: a
+  caller that has not opted in is never handed a form it cannot mount;
+- `negotiatePaymentCheckoutHandoff(capabilities, input)` resolves the pair, and
+  `paymentCheckoutRedirectUrl(checkout)` is how a redirect-only caller reads a
+  URL without narrowing the union itself.
+
+The conformance kit covers both arms and the downgrade: an adapter declaring
+`embeddedCheckout` must return a well-formed `embedded` arm to a caller that
+accepts one (`embeddedInitiation` fixture), and *every* adapter must keep serving
+a caller that only accepts `redirect`.
+
+Finance's `CardPaymentStarter` is a redirect-only caller today: it never requests
+the embedded arm, and `payment_sessions.redirect_url` stays the persisted
+projection. Persisting an embedded handoff so a storefront can mount a form is
+the follow-on work, not part of the port.
 
 The existing finance `CardPaymentStarter` seam remains as the checkout bridge.
 Deployments can adapt a selected `PaymentAdapter` through

--- a/packages/finance/src/card-payment.ts
+++ b/packages/finance/src/card-payment.ts
@@ -12,6 +12,7 @@
  * callers fall back gracefully (bank-transfer paths still work).
  */
 import type { PaymentAdapter, PaymentAdapterRuntimeContext } from "@voyant-travel/payments"
+import { paymentCheckoutRedirectUrl } from "@voyant-travel/payments"
 import { and, eq, isNull, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
@@ -224,7 +225,10 @@ export async function startPaymentAdapterCardPayment(
     throw error
   }
 
-  return { redirectUrl: result.checkout?.url ?? null }
+  // This starter has no way to mount an in-page form, so it never asks for the
+  // embedded handoff and an adapter must not hand it one. `null` here is the
+  // same "nothing to redirect to" the seam has always been able to return.
+  return { redirectUrl: paymentCheckoutRedirectUrl(result.checkout) }
 }
 
 export function createPaymentAdapterCardPaymentStarter(

--- a/packages/finance/src/payment-adapter-events.ts
+++ b/packages/finance/src/payment-adapter-events.ts
@@ -5,6 +5,7 @@ import type {
   PaymentSessionState,
   PaymentStatusResult,
 } from "@voyant-travel/payments"
+import { paymentCheckoutRedirectUrl } from "@voyant-travel/payments"
 import { eq } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import {
@@ -202,7 +203,7 @@ export async function applyPaymentAdapterInitiationResult(
       processorIdentity: result.processorIdentity,
       processorSessionId: result.processorSessionId,
       processorPaymentId: result.processorPaymentId,
-      redirectUrl: result.checkout?.url ?? null,
+      redirectUrl: paymentCheckoutRedirectUrl(result.checkout),
       idempotencyKey: result.idempotencyKey,
       initiationClaimedAt: claim.claimedAt,
     },

--- a/packages/operator-settings/src/payment-provider-routes.ts
+++ b/packages/operator-settings/src/payment-provider-routes.ts
@@ -64,6 +64,9 @@ function asRouteResponse(response: Promise<Response>): Promise<any> {
 const capabilitiesSchema = z.object({
   hostedCheckout: z.boolean(),
   redirectCheckout: z.boolean(),
+  // Optional for the same reason it is optional on the adapter contract: a
+  // descriptor written before in-page checkout existed means `false`.
+  embeddedCheckout: z.boolean().optional(),
   authorize: z.boolean(),
   capture: z.boolean(),
   void: z.boolean(),

--- a/packages/payments/src/checkout-handoff.test.ts
+++ b/packages/payments/src/checkout-handoff.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest"
+import {
+  acceptedPaymentCheckoutHandoffs,
+  isEmbeddedPaymentCheckout,
+  isRedirectPaymentCheckout,
+  negotiatePaymentCheckoutHandoff,
+  type PaymentAdapterCapabilities,
+  type PaymentEmbeddedCheckout,
+  type PaymentRedirectCheckout,
+  paymentCheckoutHandoff,
+  paymentCheckoutRedirectUrl,
+  supportedPaymentCheckoutHandoffs,
+} from "./index.js"
+
+const redirect: PaymentRedirectCheckout = {
+  kind: "redirect",
+  url: "https://payments.example/continue",
+}
+const hosted: PaymentRedirectCheckout = {
+  kind: "hosted_checkout",
+  url: "https://payments.example/checkout",
+}
+const embedded: PaymentEmbeddedCheckout = {
+  kind: "embedded",
+  clientSecret: "session-secret-1",
+  publishableKey: "pk-test-1",
+}
+
+const capabilities = (overrides: Partial<PaymentAdapterCapabilities>) =>
+  ({
+    hostedCheckout: false,
+    redirectCheckout: false,
+    authorize: false,
+    capture: false,
+    void: false,
+    refund: false,
+    status: false,
+    callbackSignatureVerification: true,
+    idempotencyKeys: true,
+    retrySafeInitiation: true,
+    ...overrides,
+  }) satisfies PaymentAdapterCapabilities
+
+describe("checkout handoff arms", () => {
+  it("narrows both redirect kinds and the embedded kind", () => {
+    expect(isRedirectPaymentCheckout(redirect)).toBe(true)
+    expect(isRedirectPaymentCheckout(hosted)).toBe(true)
+    expect(isRedirectPaymentCheckout(embedded)).toBe(false)
+    expect(isEmbeddedPaymentCheckout(embedded)).toBe(true)
+  })
+
+  it("collapses both redirect kinds into the redirect handoff", () => {
+    expect(paymentCheckoutHandoff(redirect)).toBe("redirect")
+    expect(paymentCheckoutHandoff(hosted)).toBe("redirect")
+    expect(paymentCheckoutHandoff(embedded)).toBe("embedded")
+  })
+
+  it("yields a url only for an arm that has one", () => {
+    expect(paymentCheckoutRedirectUrl(hosted)).toBe("https://payments.example/checkout")
+    expect(paymentCheckoutRedirectUrl(embedded)).toBeNull()
+    expect(paymentCheckoutRedirectUrl(null)).toBeNull()
+    expect(paymentCheckoutRedirectUrl(undefined)).toBeNull()
+  })
+})
+
+describe("checkout handoff negotiation", () => {
+  it("defaults an unstated caller to redirect only", () => {
+    expect(acceptedPaymentCheckoutHandoffs({})).toEqual(["redirect"])
+    expect(acceptedPaymentCheckoutHandoffs({ acceptedCheckoutHandoffs: [] })).toEqual(["redirect"])
+  })
+
+  it("preserves caller preference order and drops repeats", () => {
+    expect(
+      acceptedPaymentCheckoutHandoffs({
+        acceptedCheckoutHandoffs: ["embedded", "redirect", "embedded"],
+      }),
+    ).toEqual(["embedded", "redirect"])
+  })
+
+  it("reads the arms an adapter's capabilities can produce", () => {
+    expect(supportedPaymentCheckoutHandoffs(capabilities({ redirectCheckout: true }))).toEqual([
+      "redirect",
+    ])
+    expect(supportedPaymentCheckoutHandoffs(capabilities({ hostedCheckout: true }))).toEqual([
+      "redirect",
+    ])
+    expect(
+      supportedPaymentCheckoutHandoffs(
+        capabilities({ hostedCheckout: true, embeddedCheckout: true }),
+      ),
+    ).toEqual(["redirect", "embedded"])
+    expect(supportedPaymentCheckoutHandoffs(capabilities({}))).toEqual([])
+  })
+
+  it("serves the caller's first preference the adapter supports", () => {
+    const both = capabilities({ hostedCheckout: true, embeddedCheckout: true })
+
+    expect(
+      negotiatePaymentCheckoutHandoff(both, { acceptedCheckoutHandoffs: ["embedded", "redirect"] }),
+    ).toBe("embedded")
+    expect(negotiatePaymentCheckoutHandoff(both, {})).toBe("redirect")
+  })
+
+  it("downgrades to redirect for a caller that cannot mount a form", () => {
+    const both = capabilities({ hostedCheckout: true, embeddedCheckout: true })
+
+    expect(negotiatePaymentCheckoutHandoff(both, { acceptedCheckoutHandoffs: ["redirect"] })).toBe(
+      "redirect",
+    )
+  })
+
+  it("returns null when caller and adapter cannot agree", () => {
+    expect(
+      negotiatePaymentCheckoutHandoff(capabilities({ redirectCheckout: true }), {
+        acceptedCheckoutHandoffs: ["embedded"],
+      }),
+    ).toBeNull()
+    expect(negotiatePaymentCheckoutHandoff(capabilities({}), {})).toBeNull()
+  })
+})

--- a/packages/payments/src/conformance.test.ts
+++ b/packages/payments/src/conformance.test.ts
@@ -4,11 +4,14 @@ import {
   runPaymentAdapterConformance,
 } from "./conformance.js"
 import {
+  acceptedPaymentCheckoutHandoffs,
   PAYMENT_ADAPTER_CONTRACT_VERSION,
   type PaymentAdapter,
   type PaymentAdapterErrorCode,
   type PaymentAdapterRuntimeContext,
   type PaymentCallbackRequest,
+  type PaymentHostedCheckout,
+  type PaymentInitiationInput,
   type PaymentOperationInput,
   type PaymentOperationResult,
   type PaymentStatusInput,
@@ -22,13 +25,20 @@ type BrokenBehavior =
   | "change-duplicate-operation"
   | "drop-operation-identity"
   | "drop-status-identity"
+  | "embed-without-capability"
+  | "embed-without-client-secret"
+  | "ignore-accepted-handoffs"
   | "malformed-health"
   | "manual-capture-pays"
+  | "never-embeds"
   | "remap-status-identity"
   | "untyped-conflict-error"
   | "verify-invalid-callback"
   | "verify-malformed-callback"
   | "verify-replayed-callback"
+
+/** Whether the fake adapter declares (and can serve) in-page checkout. */
+type FakeAdapterOptions = { embeddedCheckout?: boolean }
 
 const context: PaymentAdapterRuntimeContext = {
   env: {},
@@ -59,8 +69,69 @@ describe("payment adapter conformance", () => {
         "enforces partial capture bounds",
         "enforces partial refund bounds",
         "reports typed health diagnostics",
+        "honors declared embedded checkout capability",
+        "serves a caller that can only redirect",
       ]),
     )
+  })
+
+  it("passes an embedded-capable adapter across both checkout arms", async () => {
+    const results = await runPaymentAdapterConformance(
+      createHarness(undefined, { embeddedCheckout: true }),
+    )
+
+    expect(results.filter((result) => !result.passed)).toEqual([])
+    expect(results.map((result) => result.name)).toEqual(
+      expect.arrayContaining([
+        "honors declared embedded checkout capability",
+        "serves a caller that can only redirect",
+      ]),
+    )
+  })
+
+  it("fails when a declared embedded capability has no fixture", async () => {
+    const harness = createHarness(undefined, { embeddedCheckout: true })
+    harness.embeddedInitiation = undefined
+
+    expect(await failedCaseNames(harness)).toContain("honors declared embedded checkout capability")
+  })
+
+  it("skips the embedded case when the capability is not declared", async () => {
+    const harness = createHarness()
+    harness.embeddedInitiation = undefined
+
+    expect(await failedCaseNames(harness)).not.toContain(
+      "honors declared embedded checkout capability",
+    )
+  })
+
+  it("fails when the embedded fixture does not accept the embedded handoff", async () => {
+    const harness = createHarness(undefined, { embeddedCheckout: true })
+    harness.embeddedInitiation = {
+      ...(harness.embeddedInitiation as NonNullable<typeof harness.embeddedInitiation>),
+      acceptedCheckoutHandoffs: ["redirect"],
+    }
+
+    expect(await failedCaseNames(harness)).toContain("honors declared embedded checkout capability")
+  })
+
+  it.each([
+    ["never-embeds", "honors declared embedded checkout capability"],
+    ["embed-without-client-secret", "honors declared embedded checkout capability"],
+    ["ignore-accepted-handoffs", "serves a caller that can only redirect"],
+  ] satisfies ReadonlyArray<
+    readonly [BrokenBehavior, string]
+  >)("catches a %s embedded-capable adapter", async (behavior, failedCase) => {
+    const harness = createHarness(behavior, { embeddedCheckout: true })
+
+    expect(await failedCaseNames(harness)).toContain(failedCase)
+  })
+
+  it("catches an adapter that embeds without declaring the capability", async () => {
+    const harness = createHarness("embed-without-capability")
+
+    expect(harness.adapter.capabilities.embeddedCheckout).toBe(false)
+    expect(await failedCaseNames(harness)).toContain("initiates idempotently")
   })
 
   it("fails when a declared operation has no method", async () => {
@@ -121,11 +192,23 @@ async function failedCaseNames(harness: PaymentAdapterConformanceHarness) {
     .map((result) => result.name)
 }
 
-function createHarness(behavior?: BrokenBehavior): PaymentAdapterConformanceHarness {
+function createHarness(
+  behavior?: BrokenBehavior,
+  options: FakeAdapterOptions = {},
+): PaymentAdapterConformanceHarness {
   const identity = { providerId: "fake-pay", connectionId: "connection-1" }
   return {
-    adapter: createFakeAdapter(behavior),
+    adapter: createFakeAdapter(behavior, options),
     context,
+    embeddedInitiation: options.embeddedCheckout
+      ? {
+          paymentSessionId: "payment-embedded",
+          money: { amountMinor: 1_000, currency: "EUR" },
+          captureMode: "automatic",
+          acceptedCheckoutHandoffs: ["embedded", "redirect"],
+          idempotencyKey: "init-embedded",
+        }
+      : undefined,
     initiation: {
       paymentSessionId: "payment-1",
       money: { amountMinor: 1_000, currency: "EUR" },
@@ -183,7 +266,11 @@ function operation(idempotencyKey: string, amountMinor?: number): PaymentOperati
   }
 }
 
-function createFakeAdapter(behavior?: BrokenBehavior): PaymentAdapter {
+function createFakeAdapter(
+  behavior?: BrokenBehavior,
+  options: FakeAdapterOptions = {},
+): PaymentAdapter {
+  const embeddedCheckout = options.embeddedCheckout === true
   const initiationKeys = new Map<string, { payload: string; result: unknown }>()
   const operationKeys = new Map<string, { payload: string; result: PaymentOperationResult }>()
   let operationSequence = 0
@@ -203,6 +290,29 @@ function createFakeAdapter(behavior?: BrokenBehavior): PaymentAdapter {
       !/^[A-Z]{3}$/.test(money.currency)
     ) {
       fail("INVALID_REQUEST", "Invalid money")
+    }
+  }
+
+  const redirectCheckout: PaymentHostedCheckout = {
+    kind: "redirect",
+    url: "https://payments.example/checkout",
+  }
+
+  const chooseCheckout = (
+    acceptedCheckoutHandoffs: PaymentInitiationInput["acceptedCheckoutHandoffs"],
+  ): PaymentHostedCheckout => {
+    const forced =
+      behavior === "ignore-accepted-handoffs" || behavior === "embed-without-capability"
+    const wantsEmbedded =
+      forced || acceptedPaymentCheckoutHandoffs({ acceptedCheckoutHandoffs })[0] === "embedded"
+    const canEmbed =
+      (embeddedCheckout || behavior === "embed-without-capability") && behavior !== "never-embeds"
+    if (!wantsEmbedded || !canEmbed) return redirectCheckout
+    return {
+      kind: "embedded",
+      clientSecret: behavior === "embed-without-client-secret" ? "" : "session-secret-1",
+      publishableKey: "pk-test-fake-pay",
+      providerAccountId: "acct-1",
     }
   }
 
@@ -260,6 +370,7 @@ function createFakeAdapter(behavior?: BrokenBehavior): PaymentAdapter {
     capabilities: {
       hostedCheckout: true,
       redirectCheckout: true,
+      embeddedCheckout,
       authorize: true,
       capture: true,
       void: true,
@@ -283,10 +394,7 @@ function createFakeAdapter(behavior?: BrokenBehavior): PaymentAdapter {
         processorSessionId: "processor-session-1",
         processorPaymentId: "processor-payment-1",
         processorIdentity: { providerId: "fake-pay", connectionId: "connection-1" },
-        checkout: {
-          kind: "redirect" as const,
-          url: "https://payments.example/checkout",
-        },
+        checkout: chooseCheckout(input.acceptedCheckoutHandoffs),
         nextState:
           input.captureMode === "manual" && behavior !== "manual-capture-pays"
             ? ("authorized" as const)

--- a/packages/payments/src/conformance.ts
+++ b/packages/payments/src/conformance.ts
@@ -3,6 +3,8 @@ import type {
   PaymentAdapterRuntimeContext,
   PaymentCallbackEvent,
   PaymentCallbackRequest,
+  PaymentCheckoutHandoff,
+  PaymentHostedCheckout,
   PaymentInitiationInput,
   PaymentInitiationResult,
   PaymentMoney,
@@ -13,7 +15,13 @@ import type {
   PaymentStatusInput,
   PaymentStatusResult,
 } from "./index.js"
-import { isPaymentAdapterError, paymentAdapterRuntimePort } from "./index.js"
+import {
+  acceptedPaymentCheckoutHandoffs,
+  isEmbeddedPaymentCheckout,
+  isPaymentAdapterError,
+  paymentAdapterRuntimePort,
+  paymentCheckoutHandoff,
+} from "./index.js"
 
 export interface PaymentOperationConformanceFixture {
   input: PaymentOperationInput
@@ -59,6 +67,17 @@ export interface PaymentAdapterConformanceHarness {
    * It may stop at redirect/processing/authorized, but must never report paid.
    */
   manualCaptureInitiation?: PaymentInitiationInput
+  /**
+   * A separate initiation that accepts the embedded handoff. Required when
+   * `embeddedCheckout` is declared; it must return an `embedded` arm.
+   */
+  embeddedInitiation?: PaymentInitiationInput
+  /**
+   * The initiation used for the redirect-only downgrade probe. Defaults to
+   * `initiation`, re-keyed. Supply it only when the base fixture cannot be
+   * replayed under a fresh session/idempotency key.
+   */
+  redirectOnlyInitiation?: PaymentInitiationInput
   authorize?: PaymentOperationConformanceInput
   capture?: PaymentOperationConformanceInput
   void?: PaymentOperationConformanceInput
@@ -150,6 +169,14 @@ function buildCases(harness: PaymentAdapterConformanceHarness): ConformanceCase[
     },
     { name: "honors manual capture", run: () => assertManualCapture(harness) },
     {
+      name: "honors declared embedded checkout capability",
+      run: () => assertEmbeddedCheckout(harness),
+    },
+    {
+      name: "serves a caller that can only redirect",
+      run: () => assertRedirectOnlyCaller(harness),
+    },
+    {
       name: "enforces partial capture bounds",
       run: () => assertPartialOperationBound(harness, "capture"),
     },
@@ -186,6 +213,12 @@ async function assertAdapterPort(adapter: PaymentAdapter) {
       throw new Error(`Payment adapter capability ${capability} must be boolean.`)
     }
   }
+  if (
+    adapter.capabilities.embeddedCheckout !== undefined &&
+    typeof adapter.capabilities.embeddedCheckout !== "boolean"
+  ) {
+    throw new Error("Payment adapter capability embeddedCheckout must be boolean when declared.")
+  }
   if (!adapter.capabilities.idempotencyKeys || !adapter.capabilities.retrySafeInitiation) {
     throw new Error("Payment adapters must declare idempotent, retry-safe initiation.")
   }
@@ -218,8 +251,9 @@ async function assertInitiation(harness: PaymentAdapterConformanceHarness) {
   if (duplicate.idempotencyKey !== first.idempotencyKey) {
     throw new Error("Duplicate initiation must preserve idempotency identity.")
   }
-  assertInitiationResult(harness.adapter, first)
-  assertInitiationResult(harness.adapter, duplicate)
+  const accepted = acceptedPaymentCheckoutHandoffs(harness.initiation)
+  assertInitiationResult(harness.adapter, first, accepted)
+  assertInitiationResult(harness.adapter, duplicate, accepted)
   assertSame(
     initiationIdentity(first),
     initiationIdentity(duplicate),
@@ -422,10 +456,11 @@ async function assertManualCapture(harness: PaymentAdapterConformanceHarness) {
     throw new Error("Manual capture fixture must set captureMode to manual.")
   }
   await assertMoney(input.money)
+  const accepted = acceptedPaymentCheckoutHandoffs(input)
   const first = await harness.adapter.initiate(harness.context, input)
   const duplicate = await harness.adapter.initiate(harness.context, input)
-  assertInitiationResult(harness.adapter, first)
-  assertInitiationResult(harness.adapter, duplicate)
+  assertInitiationResult(harness.adapter, first, accepted)
+  assertInitiationResult(harness.adapter, duplicate, accepted)
   if (first.nextState === "paid" || duplicate.nextState === "paid") {
     throw new Error("Manual-capture initiation must not report payment as paid.")
   }
@@ -434,6 +469,52 @@ async function assertManualCapture(harness: PaymentAdapterConformanceHarness) {
     initiationIdentity(duplicate),
     "Manual-capture initiation must be idempotent.",
   )
+}
+
+async function assertEmbeddedCheckout(harness: PaymentAdapterConformanceHarness) {
+  if (!harness.adapter.capabilities.embeddedCheckout) return
+  const input = harness.embeddedInitiation
+  if (!input) {
+    throw new Error(
+      "Adapter declares embedded checkout but no embeddedInitiation fixture was supplied.",
+    )
+  }
+  const accepted = acceptedPaymentCheckoutHandoffs(input)
+  if (!accepted.includes("embedded")) {
+    throw new Error("Embedded initiation fixture must accept the embedded handoff.")
+  }
+  await assertMoney(input.money)
+  const first = await harness.adapter.initiate(harness.context, input)
+  const duplicate = await harness.adapter.initiate(harness.context, input)
+  assertInitiationResult(harness.adapter, first, accepted)
+  assertInitiationResult(harness.adapter, duplicate, accepted)
+  if (!first.checkout || !isEmbeddedPaymentCheckout(first.checkout)) {
+    throw new Error(
+      "Adapter declares embedded checkout but returned no embedded arm to a caller that accepts one.",
+    )
+  }
+  assertSame(
+    initiationIdentity(first),
+    initiationIdentity(duplicate),
+    "Embedded initiation must be idempotent.",
+  )
+}
+
+/**
+ * A storefront that only knows how to redirect must keep working after an
+ * adapter gains in-page support. Every adapter runs this, not just the
+ * embedded-capable ones, so the downgrade stays proven as capabilities grow.
+ */
+async function assertRedirectOnlyCaller(harness: PaymentAdapterConformanceHarness) {
+  const base = harness.redirectOnlyInitiation ?? harness.initiation
+  const input: PaymentInitiationInput = {
+    ...base,
+    paymentSessionId: `${base.paymentSessionId}:redirect-only`,
+    idempotencyKey: `${base.idempotencyKey}:redirect-only`,
+    acceptedCheckoutHandoffs: ["redirect"],
+  }
+  const result = await harness.adapter.initiate(harness.context, input)
+  assertInitiationResult(harness.adapter, result, ["redirect"])
 }
 
 async function assertPartialOperationBound(
@@ -479,30 +560,67 @@ async function assertPartialOperationBound(
   )
 }
 
-function assertInitiationResult(adapter: PaymentAdapter, result: PaymentInitiationResult) {
+function assertInitiationResult(
+  adapter: PaymentAdapter,
+  result: PaymentInitiationResult,
+  accepted: readonly PaymentCheckoutHandoff[],
+) {
   assertState(result.nextState)
   assertNonEmpty(result.idempotencyKey, "Initiation result idempotency key")
   assertIdentity(result.processorIdentity)
   if (!result.checkout) return
-  let url: URL
-  try {
-    url = new URL(result.checkout.url)
-  } catch {
-    throw new Error("Hosted checkout redirects must be absolute HTTP(S) URLs.")
+  assertCheckoutArm(adapter, result.checkout)
+  const handoff = paymentCheckoutHandoff(result.checkout)
+  if (!accepted.includes(handoff)) {
+    throw new Error(
+      `Adapter returned a ${handoff} checkout to a caller that only accepts ${accepted.join(", ")}.`,
+    )
   }
-  if (!["http:", "https:"].includes(url.protocol)) {
-    throw new Error("Hosted checkout redirects must be absolute HTTP(S) URLs.")
+}
+
+function assertCheckoutArm(adapter: PaymentAdapter, checkout: PaymentHostedCheckout) {
+  switch (checkout.kind) {
+    case "hosted_checkout":
+    case "redirect": {
+      let url: URL
+      try {
+        url = new URL(checkout.url)
+      } catch {
+        throw new Error("Hosted checkout redirects must be absolute HTTP(S) URLs.")
+      }
+      if (!["http:", "https:"].includes(url.protocol)) {
+        throw new Error("Hosted checkout redirects must be absolute HTTP(S) URLs.")
+      }
+      if (checkout.kind === "hosted_checkout" && !adapter.capabilities.hostedCheckout) {
+        throw new Error("Adapter returned hosted checkout without declaring the capability.")
+      }
+      if (checkout.kind === "redirect" && !adapter.capabilities.redirectCheckout) {
+        throw new Error("Adapter returned redirect checkout without declaring the capability.")
+      }
+      break
+    }
+    case "embedded": {
+      if (!adapter.capabilities.embeddedCheckout) {
+        throw new Error("Adapter returned embedded checkout without declaring the capability.")
+      }
+      assertNonEmpty(checkout.clientSecret, "Embedded checkout client secret")
+      assertNonEmpty(checkout.publishableKey, "Embedded checkout publishable key")
+      if (checkout.providerAccountId != null) {
+        assertNonEmpty(checkout.providerAccountId, "Embedded checkout provider account id")
+      }
+      // A URL on the embedded arm means the adapter is still redirecting and
+      // has only relabelled the handoff.
+      if ("url" in checkout) {
+        throw new Error("Embedded checkout must not carry a redirect url.")
+      }
+      break
+    }
+    default: {
+      const kind = (checkout as { kind?: unknown }).kind
+      throw new Error(`Adapter returned an unknown checkout handoff kind: ${String(kind)}.`)
+    }
   }
-  if (result.checkout.kind === "hosted_checkout" && !adapter.capabilities.hostedCheckout) {
-    throw new Error("Adapter returned hosted checkout without declaring the capability.")
-  }
-  if (result.checkout.kind === "redirect" && !adapter.capabilities.redirectCheckout) {
-    throw new Error("Adapter returned redirect checkout without declaring the capability.")
-  }
-  if (
-    !["hosted_checkout", "redirect"].includes(result.checkout.kind) ||
-    (result.checkout.expiresAt != null && !isIsoTimestamp(result.checkout.expiresAt))
-  ) {
+  if (checkout.expiresAt != null && !isIsoTimestamp(checkout.expiresAt)) {
     throw new Error("Adapter returned malformed hosted checkout diagnostics.")
   }
 }

--- a/packages/payments/src/default-catalog.ts
+++ b/packages/payments/src/default-catalog.ts
@@ -16,6 +16,7 @@ import type { PaymentProviderDescriptor } from "./provider-catalog.js"
 const redirectProcessorCapabilities: PaymentAdapterCapabilities = {
   hostedCheckout: true,
   redirectCheckout: true,
+  embeddedCheckout: false,
   authorize: false,
   capture: false,
   void: false,

--- a/packages/payments/src/index.ts
+++ b/packages/payments/src/index.ts
@@ -34,9 +34,25 @@ export interface PaymentProcessorIdentity {
   connectionId: string
 }
 
+/**
+ * How the shopper is handed to the processor.
+ *
+ * `redirect` sends them somewhere else — a provider-hosted checkout page or an
+ * issuer/3DS redirect. `embedded` keeps them on the storefront and lets the
+ * page mount the provider's own payment form.
+ */
+export const PAYMENT_CHECKOUT_HANDOFFS = ["redirect", "embedded"] as const
+export type PaymentCheckoutHandoff = (typeof PAYMENT_CHECKOUT_HANDOFFS)[number]
+
 export interface PaymentAdapterCapabilities {
   hostedCheckout: boolean
   redirectCheckout: boolean
+  /**
+   * In-page checkout. Optional so an adapter written against an earlier
+   * revision of this contract keeps compiling and keeps its meaning: absent is
+   * the same fact as `false`.
+   */
+  embeddedCheckout?: boolean
   authorize: boolean
   capture: boolean
   void: boolean
@@ -47,10 +63,103 @@ export interface PaymentAdapterCapabilities {
   retrySafeInitiation: boolean
 }
 
-export interface PaymentHostedCheckout {
+/** The shopper leaves the storefront. `url` is where they go. */
+export interface PaymentRedirectCheckout {
   kind: "hosted_checkout" | "redirect"
   url: string
   expiresAt?: string | null
+}
+
+/**
+ * The shopper stays on the storefront and the page mounts the provider's own
+ * payment form (Stripe Elements, Adyen Drop-in, Braintree Hosted Fields, …).
+ *
+ * The runtime forwards opaque credentials and never learns what the front end
+ * does with them: `clientSecret` is whatever per-session token the provider
+ * issues, and `publishableKey` is the client-side identifier its SDK is
+ * initialized with. Neither is parsed here.
+ */
+export interface PaymentEmbeddedCheckout {
+  kind: "embedded"
+  clientSecret: string
+  publishableKey: string
+  /** Platform-scoped providers act on behalf of a connected account. */
+  providerAccountId?: string | null
+  expiresAt?: string | null
+}
+
+export type PaymentHostedCheckout = PaymentRedirectCheckout | PaymentEmbeddedCheckout
+
+export function isRedirectPaymentCheckout(
+  checkout: PaymentHostedCheckout,
+): checkout is PaymentRedirectCheckout {
+  return checkout.kind === "hosted_checkout" || checkout.kind === "redirect"
+}
+
+export function isEmbeddedPaymentCheckout(
+  checkout: PaymentHostedCheckout,
+): checkout is PaymentEmbeddedCheckout {
+  return checkout.kind === "embedded"
+}
+
+export function paymentCheckoutHandoff(checkout: PaymentHostedCheckout): PaymentCheckoutHandoff {
+  return isEmbeddedPaymentCheckout(checkout) ? "embedded" : "redirect"
+}
+
+/**
+ * The URL to send the shopper to, or null when the handoff carries no URL.
+ *
+ * Callers that can only redirect use this instead of reaching for `url`, so an
+ * embedded arm degrades to "nowhere to send them" rather than a type error.
+ */
+export function paymentCheckoutRedirectUrl(
+  checkout: PaymentHostedCheckout | null | undefined,
+): string | null {
+  if (!checkout || !isRedirectPaymentCheckout(checkout)) return null
+  return checkout.url
+}
+
+/** The handoffs an adapter's declared capabilities can actually produce. */
+export function supportedPaymentCheckoutHandoffs(
+  capabilities: PaymentAdapterCapabilities,
+): PaymentCheckoutHandoff[] {
+  const supported: PaymentCheckoutHandoff[] = []
+  if (capabilities.hostedCheckout || capabilities.redirectCheckout) supported.push("redirect")
+  if (capabilities.embeddedCheckout) supported.push("embedded")
+  return supported
+}
+
+/**
+ * The handoffs the caller declared it can render, in preference order.
+ *
+ * Omitting `acceptedCheckoutHandoffs` means `["redirect"]`. A caller that has
+ * not opted in must never be handed an arm it cannot mount, so silence is the
+ * conservative answer rather than "anything goes".
+ */
+export function acceptedPaymentCheckoutHandoffs(
+  input: Pick<PaymentInitiationInput, "acceptedCheckoutHandoffs">,
+): PaymentCheckoutHandoff[] {
+  const accepted = input.acceptedCheckoutHandoffs
+  if (!accepted || accepted.length === 0) return ["redirect"]
+  const seen = new Set<PaymentCheckoutHandoff>()
+  for (const handoff of accepted) {
+    if (PAYMENT_CHECKOUT_HANDOFFS.includes(handoff)) seen.add(handoff)
+  }
+  return accepted.filter((handoff) => seen.delete(handoff))
+}
+
+/**
+ * The handoff an adapter should produce for this caller: the caller's first
+ * preference the adapter can serve, or null when the two cannot agree.
+ */
+export function negotiatePaymentCheckoutHandoff(
+  capabilities: PaymentAdapterCapabilities,
+  input: Pick<PaymentInitiationInput, "acceptedCheckoutHandoffs">,
+): PaymentCheckoutHandoff | null {
+  const supported = supportedPaymentCheckoutHandoffs(capabilities)
+  return (
+    acceptedPaymentCheckoutHandoffs(input).find((handoff) => supported.includes(handoff)) ?? null
+  )
 }
 
 export interface PaymentAdapterDiagnostics {
@@ -95,6 +204,11 @@ export interface PaymentInitiationInput {
   returnUrl?: string
   cancelUrl?: string
   captureMode?: PaymentCaptureMode
+  /**
+   * The checkout handoffs this caller can render, most-preferred first.
+   * Omitted means `["redirect"]` — see `acceptedPaymentCheckoutHandoffs`.
+   */
+  acceptedCheckoutHandoffs?: readonly PaymentCheckoutHandoff[]
   idempotencyKey: string
   customer?: {
     email?: string | null
@@ -258,6 +372,12 @@ export const paymentAdapterRuntimePort = definePort<PaymentAdapter>({
     }
     if (!adapter.capabilities.callbackSignatureVerification) {
       throw new Error("Payment adapter callbacks must be signature-verified.")
+    }
+    if (
+      adapter.capabilities.embeddedCheckout !== undefined &&
+      typeof adapter.capabilities.embeddedCheckout !== "boolean"
+    ) {
+      throw new Error("Payment adapter capability embeddedCheckout must be boolean when declared.")
     }
   },
 })

--- a/packages/payments/src/provider-catalog.test.ts
+++ b/packages/payments/src/provider-catalog.test.ts
@@ -22,6 +22,7 @@ describe("default payment provider catalog", () => {
       capabilities: {
         hostedCheckout: true,
         redirectCheckout: true,
+        embeddedCheckout: false,
         authorize: false,
         capture: false,
         void: false,


### PR DESCRIPTION
Closes #4285.

`PaymentHostedCheckout` was a URL with a label: `kind` was
`"hosted_checkout" | "redirect"`, `url` was required, and both values mean "send
the shopper somewhere else". A provider that supports in-page payment (Stripe
Elements, Adyen Drop-in, Braintree Hosted Fields) hands back a per-session client
secret plus a publishable key and the page mounts the form itself — no arm of
that union could carry it, so no adapter could offer it and the shopper was
redirected off the storefront at the last step of the funnel.

## The union

| arm | `kind` | carries |
|---|---|---|
| `PaymentRedirectCheckout` | `hosted_checkout`, `redirect` | `url` — today's behaviour, unchanged |
| `PaymentEmbeddedCheckout` | `embedded` | `clientSecret`, `publishableKey`, optional `providerAccountId` — no `url` |

Both keep `expiresAt`. The runtime forwards the credentials opaquely and never
learns what the front end does with them.

## Negotiation, so gaining an arm never takes one away

- an adapter advertises `capabilities.embeddedCheckout`. **Optional, absent means
  `false`** — an existing redirect adapter needs no change, in-repo or out;
- a caller declares `PaymentInitiationInput.acceptedCheckoutHandoffs`, the arms it
  can render in preference order. **Omitting it means `["redirect"]`** — a caller
  that has not opted in is never handed a form it cannot mount;
- `negotiatePaymentCheckoutHandoff(capabilities, input)` resolves the pair, and
  `paymentCheckoutRedirectUrl(checkout)` lets a redirect-only caller read a URL
  without narrowing the union itself.

## Conformance

Two new cases:

- **honors declared embedded checkout capability** — an adapter declaring
  `embeddedCheckout` must return a well-formed `embedded` arm to a caller that
  accepts one, via the new `embeddedInitiation` fixture;
- **serves a caller that can only redirect** — runs for *every* adapter, not just
  embedded-capable ones, so the downgrade stays proven as capabilities grow.

`assertInitiationResult` is now an exhaustive switch per arm and also rejects an
arm the caller did not accept. Four broken-adapter probes cover it: `never-embeds`,
`embed-without-client-secret`, `ignore-accepted-handoffs`, `embed-without-capability`.

## Blast radius

Small. `PaymentHostedCheckout` was named in one file, and only two non-test sites
read `.checkout`: `finance/src/card-payment.ts` and
`finance/src/payment-adapter-events.ts`, both now going through
`paymentCheckoutRedirectUrl(...)`. Finance is a redirect-only caller and stays
one — `payment_sessions.redirect_url` is unchanged. Persisting an embedded handoff
so a storefront can mount a form is follow-on work, not part of the port.

`operator-settings`' zod capability mirror gained the optional flag; the Netopia
catalog descriptor declares `embeddedCheckout: false` explicitly.

No new architecture checker: this is a type contract with a conformance kit, not a
mechanical rule expressible as data.

## Verification

- `pnpm -F @voyant-travel/payments test` — 58/58 pass (6 new cases)
- `pnpm -F @voyant-travel/payments typecheck` — clean
- `pnpm -F @voyant-travel/finance... build` — clean
- `biome check` — clean

`operator-settings` and packages downstream of `distribution` were not built
locally; leaving that to CI.
