### PR TITLE
fix(payments): reconcile embedded pending sessions

### DIFF
--- a/.changeset/bright-checkouts-reconcile.md
+++ b/.changeset/bright-checkouts-reconcile.md
@@ -1,0 +1,16 @@
+---
+"@voyant-travel/finance": patch
+"@voyant-travel/storefront": patch
+---
+
+Reconcile embedded checkout sessions after browser-side payment confirmation.
+
+Payment Element handoffs intentionally persist as `pending`: the shopper is not
+redirected, and Stripe.js confirms the PaymentIntent in the browser. Status
+refresh previously excluded that state, so the scheduled job woke successfully
+but never selected the session and the booking engine could only time out while
+showing a safe pending result.
+
+Pending sessions are now eligible only after a processor identity has been
+persisted (or an ambiguous initiation is explicitly marked uncertain). Plain
+uninitiated drafts remain outside the bounded reconciliation batch.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,6 +372,8 @@ jobs:
                 tests/integration/payment-disputes.test.ts
               pnpm --filter @voyant-travel/finance exec vitest run \
                 tests/integration/refund-settlements.test.ts
+              pnpm --filter @voyant-travel/storefront exec vitest run \
+                tests/integration/payment-reconciliation-job.test.ts
               pnpm --filter @voyant-travel/bookings exec vitest run \
                 tests/integration/booking-amendments.test.ts
               pnpm --filter @voyant-travel/bookings exec vitest run \

