### PR TITLE
Every cross-module write pair read — none clear the bar, and the reasoning now lives with the data

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,22 +75,28 @@ for anything. Cross-package FKs are settled separately and are fine when
 
 > **Does the owning module do something on its own writes that this bypasses?**
 
-Measured, the answer varies enough that a single number is misleading:
+**Every pair has now been read, and none of them clear it.** The per-pair verdict
+and its evidence live in `writeNotes` in the baseline file, next to the counts:
 
-| pair | writes | owner's gate |
-|---|---|---|
-| `inventory->commerce` | 16 | **real** — `createOptionPriceRule` validates, demotes other defaults, emits `ruleChanged`. A direct write can leave **two default rules** in one scope |
-| `apps->custom-fields` | 2 | **real** — 403 when a definition is owned by someone else, plus value lifecycle on key rename |
-| `finance->bookings` | 12 | **weak** — bookings' own update is the same `revision + 1` statement, with no validation, event or hook to bypass |
-| audit-log appends | — | **none** — append-only tables; the value in routing them was removing duplicated row shapes, not encapsulation |
+- **inventory->commerce (16)** and **inventory->operations (4)** — all in
+  `inventory/src/authoring`, all writing into a product scope they just created.
+  `demoteOtherDefaultRules` is a no-op in a fresh scope, so the single-default
+  invariant cannot be broken by a pre-existing row.
+- **finance->bookings (12)**, **commerce->bookings (2)**, **commerce->finance
+  (2)** — the same statements the owner runs itself, with no validation, event
+  or hook around them.
+- **apps->custom-fields (2)** — lifecycle transitions on definitions the app
+  already owns; custom-fields has no lifecycle method or gate at all.
 
-So convert a write when the owner has a gate, and leave it when it does not.
-Routing `finance->bookings` through a service that adds nothing is the ADR-0007
-indirection ADR-0016 rejected, and it would cost a hop to buy a smaller number.
+So the number is not a backlog and should not be driven down. Converting any of
+these buys a hop and nothing else, which is the ADR-0007 indirection ADR-0016
+rejected. Re-examine a pair when its **owner grows a gate** — not when the count
+moves.
 
-Reads follow the same test and mostly fail it: a cross-module read is type-safe
-and `tsc` finds every caller on a rename. A `*Ref` mirror earns its place when it
-documents a genuinely narrow view, not as a target to hit 184 times.
+Reads follow the same test and mostly fail it too: a cross-module read is
+type-safe, and `tsc` finds every caller on a rename. A `*Ref` mirror earns its
+place when it documents a genuinely narrow view, not as a target to hit 184
+times.
 
 **The ratchet's job is drift, not cleanup.** No new pair, no new write. That is
 cheap and it holds the line; the number falling is a side effect of someone

--- a/scripts/checks/schema/table-privacy-baseline.json
+++ b/scripts/checks/schema/table-privacy-baseline.json
@@ -4,11 +4,15 @@
     "A pair may shrink, never grow; a new pair fails. Regenerate with --update-baseline",
     "ONLY when tightening. Foundation packages (db, core, utils, types, schema-kit) are exempt.",
     "",
-    "`writePairs` counts the subset that MUTATE another module's tables. A read has",
-    "two answers — the owner's service, or a local *Ref mirror. A write has one: a",
-    "mirror is read-only by construction. Writes bypass whatever the owner does on",
-    "its own writes (revision bumps, validation, events), so they should reach zero",
-    "rather than merely stop growing."
+    "`writePairs` counts the subset that MUTATE another module's tables, which a",
+    "*Ref mirror cannot answer — a mirror is read-only by construction.",
+    "",
+    "The target is NOT zero. Convert a write when the owning module does something",
+    "on its own writes that a direct write bypasses — validation, an invariant, an",
+    "event. inventory->commerce qualifies (a direct write can leave two default",
+    "pricing rules in one scope); finance->bookings does not (bookings' own update",
+    "is the same `revision + 1` with no gate). This ratchet exists to stop DRIFT,",
+    "not to be driven down: no new pair, no new write."
   ],
   "pairs": {
     "accommodations->bookings": 2,
@@ -54,5 +58,20 @@
     "finance->bookings": 12,
     "inventory->commerce": 16,
     "inventory->operations": 4
+  },
+  "writeNotes": {
+    "$comment": [
+      "Per-pair verdict on the gate test: does the owning module do something on",
+      "its own writes that a direct write bypasses? Every pair below was read.",
+      "Recorded so the answer is not re-derived, and so the counts are not mistaken",
+      "for a backlog. Re-examine a pair when its OWNER grows a gate, not when the",
+      "count changes."
+    ],
+    "inventory->commerce": "No. Every site is inventory/src/authoring — clone-pricing, clone-content, builder — and all write into a product scope they just created (builder.ts inserts the product, then rules under that id; clone maps each source optionId to a fresh target). demoteOtherDefaultRules is a no-op in a fresh scope, so the single-default invariant cannot be broken by a pre-existing row. emitRuleChanged is optional even in commerce's own path (`if (!eventBus) return`).",
+    "finance->bookings": "No. bookings' own update is the same statement finance's is — `.set({ ..., revision: revision + 1 })` — with no validation, event or hook around it. finance uses the action ledger more than bookings does (18 files vs 3). Routing these through a service would add a hop and buy nothing.",
+    "inventory->operations": "No. Same authoring path as inventory->commerce: availability rules, slots and start-times materialized for a product being created or cloned.",
+    "apps->custom-fields": "No. Both sites are lifecycle transitions on definitions the app already owns, scoped by ownerKind/ownerId/namespace. custom-fields has no lifecycle-transition method and no gate around lifecycleState; apps is in fact its primary writer. The 403 ownership check guards updateDefinition, a different operation.",
+    "commerce->bookings": "No. One `.set({ internalNotes, revision: revision + 1 })`, identical in shape to bookings' own; one audit-log append.",
+    "commerce->finance": "No. bookingItemTaxLines delete + insert with onConflictDoNothing — the same raw statements finance runs itself in service-booking-item-billing.ts."
   }
 }

