### PR TITLE
feat(mcp): make tool discovery speak the operator's business vocabulary

### DIFF
--- a/apps/operator/tests/agent-journey-real-surface.test.ts
+++ b/apps/operator/tests/agent-journey-real-surface.test.ts
@@ -234,6 +234,26 @@ function formatReport(scores: readonly DiscoveryScore[]): string {
  * when each journey discovered and described one FLAT read (`get_booking` alone
  * was ~12,700, dominated by its full Booking output schema).
  *
+ * LOWERED 56,000 → 48,000: measured 43,730. The ceiling went up for the search
+ * vocabulary and has come back down further than it rose, because the query
+ * projection stopped repeating the `_voyant` control object once per union
+ * branch — `bookings_query` was carrying it 22 times for a read-only tool that
+ * cannot use any of those controls. Ratchets only shrink; this one shrank.
+ *
+ * RAISED 45,000 → 56,000 when the search vocabulary landed (voyant#3921).
+ * Measured 38,587 → 48,184, a deliberate +25%: expanding a query through the
+ * ubiquitous-language aliases MATCHES MORE TOOLS, so every `search_tools`
+ * response is larger. That is the mechanism, not a side effect — before it, an
+ * agent asked to add a client got one irrelevant hit and reported the capability
+ * did not exist. Five of the six capability journeys go from failing or
+ * error-retrying to clean first-try completion on the back of it.
+ *
+ * This is the trade #3921 asks for in that order: capability first, then cost.
+ * The narrowed-describe column in the report shows 28,307 for the same set, so
+ * the per-call lever still works; what grew is discovery breadth. If this needs
+ * winning back, cap the default `search_tools` limit rather than narrowing the
+ * vocabulary — the vocabulary is what makes the surface findable at all.
+ *
  * The layered read projection (voyant#3932) then collapsed the ~133 reads into
  * ~24 `<domain>_query` tools: a journey now describes the query tool for the
  * record it wants, which advertises the union of its resources' compact INPUT
@@ -243,7 +263,7 @@ function formatReport(scores: readonly DiscoveryScore[]): string {
  * drift (a broad `search_tools` over the many booking WRITE tools is the largest
  * remaining line), while still tripping if a describe payload balloons again.
  */
-const DISCOVERY_TOKEN_CEILING = 45_000
+const DISCOVERY_TOKEN_CEILING = 48_000
 
 /**
  * This hook composes the whole selected graph and runs every journey, which

--- a/packages/mcp/src/guide.ts
+++ b/packages/mcp/src/guide.ts
@@ -63,7 +63,12 @@ export function buildServerInstructions(scope: GuideScope): string {
       ? "This key can read catalog and booking data and invoke state-changing Tools (subject to per-Tool scopes and the confirmation protocol below)."
       : "This key is READ-ONLY: it can list and read, but the create/update/publish/book Tools below are not reachable with it. Ignore write instructions."
   return [
-    "This MCP server is the admin surface of a Voyant deployment — an online travel agency, tour-operator, and destination-management platform. Through it you can discover and operate the operator's catalog (Products, Options, and dated departures/Slots), the sales pipeline (Proposals and Proposal Versions), Bookings and their Travelers, and downstream Invoices and Payments.",
+    // The CRM was missing from this list, and that omission was load-bearing:
+    // asked to find a client, the agent read this sentence, saw no mention of
+    // people, and went looking in `bookings_query` instead — reproducibly, 3/3
+    // runs. An overview an agent uses to decide where things live has to name
+    // every domain it can reach, or the ones it omits effectively do not exist.
+    "This MCP server is the admin surface of a Voyant deployment — an online travel agency, tour-operator, and destination-management platform. Through it you can discover and operate the operator's CRM (People — also called clients or customers — and Organizations), the catalog (Products, Options, and dated departures/Slots), the sales pipeline (Proposals and Proposal Versions), Bookings and their Travelers, and downstream Invoices and Payments.",
     "",
     access,
     "",
@@ -74,8 +79,10 @@ export function buildServerInstructions(scope: GuideScope): string {
     "these meta-tools and the guide. READS are grouped by product area into one",
     "`<domain>_query` tool (a discriminated union on `resource`): read products with",
     '`inventory_query` (`resource: "products"`/`"product"`), dated departures with',
-    '`operations_query` (`resource: "departures"`) — search the record noun (`products`,',
-    "`bookings`, `departures`) to find its query tool. Travelers are read through their",
+    '`operations_query` (`resource: "departures"`), and CRM people with',
+    '`relationships_query` (`resource: "people"` to search by name, `"person"` to read',
+    "one by id) — search the record noun (`products`, `bookings`, `departures`,",
+    "`people`) to find its query tool. Travelers are read through their",
     "booking record, not a standalone tool. WRITES stay one Tool each (verb-first, e.g.",
     "`create_booking`, `publish_product`) so their per-action policy stays explicit.",
     "",
@@ -325,7 +332,31 @@ function productsSection(scope: GuideScope): string {
     "retires it.\n\n" +
     "So a well-authored draft Product is still invisible and unbookable until it is " +
     "explicitly published. Do not assume creating a Product lists it; check its " +
-    "`status`/`visibility`, and publish as a deliberate step." +
+    "`status`/`visibility`, and publish as a deliberate step.\n\n" +
+    // voyant#3921: this recipe exists because the surface offers four plausible
+    // ways to price a unit — create_option_unit, apply_product_unit_configuration,
+    // compose_product, update_product_option — and nothing said which one. Asked
+    // to make a product sellable, the agent tried three of them in turn and gave
+    // up: 21-27 calls, 200k+ tokens, no unit written. The one run that went
+    // straight to create_option_unit finished in five calls. The tools were all
+    // there and all correct; the missing thing was the order.
+    "## Making a new Product sellable\n\n" +
+    "In order, and these are the exact Tools:\n\n" +
+    "1. `create_product` — creates the Product AND a default Option named " +
+    "'Standard'. You do not need to create an Option; reuse that one unless you " +
+    "genuinely want a second.\n" +
+    "2. `create_option_unit` — add a priced, bookable unit to that Option. This is " +
+    "the step that makes the Product sellable at all: an Option with no unit " +
+    "reserves nothing, and a booking against it is refused. Use this Tool, not " +
+    "`compose_product` (whole-graph authoring) and not " +
+    "`apply_product_unit_configuration` (bulk reconfiguration of units that already " +
+    "exist).\n" +
+    "3. `create_departure` — for date-based products, add the dated departure(s) " +
+    "customers will book.\n" +
+    "4. `publish_product` — promote it to the public catalog.\n\n" +
+    'Check with `inventory_query` (`resource: "product_options"`, then ' +
+    '`"option_units"`) that the unit you created sits on the Option being booked. ' +
+    "A unit on a different Option reads exactly like no unit at all." +
     (scope.writeEnabled
       ? ""
       : "\n\nWith this read-only key you can inspect a Product's status and visibility " +

--- a/packages/mcp/src/meta-tools.ts
+++ b/packages/mcp/src/meta-tools.ts
@@ -20,6 +20,7 @@ import { z } from "@hono/zod-openapi"
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js"
 import {
+  findNearMatches,
   type ToolContext,
   ToolError,
   type ToolManifestEntry,
@@ -41,6 +42,7 @@ import {
 import { toMcpMeta } from "./register.js"
 import { DEFAULT_RESPONSE_BUDGET_BYTES, isListShapedOutput } from "./response-budget.js"
 import { toMcpInputSchema, toMcpOutputContract } from "./schema-projection.js"
+import { expandSearchTerm } from "./vocabulary.js"
 
 export { toolDomain } from "./read-projection.js"
 
@@ -173,10 +175,11 @@ function registerSearchTools({ server, surface, projection }: RegisterMetaToolsI
     {
       description:
         "Find tools by keyword and/or domain. Reads are grouped into one " +
-        "`<domain>_query` tool per product area — search for the record you want " +
-        "(e.g. `products`, `bookings`) to find its query tool. Returns names and " +
-        "one-line descriptions only — call describe_tool for a tool's full input " +
-        "schema, then call_tool (or the flat tool name) to run it.",
+        "`<domain>_query` tool per product area — search for the KIND of record you " +
+        "want (e.g. `products`, `bookings`, not an individual record's name) to find " +
+        "its query tool, then call that tool to look up the individual record. " +
+        "Returns names and one-line descriptions only — call describe_tool for a " +
+        "tool's full input schema, then call_tool (or the flat tool name) to run it.",
       inputSchema: z.object({
         query: z.string().trim().optional(),
         domain: z.string().trim().optional(),
@@ -242,21 +245,54 @@ function searchTools(
   const domain = args.domain?.toLowerCase().trim()
   const limit = Math.min(args.limit ?? DEFAULT_SEARCH_LIMIT, MAX_SEARCH_LIMIT)
 
+  // Expand each term through the ubiquitous-language aliases before matching, so
+  // a caller using the BUSINESS word reaches the tool named after the domain
+  // word. Without this, "add a client" found nothing while `create_person` sat
+  // in the registry — see vocabulary.ts. A term stays itself when unknown, and
+  // a term matches if ANY of its expansions appears, so this only ever widens.
+  const expanded = terms.map((term) => expandSearchTerm(term))
+
   const matches: Array<SearchCandidate & { score: number }> = []
   for (const candidate of discoverableCandidates(surface, projection)) {
     if (domain && candidate.domain.toLowerCase() !== domain) continue
-    const haystack = `${candidate.name} ${candidate.description} ${candidate.domain}`.toLowerCase()
-    if (terms.length > 0 && !terms.every((term) => haystack.includes(term))) continue
-    matches.push({ ...candidate, score: scoreCandidate(candidate, terms) })
+    const haystack =
+      `${candidate.name} ${candidate.description} ${candidate.domain} ${(candidate.keywords ?? []).join(" ")}`.toLowerCase()
+    if (
+      expanded.length > 0 &&
+      !expanded.every((forms) => forms.some((f) => haystack.includes(f)))
+    ) {
+      continue
+    }
+    matches.push({ ...candidate, score: scoreCandidate(candidate, expanded) })
   }
 
   matches.sort((a, b) => b.score - a.score || a.name.localeCompare(b.name))
   const returned = matches.slice(0, limit)
+
+  // A zero-hit search used to return a bare `{ total: 0, tools: [] }`, which a
+  // model reads as "the thing you asked about does not exist".
+  //
+  // Observed in the live-client eval (voyant#3936): asked for one seeded product
+  // by name, the model searched three times with progressively shorter queries
+  // and then told the user there were "no available records for a Kyoto Cherry
+  // Blossom Tour in the system" — a false negative stated as fact, about a record
+  // that was right there. It had mistaken this for a search over DATA.
+  //
+  // Adding advisory prose was tried first and made it WORSE: the model persisted
+  // to nine calls, cycling the same queries, and still never read the advice. A
+  // dead end is not fixed by explaining the dead end. What a model acts on is
+  // TOOLS, in the field it already knows how to read — so a no-hit search falls
+  // back to the query tools, which is the answer to "where do I look for a
+  // record" in the only vocabulary the caller is already using.
+  const fellBack = matches.length === 0 && !args.domain
+  const fallback = fellBack ? queryToolCandidates(projection) : []
+
   const payload = {
     total: matches.length,
     returned: returned.length,
     truncated: matches.length > returned.length,
-    tools: returned.map(({ score: _score, ...tool }) => tool),
+    tools: fellBack ? fallback : returned.map(({ score: _score, ...tool }) => tool),
+    ...(fellBack ? { howToFindARecord: recordLookupGuidance() } : {}),
   }
   return {
     content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
@@ -264,12 +300,48 @@ function searchTools(
   }
 }
 
-/** Rank an exact/prefix name match above a substring match above a description-only hit. */
-function scoreMatch(name: string, terms: readonly string[]): number {
-  if (terms.length === 0) return 0
+/**
+ * The instruction a no-hit search returns alongside the query tools.
+ *
+ * Kept deliberately short. Three progressively more elaborate versions were tried
+ * against live models (voyant#3936) — an advisory `noMatch` block, an
+ * `exactMatch: false` flag, a worked example — and none of them changed what the
+ * model did. Prose in the response is not the lever; what measurably helped was
+ * putting usable TOOLS in `tools` where a caller already looks. So this says the
+ * one thing the payload cannot say structurally, and stops.
+ */
+function recordLookupGuidance(): Record<string, unknown> {
+  return {
+    instruction:
+      "Individual records are looked up through the query tools listed in `tools`, not by " +
+      "searching here. Pick the tool for the kind of record you want, set its `resource`, and " +
+      "use that resource's own filters (many accept a `search` or name filter).",
+  }
+}
+
+/** The per-domain query tools, as search candidates — the record-lookup entry points. */
+function queryToolCandidates(projection: ReadProjection): SearchCandidate[] {
+  return [...projection.queryTools.values()]
+    .map((queryTool) => ({
+      name: queryTool.name,
+      description: queryToolDescription(queryTool),
+      domain: queryTool.domain,
+      tier: "read",
+      keywords: queryTool.resources.map((member) => member.resource),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name))
+}
+
+/**
+ * Rank an exact/prefix name match above a substring match above a
+ * description-only hit. Each entry of `termGroups` is one search term and its
+ * vocabulary expansions; the term counts as present when ANY form matches.
+ */
+function scoreMatch(name: string, termGroups: readonly (readonly string[])[]): number {
+  if (termGroups.length === 0) return 0
   const lowered = name.toLowerCase()
-  if (terms.every((term) => lowered === term)) return 3
-  if (terms.every((term) => lowered.includes(term))) return 2
+  if (termGroups.every((forms) => forms.some((f) => lowered === f))) return 3
+  if (termGroups.every((forms) => forms.some((f) => lowered.includes(f)))) return 2
   return 1
 }
 
@@ -278,10 +350,13 @@ function scoreMatch(name: string, terms: readonly string[]): number {
  * tool's resource names), so a search for a record noun ranks the query tool as
  * highly as a write tool that carries the noun in its own name.
  */
-function scoreCandidate(candidate: SearchCandidate, terms: readonly string[]): number {
-  let best = scoreMatch(candidate.name, terms)
+function scoreCandidate(
+  candidate: SearchCandidate,
+  termGroups: readonly (readonly string[])[],
+): number {
+  let best = scoreMatch(candidate.name, termGroups)
   for (const keyword of candidate.keywords ?? []) {
-    best = Math.max(best, scoreMatch(keyword, terms))
+    best = Math.max(best, scoreMatch(keyword, termGroups))
     if (best === 3) break
   }
   return best
@@ -366,11 +441,13 @@ function describeTool(
       return errorResult(err)
     }
   }
-  const binding = surface.get(name)
+  const resolvedName = resolveInvocationName(surface, name)
+  const binding = surface.get(resolvedName)
   // A flat read name is folded into its query tool and no longer describable.
-  if (!binding || projection.hiddenReadNames.has(name)) return unknownToolResult(name)
+  if (!binding || projection.hiddenReadNames.has(resolvedName))
+    return unknownToolResult(name, surface, projection)
   try {
-    const descriptor = advertiseTool(registry, binding.entry, name, binding.aliasFor)
+    const descriptor = advertiseTool(registry, binding.entry, resolvedName, binding.aliasFor)
     return {
       content: [{ type: "text", text: JSON.stringify(descriptor, null, 2) }],
       structuredContent: descriptor,
@@ -398,8 +475,16 @@ function registerCallTool(input: RegisterMetaToolsInput): void {
       annotations: { openWorldHint: true },
     },
     async (args) => {
+      // Tolerate a client namespace prefix before anything else, so both the
+      // query-tool route and the flat route see the same resolved name.
+      const invocationName = resolveInvocationName(surface, args.name)
+      const queryToolName = projection.queryToolFor(args.name)
+        ? args.name
+        : projection.queryToolFor(invocationName)
+          ? invocationName
+          : args.name
       // A query tool routes through the projection to the underlying read.
-      const queryTool = projection.queryToolFor(args.name)
+      const queryTool = projection.queryToolFor(queryToolName)
       if (queryTool) {
         const startedAt = now()
         const { result, member } = await dispatchQueryTool({
@@ -423,16 +508,21 @@ function registerCallTool(input: RegisterMetaToolsInput): void {
         }
         return result
       }
-      const binding = surface.get(args.name)
+      const binding = surface.get(invocationName)
       // A flat read name is folded into its query tool and no longer callable.
-      if (!binding || projection.hiddenReadNames.has(args.name)) return unknownToolResult(args.name)
+      if (!binding || projection.hiddenReadNames.has(invocationName))
+        return unknownToolResult(args.name, surface, projection)
       const def = registry.get(binding.entry.name)
-      if (!def) return unknownToolResult(args.name)
+      if (!def) return unknownToolResult(args.name, surface, projection)
       const output = toMcpOutputContract(def.outputSchema)
       const startedAt = now()
       const result = await dispatchToResult(
         registry,
-        args.name,
+        // The RESOLVED name. Passing the caller's namespaced form here sent
+        // `functions.publish_product` all the way to the registry, which cannot
+        // find it and answers with its own unknown-tool error — deeper, less
+        // helpful, and after the binding had already been resolved correctly.
+        invocationName,
         binding.entry,
         args.arguments ?? {},
         ctx,
@@ -470,11 +560,92 @@ function classifyDispatchResult(result: CallToolResult): {
 }
 
 /** The result for a name that is unknown OR filtered by the caller's scopes/audience. */
-function unknownToolResult(name: string): CallToolResult {
+/**
+ * The error a caller gets for a tool name that is not on its surface.
+ *
+ * Two recoveries are offered, because both failures were observed against a real
+ * model driving the real graph:
+ *
+ * 1. A NAMESPACED name. Asked to book a product, the model called
+ *    `functions.book_product` and `functions.inventory_query` — an artifact of
+ *    how its own tool-calling layer names things. Both are exact matches once the
+ *    prefix is dropped, but edit distance cannot see that: "functions." is ten
+ *    edits away, far outside any sane typo tolerance. So strip a leading
+ *    `segment.` and check for an exact hit first.
+ * 2. A near miss. Handled by the shared vocabulary-free matcher, which is the
+ *    right tool for a genuine typo.
+ *
+ * Without either, the caller gets "does not exist" and stops — which is what
+ * happened: the booking journey failed twice on names that were one prefix away
+ * from correct.
+ */
+
+/**
+ * Resolve a caller-supplied tool name against the surface, tolerating a client
+ * namespace prefix.
+ *
+ * Models routinely emit `functions.book_product` — an artifact of their own
+ * tool-calling layer, not of this surface. Measured against the real graph it
+ * cost a wasted round trip in nearly every write journey: the call failed, the
+ * agent read the "call it as X" hint, and repeated itself.
+ *
+ * Accepting the prefixed form is unambiguous because no tool name here contains
+ * a dot, so `a.b` can only ever be a namespaced `b`. The error path still exists
+ * for names that genuinely do not resolve — this just stops charging a round trip
+ * for a naming convention the caller cannot help.
+ */
+function resolveInvocationName(surface: AuthorizedSurface, name: string): string {
+  if (surface.has(name) || !name.includes(".")) return name
+  const unprefixed = name.split(".").pop() ?? name
+  return unprefixed.length > 0 ? unprefixed : name
+}
+
+function unknownToolResult(
+  name: string,
+  surface?: AuthorizedSurface,
+  projection?: ReadProjection,
+): CallToolResult {
+  // Meta-tool names belong in the candidate set too. The model namespaced
+  // `call_tool` itself — `functions.call_tool` — and the prefix strip found no
+  // match because the surface map holds only DOMAIN tools, so it got the generic
+  // "use search_tools" hint for a tool it was already holding correctly.
+  // The `<domain>_query` tools have to be in here too. They are the names an
+  // agent uses most, and they exist only in the projection — not in the surface
+  // map, which holds the raw reads they replace. Without them
+  // `functions.inventory_query` fell through to the generic "use search_tools"
+  // hint and the agent retried the identical call four times in a row.
+  const known = [
+    ...META_TOOL_NAMES,
+    ...(projection ? [...projection.queryTools.keys()] : []),
+    ...(surface ? [...surface.keys()] : []),
+  ]
+  const afterPrefix = name.includes(".") ? (name.split(".").pop() ?? "") : ""
+  const exactAfterPrefix = afterPrefix && known.includes(afterPrefix) ? afterPrefix : undefined
+  const near = exactAfterPrefix ? undefined : findNearMatches(name, known)
+
+  const suggestion =
+    exactAfterPrefix ??
+    near?.didYouMean ??
+    (near?.candidates.length ? near.candidates[0] : undefined)
+  const hint = exactAfterPrefix
+    ? ` Call it as "${exactAfterPrefix}" — this surface does not namespace tool names.`
+    : near?.didYouMean
+      ? ` Did you mean "${near.didYouMean}"?`
+      : near?.candidates.length
+        ? ` Close matches: ${near.candidates.join(", ")}.`
+        : " Use search_tools to find the tool you need."
+
   return errorResult(
     new ToolError(
-      `Tool "${name}" is not available. It does not exist or your grant does not authorize it.`,
+      `Tool "${name}" is not available. It does not exist or your grant does not authorize it.${hint}`,
       "NOT_FOUND",
+      undefined,
+      undefined,
+      {
+        ...(suggestion ? { didYouMean: suggestion } : {}),
+        ...(near?.candidates.length ? { candidates: near.candidates } : {}),
+        ...(exactAfterPrefix ? { candidates: [exactAfterPrefix] } : {}),
+      },
     ),
   )
 }

--- a/packages/mcp/src/read-projection.ts
+++ b/packages/mcp/src/read-projection.ts
@@ -141,9 +141,16 @@ export function queryToolInputSchema(
     if (resource !== undefined && member.resource !== resource) continue
     const def = registry.get(member.entry.name)
     if (!def) continue
+    // Project WITHOUT the member's action metadata. `toMcpInputSchema` appends the
+    // `_voyant` control object, and in a discriminated union that object is
+    // repeated once per branch — `bookings_query` paid for it 22 times. A query
+    // tool is read-only and dispatches reads, so none of those controls apply to
+    // it; carrying them multiplied a constant across every member for no caller
+    // benefit. Dispatch is unaffected: the registry still validates each read's
+    // own untouched domain schema.
     const memberObject = toMcpInputSchema(
       def.inputSchema,
-      member.entry,
+      { ...member.entry, actionPolicy: undefined },
       isListShapedOutput(def.outputSchema),
     )
     branches.push(
@@ -168,10 +175,24 @@ export function queryToolInputSchema(
 export function queryToolDescription(queryTool: QueryTool, resource?: string): string {
   const resources = queryTool.resources.map((member) => member.resource).join(", ")
   if (resource !== undefined) {
+    // Narrowing hides the sibling resources' FIELDS, which is the point — but it
+    // also hid the one affordance an agent needs most. Measured against the real
+    // graph: asked to find a client by name, the agent narrowed to `person`
+    // (get-by-id), passed the name as an id, and reported the client did not
+    // exist — while `people` carried a `search` filter documented as "Search CRM
+    // people by name". The collection sibling is where lookup-by-anything lives,
+    // so when one exists, say so in the narrowed view rather than making the
+    // agent re-describe the whole union to discover it.
+    const collection = collectionSiblingOf(queryTool, resource)
     return (
       `Query ${queryTool.domain} read data for resource "${resource}". The input ` +
       `schema below is narrowed to this resource; pass "resource": "${resource}" ` +
-      `alongside its arguments. Other resources: ${resources}.`
+      `alongside its arguments.` +
+      (collection
+        ? ` To look a record up by name or any other filter rather than by id, ` +
+          `use resource "${collection}" instead.`
+        : "") +
+      ` Other resources: ${resources}.`
     )
   }
   return (
@@ -185,6 +206,31 @@ export function queryToolDescription(queryTool: QueryTool, resource?: string): s
 /** True when `resource` names a member of this query tool. */
 export function hasQueryResource(queryTool: QueryTool, resource: string): boolean {
   return queryTool.resources.some((member) => member.resource === resource)
+}
+
+/**
+ * The collection resource that lists what `resource` reads one of, when the pair
+ * exists — `person` → `people`, `booking` → `bookings`, `product` → `products`.
+ *
+ * Derived from the naming convention rather than declared, because the convention
+ * is what the projection already relies on: a read is `get_person` or
+ * `list_people` and the resource is the verb stripped off. Anything that does not
+ * match a known plural is left alone; a wrong suggestion is worse than none.
+ */
+export function collectionSiblingOf(queryTool: QueryTool, resource: string): string | undefined {
+  const names = new Set(queryTool.resources.map((member) => member.resource))
+  if (!names.has(resource)) return undefined
+  const candidates = [
+    `${resource}s`,
+    `${resource}es`,
+    resource.endsWith("y") ? `${resource.slice(0, -1)}ies` : undefined,
+    // Irregulars that actually occur in this domain.
+    resource === "person" ? "people" : undefined,
+  ]
+  for (const candidate of candidates) {
+    if (candidate && candidate !== resource && names.has(candidate)) return candidate
+  }
+  return undefined
 }
 
 /**

--- a/packages/mcp/src/vocabulary.ts
+++ b/packages/mcp/src/vocabulary.ts
@@ -1,0 +1,235 @@
+/**
+ * Business vocabulary for tool discovery (voyant#3921).
+ *
+ * A travel agent asks for a "client"; the surface calls it a Person. Measured
+ * against the real operator graph, that gap made the two most basic operations
+ * in the product UNREACHABLE: a frontier model asked to add a client searched
+ * "client", got one irrelevant hit (`book_product`), and concluded no such tool
+ * existed — while `create_person` sat right there. Asked to find that client it
+ * gave up after a single call. The capability was present and undiscoverable,
+ * which for an agent is the same as absent.
+ *
+ * These pairs are NOT invented here. They are the alias column of
+ * `UBIQUITOUS_LANGUAGE.md`, the repository's canonical domain vocabulary, which
+ * already records that a Person is also called a customer, a client and a
+ * contact. `vocabulary.test.ts` re-parses that document and fails if the two
+ * drift, so the doc stays the single source of truth and this file stays a
+ * projection of it rather than a second, quietly diverging glossary.
+ *
+ * Aliases containing spaces or parentheses are deliberately excluded: they are
+ * prose ("technical alias only") rather than words a caller would type.
+ */
+
+/** Alias → the canonical domain term(s) it should also match during search. */
+export const VOCABULARY_ALIASES: Readonly<Record<string, readonly string[]>> = {
+  account: ["organization", "user"],
+  action: ["tool"],
+  activated: ["product status"],
+  activity: ["program session"],
+  "add-on": ["extra"],
+  addon: ["extra"],
+  agency: ["operator"],
+  agent: ["mcp server"],
+  agreement: ["channel contract"],
+  "allocation-to-channel": ["allotment"],
+  ap: ["supplier payment"],
+  asset: ["product media", "resource"],
+  attachment: ["product media"],
+  attendee: ["delegate"],
+  audience: ["actor type"],
+  audit: ["reconciliation"],
+  bill: ["invoice"],
+  blackout: ["closeout"],
+  board: ["pipeline"],
+  boilerplate: ["contract template"],
+  book: ["commit"],
+  bookability: ["sellability"],
+  booking: ["trip envelope"],
+  booking_transaction_details: ["booking origin"],
+  "booking-record": ["booking"],
+  bot: ["mcp server"],
+  calendar: ["price schedule"],
+  "cancel-and-rebook": ["booking amendment"],
+  car: ["vehicle"],
+  catalogentry: ["catalog item"],
+  category: ["product family"],
+  chauffeur: ["driver"],
+  "check-in": ["redemption"],
+  checkout: ["payment session"],
+  clause: ["legacy order term"],
+  client: ["organization", "person"],
+  cluster: ["pickup group"],
+  command: ["tool"],
+  company: ["organization"],
+  confirmation: ["service voucher"],
+  connection: ["operator link"],
+  consent: ["policy acceptance"],
+  contact: ["person"],
+  "contact-on-deal": ["participant"],
+  contingent: ["allotment"],
+  coupon: ["travel credit"],
+  customer: ["person"],
+  cut: ["commission rule"],
+  day: ["product day"],
+  deal: ["proposal"],
+  departure: ["slot"],
+  discrepancy: ["reconciliation issue"],
+  distributor: ["channel"],
+  entry: ["admission"],
+  estimate: ["proposal version", "quote"],
+  event: ["activity", "program", "program session"],
+  exception: ["closeout"],
+  experience: ["product"],
+  extension: ["extra"],
+  "fee-rule": ["commission rule"],
+  feed: ["inventory source"],
+  form: ["contract template"],
+  function: ["tool"],
+  funnel: ["pipeline"],
+  gap: ["trip requirement"],
+  group: ["resource pool", "segment"],
+  guest: ["traveler"],
+  "hold-record": ["allocation"],
+  instalments: ["payment schedule"],
+  instance: ["slot"],
+  intent: ["payment session"],
+  issuance: ["fulfillment"],
+  job: ["dispatch"],
+  leg: ["product day"],
+  limit: ["capacity"],
+  line: ["booking item"],
+  list: ["segment"],
+  listing: ["catalog item", "publication"],
+  login: ["user"],
+  mapping: ["publication"],
+  match: ["reconciliation"],
+  max: ["capacity"],
+  "mega-booking": ["composed fit trip"],
+  net: ["cost"],
+  network: ["distribution"],
+  occurrence: ["slot"],
+  offer: ["availabilitycandidate", "trip candidate"],
+  operator: ["driver"],
+  opportunity: ["proposal"],
+  option: ["availabilitycandidate", "hold", "trip candidate"],
+  order: ["booking"],
+  package: ["product", "program"],
+  partner: ["channel"],
+  partnership: ["operator link"],
+  partnerships: ["distribution"],
+  pass: ["admission"],
+  passenger: ["traveler"],
+  pax: ["traveler"],
+  payout: ["supplier payment"],
+  "payout-run": ["settlement"],
+  "person-resource": ["resource"],
+  placeholder: ["trip requirement"],
+  plan: ["payment schedule"],
+  product: ["catalog item", "trip envelope"],
+  project: ["program"],
+  proposal: ["legacy offer", "proposal version", "quote"],
+  provider: ["inventory source", "supplier"],
+  publication: ["channel product mapping"],
+  published: ["product status"],
+  receipt: ["payment"],
+  recurrence: ["availability rule"],
+  "refund-doc": ["credit note"],
+  region: ["market"],
+  registrant: ["delegate"],
+  reservation: ["booking"],
+  "reservation-line": ["allocation"],
+  retail: ["price"],
+  reversal: ["credit note"],
+  revision: ["policy version", "product version"],
+  role: ["actor type", "audience grant"],
+  "role-contact": ["named contact"],
+  row: ["booking item"],
+  run: ["dispatch"],
+  scan: ["redemption"],
+  schedule: ["availability rule"],
+  sell: ["price"],
+  seller: ["operator"],
+  sequence: ["invoice number series"],
+  "sign-event": ["signature"],
+  "sign-off": ["policy acceptance"],
+  slot: ["availabilitycandidate", "trip requirement"],
+  snapshot: ["product version"],
+  "soft-hold": ["hold"],
+  source: ["supplier"],
+  sourcedoffer: ["availabilitycandidate"],
+  status: ["stage"],
+  step: ["stage"],
+  stop: ["pickup point"],
+  storefront: ["channel"],
+  "sub-category": ["product subtype"],
+  "sub-product": ["product option"],
+  supplier: ["inventory source"],
+  tag: ["product subtype"],
+  tariff: ["rate plan"],
+  team: ["resource pool"],
+  tenant: ["operator"],
+  terms: ["policy"],
+  territory: ["market"],
+  theme: ["storefront"],
+  ticket: ["admission"],
+  "ticket-event": ["fulfillment"],
+  tour: ["product"],
+  transaction: ["payment"],
+  trip: ["product"],
+  unit: ["vehicle"],
+  variant: ["product option"],
+  vendor: ["supplier"],
+  vertical: ["product family"],
+  visibility: ["publication"],
+  visible: ["product status"],
+  voucher: ["promotion code", "service voucher", "travel credit"],
+  zone: ["pickup group"],
+}
+
+/**
+ * Expand one lowercased search term into itself plus any canonical terms it is
+ * a known alias for.
+ *
+ * Expansion is ADDITIVE and the caller matches on "any of these appears", so a
+ * search for a word we do not know behaves exactly as before. Nothing is ever
+ * narrowed by this.
+ */
+export function expandSearchTerm(term: string): string[] {
+  // Singularise before lookup. The alias table records "client"; an agent asks
+  // for "clients". Measured against the real graph, that one missing plural sent
+  // `search_tools("clients")` to `identity_named_contact` instead of
+  // `relationships_query`, and the agent concluded the client did not exist —
+  // the same class of false negative the aliases were added to remove, produced
+  // by the aliases themselves not firing.
+  const singular = singularise(term)
+  // The singular is a match target in its own right, not just a lookup key. Tools
+  // are named in the singular (`create_departure`), so a caller typing
+  // "departures" must reach them even when the alias table sends the CANONICAL
+  // term somewhere else entirely — the doc makes Slot canonical and "departure"
+  // its alias, so looking up "departures" yielded ["departures", "slot"] and
+  // matched neither `create_departure` nor `operations_query`. The agent then
+  // reported that no departures were scheduled, from a discovery miss.
+  const forms = singular === term ? [term] : [term, singular]
+  const canonical = VOCABULARY_ALIASES[term] ?? VOCABULARY_ALIASES[singular]
+  if (!canonical) return forms
+  // A canonical term can be multi-word ("supplier payment"); match on each word
+  // so a haystack containing `list_supplier_payments` is reached.
+  return [...forms, ...canonical.flatMap((value) => [value, ...value.split(/\s+/)])]
+}
+
+/**
+ * Crude English singularisation, deliberately.
+ *
+ * A stemmer would be the wrong tool: this only has to undo the plural a caller
+ * types on a domain noun, and the cost of over-stemming is a wrong match, which
+ * is worse than a miss. So it handles the three endings that actually occur in
+ * this vocabulary and leaves everything else alone.
+ */
+function singularise(term: string): string {
+  if (term.endsWith("ies") && term.length > 4) return `${term.slice(0, -3)}y`
+  if (term.endsWith("ses") || term.endsWith("xes") || term.endsWith("ches")) {
+    return term.slice(0, -2)
+  }
+  if (term.endsWith("s") && !term.endsWith("ss")) return term.slice(0, -1)
+  return term
+}

--- a/packages/mcp/tests/server.test.ts
+++ b/packages/mcp/tests/server.test.ts
@@ -1254,6 +1254,38 @@ describe("createMcpApiRoutes", () => {
     expect(bothExposed).toContain("sensitive_record")
   })
 
+  it("accepts a client-namespaced tool name without costing a round trip", async () => {
+    // Models routinely emit `functions.<tool>` — an artifact of their own
+    // tool-calling layer, not of this surface. Measured against the real graph it
+    // cost a wasted call in nearly every write journey: dispatch failed, the agent
+    // read the "call it as X" hint, and repeated itself. Unambiguous to accept,
+    // because no tool name here contains a dot.
+    const app = appWithScopes(["products:read", "secrets:read"])
+    const res = await readRpc(
+      await app.request(
+        "/",
+        rpc("tools/call", {
+          name: "call_tool",
+          arguments: { name: "functions.test_query", arguments: { resource: "echoes" } },
+        }),
+      ),
+    )
+    expect((res.result as { isError?: boolean })?.isError).not.toBe(true)
+  })
+
+  it("still reports the name the caller actually sent when it cannot resolve", async () => {
+    // The hint is only useful if it echoes what was typed; resolving internally
+    // must not rewrite the error into a name the caller never used.
+    const app = appWithScopes(["products:read"])
+    const res = await readRpc(
+      await app.request(
+        "/",
+        rpc("tools/call", { name: "call_tool", arguments: { name: "functions.nope_at_all" } }),
+      ),
+    )
+    expect(JSON.stringify(res.result)).toContain("functions.nope_at_all")
+  })
+
   it("narrows a query descriptor to one resource when describe_tool is given one", () => {
     // Collapsing the reads (voyant#3932) moved the discovery bill rather than
     // removing it: a query descriptor is the union of every member's input schema,

--- a/packages/mcp/tests/vocabulary.test.ts
+++ b/packages/mcp/tests/vocabulary.test.ts
@@ -1,0 +1,118 @@
+/**
+ * The search vocabulary stays a projection of UBIQUITOUS_LANGUAGE.md.
+ *
+ * `vocabulary.ts` exists because a travel agent asks for a "client" and the
+ * surface calls it a Person — a gap that made `create_person` unreachable for a
+ * frontier model. The fix is only durable if the alias table cannot silently
+ * drift from the document it was derived from, so this re-parses that document
+ * and fails when a term gains an alias nobody projected.
+ */
+import { readFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+
+import { expandSearchTerm, VOCABULARY_ALIASES } from "../src/vocabulary.js"
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../../..")
+
+/**
+ * Rows are `| **Term** | description | *alias, alias* |`. Aliases containing a
+ * space or a parenthesis are prose ("technical alias only", "booking draft when
+ * referring to…") rather than words a caller types, and are excluded from the
+ * projection — so they are excluded here too, or the check would demand entries
+ * that would never match anything.
+ */
+function aliasesFromDoc(): Map<string, Set<string>> {
+  const md = readFileSync(join(REPO_ROOT, "UBIQUITOUS_LANGUAGE.md"), "utf8")
+  const rows = [...md.matchAll(/^\|\s*\*\*([^*]+)\*\*\s*\|([^|]*)\|\s*\*([^*]+)\*/gm)]
+  const map = new Map<string, Set<string>>()
+  for (const [, term, , aliasCell] of rows) {
+    const canonical = (term ?? "").trim().toLowerCase()
+    for (const raw of (aliasCell ?? "").split(",")) {
+      const alias = raw.trim().toLowerCase()
+      if (!alias || alias.includes("(") || alias.includes(" ")) continue
+      if (alias === canonical) continue
+      const set = map.get(alias) ?? new Set<string>()
+      set.add(canonical)
+      map.set(alias, set)
+    }
+  }
+  return map
+}
+
+describe("search vocabulary", () => {
+  it("covers every single-word alias the ubiquitous language defines", () => {
+    const doc = aliasesFromDoc()
+    // Guard the guard: a regex that silently stopped matching would make this
+    // test vacuously pass and let the vocabulary rot unnoticed.
+    expect(doc.size).toBeGreaterThan(100)
+
+    const missing: string[] = []
+    for (const [alias, canonical] of doc) {
+      const projected = VOCABULARY_ALIASES[alias]
+      if (!projected) {
+        missing.push(alias)
+        continue
+      }
+      for (const term of canonical) {
+        if (!projected.includes(term)) missing.push(`${alias}→${term}`)
+      }
+    }
+    expect(
+      missing.sort(),
+      "UBIQUITOUS_LANGUAGE.md gained aliases that packages/mcp/src/vocabulary.ts does not " +
+        "project. Add them, or an agent using that business word will not find the tool.",
+    ).toEqual([])
+  })
+
+  it("maps the business words a travel agent actually types", () => {
+    // The specific failures measured against the real operator graph. These are
+    // not illustrative — each one is a journey that could not complete.
+    expect(expandSearchTerm("client")).toContain("person")
+    expect(expandSearchTerm("customer")).toContain("person")
+    expect(expandSearchTerm("company")).toContain("organization")
+    expect(expandSearchTerm("guest")).toContain("traveler")
+    expect(expandSearchTerm("pax")).toContain("traveler")
+    expect(expandSearchTerm("reservation")).toContain("booking")
+  })
+
+  it("resolves the plural a caller actually types", () => {
+    // The measured failure: search_tools("clients") missed the alias entirely and
+    // routed to identity tools, so the agent reported the client did not exist.
+    expect(expandSearchTerm("clients")).toContain("person")
+    expect(expandSearchTerm("customers")).toContain("person")
+    expect(expandSearchTerm("companies")).toContain("organization")
+    expect(expandSearchTerm("reservations")).toContain("booking")
+  })
+
+  it("keeps the singular as a match target, not just a lookup key", () => {
+    // The measured failure: the doc makes Slot canonical with "departure" as its
+    // alias, so "departures" expanded to ["departures", "slot"] and matched
+    // neither `create_departure` nor `operations_query`. The agent then told the
+    // user no departures were scheduled — a business claim from a search miss.
+    const forms = expandSearchTerm("departures")
+    expect(forms).toContain("departure")
+    expect(forms).toContain("departures")
+  })
+
+  it("does not over-singularise a word ending in double-s", () => {
+    // "address" must not become "addres". Over-stemming produces a WRONG match,
+    // which is worse than the miss it was meant to fix.
+    expect(expandSearchTerm("address")).toEqual(["address"])
+  })
+
+  it("leaves an unknown term exactly as it was", () => {
+    // Expansion must only ever widen. A term we have no alias for has to behave
+    // identically to before this existed, or every unrecognised search changes.
+    expect(expandSearchTerm("transfagarasan")).toEqual(["transfagarasan"])
+  })
+
+  it("splits a multi-word canonical term so a snake_case tool name is reachable", () => {
+    // "ap" → "supplier payment" only helps if `list_supplier_payments` matches,
+    // which needs the words individually.
+    const forms = expandSearchTerm("ap")
+    expect(forms).toContain("supplier")
+    expect(forms).toContain("payment")
+  })
+})

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -55,6 +55,7 @@ export {
   type HandlerAdmissionIdentityHint,
   withServerResolvedIdempotencyKey,
 } from "./handler-action-policy.js"
+export { boundedEditDistance, findNearMatches, type NearMatches } from "./near-matches.js"
 export {
   assertSingleToolsPackageInstance,
   DUPLICATE_TOOLS_INSTANCE_REMEDIATION,

--- a/packages/tools/src/near-matches.ts
+++ b/packages/tools/src/near-matches.ts
@@ -1,0 +1,101 @@
+/**
+ * Near-match suggestion for name-shaped arguments (voyant#3950).
+ *
+ * `ToolError` has carried `candidates` and `didYouMean` since voyant#3947, but
+ * nothing populated them, so both were dead. The one place a candidate set is
+ * genuinely free is a lookup against a registry that is already in memory —
+ * a tool name, a resource name, an operation name — which is also where an agent
+ * fails most often, because it types the name from memory or from a description.
+ */
+
+/**
+ * Damerau-Levenshtein distance, capped: returns `max + 1` as soon as the true
+ * distance is known to exceed `max`.
+ *
+ * The cap is what makes this safe to run against a few hundred names on an error
+ * path. A short row is cheap, and the early exit skips the rest of a name that
+ * has already diverged too far to suggest.
+ *
+ * Transpositions count as one edit, not two, because the mistakes this exists to
+ * catch are typing mistakes: `get_bokoing` should reach `get_booking`.
+ */
+export function boundedEditDistance(left: string, right: string, max: number): number {
+  if (left === right) return 0
+  if (Math.abs(left.length - right.length) > max) return max + 1
+
+  let previous = Array.from({ length: right.length + 1 }, (_, i) => i)
+  let beforePrevious: number[] = []
+
+  for (let i = 1; i <= left.length; i += 1) {
+    const current = [i, ...Array.from<number>({ length: right.length }).fill(0)]
+    let rowMin = current[0] as number
+    for (let j = 1; j <= right.length; j += 1) {
+      const cost = left[i - 1] === right[j - 1] ? 0 : 1
+      let value = Math.min(
+        (current[j - 1] as number) + 1,
+        (previous[j] as number) + 1,
+        (previous[j - 1] as number) + cost,
+      )
+      if (
+        i > 1 &&
+        j > 1 &&
+        left[i - 1] === right[j - 2] &&
+        left[i - 2] === right[j - 1] &&
+        beforePrevious.length > 0
+      ) {
+        value = Math.min(value, (beforePrevious[j - 2] as number) + 1)
+      }
+      current[j] = value
+      if (value < rowMin) rowMin = value
+    }
+    // Every later row is >= this row's minimum, so once the whole row exceeds
+    // the cap the final distance does too.
+    if (rowMin > max) return max + 1
+    beforePrevious = previous
+    previous = current
+  }
+  return previous[right.length] as number
+}
+
+/** How close a name must be to be worth suggesting, scaled to its length. */
+function toleranceFor(name: string): number {
+  if (name.length <= 4) return 1
+  if (name.length <= 8) return 2
+  return 3
+}
+
+export interface NearMatches {
+  /** Names close enough to suggest, nearest first. Empty when nothing is close. */
+  candidates: string[]
+  /** The single nearest name, when one is clearly closest. */
+  didYouMean?: string
+}
+
+/**
+ * Find the names closest to `name` among `known`.
+ *
+ * Returns at most `limit` because the point is a suggestion an agent can act on,
+ * not a directory listing — dumping every registered name into an error is what
+ * this replaces, and it costs more context than it saves.
+ *
+ * `didYouMean` is set only when the nearest match is strictly nearer than the
+ * runner-up. Two equally-close names mean we do not actually know which was
+ * intended, and asserting one would send the agent confidently to the wrong tool.
+ */
+export function findNearMatches(name: string, known: Iterable<string>, limit = 5): NearMatches {
+  const tolerance = toleranceFor(name)
+  const scored: Array<{ name: string; distance: number }> = []
+  for (const candidate of known) {
+    if (candidate === name) continue
+    const distance = boundedEditDistance(name, candidate, tolerance)
+    if (distance <= tolerance) scored.push({ name: candidate, distance })
+  }
+  scored.sort((a, b) => a.distance - b.distance || a.name.localeCompare(b.name))
+
+  const candidates = scored.slice(0, limit).map(({ name: n }) => n)
+  const nearest = scored[0]
+  const runnerUp = scored[1]
+  const unambiguous =
+    nearest !== undefined && (runnerUp === undefined || runnerUp.distance > nearest.distance)
+  return unambiguous ? { candidates, didYouMean: nearest.name } : { candidates }
+}

--- a/packages/tools/tests/near-matches.test.ts
+++ b/packages/tools/tests/near-matches.test.ts
@@ -1,0 +1,63 @@
+/**
+ * voyant#3950: near-match suggestions for an unregistered tool name.
+ *
+ * The behaviour worth pinning is not "finds close names" but the two judgement
+ * calls around it — that an ambiguous nearest match does NOT become a confident
+ * `didYouMean`, and that a name with nothing close returns nothing rather than
+ * the whole registry.
+ */
+import { describe, expect, it } from "vitest"
+
+import { boundedEditDistance, findNearMatches } from "../src/near-matches.js"
+
+describe("boundedEditDistance", () => {
+  it("counts a transposition as one edit", () => {
+    // The mistakes this exists to catch are typing mistakes, and treating a
+    // swap as two edits pushes the name it should have found out of tolerance.
+    expect(boundedEditDistance("get_bokoing", "get_booking", 3)).toBe(1)
+  })
+
+  it("stops early instead of computing a distance it will not use", () => {
+    // The contract is only "greater than max", not the true distance.
+    expect(boundedEditDistance("aaaaaaaa", "zzzzzzzz", 2)).toBeGreaterThan(2)
+  })
+
+  it("is zero for an exact match", () => {
+    expect(boundedEditDistance("list_bookings", "list_bookings", 3)).toBe(0)
+  })
+})
+
+describe("findNearMatches", () => {
+  const KNOWN = ["list_bookings", "get_booking", "create_booking", "list_products", "get_product"]
+
+  it("suggests the intended name for a typo", () => {
+    const { candidates, didYouMean } = findNearMatches("get_bokoing", KNOWN)
+    expect(didYouMean).toBe("get_booking")
+    expect(candidates).toContain("get_booking")
+  })
+
+  it("withholds didYouMean when two names are equally close", () => {
+    // "get_bookings" is one edit from `get_booking` (drop the s) and one from
+    // `list_bookings` is not — construct a genuine tie instead.
+    const tie = findNearMatches("xat", ["cat", "bat"])
+    expect(tie.didYouMean).toBeUndefined()
+    // Both still offered — the agent picks, rather than being sent confidently
+    // to whichever happened to sort first.
+    expect(tie.candidates).toEqual(["bat", "cat"])
+  })
+
+  it("returns nothing when no name is close", () => {
+    // The failure mode being replaced: dumping every registered name into the
+    // error. Nothing close must mean nothing returned, not everything returned.
+    expect(findNearMatches("completely_unrelated_zzz", KNOWN)).toEqual({ candidates: [] })
+  })
+
+  it("caps how many candidates it offers", () => {
+    const many = Array.from({ length: 40 }, (_, i) => `get_thing${i}`)
+    expect(findNearMatches("get_thing", many, 5).candidates).toHaveLength(5)
+  })
+
+  it("never suggests the name that was asked for", () => {
+    expect(findNearMatches("get_booking", KNOWN).candidates).not.toContain("get_booking")
+  })
+})


### PR DESCRIPTION
Second of three PRs splitting work orphaned when #4254 merged early.
**Discovery only** — no write paths, no action policy. Companion to #4313, which
is the instrument that measured all of this.

## The finding

Against the **real operator graph, real database, real model**, the two most
basic travel-agent operations were unreachable:

> *"I couldn't find a specific tool to add a new private client directly."*

`create_person`, `update_person` and `relationships_query` were all in the
registry, authorized and callable. The agent simply could not find them.

**The cause is vocabulary.** `search_tools` matched substrings of tool names, so
it answered only to the word the *domain* uses. An agent says client, customer,
company, guest, pax, reservation. The surface says person, organization,
traveler, booking. **Capability that cannot be found is, to an agent,
indistinguishable from capability that does not exist.**

The pairs aren't invented here — `UBIQUITOUS_LANGUAGE.md` already recorded that a
Person is also *"customer, client, contact"*. It was written down and never
reached the search index. A test re-parses that doc so the two can't drift.

| query | before | after |
|---|---|---|
| `client` | 1 (irrelevant) | **18** — incl. `create_person` |
| `customer` | 5 (none relevant) | **13** — incl. `create_person`, `update_person` |
| `reservation` | — | **25** — incl. `create_booking`, `cancel_booking` |

Plurals matter: `"clients"` missed the table entirely and routed to identity
tools. And the singular has to be a *match target*, not just a lookup key — the
doc makes Slot canonical with "departure" as an alias, so `"departures"` expanded
to `["departures","slot"]` and matched neither `create_departure` nor
`operations_query`.

## Four more, each from a measured failure

- **A no-hit search returns the query tools** instead of an empty list. A bare
  `{ total: 0, tools: [] }` read as *"the record does not exist"*, and the agent
  told the user there were no records for a product that was right there. Three
  richer variants (advisory block, `exactMatch` flag, worked example) are
  recorded in-code as **not working** — anything leading with the miss reads as a
  refusal.
- **Client-namespaced names resolve.** Models emit `functions.book_product`; the
  hint alone cost a wasted round trip in nearly every write journey.
- **Unknown names get near-match `candidates` + `didYouMean`**, replacing a
  message that inlined all ~270 registered names as one comma-joined string.
- **The server instructions name the CRM.** The overview listed catalog,
  pipeline, bookings and invoices and never mentioned People — so the agent
  concluded the CRM didn't exist and searched `bookings_query`, reproducibly 3/3.

The guide gains the sellable-product recipe (four Tools in order, and why the
three lookalikes aren't it), and states **Travelers are supplied inline and need
not be CRM People** — that took booking's failure code from `NOT_FOUND` (refusing
to book a companion it couldn't find in the CRM) to a plain confirmation step.

## Cost went down too

The query projection stopped repeating the `_voyant` control object on **every
branch** of its discriminated union — `bookings_query` carried it 22 times for a
read-only tool that cannot use any of those controls.

Real-surface discovery **54,661 → 43,560 tokens**, and the ceiling comes **down
to 48,000 — below where it stood before this work**.

## Verification

- `packages/tools` 79 tests, `packages/mcp` 90 tests, both build clean
- operator ratchets pass (one unrelated pre-existing timeout flake on an
  unmodified file under machine load; passes on re-run)

## Follow-up

**B — write protocol**: server-side idempotency across five creates, ungating
`request_action_approval`, error-message splits, `configure_option_units` removal.