### PR TITLE
Add authenticated managed-runtime job wakes

### DIFF
--- a/.changeset/tender-jobs-wake.md
+++ b/.changeset/tender-jobs-wake.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": minor
+---
+
+Add an authenticated, deployment-bound, idempotent managed job wake contract for graph-registered wakeable jobs.

--- a/docs/architecture/deployment-targets.md
+++ b/docs/architecture/deployment-targets.md
@@ -129,6 +129,27 @@ workload class well. On Node none of it is necessary.
   `/__voyant/scheduled?schedule=<stable-id>` with the
   origin-trust header. During rollout the emitted URL also carries `cron` as a
   compatibility fallback for older runtimes.
+- **Managed job wakes:** the queue dispatcher posts a JSON envelope to
+  `POST /__voyant/jobs/wake` with the origin-trust header. The closed envelope
+  contains `deploymentId`, graph-registered `jobId`, durable `eventId`, and
+  caller-stable `idempotencyKey`; no job payload or arbitrary handler name is
+  accepted. The runtime compares `deploymentId` with its bound
+  `VOYANT_CLOUD_DEPLOYMENT_ID` before admission and only admits jobs declared
+  `wakeup: true`.
+
+  An accepted wake returns `202` with `disposition: "accepted"`; an observed
+  redelivery returns `200` with `disposition: "duplicate"`. Both say
+  `retry: false`. Authentication, malformed input, stale deployments, unknown
+  jobs, and idempotency conflicts are permanent failures (`retry: false`). A
+  runtime that is not bound or cannot admit the wake returns `503`,
+  `disposition: "retryable_failure"`, `retry: true`, and `Retry-After`.
+
+  The host keeps only a bounded, expiring process-local receipt cache to make
+  ordinary queue redelivery observable and coalesced. It is not a durable work
+  ledger: fixed jobs must claim domain-owned durable work idempotently, and a
+  declared schedule remains the recovery authority after process loss or a
+  lost wake. The endpoint starts no database pool and permits at most the
+  host's existing one running plus one coalesced invocation per job.
 - **CI:** the `node-smoke` job builds the operator, boots it under Node, and
   asserts `/healthz`, API dispatch, and a TanStack SSR page. `/healthz` is only
   a liveness signal; packaged-starter acceptance gates the complete server

--- a/packages/framework/src/node-job-host.test.ts
+++ b/packages/framework/src/node-job-host.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest"
 
-import { createVoyantNodeJobHost, VOYANT_PRODUCT_JOB_ROUTE } from "./node-job-host.js"
+import {
+  createVoyantNodeJobHost,
+  VOYANT_MANAGED_JOB_WAKE_ROUTE,
+  VOYANT_PRODUCT_JOB_ROUTE,
+} from "./node-job-host.js"
 import {
   createVoyantGraphRuntime,
   type VoyantGraphRuntime,
@@ -79,6 +83,32 @@ function inventory(
   ]
 }
 
