### PR TITLE
fix: scroll payment setup dialogs

### DIFF
--- a/packages/operator-settings-react/src/payments-settings-page.tsx
+++ b/packages/operator-settings-react/src/payments-settings-page.tsx
@@ -26,6 +26,7 @@ import {
   CardHeader,
   CardTitle,
   Dialog,
+  DialogBody,
   DialogContent,
   DialogDescription,
   DialogFooter,
@@ -934,27 +935,29 @@ export function PaymentsSettingsPage({ embeddedOnboardingClient }: PaymentsSetti
                   <DialogDescription>{t.onboardingDescription}</DialogDescription>
                 </DialogHeader>
 
-                {onboardingSession ? (
-                  <PaymentEmbeddedOnboardingBoundary
-                    key={onboardingSession.expiresAt}
-                    session={onboardingSession}
-                    client={embeddedOnboardingClient}
-                    refreshClientSecret={refreshOnboardingClientSecret}
-                    onExit={closeDialog}
-                    fallbackTitle={t.onboardingUnavailableTitle}
-                    fallbackDescription={t.onboardingUnavailableDescription}
-                  />
-                ) : (
-                  <FieldGroup>
-                    <ModeField
-                      modes={dialogProvider.modes}
-                      mode={mode}
-                      onChange={setMode}
-                      label={t.modeLabel}
-                      labels={modeLabels}
+                <DialogBody>
+                  {onboardingSession ? (
+                    <PaymentEmbeddedOnboardingBoundary
+                      key={onboardingSession.expiresAt}
+                      session={onboardingSession}
+                      client={embeddedOnboardingClient}
+                      refreshClientSecret={refreshOnboardingClientSecret}
+                      onExit={closeDialog}
+                      fallbackTitle={t.onboardingUnavailableTitle}
+                      fallbackDescription={t.onboardingUnavailableDescription}
                     />
-                  </FieldGroup>
-                )}
+                  ) : (
+                    <FieldGroup>
+                      <ModeField
+                        modes={dialogProvider.modes}
+                        mode={mode}
+                        onChange={setMode}
+                        label={t.modeLabel}
+                        labels={modeLabels}
+                      />
+                    </FieldGroup>
+                  )}
+                </DialogBody>
 
                 <DialogFooter>
                   <Button type="button" variant="outline" onClick={closeDialog}>
@@ -984,86 +987,89 @@ export function PaymentsSettingsPage({ embeddedOnboardingClient }: PaymentsSetti
                 </DialogHeader>
 
                 <form
+                  className="flex min-h-0 flex-1 flex-col"
                   onSubmit={(event) => {
                     event.preventDefault()
                     connect.mutate(dialogProvider)
                   }}
                 >
-                  <FieldGroup>
-                    <ModeField
-                      modes={dialogProvider.modes}
-                      mode={mode}
-                      onChange={setMode}
-                      label={t.modeLabel}
-                      labels={modeLabels}
-                    />
+                  <DialogBody>
+                    <FieldGroup>
+                      <ModeField
+                        modes={dialogProvider.modes}
+                        mode={mode}
+                        onChange={setMode}
+                        label={t.modeLabel}
+                        labels={modeLabels}
+                      />
 
-                    {dialogProvider.credentialFieldSchema.map((field) => (
-                      <Field key={field.key}>
-                        <FieldLabel htmlFor={`payment-${field.key}`}>{field.label}</FieldLabel>
-                        {field.kind === "boolean" ? (
-                          <Switch
-                            id={`payment-${field.key}`}
-                            checked={Boolean(credentials[field.key])}
-                            aria-required={field.required}
-                            onCheckedChange={(checked) =>
-                              setCredentials((current) => ({
-                                ...current,
-                                [field.key]: checked,
-                              }))
-                            }
-                          />
-                        ) : field.kind === "select" ? (
-                          <NativeSelect
-                            id={`payment-${field.key}`}
-                            required={field.required}
-                            value={String(credentials[field.key] ?? "")}
-                            onChange={(event) =>
-                              setCredentials((current) => ({
-                                ...current,
-                                [field.key]: event.target.value,
-                              }))
-                            }
-                          >
-                            <NativeSelectOption value="" />
-                            {(field.options ?? []).map((option) => (
-                              <NativeSelectOption key={option.value} value={option.value}>
-                                {option.label}
-                              </NativeSelectOption>
-                            ))}
-                          </NativeSelect>
-                        ) : (
-                          <Input
-                            id={`payment-${field.key}`}
-                            type={field.kind === "secret" ? "password" : "text"}
-                            autoComplete="off"
-                            required={field.required}
-                            placeholder={field.placeholder}
-                            value={String(credentials[field.key] ?? "")}
-                            onChange={(event) =>
-                              setCredentials((current) => ({
-                                ...current,
-                                [field.key]: event.target.value,
-                              }))
-                            }
-                          />
-                        )}
-                        {field.helpText ? (
-                          <FieldDescription>{field.helpText}</FieldDescription>
-                        ) : null}
-                      </Field>
-                    ))}
+                      {dialogProvider.credentialFieldSchema.map((field) => (
+                        <Field key={field.key}>
+                          <FieldLabel htmlFor={`payment-${field.key}`}>{field.label}</FieldLabel>
+                          {field.kind === "boolean" ? (
+                            <Switch
+                              id={`payment-${field.key}`}
+                              checked={Boolean(credentials[field.key])}
+                              aria-required={field.required}
+                              onCheckedChange={(checked) =>
+                                setCredentials((current) => ({
+                                  ...current,
+                                  [field.key]: checked,
+                                }))
+                              }
+                            />
+                          ) : field.kind === "select" ? (
+                            <NativeSelect
+                              id={`payment-${field.key}`}
+                              required={field.required}
+                              value={String(credentials[field.key] ?? "")}
+                              onChange={(event) =>
+                                setCredentials((current) => ({
+                                  ...current,
+                                  [field.key]: event.target.value,
+                                }))
+                              }
+                            >
+                              <NativeSelectOption value="" />
+                              {(field.options ?? []).map((option) => (
+                                <NativeSelectOption key={option.value} value={option.value}>
+                                  {option.label}
+                                </NativeSelectOption>
+                              ))}
+                            </NativeSelect>
+                          ) : (
+                            <Input
+                              id={`payment-${field.key}`}
+                              type={field.kind === "secret" ? "password" : "text"}
+                              autoComplete="off"
+                              required={field.required}
+                              placeholder={field.placeholder}
+                              value={String(credentials[field.key] ?? "")}
+                              onChange={(event) =>
+                                setCredentials((current) => ({
+                                  ...current,
+                                  [field.key]: event.target.value,
+                                }))
+                              }
+                            />
+                          )}
+                          {field.helpText ? (
+                            <FieldDescription>{field.helpText}</FieldDescription>
+                          ) : null}
+                        </Field>
+                      ))}
+                    </FieldGroup>
+                  </DialogBody>
 
-                    <DialogFooter>
-                      <Button type="button" variant="outline" onClick={closeDialog}>
-                        {t.cancel}
-                      </Button>
-                      <Button type="submit" disabled={connect.isPending}>
-                        {connect.isPending ? <Spinner data-icon="inline-start" /> : null}
-                        {t.connect}
-                      </Button>
-                    </DialogFooter>
-                  </FieldGroup>
+                  <DialogFooter>
+                    <Button type="button" variant="outline" onClick={closeDialog}>
+                      {t.cancel}
+                    </Button>
+                    <Button type="submit" disabled={connect.isPending}>
+                      {connect.isPending ? <Spinner data-icon="inline-start" /> : null}
+                      {t.connect}
+                    </Button>
+                  </DialogFooter>
                 </form>
               </>
             )

--- a/packages/storefront-sdk/tests/unit/booking-session-v1.test.ts
+++ b/packages/storefront-sdk/tests/unit/booking-session-v1.test.ts
@@ -85,6 +85,10 @@ describe("Booking Session v1 SDK", () => {
                   amountCents: 10000,
                   currency: "EUR",
                   redirectUrl: "https://payments.example.test/checkout/pays_demo",
+                  checkout: {
+                    kind: "redirect",
+                    url: "https://payments.example.test/checkout/pays_demo",
+                  },
                   expiresAt: "2026-08-01T12:15:00.000Z",
                 },
               },


### PR DESCRIPTION
## Summary

- wrap embedded payment onboarding content in the design-system `DialogBody` scroll region
- give credential setup dialogs the same scrollable body with a pinned action footer
- update the storefront payment-continuation fixture for the current checkout-handoff schema, resolving the CI failure inherited from `main`

## Root cause

The payment setup dialog rendered its dynamic body directly between the header and footer, allowing long provider forms to exceed the viewport and push every action out of reach. Separately, the inherited storefront SDK test fixture omitted the required `paymentSession.checkout` handoff.

Fixes #4353.

## Validation

Not run locally, per request. GitHub Actions CI is running.