### PR TITLE
feat(proposals): prepare bookings on proposal acceptance

### DIFF
--- a/.changeset/calm-proposals-prepare-bookings.md
+++ b/.changeset/calm-proposals-prepare-bookings.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/proposals": minor
+---
+
+Add an intent-level proposal acceptance tool that validates the frozen Trip snapshot and atomically prepares the Booking Session.

--- a/docs/architecture/agent-tool-library.md
+++ b/docs/architecture/agent-tool-library.md
@@ -279,6 +279,13 @@ fingerprint is stable across request and execution, successful execution carries
 approval/causation fields into the ledger, and a replay resolves the previously issued
 invoice instead of creating another.
 
+Proposals owns the proposal-to-reservation handoff. `accept_proposal_for_booking`
+reuses the same advisory-locked workflow as public proposal acceptance: it
+revalidates the frozen Trip snapshot, accepts exactly that Proposal Version, and
+creates the idempotent Booking Session in one transaction. The agent does not
+carry snapshot or reservation-plan identifiers between tools, and a Booking
+Session refusal rolls proposal acceptance back.
+
 ## Coverage posture
 
 Every first-party `voyant.module.v1` module and `voyant.plugin.v1` plugin unit must make

--- a/packages/proposals/src/mcp-runtime.ts
+++ b/packages/proposals/src/mcp-runtime.ts
@@ -2,6 +2,7 @@ import type { ActionLedgerRequestContextValues } from "@voyant-travel/action-led
 import {
   defineToolContextContribution,
   requireService,
+  ToolError,
   type ToolHandlerActionPolicyContext,
 } from "@voyant-travel/tools"
 import type { Context } from "hono"
@@ -14,12 +15,16 @@ import {
   proposalsPresentationRuntimePort,
 } from "./runtime-port.js"
 import { proposalsService } from "./service/index.js"
+import {
+  acceptProposalAndPrepareBooking,
+  ProposalAcceptanceError,
+} from "./service/proposal-acceptance.js"
 import { executeSnapshotAndSendProposalCommand } from "./service/proposal-delivery.js"
 
 export * from "./tools.js"
 
 export const voyantToolContextContribution = defineToolContextContribution({
-  context: ["proposals", "proposalDelivery"],
+  context: ["proposals", "proposalDelivery", "proposalAcceptance"],
   contribute: ({ context, request, resources }) => {
     const db = context.db as Parameters<typeof proposalsService.listProposals>[0]
     const c = request as Context
@@ -106,6 +111,40 @@ export const voyantToolContextContribution = defineToolContextContribution({
             publicProposalBaseUrl: proposal.resolvePublicProposalBaseUrl(c),
           })
           return result.value
+        },
+      },
+      proposalAcceptance: {
+        async acceptProposalForBooking(proposalVersionId: string) {
+          const proposal = await Promise.resolve(
+            requireService(
+              resources[proposalsPresentationRuntimePort.id] as
+                | ProposalsPresentationRuntime
+                | Promise<ProposalsPresentationRuntime>
+                | undefined,
+              proposalsPresentationRuntimePort.id,
+            ),
+          )
+          try {
+            return await acceptProposalAndPrepareBooking(
+              db,
+              proposalVersionId,
+              (transactionalDb, input) =>
+                proposal.seedAcceptedProposalBookingSession(transactionalDb, input, c),
+            )
+          } catch (error) {
+            if (error instanceof ProposalAcceptanceError) {
+              const code = error.code === "not_found" ? "NOT_FOUND" : "INVALID_INPUT"
+              throw new ToolError(error.message, code, {
+                nextSteps:
+                  error.code === "booking_session_rejected"
+                    ? [
+                        `Resolve the Booking Session rejection (${error.detail ?? "unknown"}) and call again with the same Proposal Version. Acceptance and session creation are atomic.`,
+                      ]
+                    : undefined,
+              })
+            }
+            throw error
+          }
         },
       },
     }

--- a/packages/proposals/src/proposal-routes.ts
+++ b/packages/proposals/src/proposal-routes.ts
@@ -30,19 +30,21 @@ import { OpenAPIHono } from "@hono/zod-openapi"
 import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
 import { parseJsonBody, parseOptionalJsonBody } from "@voyant-travel/hono"
 import type { ApiExtension } from "@voyant-travel/hono/module"
