### PR TITLE
Commit paid Booking Sessions on settlement

### DIFF
--- a/.changeset/paid-booking-session-settlement.md
+++ b/.changeset/paid-booking-session-settlement.md
@@ -1,0 +1,13 @@
+---
+"@voyant-travel/catalog": patch
+"@voyant-travel/commerce": patch
+---
+
+Commit a paid Booking Session from `payment.completed`, even when the shopper
+does not return from hosted checkout.
+
+The settlement subscriber now re-enters the canonical Booking Session Commit
+with the exact paid payment-session id, so booking creation, hold consumption,
+payment transfer, invoice creation, and retries retain the same invariants as a
+shopper-initiated commit. A concurrent returning shopper and settlement event
+converge on the single durable Session commit.

--- a/packages/catalog/package.json
+++ b/packages/catalog/package.json
@@ -57,6 +57,7 @@
     "./booking-engine/operator-routes": "./src/booking-engine/operator-routes.ts",
     "./runtime-port": "./src/content-runtime-port.ts",
     "./booking-session-maintenance-job": "./src/booking-session-maintenance-job.ts",
+    "./booking-session-settlement-runtime-port": "./src/booking-session-settlement-runtime-port.ts",
     "./reindex-job": "./src/reindex-job.ts",
     "./sources-sync-job": "./src/sources-sync-job.ts",
     "./graph-runtime": "./src/graph-runtime.ts",
@@ -376,6 +377,11 @@
         "types": "./dist/booking-session-maintenance-job.d.ts",
         "import": "./dist/booking-session-maintenance-job.js",
         "default": "./dist/booking-session-maintenance-job.js"
+      },
+      "./booking-session-settlement-runtime-port": {
+        "types": "./dist/booking-session-settlement-runtime-port.d.ts",
+        "import": "./dist/booking-session-settlement-runtime-port.js",
+        "default": "./dist/booking-session-settlement-runtime-port.js"
       },
       "./reindex-job": {
         "types": "./dist/reindex-job.d.ts",

--- a/packages/catalog/package.json
+++ b/packages/catalog/package.json
@@ -57,7 +57,6 @@
     "./booking-engine/operator-routes": "./src/booking-engine/operator-routes.ts",
     "./runtime-port": "./src/content-runtime-port.ts",
     "./booking-session-maintenance-job": "./src/booking-session-maintenance-job.ts",
-    "./booking-session-settlement-runtime-port": "./src/booking-session-settlement-runtime-port.ts",
     "./reindex-job": "./src/reindex-job.ts",
     "./sources-sync-job": "./src/sources-sync-job.ts",
     "./graph-runtime": "./src/graph-runtime.ts",
@@ -377,11 +376,6 @@
         "types": "./dist/booking-session-maintenance-job.d.ts",
         "import": "./dist/booking-session-maintenance-job.js",
         "default": "./dist/booking-session-maintenance-job.js"
-      },
-      "./booking-session-settlement-runtime-port": {
-        "types": "./dist/booking-session-settlement-runtime-port.d.ts",
-        "import": "./dist/booking-session-settlement-runtime-port.js",
-        "default": "./dist/booking-session-settlement-runtime-port.js"
       },
       "./reindex-job": {
         "types": "./dist/reindex-job.d.ts",

--- a/packages/catalog/src/booking-engine/sessions-drizzle.ts
+++ b/packages/catalog/src/booking-engine/sessions-drizzle.ts
@@ -316,6 +316,14 @@ export function createDrizzleBookingSessionRepository(
         .limit(1)
       return row ? mapCommit(row) : null
     },
+    async getCommitForSession(sessionId) {
+      const [row] = await resolveDb()
+        .select()
+        .from(bookingSessionCommitsTable)
+        .where(eq(bookingSessionCommitsTable.sessionId, sessionId))
+        .limit(1)
+      return row ? mapCommit(row) : null
+    },
     async saveCommit(record) {
       await resolveDb().insert(bookingSessionCommitsTable).values({
         id: record.id,

--- a/packages/catalog/src/booking-engine/sessions-memory.ts
+++ b/packages/catalog/src/booking-engine/sessions-memory.ts
@@ -116,6 +116,12 @@ export function createInMemoryBookingSessionRepository(): InMemoryBookingSession
       )
       return commit ? cloneCommit(commit) : null
     },
+    async getCommitForSession(sessionId) {
+      const commit = [...repository.commits.values()].find(
+        (record) => record.sessionId === sessionId,
+      )
+      return commit ? cloneCommit(commit) : null
+    },
     async saveCommit(record) {
       repository.commits.set(record.id, cloneCommit(record))
     },

--- a/packages/catalog/src/booking-engine/sessions-payment-production.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-payment-production.test.ts
@@ -228,6 +228,53 @@ describe("production Booking Session checkout handoff preference", () => {
   })
 })
 
