### PR TITLE
Managed runtime composes no LinkService — serve storefront channel bindings from the request database

### DIFF
--- a/.changeset/managed-storefront-channel-link-service.md
+++ b/.changeset/managed-storefront-channel-link-service.md
@@ -1,0 +1,27 @@
+---
+"@voyant-travel/auth": patch
+---
+
+Serve storefront channel bindings from the request database when the deployment
+wires no `LinkService`.
+
+`createLinkServiceStorefrontChannelBindingProvider` required `context.link`, a
+service that reaches the request only when the composition wired the generated
+project link registry. `loadVoyantProject` does that; the managed operator
+runtime composes the graph straight from a profile snapshot and never reads
+those artifacts, so `context.link` was absent on every managed request and the
+provider threw on all of them — `GET /v1/admin/storefronts/storefronts` answered
+500 and the admin rendered "Storefronts unavailable" on every managed
+deployment.
+
+The type already called the service optional. It now is: the provider builds a
+request-scoped service over its own `storefrontChannelLink` when the deployment
+supplied none, reading and writing the same
+`auth_storefront_distribution_channel` pivot table that ships as a
+`@voyant-travel/db` migration. A deployment-supplied `LinkService` is still
+preferred where one exists, so the self-hosted path is unchanged.
+
+Degrading to "no binding" was the other option on the table and is worse: the
+public catalog guard refuses on a missing channel rather than on an error, so a
+provider that returned nothing would trade a 500 in the admin for a silent 403
+on every storefront read.

--- a/packages/auth/src/storefront-channel-binding-provider.ts
+++ b/packages/auth/src/storefront-channel-binding-provider.ts
@@ -1,4 +1,6 @@
 import type { LinkService } from "@voyant-travel/core"
+import type { DrizzleClient } from "@voyant-travel/db"
+import { createLinkServiceFactory } from "@voyant-travel/db/links"
 import { sql } from "drizzle-orm"
 
 import { storefrontChannelLink } from "./standard-links.js"