-import {
-  type TripSnapshot,
-  type TripSnapshotProposalLine,
-  TripsInvariantError,
-  tripsService,
-} from "@voyant-travel/trips"
-import { sql } from "drizzle-orm"
+import { type TripSnapshot, TripsInvariantError, tripsService } from "@voyant-travel/trips"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { type Context, Hono } from "hono"
 import { z } from "zod"
 import { proposalsPresentationRuntimePort, proposalsSnapshotRuntimePort } from "./runtime-port.js"
 import type { ProposalVersion, ProposalVersionLine } from "./schema.js"
 import { ProposalVersionConflictError, proposalsService } from "./service/index.js"
+import {
+  type AcceptedProposalBookingSession,
+  type AcceptedProposalBookingSessionSeed,
+  type AcceptedProposalBookingSessionSeedResult,
+  acceptProposalAndPrepareBooking,
+  ProposalAcceptanceError,
+  tripSnapshotToProposalVersionApply,
+} from "./service/proposal-acceptance.js"
 import { sendProposalVersionSchema } from "./validation.js"
 
 /**
@@ -178,34 +180,17 @@ export interface AcceptPublicProposalResult {
   bookingSession: AcceptedProposalBookingSession
 }
 
-export interface AcceptedProposalBookingSessionSeed {
-  proposalId: string
-  proposalVersionId: string
-  tripSnapshotId: string
-  tripEnvelopeId: string
-  selection?: Record<string, unknown>
-}
-
-export interface AcceptedProposalBookingSession {
-  id: string
-  state: string
-  revision: number
-  expiresAt: string
-}
-
-export type AcceptedProposalBookingSessionSeedResult =
-  | { kind: "created"; session: AcceptedProposalBookingSession }
-  | { kind: "rejected"; code: string }
+export type {
+  AcceptedProposalBookingSession,
+  AcceptedProposalBookingSessionSeed,
+  AcceptedProposalBookingSessionSeedResult,
+} from "./service/proposal-acceptance.js"
 
 export type ApplyTripSnapshotToProposalVersionResult = {
   snapshot: TripSnapshot
   proposalVersion: ProposalVersion
   lines: ProposalVersionLine[]
 }
-
-type ApplyTripSnapshotPayload = Parameters<
-  typeof proposalsService.applyTripSnapshotToProposalVersion
->[2]
 
 type ProposalVersionProposalReadModel = NonNullable<
   Awaited<ReturnType<typeof proposalsService.getProposalVersionProposal>>
@@ -527,161 +512,33 @@ async function handleAcceptPublicProposal(
   if (!proposalVersionId) return c.json({ error: "Proposal Version id is required" }, 400)
 
   const db = options.resolveDb(c)
-  const proposalForLock = await proposalsService.getProposalVersionProposal(db, proposalVersionId)
-
-  if (!proposalForLock) return c.json({ error: "Proposal not found" }, 404)
-  const proposalId = proposalForLock.proposal.id
-
   try {
-    const accepted = await db.transaction(async (tx) => {
-      const transactionalDb = tx as PostgresJsDatabase
-      await lockProposalAccept(transactionalDb, proposalId)
-      await proposalsService.expireProposalVersionIfPastValidUntil(
-        transactionalDb,
-        proposalVersionId,
-      )
-      const proposal = await proposalsService.getProposalVersionProposal(
-        transactionalDb,
-        proposalVersionId,
-      )
-
-      if (!proposal || proposal.proposalVersion.status === "draft") {
-        return { kind: "response" as const, response: c.json({ error: "Proposal not found" }, 404) }
-      }
-      if (proposal.proposalVersion.status === "superseded") {
-        return {
-          kind: "response" as const,
-          response: c.json({ error: "Proposal has been superseded" }, 410),
-        }
-      }
-      const isAcceptedReplay =
-        proposal.proposalVersion.status === "accepted" &&
-        proposal.proposal.acceptedVersionId === proposal.proposalVersion.id
-      if (proposal.proposalVersion.status !== "sent" && !isAcceptedReplay) {
-        return {
-          kind: "response" as const,
-          response: c.json({ error: "Proposal can no longer be accepted" }, 409),
-        }
-      }
-
-      if (!proposal.proposalVersion.tripSnapshotId) {
-        return {
-          kind: "response" as const,
-          response: c.json(
-            { error: "A frozen Trip snapshot is required before Proposal acceptance" },
-            409,
-          ),
-        }
-      }
-      const snapshot = await tripsService.getTripSnapshotById(
-        transactionalDb,
-        proposal.proposalVersion.tripSnapshotId,
-      )
-      if (!snapshot) {
-        return {
-          kind: "response" as const,
-          response: c.json({ error: "Proposal Trip snapshot not found" }, 409),
-        }
-      }
-      assertProposalMatchesTripSnapshot(proposal, snapshot)
-
-      const result = await proposalsService.acceptProposalVersion(
-        transactionalDb,
-        proposalVersionId,
-        {},
-      )
-      if (!result) {
-        return { kind: "response" as const, response: c.json({ error: "Proposal not found" }, 404) }
-      }
-      const session = await options.seedAcceptedProposalBookingSession(
-        transactionalDb,
-        {
-          proposalId: result.proposal.id,
-          proposalVersionId: result.proposalVersion.id,
-          tripSnapshotId: snapshot.id,
-          tripEnvelopeId: snapshot.envelopeId,
-        },
-        c,
-      )
-      if (session.kind === "rejected") {
-        throw new ProposalBookingSessionSeedError(session.code)
-      }
-      return { kind: "accepted" as const, result, session: session.session }
-    })
-    if (accepted.kind === "response") return accepted.response
-
-    return c.json({
-      data: {
-        status: "accepted",
-        currency: accepted.result.proposalVersion.currency,
-        totalAmountCents: accepted.result.proposalVersion.totalAmountCents,
-        bookingSession: accepted.session,
-      } satisfies AcceptPublicProposalResult,
-    })
+    const accepted = await acceptProposalAndPrepareBooking(
+      db,
+      proposalVersionId,
+      (transactionalDb, input) =>
+        options.seedAcceptedProposalBookingSession(transactionalDb, input, c),
+    )
+    return c.json({ data: accepted satisfies AcceptPublicProposalResult })
   } catch (error) {
+    if (error instanceof ProposalAcceptanceError) {
+      if (error.code === "not_found") return c.json({ error: error.message }, 404)
+      if (error.code === "superseded") return c.json({ error: error.message }, 410)
+      if (error.code === "booking_session_rejected") {
+        return c.json(
+          { error: error.message, code: error.detail },
+          error.detail === "capability_required" ? 400 : 409,
+        )
+      }
+      return c.json({ error: error.message }, 409)
+    }
     if (error instanceof ProposalVersionConflictError) {
       return c.json({ error: error.message }, 409)
     }
     if (error instanceof TripsInvariantError) {
       return c.json({ error: error.message }, error.message.includes("was not found") ? 404 : 409)
     }
-    if (error instanceof ProposalBookingSessionSeedError) {
-      return c.json(
-        { error: "Proposal acceptance could not seed a Booking Session", code: error.code },
-        error.code === "capability_required" ? 400 : 409,
-      )
-    }
     throw error
-  }
-}
-
-class ProposalBookingSessionSeedError extends Error {
-  constructor(readonly code: string) {
-    super(`proposal_booking_session_seed_${code}`)
-  }
-}
-
-function lockProposalAccept(db: PostgresJsDatabase, proposalId: string) {
-  return db.execute(
-    // agent-quality: raw-sql reviewed -- owner: proposals; dynamic SQL interpolation uses Drizzle parameter binding or vetted SQL identifiers.
-    sql`SELECT pg_advisory_xact_lock(hashtextextended(${proposalAcceptLockKey(proposalId)}, 0))`,
-  )
-}
-
-function proposalAcceptLockKey(proposalId: string) {
-  return `proposal-accept:${proposalId}`
-}
-
-function assertProposalMatchesTripSnapshot(
-  proposal: ProposalVersionProposalReadModel,
-  snapshot: TripSnapshot,
-) {
-  const expected = tripSnapshotToProposalVersionApply(snapshot)
-  const actual = proposal.proposalVersion
-
-  if (
-    actual.tripSnapshotId !== snapshot.id ||
-    actual.currency !== expected.currency ||
-    actual.subtotalAmountCents !== expected.subtotalAmountCents ||
-    actual.taxAmountCents !== expected.taxAmountCents ||
-    actual.totalAmountCents !== expected.totalAmountCents ||
-    proposal.lines.length !== expected.lines.length
-  ) {
-    throw new ProposalVersionConflictError("Proposal does not match its frozen Trip snapshot")
-  }
-
-  for (const [index, expectedLine] of expected.lines.entries()) {
-    const actualLine = proposal.lines[index]
-    if (
-      !actualLine ||
-      actualLine.description !== expectedLine.description ||
-      actualLine.quantity !== expectedLine.quantity ||
-      actualLine.unitPriceAmountCents !== expectedLine.unitPriceAmountCents ||
-      actualLine.totalAmountCents !== expectedLine.totalAmountCents ||
-      actualLine.currency !== expectedLine.currency
-    ) {
-      throw new ProposalVersionConflictError("Proposal does not match its frozen Trip snapshot")
-    }
   }
 }
 
@@ -738,30 +595,4 @@ async function handleFreezeProposalVersionSnapshot(
   }
 }
 
-/** Map a frozen Trip snapshot's proposal into a proposal-version apply payload. */
-export function tripSnapshotToProposalVersionApply(
-  snapshot: TripSnapshot,
-): ApplyTripSnapshotPayload {
-  const proposal = snapshot.proposal
-  return {
-    tripSnapshotId: snapshot.id,
-    currency: proposal.currency,
-    subtotalAmountCents: proposal.subtotalAmountCents,
-    taxAmountCents: proposal.taxAmountCents,
-    totalAmountCents: proposal.totalAmountCents,
-    lines: proposal.lines.map(tripSnapshotLineToProposalVersionLine),
-  }
-}
-
-function tripSnapshotLineToProposalVersionLine(line: TripSnapshotProposalLine) {
-  return {
-    componentId: line.componentId,
-    productId: line.entityModule === "products" ? line.entityId : null,
-    supplierServiceId: line.entityModule === "supplier_services" ? line.entityId : null,
-    description: line.description,
-    quantity: 1,
-    unitPriceAmountCents: line.subtotalAmountCents,
-    totalAmountCents: line.totalAmountCents,
-    currency: line.currency,
-  }
-}
+export { tripSnapshotToProposalVersionApply } from "./service/proposal-acceptance.js"

