### PR TITLE
Fix portable admin shell entry document

### DIFF
--- a/.changeset/portable-admin-shell-entry.md
+++ b/.changeset/portable-admin-shell-entry.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/admin": patch
+"@voyant-travel/operator-standard": patch
+---
+
+Boot the portable operator shell without SSR state through the same-origin API contract and expose its pending state accessibly.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,6 +232,7 @@ jobs:
           ln -s "$acceptance_deploy/node_modules" apps/operator/dist/node_modules
           node scripts/measure-operator-application.mjs --require-build --check
           node --test scripts/tests/minimal-starter-acceptance.test.mjs
+          node --test scripts/tests/operator-admin-shell-browser.test.mjs
 
   package-artifacts:
     name: package-artifacts

--- a/apps/operator/README.md
+++ b/apps/operator/README.md
@@ -143,8 +143,11 @@ runtime; this is a packaging profile, not a second product.
 
 Every build also places the portable shell at `/app/admin-shell`. Its
 `manifest.json` records the source revision, image version, graph hash, UI build
-ID, bootstrap compatibility range, and hashes for every fingerprinted client
-file. Export the exact same bytes without constructing another frontend:
+ID, bootstrap compatibility range, and hashes and media types for every
+fingerprinted client file. The packaged `client/index.html` is generated from
+the build manifest, boots without SSR state, and is both the navigation entry
+document and deep-link fallback. Export the exact same bytes without
+constructing another frontend:
 
 ```bash
 docker build -f apps/operator/Dockerfile --target admin-shell-artifact \

--- a/apps/operator/src/client.tsx
+++ b/apps/operator/src/client.tsx
@@ -1,0 +1,22 @@
+import { RouterProvider } from "@tanstack/react-router"
+import { StartClient } from "@tanstack/react-start/client"
+import { StrictMode, startTransition } from "react"
+import { createRoot, hydrateRoot } from "react-dom/client"
+import { getRouter } from "./router.js"
+
+startTransition(() => {
+  if (document.documentElement.dataset.voyantPortableShell === "1") {
+    createRoot(document).render(
+      <StrictMode>
+        <RouterProvider router={getRouter()} />
+      </StrictMode>,
+    )
+  } else {
+    hydrateRoot(
+      document,
+      <StrictMode>
+        <StartClient />
+      </StrictMode>,
+    )
+  }
+})

--- a/docs/architecture/operator-image-distribution.md
+++ b/docs/architecture/operator-image-distribution.md
@@ -208,10 +208,15 @@ The frontend build is assembled once into `dist/client`. The build then copies
 those exact bytes into the versioned `admin-shell` artifact and the runtime image
 embeds that directory at `/app/admin-shell`; the Docker
 `admin-shell-artifact` target exports the same directory rather than rebuilding
-it. `manifest.json` is the machine-readable receipt. It records source revision,
-image version, resolved graph hash, a content-derived UI build ID, the relative
-`/api` base, the shell-bootstrap compatibility interval, portable document
-fallback/API passthrough routing, and each file's size and SHA-256 digest.
+it. Packaging generates `client/index.html` from the build's root assets; that
+document contains no tenant or user state and boots the client directly against
+same-origin `/api`. `manifest.json` is the machine-readable receipt. It records
+source revision, image version, resolved graph hash, a content-derived UI build
+ID, the relative `/api` base, the shell-bootstrap compatibility interval,
+portable document fallback/API passthrough routing, and each file's media type,
+size, and SHA-256 digest. Verification requires the declared HTML entry and
+fallback to identify that receipt file and rejects document references to
+anything outside the receipt.
 
 The shell contains build-time admitted presentation code only. Authenticated
 bootstrap data can select active capabilities, entitlements, navigation,

--- a/packages/admin/src/app/workspace.tsx
+++ b/packages/admin/src/app/workspace.tsx
@@ -140,7 +140,11 @@ export function createAdminWorkspaceBeforeLoad<TUser>({
 
 export function AdminWorkspacePendingFallback({ label }: { label?: string }) {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background">
+    <div
+      className="flex min-h-screen items-center justify-center bg-background"
+      role="status"
+      aria-live="polite"
+    >
       <div className="flex flex-col items-center gap-4">
         <Loader2 className="size-8 animate-spin text-muted-foreground" />
         {label ? <p className="text-sm text-muted-foreground">{label}</p> : null}

--- a/packages/operator-standard/src/standard-frontend.tsx
+++ b/packages/operator-standard/src/standard-frontend.tsx
@@ -235,10 +235,40 @@ const getShellBootstrap = createServerFn({ method: "GET" })
     return bootstrap
   })
 
+async function fetchBrowserApi<T>(path: string): Promise<T | null> {
+  const response = await fetch(`/api${path}`, { credentials: "include", cache: "no-store" })
+  if (response.status === 401) return null
+  if (!response.ok) throw new Error(`Failed to fetch ${path}`)
+  return response.json() as Promise<T>
+}
+
+const getBrowserBootstrapStatus = async () => {
+  const status = await fetchBrowserApi<{ hasUsers: boolean; authMode?: "local" | "voyant-cloud" }>(
+    "/auth/bootstrap-status",
+  )
+  if (!status) throw new Error("Failed to fetch bootstrap status")
+  return status
+}
+
+const getBrowserCurrentUser = () => fetchBrowserApi<StandardOperatorCurrentUser>("/auth/me")
+
+const getBrowserShellBootstrap = async () => {
+  const bootstrap = await fetchBrowserApi<StandardOperatorShellBootstrap>("/auth/shell-bootstrap")
+  if (bootstrap && (bootstrap.version !== 1 || bootstrap.compatibility.minimumShellVersion > 1)) {
+    throw new Error(
+      `Incompatible admin shell bootstrap contract (received ${bootstrap.version}, shell supports 1)`,
+    )
+  }
+  return bootstrap
+}
+
+const isPortableBrowser =
+  typeof document !== "undefined" && document.documentElement.dataset.voyantPortableShell === "1"
+
 const adminAuthRuntime: AdminAuthRuntime<StandardOperatorCurrentUser> = {
-  getCurrentUser,
-  getShellBootstrap,
-  getBootstrapStatus,
+  getCurrentUser: isPortableBrowser ? getBrowserCurrentUser : getCurrentUser,
+  getShellBootstrap: isPortableBrowser ? getBrowserShellBootstrap : getShellBootstrap,
+  getBootstrapStatus: isPortableBrowser ? getBrowserBootstrapStatus : getBootstrapStatus,
   cloudAuthStartHref,
   signOut: async () => {
     await authClient.signOut()

--- a/scripts/check-operator-frontend-shell-authority.mjs
+++ b/scripts/check-operator-frontend-shell-authority.mjs
@@ -13,6 +13,7 @@ const expected = [
   "admin/README.md",
   "api/admin/README.md",
   "api/public/README.md",
+  "client.tsx",
   "extensions/README.md",
   "links/README.md",
   "modules/README.md",
@@ -48,7 +49,7 @@ assert(
   "custom-fields overlay must stay deleted",
 )
 
-const composition = ["router.tsx", "start.ts", "styles.css"]
+const composition = ["client.tsx", "router.tsx", "start.ts", "styles.css"]
   .map((file) => readFileSync(join(applicationRoot, file), "utf8"))
   .join("\n")
 assert(!composition.includes("#"), "application composition must not contain first-party unit IDs")
@@ -60,6 +61,17 @@ assert(
   !composition.includes("@voyant-travel/finance"),
   "application must not select product packages",
 )
+
+const client = readFileSync(join(applicationRoot, "client.tsx"), "utf8")
+for (const token of [
+  'document.documentElement.dataset.voyantPortableShell === "1"',
+  "createRoot(document).render(",
+  "<RouterProvider router={getRouter()} />",
+  "hydrateRoot(",
+  "<StartClient />",
+]) {
+  assert(client.includes(token), `application client bootstrap must contain ${token}`)
+}
 
 const routeRegistry = readFileSync(
   join(root, "packages/operator-standard/src/standard-route-files.ts"),

--- a/scripts/package-operator-admin-shell.mjs
+++ b/scripts/package-operator-admin-shell.mjs
@@ -1,13 +1,14 @@
 import { createHash } from "node:crypto"
 import { cp, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises"
 import path from "node:path"
-import { fileURLToPath } from "node:url"
+import { fileURLToPath, pathToFileURL } from "node:url"
 
 const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..")
 const OPERATOR = path.join(ROOT, "apps/operator")
 const CLIENT = path.join(OPERATOR, "dist/client")
 const OUTPUT = path.join(OPERATOR, "dist/admin-shell")
 const GRAPH = path.join(OPERATOR, ".voyant/deployment-graph.generated.json")
+const SERVER_ASSETS = path.join(OPERATOR, "dist/server/assets")
 
 const revision = process.env.VOYANT_IMAGE_REVISION?.trim() || "unknown"
 const imageVersion = process.env.VOYANT_IMAGE_VERSION?.trim() || "development"
@@ -16,6 +17,7 @@ const graph = JSON.parse(await readFile(GRAPH, "utf8"))
 await rm(OUTPUT, { recursive: true, force: true })
 await mkdir(OUTPUT, { recursive: true })
 await cp(CLIENT, path.join(OUTPUT, "client"), { recursive: true })
+await writePortableEntryDocument(path.join(OUTPUT, "client/index.html"))
 
 const files = await fingerprintFiles(path.join(OUTPUT, "client"))
 const uiBuildId = `sha256:${sha256(JSON.stringify(files))}`
@@ -53,9 +55,83 @@ async function walk(root, directory, files) {
         path: path.relative(root, absolute).split(path.sep).join("/"),
         bytes: bytes.byteLength,
         sha256: sha256(bytes),
+        mediaType: mediaTypeFor(entry.name),
       })
     }
   }
+}
+
+async function writePortableEntryDocument(output) {
+  const entries = await readdir(SERVER_ASSETS)
+  const manifestFiles = entries.filter((entry) => /^_tanstack-start-manifest.*\.js$/.test(entry))
+  if (manifestFiles.length !== 1) {
+    throw new Error(`Expected one TanStack Start manifest, found ${manifestFiles.length}.`)
+  }
+
+  const manifestModule = await import(
+    `${pathToFileURL(path.join(SERVER_ASSETS, manifestFiles[0])).href}?admin-shell`
+  )
+  const rootRoute = manifestModule.tsrStartManifest()?.routes?.__root__
+  if (!rootRoute) throw new Error("TanStack Start manifest has no root route assets.")
+
+  const styles = (rootRoute.css ?? []).map(assetHref)
+  const preloads = rootRoute.preloads ?? []
+  const scripts = (rootRoute.scripts ?? []).map((script) => script.attrs?.src).filter(Boolean)
+  if (scripts.length === 0) throw new Error("TanStack Start manifest has no client entry script.")
+
+  const referenced = ["/favicon.png", ...styles, ...preloads, ...scripts]
+  for (const href of referenced) {
+    const relative = href.startsWith("/") ? href.slice(1) : href
+    if (!relative || relative.includes("?") || relative.includes("#")) {
+      throw new Error(`Admin shell document has a non-file asset reference: ${href}`)
+    }
+    await readFile(path.join(CLIENT, relative))
+  }
+
+  const document = [
+    "<!doctype html>",
+    '<html lang="en" data-voyant-portable-shell="1">',
+    "<head>",
+    '<meta charset="utf-8">',
+    '<meta name="viewport" content="width=device-width, initial-scale=1">',
+    '<meta name="robots" content="noindex,nofollow">',
+    '<meta name="theme-color" content="#ffffff">',
+    "<title>Voyant</title>",
+    '<link rel="icon" type="image/png" href="/favicon.png">',
+    ...styles.map((href) => `<link rel="stylesheet" href="${escapeAttribute(href)}">`),
+    ...preloads.map((href) => `<link rel="modulepreload" href="${escapeAttribute(href)}">`),
+    '<script>(function(){globalThis.__zod_globalConfig=Object.assign({},globalThis.__zod_globalConfig,{jitless:true});var t=localStorage.getItem("theme");if(t==="dark"||(!t||t==="system")&&matchMedia("(prefers-color-scheme:dark)").matches){document.documentElement.classList.add("dark")}var l=localStorage.getItem("admin-locale")||(navigator.language||"en");l=l.toLowerCase().split("-")[0];document.documentElement.lang=l==="ro"?"ro":"en"})()</script>',
+    "</head>",
+    '<body class="min-h-screen bg-background font-sans antialiased">',
+    ...scripts.map((src) => `<script type="module" src="${escapeAttribute(src)}"></script>`),
+    "</body>",
+    "</html>",
+    "",
+  ].join("\n")
+  await writeFile(output, document)
+}
+
+function assetHref(asset) {
+  return typeof asset === "string" ? asset : asset.href
+}
+
+function escapeAttribute(value) {
+  return value.replaceAll("&", "&amp;").replaceAll('"', "&quot;")
+}
+
+function mediaTypeFor(fileName) {
+  const extension = path.extname(fileName).toLowerCase()
+  return (
+    {
+      ".css": "text/css",
+      ".html": "text/html",
+      ".js": "text/javascript",
+      ".json": "application/json",
+      ".png": "image/png",
+      ".svg": "image/svg+xml",
+      ".woff2": "font/woff2",
+    }[extension] ?? "application/octet-stream"
+  )
 }
 
 function sha256(value) {

--- a/scripts/tests/operator-admin-shell-browser.test.mjs
+++ b/scripts/tests/operator-admin-shell-browser.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import { createServer } from "node:http"
+import path from "node:path"
+import { after, before, test } from "node:test"
+import { chromium } from "playwright"
+
+const SHELL = path.resolve("apps/operator/dist/admin-shell/client")
+let browser
+let origin
+let server
+
+before(async () => {
+  server = createServer(async (request, response) => {
+    const url = new URL(request.url, "http://admin-shell.invalid")
+    if (url.pathname.startsWith("/api/")) {
+      if (url.pathname === "/api/auth/bootstrap-status") {
+        await new Promise((resolve) => setTimeout(resolve, 1_500))
+        response.setHeader("content-type", "application/json")
+        response.end(JSON.stringify({ hasUsers: true, authMode: "local" }))
+        return
+      }
+      response.setHeader("content-type", "application/json")
+      response.end("null")
+      return
+    }
+
+    const relative = url.pathname === "/" ? "index.html" : url.pathname.slice(1)
+    const candidate = path.resolve(SHELL, relative)
+    const file = candidate.startsWith(`${SHELL}${path.sep}`)
+      ? candidate
+      : path.join(SHELL, "index.html")
+    const fallback = path.join(SHELL, "index.html")
+    const bytes = await readFile(file).catch(() => readFile(fallback))
+    response.setHeader("content-type", contentType(file))
+    response.end(bytes)
+  })
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve))
+  origin = `http://127.0.0.1:${server.address().port}`
+  browser = await chromium.launch({ headless: true })
+})
+
+after(async () => {
+  await browser?.close()
+  await new Promise((resolve, reject) =>
+    server?.close((error) => (error ? reject(error) : resolve())),
+  )
+})
+
+test("packaged document boots pending UI and redirects a deep link to login", async () => {
+  const page = await browser.newPage()
+  const consoleErrors = []
+  const failedRequests = []
+  page.on("console", (message) => {
+    if (message.type() === "error") consoleErrors.push(message.text())
+  })
+  page.on("requestfailed", (request) => failedRequests.push(request.url()))
+
+  const pendingVisible = page.getByRole("status").waitFor({ timeout: 5_000 })
+  const navigation = await page.goto(`${origin}/bookings?tab=upcoming`)
+  assert.match(await navigation.text(), /data-voyant-portable-shell="1"/)
+  await pendingVisible.catch(async (error) => {
+    throw new Error(
+      `${error.message}\nurl=${page.url()}\nconsole=${JSON.stringify(consoleErrors)}\nfailed=${JSON.stringify(failedRequests)}\nhtml=${(await page.content()).slice(0, 2_000)}`,
+    )
+  })
+  await page.waitForURL(/\/sign-in/)
+  await page.waitForTimeout(100)
+
+  assert.deepEqual(consoleErrors, [])
+  assert.deepEqual(failedRequests, [])
+  await page.close()
+})
+
+function contentType(file) {
+  if (file.endsWith(".css")) return "text/css"
+  if (file.endsWith(".js")) return "text/javascript"
+  if (file.endsWith(".png")) return "image/png"
+  if (file.endsWith(".woff2")) return "font/woff2"
+  return "text/html"
+}