@@ -22,11 +24,23 @@ type ChannelRow = {
 
 const ACTIVE_CHANNEL_STATUS = "active"
 
-function requireLinkService(context: BindingContext): LinkService {
-  if (!context.link) {
-    throw new Error("Storefront channel binding requires the deployment LinkService.")
-  }
-  return context.link
+/**
+ * A deployment-wide `LinkService` reaches the request context only when the
+ * composition wired the generated project link registry. `loadVoyantProject`
+ * does; the managed operator runtime composes the graph straight from a profile
+ * snapshot and never reads those artifacts, so `context.link` is absent on every
+ * managed request and this provider used to throw on all of them (voyant#4336).
+ *
+ * The one link it needs is its own, and its pivot table ships as a
+ * `@voyant-travel/db` migration, so serve it from the request database when the
+ * deployment supplied nothing. That keeps `link` genuinely optional — the type
+ * already said so — instead of naming a service half the compositions cannot
+ * produce.
+ */
+const createOwnedLinkService = createLinkServiceFactory([storefrontChannelLink])
+
+function resolveLinkService(context: BindingContext): LinkService {
+  return context.link ?? createOwnedLinkService(() => context.db as DrizzleClient)
 }
 
 function iso(value: Date | string | null | undefined): string | null {
@@ -106,7 +120,7 @@ export function createLinkServiceStorefrontChannelBindingProvider(): StorefrontC
 
   return {
     async listStorefrontChannelBindings(context, storefrontIds) {
-      const link = requireLinkService(context)
+      const link = resolveLinkService(context)
       const ids = [...new Set(storefrontIds)].filter(Boolean)
       const result = Object.fromEntries(ids.map((id) => [id, null])) as Record<
         string,
@@ -160,17 +174,14 @@ export function createLinkServiceStorefrontChannelBindingProvider(): StorefrontC
         throw new StorefrontInputError("Storefront can only bind to an active channel.")
       }
 
-      const existing = await requireLinkService(context).list(linkKey, { leftId: storefrontId })
+      const link = resolveLinkService(context)
+      const existing = await link.list(linkKey, { leftId: storefrontId })
       for (const row of existing) {
         if (row.rightId !== input.channelId) {
-          await requireLinkService(context).dismiss(linkKey, storefrontId, row.rightId)
+          await link.dismiss(linkKey, storefrontId, row.rightId)
         }
       }
-      const linkRow = await requireLinkService(context).create(
-        linkKey,
-        storefrontId,
-        input.channelId,
-      )
+      const linkRow = await link.create(linkKey, storefrontId, input.channelId)
       const binding = toBinding(storefrontId, channel, linkRow)
       if (!binding) {
         throw new StorefrontInputError("Storefront can only bind to an active channel.")
@@ -179,10 +190,9 @@ export function createLinkServiceStorefrontChannelBindingProvider(): StorefrontC
     },
 
     async clearStorefrontChannelBinding(context, storefrontId) {
-      const rows = await requireLinkService(context).list(linkKey, { leftId: storefrontId })
-      await Promise.all(
-        rows.map((row) => requireLinkService(context).dismiss(linkKey, storefrontId, row.rightId)),
-      )
+      const link = resolveLinkService(context)
+      const rows = await link.list(linkKey, { leftId: storefrontId })
+      await Promise.all(rows.map((row) => link.dismiss(linkKey, storefrontId, row.rightId)))
     },
   }
 }

--- a/packages/auth/tests/unit/storefront-channel-binding-provider.test.ts
+++ b/packages/auth/tests/unit/storefront-channel-binding-provider.test.ts
@@ -1,0 +1,163 @@
+import type { LinkService } from "@voyant-travel/core"
+import type { SQL } from "drizzle-orm"
+import { PgDialect } from "drizzle-orm/pg-core"
+import { describe, expect, it, vi } from "vitest"
+
+import { createLinkServiceStorefrontChannelBindingProvider } from "../../src/storefront-channel-binding-provider.js"
+import { StorefrontInputError } from "../../src/storefront-origins.js"
+import type { StorefrontRequestContext } from "../../src/storefront-runtime-port.js"
+
+const dialect = new PgDialect()
+
+const BINDING_TABLE = "auth_storefront_distribution_channel"
+
+type Statement = { sql: string; params: unknown[] }
+
+/**
+ * Managed-shaped request context: `db` and `bindings`, no deployment
+ * `LinkService`. That is exactly what the managed operator runtime composes
+ * (voyant#4336) — the provider has to serve it from the database alone.
+ */
+function managedContext(respond: (statement: Statement) => unknown[]) {
+  const statements: Statement[] = []
+  const db = {
+    execute(query: SQL) {
+      const statement = dialect.sqlToQuery(query)
+      const recorded = { sql: statement.sql, params: statement.params }
+      statements.push(recorded)
+      return Promise.resolve(respond(recorded))
+    },
+  }
+  const context = { bindings: {}, db } as unknown as StorefrontRequestContext
+  return { context, statements }
+}
+
+function linkRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "lnk_1",
+    storefront_id: "sf_1",
+    channel_id: "chan_1",
+    created_at: new Date("2026-08-01T00:00:00.000Z"),
+    updated_at: new Date("2026-08-02T00:00:00.000Z"),
+    deleted_at: null,
+    ...overrides,
+  }
+}
+
+function activeChannelRow(overrides: Record<string, unknown> = {}) {
+  return { id: "chan_1", name: "Direct", status: "active", ...overrides }
+}
+
+describe("storefront channel binding without a deployment LinkService", () => {
+  it("lists bindings by reading the pivot table from the request database", async () => {
+    const provider = createLinkServiceStorefrontChannelBindingProvider()
+    const { context, statements } = managedContext(({ sql }) => {
+      if (sql.includes(BINDING_TABLE)) return [linkRow()]
+      if (sql.includes("channels")) return [activeChannelRow()]
+      return []
+    })
+
+    const bindings = await provider.listStorefrontChannelBindings(context, ["sf_1", "sf_2"])
+
+    expect(bindings).toEqual({
+      sf_1: {
+        storefrontId: "sf_1",
+        channelId: "chan_1",
+        channelName: "Direct",
+        channelStatus: "active",
+        createdAt: "2026-08-01T00:00:00.000Z",
+        updatedAt: "2026-08-02T00:00:00.000Z",
+      },
+      sf_2: null,
+    })
+    const pivotRead = statements.find((statement) => statement.sql.includes(BINDING_TABLE))
+    expect(pivotRead?.sql).toContain('"storefront_id"')
+    expect(pivotRead?.params).toContainEqual(["sf_1", "sf_2"])
+  })
+
+  it("resolves a single binding through the same path", async () => {
+    const provider = createLinkServiceStorefrontChannelBindingProvider()
+    const { context } = managedContext(({ sql }) => {
+      if (sql.includes(BINDING_TABLE)) return [linkRow()]
+      if (sql.includes("channels")) return [activeChannelRow()]
+      return []
+    })
+
+    await expect(provider.getStorefrontChannelBinding(context, "sf_1")).resolves.toMatchObject({
+      storefrontId: "sf_1",
+      channelId: "chan_1",
+    })
+  })
+
+  it("still refuses a storefront carrying more than one active binding", async () => {
+    const provider = createLinkServiceStorefrontChannelBindingProvider()
+    const { context } = managedContext(({ sql }) => {
+      if (sql.includes(BINDING_TABLE)) {
+        return [linkRow(), linkRow({ id: "lnk_2", channel_id: "chan_2" })]
+      }
+      return []
+    })
+
+    await expect(provider.listStorefrontChannelBindings(context, ["sf_1"])).rejects.toThrow(
+      StorefrontInputError,
+    )
+  })
+
+  it("writes a binding into the pivot table", async () => {
+    const provider = createLinkServiceStorefrontChannelBindingProvider()
+    const { context, statements } = managedContext(({ sql }) => {
+      if (sql.startsWith("INSERT INTO")) return [linkRow()]
+      if (sql.includes("channels")) return [activeChannelRow()]
+      return []
+    })
+
+    const binding = await provider.setStorefrontChannelBinding(context, "sf_1", {
+      channelId: "chan_1",
+    })
+
+    expect(binding).toMatchObject({ storefrontId: "sf_1", channelId: "chan_1" })
+    const insert = statements.find((statement) => statement.sql.startsWith("INSERT INTO"))
+    expect(insert?.sql).toContain(BINDING_TABLE)
+    expect(insert?.params).toEqual(expect.arrayContaining(["sf_1", "chan_1"]))
+  })
+
+  it("clears a binding by soft-deleting its pivot rows", async () => {
+    const provider = createLinkServiceStorefrontChannelBindingProvider()
+    const { context, statements } = managedContext(({ sql }) =>
+      sql.startsWith("SELECT") ? [linkRow()] : [],
+    )
+
+    await provider.clearStorefrontChannelBinding(context, "sf_1")
+
+    const update = statements.find((statement) => statement.sql.startsWith("UPDATE"))
+    expect(update?.sql).toContain(BINDING_TABLE)
+    expect(update?.sql).toContain('"deleted_at" = now()')
+    expect(update?.params).toEqual(expect.arrayContaining(["sf_1", "chan_1"]))
+  })
+})
+
+describe("storefront channel binding with a deployment LinkService", () => {
+  it("prefers the wired service over the database fallback", async () => {
+    const provider = createLinkServiceStorefrontChannelBindingProvider()
+    const { context, statements } = managedContext(({ sql }) =>
+      sql.includes("channels") ? [activeChannelRow()] : [],
+    )
+    const list = vi.fn(async () => [
+      {
+        id: "lnk_1",
+        leftId: "sf_1",
+        rightId: "chan_1",
+        createdAt: new Date("2026-08-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-08-02T00:00:00.000Z"),
+        deletedAt: null,
+      },
+    ])
+    const link = { list } as unknown as LinkService
+
+    const bindings = await provider.listStorefrontChannelBindings({ ...context, link }, ["sf_1"])
+
+    expect(bindings.sf_1).toMatchObject({ channelId: "chan_1", channelName: "Direct" })
+    expect(list).toHaveBeenCalledWith(BINDING_TABLE, { leftIds: ["sf_1"] })
+    expect(statements.every((statement) => !statement.sql.includes(BINDING_TABLE))).toBe(true)
+  })
+})


