### PR TITLE
Refresh generated package dist configs

### DIFF
--- a/packages/accommodations/tsconfig.build.json
+++ b/packages/accommodations/tsconfig.build.json
@@ -1666,6 +1666,9 @@
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"
       ],
+      "@voyant-travel/products-contracts/occupancy-pricing": [
+        "../products-contracts/dist/occupancy-pricing.d.ts"
+      ],
       "@voyant-travel/products-contracts/product-version-snapshot": [
         "../products-contracts/dist/product-version-snapshot.d.ts"
       ],

--- a/packages/accommodations/tsconfig.typecheck.json
+++ b/packages/accommodations/tsconfig.typecheck.json
@@ -1667,6 +1667,9 @@
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"
       ],
+      "@voyant-travel/products-contracts/occupancy-pricing": [
+        "../products-contracts/dist/occupancy-pricing.d.ts"
+      ],
       "@voyant-travel/products-contracts/product-version-snapshot": [
         "../products-contracts/dist/product-version-snapshot.d.ts"
       ],

--- a/packages/catalog/tsconfig.build.json
+++ b/packages/catalog/tsconfig.build.json
@@ -1621,6 +1621,9 @@
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"
       ],
+      "@voyant-travel/products-contracts/occupancy-pricing": [
+        "../products-contracts/dist/occupancy-pricing.d.ts"
+      ],
       "@voyant-travel/products-contracts/product-version-snapshot": [
         "../products-contracts/dist/product-version-snapshot.d.ts"
       ],

--- a/packages/catalog/tsconfig.typecheck.json
+++ b/packages/catalog/tsconfig.typecheck.json
@@ -1622,6 +1622,9 @@
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"
       ],
+      "@voyant-travel/products-contracts/occupancy-pricing": [
+        "../products-contracts/dist/occupancy-pricing.d.ts"
+      ],
       "@voyant-travel/products-contracts/product-version-snapshot": [
         "../products-contracts/dist/product-version-snapshot.d.ts"
       ],

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -1626,6 +1626,9 @@
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"
       ],
+      "@voyant-travel/products-contracts/occupancy-pricing": [
+        "../products-contracts/dist/occupancy-pricing.d.ts"
+      ],
       "@voyant-travel/products-contracts/product-version-snapshot": [
         "../products-contracts/dist/product-version-snapshot.d.ts"
       ],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -1620,6 +1620,9 @@
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"
       ],
+      "@voyant-travel/products-contracts/occupancy-pricing": [
+        "../products-contracts/dist/occupancy-pricing.d.ts"
+      ],
       "@voyant-travel/products-contracts/product-version-snapshot": [
         "../products-contracts/dist/product-version-snapshot.d.ts"
       ],

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -1671,6 +1671,9 @@
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"
       ],
+      "@voyant-travel/products-contracts/occupancy-pricing": [
+        "../products-contracts/dist/occupancy-pricing.d.ts"
+      ],
       "@voyant-travel/products-contracts/product-version-snapshot": [
         "../products-contracts/dist/product-version-snapshot.d.ts"
       ],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -1672,6 +1672,9 @@
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"
       ],
+      "@voyant-travel/products-contracts/occupancy-pricing": [
+        "../products-contracts/dist/occupancy-pricing.d.ts"
+      ],
       "@voyant-travel/products-contracts/product-version-snapshot": [
         "../products-contracts/dist/product-version-snapshot.d.ts"
       ],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -1675,6 +1675,9 @@
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"
       ],
+      "@voyant-travel/products-contracts/occupancy-pricing": [
+        "../products-contracts/dist/occupancy-pricing.d.ts"
+      ],
       "@voyant-travel/products-contracts/product-version-snapshot": [
         "../products-contracts/dist/product-version-snapshot.d.ts"
       ],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -1676,6 +1676,9 @@
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"
       ],
+      "@voyant-travel/products-contracts/occupancy-pricing": [
+        "../products-contracts/dist/occupancy-pricing.d.ts"
+      ],
       "@voyant-travel/products-contracts/product-version-snapshot": [
         "../products-contracts/dist/product-version-snapshot.d.ts"
       ],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -1707,6 +1707,9 @@
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"
       ],