--- a/scripts/tests/verify-operator-admin-shell.test.mjs
+++ b/scripts/tests/verify-operator-admin-shell.test.mjs
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict"
+import { execFile } from "node:child_process"
+import { createHash } from "node:crypto"
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import { promisify } from "node:util"
+import { describe, it } from "vitest"
+
+const execFileAsync = promisify(execFile)
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "../..")
+const VERIFIER = path.join(ROOT, "scripts/verify-operator-admin-shell.mjs")
+const HTML =
+  '<!doctype html><link rel="icon" href="/favicon.png"><script type="module" src="/assets/client.js"></script>\n'
+
+describe("operator admin shell verifier", () => {
+  it("accepts a receipt-backed portable HTML document", async () => {
+    const root = await fixture()
+    await assert.doesNotReject(() => verify(root))
+  })
+
+  it("rejects an entry document absent from the receipt", async () => {
+    const root = await fixture((manifest) => {
+      manifest.files = manifest.files.filter((file) => file.path !== "index.html")
+    })
+    await rejects(root, "entry document is absent from the receipt")
+  })
+
+  it("rejects a mismatched document fallback", async () => {
+    const root = await fixture((manifest) => {
+      manifest.routing.documentFallback = "client/other.html"
+    })
+    await rejects(root, "routing must preserve API passthrough and document fallback")
+  })
+
+  it("rejects an entry document outside client", async () => {
+    const root = await fixture((manifest) => {
+      manifest.entryDocument = "../index.html"
+      manifest.routing.documentFallback = "../index.html"
+    })
+    await rejects(root, "must be a normalized HTML path inside client")
+  })
+
+  it("rejects an entry document not declared as text/html", async () => {
+    const root = await fixture((manifest) => {
+      manifest.files.find((file) => file.path === "index.html").mediaType = "text/plain"
+    })
+    await rejects(root, "must have media type text/html")
+  })
+
+  it("rejects document assets absent from the receipt", async () => {
+    const root = await fixture((manifest) => {
+      manifest.files = manifest.files.filter((file) => file.path !== "assets/client.js")
+    })
+    await rejects(root, "references a file absent from the receipt: assets/client.js")
+  })
+
+  it("rejects cross-origin document assets even when their path is receipted", async () => {
+    const root = await fixture(
+      () => {},
+      HTML.replace("/assets/client.js", "https://evil.test/assets/client.js"),
+    )
+    await rejects(root, "has a cross-origin reference")
+  })
+})
+
+async function fixture(mutate = () => {}, html = HTML) {
+  const root = await mkdtemp(path.join(tmpdir(), "voyant-admin-shell-"))
+  await mkdir(path.join(root, "client/assets"), { recursive: true })
+  const contents = new Map([
+    ["index.html", html],
+    ["favicon.png", "png"],
+    ["assets/client.js", "console.log('boot')\n"],
+  ])
+  for (const [relative, contentsForFile] of contents) {
+    await writeFile(path.join(root, "client", relative), contentsForFile)
+  }
+  const files = [...contents].map(([filePath, contentsForFile]) => {
+    const bytes = Buffer.from(contentsForFile)
+    return {
+      path: filePath,
+      bytes: bytes.byteLength,
+      sha256: createHash("sha256").update(bytes).digest("hex"),
+      mediaType: filePath === "index.html" ? "text/html" : "application/octet-stream",
+    }
+  })
+  const manifest = {
+    schemaVersion: "voyant.admin-shell-artifact.v1",
+    graphHash: `sha256:${"a".repeat(64)}`,
+    uiBuildId: `sha256:${"b".repeat(64)}`,
+    apiBasePath: "/api",
+    shellBootstrap: { current: 1, minimum: 1 },
+    entryDocument: "client/index.html",
+    routing: {
+      passthroughPrefixes: ["/api/"],
+      documentFallback: "client/index.html",
+    },
+    files,
+  }
+  mutate(manifest)
+  await writeFile(path.join(root, "manifest.json"), JSON.stringify(manifest))
+  return root
+}
+
+async function verify(root) {
+  return execFileAsync(process.execPath, [VERIFIER, root])
+}
+
+async function rejects(root, message) {
+  await assert.rejects(
+    () => verify(root),
+    (error) => {
+      assert.match(error.stderr, new RegExp(message))
+      return true
+    },
+  )
+}

