### PR TITLE
feat(finance): add invoice booking intent tool

### DIFF
--- a/.changeset/tidy-tools-invoice-booking.md
+++ b/.changeset/tidy-tools-invoice-booking.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/finance": minor
+---
+
+Add the `invoice_booking` intent Tool, which keeps the authoritative financial snapshot server-side across approval and issuance.

--- a/docs/architecture/agent-tool-library.md
+++ b/docs/architecture/agent-tool-library.md
@@ -118,6 +118,16 @@ reach back into Finance to do the real work. When a workflow's home is
 non-obvious, it is because the orchestration service already lives somewhere the
 job's name does not point to — follow the service, not the noun.
 
+Invoice issuance follows the same ownership rule. `invoice_booking` lives in
+Finance because Finance owns both the authoritative booking-billing projection
+and invoice issuance. Its first call returns the payer, amount, lines, and taxes
+alongside a server-issued approval; after that approval is granted, the same Tool
+rebuilds the snapshot and issues only if it still matches. The fingerprint stays
+server-owned. This is intentionally a two-stage financial interlock rather than a
+single blind write: resolving the fingerprint at execution time alone would make
+the stale-snapshot check compare a value with itself and silently approve changed
+money.
+
 ## Domain completeness notes
 
 Inventory owns guarded core authoring and lifecycle Tools (`create_product`,

--- a/packages/finance/src/mcp-runtime.ts
+++ b/packages/finance/src/mcp-runtime.ts
@@ -232,6 +232,58 @@ export const voyantToolContextContribution = defineToolContextContribution({
           }
           return snapshot
         },
+        async invoiceBooking(input: {
+          bookingId: string
+          issueDate: string
+          dueDate: string
+          approvalId?: string
+        }) {
+          const preview = await buildUnsyncedProformaApprovalSnapshot(
+            db,
+            input.bookingId,
+            getFinanceRouteRuntime(c),
+          )
+          if (!preview) {
+            throw new ToolError("Booking was not found.", "NOT_FOUND", {
+              bookingId: input.bookingId,
+            })
+          }
+          const command = {
+            bookingId: input.bookingId,
+            issueDate: input.issueDate,
+            dueDate: input.dueDate,
+            invoiceType: "proforma" as const,
+            skipExternalSync: true,
+          }
+          const authorizationCommand = {
+            ...command,
+            bookingUpdatedAt: preview.bookingUpdatedAt,
+            snapshotFingerprint: preview.snapshotFingerprint,
+          }
+          const result = await executeInvoiceIssueTool({
+            db,
+            c,
+            command,
+            authorizationCommand,
+            expectedBookingUpdatedAt: preview.bookingUpdatedAt,
+            expectedSnapshotFingerprint: preview.snapshotFingerprint,
+            idempotencyKey: await deriveCommandIdempotencyKey(
+              "invoice-booking",
+              authorizationCommand,
+            ),
+            approvalId: input.approvalId,
+          })
+          return result.status === "approval_required"
+            ? {
+                ...result,
+                preview,
+                nextSteps: [
+                  `1. Call approve_action_approval with approvalId "${result.approval.id}". This approval is already pending; do not request another one.`,
+                  `2. Call invoice_booking again with the identical bookingId, issueDate, and dueDate plus the nested control object "_voyant": {"approvalId": "${result.approval.id}"}. The server will rebuild the financial snapshot and refuse if it changed.`,
+                ],
+              }
+            : result
+        },
         async issueUnsyncedProformaFromBooking(input: {
           bookingId: string
           bookingUpdatedAt: string

--- a/packages/finance/src/tools.ts
+++ b/packages/finance/src/tools.ts
@@ -97,6 +97,11 @@ export interface FinanceToolServices {
   issueUnsyncedProformaFromBooking(
     input: z.infer<typeof issueUnsyncedProformaFromBookingToolInputSchema>,
   ): Promise<unknown>
+  invoiceBooking(
+    input: z.infer<typeof invoiceBookingToolInputSchema> & {
+      approvalId?: string
+    },
+  ): Promise<unknown>
 }
 
 export type FinanceToolContext = ToolContext & { finance?: FinanceToolServices }
@@ -417,6 +422,50 @@ export const unsyncedProformaApprovalSnapshotSchema = z.object({
   ),
 })
 
+export const invoiceBookingToolInputSchema = z.strictObject({
+  bookingId: z.string().min(1),
+  issueDate: z.string().min(1).describe("The proforma issue date (YYYY-MM-DD)."),
+  dueDate: z.string().min(1).describe("The proforma due date (YYYY-MM-DD)."),
+})
+
+export const invoiceBookingToolOutputSchema = z.union([
+  pendingFinanceApprovalSchema.extend({ preview: unsyncedProformaApprovalSnapshotSchema }),
+  z.object({ status: z.literal("issued"), invoice: invoiceSchema, replayed: z.boolean() }),
+])
+
+export const invoiceBookingTool = defineTool<
+  z.infer<typeof invoiceBookingToolInputSchema>,
+  z.infer<typeof invoiceBookingToolOutputSchema>,
+  FinanceToolContext
+>({
+  owner: "@voyant-travel/finance",
+  capabilityId: "@voyant-travel/finance#tool.invoice-booking",
+  capabilityVersion: "v1",
+  name: "invoice_booking",
+  description:
+    "Issue an unsynced proforma for a booking. The first call returns the exact payer, amount, lines, taxes, and a server-issued approval without writing a document. Approve it, then retry the same business input with `_voyant.approvalId`; the server revalidates the financial snapshot before issuing.",
+  inputSchema: invoiceBookingToolInputSchema,
+  outputSchema: invoiceBookingToolOutputSchema,
+  requiredScopes: ["finance:write", "bookings:read"],
+  audience: { source: "grant", allowed: ["staff"] },
+  resolvesIdempotencyKeyServerSide: true,
+  actionPolicyEnforcement: "handler",
+  tier: "destructive",
+  riskPolicy: {
+    destructive: false,
+    reversible: false,
+    dryRunSupported: false,
+    confirmationRequired: false,
+    sideEffects: ["data-write"],
+  },
+  annotations: { idempotentHint: true },
+  async handler(input, ctx) {
+    return invoiceBookingToolOutputSchema.parse(
+      await finance(ctx).invoiceBooking({ ...input, approvalId: handlerApprovalId(ctx) }),
+    )
+  },
+})
+
 export const previewUnsyncedProformaFromBookingTool = defineTool<
   { bookingId: string },
   z.infer<typeof unsyncedProformaApprovalSnapshotSchema>,
@@ -427,7 +476,7 @@ export const previewUnsyncedProformaFromBookingTool = defineTool<
   capabilityVersion: "v1",
   name: "preview_unsynced_proforma_from_booking",
   description:
-    "Read the exact authoritative payer, amount, line, and tax snapshot for an unsynced proforma. Call once before issue_unsynced_proforma_from_booking and pass its revision and fingerprint unchanged.",
+    "Advanced read of the exact authoritative payer, amount, line, and tax snapshot for an unsynced proforma. Prefer invoice_booking for the ordinary issue workflow.",
   inputSchema: z.strictObject({ bookingId: z.string().min(1) }),
   outputSchema: unsyncedProformaApprovalSnapshotSchema,
   requiredScopes: ["finance:write", "bookings:read"],
@@ -478,7 +527,7 @@ export const issueUnsyncedProformaFromBookingTool = defineTool<
   capabilityVersion: "v1",
   name: "issue_unsynced_proforma_from_booking",
   description:
-    "Create and issue one proforma from a known booking after exact approval, without fiscalizing it, syncing it to an external accounting provider, sending it, or creating a payment link. This capability cannot create a draft: for a draft-only request, do not call it; explain that draft-only is unsupported and offer either this created/issued unsynced proforma or no document. Call preview_unsynced_proforma_from_booking once, then pass its booking id, revision, and snapshot fingerprint unchanged. Amount, currency, payer, line items, and taxes are derived from that authoritative snapshot.",
+    "Advanced low-level command that creates and issues one unsynced proforma from a caller-held approval snapshot. Prefer invoice_booking for the ordinary workflow; use this only when the caller deliberately manages the revision, fingerprint, and idempotency contract.",
   inputSchema: issueUnsyncedProformaFromBookingToolInputSchema,
   outputSchema: issueInvoiceFromBookingToolOutputSchema,
   requiredScopes: ["finance:write", "bookings:read"],
@@ -625,6 +674,7 @@ export const financeTools = [
   voidInvoiceTool,
   issueInvoiceRefundTool,
   issueInvoiceFromBookingTool,
+  invoiceBookingTool,
   recordPaymentDisputeTool,
   recordRefundSettlementTool,
   previewUnsyncedProformaFromBookingTool,

--- a/packages/finance/src/voyant.ts
+++ b/packages/finance/src/voyant.ts
@@ -478,6 +478,17 @@ export const financeVoyantModule = defineModule({
       risk: "low",
     },
     {
+      id: "@voyant-travel/finance#tool.invoice-booking",
+      name: "invoice_booking",
+      runtime: {
+        entry: "@voyant-travel/finance/tools",
+        export: "invoiceBookingTool",
+      },
+      requiredScopes: ["finance:write", "bookings:read"],
+      context: ["finance"],
+      risk: "high",
+    },
+    {
       id: "@voyant-travel/finance#tool.issue-unsynced-proforma-from-booking",
       name: "issue_unsynced_proforma_from_booking",
       runtime: {
@@ -603,6 +614,7 @@ export const financeVoyantModule = defineModule({
         tools: [
           "@voyant-travel/finance#tool.issue-invoice-from-booking",
           "@voyant-travel/finance#tool.issue-unsynced-proforma-from-booking",
+          "@voyant-travel/finance#tool.invoice-booking",
         ],
       },
     },

--- a/packages/finance/tests/tools.test.ts
+++ b/packages/finance/tests/tools.test.ts
@@ -12,6 +12,7 @@ import {
   type FinanceToolServices,
   financeBookingsCreateTools,
   financeTools,
+  invoiceBookingTool,
   issueInvoiceFromBookingTool,
   issueInvoiceFromBookingToolInputSchema,
   issueInvoiceRefundInputSchema,
@@ -87,6 +88,71 @@ function bookingDetail(id = "booking_1") {
 }
 
 describe("finance tools", () => {
+  it("previews and requests approval through one invoice-booking intent call", async () => {
+    const received: unknown[] = []
+    const preview = {
+      id: "booking_1",
+      bookingId: "booking_1",
+      bookingNumber: "BK-1",
+      bookingUpdatedAt: "2026-07-15T09:30:00.000Z",
+      snapshotFingerprint: "snapshot_1",
+      payer: { type: "organization" as const, id: "org_1" },
+      currency: "EUR",
+      subtotalCents: 80_000,
+      taxCents: 0,
+      totalCents: 80_000,
+      lines: [],
+    }
+    const services: Partial<FinanceToolServices> = {
+      async invoiceBooking(input) {
+        received.push(input)
+        return {
+          status: "approval_required",
+          requestedAction: {
+            id: "action_1",
+            status: "awaiting_approval",
+            actionName: "finance.invoice.issue_from_booking",
+            targetType: "booking",
+            targetId: "booking_1",
+          },
+          approval: {
+            id: "approval_1",
+            status: "pending",
+            requestedActionId: "action_1",
+            policyName: "finance-invoice-issue-approval-v1",
+            policyVersion: "v1",
+            riskSnapshot: "high",
+            reasonCode: "invoice_issue_from_booking_requested_by_agent",
+            expiresAt: null,
+            createdAt: "2026-07-15T10:00:00.000Z",
+          },
+          replayed: false,
+          preview,
+          nextSteps: [],
+        }
+      },
+    }
+
+    await expect(
+      invoiceBookingTool.handler(
+        { bookingId: "booking_1", issueDate: "2026-07-15", dueDate: "2026-08-15" },
+        ctx(services),
+      ),
+    ).resolves.toMatchObject({
+      status: "approval_required",
+      approval: { id: "approval_1" },
+      preview: { bookingId: "booking_1", totalCents: 80_000 },
+    })
+    expect(received).toEqual([
+      {
+        bookingId: "booking_1",
+        issueDate: "2026-07-15",
+        dueDate: "2026-08-15",
+        approvalId: undefined,
+      },
+    ])
+  })
+
   it("carries approvals through the _voyant admission instead of a duplicate domain field", async () => {
     expect(issueInvoiceFromBookingToolInputSchema.shape).not.toHaveProperty("approvalId")
     expect(issueInvoiceRefundInputSchema.shape).not.toHaveProperty("approvalId")
@@ -181,6 +247,7 @@ describe("finance tools", () => {
     const list = registry.list()
     expect(list.map((t) => t.name).sort()).toEqual([
       "get_invoice",
+      "invoice_booking",
       "issue_invoice_from_booking",
       "issue_invoice_refund",
       "issue_unsynced_proforma_from_booking",
@@ -381,6 +448,9 @@ describe("finance tools", () => {
           },
           replayed: false,
         }
+      },
+      async invoiceBooking() {
+        throw new Error("not called")
       },
     }
     expect(await registry.dispatch("get_invoice", { id: "inv_1" }, ctx(services))).toMatchObject({

--- a/packages/finance/tests/unit/mcp-runtime-invoice-booking.test.ts
+++ b/packages/finance/tests/unit/mcp-runtime-invoice-booking.test.ts
@@ -1,0 +1,173 @@
+import type { ToolContext } from "@voyant-travel/tools"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+const authorizeFinanceInvoiceIssue = vi.hoisted(() => vi.fn())
+const buildUnsyncedProformaApprovalSnapshot = vi.hoisted(() => vi.fn())
+
+vi.mock("../../src/invoice-issue-authorization.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/invoice-issue-authorization.js")>()),
+  authorizeFinanceInvoiceIssue,
+}))
+vi.mock("../../src/service-issue.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/service-issue.js")>()),
+  buildUnsyncedProformaApprovalSnapshot,
+}))
+
+import { voyantToolContextContribution } from "../../src/mcp-runtime.js"
+import type { FinanceToolServices } from "../../src/tools.js"
+
+const toolContext: ToolContext = {
+  db: {},
+  actor: "staff",
+  audience: "staff",
+  tenantId: "operator_1",
+  resolverScope: { locale: "en", audience: "staff", market: "default", actor: "staff" },
+}
+const request = {
+  get(key: string) {
+    return {
+      actor: "staff",
+      callerType: "agent",
+      scopes: ["finance:write", "bookings:read"],
+      agentId: "agent_1",
+      isInternalRequest: false,
+    }[key]
+  },
+  req: { header: () => null },
+}
+const preview = {
+  id: "booking_1",
+  bookingId: "booking_1",
+  bookingNumber: "BK-1",
+  bookingUpdatedAt: "2026-07-15T09:30:00.000Z",
+  snapshotFingerprint: "snapshot_1",
+  payer: { type: "organization", id: "org_1" },
+  currency: "EUR",
+  subtotalCents: 80_000,
+  taxCents: 0,
+  totalCents: 80_000,
+  lines: [],
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  authorizeFinanceInvoiceIssue.mockReset()
+  buildUnsyncedProformaApprovalSnapshot.mockReset()
+})
+
+async function financeTools() {
+  const contribution = await voyantToolContextContribution.contribute({
+    context: toolContext,
+    request,
+    resources: {},
+  })
+  return contribution.finance as FinanceToolServices
+}
+
+describe("invoice_booking intent", () => {
+  it("returns the authoritative preview with the approval created for that snapshot", async () => {
+    buildUnsyncedProformaApprovalSnapshot.mockResolvedValue(preview)
+    authorizeFinanceInvoiceIssue.mockResolvedValue({
+      status: "approval_required",
+      requestedAction: {
+        id: "action_1",
+        status: "awaiting_approval",
+        actionName: "finance.invoice.issue_from_booking",
+        targetType: "booking",
+        targetId: "booking_1",
+      },
+      approval: {
+        id: "approval_1",
+        status: "pending",
+        requestedActionId: "action_1",
+        policyName: "finance-invoice-issue-approval-v1",
+        policyVersion: "v1",
+        riskSnapshot: "high",
+        reasonCode: "invoice_issue_from_booking_requested_by_agent",
+        expiresAt: null,
+        createdAt: new Date("2026-07-15T10:00:00.000Z"),
+      },
+      replayed: false,
+    })
+
+    await expect(
+      (await financeTools()).invoiceBooking({
+        bookingId: "booking_1",
+        issueDate: "2026-07-15",
+        dueDate: "2026-08-15",
+      }),
+    ).resolves.toMatchObject({
+      status: "approval_required",
+      approval: { id: "approval_1" },
+      preview: { bookingId: "booking_1", totalCents: 80_000 },
+      nextSteps: [
+        expect.stringContaining("approve_action_approval"),
+        expect.stringContaining("invoice_booking"),
+      ],
+    })
+    expect(authorizeFinanceInvoiceIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        commandInput: expect.objectContaining({
+          bookingId: "booking_1",
+          bookingUpdatedAt: preview.bookingUpdatedAt,
+          snapshotFingerprint: preview.snapshotFingerprint,
+        }),
+      }),
+    )
+  })
+
+  it("recomputes the snapshot on the approved retry and refuses changed money", async () => {
+    buildUnsyncedProformaApprovalSnapshot.mockResolvedValueOnce(preview).mockResolvedValueOnce({
+      ...preview,
+      snapshotFingerprint: "snapshot_changed",
+      totalCents: 90_000,
+    })
+    authorizeFinanceInvoiceIssue
+      .mockResolvedValueOnce({
+        status: "approval_required",
+        requestedAction: {
+          id: "action_1",
+          status: "awaiting_approval",
+          actionName: "finance.invoice.issue_from_booking",
+          targetType: "booking",
+          targetId: "booking_1",
+        },
+        approval: {
+          id: "approval_1",
+          status: "pending",
+          requestedActionId: "action_1",
+          policyName: "finance-invoice-issue-approval-v1",
+          policyVersion: "v1",
+          riskSnapshot: "high",
+          reasonCode: "invoice_issue_from_booking_requested_by_agent",
+          expiresAt: null,
+          createdAt: new Date("2026-07-15T10:00:00.000Z"),
+        },
+        replayed: false,
+      })
+      .mockResolvedValueOnce({
+        status: "invalid_approval",
+        validation: { ok: false, reason: "fingerprint_mismatch" },
+      })
+    const tools = await financeTools()
+    const input = {
+      bookingId: "booking_1",
+      issueDate: "2026-07-15",
+      dueDate: "2026-08-15",
+    }
+
+    await tools.invoiceBooking(input)
+    await expect(
+      tools.invoiceBooking({ ...input, approvalId: "approval_1" }),
+    ).rejects.toMatchObject({ code: "INVALID_INPUT" })
+    expect(authorizeFinanceInvoiceIssue).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        approvalId: "approval_1",
+        commandInput: expect.objectContaining({
+          snapshotFingerprint: "snapshot_changed",
+        }),
+      }),
+    )
+  })
+})

--- a/packages/finance/tests/unit/voyant-manifest.test.ts
+++ b/packages/finance/tests/unit/voyant-manifest.test.ts
@@ -138,6 +138,11 @@ describe("finance deployment manifest", () => {
           name: "issue_unsynced_proforma_from_booking",
           risk: "high",
         }),
+        expect.objectContaining({
+          id: "@voyant-travel/finance#tool.invoice-booking",
+          name: "invoice_booking",
+          risk: "high",
+        }),
       ]),
     )
     expect(financeVoyantModule.actions).toContainEqual(
@@ -161,6 +166,7 @@ describe("finance deployment manifest", () => {
           tools: [
             "@voyant-travel/finance#tool.issue-invoice-from-booking",
             "@voyant-travel/finance#tool.issue-unsynced-proforma-from-booking",
+            "@voyant-travel/finance#tool.invoice-booking",
           ],
         },
       }),


### PR DESCRIPTION
## Summary

- add `invoice_booking` as the ordinary intent-level proforma workflow
- return the authoritative payer/amount/line/tax preview together with a server-issued approval
- rebuild and revalidate the snapshot on the approved retry, keeping revision, fingerprint, and idempotency server-owned
- retain the lower-level preview/issue Tools for advanced callers while deleting their orchestration script descriptions
- document why Finance owns this workflow and why its financial interlock remains two-stage

## Measured reason

The live `gpt-5.6-terra` run under #4378 completed publication and booking but exhausted 27 calls after reaching the old proforma preview/issue/approval sequence. This Tool collapses the model-visible workflow without weakening the stale-snapshot safety check.

## Validation

- remote focused tests: 19/19
- remote `@voyant-travel/finance` typecheck
- Biome and `git diff --check`

## Architecture

No new checker is needed: the capability is data in the existing Finance Voyant manifest and is bound to the existing invoice-issue action. This PR does not add an imperative architecture script.

Closes the invoice-a-booking slice of #3933. Tracks #4378.