### PR TITLE
feat(admin): add authenticated shell bootstrap

### DIFF
--- a/.changeset/bright-shell-bootstrap.md
+++ b/.changeset/bright-shell-bootstrap.md
@@ -1,0 +1,10 @@
+---
+"@voyant-travel/admin": minor
+"@voyant-travel/admin-host": minor
+"@voyant-travel/auth": minor
+"@voyant-travel/operator-standard": minor
+"@voyant-travel/runtime": minor
+---
+
+Add the versioned authenticated admin shell bootstrap contract, managed-host
+resolver seam, and TanStack Query hydration path for shell-critical state.

--- a/docs/architecture/admin-architecture.md
+++ b/docs/architecture/admin-architecture.md
@@ -48,7 +48,7 @@ Rule:
 Voyant should own the shared admin runtime and extension seams, while templates
 own the final shell and composition.
 
-### 3. Bootstrap first-party admin shells from the current user only
+### 3. Bootstrap first-party admin shells from one authenticated contract
 
 Voyant-owned templates and apps are single-tenant per deployment. The base
 authenticated admin shell must render once the current user/session is ready.
@@ -56,11 +56,33 @@ Better Auth organization state, workspace switching, active organization
 selection, and team-management bootstrap are optional app-owned feature paths,
 not shell prerequisites.
 
+The standard shell reads `GET /auth/shell-bootstrap`. Version 1 contains the
+current user, active module ids, feature entitlements, effective navigation
+preferences, lightweight extension descriptors, and an explicit compatibility
+descriptor. The response is authenticated and carries `Cache-Control: private,
+no-store` plus `Vary: Cookie, Authorization`; neither a CDN nor a shared browser
+cache may reuse one member's snapshot for another request.
+
+The auth runtime owns authentication and the stable envelope. A managed host
+supplies live, request-scoped additions through `resolveShellBootstrap`, which
+receives the already authenticated user. This is the tenant-isolation boundary:
+the resolver must use its deployment context and that user id, never a tenant or
+member id supplied by the browser. A self-hosted host may omit the resolver and
+still serves the same contract with empty entitlement, preference, and dynamic
+extension snapshots.
+
+The route guard writes shell-critical snapshots into React Query before child
+loaders render. This prevents the sidebar and extension seams from immediately
+re-fetching the same data and lets TanStack's existing router dehydrate/hydrate
+path carry it across SSR. Full organization, billing, and extension manifests
+remain deferred until after the shell is interactive. Entitlement query state
+is focus/event invalidated and has no polling interval.
+
 Rule:
 
-`/auth/me` or an equivalent current-user primitive is sufficient for the base
-admin shell. Do not make `/auth/workspace/*` or `/auth/organization/*` part of
-first-party shell bootstrap.
+`/auth/shell-bootstrap` is the first-party shell bootstrap boundary. Do not make
+`/auth/workspace/*` or `/auth/organization/*` shell prerequisites, and do not
+put secrets or full extension manifests in the bootstrap response.
 
 For Voyant Cloud-provisioned deployments, `/auth/me` is still backed by a local
 Better Auth session. The browser reaches that local session through the
@@ -246,7 +268,7 @@ When adding or reviewing an admin capability in Voyant:
 
 1. Decide whether it belongs in the shared admin runtime or the starter-owned
    shell.
-2. Use current-user readiness as the base shell bootstrap dependency.
+2. Use the versioned authenticated shell bootstrap as the base shell dependency.
 3. Keep workspace/organization/team-management bootstrap behind explicit
    app-owned routes.
 4. Prefer explicit admin UI routes, nav contributions, or widget slots over

--- a/packages/admin-host/src/workspace.tsx
+++ b/packages/admin-host/src/workspace.tsx
@@ -42,6 +42,9 @@ export interface CreateAdminHostWorkspaceOptions<
   }
   icons?: OperatorAdminNavigationIcons
   signInPath?: string
