### PR TITLE
Table privacy targets a bypassed gate, not zero — and restore AGENTS.md content lost to a stale merge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,10 +59,92 @@ it names the only paths (globs allowed) that may reference the symbol, so a new
 file anywhere else fails on its own. An authority wants `onlyIn`: it is the
 difference between guarding the meaning and guarding a list of filenames.
 
-Two run as ratchets, holding a line rather than demanding it be clean today:
-`verify:table-privacy` (cross-module table reach-ins) and
-`verify:package-descriptions`. **Their baselines may only shrink.** Regenerate
-one only when tightening it; never to make a failure go away.
+Three run as ratchets, holding a line rather than demanding it be clean today:
+`verify:table-privacy` (cross-module table reach-ins),
+`verify:package-descriptions`, and `verify:typecheck-coverage`. **Their
+baselines may only shrink.** Regenerate one only when tightening it; never to
+make a failure go away.
+
+`verify:table-privacy` carries **184 reach-ins across 35 module pairs**, of which
+**38 are cross-module WRITES**, counted separately in the baseline's `writePairs`.
+
+**The goal is not zero, and it is not decoupling.** ADR-0016 made modules
+components of one deployable, so "so they can ship separately" is not a reason
+for anything. Cross-package FKs are settled separately and are fine when
+`requiresSchemas`-backed. What is left is one question, asked per site:
+
+> **Does the owning module do something on its own writes that this bypasses?**
+
+Measured, the answer varies enough that a single number is misleading:
+
+| pair | writes | owner's gate |
+|---|---|---|
+| `inventory->commerce` | 16 | **real** — `createOptionPriceRule` validates, demotes other defaults, emits `ruleChanged`. A direct write can leave **two default rules** in one scope |
+| `apps->custom-fields` | 2 | **real** — 403 when a definition is owned by someone else, plus value lifecycle on key rename |
+| `finance->bookings` | 12 | **weak** — bookings' own update is the same `revision + 1` statement, with no validation, event or hook to bypass |
+| audit-log appends | — | **none** — append-only tables; the value in routing them was removing duplicated row shapes, not encapsulation |
+
+So convert a write when the owner has a gate, and leave it when it does not.
+Routing `finance->bookings` through a service that adds nothing is the ADR-0007
+indirection ADR-0016 rejected, and it would cost a hop to buy a smaller number.
+
+Reads follow the same test and mostly fail it: a cross-module read is type-safe
+and `tsc` finds every caller on a rename. A `*Ref` mirror earns its place when it
+documents a genuinely narrow view, not as a target to hit 184 times.
+
+**The ratchet's job is drift, not cleanup.** No new pair, no new write. That is
+cheap and it holds the line; the number falling is a side effect of someone
+fixing a real gate, not a goal in itself.
+
+`verify:typecheck-coverage` enforces that every test file is typechecked by some
+CI job. A package whose tsconfig includes only `src/**` gets no typecheck job at
+all — `build` still checks its `src`, but nothing checks its tests, so a fixture
+may drift from the type it claims to match and the test still passes. 56
+packages carry 844 such test files today ([#4244](https://github.com/voyant-travel/voyant/issues/4244));
+the baseline is on **membership**, so a listed package may still gain tests but
+an unlisted one may never start. Fix a package with the tsconfig split from
+[#4243](https://github.com/voyant-travel/voyant/pull/4243):
+
+- `tsconfig.json` — shared/editor project, `include: ["src/**/*", "tests/**/*"]`,
+  **no** `outDir`/`rootDir`
+- `tsconfig.build.json` — stands alone, re-declares the emit geometry and
+  `include: ["src/**/*"]` so tests never reach `dist`
+- `tsconfig.typecheck.json` — unchanged; inherits the wider include
+
+Widening `tsconfig.typecheck.json` directly instead produces `TS6059` wherever a
+test imports a sibling package by relative path, because `rootDir: "src"` is
+inherited. Moving the emit geometry out of the shared project is what resolves
+it.
+
+### A checker reads the tracked tree, not the working directory
+
+A checker that walks the filesystem from the repository root sees whatever is on
+disk: a git worktree parked in the root, a leftover directory from a deleted
+package, a stale `.tsbuildinfo`. None of that is this tree's source and none of
+it exists in CI's checkout.
+
+It fails in both directions, and the second is the one that hurts:
+
+- **false red** — fails locally on content CI never sees, which teaches everyone
+  to dismiss the checker, including when it is right
+- **false green** — resolves *another* checkout's files and validates those,
+  reporting success while this tree is broken
+
+The false green is not hypothetical. `verify:retail-spine-closure` printed
+"Verified retail spine package closure" against `worktrees/<branch>/packages/*`
+while this tree carried a forbidden edge, and only CI caught it
+([#4281](https://github.com/voyant-travel/voyant/pull/4281)).
+
+Use `trackedFilesIn(root)` from `scripts/lib/tracked-files.mjs`. It returns the
+git listing when `root` is the repository toplevel and **null** otherwise, so a
+checker driven over a `--root <fixture>` tree keeps walking — a fixture is not a
+repository, and silently finding nothing there would turn its own vacuity tests
+green while checking nothing.
+
+`verify:tracked-tree-scan` holds the line: it plants an untracked worktree in the
+repo root and asserts each converted checker ignores it, paired with an assertion
+that one still goes red on a tracked violation. Only the pair means anything — a
+checker that ignored everything would pass the first half.
 
 ### Converting an authority script you are already editing
 
@@ -83,10 +165,29 @@ substring.** You already have the context loaded; converting cold costs far more
 Some assertions are none of these — they pin a call shape or a signature inside a
 factory. Leave those alone rather than forcing a fit, and say so in the PR.
 
-There is deliberately **no campaign** to convert the rest. The corpus shrinks as
-a side effect of normal work, which is cheaper than a sweep and puts each
-conversion in the hands of someone who knows what the module does. See
-[#3898](https://github.com/voyant-travel/voyant/issues/3898).
+There is deliberately **no campaign** to convert the rest, because converting
+cold costs far more than converting while you already have the module loaded.
+See [#3898](https://github.com/voyant-travel/voyant/issues/3898).
+
+**Do not read that as a shrink plan.** It is not one, and measuring it says so.
+Between ADR-0016 (2026-07-30) and 2026-08-05 the corpus went 47 scripts / 5,578
+lines / 38 using `.includes()` → **47 / 5,522 / 38**: not one script retired,
+while `verify:architecture` grew from 62 chain links to 80. Opportunistic
+conversion is real but it does not keep pace with new checks, so the imperative
+corpus is flat and the chain is growing.
+
+What actually holds the line is the **new-check rule** below, not attrition.
+
+### A new architecture check is declarative by default
+
+Add a rule to an existing rule file, or add a new rule file. Reach for a new
+`scripts/check-*.mjs` only when the rule cannot be expressed as data — it pins a
+call shape, a signature inside a factory, or needs a TypeScript program — and
+**say which in the PR description**.
+
+This is the half of the problem that is moving. A declarative rule costs one
+line to extend and cannot rot into substring matching; an imperative script is a
+permanent line item in a 80-link chain.
 
 ## Local Verification Lanes
 

--- a/scripts/checks/schema/table-privacy-runner.ts
+++ b/scripts/checks/schema/table-privacy-runner.ts
@@ -119,8 +119,7 @@ function main(): void {
   const writeTotal = [...writeCounts.values()].reduce((sum, n) => sum + n, 0)
   console.log(
     `verify:table-privacy: ${total} reach-ins across ${counts.size} pairs, none new. ` +
-      `Of those, ${writeTotal} are cross-module WRITES across ${writeCounts.size} pairs — ` +
-      "these have no mirror answer and should reach zero.",
+      `Of those, ${writeTotal} are cross-module WRITES across ${writeCounts.size} pairs.`,
   )
 }
 
@@ -129,11 +128,15 @@ const BASELINE_COMMENT = [
   "A pair may shrink, never grow; a new pair fails. Regenerate with --update-baseline",
   "ONLY when tightening. Foundation packages (db, core, utils, types, schema-kit) are exempt.",
   "",
-  "`writePairs` counts the subset that MUTATE another module's tables. A read has",
-  "two answers — the owner's service, or a local *Ref mirror. A write has one: a",
-  "mirror is read-only by construction. Writes bypass whatever the owner does on",
-  "its own writes (revision bumps, validation, events), so they should reach zero",
-  "rather than merely stop growing.",
+  "`writePairs` counts the subset that MUTATE another module's tables, which a",
+  "*Ref mirror cannot answer — a mirror is read-only by construction.",
+  "",
+  "The target is NOT zero. Convert a write when the owning module does something",
+  "on its own writes that a direct write bypasses — validation, an invariant, an",
+  "event. inventory->commerce qualifies (a direct write can leave two default",
+  "pricing rules in one scope); finance->bookings does not (bookings' own update",
+  "is the same `revision + 1` with no gate). This ratchet exists to stop DRIFT,",
+  "not to be driven down: no new pair, no new write.",
 ]
 
 /** Adds an import binding, stripping an `x as y` alias to its local name. */


### PR DESCRIPTION
Part of #4266. Step 1 of 3 — the framing is wrong and is currently pointing the next person at the wrong 20 writes.

## 1. Restores AGENTS.md content lost to a stale-branch merge

#4313 branched from a `main` that predated #4276, #4282 and #4286. Merging it removed **111 lines** and took four sections with it:

- the tracked-tree scan rule (#4282)
- the `verify:typecheck-coverage` ratchet documentation
- the declarative-by-default rule for new checks (#4276)
- the cross-module write documentation (#4286)

241 lines → 157. No conflict was raised because the file was edited wholesale rather than in place.

**#4313's own addition is kept verbatim** — "Reading a build result correctly", on `$?` after a pipe and on not switching branches under a running `tsc`. It is a good section and it cost me an hour today in precisely the way it describes.

## 2. Corrects the write framing, which I wrote and cannot support

#4286 said writes **"should reach zero"**. I checked what the owning modules actually do on their own writes, and that does not hold:

| pair | writes | owner's gate |
|---|---|---|
| `inventory->commerce` | 16 | **real** — `createOptionPriceRule` validates, demotes other defaults, emits `ruleChanged`. A direct write can leave **two default rules** in one scope. |
| `apps->custom-fields` | 2 | **real** — 403 when a definition belongs to another owner, plus value lifecycle on key rename. |
| `finance->bookings` | 12 | **weak** — bookings' own update is the same `revision + 1` statement. No validation, no event, no hook to bypass. |
| audit-log appends | — | **none** — append-only tables. Routing them removed duplicated row shapes, which is DRY, not encapsulation. |

So the test is per site — *does the owner do something a direct write bypasses* — not a count to drive down. Routing `finance->bookings` through a service that adds nothing is the ADR-0007 indirection ADR-0016 rejected, bought with an extra hop.

The same test applies to reads, and they mostly fail it: a cross-module read is type-safe, and `tsc` finds every caller on a rename. **184 is not a backlog.**

The ratchet keeps its real job: **no new pair, no new write.** Drift, not cleanup.

## What this changes downstream

The next work is `inventory->commerce` (16) and `apps->custom-fields` (2) — 18 writes with a concrete bug behind them — and **not** `finance->bookings`, which was the larger-looking number and is the one to leave alone.

## Verification

```
table-privacy         184 / 35 pairs; 38 writes / 6 pairs
table-privacy tests   15 pass
AGENTS.md             157 -> 258 lines; all four lost sections restored,
                      #4313's build-result section retained
```

Docs and checker output only — no behaviour change, no changeset.