### PR DESCRIPTION
Closes #4336.

## What was actually wrong

`context.link` is populated from `c.get("link")`, and the Hono app only sets that
variable when it was handed link definitions. Those come from the generated
project link registry (`.voyant/runtime/project-links.generated.ts`), which
`loadVoyantProject` loads and passes as `app.linkDefinitions`.

The managed operator runtime does not take that path. It composes the graph
straight from a profile snapshot — `resolveProject` → `loadVoyantNodeRuntime`
with `app: { basePath, auth }` — and never reads the generated artifacts, so
`linkDefinitions` is empty, the middleware that sets `link` is never mounted, and
`context.link` is `undefined` on **every** managed request. The provider threw on
all of them.

Same shape as #4330: a fact declared where only one of the two resolution paths
looks. It is not a regression and #4325 does not touch it.

## The fix

The type already called the service optional. The code now matches it: the
provider builds a request-scoped `LinkService` over its own
`storefrontChannelLink` when the deployment supplied none, reading and writing
the same `auth_storefront_distribution_channel` pivot that ships as the
`packages/db` migration `20260801173000_storefront_channel_binding_cutover.sql`.
A deployment-supplied service is still preferred where one exists, so the
self-hosted path is byte-for-byte unchanged.

**Not the "degrade" option.** Returning "no binding" would fix the admin 500 and
leave the public surface broken: the `/v1/public/*` guard refuses on a *missing*
channel, not on an error, so degrading trades a visible 500 for a silent 403 on
every storefront read.

## Verification

New unit test drives the real provider through a managed-shaped context — `db`
and `bindings`, **no** `link` — with a fake client that renders each statement
through drizzle's `PgDialect`, so the assertions are on the SQL and bound
parameters the provider actually emits, not on a hand-built input:

- list resolves bindings from the pivot table (`storefront_id = ANY($1)`)
- single-binding read goes through the same path
- multiple active bindings still raise `StorefrontInputError`
- set writes `INSERT INTO auth_storefront_distribution_channel`
- clear soft-deletes (`UPDATE … SET "deleted_at" = now()`)
- a wired `LinkService` is still preferred, and the fallback issues no pivot SQL

Red/green confirmed: with the old `requireLinkService`, 5 of the 6 fail; the
sixth is the wired-service case, which passes either way.

`pnpm --filter @voyant-travel/auth test` — 281 passed / 20 skipped.
`pnpm --filter @voyant-travel/auth typecheck` — 0 errors (test file typechecked
separately; `auth` is in the #4244 baseline so its tests get no CI typecheck job).
`pnpm verify:architecture` — green. `biome check .` — 0 errors, 21 warnings,
8 infos, matching main.

## Adjacent, not fixed here

The managed profile never calls `withResolvedStorefrontChannel` at all — it is
applied in `loadVoyantProject`, which managed does not use. So #4323/#4325's
channel resolution, and the diagnostic sink that would have named this failure,
are both dead on the managed profile. That is a separate wiring gap and is left
alone here.