+  hydrateShellBootstrap?: Parameters<
+    typeof createAdminWorkspaceBeforeLoad<TUser>
+  >[0]["hydrateShellBootstrap"]
 }
 
 export interface AdminHostWorkspace<TUser> {
@@ -66,6 +69,7 @@ export function createAdminHostWorkspace<
   realtime,
   icons = defaultOperatorNavIcons,
   signInPath = "/sign-in",
+  hydrateShellBootstrap,
 }: CreateAdminHostWorkspaceOptions<
   TUser,
   TFetcher,
@@ -74,7 +78,7 @@ export function createAdminHostWorkspace<
 >): AdminHostWorkspace<TUser> {
   const { UserProvider, useUser } = createAdminUserBindings<TUser>(auth.getCurrentUser)
   const destinations = createAdminHostDestinations(presentation.extensions)
-  const beforeLoad = createAdminWorkspaceBeforeLoad({ auth, signInPath })
+  const beforeLoad = createAdminWorkspaceBeforeLoad({ auth, signInPath, hydrateShellBootstrap })
 
   function Workspace({ initialUser, children }: { initialUser: TUser; children: ReactNode }) {
     return (

--- a/packages/admin/src/app/auth-runtime.ts
+++ b/packages/admin/src/app/auth-runtime.ts
@@ -33,6 +33,17 @@ export interface AdminBootstrapStatus {
   modules?: readonly string[]
 }
 
+/** Framework-neutral shape consumed by the authenticated shell guard. */
+export interface AdminShellBootstrap<TUser> {
+  version: number
+  compatibility: { minimumShellVersion: number; capabilities: readonly string[] }
+  user: TUser
+  activeModules: readonly string[]
+  entitlements: Readonly<Record<string, boolean>>
+  navigationPreferences: unknown
+  extensions: readonly Readonly<Record<string, unknown>>[]
+}
+
 /**
  * The auth capability a deployment supplies to the packaged admin. `TUser` is
  * the deployment's loaded-user shape (a structural superset of
@@ -41,6 +52,8 @@ export interface AdminBootstrapStatus {
 export interface AdminAuthRuntime<TUser> {
   /** Resolve the current user (server fn / cookie-forwarding fetch); `null` when signed out. */
   getCurrentUser: () => Promise<TUser | null | undefined>
+  /** Preferred one-request shell bootstrap; older/custom hosts may omit it. */
+  getShellBootstrap?: () => Promise<AdminShellBootstrap<TUser> | null | undefined>
   /** Whether any user exists yet + the identity-broker mode driving redirects. */
   getBootstrapStatus: () => Promise<AdminBootstrapStatus>
   /** Href that starts the Voyant Cloud identity-broker flow (used in `voyant-cloud` mode). */

--- a/packages/admin/src/app/workspace.tsx
+++ b/packages/admin/src/app/workspace.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query"
+import { type QueryClient, useQuery } from "@tanstack/react-query"
 import { Link, redirect, useRouter, useRouterState } from "@tanstack/react-router"
 import { useVoyantReactContext } from "@voyant-travel/react"
 import { Loader2 } from "lucide-react"
@@ -70,10 +70,16 @@ export interface CreateAdminWorkspaceBeforeLoadOptions<TUser> {
    */
   auth: Pick<
     AdminAuthRuntime<TUser>,
-    "getCurrentUser" | "getBootstrapStatus" | "cloudAuthStartHref"
+    "getCurrentUser" | "getShellBootstrap" | "getBootstrapStatus" | "cloudAuthStartHref"
   >
   /** Where unauthenticated visitors are sent in `local` auth mode. Default `/sign-in`. */
   signInPath?: string
+  hydrateShellBootstrap?: (
+    bootstrap: NonNullable<
+      Awaited<ReturnType<NonNullable<AdminAuthRuntime<TUser>["getShellBootstrap"]>>>
+    >,
+    queryClient: QueryClient,
+  ) => void
 }
 
 /**
@@ -93,19 +99,33 @@ export interface CreateAdminWorkspaceBeforeLoadOptions<TUser> {
 export function createAdminWorkspaceBeforeLoad<TUser>({
   auth,
   signInPath = "/sign-in",
+  hydrateShellBootstrap,
 }: CreateAdminWorkspaceBeforeLoadOptions<TUser>) {
-  return async ({ location }: { location: { href: string } }): Promise<{ user: TUser }> => {
-    const user = await auth.getCurrentUser()
+  return async ({
+    location,
+    context,
+  }: {
+    location: { href: string }
+    context?: { queryClient?: QueryClient }
+  }): Promise<{ user: TUser }> => {
+    const usesShellBootstrap = auth.getShellBootstrap !== undefined
+    const shellBootstrap = await auth.getShellBootstrap?.()
+    const user = usesShellBootstrap ? shellBootstrap?.user : await auth.getCurrentUser()
 
-    if (user) return { user }
+    if (user) {
+      if (shellBootstrap && context?.queryClient) {
+        hydrateShellBootstrap?.(shellBootstrap, context.queryClient)
+      }
+      return { user }
+    }
 
     // Unauthenticated: send to the Cloud broker in voyant-cloud mode, else the
     // local sign-in. A failed bootstrap probe falls back to the local path.
-    const bootstrap = await auth
+    const bootstrapStatus = await auth
       .getBootstrapStatus()
       .catch((): AdminBootstrapStatus => ({ hasUsers: true }))
 
-    if (bootstrap.authMode === "voyant-cloud") {
+    if (bootstrapStatus.authMode === "voyant-cloud") {
       // `cloudAuthStartHref` is a relative API path (`/api/auth/admin/cloud/start…`).
       // TanStack only infers a full-document redirect for absolute hrefs, so on
       // a client-side navigation a relative href would be handled as in-app

--- a/packages/admin/tests/app/admin-app.test.ts
+++ b/packages/admin/tests/app/admin-app.test.ts
@@ -1,3 +1,4 @@
+import { QueryClient } from "@tanstack/react-query"
 import { describe, expect, it, vi } from "vitest"
 import { adminRootHead } from "../../src/app/root.js"
 import {
@@ -100,6 +101,36 @@ describe("createAdminWorkspaceBeforeLoad", () => {
     const beforeLoad = createAdminWorkspaceBeforeLoad({ auth: authStub({ user }) })
 
     await expect(beforeLoad({ location: { href: "/bookings" } })).resolves.toEqual({ user })
+  })
+
+  it("uses one bootstrap request and hydrates shell-critical query state", async () => {
+    const user = { id: "usr_bootstrap" }
+    const getCurrentUser = vi.fn(async () => user)
+    const bootstrap = {
+      version: 1,
+      compatibility: { minimumShellVersion: 1, capabilities: ["admin.shell-bootstrap.v1"] },
+      user,
+      activeModules: ["bookings"],
+      entitlements: { bookings: true },
+      navigationPreferences: null,
+      extensions: [],
+    }
+    const hydrateShellBootstrap = vi.fn()
+    const queryClient = new QueryClient()
+    const beforeLoad = createAdminWorkspaceBeforeLoad({
+      auth: {
+        ...authStub(),
+        getCurrentUser,
+        getShellBootstrap: vi.fn(async () => bootstrap),
+      },
+      hydrateShellBootstrap,
+    })
+
+    await expect(
+      beforeLoad({ location: { href: "/bookings" }, context: { queryClient } }),
+    ).resolves.toEqual({ user })
+    expect(getCurrentUser).not.toHaveBeenCalled()
+    expect(hydrateShellBootstrap).toHaveBeenCalledWith(bootstrap, queryClient)
   })
 
   it("redirects unauthenticated visitors to sign-in with a next param (local mode)", async () => {

--- a/packages/auth/src/node-runtime.ts
+++ b/packages/auth/src/node-runtime.ts
@@ -174,6 +174,27 @@ export interface OperatorCurrentUser {
   profilePictureUrl: string | null
 }
 
+export const OPERATOR_SHELL_BOOTSTRAP_VERSION = 1 as const
+
+export interface OperatorShellBootstrapAdditions {
+  /** Host-owned feature entitlements. Keys are stable capability ids. */
+  entitlements?: Readonly<Record<string, boolean>>
+  /** Effective navigation snapshot, or null when the selected graph has no preference authority. */
+  navigationPreferences?: unknown
+  /** Lightweight, non-secret descriptors only. Full extension manifests remain deferred. */
+  extensions?: readonly Readonly<Record<string, unknown>>[]
+}
+
+export interface OperatorShellBootstrap extends Required<OperatorShellBootstrapAdditions> {
+  version: typeof OPERATOR_SHELL_BOOTSTRAP_VERSION
+  compatibility: {
+    minimumShellVersion: typeof OPERATOR_SHELL_BOOTSTRAP_VERSION
+    capabilities: readonly string[]
+  }
+  user: OperatorCurrentUser
+  activeModules: readonly string[]
+}
+
 export type OperatorAuthBootstrapStatus = {
   hasUsers: boolean
   authMode?: OperatorAuthMode
@@ -227,6 +248,16 @@ export interface CreateOperatorAuthNodeRuntimeOptions<Env extends OperatorAuthNo
     | Pick<BetterAuthAdvancedOptions, "crossSubDomainCookies" | "defaultCookieAttributes">
     | undefined
   resolveEmailSender?: (env: Env) => OperatorAuthEmailSender | null
+  /**
+   * Request-scoped managed-host data for the authenticated shell bootstrap.
+   * The resolver receives the already authenticated user so hosts cannot
+   * accidentally resolve another member's or deployment's snapshot.
+   */
+  resolveShellBootstrap?: (input: {
+    env: Env
+    request: Request
+    user: OperatorCurrentUser
+  }) => OperatorShellBootstrapAdditions | Promise<OperatorShellBootstrapAdditions>
   customerBusinessAccountOnboarding?: CustomerBusinessAccountOnboardingRuntimeProvider
   /**
    * Storefront/BFF seam for a canonical public auth origin and resolved
@@ -1448,6 +1479,58 @@ export function createOperatorAuthNodeRuntime<Env extends OperatorAuthNodeEnv>(
         return c.json({ error: "Unauthorized" }, 401)
       }
       return c.json(currentUser)
+    } catch (error) {
+      if (error instanceof CurrentUserNotFoundError) {
+        return c.json({ error: "User not found" }, 404)
+      }
+      throw error
+    }
+  })
+
+  /**
+   * GET /auth/shell-bootstrap
+   *
+   * The single authenticated, versioned response needed to render the admin
+   * shell. It is deliberately private and uncacheable: it contains member- and
+   * deployment-scoped authorization state. Managed hosts may add their live
+   * entitlement/preference/extension snapshot through the request-scoped port;
+   * self-hosted deployments get the same stable contract with empty additions.
+   */
+  auth.get("/auth/shell-bootstrap", async (c) => {
+    c.header("Cache-Control", "private, no-store")
+    c.header("Vary", "Cookie, Authorization")
+    try {
+      const user = await getCurrentUserForRequest(c.req.raw, c.env)
+      if (!user) return c.json({ error: "Unauthorized" }, 401)
+
+      const additions =
+        (await runtimeOptions.resolveShellBootstrap?.({
+          env: c.env,
+          request: c.req.raw,
+          user,
+        })) ?? {}
+      const capabilities = [
+        "admin.shell-bootstrap.v1",
+        "admin.shell-bootstrap.focus-invalidation",
+        ...(additions.entitlements ? ["admin.shell-bootstrap.entitlements"] : []),
+        ...(additions.navigationPreferences
+          ? ["admin.shell-bootstrap.navigation-preferences"]
+          : []),
+        ...(additions.extensions ? ["admin.shell-bootstrap.extensions"] : []),
+      ]
+      const bootstrap: OperatorShellBootstrap = {
+        version: OPERATOR_SHELL_BOOTSTRAP_VERSION,
+        compatibility: {
+          minimumShellVersion: OPERATOR_SHELL_BOOTSTRAP_VERSION,
+          capabilities,
+        },
+        user,
+        activeModules: [...(runtimeOptions.activeModules ?? [])],
+        entitlements: { ...(additions.entitlements ?? {}) },
+        navigationPreferences: additions.navigationPreferences ?? null,
+        extensions: [...(additions.extensions ?? [])],
+      }
+      return c.json(bootstrap)
     } catch (error) {
       if (error instanceof CurrentUserNotFoundError) {
         return c.json({ error: "User not found" }, 404)

--- a/packages/auth/tests/unit/node-runtime.test.ts
+++ b/packages/auth/tests/unit/node-runtime.test.ts
@@ -167,6 +167,33 @@ describe("createOperatorAuthNodeRuntime", () => {
     expect(openDatabase).not.toHaveBeenCalled()
   })
 
+  it("keeps the shell bootstrap private and rejects unauthenticated requests", async () => {
+    const resolver = vi.fn()
+    const runtime = createOperatorAuthNodeRuntime({
+      accessCatalog: { resources: [], presets: [] },
+      activeModules: ["catalog"],
+      appName: "auth-test",
+      authMode: "local",
+      reporter: { captureException: vi.fn() },
+      resolveShellBootstrap: resolver,
+    })
+
+    const response = await runtime.handler.fetch(
+      new Request("https://localhost/auth/shell-bootstrap"),
+      {
+        DATABASE_URL: "postgres://unused",
+        SESSION_CLAIMS_ADMIN_SECRET: "admin-session-claims-secret",
+        VOYANT_OPERATOR_BROWSER_EVIDENCE: "1",
+      },
+      { waitUntil: vi.fn() } as never,
+    )
+
+    expect(response.status).toBe(401)
+    expect(response.headers.get("cache-control")).toBe("private, no-store")
+    expect(response.headers.get("vary")).toBe("Cookie, Authorization")
+    expect(resolver).not.toHaveBeenCalled()
+  })
+
   it("exposes only the canonical admin cloud start route", async () => {
     const openDatabase = vi.fn(() => {
       throw new Error("cloud start route must not open the database")

--- a/packages/operator-standard/src/standard-frontend.tsx
+++ b/packages/operator-standard/src/standard-frontend.tsx
@@ -15,6 +15,7 @@ import {
   type AdminChildProvider,
   OperatorAdminShellProvider,
 } from "@voyant-travel/admin/providers/operator-admin-shell"
+import { UI_EXTENSIONS_QUERY_KEY } from "@voyant-travel/admin/ui-extensions"
 import { adminFetcher, getAdminApiUrl } from "@voyant-travel/admin-app/runtime"
 import {
   type AdminHostPresentation,
@@ -24,6 +25,7 @@ import {
   type AdminHostWorkspace,
   createAdminHostWorkspace,
 } from "@voyant-travel/admin-host/workspace"
+import type { OperatorShellBootstrap } from "@voyant-travel/auth/node-runtime"
 import { createAuthBasePathFetcher } from "@voyant-travel/auth-react/client"
 import type {
   LocalAuthPresentationRuntime,
@@ -39,6 +41,7 @@ import type {
   FinancePublicRouteRuntime,
 } from "@voyant-travel/finance-react/public-routes"
 import { ProductDetailPageProducts } from "@voyant-travel/inventory-react/storefront"
+import { navigationPreferencesQueryKey } from "@voyant-travel/navigation-preferences-react"
 import type {
   createProposalsPublicRouteContribution,
   ProposalsPublicRouteRuntime,
@@ -83,6 +86,10 @@ export interface StandardOperatorCurrentUser {
   profilePictureUrl?: string | null
 }
 
+type StandardOperatorShellBootstrap = Omit<OperatorShellBootstrap, "user"> & {
+  user: StandardOperatorCurrentUser
+}
+
 export interface CreateStandardOperatorFrontendOptions {
   accessCatalog: AccessCatalog
   selected: Parameters<typeof createAdminHostPresentation>[0]["selected"]
@@ -123,6 +130,7 @@ const ADMIN_SHARED_AUTH_PATHS = [
   "/me",
   "/status",
   "/bootstrap-status",
+  "/shell-bootstrap",
   "/api-tokens",
   "/organization/list-members",
 ] as const
@@ -197,8 +205,33 @@ const getCurrentUser = createServerFn({ method: "GET" })
     return (await response.json()) as StandardOperatorCurrentUser
   })
 
+const getShellBootstrap = createServerFn({ method: "GET" })
+  .middleware([withRequest])
+  .handler(async ({ context }) => {
+    if (shouldUseBrowserEvidenceFallback(context.request)) return null
+    const headers = new Headers()
+    const cookie = context.request.headers.get("cookie")
+    const authorization = context.request.headers.get("authorization")
+    if (cookie) headers.set("cookie", cookie)
+    if (authorization) headers.set("authorization", authorization)
+    const response = await fetch(new URL("/api/auth/shell-bootstrap", context.request.url), {
+      headers,
+      cache: "no-store",
+    })
+    if (response.status === 401) return null
+    if (!response.ok) throw new Error("Failed to fetch admin shell bootstrap")
+    const bootstrap = (await response.json()) as StandardOperatorShellBootstrap
+    if (bootstrap.version !== 1 || bootstrap.compatibility.minimumShellVersion > 1) {
+      throw new Error(
+        `Incompatible admin shell bootstrap contract (received ${bootstrap.version}, shell supports 1)`,
+      )
+    }
+    return bootstrap
+  })
+
 const adminAuthRuntime: AdminAuthRuntime<StandardOperatorCurrentUser> = {
   getCurrentUser,
+  getShellBootstrap,
   getBootstrapStatus,
   cloudAuthStartHref,
   signOut: async () => {
@@ -342,6 +375,27 @@ function createPresentationRuntime(
       Provider: AdminWorkspaceRealtimeProvider,
       channel: RealtimeChannel,
       useSession: authClient.useSession,
+    },
+    hydrateShellBootstrap: (bootstrap, queryClient) => {
+      const capabilities = new Set(bootstrap.compatibility.capabilities)
+      if (capabilities.has("admin.shell-bootstrap.navigation-preferences")) {
+        queryClient.setQueryData(
+          navigationPreferencesQueryKey(bootstrap.user.id),
+          bootstrap.navigationPreferences,
+        )
+      }
+      if (capabilities.has("admin.shell-bootstrap.extensions")) {
+        queryClient.setQueryData(UI_EXTENSIONS_QUERY_KEY, bootstrap.extensions)
+      }
+      queryClient.setQueryDefaults(["voyant", "admin", "entitlements"], {
+        staleTime: Number.POSITIVE_INFINITY,
+        refetchOnWindowFocus: true,
+        refetchInterval: false,
+      })
+      if (capabilities.has("admin.shell-bootstrap.entitlements")) {
+        queryClient.setQueryData(["voyant", "admin", "entitlements"], bootstrap.entitlements)
+      }
+      queryClient.setQueryData(["voyant", "admin", "active-modules"], bootstrap.activeModules)
     },
   })
   const mcpConsent = mcpConsentFactory?.()

--- a/packages/operator-standard/src/standard-route-files.ts
+++ b/packages/operator-standard/src/standard-route-files.ts
@@ -115,7 +115,7 @@ const workspace = operatorFrontend.workspace
 
 export const Route = createFileRoute("/_workspace")({
   ssr: "data-only",
-  beforeLoad: ({ location }) => workspace.beforeLoad({ location }),
+  beforeLoad: ({ location, context }) => workspace.beforeLoad({ location, context }),
   loader: ({ context }) => ({ user: context.user }),
   pendingComponent: workspace.PendingComponent,
   component: WorkspaceLayout,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -19,6 +19,8 @@ import {
   createOperatorAuthNodeRuntime,
   type OperatorAuthEmailSender,
   type OperatorAuthNodeEnv,
+  type OperatorCurrentUser,
+  type OperatorShellBootstrapAdditions,
 } from "@voyant-travel/auth/node-runtime"
 import { createLinkServiceStorefrontChannelBindingProvider } from "@voyant-travel/auth/storefront-channel-binding-provider"
 import {
@@ -139,6 +141,12 @@ export interface LoadVoyantProjectOptions {
     ) => Promise<string | null>
     /** Project-owned transport for verification codes and password resets. */
     resolveAuthEmailSender?: (env: OperatorAuthNodeEnv) => OperatorAuthEmailSender | null
+    /** Managed-host additions for the authenticated, tenant-scoped admin shell bootstrap. */
+    resolveShellBootstrap?: (input: {
+      env: OperatorAuthNodeEnv
+      request: Request
+      user: OperatorCurrentUser
+    }) => OperatorShellBootstrapAdditions | Promise<OperatorShellBootstrapAdditions>
   }
 }
 
@@ -428,6 +436,9 @@ export async function loadVoyantProject(
     reporter,
     ...(customerBusinessAccountOnboarding ? { customerBusinessAccountOnboarding } : {}),
     resolveEmailSender: options.host?.resolveAuthEmailSender ?? resolveVoyantCloudAuthEmailSender,
+    ...(options.host?.resolveShellBootstrap
+      ? { resolveShellBootstrap: options.host.resolveShellBootstrap }
+      : {}),
     ...(customerAuthContextResolver
       ? { resolveCustomerAuthContext: customerAuthContextResolver }
       : {}),


### PR DESCRIPTION
## What changed

- add `GET /auth/shell-bootstrap`, a versioned authenticated contract containing the current user, selected modules, entitlements, navigation preferences, lightweight extension descriptors, and compatibility capabilities
- enforce private/no-store cache semantics and resolve managed additions only after authentication through a request-scoped host port
- preserve self-hosted support with the same envelope and safe empty optional snapshots
- consume the contract in the standard operator route guard and seed React Query before child loaders and SSR dehydration
- use focus/event invalidation for entitlement state with polling disabled
- document the contract, isolation boundary, deferred data, and cache rules
- add a changeset for the affected packages

## Root cause

The standard shell authenticated through `/auth/me`, while module state and optional preference/extension state lived behind separate reads. There was no versioned compatibility envelope or host port capable of producing one member- and deployment-scoped snapshot, so the global shell could not hydrate its critical state without follow-up requests.

## Validation

- Biome check on all changed TypeScript files
- `@voyant-travel/admin` typecheck (Sprite)
- `@voyant-travel/auth` typecheck (Sprite)
- `@voyant-travel/admin-host` typecheck with expanded heap (Sprite)
- `packages/auth/tests/unit/node-runtime.test.ts`: 40 passed
- `packages/admin/tests/app/admin-app.test.ts`: 18 passed
- `packages/operator-standard/tests/standard-route-files.test.ts`: 6 passed

The first combined remote typecheck hit the default 2 GB heap in `admin-host`; its isolated rerun passed. Isolated `operator-standard` and `runtime` typechecks produced no TypeScript diagnostics but exceeded the disposable Sprite execution window, so CI remains the full check for those two large graphs. Browser evidence is intentionally not fabricated: it requires the managed sandbox host to supply its real `resolveShellBootstrap` additions and is a follow-up verification gate before this draft is marked ready.

Closes #4363