### PR TITLE
fix(mcp): complete the booking and invoice approval chain

### DIFF
--- a/apps/operator/tests/mcp-capability.test.ts
+++ b/apps/operator/tests/mcp-capability.test.ts
@@ -526,25 +526,11 @@ function buildJourneys(RUN_MARK: string): CapabilityJourney[] {
       verify: `select 1 from invoices i join bookings b on b.id = i.booking_id
              join people pe on pe.id = b.person_id
              where pe.last_name ilike '%marinescu${RUN_MARK}%'`,
-      // Measured 0/3 with errors=0 — which is the finding, not a null result. The
-      // agent hit NOTHING it could recognise as a failure: the first call returns
-      // `approval_required`, a SUCCESS payload carrying an approval id and no
-      // instruction, so it reported that and stopped. The actionable-errors work
-      // (voyant#3950) only ever reached the ERROR path, so this was never covered.
-      // Fixed by deriving the idempotency key from the command and returning the
-      // two concrete next steps; see finance/src/mcp-runtime.ts.
-      //
-      // Still a knownGap because the fix is unit-tested but NOT yet confirmed
-      // end to end: the run after it broke upstream at product-option-create, so
-      // this journey never received a booking to invoice. Do not read a future
-      // 0/3 here as the approval payload regressing without first checking that
-      // booking-create passed on that attempt.
-      // The measured trace is the agent doing the RIGHT thing: it queries bookings
-      // for the client, finds none because booking-create was refused upstream,
-      // and stops rather than inventing one. So a 0/3 here has never yet been
-      // evidence about invoicing at all — it is product publication failing three
-      // links earlier. Fix that before reading anything into this number.
-      knownGap: "unit-tested; blocked upstream on product publication, not on invoicing",
+      // First completed end to end once the harness supplied ordinary deployment
+      // configuration (a default proforma number series) and Finance consumed the
+      // approval id from the shared `_voyant` control. This is asserted now: a
+      // future failure is a regression, though its rate remains capped by the
+      // chained publication and booking journeys above it.
     },
     {
       id: "contracts-read",

--- a/apps/operator/tests/mcp-capability.test.ts
+++ b/apps/operator/tests/mcp-capability.test.ts
@@ -667,6 +667,18 @@ function report(): string {
       // misplaced and false control fields all produce the same error code.
       lines.push(`        args: ${JSON.stringify(failed.args).slice(0, 800)}`)
     }
+    // Approval protocols often return a successful `approval_required` payload.
+    // If the journey later fails, error-only logging hides the decisive call and
+    // makes a stalled protocol look like "errors=0". Preserve a bounded trace of
+    // every successful dispatch for failed journeys so the real-model run is
+    // diagnosable without changing what the model itself saw.
+    if (!done) {
+      for (const call of run.calls.filter((c) => !c.isError)) {
+        lines.push(
+          `      · ${call.name} args=${JSON.stringify(call.args).slice(0, 500)} result=${call.snippet.slice(0, 300)}`,
+        )
+      }
+    }
     // Across ALL attempts, not just the last. A 6/10 journey fails for a reason
     // the final transcript may not contain at all, and reading one sample to
     // explain an aggregate is how you end up fixing whichever failure happened to

--- a/apps/operator/tests/mcp-capability.test.ts
+++ b/apps/operator/tests/mcp-capability.test.ts
@@ -662,6 +662,10 @@ function report(): string {
     if (!done) lines.push(`      answer: ${run.answer.slice(0, 220)}`)
     for (const failed of run.calls.filter((c) => c.isError)) {
       lines.push(`      ✗ ${failed.name}: ${failed.snippet.slice(0, 200)}`)
+      // The error tells us which guard refused; the arguments tell us why. This
+      // is especially important for `_voyant` protocol failures, where omitted,
+      // misplaced and false control fields all produce the same error code.
+      lines.push(`        args: ${JSON.stringify(failed.args).slice(0, 800)}`)
     }
     // Across ALL attempts, not just the last. A 6/10 journey fails for a reason
     // the final transcript may not contain at all, and reading one sample to

--- a/apps/operator/tests/mcp-capability.test.ts
+++ b/apps/operator/tests/mcp-capability.test.ts
@@ -50,6 +50,7 @@ import { readFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { join } from "node:path"
 import { createDbClient } from "@voyant-travel/db"
+import { financeService } from "@voyant-travel/finance"
 import { composeVoyantGraphRuntime } from "@voyant-travel/framework"
 import { sql as sqlRaw } from "drizzle-orm"
 import { Hono } from "hono"
@@ -710,6 +711,26 @@ describe.skipIf(!enabled)("MCP capability — a travel agent's job", () => {
     async () => {
       if (!enabled) return
       const app = await mountRealMcp()
+      // Invoice numbering is deployment configuration, not part of the travel
+      // agent's request to issue a proforma. A real agency configures this before
+      // taking bookings; an empty disposable database does not. Seed the same
+      // prerequisite through Finance's real service so this journey measures the
+      // issue capability rather than whether a brand-new deployment was set up.
+      await financeService.createInvoiceNumberSeries(verifyDb as NonNullable<typeof verifyDb>, {
+        code: "CAPABILITY-PROFORMA",
+        name: "Capability evaluation proformas",
+        prefix: "PF",
+        separator: "-",
+        padLength: 6,
+        currentSequence: 0,
+        resetStrategy: "annual",
+        resetAt: null,
+        scope: "proforma",
+        isDefault: true,
+        externalProvider: null,
+        externalConfigKey: null,
+        active: true,
+      })
       // Handshake first, like a real client: `instructions` is returned here and
       // nowhere else.
       const initialized = await readRpc(

--- a/packages/action-ledger/src/created-command-internal.ts
+++ b/packages/action-ledger/src/created-command-internal.ts
@@ -1153,7 +1153,9 @@ async function throwHandlerApprovalRequired(input: {
       // one and loop on the first. See that site for the measured trace.
       nextSteps: [
         `1. Call approve_action_approval with approvalId "${result.approval.id}". This approval already exists and is PENDING — do NOT call request_action_approval, which would create a different one and leave this one blocking.`,
-        `2. Re-call this tool with _voyant.approvalId set to "${result.approval.id}" and the command otherwise unchanged.`,
+        // Confirmation is re-asserted on the approved retry too — see the note at
+        // the matching step in tool-action-policy.ts.
+        `2. Re-call this tool with _voyant.approvalId set to "${result.approval.id}", KEEPING _voyant.confirmed=true, and the command otherwise unchanged. Both fields must be present on the same call.`,
       ],
     },
   )

--- a/packages/action-ledger/src/created-command-internal.ts
+++ b/packages/action-ledger/src/created-command-internal.ts
@@ -1155,7 +1155,7 @@ async function throwHandlerApprovalRequired(input: {
         `1. Call approve_action_approval with approvalId "${result.approval.id}". This approval already exists and is PENDING — do NOT call request_action_approval, which would create a different one and leave this one blocking.`,
         // Confirmation is re-asserted on the approved retry too — see the note at
         // the matching step in tool-action-policy.ts.
-        `2. Re-call this tool with _voyant.approvalId set to "${result.approval.id}", KEEPING _voyant.confirmed=true, and the command otherwise unchanged. Both fields must be present on the same call.`,
+        `2. Re-call this tool with the nested control object "_voyant": {"confirmed": true, "approvalId": "${result.approval.id}"}, and the command otherwise unchanged. Do not send flat keys such as "_voyant.confirmed". Both fields must be present on the same call.`,
       ],
     },
   )

--- a/packages/action-ledger/src/tool-action-policy.ts
+++ b/packages/action-ledger/src/tool-action-policy.ts
@@ -110,13 +110,15 @@ export function createToolActionPolicyGate(
       // metadata requires requestId`.
       //
       // `fingerprint` is already a deterministic hash of this exact command,
-      // computed one line above for the approval record. Defaulting to it gives
+      // computed one line above for the approval record. Using it gives
       // the stability the protocol wants by construction: the request and the
       // approved retry hash identically, while a different command gets a
-      // different key. An explicit requestId still wins, so nothing that supplies
-      // one changes behaviour.
+      // different key. Do not let an explicit requestId override it: a live GPT
+      // client supplied a placeholder on the approval request and omitted it on
+      // the retry, which made the approved command reject its own retry. The
+      // server-owned path must have exactly one authority for this key.
       const executionKey = serverOwnedTarget
-        ? (execution.invocation.requestId?.trim() ?? "") || `mcp-request:${fingerprint}`
+        ? `mcp-request:${fingerprint}`
         : requiredInvocationString(execution, "idempotencyKey")
       const approved =
         selected.approval === "required"

--- a/packages/action-ledger/src/tool-action-policy.ts
+++ b/packages/action-ledger/src/tool-action-policy.ts
@@ -99,11 +99,25 @@ export function createToolActionPolicyGate(
         return dispatch()
       }
 
-      const executionKey = requiredInvocationString(
-        execution,
-        serverOwnedTarget ? "requestId" : "idempotencyKey",
-      )
       const fingerprint = await commandFingerprint(selected, execution, targetId)
+      // A server-owned target has no caller-supplied id to key on, so the protocol
+      // asked the caller to invent a `requestId` — and then required the SAME one
+      // on the approved retry (see validateApproval, which compares it to the
+      // requested action's idempotencyKey). Asking a model to mint an opaque token
+      // and carry it across a human approval is the least reliable way to satisfy
+      // a requirement the server can satisfy itself, and measured against a real
+      // agent it simply failed: `ACTION_POLICY_REQUIRED: Tool action invocation
+      // metadata requires requestId`.
+      //
+      // `fingerprint` is already a deterministic hash of this exact command,
+      // computed one line above for the approval record. Defaulting to it gives
+      // the stability the protocol wants by construction: the request and the
+      // approved retry hash identically, while a different command gets a
+      // different key. An explicit requestId still wins, so nothing that supplies
+      // one changes behaviour.
+      const executionKey = serverOwnedTarget
+        ? (execution.invocation.requestId?.trim() ?? "") || `mcp-request:${fingerprint}`
+        : requiredInvocationString(execution, "idempotencyKey")
       const approved =
         selected.approval === "required"
           ? serverOwnedTarget

--- a/packages/action-ledger/src/tool-action-policy.ts
+++ b/packages/action-ledger/src/tool-action-policy.ts
@@ -605,7 +605,13 @@ async function requestApprovalPreflight(input: {
       // id the caller can get wrong.
       nextSteps: [
         `1. Call approve_action_approval with approvalId "${result.approval.id}". This approval already exists and is PENDING — do NOT call request_action_approval, which would create a different one and leave this one blocking.`,
-        `2. Re-call this tool with _voyant.approvalId set to "${result.approval.id}" and the command otherwise unchanged.`,
+        // "keep _voyant.confirmed=true" is not padding. assertConfirmation runs on
+        // EVERY dispatch, the approved retry included, so a caller that rebuilds
+        // the control block with only approvalId loses its confirmation and is
+        // bounced with CONFIRMATION_REQUIRED — which is precisely what a measured
+        // agent did four times in one booking journey, alternating between the two
+        // errors without ever holding both fields at once.
+        `2. Re-call this tool with _voyant.approvalId set to "${result.approval.id}", KEEPING _voyant.confirmed=true, and the command otherwise unchanged. Both fields must be present on the same call.`,
       ],
     },
   )

--- a/packages/action-ledger/src/tool-action-policy.ts
+++ b/packages/action-ledger/src/tool-action-policy.ts
@@ -611,7 +611,7 @@ async function requestApprovalPreflight(input: {
         // bounced with CONFIRMATION_REQUIRED — which is precisely what a measured
         // agent did four times in one booking journey, alternating between the two
         // errors without ever holding both fields at once.
-        `2. Re-call this tool with _voyant.approvalId set to "${result.approval.id}", KEEPING _voyant.confirmed=true, and the command otherwise unchanged. Both fields must be present on the same call.`,
+        `2. Re-call this tool with the nested control object "_voyant": {"confirmed": true, "approvalId": "${result.approval.id}"}, and the command otherwise unchanged. Do not send flat keys such as "_voyant.confirmed". Both fields must be present on the same call.`,
       ],
     },
   )

--- a/packages/action-ledger/src/tools.ts
+++ b/packages/action-ledger/src/tools.ts
@@ -476,12 +476,13 @@ const approvalDecisionRisk = {
 const approvalDecisionOutputSchema = z.object({
   approval: actionApprovalDtoSchema,
   decisionAction: actionLedgerEntryDtoSchema,
+  nextSteps: z.array(z.string()),
 })
 
 export const approveActionApprovalTool = defineTool({
   name: "approve_action_approval",
   description:
-    "Approve one pending request only when its capability and approval policy remain selected in the graph, it is unexpired, and the caller is the assigned staff principal when assigned.",
+    "Approve one pending request only when its capability and approval policy remain selected in the graph, it is unexpired, and the caller is the assigned staff principal when assigned. Approval does NOT execute the original action: after this succeeds, retry the original Tool with the exact same command and the approved id in its nested `_voyant` control.",
   inputSchema: decideApprovalInputSchema,
   outputSchema: approvalDecisionOutputSchema,
   requiredScopes: ["action-ledger:approve"],
@@ -489,7 +490,18 @@ export const approveActionApprovalTool = defineTool({
   riskPolicy: approvalDecisionRisk,
   actionPolicyEnforcement: "handler",
   async handler({ approvalId }, ctx: ActionLedgerToolContext) {
-    return service(ctx).decideApproval({ approvalId, status: "approved" })
+    const result = await service(ctx).decideApproval({ approvalId, status: "approved" })
+    return {
+      ...result,
+      // The approval decision is itself a successful Tool call, so error
+      // remediation is no longer visible when the model receives this result.
+      // A live GPT client approved correctly and then stopped, leaving the
+      // original invoice action awaiting execution. Keep the continuation on
+      // the success payload, where the client can act on it.
+      nextSteps: [
+        `Approval "${approvalId}" is now approved, but the original action has NOT executed. Re-call the original Tool with the exact same command and the nested control object "_voyant": {"confirmed": true, "approvalId": "${approvalId}"}.`,
+      ],
+    }
   },
 })
 
@@ -504,7 +516,13 @@ export const denyActionApprovalTool = defineTool({
   riskPolicy: approvalDecisionRisk,
   actionPolicyEnforcement: "handler",
   async handler({ approvalId }, ctx: ActionLedgerToolContext) {
-    return service(ctx).decideApproval({ approvalId, status: "denied" })
+    const result = await service(ctx).decideApproval({ approvalId, status: "denied" })
+    return {
+      ...result,
+      nextSteps: [
+        `Approval "${approvalId}" was denied. Do not retry the original action with this approval id.`,
+      ],
+    }
   },
 })
 

--- a/packages/action-ledger/tests/unit/tool-action-policy.test.ts
+++ b/packages/action-ledger/tests/unit/tool-action-policy.test.ts
@@ -166,6 +166,7 @@ describe("generic MCP action-policy gate", () => {
 
   it("creates and replays an approval preflight without dispatch", async () => {
     const selected = action({ approval: "required" })
+    const derivedRequestId = `mcp-request:${await exactFingerprint(selected, { value: 1 })}`
     const requestApproval = vi.spyOn(actionLedgerService, "requestApproval")
     requestApproval
       .mockResolvedValueOnce(approvalRequest(false) as never)
@@ -180,7 +181,7 @@ describe("generic MCP action-policy gate", () => {
         approvalId: "approval_1",
         requestedActionId: "requested_1",
         status: "pending",
-        requestId,
+        requestId: derivedRequestId,
         idempotencyFingerprint: expect.stringMatching(/^sha256:/),
         replayed: false,
       },
@@ -189,7 +190,7 @@ describe("generic MCP action-policy gate", () => {
       code: "APPROVAL_REQUIRED",
       meta: {
         approvalId: "approval_1",
-        requestId,
+        requestId: derivedRequestId,
         idempotencyFingerprint: expect.stringMatching(/^sha256:/),
         replayed: true,
       },
@@ -200,7 +201,7 @@ describe("generic MCP action-policy gate", () => {
       expect.objectContaining({
         requestedAction: expect.objectContaining({
           targetId: "target_1",
-          idempotencyKey: requestId,
+          idempotencyKey: derivedRequestId,
           idempotencyFingerprint: expect.stringMatching(/^sha256:/),
         }),
       }),
@@ -259,10 +260,11 @@ describe("generic MCP action-policy gate", () => {
     const selected = action({ approval: "required" })
     const commandInput = { value: 1 }
     const fingerprint = await exactFingerprint(selected, commandInput)
+    const derivedRequestId = `mcp-request:${fingerprint}`
     vi.spyOn(actionLedgerService, "validateApprovedAction").mockResolvedValue({
       ok: true,
       approval: { id: "approval_1" },
-      requestedAction: { id: "requested_1", idempotencyKey: requestId },
+      requestedAction: { id: "requested_1", idempotencyKey: derivedRequestId },
       idempotencyFingerprint: fingerprint,
     } as never)
     const appended: unknown[] = []

--- a/packages/action-ledger/tests/unit/tool-action-policy.test.ts
+++ b/packages/action-ledger/tests/unit/tool-action-policy.test.ts
@@ -43,7 +43,7 @@ describe("generic MCP action-policy gate", () => {
     expect(dispatch).not.toHaveBeenCalled()
   })
 
-  it("writes a server-owned required-ledger preflight before dispatch and records success", async () => {
+  it("derives a stable key for a server-owned required-ledger action", async () => {
     const selected = action()
     const events: string[] = []
     let sequence = 0
@@ -54,7 +54,7 @@ describe("generic MCP action-policy gate", () => {
     })
 
     const result = await gate(selected).execute(
-      execution(selected, { confirmed: true, requestId }),
+      execution(selected, { confirmed: true }),
       async () => {
         events.push("dispatch")
         return { ok: true }
@@ -67,7 +67,7 @@ describe("generic MCP action-policy gate", () => {
       expect.anything(),
       expect.objectContaining({
         targetId: "target_1",
-        idempotencyKey: requestId,
+        idempotencyKey: expect.stringMatching(/^mcp-request:[0-9a-f]{64}$/),
       }),
     )
   })

--- a/packages/action-ledger/tests/unit/tool-action-policy.test.ts
+++ b/packages/action-ledger/tests/unit/tool-action-policy.test.ts
@@ -54,7 +54,10 @@ describe("generic MCP action-policy gate", () => {
     })
 
     const result = await gate(selected).execute(
-      execution(selected, { confirmed: true }),
+      // Even an old client-supplied requestId cannot override the server's
+      // command-derived key; otherwise omitting it on an approved retry changes
+      // the key and invalidates the approval.
+      execution(selected, { confirmed: true, requestId: "caller-placeholder" }),
       async () => {
         events.push("dispatch")
         return { ok: true }

--- a/packages/action-ledger/tests/unit/tool-action-policy.test.ts
+++ b/packages/action-ledger/tests/unit/tool-action-policy.test.ts
@@ -152,6 +152,10 @@ describe("generic MCP action-policy gate", () => {
     expect(error.nextSteps?.[0]).toContain("approval_1")
     expect(error.nextSteps?.[1]).toContain("_voyant.approvalId")
     expect(error.nextSteps?.[1]).toContain("approval_1")
+    // Confirmation is asserted on the approved retry too, so the retry step has
+    // to say to keep it. Without this an agent alternates between
+    // APPROVAL_REQUIRED and CONFIRMATION_REQUIRED, holding one field at a time.
+    expect(error.nextSteps?.[1]).toContain("_voyant.confirmed=true")
     // The loop-causing instruction must not survive anywhere in the remediation.
     expect(error.nextSteps?.join(" ")).toMatch(/do NOT call request_action_approval/)
   })

--- a/packages/action-ledger/tests/unit/tool-action-policy.test.ts
+++ b/packages/action-ledger/tests/unit/tool-action-policy.test.ts
@@ -150,12 +150,13 @@ describe("generic MCP action-policy gate", () => {
     // The concrete id, not a description of where to find it.
     expect(error.nextSteps?.[0]).toContain("approve_action_approval")
     expect(error.nextSteps?.[0]).toContain("approval_1")
-    expect(error.nextSteps?.[1]).toContain("_voyant.approvalId")
+    expect(error.nextSteps?.[1]).toContain('"approvalId": "approval_1"')
     expect(error.nextSteps?.[1]).toContain("approval_1")
     // Confirmation is asserted on the approved retry too, so the retry step has
     // to say to keep it. Without this an agent alternates between
     // APPROVAL_REQUIRED and CONFIRMATION_REQUIRED, holding one field at a time.
-    expect(error.nextSteps?.[1]).toContain("_voyant.confirmed=true")
+    expect(error.nextSteps?.[1]).toContain('"confirmed": true')
+    expect(error.nextSteps?.[1]).toContain("Do not send flat keys")
     // The loop-causing instruction must not survive anywhere in the remediation.
     expect(error.nextSteps?.join(" ")).toMatch(/do NOT call request_action_approval/)
   })

--- a/packages/action-ledger/tests/unit/tool-action-policy.test.ts
+++ b/packages/action-ledger/tests/unit/tool-action-policy.test.ts
@@ -67,7 +67,7 @@ describe("generic MCP action-policy gate", () => {
       expect.anything(),
       expect.objectContaining({
         targetId: "target_1",
-        idempotencyKey: expect.stringMatching(/^mcp-request:[0-9a-f]{64}$/),
+        idempotencyKey: expect.stringMatching(/^mcp-request:sha256:[0-9a-f]{64}$/),
       }),
     )
   })

--- a/packages/action-ledger/tests/unit/tools.test.ts
+++ b/packages/action-ledger/tests/unit/tools.test.ts
@@ -92,6 +92,22 @@ describe("action-ledger Tool definitions", () => {
       code: "NOT_FOUND",
     })
   })
+
+  it("tells an approver to resume the original Tool after a successful decision", async () => {
+    const services = noopServices()
+    services.decideApproval = vi.fn().mockResolvedValue({
+      approval: makeApproval({ id: "approval_1", status: "approved" }),
+      decisionAction: makeEntry({ actionKind: "approve", status: "approved" }),
+    })
+
+    const result = await approveActionApprovalTool.handler(
+      { approvalId: "approval_1" },
+      toolContext(services),
+    )
+
+    expect(result.nextSteps[0]).toContain("original action has NOT executed")
+    expect(result.nextSteps[0]).toContain('"approvalId": "approval_1"')
+  })
 })
 
 describe("action-ledger Tool services", () => {

--- a/packages/finance/src/book-product.ts
+++ b/packages/finance/src/book-product.ts
@@ -114,7 +114,7 @@ export const bookProductToolInputSchema = z.object({
     .min(1)
     .optional()
     .describe(
-      "Billing party for a private client. Provide exactly one of `personId` or `organizationId`.",
+      "TOP-LEVEL billing party id for a private client. Provide exactly one of `personId` or `organizationId`; do not wrap it in a `billingParty` object.",
     ),
   organizationId: z
     .string()
@@ -126,7 +126,7 @@ export const bookProductToolInputSchema = z.object({
   billingContact: bookProductBillingContactSchema
     .optional()
     .describe(
-      "Billing-contact snapshot captured on the booking. For a private client a real name and an email or phone are required.",
+      "TOP-LEVEL billing-contact snapshot captured on the booking. For a private client, send firstName, lastName, and a real email or phone here.",
     ),
   pax: z
     .number()
@@ -273,10 +273,21 @@ export function collectBookProductIssues(
   if (parsed.success) return null
   return parsed.error.issues
     .filter((issue) => !(issue.path.length === 1 && issue.path[0] === "bookingNumber"))
-    .map((issue) => ({
-      path: issue.path.map((segment) => String(segment)).join("."),
-      message: issue.message,
-    }))
+    .map((issue) => {
+      const rawPath = issue.path.map((segment) => String(segment)).join(".")
+      const path = rawPath.startsWith("contact")
+        ? `billingContact.${rawPath.slice("contact".length, "contact".length + 1).toLowerCase()}${rawPath.slice("contact".length + 1)}`
+        : rawPath
+      const message =
+        rawPath === "personId"
+          ? "Set the TOP-LEVEL personId for a private client (or top-level organizationId for a company). Do not send a billingParty object."
+          : rawPath === "contactFirstName" || rawPath === "contactLastName"
+            ? "Set billingContact.firstName and billingContact.lastName for the private billing party."
+            : rawPath === "contactEmail"
+              ? "Set billingContact.email to a real address, or set billingContact.phone."
+              : issue.message
+      return { path, message }
+    })
 }
 
 /**

--- a/packages/finance/src/booking-create-command.ts
+++ b/packages/finance/src/booking-create-command.ts
@@ -240,9 +240,15 @@ export function bookingCreateCommandError(
     // Observed ending a real booking journey after the product, option, unit and
     // departure had all been created successfully. The neighbouring cases below
     // already name their problem and their fix; these now do too.
+    // The generic sentence remains only as a fallback. When the diagnostic ran it
+    // names the actual cause, because "not found, or is not bookable, confirm it
+    // is published" was a guess covering five unrelated failures — and it sent a
+    // real agent to verify a publication that was already correct while the true
+    // cause (a departure on a different option) went unmentioned.
     case "product_not_found":
       return new ToolError(
-        "The product being booked was not found, or is not bookable. Confirm the product id with inventory_query, and that the product is published with at least one option carrying a priced unit.",
+        outcome.detail ??
+          "The product being booked was not found, or is not bookable. Confirm the product id with inventory_query, and that the product is published with at least one option carrying a priced unit.",
         "NOT_FOUND",
         { outcome },
       )

--- a/packages/finance/src/booking-create-command.ts
+++ b/packages/finance/src/booking-create-command.ts
@@ -242,9 +242,9 @@ export function bookingCreateCommandError(
     // already name their problem and their fix; these now do too.
     // The generic sentence remains only as a fallback. When the diagnostic ran it
     // names the actual cause, because "not found, or is not bookable, confirm it
-    // is published" was a guess covering five unrelated failures — and it sent a
-    // real agent to verify a publication that was already correct while the true
-    // cause (a departure on a different option) went unmentioned.
+    // is published" was a guess covering five unrelated failures. In the measured
+    // run the publication was already correct, but the trace could not distinguish
+    // the remaining causes; the diagnostic makes the next failure say which fired.
     case "product_not_found":
       return new ToolError(
         outcome.detail ??

--- a/packages/finance/src/mcp-runtime.test.ts
+++ b/packages/finance/src/mcp-runtime.test.ts
@@ -142,7 +142,7 @@ describe("finance issue_invoice_from_booking MCP runtime", () => {
     }
 
     expect(error.code).toBe("INVALID_INPUT")
-    expect(error.nextSteps?.[0]).toContain("create_invoice_number_series")
+    expect(error.nextSteps?.[0]).toContain("Finance admin surface")
     expect(error.meta).toMatchObject({ reason: "no_active_series_for_scope", scope: "proforma" })
   })
 

--- a/packages/finance/src/mcp-runtime.ts
+++ b/packages/finance/src/mcp-runtime.ts
@@ -329,7 +329,7 @@ export const voyantToolContextContribution = defineToolContextContribution({
               // by requesting another approval.
               nextSteps: [
                 `1. Call approve_action_approval with approvalId "${authorization.approval.id}". The approval exists but is PENDING; re-calling issue_invoice_refund before this step returns this same response.`,
-                `2. Call issue_invoice_refund again with the identical input plus approvalId "${authorization.approval.id}", keeping _voyant.confirmed=true. An altered command no longer matches what was approved.`,
+                `2. Call issue_invoice_refund again with the identical input, _voyant.approvalId set to "${authorization.approval.id}", and _voyant.confirmed=true. Do not put approvalId at the top level. An altered command no longer matches what was approved.`,
               ],
             }
           }
@@ -662,7 +662,7 @@ function pendingApprovalResult(input: {
     // happened here, and telling the caller to repeat it is what caused the loop.
     nextSteps: [
       `1. Call approve_action_approval with approvalId "${input.approval.id}". The approval exists but is PENDING until it is decided; re-calling issue_invoice_from_booking before this step returns this same response.`,
-      `2. Call issue_invoice_from_booking again with the identical command plus approvalId "${input.approval.id}", keeping _voyant.confirmed=true. Do not change the command — an altered command no longer matches what was approved.`,
+      `2. Call issue_invoice_from_booking again with the identical command, _voyant.approvalId set to "${input.approval.id}", and _voyant.confirmed=true. Do not put approvalId at the top level. Do not change the command — an altered command no longer matches what was approved.`,
     ],
     replayed: input.replayed,
   }

--- a/packages/finance/src/mcp-runtime.ts
+++ b/packages/finance/src/mcp-runtime.ts
@@ -329,7 +329,7 @@ export const voyantToolContextContribution = defineToolContextContribution({
               // by requesting another approval.
               nextSteps: [
                 `1. Call approve_action_approval with approvalId "${authorization.approval.id}". The approval exists but is PENDING; re-calling issue_invoice_refund before this step returns this same response.`,
-                `2. Call issue_invoice_refund again with the identical input plus approvalId "${authorization.approval.id}". An altered command no longer matches what was approved.`,
+                `2. Call issue_invoice_refund again with the identical input plus approvalId "${authorization.approval.id}", keeping _voyant.confirmed=true. An altered command no longer matches what was approved.`,
               ],
             }
           }
@@ -662,7 +662,7 @@ function pendingApprovalResult(input: {
     // happened here, and telling the caller to repeat it is what caused the loop.
     nextSteps: [
       `1. Call approve_action_approval with approvalId "${input.approval.id}". The approval exists but is PENDING until it is decided; re-calling issue_invoice_from_booking before this step returns this same response.`,
-      `2. Call issue_invoice_from_booking again with the identical command plus approvalId "${input.approval.id}". Do not change the command — an altered command no longer matches what was approved.`,
+      `2. Call issue_invoice_from_booking again with the identical command plus approvalId "${input.approval.id}", keeping _voyant.confirmed=true. Do not change the command — an altered command no longer matches what was approved.`,
     ],
     replayed: input.replayed,
   }

--- a/packages/finance/src/mcp-runtime.ts
+++ b/packages/finance/src/mcp-runtime.ts
@@ -566,7 +566,7 @@ function financeRefundAuthorizationError(
 // check the codes that exist today.
 const INVOICE_NUMBERING_REMEDIATION: Record<InvoiceNumberAllocationErrorCode, string> = {
   no_active_series_for_scope:
-    "No active number series exists for this document type. Create one with create_invoice_number_series for this scope, or activate an existing one, then retry.",
+    "No active number series exists for this document type. Ask an operator to create or activate a default series for this scope, then retry. Number-series setup is currently available through the Finance admin surface, not an MCP Tool.",
   invoice_number_series_not_found:
     "The requested number series id does not exist. List the series and pass a valid id, or omit seriesId to use the default for the scope.",
   invoice_number_series_inactive:

--- a/packages/finance/src/mcp-runtime.ts
+++ b/packages/finance/src/mcp-runtime.ts
@@ -329,7 +329,7 @@ export const voyantToolContextContribution = defineToolContextContribution({
               // by requesting another approval.
               nextSteps: [
                 `1. Call approve_action_approval with approvalId "${authorization.approval.id}". The approval exists but is PENDING; re-calling issue_invoice_refund before this step returns this same response.`,
-                `2. Call issue_invoice_refund again with the identical input, _voyant.approvalId set to "${authorization.approval.id}", and _voyant.confirmed=true. Do not put approvalId at the top level. An altered command no longer matches what was approved.`,
+                `2. Call issue_invoice_refund again with the identical input and the nested control object "_voyant": {"confirmed": true, "approvalId": "${authorization.approval.id}"}. Do not use flat dotted keys or put approvalId at the top level. An altered command no longer matches what was approved.`,
               ],
             }
           }
@@ -662,7 +662,7 @@ function pendingApprovalResult(input: {
     // happened here, and telling the caller to repeat it is what caused the loop.
     nextSteps: [
       `1. Call approve_action_approval with approvalId "${input.approval.id}". The approval exists but is PENDING until it is decided; re-calling issue_invoice_from_booking before this step returns this same response.`,
-      `2. Call issue_invoice_from_booking again with the identical command, _voyant.approvalId set to "${input.approval.id}", and _voyant.confirmed=true. Do not put approvalId at the top level. Do not change the command — an altered command no longer matches what was approved.`,
+      `2. Call issue_invoice_from_booking again with the identical command and the nested control object "_voyant": {"confirmed": true, "approvalId": "${input.approval.id}"}. Do not use flat dotted keys or put approvalId at the top level. Do not change the command — an altered command no longer matches what was approved.`,
     ],
     replayed: input.replayed,
   }

--- a/packages/finance/src/service-booking-create.ts
+++ b/packages/finance/src/service-booking-create.ts
@@ -680,7 +680,10 @@ export type BookingCreateOutcome =
       periodEnd: string
       message: string
     }
-  | { status: "product_not_found" }
+  // `detail` names WHICH of the five refusal causes actually fired. The inner
+  // bookings create returns a bare `null` for all of them, so this status has
+  // always been a guess dressed as a diagnosis. See diagnoseProductRefusal.
+  | { status: "product_not_found"; detail?: string }
   | { status: "travel_credit_not_found" }
   | { status: "travel_credit_inactive" }
   | { status: "travel_credit_not_started" }
@@ -852,6 +855,80 @@ async function findDuplicateBookingForCreate(
  * depend on it directly — adding a runtime dependency for a log-only
  * sanity check would be overkill.
  */
+/**
+ * Work out which of the five refusals actually fired.
+ *
+ * `bookingsService.createBooking` returns a bare `null` when the product is
+ * missing, when a line's optionId does not belong to the product, when the
+ * selected optionId does not belong to the product, when the slotId does not
+ * exist for the product, or when the slot belongs to a DIFFERENT option than the
+ * one selected. One return value, five causes, and the caller-facing message had
+ * to pick one and hope.
+ *
+ * It picked "confirm the product is published", which is the one cause this
+ * function can rule out first — and measured against a real agent that is exactly
+ * what went wrong: the product was published and active, the departure existed,
+ * and the booking was refused because the two were attached to different options.
+ * The agent was told to go and check something that was already true.
+ *
+ * Ordered from the most fundamental to the most specific so the first true
+ * statement is also the most useful one.
+ */
+async function diagnoseProductRefusal(
+  tx: PostgresJsDatabase,
+  input: {
+    productId: string
+    optionId: string | null
+    slotId: string | null
+    lineOptionIds: readonly string[]
+  },
+): Promise<string> {
+  const [product] = (await tx.execute(sql`
+    SELECT id, status FROM products WHERE id = ${input.productId} LIMIT 1
+  `)) as unknown as Array<{ id: string; status: string }>
+  if (!product) {
+    return `No product exists with id ${input.productId}. Find the id with inventory_query before retrying.`
+  }
+
+  const optionIds = [
+    ...new Set([...(input.optionId ? [input.optionId] : []), ...input.lineOptionIds]),
+  ]
+  if (optionIds.length > 0) {
+    const owned = (await tx.execute(sql`
+      SELECT id FROM product_options
+      WHERE product_id = ${input.productId} AND id IN ${sql.raw(`('${optionIds.join("','")}')`)}
+    `)) as unknown as Array<{ id: string }>
+    const ownedIds = new Set(owned.map((row) => row.id))
+    const foreign = optionIds.filter((id) => !ownedIds.has(id))
+    if (foreign.length > 0) {
+      return `Option ${foreign.join(", ")} does not belong to product ${input.productId}. List that product's options with inventory_query and use one of those.`
+    }
+  }
+
+  if (input.slotId) {
+    const [slot] = (await tx.execute(sql`
+      SELECT id, product_id AS "productId", option_id AS "optionId"
+      FROM availability_slots WHERE id = ${input.slotId} LIMIT 1
+    `)) as unknown as Array<{ id: string; productId: string; optionId: string | null }>
+    if (!slot) {
+      return `No departure exists with id ${input.slotId}.`
+    }
+    if (slot.productId !== input.productId) {
+      return `Departure ${input.slotId} belongs to product ${slot.productId}, not ${input.productId}.`
+    }
+    if (input.optionId && slot.optionId && slot.optionId !== input.optionId) {
+      return `Departure ${input.slotId} is attached to option ${slot.optionId}, but the booking selected option ${input.optionId}. Book the option the departure belongs to, or create a departure for the option you want to sell.`
+    }
+  }
+
+  // Publication is checked LAST because it is the cause the old message always
+  // named and the least often responsible.
+  if (product.status !== "active") {
+    return `Product ${input.productId} is ${product.status}, not active. Publish it with publish_product before selling it.`
+  }
+  return "The product, its options and its departure all resolve individually, so the refusal is not one of the usual four. Re-read the product with inventory_query and confirm the option carries a priced, bookable unit."
+}
+
 async function loadProductOptionUnits(
   tx: PostgresJsDatabase,
   productId: string,
@@ -2482,7 +2559,25 @@ export async function createBookingMutation(
       if (!booking) {
         // Caller gave us a product that doesn't resolve. Throw so drizzle
         // rolls back any writes the convert helper may have made.
-        throw new BookingCreateAbort({ status: "product_not_found" })
+        //
+        // `null` here means one of five unrelated things (see diagnoseProductRefusal),
+        // and the message this becomes used to guess at the most likely one —
+        // telling the caller to check that the product is published even when the
+        // product was published and the real problem was a departure attached to a
+        // different option. Diagnosing costs a few reads on a path that is already
+        // failing and about to roll back, which is the cheapest possible place to
+        // spend them.
+        throw new BookingCreateAbort({
+          status: "product_not_found",
+          detail: await diagnoseProductRefusal(tx, {
+            productId: input.productId,
+            optionId: input.optionId ?? null,
+            slotId: input.slotId ?? null,
+            lineOptionIds: normalizedItemLines
+              .map((line) => line.optionId)
+              .filter((value): value is string => typeof value === "string"),
+          }),
+        })
       }
       const bookingId = booking.id
       if (input.storefrontOrigin) {

--- a/packages/finance/src/service-booking-create.ts
+++ b/packages/finance/src/service-booking-create.ts
@@ -865,11 +865,10 @@ async function findDuplicateBookingForCreate(
  * one selected. One return value, five causes, and the caller-facing message had
  * to pick one and hope.
  *
- * It picked "confirm the product is published", which is the one cause this
- * function can rule out first — and measured against a real agent that is exactly
- * what went wrong: the product was published and active, the departure existed,
- * and the booking was refused because the two were attached to different options.
- * The agent was told to go and check something that was already true.
+ * It picked "confirm the product is published" even when the measured product
+ * was already active. The trace did not expose which of the remaining causes
+ * fired, so this diagnostic makes that distinction observable instead of
+ * presenting an inference as the answer.
  *
  * Ordered from the most fundamental to the most specific so the first true
  * statement is also the most useful one.
@@ -930,7 +929,7 @@ async function diagnoseProductRefusal(
   if (product.status !== "active") {
     return `Product ${input.productId} is ${product.status}, not active. Publish it with publish_product before selling it.`
   }
-  return "The product, its options and its departure all resolve individually, so the refusal is not one of the usual four. Re-read the product with inventory_query and confirm the option carries a priced, bookable unit."
+  return "The product, its options and its departure all resolve individually, so the refusal is not one of the diagnosed identity or ownership mismatches. Re-read the product with inventory_query and confirm the option carries a priced, bookable unit."
 }
 
 async function loadProductOptionUnits(

--- a/packages/finance/src/service-booking-create.ts
+++ b/packages/finance/src/service-booking-create.ts
@@ -2573,9 +2573,18 @@ export async function createBookingMutation(
             productId: input.productId,
             optionId: input.optionId ?? null,
             slotId: input.slotId ?? null,
-            lineOptionIds: normalizedItemLines
-              .map((line) => line.optionId)
-              .filter((value): value is string => typeof value === "string"),
+            // Item lines carry an optionUnitId, not an optionId, so the options
+            // a booking actually touches have to come back through the units.
+            lineOptionIds: [
+              ...new Set(
+                (normalizedItemLines ?? []).flatMap((line) => {
+                  const unit = productOptionUnits.find(
+                    (candidate) => candidate.optionUnitId === line.optionUnitId,
+                  )
+                  return unit?.optionId ? [unit.optionId] : []
+                }),
+              ),
+            ],
           }),
         })
       }

--- a/packages/finance/src/service-booking-create.ts
+++ b/packages/finance/src/service-booking-create.ts
@@ -896,7 +896,11 @@ async function diagnoseProductRefusal(
   if (optionIds.length > 0) {
     const owned = (await tx.execute(sql`
       SELECT id FROM product_options
-      WHERE product_id = ${input.productId} AND id IN ${sql.raw(`('${optionIds.join("','")}')`)}
+      WHERE product_id = ${input.productId}
+        AND id IN (${sql.join(
+          optionIds.map((optionId) => sql`${optionId}`),
+          sql`, `,
+        )})
     `)) as unknown as Array<{ id: string }>
     const ownedIds = new Set(owned.map((row) => row.id))
     const foreign = optionIds.filter((id) => !ownedIds.has(id))

--- a/packages/finance/src/tools.ts
+++ b/packages/finance/src/tools.ts
@@ -87,7 +87,7 @@ export interface FinanceToolServices {
     admitted: ReturnType<typeof admitHandlerActionPolicy>,
   ): Promise<BookProductOutput>
   issueInvoiceFromBooking(
-    input: z.infer<typeof issueInvoiceFromBookingToolInputSchema>,
+    input: z.infer<typeof issueInvoiceFromBookingToolInputSchema> & { approvalId?: string },
   ): Promise<unknown>
   recordPaymentDispute(input: z.infer<typeof recordPaymentDisputeToolInputSchema>): Promise<unknown>
   recordRefundSettlement(
@@ -103,6 +103,10 @@ export type FinanceToolContext = ToolContext & { finance?: FinanceToolServices }
 
 function finance(ctx: FinanceToolContext): FinanceToolServices {
   return requireService(ctx.finance, "finance")
+}
+
+function handlerApprovalId(ctx: FinanceToolContext): string | undefined {
+  return ctx.handlerActionPolicy?.invocation.approvalId?.trim() || undefined
 }
 
 export const listInvoicesTool = defineTool<
@@ -179,12 +183,6 @@ export const issueInvoiceRefundInputSchema = insertCreditNoteSchema.omit({ statu
     .trim()
     .min(1)
     .describe("Stable key used when requesting approval and replaying the command."),
-  approvalId: z
-    .string()
-    .trim()
-    .min(1)
-    .optional()
-    .describe("Approval id returned after the prior request is approved."),
 })
 
 const pendingFinanceApprovalSchema = z.object({
@@ -243,7 +241,9 @@ export const issueInvoiceRefundTool = defineTool<
   annotations: { idempotentHint: true },
   actionPolicyEnforcement: "handler",
   async handler(input, ctx) {
-    return issueInvoiceRefundOutputSchema.parse(await finance(ctx).issueInvoiceRefund(input))
+    return issueInvoiceRefundOutputSchema.parse(
+      await finance(ctx).issueInvoiceRefund({ ...input, approvalId: handlerApprovalId(ctx) }),
+    )
   },
 })
 
@@ -332,14 +332,6 @@ export const issueInvoiceFromBookingToolInputSchema = z.object({
     .describe(
       "Optional. Leave this out — the platform derives a stable key from the command itself. Only send one to override that.",
     ),
-  approvalId: z
-    .string()
-    .trim()
-    .min(1)
-    .optional()
-    .describe(
-      "The approval id from a prior `approval_required` response, once that approval has been APPROVED. Omit on the first call.",
-    ),
 })
 
 export const issueInvoiceFromBookingToolOutputSchema = z.union([
@@ -363,7 +355,7 @@ export const issueInvoiceFromBookingTool = defineTool<
   // order, with a human decision in between. Issuing an invoice needs approval,
   // so the first call never issues anything, and nothing here said so.
   description:
-    "Issue an invoice or proforma from a booking. This takes TWO calls because issuing is approval-gated. First call it with just the `command`: it creates an approval and returns `approval_required` — no invoice exists yet. Then have that approval approved (`approve_action_approval`) and call this again with the identical `command` plus the `approvalId`, which issues the document. The returned `nextSteps` spell out both steps with the concrete id. Do not invent an idempotency key; the platform derives one from the command so the approved retry replays rather than issuing twice.",
+    "Issue an invoice or proforma from a booking. This takes TWO calls because issuing is approval-gated. First call it with the `command` and `_voyant.confirmed: true`: it creates an approval and returns `approval_required` — no invoice exists yet. Then approve that request with `approve_action_approval` and call this again with the identical `command`, `_voyant.confirmed: true`, and `_voyant.approvalId` set to the approved id. The returned `nextSteps` spell out both steps with the concrete id. Do not put approvalId at the top level and do not invent an idempotency key; both are protocol controls owned by the platform.",
   inputSchema: issueInvoiceFromBookingToolInputSchema,
   outputSchema: issueInvoiceFromBookingToolOutputSchema,
   requiredScopes: ["finance:write", "bookings:read"],
@@ -381,7 +373,7 @@ export const issueInvoiceFromBookingTool = defineTool<
   annotations: { idempotentHint: true },
   async handler(input, ctx) {
     return issueInvoiceFromBookingToolOutputSchema.parse(
-      await finance(ctx).issueInvoiceFromBooking(input),
+      await finance(ctx).issueInvoiceFromBooking({ ...input, approvalId: handlerApprovalId(ctx) }),
     )
   },
 })

--- a/packages/finance/src/tools.ts
+++ b/packages/finance/src/tools.ts
@@ -298,7 +298,7 @@ export const bookProductTool = defineTool({
   capabilityVersion: "v1",
   name: "book_product",
   description:
-    "Book a product for a client in one call: product and option, the billing party (a `personId` for a private client or an `organizationId` for a company), travelers, and rooms. Travelers are given INLINE here as names and details — they do not need to exist as CRM People first, so do not go looking for a companion in the CRM or create one before booking; only the billing party is an existing record. The platform resolves the booking reference and the idempotency key server-side, so nothing has to be carried across calls. An incomplete request returns actionable issues and creates nothing.",
+    "Book a product for a client in one call. Put the billing party id at the TOP LEVEL as `personId` for a private client or `organizationId` for a company; do not send a `billingParty` object. For a private client also send the TOP-LEVEL `billingContact` object with firstName, lastName, and email or phone. Travelers are given INLINE here as names and details — they do not need to exist as CRM People first, so do not go looking for a companion in the CRM or create one before booking; only the billing party is an existing record. The platform resolves the booking reference and the idempotency key server-side, so nothing has to be carried across calls. An incomplete request returns actionable issues and creates nothing.",
   inputSchema: bookProductToolInputSchema,
   outputSchema: bookProductToolOutputSchema,
   requiredScopes: ["bookings:write", "finance:write"],

--- a/packages/finance/tests/integration/booking-create.test.ts
+++ b/packages/finance/tests/integration/booking-create.test.ts
@@ -5051,6 +5051,36 @@ describe.skipIf(!DB_AVAILABLE)("createBooking", () => {
     })
 
     expect(outcome.status).toBe("product_not_found")
+    expect(outcome).toMatchObject({
+      detail: expect.stringContaining("No product exists with id prod_nope"),
+    })
+    expect(await db.select().from(bookings)).toHaveLength(0)
+  })
+
+  it("names a departure/option mismatch instead of blaming publication", async () => {
+    const { productId, optionId, unitId } = await seedProduct()
+    const otherOptionId = `${optionId}_other`
+    await db.execute(sql`
+      INSERT INTO product_options (id, product_id, name, status, is_default, sort_order)
+      VALUES (${otherOptionId}, ${productId}, 'Other', 'active', false, 1)
+    `)
+    const slot = await seedSlot({ productId, optionId: otherOptionId })
+
+    const outcome = await createBooking(db, {
+      productId,
+      optionId,
+      slotId: slot.id,
+      bookingNumber: nextBookingNumber(),
+      ...bookingParty(),
+      itemLines: [{ optionUnitId: unitId, quantity: 1 }],
+    })
+
+    expect(outcome).toMatchObject({
+      status: "product_not_found",
+      detail: expect.stringContaining(
+        `Departure ${slot.id} is attached to option ${otherOptionId}, but the booking selected option ${optionId}`,
+      ),
+    })
     expect(await db.select().from(bookings)).toHaveLength(0)
   })
 

--- a/packages/finance/tests/tools.test.ts
+++ b/packages/finance/tests/tools.test.ts
@@ -12,6 +12,10 @@ import {
   type FinanceToolServices,
   financeBookingsCreateTools,
   financeTools,
+  issueInvoiceFromBookingTool,
+  issueInvoiceFromBookingToolInputSchema,
+  issueInvoiceRefundInputSchema,
+  issueInvoiceRefundTool,
   issueUnsyncedProformaFromBookingToolInputSchema,
 } from "../src/tools.js"
 import { financeBookingsCreateVoyantPlugin } from "../src/voyant.js"
@@ -83,6 +87,70 @@ function bookingDetail(id = "booking_1") {
 }
 
 describe("finance tools", () => {
+  it("carries approvals through the _voyant admission instead of a duplicate domain field", async () => {
+    expect(issueInvoiceFromBookingToolInputSchema.shape).not.toHaveProperty("approvalId")
+    expect(issueInvoiceRefundInputSchema.shape).not.toHaveProperty("approvalId")
+
+    const received: Array<{ tool: string; approvalId?: string }> = []
+    const approvalRequired = (targetType: "booking" | "invoice") => ({
+      status: "approval_required" as const,
+      requestedAction: {
+        id: `action_${targetType}`,
+        status: "awaiting_approval" as const,
+        actionName: `finance.${targetType}.issue`,
+        targetType,
+        targetId: `${targetType}_1`,
+      },
+      approval: {
+        id: "approval_1",
+        status: "pending" as const,
+        requestedActionId: `action_${targetType}`,
+        policyName: "finance-approval-v1",
+        policyVersion: "v1",
+        riskSnapshot: "high",
+        reasonCode: null,
+        expiresAt: null,
+        createdAt: "2026-08-06T10:00:00.000Z",
+      },
+      replayed: false,
+      nextSteps: [],
+    })
+    const services: Partial<FinanceToolServices> = {
+      async issueInvoiceFromBooking(input) {
+        received.push({ tool: "invoice", approvalId: input.approvalId })
+        return approvalRequired("booking")
+      },
+      async issueInvoiceRefund(input) {
+        received.push({ tool: "refund", approvalId: input.approvalId })
+        return approvalRequired("invoice")
+      },
+    }
+    const handlerPolicy = {
+      invocation: { approvalId: "approval_1", confirmed: true },
+    } as ToolHandlerActionPolicyContext
+
+    await issueInvoiceFromBookingTool.handler(
+      { command: { bookingId: "booking_1", issueDate: "2026-08-06", dueDate: "2026-08-13" } },
+      ctx(services, handlerPolicy),
+    )
+    await issueInvoiceRefundTool.handler(
+      {
+        invoiceId: "invoice_1",
+        creditNoteNumber: "CN-1",
+        amountCents: 1_000,
+        currency: "EUR",
+        reason: "correction",
+        idempotencyKey: "refund-1",
+      },
+      ctx(services, handlerPolicy),
+    )
+
+    expect(received).toEqual([
+      { tool: "invoice", approvalId: "approval_1" },
+      { tool: "refund", approvalId: "approval_1" },
+    ])
+  })
+
   it("refuses draft-only and raw external-sync controls before mutation", () => {
     const base = {
       bookingId: "booking_1",

--- a/packages/finance/tests/tools.test.ts
+++ b/packages/finance/tests/tools.test.ts
@@ -108,7 +108,7 @@ describe("finance tools", () => {
         policyName: "finance-approval-v1",
         policyVersion: "v1",
         riskSnapshot: "high",
-        reasonCode: null,
+        reasonCode: "finance_approval_requested",
         expiresAt: null,
         createdAt: "2026-08-06T10:00:00.000Z",
       },

--- a/packages/finance/tests/unit/book-product.test.ts
+++ b/packages/finance/tests/unit/book-product.test.ts
@@ -32,7 +32,7 @@ describe("book_product validate-before-write", () => {
     expect(issues).toContainEqual(
       expect.objectContaining({
         path: "personId",
-        message: expect.stringMatching(/billing party/i),
+        message: expect.stringContaining("TOP-LEVEL personId"),
       }),
     )
   })
@@ -42,7 +42,12 @@ describe("book_product validate-before-write", () => {
       completeInput({ billingContact: { firstName: "Ada", lastName: "Lovelace" } }),
     )
     expect(issues).not.toBeNull()
-    expect(issues?.some((issue) => /email or phone/i.test(issue.message))).toBe(true)
+    expect(issues).toContainEqual(
+      expect.objectContaining({
+        path: "billingContact.email",
+        message: expect.stringContaining("billingContact.email"),
+      }),
+    )
   })
 
   it("flags an unknown travelerKey referenced by a room", () => {

--- a/packages/inventory/src/tools.ts
+++ b/packages/inventory/src/tools.ts
@@ -212,7 +212,14 @@ const productOpenGraphMediaToolSchema = z
   })
   .passthrough()
   .nullable()
-const productIdArgs = z.object({ id: z.string().min(1).describe("The product id.") })
+const productIdArgs = z.object({
+  id: z
+    .string()
+    .min(1)
+    .describe(
+      "The full product id returned by inventory_query (normally starts with `prod_`). A product name, numeric suffix, or run marker is not an id.",
+    ),
+})
 
 export type ProductContentToolInput = z.output<typeof getProductContentArgs>
 
@@ -615,7 +622,7 @@ function productLifecycleToolDefinition(input: {
     name: input.name,
     description: input.description,
     inputSchema: productIdArgs,
-    outputSchema: productToolSchema.nullable(),
+    outputSchema: productToolSchema,
     requiredScopes: ["products:write"],
     audience: STAFF_AUDIENCE,
     tier: "write",
@@ -623,10 +630,20 @@ function productLifecycleToolDefinition(input: {
     annotations: { idempotentHint: true },
     async handler({ id }: z.infer<typeof productIdArgs>, ctx: InventoryToolContext) {
       try {
-        return parseJsonResult(
-          productToolSchema.nullable(),
-          await inventory(ctx).updateProduct(id, input.patch),
-        )
+        const product = await inventory(ctx).updateProduct(id, input.patch)
+        if (!product) {
+          // A lifecycle mutation returning `null` is not success. The live GPT
+          // client supplied a run-marker suffix as the id, received
+          // `{ result: null }`, and confidently reported publication even though
+          // the database stayed in draft. Turn absence into an actionable error
+          // and require the same concrete output shape as a successful mutation.
+          throw new ToolError(
+            `No product exists with id "${id}". Resolve the full product id with inventory_query, then retry this lifecycle action.`,
+            "NOT_FOUND",
+            { id },
+          )
+        }
+        return parseJsonResult(productToolSchema, product)
       } catch (error) {
         throw toPublishReadinessToolError(error)
       }

--- a/packages/inventory/tests/tools.test.ts
+++ b/packages/inventory/tests/tools.test.ts
@@ -553,6 +553,23 @@ describe("inventory tools", () => {
     ])
   })
 
+  it("refuses a missing lifecycle target instead of reporting null success", async () => {
+    const error = await publishProductTool
+      .handler(
+        { id: "8014752" },
+        ctxWith({
+          async updateProduct() {
+            return null
+          },
+        } as never),
+      )
+      .catch((thrown: unknown) => thrown as { code?: string; message?: string })
+
+    expect(error.code).toBe("NOT_FOUND")
+    expect(error.message).toContain("inventory_query")
+    expect(error.message).toContain("8014752")
+  })
+
   it("leaves a non-readiness failure from the same handler untouched", async () => {
     // The converter must not swallow unrelated throws — that would replace a real
     // failure with a confident, wrong remediation.

--- a/packages/mcp/tests/server.test.ts
+++ b/packages/mcp/tests/server.test.ts
@@ -1668,8 +1668,8 @@ describe("createMcpApiRoutes", () => {
             enforcement: "generic",
             invocation: {
               controlField: "_voyant",
-              requiredFields: ["confirmed", "requestId"],
-              optionalFields: ["reasonCode", "approvalId"],
+              requiredFields: ["confirmed"],
+              optionalFields: ["reasonCode", "approvalId", "requestId"],
               targetResolution: "package-resolver",
             },
           },
@@ -1686,7 +1686,6 @@ describe("createMcpApiRoutes", () => {
             message: "hello",
             _voyant: {
               confirmed: true,
-              requestId: "6c0f3fb4-2c96-4c3a-a520-28166167fb18",
               approvalId: "approval_1",
             },
           },
@@ -1703,7 +1702,7 @@ describe("createMcpApiRoutes", () => {
         resolvedTargetId: "notification:hello",
         invocation: {
           confirmed: true,
-          requestId: "6c0f3fb4-2c96-4c3a-a520-28166167fb18",
+          requestId: expect.stringMatching(/^mcp-request:[0-9a-f]{64}$/),
           approvalId: "approval_1",
         },
       }),

--- a/packages/mcp/tests/server.test.ts
+++ b/packages/mcp/tests/server.test.ts
@@ -1793,7 +1793,6 @@ describe("createMcpApiRoutes", () => {
             recordId: " ",
             _voyant: {
               confirmed: true,
-              requestId: "6c0f3fb4-2c96-4c3a-a520-28166167fb18",
             },
           },
         }),

--- a/packages/mcp/tests/server.test.ts
+++ b/packages/mcp/tests/server.test.ts
@@ -1669,7 +1669,7 @@ describe("createMcpApiRoutes", () => {
             invocation: {
               controlField: "_voyant",
               requiredFields: ["confirmed"],
-              optionalFields: ["reasonCode", "approvalId", "requestId"],
+              optionalFields: ["reasonCode", "approvalId"],
               targetResolution: "package-resolver",
             },
           },

--- a/packages/mcp/tests/server.test.ts
+++ b/packages/mcp/tests/server.test.ts
@@ -1702,7 +1702,6 @@ describe("createMcpApiRoutes", () => {
         resolvedTargetId: "notification:hello",
         invocation: {
           confirmed: true,
-          requestId: expect.stringMatching(/^mcp-request:[0-9a-f]{64}$/),
           approvalId: "approval_1",
         },
       }),

--- a/packages/tools/src/binding.ts
+++ b/packages/tools/src/binding.ts
@@ -108,6 +108,10 @@ export interface ToolActionInvocationPolicy {
     | "approvalId"
     | "targetId"
     | "idempotencyKey"
+    // `requestId` moved from requiredFields to here: the generic gate derives it
+    // from the command fingerprint, so a caller no longer has to mint one, but
+    // an explicitly supplied value is still honoured.
+    | "requestId"
     | "idempotencyFingerprint"
   )[]
   fingerprintAlgorithm: "action-ledger-command-v1"

--- a/packages/tools/src/binding.ts
+++ b/packages/tools/src/binding.ts
@@ -108,10 +108,6 @@ export interface ToolActionInvocationPolicy {
     | "approvalId"
     | "targetId"
     | "idempotencyKey"
-    // `requestId` moved from requiredFields to here: the generic gate derives it
-    // from the command fingerprint, so a caller no longer has to mint one, but
-    // an explicitly supplied value is still honoured.
-    | "requestId"
     | "idempotencyFingerprint"
   )[]
   fingerprintAlgorithm: "action-ledger-command-v1"

--- a/packages/tools/src/errors.ts
+++ b/packages/tools/src/errors.ts
@@ -73,7 +73,7 @@ export const TOOL_ERROR_DEFAULTS: Record<ToolErrorCode, ToolErrorDefault> = {
     nextSteps: [
       "1. Call request_action_approval to create an approval for this exact command; it returns an approval id.",
       "2. Call approve_action_approval with that id. A requested approval is pending until it is decided — re-calling before this step fails identically.",
-      "3. Re-call this tool with _voyant.approvalId set to that id, and the command otherwise unchanged.",
+      '3. Re-call this tool with a nested control object like "_voyant": {"confirmed": true, "approvalId": "<approved id>"}, and the command otherwise unchanged. Do not send flat keys such as "_voyant.approvalId".',
     ],
   },
   CONFIRMATION_REQUIRED: {
@@ -84,7 +84,7 @@ export const TOOL_ERROR_DEFAULTS: Record<ToolErrorCode, ToolErrorDefault> = {
     // Measured: four CONFIRMATION_REQUIRED in a single booking journey, from an
     // agent that had already obtained its approval and kept dropping it.
     nextSteps: [
-      "Re-call this tool with _voyant.confirmed=true to proceed. Keep any _voyant.approvalId you have already obtained on the same call — confirmation and approval are checked separately, and supplying one without the other fails on the one you dropped.",
+      'Re-call this tool with a nested control object exactly like "_voyant": {"confirmed": true}. Do not send a flat "_voyant.confirmed" key. If you already have an approval id, keep it in that same object as "approvalId" — confirmation and approval are checked separately.',
     ],
   },
   NOT_FOUND: {

--- a/packages/tools/src/errors.ts
+++ b/packages/tools/src/errors.ts
@@ -78,7 +78,14 @@ export const TOOL_ERROR_DEFAULTS: Record<ToolErrorCode, ToolErrorDefault> = {
   },
   CONFIRMATION_REQUIRED: {
     retryable: false,
-    nextSteps: ["Re-call this tool with _voyant.confirmed=true to proceed."],
+    // The second clause exists because confirmation and approval are asserted
+    // INDEPENDENTLY on every dispatch, so a caller holding one and rebuilding the
+    // control block without the other ping-pongs between the two errors forever.
+    // Measured: four CONFIRMATION_REQUIRED in a single booking journey, from an
+    // agent that had already obtained its approval and kept dropping it.
+    nextSteps: [
+      "Re-call this tool with _voyant.confirmed=true to proceed. Keep any _voyant.approvalId you have already obtained on the same call — confirmation and approval are checked separately, and supplying one without the other fails on the one you dropped.",
+    ],
   },
   NOT_FOUND: {
     retryable: false,

--- a/packages/tools/src/registered-tool.ts
+++ b/packages/tools/src/registered-tool.ts
@@ -145,9 +145,10 @@ function deriveActionPolicy(
   }
   if (enforcement === "generic") {
     if (serverOwnedGenericTarget) {
-      if (action.kind === "execute" && action.ledger === "required") {
-        requiredFields.push("requestId")
-      }
+      // `requestId` is deliberately NOT pushed here any more. The generic gate
+      // derives it from the command fingerprint it already computes, so there is
+      // no token for the caller to invent or carry across an approval. It stays
+      // honoured when supplied — see the optionalFields list below.
     } else {
       if (action.ledger === "required") requiredFields.push("targetId")
       if (action.kind === "execute" && action.ledger === "required") {
@@ -180,7 +181,7 @@ function deriveActionPolicy(
       optionalFields:
         enforcement === "generic"
           ? serverOwnedGenericTarget
-            ? ["reasonCode", "approvalId"]
+            ? ["reasonCode", "approvalId", "requestId"]
             : ["reasonCode", "approvalId", "idempotencyFingerprint"]
           : ["reasonCode", "approvalId", "idempotencyFingerprint"],
       fingerprintAlgorithm: "action-ledger-command-v1",

--- a/packages/tools/src/registered-tool.ts
+++ b/packages/tools/src/registered-tool.ts
@@ -145,10 +145,9 @@ function deriveActionPolicy(
   }
   if (enforcement === "generic") {
     if (serverOwnedGenericTarget) {
-      // `requestId` is deliberately NOT pushed here any more. The generic gate
-      // derives it from the command fingerprint it already computes, so there is
-      // no token for the caller to invent or carry across an approval. It stays
-      // honoured when supplied — see the optionalFields list below.
+      // `requestId` is deliberately not advertised. The generic gate derives it
+      // from the command fingerprint it already computes, so there is no token
+      // for the caller to invent or carry across an approval.
     } else {
       if (action.ledger === "required") requiredFields.push("targetId")
       if (action.kind === "execute" && action.ledger === "required") {
@@ -181,7 +180,7 @@ function deriveActionPolicy(
       optionalFields:
         enforcement === "generic"
           ? serverOwnedGenericTarget
-            ? ["reasonCode", "approvalId", "requestId"]
+            ? ["reasonCode", "approvalId"]
             : ["reasonCode", "approvalId", "idempotencyFingerprint"]
           : ["reasonCode", "approvalId", "idempotencyFingerprint"],
       fingerprintAlgorithm: "action-ledger-command-v1",

--- a/packages/tools/tests/errors.test.ts
+++ b/packages/tools/tests/errors.test.ts
@@ -22,11 +22,9 @@ describe("ToolError actionable fields", () => {
   })
 
   it("states the exact remediation for approval and confirmation gates", () => {
-    expect(new ToolError("x", "APPROVAL_REQUIRED").nextSteps.join(" ")).toContain(
-      "_voyant.approvalId",
-    )
+    expect(new ToolError("x", "APPROVAL_REQUIRED").nextSteps.join(" ")).toContain('"approvalId"')
     expect(new ToolError("x", "CONFIRMATION_REQUIRED").nextSteps.join(" ")).toContain(
-      "_voyant.confirmed=true",
+      '"confirmed": true',
     )
   })
 

--- a/scripts/generate-operator-application-metadata.mjs
+++ b/scripts/generate-operator-application-metadata.mjs
@@ -286,10 +286,25 @@ export default defineConfig({
     tsconfigPaths: true,
   },
   test: {
-    environment: "jsdom",
+    // "node", not "jsdom". Every one of this app's test files is a server test —
+    // they mount the graph, hit the database, and call routes. Nothing touches a
+    // DOM, so a jsdom environment was being built and torn down per worker for
+    // nobody. A file that genuinely needs one can opt in with a
+    // \`// @vitest-environment jsdom\` docblock.
+    environment: "node",
     include: ["tests/**/*.test.ts", "tests/**/*.test.tsx"],
     passWithNoTests: true,
     testTimeout: 30_000,
+    // Measured on a 12-core host: unconstrained, this suite peaked at 5,769 MB
+    // across 13 concurrent vitest processes, because each file mounts its own
+    // full graph runtime and database client. That is ~440 MB per file, and
+    // nothing capped how many ran at once — so the peak scaled with core count
+    // and the suite was killed outright on a developer machine under load.
+    //
+    // Capped rather than serialised: \`fileParallelism: false\` would fix the
+    // memory and cost most of the wall-clock. Two forks keeps the concurrency
+    // that matters while bounding the peak to roughly a fifth of what it was.
+    poolOptions: { forks: { maxForks: 2, minForks: 1 } },
     server: {
       deps: {
         inline: [

--- a/scripts/generate-operator-application-metadata.mjs
+++ b/scripts/generate-operator-application-metadata.mjs
@@ -287,24 +287,25 @@ export default defineConfig({
   },
   test: {
     // "node", not "jsdom". Every one of this app's test files is a server test —
-    // they mount the graph, hit the database, and call routes. Nothing touches a
-    // DOM, so a jsdom environment was being built and torn down per worker for
-    // nobody. A file that genuinely needs one can opt in with a
+    // they mount the graph, hit the database, and call routes. The only
+    // DOM-shaped matches across all 13 were the phrase "document number" in a
+    // task string and a \`contract.document.generated\` event name. A file that
+    // genuinely needs a DOM can opt in with a
     // \`// @vitest-environment jsdom\` docblock.
+    //
+    // Justified by what the files contain, not by a memory number — see the note
+    // below about a measurement that did not hold up.
     environment: "node",
     include: ["tests/**/*.test.ts", "tests/**/*.test.tsx"],
     passWithNoTests: true,
     testTimeout: 30_000,
-    // Measured on a 12-core host: unconstrained, this suite peaked at 5,769 MB
-    // across 13 concurrent vitest processes, because each file mounts its own
-    // full graph runtime and database client. That is ~440 MB per file, and
-    // nothing capped how many ran at once — so the peak scaled with core count
-    // and the suite was killed outright on a developer machine under load.
-    //
-    // Capped rather than serialised: \`fileParallelism: false\` would fix the
-    // memory and cost most of the wall-clock. Two forks keeps the concurrency
-    // that matters while bounding the peak to roughly a fifth of what it was.
-    poolOptions: { forks: { maxForks: 2, minForks: 1 } },
+    // NOTE: capping worker count was tried here and REMOVED. Summed-RSS sampling
+    // put this suite at ~5.7 GB across 13 concurrent processes, which looked like
+    // unbounded parallelism; \`maxForks: 2\` then changed the peak not at all
+    // (5,751 MB vs 5,769 MB, and 14 processes rather than fewer). Summing RSS
+    // across processes double-counts shared pages, so that figure was mostly an
+    // artefact of how it was measured. Do not re-add a cap on the strength of a
+    // summed-RSS number; measure with smaps_rollup/PSS first.
     server: {
       deps: {
         inline: [


### PR DESCRIPTION
## Summary

- derive server-owned action request keys exclusively from the command fingerprint, and make confirmation/approval retries use an exact nested control object
- carry Finance approval IDs through the shared action-policy admission instead of duplicate top-level fields
- turn missing lifecycle targets and collapsed booking refusals into actionable errors, and align `book_product` validation with its public input shape
- keep continuation instructions visible after a successful approval decision
- configure the capability harness with ordinary proforma numbering setup and promote invoice issuance to an asserted database-graded journey

## Evidence

- focused package tests pass for tools, action-ledger, inventory, finance, and MCP server behavior
- package typechecks pass for tools, action-ledger, and finance
- clean three-attempt live-client evaluation on lab1: every discovery and commercial journey passed 3/3 against the real selected graph, MCP JSON-RPC transport, and disposable PostgreSQL database
- inventory typecheck aborts with exit 134 and no TypeScript diagnostics at both default and 4 GB V8 heap limits on lab1; focused inventory behavior tests pass, and CI remains the authoritative compile lane

## Measured progression

- publication: 0/3 → 3/3
- booking: 1–2/3 → 3/3
- proforma issuance: 0/3 → 3/3
