### PR TITLE
A Booking Session Commit can state which checkout handoff the storefront can render

### DIFF
--- a/.changeset/booking-session-checkout-handoff-preference.md
+++ b/.changeset/booking-session-checkout-handoff-preference.md
@@ -1,0 +1,35 @@
+---
+"@voyant-travel/catalog-contracts": minor
+"@voyant-travel/catalog-react": minor
+"@voyant-travel/catalog": minor
+---
+
+A Booking Session commit can state which checkout handoffs the storefront can
+render, and forwards it to the payment adapter.
+
+The payment port gained an `embedded` handoff and
+`PaymentInitiationInput.acceptedCheckoutHandoffs` to negotiate it, but nothing
+connected a Booking Session to either: `commitBookingSessionV1.payment` carried
+only `returnUrl` and `cancelUrl`, and the commit never set
+`acceptedCheckoutHandoffs` on the initiation. So the negotiation had no caller —
+a control plane could implement the embedded arm in full and still only ever be
+asked for a redirect.
+
+- `commitBookingSessionV1.payment.acceptedCheckoutHandoffs` is an ordered
+  preference, most-preferred first. Absent means `["redirect"]`, so an existing
+  storefront keeps getting a hosted page rather than a client secret it cannot
+  mount.
+- The commit forwards it verbatim. It interprets none of it: the storefront is
+  the only party that knows what it can render, and an adapter without
+  `embeddedCheckout` still answers a client that prefers `embedded` with a
+  redirect through the existing `negotiatePaymentCheckoutHandoff`.
+- `returnUrl` stays optional and is still accepted alongside an `embedded`
+  preference — the shopper is not sent anywhere, but an issuer authentication
+  step still wants a URL to return to.
+
+The `payment_required` outcome continues to project `redirectUrl` rather than
+the handoff union, so a storefront that asked for `embedded` reads the handoff
+back from `GET /v1/public/finance/payment-sessions/{id}`. `redirectUrl` is
+`null` for that arm, so `commitBookingSessionJourneyV1`'s `payment_required`
+result now also carries `paymentSessionId` — without it the preference the
+helper can now state would have nowhere to land.

--- a/docs/architecture/payment-adapter-boundary.md
+++ b/docs/architecture/payment-adapter-boundary.md
@@ -104,11 +104,22 @@ between decides on its behalf:
 landing page ──acceptedCheckoutHandoffs──▶ POST /start-card ──▶ startCardPayment
      ▲                                                              │
      └────────────── checkout ◀── payment_sessions.checkout ◀── adapter.initiate