+function managedWakeRequest(
+  overrides: Partial<{
+    deploymentId: string
+    jobId: string
+    eventId: string
+    idempotencyKey: string
+  }> = {},
+  headers: Record<string, string> = {},
+): Request {
+  return new Request(`https://operator.test${VOYANT_MANAGED_JOB_WAKE_ROUTE}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-voyant-origin-trust": "secret",
+      ...headers,
+    },
+    body: JSON.stringify({
+      deploymentId: "deployment_current",
+      jobId,
+      eventId: "event_1",
+      idempotencyKey: "queue-delivery-1",
+      ...overrides,
+    }),
+  })
+}
+
 describe("Voyant Node product job host", () => {
   it("requires exact parity between provisioning.jobs and runtime.jobs", () => {
     expect(() =>
@@ -139,6 +169,150 @@ describe("Voyant Node product job host", () => {
         executionToken: "00000000-0000-4000-8000-000000000001",
       }),
     )
+  })
+
+  it("accepts an authenticated managed wake bound to this deployment", async () => {
+    const handler = vi.fn(async () => {})
+    const host = createVoyantNodeJobHost({
+      runtime: jobRuntime(handler),
+      jobs: inventory(),
+      originTrustSecret: "secret",
+      managedDeploymentId: "deployment_current",
+    })
+
+    const response = await host.handleRequest(managedWakeRequest())
+
+    expect(response?.status).toBe(202)
+    await expect(response?.json()).resolves.toMatchObject({
+      ok: true,
+      disposition: "accepted",
+      retry: false,
+      deploymentId: "deployment_current",
+      jobId,
+      eventId: "event_1",
+    })
+    await host.settled(jobId)
+    expect(handler).toHaveBeenCalledOnce()
+  })
+
+  it("acknowledges an exact managed wake redelivery without repeating work", async () => {
+    const handler = vi.fn(async () => {})
+    const host = createVoyantNodeJobHost({
+      runtime: jobRuntime(handler),
+      jobs: inventory(),
+      originTrustSecret: "secret",
+      managedDeploymentId: "deployment_current",
+    })
+
+    expect((await host.handleRequest(managedWakeRequest()))?.status).toBe(202)
+    await host.settled(jobId)
+    const duplicate = await host.handleRequest(managedWakeRequest())
+
+    expect(duplicate?.status).toBe(200)
+    await expect(duplicate?.json()).resolves.toMatchObject({
+      ok: true,
+      disposition: "duplicate",
+      retry: false,
+    })
+    expect(handler).toHaveBeenCalledOnce()
+  })
+
+  it("permanently rejects a wake for a stale deployment", async () => {
+    const handler = vi.fn(async () => {})
+    const host = createVoyantNodeJobHost({
+      runtime: jobRuntime(handler),
+      jobs: inventory(),
+      originTrustSecret: "secret",
+      managedDeploymentId: "deployment_current",
+    })
+
+    const response = await host.handleRequest(
+      managedWakeRequest({ deploymentId: "deployment_stale" }),
+    )
+
+    expect(response?.status).toBe(409)
+    await expect(response?.json()).resolves.toEqual({
+      ok: false,
+      disposition: "permanent_failure",
+      retry: false,
+      code: "deployment_mismatch",
+    })
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it("permanently rejects an unknown or non-wakeable job", async () => {
+    const host = createVoyantNodeJobHost({
+      runtime: jobRuntime(() => {}),
+      jobs: inventory(),
+      originTrustSecret: "secret",
+      managedDeploymentId: "deployment_current",
+    })
+
+    const response = await host.handleRequest(managedWakeRequest({ jobId: "unknown.job" }))
+
+    expect(response?.status).toBe(404)
+    await expect(response?.json()).resolves.toMatchObject({
+      disposition: "permanent_failure",
+      retry: false,
+      code: "unknown_job",
+    })
+  })
+
+  it("returns a retryable response when managed wake admission fails", async () => {
+    const handler = vi.fn(async () => {})
+    const host = createVoyantNodeJobHost({
+      runtime: jobRuntime(handler),
+      jobs: inventory(),
+      originTrustSecret: "secret",
+      managedDeploymentId: "deployment_current",
+      acquireDistributedLease: async () => {
+        throw new Error("lease store unavailable")
+      },
+    })
+
+    const response = await host.handleRequest(managedWakeRequest())
+
+    expect(response?.status).toBe(503)
+    expect(response?.headers.get("retry-after")).toBe("5")
+    await expect(response?.json()).resolves.toEqual({
+      ok: false,
+      disposition: "retryable_failure",
+      retry: true,
+      code: "temporarily_unavailable",
+    })
+    expect(handler).not.toHaveBeenCalled()
+    // Failed admission did not consume the key.
+    expect((await host.handleRequest(managedWakeRequest()))?.status).toBe(503)
+  })
+
+  it("authenticates managed wakes and rejects idempotency-key reuse for another event", async () => {
+    const handler = vi.fn(async () => {})
+    const host = createVoyantNodeJobHost({
+      runtime: jobRuntime(handler),
+      jobs: inventory(),
+      originTrustSecret: "secret",
+      managedDeploymentId: "deployment_current",
+    })
+
+    const unauthenticated = await host.handleRequest(
+      managedWakeRequest({}, { "x-voyant-origin-trust": "wrong-secret" }),
+    )
+    expect(unauthenticated?.status).toBe(403)
+    await expect(unauthenticated?.json()).resolves.toEqual({
+      ok: false,
+      disposition: "permanent_failure",
+      retry: false,
+      code: "authentication_failed",
+    })
+    expect((await host.handleRequest(managedWakeRequest()))?.status).toBe(202)
+    const conflict = await host.handleRequest(managedWakeRequest({ eventId: "event_2" }))
+    expect(conflict?.status).toBe(409)
+    await expect(conflict?.json()).resolves.toMatchObject({
+      code: "idempotency_conflict",
+      retry: false,
+    })
+    await host.settled(jobId)
+    expect(handler).toHaveBeenCalledOnce()
   })
 
   it("accepts an empty streamed invocation body while rejecting actual request input", async () => {

--- a/packages/framework/src/node-job-host.ts
+++ b/packages/framework/src/node-job-host.ts
@@ -5,6 +5,7 @@ import { invokeVoyantGraphJob, type VoyantGraphRuntimePorts } from "./runtime-co
 import type { VoyantGraphRuntime } from "./runtime-lowering.js"
 
 export const VOYANT_PRODUCT_JOB_ROUTE = "/__voyant/jobs"
+export const VOYANT_MANAGED_JOB_WAKE_ROUTE = "/__voyant/jobs/wake"
 export const VOYANT_PRODUCT_JOB_RELEASE_HEADER = "x-voyant-product-job-release"
 export const VOYANT_PRODUCT_JOB_EXECUTION_HEADER = "x-voyant-product-job-execution"
 
@@ -72,6 +73,10 @@ export interface CreateVoyantNodeJobHostOptions {
   maximumWakeHorizonMs?: number
   /** Required for the fixed internal HTTP invocation surface. */
   originTrustSecret?: string
+  /** Deployment identity bound into this runtime by the managed control plane. */
+  managedDeploymentId?: string
+  /** Bounds process-local queue-redelivery observations; jobs remain durably idempotent. */
+  managedWakeIdempotency?: { ttlMs?: number; maxEntries?: number }
   /** Best-effort terminal execution reporting; failures never repeat domain work. */
   reportExecution?: (report: VoyantNodeJobExecutionReport) => Promise<void> | void
   /**
@@ -118,6 +123,11 @@ interface JobExecutionState {
   pendingCorrelation?: VoyantProductJobExecutionCorrelation
 }
 
+interface ManagedWakeReceipt {
+  fingerprint: string
+  acceptedAt: number
+}
+
 /**
  * Host fixed product jobs selected by the resolved graph.
  *
@@ -150,6 +160,15 @@ export function createVoyantNodeJobHost(
     options.maximumWakeHorizonMs ?? 6 * 60 * 60 * 1_000,
     "maximumWakeHorizonMs",
   )
+  const managedWakeTtlMs = positiveInteger(
+    options.managedWakeIdempotency?.ttlMs ?? 24 * 60 * 60 * 1_000,
+    "managedWakeIdempotency.ttlMs",
+  )
+  const managedWakeMaxEntries = positiveInteger(
+    options.managedWakeIdempotency?.maxEntries ?? 10_000,
+    "managedWakeIdempotency.maxEntries",
+  )
+  const managedWakeReceipts = new Map<string, ManagedWakeReceipt>()
   const states = new Map<string, JobExecutionState>(
     inventory.map((job) => [job.id, { pending: false } satisfies JobExecutionState]),
   )
@@ -336,14 +355,30 @@ export function createVoyantNodeJobHost(
       !url.pathname.startsWith(`${VOYANT_PRODUCT_JOB_ROUTE}/`)
     )
       return undefined
+    const isManagedWake = url.pathname === VOYANT_MANAGED_JOB_WAKE_ROUTE
     const trustSecret = (requestOriginTrustSecret ?? options.originTrustSecret)?.trim()
     if (!trustSecret) {
+      if (isManagedWake) return managedWakeFailure(503, "runtime_not_authenticated", true)
       return new Response("Product job HTTP invocation requires ORIGIN_TRUST_SECRET", {
         status: 503,
       })
     }
     if (!verifyOriginTrust(request, trustSecret)) {
+      if (isManagedWake) return managedWakeFailure(403, "authentication_failed", false)
       return new Response("Forbidden: invalid origin trust", { status: 403 })
+    }
+    if (isManagedWake) {
+      return handleManagedWakeRequest({
+        request,
+        url,
+        jobsById,
+        managedDeploymentId: options.managedDeploymentId,
+        receipts: managedWakeReceipts,
+        receiptTtlMs: managedWakeTtlMs,
+        maxReceipts: managedWakeMaxEntries,
+        now,
+        invoke,
+      })
     }
     if (url.pathname === VOYANT_PRODUCT_JOB_ROUTE) {
       if (request.method !== "GET") return new Response("Method Not Allowed", { status: 405 })
@@ -435,6 +470,164 @@ export function createVoyantNodeJobHost(
       for (const { timer: wakeTimer } of armedWakes.values()) clearTimeout(wakeTimer)
       armedWakes.clear()
     },
+  }
+}
+
+interface ManagedWakeRequest {
+  deploymentId: string
+  jobId: string
+  eventId: string
+  idempotencyKey: string
+}
+
+async function handleManagedWakeRequest(input: {
+  request: Request
+  url: URL
+  jobsById: ReadonlyMap<string, VoyantGraphProvisionedJob>
+  managedDeploymentId?: string
+  receipts: Map<string, ManagedWakeReceipt>
+  receiptTtlMs: number
+  maxReceipts: number
+  now: () => Date
+  invoke: VoyantNodeJobHost["invoke"]
+}): Promise<Response> {
+  if (input.request.method !== "POST") return managedWakeFailure(405, "method_not_allowed", false)
+  if (input.url.search) return managedWakeFailure(400, "invalid_request", false)
+
+  const deploymentId = input.managedDeploymentId?.trim()
+  if (!deploymentId) return managedWakeFailure(503, "runtime_not_bound", true)
+
+  const body = await readManagedWakeRequest(input.request)
+  if (body instanceof Response) return body
+  if (body.deploymentId !== deploymentId) {
+    return managedWakeFailure(409, "deployment_mismatch", false)
+  }
+  const job = input.jobsById.get(body.jobId)
+  if (!job?.wakeup) return managedWakeFailure(404, "unknown_job", false)
+
+  const current = input.now().getTime()
+  pruneManagedWakeReceipts(input.receipts, current - input.receiptTtlMs, input.maxReceipts)
+  const fingerprint = `${body.deploymentId}\0${body.jobId}\0${body.eventId}`
+  const previous = input.receipts.get(body.idempotencyKey)
+  if (previous) {
+    if (previous.fingerprint !== fingerprint) {
+      return managedWakeFailure(409, "idempotency_conflict", false)
+    }
+    return Response.json({
+      ok: true,
+      disposition: "duplicate",
+      retry: false,
+      deploymentId,
+      jobId: body.jobId,
+      eventId: body.eventId,
+    })
+  }
+
+  // Reserve before awaiting lease acquisition so concurrent redelivery cannot
+  // enqueue a second invocation. Remove the reservation if admission fails.
+  input.receipts.set(body.idempotencyKey, { fingerprint, acceptedAt: current })
+  try {
+    const result = await input.invoke(body.jobId, "wakeup")
+    return Response.json(
+      {
+        ok: true,
+        disposition: "accepted",
+        retry: false,
+        deploymentId,
+        jobId: body.jobId,
+        eventId: body.eventId,
+        result,
+      },
+      { status: 202 },
+    )
+  } catch {
+    input.receipts.delete(body.idempotencyKey)
+    return managedWakeFailure(503, "temporarily_unavailable", true)
+  }
+}
+
+async function readManagedWakeRequest(request: Request): Promise<ManagedWakeRequest | Response> {
+  const contentLength = Number(request.headers.get("content-length") ?? "0")
+  if (Number.isFinite(contentLength) && contentLength > 8_192) {
+    return managedWakeFailure(413, "request_too_large", false)
+  }
+  let value: unknown
+  try {
+    const bytes = await readBoundedRequestBytes(request, 8_192)
+    if (!bytes) return managedWakeFailure(413, "request_too_large", false)
+    value = JSON.parse(new TextDecoder().decode(bytes))
+  } catch {
+    return managedWakeFailure(400, "invalid_request", false)
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return managedWakeFailure(400, "invalid_request", false)
+  }
+  const record = value as Record<string, unknown>
+  const allowed = new Set(["deploymentId", "jobId", "eventId", "idempotencyKey"])
+  if (Object.keys(record).some((key) => !allowed.has(key))) {
+    return managedWakeFailure(400, "invalid_request", false)
+  }
+  for (const key of allowed) {
+    const field = record[key]
+    if (
+      typeof field !== "string" ||
+      field.trim() !== field ||
+      field.length < 1 ||
+      field.length > 255
+    ) {
+      return managedWakeFailure(400, "invalid_request", false)
+    }
+  }
+  return record as unknown as ManagedWakeRequest
+}
+
+async function readBoundedRequestBytes(
+  request: Request,
+  limit: number,
+): Promise<Uint8Array | null> {
+  if (!request.body) return new Uint8Array()
+  const reader = request.body.getReader()
+  const chunks: Uint8Array[] = []
+  let length = 0
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      length += value.byteLength
+      if (length > limit) {
+        void reader.cancel().catch(() => {})
+        return null
+      }
+      chunks.push(value)
+    }
+  } catch {
+    void reader.cancel().catch(() => {})
+    throw new Error("Unreadable managed wake request")
+  }
+  const bytes = new Uint8Array(length)
+  let offset = 0
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return bytes
+}
+
+function managedWakeFailure(status: number, code: string, retry: boolean): Response {
+  return Response.json(
+    { ok: false, disposition: retry ? "retryable_failure" : "permanent_failure", retry, code },
+    { status, headers: retry ? { "retry-after": "5" } : undefined },
+  )
+}
+
+function pruneManagedWakeReceipts(
+  receipts: Map<string, ManagedWakeReceipt>,
+  expiresBefore: number,
+  maxEntries: number,
+): void {
+  for (const [key, receipt] of receipts) {
+    if (receipt.acceptedAt >= expiresBefore && receipts.size < maxEntries) break
+    receipts.delete(key)
   }
 }
 

--- a/packages/framework/src/node-runtime.ts
+++ b/packages/framework/src/node-runtime.ts
@@ -375,6 +375,9 @@ export async function loadVoyantNodeRuntime(
     bindings: env,
     ...(runtimePorts ? { ports: runtimePorts } : {}),
     ...(env.ORIGIN_TRUST_SECRET ? { originTrustSecret: env.ORIGIN_TRUST_SECRET } : {}),
+    ...(env.VOYANT_CLOUD_DEPLOYMENT_ID
+      ? { managedDeploymentId: env.VOYANT_CLOUD_DEPLOYMENT_ID }
+      : {}),
     ...(managedJobHealthReporter ? { reportExecution: managedJobHealthReporter } : {}),
   })
   const actionLedgerCapabilities = lowerVoyantGraphActionsToActionLedgerRegistry(


### PR DESCRIPTION
Closes #4362.

## What changed

- add `POST /__voyant/jobs/wake` as the stable managed-runtime queue wake contract
- authenticate with the existing origin-trust boundary and bind every request to `VOYANT_CLOUD_DEPLOYMENT_ID`
- accept only graph-registered jobs declared `wakeup: true`; no payload or arbitrary handler dispatch is possible
- accept durable event and idempotency identities, coalesce observed redelivery, and reject conflicting key reuse
- return explicit accepted, duplicate, permanent-failure, and retryable-failure response semantics
- bound request bodies and the process-local receipt cache while retaining the existing host overlap limits
- preserve declared schedules as the durable recovery path
- document the contract and add a framework changeset

## Root cause

The existing internal product-job endpoint authenticated fixed job invocation, but it was intentionally payload-free and accepted no deployment, event, or idempotency identity. A managed queue consumer therefore could not prove that it had reached the tenant deployment it selected, distinguish safe redelivery from a new wake, or make an explicit acknowledge-versus-retry decision.

The new endpoint is a delivery/admission contract, not a second work ledger. Job implementations still claim domain-owned durable work idempotently, and their declared schedule repairs lost wakes. This composes directly with #4367, which bounds the first consumer, `infrastructure.event-outbox-drain`.

## Response contract

- `202 accepted`: wake admitted; acknowledge
- `200 duplicate`: exact observed redelivery; acknowledge
- `4xx permanent_failure`: authentication, request, deployment, job, or idempotency error; do not retry
- `503 retryable_failure` plus `Retry-After`: runtime binding/admission unavailable; retry

## Validation

- `pnpm --filter @voyant-travel/framework lint`
- `pnpm --filter @voyant-travel/framework typecheck`
- `pnpm --filter @voyant-travel/framework test` — 40 files, 407 tests passed
- `git diff --check`

The repository architecture chain was also started on a disposable Sprite and passed chain reachability, supply-chain, and tenant-scoping before its dependency-boundary fixture suite expanded into a long full-tree run; the redundant run was stopped. PR CI remains the authoritative full-chain gate.
