### PR TITLE
Initiate hosted checkout with meaning, not identifiers

### DIFF
--- a/.changeset/hosted-checkout-initiation-meaning.md
+++ b/.changeset/hosted-checkout-initiation-meaning.md
@@ -1,0 +1,36 @@
+---
+"@voyant-travel/payments": minor
+"@voyant-travel/finance": minor
+"@voyant-travel/inventory": minor
+"@voyant-travel/catalog": minor
+---
+
+A hosted checkout is initiated with what the shopper is buying, in their
+language, keyed to a customer rather than an email address.
+
+`PaymentInitiationInput` is what a hosted-checkout provider renders to the
+shopper, and three of its fields could not carry the meaning that page needs.
+
+`description` is the only product-shaped field on the contract, so a caller that
+sends an identifier leaves the provider nothing else to show — and the Booking
+Session commit path sent `Booking Session bses_01k…`. It now names the product
+and, where the target has one, its departure, both resolved in the Session's
+locale. The name comes from `loadProductPaymentPolicyContext`, which takes an
+optional `locale` and returns the product's translated `name`, falling back to
+its base name rather than to a language the shopper did not ask for.
+
+`locale` is new and optional: a BCP 47 tag for the language the shopper has been
+reading the funnel in, so a hosted page is rendered in it instead of guessed
+from the browser. The Booking Session populates it from its own scope.
+
+`customer.reference` is new and optional: an opaque, stable reference to the
+runtime's own customer record. Without it a provider that wants to reuse a
+stored customer — and therefore offer a stored payment method — has to key that
+binding on the email address, which binds two people who share an inbox, breaks
+when the address is corrected, and forces the provider to retain personal data
+purely as a join key. The Booking Session populates it from the CRM person the
+buyer was identified as, falling back to the owning principal only on a
+customer-actor Session: on a staff-created one the principal is the agent, not
+the shopper.
+
+All three are additive. An adapter that ignores them behaves exactly as before.

