### PR TITLE
Scope regional application cells by tenant

### DIFF
--- a/.changeset/calm-cells-scope.md
+++ b/.changeset/calm-cells-scope.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/db": minor
+"@voyant-travel/framework": minor
+---
+
+Add a bounded tenant-scoped Node application-cell host and disposable per-tenant database pools.

--- a/.changeset/tender-jobs-wake.md
+++ b/.changeset/tender-jobs-wake.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": minor
+---
+
+Add an authenticated, deployment-bound, idempotent managed job wake contract for graph-registered wakeable jobs.

--- a/.changeset/tidy-spoons-drain.md
+++ b/.changeset/tidy-spoons-drain.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/db": patch
+---
+
+Bound transactional outbox delivery, maintenance, and operational statistics while allowing wakeups to drain multiple batches within a work and time budget.

--- a/docs/adr/0001-tenant-scoping.md
+++ b/docs/adr/0001-tenant-scoping.md
@@ -10,10 +10,12 @@ operator, supplier, distribution). Every domain module — bookings,
 products, finance, transactions, etc. — runs against a single Postgres
 database and is mounted into a single Hono app at deploy time.
 
-Customers buy Voyant per organization. Voyant Cloud's commercial offering
-provisions **one Postgres database + one Node application runtime per customer
-organization**. Customers self-hosting Voyant own their own infra and run the
-same one-DB-per-org topology.
+Customers buy Voyant per organization. Voyant Cloud originally provisioned
+**one Postgres database + one Node process per customer organization**. Managed
+regional application cells may now place a bounded set of tenant runtimes in one
+process, while retaining one database, credential role, immutable runtime
+context, and fully composed application runtime per tenant. Customers
+self-hosting Voyant retain the simpler one-process, one-DB-per-org topology.
 
 There is no shared-tier today. There has never been one in the framework's
 history. There are no schema columns named `organizationId` whose purpose
@@ -44,7 +46,9 @@ Concretely, this means:
   not per-request organization scoping.
 
 When asked "how is one customer's data isolated from another customer's?"
-the answer is: **separate Postgres database, separate compute runtime.**
+the answer is: **a separate Postgres database and a separate composed runtime
+selected at the trusted process boundary.** A cell shares process compute, not
+authoritative state or a domain runtime.
 Voyant Cloud's provisioning is the enforcement; customers self-hosting
 inherit the same model.
 
@@ -73,6 +77,35 @@ choose Redis for shared state explicitly; when they also provide
 self-hoster's infrastructure contract rather than a framework-provided
 shared-tenant isolation mechanism.
 
+## Managed application-cell invariants
+
+The framework-owned Node cell host resolves a trusted hostname and, for queue
+wakes, the deployment identity in the authenticated contract into one frozen
+tenant context before domain code runs. Unknown, stale, or conflicting mappings
+fail closed and emit security telemetry. The context owns server-only database
+credentials; it is never serialized into responses or deployment manifests.
+
+Each resident tenant gets its own composed module and extension registries,
+in-memory caches, authorization integration, event bus, job host, timers, and
+database pool. Queue wakes must match both the request hostname and the
+deployment identity consumed by that tenant's job host. Background invocation
+by the cell API accepts a deployment identity, never an arbitrary database or
+tenant override.
+
+The capacity boundary is explicit: per-tenant connection concurrency remains
+bounded by `DATABASE_MAX_CONNECTIONS`; `DATABASE_MAX_TENANT_POOLS` bounds pools
+per process; the cell bounds resident runtimes; and idle tenants are evicted
+only while they have no admitted request. A resident runtime holds its pool so
+detached job work cannot lose sockets mid-execution. Pool disposal closes Node
+driver sockets.
+
+This is not shared-schema tenancy. A tenant context still points at one database
+and domain packages still issue unscoped queries. Provisioning must reject two
+tenant identities that resolve to the same database/role. High-volume or
+regulated tenants retain the dedicated-process escape hatch, using the existing
+single-tenant runtime without the cell host. Self-hosted deployments do the same
+by default.
+
 ## Consequences
 
 ### Positive
@@ -98,7 +131,7 @@ shared-tenant isolation mechanism.
   deployment must understand that tenancy is not enforced by the
   framework. A customer who tries to consolidate two organizations into
   one DB to save costs has zero protection.
-- **Future shared-tier work would require a re-architecture.** If
+- **Future shared-database work would require a re-architecture.** If
   Voyant ever adds a "shared starter tier" (multiple orgs in one DB),
   every domain module would need to be audited for organization-scoping
   and a middleware/proxy layer would need to be added. This is a real
@@ -128,8 +161,8 @@ topology. Adding it later (if a shared-tier ever ships) is feasible;
 ripping it out if it bloats every read path is harder. The current
 single-tenant deployment model is the actual product reality.
 
-If the threat model ever shifts (shared-tier, multi-org dashboards on a
-shared DB, etc.), this ADR is the place to mark superseded and the work
+If the threat model ever shifts to shared-schema databases or multi-org
+dashboards on a shared DB, this ADR is the place to mark superseded and the work
 to add Alternative A becomes the new baseline.
 
 ### Alternative B: Hybrid (chosen)

--- a/docs/architecture/deployment-targets.md
+++ b/docs/architecture/deployment-targets.md
@@ -129,6 +129,27 @@ workload class well. On Node none of it is necessary.
   `/__voyant/scheduled?schedule=<stable-id>` with the
   origin-trust header. During rollout the emitted URL also carries `cron` as a
   compatibility fallback for older runtimes.
+- **Managed job wakes:** the queue dispatcher posts a JSON envelope to
+  `POST /__voyant/jobs/wake` with the origin-trust header. The closed envelope
+  contains `deploymentId`, graph-registered `jobId`, durable `eventId`, and
+  caller-stable `idempotencyKey`; no job payload or arbitrary handler name is
+  accepted. The runtime compares `deploymentId` with its bound
+  `VOYANT_CLOUD_DEPLOYMENT_ID` before admission and only admits jobs declared
+  `wakeup: true`.
+
+  An accepted wake returns `202` with `disposition: "accepted"`; an observed
+  redelivery returns `200` with `disposition: "duplicate"`. Both say
+  `retry: false`. Authentication, malformed input, stale deployments, unknown
+  jobs, and idempotency conflicts are permanent failures (`retry: false`). A
+  runtime that is not bound or cannot admit the wake returns `503`,
+  `disposition: "retryable_failure"`, `retry: true`, and `Retry-After`.
+
+  The host keeps only a bounded, expiring process-local receipt cache to make
+  ordinary queue redelivery observable and coalesced. It is not a durable work
+  ledger: fixed jobs must claim domain-owned durable work idempotently, and a
+  declared schedule remains the recovery authority after process loss or a
+  lost wake. The endpoint starts no database pool and permits at most the
+  host's existing one running plus one coalesced invocation per job.
 - **CI:** the `node-smoke` job builds the operator, boots it under Node, and
   asserts `/healthz`, API dispatch, and a TanStack SSR page. `/healthz` is only
   a liveness signal; packaged-starter acceptance gates the complete server

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -50,10 +50,40 @@ import { webhookSubscriptionsTable } from "@voyant-travel/db/schema/infra"
 | `./primitives` | Shared primitive tables (catalog, offers, etc.) |
 | `./crud` | `createCrudService` — list/retrieve/create/update/delete factory |
 | `./links` | `createLinkService`, `syncLinks` runtime link management |
+| `./outbox` | Transactional event capture, bounded drain, retry, pruning, and backlog statistics |
 | `./transaction-capability` | Transaction/disposal metadata helpers for runtime database clients |
 | `./schema/iam` | IAM schemas — Better Auth, users, API keys, KMS, roles |
 | `./schema/infra` | Infra schemas — webhooks, domains, email domain records |
 | `./test-utils` | `createTestDb`, `cleanupTestDb` for integration tests |
+
+## Transactional outbox operations
+
+`drainOutbox` repeatedly claims due rows with `FOR UPDATE SKIP LOCKED` until the
+queue is empty or its configurable batch, event, batch-count, or time budget is
+reached. `limit` bounds each claim and `concurrency` bounds simultaneous
+subscriber delivery; a visibility lease makes a crashed worker's rows eligible
+for at-least-once redelivery without changing their stable event IDs.
+
+The always-on `infrastructure.event-outbox-drain` job is both wakeable and
+scheduled. Every run emits a structured log with claimed, delivered, retried,
+dead-lettered, remaining backlog (with a cap flag), oldest pending age, and
+duration. The schedule remains the recovery path when an immediate wake is
+missed.
+
+Maintenance and telemetry queries are intentionally bounded:
+
+- delivered receipts are pruned oldest-first with a row limit;
+- stale write intents expire oldest-first with a row limit;
+- backlog/dead-letter counts inspect at most `scanLimit + 1` rows and report
+  whether the displayed count is a lower bound.
+
+The query plans rely on partial indexes whose predicates match the SQL exactly:
+`event_outbox_due_idx` for ordered claims and due counts,
+`event_outbox_pending_created_idx` for backlog age/counts,
+`event_outbox_failed_created_idx` for dead-letter counts,
+`event_outbox_delivered_idx` for retention pruning, and
+`event_outbox_pending_intent_idx` for the pending-intent safeguard. The write
+intent candidate scan uses `write_intents_pending_idx`.
 
 ## License
 

--- a/packages/db/migrations/20260806190000_bounded_outbox_drain.sql
+++ b/packages/db/migrations/20260806190000_bounded_outbox_drain.sql
@@ -1,0 +1,8 @@
+DROP INDEX IF EXISTS "event_outbox_due_idx";
+CREATE INDEX "event_outbox_due_idx" ON "event_outbox" USING btree ("next_attempt_at", "id") WHERE "status" = 'pending';
+CREATE INDEX "event_outbox_pending_created_idx" ON "event_outbox" USING btree ("created_at") WHERE "status" = 'pending';
+CREATE INDEX "event_outbox_failed_created_idx" ON "event_outbox" USING btree ("created_at") WHERE "status" = 'failed';
+CREATE INDEX "event_outbox_delivered_idx" ON "event_outbox" USING btree ("delivered_at", "id") WHERE "status" = 'delivered';
+CREATE INDEX "event_outbox_pending_intent_idx" ON "event_outbox" USING btree (("payload" ->> 'intentId')) WHERE "status" = 'pending';
+DROP INDEX IF EXISTS "write_intents_pending_idx";
+CREATE INDEX "write_intents_pending_idx" ON "write_intents" USING btree ("created_at", "id") WHERE "status" = 'pending';

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1785920400000,
       "tag": "20260805090000_storefront_deployment_scope",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1786042800000,
+      "tag": "20260806190000_bounded_outbox_drain",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -107,19 +107,29 @@ export function createDbClient<TSchema extends Record<string, unknown> = Record<
     const primary = tagTransactionCapability(
       schema ? drizzlePostgres(client, { schema }) : drizzlePostgres(client),
       true,
+      async () => client.end({ timeout: 5 }),
     )
 
     if (replicas.length === 0) {
       return primary
     }
 
