### PR TITLE
fix(runtime): preserve resident database pools across requests

### DIFF
--- a/.changeset/calm-pools-stay-open.md
+++ b/.changeset/calm-pools-stay-open.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": patch
+---
+
+Keep the resident Node database pool open when individual HTTP requests finish.

--- a/packages/framework/src/node-runtime-db-lifecycle.test.ts
+++ b/packages/framework/src/node-runtime-db-lifecycle.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const { createVoyantAppMock, openNodeDatabaseMock } = vi.hoisted(() => ({
+  createVoyantAppMock: vi.fn((config: unknown) => config),
+  openNodeDatabaseMock: vi.fn(),
+}))
+
+vi.mock("./create-app.js", () => ({ createVoyantApp: createVoyantAppMock }))
+
+vi.mock("@voyant-travel/db/runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@voyant-travel/db/runtime")>()),
+  openNodeDatabase: openNodeDatabaseMock,
+}))
+
+import { createVoyantNodeApp } from "./node-runtime.js"
+
+type RequestDbFactory = (env: unknown) => {
+  db: unknown
+  dispose: () => Promise<void>
+}
+
+describe("createVoyantNodeApp database lifecycle", () => {
+  beforeEach(() => {
+    createVoyantAppMock.mockClear()
+    openNodeDatabaseMock.mockReset()
+  })
+
+  it("does not dispose the process-owned database after a request", async () => {
+    const processDispose = vi.fn(async () => {})
+    const processDatabase = Object.defineProperty({}, Symbol.for("voyant.db.dispose"), {
+      value: processDispose,
+    })
+    openNodeDatabaseMock.mockReturnValue({
+      db: processDatabase,
+      dispose: async () => {},
+    })
+
+    const config = createVoyantNodeApp({
+      applicationId: "test",
+      activeModules: [],
+      deployment: {
+        providers: {},
+        redis: { isolation: "dedicated", network: "trusted" },
+      },
+    }) as unknown as {
+      db: RequestDbFactory
+      dbTransactional: RequestDbFactory
+    }
+
+    for (const factory of [config.db, config.dbTransactional]) {
+      const requestDatabase = factory({ DATABASE_URL: "postgres://example.invalid/test" })
+      expect(requestDatabase.db).toBe(processDatabase)
+      await requestDatabase.dispose()
+    }
+
+    expect(openNodeDatabaseMock).toHaveBeenCalledTimes(2)
+    expect(processDispose).not.toHaveBeenCalled()
+  })
+})

--- a/packages/framework/src/node-runtime.ts
+++ b/packages/framework/src/node-runtime.ts
@@ -7,6 +7,7 @@ import type { EventEnvelope, VoyantRuntimeHostPrimitives } from "@voyant-travel/
 import {
   createPostgresFixedWindowRateLimitStore,
   createPostgresKvStore,
+  openNodeDatabase,
   resolveNodeDatabase,
 } from "@voyant-travel/db/runtime"
 import {
@@ -575,8 +576,11 @@ export function createVoyantNodeApp(options: {
 }) {
   const auth = options.app?.auth ?? options.auth
   return createVoyantApp<VoyantNodeRuntimeEnv, VoyantNodeRuntimeResources>({
-    db: resolveDb,
-    dbTransactional: resolveDb,
+    // Hono owns request-scoped disposers. Adapt the resident process pool with
+    // an explicit no-op disposer so one completed request cannot close sockets
+    // still used by its neighbours.
+    db: openRequestNodeDatabase,
+    dbTransactional: openRequestNodeDatabase,
     outbox: true,
     ...options.app,
     modules: {
@@ -917,6 +921,14 @@ function redisUrlProtocol(value: string): string {
 
 function resolveDb(env: unknown): VoyantDb {
   return resolveNodeDatabase(env as VoyantNodeRuntimeEnv) as VoyantDb
+}
+
+function openRequestNodeDatabase(env: VoyantNodeRuntimeEnv): {
+  db: VoyantDb
+  dispose: () => Promise<void>
+} {
+  const requestDatabase = openNodeDatabase(env)
+  return { ...requestDatabase, db: requestDatabase.db as VoyantDb }
 }
 
 export type {


### PR DESCRIPTION
## What changed

- adapt the process-owned Node database pool to the request lifecycle with `openNodeDatabase()`
- keep request cleanup as a no-op for the resident shared pool
- add a regression test covering both normal and transactional request database factories
- add a patch changeset for `@voyant-travel/framework`

## Why

The 0.10.0 canary added `VOYANT_DB_DISPOSE` to the shared Node database client. The Hono request lifecycle then treated that resident client as request-owned and disposed it after each request, closing PostgreSQL sockets still being used by concurrent requests.

On the managed canary this produced 120 `CONNECTION_ENDED` failures on the new sandbox revision in roughly three minutes, versus zero on the preceding revision over the prior day. User-facing admin probes and dashboard APIs returned 500s.

The platform canary was rolled back to the last-known-good runtime. Stable was not changed.

## Validation

Run remotely on a disposable Sprite:

- `pnpm --filter @voyant-travel/framework exec vitest run src/node-runtime-db-lifecycle.test.ts`
- `pnpm --filter @voyant-travel/framework typecheck`

Both passed. Biome and `git diff --check` also pass locally.

## Rollout note

After merge, publish 0.10.1 and repeat the managed-runtime base-image promotion with a new platform revision before canarying again.