### PR TITLE
Preserve sale-time cancellation terms on booking items

### DIFF
--- a/.changeset/freeze-booking-cancellation-terms.md
+++ b/.changeset/freeze-booking-cancellation-terms.md
@@ -1,0 +1,8 @@
+---
+"@voyant-travel/bookings-contracts": patch
+"@voyant-travel/bookings": patch
+"@voyant-travel/catalog": patch
+"@voyant-travel/finance": patch
+---
+
+Preserve accepted quote cancellation terms as an immutable, per-item Booking snapshot during owned and sourced booking commitment.

--- a/docs/architecture/catalog-architecture.md
+++ b/docs/architecture/catalog-architecture.md
@@ -1208,6 +1208,14 @@ booking_catalog_snapshot rows:
 
 Refunding, modifying, or status-syncing this booking eight months later can read each component's frozen view to know exactly what the customer paid for and what cancellation policy applied to each piece. The same pattern applies whether the composite vertical exists today or is added later — the snapshot table accepts any registered `entity_module`.
 
+At commercial commitment, accepted Quote cancellation evidence is also copied to
+`booking_items.cancellation_terms_snapshot`. The per-item snapshot adds the sold
+amount, currency, service date, Quote identity, and capture time to the frozen
+policy payload. It is immutable sale evidence: later policy publication must not
+refresh it. Legacy items and commits whose Quote carried no authoritative
+cancellation evidence remain `NULL`; consumers must treat that as unknown/manual
+review rather than infer historical terms from current authoring state.
+
 ## 9. Adoption plan
 
 v1 is a single coordinated piece of work: the catalog plane lands and every existing vertical adopts it together. Sequencing inside the work is for development convenience; the release is one cut, not five.

--- a/packages/bookings-contracts/src/validation-bookings.ts
+++ b/packages/bookings-contracts/src/validation-bookings.ts
@@ -173,6 +173,15 @@ export const sharingGroupsForSlotQuerySchema = z.object({
   slotId: z.string().min(1),
 })
 