--- a/packages/proposals/src/service/proposal-acceptance.ts
+++ b/packages/proposals/src/service/proposal-acceptance.ts
@@ -1,0 +1,180 @@
+import {
+  type TripSnapshot,
+  type TripSnapshotProposalLine,
+  tripsService,
+} from "@voyant-travel/trips"
+import { sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { ProposalVersionConflictError, proposalsService } from "./index.js"
+
+export interface AcceptedProposalBookingSessionSeed {
+  proposalId: string
+  proposalVersionId: string
+  tripSnapshotId: string
+  tripEnvelopeId: string
+  selection?: Record<string, unknown>
+}
+
+export interface AcceptedProposalBookingSession {
+  id: string
+  state: string
+  revision: number
+  expiresAt: string
+}
+
+export type AcceptedProposalBookingSessionSeedResult =
+  | { kind: "created"; session: AcceptedProposalBookingSession }
+  | { kind: "rejected"; code: string }
+
+export class ProposalAcceptanceError extends Error {
+  constructor(
+    message: string,
+    readonly code:
+      | "not_found"
+      | "superseded"
+      | "not_acceptable"
+      | "snapshot_required"
+      | "snapshot_not_found"
+      | "booking_session_rejected",
+    readonly detail?: string,
+  ) {
+    super(message)
+  }
+}
+
+export async function acceptProposalAndPrepareBooking(
+  db: PostgresJsDatabase,
+  proposalVersionId: string,
+  seedBookingSession: (
+    db: PostgresJsDatabase,
+    input: AcceptedProposalBookingSessionSeed,
+  ) => Promise<AcceptedProposalBookingSessionSeedResult>,
+) {
+  const proposalForLock = await proposalsService.getProposalVersionProposal(db, proposalVersionId)
+  if (!proposalForLock) throw new ProposalAcceptanceError("Proposal not found", "not_found")
+
+  return db.transaction(async (tx) => {
+    const transactionalDb = tx as PostgresJsDatabase
+    await transactionalDb.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtextextended(${`proposal-accept:${proposalForLock.proposal.id}`}, 0))`,
+    )
+    await proposalsService.expireProposalVersionIfPastValidUntil(transactionalDb, proposalVersionId)
+    const proposal = await proposalsService.getProposalVersionProposal(
+      transactionalDb,
+      proposalVersionId,
+    )
+    if (!proposal || proposal.proposalVersion.status === "draft") {
+      throw new ProposalAcceptanceError("Proposal not found", "not_found")
+    }
+    if (proposal.proposalVersion.status === "superseded") {
+      throw new ProposalAcceptanceError("Proposal has been superseded", "superseded")
+    }
+    const isAcceptedReplay =
+      proposal.proposalVersion.status === "accepted" &&
+      proposal.proposal.acceptedVersionId === proposal.proposalVersion.id
+    if (proposal.proposalVersion.status !== "sent" && !isAcceptedReplay) {
+      throw new ProposalAcceptanceError("Proposal can no longer be accepted", "not_acceptable")
+    }
+    if (!proposal.proposalVersion.tripSnapshotId) {
+      throw new ProposalAcceptanceError(
+        "A frozen Trip snapshot is required before Proposal acceptance",
+        "snapshot_required",
+      )
+    }
+    const snapshot = await tripsService.getTripSnapshotById(
+      transactionalDb,
+      proposal.proposalVersion.tripSnapshotId,
+    )
+    if (!snapshot) {
+      throw new ProposalAcceptanceError("Proposal Trip snapshot not found", "snapshot_not_found")
+    }
+    assertProposalMatchesTripSnapshot(proposal, snapshot)
+
+    const result = await proposalsService.acceptProposalVersion(
+      transactionalDb,
+      proposalVersionId,
+      {},
+    )
+    if (!result) throw new ProposalAcceptanceError("Proposal not found", "not_found")
+    const seeded = await seedBookingSession(transactionalDb, {
+      proposalId: result.proposal.id,
+      proposalVersionId: result.proposalVersion.id,
+      tripSnapshotId: snapshot.id,
+      tripEnvelopeId: snapshot.envelopeId,
+    })
+    if (seeded.kind === "rejected") {
+      throw new ProposalAcceptanceError(
+        "Proposal acceptance could not seed a Booking Session",
+        "booking_session_rejected",
+        seeded.code,
+      )
+    }
+    return {
+      status: "accepted" as const,
+      currency: result.proposalVersion.currency,
+      totalAmountCents: result.proposalVersion.totalAmountCents,
+      bookingSession: seeded.session,
+    }
+  })
+}
+
+type ProposalVersionProposalReadModel = NonNullable<
+  Awaited<ReturnType<typeof proposalsService.getProposalVersionProposal>>
+>
+
+function assertProposalMatchesTripSnapshot(
+  proposal: ProposalVersionProposalReadModel,
+  snapshot: TripSnapshot,
+) {
+  const expected = tripSnapshotToProposalVersionApply(snapshot)
+  const actual = proposal.proposalVersion
+  if (
+    actual.tripSnapshotId !== snapshot.id ||
+    actual.currency !== expected.currency ||
+    actual.subtotalAmountCents !== expected.subtotalAmountCents ||
+    actual.taxAmountCents !== expected.taxAmountCents ||
+    actual.totalAmountCents !== expected.totalAmountCents ||
+    proposal.lines.length !== expected.lines.length
+  ) {
+    throw new ProposalVersionConflictError("Proposal does not match its frozen Trip snapshot")
+  }
+  for (const [index, expectedLine] of expected.lines.entries()) {
+    const actualLine = proposal.lines[index]
+    if (
+      !actualLine ||
+      actualLine.description !== expectedLine.description ||
+      actualLine.quantity !== expectedLine.quantity ||
+      actualLine.unitPriceAmountCents !== expectedLine.unitPriceAmountCents ||
+      actualLine.totalAmountCents !== expectedLine.totalAmountCents ||
+      actualLine.currency !== expectedLine.currency
+    ) {
+      throw new ProposalVersionConflictError("Proposal does not match its frozen Trip snapshot")
+    }
+  }
+}
+
+/** Map a frozen Trip snapshot's proposal into a proposal-version apply payload. */
+export function tripSnapshotToProposalVersionApply(snapshot: TripSnapshot) {
+  const proposal = snapshot.proposal
+  return {
+    tripSnapshotId: snapshot.id,
+    currency: proposal.currency,
+    subtotalAmountCents: proposal.subtotalAmountCents,
+    taxAmountCents: proposal.taxAmountCents,
+    totalAmountCents: proposal.totalAmountCents,
+    lines: proposal.lines.map(tripSnapshotLineToProposalVersionLine),
+  }
+}
+
+function tripSnapshotLineToProposalVersionLine(line: TripSnapshotProposalLine) {
+  return {
+    componentId: line.componentId,
+    productId: line.entityModule === "products" ? line.entityId : null,
+    supplierServiceId: line.entityModule === "supplier_services" ? line.entityId : null,
+    description: line.description,
+    quantity: 1,
+    unitPriceAmountCents: line.subtotalAmountCents,
+    totalAmountCents: line.totalAmountCents,
+    currency: line.currency,
+  }
+}

--- a/packages/proposals/src/tools.ts
+++ b/packages/proposals/src/tools.ts
@@ -71,9 +71,21 @@ export interface ProposalDeliveryToolServices {
   ): Promise<unknown>
 }
 
+export interface ProposalAcceptanceToolServices {
+  acceptProposalForBooking(proposalVersionId: string): Promise<unknown>
+}
+
 export type ProposalsToolContext = ToolContext & {
   proposals?: ProposalsToolServices
   proposalDelivery?: ProposalDeliveryToolServices
+  proposalAcceptance?: ProposalAcceptanceToolServices
+}
+
+function proposalAcceptance(ctx: ProposalsToolContext): ProposalAcceptanceToolServices {
+  if (ctx.actor !== "staff" || ctx.audience !== "staff") {
+    throw new ToolError("Proposal acceptance Tools require a staff grant.", "AUTHORIZATION_DENIED")
+  }
+  return requireService(ctx.proposalAcceptance, "proposalAcceptance")
 }
 
 function proposals(ctx: ProposalsToolContext): ProposalsToolServices {
@@ -360,6 +372,39 @@ export const acceptProposalVersionTool = defineTool({
   },
 })
 
+export const acceptProposalForBookingOutputSchema = z.object({
+  status: z.literal("accepted"),
+  currency: z.string().min(1),
+  totalAmountCents: z.number().int(),
+  bookingSession: z.object({
+    id: z.string().min(1),
+    state: z.string().min(1),
+    revision: z.number().int(),
+    expiresAt: z.string().min(1),
+  }),
+})
+
+export const acceptProposalForBookingTool = defineTool({
+  owner: `${OWNER}#presentation-extension`,
+  capabilityId: `${OWNER}#presentation-extension.tool.accept-proposal-for-booking`,
+  capabilityVersion: VERSION,
+  name: "accept_proposal_for_booking",
+  description:
+    "Accept a sent, snapshot-backed proposal and atomically prepare its Booking Session. " +
+    "The server validates the frozen Trip snapshot and resolves the reservation handoff.",
+  inputSchema: z.object({ proposalVersionId: proposalVersionIdSchema }),
+  outputSchema: acceptProposalForBookingOutputSchema,
+  requiredScopes: WRITE_SCOPES,
+  audience: STAFF_AUDIENCE,
+  tier: "destructive",
+  riskPolicy: proposalWriteRisk,
+  async handler({ proposalVersionId }, ctx: ProposalsToolContext) {
+    return acceptProposalForBookingOutputSchema.parse(
+      await proposalAcceptance(ctx).acceptProposalForBooking(proposalVersionId),
+    )
+  },
+})
+
 export const declineProposalVersionTool = defineTool({
   owner: OWNER,
   capabilityId: `${OWNER}#tool.decline-proposal-version`,
@@ -392,6 +437,7 @@ export const proposalsTools = [
   sendProposalVersionTool,
   snapshotAndSendProposalTool,
   acceptProposalVersionTool,
+  acceptProposalForBookingTool,
   declineProposalVersionTool,
 ] as const
 

--- a/packages/proposals/src/voyant.ts
+++ b/packages/proposals/src/voyant.ts
@@ -471,6 +471,17 @@ export const proposalsPresentationVoyantExtension = defineExtension({
   ],
   tools: [
     {
+      id: "@voyant-travel/proposals#presentation-extension.tool.accept-proposal-for-booking",
+      name: "accept_proposal_for_booking",
+      runtime: {
+        entry: "@voyant-travel/proposals/tools",
+        export: "acceptProposalForBookingTool",
+      },
+      requiredScopes: ["proposals:write"],
+      context: ["proposalAcceptance"],
+      risk: "high",
+    },
+    {
       id: "@voyant-travel/proposals#presentation-extension.tool.snapshot-and-send-proposal",
       name: "snapshot_and_send_proposal",
       runtime: {
@@ -483,6 +494,27 @@ export const proposalsPresentationVoyantExtension = defineExtension({
     },
   ],
   actions: [
+    {
+      id: "@voyant-travel/proposals#presentation-extension.action.accept-proposal-for-booking",
+      version: "v1",
+      kind: "execute",
+      targetType: "proposal-version",
+      commandTargetField: "proposalVersionId",
+      targetLifecycle: "existing",
+      effectBoundary: "local",
+      resource: "proposals",
+      action: "write",
+      requiredScopes: ["proposals:write"],
+      risk: "high",
+      ledger: "required",
+      approval: "required",
+      reversible: false,
+      allowedActorTypes: ["staff"],
+      availability: { status: "available" },
+      from: {
+        tools: ["@voyant-travel/proposals#presentation-extension.tool.accept-proposal-for-booking"],
+      },
+    },
     {
       id: "@voyant-travel/proposals#presentation-extension.action.snapshot-and-send-proposal",
       version: "v2",

--- a/packages/proposals/tests/tools.test.ts
+++ b/packages/proposals/tests/tools.test.ts
@@ -166,6 +166,7 @@ describe("proposals Tools", () => {
   it("registers structural reads and the complete guarded proposal lifecycle", () => {
     const list = registry().list()
     expect(list.map((tool) => tool.name).sort()).toEqual([
+      "accept_proposal_for_booking",
       "accept_proposal_version",
       "add_proposal_product",
       "create_proposal",
@@ -178,12 +179,16 @@ describe("proposals Tools", () => {
       "snapshot_and_send_proposal",
       "snapshot_proposal_version",
     ])
-    for (const tool of list.filter(({ name }) => name !== "snapshot_and_send_proposal")) {
+    for (const tool of list.filter(
+      ({ name }) => name !== "snapshot_and_send_proposal" && name !== "accept_proposal_for_booking",
+    )) {
       expect(tool.owner).toBe("@voyant-travel/proposals")
     }
-    expect(list.find(({ name }) => name === "snapshot_and_send_proposal")?.owner).toBe(
-      "@voyant-travel/proposals#presentation-extension",
-    )
+    for (const name of ["accept_proposal_for_booking", "snapshot_and_send_proposal"]) {
+      expect(list.find((tool) => tool.name === name)?.owner).toBe(
+        "@voyant-travel/proposals#presentation-extension",
+      )
+    }
     for (const tool of list) {
       expect(tool.capabilityVersion).toBe(tool.name === "snapshot_and_send_proposal" ? "v2" : "v1")
       expect(tool.audience).toEqual({ source: "grant", allowed: ["staff"] })

--- a/packages/proposals/tests/unit/voyant-manifest.test.ts
+++ b/packages/proposals/tests/unit/voyant-manifest.test.ts
@@ -246,6 +246,13 @@ describe("proposals deployment manifests", () => {
       ],
       tools: [
         {
+          id: "@voyant-travel/proposals#presentation-extension.tool.accept-proposal-for-booking",
+          name: "accept_proposal_for_booking",
+          requiredScopes: ["proposals:write"],
+          context: ["proposalAcceptance"],
+          risk: "high",
+        },
+        {
           id: "@voyant-travel/proposals#presentation-extension.tool.snapshot-and-send-proposal",
           name: "snapshot_and_send_proposal",
           requiredScopes: ["proposals:write", "notifications:send"],
@@ -254,6 +261,17 @@ describe("proposals deployment manifests", () => {
         },
       ],
       actions: [
+        {
+          id: "@voyant-travel/proposals#presentation-extension.action.accept-proposal-for-booking",
+          version: "v1",
+          commandTargetField: "proposalVersionId",
+          targetLifecycle: "existing",
+          effectBoundary: "local",
+          ledger: "required",
+          approval: "required",
+          reversible: false,
+          allowedActorTypes: ["staff"],
+        },
         {
           id: "@voyant-travel/proposals#presentation-extension.action.snapshot-and-send-proposal",
           version: "v2",


### PR DESCRIPTION
## Summary
- add `accept_proposal_for_booking` as an intent-level operator tool
- share the advisory-locked proposal acceptance workflow between HTTP and MCP
- validate the frozen Trip snapshot and roll acceptance back when Booking Session creation fails
- document Proposals as the orchestration owner and add a package changeset

Closes part of #3933
Tracks #4378

## Verification
CI is the requested verification lane for this PR.