### PR TITLE
The negotiated checkout handoff reaches the storefront that asked for it

### DIFF
--- a/.changeset/booking-session-checkout-handoff-return.md
+++ b/.changeset/booking-session-checkout-handoff-return.md
@@ -1,0 +1,38 @@
+---
+"@voyant-travel/catalog-contracts": minor
+"@voyant-travel/catalog-react": minor
+"@voyant-travel/catalog": minor
+"@voyant-travel/finance": patch
+---
+
+The negotiated checkout handoff reaches the storefront that asked for it.
+
+The previous release let a Booking Session Commit state
+`payment.acceptedCheckoutHandoffs` and forwarded it to the adapter. Nothing
+carried the answer back: `payment_required.paymentSession` projected
+`redirectUrl`, which is only the redirect arm's flattened value and is `null`
+for an embedded one. So a storefront could ask for an in-page form, have the
+preference honoured all the way to the adapter, and be handed a
+`payment_required` with a null URL and no client secret — the token dying
+between the adapter and the only outcome the storefront reads. Half the path was
+inert.
+
+- `payment_required.paymentSession` gains `checkout`, the whole
+  `PaymentHostedCheckout` union, alongside the unchanged `redirectUrl`. It is
+  required-and-nullable like `redirectUrl`, so a lifecycle implementor that
+  omits it fails to parse rather than silently starving the storefront.
+- The schema is re-exported from `@voyant-travel/finance-contracts` as
+  `bookingPaymentCheckoutV1` rather than mirrored a third time. It is finance's
+  object and that mirror is already pinned to the port by an annotated
+  projection in finance's public service; a private copy here would be the drift
+  the pin exists to prevent. Both are zod-only packages, so nothing
+  runtime-shaped enters the closure.
+- `commitBookingSessionJourneyV1`'s `payment_required` result carries
+  `paymentSessionId` and `checkout`.
+- An initiation that produces an embedded arm is recorded as `pending`, not
+  `requires_redirect`. That state asserts there is somewhere to send the shopper
+  and this arm has nowhere, so the two columns contradicted each other and every
+  reader keyed on it — the status pollers, the pending aggregates, the reuse
+  arms — would wait on a return trip nobody was sent on. `PaymentSessionState`
+  is the framework's vocabulary and the conformance kit pins no state to the
+  arm, so the framework settles it rather than trusting each adapter to.

--- a/docs/architecture/payment-adapter-boundary.md
+++ b/docs/architecture/payment-adapter-boundary.md
@@ -107,7 +107,7 @@ landing page ──acceptedCheckoutHandoffs──▶ POST /start-card ──▶ 
 
 storefront ──commit.payment.acceptedCheckoutHandoffs──▶ POST …/commit ──▶ startCardPayment
      ▲                                                                        │