+export const cancellationTermsEvidenceV1Schema = z.object({
+  schemaVersion: z.literal(1),
+  source: z.enum(["booking_quote", "supplier_quote"]),
+  sourceId: z.string().min(1),
+  capturedAt: z.string().datetime(),
+  /** Frozen cancellation terms carried by the accepted quote. */
+  policy: z.unknown(),
+})
+
 export const convertProductSchema = z
   .object({
     productId: z.string().min(1),
@@ -239,6 +248,11 @@ export const convertProductSchema = z
     contactAddressLine1: z.string().max(500).optional().nullable(),
     contactAddressLine2: z.string().max(500).optional().nullable(),
     contactPostalCode: z.string().max(20).optional().nullable(),
+    /**
+     * Server-held evidence from the accepted quote. Public/operator inputs must
+     * not expose this field; the booking-session commit boundary supplies it.
+     */
+    cancellationTermsEvidence: cancellationTermsEvidenceV1Schema.optional().nullable(),
     itemLines: z
       .array(
         z.object({

--- a/packages/bookings/migrations/0000_bookings_baseline.sql
+++ b/packages/bookings/migrations/0000_bookings_baseline.sql
@@ -471,6 +471,7 @@ CREATE TABLE "booking_items" (
 	"departure_label_snapshot" text,
 	"source_snapshot_id" text,
 	"source_offer_id" text,
+	"cancellation_terms_snapshot" jsonb,
 	"metadata" jsonb,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,

--- a/packages/bookings/migrations/20260807143000_booking_item_cancellation_terms_snapshot.sql
+++ b/packages/bookings/migrations/20260807143000_booking_item_cancellation_terms_snapshot.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "booking_items"
+ADD COLUMN IF NOT EXISTS "cancellation_terms_snapshot" jsonb;

--- a/packages/bookings/migrations/meta/_journal.json
+++ b/packages/bookings/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1786093200000,
       "tag": "20260807110000_booking_inquiries",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1786102200000,
+      "tag": "20260807143000_booking_item_cancellation_terms_snapshot",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/bookings/src/schema-items.ts
+++ b/packages/bookings/src/schema-items.ts
@@ -25,6 +25,17 @@ import {
   bookingRedemptionMethodEnum,
 } from "./schema-shared.js"
 
+export interface BookingItemCancellationTermsSnapshotV1 {
+  schemaVersion: 1
+  source: "booking_quote" | "supplier_quote"
+  sourceId: string
+  capturedAt: string
+  policy: unknown
+  sellCurrency: string
+  totalSellAmountCents: number | null
+  serviceDate: string | null
+}
+
 export const bookingItems = pgTable(
   "booking_items",
   {
@@ -71,6 +82,9 @@ export const bookingItems = pgTable(
     departureLabelSnapshot: text("departure_label_snapshot"),
     sourceSnapshotId: text("source_snapshot_id"),
     sourceOfferId: text("source_offer_id"),
+    cancellationTermsSnapshot: jsonb(
+      "cancellation_terms_snapshot",
+    ).$type<BookingItemCancellationTermsSnapshotV1>(),
     metadata: jsonb("metadata").$type<Record<string, unknown>>(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),

--- a/packages/bookings/src/service-core.ts
+++ b/packages/bookings/src/service-core.ts
@@ -2629,6 +2629,14 @@ const bookingsServiceInternal = {
               ...productOptionSnapshot,
               unitNameSnapshot: unit.name,
               ...slotFields,
+              cancellationTermsSnapshot: data.cancellationTermsEvidence
+                ? {
+                    ...data.cancellationTermsEvidence,
+                    sellCurrency: product.sellCurrency,
+                    totalSellAmountCents,
+                    serviceDate: slot?.dateLocal ?? null,
+                  }
+                : null,
               metadata: itemLineMetadata(line.clientLineKey),
             }
           })
@@ -2670,6 +2678,16 @@ const bookingsServiceInternal = {
                 ...productOptionSnapshot,
                 unitNameSnapshot: unit.name,
                 ...slotFields,
+                cancellationTermsSnapshot: data.cancellationTermsEvidence
+                  ? {
+                      ...data.cancellationTermsEvidence,
+                      sellCurrency: product.sellCurrency,
+                      totalSellAmountCents: singleSeedItem
+                        ? (effectiveSellAmountCents ?? null)
+                        : null,
+                      serviceDate: slot?.dateLocal ?? null,
+                    }
+                  : null,
               }
             })
           : [
@@ -2692,6 +2710,14 @@ const bookingsServiceInternal = {
                 ...productOptionSnapshot,
                 unitNameSnapshot: null,
                 ...slotFields,
+                cancellationTermsSnapshot: data.cancellationTermsEvidence
+                  ? {
+                      ...data.cancellationTermsEvidence,
+                      sellCurrency: product.sellCurrency,
+                      totalSellAmountCents: effectiveSellAmountCents ?? null,
+                      serviceDate: slot?.dateLocal ?? null,
+                    }
+                  : null,
               },
             ]
 

--- a/packages/bookings/src/service-sourced-commitment.ts
+++ b/packages/bookings/src/service-sourced-commitment.ts
@@ -2,6 +2,7 @@ import { newId } from "@voyant-travel/db/lib/typeid"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import { bookings, bookingTravelers } from "./schema-core.js"
+import type { BookingItemCancellationTermsSnapshotV1 } from "./schema-items.js"
 import { bookingAllocations, bookingItems, bookingItemTravelers } from "./schema-items.js"
 import { upsertBookingOrigin } from "./service-origin.js"
 
@@ -50,6 +51,10 @@ export interface CreateSourcedBookingCommitmentInput {
   channelId?: string | null
   supplierOperationId: string
   now: Date
+  cancellationTermsEvidence?: Omit<
+    BookingItemCancellationTermsSnapshotV1,
+    "sellCurrency" | "totalSellAmountCents" | "serviceDate"
+  > | null
 }
 
 export interface CreateSourcedBookingCommitmentResult {
@@ -118,6 +123,14 @@ export async function createSourcedBookingCommitment(
     totalSellAmountCents: input.sellAmountCents,
     productNameSnapshot: input.title,
     sourceOfferId: input.sourceRef,
+    cancellationTermsSnapshot: input.cancellationTermsEvidence
+      ? {
+          ...input.cancellationTermsEvidence,
+          sellCurrency: input.sellCurrency,
+          totalSellAmountCents: input.sellAmountCents,
+          serviceDate: input.serviceDate ?? startDate,
+        }
+      : null,
     metadata: {
       entityModule: input.entityModule,
       entityId: input.entityId,

--- a/packages/bookings/tests/unit/validation-booking.test.ts
+++ b/packages/bookings/tests/unit/validation-booking.test.ts
@@ -335,6 +335,30 @@ describe("Convert product schema", () => {
     expect(result.slotId).toBeUndefined()
   })
 
+  it("accepts only typed server-held cancellation evidence", () => {
+    const evidence = {
+      schemaVersion: 1 as const,
+      source: "booking_quote" as const,
+      sourceId: "quote_1",
+      capturedAt: "2026-08-07T10:00:00.000Z",
+      policy: { policyVersionId: "polv_sale", rules: [] },
+    }
+    expect(
+      convertProductSchema.parse({
+        productId: "prod_abc",
+        bookingNumber: "BK-001",
+        cancellationTermsEvidence: evidence,
+      }).cancellationTermsEvidence,
+    ).toEqual(evidence)
+    expect(() =>
+      convertProductSchema.parse({
+        productId: "prod_abc",
+        bookingNumber: "BK-001",
+        cancellationTermsEvidence: { ...evidence, schemaVersion: 2 },
+      }),
+    ).toThrow()
+  })
+
   it("rejects placeholder organization IDs", () => {
     expect(() =>
       convertProductSchema.parse({

--- a/packages/catalog/src/booking-engine/sessions-production.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-production.test.ts
@@ -305,6 +305,53 @@ describe("production Booking Session ports", () => {
     })
   })
 
+  it("carries frozen quote cancellation terms into the server-held create command", async () => {
+    const policy = {
+      policyId: "pol_cancellation",
+      policyVersionId: "polv_sale",
+      version: 3,
+      rules: [{ daysBeforeDeparture: 30, refundPercent: 80 }],
+    }
+    const module = createCommittableProductionModule({}, { cancellationSnapshot: policy })
+    const access = {
+      actorKind: "anonymous" as const,
+      capability: TEST_CAPABILITY,
+      ...STOREFRONT_ACCESS,
+    }
+    const created = await module.createSession(committableCreateInput("create_terms"), access)
+    if (created.kind !== "session_created") throw new Error("session not created")
+    const prepared = await quoteAndHoldForCommit(
+      module,
+      created.session.id,
+      created.session.revision,
+      access,
+      "terms",
+    )
+
+    await module.commitSession(
+      created.session.id,
+      {
+        expectedRevision: created.session.revision,
+        ...prepared,
+        idempotencyKey: "commit_terms",
+      },
+      access,
+    )
+
+    expect(financeCreate.resolvedCommand).toMatchObject({
+      cancellationTermsEvidence: {
+        schemaVersion: 1,
+        source: "booking_quote",
+        sourceId: prepared.quoteId,
+        policy,
+      },
+    })
+    expect(
+      (financeCreate.resolvedCommand?.cancellationTermsEvidence as { capturedAt: string })
+        .capturedAt,
+    ).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+  })
+
   it.each([
     [
       "anonymous",
@@ -792,7 +839,10 @@ describe("production Booking Session ports", () => {
   })
 })
 
-function createCommittableProductionModule(command: Record<string, unknown> = {}) {
+function createCommittableProductionModule(
+  command: Record<string, unknown> = {},
+  upstreamPayload?: Record<string, unknown>,
+) {
   const repository = createInMemoryBookingSessionRepository()
   const handlers = createOwnedBookingHandlerRegistry()
   handlers.register({
@@ -808,6 +858,7 @@ function createCommittableProductionModule(command: Record<string, unknown> = {}
           surcharges: 0,
           currency: "EUR",
         },
+        upstreamPayload,
       }
     },
     async placeHold(_context, request) {

--- a/packages/catalog/src/booking-engine/sessions-production.ts
+++ b/packages/catalog/src/booking-engine/sessions-production.ts
@@ -492,6 +492,7 @@ async function commitSourcedBooking(
       channelId: input.session.storefrontOrigin?.channelId,
       supplierOperationId: operation.id,
       now: input.now,
+      cancellationTermsEvidence: cancellationTermsEvidence(input.quote, "supplier_quote"),
     })
     await captureSnapshot(transaction, {
       bookingId: materialized.bookingId,
@@ -613,10 +614,15 @@ async function commitOwnedBookingInTransaction(
     },
   )
   if (derived.status !== "ok") throw new BookingSessionCommitRejectedError(derived.reason)
-  const command =
+  const derivedCommand =
     input.access.actorKind === "staff" && input.access.staffBookingAuthority?.admitted
       ? applyStaffSelection(derived.command, input.session.statePayload)
       : derived.command
+  const termsEvidence = cancellationTermsEvidence(input.quote, "booking_quote")
+  const command = {
+    ...derivedCommand,
+    ...(termsEvidence ? { cancellationTermsEvidence: termsEvidence } : {}),
+  }
 
   const routeActions = createRouteActionRegistry()
   routeActions.register(FINANCE_BOOKING_CREATE_SELF_SERVICE_ROUTE_ACTION)
@@ -825,6 +831,21 @@ function policyEvidenceFromValues(values?: Record<string, unknown>) {
   return {
     ...(cancellation !== undefined ? { cancellation } : {}),
     ...(bookingTerms !== undefined ? { bookingTerms } : {}),
+  }
+}
+
+function cancellationTermsEvidence(
+  quote: CommitOwnedBookingInput["quote"] | CommitSourcedBookingInput["quote"],
+  source: "booking_quote" | "supplier_quote",
+) {
+  const policy = quote.pricing.policyEvidence?.cancellation
+  if (policy === undefined) return null
+  return {
+    schemaVersion: 1 as const,
+    source,
+    sourceId: quote.id,
+    capturedAt: quote.quotedAt.toISOString(),
+    policy,
   }
 }
 

--- a/packages/finance/src/service-booking-create.ts
+++ b/packages/finance/src/service-booking-create.ts
@@ -20,7 +20,6 @@ import {
   bookings,
   bookingTravelers,
 } from "@voyant-travel/bookings/schema"
-import { cancellationTermsEvidenceV1Schema } from "@voyant-travel/bookings-contracts"
 import { withBookingFinanceInsertionFence } from "@voyant-travel/db/booking-finance-fence"
 import { classifyOccupancyPrice } from "@voyant-travel/products-contracts/occupancy-pricing"
 import { and, asc, eq, sql } from "drizzle-orm"
@@ -549,7 +548,16 @@ const bookingCreateBaseSchema = z.object({
   contactAddressLine1: z.string().max(500).optional().nullable(),
   contactAddressLine2: z.string().max(500).optional().nullable(),
   contactPostalCode: z.string().max(20).optional().nullable(),
-  cancellationTermsEvidence: cancellationTermsEvidenceV1Schema.optional().nullable(),
+  cancellationTermsEvidence: z
+    .object({
+      schemaVersion: z.literal(1),
+      source: z.enum(["booking_quote", "supplier_quote"]),
+      sourceId: z.string().min(1),
+      capturedAt: z.string().datetime(),
+      policy: z.unknown(),
+    })
+    .optional()
+    .nullable(),
 
   // Orchestration fields
   travelers: z

--- a/packages/finance/src/service-booking-create.ts
+++ b/packages/finance/src/service-booking-create.ts
@@ -20,6 +20,7 @@ import {
   bookings,
   bookingTravelers,
 } from "@voyant-travel/bookings/schema"
+import { cancellationTermsEvidenceV1Schema } from "@voyant-travel/bookings-contracts"
 import { withBookingFinanceInsertionFence } from "@voyant-travel/db/booking-finance-fence"
 import { classifyOccupancyPrice } from "@voyant-travel/products-contracts/occupancy-pricing"
 import { and, asc, eq, sql } from "drizzle-orm"
@@ -548,6 +549,7 @@ const bookingCreateBaseSchema = z.object({
   contactAddressLine1: z.string().max(500).optional().nullable(),
   contactAddressLine2: z.string().max(500).optional().nullable(),
   contactPostalCode: z.string().max(20).optional().nullable(),
+  cancellationTermsEvidence: cancellationTermsEvidenceV1Schema.optional().nullable(),
 
   // Orchestration fields
   travelers: z
@@ -583,6 +585,7 @@ const bookingCreateOperatorInputSchema = bookingCreateBaseSchema
     catalogSellAmountCents: true,
     confirmedSellAmountCents: true,
     priceOverrideReason: true,
+    cancellationTermsEvidence: true,
   })
   .extend({
     // The reference is resolved server-side: omit it and the tool allocates one.


### PR DESCRIPTION
## What changed

- adds a dedicated nullable cancellation-terms snapshot to each Booking Item
- carries accepted Quote cancellation evidence through both owned and supplier-backed commitment paths
- enriches the frozen evidence with Quote identity/time and authoritative item amount, currency, and service date
- keeps the evidence out of operator/tool input schemas
- leaves legacy and no-evidence items null rather than inferring historic terms from current policy state
- documents the immutable boundary and adds focused contract/commit-path coverage

## Why

The current cancellation evaluator follows a policy's mutable current version, while Booking cancellation does not preserve or approve the contractual refund entitlement. A safe intent-level cancellation tool must start from the terms accepted at sale, not caller-supplied facts or today's authoring state.

This is Slice 1 of #4405 and a prerequisite for #3933 and #4378.

## Validation

- git diff --check
- focused Biome check passed for all changed TypeScript files
- focused Vitest invocation was attempted, but this isolated worktree has no workspace package links; both suites stopped during import before running tests
- GitHub CI is the executable validation lane for typecheck, tests, migration, OpenAPI, and architecture checks
