### PR TITLE
fix(runtime): bound resident database connections

### DIFF
--- a/.changeset/calm-runtimes-share.md
+++ b/.changeset/calm-runtimes-share.md
@@ -1,0 +1,15 @@
+---
+"@voyant-travel/bookings": patch
+"@voyant-travel/db": patch
+"@voyant-travel/distribution": patch
+"@voyant-travel/finance": patch
+"@voyant-travel/framework": patch
+"@voyant-travel/inventory": patch
+"@voyant-travel/operations": patch
+"@voyant-travel/runtime": patch
+---
+
+Bound resident Node database pools to four connections by default, allow an
+explicit `DATABASE_MAX_CONNECTIONS` override, and only attach dashboard cache
+headers after an aggregate response succeeds so transient server errors are not
+cached by browsers.

--- a/packages/bookings/src/routes-admin.ts
+++ b/packages/bookings/src/routes-admin.ts
@@ -1941,12 +1941,12 @@ const readsRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidationHook })
   })
   .openapi(aggregatesRoute, async (c) => {
     const query = c.req.valid("query")
-    cacheDashboardAggregates(c)
     const snapshot = await readThroughAggregateSnapshot(c.get("db"), {
       key: aggregateSnapshotKey("bookings", "aggregates", query),
       ttlSeconds: DASHBOARD_AGGREGATES_TTL_SECONDS,
       compute: () => bookingsService.getBookingAggregates(c.get("db"), query),
     })
+    cacheDashboardAggregates(c)
     return c.json({ data: snapshot.data }, 200)
   })
   .openapi(overviewRoute, async (c) => {

--- a/packages/db/src/runtime/node-database.ts
+++ b/packages/db/src/runtime/node-database.ts
@@ -4,6 +4,8 @@ export interface NodeDatabaseEnv {
   DATABASE_URL: string
   DATABASE_URL_DIRECT?: string
   DATABASE_URL_REPLICAS?: string
+  /** Maximum postgres-js sockets owned by this resident process. Default: 4. */
+  DATABASE_MAX_CONNECTIONS?: string
 }
 
 export type NodeDatabase = ReturnType<typeof createDbClient>
@@ -16,17 +18,34 @@ export function resolveNodeDatabase(env: NodeDatabaseEnv): NodeDatabase {
   if (!url) throw new Error("Voyant Node runtime requires DATABASE_URL.")
 
   const replicas = parseReplicaUrls(env.DATABASE_URL_REPLICAS, url)
-  const cacheKey = `${url}\n${replicas.join("\n")}`
+  const maxConnections = parseMaxConnections(env.DATABASE_MAX_CONNECTIONS)
+  const cacheKey = `${url}\n${replicas.join("\n")}\nmax=${maxConnections}`
   if (pooledDatabase?.cacheKey !== cacheKey) {
     pooledDatabase = {
       cacheKey,
       database: createDbClient(url, {
         adapter: "node",
+        nodeMaxConnections: maxConnections,
         ...(replicas.length > 0 ? { replicas } : {}),
       }),
     }
   }
   return pooledDatabase.database
+}
+
+/**
+ * Keep resident serverless processes inside a predictable connection budget.
+ * postgres-js otherwise defaults to ten sockets per process, which multiplies
+ * quickly as Cloud Run adds instances. Four leaves headroom for migrations and
+ * control-plane access while still allowing useful query parallelism.
+ */
+function parseMaxConnections(raw: string | undefined): number {
+  if (raw === undefined || raw.trim() === "") return 4
+  const parsed = Number(raw)
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new Error("DATABASE_MAX_CONNECTIONS must be a positive integer.")
+  }
+  return parsed
 }
 
 /**

--- a/packages/db/tests/unit/node-database-runtime.test.ts
+++ b/packages/db/tests/unit/node-database-runtime.test.ts
@@ -39,6 +39,29 @@ describe("Node database runtime", () => {
     ).not.toBe(database)
   })
 
+  it("refreshes the process client when the connection budget changes", () => {
+    const database = resolveNodeDatabase({
+      DATABASE_URL: `${PRIMARY}_pool_budget`,
+      DATABASE_MAX_CONNECTIONS: "4",
+    })
+
+    expect(
+      resolveNodeDatabase({
+        DATABASE_URL: `${PRIMARY}_pool_budget`,
+        DATABASE_MAX_CONNECTIONS: "5",
+      }),
+    ).not.toBe(database)
+  })
+
+  it("rejects invalid connection budgets", () => {
+    expect(() =>
+      resolveNodeDatabase({
+        DATABASE_URL: `${PRIMARY}_invalid_pool_budget`,
+        DATABASE_MAX_CONNECTIONS: "0",
+      }),
+    ).toThrow("DATABASE_MAX_CONNECTIONS must be a positive integer.")
+  })
+
   it("provides lifecycle adapters without disposing the process-owned pool", async () => {
     const env = { DATABASE_URL: `${PRIMARY}_lifecycle` }
     const resource = openNodeDatabase(env)

--- a/packages/distribution/src/suppliers/routes.ts
+++ b/packages/distribution/src/suppliers/routes.ts
@@ -422,12 +422,12 @@ const supplierRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidationHook
   // GET /aggregates before /{id} so the matcher doesn't swallow it.
   .openapi(getAggregatesRoute, async (c) => {
     const query = c.req.valid("query")
-    cacheDashboardAggregates(c)
     const snapshot = await readThroughAggregateSnapshot(c.get("db"), {
       key: aggregateSnapshotKey("suppliers", "aggregates", query),
       ttlSeconds: DASHBOARD_AGGREGATES_TTL_SECONDS,
       compute: () => suppliersService.getSupplierAggregates(c.get("db"), query),
     })
+    cacheDashboardAggregates(c)
     return c.json({ data: snapshot.data }, 200)
   })
   .openapi(listSuppliersRoute, async (c) =>

--- a/packages/finance/src/routes.ts
+++ b/packages/finance/src/routes.ts
@@ -35,14 +35,14 @@ export const financeRoutes = new OpenAPIHono<Env>()
   // is ~11 queries, so a warm dashboard load becomes one indexed read (#1629).
   .get("/aggregates", async (c) => {
     const query = parseQuery(c, financeAggregatesQuerySchema)
-    c.header("Cache-Control", DASHBOARD_AGGREGATES_CACHE_CONTROL)
-    c.header("Vary", "Authorization", { append: true })
-    c.header("Vary", "Cookie", { append: true })
     const snapshot = await readThroughAggregateSnapshot(c.get("db"), {
       key: aggregateSnapshotKey("finance", "aggregates", query),
       ttlSeconds: DASHBOARD_AGGREGATES_TTL_SECONDS,
       compute: () => financeService.getFinanceAggregates(c.get("db"), query),
     })
+    c.header("Cache-Control", DASHBOARD_AGGREGATES_CACHE_CONTROL)
+    c.header("Vary", "Authorization", { append: true })
+    c.header("Vary", "Cookie", { append: true })
     return c.json({ data: snapshot.data })
   })
   .route("/", financePaymentProcessingRoutes)

--- a/packages/framework/src/node-runtime.ts
+++ b/packages/framework/src/node-runtime.ts
@@ -75,6 +75,7 @@ import {
 export interface VoyantNodeRuntimeEnv extends VoyantBindings {
   DATABASE_URL_DIRECT?: string
   DATABASE_URL_REPLICAS?: string
+  DATABASE_MAX_CONNECTIONS?: string
   S3_ENDPOINT?: string
   S3_REGION?: string
   S3_ACCESS_KEY_ID?: string

--- a/packages/inventory/src/routes-core.ts
+++ b/packages/inventory/src/routes-core.ts
@@ -328,12 +328,12 @@ export const productCoreRoutes = new OpenAPIHono<Env>({ defaultHook: openApiVali
   // doesn't swallow it). Served from a read-through TTL snapshot (#1629).
   .openapi(getAggregatesRoute, async (c) => {
     const query = c.req.valid("query")
-    cacheDashboardAggregates(c)
     const snapshot = await readThroughAggregateSnapshot(c.get("db"), {
       key: aggregateSnapshotKey("products", "aggregates", query),
       ttlSeconds: DASHBOARD_AGGREGATES_TTL_SECONDS,
       compute: () => productsService.getProductAggregates(c.get("db"), query),
     })
+    cacheDashboardAggregates(c)
     return c.json({ data: snapshot.data }, 200)
   })
   // GET / — List products

--- a/packages/operations/src/availability/routes-core.ts
+++ b/packages/operations/src/availability/routes-core.ts
@@ -445,12 +445,12 @@ const getOverviewRoute = createRoute({
 const dashboardRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidationHook })
   .openapi(getAggregatesRoute, async (c) => {
     const query = c.req.valid("query")
-    cacheDashboardAggregates(c)
     const snapshot = await readThroughAggregateSnapshot(c.get("db"), {
       key: aggregateSnapshotKey("availability", "aggregates", query),
       ttlSeconds: DASHBOARD_AGGREGATES_TTL_SECONDS,
       compute: () => availabilityService.getAvailabilityAggregates(c.get("db"), query),
     })
+    cacheDashboardAggregates(c)
     return c.json({ data: snapshot.data }, 200)
   })
   .openapi(getOverviewRoute, async (c) =>

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -649,6 +649,9 @@ function resolveOptionalNodeDatabase(
     DATABASE_URL: databaseUrl,
     ...(env.DATABASE_URL_DIRECT ? { DATABASE_URL_DIRECT: env.DATABASE_URL_DIRECT } : {}),
     ...(env.DATABASE_URL_REPLICAS ? { DATABASE_URL_REPLICAS: env.DATABASE_URL_REPLICAS } : {}),
+    ...(env.DATABASE_MAX_CONNECTIONS
+      ? { DATABASE_MAX_CONNECTIONS: env.DATABASE_MAX_CONNECTIONS }
+      : {}),
   })
 }
 


### PR DESCRIPTION
## What

- Add a configurable `DATABASE_MAX_CONNECTIONS` budget to the shared Node database runtime, defaulting to 4 connections per process.
- Include the connection budget in database-runtime cache identity and propagate it through framework/runtime environment types.
- Only attach short-lived aggregate cache headers after snapshot computation succeeds, so failed responses are not cached and retried as fresh work.
- Add a changeset and focused coverage for pool sizing and cache reuse.

## Why

Managed runtimes could create pools whose combined capacity exceeded the tenant role's connection limit. Under concurrent startup/load this produced `too many connections for role`, repeated 500 responses, and retry amplification. Some aggregate routes also attached cache headers before the underlying snapshot succeeded, allowing failures to be cached.

This is the OSS half of [platform#1908](https://github.com/voyant-travel/platform/issues/1908). [platform#1910](https://github.com/voyant-travel/platform/pull/1910) shares process-level pools and sets the deployment connection budget explicitly.

## Impact and rollout

The default resident pool budget becomes 4 connections. Deployments can override it with `DATABASE_MAX_CONNECTIONS`. The OSS release from this PR must be included in the managed-runtime base image before the coordinated platform scaling defaults are rolled out.

## Verification

- Remote Sprite: 28 focused tests passed, including Node database runtime, connection configuration, and bookings aggregate snapshot coverage.
- Remote Sprite: `@voyant/db` and `@voyant/framework` typechecks passed.
- Depot: `@voyant/runtime` typecheck passed ([build](https://depot.dev/orgs/5ctgrq9prr/projects/8sdzjrn9pr/builds/x5795pc4jb)).