--- a/packages/catalog/src/booking-engine/sessions-payment-production.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-payment-production.test.ts
@@ -1,6 +1,30 @@
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { createProductionBookingSessionPaymentPorts } from "./sessions-payment-production.js"
+
+const startPaymentAdapterCardPayment = vi.hoisted(() => vi.fn(async (..._args: unknown[]) => null))
+
+vi.mock("@voyant-travel/finance", () => ({
+  computePaymentSchedule: () => [
+    { amountCents: 10_000, currency: "EUR", scheduleType: "deposit", dueDate: "2026-08-05" },
+  ],
+  createOrReuseBookingSessionPayment: async () => ({
+    id: "pmts_1",
+    status: "pending",
+    amountCents: 10_000,
+    currency: "EUR",
+    redirectUrl: null,
+    expiresAt: null,
+  }),
+  expirePendingBookingSessionPayments: vi.fn(),
+  financeService: { getPaymentSessionById: async () => null },
+  findEstablishedBookingSessionPayment: async () => null,
+  noDepositPolicy: { kind: "no_deposit" },
+  resolveEffectivePaymentPolicy: () => ({ policy: { kind: "deposit" }, source: "operator" }),
+  resolvePaymentCallbackUrl: () => undefined,
+  startPaymentAdapterCardPayment,
+  transferBookingSessionPaymentToBooking: vi.fn(),
+}))
 
 describe("production Booking Session staff payment policy", () => {
   it("does not create a customer checkout when staff supplied a collection schedule", async () => {
@@ -44,3 +68,137 @@ describe("production Booking Session staff payment policy", () => {
     expect(loadProductPaymentPolicyContext).not.toHaveBeenCalled()
   })
 })
+
+/**
+ * A hosted-checkout provider renders the initiation payload to the shopper, so
+ * what is in it has to mean something to them. Nothing downstream can repair a
+ * line item that names a Session, a page rendered in a guessed language, or a
+ * customer that can only be keyed on their email address.
+ */
+describe("production Booking Session hosted-checkout initiation", () => {
+  beforeEach(() => {
+    startPaymentAdapterCardPayment.mockClear()
+  })
+
+  it("names the product and its departure in the Session locale", async () => {
+    await prepare({ locale: "en-GB", departureDate: "2026-09-12" })
+
+    expect(startArgs().description).toBe("Danube Delta tour — 12 September 2026")
+  })
+
+  it("renders the departure in the Session's own locale", async () => {
+    await prepare({ locale: "ro-RO", departureDate: "2026-09-12", name: "Tur în Delta Dunării" })
+
+    expect(startArgs().description).toBe("Tur în Delta Dunării — 12 septembrie 2026")
+  })
+
+  it("names the product alone when the target has no departure", async () => {
+    await prepare({ locale: "en-GB", departureDate: null })
+
+    expect(startArgs().description).toBe("Danube Delta tour")
+  })
+
+  it("never sends the Session id as the line item", async () => {
+    await prepare({ locale: "en-GB", departureDate: "2026-09-12" })
+
+    expect(startArgs().description).not.toContain("bses_")
+  })
+
+  it("carries the Session locale so the provider does not guess from the browser", async () => {
+    await prepare({ locale: "ro-RO", departureDate: null })
+
+    expect(startArgs().locale).toBe("ro-RO")
+  })
+
+  it("references the CRM person the buyer was identified as", async () => {
+    await prepare({ locale: "en-GB", departureDate: null, personId: "per_01k" })
+
+    expect(startArgs().customerReference).toBe("per_01k")
+  })
+
+  it("falls back to the owning principal for a customer-actor Session", async () => {
+    await prepare({
+      locale: "en-GB",
+      departureDate: null,
+      actorKind: "customer",
+      ownerPrincipalId: "usr_shopper",
+    })
+
+    expect(startArgs().customerReference).toBe("usr_shopper")
+  })
+
+  it("does not reference the agent's principal on a staff-created Session", async () => {
+    await prepare({
+      locale: "en-GB",
+      departureDate: null,
+      actorKind: "staff",
+      ownerPrincipalId: "usr_agent",
+    })
+
+    expect(startArgs().customerReference).toBeUndefined()
+  })
+})
+
+async function prepare(input: {
+  locale: string
+  departureDate: string | null
+  name?: string
+  personId?: string
+  actorKind?: string
+  ownerPrincipalId?: string
+}) {
+  const payments = createProductionBookingSessionPaymentPorts({
+    db: {} as never,
+    inventory: {
+      loadProductPaymentPolicyContext: async () => ({
+        listingPolicy: null,
+        categoryPolicy: null,
+        supplierId: null,
+        departureDate: input.departureDate,
+        name: input.name ?? "Danube Delta tour",
+      }),
+    },
+    distribution: { loadSupplierPaymentPolicy: async () => null },
+    settings: { resolveOperatorDefaultPaymentPolicy: async () => null },
+    resolvePaymentAdapter: () => ({ id: "test" }) as never,
+  })
+
+  return payments.prepare({
+    session: {
+      id: "bses_01k",
+      actorKind: input.actorKind ?? "anonymous",
+      ownerPrincipalId: input.ownerPrincipalId,
+      scope: { locale: input.locale, market: "default" },
+      target: { kind: "product", productId: "prod_1" },
+      expiresAt: new Date("2026-08-06T00:00:00Z"),
+      statePayload: {
+        billing: {
+          contact: {
+            firstName: "Ana",
+            lastName: "Pop",
+            email: "ana@example.com",
+            ...(input.personId ? { personId: input.personId } : {}),
+          },
+        },
+      },
+    },
+    quote: {
+      id: "bqot_01k",
+      pricing: { total: 10_000, currency: "EUR" },
+      expiresAt: new Date("2026-08-06T00:00:00Z"),
+    },
+    commit: { idempotencyKey: "commit-1" },
+    access: { actorKind: input.actorKind ?? "anonymous" },
+    now: new Date("2026-08-05T00:00:00Z"),
+  } as never)
+}
+
+function startArgs() {
+  const call = startPaymentAdapterCardPayment.mock.calls.at(-1)
+  if (!call) throw new Error("the card-payment starter was never called")
+  return call[1] as {
+    description?: string
+    locale?: string
+    customerReference?: string
+  }
+}

--- a/packages/catalog/src/booking-engine/sessions-payment-production.ts
+++ b/packages/catalog/src/booking-engine/sessions-payment-production.ts
@@ -51,6 +51,7 @@ export function createProductionBookingSessionPaymentPorts(
       const context = await deps.inventory.loadProductPaymentPolicyContext(
         deps.db,
         session.target.productId,
+        { locale: session.scope.locale },
       )
       if (!context) throw new Error("booking_session_payment_product_not_found")
       const [supplierPolicy, operatorDefault] = await Promise.all([
@@ -117,6 +118,7 @@ export function createProductionBookingSessionPaymentPorts(
 
       const adapter = await deps.resolvePaymentAdapter?.()
       if (adapter && paymentSession.status === "pending" && contact.email && contact.firstName) {
+        const reference = customerReference(session)
         await startPaymentAdapterCardPayment(
           adapter,
           {
@@ -129,7 +131,13 @@ export function createProductionBookingSessionPaymentPorts(
               ...(contact.phone ? { phone: contact.phone } : {}),
               ...(contact.country ? { country: contact.country } : {}),
             },
-            description: `Booking Session ${session.id}`,
+            description: checkoutLineItem({
+              productName: context.name,
+              departureDate: context.departureDate,
+              locale: session.scope.locale,
+            }),
+            locale: session.scope.locale,
+            ...(reference ? { customerReference: reference } : {}),
             returnUrl: commit.payment?.returnUrl,
             cancelUrl: commit.payment?.cancelUrl,
             metadata: {
@@ -161,6 +169,64 @@ export function createProductionBookingSessionPaymentPorts(
       await expirePendingBookingSessionPayments(tx as PostgresJsDatabase, bookingSessionId, at)
     },
   }
+}
+
+/**
+ * What the shopper is asked to pay for on the hosted checkout page.
+ *
+ * `description` is the only product-shaped field on `PaymentInitiationInput`,
+ * so whatever is put here is the whole of what a provider can render — nothing
+ * downstream can repair an identifier sent in its place. Names the product and,
+ * where the target has one, its departure, in the Session's locale.
+ *
+ * Undefined when the product has no name: finance then falls back to the
+ * payment session's own notes, which is still better than an id.
+ */
+function checkoutLineItem(input: {
+  productName: string | null
+  departureDate: string | null
+  locale: string
+}): string | undefined {
+  const name = input.productName?.trim()
+  if (!name) return undefined
+  const departure = formatDepartureDate(input.departureDate, input.locale)
+  return departure ? `${name} — ${departure}` : name
+}
+
+/**
+ * Render a date-only departure in the Session's locale. The column is a plain
+ * calendar date, so it is formatted in UTC — resolving it against the server's
+ * zone would move it a day for a shopper west of the meridian.
+ */
+function formatDepartureDate(departureDate: string | null, locale: string): string | null {
+  if (!departureDate) return null
+  const parsed = new Date(`${departureDate}T00:00:00Z`)
+  if (Number.isNaN(parsed.getTime())) return null
+  try {
+    return new Intl.DateTimeFormat(locale, { dateStyle: "long", timeZone: "UTC" }).format(parsed)
+  } catch {
+    // An unparseable locale tag must not fail a checkout; the ISO date still
+    // tells the shopper which departure they are paying for.
+    return departureDate
+  }
+}
+
+/**
+ * The opaque, stable customer reference a hosted provider binds a stored
+ * customer to. Prefers the CRM person the buyer was identified as; falls back
+ * to the owning principal only for a customer-actor Session, because on a
+ * staff-created Session the principal is the agent, not the shopper.
+ */
+function customerReference(session: {
+  actorKind: string
+  ownerPrincipalId?: string
+  statePayload: Record<string, unknown>
+}): string | undefined {
+  const billing = record(session.statePayload.billing)
+  const personId = stringValue(record(billing?.contact)?.personId)
+  if (personId) return personId
+  if (session.actorKind !== "customer") return undefined
+  return stringValue(session.ownerPrincipalId) ?? undefined
 }
 
 function hasStaffPaymentSchedule(payload: Record<string, unknown>): boolean {

--- a/packages/catalog/src/runtime-contracts.ts
+++ b/packages/catalog/src/runtime-contracts.ts
@@ -179,14 +179,26 @@ export interface CatalogInventoryRuntimeExtension {
     db: AnyDrizzleDb,
     productId: string,
   ): Promise<{ supplierId: string | null; reservationTimeoutMinutes: number | null } | null>
+  /**
+   * Read what pricing a customer checkout for this product owes and what the
+   * shopper is being asked to pay for. `locale` selects the language `name` is
+   * returned in — the checkout line item a hosted provider renders is built
+   * from it, so it has to be the shopper's language, not the operator's.
+   */
   loadProductPaymentPolicyContext(
     db: AnyDrizzleDb,
     productId: string,
+    options?: { locale?: string },
   ): Promise<{
     listingPolicy: PaymentPolicy | null
     categoryPolicy: PaymentPolicy | null
     supplierId: string | null
     departureDate: string | null
+    /**
+     * The product's name in the requested locale, falling back to its base
+     * `name` when that language has no translation.
+     */
+    name: string | null
   } | null>
   buildSnapshotInput(
     db: AnyDrizzleDb,

--- a/packages/finance/src/card-payment.ts
+++ b/packages/finance/src/card-payment.ts
@@ -47,7 +47,20 @@ export interface CardPaymentStartArgs {
   db: PostgresJsDatabase
   sessionId: string
   billing: CardPaymentBilling
+  /**
+   * What the shopper is paying for, in `locale`. A hosted-checkout provider
+   * renders it as the line item, so it names the product — never an internal
+   * identifier.
+   */
   description?: string
+  /** BCP 47 tag for the language the checkout page should be rendered in. */
+  locale?: string
+  /**
+   * Opaque, stable reference to the caller's own customer record, so a
+   * provider can bind a stored customer without keying on the email address.
+   * See `PaymentInitiationInput["customer"].reference`.
+   */
+  customerReference?: string
   returnUrl?: string
   cancelUrl?: string
   shipping?: Record<string, unknown>
@@ -176,10 +189,12 @@ export async function startPaymentAdapterCardPayment(
       paymentSessionId: session.id,
       money: { amountMinor: session.amountCents, currency: session.currency },
       description: args.description ?? session.notes ?? undefined,
+      locale: args.locale,
       returnUrl: args.returnUrl ?? session.returnUrl ?? undefined,
       cancelUrl: args.cancelUrl ?? session.cancelUrl ?? undefined,
       idempotencyKey,
       customer: {
+        reference: args.customerReference ?? null,
         email: args.billing.email,
         phone: args.billing.phone ?? null,
         firstName: args.billing.firstName,

--- a/packages/inventory/src/catalog-runtime-extension.ts
+++ b/packages/inventory/src/catalog-runtime-extension.ts
@@ -11,7 +11,12 @@ import { productPricingCatalogPolicy } from "./catalog-policy-pricing.js"
 import { productPromotionsCatalogPolicy } from "./catalog-policy-promotions.js"
 import { productTaxonomyCatalogPolicy } from "./catalog-policy-taxonomy.js"
 import { extrasCatalogPolicy } from "./extras.js"
-import { productCategories, productCategoryProducts, products } from "./schema.js"
+import {
+  productCategories,
+  productCategoryProducts,
+  products,
+  productTranslations,
+} from "./schema.js"
 import { productsService } from "./service.js"
 import {
   buildProductSnapshotInput,
@@ -78,10 +83,11 @@ export const catalogInventoryRuntimeExtension = {
       .limit(1)
     return product ?? null
   },
-  async loadProductPaymentPolicyContext(db, productId) {
-    const [[product], [category]] = await Promise.all([
+  async loadProductPaymentPolicyContext(db, productId, options) {
+    const [[product], [category], translations] = await Promise.all([
       db
         .select({
+          name: products.name,
           listingPolicy: products.customerPaymentPolicy,
           supplierId: products.supplierId,
           departureDate: products.startDate,
@@ -101,6 +107,15 @@ export const catalogInventoryRuntimeExtension = {
         )
         .orderBy(asc(productCategoryProducts.sortOrder), asc(productCategoryProducts.createdAt))
         .limit(1),
+      options?.locale
+        ? db
+            .select({
+              languageTag: productTranslations.languageTag,
+              name: productTranslations.name,
+            })
+            .from(productTranslations)
+            .where(eq(productTranslations.productId, productId))
+        : Promise.resolve([]),
     ])
     if (!product) return null
     return {
@@ -108,7 +123,29 @@ export const catalogInventoryRuntimeExtension = {
       categoryPolicy: (category?.categoryPolicy as PaymentPolicy | null | undefined) ?? null,
       supplierId: product.supplierId,
       departureDate: product.departureDate,
+      name: pickTranslatedName(translations, options?.locale) ?? product.name,
     }
   },
   buildSnapshotInput: (db, productId, options) => buildProductSnapshotInput(db, productId, options),
 } satisfies CatalogInventoryRuntimeExtension
+
+/**
+ * Resolve a product's name in `locale` from its translation rows.
+ *
+ * Exact tag, then case-insensitive, then the language subtag — the same
+ * precedence the storefront-card projection uses. Unlike that projection this
+ * does **not** fall back to an arbitrary translation: the caller is building a
+ * checkout line item, where the product's base `name` is a better answer than
+ * a language the shopper did not ask for.
+ */
+function pickTranslatedName(
+  rows: ReadonlyArray<{ languageTag: string; name: string }>,
+  locale: string | undefined,
+): string | null {
+  if (!locale) return null
+  const match =
+    rows.find((row) => row.languageTag === locale) ??
+    rows.find((row) => row.languageTag.toLowerCase() === locale.toLowerCase()) ??
+    rows.find((row) => row.languageTag.split("-")[0] === locale.split("-")[0])
+  return match?.name.trim() || null
+}

--- a/packages/inventory/tests/unit/catalog-runtime-payment-context.test.ts
+++ b/packages/inventory/tests/unit/catalog-runtime-payment-context.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest"
+
+import { catalogInventoryRuntimeExtension } from "../../src/catalog-runtime-extension.js"
+import { products } from "../../src/schema.js"
+import { productTranslations } from "../../src/schema-settings.js"
+
+const BASE_PRODUCT = {
+  name: "Base tour",
+  listingPolicy: null,
+  supplierId: null,
+  departureDate: null,
+}
+
+const TRANSLATIONS = [
+  { languageTag: "en-GB", name: "Danube Delta tour" },
+  { languageTag: "ro-RO", name: "Tur în Delta Dunării" },
+]
+
+/**
+ * The product name this reader returns becomes the checkout line item a hosted
+ * payment provider renders, so the locale it resolves is the shopper's, not the
+ * operator's. See `PaymentInitiationInput.description`.
+ */
+describe("loadProductPaymentPolicyContext product name", () => {
+  it("returns the translation for the requested locale", async () => {
+    const db = fakeDb([
+      [products, [{ ...BASE_PRODUCT, departureDate: "2026-09-12" }]],
+      [productTranslations, TRANSLATIONS],
+    ])
+
+    const context = await catalogInventoryRuntimeExtension.loadProductPaymentPolicyContext(
+      db,
+      "prod_1",
+      { locale: "ro-RO" },
+    )
+
+    expect(context?.name).toBe("Tur în Delta Dunării")
+    expect(context?.departureDate).toBe("2026-09-12")
+  })
+
+  it("matches on the language subtag when the exact tag has no translation", async () => {
+    const db = fakeDb([
+      [products, [BASE_PRODUCT]],
+      [productTranslations, TRANSLATIONS],
+    ])
+
+    const context = await catalogInventoryRuntimeExtension.loadProductPaymentPolicyContext(
+      db,
+      "prod_1",
+      { locale: "ro" },
+    )
+
+    expect(context?.name).toBe("Tur în Delta Dunării")
+  })
+
+  it("falls back to the base name rather than an unrequested language", async () => {
+    const db = fakeDb([
+      [products, [BASE_PRODUCT]],
+      [productTranslations, TRANSLATIONS],
+    ])
+
+    const context = await catalogInventoryRuntimeExtension.loadProductPaymentPolicyContext(
+      db,
+      "prod_1",
+      { locale: "de-DE" },
+    )
+
+    expect(context?.name).toBe("Base tour")
+  })
+
+  it("does not read translations when no locale is stated", async () => {
+    let readTranslations = false
+    const db = fakeDb(
+      [
+        [products, [BASE_PRODUCT]],
+        [productTranslations, TRANSLATIONS],
+      ],
+      (table) => {
+        if (table === productTranslations) readTranslations = true
+      },
+    )
+
+    const context = await catalogInventoryRuntimeExtension.loadProductPaymentPolicyContext(
+      db,
+      "prod_1",
+    )
+
+    expect(context?.name).toBe("Base tour")
+    expect(readTranslations).toBe(false)
+  })
+})
+
+/**
+ * Minimal drizzle stand-in covering the three chains this reader builds:
+ * `from().where().limit()`, `from().innerJoin().where().orderBy().limit()`, and
+ * `from().where()`. Projections are ignored, so fixtures are keyed by the alias
+ * the reader selects into. Rows are keyed by the table the query starts from.
+ */
+function fakeDb(tables: Array<[unknown, unknown[]]>, onFrom?: (table: unknown) => void) {
+  const rowsByTable = new Map(tables)
+  return {
+    select: () => ({
+      from: (table: unknown) => {
+        onFrom?.(table)
+        return chain(rowsByTable.get(table) ?? [])
+      },
+    }),
+  } as never
+}
+
+function chain(rows: unknown[]) {
+  const settled = Promise.resolve(rows) as Promise<unknown[]> & Record<string, unknown>
+  const self = {
+    innerJoin: () => self,
+    where: () => settled,
+    orderBy: () => settled,
+    limit: (limit: number) => Promise.resolve(rows.slice(0, limit)),
+  }
+  settled.innerJoin = () => self
+  settled.where = () => settled
+  settled.orderBy = () => settled
+  settled.limit = (limit: number) => Promise.resolve(rows.slice(0, limit))
+  return self
+}

--- a/packages/payments/src/index.ts
+++ b/packages/payments/src/index.ts
@@ -91,12 +91,36 @@ export function isPaymentAdapterError(error: unknown): error is PaymentAdapterEr
 export interface PaymentInitiationInput {
   paymentSessionId: string
   money: PaymentMoney
+  /**
+   * What the shopper is being asked to pay for, in `locale`. A hosted-checkout
+   * provider renders this as the line item, and it is the only product-shaped
+   * field on this contract — a caller that sends an internal identifier here
+   * leaves the provider nothing else to show.
+   */
   description?: string
+  /**
+   * BCP 47 tag for the language the shopper has been reading the funnel in.
+   * A hosted provider renders its page in this language instead of guessing
+   * from the browser. Absent when the caller has no locale to state.
+   */
+  locale?: string
   returnUrl?: string
   cancelUrl?: string
   captureMode?: PaymentCaptureMode
   idempotencyKey: string
   customer?: {
+    /**
+     * Opaque, stable reference to the runtime's own customer record. A
+     * provider binds a stored customer — and therefore a stored payment
+     * method — to this rather than to `email`, which is neither unique to a
+     * person nor stable when it is corrected. Not addressable, not parseable,
+     * and carries no personal data, so a provider may retain it without
+     * retaining the rest of `customer`.
+     *
+     * Stable for a given customer across payment sessions. The remaining
+     * fields are prefill a provider may forget.
+     */
+    reference?: string | null
     email?: string | null
     phone?: string | null
     firstName?: string | null


### PR DESCRIPTION
Closes #4284.

A hosted-checkout provider renders `PaymentInitiationInput` to the shopper. Three of its fields could not carry what that page needs, and each was invisible to a green suite — the conformance harness asserts the *shape* of the initiation input, not that the values in it mean anything.

## 1. The line item named the Session

`description` is the only product-shaped field on the contract, so a caller that sends an identifier leaves the provider nothing else to render — nothing downstream can repair it. The Booking Session commit path sent `Booking Session bses_01k…`.

It now names the product and, where the target has one, its departure, both resolved in the Session's locale:

```
Danube Delta tour — 12 September 2026
Tur în Delta Dunării — 12 septembrie 2026
```

`loadProductPaymentPolicyContext` — already called on this path for the listing/category policy — takes an optional `locale` and returns the product's translated `name`. Resolution is exact tag → case-insensitive → language subtag, then the product's **base name**. Unlike the storefront-card projection it does *not* fall back to an arbitrary translation: on a checkout line item the base name beats a language the shopper did not ask for. The date column is date-only, so it is formatted in UTC — resolving it against the server's zone would move it a day for a shopper west of the meridian.

## 2. `locale`

New and optional on `PaymentInitiationInput`: the BCP 47 tag for the language the shopper has been reading the funnel in, so a hosted page is rendered in it instead of guessed from the browser. The Booking Session populates it from its own scope, which is fixed at create.

## 3. `customer.reference`

New and optional: an opaque, stable reference to the runtime's own customer record. Without it a provider that wants to reuse a stored customer — so a returning shopper can be offered a stored payment method — has to key that binding on the email address, which binds two people who share an inbox, breaks when the address is corrected, and forces the provider to retain personal data purely as a join key. A provider can now bind by reference and treat the rest of `customer` as prefill it may forget.

The Booking Session populates it from `billing.contact.personId` — the CRM person the buyer was identified as — falling back to `ownerPrincipalId` **only on a customer-actor Session**. On a staff-created Session the owning principal is the agent, not the shopper, so binding a stored payment method to it would be wrong.

## Compatibility

All three are additive and optional. An adapter that ignores them behaves exactly as before; the remote adapter passes the payload through untouched.

## Verification

- New tests: 9 in `sessions-payment-production.test.ts` (line item with/without departure, both locales, never the Session id, locale carried, person id preferred, principal fallback for a customer actor, **no** fallback for a staff actor) and 4 in `catalog-runtime-payment-context.test.ts` (exact tag, subtag match, base-name fallback, no translation read without a locale). All pass.
- `pnpm verify:architecture` — full chain green, including the `verify:typecheck-coverage` ratchet with the new test file.
- Biome clean.
- `@voyant-travel/payments` builds clean. The `finance`/`catalog`/`inventory` `tsc` builds were not completed locally — the first run was killed under memory pressure (SIGTERM, no `error TS`) and was not retried. **CI is the gate for those.**
