### PR TITLE
chore(framework): publish managed runtime identity

### DIFF
--- a/.changeset/calm-runtime-identity.md
+++ b/.changeset/calm-runtime-identity.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": patch
+---
+
+Publish a fresh framework identity for the managed operator bundle carrying embedded payment reconciliation and portable admin-shell bootstrap fixes.


### PR DESCRIPTION
## Summary

- publish a patch identity for `@voyant-travel/framework`
- give the managed operator bundle carrying the embedded-payment reconciliation and portable admin-shell fixes a new immutable framework version

The operator 0.10.2 image correctly contains those fixes, but still identifies its bundled framework as 0.80.1. Platform cannot register a second immutable managed release under that existing version, and correctly rejects labeling the bytes 0.80.2. This changeset produces framework 0.80.2 without weakening that identity check.

## Validation

- changeset is limited to `@voyant-travel/framework`
- no source or migration bytes change
- downstream package publication and operator image smoke remain gated by existing CI/release workflows
