### PR TITLE
test(mcp): add the real GPT-5.6 capability evaluation lane

### DIFF
--- a/apps/operator/tests/mcp-capability.test.ts
+++ b/apps/operator/tests/mcp-capability.test.ts
@@ -46,15 +46,16 @@
  * the product before the departure — because that dependency is exactly what an
  * endpoint-shaped surface makes hard and what #3921 is trying to fix.
  */
-import { readFileSync } from "node:fs"
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { homedir } from "node:os"
-import { join } from "node:path"
+import { dirname, join, resolve } from "node:path"
 import { createDbClient } from "@voyant-travel/db"
+import { dbClientDispose } from "@voyant-travel/db/transaction-capability"
 import { financeService } from "@voyant-travel/finance"
 import { composeVoyantGraphRuntime } from "@voyant-travel/framework"
 import { sql as sqlRaw } from "drizzle-orm"
 import { Hono } from "hono"
-import { beforeAll, describe, expect, it } from "vitest"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
 
 import { accessCatalog } from "../.voyant/access/selected-access-catalog.generated"
 import {
@@ -75,7 +76,9 @@ function resolveKey(): string | undefined {
   }
 }
 const apiKey = resolveKey()
-const MODEL = process.env.VOYANT_EVAL_MODEL ?? "gpt-4o"
+const MODEL = process.env.VOYANT_EVAL_MODEL ?? "gpt-5.6-terra"
+const REASONING_EFFORT = "medium"
+const REPORT_FILE = process.env.VOYANT_EVAL_REPORT_FILE?.trim()
 const enabled = Boolean(TEST_DATABASE_URL && apiKey)
 
 /** A live model turn plus a real dispatch is slow; the default would time out on latency. */
@@ -200,7 +203,9 @@ async function runJourney(input: {
         messages,
         tools: input.tools,
         tool_choice: "auto",
-        temperature: 0,
+        ...(MODEL.startsWith("gpt-5")
+          ? { reasoning_effort: REASONING_EFFORT }
+          : { temperature: 0 }),
       }),
     })
     if (!res.ok) throw new Error(`OpenAI ${res.status}: ${(await res.text()).slice(0, 300)}`)
@@ -692,6 +697,77 @@ function report(): string {
   return lines.join("\n")
 }
 
