### PR TITLE
fix(runtime): resolve the storefront channel on the managed auth profile

### DIFF
--- a/.changeset/lucky-hoops-shave.md
+++ b/.changeset/lucky-hoops-shave.md
@@ -1,0 +1,24 @@
+---
+"@voyant-travel/auth": patch
+"@voyant-travel/runtime": patch
+---
+
+Resolve the storefront sales channel on both auth profiles, not just self-host.
+
+A managed deployment supplies its own `resolveCustomerAuthContext`, which brokers
+storefront credentials through a control plane that has no channel concept. The
+returned context therefore never carried `storefrontChannel`, so every
+`/v1/public/*` catalog read answered `403 Public storefront channel context is
+required.` on a guard that profile could never satisfy — while the
+Storefront -> Channel link rows sat unread in the deployment database.
+
+The runtime now decorates a host-supplied resolver with
+`withResolvedStorefrontChannel`, which reads that binding through the existing
+link-service provider and fills in the channel the host could not know. A
+context that already carries a channel is returned untouched, and a lookup that
+cannot resolve one leaves the host's context alone rather than failing the
+request — the downstream guards still apply.
+
+Each state in which a public request ends up without a channel (storefront not
+resolved here, no binding, binding inactive) is now logged as a distinguishable
+warning, so the identical 403 they all produce can be told apart from outside.

--- a/packages/auth/src/storefront-customer-auth-resolver.ts
+++ b/packages/auth/src/storefront-customer-auth-resolver.ts
@@ -22,6 +22,7 @@ import {
 } from "./storefront-origins.js"
 import type {
   StorefrontChannelBindingDto,
+  StorefrontDto,
   StorefrontResolveContext,
   StorefrontRuntimeProvider,
 } from "./storefront-runtime-port.js"
@@ -219,6 +220,162 @@ export function createLocalStorefrontCustomerAuthResolver<Env>(
           channelStatus: channelBinding.channelStatus,
         },
       }