--- a/scripts/verify-operator-admin-shell.mjs
+++ b/scripts/verify-operator-admin-shell.mjs
@@ -27,7 +27,31 @@ if (manifest.shellBootstrap?.current !== 1 || manifest.shellBootstrap?.minimum !
   throw new Error("Admin shell compatibility range must describe bootstrap v1.")
 }
 
-for (const file of manifest.files ?? []) {
+const entryDocument = validateDocumentPath(manifest.entryDocument, "entryDocument")
+const documentFallback = validateDocumentPath(
+  manifest.routing?.documentFallback,
+  "routing.documentFallback",
+)
+if (entryDocument !== documentFallback) {
+  throw new Error("Admin shell entry document and document fallback must match.")
+}
+
+const files = manifest.files ?? []
+const paths = new Set()
+for (const file of files) {
+  validateReceiptPath(file.path)
+  if (paths.has(file.path)) throw new Error(`Duplicate admin shell receipt path: ${file.path}`)
+  paths.add(file.path)
+}
+
+const entryReceiptPath = entryDocument.slice("client/".length)
+const entryReceipt = files.find((file) => file.path === entryReceiptPath)
+if (!entryReceipt) throw new Error("Admin shell entry document is absent from the receipt.")
+if (entryReceipt.mediaType !== "text/html") {
+  throw new Error("Admin shell entry document must have media type text/html.")
+}
+
+for (const file of files) {
   const bytes = await readFile(path.join(root, "client", file.path))
   const digest = createHash("sha256").update(bytes).digest("hex")
   if (digest !== file.sha256 || bytes.byteLength !== file.bytes) {
@@ -35,6 +59,52 @@ for (const file of manifest.files ?? []) {
   }
 }
 
+const document = await readFile(path.join(root, entryDocument), "utf8")
+if (!/^\s*<!doctype html>/i.test(document)) {
+  throw new Error("Admin shell entry document is not HTML.")
+}
+for (const reference of document.matchAll(/(?:src|href)=["']([^"']+)["']/g)) {
+  const resolved = new URL(reference[1], "https://admin-shell.invalid")
+  const pathname = resolved.pathname
+  if (!pathname.startsWith("/") || pathname.startsWith("//")) {
+    throw new Error(`Admin shell document has a non-local reference: ${reference[1]}`)
+  }
+  if (resolved.origin !== "https://admin-shell.invalid") {
+    throw new Error(`Admin shell document has a cross-origin reference: ${reference[1]}`)
+  }
+  const receiptPath = decodeURIComponent(pathname.slice(1))
+  if (!paths.has(receiptPath)) {
+    throw new Error(
+      `Admin shell document references a file absent from the receipt: ${receiptPath}`,
+    )
+  }
+}
+
 console.log(
   `Verified admin shell ${manifest.uiBuildId} for ${manifest.graphHash} (${manifest.files.length} files).`,
 )
+
+function validateDocumentPath(value, field) {
+  if (
+    typeof value !== "string" ||
+    !value.startsWith("client/") ||
+    value === "client/" ||
+    path.posix.normalize(value) !== value ||
+    path.posix.extname(value).toLowerCase() !== ".html"
+  ) {
+    throw new Error(`Admin shell ${field} must be a normalized HTML path inside client/.`)
+  }
+  return value
+}
+
+function validateReceiptPath(value) {
+  if (
+    typeof value !== "string" ||
+    !value ||
+    value.startsWith("/") ||
+    path.posix.normalize(value) !== value ||
+    value.startsWith("../")
+  ) {
+    throw new Error(`Invalid admin shell receipt path: ${String(value)}`)
+  }
+}


### PR DESCRIPTION
Closes #4385.

## What changed

- add a client-only portable shell bootstrap while preserving the existing SSR hydration path for the all-in-one host
- generate `client/index.html` from TanStack Start's emitted root assets and use same-origin `/api` for portable auth/bootstrap calls
- include media types in the artifact receipt and require the entry document/fallback plus every referenced asset to be receipted
- add verifier regression coverage and packaged Chromium acceptance for pending UI, deep-link fallback, login redirect, console errors, and failed requests
- document the portable entry contract and add patch changesets

## Root cause

The artifact manifest declared `client/index.html`, but the packager only copied TanStack Start's SSR client bundle. The verifier recomputed listed file hashes without proving that the declared navigation document existed or was HTML.

## Validation

- `pnpm exec vitest run scripts/tests/verify-operator-admin-shell.test.mjs` (7 tests)
- `pnpm --filter operator build` on a disposable Sprite
- `node scripts/verify-operator-admin-shell.mjs apps/operator/dist/admin-shell` (561 files)
- `node --test scripts/tests/operator-admin-shell-browser.test.mjs` in Chromium on a disposable Sprite
- `node scripts/check-operator-image-publication.mjs`
- Biome checks for all changed source/test files

The local `check-operator-application` attempt could not run in the isolated worktree because it expects a worktree-local `node_modules/.pnpm`; the production operator build and browser acceptance ran remotely with a fresh frozen install.