+function writeMachineReport(): void {
+  if (!REPORT_FILE) return
+
+  const destination = resolve(REPORT_FILE)
+  const journeys = JOURNEYS.map((journey) => {
+    const journeyAttempts = attempts.get(journey.id) ?? []
+    const outcomes = passes.get(journey.id) ?? []
+    return {
+      id: journey.id,
+      domain: journey.domain,
+      classification: journey.knownGap
+        ? "known-gap"
+        : journey.intermittent
+          ? "intermittent"
+          : "gated",
+      passCount: outcomes.filter(Boolean).length,
+      attemptCount: outcomes.length,
+      callBudget: journey.maxCalls,
+      attempts: journeyAttempts.map((attempt, index) => ({
+        index: index + 1,
+        passed: outcomes[index] ?? false,
+        calls: attempt.calls.length,
+        errors: attempt.calls.filter((call) => call.isError).length,
+        tokens: attempt.tokens,
+        exhausted: attempt.exhausted,
+        trace: attempt.calls.map((call) => ({
+          name: call.name,
+          isError: call.isError,
+          args: JSON.stringify(call.args).slice(0, 1_000),
+          result: call.snippet.slice(0, 1_000),
+        })),
+        answer: attempt.answer.slice(0, 2_000),
+      })),
+    }
+  })
+
+  mkdirSync(dirname(destination), { recursive: true })
+  writeFileSync(
+    destination,
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        generatedAt: new Date().toISOString(),
+        model: MODEL,
+        reasoningEffort: MODEL.startsWith("gpt-5") ? REASONING_EFFORT : null,
+        runMark: RUN_MARK,
+        configuredRuns: RUNS,
+        journeys,
+        totals: {
+          journeys: journeys.length,
+          attempts: journeys.reduce((total, journey) => total + journey.attemptCount, 0),
+          passes: journeys.reduce((total, journey) => total + journey.passCount, 0),
+          calls: journeys.reduce(
+            (total, journey) =>
+              total + journey.attempts.reduce((sum, attempt) => sum + attempt.calls, 0),
+            0,
+          ),
+          tokens: journeys.reduce(
+            (total, journey) =>
+              total + journey.attempts.reduce((sum, attempt) => sum + attempt.tokens, 0),
+            0,
+          ),
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  )
+  process.stdout.write(`machine report: ${destination}\n`)
+}
+
 describe.skipIf(!enabled)("MCP capability — a travel agent's job", () => {
   beforeAll(
     async () => {
@@ -803,9 +879,15 @@ describe.skipIf(!enabled)("MCP capability — a travel agent's job", () => {
         }
       }
       process.stdout.write(`\n${report()}\n\n`)
+      writeMachineReport()
     },
     JOURNEY_TIMEOUT_MS * JOURNEYS.length * RUNS,
   )
+
+  afterAll(async () => {
+    const dispose = dbClientDispose(verifyDb)
+    if (dispose) await dispose()
+  })
 
   it.each(
     JOURNEYS.filter((journey) => journey.intermittent),

--- a/apps/operator/tests/mcp-capability.test.ts
+++ b/apps/operator/tests/mcp-capability.test.ts
@@ -172,72 +172,80 @@ async function runJourney(input: {
   /** The server's own `instructions`, exactly as a real MCP client surfaces them. */
   serverInstructions: string
 }): Promise<JourneyRun> {
-  const messages: Array<Record<string, unknown>> = [
-    {
-      role: "system",
-      content:
-        "You are the back-office agent for a travel operator, connected to its MCP server. " +
-        "Use the tools to actually perform the work end to end. Never invent data. If a write " +
-        "reports that confirmation or approval is required, follow the instructions in the " +
-        "error and complete it. Finish by stating what you created, including any ids." +
-        // A real MCP client reads `instructions` from `initialize` and puts it in
-        // front of the model. This harness did not, which made it a WORSE client
-        // than the ones we ship to — and the guide layer (voyant#3931) exists
-        // precisely to orient the agent before its first call. Measuring a surface
-        // while withholding its own operating instructions measures the harness.
-        (input.serverInstructions
-          ? `\n\n--- server instructions ---\n${input.serverInstructions}`
-          : ""),
-    },
-    { role: "user", content: input.task },
-  ]
+  const instructions =
+    "You are the back-office agent for a travel operator, connected to its MCP server. " +
+    "Use the tools to actually perform the work end to end. Never invent data. If a write " +
+    "reports that confirmation or approval is required, follow the instructions in the " +
+    "error and complete it. Finish by stating what you created, including any ids." +
+    // A real MCP client reads `instructions` from `initialize` and puts it in
+    // front of the model. This harness did not, which made it a WORSE client
+    // than the ones we ship to — and the guide layer (voyant#3931) exists
+    // precisely to orient the agent before its first call. Measuring a surface
+    // while withholding its own operating instructions measures the harness.
+    (input.serverInstructions ? `\n\n--- server instructions ---\n${input.serverInstructions}` : "")
   const calls: ToolCallRecord[] = []
   let tokens = 0
+  let previousResponseId: string | undefined
+  let nextInput: unknown = input.task
 
   for (let turn = 0; turn <= input.maxCalls; turn += 1) {
-    const res = await fetch("https://api.openai.com/v1/chat/completions", {
+    const res = await fetch("https://api.openai.com/v1/responses", {
       method: "POST",
       headers: { "content-type": "application/json", authorization: `Bearer ${apiKey}` },
       body: JSON.stringify({
         model: MODEL,
-        messages,
+        instructions,
+        input: nextInput,
         tools: input.tools,
         tool_choice: "auto",
-        ...(MODEL.startsWith("gpt-5")
-          ? { reasoning_effort: REASONING_EFFORT }
-          : { temperature: 0 }),
+        reasoning: { effort: REASONING_EFFORT },
+        previous_response_id: previousResponseId,
+        store: true,
       }),
     })
     if (!res.ok) throw new Error(`OpenAI ${res.status}: ${(await res.text()).slice(0, 300)}`)
     const body = (await res.json()) as {
-      choices?: Array<{ message: Record<string, unknown> }>
-      usage?: { prompt_tokens?: number; completion_tokens?: number }
+      id?: string
+      output_text?: string
+      output?: Array<
+        | { type: "function_call"; call_id: string; name: string; arguments: string }
+        | { type: string; content?: Array<{ type?: string; text?: string }> }
+      >
+      usage?: { input_tokens?: number; output_tokens?: number }
     }
-    tokens += (body.usage?.prompt_tokens ?? 0) + (body.usage?.completion_tokens ?? 0)
-    const message = body.choices?.[0]?.message
-    if (!message) throw new Error("OpenAI returned no message")
-    messages.push(message)
-
-    const toolCalls =
-      (message.tool_calls as Array<{
-        id: string
-        function: { name: string; arguments: string }
-      }>) ?? []
+    if (!body.id) throw new Error("OpenAI returned no response id")
+    previousResponseId = body.id
+    tokens += (body.usage?.input_tokens ?? 0) + (body.usage?.output_tokens ?? 0)
+    const toolCalls = (body.output ?? []).filter(
+      (item): item is Extract<NonNullable<typeof body.output>[number], { type: "function_call" }> =>
+        item.type === "function_call",
+    )
     if (toolCalls.length === 0) {
-      return { calls, answer: String(message.content ?? ""), tokens, exhausted: false }
+      const text =
+        body.output_text ??
+        (body.output ?? [])
+          .flatMap((item) => ("content" in item ? (item.content ?? []) : []))
+          .map((content) => content.text ?? "")
+          .join("")
+      return { calls, answer: text, tokens, exhausted: false }
     }
 
+    const functionOutputs: Array<{
+      type: "function_call_output"
+      call_id: string
+      output: string
+    }> = []
     for (const call of toolCalls) {
       let args: Record<string, unknown> = {}
       try {
-        args = JSON.parse(call.function.arguments || "{}") as Record<string, unknown>
+        args = JSON.parse(call.arguments || "{}") as Record<string, unknown>
       } catch {
         args = {}
       }
       const rpcBody = await readRpc(
         await input.app.request(
           "/",
-          rpc("tools/call", { name: call.function.name, arguments: args }),
+          rpc("tools/call", { name: call.name, arguments: args }),
           TEST_ENV,
           TEST_CTX,
         ),
@@ -251,13 +259,14 @@ async function runJourney(input: {
           : (result?.content?.[0]?.text ?? JSON.stringify(rpcBody))
       ).slice(0, 12_000)
       calls.push({
-        name: call.function.name,
+        name: call.name,
         args,
         isError: result?.isError === true,
         snippet: text.slice(0, 300),
       })
-      messages.push({ role: "tool", tool_call_id: call.id, content: text })
+      functionOutputs.push({ type: "function_call_output", call_id: call.call_id, output: text })
     }
+    nextInput = functionOutputs
   }
   return { calls, answer: "", tokens, exhausted: true }
 }
@@ -819,11 +828,9 @@ describe.skipIf(!enabled)("MCP capability — a travel agent's job", () => {
         (listed.result as { tools?: Array<Record<string, unknown>> } | undefined)?.tools ?? []
       ).map((tool) => ({
         type: "function" as const,
-        function: {
-          name: String(tool.name),
-          description: String(tool.description ?? "").slice(0, 1024),
-          parameters: tool.inputSchema ?? { type: "object", properties: {} },
-        },
+        name: String(tool.name),
+        description: String(tool.description ?? "").slice(0, 1024),
+        parameters: tool.inputSchema ?? { type: "object", properties: {} },
       }))
 
       for (let attempt = 0; attempt < RUNS; attempt += 1) {

--- a/docs/architecture/mcp-capability-evaluation.md
+++ b/docs/architecture/mcp-capability-evaluation.md
@@ -36,10 +36,11 @@ depend on stale JavaScript beside package TypeScript sources.
 The default model is `gpt-5.6-terra` at medium reasoning effort: the balanced
 quality/cost tier for a multi-step operator capability evaluation. Use
 `--model gpt-5.6-luna` for an explicit cost-sensitive comparison; never mix model
-results under one baseline. The harness currently uses Chat Completions because
-that is the established client contract and both GPT-5.6 tiers support it with
-function calling. Evaluate a Responses API migration separately so endpoint
-effects are not misattributed to the model change.
+results under one baseline. The harness uses the Responses API with medium
+reasoning and continues each Tool turn through `previous_response_id`. GPT-5.6
+does not support function Tools with nonzero reasoning effort on Chat Completions;
+using Responses preserves the reasoning baseline instead of silently setting it
+to `none`.
 
 Artifacts are written under `.agent-runs/mcp-capability/<timestamp>/` unless
 `--artifacts` selects another directory. `report.json` records the model, run count,

--- a/docs/architecture/mcp-capability-evaluation.md
+++ b/docs/architecture/mcp-capability-evaluation.md
@@ -29,6 +29,10 @@ temporary PostgreSQL 16 Docker container on a random localhost port, migrates it
 runs the focused evaluation, and removes the container. A supplied database is
 assumed disposable and is not dropped by the runner.
 
+Migration runs with the repository's development export condition and the `tsx`
+loader, matching the integration CI lane. A clean workspace therefore does not
+depend on stale JavaScript beside package TypeScript sources.
+
 The default model is `gpt-5.6-terra` at medium reasoning effort: the balanced
 quality/cost tier for a multi-step operator capability evaluation. Use
 `--model gpt-5.6-luna` for an explicit cost-sensitive comparison; never mix model

--- a/docs/architecture/mcp-capability-evaluation.md
+++ b/docs/architecture/mcp-capability-evaluation.md
@@ -1,0 +1,65 @@
+# MCP Capability Evaluation
+
+The MCP capability evaluation answers one question: can a real GPT model complete an
+operator job through the real selected deployment graph and MCP JSON-RPC transport?
+It is not a substitute for deterministic package tests. It measures whether the Tool
+surface is discoverable, drivable, and complete when the caller is a model.
+
+The harness is `apps/operator/tests/mcp-capability.test.ts`. Writes are graded from
+the disposable database, reads must dispatch a real data Tool, and the textual answer
+is secondary evidence.
+
+## Supported command
+
+Run a one-attempt smoke evaluation:
+
+```sh
+pnpm eval:mcp-capability -- --mode smoke
+```
+
+Measure a Tool-surface change across five attempts:
+
+```sh
+pnpm eval:mcp-capability -- --mode measure --model gpt-5.6-terra
+```
+
+The runner requires `OPENAI_API_KEY` or the existing
+`~/.config/agent-run/openai-token`. When `TEST_DATABASE_URL` is absent it starts a
+temporary PostgreSQL 16 Docker container on a random localhost port, migrates it,
+runs the focused evaluation, and removes the container. A supplied database is
+assumed disposable and is not dropped by the runner.
+
+The default model is `gpt-5.6-terra` at medium reasoning effort: the balanced
+quality/cost tier for a multi-step operator capability evaluation. Use
+`--model gpt-5.6-luna` for an explicit cost-sensitive comparison; never mix model
+results under one baseline. The harness currently uses Chat Completions because
+that is the established client contract and both GPT-5.6 tiers support it with
+function calling. Evaluate a Responses API migration separately so endpoint
+effects are not misattributed to the model change.
+
+Artifacts are written under `.agent-runs/mcp-capability/<timestamp>/` unless
+`--artifacts` selects another directory. `report.json` records the model, run count,
+per-journey pass rate, calls, error state, bounded traces, and token usage. Logs and
+the final exit code are stored beside it. Never point the runner at production data.
+
+## Remote lane
+
+The Mac is the control plane. Run the command on `lab1` through the approved
+`agent-run` fleet when measuring a pushed branch, or through a Sprite when a safe
+snapshot and the required credential/database arrangement are available. Never use
+`lab2`; it is reserved for GitHub Actions CI.
+
+The execution brief must request the exact command above, sequential execution, the
+result artifact directory, and database cleanup confirmation. Remote execution and
+secret injection remain owned by `../internal-dev-agent`; this repository owns the
+product harness and its artifact contract.
+
+## Reading results
+
+Journeys are chained. Diagnose the first link below 5/5; downstream failures are
+usually consequences. A refusal is useful only if the model-visible payload explains
+and enables the repair. A model answer without a data dispatch is not a read success.
+
+Use smoke mode for wiring checks only. Claims about a write-path improvement require
+five-attempt measurement evidence, because a single model-driven run cannot separate
+a real fix from variance.

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "report:agent-write-coverage": "tsx scripts/check-agent-write-coverage.ts --report",
     "verify:agent-write-coverage": "node --test scripts/tests/check-agent-write-coverage.test.mjs && tsx scripts/check-agent-write-coverage.ts",
     "report:agent-tool-coverage": "tsx scripts/check-agent-tool-coverage.ts --report",
+    "eval:mcp-capability": "node scripts/run-mcp-capability-eval.mjs",
     "verify:agent-tool-coverage": "node --test scripts/tests/check-agent-tool-coverage.test.mjs && tsx scripts/check-agent-tool-coverage.ts",
     "verify:tool-refinement-visibility": "tsx scripts/check-tool-refinement-visibility.ts",
     "verify:first-party-tool-output-schemas": "node --test scripts/tests/check-first-party-tool-output-schemas.test.mjs && node scripts/check-first-party-tool-output-schemas.mjs",

--- a/scripts/run-mcp-capability-eval.mjs
+++ b/scripts/run-mcp-capability-eval.mjs
@@ -1,0 +1,227 @@
+import { spawn, spawnSync } from "node:child_process"
+import { randomBytes } from "node:crypto"
+import { mkdirSync, writeFileSync } from "node:fs"
+import net from "node:net"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+export function parseArgs(argv) {
+  const options = {
+    artifactDir: null,
+    databaseUrl: process.env.TEST_DATABASE_URL?.trim() || null,
+    mode: "smoke",
+    model: "gpt-5.6-terra",
+  }
+  const values = [...argv]
+  while (values.length > 0) {
+    const value = values.shift()
+    if (value === "--mode") {
+      options.mode = requiredValue(value, values.shift())
+      continue
+    }
+    if (value === "--model") {
+      options.model = requiredValue(value, values.shift())
+      continue
+    }
+    if (value === "--artifacts") {
+      options.artifactDir = path.resolve(requiredValue(value, values.shift()))
+      continue
+    }
+    if (value === "--database-url") {
+      options.databaseUrl = requiredValue(value, values.shift())
+      continue
+    }
+    if (value === "--help" || value === "-h") {
+      options.help = true
+      continue
+    }
+    throw new Error(`unknown option: ${value}`)
+  }
+  if (!new Set(["smoke", "measure"]).has(options.mode)) {
+    throw new Error(`--mode must be smoke or measure, received ${options.mode}`)
+  }
+  return options
+}
+
+export function usage() {
+  return `Usage: pnpm eval:mcp-capability -- [options]
+
+Options:
+  --mode smoke|measure     One run for smoke, five runs for measurement (default: smoke)
+  --model <model>          OpenAI model name (default: gpt-5.6-terra)
+  --artifacts <directory>  Result directory (default: .agent-runs/mcp-capability/<timestamp>)
+  --database-url <url>     Existing disposable database; otherwise start a temporary Docker Postgres
+  --help                   Show this help
+
+Requires OPENAI_API_KEY or ~/.config/agent-run/openai-token. The database is mutated.`
+}
+
+function requiredValue(option, value) {
+  if (!value) throw new Error(`${option} requires a value`)
+  return value
+}
+
+function run(command, args, { env = process.env, logFile } = {}) {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(command, args, { cwd: repoRoot, env, stdio: ["ignore", "pipe", "pipe"] })
+    const chunks = []
+    for (const stream of [child.stdout, child.stderr]) {
+      stream.on("data", (chunk) => {
+        process.stdout.write(chunk)
+        chunks.push(chunk)
+      })
+    }
+    child.on("error", reject)
+    child.on("close", (code) => {
+      if (logFile) writeFileSync(logFile, Buffer.concat(chunks))
+      resolvePromise(code ?? 1)
+    })
+  })
+}
+
+function capture(command, args) {
+  const result = spawnSync(command, args, { cwd: repoRoot, encoding: "utf8" })
+  if (result.status !== 0) {
+    throw new Error(result.stderr?.trim() || `${command} exited ${result.status}`)
+  }
+  return result.stdout.trim()
+}
+
+function canConnect(port) {
+  return new Promise((resolvePromise) => {
+    const socket = net.createConnection({ host: "127.0.0.1", port })
+    socket.once("connect", () => {
+      socket.end()
+      resolvePromise(true)
+    })
+    socket.once("error", () => resolvePromise(false))
+  })
+}
+
+async function waitForPostgres(port) {
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    if (await canConnect(port)) return
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 500))
+  }
+  throw new Error(`timed out waiting for temporary Postgres on port ${port}`)
+}
+
+function startTemporaryPostgres() {
+  const suffix = randomBytes(5).toString("hex")
+  const name = `voyant-mcp-eval-${suffix}`
+  capture("docker", [
+    "run",
+    "--detach",
+    "--rm",
+    "--name",
+    name,
+    "--tmpfs",
+    "/var/lib/postgresql/data",
+    "-e",
+    "POSTGRES_USER=voyant_eval",
+    "-e",
+    "POSTGRES_PASSWORD=voyant_eval",
+    "-e",
+    "POSTGRES_DB=voyant_eval",
+    "-p",
+    "127.0.0.1::5432",
+    "postgres:16-alpine",
+  ])
+  const mapping = capture("docker", ["port", name, "5432/tcp"])
+  const port = Number(mapping.match(/:(\d+)$/)?.[1])
+  if (!Number.isInteger(port)) throw new Error(`could not parse Docker port mapping: ${mapping}`)
+  return {
+    name,
+    port,
+    url: `postgresql://voyant_eval:voyant_eval@127.0.0.1:${port}/voyant_eval`,
+  }
+}
+
+function stopTemporaryPostgres(name) {
+  spawnSync("docker", ["stop", name], { cwd: repoRoot, stdio: "inherit" })
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+  if (options.help) {
+    process.stdout.write(`${usage()}\n`)
+    return
+  }
+
+  const timestamp = new Date().toISOString().replaceAll(":", "-")
+  const artifactDir =
+    options.artifactDir ?? path.join(repoRoot, ".agent-runs", "mcp-capability", timestamp)
+  mkdirSync(artifactDir, { recursive: true })
+
+  let temporaryDatabase = null
+  let databaseUrl = options.databaseUrl
+  try {
+    if (!databaseUrl) {
+      temporaryDatabase = startTemporaryPostgres()
+      await waitForPostgres(temporaryDatabase.port)
+      databaseUrl = temporaryDatabase.url
+    }
+
+    const env = {
+      ...process.env,
+      DATABASE_URL: databaseUrl,
+      TEST_DATABASE_URL: databaseUrl,
+      VOYANT_EVAL_MODEL: options.model,
+      VOYANT_EVAL_REPORT_FILE: path.join(artifactDir, "report.json"),
+      VOYANT_EVAL_RUNS: options.mode === "measure" ? "5" : "1",
+    }
+    writeFileSync(
+      path.join(artifactDir, "run.json"),
+      `${JSON.stringify(
+        {
+          schemaVersion: 1,
+          startedAt: new Date().toISOString(),
+          mode: options.mode,
+          model: options.model,
+          runs: Number(env.VOYANT_EVAL_RUNS),
+          database: temporaryDatabase ? "temporary-docker" : "provided",
+        },
+        null,
+        2,
+      )}\n`,
+    )
+
+    let status = await run("pnpm", ["--filter", "operator", "prepare:verify"], {
+      env,
+      logFile: path.join(artifactDir, "prepare.log"),
+    })
+    if (status === 0) {
+      status = await run("pnpm", ["-C", "apps/operator", "db:migrate"], {
+        env,
+        logFile: path.join(artifactDir, "migrate.log"),
+      })
+    }
+    if (status === 0) {
+      status = await run(
+        "pnpm",
+        [
+          "-C",
+          "apps/operator",
+          "exec",
+          "vitest",
+          "run",
+          "tests/mcp-capability.test.ts",
+          "--config",
+          ".voyant/vitest.config.ts",
+        ],
+        { env, logFile: path.join(artifactDir, "eval.log") },
+      )
+    }
+    writeFileSync(path.join(artifactDir, "exit-code.txt"), `${status}\n`)
+    process.stdout.write(`MCP capability artifacts: ${artifactDir}\n`)
+    process.exitCode = status
+  } finally {
+    if (temporaryDatabase) stopTemporaryPostgres(temporaryDatabase.name)
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main()
+}

--- a/scripts/run-mcp-capability-eval.mjs
+++ b/scripts/run-mcp-capability-eval.mjs
@@ -17,6 +17,7 @@ export function parseArgs(argv) {
   const values = [...argv]
   while (values.length > 0) {
     const value = values.shift()
+    if (value === "--") continue
     if (value === "--mode") {
       options.mode = requiredValue(value, values.shift())
       continue

--- a/scripts/run-mcp-capability-eval.mjs
+++ b/scripts/run-mcp-capability-eval.mjs
@@ -195,7 +195,17 @@ async function main() {
     })
     if (status === 0) {
       status = await run("pnpm", ["-C", "apps/operator", "db:migrate"], {
-        env,
+        env: {
+          ...env,
+          NODE_OPTIONS: [
+            process.env.NODE_OPTIONS,
+            "--conditions=development",
+            "--import=tsx",
+            "--max-old-space-size=8192",
+          ]
+            .filter(Boolean)
+            .join(" "),
+        },
         logFile: path.join(artifactDir, "migrate.log"),
       })
     }

--- a/scripts/run-mcp-capability-eval.mjs
+++ b/scripts/run-mcp-capability-eval.mjs
@@ -198,7 +198,7 @@ async function main() {
         env: {
           ...env,
           NODE_OPTIONS: [
-            process.env.NODE_OPTIONS,
+            env.NODE_OPTIONS,
             "--conditions=development",
             "--import=tsx",
             "--max-old-space-size=8192",

--- a/scripts/tests/run-mcp-capability-eval.test.mjs
+++ b/scripts/tests/run-mcp-capability-eval.test.mjs
@@ -10,7 +10,15 @@ test("defaults to a one-run smoke evaluation", () => {
 })
 
 test("accepts the measurement lane and artifact destination", () => {
-  const options = parseArgs(["--mode", "measure", "--model", "gpt-test", "--artifacts", "tmp/eval"])
+  const options = parseArgs([
+    "--",
+    "--mode",
+    "measure",
+    "--model",
+    "gpt-test",
+    "--artifacts",
+    "tmp/eval",
+  ])
   assert.equal(options.mode, "measure")
   assert.equal(options.model, "gpt-test")
   assert.match(options.artifactDir, /tmp\/eval$/)

--- a/scripts/tests/run-mcp-capability-eval.test.mjs
+++ b/scripts/tests/run-mcp-capability-eval.test.mjs
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { parseArgs, usage } from "../run-mcp-capability-eval.mjs"
+
+test("defaults to a one-run smoke evaluation", () => {
+  const options = parseArgs([])
+  assert.equal(options.mode, "smoke")
+  assert.equal(options.model, "gpt-5.6-terra")
+})
+
+test("accepts the measurement lane and artifact destination", () => {
+  const options = parseArgs(["--mode", "measure", "--model", "gpt-test", "--artifacts", "tmp/eval"])
+  assert.equal(options.mode, "measure")
+  assert.equal(options.model, "gpt-test")
+  assert.match(options.artifactDir, /tmp\/eval$/)
+})
+
+test("rejects unknown modes and documents the destructive database requirement", () => {
+  assert.throws(() => parseArgs(["--mode", "fast"]), /smoke or measure/)
+  assert.match(usage(), /database is mutated/i)
+})


### PR DESCRIPTION
## What changed

- add `pnpm eval:mcp-capability` with one-run smoke and five-run measurement modes
- provision and clean up an isolated PostgreSQL 16 database when no disposable URL is supplied
- emit structured run metadata, per-journey pass rates, bounded traces, token totals, logs, and exit status
- dispose the harness database client explicitly
- make `gpt-5.6-terra` the default and retain `gpt-5.6-luna` as an explicit cost-sensitive comparison
- drive GPT-5.6 through the Responses API at medium reasoning, continuing Tool calls with `previous_response_id`
- document the supported local/remote lane and how to interpret chained journey failures

## Why

The existing real-model test proved the product path but remained an opt-in test whose database setup, model selection, cleanup, and evidence collection had to be reconstructed manually. #4378 makes that instrument repeatable before the remaining endpoint-shaped Tools are redesigned.

A live compatibility probe found that GPT-5.6 Terra rejects function Tools with nonzero reasoning effort on Chat Completions. Responses API succeeds with the same model and medium reasoning, so the harness uses Responses instead of silently weakening the eval to `reasoning_effort: none`.

## Validation

- runner unit tests: 3 passed
- Biome and `git diff --check`: clean
- disposable Sprite: dependency install, selected-graph generation, and focused capability-test import/transform passed; Sprite destroyed
- direct OpenAI Responses probe: `gpt-5.6-terra` returned `reasoning` plus `function_call`
- lab1: temporary Postgres started, all 33 selected migrations applied, and the container was removed

The full live journey is not claimed here: lab1 ran out of root-disk capacity while repairing an incomplete native optional dependency before Vitest could start. Terminal clean worktrees were subsequently pruned, restoring approximately 2 GB. The runner and exact rerun command are now in place; five-run promotion evidence remains follow-up work under #4378.

Closes the phase-1 implementation slice of #4378; the umbrella stays open for live measurement and intent-level workflow execution.