--- a/packages/finance/src/payment-adapter-status.ts
+++ b/packages/finance/src/payment-adapter-status.ts
@@ -16,7 +16,16 @@ export interface PaymentAdapterStatusRefreshExecution {
 const PAYMENT_ADAPTER_STATUS_REFRESH_LEASE_MS = 120_000
 const PAYMENT_ADAPTER_STATUS_REFRESH_AFTER_KEY = "paymentAdapterStatusRefreshAfter"
 const PAYMENT_ADAPTER_INITIATION_STATE_KEY = "paymentAdapterInitiationState"
-const PAYMENT_ADAPTER_POLLABLE_STATES = ["requires_redirect", "processing", "authorized"] as const
+// Embedded Payment Element confirmation happens in the shopper's browser. The
+// tenant therefore still has a `pending` session when it first asks the adapter
+// for the processor's authoritative result. The identity guard in the lease
+// query keeps uninitiated pending sessions out of provider polling.
+const PAYMENT_ADAPTER_POLLABLE_STATES = [
+  "pending",
+  "requires_redirect",
+  "processing",
+  "authorized",
+] as const
 
 /**
  * Refresh one persisted session through the deployment-selected adapter.

--- a/packages/storefront/src/payment-reconciliation-job.ts
+++ b/packages/storefront/src/payment-reconciliation-job.ts
@@ -2,7 +2,7 @@ import type { VoyantGraphRuntimeFactoryContext } from "@voyant-travel/core/proje
 import { refreshPaymentAdapterStatus } from "@voyant-travel/finance"
 import { paymentSessions } from "@voyant-travel/finance/schema"
 import type { PaymentAdapter } from "@voyant-travel/payments"
-import { asc, inArray } from "drizzle-orm"
+import { and, asc, inArray, isNotNull, or, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import {
@@ -10,7 +10,8 @@ import {
   storefrontPaymentReconciliationJobRuntimePort,
 } from "./runtime-port.js"
 
-const POLLABLE_STATES = ["requires_redirect", "processing", "authorized"] as const
+const POLLABLE_STATES = ["pending", "requires_redirect", "processing", "authorized"] as const
+const PAYMENT_ADAPTER_INITIATION_STATE_KEY = "paymentAdapterInitiationState"
 const DEFAULT_BATCH_SIZE = 100
 
 export type { PaymentReconciliationJobRuntime } from "./runtime-port.js"
@@ -36,7 +37,22 @@ const dependencies: ReconciliationDependencies = {
     const rows = await db
       .select({ id: paymentSessions.id })
       .from(paymentSessions)
-      .where(inArray(paymentSessions.status, POLLABLE_STATES))
+      .where(
+        and(
+          inArray(paymentSessions.status, POLLABLE_STATES),
+          // A plain pending session has not necessarily reached a processor.
+          // Embedded checkout is distinguishable by the processor identity
+          // persisted at bootstrap, while an ambiguous initiation is marked
+          // uncertain. Excluding every other pending row prevents old drafts
+          // from consuming the bounded batch forever.
+          or(
+            isNotNull(paymentSessions.providerConnectionId),
+            isNotNull(paymentSessions.providerSessionId),
+            isNotNull(paymentSessions.providerPaymentId),
+            sql`${paymentSessions.metadata}->>${PAYMENT_ADAPTER_INITIATION_STATE_KEY}::text = 'uncertain'`,
+          ),
+        ),
+      )
       .orderBy(asc(paymentSessions.updatedAt))
       .limit(limit)
     return rows.map((row) => row.id)

--- a/packages/storefront/tests/integration/payment-reconciliation-job.test.ts
+++ b/packages/storefront/tests/integration/payment-reconciliation-job.test.ts
@@ -1,0 +1,91 @@
+import { cleanupTestDb, createTestDb } from "@voyant-travel/db/test-utils"
+import { paymentSessions } from "@voyant-travel/finance/schema"
+import type { PaymentAdapter } from "@voyant-travel/payments"
+import { eq } from "drizzle-orm"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { reconcilePaymentAdapterStatuses } from "../../src/payment-reconciliation-job.js"
+import type { PaymentReconciliationJobRuntime } from "../../src/runtime-port.js"
+
+const DB_AVAILABLE = Boolean(process.env.TEST_DATABASE_URL)
+const db = DB_AVAILABLE ? createTestDb() : (null as never)
+
+describe.skipIf(!DB_AVAILABLE)("payment reconciliation job", () => {
+  beforeEach(async () => {
+    await cleanupTestDb(db)
+  })
+
+  it("reconciles an embedded checkout that is pending with a processor payment id", async () => {
+    const [unbound, embedded] = await db
+      .insert(paymentSessions)
+      .values([
+        {
+          targetType: "other",
+          targetId: "unbound-checkout",
+          status: "pending",
+          currency: "EUR",
+          amountCents: 8900,
+          updatedAt: new Date("2026-08-07T08:00:00.000Z"),
+        },
+        {
+          targetType: "booking_session",
+          targetId: "bses_embedded",
+          status: "pending",
+          provider: "voyant-pay",
+          providerConnectionId: "pacc_embedded",
+          providerPaymentId: "pi_embedded",
+          currency: "EUR",
+          amountCents: 8900,
+          updatedAt: new Date("2026-08-07T08:01:00.000Z"),
+        },
+      ])
+      .returning()
+    if (!unbound || !embedded) throw new Error("Payment-session seed failed")
+
+    const status = vi.fn(async () => ({
+      nextState: "processing" as const,
+      processorIdentity: {
+        providerId: "voyant-pay",
+        connectionId: "pacc_embedded",
+      },
+      processorPaymentId: "pi_embedded",
+    }))
+    const adapter = {
+      capabilities: { status: true },
+      status,
+    } as PaymentAdapter
+    const runtime: PaymentReconciliationJobRuntime = {
+      resolveDb: async () => db,
+      resolveAdapter: async () => adapter,
+      resolveEnv: () => ({}),
+    }
+
+    await expect(reconcilePaymentAdapterStatuses(runtime, {})).resolves.toEqual({
+      examined: 1,
+      refreshed: 1,
+      failed: 0,
+    })
+    expect(status).toHaveBeenCalledWith(expect.anything(), {
+      paymentSessionId: embedded.id,
+      processorSessionId: null,
+      processorPaymentId: "pi_embedded",
+      processorIdentity: {
+        providerId: "voyant-pay",
+        connectionId: "pacc_embedded",
+      },
+    })
+
+    await expect(
+      db
+        .select({ status: paymentSessions.status })
+        .from(paymentSessions)
+        .where(eq(paymentSessions.id, embedded.id)),
+    ).resolves.toEqual([{ status: "processing" }])
+    await expect(
+      db
+        .select({ status: paymentSessions.status })
+        .from(paymentSessions)
+        .where(eq(paymentSessions.id, unbound.id)),
+    ).resolves.toEqual([{ status: "pending" }])
+  })
+})


### PR DESCRIPTION
## What changed

- admit processor-bound `pending` payment sessions to adapter status refresh
- keep plain uninitiated pending drafts outside the bounded reconciliation batch
- add a real-Postgres regression test covering the embedded Payment Element state
- gate that regression test in the database CI lane

## Why

Embedded Payment Element confirmation happens in the shopper's browser. The tenant persists the PaymentIntent identity while the payment session remains `pending`, then the booking engine wakes `storefront.reconcile-payment-sessions` on the return leg.

The job and Finance refresh lease both excluded `pending`, so the wake returned 202 but examined zero rows. The booking engine consequently remained safely pending even after Stripe had confirmed the PaymentIntent. Operator 0.10.1 fixed the resident PostgreSQL pool lifecycle, but did not change this eligibility predicate.

## Live evidence

- sandbox is serving managed framework 0.80.1 at 100% traffic
- `/_engine/payment-reconcile` returns `woken: true`
- Cloud Run receives `POST /__voyant/jobs/storefront.reconcile-payment-sessions` with 202
- the payment session remains `pending`
- the 0.10.1 source predicate contains only `requires_redirect`, `processing`, and `authorized`

## Validation

- real PostgreSQL regression test: RED (`examined: 0`) before the fix, GREEN after it
- existing Storefront reconciliation unit tests pass
- Biome passes on changed TypeScript files
- Finance package typecheck passes
- Storefront package typecheck deferred to CI after the disposable Sprite exhausted its 4 GB default heap; the retry with 8 GB lost the Sprite connection without emitting a diagnostic
