### PR TITLE
Carry checkout intent through Booking Session commit

### DIFF
--- a/.changeset/booking-session-checkout-intent.md
+++ b/.changeset/booking-session-checkout-intent.md
@@ -1,6 +1,7 @@
 ---
 "@voyant-travel/catalog-contracts": minor
 "@voyant-travel/catalog": minor
+"@voyant-travel/core": patch
 ---
 
 Carry a quote-supported checkout intent through Booking Session commit, reject stale or unsupported choices before side effects, and return durable bank-transfer instructions when the host configures offline-payment orchestration.

--- a/.changeset/booking-session-checkout-intent.md
+++ b/.changeset/booking-session-checkout-intent.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/catalog-contracts": minor
+"@voyant-travel/catalog": minor
+---
+
+Carry a quote-supported checkout intent through Booking Session commit, reject stale or unsupported choices before side effects, and return durable bank-transfer instructions when the host configures offline-payment orchestration.

--- a/docs/architecture/catalog-booking-engine.md
+++ b/docs/architecture/catalog-booking-engine.md
@@ -154,6 +154,19 @@ Quotes. Commit rejects stale revisions, expired/superseded Quotes, expired or
 mismatched Holds, and different server-recomputed prices. Stable idempotency
 keys replay the original Commit result; a different key after consumption is
 rejected rather than creating another Booking.
+
+The Quote's `requirements.paymentIntents` is also the authoritative checkout
+capability list. Commit may echo one value as `checkoutIntent`; the engine
+revalidates it against that exact active Quote before invoking payment or
+booking ports, and fingerprints the resolved intent with the idempotency key.
+Omission is the v1 compatibility spelling of `card` and is accepted only when
+the Quote advertises card. Card collection returns `payment_required` with the
+selected intent. Bank transfer is a distinct pay-later Commit path: after the
+Booking id exists, a configured payment port can atomically establish durable
+instructions and an invoice/proforma reference, which are persisted in and
+replayed from the Commit outcome. The contracts package owns the one versioned
+checkout-intent vocabulary used by Quote discovery, Commit, and outcome.
+
 Anonymous Sessions return a capability once at creation. Public update, Quote,
 Hold, Commit, and Commit replay calls must present that capability; staff
 adapters use the same module without a public capability token.

--- a/packages/catalog-contracts/src/booking-engine/lifecycle-conformance.ts
+++ b/packages/catalog-contracts/src/booking-engine/lifecycle-conformance.ts
@@ -1,6 +1,6 @@
 import { z } from "zod"
 import type { BookingRequirementsV1, PaxBandDependencyV1 } from "./requirements-contracts.js"