+      "@voyant-travel/products-contracts/occupancy-pricing": [
+        "../products-contracts/dist/occupancy-pricing.d.ts"
+      ],
       "@voyant-travel/products-contracts/product-version-snapshot": [
         "../products-contracts/dist/product-version-snapshot.d.ts"
       ],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -1702,6 +1702,9 @@
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"
       ],
+      "@voyant-travel/products-contracts/occupancy-pricing": [
+        "../products-contracts/dist/occupancy-pricing.d.ts"
+      ],
       "@voyant-travel/products-contracts/product-version-snapshot": [
         "../products-contracts/dist/product-version-snapshot.d.ts"
       ],

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -1707,6 +1707,9 @@
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"
       ],
+      "@voyant-travel/products-contracts/occupancy-pricing": [
+        "../products-contracts/dist/occupancy-pricing.d.ts"
+      ],
       "@voyant-travel/products-contracts/product-version-snapshot": [
         "../products-contracts/dist/product-version-snapshot.d.ts"
       ],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -1702,6 +1702,9 @@
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"
       ],
+      "@voyant-travel/products-contracts/occupancy-pricing": [
+        "../products-contracts/dist/occupancy-pricing.d.ts"
+      ],
       "@voyant-travel/products-contracts/product-version-snapshot": [
         "../products-contracts/dist/product-version-snapshot.d.ts"
       ],

--- a/packages/inventory/tsconfig.build.json
+++ b/packages/inventory/tsconfig.build.json
@@ -1639,6 +1639,9 @@
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"
       ],
+      "@voyant-travel/products-contracts/occupancy-pricing": [
+        "../products-contracts/dist/occupancy-pricing.d.ts"
+      ],
       "@voyant-travel/products-contracts/product-version-snapshot": [
         "../products-contracts/dist/product-version-snapshot.d.ts"
       ],

--- a/packages/inventory/tsconfig.typecheck.json
+++ b/packages/inventory/tsconfig.typecheck.json
@@ -1640,6 +1640,9 @@
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"
       ],
+      "@voyant-travel/products-contracts/occupancy-pricing": [
+        "../products-contracts/dist/occupancy-pricing.d.ts"
+      ],
       "@voyant-travel/products-contracts/product-version-snapshot": [
         "../products-contracts/dist/product-version-snapshot.d.ts"
       ],

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -1606,6 +1606,9 @@
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"
       ],
+      "@voyant-travel/products-contracts/occupancy-pricing": [
+        "../products-contracts/dist/occupancy-pricing.d.ts"
+      ],
       "@voyant-travel/products-contracts/product-version-snapshot": [
         "../products-contracts/dist/product-version-snapshot.d.ts"
       ],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -1601,6 +1601,9 @@
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"
       ],
+      "@voyant-travel/products-contracts/occupancy-pricing": [
+        "../products-contracts/dist/occupancy-pricing.d.ts"
+      ],
       "@voyant-travel/products-contracts/product-version-snapshot": [
         "../products-contracts/dist/product-version-snapshot.d.ts"
       ],

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -1718,6 +1718,9 @@
       "@voyant-travel/products-contracts/content-shape": [
         "../products-contracts/dist/content-shape.d.ts"
       ],
+      "@voyant-travel/products-contracts/occupancy-pricing": [
+        "../products-contracts/dist/occupancy-pricing.d.ts"
+      ],
       "@voyant-travel/products-contracts/product-version-snapshot": [
         "../products-contracts/dist/product-version-snapshot.d.ts"
       ],


### PR DESCRIPTION
## What changed

Regenerates package dist configs and the shared dependency-path map with the repository-owned generator.

## Why

The architecture job on #4406 found current main's generated dist configs stale. The cancellation snapshot PR was merged before this mechanical follow-up commit landed, so this PR preserves that required correction separately.

## Validation

- generated remotely with `pnpm generate:dist-configs` after a frozen install
- generator exited successfully: 1,297 shared paths across 108 configured packages
- `git diff --check`