+describe("production Booking Session settlement", () => {
+  beforeEach(() => {
+    startPaymentAdapterCardPayment.mockClear()
+    getPaymentSessionById.mockClear()
+  })
+
+  it("uses the exact paid Session named by the completion event", async () => {
+    getPaymentSessionById.mockResolvedValue({
+      id: "pmts_paid",
+      targetType: "booking_session",
+      targetId: "bses_01k",
+      status: "paid",
+      amountCents: 10_000,
+      currency: "EUR",
+    })
+
+    await expect(
+      prepare({
+        locale: "en-GB",
+        departureDate: null,
+        settlementPaymentSessionId: "pmts_paid",
+      }),
+    ).resolves.toEqual({ kind: "established", paymentSessionId: "pmts_paid" })
+    expect(getPaymentSessionById).toHaveBeenCalledWith({}, "pmts_paid")
+    expect(startPaymentAdapterCardPayment).not.toHaveBeenCalled()
+  })
+
+  it("rejects a completion event whose payment does not belong to the Session", async () => {
+    getPaymentSessionById.mockResolvedValue({
+      id: "pmts_paid",
+      targetType: "booking_session",
+      targetId: "bses_other",
+      status: "paid",
+      amountCents: 10_000,
+      currency: "EUR",
+    })
+
+    await expect(
+      prepare({
+        locale: "en-GB",
+        departureDate: null,
+        settlementPaymentSessionId: "pmts_paid",
+      }),
+    ).rejects.toThrow("booking_session_settlement_payment_not_established")
+  })
+})
+
 async function prepare(input: {
   locale: string
   departureDate: string | null
@@ -238,6 +285,7 @@ async function prepare(input: {
   acceptedCheckoutHandoffs?: readonly ("redirect" | "embedded")[]
   refreshedCheckout?: Record<string, unknown>
   refreshedRedirectUrl?: string | null
+  settlementPaymentSessionId?: string
 }) {
   if (input.refreshedCheckout !== undefined) {
     // What the adapter persisted, read back by the port exactly as production
@@ -299,7 +347,18 @@ async function prepare(input: {
         ? { payment: { acceptedCheckoutHandoffs: input.acceptedCheckoutHandoffs } }
         : {}),
     },
-    access: { actorKind: input.actorKind ?? "anonymous" },
+    access: {
+      actorKind: input.actorKind ?? "anonymous",
+      ...(input.settlementPaymentSessionId
+        ? {
+            settlementAuthority: {
+              admitted: true,
+              reason: "paid booking session settlement",
+              paymentSessionId: input.settlementPaymentSessionId,
+            },
+          }
+        : {}),
+    },
     now: new Date("2026-08-05T00:00:00Z"),
   } as never)
 }

--- a/packages/catalog/src/booking-engine/sessions-payment-production.ts
+++ b/packages/catalog/src/booking-engine/sessions-payment-production.ts
@@ -78,6 +78,24 @@ export function createProductionBookingSessionPaymentPorts(
       )[0]
       if (!dueNow || dueNow.amountCents <= 0) return { kind: "not_required" }
 
+      const settlementPaymentSessionId = access.settlementAuthority?.paymentSessionId
+      if (settlementPaymentSessionId) {
+        const settled = await financeService.getPaymentSessionById(
+          deps.db,
+          settlementPaymentSessionId,
+        )
+        if (
+          settled?.targetType !== "booking_session" ||
+          settled.targetId !== session.id ||
+          settled.amountCents !== dueNow.amountCents ||
+          settled.currency !== dueNow.currency ||
+          (settled.status !== "authorized" && settled.status !== "paid")
+        ) {
+          throw new Error("booking_session_settlement_payment_not_established")
+        }
+        return { kind: "established", paymentSessionId: settled.id }
+      }
+
       const established = await findEstablishedBookingSessionPayment(deps.db, session.id, {
         amountCents: dueNow.amountCents,
         currency: dueNow.currency,

--- a/packages/catalog/src/booking-engine/sessions-service.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-service.test.ts
@@ -198,6 +198,67 @@ describe("Booking Session v1 owned tracer", () => {
     ])
   })
 
+  it("commits a paid Session without the shopper capability and converges retries", async () => {
+    const payment = createPaymentHarness()
+    payment.established = true
+    const harness = createHarness({}, payment.ports)
+    const { session } = await createQuoteAndHold(harness)
+
+    const first = await harness.module.commitPaidSession({
+      bookingSessionId: session.id,
+      paymentSessionId: "payment_session_1",
+    })
+    const retry = await harness.module.commitPaidSession({
+      bookingSessionId: session.id,
+      paymentSessionId: "payment_session_1",
+    })
+
+    expect(retry).toEqual(first)
+    expect(harness.inventory.bookingIds).toEqual([first.bookingId])
+    expect(payment.transfers).toEqual([
+      expect.objectContaining({
+        paymentSessionId: "payment_session_1",
+        bookingSessionId: session.id,
+        bookingId: first.bookingId,
+      }),
+    ])
+    expect(
+      [...harness.repository.auditEvents.values()].find((event) => event.action === "commit"),
+    ).toMatchObject({
+      actorKind: "system",
+      authorityReason: "paid booking session settlement",
+    })
+  })
+
+  it("converges a settlement commit racing the returning shopper", async () => {
+    const payment = createPaymentHarness()
+    payment.established = true
+    const harness = createHarness({}, payment.ports)
+    const { session, quote, hold } = await createQuoteAndHold(harness)
+
+    const [settled] = await Promise.all([
+      harness.module.commitPaidSession({
+        bookingSessionId: session.id,
+        paymentSessionId: "payment_session_1",
+      }),
+      harness.module.commitSession(
+        session.id,
+        {
+          expectedRevision: session.revision,
+          quoteId: quote.id,
+          requirementsFingerprint: quote.requirementsFingerprint,
+          holdId: hold.id,
+          idempotencyKey: "returning_shopper_commit",
+        },
+        ANONYMOUS_ACCESS,
+      ),
+    ])
+
+    expect(harness.inventory.bookingIds).toEqual([settled.bookingId])
+    expect(harness.repository.commits.size).toBe(1)
+    expect(payment.transfers).toHaveLength(1)
+  })
+
   it("returns a typed conflict when a reused Commit key maps to a changed payment requirement", async () => {
     const payment = createPaymentHarness()
     payment.ports.prepare = async () => {

--- a/packages/catalog/src/booking-engine/sessions-service.ts
+++ b/packages/catalog/src/booking-engine/sessions-service.ts
@@ -189,6 +189,7 @@ export interface BookingSessionRepository {
     sessionId: string,
     idempotencyKey: string,
   ): Promise<BookingCommitInternalRecord | null>
+  getCommitForSession(sessionId: string): Promise<BookingCommitInternalRecord | null>
   saveCommit(record: BookingCommitInternalRecord): Promise<void>
   claimOperation(input: {
     id: string
@@ -463,6 +464,8 @@ export interface BookingSessionAccessContext {
   staffAuthority?: { admitted: true; reason: string }
   /** Additional Finance + Bookings authority for operator booking details. */
   staffBookingAuthority?: { admitted: true; reason: string }
+  /** Trusted settlement subscriber authority; never populated by request transports. */
+  settlementAuthority?: { admitted: true; reason: string; paymentSessionId: string }
 }
 
 export interface BookingSessionModulePorts {
@@ -609,6 +612,10 @@ export interface BookingSessionModule {
     input: CommitBookingSessionV1,
     access: BookingSessionAccessContext,
   ): Promise<BookingSessionOutcomeV1>
+  commitPaidSession(input: {
+    bookingSessionId: string
+    paymentSessionId: string
+  }): Promise<{ bookingId: string }>
   expireDueSessions(
     input: { limit: number },
     access: BookingSessionAccessContext,
@@ -1678,6 +1685,49 @@ export function createBookingSessionModule(
       return { kind: "commit_result", outcome }
     },
 
+    async commitPaidSession({ bookingSessionId, paymentSessionId }) {
+      const existingCommit = await repository.getCommitForSession(bookingSessionId)
+      if (existingCommit) return { bookingId: bookingIdFromCommit(existingCommit) }
+
+      const session = await repository.getSession(bookingSessionId)
+      if (!session) throw new Error("booking_session_settlement_session_not_found")
+      const quotes = await repository.listActiveQuotes(bookingSessionId)
+      if (quotes.length !== 1) {
+        throw new Error(`booking_session_settlement_expected_one_quote:${quotes.length}`)
+      }
+      const quote = quotes[0]!
+      const holds = await repository.listActiveHolds(bookingSessionId)
+      if (holds.length > 1) {
+        throw new Error(`booking_session_settlement_expected_at_most_one_hold:${holds.length}`)
+      }
+
+      const outcome = await bookingSessionModule.commitSession(
+        bookingSessionId,
+        {
+          expectedRevision: session.revision,
+          quoteId: quote.id,
+          requirementsFingerprint: quote.requirementsFingerprint,
+          ...(holds[0] ? { holdId: holds[0].id } : {}),
+          idempotencyKey: `payment-settlement:${paymentSessionId}`,
+        },
+        {
+          actorKind: session.actorKind,
+          settlementAuthority: {
+            admitted: true,
+            reason: "paid booking session settlement",
+            paymentSessionId,
+          },
+        },
+      )
+      const committed = settlementBookingId(outcome)
+      if (committed) return { bookingId: committed }
+
+      // A shopper may win the commit race under another idempotency key.
+      const concurrentCommit = await repository.getCommitForSession(bookingSessionId)
+      if (concurrentCommit) return { bookingId: bookingIdFromCommit(concurrentCommit) }
+      throw new Error(`booking_session_settlement_commit_rejected:${settlementFailure(outcome)}`)
+    },
+
     async expireDueSessions(input, access) {
       if (access.actorKind !== "staff" || !access.staffAuthority?.admitted) {
         throw new Error("booking_session_expiry_sweep_not_authorized")
@@ -2228,6 +2278,27 @@ function replayCommit(commit: BookingCommitInternalRecord): BookingSessionOutcom
   }
 }
 
+function settlementBookingId(outcome: BookingSessionOutcomeV1): string | null {
+  if (outcome.kind !== "commit_result") return null
+  const result =
+    outcome.outcome.kind === "idempotent_replay" ? outcome.outcome.originalOutcome : outcome.outcome
+  if (result.kind === "committed") return result.booking.id
+  if (result.kind === "component_bookings_committed") {
+    return result.bookings[0]?.bookingId ?? null
+  }
+  return null
+}
+
+function bookingIdFromCommit(commit: BookingCommitInternalRecord): string {
+  if (!commit.bookingId) throw new Error("booking_session_settlement_commit_missing_booking")
+  return commit.bookingId
+}
+
+function settlementFailure(outcome: BookingSessionOutcomeV1): string {
+  if (outcome.kind === "rejected") return outcome.error.kind
+  return outcome.kind === "commit_result" ? outcome.outcome.kind : outcome.kind
+}
+
 async function replayConcurrentCommit(
   repository: BookingSessionRepository,
   sessionId: string,
@@ -2442,6 +2513,7 @@ async function authorizeSessionAccess(
   access: BookingSessionAccessContext,
   action: BookingSessionCapabilityActionV1,
 ): Promise<BookingSessionOutcomeV1 | null> {
+  if (access.settlementAuthority?.admitted && action === "commit") return null
   if (access.actorKind === "staff") {
     return access.principalId && access.staffAuthority?.admitted
       ? null
@@ -2507,10 +2579,10 @@ async function appendSessionAudit(
     id: newId("booking_session_audit_events"),
     sessionId: session.id,
     action,
-    actorKind: access.actorKind,
+    actorKind: access.settlementAuthority?.admitted ? "system" : access.actorKind,
     principalId: access.principalId,
     organizationId: access.organizationId,
-    authorityReason: access.staffAuthority?.reason,
+    authorityReason: access.settlementAuthority?.reason ?? access.staffAuthority?.reason,
     metadata,
     createdAt: at,
   })

--- a/packages/catalog/src/booking-session-settlement-runtime-port.ts
+++ b/packages/catalog/src/booking-session-settlement-runtime-port.ts
@@ -1,0 +1,24 @@
+import { definePort } from "@voyant-travel/core/project"
+
+export interface CatalogBookingSessionSettlementRuntime {
+  commitPaidSession(input: {
+    bookingSessionId: string
+    paymentSessionId: string
+  }): Promise<{ bookingId: string }>
+}
+
+export const catalogBookingSessionSettlementRuntimePort =
+  definePort<CatalogBookingSessionSettlementRuntime>({
+    id: "catalog.booking-session-settlement-runtime",
+    test(provider) {
+      if (
+        provider === null ||
+        typeof provider !== "object" ||
+        typeof provider.commitPaidSession !== "function"
+      ) {
+        throw new Error(
+          "catalog.booking-session-settlement-runtime provider must implement commitPaidSession().",
+        )
+      }
+    },
+  })

--- a/packages/catalog/src/runtime-contracts.ts
+++ b/packages/catalog/src/runtime-contracts.ts
@@ -7,6 +7,12 @@ import type {
   IndexerSlice,
 } from "@voyant-travel/catalog-contracts/indexer/contract"
 import { definePort } from "@voyant-travel/core/project"
+
+export {
+  type CatalogBookingSessionSettlementRuntime,
+  catalogBookingSessionSettlementRuntimePort,
+} from "./booking-session-settlement-runtime-port.js"
+
 import type { AnyDrizzleDb } from "@voyant-travel/db"
 import type { PaymentPolicy } from "@voyant-travel/finance"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"

--- a/packages/catalog/src/runtime-contributor.ts
+++ b/packages/catalog/src/runtime-contributor.ts
@@ -55,6 +55,10 @@ import {
   catalogBookingSessionMaintenanceJobRuntimePort,
 } from "./booking-session-maintenance-job-runtime-port.js"
 import {
+  type CatalogBookingSessionSettlementRuntime,
+  catalogBookingSessionSettlementRuntimePort,
+} from "./booking-session-settlement-runtime-port.js"
+import {
   type CatalogReindexCheckpoint,
   type CatalogReindexClaim,
   catalogReindexJobRuntimePort,
@@ -199,6 +203,32 @@ export function createCatalogRuntimePortContribution(
       return services.ensureSourceRegistry(host.primitives.env(bindings))
     },
   }
+  const resolveBookingSessionModule = async () => {
+    const db = host.primitives.database.resolve(undefined) as PostgresJsDatabase
+    const runtime = await contribution
+    const services = await runtime.services
+    const [, , , distribution, , inventory, , settings] = await dependencies
+    return createProductionBookingSessionModule({
+      db,
+      ...(analytics ? { analytics } : {}),
+      repository: createDrizzleBookingSessionRepository(db),
+      resolveOwnedHandlers: () => services.getOwnedHandlers(host.primitives.env(undefined)),
+      resolveSourceRegistry: () => services.ensureSourceRegistry(host.primitives.env(undefined)),
+      resolveCompositeHandler: () => services.getCompositeBookingSessionHandler?.(),
+      payments: {
+        inventory,
+        distribution,
+        settings,
+        async resolvePaymentAdapter() {
+          if (host.hasRuntimePort?.(paymentAdapterRuntimePortReference) !== true) return null
+          return host.getRuntimePort<PaymentAdapter>(paymentAdapterRuntimePortReference)
+        },
+        paymentAdapterContext: {
+          env: host.primitives.env(undefined) as Readonly<Record<string, unknown>>,
+        },
+      },
+    })
+  }
   return {
     [bookingActionSourceRuntimePort.id]:
       catalogBookingActionSource satisfies BookingActionSourceRuntime,
@@ -208,6 +238,11 @@ export function createCatalogRuntimePortContribution(
     [catalogContentRuntimePort.id]: contribution.then((runtime) => runtime.content),
     [catalogProjectionRuntimePort.id]: contribution.then((runtime) => runtime.projection),
     [catalogBookingSnapshotRuntimePort.id]: contribution.then((runtime) => runtime.bookingSnapshot),
+    [catalogBookingSessionSettlementRuntimePort.id]: {
+      async commitPaidSession(input) {
+        return (await resolveBookingSessionModule()).commitPaidSession(input)
+      },
+    } satisfies CatalogBookingSessionSettlementRuntime,
     [catalogRuntimeServicesPort.id]: contribution.then((runtime) => runtime.services),
     [bookingsSupplierAmendmentRuntimePort.id]: createCatalogBookingAmendmentRuntime({
       async resolveRegistry() {
@@ -217,32 +252,8 @@ export function createCatalogRuntimePortContribution(
       },
     }) satisfies BookingsSupplierAmendmentRuntime,
     [catalogBookingSessionMaintenanceJobRuntimePort.id]: {
-      async resolveModule() {
-        const db = host.primitives.database.resolve(undefined) as PostgresJsDatabase
-        const runtime = await contribution
-        const services = await runtime.services
-        const [, , , distribution, , inventory, , settings] = await dependencies
-        return createProductionBookingSessionModule({
-          db,
-          ...(analytics ? { analytics } : {}),
-          repository: createDrizzleBookingSessionRepository(db),
-          resolveOwnedHandlers: () => services.getOwnedHandlers(host.primitives.env(undefined)),
-          resolveSourceRegistry: () =>
-            services.ensureSourceRegistry(host.primitives.env(undefined)),
-          resolveCompositeHandler: () => services.getCompositeBookingSessionHandler?.(),
-          payments: {
-            inventory,
-            distribution,
-            settings,
-            async resolvePaymentAdapter() {
-              if (host.hasRuntimePort?.(paymentAdapterRuntimePortReference) !== true) return null
-              return host.getRuntimePort<PaymentAdapter>(paymentAdapterRuntimePortReference)
-            },
-            paymentAdapterContext: {
-              env: host.primitives.env(undefined) as Readonly<Record<string, unknown>>,
-            },
-          },
-        })
+      resolveModule() {
+        return resolveBookingSessionModule()
       },
       resolveRetentionMs: () => resolveBookingSessionRetentionMs(host.primitives.env(undefined)),
       reportFailure(error, details) {

--- a/packages/catalog/src/voyant.ts
+++ b/packages/catalog/src/voyant.ts
@@ -21,6 +21,7 @@ import {
   catalogSearchRuntimePort,
 } from "./api-runtime-ports.js"
 import { catalogBookingSessionMaintenanceJobRuntimePort } from "./booking-session-maintenance-job-runtime-port.js"
+import { catalogBookingSessionSettlementRuntimePort } from "./booking-session-settlement-runtime-port.js"
 import { catalogBookingSnapshotSubscriberDeclaration } from "./booking-snapshot-subscriber-declaration.js"
 import { catalogContentRuntimePort } from "./content-runtime-port.js"
 import { catalogIndexSubscriberDeclarations } from "./index-subscriber-declarations.js"
@@ -97,6 +98,7 @@ export const catalogVoyantModule = defineModule({
       providePort(catalogProjectionRuntimePort),
       providePort(catalogBookingSnapshotRuntimePort),
       providePort(catalogBookingSessionMaintenanceJobRuntimePort),
+      providePort(catalogBookingSessionSettlementRuntimePort),
       providePort(catalogRuntimeServicesPort),
       providePort(catalogReindexJobRuntimePort),
       providePort(catalogSourcesSyncJobRuntimePort),
@@ -110,6 +112,7 @@ export const catalogVoyantModule = defineModule({
     requirePort(catalogProjectionRuntimePort),
     requirePort(catalogBookingSnapshotRuntimePort),
     requirePort(catalogBookingSessionMaintenanceJobRuntimePort),
+    requirePort(catalogBookingSessionSettlementRuntimePort),
     requirePort(catalogReindexJobRuntimePort),
     requirePort(catalogSourcesSyncJobRuntimePort),
   ],

--- a/packages/catalog/tests/unit/voyant-manifest.test.ts
+++ b/packages/catalog/tests/unit/voyant-manifest.test.ts
@@ -25,6 +25,7 @@ describe("catalog deployment manifest", () => {
           { id: "catalog.projection-runtime" },
           { id: "catalog.booking-snapshot-runtime" },
           { id: "catalog.booking-session-maintenance-job" },
+          { id: "catalog.booking-session-settlement-runtime" },
           { id: "catalog.runtime-services" },
           { id: "catalog.reindex-products-job" },
           { id: "catalog.sources-sync-job" },
@@ -112,6 +113,7 @@ describe("catalog deployment manifest", () => {
       { id: "catalog.projection-runtime" },
       { id: "catalog.booking-snapshot-runtime" },
       { id: "catalog.booking-session-maintenance-job" },
+      { id: "catalog.booking-session-settlement-runtime" },
       { id: "catalog.reindex-products-job" },
       { id: "catalog.sources-sync-job" },
     ])

--- a/packages/commerce/src/checkout/subscriber-runtime.ts
+++ b/packages/commerce/src/checkout/subscriber-runtime.ts
@@ -6,7 +6,7 @@ import {
 import {
   type CatalogBookingSessionSettlementRuntime,
   catalogBookingSessionSettlementRuntimePort,
-} from "@voyant-travel/catalog/booking-session-settlement-runtime-port"
+} from "@voyant-travel/catalog/ports"
 import type { BootstrapContext, EventBus, SubscriberRuntimeDescriptor } from "@voyant-travel/core"
 import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"

--- a/packages/commerce/src/checkout/subscriber-runtime.ts
+++ b/packages/commerce/src/checkout/subscriber-runtime.ts
@@ -3,6 +3,10 @@ import {
   resolveMonthlyBookingLimit,
   selectMonthlyBookingLimit,
 } from "@voyant-travel/bookings"
+import {
+  type CatalogBookingSessionSettlementRuntime,
+  catalogBookingSessionSettlementRuntimePort,
+} from "@voyant-travel/catalog/booking-session-settlement-runtime-port"
 import type { BootstrapContext, EventBus, SubscriberRuntimeDescriptor } from "@voyant-travel/core"
 import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
@@ -49,6 +53,7 @@ export interface AcceptanceSignatureSubscriberRuntimeOptions<TBindings = unknown
 export interface CheckoutFinalizeSubscriberRuntimeOptions<TBindings = unknown>
   extends CatalogCheckoutRuntimeDatabase<TBindings> {
   finalize?: typeof finalizeCheckout
+  settleBookingSession?: CatalogBookingSessionSettlementRuntime["commitPaidSession"]
   logger?: Pick<Console, "error">
   /**
    * Per-event monthly booking allowance, for hosts whose plan entitlement
@@ -66,6 +71,8 @@ interface ContractDocumentGeneratedPayload {
 interface PaymentCompletedPayload {
   bookingId: string | null
   paymentSessionId: string
+  targetType?: string
+  targetId?: string | null
   paymentIntent?: "card" | "bank_transfer" | "hold" | "ticket_on_credit"
 }
 
@@ -123,23 +130,35 @@ export function createCheckoutFinalizeSubscriberRuntime<TBindings = unknown>(
       eventBus.subscribe<PaymentCompletedPayload>(
         "payment.completed",
         async ({ data }, context) => {
-          if (!data.bookingId) return
-          const bookingId = data.bookingId
-          // Resolved per event, not at registration: the subscriber outlives
-          // any single tenant plan state.
-          const monthlyBookingLimit = selectMonthlyBookingLimit(
-            options.resolveMonthlyBookingLimit,
-            configuredMonthlyBookingLimit,
-          )
-          const nestedEventBus = (context?.eventBus ?? eventBus) as EventBus
-
+          let bookingId = data.bookingId
           try {
+            if (!bookingId && data.targetType === "booking_session" && data.targetId) {
+              if (!options.settleBookingSession) {
+                throw new Error("Booking Session settlement runtime is not configured")
+              }
+              bookingId = (
+                await options.settleBookingSession({
+                  bookingSessionId: data.targetId,
+                  paymentSessionId: data.paymentSessionId,
+                })
+              ).bookingId
+            }
+            if (!bookingId) return
+            const finalizedBookingId = bookingId
+            // Resolved per event, not at registration: the subscriber outlives
+            // any single tenant plan state.
+            const monthlyBookingLimit = selectMonthlyBookingLimit(
+              options.resolveMonthlyBookingLimit,
+              configuredMonthlyBookingLimit,
+            )
+            const nestedEventBus = (context?.eventBus ?? eventBus) as EventBus
+
             await options.withDb(runtimeBindings, (db) =>
               finalize({
                 db,
                 eventBus: nestedEventBus,
                 input: {
-                  bookingId,
+                  bookingId: finalizedBookingId,
                   paymentSessionId: data.paymentSessionId,
                   paymentIntent: data.paymentIntent,
                 },
@@ -148,7 +167,7 @@ export function createCheckoutFinalizeSubscriberRuntime<TBindings = unknown>(
             )
           } catch (error) {
             logger.error(
-              `[catalog-checkout] checkout finalization failed for booking ${bookingId}`,
+              `[catalog-checkout] checkout finalization failed for booking ${bookingId ?? data.targetId ?? "unknown"}`,
               error,
             )
             throw error
@@ -173,12 +192,14 @@ export const createAcceptanceSignatureSubscriberGraphRuntime = defineGraphRuntim
 export const createCheckoutFinalizeSubscriberGraphRuntime = defineGraphRuntimeFactory(
   async ({ getPort, hostOptions }) => {
     const database = await getPort(catalogCheckoutDatabaseRuntimePort)
+    const settlement = await getPort(catalogBookingSessionSettlementRuntimePort)
     return {
       id: COMMERCE_CHECKOUT_FINALIZE_SUBSCRIBER_ID,
       eventType: "payment.completed",
       register: async (context: BootstrapContext) => {
         const descriptor = createCheckoutFinalizeSubscriberRuntime({
           ...database,
+          settleBookingSession: (input) => settlement.commitPaidSession(input),
           // Finalizing a checkout accepts a booking, so this path draws on the
           // same monthly quota as the booking and finance routes. Before host
           // options existed this factory took none, which left the seam

--- a/packages/commerce/src/voyant.ts
+++ b/packages/commerce/src/voyant.ts
@@ -1,5 +1,5 @@
-import { catalogBookingSessionSettlementRuntimePort } from "@voyant-travel/catalog/booking-session-settlement-runtime-port"
 import {
+  catalogBookingSessionSettlementRuntimePort,
   catalogCommerceRuntimeExtensionPort,
   catalogPublicationRuntimePort,
   catalogRuntimeServicesPort,

--- a/packages/commerce/src/voyant.ts
+++ b/packages/commerce/src/voyant.ts
@@ -1,3 +1,4 @@
+import { catalogBookingSessionSettlementRuntimePort } from "@voyant-travel/catalog/booking-session-settlement-runtime-port"
 import {
   catalogCommerceRuntimeExtensionPort,
   catalogPublicationRuntimePort,
@@ -530,6 +531,7 @@ export const commerceCatalogCheckoutVoyantPlugin = defineExtension({
     requirePort(catalogCheckoutApiRuntimePort),
     requirePort(catalogCheckoutDatabaseRuntimePort),
     requirePort(catalogCheckoutLegalRuntimePort),
+    requirePort(catalogBookingSessionSettlementRuntimePort),
   ],
   api: [
     {

--- a/packages/commerce/tests/unit/catalog-checkout-subscriber-runtime.test.ts
+++ b/packages/commerce/tests/unit/catalog-checkout-subscriber-runtime.test.ts
@@ -126,6 +126,46 @@ describe("catalog-checkout subscriber runtimes", () => {
     )
   })
 
+  it("commits paid Booking Sessions before finalizing their booking", async () => {
+    const db = {} as PostgresJsDatabase
+    const calls: string[] = []
+    const settleBookingSession = vi.fn(async () => {
+      calls.push("settle")
+      return { bookingId: "booking_settled" }
+    })
+    const finalize = vi.fn(async () => {
+      calls.push("finalize")
+    })
+    const withDb = vi.fn(async (_bindings, operation) => operation(db))
+    const { eventBus, subscriptions } = recordingEventBus()
+    const descriptor = createCheckoutFinalizeSubscriberRuntime({
+      withDb,
+      finalize,
+      settleBookingSession,
+    })
+    await descriptor.register({ bindings: {}, container: createContainer(), eventBus })
+
+    await subscriptions[0]?.handler(
+      event("payment.completed", {
+        bookingId: null,
+        paymentSessionId: "payment_session_1",
+        targetType: "booking_session",
+        targetId: "booking_session_1",
+      }),
+    )
+
+    expect(settleBookingSession).toHaveBeenCalledWith({
+      bookingSessionId: "booking_session_1",
+      paymentSessionId: "payment_session_1",
+    })
+    expect(finalize).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({ bookingId: "booking_settled" }),
+      }),
+    )
+    expect(calls).toEqual(["settle", "finalize"])
+  })
+
   it("resolves the monthly booking limit per event, not once at registration", async () => {
     let live: number | null | undefined = 10
     const finalize = vi.fn(async () => undefined)

--- a/packages/commerce/tests/unit/voyant-manifest.test.ts
+++ b/packages/commerce/tests/unit/voyant-manifest.test.ts
@@ -1,5 +1,5 @@
-import { catalogBookingSessionSettlementRuntimePort } from "@voyant-travel/catalog/booking-session-settlement-runtime-port"
 import {
+  catalogBookingSessionSettlementRuntimePort,
   catalogCommerceRuntimeExtensionPort,
   catalogPublicationRuntimePort,
   catalogRuntimeServicesPort,

--- a/packages/commerce/tests/unit/voyant-manifest.test.ts
+++ b/packages/commerce/tests/unit/voyant-manifest.test.ts
@@ -1,3 +1,4 @@
+import { catalogBookingSessionSettlementRuntimePort } from "@voyant-travel/catalog/booking-session-settlement-runtime-port"
 import {
   catalogCommerceRuntimeExtensionPort,
   catalogPublicationRuntimePort,
@@ -252,6 +253,7 @@ describe("commerce deployment manifest", () => {
         { id: catalogCheckoutApiRuntimePort.id },
         { id: catalogCheckoutDatabaseRuntimePort.id },
         { id: catalogCheckoutLegalRuntimePort.id },
+        { id: catalogBookingSessionSettlementRuntimePort.id },
       ],
       api: [
         {


### PR DESCRIPTION
Closes #4354.

## What changed

- Re-enter the canonical Booking Session Commit when payment.completed targets a booking_session.
- Pin settlement to the exact paid payment-session id and validate its target, amount, currency, and state.
- Converge settlement retries and a racing shopper return on the single durable Session commit.
- Continue through the existing checkout finalizer so the booking receives its invoice and recorded payment.
- Add Catalog and Commerce patch changesets.

## Root cause

Booking creation was reachable only from the client-initiated commit. Reconciliation could move a hosted-checkout payment to paid after the shopper left, but no subscriber performed the commit, leaving the paid payment session orphaned.

## Validation

- Catalog focused suites: 68 tests passed on a disposable Sprite.
- Commerce focused suites: 10 tests passed on a disposable Sprite.
- Catalog source build passed on a disposable Sprite.
- Commit and push hooks were bypassed as requested; GitHub Actions is the final verification lane.