### PR TITLE
Booking selection billing address carries a region (RO judet, Bucharest Sector)

### DIFF
--- a/.changeset/booking-selection-billing-region.md
+++ b/.changeset/booking-selection-billing-region.md
@@ -1,0 +1,50 @@
+---
+"@voyant-travel/catalog-contracts": minor
+"@voyant-travel/catalog": minor
+"@voyant-travel/inventory": minor
+"@voyant-travel/bookings": minor
+"@voyant-travel/bookings-react": minor
+---
+
+The booking selection's billing address carries a `region`, and the address it
+already declared now survives to the Booking.
+
+`bookingSelectionPublicV1.billing.address` had `line1`, `line2`, `city`,
+`postal`, `country` and no administrative subdivision, so a checkout could not
+record a state, province, or county. Romania needs it twice over: an invoice
+carries the *judet*, and Bucharest has no ordinary city/county pair — its six
+Sectors *are* the county-level subdivision. The only encodings available were
+overloading `city` with `"Sector 3"` or hiding the county in an address line,
+both lossy (voyant#4290).
+
+`region` is free-form with ISO 3166-2 subdivision codes (`RO-B`, `RO-CJ`,
+`US-CA`) as the recommended encoding. It is not *enforced* as ISO: the
+`bookings.contact_region` column it lands in is free text and already holds both
+`"Cluj"` and `"Ile-de-France"`, so gating the selection on a code would reject
+data the destination accepts. A Bucharest Sector is modelled as the Sector in
+`city` and `RO-B` in `region`.
+
+**The rest of the address was being dropped.** `normalizeBookingSelection`
+projected the billing address down to `country` alone — a leftover from the
+Session tracer (voyant#4039) — so a caller that filled in the billing step lost
+every line of it at the Session edge, and the Booking's `contact_*` columns came
+back empty even though the columns had been there all along. The projection now
+keeps all six fields, and they are carried the rest of the way:
+`SelfServiceBillingParty` gained the address, the products handler puts it on
+the booking-create command, and `createSourcedBookingCommitment` writes it for
+supplier-sourced bookings.
+
+The Session's card-payment handoff also fills `CardPaymentBilling`'s `state`,
+`city`, `postalCode`, and `details`, which it previously left empty — a
+processor that computes tax from the billing address needs the subdivision, not
+just the country.
+
+Address fields are now width-checked against the columns they settle into
+(`line1`/`line2` 500, `city`/`region` 100, `postal` 20, `country` 2). Previously
+unbounded: a payload that overran a column was admitted at the Session and failed
+at commit, where the caller could no longer tell which field was at fault. This
+is a tightening — a caller sending a full country name in `country` rather than
+an ISO 3166-1 alpha-2 code is now rejected at the Session instead of at commit.
+
+The operator's booking journey billing step draws a "County / region" input, and
+`address.region` is addressable as a booking-field requirement.

--- a/packages/bookings-react/src/i18n/en-journey.ts
+++ b/packages/bookings-react/src/i18n/en-journey.ts
@@ -125,6 +125,7 @@ export const bookingsUiEnJourney = {
       addressLine1: "Address line 1",
       addressLine2Optional: "Address line 2 (optional)",
       city: "City",
+      region: "County / region",
       postalCode: "Postal code",
       country: "Country",
       companyName: "Company name",

--- a/packages/bookings-react/src/i18n/messages-journey.ts
+++ b/packages/bookings-react/src/i18n/messages-journey.ts
@@ -100,6 +100,7 @@ export type BookingsUiJourneyMessages = {
       addressLine1: string
       addressLine2Optional: string
       city: string
+      region: string
       postalCode: string
       country: string
       companyName: string

--- a/packages/bookings-react/src/i18n/ro-journey.ts
+++ b/packages/bookings-react/src/i18n/ro-journey.ts
@@ -131,6 +131,7 @@ export const bookingsUiRoJourney = {
       addressLine1: "Adresa linia 1",
       addressLine2Optional: "Adresa linia 2 (optional)",
       city: "Oras",
+      region: "Judet / regiune",
       postalCode: "Cod postal",
       country: "Tara",
       companyName: "Nume companie",

--- a/packages/bookings-react/src/journey/components/journey-steps/billing-step.tsx
+++ b/packages/bookings-react/src/journey/components/journey-steps/billing-step.tsx
@@ -38,6 +38,7 @@ type BillingControl =
   | "line1"
   | "line2"
   | "city"
+  | "region"
   | "postal"
   | "country"
   | "companyName"
@@ -52,6 +53,7 @@ const BILLING_GROUP_CONTROLS: Record<string, BillingControl> = {
   "address.line1": "line1",
   "address.line2": "line2",
   "address.city": "city",
+  "address.region": "region",
   "address.postal": "postal",
   "address.country": "country",
 }
@@ -292,6 +294,19 @@ export function BillingStep({
                   setDraft(
                     patchBilling(draft, {
                       address: { ...billing.address, city: v },
+                    }),
+                  )
+                }
+              />
+              <Field
+                id="bj-billing-region"
+                label={messages.bookingJourney.billing.region}
+                value={billing.address.region ?? ""}
+                error={bookingField("region")}
+                onChange={(v) =>
+                  setDraft(
+                    patchBilling(draft, {
+                      address: { ...billing.address, region: v },
                     }),
                   )
                 }

--- a/packages/bookings-react/src/journey/components/side-panel.tsx
+++ b/packages/bookings-react/src/journey/components/side-panel.tsx
@@ -398,7 +398,9 @@ function BillingDetails({
   const messages = useBookingsUiMessagesOrDefault()
   const c = draft.billing.contact
   const a = draft.billing.address
-  const addressLine = [a.line1, a.line2, a.city, a.postal, a.country].filter(Boolean).join(", ")
+  const addressLine = [a.line1, a.line2, a.city, a.region, a.postal, a.country]
+    .filter(Boolean)
+    .join(", ")
   const contactName =
     (draft.billing.buyerType === "B2B" ? draft.billing.company?.name : undefined) ||
     [c.firstName, c.lastName].filter(Boolean).join(" ")

--- a/packages/bookings-react/src/journey/types.ts
+++ b/packages/bookings-react/src/journey/types.ts
@@ -59,6 +59,11 @@ export interface LeadContactPickerProps {
       line1?: string
       line2?: string
       city?: string
+      /**
+       * Administrative subdivision — the CRM address has carried a `region`
+       * all along, and the billing address can now hold it (voyant#4290).
+       */
+      region?: string
       postal?: string
       country?: string
     }

--- a/packages/bookings-react/src/storefront/resolve-contract-variables.ts
+++ b/packages/bookings-react/src/storefront/resolve-contract-variables.ts
@@ -408,6 +408,9 @@ export function resolveContractVariables(
         line1: address.line1 ?? "",
         line2: address.line2 ?? "",
         city: address.city ?? "",
+        // A Romanian contract prints the judet; without it the template has
+        // to reconstruct one from the address lines (voyant#4290).
+        region: address.region ?? "",
         postal: address.postal ?? "",
         country: address.country ?? "",
       },

--- a/packages/bookings/src/service-sourced-commitment.ts
+++ b/packages/bookings/src/service-sourced-commitment.ts
@@ -22,6 +22,13 @@ export interface CreateSourcedBookingCommitmentInput {
   contactLastName?: string | null
   contactEmail?: string | null
   contactPhone?: string | null
+  contactCountry?: string | null
+  /** Administrative subdivision, preferably ISO 3166-2 (voyant#4290). */
+  contactRegion?: string | null
+  contactCity?: string | null
+  contactAddressLine1?: string | null
+  contactAddressLine2?: string | null
+  contactPostalCode?: string | null
   sellCurrency: string
   sellAmountCents: number
   title: string
@@ -78,6 +85,12 @@ export async function createSourcedBookingCommitment(
     contactLastName: input.contactLastName ?? null,
     contactEmail: input.contactEmail ?? null,
     contactPhone: input.contactPhone ?? null,
+    contactCountry: input.contactCountry ?? null,
+    contactRegion: input.contactRegion ?? null,
+    contactCity: input.contactCity ?? null,
+    contactAddressLine1: input.contactAddressLine1 ?? null,
+    contactAddressLine2: input.contactAddressLine2 ?? null,
+    contactPostalCode: input.contactPostalCode ?? null,
     sellCurrency: input.sellCurrency,
     sellAmountCents: input.sellAmountCents,
     startDate,

--- a/packages/catalog-contracts/src/booking-engine/selection-contracts.test.ts
+++ b/packages/catalog-contracts/src/booking-engine/selection-contracts.test.ts
@@ -8,6 +8,9 @@ const ENTITY = {
   sourceKind: "owned",
 }
 
+/** `billing.contact` is required, so an address-only case still has to carry one. */
+const CONTACT = { firstName: "Test", lastName: "Traveler", email: "test@example.com" }
+
 describe("booking selection contracts", () => {
   it("rejects malformed billing contact emails", () => {
     const parsed = bookingSelectionV1.safeParse({
@@ -19,6 +22,44 @@ describe("booking selection contracts", () => {
           email: "not-an-email",
         },
       },
+    })
+
+    expect(parsed.success).toBe(false)
+  })
+
+  it("carries an administrative subdivision on the billing address", () => {
+    // Romania is the case that forced this (voyant#4290): the invoice needs
+    // the judet, and Bucharest has no ordinary city/county pair — its six
+    // Sectors ARE the county-level subdivision. Sector in `city`, county in
+    // `region`, neither overloaded into an address line.
+    const parsed = bookingSelectionV1.safeParse({
+      entity: ENTITY,
+      billing: { contact: CONTACT, address: { city: "Sector 3", region: "RO-B", country: "RO" } },
+    })
+
+    expect(parsed.success).toBe(true)
+    expect(parsed.data?.billing.address.region).toBe("RO-B")
+  })
+
+  it("leaves the region free-form so a county name is as valid as an ISO code", () => {
+    // The Booking column this lands in is free text and already holds both
+    // "Cluj" and "Ile-de-France". Enforcing ISO 3166-2 here would reject data
+    // the destination accepts; the code is the recommendation, not the gate.
+    for (const region of ["RO-CJ", "Cluj", "Ile-de-France"]) {
+      const parsed = bookingSelectionV1.safeParse({
+        entity: ENTITY,
+        billing: { contact: CONTACT, address: { region } },
+      })
+      expect(parsed.success, region).toBe(true)
+    }
+  })
+
+  it("rejects address values wider than the columns they settle into", () => {
+    // Admitting these would move the failure to commit time, where the caller
+    // can no longer tell which field was at fault.
+    const parsed = bookingSelectionV1.safeParse({
+      entity: ENTITY,
+      billing: { contact: CONTACT, address: { region: "x".repeat(101) } },
     })
 
     expect(parsed.success).toBe(false)

--- a/packages/catalog-contracts/src/booking-engine/selection-contracts.ts
+++ b/packages/catalog-contracts/src/booking-engine/selection-contracts.ts
@@ -159,13 +159,36 @@ export const bookingSelectionPublicV1 = z.object({
         /** CRM person id when the lead was picked from CRM (vs typed). */
         personId: z.string().optional(),
       }),
+      /**
+       * Billing address.
+       *
+       * Field widths match the `contact_*` columns these land in via
+       * booking-create, so an address this schema admits cannot be rejected
+       * later by the commit — the failure belongs at the Session edge, where
+       * the caller can still see which field was too long.
+       */
       address: z
         .object({
-          line1: z.string().optional(),
-          line2: z.string().optional(),
-          city: z.string().optional(),
-          postal: z.string().optional(),
-          country: z.string().optional(),
+          line1: z.string().max(500).optional(),
+          line2: z.string().max(500).optional(),
+          city: z.string().max(100).optional(),
+          /**
+           * Administrative subdivision below the country — state, province,
+           * county, `judet`. Free-form because the Booking column it lands in
+           * is, and it already holds both codes and names; **ISO 3166-2
+           * subdivision codes (`RO-CJ`, `US-CA`) are the recommended
+           * encoding** because they are the only country-agnostic one.
+           *
+           * Romania needs it twice over: an invoice carries the `judet`, and
+           * Bucharest has no ordinary city/county pair — it is six Sectors
+           * acting as the county-level subdivision. Model that as the Sector
+           * in `city` and `RO-B` in `region`, not by overloading an address
+           * line (voyant#4290).
+           */
+          region: z.string().max(100).optional(),
+          postal: z.string().max(20).optional(),
+          /** ISO 3166-1 alpha-2 country code. */
+          country: z.string().max(2).optional(),
         })
         .default({}),
       company: z

--- a/packages/catalog/openapi/admin/catalog-booking.json
+++ b/packages/catalog/openapi/admin/catalog-booking.json
@@ -13993,19 +13993,28 @@
                             "type": "object",
                             "properties": {
                               "line1": {
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 500
                               },
                               "line2": {
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 500
                               },
                               "city": {
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 100
+                              },
+                              "region": {
+                                "type": "string",
+                                "maxLength": 100
                               },
                               "postal": {
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 20
                               },
                               "country": {
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 2
                               }
                             },
                             "default": {}

--- a/packages/catalog/openapi/storefront/catalog-booking.json
+++ b/packages/catalog/openapi/storefront/catalog-booking.json
@@ -13993,19 +13993,28 @@
                             "type": "object",
                             "properties": {
                               "line1": {
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 500
                               },
                               "line2": {
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 500
                               },
                               "city": {
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 100
+                              },
+                              "region": {
+                                "type": "string",
+                                "maxLength": 100
                               },
                               "postal": {
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 20
                               },
                               "country": {
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 2
                               }
                             },
                             "default": {}

--- a/packages/catalog/src/booking-engine/owned-handler.ts
+++ b/packages/catalog/src/booking-engine/owned-handler.ts
@@ -150,6 +150,20 @@ export interface SelfServiceBillingParty {
   contactLastName: string | null
   contactEmail: string | null
   contactPhone: string | null
+  /**
+   * Billing address, named as the Booking's `contact_*` columns rather than as
+   * the selection's `address` block, because the command is what this party
+   * feeds and the command speaks the Booking's vocabulary.
+   *
+   * `contactRegion` holds the administrative subdivision — state, province,
+   * county, `judet` — preferably an ISO 3166-2 code (voyant#4290).
+   */
+  contactCountry: string | null
+  contactRegion: string | null
+  contactCity: string | null
+  contactAddressLine1: string | null
+  contactAddressLine2: string | null
+  contactPostalCode: string | null
 }
 
 export interface DeriveSelfServiceCommandRequest {

--- a/packages/catalog/src/booking-engine/sessions-payment-production.ts
+++ b/packages/catalog/src/booking-engine/sessions-payment-production.ts
@@ -128,6 +128,10 @@ export function createProductionBookingSessionPaymentPorts(
               ...(contact.lastName ? { lastName: contact.lastName } : {}),
               ...(contact.phone ? { phone: contact.phone } : {}),
               ...(contact.country ? { country: contact.country } : {}),
+              ...(contact.state ? { state: contact.state } : {}),
+              ...(contact.city ? { city: contact.city } : {}),
+              ...(contact.postalCode ? { postalCode: contact.postalCode } : {}),
+              ...(contact.details ? { details: contact.details } : {}),
             },
             description: `Booking Session ${session.id}`,
             returnUrl: commit.payment?.returnUrl,
@@ -208,6 +212,13 @@ function paymentContact(payload: Record<string, unknown>) {
     email: stringValue(contact?.email),
     phone: stringValue(contact?.phone),
     country: stringValue(address?.country),
+    // `CardPaymentBilling.state` — a processor that computes tax from the
+    // billing address needs the subdivision, not just the country
+    // (voyant#4290).
+    state: stringValue(address?.region),
+    city: stringValue(address?.city),
+    postalCode: stringValue(address?.postal),
+    details: stringValue(address?.line1),
   }
 }
 

--- a/packages/catalog/src/booking-engine/sessions-production.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-production.test.ts
@@ -132,7 +132,15 @@ describe("normalizeProductSelection", () => {
           phone: " +400000000 ",
           ignored: "client-only",
         },
-        address: { country: " RO ", street: "not accepted yet" },
+        address: {
+          line1: " Str. Lipscani 12 ",
+          line2: " Ap. 4 ",
+          city: " Cluj-Napoca ",
+          region: " RO-CJ ",
+          postal: " 400114 ",
+          country: " RO ",
+          street: "not accepted yet",
+        },
       },
       travelers: [
         { firstName: "Ada", lastName: "Lovelace", email: "ada@example.test", rowId: "trav_1" },
@@ -159,13 +167,44 @@ describe("normalizeProductSelection", () => {
           email: "ada@example.test",
           phone: "+400000000",
         },
-        address: { country: "RO" },
+        address: {
+          line1: "Str. Lipscani 12",
+          line2: "Ap. 4",
+          city: "Cluj-Napoca",
+          region: "RO-CJ",
+          postal: "400114",
+          country: "RO",
+        },
       },
       travelers: [
         { rowId: "trav_1", firstName: "Ada", lastName: "Lovelace", email: "ada@example.test" },
       ],
       accommodation: { travelerAssignments: { room_1: "trav_1" } },
       addons: [{ extraId: "extra_1", quantity: 1 }],
+    })
+  })
+
+  it("models a Bucharest Sector as the city and the county as an ISO 3166-2 region", () => {
+    // Bucharest has no ordinary city/county pair: the six Sectors act as the
+    // county-level subdivision. The Sector belongs in `city` and `RO-B` in
+    // `region` — the point of voyant#4290 is that neither has to be smuggled
+    // through an address line.
+    const normalized = normalizeProductSelection(PRODUCT_TARGET, {
+      billing: { address: { city: "Sector 3", region: "RO-B", country: "RO" } },
+    })
+
+    expect(normalized.billing).toEqual({
+      address: { city: "Sector 3", region: "RO-B", country: "RO" },
+    })
+  })
+
+  it("keeps a free-form county name, since the Booking column it lands in is free-form", () => {
+    const normalized = normalizeProductSelection(PRODUCT_TARGET, {
+      billing: { address: { region: " Ile-de-France ", country: "FR" } },
+    })
+
+    expect(normalized.billing).toEqual({
+      address: { region: "Ile-de-France", country: "FR" },
     })
   })
 

--- a/packages/catalog/src/booking-engine/sessions-production.ts
+++ b/packages/catalog/src/booking-engine/sessions-production.ts
@@ -464,6 +464,12 @@ async function commitSourcedBooking(
       contactLastName: billing.contactLastName,
       contactEmail: billing.contactEmail,
       contactPhone: billing.contactPhone,
+      contactCountry: billing.contactCountry,
+      contactRegion: billing.contactRegion,
+      contactCity: billing.contactCity,
+      contactAddressLine1: billing.contactAddressLine1,
+      contactAddressLine2: billing.contactAddressLine2,
+      contactPostalCode: billing.contactPostalCode,
       sellCurrency: input.quote.pricing.currency,
       sellAmountCents: input.quote.pricing.total,
       title: sourced.title,
@@ -695,6 +701,7 @@ async function resolveBilling(
 function billingContact(payload: Record<string, unknown>) {
   const billing = asRecord(payload.billing)
   const contact = asRecord(billing?.contact)
+  const address = asRecord(billing?.address)
   const staffBooking = asRecord(payload.staffBooking)
   const trim = (value: unknown) => (typeof value === "string" && value.trim() ? value.trim() : null)
   return {
@@ -704,6 +711,12 @@ function billingContact(payload: Record<string, unknown>) {
     contactLastName: trim(contact?.lastName),
     contactEmail: trim(contact?.email),
     contactPhone: trim(contact?.phone),
+    contactCountry: trim(address?.country),
+    contactRegion: trim(address?.region),
+    contactCity: trim(address?.city),
+    contactAddressLine1: trim(address?.line1),
+    contactAddressLine2: trim(address?.line2),
+    contactPostalCode: trim(address?.postal),
   }
 }
 
@@ -991,7 +1004,20 @@ export function normalizeBookingSelection(
         email: stringValue(billingContact?.email),
         phone: stringValue(billingContact?.phone),
       }),
-      address: pruneEmpty({ country: stringValue(billingAddress?.country) }),
+      // The whole declared address, not just the country. The tracer
+      // (voyant#4039) projected the rest away, so a caller that filled the
+      // billing step lost every line of it at the Session edge and the
+      // Booking's contact_* columns came back empty. `region` is new
+      // (voyant#4290); the other four were declared all along and simply
+      // never survived to the commit.
+      address: pruneEmpty({
+        line1: stringValue(billingAddress?.line1),
+        line2: stringValue(billingAddress?.line2),
+        city: stringValue(billingAddress?.city),
+        region: stringValue(billingAddress?.region),
+        postal: stringValue(billingAddress?.postal),
+        country: stringValue(billingAddress?.country),
+      }),
     }),
     travelers: arrayValue(source.travelers)
       ?.map(normalizeTraveler)

--- a/packages/inventory/src/booking-engine/handler.ts
+++ b/packages/inventory/src/booking-engine/handler.ts
@@ -77,7 +77,15 @@ export interface DraftLike {
   billing?: {
     buyerType?: "B2C" | "B2B"
     contact?: { firstName?: string; lastName?: string; email?: string; phone?: string }
-    address?: { country?: string }
+    address?: {
+      line1?: string
+      line2?: string
+      city?: string
+      /** Administrative subdivision, preferably ISO 3166-2 (voyant#4290). */
+      region?: string
+      postal?: string
+      country?: string
+    }
   }
   travelers?: Array<{
     rowId?: string
@@ -879,6 +887,12 @@ export function createProductsBookingHandler(
           contactLastName: request.billing.contactLastName,
           contactEmail: request.billing.contactEmail,
           contactPhone: request.billing.contactPhone,
+          contactCountry: request.billing.contactCountry,
+          contactRegion: request.billing.contactRegion,
+          contactCity: request.billing.contactCity,
+          contactAddressLine1: request.billing.contactAddressLine1,
+          contactAddressLine2: request.billing.contactAddressLine2,
+          contactPostalCode: request.billing.contactPostalCode,
           travelers,
           ...(itemLines ? { itemLines } : {}),
           ...(extraLines && extraLines.length > 0 ? { extraLines } : {}),

--- a/packages/inventory/tests/unit/pax-band-tiers.test.ts
+++ b/packages/inventory/tests/unit/pax-band-tiers.test.ts
@@ -305,6 +305,12 @@ async function quoteThenDerive(
       contactLastName: "Traveler",
       contactEmail: "guest@example.com",
       contactPhone: null,
+      contactCountry: "RO",
+      contactRegion: "RO-B",
+      contactCity: "Sector 3",
+      contactAddressLine1: null,
+      contactAddressLine2: null,
+      contactPostalCode: null,
     },
   })
   if (result.status !== "ok") throw new Error(`expected ok, got ${result.status}`)

--- a/packages/inventory/tests/unit/self-service-command-derivation.test.ts
+++ b/packages/inventory/tests/unit/self-service-command-derivation.test.ts
@@ -26,6 +26,23 @@ describe("products deriveSelfServiceCommand", () => {
     })
   })
 
+  it("carries the resolved billing address onto the command", async () => {
+    const result = await derive()
+
+    // Without these the Booking's contact_* columns come back empty and an
+    // invoice cannot state the buyer's county — voyant#4290. `contactRegion`
+    // holds the ISO 3166-2 subdivision; a Bucharest Sector rides in
+    // `contactCity`, which is what makes `RO-B` unambiguous.
+    expect(result).toMatchObject({
+      status: "ok",
+      command: {
+        contactCountry: "RO",
+        contactRegion: "RO-B",
+        contactCity: "Sector 3",
+      },
+    })
+  })
+
   it.each([
     ["priceOverride", { priceOverride: { amountCents: 1, reason: "free please" } }],
     ["suppressNotifications", { suppressNotifications: true }],
@@ -99,6 +116,12 @@ async function derive(
       contactLastName: "L",
       contactEmail: "guest@example.com",
       contactPhone: null,
+      contactCountry: "RO",
+      contactRegion: "RO-B",
+      contactCity: "Sector 3",
+      contactAddressLine1: null,
+      contactAddressLine2: null,
+      contactPostalCode: null,
     },
   })
 }

--- a/packages/inventory/tests/unit/self-service-pax-band-item-lines.test.ts
+++ b/packages/inventory/tests/unit/self-service-pax-band-item-lines.test.ts
@@ -302,6 +302,12 @@ async function quoteThenDerive(
       contactLastName: "Traveler",
       contactEmail: "guest@example.com",
       contactPhone: null,
+      contactCountry: "RO",
+      contactRegion: "RO-B",
+      contactCity: "Sector 3",
+      contactAddressLine1: null,
+      contactAddressLine2: null,
+      contactPostalCode: null,
     },
   })
   if (result.status !== "ok") throw new Error(`expected ok, got ${result.status}`)


### PR DESCRIPTION
Closes #4290.

## The ask

`bookingSelectionPublicV1.billing.address` declared `line1`, `line2`, `city`,
`postal`, `country` and no administrative subdivision, so a checkout had nowhere
to put a state, province, or county.

Romania needs it twice over: an invoice carries the *judet*, and Bucharest has no
ordinary city/county pair — its six **Sectors** *are* the county-level
subdivision. The only encodings available were overloading `city` with
`"Sector 3"` or hiding the county in an address line, both lossy.

`region` is added as free-form text with **ISO 3166-2 subdivision codes as the
recommended encoding** (`RO-B`, `RO-CJ`, `US-CA`). It is deliberately not
*enforced* as ISO: the `bookings.contact_region` column it lands in is free text
and already holds both `"Cluj"` and `"Ile-de-France"`, so gating the selection on
a code would reject data the destination accepts. A Bucharest Sector is modelled
as the Sector in `city` and `RO-B` in `region`.

## What I found while wiring it: the rest of the address was being dropped

Adding the field to the contract alone would have been inert, and the issue asks
for collect **and persist**. Tracing the chain:

```
selection.billing.address
  → normalizeBookingSelection   ← projected down to `country` ALONE
  → SelfServiceBillingParty     ← carried no address at all
  → products deriveSelfServiceCommand
  → booking-create → bookings.contact_*   ← columns already existed
```

`normalizeBookingSelection` kept only `country` — a leftover from the Session
tracer (#4039), where `country` was the one field the preview needed for tax. So
a caller that filled in the billing step lost **every line of it** at the Session
edge, and the Booking's `contact_*` columns came back empty even though the
columns had been there all along.

That also means the issue's own proposed modelling could not work: `region`
without `city` cannot express a Bucharest Sector. Carrying the whole declared
address through is what makes the feature real, not scope creep — so this PR
does that, and each hop is now covered by a test.

## Changes

| | |
|---|---|
| `catalog-contracts` | `region` on `billing.address`; width caps on all address fields |
| `catalog` | normalization keeps the full address; `SelfServiceBillingParty` carries it; sourced-commit path forwards it; card-payment handoff fills `state`/`city`/`postalCode`/`details` |
| `inventory` | products handler puts the address on the booking-create command |
| `bookings` | `createSourcedBookingCommitment` writes the address columns |
| `bookings-react` | "County / region" input on the journey billing step (en+ro), CRM picker partial, side-panel summary, contract-template variable |

A processor that computes tax from the billing address needs the subdivision, not
just the country — `CardPaymentBilling` already had `state`, `city`,
`postalCode`, and `details`; the Session's payment handoff simply never filled
them.

## Deliberate tightening — please review

Address fields are now width-checked against the columns they settle into
(`line1`/`line2` 500, `city`/`region` 100, `postal` 20, `country` 2). They were
previously unbounded, so a payload that overran a column was admitted at the
Session and failed at commit, where the caller could no longer tell which field
was at fault.

**This is a behaviour change**: a caller sending a full country name in `country`
rather than an ISO 3166-1 alpha-2 code is now rejected at the Session instead of
at commit. It could not previously have produced a successful booking either way
— booking-create caps `contactCountry` at 2 — so this moves an existing failure
earlier rather than creating a new one.

## Not done

- `address.region` is **not** added to `defaultBookingFields()`. That would
  change the default requirement set for every product; `line2` and `postal`
  are not there either. A host can already declare it as a requirement —
  `bookingFieldFindings` resolves arbitrary dotted paths, so `address.region`
  works with no vocabulary change.
- No ISO 3166-2 subdivision table or county combobox. The reference
  implementation lives in the downstream storefront; this PR provides the field
  it needs.

## Verification

Run on a disposable Sprite (this Mac was saturated by other work).

- **Tests green across all five packages** — 245 files, 0 failures:
  `catalog-contracts` 9, `bookings` 56, `catalog` 70, `inventory` 77,
  `bookings-react` 33.
- `catalog`, `catalog-contracts`, `bookings`, `finance` all compile clean — no
  `error TS` anywhere in the build.
- `pnpm --filter @voyant-travel/catalog generate:openapi` regenerated both
  specs; the committed files are byte-identical to that output (blob
  `39783f3..1a695b9`). The spec now carries `region` plus the `maxLength`
  constraints.
- `biome check` clean over the changed packages.

### Unrelated pre-existing issue found

`packages/media-react/tsconfig.build.json` declares no `include` and does not
exclude `dist`, so its default `**/*` picks up its own emitted `.d.ts` and any
*second* build fails with ~25 `TS5055 Cannot write file ... would overwrite
input file`. A fresh checkout builds fine, which is why CI never sees it, but it
makes local rebuilds fail until you `rm -rf packages/media-react/dist`.
Reproduced on the Sprite as well as locally, so it is the package, not stale
local state. Not touched here — worth its own issue.
