### PR TITLE
Append PII-access audit records through bookings, and close an optional-call hole in the write ratchet

### DIFF
--- a/packages/bookings/src/service-core.ts
+++ b/packages/bookings/src/service-core.ts
@@ -75,10 +75,12 @@ import {
   bookingItems,
   bookingItemTravelers,
   bookingNotes,
+  bookingPiiAccessLog,
   bookingRedemptionEvents,
   bookingSupplierStatuses,
   bookings,
   bookingTravelers,
+  type NewBookingPiiAccessLog,
 } from "./schema.js"
 import { cleanupGroupOnBookingCancelled } from "./service-groups.js"
 import { type BookingStatus, canTransitionBooking, transitionBooking } from "./state-machine.js"
@@ -2032,6 +2034,45 @@ function toRows<T>(result: unknown): T[] {
 }
 
 const bookingsServiceInternal = {
+  /**
+   * Append a PII-access audit record.
+   *
+   * `booking_pii_access_log` is bookings' table, and every reveal of traveller
+   * PII has to land in it whichever module performed the reveal — `legal` does
+   * so for contract templates, reviews, drafts and document delivery. Those
+   * callers went through `db.insert(bookingPiiAccessLog)` directly, which meant
+   * five copies of the row shape outside the module that defines it, and no
+   * single place to change if the audit record ever grows a required field.
+   *
+   * Append-only by construction: there is no update or delete counterpart.
+   */
+  async recordPiiAccess(
+    db: PostgresJsDatabase,
+    entry: {
+      bookingId?: string | null
+      travelerId?: string | null
+      actorId?: string | null
+      actorType?: string | null
+      callerType?: string | null
+      action: NewBookingPiiAccessLog["action"]
+      outcome: NewBookingPiiAccessLog["outcome"]
+      reason?: string | null
+      metadata?: Record<string, unknown> | null
+    },
+  ) {
+    await db.insert(bookingPiiAccessLog).values({
+      bookingId: entry.bookingId ?? null,
+      travelerId: entry.travelerId ?? null,
+      actorId: entry.actorId ?? null,
+      actorType: entry.actorType ?? null,
+      callerType: entry.callerType ?? null,
+      action: entry.action,
+      outcome: entry.outcome,
+      reason: entry.reason ?? null,
+      metadata: entry.metadata ?? null,
+    })
+  },
+
   /**
    * Pre-aggregated dashboard numbers for the admin bookings surface. Replaces
    * the pattern of fetching a large `listBookings` page and deriving KPIs

--- a/packages/legal/src/contracts/routes.ts
+++ b/packages/legal/src/contracts/routes.ts
@@ -18,8 +18,7 @@
 // in-handler; multipart upload + redirect download legs declare their non-JSON
 // shapes explicitly. The factory/provider wiring + business logic are unchanged.
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
-import { shouldRevealBookingPii } from "@voyant-travel/bookings"
-import { bookingPiiAccessLog } from "@voyant-travel/bookings/schema"
+import { bookingsService, shouldRevealBookingPii } from "@voyant-travel/bookings"
 import type { EventBus, ModuleContainer } from "@voyant-travel/core"
 import {
   idempotencyKey,
@@ -100,32 +99,29 @@ async function auditManagedBookingAttachmentDelivery(
     reason: "contract_document_delivery_reveal" | "insufficient_scope"
   },
 ) {
-  await c
-    .get("db")
-    .insert(bookingPiiAccessLog)
-    .values({
-      bookingId: input.bookingId,
-      travelerId: null,
-      actorId: routeActorId(c),
-      actorType: c.get("actor") ?? null,
-      callerType: c.get("callerType") ?? null,
-      action: "read",
-      outcome: input.outcome,
-      reason: input.reason,
-      metadata:
-        input.outcome === "denied"
-          ? {
-              contractId: input.contractId,
-              attachmentId: input.attachmentId,
-              reveal: false,
-              requiredScopes: ["legal:read", "bookings-pii:read"],
-            }
-          : {
-              contractId: input.contractId,
-              attachmentId: input.attachmentId,
-              reveal: true,
-            },
-    })
+  await bookingsService.recordPiiAccess(c.get("db"), {
+    bookingId: input.bookingId,
+    travelerId: null,
+    actorId: routeActorId(c),
+    actorType: c.get("actor") ?? null,
+    callerType: c.get("callerType") ?? null,
+    action: "read",
+    outcome: input.outcome,
+    reason: input.reason,
+    metadata:
+      input.outcome === "denied"
+        ? {
+            contractId: input.contractId,
+            attachmentId: input.attachmentId,
+            reveal: false,
+            requiredScopes: ["legal:read", "bookings-pii:read"],
+          }
+        : {
+            contractId: input.contractId,
+            attachmentId: input.attachmentId,
+            reveal: true,
+          },
+  })
 }
 
 type Env = {

--- a/packages/legal/src/mcp-runtime.ts
+++ b/packages/legal/src/mcp-runtime.ts
@@ -7,8 +7,8 @@ import {
   executeAdmittedCreatedTargetCommand,
   mapActionLedgerRequestContext,
 } from "@voyant-travel/action-ledger"
-import { shouldRevealBookingPii } from "@voyant-travel/bookings"
-import { bookingItems, bookingPiiAccessLog, bookings } from "@voyant-travel/bookings/schema"
+import { bookingsService, shouldRevealBookingPii } from "@voyant-travel/bookings"
+import { bookingItems, bookings } from "@voyant-travel/bookings/schema"
 import type { EventBus } from "@voyant-travel/core"
 import {
   defineToolContextContribution,
@@ -173,7 +173,7 @@ export function createLegalToolServices(
     async listApplicableBookingTemplates(input) {
       const result = await listApplicableBookingContractTemplates(db, input)
       if (result.bookingFound) {
-        await db.insert(bookingPiiAccessLog).values({
+        await bookingsService.recordPiiAccess(db, {
           bookingId: input.bookingId,
           travelerId: null,
           actorId:
@@ -198,7 +198,7 @@ export function createLegalToolServices(
     async getBookingContractReview({ contractId }) {
       const review = await getBookingContractReview(db, contractId)
       if (review) {
-        await db.insert(bookingPiiAccessLog).values({
+        await bookingsService.recordPiiAccess(db, {
           bookingId: review.booking.id,
           travelerId: null,
           actorId:
@@ -489,7 +489,7 @@ async function authorizeLegalContractDraftBookingSnapshotRead(
     enforceRbac: true,
   })
 
-  await db.insert(bookingPiiAccessLog).values({
+  await bookingsService.recordPiiAccess(db, {
     bookingId,
     travelerId: null,
     actorId:
@@ -935,7 +935,7 @@ export function createLegalContractDocumentToolServices(input: {
         attachmentId,
       )
       if (delivery && row?.contract.bookingId && hasManagedBookingWorkflow(row.contract.metadata)) {
-        await input.db.insert(bookingPiiAccessLog).values({
+        await bookingsService.recordPiiAccess(input.db, {
           bookingId: row.contract.bookingId,
           travelerId: null,
           actorId:

--- a/packages/legal/src/tools.ts
+++ b/packages/legal/src/tools.ts
@@ -1,6 +1,6 @@
 // agent-quality: file-size exception -- owner: legal; contract lifecycle tools stay co-located because create/read/update/document handlers share one admission and schema surface.
 
-import { bookingPiiAccessLog } from "@voyant-travel/bookings/schema"
+import { bookingsService } from "@voyant-travel/bookings"
 import {
   admitHandlerActionPolicy,
   defineTool,
@@ -584,8 +584,10 @@ async function requireBookingPiiReadScope(
   input: { bookingId?: string | null; contractId?: string; attachmentId?: string },
 ) {
   if (hasBookingPiiReadScope(ctx)) return
-  const db = ctx.db as { insert?: (table: unknown) => { values(input: unknown): Promise<unknown> } }
-  await db.insert?.(bookingPiiAccessLog).values({
+  // Some tool contexts carry a stub db with no writer; the original guarded on
+  // `insert` existing, so keep that rather than assume one.
+  if (typeof (ctx.db as { insert?: unknown }).insert !== "function") return
+  await bookingsService.recordPiiAccess(ctx.db as PostgresJsDatabase, {
     bookingId: input.bookingId ?? null,
     travelerId: null,
     actorId:

--- a/scripts/checks/schema/table-privacy-baseline.json
+++ b/scripts/checks/schema/table-privacy-baseline.json
@@ -29,7 +29,7 @@
     "inventory->bookings": 1,
     "inventory->commerce": 25,
     "inventory->operations": 9,
-    "legal->bookings": 7,
+    "legal->bookings": 4,
     "legal->distribution": 2,
     "legal->relationships": 4,
     "mice->accommodations": 2,
@@ -53,7 +53,6 @@
     "commerce->finance": 2,
     "finance->bookings": 12,
     "inventory->commerce": 16,
-    "inventory->operations": 4,
-    "legal->bookings": 5
+    "inventory->operations": 4
   }
 }

--- a/scripts/checks/schema/table-privacy-runner.ts
+++ b/scripts/checks/schema/table-privacy-runner.ts
@@ -67,7 +67,9 @@ function main(): void {
       }
     }
     const names: string[] = []
-    for (const match of text.matchAll(/\.(?:update|insert|delete)\(\s*(\w+)\s*[),]/g)) {
+    // `?.(` as well as `(`: a defensive `db.insert?.(table)` is still a write,
+    // and treating it as anything else leaves a hole the ratchet cannot see.
+    for (const match of text.matchAll(/\.(?:update|insert|delete)\??\.?\(\s*(\w+)\s*[),]/g)) {
       if (imported.has(match[1] as string)) names.push(match[1] as string)
     }
     if (names.length > 0) writeSites.push({ importer, names })


### PR DESCRIPTION
Part of #4266. Follows #4296, which took the first two write pairs.

## legal → bookings: 5 → 0

All five were the same operation — appending to `booking_pii_access_log` after revealing traveller PII, from contract templates, contract review, draft creation, and document delivery. Five copies of the row shape living outside the module that defines it, and no single place to change if the audit record ever grows a required field.

`bookingsService.recordPiiAccess` takes them. Append-only by construction — there is no update or delete counterpart, because the log has none.

## A sixth site the checker could not see

Converting these turned up a write the ratchet was blind to:

```
packages/legal/src/tools.ts:588
await db.insert?.(bookingPiiAccessLog).values({ ... })
```

The detection regex matched `.insert(` but not `.insert?.(`. An optional-call write was invisible — a hole a future write could have slipped through without failing anything.

Widened to `\.(?:update|insert|delete)\??\.?\(` and checked against all four call forms:

```
.insert(foo)      -> foo
db.insert?.(bar)  -> bar
.update( baz )    -> baz
.delete(qux,      -> qux
```

That site is one of only two optional-call forms in the workspace. It is converted too, keeping its defensive guard — some tool contexts carry a stub `db` with no writer, and the original checked for that rather than assuming one.

I would rather report this than quietly widen the regex: the write baseline seeded in #4286 was **undercounting**, and this is how much.

## Result

```
reads   187 -> 184  across 35 pairs
writes   43 ->  38  across 7 -> 6 pairs
```

Remaining write pairs: `inventory->commerce` 16, `finance->bookings` 12, `inventory->operations` 4, `apps->custom-fields` 2, `commerce->bookings` 2, `commerce->finance` 2.

## Verification

```
bookings build   REAL_EXIT=0, 0 TS errors
legal build      REAL_EXIT=0, 0 TS errors
table-privacy    184 / 35 pairs; 38 writes / 6 pairs
table-privacy tests  15 pass
```

Worth noting for reviewers: `legal` first produced six `TS2339: Property 'recordPiiAccess' does not exist` against the **stale** bookings dist. They resolve once bookings is built first — consumers typecheck against `dist/*.d.ts`, not source. The method is declared on `bookingsServiceInternal` and reaches the exported `bookingsService` through the rest-spread at `service-core.ts`, which is worth stating because it is not obvious from the declaration site.