-import { bookingRequirementsV1 } from "./requirements-contracts.js"
+import { bookingCheckoutIntentV1, bookingRequirementsV1 } from "./requirements-contracts.js"
 import {
   requiredRequirementKeysV1,
   unsatisfiableRequiredRequirementsV1,
@@ -55,6 +55,28 @@ export const bookingPaymentCheckoutV1 = z.discriminatedUnion("kind", [
   bookingPaymentEmbeddedCheckoutV1,
 ])
 export type BookingPaymentCheckoutV1 = z.infer<typeof bookingPaymentCheckoutV1>
+
+/** Durable offline-payment material persisted with a successful Commit. */
+export const bookingSessionBankTransferV1 = z.object({
+  paymentSessionId: z.string().min(1).nullable(),
+  document: z
+    .object({
+      id: z.string().min(1),
+      number: z.string().min(1),
+      type: z.enum(["proforma", "invoice"]),
+    })
+    .nullable(),
+  instructions: z.object({
+    beneficiary: z.string().min(1),
+    iban: z.string().min(1),
+    bankName: z.string().min(1).nullable(),
+    reference: z.string().min(1),
+    amountCents: z.number().int().positive(),
+    currency: z.string().length(3),
+    dueAt: z.string().datetime(),
+  }),
+})
+export type BookingSessionBankTransferV1 = z.infer<typeof bookingSessionBankTransferV1>
 
 export const bookingCommitmentPolicyKindV1 = z.enum([
   "owned_atomic_commit",
@@ -301,6 +323,8 @@ const bookingLifecycleOriginalCommitOutcomeV1 = z.discriminatedUnion("kind", [
   z.object({
     kind: z.literal("committed"),
     nextAction: z.literal("none"),
+    checkoutIntent: bookingCheckoutIntentV1.optional(),
+    bankTransfer: bookingSessionBankTransferV1.optional(),
     booking: z.object({ id: z.string().min(1), status: bookingStatusAfterCommitV1 }),
     allocationIds: z.array(z.string().min(1)),
     consumedSessionId: z.string().min(1),
@@ -312,6 +336,8 @@ const bookingLifecycleOriginalCommitOutcomeV1 = z.discriminatedUnion("kind", [
   z.object({
     kind: z.literal("component_bookings_committed"),
     nextAction: z.literal("none"),
+    checkoutIntent: bookingCheckoutIntentV1.optional(),
+    bankTransfer: bookingSessionBankTransferV1.optional(),
     bookings: z
       .array(
         z.object({
@@ -347,6 +373,7 @@ const bookingLifecycleOriginalCommitOutcomeV1 = z.discriminatedUnion("kind", [
   z.object({
     kind: z.literal("payment_required"),
     nextAction: z.literal("establish_payment_guarantee"),
+    checkoutIntent: bookingCheckoutIntentV1.optional(),
     paymentTarget: z.enum(["booking_session", "quote", "supplier_operation"]),
     allowedGuarantees: z.array(z.enum(["deposit", "pre_auth", "card_on_file", "agency_letter"])),
     paymentSession: z.object({

--- a/packages/catalog-contracts/src/booking-engine/requirements-contracts.ts
+++ b/packages/catalog-contracts/src/booking-engine/requirements-contracts.ts
@@ -37,6 +37,20 @@
 
 import { z } from "zod"
 
+/**
+ * Versioned checkout choices shared by quote capability discovery, Commit,
+ * and Commit outcomes. A host selects one of the intents advertised by the
+ * active Quote; it never invents an integration-specific payment method.
+ */
+export const bookingCheckoutIntentV1 = z.enum([
+  "hold",
+  "card",
+  "bank_transfer",
+  "ticket_on_credit",
+  "inquiry",
+])
+export type BookingCheckoutIntentV1 = z.infer<typeof bookingCheckoutIntentV1>
+
 // ─────────────────────────────────────────────────────────────────
 // Sub-step descriptors
 // ─────────────────────────────────────────────────────────────────
@@ -353,6 +367,6 @@ export const bookingRequirementsV1 = z.object({
     .optional(),
 
   // ── Payment ───────────────────────────────────────────────────
-  paymentIntents: z.array(z.enum(["hold", "card", "bank_transfer", "ticket_on_credit", "inquiry"])),
+  paymentIntents: z.array(bookingCheckoutIntentV1),
 })
 export type BookingRequirementsV1 = z.infer<typeof bookingRequirementsV1>

--- a/packages/catalog-contracts/src/booking-engine/session-contracts.test.ts
+++ b/packages/catalog-contracts/src/booking-engine/session-contracts.test.ts
@@ -93,6 +93,18 @@ describe("Booking Session v1 contracts", () => {
     expect(parsed.payment?.acceptedCheckoutHandoffs).toEqual(["embedded", "redirect"])
   })
 
+  it("carries the shopper's selected checkout intent through Commit", () => {
+    const parsed = commitBookingSessionV1.parse({
+      expectedRevision: 1,
+      quoteId: "bsqu_1",
+      requirementsFingerprint: "requirements_fingerprint_1",
+      idempotencyKey: "stable_commit_key",
+      checkoutIntent: "bank_transfer",
+    })
+
+    expect(parsed.checkoutIntent).toBe("bank_transfer")
+  })
+
   it("leaves the preference absent when the storefront states nothing", () => {
     const parsed = commitBookingSessionV1.parse({
       expectedRevision: 1,
@@ -162,6 +174,36 @@ describe("Booking Session v1 contracts", () => {
       error: {
         kind: "quote_superseded",
         nextAction: "request_fresh_quote",
+      },
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it("represents durable bank-transfer instructions on a committed outcome", () => {
+    const result = bookingSessionOutcomeV1.safeParse({
+      kind: "commit_result",
+      outcome: {
+        kind: "committed",
+        nextAction: "none",
+        checkoutIntent: "bank_transfer",
+        bankTransfer: {
+          paymentSessionId: "pays_bank",
+          document: { id: "invc_proforma", number: "PRO-42", type: "proforma" },
+          instructions: {
+            beneficiary: "Voyant Travel",
+            iban: "RO49AAAA1B31007593840000",
+            bankName: "Voyant Bank",
+            reference: "BOOK-42",
+            amountCents: 10_000,
+            currency: "EUR",
+            dueAt: "2026-08-08T12:00:00.000Z",
+          },
+        },
+        booking: { id: "book_42", status: "confirmed" },
+        allocationIds: ["bkac_42"],
+        consumedSessionId: "bses_42",
+        consumedQuoteId: "bsqu_42",
       },
     })
 

--- a/packages/catalog-contracts/src/booking-engine/session-contracts.ts
+++ b/packages/catalog-contracts/src/booking-engine/session-contracts.ts
@@ -1,7 +1,7 @@
 import { z } from "zod"
 import { bookingLifecycleCommitOutcomeV1 } from "./lifecycle-conformance.js"
 import { pricingBreakdownV1 } from "./pricing-contracts.js"
-import { bookingRequirementsV1 } from "./requirements-contracts.js"
+import { bookingCheckoutIntentV1, bookingRequirementsV1 } from "./requirements-contracts.js"
 import { unsatisfiedRequirementV1 } from "./requirements-validation.js"
 
 export const bookingSessionActorKindV1 = z.enum(["anonymous", "customer", "staff", "partner"])
@@ -283,6 +283,12 @@ export const commitBookingSessionV1 = z.object({
   /** Required for owned inventory; sourced targets may commit without a Hold. */
   holdId: z.string().min(1).optional(),
   idempotencyKey: z.string().min(8).max(128),
+  /**
+   * Shopper-selected intent from the active Quote's `paymentIntents`.
+   * Optional for v1 compatibility; omission retains the historical card
+   * checkout behavior when the Quote advertises card.
+   */
+  checkoutIntent: bookingCheckoutIntentV1.optional(),
   payment: z
     .object({
       /**
@@ -415,6 +421,12 @@ export const bookingSessionLifecycleErrorV1 = z.discriminatedUnion("kind", [
     kind: z.literal("requirements_changed"),
     requirementsFingerprint: z.string().min(1),
     nextAction: z.literal("request_fresh_quote"),
+  }),
+  z.object({
+    kind: z.literal("checkout_intent_not_offered"),
+    checkoutIntent: bookingCheckoutIntentV1,
+    offeredCheckoutIntents: z.array(bookingCheckoutIntentV1),
+    nextAction: z.literal("select_supported_checkout_intent"),
   }),
   z.object({
     kind: z.literal("invalid_selection"),

--- a/packages/catalog/openapi/admin/catalog-booking.json
+++ b/packages/catalog/openapi/admin/catalog-booking.json
@@ -8683,6 +8683,81 @@
                         "type": "string",
                         "enum": ["none"]
                       },
+                      "checkoutIntent": {
+                        "type": "string",
+                        "enum": ["hold", "card", "bank_transfer", "ticket_on_credit", "inquiry"]
+                      },
+                      "bankTransfer": {
+                        "type": "object",
+                        "properties": {
+                          "paymentSessionId": {
+                            "type": ["string", "null"],
+                            "minLength": 1
+                          },
+                          "document": {
+                            "type": ["object", "null"],
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "number": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "type": {
+                                "type": "string",
+                                "enum": ["proforma", "invoice"]
+                              }
+                            },
+                            "required": ["id", "number", "type"]
+                          },
+                          "instructions": {
+                            "type": "object",
+                            "properties": {
+                              "beneficiary": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "iban": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "bankName": {
+                                "type": ["string", "null"],
+                                "minLength": 1
+                              },
+                              "reference": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "amountCents": {
+                                "type": "integer",
+                                "exclusiveMinimum": 0
+                              },
+                              "currency": {
+                                "type": "string",
+                                "minLength": 3,
+                                "maxLength": 3
+                              },
+                              "dueAt": {
+                                "type": "string",
+                                "format": "date-time"
+                              }
+                            },
+                            "required": [
+                              "beneficiary",
+                              "iban",
+                              "bankName",
+                              "reference",
+                              "amountCents",
+                              "currency",
+                              "dueAt"
+                            ]
+                          }
+                        },
+                        "required": ["paymentSessionId", "document", "instructions"]
+                      },
                       "booking": {
                         "type": "object",
                         "properties": {
@@ -8743,6 +8818,81 @@
                       "nextAction": {
                         "type": "string",
                         "enum": ["none"]
+                      },
+                      "checkoutIntent": {
+                        "type": "string",
+                        "enum": ["hold", "card", "bank_transfer", "ticket_on_credit", "inquiry"]
+                      },
+                      "bankTransfer": {
+                        "type": "object",
+                        "properties": {
+                          "paymentSessionId": {
+                            "type": ["string", "null"],
+                            "minLength": 1
+                          },
+                          "document": {
+                            "type": ["object", "null"],
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "number": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "type": {
+                                "type": "string",
+                                "enum": ["proforma", "invoice"]
+                              }
+                            },
+                            "required": ["id", "number", "type"]
+                          },
+                          "instructions": {
+                            "type": "object",
+                            "properties": {
+                              "beneficiary": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "iban": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "bankName": {
+                                "type": ["string", "null"],
+                                "minLength": 1
+                              },
+                              "reference": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "amountCents": {
+                                "type": "integer",
+                                "exclusiveMinimum": 0
+                              },
+                              "currency": {
+                                "type": "string",
+                                "minLength": 3,
+                                "maxLength": 3
+                              },
+                              "dueAt": {
+                                "type": "string",
+                                "format": "date-time"
+                              }
+                            },
+                            "required": [
+                              "beneficiary",
+                              "iban",
+                              "bankName",
+                              "reference",
+                              "amountCents",
+                              "currency",
+                              "dueAt"
+                            ]
+                          }
+                        },
+                        "required": ["paymentSessionId", "document", "instructions"]
                       },
                       "bookings": {
                         "type": "array",
@@ -8852,6 +9002,10 @@
                       "nextAction": {
                         "type": "string",
                         "enum": ["establish_payment_guarantee"]
+                      },
+                      "checkoutIntent": {
+                        "type": "string",
+                        "enum": ["hold", "card", "bank_transfer", "ticket_on_credit", "inquiry"]
                       },
                       "paymentTarget": {
                         "type": "string",
@@ -9160,6 +9314,87 @@
                                 "type": "string",
                                 "enum": ["none"]
                               },
+                              "checkoutIntent": {
+                                "type": "string",
+                                "enum": [
+                                  "hold",
+                                  "card",
+                                  "bank_transfer",
+                                  "ticket_on_credit",
+                                  "inquiry"
+                                ]
+                              },
+                              "bankTransfer": {
+                                "type": "object",
+                                "properties": {
+                                  "paymentSessionId": {
+                                    "type": ["string", "null"],
+                                    "minLength": 1
+                                  },
+                                  "document": {
+                                    "type": ["object", "null"],
+                                    "properties": {
+                                      "id": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      },
+                                      "number": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      },
+                                      "type": {
+                                        "type": "string",
+                                        "enum": ["proforma", "invoice"]
+                                      }
+                                    },
+                                    "required": ["id", "number", "type"]
+                                  },
+                                  "instructions": {
+                                    "type": "object",
+                                    "properties": {
+                                      "beneficiary": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      },
+                                      "iban": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      },
+                                      "bankName": {
+                                        "type": ["string", "null"],
+                                        "minLength": 1
+                                      },
+                                      "reference": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      },
+                                      "amountCents": {
+                                        "type": "integer",
+                                        "exclusiveMinimum": 0
+                                      },
+                                      "currency": {
+                                        "type": "string",
+                                        "minLength": 3,
+                                        "maxLength": 3
+                                      },
+                                      "dueAt": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                      }
+                                    },
+                                    "required": [
+                                      "beneficiary",
+                                      "iban",
+                                      "bankName",
+                                      "reference",
+                                      "amountCents",
+                                      "currency",
+                                      "dueAt"
+                                    ]
+                                  }
+                                },
+                                "required": ["paymentSessionId", "document", "instructions"]
+                              },
                               "booking": {
                                 "type": "object",
                                 "properties": {
@@ -9220,6 +9455,87 @@
                               "nextAction": {
                                 "type": "string",
                                 "enum": ["none"]
+                              },
+                              "checkoutIntent": {
+                                "type": "string",
+                                "enum": [
+                                  "hold",
+                                  "card",
+                                  "bank_transfer",
+                                  "ticket_on_credit",
+                                  "inquiry"
+                                ]
+                              },
+                              "bankTransfer": {
+                                "type": "object",
+                                "properties": {
+                                  "paymentSessionId": {
+                                    "type": ["string", "null"],
+                                    "minLength": 1
+                                  },
+                                  "document": {
+                                    "type": ["object", "null"],
+                                    "properties": {
+                                      "id": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      },
+                                      "number": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      },
+                                      "type": {
+                                        "type": "string",
+                                        "enum": ["proforma", "invoice"]
+                                      }
+                                    },
+                                    "required": ["id", "number", "type"]
+                                  },
+                                  "instructions": {
+                                    "type": "object",
+                                    "properties": {
+                                      "beneficiary": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      },
+                                      "iban": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      },
+                                      "bankName": {
+                                        "type": ["string", "null"],
+                                        "minLength": 1
+                                      },
+                                      "reference": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      },
+                                      "amountCents": {
+                                        "type": "integer",
+                                        "exclusiveMinimum": 0
+                                      },
+                                      "currency": {
+                                        "type": "string",
+                                        "minLength": 3,
+                                        "maxLength": 3
+                                      },
+                                      "dueAt": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                      }
+                                    },
+                                    "required": [
+                                      "beneficiary",
+                                      "iban",
+                                      "bankName",
+                                      "reference",
+                                      "amountCents",
+                                      "currency",
+                                      "dueAt"
+                                    ]
+                                  }
+                                },
+                                "required": ["paymentSessionId", "document", "instructions"]
                               },
                               "bookings": {
                                 "type": "array",
@@ -9334,6 +9650,16 @@
                               "nextAction": {
                                 "type": "string",
                                 "enum": ["establish_payment_guarantee"]
+                              },
+                              "checkoutIntent": {
+                                "type": "string",
+                                "enum": [
+                                  "hold",
+                                  "card",
+                                  "bank_transfer",
+                                  "ticket_on_credit",
+                                  "inquiry"
+                                ]
                               },
                               "paymentTarget": {
                                 "type": "string",
@@ -10653,6 +10979,31 @@
                       }
                     },
                     "required": ["kind", "requirementsFingerprint", "nextAction"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": ["checkout_intent_not_offered"]
+                      },
+                      "checkoutIntent": {
+                        "type": "string",
+                        "enum": ["hold", "card", "bank_transfer", "ticket_on_credit", "inquiry"]
+                      },
+                      "offeredCheckoutIntents": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "enum": ["hold", "card", "bank_transfer", "ticket_on_credit", "inquiry"]
+                        }
+                      },
+                      "nextAction": {
+                        "type": "string",
+                        "enum": ["select_supported_checkout_intent"]
+                      }
+                    },
+                    "required": ["kind", "checkoutIntent", "offeredCheckoutIntents", "nextAction"]
                   },
                   {
                     "type": "object",
@@ -12740,6 +13091,31 @@
                     "properties": {
                       "kind": {
                         "type": "string",
+                        "enum": ["checkout_intent_not_offered"]
+                      },
+                      "checkoutIntent": {
+                        "type": "string",
+                        "enum": ["hold", "card", "bank_transfer", "ticket_on_credit", "inquiry"]
+                      },
+                      "offeredCheckoutIntents": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "enum": ["hold", "card", "bank_transfer", "ticket_on_credit", "inquiry"]
+                        }
+                      },
+                      "nextAction": {
+                        "type": "string",
+                        "enum": ["select_supported_checkout_intent"]
+                      }
+                    },
+                    "required": ["kind", "checkoutIntent", "offeredCheckoutIntents", "nextAction"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
                         "enum": ["invalid_selection"]
                       },
                       "reason": {
@@ -13792,6 +14168,10 @@
                     "type": "string",
                     "minLength": 8,
                     "maxLength": 128
+                  },
+                  "checkoutIntent": {
+                    "type": "string",
+                    "enum": ["hold", "card", "bank_transfer", "ticket_on_credit", "inquiry"]
                   },
                   "payment": {
                     "type": "object",

--- a/packages/catalog/openapi/storefront/catalog-booking.json
+++ b/packages/catalog/openapi/storefront/catalog-booking.json
@@ -8683,6 +8683,81 @@
                         "type": "string",
                         "enum": ["none"]
                       },
+                      "checkoutIntent": {
+                        "type": "string",
+                        "enum": ["hold", "card", "bank_transfer", "ticket_on_credit", "inquiry"]
+                      },
+                      "bankTransfer": {
+                        "type": "object",
+                        "properties": {
+                          "paymentSessionId": {
+                            "type": ["string", "null"],
+                            "minLength": 1
+                          },
+                          "document": {
+                            "type": ["object", "null"],
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "number": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "type": {
+                                "type": "string",
+                                "enum": ["proforma", "invoice"]
+                              }
+                            },
+                            "required": ["id", "number", "type"]
+                          },
+                          "instructions": {
+                            "type": "object",
+                            "properties": {
+                              "beneficiary": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "iban": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "bankName": {
+                                "type": ["string", "null"],
+                                "minLength": 1
+                              },
+                              "reference": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "amountCents": {
+                                "type": "integer",
+                                "exclusiveMinimum": 0
+                              },
+                              "currency": {
+                                "type": "string",
+                                "minLength": 3,
+                                "maxLength": 3
+                              },
+                              "dueAt": {
+                                "type": "string",
+                                "format": "date-time"
+                              }
+                            },
+                            "required": [
+                              "beneficiary",
+                              "iban",
+                              "bankName",
+                              "reference",
+                              "amountCents",
+                              "currency",
+                              "dueAt"
+                            ]
+                          }
+                        },
+                        "required": ["paymentSessionId", "document", "instructions"]
+                      },
                       "booking": {
                         "type": "object",
                         "properties": {
@@ -8743,6 +8818,81 @@
                       "nextAction": {
                         "type": "string",
                         "enum": ["none"]
+                      },
+                      "checkoutIntent": {
+                        "type": "string",
+                        "enum": ["hold", "card", "bank_transfer", "ticket_on_credit", "inquiry"]
+                      },
+                      "bankTransfer": {
+                        "type": "object",
+                        "properties": {
+                          "paymentSessionId": {
+                            "type": ["string", "null"],
+                            "minLength": 1
+                          },
+                          "document": {
+                            "type": ["object", "null"],
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "number": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "type": {
+                                "type": "string",
+                                "enum": ["proforma", "invoice"]
+                              }
+                            },
+                            "required": ["id", "number", "type"]
+                          },
+                          "instructions": {
+                            "type": "object",
+                            "properties": {
+                              "beneficiary": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "iban": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "bankName": {
+                                "type": ["string", "null"],
+                                "minLength": 1
+                              },
+                              "reference": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "amountCents": {
+                                "type": "integer",
+                                "exclusiveMinimum": 0
+                              },
+                              "currency": {
+                                "type": "string",
+                                "minLength": 3,
+                                "maxLength": 3
+                              },
+                              "dueAt": {
+                                "type": "string",
+                                "format": "date-time"
+                              }
+                            },
+                            "required": [
+                              "beneficiary",
+                              "iban",
+                              "bankName",
+                              "reference",
+                              "amountCents",
+                              "currency",
+                              "dueAt"
+                            ]
+                          }
+                        },
+                        "required": ["paymentSessionId", "document", "instructions"]
                       },
                       "bookings": {
                         "type": "array",
@@ -8852,6 +9002,10 @@
                       "nextAction": {
                         "type": "string",
                         "enum": ["establish_payment_guarantee"]
+                      },
+                      "checkoutIntent": {
+                        "type": "string",
+                        "enum": ["hold", "card", "bank_transfer", "ticket_on_credit", "inquiry"]
                       },
                       "paymentTarget": {
                         "type": "string",
@@ -9160,6 +9314,87 @@
                                 "type": "string",
                                 "enum": ["none"]
                               },
+                              "checkoutIntent": {
+                                "type": "string",
+                                "enum": [
+                                  "hold",
+                                  "card",
+                                  "bank_transfer",
+                                  "ticket_on_credit",
+                                  "inquiry"
+                                ]
+                              },
+                              "bankTransfer": {
+                                "type": "object",
+                                "properties": {
+                                  "paymentSessionId": {
+                                    "type": ["string", "null"],
+                                    "minLength": 1
+                                  },
+                                  "document": {
+                                    "type": ["object", "null"],
+                                    "properties": {
+                                      "id": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      },
+                                      "number": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      },
+                                      "type": {
+                                        "type": "string",
+                                        "enum": ["proforma", "invoice"]
+                                      }
+                                    },
+                                    "required": ["id", "number", "type"]
+                                  },
+                                  "instructions": {
+                                    "type": "object",
+                                    "properties": {
+                                      "beneficiary": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      },
+                                      "iban": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      },
+                                      "bankName": {
+                                        "type": ["string", "null"],
+                                        "minLength": 1
+                                      },
+                                      "reference": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      },
+                                      "amountCents": {
+                                        "type": "integer",
+                                        "exclusiveMinimum": 0
+                                      },
+                                      "currency": {
+                                        "type": "string",
+                                        "minLength": 3,
+                                        "maxLength": 3
+                                      },
+                                      "dueAt": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                      }
+                                    },
+                                    "required": [
+                                      "beneficiary",
+                                      "iban",
+                                      "bankName",
+                                      "reference",
+                                      "amountCents",
+                                      "currency",
+                                      "dueAt"
+                                    ]
+                                  }
+                                },
+                                "required": ["paymentSessionId", "document", "instructions"]
+                              },
                               "booking": {
                                 "type": "object",
                                 "properties": {
@@ -9220,6 +9455,87 @@
                               "nextAction": {
                                 "type": "string",
                                 "enum": ["none"]
+                              },
+                              "checkoutIntent": {
+                                "type": "string",
+                                "enum": [
+                                  "hold",
+                                  "card",
+                                  "bank_transfer",
+                                  "ticket_on_credit",
+                                  "inquiry"
+                                ]
+                              },
+                              "bankTransfer": {
+                                "type": "object",
+                                "properties": {
+                                  "paymentSessionId": {
+                                    "type": ["string", "null"],
+                                    "minLength": 1
+                                  },
+                                  "document": {
+                                    "type": ["object", "null"],
+                                    "properties": {
+                                      "id": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      },
+                                      "number": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      },
+                                      "type": {
+                                        "type": "string",
+                                        "enum": ["proforma", "invoice"]
+                                      }
+                                    },
+                                    "required": ["id", "number", "type"]
+                                  },
+                                  "instructions": {
+                                    "type": "object",
+                                    "properties": {
+                                      "beneficiary": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      },
+                                      "iban": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      },
+                                      "bankName": {
+                                        "type": ["string", "null"],
+                                        "minLength": 1
+                                      },
+                                      "reference": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      },
+                                      "amountCents": {
+                                        "type": "integer",
+                                        "exclusiveMinimum": 0
+                                      },
+                                      "currency": {
+                                        "type": "string",
+                                        "minLength": 3,
+                                        "maxLength": 3
+                                      },
+                                      "dueAt": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                      }
+                                    },
+                                    "required": [
+                                      "beneficiary",
+                                      "iban",
+                                      "bankName",
+                                      "reference",
+                                      "amountCents",
+                                      "currency",
+                                      "dueAt"
+                                    ]
+                                  }
+                                },
+                                "required": ["paymentSessionId", "document", "instructions"]
                               },
                               "bookings": {
                                 "type": "array",
@@ -9334,6 +9650,16 @@
                               "nextAction": {
                                 "type": "string",
                                 "enum": ["establish_payment_guarantee"]
+                              },
+                              "checkoutIntent": {
+                                "type": "string",
+                                "enum": [
+                                  "hold",
+                                  "card",
+                                  "bank_transfer",
+                                  "ticket_on_credit",
+                                  "inquiry"
+                                ]
                               },
                               "paymentTarget": {
                                 "type": "string",
@@ -10653,6 +10979,31 @@
                       }
                     },
                     "required": ["kind", "requirementsFingerprint", "nextAction"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": ["checkout_intent_not_offered"]
+                      },
+                      "checkoutIntent": {
+                        "type": "string",
+                        "enum": ["hold", "card", "bank_transfer", "ticket_on_credit", "inquiry"]
+                      },
+                      "offeredCheckoutIntents": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "enum": ["hold", "card", "bank_transfer", "ticket_on_credit", "inquiry"]
+                        }
+                      },
+                      "nextAction": {
+                        "type": "string",
+                        "enum": ["select_supported_checkout_intent"]
+                      }
+                    },
+                    "required": ["kind", "checkoutIntent", "offeredCheckoutIntents", "nextAction"]
                   },
                   {
                     "type": "object",
@@ -12740,6 +13091,31 @@
                     "properties": {
                       "kind": {
                         "type": "string",
+                        "enum": ["checkout_intent_not_offered"]
+                      },
+                      "checkoutIntent": {
+                        "type": "string",
+                        "enum": ["hold", "card", "bank_transfer", "ticket_on_credit", "inquiry"]
+                      },
+                      "offeredCheckoutIntents": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "enum": ["hold", "card", "bank_transfer", "ticket_on_credit", "inquiry"]
+                        }
+                      },
+                      "nextAction": {
+                        "type": "string",
+                        "enum": ["select_supported_checkout_intent"]
+                      }
+                    },
+                    "required": ["kind", "checkoutIntent", "offeredCheckoutIntents", "nextAction"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
                         "enum": ["invalid_selection"]
                       },
                       "reason": {
@@ -13792,6 +14168,10 @@
                     "type": "string",
                     "minLength": 8,
                     "maxLength": 128
+                  },
+                  "checkoutIntent": {
+                    "type": "string",
+                    "enum": ["hold", "card", "bank_transfer", "ticket_on_credit", "inquiry"]
                   },
                   "payment": {
                     "type": "object",

--- a/packages/catalog/src/booking-engine/sessions-payment-production.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-payment-production.test.ts
@@ -78,6 +78,46 @@ describe("production Booking Session staff payment policy", () => {
   })
 })
 
+describe("production Booking Session bank-transfer intent", () => {
+  it("does not start card collection and delegates durable offline establishment", async () => {
+    const loadProductPaymentPolicyContext = vi.fn()
+    const establishBankTransfer = vi.fn(async () => ({
+      paymentSessionId: "pays_bank",
+      document: { id: "invc_proforma", number: "PRO-42", type: "proforma" as const },
+      instructions: {
+        beneficiary: "Voyant Travel",
+        iban: "RO49AAAA1B31007593840000",
+        bankName: "Voyant Bank",
+        reference: "BOOK-42",
+        amountCents: 10_000,
+        currency: "EUR",
+        dueAt: "2026-08-08T12:00:00.000Z",
+      },
+    }))
+    const payments = createProductionBookingSessionPaymentPorts({
+      db: {} as never,
+      inventory: { loadProductPaymentPolicyContext },
+      distribution: { loadSupplierPaymentPolicy: vi.fn() },
+      settings: { resolveOperatorDefaultPaymentPolicy: vi.fn() },
+      establishBankTransfer,
+    })
+
+    await expect(
+      payments.prepare({
+        session: { target: { kind: "product", productId: "prod_1" }, statePayload: {} },
+        commit: { checkoutIntent: "bank_transfer" },
+        access: { actorKind: "anonymous" },
+      } as never),
+    ).resolves.toEqual({ kind: "not_required" })
+    await expect(
+      payments.establishBankTransfer?.({ bookingId: "book_42" } as never),
+    ).resolves.toMatchObject({ document: { id: "invc_proforma" } })
+    expect(loadProductPaymentPolicyContext).not.toHaveBeenCalled()
+    expect(startPaymentAdapterCardPayment).not.toHaveBeenCalled()
+    expect(establishBankTransfer).toHaveBeenCalledWith({ bookingId: "book_42" })
+  })
+})
+
 /**
  * A hosted-checkout provider renders the initiation payload to the shopper, so
  * what is in it has to mean something to them. Nothing downstream can repair a

--- a/packages/catalog/src/booking-engine/sessions-payment-production.ts
+++ b/packages/catalog/src/booking-engine/sessions-payment-production.ts
@@ -29,6 +29,8 @@ export interface ProductionBookingSessionPaymentDeps {
   resolvePaymentAdapter?: () => PaymentAdapter | null | Promise<PaymentAdapter | null>
   paymentAdapterContext?: PaymentAdapterRuntimeContext
   financeRuntime?: Parameters<typeof createOrReuseBookingSessionPayment>[2]
+  /** Host-owned bank-transfer document/instruction orchestration. */
+  establishBankTransfer?: BookingSessionPaymentPorts["establishBankTransfer"]
 }
 
 export function createProductionBookingSessionPaymentPorts(
@@ -48,6 +50,10 @@ export function createProductionBookingSessionPaymentPorts(
       ) {
         return { kind: "not_required" }
       }
+      // Bank transfer is a pay-later Commit path. Its durable document and
+      // instructions are established once the Booking id exists, inside the
+      // same Commit transaction, by `establishBankTransfer` below.
+      if (commit.checkoutIntent === "bank_transfer") return { kind: "not_required" }
 
       const context = await deps.inventory.loadProductPaymentPolicyContext(
         deps.db,
@@ -200,6 +206,9 @@ export function createProductionBookingSessionPaymentPorts(
     },
     async expirePending({ tx, bookingSessionId, at }) {
       await expirePendingBookingSessionPayments(tx as PostgresJsDatabase, bookingSessionId, at)
+    },
+    async establishBankTransfer(input) {
+      return (await deps.establishBankTransfer?.(input)) ?? null
     },
   }
 }

--- a/packages/catalog/src/booking-engine/sessions-service.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-service.test.ts
@@ -149,6 +149,7 @@ describe("Booking Session v1 owned tracer", () => {
       requirementsFingerprint: quote.requirementsFingerprint,
       holdId: hold.id,
       idempotencyKey: "commit_payment_required",
+      checkoutIntent: "card" as const,
     }
 
     const first = await harness.module.commitSession(session.id, input, ANONYMOUS_ACCESS)
@@ -158,6 +159,7 @@ describe("Booking Session v1 owned tracer", () => {
       kind: "commit_result",
       outcome: {
         kind: "payment_required",
+        checkoutIntent: "card",
         paymentTarget: "booking_session",
         paymentSession: { id: "payment_session_1", status: "requires_redirect" },
       },
@@ -169,6 +171,97 @@ describe("Booking Session v1 owned tracer", () => {
     expect(harness.repository.sessions.get(session.id)?.state).toBe("active")
     expect(harness.repository.quotes.get(quote.id)?.state).toBe("active")
     expect(harness.repository.holds.get(hold.id)?.state).toBe("active")
+  })
+
+  it("rejects an intent the active Quote did not offer before payment or booking side effects", async () => {
+    const payment = createPaymentHarness()
+    const requirements = { ...inMemoryBookingRequirements(), paymentIntents: ["card" as const] }
+    const harness = createHarness({}, payment.ports, undefined, requirements)
+    const { session, quote, hold } = await createQuoteAndHold(harness)
+
+    const outcome = await harness.module.commitSession(
+      session.id,
+      {
+        expectedRevision: session.revision,
+        quoteId: quote.id,
+        requirementsFingerprint: quote.requirementsFingerprint,
+        holdId: hold.id,
+        idempotencyKey: "commit_unsupported_intent",
+        checkoutIntent: "bank_transfer",
+      },
+      ANONYMOUS_ACCESS,
+    )
+
+    expect(outcome).toEqual({
+      kind: "rejected",
+      error: {
+        kind: "checkout_intent_not_offered",
+        checkoutIntent: "bank_transfer",
+        offeredCheckoutIntents: ["card"],
+        nextAction: "select_supported_checkout_intent",
+      },
+    })
+    expect(payment.prepareCalls).toBe(0)
+    expect(harness.inventory.bookingIds).toEqual([])
+    expect(harness.repository.commits.size).toBe(0)
+    expect(harness.repository.sessions.get(session.id)?.state).toBe("active")
+    expect(harness.repository.holds.get(hold.id)?.state).toBe("active")
+  })
+
+  it("commits bank transfer with durable instructions and conflicts on a changed intent", async () => {
+    const payment = createBankTransferHarness()
+    const harness = createHarness({}, payment.ports)
+    const { session, quote, hold } = await createQuoteAndHold(harness)
+    const input = {
+      expectedRevision: session.revision,
+      quoteId: quote.id,
+      requirementsFingerprint: quote.requirementsFingerprint,
+      holdId: hold.id,
+      idempotencyKey: "commit_bank_transfer",
+      checkoutIntent: "bank_transfer" as const,
+    }
+
+    const first = await harness.module.commitSession(session.id, input, ANONYMOUS_ACCESS)
+    const retry = await harness.module.commitSession(session.id, input, ANONYMOUS_ACCESS)
+    const conflict = await harness.module.commitSession(
+      session.id,
+      { ...input, checkoutIntent: "card" },
+      ANONYMOUS_ACCESS,
+    )
+
+    expect(first).toMatchObject({
+      kind: "commit_result",
+      outcome: {
+        kind: "committed",
+        checkoutIntent: "bank_transfer",
+        bankTransfer: {
+          paymentSessionId: "pays_bank_transfer",
+          document: { id: "invc_proforma", number: "PRO-42", type: "proforma" },
+          instructions: {
+            beneficiary: "Voyant Travel",
+            iban: "RO49AAAA1B31007593840000",
+            reference: "BOOK-42",
+            amountCents: 10_000,
+            currency: "EUR",
+          },
+        },
+      },
+    })
+    expect(retry).toMatchObject({
+      kind: "commit_result",
+      outcome: {
+        kind: "idempotent_replay",
+        originalOutcome: {
+          kind: "committed",
+          checkoutIntent: "bank_transfer",
+          bankTransfer: { document: { id: "invc_proforma" } },
+        },
+      },
+    })
+    expect(conflict).toEqual({ kind: "rejected", error: { kind: "idempotency_conflict" } })
+    expect(payment.prepareCalls).toBe(1)
+    expect(payment.establishCalls).toBe(1)
+    expect(harness.inventory.bookingIds).toHaveLength(1)
   })
 
   it("transfers an established Session payment in the atomic Commit transaction", async () => {
@@ -1890,6 +1983,40 @@ function createPaymentHarness() {
     async expirePending(input) {
       expirations.push(input)
     },
+  }
+  return harness
+}
+
+function createBankTransferHarness() {
+  const harness = {
+    prepareCalls: 0,
+    establishCalls: 0,
+    ports: undefined as unknown as BookingSessionPaymentPorts,
+  }
+  harness.ports = {
+    async prepare({ commit }) {
+      harness.prepareCalls += 1
+      expect(commit.checkoutIntent).toBe("bank_transfer")
+      return { kind: "not_required" }
+    },
+    async establishBankTransfer() {
+      harness.establishCalls += 1
+      return {
+        paymentSessionId: "pays_bank_transfer",
+        document: { id: "invc_proforma", number: "PRO-42", type: "proforma" as const },
+        instructions: {
+          beneficiary: "Voyant Travel",
+          iban: "RO49AAAA1B31007593840000",
+          bankName: "Voyant Bank",
+          reference: "BOOK-42",
+          amountCents: 10_000,
+          currency: "EUR",
+          dueAt: "2026-08-08T12:00:00.000Z",
+        },
+      }
+    },
+    async transferToBooking() {},
+    async expirePending() {},
   }
   return harness
 }

--- a/packages/catalog/src/booking-engine/sessions-service.ts
+++ b/packages/catalog/src/booking-engine/sessions-service.ts
@@ -31,8 +31,10 @@ import { createSafeAnalytics } from "@voyant-travel/core/analytics"
 import { newId } from "@voyant-travel/db/lib/typeid"
 import { withBookingSessionAnalytics } from "./analytics.js"
 import type {
+  BookingCheckoutIntentV1,
   BookingLifecycleCommitOutcomeV1,
   BookingRequirementsV1,
+  BookingSessionBankTransferV1,
   PricingBreakdownV1,
   UnsatisfiedRequirementV1,
 } from "./contracts.js"
@@ -444,6 +446,19 @@ export interface BookingSessionPaymentPorts {
         allowedGuarantees: Array<"deposit" | "pre_auth" | "card_on_file" | "agency_letter">
       }
   >
+  /**
+   * Establish the durable offline-payment record after the Booking id exists
+   * but before the surrounding Commit transaction is consumed.
+   */
+  establishBankTransfer?(input: {
+    tx: unknown
+    session: BookingSessionInternalRecord
+    quote: BookingQuoteInternalRecord
+    commit: CommitBookingSessionV1
+    access: BookingSessionAccessContext
+    bookingId: string
+    now: Date
+  }): Promise<BookingSessionBankTransferV1 | null>
   transferToBooking(input: {
     tx: unknown
     paymentSessionId: string
@@ -1329,6 +1344,22 @@ export function createBookingSessionModule(
           }
         }
 
+        const checkoutIntent: BookingCheckoutIntentV1 = input.checkoutIntent ?? "card"
+        if (!quote.requirements.paymentIntents.includes(checkoutIntent)) {
+          return {
+            status: "outcome" as const,
+            outcome: {
+              kind: "rejected",
+              error: {
+                kind: "checkout_intent_not_offered",
+                checkoutIntent,
+                offeredCheckoutIntents: quote.requirements.paymentIntents,
+                nextAction: "select_supported_checkout_intent",
+              },
+            } as const,
+          }
+        }
+
         const hold = input.holdId
           ? durableContinuation
             ? await loadPersistedSourcedHold(repository, input.holdId, session, quote)
@@ -1353,7 +1384,7 @@ export function createBookingSessionModule(
         }
 
         if (durableContinuation) {
-          return { status: "ready" as const, session, quote, hold, at }
+          return { status: "ready" as const, session, quote, hold, at, checkoutIntent }
         }
 
         const freshQuote = await options.ports.composeQuote({ session, now: at, tx })
@@ -1413,11 +1444,12 @@ export function createBookingSessionModule(
           await releaseLiveHolds(repository, options.ports, session, access, at, tx)
           return { status: "outcome" as const, outcome: selectionIncomplete(unsatisfied) }
         }
-        return { status: "ready" as const, session, quote, hold, at }
+        return { status: "ready" as const, session, quote, hold, at, checkoutIntent }
       })
       if (preflight.status === "outcome") return preflight.outcome
 
-      const { session, quote, hold, at } = preflight
+      const { session, quote, hold, at, checkoutIntent } = preflight
+      const commitInput: CommitBookingSessionV1 = { ...input, checkoutIntent }
 
       let preparedPayment: Awaited<ReturnType<BookingSessionPaymentPorts["prepare"]>>
       try {
@@ -1426,7 +1458,7 @@ export function createBookingSessionModule(
               session,
               quote,
               ...(hold ? { hold } : {}),
-              commit: input,
+              commit: commitInput,
               access,
               now: at,
             })
@@ -1440,6 +1472,7 @@ export function createBookingSessionModule(
           kind: "commit_result",
           outcome: {
             kind: "payment_required",
+            checkoutIntent,
             nextAction: "establish_payment_guarantee",
             paymentTarget: "booking_session",
             allowedGuarantees: preparedPayment.allowedGuarantees,
@@ -1450,7 +1483,7 @@ export function createBookingSessionModule(
       const paymentSessionId =
         preparedPayment.kind === "established" ? preparedPayment.paymentSessionId : undefined
 
-      const requestFingerprint = await commitRequestFingerprint(input)
+      const requestFingerprint = await commitRequestFingerprint(commitInput)
       let committed: {
         bookingId: string
         allocationIds: string[]
@@ -1475,7 +1508,7 @@ export function createBookingSessionModule(
                 hold,
                 access,
                 paymentSessionId,
-                input,
+                input: commitInput,
                 requestFingerprint,
                 bookings,
                 tx,
@@ -1500,11 +1533,19 @@ export function createBookingSessionModule(
           if (compositeResult.bookings.length === 0) {
             throw new BookingSessionCommitRejectedError("entity_not_bookable")
           }
+          const persistedCommit = await repository.getCommitByIdempotency(
+            session.id,
+            commitInput.idempotencyKey,
+          )
+          if (persistedCommit) {
+            return { kind: "commit_result", outcome: persistedCommit.outcome }
+          }
           return {
             kind: "commit_result",
             outcome: {
               kind: "component_bookings_committed",
               nextAction: "none",
+              checkoutIntent,
               bookings: compositeResult.bookings.map((booking) => ({
                 componentId: booking.componentId,
                 bookingId: booking.bookingId,
@@ -1538,7 +1579,7 @@ export function createBookingSessionModule(
                 hold,
                 access,
                 paymentSessionId,
-                input,
+                input: commitInput,
                 requestFingerprint,
                 bookingId,
                 allocationIds,
@@ -1575,7 +1616,7 @@ export function createBookingSessionModule(
                 hold,
                 access,
                 paymentSessionId,
-                input,
+                input: commitInput,
                 requestFingerprint,
                 bookingId,
                 allocationIds,
@@ -1673,6 +1714,7 @@ export function createBookingSessionModule(
       const outcome: BookingLifecycleCommitOutcomeV1 = {
         kind: "committed",
         nextAction: "none",
+        checkoutIntent,
         booking: { id: committed.bookingId, status: "confirmed" },
         allocationIds: committed.allocationIds,
         consumedSessionId: session.id,
@@ -1682,7 +1724,11 @@ export function createBookingSessionModule(
           ? { supplierOperationId: committed.supplierOperationId }
           : {}),
       }
-      return { kind: "commit_result", outcome }
+      const persistedCommit = await repository.getCommitByIdempotency(
+        session.id,
+        commitInput.idempotencyKey,
+      )
+      return { kind: "commit_result", outcome: persistedCommit?.outcome ?? outcome }
     },
 
     async commitPaidSession({ bookingSessionId, paymentSessionId }) {
@@ -1821,16 +1867,6 @@ async function consumeCommittedSources(input: {
   tx: unknown
   now: () => Date
 }): Promise<void> {
-  const outcome: BookingLifecycleCommitOutcomeV1 = {
-    kind: "committed",
-    nextAction: "none",
-    booking: { id: input.bookingId, status: "confirmed" },
-    allocationIds: input.allocationIds,
-    consumedSessionId: input.session.id,
-    consumedQuoteId: input.quote.id,
-    ...(input.hold ? { convertedHoldId: input.hold.id } : {}),
-    ...(input.supplierOperationId ? { supplierOperationId: input.supplierOperationId } : {}),
-  }
   await input.repository.withTransactionContext(input.tx, async () => {
     const currentAt = input.now()
     const currentSession = await input.repository.getSession(input.session.id)
@@ -1918,6 +1954,30 @@ async function consumeCommittedSources(input: {
         })
       }
     }
+    const bankTransfer =
+      input.input.checkoutIntent === "bank_transfer"
+        ? await input.ports.payments?.establishBankTransfer?.({
+            tx: input.tx,
+            session: currentSession,
+            quote: currentQuote,
+            commit: input.input,
+            access: input.access,
+            bookingId: input.bookingId,
+            now: currentAt,
+          })
+        : undefined
+    const outcome: BookingLifecycleCommitOutcomeV1 = {
+      kind: "committed",
+      nextAction: "none",
+      checkoutIntent: input.input.checkoutIntent,
+      ...(bankTransfer ? { bankTransfer } : {}),
+      booking: { id: input.bookingId, status: "confirmed" },
+      allocationIds: input.allocationIds,
+      consumedSessionId: input.session.id,
+      consumedQuoteId: input.quote.id,
+      ...(input.hold ? { convertedHoldId: input.hold.id } : {}),
+      ...(input.supplierOperationId ? { supplierOperationId: input.supplierOperationId } : {}),
+    }
     await input.repository.consumeCommit({
       sessionId: currentSession.id,
       quoteId: currentQuote.id,
@@ -1984,20 +2044,6 @@ async function consumeCompositeCommittedSources(input: {
 }): Promise<void> {
   const primary = input.bookings[0]
   if (!primary) throw new BookingSessionCommitRejectedError("entity_not_bookable")
-  const outcome: BookingLifecycleCommitOutcomeV1 = {
-    kind: "component_bookings_committed",
-    nextAction: "none",
-    bookings: input.bookings.map((booking) => ({
-      componentId: booking.componentId,
-      bookingId: booking.bookingId,
-      status: "confirmed",
-      allocationIds: booking.allocationIds,
-      ...(booking.supplierOperationId ? { supplierOperationId: booking.supplierOperationId } : {}),
-    })),
-    consumedSessionId: input.session.id,
-    consumedQuoteId: input.quote.id,
-    ...(input.hold ? { convertedHoldId: input.hold.id } : {}),
-  }
   await input.repository.withTransactionContext(input.tx, async () => {
     const currentAt = input.now()
     const currentSession = await input.repository.getSession(input.session.id)
@@ -2048,6 +2094,36 @@ async function consumeCompositeCommittedSources(input: {
         nextAction: "request_new_hold",
         reason: currentHold === "expired" ? "expired" : "missing",
       })
+    }
+    const bankTransfer =
+      input.input.checkoutIntent === "bank_transfer"
+        ? await input.ports.payments?.establishBankTransfer?.({
+            tx: input.tx,
+            session: currentSession,
+            quote: currentQuote,
+            commit: input.input,
+            access: input.access,
+            bookingId: primary.bookingId,
+            now: currentAt,
+          })
+        : undefined
+    const outcome: BookingLifecycleCommitOutcomeV1 = {
+      kind: "component_bookings_committed",
+      nextAction: "none",
+      checkoutIntent: input.input.checkoutIntent,
+      ...(bankTransfer ? { bankTransfer } : {}),
+      bookings: input.bookings.map((booking) => ({
+        componentId: booking.componentId,
+        bookingId: booking.bookingId,
+        status: "confirmed",
+        allocationIds: booking.allocationIds,
+        ...(booking.supplierOperationId
+          ? { supplierOperationId: booking.supplierOperationId }
+          : {}),
+      })),
+      consumedSessionId: input.session.id,
+      consumedQuoteId: input.quote.id,
+      ...(input.hold ? { convertedHoldId: input.hold.id } : {}),
     }
     await input.repository.consumeCommit({
       sessionId: currentSession.id,
@@ -2259,6 +2335,10 @@ async function commitRequestFingerprint(input: CommitBookingSessionV1): Promise<
     // Part of what the request asked for: replaying an idempotency key against
     // a different descriptor is a different Commit, not a replay of the first.
     requirementsFingerprint: input.requirementsFingerprint,
+    // Omission is the v1 compatibility spelling of card. Fingerprint the
+    // resolved meaning so omitted and explicit card replay, while a different
+    // shopper choice conflicts before any payment or booking side effect.
+    checkoutIntent: input.checkoutIntent ?? "card",
   })
 }
 

--- a/packages/core/src/analytics-events.ts
+++ b/packages/core/src/analytics-events.ts
@@ -117,6 +117,7 @@ export const ANALYTICS_FAILURE_REASONS = [
   "supplier_operation_active",
   "selection_incomplete",
   "requirements_changed",
+  "checkout_intent_not_offered",
   "quote_required",
   "quote_expired",
   "quote_superseded",


### PR DESCRIPTION
Closes #4393.

## What changed

- define one versioned checkout-intent vocabulary shared by quote requirements, Commit input, and Commit outcomes
- validate the selected intent against the active Quote before payment or booking side effects
- include the resolved intent in Commit idempotency fingerprints and authoritative card/bank-transfer outcomes
- add a host-owned transactional bank-transfer hook whose durable instructions and invoice/proforma reference are persisted in Commit replay state
- preserve existing hosts by treating an omitted intent as card only when card is advertised by the Quote
- document the lifecycle rule and add release changesets for `@voyant-travel/catalog-contracts` and `@voyant-travel/catalog`

## Root cause

Checkout capability discovery lived in `requirements.paymentIntents`, but the public Commit contract had no field for the shopper's selection. The payment path therefore defaulted to card and Commit idempotency could not distinguish checkout choices.

## Validation

- `vitest run packages/catalog-contracts/src/booking-engine/session-contracts.test.ts packages/catalog/src/booking-engine/sessions-service.test.ts --maxWorkers=1`
- `vitest run packages/catalog/src/booking-engine/sessions-payment-production.test.ts --maxWorkers=1`
- targeted Biome check over all changed TypeScript files
- package typechecks and broader verification intentionally deferred to GitHub Actions per request