+
+storefront ──commit.payment.acceptedCheckoutHandoffs──▶ POST …/commit ──▶ startCardPayment
+     ▲                                                                        │
+     └── checkout ◀── GET /v1/public/finance/payment-sessions/{id} ◀── adapter.initiate
 ```
 
 - **the page** sets `acceptedCheckoutHandoffs` only when a
   `embeddedCheckoutClient` is wired into `<PaymentLinkLandingPage>`. Nothing
   else about a deployment turns in-page checkout on;
+- **the Booking Session commit** carries the same declaration on
+  `commitBookingSessionV1.payment.acceptedCheckoutHandoffs` and forwards it
+  verbatim. The Session is the only path between a storefront and the adapter,
+  so without it a control plane could implement the embedded arm in full and
+  still only ever be asked for a redirect (voyant#4346). The `payment_required`
+  outcome projects `redirectUrl` and not the union, so a storefront that asked
+  for `embedded` reads the handoff back from the payment session by id;
 - **`payment_sessions.checkout`** (jsonb) stores the whole union.
   `redirect_url` remains the redirect arm's flattened projection and the column
   every existing reader uses. A paid session clears both, so a spent client
@@ -127,10 +138,10 @@ is a `ComponentType` the deployment supplies — the same prop-injection seam
 enters the storefront bundle. The client secret reaches it through a
 `fetchClientSecret` callback rather than a prop.
 
-Two callers deliberately stay redirect-only: the commerce booking-engine
-checkout, and `POST /payment-sessions/{id}/requires-redirect`, which stamps a URL
-by name and by contract. Both are safe because of the redirect default, not
-because anything guards them.
+One caller deliberately stays redirect-only:
+`POST /payment-sessions/{id}/requires-redirect`, which stamps a URL by name and
+by contract. It is safe because of the redirect default, not because anything
+guards it.
 
 ## Disputes
 

--- a/packages/catalog-contracts/src/booking-engine/session-contracts.test.ts
+++ b/packages/catalog-contracts/src/booking-engine/session-contracts.test.ts
@@ -81,6 +81,81 @@ describe("Booking Session v1 contracts", () => {
     expect("price" in parsed).toBe(false)
   })
 
+  it("lets a Commit state the checkout handoffs the storefront can render", () => {
+    const parsed = commitBookingSessionV1.parse({
+      expectedRevision: 1,
+      quoteId: "bsqu_1",
+      requirementsFingerprint: "requirements_fingerprint_1",
+      idempotencyKey: "stable_commit_key",
+      payment: { acceptedCheckoutHandoffs: ["embedded", "redirect"] },
+    })
+
+    expect(parsed.payment?.acceptedCheckoutHandoffs).toEqual(["embedded", "redirect"])
+  })
+
+  it("leaves the preference absent when the storefront states nothing", () => {
+    const parsed = commitBookingSessionV1.parse({
+      expectedRevision: 1,
+      quoteId: "bsqu_1",
+      requirementsFingerprint: "requirements_fingerprint_1",
+      idempotencyKey: "stable_commit_key",
+      payment: { returnUrl: "https://shop.example.test/return" },
+    })
+
+    // Not defaulted here: `["redirect"]` is what an absent field *means*, and
+    // the one place that decides it is `acceptedPaymentCheckoutHandoffs`. A
+    // default stamped at the edge would be a second answer to the same
+    // question.
+    expect(parsed.payment?.acceptedCheckoutHandoffs).toBeUndefined()
+  })
+
+  it("accepts a Commit that omits returnUrl, which an embedded handoff never uses", () => {
+    expect(
+      commitBookingSessionV1.safeParse({
+        expectedRevision: 1,
+        quoteId: "bsqu_1",
+        requirementsFingerprint: "requirements_fingerprint_1",
+        idempotencyKey: "stable_commit_key",
+        payment: { acceptedCheckoutHandoffs: ["embedded"] },
+      }).success,
+    ).toBe(true)
+    // ...and still takes one when supplied, because an issuer authentication
+    // step wants somewhere to return to.
+    expect(
+      commitBookingSessionV1.safeParse({
+        expectedRevision: 1,
+        quoteId: "bsqu_1",
+        requirementsFingerprint: "requirements_fingerprint_1",
+        idempotencyKey: "stable_commit_key",
+        payment: {
+          acceptedCheckoutHandoffs: ["embedded"],
+          returnUrl: "https://shop.example.test/return",
+        },
+      }).success,
+    ).toBe(true)
+  })
+
+  it("rejects a handoff the payment port cannot produce, and an empty preference", () => {
+    expect(
+      commitBookingSessionV1.safeParse({
+        expectedRevision: 1,
+        quoteId: "bsqu_1",
+        requirementsFingerprint: "requirements_fingerprint_1",
+        idempotencyKey: "stable_commit_key",
+        payment: { acceptedCheckoutHandoffs: ["iframe"] },
+      }).success,
+    ).toBe(false)
+    expect(
+      commitBookingSessionV1.safeParse({
+        expectedRevision: 1,
+        quoteId: "bsqu_1",
+        requirementsFingerprint: "requirements_fingerprint_1",
+        idempotencyKey: "stable_commit_key",
+        payment: { acceptedCheckoutHandoffs: [] },
+      }).success,
+    ).toBe(false)
+  })
+
   it("returns typed lifecycle outcomes instead of prose-only errors", () => {
     const result = bookingSessionOutcomeV1.safeParse({
       kind: "rejected",

--- a/packages/catalog-contracts/src/booking-engine/session-contracts.ts
+++ b/packages/catalog-contracts/src/booking-engine/session-contracts.ts
@@ -285,8 +285,35 @@ export const commitBookingSessionV1 = z.object({
   idempotencyKey: z.string().min(8).max(128),
   payment: z
     .object({
+      /**
+       * Where the shopper is sent back to once a redirect handoff completes.
+       * Required in practice for the redirect arm and irrelevant to `embedded`
+       * — nobody is sent anywhere — but still accepted there, because an
+       * issuer authentication step wants a URL to return to.
+       */
       returnUrl: z.string().url().optional(),
       cancelUrl: z.string().url().optional(),
+      /**
+       * The checkout handoffs this storefront can render, most-preferred first.
+       *
+       * Absent means `["redirect"]`, so a page built before in-page checkout
+       * existed keeps getting a hosted page rather than a client secret it
+       * cannot mount. The storefront is the only party that knows what it can
+       * render, and the Booking Session is the only path between it and the
+       * adapter: the commit forwards this to
+       * `PaymentInitiationInput.acceptedCheckoutHandoffs` verbatim and
+       * interprets none of it, because the adapter's own capabilities decide
+       * the outcome through `negotiatePaymentCheckoutHandoff` (voyant#4346).
+       *
+       * Mirrors `PaymentCheckoutHandoff` from `@voyant-travel/payments`, which
+       * a contracts package describes rather than imports. The mirror is pinned
+       * by the commit forwarding it into a `readonly PaymentCheckoutHandoff[]`
+       * argument, so an arm added here and nowhere else fails the build.
+       */
+      acceptedCheckoutHandoffs: z
+        .array(z.enum(["redirect", "embedded"]))
+        .min(1)
+        .optional(),
     })
     .optional(),
 })

--- a/packages/catalog-react/src/booking-engine/session-journey.test.ts
+++ b/packages/catalog-react/src/booking-engine/session-journey.test.ts
@@ -118,7 +118,60 @@ describe("Booking Session v1 journey", () => {
       requirementsFingerprint: "requirements-fingerprint-1",
       holdId: "bshd_1",
       commitIdempotencyKey: "manual-booking:payment:commit",
+      paymentSessionId: "pays_1",
       redirectUrl: "https://payments.test/pays_1",
+    })
+  })
+
+  it("carries the stated handoff preference to Commit and hands back the payment session id", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = []
+    const fetcher = vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({ url, body: JSON.parse(String(init?.body ?? "{}")) })
+      if (url.endsWith("/booking-sessions")) {
+        return json({ kind: "session_created", session: session() })
+      }
+      if (url.endsWith("/quote")) return json(quote())
+      if (url.endsWith("/hold")) return json(hold())
+      return json({
+        kind: "commit_result",
+        outcome: {
+          kind: "payment_required",
+          nextAction: "establish_payment_guarantee",
+          paymentTarget: "booking_session",
+          allowedGuarantees: ["deposit"],
+          paymentSession: {
+            id: "pays_1",
+            status: "requires_redirect",
+            amountCents: 5000,
+            currency: "EUR",
+            // An embedded handoff carries no URL. Without the id, a storefront
+            // that asked for one would be told to pay and given nowhere to do
+            // it.
+            redirectUrl: null,
+            expiresAt: "2026-08-01T12:15:00.000Z",
+          },
+        },
+      })
+    })
+
+    const result = await commitBookingSessionJourneyV1(
+      createBookingJourneyApi({ baseUrl: "", fetcher }),
+      {
+        target: { kind: "product", productId: "prod_1" },
+        selection: {},
+        quantity: 1,
+        idempotencyKey: "manual-booking:embedded",
+        payment: { acceptedCheckoutHandoffs: ["embedded", "redirect"] },
+      },
+    )
+
+    expect(calls.at(-1)?.body.payment).toEqual({
+      acceptedCheckoutHandoffs: ["embedded", "redirect"],
+    })
+    expect(result).toMatchObject({
+      kind: "payment_required",
+      paymentSessionId: "pays_1",
+      redirectUrl: null,
     })
   })
 

--- a/packages/catalog-react/src/booking-engine/session-journey.ts
+++ b/packages/catalog-react/src/booking-engine/session-journey.ts
@@ -63,6 +63,15 @@ export type BookingSessionJourneyResult =
   | { kind: "committed"; bookingId: string }
   | ({
       kind: "payment_required"
+      /**
+       * The payment session the guarantee is owed on. Carried because
+       * `redirectUrl` is the redirect arm's projection and is `null` for an
+       * embedded handoff: a storefront that stated
+       * `payment.acceptedCheckoutHandoffs: ["embedded", …]` reads the handoff
+       * itself back by this id, and without it the preference it stated would
+       * have nowhere to land (voyant#4346).
+       */
+      paymentSessionId: string
       redirectUrl: string | null
     } & BookingSessionJourneyContinuation)
 
@@ -143,6 +152,7 @@ async function commitContinuation(
     return {
       kind: "payment_required",
       ...continuation,
+      paymentSessionId: outcome.paymentSession.id,
       redirectUrl: outcome.paymentSession.redirectUrl,
     }
   }

--- a/packages/catalog/openapi/admin/catalog-booking.json
+++ b/packages/catalog/openapi/admin/catalog-booking.json
@@ -13711,6 +13711,14 @@
                       "cancelUrl": {
                         "type": "string",
                         "format": "uri"
+                      },
+                      "acceptedCheckoutHandoffs": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "enum": ["redirect", "embedded"]
+                        },
+                        "minItems": 1
                       }
                     }
                   }

--- a/packages/catalog/openapi/storefront/catalog-booking.json
+++ b/packages/catalog/openapi/storefront/catalog-booking.json
@@ -13711,6 +13711,14 @@
                       "cancelUrl": {
                         "type": "string",
                         "format": "uri"
+                      },
+                      "acceptedCheckoutHandoffs": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "enum": ["redirect", "embedded"]
+                        },
+                        "minItems": 1
                       }
                     }
                   }

--- a/packages/catalog/src/booking-engine/sessions-payment-production.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-payment-production.test.ts
@@ -139,6 +139,49 @@ describe("production Booking Session hosted-checkout initiation", () => {
   })
 })
 
+/**
+ * The storefront is the only party that knows whether it can mount a payment
+ * form, and the Booking Session is the only path between it and the adapter.
+ * The commit therefore carries the preference and interprets none of it —
+ * negotiation is the adapter's, via `negotiatePaymentCheckoutHandoff`
+ * (voyant#4346).
+ */
+describe("production Booking Session checkout handoff preference", () => {
+  beforeEach(() => {
+    startPaymentAdapterCardPayment.mockClear()
+  })
+
+  it("forwards the storefront's stated preference to the adapter unmodified", async () => {
+    const acceptedCheckoutHandoffs = ["embedded", "redirect"] as const
+
+    await prepare({ locale: "en-GB", departureDate: null, acceptedCheckoutHandoffs })
+
+    // Same value, same order: a re-sorted or de-duplicated copy here would be
+    // a second opinion about what the page can render.
+    expect(startArgs().acceptedCheckoutHandoffs).toBe(acceptedCheckoutHandoffs)
+  })
+
+  it("says nothing to the adapter when the storefront said nothing", async () => {
+    await prepare({ locale: "en-GB", departureDate: null })
+
+    // Absent, not `["redirect"]`. The default lives in
+    // `acceptedPaymentCheckoutHandoffs`, and stamping it here would put a
+    // second copy of it on the path.
+    expect(startArgs().acceptedCheckoutHandoffs).toBeUndefined()
+    expect("acceptedCheckoutHandoffs" in startArgs()).toBe(true)
+  })
+
+  it("forwards a redirect-only preference as stated", async () => {
+    await prepare({
+      locale: "en-GB",
+      departureDate: null,
+      acceptedCheckoutHandoffs: ["redirect"],
+    })
+
+    expect(startArgs().acceptedCheckoutHandoffs).toEqual(["redirect"])
+  })
+})
+
 async function prepare(input: {
   locale: string
   departureDate: string | null
@@ -146,6 +189,7 @@ async function prepare(input: {
   personId?: string
   actorKind?: string
   ownerPrincipalId?: string
+  acceptedCheckoutHandoffs?: readonly ("redirect" | "embedded")[]
 }) {
   const payments = createProductionBookingSessionPaymentPorts({
     db: {} as never,
@@ -187,7 +231,12 @@ async function prepare(input: {
       pricing: { total: 10_000, currency: "EUR" },
       expiresAt: new Date("2026-08-06T00:00:00Z"),
     },
-    commit: { idempotencyKey: "commit-1" },
+    commit: {
+      idempotencyKey: "commit-1",
+      ...(input.acceptedCheckoutHandoffs
+        ? { payment: { acceptedCheckoutHandoffs: input.acceptedCheckoutHandoffs } }
+        : {}),
+    },
     access: { actorKind: input.actorKind ?? "anonymous" },
     now: new Date("2026-08-05T00:00:00Z"),
   } as never)
@@ -200,5 +249,6 @@ function startArgs() {
     description?: string
     locale?: string
     customerReference?: string
+    acceptedCheckoutHandoffs?: readonly ("redirect" | "embedded")[]
   }
 }

--- a/packages/catalog/src/booking-engine/sessions-payment-production.ts
+++ b/packages/catalog/src/booking-engine/sessions-payment-production.ts
@@ -144,6 +144,16 @@ export function createProductionBookingSessionPaymentPorts(
             ...(reference ? { customerReference: reference } : {}),
             returnUrl: commit.payment?.returnUrl,
             cancelUrl: commit.payment?.cancelUrl,
+            // Forwarded verbatim: the storefront is the only party that knows
+            // what it can render, and nothing between it and the adapter is
+            // entitled to decide on its behalf. Absent stays absent, which
+            // `acceptedPaymentCheckoutHandoffs` reads as `["redirect"]`, and
+            // an adapter without `embeddedCheckout` still answers with a
+            // redirect through `negotiatePaymentCheckoutHandoff`
+            // (voyant#4346). The parameter type is
+            // `readonly PaymentCheckoutHandoff[]`, which is what pins the
+            // contract's mirrored enum to the port.
+            acceptedCheckoutHandoffs: commit.payment?.acceptedCheckoutHandoffs,
             metadata: {
               bookingSessionId: session.id,
               quoteId: quote.id,


### PR DESCRIPTION
Closes #4346.

#4285 gave the payment port an `embedded` handoff and
`PaymentInitiationInput.acceptedCheckoutHandoffs` to negotiate it. Nothing
connected a Booking Session to either, so the negotiation had no caller: a
control plane could implement the embedded arm in full and still only ever be
asked for a redirect.

## The two missing links

**The Commit can now express it.**
`commitBookingSessionV1.payment.acceptedCheckoutHandoffs` is an ordered
preference, most-preferred first, `min(1)`. Absent means `["redirect"]`, and the
default is deliberately *not* stamped at the edge — `["redirect"]` is what an
absent field means, and `acceptedPaymentCheckoutHandoffs` is the one place that
decides it. A second copy at the transport would be a second answer to the same
question.

**The Commit now forwards it.** `sessions-payment-production.ts` passes it into
`startPaymentAdapterCardPayment` verbatim and interprets none of it. The
parameter is a `readonly PaymentCheckoutHandoff[]`, which is what pins the
contract's mirrored enum to the port — a contracts package describes the wire
and does not import a runtime package, so an arm added to the mirror alone fails
the build rather than drifting.

`returnUrl` needed no change: it was already optional, and it is still accepted
alongside an `embedded` preference, because an issuer authentication step wants
somewhere to return to even when the shopper is never sent anywhere. That is now
stated in the contract and covered by a test rather than being true by accident.

## The third link, which the preference would otherwise have nowhere to land in

The `payment_required` outcome projects `redirectUrl`, not the handoff union,
and `redirectUrl` is `null` for an embedded arm. The handoff is read back by
payment session id from `GET /v1/public/finance/payment-sessions/{id}` — which
is anonymous for a booking-session-targeted row and already has a client in
`finance-react` — but `commitBookingSessionJourneyV1` was **dropping the id**,
keeping only `redirectUrl`. A storefront on that helper could state a preference
and then be told to pay with nowhere to do it, which is the same shape as #4330:
configured, green, and inert.

So the journey result gains `paymentSessionId`. That is additive and is the
minimum needed for the acceptance criterion to be true through this repo's own
helper. The wire projection itself is unchanged — widening
`bookingLifecycleCommitOutcomeV1` to carry the union is a separate decision.

## Acceptance

| | |
|---|---|
| a storefront can state it can render an embedded handoff | `session-contracts.test.ts` — parses and preserves order |
| a storefront that states nothing still receives a redirect | forwarded as `undefined`, not `["redirect"]`; `acceptedPaymentCheckoutHandoffs` resolves it (`sessions-payment-production.test.ts`) |
| the preference reaches the adapter unmodified | asserted by identity (`toBe`), so a re-sorted or de-duplicated copy fails |
| an adapter without `embeddedCheckout` still answers redirect | existing `negotiatePaymentCheckoutHandoff` tests. Note `["embedded"]` **alone** against a redirect-only adapter negotiates to `null` by design — a client that can only mount a form and an adapter that cannot produce one genuinely do not agree. `["embedded", "redirect"]` downgrades |

No new architecture checker: the rule this adds is a type constraint the
existing `readonly PaymentCheckoutHandoff[]` parameter already enforces, so
there was nothing left to express as data.

## Verification

- `catalog-contracts` 96, `catalog` 753 (+52 skipped), `catalog-react` 66 — all pass; new tests confirmed by name in verbose runs
- `typecheck` clean on all three (0 `error TS`, explicit exit 0)
- `biome check .` from root: 0 errors, 21 warnings / 8 infos — main's baseline
- `generate:openapi` regenerated; the field lands in both the admin and
  storefront `catalog-booking.json`, so the published storefront contract
  describes it
- `verify:architecture` run locally