-    const replicaInstances = replicas.map((replicaUrl) => {
-      const replicaClient = postgres(replicaUrl, nodeOptions)
+    const replicaClients = replicas.map((replicaUrl) => postgres(replicaUrl, nodeOptions))
+    const replicaInstances = replicaClients.map((replicaClient) => {
       return schema ? drizzlePostgres(replicaClient, { schema }) : drizzlePostgres(replicaClient)
     })
     const [firstReplica, ...otherReplicas] = replicaInstances
     if (firstReplica) {
-      return tagTransactionCapability(withReplicas(primary, [firstReplica, ...otherReplicas]), true)
+      return tagTransactionCapability(
+        withReplicas(primary, [firstReplica, ...otherReplicas]),
+        true,
+        async () => {
+          await Promise.all([
+            client.end({ timeout: 5 }),
+            ...replicaClients.map((replicaClient) => replicaClient.end({ timeout: 5 })),
+          ])
+        },
+      )
     }
     return primary
   }

--- a/packages/db/src/outbox-job-runtime-port.ts
+++ b/packages/db/src/outbox-job-runtime-port.ts
@@ -7,6 +7,8 @@ import type { DrizzleClient } from "./types.js"
 export interface EventOutboxJobRuntime {
   withDb<T>(operation: (db: DrizzleClient) => Promise<T>): Promise<T>
   deliver(envelope: EventEnvelope): Promise<DeliveryResult>
+  /** Healthy-run operational telemetry; older hosts fall back to warn(). */
+  log?(message: string): void
   warn(message: string): void
 }
 

--- a/packages/db/src/outbox-job.ts
+++ b/packages/db/src/outbox-job.ts
@@ -1,6 +1,6 @@
 import type { VoyantGraphRuntimeFactoryContext } from "@voyant-travel/core/project"
 
-import { drainOutbox, getOutboxStats, pruneDeliveredOutboxEvents } from "./outbox.js"
+import { drainOutbox, getBoundedOutboxStats, pruneDeliveredOutboxEvents } from "./outbox.js"
 import { eventOutboxJobRuntimePort } from "./outbox-job-runtime-port.js"
 import { expireStaleWriteIntents } from "./write-intents.js"
 
@@ -15,14 +15,49 @@ export async function runEventOutboxDrainJob(
     const result = await drainOutbox(
       db,
       { deliver: (envelope) => runtime.deliver(envelope) },
-      { limit: 50, visibilityTimeoutMs: 120_000 },
+      {
+        limit: 50,
+        concurrency: 5,
+        maxEvents: 500,
+        maxBatches: 10,
+        timeBudgetMs: 50_000,
+        budgetReserveMs: 5_000,
+        visibilityTimeoutMs: 120_000,
+      },
     )
-    await pruneDeliveredOutboxEvents(db, { olderThanDays: 14 })
-    const expiredIntents = await expireStaleWriteIntents(db, { olderThanMinutes: 30 })
+    const pruned = await pruneDeliveredOutboxEvents(db, { olderThanDays: 14, limit: 500 })
+    const expiredIntents = await expireStaleWriteIntents(db, {
+      olderThanMinutes: 30,
+      limit: 250,
+    })
     if (expiredIntents > 0) {
       runtime.warn(`[outbox-drain] expired ${expiredIntents} stale write intent(s)`)
     }
-    const stats = await getOutboxStats(db)
+    const stats = await getBoundedOutboxStats(db, { scanLimit: 10_000 })
+    const oldestPendingAgeMs = stats.oldestPendingAt
+      ? Math.max(0, Date.now() - stats.oldestPendingAt.getTime())
+      : null
+    const log = runtime.log ?? runtime.warn
+    log(
+      `[outbox-drain] ${JSON.stringify({
+        claimed: result.claimed,
+        delivered: result.delivered,
+        retried: result.retried,
+        deadLettered: result.deadLettered,
+        batches: result.batches,
+        budgetExhausted: result.budgetExhausted,
+        remainingBacklog: stats.pending,
+        remainingBacklogCapped: stats.pendingCapped,
+        dueNow: stats.dueNow,
+        dueNowCapped: stats.dueNowCapped,
+        failed: stats.failed,
+        failedCapped: stats.failedCapped,
+        oldestPendingAgeMs,
+        drainDurationMs: result.durationMs,
+        pruned,
+        expiredIntents,
+      })}`,
+    )
     if (stats.failed > 0) {
       runtime.warn(`[outbox-drain] ${stats.failed} dead-lettered event(s) need attention`)
     }

--- a/packages/db/src/outbox.ts
+++ b/packages/db/src/outbox.ts
@@ -14,8 +14,18 @@ const BACKOFF_BASE_MS = 5_000
 const BACKOFF_CAP_MS = 15 * 60 * 1000
 
 export interface DrainOutboxOptions {
-  /** Max rows claimed per drain pass. Default 25. */
+  /** Max rows claimed per batch. Default 25. */
   limit?: number
+  /** Max deliveries in flight at once. Default 5. */
+  concurrency?: number
+  /** Hard cap on claimed rows per invocation. Default 250. */
+  maxEvents?: number
+  /** Hard cap on claimed batches per invocation. Default 10. */
+  maxBatches?: number
+  /** Wall-clock budget for one invocation. Default 30s. */
+  timeBudgetMs?: number
+  /** Stop claiming this long before the wall-clock budget. Default 2s. */
+  budgetReserveMs?: number
   /**
    * How long a claimed row stays invisible to other drains. Must exceed
    * the worst-case delivery time of one event (all subscribers, each
@@ -30,6 +40,9 @@ export interface DrainOutboxResult {
   delivered: number
   retried: number
   deadLettered: number
+  batches: number
+  durationMs: number
+  budgetExhausted: boolean
 }
 
 /** Minimal delivery surface needed by the durable outbox drain. */
@@ -148,8 +161,8 @@ export async function claimDueOutboxEvents(
   db: DrizzleClient,
   options: DrainOutboxOptions = {},
 ): Promise<EventOutboxRow[]> {
-  const limit = options.limit ?? 25
-  const visibilityMs = options.visibilityTimeoutMs ?? 120_000
+  const limit = positiveInteger(options.limit, 25, "limit")
+  const visibilityMs = positiveInteger(options.visibilityTimeoutMs, 120_000, "visibilityTimeoutMs")
   const result = (await (db as AnyDb).execute(sql`
     UPDATE ${eventOutboxTable}
     SET
@@ -158,7 +171,7 @@ export async function claimDueOutboxEvents(
     WHERE "id" IN (
       SELECT "id" FROM ${eventOutboxTable}
       WHERE "status" = 'pending' AND "next_attempt_at" <= now()
-      ORDER BY "next_attempt_at" ASC
+      ORDER BY "next_attempt_at" ASC, "id" ASC
       LIMIT ${limit}
       FOR UPDATE SKIP LOCKED
     )
@@ -208,8 +221,9 @@ export function outboxRowToEnvelope(row: EventOutboxRow): EventEnvelope {
 }
 
 /**
- * One drain pass: claim due rows, redeliver each through the bus, mark
- * delivered / reschedule / dead-letter. Call from a scheduled handler
+ * Repeatedly claim bounded batches and redeliver them through the bus with
+ * bounded concurrency, stopping when no row is due or a work/time budget is
+ * reached. Call from a scheduled handler
  * (cron), a `waitUntil` kick after emit, or a long-running Node loop.
  * Safe to run concurrently from multiple isolates (SKIP LOCKED claim).
  */
@@ -218,17 +232,39 @@ export async function drainOutbox(
   bus: OutboxEventDelivery,
   options: DrainOutboxOptions = {},
 ): Promise<DrainOutboxResult> {
-  const claimed = await claimDueOutboxEvents(db, options)
+  const startedAt = Date.now()
+  const batchSize = positiveInteger(options.limit, 25, "limit")
+  const concurrency = Math.min(batchSize, positiveInteger(options.concurrency, 5, "concurrency"))
+  const maxEvents = positiveInteger(options.maxEvents, 250, "maxEvents")
+  const maxBatches = positiveInteger(options.maxBatches, 10, "maxBatches")
+  const timeBudgetMs = positiveInteger(options.timeBudgetMs, 30_000, "timeBudgetMs")
+  const budgetReserveMs = nonNegativeInteger(options.budgetReserveMs, 2_000, "budgetReserveMs")
+  const claimDeadline = startedAt + Math.max(0, timeBudgetMs - budgetReserveMs)
   const result: DrainOutboxResult = {
-    claimed: claimed.length,
+    claimed: 0,
     delivered: 0,
     retried: 0,
     deadLettered: 0,
+    batches: 0,
+    durationMs: 0,
+    budgetExhausted: false,
   }
-  if (claimed.length === 0) return result
 
-  await Promise.all(
-    claimed.map(async (row) => {
+  while (result.batches < maxBatches && result.claimed < maxEvents) {
+    if (Date.now() >= claimDeadline) {
+      result.budgetExhausted = true
+      break
+    }
+
+    const claimed = await claimDueOutboxEvents(db, {
+      limit: Math.min(batchSize, maxEvents - result.claimed),
+      visibilityTimeoutMs: options.visibilityTimeoutMs,
+    })
+    if (claimed.length === 0) break
+    result.batches += 1
+    result.claimed += claimed.length
+
+    await forEachConcurrent(claimed, concurrency, async (row) => {
       const envelope = outboxRowToEnvelope(row)
       let failedCount = 0
       let errors: string[] = []
@@ -257,10 +293,29 @@ export async function drainOutbox(
       const status = await failOutboxEvent(db, row.id, errors.join("; "))
       if (status === "failed") result.deadLettered += 1
       else result.retried += 1
-    }),
-  )
+    })
+  }
 
+  result.budgetExhausted ||=
+    result.claimed >= maxEvents || result.batches >= maxBatches || Date.now() >= claimDeadline
+  result.durationMs = Date.now() - startedAt
   return result
+}
+
+async function forEachConcurrent<T>(
+  values: readonly T[],
+  concurrency: number,
+  operation: (value: T) => Promise<void>,
+): Promise<void> {
+  let cursor = 0
+  const worker = async () => {
+    while (cursor < values.length) {
+      const value = values[cursor]
+      cursor += 1
+      if (value !== undefined) await operation(value)
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(concurrency, values.length) }, worker))
 }
 
 /**
@@ -271,37 +326,125 @@ export async function drainOutbox(
  */
 export async function pruneDeliveredOutboxEvents(
   db: DrizzleClient,
-  options: { olderThanDays?: number } = {},
+  options: { olderThanDays?: number; limit?: number } = {},
 ): Promise<number> {
-  const days = options.olderThanDays ?? 14
+  const days = positiveInteger(options.olderThanDays, 14, "olderThanDays")
+  const limit = positiveInteger(options.limit, 500, "limit")
   const result = (await (db as AnyDb).execute(sql`
+    WITH candidates AS (
+      SELECT "id" FROM ${eventOutboxTable}
+      WHERE "status" = 'delivered'
+        AND "delivered_at" < now() - (${days} * interval '1 day')
+      ORDER BY "delivered_at" ASC, "id" ASC
+      LIMIT ${limit}
+      FOR UPDATE SKIP LOCKED
+    )
     DELETE FROM ${eventOutboxTable}
-    WHERE "status" = 'delivered'
-      AND "delivered_at" < now() - (${days} * interval '1 day')
+    WHERE "id" IN (SELECT "id" FROM candidates)
     RETURNING "id"
   `)) as unknown
   const rows = Array.isArray(result) ? result : ((result as { rows?: unknown[] }).rows ?? [])
   return rows.length
 }
 
-/** Row counts by status — observability for dashboards/health checks. */
-export async function getOutboxStats(
+export interface BoundedOutboxStats {
+  pending: number
+  pendingCapped: boolean
+  delivered: number
+  deliveredCapped: boolean
+  dueNow: number
+  dueNowCapped: boolean
+  failed: number
+  failedCapped: boolean
+  oldestPendingAt: Date | null
+}
+
+/**
+ * Bounded operational snapshot for wake/schedule logs. Counts stop at
+ * `scanLimit`; the matching `*Capped` flag means the reported value is a lower
+ * bound. Dedicated partial indexes keep every subquery proportional to that
+ * limit even when delivered history or pending backlog is large.
+ */
+export async function getBoundedOutboxStats(
   db: DrizzleClient,
-): Promise<{ pending: number; delivered: number; failed: number; dueNow: number }> {
+  options: { scanLimit?: number } = {},
+): Promise<BoundedOutboxStats> {
+  const scanLimit = positiveInteger(options.scanLimit, 10_000, "scanLimit")
+  const sampleLimit = scanLimit + 1
   const result = (await (db as AnyDb).execute(sql`
     SELECT
-      count(*) FILTER (WHERE "status" = 'pending')::int AS pending,
-      count(*) FILTER (WHERE "status" = 'delivered')::int AS delivered,
-      count(*) FILTER (WHERE "status" = 'failed')::int AS failed,
-      count(*) FILTER (WHERE "status" = 'pending' AND "next_attempt_at" <= now())::int AS due_now
-    FROM ${eventOutboxTable}
+      (SELECT count(*)::int FROM (
+        SELECT 1 FROM ${eventOutboxTable}
+        WHERE "status" = 'pending'
+        ORDER BY "created_at" ASC
+        LIMIT ${sampleLimit}
+      ) pending_sample) AS pending,
+      (SELECT count(*)::int FROM (
+        SELECT 1 FROM ${eventOutboxTable}
+        WHERE "status" = 'pending' AND "next_attempt_at" <= now()
+        ORDER BY "next_attempt_at" ASC, "id" ASC
+        LIMIT ${sampleLimit}
+      ) due_sample) AS due_now,
+      (SELECT count(*)::int FROM (
+        SELECT 1 FROM ${eventOutboxTable}
+        WHERE "status" = 'failed'
+        ORDER BY "created_at" ASC
+        LIMIT ${sampleLimit}
+      ) failed_sample) AS failed,
+      (SELECT count(*)::int FROM (
+        SELECT 1 FROM ${eventOutboxTable}
+        WHERE "status" = 'delivered'
+        ORDER BY "delivered_at" ASC, "id" ASC
+        LIMIT ${sampleLimit}
+      ) delivered_sample) AS delivered,
+      (SELECT "created_at" FROM ${eventOutboxTable}
+        WHERE "status" = 'pending'
+        ORDER BY "created_at" ASC
+        LIMIT 1) AS oldest_pending_at
   `)) as unknown
   const rows = Array.isArray(result) ? result : ((result as { rows?: unknown[] }).rows ?? [])
-  const row = (rows[0] ?? {}) as Record<string, number>
+  const row = (rows[0] ?? {}) as Record<string, unknown>
+  const pendingSample = Number(row.pending ?? 0)
+  const dueSample = Number(row.due_now ?? 0)
+  const failedSample = Number(row.failed ?? 0)
+  const deliveredSample = Number(row.delivered ?? 0)
   return {
-    pending: row.pending ?? 0,
-    delivered: row.delivered ?? 0,
-    failed: row.failed ?? 0,
-    dueNow: row.due_now ?? 0,
+    pending: Math.min(pendingSample, scanLimit),
+    pendingCapped: pendingSample > scanLimit,
+    delivered: Math.min(deliveredSample, scanLimit),
+    deliveredCapped: deliveredSample > scanLimit,
+    dueNow: Math.min(dueSample, scanLimit),
+    dueNowCapped: dueSample > scanLimit,
+    failed: Math.min(failedSample, scanLimit),
+    failedCapped: failedSample > scanLimit,
+    oldestPendingAt: row.oldest_pending_at == null ? null : coerceDate(row.oldest_pending_at),
   }
+}
+
+/**
+ * Backward-compatible name for the bounded operational snapshot. Consumers
+ * needing an exact historical delivered count should use an offline reporting
+ * query rather than adding full-table work to a wake path.
+ */
+export async function getOutboxStats(
+  db: DrizzleClient,
+  options: { scanLimit?: number } = {},
+): Promise<BoundedOutboxStats> {
+  return getBoundedOutboxStats(db, options)
+}
+
+function positiveInteger(value: number | undefined, fallback: number, name: string): number {
+  const resolved = value ?? fallback
+  if (!Number.isSafeInteger(resolved) || resolved <= 0) {
+    throw new RangeError(`${name} must be a positive integer`)
+  }
+  return resolved
+}
+
+function nonNegativeInteger(value: number | undefined, fallback: number, name: string): number {
+  const resolved = value ?? fallback
+  if (!Number.isSafeInteger(resolved) || resolved < 0) {
+    throw new RangeError(`${name} must be a non-negative integer`)
+  }
+  return resolved
 }

--- a/packages/db/src/runtime-contributor.ts
+++ b/packages/db/src/runtime-contributor.ts
@@ -14,6 +14,7 @@ export function createDbRuntimePortContribution(
     withDb: (operation) => operation(host.primitives.database.resolve(undefined)),
     deliver: (envelope) =>
       host.primitives.events.deliver(envelope, undefined) as Promise<DeliveryResult>,
+    log: (message) => console.info(message),
     warn: (message) => console.warn(message),
   }
   return {

--- a/packages/db/src/runtime/index.ts
+++ b/packages/db/src/runtime/index.ts
@@ -16,6 +16,7 @@ export {
 export { createGraphDbProvider } from "./graph-provider.js"
 export { createPostgresAdvisoryLockManager } from "./locks.js"
 export {
+  acquireNodeDatabase,
   type NodeDatabaseEnv,
   openNodeDatabase,
   resolveNodeDatabase,

--- a/packages/db/src/runtime/node-database.ts
+++ b/packages/db/src/runtime/node-database.ts
@@ -1,4 +1,5 @@
 import { createDbClient } from "../index.js"
+import { dbClientDispose } from "../transaction-capability.js"
 
 export interface NodeDatabaseEnv {
   DATABASE_URL: string
@@ -6,11 +7,22 @@ export interface NodeDatabaseEnv {
   DATABASE_URL_REPLICAS?: string
   /** Maximum postgres-js sockets owned by this resident process. Default: 4. */
   DATABASE_MAX_CONNECTIONS?: string
+  /** Maximum tenant-specific pools retained by one process. Default: 32. */
+  DATABASE_MAX_TENANT_POOLS?: string
+  /** Idle milliseconds before an unused tenant pool is evicted. Default: 300000. */
+  DATABASE_TENANT_POOL_IDLE_MS?: string
 }
 
 export type NodeDatabase = ReturnType<typeof createDbClient>
 
-let pooledDatabase: { cacheKey: string; database: NodeDatabase } | undefined
+interface PooledDatabase {
+  cacheKey: string
+  database: NodeDatabase
+  active: number
+  lastUsedAt: number
+}
+
+const pooledDatabases = new Map<string, PooledDatabase>()
 
 /** Resolve the process-cached Postgres client for a resident Node deployment. */
 export function resolveNodeDatabase(env: NodeDatabaseEnv): NodeDatabase {
@@ -20,7 +32,10 @@ export function resolveNodeDatabase(env: NodeDatabaseEnv): NodeDatabase {
   const replicas = parseReplicaUrls(env.DATABASE_URL_REPLICAS, url)
   const maxConnections = parseMaxConnections(env.DATABASE_MAX_CONNECTIONS)
   const cacheKey = `${url}\n${replicas.join("\n")}\nmax=${maxConnections}`
-  if (pooledDatabase?.cacheKey !== cacheKey) {
+  let pooledDatabase = pooledDatabases.get(cacheKey)
+  if (!pooledDatabase) {
+    evictIdleDatabases(env)
+    enforcePoolCapacity(env)
     pooledDatabase = {
       cacheKey,
       database: createDbClient(url, {
@@ -28,9 +43,67 @@ export function resolveNodeDatabase(env: NodeDatabaseEnv): NodeDatabase {
         nodeMaxConnections: maxConnections,
         ...(replicas.length > 0 ? { replicas } : {}),
       }),
+      active: 0,
+      lastUsedAt: Date.now(),
     }
+    pooledDatabases.set(cacheKey, pooledDatabase)
   }
+  pooledDatabase.lastUsedAt = Date.now()
   return pooledDatabase.database
+}
+
+/** Hold a tenant pool for active work so idle eviction cannot close it mid-request/job. */
+export function acquireNodeDatabase(env: NodeDatabaseEnv): {
+  db: NodeDatabase
+  release: () => void
+} {
+  const db = resolveNodeDatabase(env)
+  const entry = [...pooledDatabases.values()].find((candidate) => candidate.database === db)
+  if (!entry) throw new Error("Voyant Node database pool was not retained.")
+  entry.active += 1
+  let released = false
+  return {
+    db,
+    release: () => {
+      if (released) return
+      released = true
+      entry.active -= 1
+      entry.lastUsedAt = Date.now()
+    },
+  }
+}
+
+function evictIdleDatabases(env: NodeDatabaseEnv): void {
+  const idleMs = parsePositiveInteger(
+    env.DATABASE_TENANT_POOL_IDLE_MS,
+    300_000,
+    "DATABASE_TENANT_POOL_IDLE_MS",
+  )
+  const cutoff = Date.now() - idleMs
+  for (const [key, entry] of pooledDatabases) {
+    if (entry.active === 0 && entry.lastUsedAt <= cutoff) evictDatabase(key, entry)
+  }
+}
+
+function enforcePoolCapacity(env: NodeDatabaseEnv): void {
+  const maximum = parsePositiveInteger(
+    env.DATABASE_MAX_TENANT_POOLS,
+    32,
+    "DATABASE_MAX_TENANT_POOLS",
+  )
+  if (pooledDatabases.size < maximum) return
+  const candidate = [...pooledDatabases.entries()]
+    .filter(([, entry]) => entry.active === 0)
+    .sort((left, right) => left[1].lastUsedAt - right[1].lastUsedAt)[0]
+  if (!candidate) throw new Error("Voyant Node tenant database pool capacity is exhausted.")
+  evictDatabase(candidate[0], candidate[1])
+}
+
+function evictDatabase(key: string, entry: PooledDatabase): void {
+  pooledDatabases.delete(key)
+  void dbClientDispose(entry.database)?.().catch((error) => {
+    console.error("[node-database] tenant pool disposal failed", error)
+  })
 }
 
 /**
@@ -40,11 +113,14 @@ export function resolveNodeDatabase(env: NodeDatabaseEnv): NodeDatabase {
  * control-plane access while still allowing useful query parallelism.
  */
 function parseMaxConnections(raw: string | undefined): number {
-  if (raw === undefined || raw.trim() === "") return 4
+  return parsePositiveInteger(raw, 4, "DATABASE_MAX_CONNECTIONS")
+}
+
+function parsePositiveInteger(raw: string | undefined, fallback: number, name: string): number {
+  if (raw === undefined || raw.trim() === "") return fallback
   const parsed = Number(raw)
-  if (!Number.isSafeInteger(parsed) || parsed < 1) {
-    throw new Error("DATABASE_MAX_CONNECTIONS must be a positive integer.")
-  }
+  if (!Number.isSafeInteger(parsed) || parsed < 1)
+    throw new Error(`${name} must be a positive integer.`)
   return parsed
 }
 

--- a/packages/db/src/schema/infra/event_outbox.ts
+++ b/packages/db/src/schema/infra/event_outbox.ts
@@ -61,7 +61,21 @@ export const eventOutboxTable = pgTable(
     // The drain's working set: due pending rows only. Partial keeps the
     // index tiny once delivered/failed rows accumulate.
     // agent-quality: raw-sql reviewed -- owner: db; dynamic SQL interpolation uses Drizzle parameter binding or vetted SQL identifiers.
-    index("event_outbox_due_idx").on(table.nextAttemptAt).where(sql`${table.status} = 'pending'`),
+    index("event_outbox_due_idx")
+      .on(table.nextAttemptAt, table.id)
+      .where(sql`${table.status} = 'pending'`),
+    index("event_outbox_pending_created_idx")
+      .on(table.createdAt)
+      .where(sql`${table.status} = 'pending'`),
+    index("event_outbox_failed_created_idx")
+      .on(table.createdAt)
+      .where(sql`${table.status} = 'failed'`),
+    index("event_outbox_delivered_idx")
+      .on(table.deliveredAt, table.id)
+      .where(sql`${table.status} = 'delivered'`),
+    index("event_outbox_pending_intent_idx")
+      .on(sql`(${table.payload} ->> 'intentId')`)
+      .where(sql`${table.status} = 'pending'`),
     index("event_outbox_created_idx").on(table.createdAt),
   ],
 ).enableRLS()

--- a/packages/db/src/schema/infra/write_intents.ts
+++ b/packages/db/src/schema/infra/write_intents.ts
@@ -50,7 +50,9 @@ export const writeIntentsTable = pgTable(
     uniqueIndex("write_intents_idempotency_key_uniq").on(table.idempotencyKey),
     // Stale-sweep working set; partial keeps it tiny.
     // agent-quality: raw-sql reviewed -- owner: db; dynamic SQL interpolation uses Drizzle parameter binding or vetted SQL identifiers.
-    index("write_intents_pending_idx").on(table.createdAt).where(sql`${table.status} = 'pending'`),
+    index("write_intents_pending_idx")
+      .on(table.createdAt, table.id)
+      .where(sql`${table.status} = 'pending'`),
   ],
 ).enableRLS()
 

--- a/packages/db/src/write-intents.ts
+++ b/packages/db/src/write-intents.ts
@@ -96,21 +96,36 @@ export async function settleWriteIntent(
  */
 export async function expireStaleWriteIntents(
   db: DrizzleClient,
-  options: { olderThanMinutes?: number } = {},
+  options: { olderThanMinutes?: number; limit?: number } = {},
 ): Promise<number> {
   const minutes = options.olderThanMinutes ?? 30
+  const limit = options.limit ?? 250
+  if (!Number.isSafeInteger(minutes) || minutes <= 0) {
+    throw new RangeError("olderThanMinutes must be a positive integer")
+  }
+  if (!Number.isSafeInteger(limit) || limit <= 0) {
+    throw new RangeError("limit must be a positive integer")
+  }
   const result = (await (db as AnyDb).execute(sql`
+    WITH candidates AS (
+      SELECT ${writeIntentsTable.id}
+      FROM ${writeIntentsTable}
+      WHERE ${writeIntentsTable.status} = 'pending'
+        AND ${writeIntentsTable.createdAt} < now() - (${minutes} * interval '1 minute')
+        AND NOT EXISTS (
+          SELECT 1 FROM ${eventOutboxTable}
+          WHERE ${eventOutboxTable.status} = 'pending'
+            AND ${eventOutboxTable.payload} ->> 'intentId' = ${writeIntentsTable.id}
+        )
+      ORDER BY ${writeIntentsTable.createdAt} ASC, ${writeIntentsTable.id} ASC
+      LIMIT ${limit}
+      FOR UPDATE SKIP LOCKED
+    )
     UPDATE ${writeIntentsTable}
     SET "status" = 'failed',
         "error" = 'intent expired before a handler settled it',
         "completed_at" = now()
-    WHERE "status" = 'pending'
-      AND "created_at" < now() - (${minutes} * interval '1 minute')
-      AND NOT EXISTS (
-        SELECT 1 FROM ${eventOutboxTable}
-        WHERE ${eventOutboxTable.status} = 'pending'
-          AND ${eventOutboxTable.payload} ->> 'intentId' = ${writeIntentsTable.id}
-      )
+    WHERE ${writeIntentsTable.id} IN (SELECT "id" FROM candidates)
     RETURNING "id"
   `)) as unknown
   const rows = Array.isArray(result) ? result : ((result as { rows?: unknown[] }).rows ?? [])

--- a/packages/db/tests/integration/outbox.test.ts
+++ b/packages/db/tests/integration/outbox.test.ts
@@ -8,8 +8,10 @@ import {
   createOutboxEventStore,
   drainOutbox,
   failOutboxEvent,
+  getBoundedOutboxStats,
   getOutboxStats,
   insertOutboxEvents,
+  pruneDeliveredOutboxEvents,
 } from "../../src/outbox.js"
 import { eventOutboxTable } from "../../src/schema/infra/event_outbox.js"
 import { createTestDb } from "../../src/test-utils.js"
@@ -47,6 +49,16 @@ describe.skipIf(!DB_AVAILABLE)("event outbox", () => {
         "delivered_at" timestamptz
       );
       CREATE UNIQUE INDEX IF NOT EXISTS "event_outbox_event_id_uniq" ON "event_outbox" ("event_id");
+      CREATE INDEX IF NOT EXISTS "event_outbox_due_idx"
+        ON "event_outbox" ("next_attempt_at", "id") WHERE "status" = 'pending';
+      CREATE INDEX IF NOT EXISTS "event_outbox_pending_created_idx"
+        ON "event_outbox" ("created_at") WHERE "status" = 'pending';
+      CREATE INDEX IF NOT EXISTS "event_outbox_failed_created_idx"
+        ON "event_outbox" ("created_at") WHERE "status" = 'failed';
+      CREATE INDEX IF NOT EXISTS "event_outbox_delivered_idx"
+        ON "event_outbox" ("delivered_at", "id") WHERE "status" = 'delivered';
+      CREATE INDEX IF NOT EXISTS "event_outbox_pending_intent_idx"
+        ON "event_outbox" (("payload" ->> 'intentId')) WHERE "status" = 'pending';
     `)
   })
 
@@ -110,6 +122,26 @@ describe.skipIf(!DB_AVAILABLE)("event outbox", () => {
       const claimed = await claimDueOutboxEvents(db, { limit: 10 })
       expect(claimed).toHaveLength(0)
     })
+
+    it("does not return the same row to concurrent claimers", async () => {
+      await insertOutboxEvents(
+        db,
+        Array.from({ length: 12 }, (_, index) => ({
+          name: "x",
+          data: { index },
+          metadata: { eventId: `evt_claim_${index}` },
+        })),
+      )
+
+      const [left, right] = await Promise.all([
+        claimDueOutboxEvents(db, { limit: 6 }),
+        claimDueOutboxEvents(db, { limit: 6 }),
+      ])
+
+      expect(left).toHaveLength(6)
+      expect(right).toHaveLength(6)
+      expect(new Set([...left, ...right].map((row) => row.eventId)).size).toBe(12)
+    })
   })
 
   describe("failOutboxEvent", () => {
@@ -153,7 +185,14 @@ describe.skipIf(!DB_AVAILABLE)("event outbox", () => {
 
       const result = await drainOutbox(db, bus)
 
-      expect(result).toEqual({ claimed: 1, delivered: 1, retried: 0, deadLettered: 0 })
+      expect(result).toMatchObject({
+        claimed: 1,
+        delivered: 1,
+        retried: 0,
+        deadLettered: 0,
+        batches: 1,
+        budgetExhausted: false,
+      })
       expect(handler).toHaveBeenCalledOnce()
       expect(handler).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -176,7 +215,12 @@ describe.skipIf(!DB_AVAILABLE)("event outbox", () => {
 
       const result = await drainOutbox(db, bus)
 
-      expect(result).toEqual({ claimed: 1, delivered: 0, retried: 1, deadLettered: 0 })
+      expect(result).toMatchObject({
+        claimed: 1,
+        delivered: 0,
+        retried: 1,
+        deadLettered: 0,
+      })
       const stats = await getOutboxStats(db)
       expect(stats.pending).toBe(1)
       errorSpy.mockRestore()
@@ -184,7 +228,134 @@ describe.skipIf(!DB_AVAILABLE)("event outbox", () => {
 
     it("returns an empty result when nothing is due", async () => {
       const result = await drainOutbox(db, createEventBus())
-      expect(result).toEqual({ claimed: 0, delivered: 0, retried: 0, deadLettered: 0 })
+      expect(result).toMatchObject({
+        claimed: 0,
+        delivered: 0,
+        retried: 0,
+        deadLettered: 0,
+        batches: 0,
+        budgetExhausted: false,
+      })
+    })
+
+    it("drains multiple batches while bounding delivery concurrency", async () => {
+      await insertOutboxEvents(
+        db,
+        Array.from({ length: 7 }, (_, index) => ({
+          name: "bounded",
+          data: { index },
+          metadata: { eventId: `evt_bounded_${index}` },
+        })),
+      )
+      let active = 0
+      let maxActive = 0
+      const result = await drainOutbox(
+        db,
+        {
+          async deliver() {
+            active += 1
+            maxActive = Math.max(maxActive, active)
+            await new Promise((resolve) => setTimeout(resolve, 5))
+            active -= 1
+            return { attempted: 1, failed: 0, errors: [] }
+          },
+        },
+        { limit: 3, concurrency: 2, maxEvents: 20, maxBatches: 10 },
+      )
+
+      expect(result).toMatchObject({ claimed: 7, delivered: 7, batches: 3 })
+      expect(maxActive).toBe(2)
+    })
+
+    it("stops at the configured work budget and leaves backlog for another wake", async () => {
+      await insertOutboxEvents(
+        db,
+        Array.from({ length: 8 }, (_, index) => ({
+          name: "budgeted",
+          data: { index },
+          metadata: { eventId: `evt_budgeted_${index}` },
+        })),
+      )
+
+      const result = await drainOutbox(db, createEventBus(), {
+        limit: 2,
+        concurrency: 1,
+        maxEvents: 3,
+        maxBatches: 10,
+      })
+
+      expect(result).toMatchObject({
+        claimed: 3,
+        delivered: 3,
+        batches: 2,
+        budgetExhausted: true,
+      })
+      expect((await getOutboxStats(db)).pending).toBe(5)
+    })
+  })
+
+  describe("bounded maintenance and statistics", () => {
+    it("prunes only the configured number of oldest delivered rows", async () => {
+      const rows = await insertOutboxEvents(
+        db,
+        Array.from({ length: 5 }, (_, index) => ({
+          name: "receipt",
+          data: { index },
+          metadata: { eventId: `evt_receipt_${index}` },
+        })),
+      )
+      for (const row of rows) await completeOutboxEvent(db, row.id)
+      await db.execute(
+        sql`UPDATE ${eventOutboxTable} SET "delivered_at" = now() - interval '30 days'`,
+      )
+
+      expect(await pruneDeliveredOutboxEvents(db, { olderThanDays: 14, limit: 2 })).toBe(2)
+      expect((await getOutboxStats(db)).delivered).toBe(3)
+    })
+
+    it("caps backlog scans and still reports the true oldest pending row", async () => {
+      await insertOutboxEvents(
+        db,
+        Array.from({ length: 4 }, (_, index) => ({
+          name: "stats",
+          data: { index },
+          metadata: { eventId: `evt_stats_${index}` },
+        })),
+      )
+      await db.execute(
+        sql`UPDATE ${eventOutboxTable} SET "created_at" = now() - interval '2 hours' WHERE "event_id" = 'evt_stats_0'`,
+      )
+
+      const stats = await getBoundedOutboxStats(db, { scanLimit: 2 })
+
+      expect(stats).toMatchObject({
+        pending: 2,
+        pendingCapped: true,
+        dueNow: 2,
+        dueNowCapped: true,
+      })
+      expect(stats.oldestPendingAt?.getTime()).toBeLessThan(Date.now() - 60 * 60 * 1000)
+    })
+
+    it("keeps the partial indexes required by claim, retry stats, and pruning", async () => {
+      const result = (await db.execute(/* sql */ `
+        SELECT indexname FROM pg_indexes
+        WHERE schemaname = current_schema() AND tablename = 'event_outbox'
+      `)) as unknown
+      const rows = Array.isArray(result)
+        ? result
+        : ((result as { rows?: Array<{ indexname: string }> }).rows ?? [])
+      const names = new Set(rows.map((row) => row.indexname))
+
+      for (const name of [
+        "event_outbox_due_idx",
+        "event_outbox_pending_created_idx",
+        "event_outbox_failed_created_idx",
+        "event_outbox_delivered_idx",
+        "event_outbox_pending_intent_idx",
+      ]) {
+        expect(names).toContain(name)
+      }
     })
   })
 

--- a/packages/db/tests/integration/write-intents.test.ts
+++ b/packages/db/tests/integration/write-intents.test.ts
@@ -1,5 +1,6 @@
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest"
-
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest"
+import { insertOutboxEvents } from "../../src/outbox.js"
+import { runEventOutboxDrainJob } from "../../src/outbox-job.js"
 import { createTestDb } from "../../src/test-utils.js"
 import {
   enqueueWriteIntent,
@@ -40,6 +41,8 @@ describe.skipIf(!DB_AVAILABLE)("write intents", () => {
         "created_at" timestamptz NOT NULL DEFAULT now(),
         "delivered_at" timestamptz
       );
+      CREATE UNIQUE INDEX IF NOT EXISTS "event_outbox_event_id_uniq"
+        ON "event_outbox" ("event_id");
       CREATE TABLE IF NOT EXISTS "write_intents" (
         "id" text PRIMARY KEY,
         "kind" text NOT NULL,
@@ -53,6 +56,8 @@ describe.skipIf(!DB_AVAILABLE)("write intents", () => {
       );
       CREATE UNIQUE INDEX IF NOT EXISTS "write_intents_idempotency_key_uniq"
         ON "write_intents" ("idempotency_key");
+      CREATE INDEX IF NOT EXISTS "write_intents_pending_idx"
+        ON "write_intents" ("created_at", "id") WHERE "status" = 'pending';
     `)
   })
 
@@ -176,5 +181,71 @@ describe.skipIf(!DB_AVAILABLE)("write intents", () => {
 
     expect(expired).toBe(1)
     expect((await getWriteIntent(db, intent.id))?.status).toBe("failed")
+  })
+
+  it("expires stale intents in bounded oldest-first batches", async () => {
+    const intents = await Promise.all(
+      Array.from({ length: 4 }, (_, index) =>
+        enqueueWriteIntent(db, {
+          kind: "k",
+          payload: {},
+          idempotencyKey: `bounded-${index}`,
+        }),
+      ),
+    )
+    await db.execute(/* sql */ `
+      UPDATE "write_intents" SET "created_at" = now() - interval '2 hours'
+    `)
+
+    expect(await expireStaleWriteIntents(db, { olderThanMinutes: 30, limit: 2 })).toBe(2)
+    const states = await Promise.all(intents.map(({ intent }) => getWriteIntent(db, intent.id)))
+    expect(states.filter((intent) => intent?.status === "failed")).toHaveLength(2)
+    expect(states.filter((intent) => intent?.status === "pending")).toHaveLength(2)
+  })
+
+  it("logs the bounded drain outcome and remaining backlog on every job wake", async () => {
+    await insertOutboxEvents(db, [
+      { name: "job.event", data: {}, metadata: { eventId: "evt_job_metrics" } },
+    ])
+    const log = vi.fn()
+    const warn = vi.fn()
+
+    await runEventOutboxDrainJob({
+      getPort: async () => ({
+        withDb: async (operation: (database: typeof db) => Promise<unknown>) => operation(db),
+        deliver: async () => ({ attempted: 1, failed: 0, errors: [] }),
+        log,
+        warn,
+      }),
+    } as never)
+
+    expect(log).toHaveBeenCalledOnce()
+    const message = String(log.mock.calls[0]?.[0])
+    expect(message).toMatch(/^\[outbox-drain\] /)
+    expect(JSON.parse(message.replace(/^\[outbox-drain\] /, ""))).toMatchObject({
+      claimed: 1,
+      delivered: 1,
+      retried: 0,
+      deadLettered: 0,
+      remainingBacklog: 0,
+      oldestPendingAgeMs: null,
+      pruned: 0,
+      expiredIntents: 0,
+    })
+  })
+
+  it("keeps the partial index required by bounded oldest-first expiration", async () => {
+    const result = (await db.execute(/* sql */ `
+      SELECT indexdef FROM pg_indexes
+      WHERE schemaname = current_schema()
+        AND tablename = 'write_intents'
+        AND indexname = 'write_intents_pending_idx'
+    `)) as unknown
+    const rows = Array.isArray(result)
+      ? result
+      : ((result as { rows?: Array<{ indexdef: string }> }).rows ?? [])
+
+    expect(rows[0]?.indexdef).toContain("(created_at, id)")
+    expect(rows[0]?.indexdef).toContain("status = 'pending'")
   })
 })

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -21,6 +21,7 @@
     "./runtime-attestation": "./src/runtime-attestation.ts",
     "./node-host": "./src/node-host.ts",
     "./node-runtime": "./src/node-runtime.ts",
+    "./node-cell-runtime": "./src/node-cell-runtime.ts",
     "./worker-job-host": "./src/worker-job-host.ts",
     "./scheduled-jobs": "./src/scheduled-jobs.ts"
   },
@@ -156,6 +157,10 @@
       "./node-runtime": {
         "types": "./dist/node-runtime.d.ts",
         "import": "./dist/node-runtime.js"
+      },
+      "./node-cell-runtime": {
+        "types": "./dist/node-cell-runtime.d.ts",
+        "import": "./dist/node-cell-runtime.js"
       },
       "./worker-job-host": {
         "types": "./dist/worker-job-host.d.ts",

--- a/packages/framework/src/node-cell-runtime.test.ts
+++ b/packages/framework/src/node-cell-runtime.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { createVoyantNodeCellRuntime, type VoyantTenantContext } from "./node-cell-runtime.js"
+import type { VoyantNodeRuntime, VoyantNodeRuntimeOptions } from "./node-runtime.js"
+
+function context(tenantId: string): VoyantTenantContext {
+  return {
+    tenantId,
+    deploymentId: `deployment-${tenantId}`,
+    hostname: `${tenantId}.example.test`,
+    env: {
+      DATABASE_URL: `postgres://db/${tenantId}`,
+      DATABASE_MAX_CONNECTIONS: "2",
+      DATABASE_MAX_TENANT_POOLS: "2",
+      VOYANT_CLOUD_DEPLOYMENT_ID: `deployment-${tenantId}`,
+    },
+  }
+}
+
+function runtimeOptions(): Omit<VoyantNodeRuntimeOptions, "env"> {
+  return {
+    graphRuntime: {} as VoyantNodeRuntimeOptions["graphRuntime"],
+    jobs: [],
+    deployment: { providers: {}, redis: {} },
+    deploymentRequirements: { env: [], resources: [] },
+  } as unknown as Omit<VoyantNodeRuntimeOptions, "env">
+}
+
+describe("createVoyantNodeCellRuntime", () => {
+  it("isolates authenticated reads, writes, caches, and jobs across two tenants", async () => {
+    const tenants = [context("alpha"), context("beta")]
+    const values = new Map<string, string>()
+    const caches = new Map<string, string>()
+    const jobs = new Map<string, number>()
+    const loadRuntime = vi.fn(async (options: VoyantNodeRuntimeOptions) => {
+      const deploymentId = String(options.env?.VOYANT_CLOUD_DEPLOYMENT_ID ?? "missing")
+      return {
+        env: options.env,
+        fetch: async (request: Request) => {
+          if (request.headers.get("authorization") !== `Bearer ${deploymentId}`) {
+            return new Response("unauthorized", { status: 401 })
+          }
+          const url = new URL(request.url)
+          if (url.pathname === "/cache") {
+            if (request.method === "POST") caches.set(deploymentId, await request.text())
+            return new Response(caches.get(deploymentId) ?? "")
+          }
+          if (request.method === "POST") values.set(deploymentId, await request.text())
+          return new Response(values.get(deploymentId) ?? "")
+        },
+        jobs: {
+          invoke: async () => {
+            jobs.set(deploymentId, (jobs.get(deploymentId) ?? 0) + 1)
+            return "started"
+          },
+        },
+      } as unknown as VoyantNodeRuntime
+    })
+    const cell = createVoyantNodeCellRuntime({
+      runtime: runtimeOptions(),
+      resolver: {
+        resolve: async ({ hostname, deploymentId }) =>
+          tenants.find(
+            (tenant) =>
+              (!hostname || tenant.hostname === hostname) &&
+              (!deploymentId || tenant.deploymentId === deploymentId),
+          ) ?? null,
+      },
+      loadRuntime,
+      maxTenants: 2,
+    })
+
+    const request = (tenant: "alpha" | "beta", path: string, init?: RequestInit) =>
+      cell.fetch(
+        new Request(`https://${tenant}.example.test${path}`, {
+          ...init,
+          headers: { authorization: `Bearer deployment-${tenant}`, ...init?.headers },
+        }),
+      )
+    expect((await request("alpha", "/value", { method: "POST", body: "alpha-value" })).status).toBe(
+      200,
+    )
+    expect((await request("beta", "/value", { method: "POST", body: "beta-value" })).status).toBe(
+      200,
+    )
+    await request("alpha", "/cache", { method: "POST", body: "alpha-cache" })
+    await request("beta", "/cache", { method: "POST", body: "beta-cache" })
+
+    expect(await (await request("alpha", "/value")).text()).toBe("alpha-value")
+    expect(await (await request("beta", "/value")).text()).toBe("beta-value")
+    expect(await (await request("alpha", "/cache")).text()).toBe("alpha-cache")
+    expect(await (await request("beta", "/cache")).text()).toBe("beta-cache")
+    await cell.invokeJob("deployment-alpha", "job")
+    await cell.invokeJob("deployment-beta", "job")
+    expect(jobs).toEqual(
+      new Map([
+        ["deployment-alpha", 1],
+        ["deployment-beta", 1],
+      ]),
+    )
+    expect(loadRuntime).toHaveBeenCalledTimes(2)
+  })
+
+  it("fails closed and emits security telemetry for unknown and conflicting mappings", async () => {
+    const alpha = context("alpha")
+    const telemetry = vi.fn()
+    const cell = createVoyantNodeCellRuntime({
+      runtime: runtimeOptions(),
+      resolver: {
+        resolve: async ({ hostname }) =>
+          hostname === alpha.hostname ? { ...alpha, deploymentId: "stale-deployment" } : null,
+      },
+      securityTelemetry: telemetry,
+      loadRuntime: vi.fn(),
+    })
+
+    expect((await cell.fetch(new Request("https://unknown.example.test/"))).status).toBe(421)
+    expect((await cell.fetch(new Request(`https://${alpha.hostname}/`))).status).toBe(421)
+    expect(telemetry.mock.calls.map(([event]) => event.type)).toEqual([
+      "unknown_mapping",
+      "stale_mapping",
+    ])
+  })
+
+  it("binds managed wake selection to both hostname and deployment identity", async () => {
+    const alpha = context("alpha")
+    const telemetry = vi.fn()
+    const cell = createVoyantNodeCellRuntime({
+      runtime: runtimeOptions(),
+      resolver: {
+        resolve: async ({ hostname, deploymentId }) =>
+          hostname === alpha.hostname && deploymentId === alpha.deploymentId ? alpha : null,
+      },
+      securityTelemetry: telemetry,
+      loadRuntime: vi.fn(),
+    })
+    const response = await cell.fetch(
+      new Request("https://alpha.example.test/__voyant/jobs/wake", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          deploymentId: "deployment-beta",
+          jobId: "job",
+          eventId: "event",
+          idempotencyKey: "key",
+        }),
+      }),
+    )
+    expect(response.status).toBe(421)
+    expect(telemetry).toHaveBeenCalledWith(expect.objectContaining({ type: "unknown_mapping" }))
+  })
+})

--- a/packages/framework/src/node-cell-runtime.ts
+++ b/packages/framework/src/node-cell-runtime.ts
@@ -1,0 +1,311 @@
+import { acquireNodeDatabase } from "@voyant-travel/db/runtime"
+import {
+  type CreateNodeServerOptions,
+  createNodeServer,
+  type ExecutionContextLike,
+  type NodeServerHandle,
+} from "@voyant-travel/runtime-core"
+
+import { VOYANT_MANAGED_JOB_WAKE_ROUTE } from "./node-job-host.js"
+import {
+  loadVoyantNodeRuntime,
+  type VoyantNodeRuntime,
+  type VoyantNodeRuntimeEnv,
+  type VoyantNodeRuntimeOptions,
+} from "./node-runtime.js"
+
+export interface VoyantTenantContext {
+  readonly tenantId: string
+  readonly deploymentId: string
+  readonly hostname: string
+  /** Server-only bindings. They must never be serialized into a response or edge manifest. */
+  readonly env: VoyantNodeRuntimeEnv
+}
+
+export interface VoyantTenantContextResolver {
+  resolve(input: {
+    readonly hostname?: string
+    readonly deploymentId?: string
+  }): Promise<VoyantTenantContext | null>
+}
+
+export interface VoyantNodeCellSecurityEvent {
+  type: "unknown_mapping" | "conflicting_mapping" | "stale_mapping" | "capacity_exhausted"
+  hostname?: string
+  deploymentId?: string
+}
+
+export interface VoyantNodeCellRuntimeOptions {
+  resolver: VoyantTenantContextResolver
+  runtime: Omit<VoyantNodeRuntimeOptions, "env">
+  maxTenants?: number
+  idleTenantMs?: number
+  securityTelemetry?: (event: VoyantNodeCellSecurityEvent) => void
+  loadRuntime?: typeof loadVoyantNodeRuntime
+}
+
+export interface VoyantNodeCellRuntime {
+  fetch(request: Request, ctx?: ExecutionContextLike): Promise<Response>
+  invokeJob(deploymentId: string, jobId: string): Promise<unknown>
+  dispatchSchedule(
+    deploymentId: string,
+    event: { scheduleId?: string; cron?: string },
+  ): Promise<void>
+  start(options?: Partial<CreateNodeServerOptions<VoyantNodeRuntimeEnv>>): NodeServerHandle
+}
+
+interface ResidentTenant {
+  context: VoyantTenantContext
+  runtime: VoyantNodeRuntime
+  active: number
+  lastUsedAt: number
+  releaseDatabase: () => void
+}
+
+/**
+ * Host a bounded set of database-per-tenant runtimes in one regional process.
+ * Domain code still sees one deployment-static environment and one database;
+ * tenant selection happens before its app, registries, caches, auth, or jobs run.
+ */
+export function createVoyantNodeCellRuntime(
+  options: VoyantNodeCellRuntimeOptions,
+): VoyantNodeCellRuntime {
+  const maximum = positiveInteger(options.maxTenants, 16, "maxTenants")
+  const idleMs = positiveInteger(options.idleTenantMs, 300_000, "idleTenantMs")
+  const residents = new Map<string, ResidentTenant>()
+  const pending = new Map<string, Promise<ResidentTenant>>()
+  const databaseOwners = new Map<string, string>()
+  const load = options.loadRuntime ?? loadVoyantNodeRuntime
+
+  const report = (event: VoyantNodeCellSecurityEvent) => options.securityTelemetry?.(event)
+
+  const resolveContext = async (identity: {
+    hostname?: string
+    deploymentId?: string
+  }): Promise<VoyantTenantContext | null> => {
+    const resolved = await options.resolver.resolve(identity)
+    if (!resolved) {
+      report({ type: "unknown_mapping", ...identity })
+      return null
+    }
+    const context = freezeContext(resolved)
+    if (
+      identity.hostname &&
+      normalizeHostname(context.hostname) !== normalizeHostname(identity.hostname)
+    ) {
+      report({ type: "conflicting_mapping", ...identity })
+      return null
+    }
+    if (identity.deploymentId && context.deploymentId !== identity.deploymentId) {
+      report({ type: "conflicting_mapping", ...identity })
+      return null
+    }
+    if (context.env.VOYANT_CLOUD_DEPLOYMENT_ID !== context.deploymentId) {
+      report({ type: "stale_mapping", ...identity })
+      return null
+    }
+    return context
+  }
+
+  const residentFor = async (context: VoyantTenantContext): Promise<ResidentTenant> => {
+    const current = residents.get(context.deploymentId)
+    if (current) {
+      if (!sameContext(current.context, context)) {
+        report({
+          type: "conflicting_mapping",
+          hostname: context.hostname,
+          deploymentId: context.deploymentId,
+        })
+        throw new CellAdmissionError("Tenant mapping changed while resident.")
+      }
+      current.lastUsedAt = Date.now()
+      return current
+    }
+    const loading = pending.get(context.deploymentId)
+    if (loading) return loading
+    const contextDatabase = databaseIdentity(context.env)
+    const databaseOwner = databaseOwners.get(contextDatabase)
+    if (databaseOwner && databaseOwner !== context.deploymentId) {
+      report({
+        type: "conflicting_mapping",
+        hostname: context.hostname,
+        deploymentId: context.deploymentId,
+      })
+      throw new CellAdmissionError("Two tenants resolved to the same database identity.")
+    }
+    databaseOwners.set(contextDatabase, context.deploymentId)
+    const promise = (async () => {
+      evictIdle(residents, idleMs, (resident) => {
+        databaseOwners.delete(databaseIdentity(resident.context.env))
+      })
+      if (residents.size >= maximum) {
+        const candidate = leastRecentlyUsedIdle(residents)
+        if (!candidate) {
+          report({ type: "capacity_exhausted", deploymentId: context.deploymentId })
+          throw new CellAdmissionError("Tenant runtime capacity is exhausted.")
+        }
+        residents.delete(candidate.context.deploymentId)
+        databaseOwners.delete(databaseIdentity(candidate.context.env))
+        candidate.releaseDatabase()
+      }
+      let database: ReturnType<typeof acquireNodeDatabase> | undefined
+      let runtime: VoyantNodeRuntime
+      try {
+        database = acquireNodeDatabase(context.env)
+        runtime = await load({ ...options.runtime, env: context.env })
+      } catch (error) {
+        databaseOwners.delete(contextDatabase)
+        database?.release()
+        throw error
+      }
+      if (!database) throw new CellAdmissionError("Tenant database pool was not acquired.")
+      const resident = {
+        context,
+        runtime,
+        active: 0,
+        lastUsedAt: Date.now(),
+        releaseDatabase: database.release,
+      }
+      residents.set(context.deploymentId, resident)
+      return resident
+    })()
+    pending.set(context.deploymentId, promise)
+    try {
+      return await promise
+    } finally {
+      pending.delete(context.deploymentId)
+    }
+  }
+
+  const withTenant = async <T>(
+    context: VoyantTenantContext,
+    operation: (runtime: VoyantNodeRuntime) => Promise<T>,
+  ): Promise<T> => {
+    const resident = await residentFor(context)
+    resident.active += 1
+    try {
+      return await operation(resident.runtime)
+    } finally {
+      resident.active -= 1
+      resident.lastUsedAt = Date.now()
+    }
+  }
+
+  const fetch = async (request: Request, ctx?: ExecutionContextLike): Promise<Response> => {
+    try {
+      const url = new URL(request.url)
+      const hostname = normalizeHostname(url.hostname)
+      const deploymentId =
+        url.pathname === VOYANT_MANAGED_JOB_WAKE_ROUTE
+          ? await managedWakeDeploymentId(request)
+          : undefined
+      const context = await resolveContext({ hostname, ...(deploymentId ? { deploymentId } : {}) })
+      if (!context) return admissionFailure(421, "tenant_mapping_rejected")
+      return await withTenant(context, (runtime) =>
+        Promise.resolve(runtime.fetch(request, context.env, ctx)),
+      )
+    } catch (error) {
+      if (error instanceof CellAdmissionError)
+        return admissionFailure(503, "tenant_capacity_unavailable")
+      throw error
+    }
+  }
+
+  return {
+    fetch,
+    invokeJob: async (deploymentId, jobId) => {
+      const context = await resolveContext({ deploymentId })
+      if (!context) throw new CellAdmissionError("Tenant mapping rejected.")
+      return withTenant(context, (runtime) => runtime.jobs.invoke(jobId, "wakeup"))
+    },
+    dispatchSchedule: async (deploymentId, event) => {
+      const context = await resolveContext({ deploymentId })
+      if (!context) throw new CellAdmissionError("Tenant mapping rejected.")
+      await withTenant(context, (runtime) => runtime.jobs.dispatchSchedule(event))
+    },
+    start: (serverOptions = {}) =>
+      createNodeServer({
+        fetch: (request, _env, ctx) => fetch(request, ctx),
+        env: {} as VoyantNodeRuntimeEnv,
+        port: 8080,
+        ...serverOptions,
+      }),
+  }
+}
+
+class CellAdmissionError extends Error {}
+
+function freezeContext(context: VoyantTenantContext): VoyantTenantContext {
+  return Object.freeze({
+    tenantId: required(context.tenantId, "tenantId"),
+    deploymentId: required(context.deploymentId, "deploymentId"),
+    hostname: normalizeHostname(required(context.hostname, "hostname")),
+    env: Object.freeze({ ...context.env }),
+  })
+}
+
+function sameContext(left: VoyantTenantContext, right: VoyantTenantContext): boolean {
+  return (
+    left.tenantId === right.tenantId &&
+    left.deploymentId === right.deploymentId &&
+    left.hostname === right.hostname &&
+    left.env.DATABASE_URL === right.env.DATABASE_URL &&
+    left.env.DATABASE_URL_DIRECT === right.env.DATABASE_URL_DIRECT
+  )
+}
+
+function databaseIdentity(env: VoyantNodeRuntimeEnv): string {
+  return `${env.DATABASE_URL_DIRECT?.trim() ?? env.DATABASE_URL?.trim() ?? ""}\0${env.DATABASE_URL_REPLICAS?.trim() ?? ""}`
+}
+
+function evictIdle(
+  residents: Map<string, ResidentTenant>,
+  idleMs: number,
+  onEvict: (resident: ResidentTenant) => void,
+): void {
+  const cutoff = Date.now() - idleMs
+  for (const [key, resident] of residents) {
+    if (resident.active === 0 && resident.lastUsedAt <= cutoff) {
+      residents.delete(key)
+      onEvict(resident)
+      resident.releaseDatabase()
+    }
+  }
+}
+
+function leastRecentlyUsedIdle(residents: Map<string, ResidentTenant>): ResidentTenant | undefined {
+  return [...residents.values()]
+    .filter((entry) => entry.active === 0)
+    .sort((left, right) => left.lastUsedAt - right.lastUsedAt)[0]
+}
+
+async function managedWakeDeploymentId(request: Request): Promise<string | undefined> {
+  if (request.method !== "POST") return undefined
+  try {
+    const body = (await request.clone().json()) as { deploymentId?: unknown }
+    return typeof body.deploymentId === "string" ? body.deploymentId.trim() : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function normalizeHostname(hostname: string): string {
+  return hostname.trim().toLowerCase().replace(/\.$/u, "")
+}
+
+function required(value: string, name: string): string {
+  const normalized = value.trim()
+  if (!normalized) throw new Error(`Tenant context ${name} is required.`)
+  return normalized
+}
+
+function positiveInteger(value: number | undefined, fallback: number, name: string): number {
+  const selected = value ?? fallback
+  if (!Number.isSafeInteger(selected) || selected < 1)
+    throw new Error(`${name} must be a positive integer.`)
+  return selected
+}
+
+function admissionFailure(status: number, code: string): Response {
+  return Response.json({ status: "permanent_failure", code }, { status })
+}

--- a/packages/framework/src/node-job-host.test.ts
+++ b/packages/framework/src/node-job-host.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest"
 
-import { createVoyantNodeJobHost, VOYANT_PRODUCT_JOB_ROUTE } from "./node-job-host.js"
+import {
+  createVoyantNodeJobHost,
+  VOYANT_MANAGED_JOB_WAKE_ROUTE,
+  VOYANT_PRODUCT_JOB_ROUTE,
+} from "./node-job-host.js"
 import {
   createVoyantGraphRuntime,
   type VoyantGraphRuntime,
@@ -79,6 +83,32 @@ function inventory(
   ]
 }
 
+function managedWakeRequest(
+  overrides: Partial<{
+    deploymentId: string
+    jobId: string
+    eventId: string
+    idempotencyKey: string
+  }> = {},
+  headers: Record<string, string> = {},
+): Request {
+  return new Request(`https://operator.test${VOYANT_MANAGED_JOB_WAKE_ROUTE}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-voyant-origin-trust": "secret",
+      ...headers,
+    },
+    body: JSON.stringify({
+      deploymentId: "deployment_current",
+      jobId,
+      eventId: "event_1",
+      idempotencyKey: "queue-delivery-1",
+      ...overrides,
+    }),
+  })
+}
+
 describe("Voyant Node product job host", () => {
   it("requires exact parity between provisioning.jobs and runtime.jobs", () => {
     expect(() =>
@@ -139,6 +169,150 @@ describe("Voyant Node product job host", () => {
         executionToken: "00000000-0000-4000-8000-000000000001",
       }),
     )
+  })
+
+  it("accepts an authenticated managed wake bound to this deployment", async () => {
+    const handler = vi.fn(async () => {})
+    const host = createVoyantNodeJobHost({
+      runtime: jobRuntime(handler),
+      jobs: inventory(),
+      originTrustSecret: "secret",
+      managedDeploymentId: "deployment_current",
+    })
+
+    const response = await host.handleRequest(managedWakeRequest())
+
+    expect(response?.status).toBe(202)
+    await expect(response?.json()).resolves.toMatchObject({
+      ok: true,
+      disposition: "accepted",
+      retry: false,
+      deploymentId: "deployment_current",
+      jobId,
+      eventId: "event_1",
+    })
+    await host.settled(jobId)
+    expect(handler).toHaveBeenCalledOnce()
+  })
+
+  it("acknowledges an exact managed wake redelivery without repeating work", async () => {
+    const handler = vi.fn(async () => {})
+    const host = createVoyantNodeJobHost({
+      runtime: jobRuntime(handler),
+      jobs: inventory(),
+      originTrustSecret: "secret",
+      managedDeploymentId: "deployment_current",
+    })
+
+    expect((await host.handleRequest(managedWakeRequest()))?.status).toBe(202)
+    await host.settled(jobId)
+    const duplicate = await host.handleRequest(managedWakeRequest())
+
+    expect(duplicate?.status).toBe(200)
+    await expect(duplicate?.json()).resolves.toMatchObject({
+      ok: true,
+      disposition: "duplicate",
+      retry: false,
+    })
+    expect(handler).toHaveBeenCalledOnce()
+  })
+
+  it("permanently rejects a wake for a stale deployment", async () => {
+    const handler = vi.fn(async () => {})
+    const host = createVoyantNodeJobHost({
+      runtime: jobRuntime(handler),
+      jobs: inventory(),
+      originTrustSecret: "secret",
+      managedDeploymentId: "deployment_current",
+    })
+
+    const response = await host.handleRequest(
+      managedWakeRequest({ deploymentId: "deployment_stale" }),
+    )
+
+    expect(response?.status).toBe(409)
+    await expect(response?.json()).resolves.toEqual({
+      ok: false,
+      disposition: "permanent_failure",
+      retry: false,
+      code: "deployment_mismatch",
+    })
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it("permanently rejects an unknown or non-wakeable job", async () => {
+    const host = createVoyantNodeJobHost({
+      runtime: jobRuntime(() => {}),
+      jobs: inventory(),
+      originTrustSecret: "secret",
+      managedDeploymentId: "deployment_current",
+    })
+
+    const response = await host.handleRequest(managedWakeRequest({ jobId: "unknown.job" }))
+
+    expect(response?.status).toBe(404)
+    await expect(response?.json()).resolves.toMatchObject({
+      disposition: "permanent_failure",
+      retry: false,
+      code: "unknown_job",
+    })
+  })
+
+  it("returns a retryable response when managed wake admission fails", async () => {
+    const handler = vi.fn(async () => {})
+    const host = createVoyantNodeJobHost({
+      runtime: jobRuntime(handler),
+      jobs: inventory(),
+      originTrustSecret: "secret",
+      managedDeploymentId: "deployment_current",
+      acquireDistributedLease: async () => {
+        throw new Error("lease store unavailable")
+      },
+    })
+
+    const response = await host.handleRequest(managedWakeRequest())
+
+    expect(response?.status).toBe(503)
+    expect(response?.headers.get("retry-after")).toBe("5")
+    await expect(response?.json()).resolves.toEqual({
+      ok: false,
+      disposition: "retryable_failure",
+      retry: true,
+      code: "temporarily_unavailable",
+    })
+    expect(handler).not.toHaveBeenCalled()
+    // Failed admission did not consume the key.
+    expect((await host.handleRequest(managedWakeRequest()))?.status).toBe(503)
+  })
+
+  it("authenticates managed wakes and rejects idempotency-key reuse for another event", async () => {
+    const handler = vi.fn(async () => {})
+    const host = createVoyantNodeJobHost({
+      runtime: jobRuntime(handler),
+      jobs: inventory(),
+      originTrustSecret: "secret",
+      managedDeploymentId: "deployment_current",
+    })
+
+    const unauthenticated = await host.handleRequest(
+      managedWakeRequest({}, { "x-voyant-origin-trust": "wrong-secret" }),
+    )
+    expect(unauthenticated?.status).toBe(403)
+    await expect(unauthenticated?.json()).resolves.toEqual({
+      ok: false,
+      disposition: "permanent_failure",
+      retry: false,
+      code: "authentication_failed",
+    })
+    expect((await host.handleRequest(managedWakeRequest()))?.status).toBe(202)
+    const conflict = await host.handleRequest(managedWakeRequest({ eventId: "event_2" }))
+    expect(conflict?.status).toBe(409)
+    await expect(conflict?.json()).resolves.toMatchObject({
+      code: "idempotency_conflict",
+      retry: false,
+    })
+    await host.settled(jobId)
+    expect(handler).toHaveBeenCalledOnce()
   })
 
   it("accepts an empty streamed invocation body while rejecting actual request input", async () => {

--- a/packages/framework/src/node-job-host.ts
+++ b/packages/framework/src/node-job-host.ts
@@ -5,6 +5,7 @@ import { invokeVoyantGraphJob, type VoyantGraphRuntimePorts } from "./runtime-co
 import type { VoyantGraphRuntime } from "./runtime-lowering.js"
 
 export const VOYANT_PRODUCT_JOB_ROUTE = "/__voyant/jobs"
+export const VOYANT_MANAGED_JOB_WAKE_ROUTE = "/__voyant/jobs/wake"
 export const VOYANT_PRODUCT_JOB_RELEASE_HEADER = "x-voyant-product-job-release"
 export const VOYANT_PRODUCT_JOB_EXECUTION_HEADER = "x-voyant-product-job-execution"
 
@@ -72,6 +73,10 @@ export interface CreateVoyantNodeJobHostOptions {
   maximumWakeHorizonMs?: number
   /** Required for the fixed internal HTTP invocation surface. */
   originTrustSecret?: string
+  /** Deployment identity bound into this runtime by the managed control plane. */
+  managedDeploymentId?: string
+  /** Bounds process-local queue-redelivery observations; jobs remain durably idempotent. */
+  managedWakeIdempotency?: { ttlMs?: number; maxEntries?: number }
   /** Best-effort terminal execution reporting; failures never repeat domain work. */
   reportExecution?: (report: VoyantNodeJobExecutionReport) => Promise<void> | void
   /**
@@ -118,6 +123,11 @@ interface JobExecutionState {
   pendingCorrelation?: VoyantProductJobExecutionCorrelation
 }
 
+interface ManagedWakeReceipt {
+  fingerprint: string
+  acceptedAt: number
+}
+
 /**
  * Host fixed product jobs selected by the resolved graph.
  *
@@ -150,6 +160,15 @@ export function createVoyantNodeJobHost(
     options.maximumWakeHorizonMs ?? 6 * 60 * 60 * 1_000,
     "maximumWakeHorizonMs",
   )
+  const managedWakeTtlMs = positiveInteger(
+    options.managedWakeIdempotency?.ttlMs ?? 24 * 60 * 60 * 1_000,
+    "managedWakeIdempotency.ttlMs",
+  )
+  const managedWakeMaxEntries = positiveInteger(
+    options.managedWakeIdempotency?.maxEntries ?? 10_000,
+    "managedWakeIdempotency.maxEntries",
+  )
+  const managedWakeReceipts = new Map<string, ManagedWakeReceipt>()
   const states = new Map<string, JobExecutionState>(
     inventory.map((job) => [job.id, { pending: false } satisfies JobExecutionState]),
   )
@@ -336,14 +355,30 @@ export function createVoyantNodeJobHost(
       !url.pathname.startsWith(`${VOYANT_PRODUCT_JOB_ROUTE}/`)
     )
       return undefined
+    const isManagedWake = url.pathname === VOYANT_MANAGED_JOB_WAKE_ROUTE
     const trustSecret = (requestOriginTrustSecret ?? options.originTrustSecret)?.trim()
     if (!trustSecret) {
+      if (isManagedWake) return managedWakeFailure(503, "runtime_not_authenticated", true)
       return new Response("Product job HTTP invocation requires ORIGIN_TRUST_SECRET", {
         status: 503,
       })
     }
     if (!verifyOriginTrust(request, trustSecret)) {
+      if (isManagedWake) return managedWakeFailure(403, "authentication_failed", false)
       return new Response("Forbidden: invalid origin trust", { status: 403 })
+    }
+    if (isManagedWake) {
+      return handleManagedWakeRequest({
+        request,
+        url,
+        jobsById,
+        managedDeploymentId: options.managedDeploymentId,
+        receipts: managedWakeReceipts,
+        receiptTtlMs: managedWakeTtlMs,
+        maxReceipts: managedWakeMaxEntries,
+        now,
+        invoke,
+      })
     }
     if (url.pathname === VOYANT_PRODUCT_JOB_ROUTE) {
       if (request.method !== "GET") return new Response("Method Not Allowed", { status: 405 })
@@ -435,6 +470,164 @@ export function createVoyantNodeJobHost(
       for (const { timer: wakeTimer } of armedWakes.values()) clearTimeout(wakeTimer)
       armedWakes.clear()
     },
+  }
+}
+
+interface ManagedWakeRequest {
+  deploymentId: string
+  jobId: string
+  eventId: string
+  idempotencyKey: string
+}
+
+async function handleManagedWakeRequest(input: {
+  request: Request
+  url: URL
+  jobsById: ReadonlyMap<string, VoyantGraphProvisionedJob>
+  managedDeploymentId?: string
+  receipts: Map<string, ManagedWakeReceipt>
+  receiptTtlMs: number
+  maxReceipts: number
+  now: () => Date
+  invoke: VoyantNodeJobHost["invoke"]
+}): Promise<Response> {
+  if (input.request.method !== "POST") return managedWakeFailure(405, "method_not_allowed", false)
+  if (input.url.search) return managedWakeFailure(400, "invalid_request", false)
+
+  const deploymentId = input.managedDeploymentId?.trim()
+  if (!deploymentId) return managedWakeFailure(503, "runtime_not_bound", true)
+
+  const body = await readManagedWakeRequest(input.request)
+  if (body instanceof Response) return body
+  if (body.deploymentId !== deploymentId) {
+    return managedWakeFailure(409, "deployment_mismatch", false)
+  }
+  const job = input.jobsById.get(body.jobId)
+  if (!job?.wakeup) return managedWakeFailure(404, "unknown_job", false)
+
+  const current = input.now().getTime()
+  pruneManagedWakeReceipts(input.receipts, current - input.receiptTtlMs, input.maxReceipts)
+  const fingerprint = `${body.deploymentId}\0${body.jobId}\0${body.eventId}`
+  const previous = input.receipts.get(body.idempotencyKey)
+  if (previous) {
+    if (previous.fingerprint !== fingerprint) {
+      return managedWakeFailure(409, "idempotency_conflict", false)
+    }
+    return Response.json({
+      ok: true,
+      disposition: "duplicate",
+      retry: false,
+      deploymentId,
+      jobId: body.jobId,
+      eventId: body.eventId,
+    })
+  }
+
+  // Reserve before awaiting lease acquisition so concurrent redelivery cannot
+  // enqueue a second invocation. Remove the reservation if admission fails.
+  input.receipts.set(body.idempotencyKey, { fingerprint, acceptedAt: current })
+  try {
+    const result = await input.invoke(body.jobId, "wakeup")
+    return Response.json(
+      {
+        ok: true,
+        disposition: "accepted",
+        retry: false,
+        deploymentId,
+        jobId: body.jobId,
+        eventId: body.eventId,
+        result,
+      },
+      { status: 202 },
+    )
+  } catch {
+    input.receipts.delete(body.idempotencyKey)
+    return managedWakeFailure(503, "temporarily_unavailable", true)
+  }
+}
+
+async function readManagedWakeRequest(request: Request): Promise<ManagedWakeRequest | Response> {
+  const contentLength = Number(request.headers.get("content-length") ?? "0")
+  if (Number.isFinite(contentLength) && contentLength > 8_192) {
+    return managedWakeFailure(413, "request_too_large", false)
+  }
+  let value: unknown
+  try {
+    const bytes = await readBoundedRequestBytes(request, 8_192)
+    if (!bytes) return managedWakeFailure(413, "request_too_large", false)
+    value = JSON.parse(new TextDecoder().decode(bytes))
+  } catch {
+    return managedWakeFailure(400, "invalid_request", false)
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return managedWakeFailure(400, "invalid_request", false)
+  }
+  const record = value as Record<string, unknown>
+  const allowed = new Set(["deploymentId", "jobId", "eventId", "idempotencyKey"])
+  if (Object.keys(record).some((key) => !allowed.has(key))) {
+    return managedWakeFailure(400, "invalid_request", false)
+  }
+  for (const key of allowed) {
+    const field = record[key]
+    if (
+      typeof field !== "string" ||
+      field.trim() !== field ||
+      field.length < 1 ||
+      field.length > 255
+    ) {
+      return managedWakeFailure(400, "invalid_request", false)
+    }
+  }
+  return record as unknown as ManagedWakeRequest
+}
+
+async function readBoundedRequestBytes(
+  request: Request,
+  limit: number,
+): Promise<Uint8Array | null> {
+  if (!request.body) return new Uint8Array()
+  const reader = request.body.getReader()
+  const chunks: Uint8Array[] = []
+  let length = 0
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      length += value.byteLength
+      if (length > limit) {
+        void reader.cancel().catch(() => {})
+        return null
+      }
+      chunks.push(value)
+    }
+  } catch {
+    void reader.cancel().catch(() => {})
+    throw new Error("Unreadable managed wake request")
+  }
+  const bytes = new Uint8Array(length)
+  let offset = 0
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return bytes
+}
+
+function managedWakeFailure(status: number, code: string, retry: boolean): Response {
+  return Response.json(
+    { ok: false, disposition: retry ? "retryable_failure" : "permanent_failure", retry, code },
+    { status, headers: retry ? { "retry-after": "5" } : undefined },
+  )
+}
+
+function pruneManagedWakeReceipts(
+  receipts: Map<string, ManagedWakeReceipt>,
+  expiresBefore: number,
+  maxEntries: number,
+): void {
+  for (const [key, receipt] of receipts) {
+    if (receipt.acceptedAt >= expiresBefore && receipts.size < maxEntries) break
+    receipts.delete(key)
   }
 }
 

--- a/packages/framework/src/node-runtime.ts
+++ b/packages/framework/src/node-runtime.ts
@@ -76,6 +76,8 @@ export interface VoyantNodeRuntimeEnv extends VoyantBindings {
   DATABASE_URL_DIRECT?: string
   DATABASE_URL_REPLICAS?: string
   DATABASE_MAX_CONNECTIONS?: string
+  DATABASE_MAX_TENANT_POOLS?: string
+  DATABASE_TENANT_POOL_IDLE_MS?: string
   S3_ENDPOINT?: string
   S3_REGION?: string
   S3_ACCESS_KEY_ID?: string
@@ -288,6 +290,7 @@ export interface VoyantNodeRuntime {
     inventory: readonly VoyantGraphProvisionedJob[]
     health: () => readonly VoyantNodeJobHealth[]
     invoke: VoyantNodeJobHost["invoke"]
+    dispatchSchedule: VoyantNodeJobHost["dispatchSchedule"]
     wakeAt: VoyantNodeJobHost["wakeAt"]
   }
   fetch: (
@@ -485,6 +488,7 @@ export async function loadVoyantNodeRuntime(
       inventory: jobHost.inventory,
       health: jobHost.health,
       invoke: jobHost.invoke,
+      dispatchSchedule: jobHost.dispatchSchedule,
       wakeAt: jobHost.wakeAt,
     },
     fetch,

--- a/packages/framework/src/node-runtime.ts
+++ b/packages/framework/src/node-runtime.ts
@@ -375,6 +375,9 @@ export async function loadVoyantNodeRuntime(
     bindings: env,
     ...(runtimePorts ? { ports: runtimePorts } : {}),
     ...(env.ORIGIN_TRUST_SECRET ? { originTrustSecret: env.ORIGIN_TRUST_SECRET } : {}),
+    ...(env.VOYANT_CLOUD_DEPLOYMENT_ID
+      ? { managedDeploymentId: env.VOYANT_CLOUD_DEPLOYMENT_ID }
+      : {}),
     ...(managedJobHealthReporter ? { reportExecution: managedJobHealthReporter } : {}),
   })
   const actionLedgerCapabilities = lowerVoyantGraphActionsToActionLedgerRegistry(


### PR DESCRIPTION
Closes #4365.

Depends on #4367 and #4368.

This PR targets `main` and is stacked by commit: it contains both dependency PR heads followed by the tenant-cell commit. Merge #4367 and #4368 first; GitHub will then reduce this PR to the cell-specific diff.

## What changed

- add a framework-owned regional Node cell host that resolves a trusted hostname/deployment identity into a frozen tenant context before domain code runs
- compose and retain a separate application runtime per tenant, isolating module registries, caches, authorization state, event handlers, schedules, and jobs
- bind managed queue wakes to both hostname and deployment identity and expose deployment-bound direct job/schedule dispatch
- fail closed on unknown, stale, conflicting, duplicate-database, or capacity-exhausted mappings and emit security telemetry
- replace the single Node database singleton with bounded per-connection-identity pools, active leases, idle/LRU eviction, and real postgres-js socket disposal
- retain the existing single-tenant runtime as the default self-hosted and dedicated-tenant path
- update ADR-0001 with the application-cell threat model, invariants, capacity boundary, and dedicated-process escape hatch
- add a two-tenant integration-style contract test covering authenticated reads/writes, caches, jobs, and failure isolation

## Why

Regional cells share process compute, but must never share a domain runtime or authoritative database state. Tenant selection therefore belongs at the trusted host boundary, before Hono/domain execution, while packages continue to operate against one unscoped database as required by ADR-0001.

## Validation

Validated on disposable Sprites against the exact local snapshot:

- Biome checks for all changed TypeScript files
- `@voyant-travel/db` typecheck
- `@voyant-travel/db` tests: 131 passed, database-gated integration tests skipped without `TEST_DATABASE_URL`
- `@voyant-travel/framework` typecheck
- framework package suite exercised: 409 tests passed before a test-only body-read bug was corrected
- final focused `node-cell-runtime.test.ts`: 3 passed
- dependency `node-job-host.test.ts`: 24 passed
- `git diff --check`
