### PR TITLE
Stop writing other modules' tables directly (relationships→identity, storefront→relationships)

### DIFF
--- a/packages/identity/src/service.ts
+++ b/packages/identity/src/service.ts
@@ -279,6 +279,70 @@ export const identityService = {
     return row ?? null
   },
 
+  /**
+   * Repoint every identity record for `entityType` from `mergeId` onto `keepId`.
+   *
+   * Account merge lives in `relationships`, but the rows being moved are
+   * identity's, and so is the rule for what counts as a duplicate: a contact
+   * point is the same contact point when its `kind` and `value` match. Keeping
+   * that here means relationships asks for a merge rather than reaching into
+   * three tables to perform one, and the dedupe rule stays with the module that
+   * defines it.
+   *
+   * Call inside the caller's transaction — this is several statements and a
+   * partial application would leave records split across both entities.
+   */
+  async reassignEntityRecords(
+    db: PostgresJsDatabase,
+    input: { entityType: string; keepId: string; mergeId: string },
+  ) {
+    const { entityType, keepId, mergeId } = input
+
+    // Drop merge-side contact points the keep side already has, so the repoint
+    // below cannot create a duplicate pair.
+    await db.delete(identityContactPoints).where(
+      and(
+        eq(identityContactPoints.entityType, entityType),
+        eq(identityContactPoints.entityId, mergeId),
+        sql`EXISTS (
+          SELECT 1
+          FROM identity_contact_points keep_point
+          WHERE keep_point.entity_type = ${entityType}
+            AND keep_point.entity_id = ${keepId}
+            AND keep_point.kind = ${identityContactPoints.kind}
+            AND keep_point.value = ${identityContactPoints.value}
+        )`,
+      ),
+    )
+
+    await db
+      .update(identityContactPoints)
+      .set({ entityId: keepId, updatedAt: new Date() })
+      .where(
+        and(
+          eq(identityContactPoints.entityType, entityType),
+          eq(identityContactPoints.entityId, mergeId),
+        ),
+      )
+
+    await db
+      .update(identityAddresses)
+      .set({ entityId: keepId, updatedAt: new Date() })
+      .where(
+        and(eq(identityAddresses.entityType, entityType), eq(identityAddresses.entityId, mergeId)),
+      )
+
+    await db
+      .update(identityNamedContacts)
+      .set({ entityId: keepId, updatedAt: new Date() })
+      .where(
+        and(
+          eq(identityNamedContacts.entityType, entityType),
+          eq(identityNamedContacts.entityId, mergeId),
+        ),
+      )
+  },
+
   async listNamedContacts(db: PostgresJsDatabase, query: NamedContactListQuery) {
     const conditions = []
     if (query.entityType) conditions.push(eq(identityNamedContacts.entityType, query.entityType))

--- a/packages/relationships/src/service/accounts-merge.ts
+++ b/packages/relationships/src/service/accounts-merge.ts
@@ -1,9 +1,5 @@
 // agent-quality: file-size exception -- owner: relationships; existing service module stays co-located until a dedicated split preserves behavior and tests.
-import {
-  identityAddresses,
-  identityContactPoints,
-  identityNamedContacts,
-} from "@voyant-travel/identity/schema"
+import { identityService } from "@voyant-travel/identity/service"
 import { and, eq, inArray, ne, or, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
@@ -236,53 +232,18 @@ async function dedupeOptionalPersonJoinTable(
   `)
 }
 
+/**
+ * Identity records for a merged entity move through identity's own service:
+ * the rows are its, and so is the rule for what counts as a duplicate contact
+ * point. See identityService.reassignEntityRecords.
+ */
 async function mergeIdentityRows(
   db: PostgresJsDatabase,
   entityType: string,
   keepId: string,
   mergeId: string,
 ) {
-  await db.delete(identityContactPoints).where(
-    and(
-      eq(identityContactPoints.entityType, entityType),
-      eq(identityContactPoints.entityId, mergeId),
-      sql`EXISTS (
-          SELECT 1
-          FROM identity_contact_points keep_point
-          WHERE keep_point.entity_type = ${entityType}
-            AND keep_point.entity_id = ${keepId}
-            AND keep_point.kind = ${identityContactPoints.kind}
-            AND keep_point.value = ${identityContactPoints.value}
-        )`,
-    ),
-  )
-
-  await db
-    .update(identityContactPoints)
-    .set({ entityId: keepId, updatedAt: new Date() })
-    .where(
-      and(
-        eq(identityContactPoints.entityType, entityType),
-        eq(identityContactPoints.entityId, mergeId),
-      ),
-    )
-
-  await db
-    .update(identityAddresses)
-    .set({ entityId: keepId, updatedAt: new Date() })
-    .where(
-      and(eq(identityAddresses.entityType, entityType), eq(identityAddresses.entityId, mergeId)),
-    )
-
-  await db
-    .update(identityNamedContacts)
-    .set({ entityId: keepId, updatedAt: new Date() })
-    .where(
-      and(
-        eq(identityNamedContacts.entityType, entityType),
-        eq(identityNamedContacts.entityId, mergeId),
-      ),
-    )
+  await identityService.reassignEntityRecords(db, { entityType, keepId, mergeId })
 }
 
 async function mergeEntityLinks(

--- a/packages/relationships/src/service/accounts-people.ts
+++ b/packages/relationships/src/service/accounts-people.ts
@@ -252,6 +252,37 @@ export const peopleAccountsService = {
     return this.getPersonById(db, row.id)
   },
 
+  /**
+   * Write the encrypted person-level PII slots.
+   *
+   * Separate from {@link updatePerson} on purpose. Those slots are not part of
+   * the CRM person update surface — putting them there would expose encrypted
+   * PII fields to every caller of it — but the columns are relationships', so
+   * the write belongs here rather than in the customer portal.
+   *
+   * The caller keeps the encryption seam and passes sealed envelopes; this only
+   * stores what it is given. An empty patch is a no-op.
+   */
+  async updatePersonEncryptedProfile(
+    db: PostgresJsDatabase,
+    id: string,
+    patch: Partial<
+      Record<
+        "accessibilityEncrypted" | "dietaryEncrypted" | "loyaltyEncrypted" | "insuranceEncrypted",
+        unknown
+      >
+    >,
+  ) {
+    const updates = Object.fromEntries(
+      Object.entries(patch).filter(([, value]) => value !== undefined),
+    ) as PgUpdateSetSource<typeof people>
+    if (Object.keys(updates).length === 0) return
+    await db
+      .update(people)
+      .set({ ...updates, updatedAt: new Date() })
+      .where(eq(people.id, id))
+  },
+
   async updatePerson(db: PostgresJsDatabase, id: string, data: UpdatePersonInput) {
     const existing = await this.getPersonById(db, id)
     if (!existing) return null

--- a/packages/storefront/src/customer-portal/service-public-impl.ts
+++ b/packages/storefront/src/customer-portal/service-public-impl.ts
@@ -1813,10 +1813,8 @@ export const publicCustomerPortalService = {
     }
     if (Object.keys(piiUpdates).length > 0) {
       const personId = await ensureLinkedPerson(db, userId, authProfile)
-      await db
-        .update(people)
-        .set({ ...piiUpdates, updatedAt: new Date() })
-        .where(eq(people.id, personId))
+      // The columns are relationships'; the portal keeps only the encryption seam.
+      await relationshipsService.updatePersonEncryptedProfile(db, personId, piiUpdates)
     }
 
     await db

--- a/scripts/checks/schema/table-privacy-baseline.json
+++ b/scripts/checks/schema/table-privacy-baseline.json
@@ -38,7 +38,7 @@
     "notifications->finance": 14,
     "notifications->legal": 2,
     "operations->identity": 3,
-    "relationships->identity": 5,
+    "relationships->identity": 2,
     "storefront->bookings": 9,
     "storefront->commerce": 5,
     "storefront->finance": 6,
@@ -54,8 +54,6 @@
     "finance->bookings": 12,
     "inventory->commerce": 16,
     "inventory->operations": 4,
-    "legal->bookings": 5,
-    "relationships->identity": 4,
-    "storefront->relationships": 1
+    "legal->bookings": 5
   }
 }


### PR DESCRIPTION
Stacked on #4286, which is what makes these countable. Part of #4266.

Two of the nine cross-module write pairs, eliminated. The small ones first, to establish the shape before `finance→bookings` (12) and `inventory→commerce` (16).

## relationships → identity: 4 → 0

`accounts-merge.ts` repointed `identity_contact_points`, `identity_addresses` and `identity_named_contacts` from the merged entity onto the kept one, plus the dedupe that has to precede it.

The rows are identity's — and so is the rule for what makes two contact points the same one: matching `kind` and `value`. Moved verbatim to **`identityService.reassignEntityRecords`**. relationships now asks for a merge instead of performing one across three of someone else's tables.

The pattern was already established: `accounts-people.ts` has called `identityService` all along. `accounts-merge.ts` was the outlier.

The identity schema import goes with it, so the pair's **read** count falls 5 → 2 as a side effect. What remains are genuine reads — contact-point joins for person search in `accounts-people.ts` and `accounts-resolve.ts`.

## storefront → relationships: 1 → 0

The customer portal wrote `people.{accessibility,dietary,loyalty,insurance}_encrypted` directly. Now **`relationshipsService.updatePersonEncryptedProfile`**.

**Deliberately not folded into `updatePerson`.** Those slots are not part of the CRM person update surface, and adding them would expose encrypted PII fields to every caller of it. The portal keeps the encryption seam and passes sealed envelopes; relationships stores what it is given.

## Result

```
reads   190 -> 187  across 35 pairs
writes   48 ->  43  across 9 -> 7 pairs
```

Baseline tightened — the only sanctioned reason to regenerate it.

## Verification

```
table-privacy         187 / 35 pairs; 43 writes / 7 pairs
identity build        clean     relationships build   clean
identity tests        40 pass   relationships unit   175 pass
storefront typecheck  clean
biome                 no new findings
```

**One caveat I could not settle locally.** A large parallel `pnpm -F "@voyant-travel/storefront..." build` reported `operations` and `distribution` as Failed, with no `error TS` lines captured. Both built clean individually beforehand, neither imports anything this PR changes, and every change here is **additive** — two new service methods; the removals are inside private function bodies, not exported API. I attribute it to memory pressure in the parallel build rather than this diff, and I am letting CI settle it rather than assert a green I did not actually observe.