+    } finally {
+      await dispose?.()
+    }
+  }
+}
+
+/**
+ * What augmenting a customer-auth context with the storefront's sales channel
+ * concluded. Every non-`resolved` variant leaves the public surface without a
+ * channel, and they are deliberately distinguishable: "no storefront", "no
+ * binding" and "binding inactive" have different fixes, and a blanket 403 that
+ * names none of them is what made #4323 take days instead of minutes.
+ */
+export type StorefrontChannelResolutionOutcome =
+  | "host_provided"
+  | "resolved"
+  | "storefront_not_resolved"
+  | "channel_binding_missing"
+  | "channel_inactive"
+  | "lookup_failed"
+
+export interface StorefrontChannelDiagnostic {
+  outcome: StorefrontChannelResolutionOutcome
+  /** Request origin the storefront was (or would have been) matched on. */
+  origin: string | null
+  storefrontId?: string
+  channelId?: string
+  channelStatus?: string
+  error?: unknown
+}
+
+export interface ResolvedStorefrontChannelConfig<Env>
+  extends Omit<LocalStorefrontCustomerAuthResolverConfig<Env>, "resolveStorefrontChannelBinding"> {
+  /** Request-time Storefront -> Channel binding reader (deployment database). */
+  resolveStorefrontChannelBinding: (
+    context: StorefrontResolveContext,
+    storefrontId: string,
+  ) => Promise<StorefrontChannelBindingDto | null>
+  /** Observability sink; called exactly once per resolution. */
+  onDiagnostic?: (diagnostic: StorefrontChannelDiagnostic) => void
+}
+
+/**
+ * Resolve the storefront a request speaks for, without re-authenticating it.
+ * The presented key selects one exactly; a deployment whose keys are minted
+ * elsewhere still declares its origins locally, so fall back to the origin —
+ * the same signal keyless CORS preflight is authorized on, and one that
+ * `resolveStorefrontByOrigin` refuses to answer ambiguously.
+ */
+async function resolveStorefrontForChannel<Env>(
+  config: ResolvedStorefrontChannelConfig<Env>,
+  context: StorefrontResolveContext,
+  request: Request,
+  origin: string | null,
+): Promise<StorefrontDto | null> {
+  const token = request.headers.get(config.keyHeader ?? STOREFRONT_KEY_HEADER)?.trim()
+  if (token) {
+    const resolved = await config.provider.resolveStorefrontByApiKey(context, token)
+    if (resolved) return resolved.storefront
+  }
+  if (!origin) return null
+  return config.provider.resolveStorefrontByOrigin(context, origin)
+}
+
+/**
+ * Decorate a `resolveCustomerAuthContext` so the resulting context always
+ * carries the deployment's Storefront -> Channel binding when one exists.
+ *
+ * The local resolver above derives `storefrontChannel` itself. A managed
+ * deployment supplies its own resolver instead, which brokers credentials
+ * through a control plane that has no channel concept — so the context came
+ * back without a channel and every `/v1/public/*` catalog read 403ed on a guard
+ * that profile could never satisfy, while the link rows describing the binding
+ * sat unread in the deployment database ([#4323](https://github.com/voyant-travel/voyant/issues/4323)).
+ * Reading them here keeps the two auth profiles from diverging on whether a
+ * public surface can obtain a channel.
+ *
+ * Best effort by construction: a context that already carries a channel is
+ * returned untouched, and a failure to resolve one returns the host's context
+ * unchanged — the downstream guards still apply — while reporting which state
+ * it was in.
+ */
+export function withResolvedStorefrontChannel<Env>(
+  resolveCustomerAuthContext: (
+    env: Env,
+    request: Request,
+  ) => CustomerAuthRuntimeContext | Promise<CustomerAuthRuntimeContext>,
+  config: ResolvedStorefrontChannelConfig<Env>,
+): (env: Env, request: Request) => Promise<CustomerAuthRuntimeContext> {
+  const originHeader = config.originHeader ?? STOREFRONT_ORIGIN_HEADER
+  const report = (diagnostic: StorefrontChannelDiagnostic) => {
+    try {
+      config.onDiagnostic?.(diagnostic)
+    } catch {
+      // a diagnostic sink must never break authentication
+    }
+  }
+
+  return async (env, request) => {
+    const context = await resolveCustomerAuthContext(env, request)
+    const origin = resolveStorefrontRequestOrigin(request, originHeader)
+    if (context.storefrontChannel) {
+      report({
+        outcome: "host_provided",
+        origin,
+        storefrontId: context.storefrontChannel.storefrontId,
+        channelId: context.storefrontChannel.channelId,
+        ...(context.storefrontChannel.channelStatus
+          ? { channelStatus: context.storefrontChannel.channelStatus }
+          : {}),
+      })
+      return context
+    }
+
+    const { context: resolveContext, dispose } = await config.openResolveContext(env, request)
+    try {
+      const storefront = await resolveStorefrontForChannel(config, resolveContext, request, origin)
+      if (!storefront) {
+        report({ outcome: "storefront_not_resolved", origin })
+        return context
+      }
+      const binding = await config.resolveStorefrontChannelBinding(resolveContext, storefront.id)
+      if (!binding) {
+        report({ outcome: "channel_binding_missing", origin, storefrontId: storefront.id })
+        return context
+      }
+      if (binding.channelStatus !== "active") {
+        report({
+          outcome: "channel_inactive",
+          origin,
+          storefrontId: storefront.id,
+          channelId: binding.channelId,
+          channelStatus: binding.channelStatus,
+        })
+        return context
+      }
+      report({
+        outcome: "resolved",
+        origin,
+        storefrontId: binding.storefrontId,
+        channelId: binding.channelId,
+        channelStatus: binding.channelStatus,
+      })
+      return {
+        ...context,
+        storefrontChannel: {
+          storefrontId: binding.storefrontId,
+          channelId: binding.channelId,
+          channelStatus: binding.channelStatus,
+        },
+      }
+    } catch (error) {
+      // The host already authenticated this request; a channel lookup that
+      // faults must not turn a working sign-in into a 500.
+      report({ outcome: "lookup_failed", origin, error })
+      return context
     } finally {
       await dispose?.()
     }

--- a/packages/auth/tests/unit/storefront-customer-auth-resolver.test.ts
+++ b/packages/auth/tests/unit/storefront-customer-auth-resolver.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from "vitest"
 
+import type { CustomerAuthRuntimeContext } from "../../src/node-runtime.js"
 import {
   createLocalStorefrontCorsOriginResolver,
   createLocalStorefrontCustomerAuthResolver,
   resolveStorefrontRequestOrigin,
   STOREFRONT_KEY_HEADER,
   STOREFRONT_ORIGIN_HEADER,
+  type StorefrontChannelDiagnostic,
   StorefrontCustomerAuthResolutionError,
+  withResolvedStorefrontChannel,
 } from "../../src/storefront-customer-auth-resolver.js"
 import { isStorefrontOriginAllowed } from "../../src/storefront-origins.js"
 import type {
@@ -292,6 +295,139 @@ describe("createLocalStorefrontCustomerAuthResolver", () => {
     // A known key from a disallowed origin is a 403 (forbidden), not a 401.
     expect(error.status).toBe(403)
     expect(error.code).toBe("forbidden")
+  })
+})
+
+describe("withResolvedStorefrontChannel", () => {
+  /** A managed host resolver: real credentials, never a channel. */
+  const hostContext: CustomerAuthRuntimeContext = {
+    baseURL: "https://shop.example.com",
+    trustedOrigins: ["https://shop.example.com"],
+    methods: { emailCode: true, emailPassword: false, socialProviders: {} },
+  }
+
+  function makeAugmented(options?: {
+    provider?: StorefrontRuntimeProvider
+    binding?: () => Promise<StorefrontChannelBindingDto | null>
+    host?: () => Promise<CustomerAuthRuntimeContext>
+  }) {
+    const diagnostics: StorefrontChannelDiagnostic[] = []
+    let disposed = 0
+    const resolver = withResolvedStorefrontChannel<Record<string, never>>(
+      options?.host ?? (async () => hostContext),
+      {
+        provider: options?.provider ?? fakeProvider(),
+        resolveStorefrontChannelBinding: options?.binding ?? (async () => ACTIVE_BINDING),
+        onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+        async openResolveContext() {
+          return {
+            context: { bindings: {}, db: {} as never },
+            dispose: async () => {
+              disposed += 1
+            },
+          }
+        },
+      },
+    )
+    return { resolver, diagnostics, disposed: () => disposed }
+  }
+
+  const publicRequest = () =>
+    request({
+      [STOREFRONT_ORIGIN_HEADER]: "https://shop.example.com",
+      [STOREFRONT_KEY_HEADER]: "vpk_token",
+    })
+
+  it("adds the storefront channel a managed host context never carries", async () => {
+    const { resolver, diagnostics, disposed } = makeAugmented()
+
+    const context = await resolver({}, publicRequest())
+
+    expect(context.storefrontChannel).toEqual({
+      storefrontId: "sf_1",
+      channelId: "chan_web",
+      channelStatus: "active",
+    })
+    // The host's own resolution is preserved verbatim.
+    expect(context.baseURL).toBe("https://shop.example.com")
+    expect(diagnostics).toEqual([
+      {
+        outcome: "resolved",
+        origin: "https://shop.example.com",
+        storefrontId: "sf_1",
+        channelId: "chan_web",
+        channelStatus: "active",
+      },
+    ])
+    expect(disposed()).toBe(1)
+  })
+
+  it("leaves a host-provided channel untouched", async () => {
+    const channel = { storefrontId: "sf_host", channelId: "chan_host", channelStatus: "active" }
+    const { resolver, diagnostics } = makeAugmented({
+      host: async () => ({ ...hostContext, storefrontChannel: channel }),
+      binding: async () => {
+        throw new Error("must not consult the binding when the host resolved one")
+      },
+    })
+
+    const context = await resolver({}, publicRequest())
+
+    expect(context.storefrontChannel).toEqual(channel)
+    expect(diagnostics[0]?.outcome).toBe("host_provided")
+  })
+
+  it("falls back to the declared origin when the key is not resolvable locally", async () => {
+    const { resolver, diagnostics } = makeAugmented({
+      provider: fakeProvider({ resolveStorefrontByApiKey: async () => null }),
+    })
+
+    const context = await resolver({}, publicRequest())
+
+    expect(context.storefrontChannel?.channelId).toBe("chan_web")
+    expect(diagnostics[0]?.outcome).toBe("resolved")
+  })
+
+  it("reports the three no-channel states distinguishably and leaves the context alone", async () => {
+    const unknownStorefront = makeAugmented({
+      provider: fakeProvider({
+        resolveStorefrontByApiKey: async () => null,
+        resolveStorefrontByOrigin: async () => null,
+      }),
+    })
+    const noBinding = makeAugmented({ binding: async () => null })
+    const inactive = makeAugmented({
+      binding: async () => ({ ...ACTIVE_BINDING, channelStatus: "archived" }),
+    })
+
+    for (const { resolver } of [unknownStorefront, noBinding, inactive]) {
+      const context = await resolver({}, publicRequest())
+      expect(context.storefrontChannel).toBeUndefined()
+    }
+
+    expect(unknownStorefront.diagnostics[0]?.outcome).toBe("storefront_not_resolved")
+    expect(noBinding.diagnostics[0]).toMatchObject({
+      outcome: "channel_binding_missing",
+      storefrontId: "sf_1",
+    })
+    expect(inactive.diagnostics[0]).toMatchObject({
+      outcome: "channel_inactive",
+      channelStatus: "archived",
+    })
+  })
+
+  it("never turns a channel lookup fault into a failed sign-in", async () => {
+    const { resolver, diagnostics, disposed } = makeAugmented({
+      binding: async () => {
+        throw new Error("channels table is unreachable")
+      },
+    })
+
+    const context = await resolver({}, publicRequest())
+
+    expect(context).toEqual(hostContext)
+    expect(diagnostics[0]?.outcome).toBe("lookup_failed")
+    expect(disposed()).toBe(1)
   })
 })
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -394,11 +394,12 @@ export async function loadVoyantProject(
             storefrontChannelBinding.getStorefrontChannelBinding(context, storefrontId),
         })
       : undefined
