### PR TITLE
test(operator): preserve API-only smoke diagnostics

### DIFF
--- a/scripts/lib/operator-image-acceptance.sh
+++ b/scripts/lib/operator-image-acceptance.sh
@@ -129,11 +129,11 @@ operator_image_boot_api_only_and_assert() {
   done
 
   local health api admin content_type
-  health=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$port/healthz")
+  health=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$port/healthz" || true)
   api=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 \
-    "http://localhost:$port/api/openapi.json")
-  admin=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$port/")
-  content_type=$(curl -s -o /dev/null -w "%{content_type}" "http://localhost:$port/")
+    "http://localhost:$port/api/openapi.json" || true)
+  admin=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$port/" || true)
+  content_type=$(curl -s -o /dev/null -w "%{content_type}" "http://localhost:$port/" || true)
   echo "api-only healthz -> $health; api -> $api; admin -> $admin ($content_type)"
   test "$health" = "200"
   test "$api" -lt 500

--- a/scripts/smoke-operator-image.sh
+++ b/scripts/smoke-operator-image.sh
@@ -14,6 +14,7 @@ cleanup() {
   status=$?
   if ((status != 0)); then
     docker logs "$container" 2>/dev/null || true
+    docker logs "$api_only_container" 2>/dev/null || true
   fi
   docker rm -f "$container" >/dev/null 2>&1 || true
   docker rm -f "$api_only_container" >/dev/null 2>&1 || true


### PR DESCRIPTION
The new API-only production-image acceptance currently exits on the first failed curl and the trap logs only the full-host container. Preserve curl status values through the assertions and print the API-only container logs on failure so CI exposes the startup defect instead of an opaque exit 7.\n\nFollow-up to #4375.