-     └── checkout ◀── GET /v1/public/finance/payment-sessions/{id} ◀── adapter.initiate
+     └──── checkout ◀── payment_required.paymentSession ◀── payment_sessions.checkout
 ```
 
 - **the page** sets `acceptedCheckoutHandoffs` only when a
@@ -115,17 +115,25 @@ storefront ──commit.payment.acceptedCheckoutHandoffs──▶ POST …/commi
   else about a deployment turns in-page checkout on;
 - **the Booking Session commit** carries the same declaration on
   `commitBookingSessionV1.payment.acceptedCheckoutHandoffs` and forwards it
-  verbatim. The Session is the only path between a storefront and the adapter,
-  so without it a control plane could implement the embedded arm in full and
-  still only ever be asked for a redirect (voyant#4346). The `payment_required`
-  outcome projects `redirectUrl` and not the union, so a storefront that asked
-  for `embedded` reads the handoff back from the payment session by id;
+  verbatim, and its `payment_required` outcome carries `checkout` back. The
+  Session is the only path between a storefront and the adapter in both
+  directions, so **the two halves are one change**: forwarding alone would let a
+  control plane be asked for an embedded arm and have the client secret dropped
+  at the projection, and projecting alone would carry a handoff nobody could ask
+  for (voyant#4346);
 - **`payment_sessions.checkout`** (jsonb) stores the whole union.
   `redirect_url` remains the redirect arm's flattened projection and the column
   every existing reader uses. A paid session clears both, so a spent client
   secret does not linger;
 - **the public session projection** carries `checkout` so the payer's browser
-  gets the token its provider SDK needs.
+  gets the token its provider SDK needs;
+- **the session state** is the framework's, not the adapter's.
+  `requires_redirect` asserts there is somewhere to send the shopper, and the
+  embedded arm has nowhere, so an initiation that produces one is recorded as
+  `pending` no matter what state the adapter reported. The conformance kit does
+  not pin a state to the arm, and the readers keyed on `requires_redirect` — the
+  status pollers, the pending aggregates, the reuse arms — would otherwise wait
+  on a return trip nobody was sent on.
 
 Every hop treats an absent `acceptedCheckoutHandoffs` as `["redirect"]`, which
 is what makes the downgrade real rather than merely typed: a client built before

--- a/packages/catalog-contracts/src/booking-engine/lifecycle-conformance.test.ts
+++ b/packages/catalog-contracts/src/booking-engine/lifecycle-conformance.test.ts
@@ -532,6 +532,7 @@ function outcomeForScenario(
           amountCents: 10_000,
           currency: "EUR",
           redirectUrl: "https://pay.example.test/session",
+          checkout: { kind: "redirect", url: "https://pay.example.test/session" },
           expiresAt: "2026-08-01T13:00:00.000Z",
         },
       }

--- a/packages/catalog-contracts/src/booking-engine/lifecycle-conformance.ts
+++ b/packages/catalog-contracts/src/booking-engine/lifecycle-conformance.ts
@@ -14,6 +14,48 @@ export {
 
 import { bookingLifecycleConformanceScenariosV1 } from "./lifecycle-conformance-scenarios.js"
 
+/**
+ * The processor checkout handoff as it appears on a Booking lifecycle outcome,
+ * mirroring `PaymentHostedCheckout` from `@voyant-travel/payments`.
+ *
+ * Mirrored rather than imported, for two reasons. A contracts package describes
+ * the wire and depends only on zod — it does not pull in a runtime package. And
+ * `@voyant-travel/finance-contracts`, which carries the same mirror for
+ * finance's own routes, is **not on the public npm surface**: importing it here
+ * would drag it and its closure back onto npm through this published package,
+ * which `verify:public-surface` rejects (voyant#4059).
+ *
+ * The copy is not free-floating. `projectPaymentSession` in
+ * `@voyant-travel/catalog` assigns the `payment_sessions.checkout` column —
+ * typed `PaymentHostedCheckout` by the port itself — into this type, so a
+ * drifted arm fails that build rather than silently serving a shape the port no
+ * longer produces.
+ */
+export const bookingPaymentRedirectCheckoutV1 = z.object({
+  kind: z.enum(["hosted_checkout", "redirect"]),
+  url: z.string(),
+  expiresAt: z.string().nullable().optional(),
+})
+
+/**
+ * The in-page arm. `clientSecret` and `publishableKey` are opaque here on
+ * purpose: the runtime forwards them and never parses them, so no provider's
+ * token format is baked into the contract.
+ */
+export const bookingPaymentEmbeddedCheckoutV1 = z.object({
+  kind: z.literal("embedded"),
+  clientSecret: z.string(),
+  publishableKey: z.string(),
+  providerAccountId: z.string().nullable().optional(),
+  expiresAt: z.string().nullable().optional(),
+})
+
+export const bookingPaymentCheckoutV1 = z.discriminatedUnion("kind", [
+  bookingPaymentRedirectCheckoutV1,
+  bookingPaymentEmbeddedCheckoutV1,
+])
+export type BookingPaymentCheckoutV1 = z.infer<typeof bookingPaymentCheckoutV1>
+
 export const bookingCommitmentPolicyKindV1 = z.enum([
   "owned_atomic_commit",
   "sourced_supplier_first",
@@ -321,7 +363,26 @@ const bookingLifecycleOriginalCommitOutcomeV1 = z.discriminatedUnion("kind", [
       ]),
       amountCents: z.number().int().positive(),
       currency: z.string().length(3),
+      /**
+       * The redirect arm's flattened projection, kept so every client that
+       * reads a URL keeps reading one. `null` for an embedded handoff — there
+       * is nowhere to send the shopper — which is why it cannot be the only
+       * handoff field here.
+       */
       redirectUrl: z.string().url().nullable(),
+      /**
+       * The handoff the adapter actually produced, whole.
+       *
+       * Without it a storefront could ask for `embedded` at Commit, have the
+       * preference honoured all the way to the adapter, and then be handed a
+       * `payment_required` with a null URL and no client secret — the token
+       * dying between the adapter and the only outcome the storefront reads.
+       * The request half and this half are one change (voyant#4346).
+       *
+       * `null` when no handoff was produced (an already-established payment, or
+       * an adapter that has not been asked yet).
+       */
+      checkout: bookingPaymentCheckoutV1.nullable(),
       expiresAt: z.string().datetime().nullable(),
     }),
   }),

--- a/packages/catalog-react/src/booking-engine/session-journey.test.ts
+++ b/packages/catalog-react/src/booking-engine/session-journey.test.ts
@@ -97,6 +97,7 @@ describe("Booking Session v1 journey", () => {
             amountCents: 5000,
             currency: "EUR",
             redirectUrl: "https://payments.test/pays_1",
+            checkout: { kind: "redirect", url: "https://payments.test/pays_1" },
             expiresAt: "2026-08-01T12:15:00.000Z",
           },
         },
@@ -119,6 +120,7 @@ describe("Booking Session v1 journey", () => {
       holdId: "bshd_1",
       commitIdempotencyKey: "manual-booking:payment:commit",
       paymentSessionId: "pays_1",
+      checkout: { kind: "redirect", url: "https://payments.test/pays_1" },
       redirectUrl: "https://payments.test/pays_1",
     })
   })
@@ -144,10 +146,14 @@ describe("Booking Session v1 journey", () => {
             status: "requires_redirect",
             amountCents: 5000,
             currency: "EUR",
-            // An embedded handoff carries no URL. Without the id, a storefront
-            // that asked for one would be told to pay and given nowhere to do
-            // it.
+            // An embedded handoff carries no URL, so `redirectUrl` alone would
+            // tell the storefront to pay and give it nowhere to do it.
             redirectUrl: null,
+            checkout: {
+              kind: "embedded",
+              clientSecret: "cs_test_secret",
+              publishableKey: "pk_test_key",
+            },
             expiresAt: "2026-08-01T12:15:00.000Z",
           },
         },
@@ -168,10 +174,18 @@ describe("Booking Session v1 journey", () => {
     expect(calls.at(-1)?.body.payment).toEqual({
       acceptedCheckoutHandoffs: ["embedded", "redirect"],
     })
+    // The whole point of stating the preference: the client secret survives the
+    // round trip. A projection that stopped at `redirectUrl` would hand back a
+    // null URL and nothing to mount.
     expect(result).toMatchObject({
       kind: "payment_required",
       paymentSessionId: "pays_1",
       redirectUrl: null,
+      checkout: {
+        kind: "embedded",
+        clientSecret: "cs_test_secret",
+        publishableKey: "pk_test_key",
+      },
     })
   })
 

--- a/packages/catalog-react/src/booking-engine/session-journey.ts
+++ b/packages/catalog-react/src/booking-engine/session-journey.ts
@@ -16,6 +16,7 @@
  * first Commit attempt precisely so a host can persist it first.
  */
 
+import type { BookingPaymentCheckoutV1 } from "@voyant-travel/catalog-contracts/booking-engine/lifecycle-conformance"
 import type {
   BookingSessionScopeV1,
   CommitBookingSessionV1,
@@ -63,15 +64,15 @@ export type BookingSessionJourneyResult =
   | { kind: "committed"; bookingId: string }
   | ({
       kind: "payment_required"
-      /**
-       * The payment session the guarantee is owed on. Carried because
-       * `redirectUrl` is the redirect arm's projection and is `null` for an
-       * embedded handoff: a storefront that stated
-       * `payment.acceptedCheckoutHandoffs: ["embedded", …]` reads the handoff
-       * itself back by this id, and without it the preference it stated would
-       * have nowhere to land (voyant#4346).
-       */
+      /** The payment session the guarantee is owed on. */
       paymentSessionId: string
+      /**
+       * The handoff to render, whole. A storefront that stated
+       * `payment.acceptedCheckoutHandoffs: ["embedded", …]` mounts its form
+       * from this; `redirectUrl` below is the redirect arm's projection and is
+       * `null` for that arm, so it is not enough on its own (voyant#4346).
+       */
+      checkout: BookingPaymentCheckoutV1 | null
       redirectUrl: string | null
     } & BookingSessionJourneyContinuation)
 
@@ -153,6 +154,7 @@ async function commitContinuation(
       kind: "payment_required",
       ...continuation,
       paymentSessionId: outcome.paymentSession.id,
+      checkout: outcome.paymentSession.checkout ?? null,
       redirectUrl: outcome.paymentSession.redirectUrl,
     }
   }

--- a/packages/catalog/openapi/admin/catalog-booking.json
+++ b/packages/catalog/openapi/admin/catalog-booking.json
@@ -8897,6 +8897,51 @@
                             "type": ["string", "null"],
                             "format": "uri"
                           },
+                          "checkout": {
+                            "oneOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "kind": {
+                                    "type": "string",
+                                    "enum": ["hosted_checkout", "redirect"]
+                                  },
+                                  "url": {
+                                    "type": "string"
+                                  },
+                                  "expiresAt": {
+                                    "type": ["string", "null"]
+                                  }
+                                },
+                                "required": ["kind", "url"]
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "kind": {
+                                    "type": "string",
+                                    "enum": ["embedded"]
+                                  },
+                                  "clientSecret": {
+                                    "type": "string"
+                                  },
+                                  "publishableKey": {
+                                    "type": "string"
+                                  },
+                                  "providerAccountId": {
+                                    "type": ["string", "null"]
+                                  },
+                                  "expiresAt": {
+                                    "type": ["string", "null"]
+                                  }
+                                },
+                                "required": ["kind", "clientSecret", "publishableKey"]
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
                           "expiresAt": {
                             "type": ["string", "null"],
                             "format": "date-time"
@@ -8908,6 +8953,7 @@
                           "amountCents",
                           "currency",
                           "redirectUrl",
+                          "checkout",
                           "expiresAt"
                         ]
                       }
@@ -9333,6 +9379,51 @@
                                     "type": ["string", "null"],
                                     "format": "uri"
                                   },
+                                  "checkout": {
+                                    "oneOf": [
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "kind": {
+                                            "type": "string",
+                                            "enum": ["hosted_checkout", "redirect"]
+                                          },
+                                          "url": {
+                                            "type": "string"
+                                          },
+                                          "expiresAt": {
+                                            "type": ["string", "null"]
+                                          }
+                                        },
+                                        "required": ["kind", "url"]
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "kind": {
+                                            "type": "string",
+                                            "enum": ["embedded"]
+                                          },
+                                          "clientSecret": {
+                                            "type": "string"
+                                          },
+                                          "publishableKey": {
+                                            "type": "string"
+                                          },
+                                          "providerAccountId": {
+                                            "type": ["string", "null"]
+                                          },
+                                          "expiresAt": {
+                                            "type": ["string", "null"]
+                                          }
+                                        },
+                                        "required": ["kind", "clientSecret", "publishableKey"]
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  },
                                   "expiresAt": {
                                     "type": ["string", "null"],
                                     "format": "date-time"
@@ -9344,6 +9435,7 @@
                                   "amountCents",
                                   "currency",
                                   "redirectUrl",
+                                  "checkout",
                                   "expiresAt"
                                 ]
                               }

--- a/packages/catalog/openapi/storefront/catalog-booking.json
+++ b/packages/catalog/openapi/storefront/catalog-booking.json
@@ -8897,6 +8897,51 @@
                             "type": ["string", "null"],
                             "format": "uri"
                           },
+                          "checkout": {
+                            "oneOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "kind": {
+                                    "type": "string",
+                                    "enum": ["hosted_checkout", "redirect"]
+                                  },
+                                  "url": {
+                                    "type": "string"
+                                  },
+                                  "expiresAt": {
+                                    "type": ["string", "null"]
+                                  }
+                                },
+                                "required": ["kind", "url"]
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "kind": {
+                                    "type": "string",
+                                    "enum": ["embedded"]
+                                  },
+                                  "clientSecret": {
+                                    "type": "string"
+                                  },
+                                  "publishableKey": {
+                                    "type": "string"
+                                  },
+                                  "providerAccountId": {
+                                    "type": ["string", "null"]
+                                  },
+                                  "expiresAt": {
+                                    "type": ["string", "null"]
+                                  }
+                                },
+                                "required": ["kind", "clientSecret", "publishableKey"]
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
                           "expiresAt": {
                             "type": ["string", "null"],
                             "format": "date-time"
@@ -8908,6 +8953,7 @@
                           "amountCents",
                           "currency",
                           "redirectUrl",
+                          "checkout",
                           "expiresAt"
                         ]
                       }
@@ -9333,6 +9379,51 @@
                                     "type": ["string", "null"],
                                     "format": "uri"
                                   },
+                                  "checkout": {
+                                    "oneOf": [
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "kind": {
+                                            "type": "string",
+                                            "enum": ["hosted_checkout", "redirect"]
+                                          },
+                                          "url": {
+                                            "type": "string"
+                                          },
+                                          "expiresAt": {
+                                            "type": ["string", "null"]
+                                          }
+                                        },
+                                        "required": ["kind", "url"]
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "kind": {
+                                            "type": "string",
+                                            "enum": ["embedded"]
+                                          },
+                                          "clientSecret": {
+                                            "type": "string"
+                                          },
+                                          "publishableKey": {
+                                            "type": "string"
+                                          },
+                                          "providerAccountId": {
+                                            "type": ["string", "null"]
+                                          },
+                                          "expiresAt": {
+                                            "type": ["string", "null"]
+                                          }
+                                        },
+                                        "required": ["kind", "clientSecret", "publishableKey"]
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  },
                                   "expiresAt": {
                                     "type": ["string", "null"],
                                     "format": "date-time"
@@ -9344,6 +9435,7 @@
                                   "amountCents",
                                   "currency",
                                   "redirectUrl",
+                                  "checkout",
                                   "expiresAt"
                                 ]
                               }

--- a/packages/catalog/src/booking-engine/sessions-payment-production.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-payment-production.test.ts
@@ -4,6 +4,15 @@ import { createProductionBookingSessionPaymentPorts } from "./sessions-payment-p
 
 const startPaymentAdapterCardPayment = vi.hoisted(() => vi.fn(async (..._args: unknown[]) => null))
 
+/**
+ * What the port re-reads after the adapter has been asked. `null` is the
+ * pre-existing default — the port then keeps the session it created, which is
+ * the "no handoff yet" path.
+ */
+const getPaymentSessionById = vi.hoisted(() =>
+  vi.fn(async (..._args: unknown[]) => null as unknown),
+)
+
 vi.mock("@voyant-travel/finance", () => ({
   computePaymentSchedule: () => [
     { amountCents: 10_000, currency: "EUR", scheduleType: "deposit", dueDate: "2026-08-05" },
@@ -17,7 +26,7 @@ vi.mock("@voyant-travel/finance", () => ({
     expiresAt: null,
   }),
   expirePendingBookingSessionPayments: vi.fn(),
-  financeService: { getPaymentSessionById: async () => null },
+  financeService: { getPaymentSessionById },
   findEstablishedBookingSessionPayment: async () => null,
   noDepositPolicy: { kind: "no_deposit" },
   resolveEffectivePaymentPolicy: () => ({ policy: { kind: "deposit" }, source: "operator" }),
@@ -149,6 +158,8 @@ describe("production Booking Session hosted-checkout initiation", () => {
 describe("production Booking Session checkout handoff preference", () => {
   beforeEach(() => {
     startPaymentAdapterCardPayment.mockClear()
+    getPaymentSessionById.mockClear()
+    getPaymentSessionById.mockResolvedValue(null)
   })
 
   it("forwards the storefront's stated preference to the adapter unmodified", async () => {
@@ -180,6 +191,41 @@ describe("production Booking Session checkout handoff preference", () => {
 
     expect(startArgs().acceptedCheckoutHandoffs).toEqual(["redirect"])
   })
+
+  it("carries the negotiated handoff back out, not just its redirect projection", async () => {
+    const outcome = await prepare({
+      locale: "en-GB",
+      departureDate: null,
+      acceptedCheckoutHandoffs: ["embedded", "redirect"],
+      refreshedCheckout: {
+        kind: "embedded",
+        clientSecret: "cs_test_secret",
+        publishableKey: "pk_test_key",
+      },
+      refreshedRedirectUrl: null,
+    })
+
+    // Asking for the arm is worth nothing if the answer dies here: the client
+    // secret has no other way out to the storefront, because `redirectUrl` is
+    // null for exactly this arm.
+    expect(outcome).toMatchObject({
+      kind: "required",
+      paymentSession: {
+        redirectUrl: null,
+        checkout: {
+          kind: "embedded",
+          clientSecret: "cs_test_secret",
+          publishableKey: "pk_test_key",
+        },
+      },
+    })
+  })
+
+  it("reports no handoff as null rather than dropping the field", async () => {
+    const outcome = await prepare({ locale: "en-GB", departureDate: null })
+
+    expect(outcome).toMatchObject({ kind: "required", paymentSession: { checkout: null } })
+  })
 })
 
 async function prepare(input: {
@@ -190,7 +236,23 @@ async function prepare(input: {
   actorKind?: string
   ownerPrincipalId?: string
   acceptedCheckoutHandoffs?: readonly ("redirect" | "embedded")[]
+  refreshedCheckout?: Record<string, unknown>
+  refreshedRedirectUrl?: string | null
 }) {
+  if (input.refreshedCheckout !== undefined) {
+    // What the adapter persisted, read back by the port exactly as production
+    // reads it — through `financeService.getPaymentSessionById`, not by
+    // handing the port a pre-built projection.
+    getPaymentSessionById.mockResolvedValue({
+      id: "pmts_1",
+      status: "pending",
+      amountCents: 10_000,
+      currency: "EUR",
+      redirectUrl: input.refreshedRedirectUrl ?? null,
+      checkout: input.refreshedCheckout,
+      expiresAt: null,
+    })
+  }
   const payments = createProductionBookingSessionPaymentPorts({
     db: {} as never,
     inventory: {

--- a/packages/catalog/src/booking-engine/sessions-payment-production.ts
+++ b/packages/catalog/src/booking-engine/sessions-payment-production.ts
@@ -1,3 +1,4 @@
+import type { BookingPaymentCheckoutV1 } from "@voyant-travel/catalog-contracts/booking-engine/lifecycle-conformance"
 import type { PaymentAdapter, PaymentAdapterRuntimeContext } from "@voyant-travel/finance"
 import {
   computePaymentSchedule,
@@ -248,6 +249,15 @@ function hasStaffPaymentSchedule(payload: Record<string, unknown>): boolean {
   return Array.isArray(staffBooking?.paymentSchedules) && staffBooking.paymentSchedules.length > 0
 }
 
+/**
+ * What the Commit outcome says about the payment the shopper still owes.
+ *
+ * `checkout` is carried whole. `redirectUrl` is only the redirect arm's
+ * flattened projection and is `null` for an embedded handoff, so a projection
+ * that stopped at it would drop the client secret between the adapter and the
+ * one outcome the storefront reads — the storefront having just been allowed to
+ * ask for that arm at Commit (voyant#4346).
+ */
 function projectPaymentSession(session: {
   id: string
   status:
@@ -262,6 +272,7 @@ function projectPaymentSession(session: {
   amountCents: number
   currency: string
   redirectUrl: string | null
+  checkout?: BookingPaymentCheckoutV1 | null
   expiresAt: Date | null
 }) {
   return {
@@ -270,6 +281,7 @@ function projectPaymentSession(session: {
     amountCents: session.amountCents,
     currency: session.currency,
     redirectUrl: session.redirectUrl,
+    checkout: session.checkout ?? null,
     expiresAt: session.expiresAt?.toISOString() ?? null,
   }
 }

--- a/packages/catalog/src/booking-engine/sessions-service.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-service.test.ts
@@ -1818,6 +1818,7 @@ function createPaymentHarness() {
           amountCents: 10_000,
           currency: "EUR",
           redirectUrl: "https://payments.example.test/session/1",
+          checkout: { kind: "redirect", url: "https://payments.example.test/session/1" },
           expiresAt: "2026-08-01T12:01:00.000Z",
         },
       }

--- a/packages/catalog/src/booking-engine/sessions-service.ts
+++ b/packages/catalog/src/booking-engine/sessions-service.ts
@@ -1,3 +1,4 @@
+import type { BookingPaymentCheckoutV1 } from "@voyant-travel/catalog-contracts/booking-engine/lifecycle-conformance"
 import type {
   OfferPreviewOutcomeV1,
   OfferPreviewRequestV1,
@@ -430,6 +431,13 @@ export interface BookingSessionPaymentPorts {
           amountCents: number
           currency: string
           redirectUrl: string | null
+          /**
+           * The handoff the adapter produced, whole. `redirectUrl` above is its
+           * redirect-arm projection and is `null` for an embedded one, so this
+           * is the only field that can carry a client secret out to the
+           * storefront that asked for it (voyant#4346).
+           */
+          checkout: BookingPaymentCheckoutV1 | null
           expiresAt: string | null
         }
         allowedGuarantees: Array<"deposit" | "pre_auth" | "card_on_file" | "agency_letter">

--- a/packages/finance/src/payment-adapter-events.ts
+++ b/packages/finance/src/payment-adapter-events.ts
@@ -6,7 +6,7 @@ import type {
   PaymentSessionState,
   PaymentStatusResult,
 } from "@voyant-travel/payments"
-import { paymentCheckoutRedirectUrl } from "@voyant-travel/payments"
+import { isEmbeddedPaymentCheckout, paymentCheckoutRedirectUrl } from "@voyant-travel/payments"
 import { eq } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import {
@@ -183,6 +183,29 @@ async function applyPaymentAdapterStateUpdate(
   return applyLockedNonCompletionStateUpdate(db, update, providerData)
 }
 
+/**
+ * The state an initiation leaves the session in.
+ *
+ * `requires_redirect` names a fact — there is a URL the shopper must be sent to
+ * — and the embedded arm has none: `redirectUrl` is null for it, so the two
+ * columns would contradict each other and every reader keyed on that state (the
+ * status pollers, the pending aggregates, the reuse arms) would sit waiting for
+ * a return that nobody was ever sent on.
+ *
+ * The framework settles this rather than the adapter. `PaymentSessionState` is
+ * the framework's own vocabulary, the conformance kit does not pin a state to
+ * the embedded arm, and a processor that has just learned to return a client
+ * secret cannot be relied on to also pick the right word for it. `pending` is
+ * the honest answer and is already an expected initiation outcome — see the
+ * uncontested-claim finalisation below — so no new state member is needed
+ * (voyant#4346).
+ */
+export function initiationNextState(result: PaymentInitiationResult): PaymentSessionState {
+  if (result.nextState !== "requires_redirect") return result.nextState
+  if (!result.checkout || !isEmbeddedPaymentCheckout(result.checkout)) return result.nextState
+  return "pending"
+}
+
 export async function applyPaymentAdapterInitiationResult(
   db: PostgresJsDatabase,
   paymentSessionId: string,
@@ -204,7 +227,7 @@ export async function applyPaymentAdapterInitiationResult(
     {
       source: "initiation",
       paymentSessionId,
-      nextState: result.nextState,
+      nextState: initiationNextState(result),
       occurredAt: new Date().toISOString(),
       processorIdentity: result.processorIdentity,
       processorSessionId: result.processorSessionId,

--- a/packages/finance/tests/unit/payment-adapter-initiation-state.test.ts
+++ b/packages/finance/tests/unit/payment-adapter-initiation-state.test.ts
@@ -1,0 +1,83 @@
+import type { PaymentInitiationResult } from "@voyant-travel/payments"
+import { describe, expect, it } from "vitest"
+
+import { initiationNextState } from "../../src/payment-adapter-events.js"
+
+/**
+ * `requires_redirect` asserts there is somewhere to send the shopper. The
+ * embedded arm has nowhere — `redirectUrl` is null for it — so an adapter that
+ * reports both leaves the row self-contradictory and every reader keyed on that
+ * state waiting for a return trip nobody was sent on. The framework owns
+ * `PaymentSessionState`, so the framework settles it (voyant#4346).
+ */
+describe("initiation state for a negotiated checkout handoff", () => {
+  it("records an embedded handoff as pending, not requires_redirect", () => {
+    expect(
+      initiationNextState(
+        result({
+          nextState: "requires_redirect",
+          checkout: {
+            kind: "embedded",
+            clientSecret: "cs_test_secret",
+            publishableKey: "pk_test_key",
+          },
+        }),
+      ),
+    ).toBe("pending")
+  })
+
+  it("leaves a redirect handoff alone", () => {
+    expect(
+      initiationNextState(
+        result({
+          nextState: "requires_redirect",
+          checkout: { kind: "redirect", url: "https://pay.example.test/session" },
+        }),
+      ),
+    ).toBe("requires_redirect")
+    expect(
+      initiationNextState(
+        result({
+          nextState: "requires_redirect",
+          checkout: { kind: "hosted_checkout", url: "https://pay.example.test/session" },
+        }),
+      ),
+    ).toBe("requires_redirect")
+  })
+
+  it("leaves requires_redirect alone when no handoff was produced", () => {
+    // Nothing to contradict. A processor that means "go somewhere" and has not
+    // said where yet is a separate problem, and not one to paper over here.
+    expect(initiationNextState(result({ nextState: "requires_redirect", checkout: null }))).toBe(
+      "requires_redirect",
+    )
+  })
+
+  it("never rewrites a state that is not requires_redirect", () => {
+    for (const nextState of ["pending", "processing", "authorized", "paid"] as const) {
+      expect(
+        initiationNextState(
+          result({
+            nextState,
+            checkout: {
+              kind: "embedded",
+              clientSecret: "cs_test_secret",
+              publishableKey: "pk_test_key",
+            },
+          }),
+        ),
+      ).toBe(nextState)
+    }
+  })
+})
+
+function result(
+  input: Pick<PaymentInitiationResult, "nextState" | "checkout">,
+): PaymentInitiationResult {
+  return {
+    nextState: input.nextState,
+    checkout: input.checkout,
+    idempotencyKey: "init-1",
+    processorIdentity: { providerId: "fake-pay", connectionId: "connection-1" },
+  }
+}


### PR DESCRIPTION
Follow-up to #4347. Refs #4346.

#4347 landed the request half: a Commit can state
`payment.acceptedCheckoutHandoffs` and the runtime forwards it verbatim. On its
own that half is **inert**, and worse than inert for the client it was built
for.

`payment_required.paymentSession` projected `id, status, amountCents, currency,
redirectUrl, expiresAt`. `redirectUrl` is only the redirect arm's flattened
value and is `null` for an embedded one. So the chain ran: storefront asks for
`embedded` → runtime forwards it → the control plane creates a PaymentIntent and
returns `{ kind: "embedded", clientSecret, publishableKey, providerAccountId }`
→ **the runtime drops it**, and the storefront gets a `payment_required` with a
null URL and nothing to mount. The token died between the adapter and the only
outcome the storefront reads, and no control plane can compensate for that from
its side.

## The return path

- `payment_required.paymentSession` gains `checkout` — the whole union —
  alongside the unchanged `redirectUrl`. **Required-and-nullable**, like
  `redirectUrl`: an implementor that omits it fails to parse rather than
  silently starving the storefront. That is not theoretical — the port fixture
  in `sessions-service.test.ts` failed to compile until it answered.
- `commitBookingSessionJourneyV1`'s `payment_required` result carries
  `paymentSessionId` and `checkout`, so a storefront on the shared helper sees
  the handoff without a second round trip.

## Status: `requires_redirect` is wrong for this arm, and the adapter cannot be the one to know it

`requires_redirect` asserts there is somewhere to send the shopper. The embedded
arm has nowhere — `redirectUrl` is null for it — so the two columns contradict
each other, and every reader keyed on that state (`PAYMENT_ADAPTER_POLLABLE_STATES`,
the pending aggregates in `service-aggregates`, the reuse arms in
`reusableStoredHandoff`) waits on a return trip nobody was sent on.

I checked whether the conformance kit already settles this: it does not.
`assertInitiationResult` validates the arm against what the caller accepted but
pins **no** `nextState` to it, so an adapter is free to report either and nothing
catches it. `PaymentSessionState` is the framework's vocabulary, so the framework
settles it — `initiationNextState` records an embedded arm as `pending`, which
the uncontested-claim finalisation already treats as an expected initiation
outcome, so no new state member is needed.

I deliberately did **not** tighten the conformance kit to reject
`requires_redirect + embedded`: that would newly fail existing adapters for a
condition the runtime now handles.

## The union is mirrored, and `verify:public-surface` is why

My first pass imported `paymentCheckoutSchema` from
`@voyant-travel/finance-contracts` to avoid a third copy. The closure checker
rejected it, correctly: `catalog-contracts` is on the public npm surface and
`finance-contracts` is not, so the import would drag it and its closure back
onto npm through a published package (#4059).

So it is mirrored as `bookingPaymentCheckoutV1` — but not free-floating.
`projectPaymentSession` assigns the `payment_sessions.checkout` column, typed
`PaymentHostedCheckout` by the port itself, into this type, so a drifted arm
fails that build rather than serving a shape the port no longer produces. The
dependency graph and lockfile are byte-identical to `main`.

## Verification

- `build` closure exit 0, `grep -c "error TS"` = 0
- `typecheck` exit 0 / 0 errors on `catalog-contracts`, `catalog`,
  `catalog-react`, `finance`
- tests: catalog-contracts 96, catalog 755 (+52 skipped), catalog-react 66,
  finance 558 (+400 skipped) — all pass. New tests confirmed **by name** in
  verbose runs, not by totals
- `biome check .` from root: **0 errors**, 21 warnings / 8 infos — main's
  baseline
- `verify:architecture` run locally
- `generate:openapi` regenerated: the `checkout` union, both arms including
  `clientSecret`, now appears in the commit response in the admin and storefront
  specs

## Deliberately not in scope

`checkout` is not added to the other `bookingLifecycleCommitOutcomeV1` arms, and
the public finance projection is unchanged — neither is load-bearing for this
path. Say so if either should come along.
