### PR TITLE
fix(inventory): make editorial overlays sourced-only

### DIFF
--- a/.changeset/editorial-overlays-sourced-only.md
+++ b/.changeset/editorial-overlays-sourced-only.md
@@ -1,0 +1,55 @@
+---
+"@voyant-travel/inventory": minor
+"@voyant-travel/inventory-react": minor
+"@voyant-travel/accommodations": patch
+"@voyant-travel/i18n": patch
+---
+
+Editorial overlays are sourced-only. An owned product no longer has an overlay
+collection at all, and the operator's product page no longer offers one.
+
+An overlay exists to restate content the operator does not control — provider
+copy from a Connect package, a bedbank, a GDS. An owned product's copy is
+authored in `product_translations`, `product_day_translations`, and the
+option/service equivalents, which the operator edits directly. Layering an
+overlay on top gave one field two authoring surfaces, with the overlay the
+silent winner and no indication in the editor that it had shadowed the row.
+
+In the operator UI this never worked at all. Every row in `products` is owned by
+construction — sourced products live in `catalog_sourced_entries` and surface at
+`/catalog/products/:id`, not in the products table — so `/products/:id` mounted
+an editor whose subject could not exist. The read model's `sourced` flag was
+supposed to hide it, but the flag only arrives if the fetch succeeds, so what an
+operator actually saw was a red "Failed to load editorial content" card wedged
+between Media and Itinerary.
+
+What changed:
+
+- `getProductContent` and `getAccommodationContent` serve the owned branch as
+  authored and never read the overlay store. The sourced branches
+  (`sourced-cache`, `sourced-fresh`, `synthesized`) merge overlays exactly as
+  before.
+- `readProductEditorialOverlayState`, `writeProductEditorialOverlay`,
+  `clearProductEditorialOverlay`, and `listProductEditorialOverlayHistory` throw
+  the new `OwnedProductNotOverlayableError` for an owned subject. Ownership is
+  the absence of a `catalog_sourced_entries` row.
+- `GET`, `PUT`, `DELETE`, and `GET .../history` on
+  `/v1/admin/products/{id}/editorial-overlays` answer `404 not_overlayable`
+  rather than 500-ing, or writing a row that read-time merge would now ignore.
+- `ProductEditorialOverlaySection` is no longer mounted on the owned product
+  detail page. It stays exported as the authoring surface for sourced product
+  content; the operator has no host for that today.
+- The read model drops `sourced` from its payload — it is `true` on every
+  response the endpoint can now produce. `contentSource` still reports which
+  sourced branch served the comparison.
+
+The ownership check reaches `readSourcedEntry` through
+`@voyant-travel/catalog/services/sourced-entry` rather than the package barrel.
+`service-editorial-overlays.ts` sits in the admin route graph, and the barrel
+pulls the whole catalog plane in behind it — enough to roughly double transform
+and import time for anything that loads those routes.
+
+No data migration ships with this. The editor returned `null` for owned
+subjects from the day it landed, so no owned overlay was ever authored through
+it; any row that predates that is inert rather than wrong, and `catalog_overlay`
+keeps its history.

--- a/docs/architecture/catalog-sourced-content.md
+++ b/docs/architecture/catalog-sourced-content.md
@@ -589,6 +589,17 @@ catalog plane what was actually served.
 
 ### 3.5.4. Editorial overlays compose on top — content-shape-aware merger
 
+**Sourced entities only.** An overlay restates content the operator does not
+control. An owned entity's copy lives in that vertical's own tables
+(`product_translations`, `product_day_translations`, and the option/service
+equivalents), which the operator edits directly, so an overlay there is a second
+authoring surface for the same field — and the one that silently wins. The
+owned branch of `getContent` therefore serves the projection as authored and
+never reads the overlay store, and the product overlay routes answer `404
+not_overlayable` for an owned subject on every verb. Question 3 in §7 recorded
+that "editorial overlays already exist for owned content"; that was descriptive
+of the pre-content-cache cruise pattern, not a rule to preserve.
+
 The existing `catalog_overlay` table now keys logically on `(entity, node_kind, node_key, field_path, locale, audience, market)`. **Overlays already work per-locale.** Existing flat rows are `root/root`. For sourced rows, an operator can curate a `ro-RO` overlay on top of what the adapter served (or didn't serve) — same machinery. Overlay merge happens at read time after locale resolution: pick the best content row, then layer locale-matching overlays on top.
 
 But the existing `resolveOverlay` (`packages/catalog/src/overlay/resolver.ts`) is field-policy-bound — it walks only the fields declared in the field-policy registry, which are flat indexed fields like `title` and `cancellation_policy_rules`. Content blobs are nested (`days[3].description`, `media[0].caption`, `cabinCategories[]`) and not addressable by the current resolver. We need a richer merge engine for content.

--- a/packages/accommodations/src/service-content.ts
+++ b/packages/accommodations/src/service-content.ts
@@ -104,24 +104,14 @@ export async function getAccommodationContent(
       preferredLocales: scope.preferredLocales,
     })
     if (!owned) return null