-  // A host-supplied resolver (the managed profile) authenticates the storefront
-  // against its control plane, which has no channel concept, so the context it
-  // returns never carries one and every public catalog read 403s on a guard it
-  // cannot satisfy (#4323). The binding rows are local either way — read them
-  // here so both auth profiles agree on whether a public surface has a channel.
+  // A host-supplied resolver (a `voyant-cloud` deployment) authenticates the
+  // storefront against its control plane, which has no channel concept, so the
+  // context it returns never carries one and every public catalog read 403s on a
+  // guard it cannot satisfy (#4323). The binding rows are local either way —
+  // read them here so both auth profiles agree on whether a public surface has
+  // a channel.
   const hostCustomerAuthContext = options.host?.resolveCustomerAuthContext
   const customerAuthContextResolver =
     hostCustomerAuthContext && storefrontRuntimeProvider

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -24,6 +24,8 @@ import { createLinkServiceStorefrontChannelBindingProvider } from "@voyant-trave
 import {
   createLocalStorefrontCorsOriginResolver,
   createLocalStorefrontCustomerAuthResolver,
+  type StorefrontChannelDiagnostic,
+  withResolvedStorefrontChannel,
 } from "@voyant-travel/auth/storefront-customer-auth-resolver"
 import {
   type StorefrontResolveContext,
@@ -153,6 +155,26 @@ export interface VoyantProjectHost {
 export interface VoyantProjectAuth {
   getBootstrapStatusForRequest(request: Request, env: VoyantNodeRuntimeEnv): Promise<unknown>
   getCurrentUserForRequest(request: Request, env: VoyantNodeRuntimeEnv): Promise<unknown>
+}
+
+/**
+ * Log the states in which a public request ends up without a sales channel.
+ * Each one produces the same opaque 403 downstream, so the log line is the only
+ * thing that distinguishes "this storefront is unknown here" from "it has no
+ * binding" from "its channel is not active" — the distinction #4323 had to be
+ * reverse-engineered from built image diffs for want of.
+ */
+function reportStorefrontChannelDiagnostic(diagnostic: StorefrontChannelDiagnostic): void {
+  if (diagnostic.outcome === "resolved" || diagnostic.outcome === "host_provided") return
+  const { outcome, origin, storefrontId, channelId, channelStatus, error } = diagnostic
+  console.warn("[voyant:storefront-channel] public request has no sales channel", {
+    outcome,
+    origin,
+    ...(storefrontId ? { storefrontId } : {}),
+    ...(channelId ? { channelId } : {}),
+    ...(channelStatus ? { channelStatus } : {}),
+    ...(error ? { error: error instanceof Error ? error.message : String(error) } : {}),
+  })
 }
 
 /** Load the generated graph and create the framework-owned Node/admin host. */
@@ -372,6 +394,22 @@ export async function loadVoyantProject(
             storefrontChannelBinding.getStorefrontChannelBinding(context, storefrontId),
         })
       : undefined
+  // A host-supplied resolver (the managed profile) authenticates the storefront
+  // against its control plane, which has no channel concept, so the context it
+  // returns never carries one and every public catalog read 403s on a guard it
+  // cannot satisfy (#4323). The binding rows are local either way — read them
+  // here so both auth profiles agree on whether a public surface has a channel.
+  const hostCustomerAuthContext = options.host?.resolveCustomerAuthContext
+  const customerAuthContextResolver =
+    hostCustomerAuthContext && storefrontRuntimeProvider
+      ? withResolvedStorefrontChannel<OperatorAuthNodeEnv>(hostCustomerAuthContext, {
+          provider: storefrontRuntimeProvider,
+          openResolveContext: openStorefrontResolveContext,
+          resolveStorefrontChannelBinding: (context, storefrontId) =>
+            storefrontChannelBinding.getStorefrontChannelBinding(context, storefrontId),
+          onDiagnostic: reportStorefrontChannelDiagnostic,
+        })
+      : (hostCustomerAuthContext ?? localStorefrontCustomerAuth)
   const localStorefrontCorsOrigin =
     storefrontRuntimeProvider && !options.host?.resolveCustomerCorsOrigin
       ? createLocalStorefrontCorsOriginResolver({
@@ -389,11 +427,8 @@ export async function loadVoyantProject(
     reporter,
     ...(customerBusinessAccountOnboarding ? { customerBusinessAccountOnboarding } : {}),
     resolveEmailSender: options.host?.resolveAuthEmailSender ?? resolveVoyantCloudAuthEmailSender,
-    ...(options.host?.resolveCustomerAuthContext || localStorefrontCustomerAuth
-      ? {
-          resolveCustomerAuthContext:
-            options.host?.resolveCustomerAuthContext ?? localStorefrontCustomerAuth,
-        }
+    ...(customerAuthContextResolver
+      ? { resolveCustomerAuthContext: customerAuthContextResolver }
       : {}),
     ...(options.host?.resolveCustomerCorsOrigin || localStorefrontCorsOrigin
       ? {

--- a/packages/runtime/src/runtime-composition.test.ts
+++ b/packages/runtime/src/runtime-composition.test.ts
@@ -335,9 +335,9 @@ describe("Voyant project runtime composition", () => {
   })
 
   it("resolves the storefront channel a host customer-auth context never carries", async () => {
-    // The managed profile supplies its own resolver and its control plane has no
-    // channel concept, so the context comes back without one and every public
-    // catalog read 403s (#4323). The binding lives in the deployment database.
+    // A `voyant-cloud` deployment supplies its own resolver and its control
+    // plane has no channel concept, so the context comes back without one and
+    // every public catalog read 403s (#4323). The binding itself is local.
     const resolveCustomerAuthContext = async () => ({
       baseURL: "https://shop.example.com",
       trustedOrigins: ["https://shop.example.com"],

--- a/packages/runtime/src/runtime-composition.test.ts
+++ b/packages/runtime/src/runtime-composition.test.ts
@@ -1,6 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises"
 import path from "node:path"
 import { customerBusinessAccountOnboardingRuntimePort } from "@voyant-travel/auth/customer-business-onboarding-runtime-port"
+import { storefrontRuntimePort } from "@voyant-travel/auth/storefront-runtime-port"
 import { createVoyantGraphRuntime } from "@voyant-travel/framework/deployment-artifacts"
 import { legalDocumentArtifactProviderPort } from "@voyant-travel/legal"
 import { describe, expect, it, vi } from "vitest"
@@ -13,6 +14,21 @@ import {
   getRuntimeCompositionMocks,
   loadVoyantProject,
 } from "./runtime-composition.test-support.js"
+
+// The link-service binding reader needs a live deployment database; the runtime
+// wiring under test is which resolver consults it, not how it reads rows.
+vi.mock("@voyant-travel/auth/storefront-channel-binding-provider", () => ({
+  createLinkServiceStorefrontChannelBindingProvider: () => ({
+    getStorefrontChannelBinding: async (_context: unknown, storefrontId: string) => ({
+      storefrontId,
+      channelId: "chan_web",
+      channelName: "Web",
+      channelStatus: "active",
+      createdAt: null,
+      updatedAt: null,
+    }),
+  }),
+}))
 
 const mocks = getRuntimeCompositionMocks()
 
@@ -316,6 +332,58 @@ describe("Voyant project runtime composition", () => {
       activeModules: ["catalog", "@acme/loyalty"],
       resolveCustomerAuthContext,
     })
+  })
+
+  it("resolves the storefront channel a host customer-auth context never carries", async () => {
+    // The managed profile supplies its own resolver and its control plane has no
+    // channel concept, so the context comes back without one and every public
+    // catalog read 403s (#4323). The binding lives in the deployment database.
+    const resolveCustomerAuthContext = async () => ({
+      baseURL: "https://shop.example.com",
+      trustedOrigins: ["https://shop.example.com"],
+      methods: { emailCode: true, emailPassword: true },
+    })
+    mocks.runtimePorts[storefrontRuntimePort.id] = {
+      resolveStorefrontByApiKey: async () => ({
+        storefront: { id: "sf_1", allowedOrigins: ["https://shop.example.com"] },
+        key: { id: "sfk_1" },
+      }),
+      resolveStorefrontByOrigin: async () => null,
+    }
+    try {
+      const projectRoot = await createGeneratedProject()
+      await loadVoyantProject({
+        projectRoot,
+        adminAssetsDir: path.join(projectRoot, "admin"),
+        env: { DATABASE_URL: "postgres://example.invalid/voyant" },
+        host: { resolveCustomerAuthContext },
+      })
+
+      const wired = mocks.authRuntimeOptions[0]?.resolveCustomerAuthContext as (
+        env: unknown,
+        request: Request,
+      ) => Promise<{ baseURL: string; storefrontChannel?: Record<string, string> }>
+      expect(wired).not.toBe(resolveCustomerAuthContext)
+
+      const context = await wired(
+        {},
+        new Request("https://api.example.com/api/v1/public/catalog/search", {
+          method: "POST",
+          headers: {
+            "x-voyant-storefront-origin": "https://shop.example.com",
+            "x-api-key": "vpk_token",
+          },
+        }),
+      )
+      expect(context.baseURL).toBe("https://shop.example.com")
+      expect(context.storefrontChannel).toEqual({
+        storefrontId: "sf_1",
+        channelId: "chan_web",
+        channelStatus: "active",
+      })
+    } finally {
+      delete mocks.runtimePorts[storefrontRuntimePort.id]
+    }
   })
 
   it("passes a provider-neutral host auth email sender to the auth runtime", async () => {


### PR DESCRIPTION
Closes #4323.

## The gap

`resolveChannel` on the public surface reads exactly one source — the
`storefrontChannel` the auth middleware sets from `VoyantAuthContext` — and the
only code that populates it is `createLocalStorefrontCustomerAuthResolver`,
which `packages/runtime` builds **only when the host supplies no resolver of its
own**. A managed (`voyant-cloud`) deployment always supplies one, and it brokers
storefront credentials through a control plane that has no channel concept, so
the context came back without a channel and every `/v1/public/*` catalog read
403ed on a guard that profile could never satisfy. Meanwhile
`createLinkServiceStorefrontChannelBindingProvider` was constructed and never
consulted, with the `auth_storefront_distribution_channel` link rows sitting
correct and unread in the deployment database.

## The fix

Suggestion 2 from the issue: consult the rows that are already there, on both
profiles.

- `withResolvedStorefrontChannel` (packages/auth) decorates any
  `resolveCustomerAuthContext` with the deployment's Storefront -> Channel
  binding. It selects the storefront by the presented key and falls back to the
  declared request origin — the same signal keyless CORS preflight is authorized
  on, and one `resolveStorefrontByOrigin` refuses to answer ambiguously.
- `packages/runtime` wraps a host-supplied resolver with it, so the two auth
  profiles no longer diverge on whether a public surface can obtain a channel.

It is best effort by construction, because the host has already authenticated
the request by the time it runs: a context that already carries a channel is
returned untouched, and a lookup that resolves nothing (or faults) returns the
host's context unchanged so the existing guards still decide. It never turns a
working sign-in into a 500.

## Diagnostics

The issue's other complaint was that the 403 named a data concept for what was a
wiring gap, with nothing logged at WARNING or above. The three states that leave
a public request without a channel are now distinguishable in the log:
`storefront_not_resolved`, `channel_binding_missing`, `channel_inactive` (plus
`lookup_failed`), each with the origin and, where known, the storefront and
channel.

## Scope

#4260 — letting the caller present a channel per request instead of deriving it
from a storefront — would also close this and is deliberately left alone here;
the public surface still ignores `body.channel`.

## Verification

- `packages/auth` — 6 new cases over `withResolvedStorefrontChannel`: it fills
  in a channel a managed context lacks, leaves a host-provided one alone, falls
  back to the origin when the key is not resolvable locally, reports the three
  no-channel states distinguishably without mutating the context, and swallows a
  binding-lookup fault. 23 passed.
- `packages/runtime` — a composition case that registers the storefront runtime
  port alongside a host resolver and asserts the wired resolver is the decorated
  one and yields the channel. 23 passed.
- `pnpm -F @voyant-travel/auth -F @voyant-travel/runtime typecheck`, `biome check`
  on the changed files.