--- a/scripts/checks/schema/table-privacy-runner.ts
+++ b/scripts/checks/schema/table-privacy-runner.ts
@@ -89,6 +89,10 @@ function main(): void {
           $comment: BASELINE_COMMENT,
           pairs: Object.fromEntries([...counts].sort()),
           writePairs: Object.fromEntries([...writeCounts].sort()),
+          // Carried through verbatim. These are read conclusions, not derived
+          // data — regenerating the counts must not silently discard the reason
+          // a pair is on the list.
+          ...(manifest.writeNotes ? { writeNotes: manifest.writeNotes } : {}),
         },
         null,
         2,


### PR DESCRIPTION
Part of #4266. Step 2 of the plan agreed in #4317 — which turned out to have no work in it.

## What I set out to do

#4317 said the next work was `inventory->commerce` (16) and `apps->custom-fields` (2) — 18 writes with a concrete bug behind them — and that `finance->bookings` (12) should be left alone.

I applied the gate test to all six pairs, one call site at a time. **The answer is no in every case.**

## The verdicts

| pair | writes | why it does not qualify |
|---|---|---|
| `inventory->commerce` | 16 | Every site is `inventory/src/authoring`. `builder.ts` **inserts the product**, then writes rules under that fresh id; `clone-pricing` maps each source `optionId` to a new target. `demoteOtherDefaultRules` is a no-op in a fresh scope, so the single-default invariant cannot be broken by a pre-existing row. `emitRuleChanged` is optional even in commerce's own path (`if (!eventBus) return`). |
| `inventory->operations` | 4 | Same authoring path — availability rules, slots, start-times for a product being created or cloned. |
| `finance->bookings` | 12 | The same statement the owner runs itself: `.set({ ..., revision: revision + 1 })`, no validation, event or hook. |
| `commerce->bookings` | 2 | One identical `revision + 1` update; one audit-log append. |
| `commerce->finance` | 2 | `bookingItemTaxLines` delete + insert with `onConflictDoNothing` — the same raw statements finance runs in `service-booking-item-billing.ts`. |
| `apps->custom-fields` | 2 | Lifecycle transitions on definitions the app already owns, scoped by `ownerKind`/`ownerId`/`namespace`. custom-fields has **no** lifecycle-transition method and no gate around `lifecycleState`; apps is in fact its primary writer. |

## Where I went wrong in #4317

I called `inventory->commerce` and `apps->custom-fields` real gates on the strength of reading the **owners'** service methods — `createOptionPriceRule` does validate and demote and emit; `updateDefinition` does throw 403. Both are true and both are irrelevant, because the callers are not performing those operations. Reading the call sites reversed both verdicts.

That is the rule doing its job. It filtered out 18 conversions that would have bought a hop and nothing else.

## What lands here

No code conversions. The verdicts and their evidence go into **`writeNotes`** in the baseline, next to the counts, so the reasoning sits with the data instead of in a commit message someone has to go find.

`--update-baseline` now carries that key through verbatim. It dropped it before — which would have discarded the analysis on the next regenerate with nobody noticing. That is the same class of silent-loss bug as the AGENTS.md clobber in #4317, so it seemed worth closing properly rather than trusting the next person to re-add it.

## Verification

```
table-privacy         184 / 35 pairs; 38 writes / 6 pairs
writeNotes survive --update-baseline   7 keys
table-privacy tests   15 pass
```

Docs and checker output only — no behaviour change, no changeset.
