### PR TITLE
Retire the duplicated retired-path arrays from seven authority scripts

### DIFF
--- a/scripts/check-custom-fields-settings-authority.mjs
+++ b/scripts/check-custom-fields-settings-authority.mjs
@@ -148,18 +148,6 @@ if (relationshipsAdmin.includes('id: "custom-fields"'))
   failures.push("Relationships admin must not expose custom-fields Settings")
 if (relationshipsPackage.includes("./custom-fields-registry"))
   failures.push("Relationships must not export a definition registry")
-for (const path of [
-  "packages/relationships/src/routes/custom-fields.ts",
-  "packages/relationships/src/service/custom-fields.ts",
-  "packages/relationships/src/service/custom-fields-registry.ts",
-  "packages/relationships/src/service/custom-fields-value-mapping.ts",
-  "packages/relationships-contracts/src/validation/custom-fields.ts",
-  "packages/relationships/tests/integration/custom-fields.test.ts",
-  "packages/relationships/tests/integration/custom-fields-values.test.ts",
-  "packages/relationships/tests/unit/custom-fields-value-mapping.test.ts",
-]) {
-  if (existsSync(resolve(root, path))) failures.push(`${path} must stay deleted`)
-}
 if (
   !genericValueIntegration.includes("/v1/admin/custom-fields/values") ||
   !genericValueIntegration.includes("/v1/admin/relationships/custom-field-values")

--- a/scripts/check-generic-node-bootstrap-authority.mjs
+++ b/scripts/check-generic-node-bootstrap-authority.mjs
@@ -16,12 +16,6 @@ const frameworkFiles = [
   "packages/framework/src/node-provider-plan.ts",
 ]
 
-for (const retiredPath of ["apps/operator/src/operator-node-provider-plan.ts"]) {
-  if (existsSync(resolve(root, retiredPath))) {
-    violations.push(`${retiredPath}: generic Node provider planning must stay framework-owned`)
-  }
-}
-
 for (const retired of retiredAdapters) {
   if (existsSync(resolve(root, retired)))
     violations.push(`${retired}: generic host adapter must stay deleted`)

--- a/scripts/check-legal-document-runtime-authority.mjs
+++ b/scripts/check-legal-document-runtime-authority.mjs
@@ -13,15 +13,6 @@ const read = (relativePath) => {
   return readFileSync(absolutePath, "utf8")
 }
 
-for (const retiredPath of [
-  "apps/operator/src/api/runtime/contract-document-runtime.ts",
-  "apps/operator/src/api/runtime/contract-document-variables.ts",
-  "apps/operator/src/api/runtime/runtime-adapter.ts",
-  "packages/legal-node",
-]) {
-  if (existsSync(path.join(root, retiredPath))) violations.push(`${retiredPath} must stay deleted`)
-}
-
 const deploymentResources = read("packages/runtime/src/deployment-resources.ts")
 const legalManifest = JSON.parse(read("packages/legal/package.json") || "{}")
 const contributor = read("packages/legal/src/runtime-contributor.ts")

--- a/scripts/check-node-host-dispatch-authority.mjs
+++ b/scripts/check-node-host-dispatch-authority.mjs
@@ -16,15 +16,6 @@ for (const file of retiredAdapters) {
     violations.push(`${file}: generic host behavior must stay package-owned`)
 }
 
-for (const file of [
-  "apps/operator/src/workflow-runtime.test.ts",
-  "apps/operator/src/scheduled-crons.test.ts",
-  "apps/operator/src/api-dispatch.test.ts",
-]) {
-  if (existsSync(resolve(root, file)))
-    violations.push(`${file}: generic tests must be framework-owned`)
-}
-
 const runtime = read("packages/runtime/src/index.ts")
 for (const token of ["loadVoyantProject", "createVoyantProjectServerEntry"]) {
   requireText(runtime, token, "packages/runtime/src/index.ts")

--- a/scripts/check-operator-domain-runtime-authority.mjs
+++ b/scripts/check-operator-domain-runtime-authority.mjs
@@ -16,13 +16,6 @@ const read = (path) => {
   }
   return readFileSync(absolute, "utf8")
 }
-for (const path of [
-  "apps/operator/src/api/runtime/trips-catalog-runtime.ts",
-  "apps/operator/src/api/runtime/trips-checkout-runtime.ts",
-  "apps/operator/src/api/runtime/trips-flight-runtime.ts",
-]) {
-  if (existsSync(join(root, path))) violations.push(`${path} must stay deleted`)
-}
 
 const tripsAdapterPath = "apps/operator/src/api/runtime/trips-runtime.ts"
 const tripsAdapter = existsSync(join(root, tripsAdapterPath)) ? read(tripsAdapterPath) : ""

--- a/scripts/check-operator-product-ui-authority.mjs
+++ b/scripts/check-operator-product-ui-authority.mjs
@@ -20,43 +20,6 @@ if (applicationFiles.length > applicationFileRatchet) {
 }
 
 for (const relativePath of [
-  "apps/operator/src/components/voyant/booking-journey/resolve-contract-variables.test.ts",
-  "apps/operator/src/components/voyant/booking-journey/resolve-contract-variables.ts",
-  "apps/operator/src/components/voyant/booking-journey/storefront-booking-errors.ts",
-  "apps/operator/src/components/voyant/booking-journey/storefront-booking-journey.test.ts",
-  "apps/operator/src/components/voyant/booking-journey/storefront-booking-journey.tsx",
-  "apps/operator/src/routes/(storefront)/shop-product-detail-accommodations-ui.test.tsx",
-  "apps/operator/src/routes/(storefront)/shop-product-detail-accommodations.test.ts",
-  "apps/operator/src/routes/(storefront)/shop-product-detail-accommodations.tsx",
-  "apps/operator/src/routes/(storefront)/shop-product-detail-content.test.ts",
-  "apps/operator/src/routes/(storefront)/shop-product-detail-content.ts",
-  "apps/operator/src/routes/(storefront)/shop-product-detail-cruises.test.tsx",
-  "apps/operator/src/routes/(storefront)/shop-product-detail-cruises.tsx",
-  "apps/operator/src/routes/(storefront)/shop-product-detail-products.tsx",
-  "apps/operator/src/routes/(storefront)/shop-product-detail-shared.tsx",
-  "apps/operator/src/routes/(storefront)/shop-product-detail-slots.test.ts",
-  "apps/operator/src/routes/(storefront)/shop-product-detail-slots.ts",
-  "apps/operator/src/routes/(storefront)/shop.test.ts",
-  "apps/operator/src/components/voyant/checkout/payment-link-booking-summary.tsx",
-  "apps/operator/src/components/voyant/checkout/payment-link-trip-summary.tsx",
-  "apps/operator/src/components/voyant/trips/storefront-composer-block.tsx",
-  "apps/operator/src/lib/customer-account.test.ts",
-  "apps/operator/src/lib/customer-account.tsx",
-  "apps/operator/src/lib/storefront-i18n.tsx",
-  "apps/operator/src/lib/storefront-scope.tsx",
-  "apps/operator/src/routes/(storefront)/storefront-market-selector.tsx",
-  "apps/operator/src/routeTree.gen.ts",
-  "apps/operator/src/routes/__root.tsx",
-  "apps/operator/src/routes/_workspace/route.tsx",
-]) {
-  if (existsSync(join(root, relativePath))) {
-    failures.push(
-      `package-owned product UI must stay deleted from the application: ${relativePath}`,
-    )
-  }
-}
-
-for (const relativePath of [
   "packages/proposals-react/src/storefront/public-proposal-page.tsx",
   "packages/finance-react/src/storefront/payment-link-resolver-page.tsx",
   "packages/finance-react/src/storefront/public-payment-link-page.tsx",

--- a/scripts/check-operator-smartbill-authority.mjs
+++ b/scripts/check-operator-smartbill-authority.mjs
@@ -64,19 +64,6 @@ if (!genericContributorInputs) {
 if (/eventBus\.subscribe|descriptor\.register/.test(applicationAuthority)) {
   violations.push("Operator code must not own or register SmartBill subscriber descriptors")
 }
-for (const relativePath of [
-  "src/api/app.ts",
-  "src/api/runtime/runtime-adapter.ts",
-  "src/api/runtime/runtime-adapter.smartbill.test.ts",
-  "src/api/runtime/smartbill-subscriber-runtime.ts",
-  "src/api/runtime/smartbill-subscriber-runtime.test.ts",
-  "src/api/subscribers/smartbill-bundle.ts",
-  "src/api/subscribers/smartbill.ts",
-]) {
-  if (existsSync(join(operatorRoot, relativePath))) {
-    violations.push(`${relativePath} must stay deleted`)
-  }
-}
 
 for (const [source, token] of [
   [financeManifest, "requirePort(financeInvoiceSettlementPollerRuntimePort, {"],

--- a/scripts/checks/regression/retired-paths.json
+++ b/scripts/checks/regression/retired-paths.json
@@ -16,6 +16,7 @@
         "catalog-subscriber-authority",
         "commerce-promotion-subscriber-authority",
         "generic-node-bootstrap-authority",
+        "operator-smartbill-authority",
         "storefront-subscriber-authority",
         "trips-subscriber-authority"
       ]
@@ -77,12 +78,16 @@
       "retiredBy": ["commerce-promotion-subscriber-authority", "operator-domain-runtime-authority"]
     },
     {
+      "path": "apps/operator/src/api/runtime/runtime-adapter.smartbill.test.ts",
+      "retiredBy": ["operator-smartbill-authority"]
+    },
+    {
       "path": "apps/operator/src/api/runtime/runtime-adapter.ts",
       "retiredBy": [
         "bookings-runtime-authority",
         "catalog-runtime-authority",
-        "commerce-promotion-subscriber-authority",
         "commerce-application-executable-authority",
+        "commerce-promotion-subscriber-authority",
         "flights-runtime-authority",
         "generated-runtime-contributor-authority",
         "generic-node-bootstrap-authority",
@@ -92,6 +97,7 @@
         "operator-booking-finance-runtime-authority",
         "operator-catalog-commerce-runtime-authority",
         "operator-final-runtime-authority",
+        "operator-smartbill-authority",
         "operator-storefront-legal-inventory-runtime-authority",
         "realtime-runtime-authority",
         "relationships-runtime-authority",
@@ -100,6 +106,14 @@
         "trips-runtime-authority",
         "trips-subscriber-authority"
       ]
+    },
+    {
+      "path": "apps/operator/src/api/runtime/smartbill-subscriber-runtime.test.ts",
+      "retiredBy": ["operator-smartbill-authority"]
+    },
+    {
+      "path": "apps/operator/src/api/runtime/smartbill-subscriber-runtime.ts",
+      "retiredBy": ["operator-smartbill-authority"]
     },
     {
       "path": "apps/operator/src/api/runtime/storefront-intake-runtime.ts",
@@ -120,6 +134,14 @@
     {
       "path": "apps/operator/src/api/runtime/trips-runtime.ts",
       "retiredBy": ["operator-domain-runtime-authority", "trips-subscriber-authority"]
+    },
+    {
+      "path": "apps/operator/src/api/subscribers/smartbill-bundle.ts",
+      "retiredBy": ["operator-smartbill-authority"]
+    },
+    {
+      "path": "apps/operator/src/api/subscribers/smartbill.ts",
+      "retiredBy": ["operator-smartbill-authority"]
     },
     {
       "path": "apps/operator/src/components/voyant/booking-journey/resolve-contract-variables.test.ts",

--- a/scripts/tests/check-custom-fields-settings-authority.test.mjs
+++ b/scripts/tests/check-custom-fields-settings-authority.test.mjs
@@ -117,10 +117,9 @@ test("rejects restored metadata globs and host injection", (t) => {
   assert.match(output, /must not restore host injection token/)
 })
 
-test("rejects restored Relationships compatibility APIs", (t) => {
-  const root = createFixture(t)
-  const path = join(root, "packages/relationships/src/routes/custom-fields.ts")
-  mkdirSync(dirname(path), { recursive: true })
-  writeFileSync(path, "export const customFieldRoutes = {}\n")
-  assert.match(fixtureFailure(root), /must stay deleted/)
-})
+// The eight retired Relationships compatibility paths this file used to prove
+// here moved to retired-paths.json, so the checker no longer pins them and this
+// fixture case has nothing to assert. Their guard is now
+// scripts/tests/retired-surfaces.test.mjs — "recreating a retired path fails
+// the check", plus "the declared list still covers what the authority scripts
+// pin", which is what stops the two drifting apart.


### PR DESCRIPTION
Step 2 of the order agreed on #4272, following #4320. Part of #4266.

## The arrays were mostly already declared

Of the **73** path-absence assertions the authority scripts hold in literal arrays, **64 were already in `retired-paths.json`**. The duplication I found in `operator-catalog-backend` (#4320) is systemic.

That is worse than redundancy — it means the declarative file was **not authoritative**. Deleting an entry from `retired-paths.json` would leave the path still pinned by a script, with nothing to explain why.

## What landed

1. **Closed the five genuine gaps** — `apps/operator` smartbill runtime and subscriber files, which no declarative rule covered.
2. **Removed the now-duplicated loops from seven scripts**, 54 paths in total.

```
47 -> 46 scripts (#4320)     5,522 -> 5,398 lines
retired-paths.json           83 -> 88 entries
```

## Proven, not assumed

Recreating `apps/operator/src/api/subscribers/smartbill.ts`:

```
- apps/operator/src/api/subscribers/smartbill.ts was retired but exists again
  (retired by: operator-smartbill-authority). If bringing it back is intended,
  remove it from retired-paths.json in the same change.
```

…while the stripped script passes. Coverage **moved**; it did not evaporate. The declarative message is also better than the one it replaces — it names the owning authority and says what to do.

## Three scripts skipped

`generated-runtime-contributor`, `node-runtime`, `operator-product-booking-backend` — their arrays resolve against a **package** root rather than the operator root, so the repo-relative path cannot be derived mechanically. They need reading, not a regex.

## Two extraction errors, recorded

Same class the #4272 re-derivation warned about, and both caught by reading rather than by the extractor:

- **`operator-frontend-shell`** looked like seven retired paths and is the exact opposite — `assert(existsSync(...))` requiring a `README.md` to **remain**. A naive "`existsSync` appears in the loop body" test reads a presence assertion as an absence one. Had I trusted it, I would have deleted a guard and declared its paths retired.
- **Two of the seven smartbill paths were already declared** under the `apps/operator/` prefix; a bare-relative-path comparison reported all seven as missing.

## Verification

```
all 7 modified scripts   pass individually
retired-surfaces         88 paths, and goes red on a recreated one
symbol-policy            OK
graph-conformance        OK
```

Remaining per #4272: the 452-entry array total is dominated by non-path shapes (identifier and specifier pins), which is where `symbol-policy` — now able to express specifiers — takes over.
