### PR TITLE
Bound transactional outbox drains

### DIFF
--- a/.changeset/tidy-spoons-drain.md
+++ b/.changeset/tidy-spoons-drain.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/db": patch
+---
+
+Bound transactional outbox delivery, maintenance, and operational statistics while allowing wakeups to drain multiple batches within a work and time budget.

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -50,10 +50,40 @@ import { webhookSubscriptionsTable } from "@voyant-travel/db/schema/infra"
 | `./primitives` | Shared primitive tables (catalog, offers, etc.) |
 | `./crud` | `createCrudService` — list/retrieve/create/update/delete factory |
 | `./links` | `createLinkService`, `syncLinks` runtime link management |
+| `./outbox` | Transactional event capture, bounded drain, retry, pruning, and backlog statistics |
 | `./transaction-capability` | Transaction/disposal metadata helpers for runtime database clients |
 | `./schema/iam` | IAM schemas — Better Auth, users, API keys, KMS, roles |
 | `./schema/infra` | Infra schemas — webhooks, domains, email domain records |
 | `./test-utils` | `createTestDb`, `cleanupTestDb` for integration tests |
+
+## Transactional outbox operations
+
+`drainOutbox` repeatedly claims due rows with `FOR UPDATE SKIP LOCKED` until the
+queue is empty or its configurable batch, event, batch-count, or time budget is
+reached. `limit` bounds each claim and `concurrency` bounds simultaneous
+subscriber delivery; a visibility lease makes a crashed worker's rows eligible
+for at-least-once redelivery without changing their stable event IDs.
+
+The always-on `infrastructure.event-outbox-drain` job is both wakeable and
+scheduled. Every run emits a structured log with claimed, delivered, retried,
+dead-lettered, remaining backlog (with a cap flag), oldest pending age, and
+duration. The schedule remains the recovery path when an immediate wake is
+missed.
+
+Maintenance and telemetry queries are intentionally bounded:
+
+- delivered receipts are pruned oldest-first with a row limit;
+- stale write intents expire oldest-first with a row limit;
+- backlog/dead-letter counts inspect at most `scanLimit + 1` rows and report
+  whether the displayed count is a lower bound.
+
+The query plans rely on partial indexes whose predicates match the SQL exactly:
+`event_outbox_due_idx` for ordered claims and due counts,
+`event_outbox_pending_created_idx` for backlog age/counts,
+`event_outbox_failed_created_idx` for dead-letter counts,
+`event_outbox_delivered_idx` for retention pruning, and
+`event_outbox_pending_intent_idx` for the pending-intent safeguard. The write
+intent candidate scan uses `write_intents_pending_idx`.
 
 ## License
 

--- a/packages/db/migrations/20260806190000_bounded_outbox_drain.sql
+++ b/packages/db/migrations/20260806190000_bounded_outbox_drain.sql
@@ -1,0 +1,8 @@
+DROP INDEX IF EXISTS "event_outbox_due_idx";
+CREATE INDEX "event_outbox_due_idx" ON "event_outbox" USING btree ("next_attempt_at", "id") WHERE "status" = 'pending';
+CREATE INDEX "event_outbox_pending_created_idx" ON "event_outbox" USING btree ("created_at") WHERE "status" = 'pending';
+CREATE INDEX "event_outbox_failed_created_idx" ON "event_outbox" USING btree ("created_at") WHERE "status" = 'failed';
+CREATE INDEX "event_outbox_delivered_idx" ON "event_outbox" USING btree ("delivered_at", "id") WHERE "status" = 'delivered';
+CREATE INDEX "event_outbox_pending_intent_idx" ON "event_outbox" USING btree (("payload" ->> 'intentId')) WHERE "status" = 'pending';
+DROP INDEX IF EXISTS "write_intents_pending_idx";
+CREATE INDEX "write_intents_pending_idx" ON "write_intents" USING btree ("created_at", "id") WHERE "status" = 'pending';

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1785920400000,
       "tag": "20260805090000_storefront_deployment_scope",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1786042800000,
+      "tag": "20260806190000_bounded_outbox_drain",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/outbox-job-runtime-port.ts
+++ b/packages/db/src/outbox-job-runtime-port.ts
@@ -7,6 +7,8 @@ import type { DrizzleClient } from "./types.js"
 export interface EventOutboxJobRuntime {
   withDb<T>(operation: (db: DrizzleClient) => Promise<T>): Promise<T>
   deliver(envelope: EventEnvelope): Promise<DeliveryResult>
+  /** Healthy-run operational telemetry; older hosts fall back to warn(). */
+  log?(message: string): void
   warn(message: string): void
 }
 

--- a/packages/db/src/outbox-job.ts
+++ b/packages/db/src/outbox-job.ts
@@ -1,6 +1,6 @@
 import type { VoyantGraphRuntimeFactoryContext } from "@voyant-travel/core/project"
 
