### PR TITLE
fix(operator): boot the packaged API-only entrypoint

### DIFF
--- a/apps/operator/scripts/start-api-only.mjs
+++ b/apps/operator/scripts/start-api-only.mjs
@@ -1,4 +1,12 @@
-const server = (await import("../dist/server/server.js")).default
+import { resolve } from "node:path"
+import { pathToFileURL } from "node:url"
+
+// Docker copies this entrypoint from apps/operator/scripts to /app while the
+// local packaged layout executes it with apps/operator as the working
+// directory. Resolve the built server from that stable project/image root;
+// an import relative to this file points at /dist after the Docker copy.
+const serverEntry = pathToFileURL(resolve("dist/server/server.js")).href
+const server = (await import(serverEntry)).default
 
 if (typeof server?.start !== "function") {
   throw new Error("The built operator server does not expose its start contract.")

--- a/scripts/lib/operator-image-acceptance.sh
+++ b/scripts/lib/operator-image-acceptance.sh
@@ -129,11 +129,11 @@ operator_image_boot_api_only_and_assert() {
   done
 
   local health api admin content_type
-  health=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$port/healthz")
+  health=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$port/healthz" || true)
   api=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 \
-    "http://localhost:$port/api/openapi.json")
-  admin=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$port/")
-  content_type=$(curl -s -o /dev/null -w "%{content_type}" "http://localhost:$port/")
+    "http://localhost:$port/api/openapi.json" || true)
+  admin=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$port/" || true)
+  content_type=$(curl -s -o /dev/null -w "%{content_type}" "http://localhost:$port/" || true)
   echo "api-only healthz -> $health; api -> $api; admin -> $admin ($content_type)"
   test "$health" = "200"
   test "$api" -lt 500

--- a/scripts/smoke-operator-image.sh
+++ b/scripts/smoke-operator-image.sh
@@ -14,6 +14,7 @@ cleanup() {
   status=$?
   if ((status != 0)); then
     docker logs "$container" 2>/dev/null || true
+    docker logs "$api_only_container" 2>/dev/null || true
   fi
   docker rm -f "$container" >/dev/null 2>&1 || true
   docker rm -f "$api_only_container" >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary

- resolve the built server from the packaged application working directory
- preserve API-only curl status diagnostics when the container is unreachable
- print the API-only container logs on smoke failure

## Root cause

The entrypoint is authored at `apps/operator/scripts/start-api-only.mjs`, where `../dist/server/server.js` is correct. The production Dockerfile copies it to `/app/start-api-only.mjs`, where the same relative import resolves to `/dist/server/server.js` instead of `/app/dist/server/server.js`. The full operator profile passed; only the new API-only acceptance failed to become reachable and exited from curl with code 7.

## Verification

- #4375 passed build, tests, architecture, packaged acceptance, database integration/replay/union, full-profile image boot, API dispatch, and admin-shell verification before exposing this API-only path failure
- production image reproduction is running on isolated lab1; CI independently rebuilds and executes the exact image smoke
