### PR TITLE
A response contract for a provider-owned port cannot be strict

### DIFF
--- a/.changeset/curly-pugs-refuse.md
+++ b/.changeset/curly-pugs-refuse.md
@@ -1,0 +1,16 @@
+---
+"@voyant-travel/auth": patch
+"@voyant-travel/auth-react": patch
+---
+
+Storefront admin responses accept fields the runtime provider owns
+
+The storefront runtime is a port, and Voyant Cloud's control plane serves managed
+storefronts with an `organizationId` this package does not model. The admin
+response contracts were `.strict()`, so that one field rejected the object, the
+object rejected the array, and the storefronts page rendered its error state on a
+healthy 200 — indistinguishable from an outage, and no retry could clear it.
+
+Request bodies stay closed; response objects now strip what they do not know.
+Refresh on the packaged storefronts page also retries every query its failure
+banner speaks for, instead of only the list.

--- a/packages/auth-react/src/components/storefronts-page.tsx
+++ b/packages/auth-react/src/components/storefronts-page.tsx
@@ -59,6 +59,13 @@ function StorefrontsView({ api }: { api: StorefrontsAdminApi }) {
   const selected = listQuery.data?.find((storefront) => storefront.id === selectedId) ?? null
   const isLoading = capabilitiesQuery.isPending || listQuery.isPending
   const loadFailed = capabilitiesQuery.isError || listQuery.isError
+  // Refresh has to retry everything the banner speaks for. Refetching only the
+  // list left a failed capabilities query reporting an error no click could
+  // clear, which reads as an outage the page can never recover from (#4342).
+  const refresh = () => {
+    void capabilitiesQuery.refetch()
+    void listQuery.refetch()
+  }
 
   return (
     <div className="mx-auto flex w-full max-w-6xl flex-col gap-6">
@@ -67,7 +74,7 @@ function StorefrontsView({ api }: { api: StorefrontsAdminApi }) {
           <h1 className="text-2xl font-semibold">{copy.title}</h1>
           <p className="text-sm text-muted-foreground">{copy.description}</p>
         </div>
-        <Button type="button" variant="outline" size="sm" onClick={() => void listQuery.refetch()}>
+        <Button type="button" variant="outline" size="sm" onClick={refresh}>
           <RefreshCw className="mr-2 h-4 w-4" />
           {copy.refresh}
         </Button>

--- a/packages/auth-react/src/storefronts-admin-api.ts
+++ b/packages/auth-react/src/storefronts-admin-api.ts
@@ -22,22 +22,26 @@ import { z } from "zod"
 import { fetchWithValidation, type VoyantFetcher } from "./client.js"
 import { authQueryKeys } from "./query-keys.js"
 
-const capabilitiesResponseSchema = z.object({ data: storefrontAdminCapabilitiesSchema }).strict()
-const storefrontsResponseSchema = z.object({ data: z.array(storefrontSchema) }).strict()
-const storefrontResponseSchema = z.object({ data: storefrontSchema }).strict()
-const storefrontChannelBindingSchema = z
-  .object({
-    storefrontId: z.string(),
-    channelId: z.string(),
-    channelName: z.string().nullable(),
-    channelStatus: z.string(),
-    createdAt: z.string().nullable(),
-    updatedAt: z.string().nullable(),
-  })
-  .strict()
-const storefrontChannelBindingResponseSchema = z
-  .object({ data: storefrontChannelBindingSchema.nullable() })
-  .strict()
+/**
+ * Response envelopes are open for the same reason the DTOs they wrap are: the
+ * storefront runtime is a port, and the control plane behind it ships on its
+ * own cadence. A `.strict()` envelope makes one added field fail the whole
+ * request, and the page reports a healthy 200 as an outage (voyant#4342).
+ */
+const capabilitiesResponseSchema = z.object({ data: storefrontAdminCapabilitiesSchema })
+const storefrontsResponseSchema = z.object({ data: z.array(storefrontSchema) })
+const storefrontResponseSchema = z.object({ data: storefrontSchema })
+const storefrontChannelBindingSchema = z.object({
+  storefrontId: z.string(),
+  channelId: z.string(),
+  channelName: z.string().nullable(),
+  channelStatus: z.string(),
+  createdAt: z.string().nullable(),
+  updatedAt: z.string().nullable(),
+})
+const storefrontChannelBindingResponseSchema = z.object({
+  data: storefrontChannelBindingSchema.nullable(),
+})
 const distributionChannelOptionSchema = z
   .object({
     id: z.string(),
@@ -45,19 +49,17 @@ const distributionChannelOptionSchema = z
     status: z.enum(["active", "inactive", "pending", "archived"]),
   })
   .passthrough()
-const distributionChannelsResponseSchema = z
-  .object({
-    data: z.array(distributionChannelOptionSchema),
-    total: z.number().optional(),
-    limit: z.number().optional(),
-    offset: z.number().optional(),
-  })
-  .strict()
-const apiKeysResponseSchema = z.object({ data: z.array(storefrontApiKeySchema) }).strict()
-const issuedKeyResponseSchema = z.object({ data: issuedStorefrontApiKeySchema }).strict()
-const providerCredentialsResponseSchema = z
-  .object({ data: z.array(storefrontProviderCredentialStatusSchema) })
-  .strict()
+const distributionChannelsResponseSchema = z.object({
+  data: z.array(distributionChannelOptionSchema),
+  total: z.number().optional(),
+  limit: z.number().optional(),
+  offset: z.number().optional(),
+})
+const apiKeysResponseSchema = z.object({ data: z.array(storefrontApiKeySchema) })
+const issuedKeyResponseSchema = z.object({ data: issuedStorefrontApiKeySchema })
+const providerCredentialsResponseSchema = z.object({
+  data: z.array(storefrontProviderCredentialStatusSchema),
+})
 
 const BASE = "/v1/admin/storefronts"
 const storefrontPath = (id: string) => `${BASE}/storefronts/${encodeURIComponent(id)}`
@@ -213,7 +215,7 @@ export function createStorefrontsAdminApi(
       return (
         await fetchWithValidation(
           `${storefrontPath(storefrontId)}/channel-binding`,
-          z.object({ data: storefrontChannelBindingSchema }).strict(),
+          z.object({ data: storefrontChannelBindingSchema }),
           options,
           json("PUT", input),
         )

--- a/packages/auth-react/src/storefronts-page.test.tsx
+++ b/packages/auth-react/src/storefronts-page.test.tsx
@@ -113,6 +113,50 @@ describe("storefront admin surface", () => {
     await expect(api.listStorefronts()).resolves.toEqual([STOREFRONT, managed])
   })
 
+  it("lists storefronts carrying fields the runtime provider owns", async () => {
+    // Verbatim from a managed deployment's 200 on
+    // GET /v1/admin/storefronts/storefronts: Voyant Cloud serves an
+    // `organizationId` this package does not model. A strict response schema
+    // rejected the whole array, so the page showed "Storefronts unavailable"
+    // on a successful response and no retry could clear it (voyant#4342).
+    const api = createStorefrontsAdminApi("/api", async () =>
+      Response.json({
+        data: [
+          {
+            id: "sf_km1j5lwnx9bv",
+            organizationId: "org_01KSTAWP6CEKZ67731P2Q646CC",
+            name: "Customer portal",
+            slug: "customer-portal",
+            hostingKind: "managed_portal",
+            siteId: null,
+            allowedOrigins: ["https://sandbox-account.onvoyant.net"],
+            methods: {
+              apple: false,
+              google: false,
+              facebook: false,
+              emailCode: true,
+              emailPassword: false,
+            },
+            accountPolicy: {
+              allowedKinds: ["personal"],
+              personalSignup: "open",
+              businessOnboarding: "disabled",
+            },
+            hostOnlyCookies: true,
+            createdAt: "2026-08-02T05:52:32.166Z",
+            updatedAt: "2026-08-02T05:52:34.106Z",
+            channelBinding: null,
+          },
+        ],
+      }),
+    )
+
+    const [storefront] = await api.listStorefronts()
+
+    expect(storefront).toMatchObject({ id: "sf_km1j5lwnx9bv", hostingKind: "managed_portal" })
+    expect(storefront).not.toHaveProperty("organizationId")
+  })
+
   it("disables business controls when the runtime capability is unavailable", async () => {
     const queryClient = seededQueryClient({
       businessAccounts: false,
@@ -281,6 +325,41 @@ describe("storefront admin surface", () => {
 
     expect(container.textContent).toContain("Channel binding is not configured")
     expect(container.querySelector("#storefront-channel-storefront_1")).toBeNull()
+
+    await act(async () => root.unmount())
+  })
+
+  it("recovers from any query the load banner speaks for, not just the list", async () => {
+    // The banner reports capabilities and storefronts together, so a refresh
+    // that retried only the list left a failed capabilities query showing an
+    // error no click could clear (voyant#4342).
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const api = pageApi()
+    let capabilitiesFail = true
+    api.getCapabilities = vi.fn(async () => {
+      if (capabilitiesFail) throw new Error("cold start")
+      return { businessAccounts: true, manageProviders: true, channelBinding: true }
+    })
+    const container = document.createElement("div")
+    const root = createRoot(container)
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <StorefrontsPage api={api} />
+        </QueryClientProvider>,
+      )
+    })
+    await vi.waitFor(() =>
+      expect(container.textContent).toContain("Storefronts could not be loaded."),
+    )
+
+    capabilitiesFail = false
+    await clickButton(container, "Refresh")
+
+    await vi.waitFor(() =>
+      expect(container.textContent).not.toContain("Storefronts could not be loaded."),
+    )
 
     await act(async () => root.unmount())
   })

--- a/packages/auth/src/storefront-admin-contracts.ts
+++ b/packages/auth/src/storefront-admin-contracts.ts
@@ -3,12 +3,25 @@
  *
  * These mirror the DTOs on {@link storefrontRuntimePort} without importing the
  * DB schema, so the admin React client can validate responses and request
- * bodies without pulling server-only modules into the browser bundle. Request
- * bodies are validated strictly against the literals this deployment accepts;
- * response fields whose vocabulary belongs to the runtime provider rather than
- * to this package stay open, so a control plane on its own release cadence can
- * add to them without breaking an older admin bundle. The runtime adapter
- * re-normalizes every write, so these are the transport contract only.
+ * bodies without pulling server-only modules into the browser bundle. The
+ * runtime adapter re-normalizes every write, so these are the transport
+ * contract only.
+ *
+ * **Requests are closed; responses are open.** A request body is this
+ * deployment's own vocabulary, so an unknown key there is a caller mistake
+ * worth refusing. A response is the runtime provider's vocabulary — the
+ * storefront runtime is a port, and a deployment can be backed by a control
+ * plane on its own release cadence. Voyant Cloud's is: it serves managed
+ * storefronts with an `organizationId` and mints `managed_portal` /
+ * `managed_booking_engine` hosting kinds this package never sees.
+ *
+ * A `.strict()` response schema turns every such addition into a total
+ * failure, because one unrecognized key rejects the object, one rejected
+ * object rejects the array, and the storefronts page renders its error state
+ * on a healthy 200 — indistinguishable from an outage, and retry cannot
+ * recover it (voyant#4342). So response objects strip what they do not know
+ * instead of refusing it, and consumers narrow with the operator-facing
+ * schemas where the distinction matters.
  */
 import { z } from "zod"
 
@@ -30,95 +43,93 @@ export const operatorStorefrontHostingKindSchema = z.enum(["cloud_site", "extern
  * 200 on the wire. Consumers narrow with `operatorStorefrontHostingKindSchema`
  * where the distinction matters, and treat anything else as read-only hosting
  * they did not provision.
+ *
+ * The same reasoning applies to the *fields* of a response, which is why the
+ * response objects below are not `.strict()`.
  */
 export const storefrontHostingKindSchema = z.string().min(1)
 export const storefrontApiKeyKindSchema = z.enum(["publishable", "secret"])
 export const storefrontSocialProviderSchema = z.enum(["google", "facebook", "apple"])
 
+const storefrontCustomerAuthMethodsShape = {
+  emailCode: z.boolean(),
+  emailPassword: z.boolean(),
+  google: z.boolean(),
+  facebook: z.boolean(),
+  apple: z.boolean(),
+}
+
+const storefrontCustomerAccountPolicyShape = {
+  allowedKinds: z.array(z.enum(["personal", "business"])).min(1),
+  personalSignup: z.enum(["open", "disabled"]),
+  businessOnboarding: z.enum(["disabled", "open", "request", "invite-only"]),
+}
+
+/** Request contract: a write may only name methods this deployment knows. */
 export const storefrontCustomerAuthMethodsSchema = z
-  .object({
-    emailCode: z.boolean(),
-    emailPassword: z.boolean(),
-    google: z.boolean(),
-    facebook: z.boolean(),
-    apple: z.boolean(),
-  })
+  .object(storefrontCustomerAuthMethodsShape)
   .strict()
 
+/** Request contract: a write may only name policy keys this deployment knows. */
 export const storefrontCustomerAccountPolicySchema = z
-  .object({
-    allowedKinds: z.array(z.enum(["personal", "business"])).min(1),
-    personalSignup: z.enum(["open", "disabled"]),
-    businessOnboarding: z.enum(["disabled", "open", "request", "invite-only"]),
-  })
+  .object(storefrontCustomerAccountPolicyShape)
   .strict()
 
-export const storefrontSchema = z
-  .object({
-    id: z.string(),
-    name: z.string(),
-    slug: z.string(),
-    hostingKind: storefrontHostingKindSchema,
-    siteId: z.string().nullable(),
-    allowedOrigins: z.array(z.string()),
-    methods: storefrontCustomerAuthMethodsSchema,
-    accountPolicy: storefrontCustomerAccountPolicySchema,
-    hostOnlyCookies: z.boolean(),
-    createdAt: z.string(),
-    updatedAt: z.string(),
-    channelBinding: z
-      .object({
-        storefrontId: z.string(),
-        channelId: z.string(),
-        channelName: z.string().nullable(),
-        channelStatus: z.string(),
-        createdAt: z.string().nullable(),
-        updatedAt: z.string().nullable(),
-      })
-      .strict()
-      .nullable()
-      .optional(),
-  })
-  .strict()
+export const storefrontSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  slug: z.string(),
+  hostingKind: storefrontHostingKindSchema,
+  siteId: z.string().nullable(),
+  allowedOrigins: z.array(z.string()),
+  methods: z.object(storefrontCustomerAuthMethodsShape),
+  accountPolicy: z.object(storefrontCustomerAccountPolicyShape),
+  hostOnlyCookies: z.boolean(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  channelBinding: z
+    .object({
+      storefrontId: z.string(),
+      channelId: z.string(),
+      channelName: z.string().nullable(),
+      channelStatus: z.string(),
+      createdAt: z.string().nullable(),
+      updatedAt: z.string().nullable(),
+    })
+    .nullable()
+    .optional(),
+})
 
-export const storefrontApiKeySchema = z
-  .object({
-    id: z.string(),
-    storefrontId: z.string(),
-    kind: storefrontApiKeyKindSchema,
-    tokenPreview: z.string(),
-    name: z.string().nullable(),
-    lastUsedAt: z.string().nullable(),
-    revokedAt: z.string().nullable(),
-    createdAt: z.string(),
-  })
-  .strict()
+export const storefrontApiKeySchema = z.object({
+  id: z.string(),
+  storefrontId: z.string(),
+  kind: storefrontApiKeyKindSchema,
+  tokenPreview: z.string(),
+  name: z.string().nullable(),
+  lastUsedAt: z.string().nullable(),
+  revokedAt: z.string().nullable(),
+  createdAt: z.string(),
+})
 
 /** Issuance/rotation payload: the plaintext token is present exactly once. */
-export const issuedStorefrontApiKeySchema = storefrontApiKeySchema
-  .extend({ token: z.string() })
-  .strict()
+export const issuedStorefrontApiKeySchema = storefrontApiKeySchema.extend({ token: z.string() })
 
-export const storefrontProviderCredentialStatusSchema = z
-  .object({
-    provider: storefrontSocialProviderSchema,
-    configured: z.boolean(),
-    updatedAt: z.string().nullable(),
-  })
-  .strict()
+export const storefrontProviderCredentialStatusSchema = z.object({
+  provider: storefrontSocialProviderSchema,
+  configured: z.boolean(),
+  updatedAt: z.string().nullable(),
+})
 
 /**
  * Operator-facing capability signal. `businessAccounts` reflects whether the
  * deployment wires the customer business-account onboarding runtime; the
  * business buyer-account controls are disabled when it is false.
  */
-export const storefrontAdminCapabilitiesSchema = z
-  .object({
-    businessAccounts: z.boolean(),
-    manageProviders: z.boolean(),
-    channelBinding: z.boolean(),
-  })
-  .strict()
+export const storefrontAdminCapabilitiesSchema = z.object({
+  businessAccounts: z.boolean(),
+  manageProviders: z.boolean(),
+  channelBinding: z.boolean(),
+})
 
 export const createStorefrontInputSchema = z
   .object({

--- a/packages/auth/tests/unit/storefront-admin-contracts.test.ts
+++ b/packages/auth/tests/unit/storefront-admin-contracts.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest"
 import {
   createStorefrontInputSchema,
   storefrontSchema,
+  updateStorefrontAccountPolicyInputSchema,
+  updateStorefrontMethodsInputSchema,
 } from "../../src/storefront-admin-contracts.js"
 
 const STOREFRONT = {
@@ -35,6 +37,42 @@ describe("storefrontSchema", () => {
   it("still requires a hosting kind to be present", () => {
     expect(storefrontSchema.safeParse({ ...STOREFRONT, hostingKind: "" }).success).toBe(false)
     expect(storefrontSchema.safeParse({ ...STOREFRONT, hostingKind: null }).success).toBe(false)
+  })
+
+  it("decodes fields the runtime provider adds, and keeps them out of the DTO", () => {
+    // Voyant Cloud serves managed storefronts with an `organizationId` this
+    // package does not model. Refusing it rejected the whole list response and
+    // rendered "Storefronts unavailable" on a healthy 200 (voyant#4342).
+    const parsed = storefrontSchema.parse({ ...STOREFRONT, organizationId: "org_1" })
+
+    expect(parsed).toEqual(STOREFRONT)
+    expect(parsed).not.toHaveProperty("organizationId")
+  })
+
+  it("decodes nested objects the runtime provider extends", () => {
+    const parsed = storefrontSchema.parse({
+      ...STOREFRONT,
+      methods: { ...STOREFRONT.methods, passkey: true },
+      accountPolicy: { ...STOREFRONT.accountPolicy, partnerOnboarding: "disabled" },
+    })
+
+    expect(parsed.methods).toEqual(STOREFRONT.methods)
+    expect(parsed.accountPolicy).toEqual(STOREFRONT.accountPolicy)
+  })
+})
+
+describe("write contracts", () => {
+  it("still refuses a request body naming a method this deployment does not have", () => {
+    expect(
+      updateStorefrontMethodsInputSchema.safeParse({ ...STOREFRONT.methods, passkey: true })
+        .success,
+    ).toBe(false)
+    expect(
+      updateStorefrontAccountPolicyInputSchema.safeParse({
+        ...STOREFRONT.accountPolicy,
+        partnerOnboarding: "disabled",
+      }).success,
+    ).toBe(false)
   })
 })
 


### PR DESCRIPTION
Closes #4342.

## What was actually happening

Not a fetch failure, not a crash, not a retry that never runs. The 200 is real
and complete — and the client threw it away.

`GET /v1/admin/storefronts/storefronts` on the sandbox returns (verbatim, captured from the live page):

```json
{"data":[{"id":"sf_km1j5lwnx9bv","organizationId":"org_01KSTAWP6CEKZ67731P2Q646CC",
          "name":"Customer portal","slug":"customer-portal",
          "hostingKind":"managed_portal", …,"channelBinding":null}, …]}
```

`organizationId`. The storefront runtime is a **port**, and on a managed
deployment the provider behind it is Voyant Cloud's control plane — which mints
these storefronts and stamps the owning organization on them. `storefrontSchema`
was `.strict()`, so:

one unrecognized key rejects the object → one rejected object rejects the array →
`fetchWithValidation` throws → the query is in error → **"Storefronts unavailable"**.

Retry is powerless by construction: every retry returns the same valid,
`organizationId`-carrying payload. No console exception, because the throw is
caught by react-query.

The issue's own lead — `channelBinding: null` — is a red herring: that field is
`.nullable().optional()` and parses fine. #4337 is not the cause either; it is
what **unmasked** this. Before it the endpoint 500'd, so the same error state was
being shown for a different reason and this one could not be reached.

## The fix

`storefront-admin-contracts.ts` already argued exactly this case one field
earlier — the doc comment on `storefrontHostingKindSchema` explains that a closed
enum "rejects the array and the storefronts page renders its error state with a
healthy 200 on the wire", and the enum was widened to `z.string()`. The
`.strict()` one line below left the identical trap open for *fields*, and the
control plane walked into it.

So the rule is now stated and applied, not half-applied:

- **Requests stay closed.** A request body is this deployment's own vocabulary;
  an unknown key there is a caller mistake worth refusing. `createStorefront`,
  `updateMethods`, `updateAccountPolicy` and friends are unchanged and still
  `.strict()` — there is a test asserting they still refuse `{…, passkey: true}`.
- **Responses are open.** Response objects strip what they do not know, so the
  DTO the UI receives is exactly the modelled shape (`organizationId` does not
  leak into it) and a control plane on its own release cadence can add fields
  without blanking an admin page.

`methods` and `accountPolicy` are both — they appear in a response DTO *and* are
request bodies in their own right — so they are built from a shared shape: strict
as the write contract, stripping inside `storefrontSchema`.

## Also fixed: a retry that cannot clear the error it reports

The packaged `StorefrontsPage` in this repo has the same "Try again never
recovers" shape for a different reason: `loadFailed` is
`capabilitiesQuery.isError || listQuery.isError`, but Refresh only refetched the
list. A capabilities failure (a cold-start 503, per #4341) therefore showed a
banner no click could clear. Refresh now retries both.

## Verification

Both new tests were confirmed **red** against the unpatched source before being
made green — not asserted from a hand-built input:

- `packages/auth/tests/unit/storefront-admin-contracts.test.ts` — the schema
  accepts a provider-added field and keeps it out of the DTO; nested `methods` /
  `accountPolicy` likewise; the write contracts still refuse the same keys.
- `packages/auth-react/src/storefronts-page.test.tsx` — drives the real
  `createStorefrontsAdminApi(...).listStorefronts()` path against the **verbatim
  production payload** above; plus a render test that fails capabilities, asserts
  the banner, clicks Refresh, and asserts recovery.

Green: `@voyant-travel/auth` 284 tests, `@voyant-travel/auth-react` 70 tests,
`typecheck` and `build` for both (0 `error TS`), root `biome check .` at main's
baseline (0 errors / 21 warnings / 8 infos), and the full `verify:architecture`
chain including `verify:openapi-drift` — unchanged, because only *input* schemas
reach the generated OpenAPI.

No new architecture checker: this is a call-shape rule inside a contracts module,
not something expressible as a declarative rule entry.