-import { drainOutbox, getOutboxStats, pruneDeliveredOutboxEvents } from "./outbox.js"
+import { drainOutbox, getBoundedOutboxStats, pruneDeliveredOutboxEvents } from "./outbox.js"
 import { eventOutboxJobRuntimePort } from "./outbox-job-runtime-port.js"
 import { expireStaleWriteIntents } from "./write-intents.js"
 
@@ -15,14 +15,49 @@ export async function runEventOutboxDrainJob(
     const result = await drainOutbox(
       db,
       { deliver: (envelope) => runtime.deliver(envelope) },
-      { limit: 50, visibilityTimeoutMs: 120_000 },
+      {
+        limit: 50,
+        concurrency: 5,
+        maxEvents: 500,
+        maxBatches: 10,
+        timeBudgetMs: 50_000,
+        budgetReserveMs: 5_000,
+        visibilityTimeoutMs: 120_000,
+      },
     )
-    await pruneDeliveredOutboxEvents(db, { olderThanDays: 14 })
-    const expiredIntents = await expireStaleWriteIntents(db, { olderThanMinutes: 30 })
+    const pruned = await pruneDeliveredOutboxEvents(db, { olderThanDays: 14, limit: 500 })
+    const expiredIntents = await expireStaleWriteIntents(db, {
+      olderThanMinutes: 30,
+      limit: 250,
+    })
     if (expiredIntents > 0) {
       runtime.warn(`[outbox-drain] expired ${expiredIntents} stale write intent(s)`)
     }
-    const stats = await getOutboxStats(db)
+    const stats = await getBoundedOutboxStats(db, { scanLimit: 10_000 })
+    const oldestPendingAgeMs = stats.oldestPendingAt
+      ? Math.max(0, Date.now() - stats.oldestPendingAt.getTime())
+      : null
+    const log = runtime.log ?? runtime.warn
+    log(
+      `[outbox-drain] ${JSON.stringify({
+        claimed: result.claimed,
+        delivered: result.delivered,
+        retried: result.retried,
+        deadLettered: result.deadLettered,
+        batches: result.batches,
+        budgetExhausted: result.budgetExhausted,
+        remainingBacklog: stats.pending,
+        remainingBacklogCapped: stats.pendingCapped,
+        dueNow: stats.dueNow,
+        dueNowCapped: stats.dueNowCapped,
+        failed: stats.failed,
+        failedCapped: stats.failedCapped,
+        oldestPendingAgeMs,
+        drainDurationMs: result.durationMs,
+        pruned,
+        expiredIntents,
+      })}`,
+    )
     if (stats.failed > 0) {
       runtime.warn(`[outbox-drain] ${stats.failed} dead-lettered event(s) need attention`)
     }

--- a/packages/db/src/outbox.ts
+++ b/packages/db/src/outbox.ts
@@ -14,8 +14,18 @@ const BACKOFF_BASE_MS = 5_000
 const BACKOFF_CAP_MS = 15 * 60 * 1000
 
 export interface DrainOutboxOptions {
-  /** Max rows claimed per drain pass. Default 25. */
+  /** Max rows claimed per batch. Default 25. */
   limit?: number
+  /** Max deliveries in flight at once. Default 5. */
+  concurrency?: number
+  /** Hard cap on claimed rows per invocation. Default 250. */
+  maxEvents?: number
+  /** Hard cap on claimed batches per invocation. Default 10. */
+  maxBatches?: number
+  /** Wall-clock budget for one invocation. Default 30s. */
+  timeBudgetMs?: number
+  /** Stop claiming this long before the wall-clock budget. Default 2s. */
+  budgetReserveMs?: number
   /**
    * How long a claimed row stays invisible to other drains. Must exceed
    * the worst-case delivery time of one event (all subscribers, each
@@ -30,6 +40,9 @@ export interface DrainOutboxResult {
   delivered: number
   retried: number
   deadLettered: number
+  batches: number
+  durationMs: number
+  budgetExhausted: boolean
 }
 
 /** Minimal delivery surface needed by the durable outbox drain. */
@@ -148,8 +161,8 @@ export async function claimDueOutboxEvents(
   db: DrizzleClient,
   options: DrainOutboxOptions = {},
 ): Promise<EventOutboxRow[]> {
-  const limit = options.limit ?? 25
-  const visibilityMs = options.visibilityTimeoutMs ?? 120_000
+  const limit = positiveInteger(options.limit, 25, "limit")
+  const visibilityMs = positiveInteger(options.visibilityTimeoutMs, 120_000, "visibilityTimeoutMs")
   const result = (await (db as AnyDb).execute(sql`
     UPDATE ${eventOutboxTable}
     SET
@@ -158,7 +171,7 @@ export async function claimDueOutboxEvents(
     WHERE "id" IN (
       SELECT "id" FROM ${eventOutboxTable}
       WHERE "status" = 'pending' AND "next_attempt_at" <= now()
-      ORDER BY "next_attempt_at" ASC
+      ORDER BY "next_attempt_at" ASC, "id" ASC
       LIMIT ${limit}
       FOR UPDATE SKIP LOCKED
     )
@@ -208,8 +221,9 @@ export function outboxRowToEnvelope(row: EventOutboxRow): EventEnvelope {
 }
 
 /**
- * One drain pass: claim due rows, redeliver each through the bus, mark
- * delivered / reschedule / dead-letter. Call from a scheduled handler
+ * Repeatedly claim bounded batches and redeliver them through the bus with
+ * bounded concurrency, stopping when no row is due or a work/time budget is
+ * reached. Call from a scheduled handler
  * (cron), a `waitUntil` kick after emit, or a long-running Node loop.
  * Safe to run concurrently from multiple isolates (SKIP LOCKED claim).
  */
@@ -218,17 +232,39 @@ export async function drainOutbox(
   bus: OutboxEventDelivery,
   options: DrainOutboxOptions = {},
 ): Promise<DrainOutboxResult> {
-  const claimed = await claimDueOutboxEvents(db, options)
+  const startedAt = Date.now()
+  const batchSize = positiveInteger(options.limit, 25, "limit")
+  const concurrency = Math.min(batchSize, positiveInteger(options.concurrency, 5, "concurrency"))
+  const maxEvents = positiveInteger(options.maxEvents, 250, "maxEvents")
+  const maxBatches = positiveInteger(options.maxBatches, 10, "maxBatches")
+  const timeBudgetMs = positiveInteger(options.timeBudgetMs, 30_000, "timeBudgetMs")
+  const budgetReserveMs = nonNegativeInteger(options.budgetReserveMs, 2_000, "budgetReserveMs")
+  const claimDeadline = startedAt + Math.max(0, timeBudgetMs - budgetReserveMs)
   const result: DrainOutboxResult = {
-    claimed: claimed.length,
+    claimed: 0,
     delivered: 0,
     retried: 0,
     deadLettered: 0,
+    batches: 0,
+    durationMs: 0,
+    budgetExhausted: false,
   }
-  if (claimed.length === 0) return result
 
-  await Promise.all(
-    claimed.map(async (row) => {
+  while (result.batches < maxBatches && result.claimed < maxEvents) {
+    if (Date.now() >= claimDeadline) {
+      result.budgetExhausted = true
+      break
+    }
+
+    const claimed = await claimDueOutboxEvents(db, {
+      limit: Math.min(batchSize, maxEvents - result.claimed),
+      visibilityTimeoutMs: options.visibilityTimeoutMs,
+    })
+    if (claimed.length === 0) break
+    result.batches += 1
+    result.claimed += claimed.length
+
+    await forEachConcurrent(claimed, concurrency, async (row) => {
       const envelope = outboxRowToEnvelope(row)
       let failedCount = 0
       let errors: string[] = []
@@ -257,10 +293,29 @@ export async function drainOutbox(
       const status = await failOutboxEvent(db, row.id, errors.join("; "))
       if (status === "failed") result.deadLettered += 1
       else result.retried += 1
-    }),
-  )
+    })
+  }
 
+  result.budgetExhausted ||=
+    result.claimed >= maxEvents || result.batches >= maxBatches || Date.now() >= claimDeadline
+  result.durationMs = Date.now() - startedAt
   return result
+}
+
+async function forEachConcurrent<T>(
+  values: readonly T[],
+  concurrency: number,
+  operation: (value: T) => Promise<void>,
+): Promise<void> {
+  let cursor = 0
+  const worker = async () => {
+    while (cursor < values.length) {
+      const value = values[cursor]
+      cursor += 1
+      if (value !== undefined) await operation(value)
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(concurrency, values.length) }, worker))
 }
 
 /**
@@ -271,37 +326,125 @@ export async function drainOutbox(
  */
 export async function pruneDeliveredOutboxEvents(
   db: DrizzleClient,
-  options: { olderThanDays?: number } = {},
+  options: { olderThanDays?: number; limit?: number } = {},
 ): Promise<number> {
-  const days = options.olderThanDays ?? 14
+  const days = positiveInteger(options.olderThanDays, 14, "olderThanDays")
+  const limit = positiveInteger(options.limit, 500, "limit")
   const result = (await (db as AnyDb).execute(sql`
+    WITH candidates AS (
+      SELECT "id" FROM ${eventOutboxTable}
+      WHERE "status" = 'delivered'
+        AND "delivered_at" < now() - (${days} * interval '1 day')
+      ORDER BY "delivered_at" ASC, "id" ASC
+      LIMIT ${limit}
+      FOR UPDATE SKIP LOCKED
+    )
     DELETE FROM ${eventOutboxTable}
-    WHERE "status" = 'delivered'
-      AND "delivered_at" < now() - (${days} * interval '1 day')
+    WHERE "id" IN (SELECT "id" FROM candidates)
     RETURNING "id"
   `)) as unknown
   const rows = Array.isArray(result) ? result : ((result as { rows?: unknown[] }).rows ?? [])
   return rows.length
 }
 
-/** Row counts by status — observability for dashboards/health checks. */
-export async function getOutboxStats(
+export interface BoundedOutboxStats {
+  pending: number
+  pendingCapped: boolean
+  delivered: number
+  deliveredCapped: boolean
+  dueNow: number
+  dueNowCapped: boolean
+  failed: number
+  failedCapped: boolean
+  oldestPendingAt: Date | null
+}
+
+/**
+ * Bounded operational snapshot for wake/schedule logs. Counts stop at
+ * `scanLimit`; the matching `*Capped` flag means the reported value is a lower
+ * bound. Dedicated partial indexes keep every subquery proportional to that
+ * limit even when delivered history or pending backlog is large.
+ */
+export async function getBoundedOutboxStats(
   db: DrizzleClient,
-): Promise<{ pending: number; delivered: number; failed: number; dueNow: number }> {
+  options: { scanLimit?: number } = {},
+): Promise<BoundedOutboxStats> {
+  const scanLimit = positiveInteger(options.scanLimit, 10_000, "scanLimit")
+  const sampleLimit = scanLimit + 1
   const result = (await (db as AnyDb).execute(sql`
     SELECT
-      count(*) FILTER (WHERE "status" = 'pending')::int AS pending,
-      count(*) FILTER (WHERE "status" = 'delivered')::int AS delivered,
-      count(*) FILTER (WHERE "status" = 'failed')::int AS failed,
-      count(*) FILTER (WHERE "status" = 'pending' AND "next_attempt_at" <= now())::int AS due_now
-    FROM ${eventOutboxTable}
+      (SELECT count(*)::int FROM (
+        SELECT 1 FROM ${eventOutboxTable}
+        WHERE "status" = 'pending'
+        ORDER BY "created_at" ASC
+        LIMIT ${sampleLimit}
+      ) pending_sample) AS pending,
+      (SELECT count(*)::int FROM (
+        SELECT 1 FROM ${eventOutboxTable}
+        WHERE "status" = 'pending' AND "next_attempt_at" <= now()
+        ORDER BY "next_attempt_at" ASC, "id" ASC
+        LIMIT ${sampleLimit}
+      ) due_sample) AS due_now,
+      (SELECT count(*)::int FROM (
+        SELECT 1 FROM ${eventOutboxTable}
+        WHERE "status" = 'failed'
+        ORDER BY "created_at" ASC
+        LIMIT ${sampleLimit}
+      ) failed_sample) AS failed,
+      (SELECT count(*)::int FROM (
+        SELECT 1 FROM ${eventOutboxTable}
+        WHERE "status" = 'delivered'
+        ORDER BY "delivered_at" ASC, "id" ASC
+        LIMIT ${sampleLimit}
+      ) delivered_sample) AS delivered,
+      (SELECT "created_at" FROM ${eventOutboxTable}
+        WHERE "status" = 'pending'
+        ORDER BY "created_at" ASC
+        LIMIT 1) AS oldest_pending_at
   `)) as unknown
   const rows = Array.isArray(result) ? result : ((result as { rows?: unknown[] }).rows ?? [])
-  const row = (rows[0] ?? {}) as Record<string, number>
+  const row = (rows[0] ?? {}) as Record<string, unknown>
+  const pendingSample = Number(row.pending ?? 0)
+  const dueSample = Number(row.due_now ?? 0)
+  const failedSample = Number(row.failed ?? 0)
+  const deliveredSample = Number(row.delivered ?? 0)
   return {
-    pending: row.pending ?? 0,
-    delivered: row.delivered ?? 0,
-    failed: row.failed ?? 0,
-    dueNow: row.due_now ?? 0,
+    pending: Math.min(pendingSample, scanLimit),
+    pendingCapped: pendingSample > scanLimit,
+    delivered: Math.min(deliveredSample, scanLimit),
+    deliveredCapped: deliveredSample > scanLimit,
+    dueNow: Math.min(dueSample, scanLimit),
+    dueNowCapped: dueSample > scanLimit,
+    failed: Math.min(failedSample, scanLimit),
+    failedCapped: failedSample > scanLimit,
+    oldestPendingAt: row.oldest_pending_at == null ? null : coerceDate(row.oldest_pending_at),
   }
+}
+
+/**
+ * Backward-compatible name for the bounded operational snapshot. Consumers
+ * needing an exact historical delivered count should use an offline reporting
+ * query rather than adding full-table work to a wake path.
+ */
+export async function getOutboxStats(
+  db: DrizzleClient,
+  options: { scanLimit?: number } = {},
+): Promise<BoundedOutboxStats> {
+  return getBoundedOutboxStats(db, options)
+}
+
+function positiveInteger(value: number | undefined, fallback: number, name: string): number {
+  const resolved = value ?? fallback
+  if (!Number.isSafeInteger(resolved) || resolved <= 0) {
+    throw new RangeError(`${name} must be a positive integer`)
+  }
+  return resolved
+}
+
+function nonNegativeInteger(value: number | undefined, fallback: number, name: string): number {
+  const resolved = value ?? fallback
+  if (!Number.isSafeInteger(resolved) || resolved < 0) {
+    throw new RangeError(`${name} must be a non-negative integer`)
+  }
+  return resolved
 }

--- a/packages/db/src/runtime-contributor.ts
+++ b/packages/db/src/runtime-contributor.ts
@@ -14,6 +14,7 @@ export function createDbRuntimePortContribution(
     withDb: (operation) => operation(host.primitives.database.resolve(undefined)),
     deliver: (envelope) =>
       host.primitives.events.deliver(envelope, undefined) as Promise<DeliveryResult>,
+    log: (message) => console.info(message),
     warn: (message) => console.warn(message),
   }
   return {

--- a/packages/db/src/schema/infra/event_outbox.ts
+++ b/packages/db/src/schema/infra/event_outbox.ts
@@ -61,7 +61,21 @@ export const eventOutboxTable = pgTable(
     // The drain's working set: due pending rows only. Partial keeps the
     // index tiny once delivered/failed rows accumulate.
     // agent-quality: raw-sql reviewed -- owner: db; dynamic SQL interpolation uses Drizzle parameter binding or vetted SQL identifiers.
-    index("event_outbox_due_idx").on(table.nextAttemptAt).where(sql`${table.status} = 'pending'`),
+    index("event_outbox_due_idx")
+      .on(table.nextAttemptAt, table.id)
+      .where(sql`${table.status} = 'pending'`),
+    index("event_outbox_pending_created_idx")
+      .on(table.createdAt)
+      .where(sql`${table.status} = 'pending'`),
+    index("event_outbox_failed_created_idx")
+      .on(table.createdAt)
+      .where(sql`${table.status} = 'failed'`),
+    index("event_outbox_delivered_idx")
+      .on(table.deliveredAt, table.id)
+      .where(sql`${table.status} = 'delivered'`),
+    index("event_outbox_pending_intent_idx")
+      .on(sql`(${table.payload} ->> 'intentId')`)
+      .where(sql`${table.status} = 'pending'`),
     index("event_outbox_created_idx").on(table.createdAt),
   ],
 ).enableRLS()

--- a/packages/db/src/schema/infra/write_intents.ts
+++ b/packages/db/src/schema/infra/write_intents.ts
@@ -50,7 +50,9 @@ export const writeIntentsTable = pgTable(
     uniqueIndex("write_intents_idempotency_key_uniq").on(table.idempotencyKey),
     // Stale-sweep working set; partial keeps it tiny.
     // agent-quality: raw-sql reviewed -- owner: db; dynamic SQL interpolation uses Drizzle parameter binding or vetted SQL identifiers.
-    index("write_intents_pending_idx").on(table.createdAt).where(sql`${table.status} = 'pending'`),
+    index("write_intents_pending_idx")
+      .on(table.createdAt, table.id)
+      .where(sql`${table.status} = 'pending'`),
   ],
 ).enableRLS()
 

--- a/packages/db/src/write-intents.ts
+++ b/packages/db/src/write-intents.ts
@@ -96,21 +96,36 @@ export async function settleWriteIntent(
  */
 export async function expireStaleWriteIntents(
   db: DrizzleClient,
-  options: { olderThanMinutes?: number } = {},
+  options: { olderThanMinutes?: number; limit?: number } = {},
 ): Promise<number> {
   const minutes = options.olderThanMinutes ?? 30
+  const limit = options.limit ?? 250
+  if (!Number.isSafeInteger(minutes) || minutes <= 0) {
+    throw new RangeError("olderThanMinutes must be a positive integer")
+  }
+  if (!Number.isSafeInteger(limit) || limit <= 0) {
+    throw new RangeError("limit must be a positive integer")
+  }
   const result = (await (db as AnyDb).execute(sql`
+    WITH candidates AS (
+      SELECT ${writeIntentsTable.id}
+      FROM ${writeIntentsTable}
+      WHERE ${writeIntentsTable.status} = 'pending'
+        AND ${writeIntentsTable.createdAt} < now() - (${minutes} * interval '1 minute')
+        AND NOT EXISTS (
+          SELECT 1 FROM ${eventOutboxTable}
+          WHERE ${eventOutboxTable.status} = 'pending'
+            AND ${eventOutboxTable.payload} ->> 'intentId' = ${writeIntentsTable.id}
+        )
+      ORDER BY ${writeIntentsTable.createdAt} ASC, ${writeIntentsTable.id} ASC
+      LIMIT ${limit}
+      FOR UPDATE SKIP LOCKED
+    )
     UPDATE ${writeIntentsTable}
     SET "status" = 'failed',
         "error" = 'intent expired before a handler settled it',
         "completed_at" = now()
-    WHERE "status" = 'pending'
-      AND "created_at" < now() - (${minutes} * interval '1 minute')
-      AND NOT EXISTS (
-        SELECT 1 FROM ${eventOutboxTable}
-        WHERE ${eventOutboxTable.status} = 'pending'
-          AND ${eventOutboxTable.payload} ->> 'intentId' = ${writeIntentsTable.id}
-      )
+    WHERE ${writeIntentsTable.id} IN (SELECT "id" FROM candidates)
     RETURNING "id"
   `)) as unknown
   const rows = Array.isArray(result) ? result : ((result as { rows?: unknown[] }).rows ?? [])

--- a/packages/db/tests/integration/outbox.test.ts
+++ b/packages/db/tests/integration/outbox.test.ts
@@ -8,8 +8,10 @@ import {
   createOutboxEventStore,
   drainOutbox,
   failOutboxEvent,
+  getBoundedOutboxStats,
   getOutboxStats,
   insertOutboxEvents,
+  pruneDeliveredOutboxEvents,
 } from "../../src/outbox.js"
 import { eventOutboxTable } from "../../src/schema/infra/event_outbox.js"
 import { createTestDb } from "../../src/test-utils.js"
@@ -47,6 +49,16 @@ describe.skipIf(!DB_AVAILABLE)("event outbox", () => {
         "delivered_at" timestamptz
       );
       CREATE UNIQUE INDEX IF NOT EXISTS "event_outbox_event_id_uniq" ON "event_outbox" ("event_id");
+      CREATE INDEX IF NOT EXISTS "event_outbox_due_idx"
+        ON "event_outbox" ("next_attempt_at", "id") WHERE "status" = 'pending';
+      CREATE INDEX IF NOT EXISTS "event_outbox_pending_created_idx"
+        ON "event_outbox" ("created_at") WHERE "status" = 'pending';
+      CREATE INDEX IF NOT EXISTS "event_outbox_failed_created_idx"
+        ON "event_outbox" ("created_at") WHERE "status" = 'failed';
+      CREATE INDEX IF NOT EXISTS "event_outbox_delivered_idx"
+        ON "event_outbox" ("delivered_at", "id") WHERE "status" = 'delivered';
+      CREATE INDEX IF NOT EXISTS "event_outbox_pending_intent_idx"
+        ON "event_outbox" (("payload" ->> 'intentId')) WHERE "status" = 'pending';
     `)
   })
 
@@ -110,6 +122,26 @@ describe.skipIf(!DB_AVAILABLE)("event outbox", () => {
       const claimed = await claimDueOutboxEvents(db, { limit: 10 })
       expect(claimed).toHaveLength(0)
     })
+
+    it("does not return the same row to concurrent claimers", async () => {
+      await insertOutboxEvents(
+        db,
+        Array.from({ length: 12 }, (_, index) => ({
+          name: "x",
+          data: { index },
+          metadata: { eventId: `evt_claim_${index}` },
+        })),
+      )
+
+      const [left, right] = await Promise.all([
+        claimDueOutboxEvents(db, { limit: 6 }),
+        claimDueOutboxEvents(db, { limit: 6 }),
+      ])
+
+      expect(left).toHaveLength(6)
+      expect(right).toHaveLength(6)
+      expect(new Set([...left, ...right].map((row) => row.eventId)).size).toBe(12)
+    })
   })
 
   describe("failOutboxEvent", () => {
@@ -153,7 +185,14 @@ describe.skipIf(!DB_AVAILABLE)("event outbox", () => {
 
       const result = await drainOutbox(db, bus)
 
-      expect(result).toEqual({ claimed: 1, delivered: 1, retried: 0, deadLettered: 0 })
+      expect(result).toMatchObject({
+        claimed: 1,
+        delivered: 1,
+        retried: 0,
+        deadLettered: 0,
+        batches: 1,
+        budgetExhausted: false,
+      })
       expect(handler).toHaveBeenCalledOnce()
       expect(handler).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -176,7 +215,12 @@ describe.skipIf(!DB_AVAILABLE)("event outbox", () => {
 
       const result = await drainOutbox(db, bus)
 
-      expect(result).toEqual({ claimed: 1, delivered: 0, retried: 1, deadLettered: 0 })
+      expect(result).toMatchObject({
+        claimed: 1,
+        delivered: 0,
+        retried: 1,
+        deadLettered: 0,
+      })
       const stats = await getOutboxStats(db)
       expect(stats.pending).toBe(1)
       errorSpy.mockRestore()
@@ -184,7 +228,134 @@ describe.skipIf(!DB_AVAILABLE)("event outbox", () => {
 
     it("returns an empty result when nothing is due", async () => {
       const result = await drainOutbox(db, createEventBus())
-      expect(result).toEqual({ claimed: 0, delivered: 0, retried: 0, deadLettered: 0 })
+      expect(result).toMatchObject({
+        claimed: 0,
+        delivered: 0,
+        retried: 0,
+        deadLettered: 0,
+        batches: 0,
+        budgetExhausted: false,
+      })
+    })
+
+    it("drains multiple batches while bounding delivery concurrency", async () => {
+      await insertOutboxEvents(
+        db,
+        Array.from({ length: 7 }, (_, index) => ({
+          name: "bounded",
+          data: { index },
+          metadata: { eventId: `evt_bounded_${index}` },
+        })),
+      )
+      let active = 0
+      let maxActive = 0
+      const result = await drainOutbox(
+        db,
+        {
+          async deliver() {
+            active += 1
+            maxActive = Math.max(maxActive, active)
+            await new Promise((resolve) => setTimeout(resolve, 5))
+            active -= 1
+            return { attempted: 1, failed: 0, errors: [] }
+          },
+        },
+        { limit: 3, concurrency: 2, maxEvents: 20, maxBatches: 10 },
+      )
+
+      expect(result).toMatchObject({ claimed: 7, delivered: 7, batches: 3 })
+      expect(maxActive).toBe(2)
+    })
+
+    it("stops at the configured work budget and leaves backlog for another wake", async () => {
+      await insertOutboxEvents(
+        db,
+        Array.from({ length: 8 }, (_, index) => ({
+          name: "budgeted",
+          data: { index },
+          metadata: { eventId: `evt_budgeted_${index}` },
+        })),
+      )
+
+      const result = await drainOutbox(db, createEventBus(), {
+        limit: 2,
+        concurrency: 1,
+        maxEvents: 3,
+        maxBatches: 10,
+      })
+
+      expect(result).toMatchObject({
+        claimed: 3,
+        delivered: 3,
+        batches: 2,
+        budgetExhausted: true,
+      })
+      expect((await getOutboxStats(db)).pending).toBe(5)
+    })
+  })
+
+  describe("bounded maintenance and statistics", () => {
+    it("prunes only the configured number of oldest delivered rows", async () => {
+      const rows = await insertOutboxEvents(
+        db,
+        Array.from({ length: 5 }, (_, index) => ({
+          name: "receipt",
+          data: { index },
+          metadata: { eventId: `evt_receipt_${index}` },
+        })),
+      )
+      for (const row of rows) await completeOutboxEvent(db, row.id)
+      await db.execute(
+        sql`UPDATE ${eventOutboxTable} SET "delivered_at" = now() - interval '30 days'`,
+      )
+
+      expect(await pruneDeliveredOutboxEvents(db, { olderThanDays: 14, limit: 2 })).toBe(2)
+      expect((await getOutboxStats(db)).delivered).toBe(3)
+    })
+
+    it("caps backlog scans and still reports the true oldest pending row", async () => {
+      await insertOutboxEvents(
+        db,
+        Array.from({ length: 4 }, (_, index) => ({
+          name: "stats",
+          data: { index },
+          metadata: { eventId: `evt_stats_${index}` },
+        })),
+      )
+      await db.execute(
+        sql`UPDATE ${eventOutboxTable} SET "created_at" = now() - interval '2 hours' WHERE "event_id" = 'evt_stats_0'`,
+      )
+
+      const stats = await getBoundedOutboxStats(db, { scanLimit: 2 })
+
+      expect(stats).toMatchObject({
+        pending: 2,
+        pendingCapped: true,
+        dueNow: 2,
+        dueNowCapped: true,
+      })
+      expect(stats.oldestPendingAt?.getTime()).toBeLessThan(Date.now() - 60 * 60 * 1000)
+    })
+
+    it("keeps the partial indexes required by claim, retry stats, and pruning", async () => {
+      const result = (await db.execute(/* sql */ `
+        SELECT indexname FROM pg_indexes
+        WHERE schemaname = current_schema() AND tablename = 'event_outbox'
+      `)) as unknown
+      const rows = Array.isArray(result)
+        ? result
+        : ((result as { rows?: Array<{ indexname: string }> }).rows ?? [])
+      const names = new Set(rows.map((row) => row.indexname))
+
+      for (const name of [
+        "event_outbox_due_idx",
+        "event_outbox_pending_created_idx",
+        "event_outbox_failed_created_idx",
+        "event_outbox_delivered_idx",
+        "event_outbox_pending_intent_idx",
+      ]) {
+        expect(names).toContain(name)
+      }
     })
   })
 

--- a/packages/db/tests/integration/write-intents.test.ts
+++ b/packages/db/tests/integration/write-intents.test.ts
@@ -1,5 +1,6 @@
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest"
-
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest"
+import { insertOutboxEvents } from "../../src/outbox.js"
+import { runEventOutboxDrainJob } from "../../src/outbox-job.js"
 import { createTestDb } from "../../src/test-utils.js"
 import {
   enqueueWriteIntent,
@@ -40,6 +41,8 @@ describe.skipIf(!DB_AVAILABLE)("write intents", () => {
         "created_at" timestamptz NOT NULL DEFAULT now(),
         "delivered_at" timestamptz
       );
+      CREATE UNIQUE INDEX IF NOT EXISTS "event_outbox_event_id_uniq"
+        ON "event_outbox" ("event_id");
       CREATE TABLE IF NOT EXISTS "write_intents" (
         "id" text PRIMARY KEY,
         "kind" text NOT NULL,
@@ -53,6 +56,8 @@ describe.skipIf(!DB_AVAILABLE)("write intents", () => {
       );
       CREATE UNIQUE INDEX IF NOT EXISTS "write_intents_idempotency_key_uniq"
         ON "write_intents" ("idempotency_key");
+      CREATE INDEX IF NOT EXISTS "write_intents_pending_idx"
+        ON "write_intents" ("created_at", "id") WHERE "status" = 'pending';
     `)
   })
 
@@ -176,5 +181,71 @@ describe.skipIf(!DB_AVAILABLE)("write intents", () => {
 
     expect(expired).toBe(1)
     expect((await getWriteIntent(db, intent.id))?.status).toBe("failed")
+  })
+
+  it("expires stale intents in bounded oldest-first batches", async () => {
+    const intents = await Promise.all(
+      Array.from({ length: 4 }, (_, index) =>
+        enqueueWriteIntent(db, {
+          kind: "k",
+          payload: {},
+          idempotencyKey: `bounded-${index}`,
+        }),
+      ),
+    )
+    await db.execute(/* sql */ `
+      UPDATE "write_intents" SET "created_at" = now() - interval '2 hours'
+    `)
+
+    expect(await expireStaleWriteIntents(db, { olderThanMinutes: 30, limit: 2 })).toBe(2)
+    const states = await Promise.all(intents.map(({ intent }) => getWriteIntent(db, intent.id)))
+    expect(states.filter((intent) => intent?.status === "failed")).toHaveLength(2)
+    expect(states.filter((intent) => intent?.status === "pending")).toHaveLength(2)
+  })
+
+  it("logs the bounded drain outcome and remaining backlog on every job wake", async () => {
+    await insertOutboxEvents(db, [
+      { name: "job.event", data: {}, metadata: { eventId: "evt_job_metrics" } },
+    ])
+    const log = vi.fn()
+    const warn = vi.fn()
+
+    await runEventOutboxDrainJob({
+      getPort: async () => ({
+        withDb: async (operation: (database: typeof db) => Promise<unknown>) => operation(db),
+        deliver: async () => ({ attempted: 1, failed: 0, errors: [] }),
+        log,
+        warn,
+      }),
+    } as never)
+
+    expect(log).toHaveBeenCalledOnce()
+    const message = String(log.mock.calls[0]?.[0])
+    expect(message).toMatch(/^\[outbox-drain\] /)
+    expect(JSON.parse(message.replace(/^\[outbox-drain\] /, ""))).toMatchObject({
+      claimed: 1,
+      delivered: 1,
+      retried: 0,
+      deadLettered: 0,
+      remainingBacklog: 0,
+      oldestPendingAgeMs: null,
+      pruned: 0,
+      expiredIntents: 0,
+    })
+  })
+
+  it("keeps the partial index required by bounded oldest-first expiration", async () => {
+    const result = (await db.execute(/* sql */ `
+      SELECT indexdef FROM pg_indexes
+      WHERE schemaname = current_schema()
+        AND tablename = 'write_intents'
+        AND indexname = 'write_intents_pending_idx'
+    `)) as unknown
+    const rows = Array.isArray(result)
+      ? result
+      : ((result as { rows?: Array<{ indexdef: string }> }).rows ?? [])
+
+    expect(rows[0]?.indexdef).toContain("(created_at, id)")
+    expect(rows[0]?.indexdef).toContain("status = 'pending'")
   })
 })


### PR DESCRIPTION
Closes #4361.

## What changed

- drain repeated bounded claim batches until the queue is empty or a configurable event, batch, or wall-clock budget is reached
- cap simultaneous subscriber deliveries instead of fanning a claimed batch out with unbounded `Promise.all`
- keep the existing `FOR UPDATE SKIP LOCKED` visibility-lease claim, retry/backoff, at-least-once delivery, and stable event IDs
- prune delivered receipts and expire stale write intents in bounded oldest-first batches
- replace wake-path full-table statistics with capped, index-backed backlog samples and cap flags
- emit one structured operational log per wake with claimed, delivered, retried, dead-lettered, remaining backlog, oldest pending age, duration, pruning, and expiration
- add the partial/composite indexes used by claims, statistics, pruning, and intent protection
- document the drain contract and query/index expectations
- add a patch changeset for `@voyant-travel/db`

## Root cause

The worker claimed only one batch, delivered every claimed row concurrently with `Promise.all`, and then ran unbounded delete, update, and aggregate queries on every wake. A dispatcher-triggered burst therefore translated directly into connection/downstream concurrency and table-work bursts.

## Validation

- `pnpm --filter @voyant-travel/db lint`
- `pnpm --filter @voyant-travel/db typecheck`
- `pnpm --filter @voyant-travel/db test` — 131 passed; database-gated integration tests skipped without the repository CI database service
- `pnpm verify:migration-boundaries`
- `pnpm verify:migration-identity`
- `pnpm verify:chain-reachability`
- `pnpm verify:agent-quality:changed`

The new PostgreSQL regression coverage exercises concurrent claims, retry behavior, multi-batch/concurrency/work caps, bounded pruning and intent expiration, structured telemetry, and required indexes when CI provides `TEST_DATABASE_URL`.