-    const overlays = await fetchOverlaysForEntity(db, "accommodations", entityId)
-    const merged = mergeOverlaysIntoAccommodationContent(
-      owned.content,
-      overlays.map((o) => ({ field_path: o.field_path, value: o.value })),
-      {
-        onOverlayError: options.onOverlayError
-          ? (e) =>
-              options.onOverlayError!({
-                field_path: e.overlay.field_path,
-                reason: e.reason,
-              })
-          : undefined,
-      },
-    )
+    // Editorial overlays restate content the operator does not control. An
+    // owned accommodation authors its copy in its own tables, so an overlay
+    // there would be a second authoring surface for the same field — and the
+    // silent winner. Sourced branches below still merge.
     return {
-      content: merged,
+      content: owned.content,
       resolution: {
-        candidate: { locale: owned.servedLocale, payload: merged },
+        candidate: { locale: owned.servedLocale, payload: owned.content },
         served_locale: owned.servedLocale,
         match_kind: owned.matchKind,
       },

--- a/packages/i18n/src/admin/products-operator/en-editorial.ts
+++ b/packages/i18n/src/admin/products-operator/en-editorial.ts
@@ -8,7 +8,6 @@ export const operatorAdminProductsMessagesEnEditorial = {
   loadFailed: "Failed to load editorial content.",
   retry: "Retry",
   loading: "Loading editorial content…",
-  unavailable: "Editorial overlays are available for sourced products only.",
   readOnly: "You do not have permission to edit editorial content.",
 
   columnSource: "Provider source",

--- a/packages/i18n/src/admin/products-operator/ro-editorial.ts
+++ b/packages/i18n/src/admin/products-operator/ro-editorial.ts
@@ -8,8 +8,6 @@ export const operatorAdminProductsMessagesRoEditorial = {
   loadFailed: "Conținutul editorial nu a putut fi încărcat.",
   retry: "Reîncearcă",
   loading: "Se încarcă conținutul editorial…",
-  unavailable:
-    "Suprapunerile editoriale sunt disponibile doar pentru produsele preluate din surse.",
   readOnly: "Nu ai permisiunea de a edita conținutul editorial.",
 
   columnSource: "Sursă furnizor",

--- a/packages/inventory-react/src/components/product-detail/editorial-overlay/product-editorial-overlay-section.test.tsx
+++ b/packages/inventory-react/src/components/product-detail/editorial-overlay/product-editorial-overlay-section.test.tsx
@@ -68,7 +68,6 @@ function statePayload(overrides: Record<string, unknown> = {}) {
   return {
     data: {
       subject: { module: "products", id: "prod_1" },
-      sourced: true,
       contentSource: "sourced-cache",
       locale: {
         requestedLocale: "ro-RO",
@@ -438,11 +437,12 @@ describe("ProductEditorialOverlaySection", () => {
     expect(byTestId("editorial-overlay-preview").textContent).toContain("Nume efectiv")
   })
 
-  it("renders nothing for owned products", async () => {
-    const { api } = makeApi(() => statePayload({ sourced: false, contentSource: "owned" }))
-    await render(<ProductEditorialOverlaySection productId="prod_1" />, api)
+  it("renders nothing, and issues no read, when the host disables it", async () => {
+    const { api, calls } = makeApi(() => statePayload())
+    await render(<ProductEditorialOverlaySection productId="prod_1" enabled={false} />, api)
 
     expect(container.textContent).not.toContain(editorial.sectionTitle)
+    expect(calls.get).toHaveLength(0)
   })
 
   it("hides write controls when the host cannot issue overlay writes", async () => {

--- a/packages/inventory-react/src/components/product-detail/editorial-overlay/product-editorial-overlay-section.tsx
+++ b/packages/inventory-react/src/components/product-detail/editorial-overlay/product-editorial-overlay-section.tsx
@@ -38,7 +38,7 @@ import {
 
 export interface ProductEditorialOverlaySectionProps {
   productId: string
-  /** False for owned products — the backend has no provider source to compare. */
+  /** Lets a host defer the fetch until it knows the subject is sourced. */
   enabled?: boolean
 }
 
@@ -46,6 +46,11 @@ export interface ProductEditorialOverlaySectionProps {
  * Operator authoring surface for localized editorial overlays on sourced
  * products (RFC #3666 phase 2). Provider source is read-only; the overlay is
  * the only editable column; effective content is what customers receive.
+ *
+ * **Sourced products only.** An owned product authors its copy directly in the
+ * products tables, so it has no overlay collection at all and the API answers
+ * 404 for one. `/products/:id` is the owned authoring surface and does not
+ * mount this section; a host for sourced product detail is where it belongs.
  */
 export function ProductEditorialOverlaySection({
   productId,
@@ -114,9 +119,7 @@ export function ProductEditorialOverlaySection({
     for (const field of overlayFields) clearField(field)
   }
 
-  // Owned products author content in their own tables; the compare editor is
-  // for provider-sourced content only.
-  if (!enabled || (state && !state.sourced)) return null
+  if (!enabled) return null
 
   return (
     <Section

--- a/packages/inventory-react/src/components/product-detail/editorial-overlay/types.ts
+++ b/packages/inventory-react/src/components/product-detail/editorial-overlay/types.ts
@@ -56,7 +56,6 @@ export const editorialOverlayNodeSchema = z.object({
 export const editorialOverlayStateSchema = z.object({
   data: z.object({
     subject: z.object({ module: z.string(), id: z.string() }),
-    sourced: z.boolean(),
     contentSource: z.string(),
     locale: z.object({
       requestedLocale: z.string(),

--- a/packages/inventory-react/src/components/product-detail/product-detail-page.tsx
+++ b/packages/inventory-react/src/components/product-detail/product-detail-page.tsx
@@ -3,7 +3,6 @@ import { Button, confirmDialog } from "@voyant-travel/ui/components"
 import { useMemo } from "react"
 import { ProductsUiMessagesProvider } from "../../i18n/index.js"
 import { ProductOptionsSection } from "../product-options-section.js"
-import { ProductEditorialOverlaySection } from "./editorial-overlay/product-editorial-overlay-section.js"
 import {
   useProductDetailApi,
   useProductDetailHost,
@@ -169,8 +168,6 @@ export function ProductDetailPage({ id }: { id: string }) {
                 }
               }}
             />
-
-            <ProductEditorialOverlaySection productId={id} />
           </section>
 
           <section id={authoringGroupAnchorId("plan")} className="flex scroll-mt-16 flex-col gap-6">

--- a/packages/inventory/src/routes-editorial-overlays.ts
+++ b/packages/inventory/src/routes-editorial-overlays.ts
@@ -11,6 +11,7 @@ import {
   clearProductEditorialOverlay,
   listProductEditorialOverlayHistory,
   OverlayVersionConflictError,
+  OwnedProductNotOverlayableError,
   readProductEditorialOverlayState,
   writeProductEditorialOverlay,
 } from "./service-editorial-overlays.js"
@@ -65,7 +66,7 @@ const readEditorialOverlayRoute = createRoute({
       content: { "application/json": { schema: z.object({ data: z.unknown() }) } },
     },
     404: {
-      description: "Product not found",
+      description: "Product not found, or owned and therefore not overlayable",
       content: { "application/json": { schema: errorSchema } },
     },
   },
@@ -90,6 +91,10 @@ const writeEditorialOverlayRoute = createRoute({
       description: "Invalid overlay target or value",
       content: { "application/json": { schema: errorSchema } },
     },
+    404: {
+      description: "Owned product — editorial overlays are sourced-only",
+      content: { "application/json": { schema: errorSchema } },
+    },
     409: {
       description: "Overlay version conflict",
       content: { "application/json": { schema: errorSchema } },
@@ -106,6 +111,10 @@ const clearEditorialOverlayRoute = createRoute({
       description: "Editorial overlay cleared",
       content: { "application/json": { schema: z.object({ data: z.unknown() }) } },
     },
+    404: {
+      description: "Owned product — editorial overlays are sourced-only",
+      content: { "application/json": { schema: errorSchema } },
+    },
     409: {
       description: "Overlay version conflict",
       content: { "application/json": { schema: errorSchema } },
@@ -121,6 +130,10 @@ const overlayHistoryRoute = createRoute({
     200: {
       description: "Editorial overlay audit history",
       content: { "application/json": { schema: z.object({ data: z.array(z.unknown()) }) } },
+    },
+    404: {
+      description: "Owned product — editorial overlays are sourced-only",
+      content: { "application/json": { schema: errorSchema } },
     },
   },
 })
@@ -143,21 +156,28 @@ export function createProductEditorialOverlayRoutes(
   return new OpenAPIHono<ProductEditorialOverlayRoutesEnv>({ defaultHook: openApiValidationHook })
     .openapi(readEditorialOverlayRoute, async (c) => {
       const query = c.req.valid("query")
-      const data = await readProductEditorialOverlayState(
-        c.var.db,
-        c.req.valid("param").id,
-        {
-          preferredLocales: [query.locale],
-          audience: query.audience === OVERLAY_DEFAULT_SCOPE ? "customer" : query.audience,
-          market: query.market,
-          acceptMachineTranslated: false,
-        },
-        { registry: options.resolveRegistry(c) },
-      )
-      if (!data) {
-        return c.json({ error: "not_found", detail: "Product not found" }, 404)
+      try {
+        const data = await readProductEditorialOverlayState(
+          c.var.db,
+          c.req.valid("param").id,
+          {
+            preferredLocales: [query.locale],
+            audience: query.audience === OVERLAY_DEFAULT_SCOPE ? "customer" : query.audience,
+            market: query.market,
+            acceptMachineTranslated: false,
+          },
+          { registry: options.resolveRegistry(c) },
+        )
+        if (!data) {
+          return c.json({ error: "not_found", detail: "Product not found" }, 404)
+        }
+        return c.json({ data }, 200)
+      } catch (err) {
+        if (err instanceof OwnedProductNotOverlayableError) {
+          return c.json({ error: "not_overlayable", detail: err.message }, 404)
+        }
+        throw err
       }
-      return c.json({ data }, 200)
     })
     .openapi(writeEditorialOverlayRoute, async (c) => {
       const body = c.req.valid("json")
@@ -192,6 +212,9 @@ export function createProductEditorialOverlayRoutes(
         })
         return c.json({ data: row }, 200)
       } catch (err) {
+        if (err instanceof OwnedProductNotOverlayableError) {
+          return c.json({ error: "not_overlayable", detail: err.message }, 404)
+        }
         if (err instanceof OverlayVersionConflictError) {
           return c.json(
             {
@@ -235,6 +258,9 @@ export function createProductEditorialOverlayRoutes(
         }
         return c.json({ data: { cleared: row != null, overlay: row } }, 200)
       } catch (err) {
+        if (err instanceof OwnedProductNotOverlayableError) {
+          return c.json({ error: "not_overlayable", detail: err.message }, 404)
+        }
         if (err instanceof OverlayVersionConflictError) {
           return c.json(
             {
@@ -250,15 +276,22 @@ export function createProductEditorialOverlayRoutes(
     })
     .openapi(overlayHistoryRoute, async (c) => {
       const query = c.req.valid("query")
-      const rows = await listProductEditorialOverlayHistory(c.var.db, c.req.valid("param").id, {
-        node_kind: query.nodeKind,
-        node_key: query.nodeKey,
-        field_path: query.fieldPath,
-        locale: query.locale,
-        audience: query.audience,
-        market: query.market,
-      })
-      return c.json({ data: rows }, 200)
+      try {
+        const rows = await listProductEditorialOverlayHistory(c.var.db, c.req.valid("param").id, {
+          node_kind: query.nodeKind,
+          node_key: query.nodeKey,
+          field_path: query.fieldPath,
+          locale: query.locale,
+          audience: query.audience,
+          market: query.market,
+        })
+        return c.json({ data: rows }, 200)
+      } catch (err) {
+        if (err instanceof OwnedProductNotOverlayableError) {
+          return c.json({ error: "not_overlayable", detail: err.message }, 404)
+        }
+        throw err
+      }
     })
 }
 

--- a/packages/inventory/src/service-content.ts
+++ b/packages/inventory/src/service-content.ts
@@ -16,6 +16,11 @@
  * service. Phase D ships sourced + synthesizer; owned dispatch
  * narrows when first sourced template adopts.
  *
+ * Editorial overlays apply to the sourced branches only. Owned products
+ * author their copy in their own tables, so an overlay there would be a
+ * second authoring surface for the same field rather than a restatement
+ * of someone else's content.
+ *
  * See `docs/architecture/catalog-sourced-content.md` §3.3, §3.4, §3.6.
  */
 
@@ -108,8 +113,9 @@ export interface GetProductContentOptions {
    */
   forceFresh?: boolean
   /**
-   * Admin comparison reads set this false to see locale-resolved provider/owned
-   * source content without applying editorial overlays.
+   * Admin comparison reads set this false to see locale-resolved provider
+   * source content without applying editorial overlays. No effect on owned
+   * products, which never carry overlays.
    */
   applyOverlays?: boolean
 }
@@ -142,9 +148,9 @@ export interface ResolvedProductContentProvenance {
 
 /**
  * Read the rich product content for one entity, resolving locale
- * preference, applying overlays, and refreshing in the background when
- * stale. Returns `null` only when the entity is unknown (no
- * sourced-entry row, no owned row).
+ * preference, applying overlays (sourced entities only), and refreshing
+ * in the background when stale. Returns `null` only when the entity is
+ * unknown (no sourced-entry row, no owned row).
  */
 export async function getProductContent(
   db: AnyDrizzleDb,
@@ -159,27 +165,23 @@ export async function getProductContent(
     // and project to ProductContent — locale resolution against
     // product_translations + product_option_translations uses the
     // same pickBestCachedLocale scoring the sourced cache reads use.
-    // Overlay merge applies the same way it does for sourced rows.
+    //
+    // Editorial overlays are deliberately NOT merged here. An overlay
+    // exists to restate copy an operator does not control; an owned
+    // product's copy lives in `product_translations` and friends, which
+    // the operator edits directly. Layering an overlay on top of that
+    // would give one product two authoring surfaces for the same field,
+    // with the overlay silently winning.
     const owned = await buildOwnedProductContent(db, entityId, {
       preferredLocales: scope.preferredLocales,
     })
     if (!owned) return null
-    const overlayResult = await applyProductEditorialOverlays(
-      db,
-      entityId,
-      owned.content,
-      scope,
-      options,
-    )
     return {
-      content: overlayResult.content,
+      content: owned.content,
       resolution: {
-        candidate: {
-          locale: effectiveServedLocale(owned.servedLocale, scope, overlayResult),
-          payload: overlayResult.content,
-        },
-        served_locale: effectiveServedLocale(owned.servedLocale, scope, overlayResult),
-        match_kind: effectiveMatchKind(owned.matchKind, scope, overlayResult),
+        candidate: { locale: owned.servedLocale, payload: owned.content },
+        served_locale: owned.servedLocale,
+        match_kind: owned.matchKind,
       },
       provenance: { source_kind: "owned" },
       source: "owned",

--- a/packages/inventory/src/service-editorial-overlay-state.ts
+++ b/packages/inventory/src/service-editorial-overlay-state.ts
@@ -1,6 +1,10 @@
 /**
  * Admin read model for product editorial overlays.
  *
+ * Sourced products only — an owned product has no provider baseline to compare
+ * against and authors its copy directly, so this read throws
+ * `OwnedProductNotOverlayableError` rather than returning an empty comparison.
+ *
  * Returns provider source content, active overlays, and effective content for
  * one locale scope, plus a per-field state map covering **every eligible
  * target** — not just the ones that already carry an overlay. The operator
@@ -81,6 +85,27 @@ export interface ProductEditorialOverlayServiceOptions {
   registry: SourceAdapterRegistry
 }
 
+/**
+ * Thrown when an editorial-overlay operation names an owned product.
+ *
+ * Overlays restate content the operator does not control. An owned product's
+ * copy is authored in `product_translations` and friends, so it has no
+ * provider baseline to overlay and no need for one — the operator edits the
+ * real row instead. Routes map this to 404: the overlay collection does not
+ * exist for that subject.
+ */
+export class OwnedProductNotOverlayableError extends Error {
+  readonly productId: string
+
+  constructor(productId: string) {
+    super(
+      `Product ${productId} is owned; editorial overlays apply to provider-sourced products only`,
+    )
+    this.name = "OwnedProductNotOverlayableError"
+    this.productId = productId
+  }
+}
+
 export async function readProductEditorialOverlayState(
   db: AnyDrizzleDb,
   productId: string,
@@ -92,6 +117,7 @@ export async function readProductEditorialOverlayState(
     applyOverlays: false,
   })
   if (!source) return null
+  if (source.source === "owned") throw new OwnedProductNotOverlayableError(productId)
 
   const effective = await getProductContent(db, productId, scope, {
     registry: options.registry,
@@ -165,8 +191,6 @@ export async function readProductEditorialOverlayState(
 
   return {
     subject: { module: "products", id: productId },
-    /** Owned products have no provider baseline to compare against. */
-    sourced: source.source !== "owned",
     contentSource: source.source,
     locale: {
       requestedLocale: scope.preferredLocales[0] ?? "en-GB",

--- a/packages/inventory/src/service-editorial-overlays.ts
+++ b/packages/inventory/src/service-editorial-overlays.ts
@@ -14,6 +14,10 @@ import {
   OverlayVersionConflictError,
   writeOverlay,
 } from "@voyant-travel/catalog/services/overlay"
+// Deep subpath, not the `@voyant-travel/catalog` barrel: this module is reached
+// from the admin route graph, and the barrel drags the whole catalog plane in
+// with it.
+import { readSourcedEntry } from "@voyant-travel/catalog/services/sourced-entry"
 import type { AnyDrizzleDb } from "@voyant-travel/db"
 
 import {
@@ -31,7 +35,10 @@ import {
   ROOT_FIELDS,
 } from "./editorial-overlay-fields.js"
 import { getProductContent, type ProductContentScope } from "./service-content.js"
-import type { ProductEditorialOverlayServiceOptions } from "./service-editorial-overlay-state.js"
+import {
+  OwnedProductNotOverlayableError,
+  type ProductEditorialOverlayServiceOptions,
+} from "./service-editorial-overlay-state.js"
 
 export type {
   ProductEditorialFieldKind,
@@ -77,6 +84,7 @@ export async function writeProductEditorialOverlay(
     applyOverlays: false,
   })
   if (!source) throw new Error(`Product ${productId} not found`)
+  if (source.source === "owned") throw new OwnedProductNotOverlayableError(productId)
 
   const target = normalizeTarget(input)
   validateTarget(source.content, target)
@@ -127,6 +135,7 @@ export async function clearProductEditorialOverlay(
   productId: string,
   input: ProductEditorialOverlayClearInput,
 ): Promise<SelectCatalogOverlay | null> {
+  await requireSourcedProduct(db, productId)
   const overlayScope = normalizeOverlayScope(input.scope)
   const target = normalizeTarget(input)
   return clearOverlayByTarget(db, {
@@ -147,6 +156,7 @@ export async function listProductEditorialOverlayHistory(
   productId: string,
   target?: Partial<ProductEditorialOverlayTarget & ProductEditorialOverlayScope>,
 ): Promise<SelectCatalogOverlayHistory[]> {
+  await requireSourcedProduct(db, productId)
   return listOverlayHistoryForTarget(db, {
     entity_module: "products",
     entity_id: productId,
@@ -167,6 +177,7 @@ export async function listProductEditorialOverlayHistory(
 }
 
 export {
+  OwnedProductNotOverlayableError,
   type ProductEditorialFieldState,
   type ProductEditorialFieldView,
   type ProductEditorialNodeView,
@@ -174,6 +185,17 @@ export {
 } from "./service-editorial-overlay-state.js"
 
 export { OverlayVersionConflictError }
+
+/**
+ * Overlays address provider-sourced products. Ownership is the absence of a
+ * sourced-entry row, so this doubles as the existence check for the clear and
+ * history paths — neither reads content, and an unknown id has no overlay
+ * collection either way.
+ */
+async function requireSourcedProduct(db: AnyDrizzleDb, productId: string): Promise<void> {
+  const entry = await readSourcedEntry(db, "products", productId)
+  if (!entry) throw new OwnedProductNotOverlayableError(productId)
+}
 
 function validateTarget(
   content: ProductContent,

--- a/packages/inventory/tests/unit/routes-editorial-overlays.test.ts
+++ b/packages/inventory/tests/unit/routes-editorial-overlays.test.ts
@@ -15,6 +15,9 @@ const serviceMocks = vi.hoisted(() => ({
   OverlayVersionConflictError: class OverlayVersionConflictError extends Error {
     currentVersion = null
   },
+  OwnedProductNotOverlayableError: class OwnedProductNotOverlayableError extends Error {
+    productId = "prod_1"
+  },
 }))
 
 vi.mock("../../src/service-editorial-overlays.js", () => serviceMocks)
@@ -187,5 +190,64 @@ describe("createProductEditorialOverlayRoutes", () => {
 
     expect(res.status).toBe(401)
     expect(serviceMocks.writeProductEditorialOverlay).not.toHaveBeenCalled()
+  })
+
+  // An owned product authors its copy directly, so it has no overlay
+  // collection. Every verb has to say that the same way — a 500, or a silent
+  // 200 with an empty comparison, is what put a broken card on the operator's
+  // owned product page in the first place.
+  it("answers 404 not_overlayable on reads of an owned product", async () => {
+    serviceMocks.readProductEditorialOverlayState.mockRejectedValueOnce(
+      new serviceMocks.OwnedProductNotOverlayableError("owned"),
+    )
+    const app = buildApp("usr_editor")
+
+    const res = await app.request("/prod_1/editorial-overlays?locale=ro-RO")
+
+    expect(res.status).toBe(404)
+    expect(await res.json()).toMatchObject({ error: "not_overlayable" })
+  })
+
+  it("answers 404 not_overlayable on writes to an owned product", async () => {
+    serviceMocks.writeProductEditorialOverlay.mockRejectedValueOnce(
+      new serviceMocks.OwnedProductNotOverlayableError("owned"),
+    )
+    const app = buildApp("usr_editor")
+
+    const res = await app.request("/prod_1/editorial-overlays", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        fieldPath: "name",
+        locale: "ro-RO",
+        audience: "customer",
+        market: "RO",
+        value: "Nume",
+      }),
+    })
+
+    expect(res.status).toBe(404)
+    expect(await res.json()).toMatchObject({ error: "not_overlayable" })
+  })
+
+  it("answers 404 not_overlayable on clears and history for an owned product", async () => {
+    serviceMocks.clearProductEditorialOverlay.mockRejectedValueOnce(
+      new serviceMocks.OwnedProductNotOverlayableError("owned"),
+    )
+    serviceMocks.listProductEditorialOverlayHistory.mockRejectedValueOnce(
+      new serviceMocks.OwnedProductNotOverlayableError("owned"),
+    )
+    const app = buildApp("usr_editor")
+    const scope = "locale=ro-RO&audience=customer&market=RO"
+
+    const cleared = await app.request(`/prod_1/editorial-overlays?fieldPath=name&${scope}`, {
+      method: "DELETE",
+    })
+    const history = await app.request(`/prod_1/editorial-overlays/history?${scope}`)
+
+    expect(cleared.status).toBe(404)
+    expect(await cleared.json()).toMatchObject({ error: "not_overlayable" })
+    expect(history.status).toBe(404)
+    expect(await history.json()).toMatchObject({ error: "not_overlayable" })
   })
 })

--- a/packages/inventory/tests/unit/service-content.test.ts
+++ b/packages/inventory/tests/unit/service-content.test.ts
@@ -409,7 +409,11 @@ describe("getProductContent cache ownership", () => {
     expect(result?.source).toBe("sourced-fresh")
   })
 
-  it("reports fallback_chain when requested-locale overlays augment owned fallback content", async () => {
+  // An owned product's copy lives in product_translations, which the operator
+  // edits directly. Merging an overlay on top would give one field two
+  // authoring surfaces and let the overlay win silently, so the owned branch
+  // serves the projection as-authored and never reads the overlay store.
+  it("serves owned content as authored and ignores overlay rows", async () => {
     const db = makeDb()
     const adapter = makeAdapter(false)
     catalogMocks.readSourcedEntry.mockResolvedValue(null)
@@ -438,9 +442,10 @@ describe("getProductContent cache ownership", () => {
       { registry: makeRegistry(adapter) },
     )
 
-    expect(result?.content.product.name).toBe("Nume romanesc")
-    expect(result?.resolution.served_locale).toBe("ro-RO")
-    expect(result?.resolution.match_kind).toBe("fallback_chain")
+    expect(result?.content.product.name).toBe("Owned English")
+    expect(result?.resolution.served_locale).toBe("en-GB")
+    expect(result?.resolution.match_kind).toBe("any")
     expect(result?.source).toBe("owned")
+    expect(catalogMocks.fetchOverlaysForEntity).not.toHaveBeenCalled()
   })
 })

--- a/packages/inventory/tests/unit/service-editorial-overlay-state.test.ts
+++ b/packages/inventory/tests/unit/service-editorial-overlay-state.test.ts
@@ -10,7 +10,10 @@ const contentMocks = vi.hoisted(() => ({
 vi.mock("@voyant-travel/catalog/services/overlay", () => overlayMocks)
 vi.mock("../../src/service-content.js", () => contentMocks)
 
-import { readProductEditorialOverlayState } from "../../src/service-editorial-overlay-state.js"
+import {
+  OwnedProductNotOverlayableError,
+  readProductEditorialOverlayState,
+} from "../../src/service-editorial-overlay-state.js"
 
 const SCOPE = {
   preferredLocales: ["ro-RO"],
@@ -109,6 +112,22 @@ describe("readProductEditorialOverlayState", () => {
       { nodeKind: "root", nodeKey: "root", dayNumber: null, label: null },
       { nodeKind: "itinerary-day", nodeKey: "day_1", dayNumber: 1, label: "Day one" },
     ])
+  })
+
+  // The read model exists to compare provider copy against an operator's
+  // restatement of it. An owned product is both sides of that comparison, so
+  // there is nothing to compare and no overlay collection to return.
+  it("refuses an owned product instead of returning an empty comparison", async () => {
+    contentMocks.getProductContent.mockResolvedValue({
+      ...makeResolved(makeContent()),
+      source: "owned",
+      provenance: { source_kind: "owned" },
+    })
+
+    await expect(
+      readProductEditorialOverlayState(makeDb(), "prod_1", SCOPE, { registry: makeRegistry() }),
+    ).rejects.toThrow(OwnedProductNotOverlayableError)
+    expect(overlayMocks.fetchOverlayRowsForEntity).not.toHaveBeenCalled()
   })
 
   it("marks locale-fallback source fields so admin can see what was served", async () => {


### PR DESCRIPTION
## What

Editorial overlays are sourced-only. An owned product no longer has an overlay
collection, and the operator's product page no longer offers one.

## Why

An overlay exists to restate content the operator does not control — provider
copy from a Connect package, a bedbank, a GDS. An owned product's copy is
authored in `product_translations`, `product_day_translations`, and the
option/service equivalents, which the operator edits directly. Layering an
overlay on top gave one field two authoring surfaces, with the overlay the
silent winner and nothing in the editor saying it had shadowed the row.

In the operator UI this never worked at all. **Every row in `products` is owned
by construction** — a sourced product's `entity_id` is the upstream id and lives
in `catalog_sourced_entries`, surfacing at `/catalog/products/:id`, never in the
products table — so `/products/:id` mounted an editor whose subject could not
exist. The read model's `sourced` flag was supposed to hide it, but the flag
only arrives if the fetch succeeds. What an operator actually saw was a red
"Failed to load editorial content." card wedged between Media and Itinerary.

## What changed

**Read path.** `getProductContent` and `getAccommodationContent` serve the owned
branch as authored and never read the overlay store. The sourced branches
(`sourced-cache`, `sourced-fresh`, `synthesized`) merge overlays exactly as
before.

**Write path.** `readProductEditorialOverlayState`, `writeProductEditorialOverlay`,
`clearProductEditorialOverlay`, and `listProductEditorialOverlayHistory` throw the
new `OwnedProductNotOverlayableError`. Ownership is the absence of a
`catalog_sourced_entries` row, which doubles as the existence check on the clear
and history paths.

**Routes.** `GET`, `PUT`, `DELETE`, and `GET .../history` on
`/v1/admin/products/{id}/editorial-overlays` answer `404 not_overlayable`.
Without this a client could still write a row that read-time merge now ignores —
a silent no-op is worse than an error.

**UI.** `ProductEditorialOverlaySection` is no longer mounted on the owned
product detail page. It stays exported from `@voyant-travel/inventory-react` as
the authoring surface for sourced product content; the operator has no host for
that today (`/catalog/products/:id` is read-only and has no admin write API), so
mounting it there is separate work.

**Read model.** Drops `sourced` from the payload — it is `true` on every response
the endpoint can now produce. `contentSource` still reports which sourced branch
served the comparison. The dead `products.editorial.unavailable` i18n key goes
with it (en + ro).

## No data migration

The editor returned `null` for owned subjects from the day it landed, so no
owned overlay was ever authored through it. Any row that predates that is inert
rather than wrong, and `catalog_overlay` keeps its history and soft-delete.

## Checker note

Per AGENTS.md: this adds no new architecture check. The rule is behavioural, not
structural — "the owned branch does not read the overlay store" is a fact about
one call, covered by unit tests in `service-content.test.ts`,
`service-editorial-overlay-state.test.ts`, and `routes-editorial-overlays.test.ts`
rather than by a data rule or a new `scripts/check-*.mjs`.
`verify:catalog-editorial-overlays` and `verify:table-privacy` both stay green
(190 reach-ins / 35 pairs, none new).

## Verification

Local, all green:

- `pnpm -F @voyant-travel/inventory -F @voyant-travel/accommodations -F @voyant-travel/i18n test`
  — 590 / 99 / 13 passing
- `pnpm -F @voyant-travel/inventory-react test` — 104 tests
- `biome check` — no errors (2 pre-existing warnings)
- `verify:catalog-editorial-overlays`, `verify:table-privacy` (190 reach-ins /
  35 pairs, none new), `verify:symbol-policy` (5 policy sets over 4329 sources)

`admin-extension.test.ts` first went red here, so it got an A/B/A run —
pristine, patched, pristine — and passed 11/11 in all three. Its dynamic-import
assertion carries a hardcoded 15s budget and this machine was running several
worktrees' typechecks at the time. That investigation is what surfaced the
barrel import: pulling `readSourcedEntry` from `@voyant-travel/catalog` instead
of the subpath roughly doubled the file's transform and import time (134s → 69s
once fixed), which is a real cost for anything loading the admin route graph.
The other 51 root-barrel call sites are left alone here and tracked in [#4312](https://github.com/voyant-travel/voyant/issues/4312).

**Typecheck is on CI, not local.** `pnpm -F @voyant-travel/inventory-react...
typecheck` rebuilds ~50 dependency packages and had not finished after an hour
on a contended machine, so it was stopped rather than reported as passing.
