### PR TITLE
Resolve booking cancellation consequences from frozen terms

### DIFF
--- a/.changeset/resolve-booking-cancellation-consequences.md
+++ b/.changeset/resolve-booking-cancellation-consequences.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/bookings": patch
+---
+
+Resolve per-item cancellation consequences from authoritative Booking facts and frozen policy evidence, with fail-closed aggregate manual-review outcomes.

--- a/apps/operator/tests/api/selected-graph-runtime.test.ts
+++ b/apps/operator/tests/api/selected-graph-runtime.test.ts
@@ -263,6 +263,7 @@ describe("selected Operator graph runtime composition", () => {
       "payment.completed",
       "booking.cancelled",
       "booking.confirmed",
+      "booking.inquiry.created",
       "contract.signed",
       "customer.signal.created",
       "invoice.settled",

--- a/docs/architecture/catalog-architecture.md
+++ b/docs/architecture/catalog-architecture.md
@@ -1223,6 +1223,13 @@ evaluation parses and evaluates those rules directly. Resolving
 `policies.currentVersionId` is reserved for prospective quote production and is
 never a valid way to evaluate a committed Booking.
 
+Bookings owns consequence composition. Its resolver reads each Booking Item's
+stored amount, currency, service date, and cancellation snapshot, then delegates
+only the frozen policy payload to Legal's pure evaluator. Missing or invalid
+evidence, missing sale facts, and mixed currencies produce an explicit
+`manual_review` result with no aggregate refund entitlement; they must never be
+coerced to a zero refund.
+
 ## 9. Adoption plan
 
 v1 is a single coordinated piece of work: the catalog plane lands and every existing vertical adopts it together. Sequencing inside the work is for development convenience; the release is one cut, not five.

--- a/packages/bookings/package.json
+++ b/packages/bookings/package.json
@@ -9,6 +9,7 @@
     "./pii": "./src/pii.ts",
     "./schema": "./src/schema.ts",
     "./service-sourced-commitment": "./src/service-sourced-commitment.ts",
+    "./cancellation-consequences": "./src/cancellation-consequences.ts",
     "./requirements": "./src/requirements/index.ts",
     "./requirements/schema": "./src/requirements/schema.ts",
     "./requirements/validation": "./src/requirements/validation.ts",
@@ -95,6 +96,11 @@
         "types": "./dist/pii.d.ts",
         "import": "./dist/pii.js",
         "default": "./dist/pii.js"
+      },
+      "./cancellation-consequences": {
+        "types": "./dist/cancellation-consequences.d.ts",
+        "import": "./dist/cancellation-consequences.js",
+        "default": "./dist/cancellation-consequences.js"
       },
       "./schema": {
         "types": "./dist/schema.d.ts",

--- a/packages/bookings/src/cancellation-consequences.ts
+++ b/packages/bookings/src/cancellation-consequences.ts
@@ -1,0 +1,241 @@
+import type { AnyDrizzleDb } from "@voyant-travel/db"
+import { asc, eq } from "drizzle-orm"
+
+import { bookingItems } from "./schema-items.js"
+
+const DAY_MS = 86_400_000
+
+export type BookingCancellationUnknownReason =
+  | "policy_snapshot_missing"
+  | "policy_snapshot_invalid"
+  | "amount_missing"
+  | "service_date_missing"
+  | "currency_missing"
+  | "currency_mismatch"
+  | "mixed_currency"
+
+export type BookingCancellationPolicyEvaluation =
+  | {
+      status: "evaluated"
+      policyId: string
+      policyVersionId: string
+      version: number
+      result: {
+        refundPercent: number
+        refundCents: number
+        refundType: "cash" | "credit" | "cash_or_credit" | "none"
+        appliedRule: unknown | null
+      }
+    }
+  | { status: "unknown"; reason: "invalid_snapshot" | "currency_mismatch" }
+
+export type BookingCancellationPolicyResult = Extract<
+  BookingCancellationPolicyEvaluation,
+  { status: "evaluated" }
+>["result"]
+
+export type BookingCancellationPolicyEvaluator = (
+  snapshot: unknown,
+  input: { daysBeforeDeparture: number; totalCents: number; currency: string },
+) => BookingCancellationPolicyEvaluation | Promise<BookingCancellationPolicyEvaluation>
+
+export interface BookingCancellationConsequenceItemInput {
+  id: string
+  title: string
+  serviceDate: string | null
+  startsAt: Date | null
+  sellCurrency: string | null
+  totalSellAmountCents: number | null
+  cancellationTermsSnapshot: unknown | null
+}
+
+export interface BookingCancellationItemConsequence {
+  bookingItemId: string
+  title: string
+  currency: string | null
+  totalCents: number | null
+  serviceDate: string | null
+  daysBeforeDeparture: number | null
+  policyId: string | null
+  policyVersionId: string | null
+  policyVersion: number | null
+  status: "evaluated" | "manual_review"
+  reason: BookingCancellationUnknownReason | null
+  result: BookingCancellationPolicyResult | null
+}
+
+export interface BookingCancellationConsequences {
+  status: "evaluated" | "manual_review"
+  asOf: string
+  currency: string | null
+  totalCents: number
+  refundCents: number | null
+  knownRefundCents: number
+  refundPercent: number | null
+  refundType: "cash" | "credit" | "cash_or_credit" | "none" | "mixed" | "unknown"
+  reasons: BookingCancellationUnknownReason[]
+  items: BookingCancellationItemConsequence[]
+}
+
+export async function resolveBookingCancellationConsequences(
+  items: readonly BookingCancellationConsequenceItemInput[],
+  asOf: Date,
+  evaluate: BookingCancellationPolicyEvaluator,
+): Promise<BookingCancellationConsequences> {
+  const consequences = await Promise.all(
+    items.map((item) => resolveItemConsequence(item, asOf, evaluate)),
+  )
+  const reasons = [...new Set(consequences.flatMap((item) => (item.reason ? [item.reason] : [])))]
+  const currencies = [
+    ...new Set(consequences.flatMap((item) => (item.currency ? [item.currency] : []))),
+  ]
+  if (currencies.length > 1) reasons.push("mixed_currency")
+  const manualReview = reasons.length > 0
+  const totalCents = consequences.reduce((sum, item) => sum + (item.totalCents ?? 0), 0)
+  const knownRefundCents = consequences.reduce(
+    (sum, item) => sum + (item.result?.refundCents ?? 0),
+    0,
+  )
+  const refundTypes = new Set(
+    consequences
+      .filter((item) => (item.result?.refundCents ?? 0) > 0)
+      .flatMap((item) => (item.result ? [item.result.refundType] : [])),
+  )
+
+  return {
+    status: manualReview ? "manual_review" : "evaluated",
+    asOf: asOf.toISOString(),
+    currency: currencies.length === 1 ? (currencies[0] ?? null) : null,
+    totalCents,
+    refundCents: manualReview ? null : knownRefundCents,
+    knownRefundCents,
+    refundPercent:
+      manualReview || totalCents === 0
+        ? manualReview
+          ? null
+          : 0
+        : Math.floor((knownRefundCents * 10_000) / totalCents),
+    refundType: manualReview
+      ? "unknown"
+      : refundTypes.size === 0
+        ? "none"
+        : refundTypes.size === 1
+          ? ([...refundTypes][0] ?? "none")
+          : "mixed",
+    reasons,
+    items: consequences,
+  }
+}
+
+export async function resolveBookingCancellationConsequencesFromDb(
+  db: AnyDrizzleDb,
+  bookingId: string,
+  asOf: Date,
+  evaluate: BookingCancellationPolicyEvaluator,
+) {
+  const items = await db
+    .select({
+      id: bookingItems.id,
+      title: bookingItems.title,
+      serviceDate: bookingItems.serviceDate,
+      startsAt: bookingItems.startsAt,
+      sellCurrency: bookingItems.sellCurrency,
+      totalSellAmountCents: bookingItems.totalSellAmountCents,
+      cancellationTermsSnapshot: bookingItems.cancellationTermsSnapshot,
+    })
+    .from(bookingItems)
+    .where(eq(bookingItems.bookingId, bookingId))
+    .orderBy(asc(bookingItems.createdAt), asc(bookingItems.id))
+  return resolveBookingCancellationConsequences(items, asOf, evaluate)
+}
+
+async function resolveItemConsequence(
+  item: BookingCancellationConsequenceItemInput,
+  asOf: Date,
+  evaluate: BookingCancellationPolicyEvaluator,
+): Promise<BookingCancellationItemConsequence> {
+  const serviceDate = item.serviceDate ?? item.startsAt?.toISOString().slice(0, 10) ?? null
+  const daysBeforeDeparture = serviceDate ? daysBetween(asOf, serviceDate) : null
+  const policy = policyFromSnapshot(item.cancellationTermsSnapshot)
+  const reason = missingReason(item, serviceDate, policy)
+  if (
+    reason ||
+    daysBeforeDeparture === null ||
+    item.totalSellAmountCents === null ||
+    !item.sellCurrency
+  ) {
+    return unknownItem(item, serviceDate, daysBeforeDeparture, reason ?? "policy_snapshot_invalid")
+  }
+  const evaluated = await evaluate(policy, {
+    daysBeforeDeparture,
+    totalCents: item.totalSellAmountCents,
+    currency: item.sellCurrency,
+  })
+  if (evaluated.status === "unknown") {
+    return unknownItem(
+      item,
+      serviceDate,
+      daysBeforeDeparture,
+      evaluated.reason === "currency_mismatch" ? "currency_mismatch" : "policy_snapshot_invalid",
+    )
+  }
+  return {
+    bookingItemId: item.id,
+    title: item.title,
+    currency: item.sellCurrency,
+    totalCents: item.totalSellAmountCents,
+    serviceDate,
+    daysBeforeDeparture,
+    policyId: evaluated.policyId,
+    policyVersionId: evaluated.policyVersionId,
+    policyVersion: evaluated.version,
+    status: "evaluated",
+    reason: null,
+    result: evaluated.result,
+  }
+}
+
+function missingReason(
+  item: BookingCancellationConsequenceItemInput,
+  serviceDate: string | null,
+  policy: unknown,
+): BookingCancellationUnknownReason | null {
+  if (item.cancellationTermsSnapshot == null) return "policy_snapshot_missing"
+  if (policy === undefined) return "policy_snapshot_invalid"
+  if (item.totalSellAmountCents == null) return "amount_missing"
+  if (!item.sellCurrency) return "currency_missing"
+  if (!serviceDate) return "service_date_missing"
+  return null
+}
+
+function policyFromSnapshot(snapshot: unknown): unknown | undefined {
+  if (!snapshot || typeof snapshot !== "object" || Array.isArray(snapshot)) return undefined
+  return Object.hasOwn(snapshot, "policy") ? (snapshot as { policy?: unknown }).policy : undefined
+}
+
+function unknownItem(
+  item: BookingCancellationConsequenceItemInput,
+  serviceDate: string | null,
+  daysBeforeDeparture: number | null,
+  reason: BookingCancellationUnknownReason,
+): BookingCancellationItemConsequence {
+  return {
+    bookingItemId: item.id,
+    title: item.title,
+    currency: item.sellCurrency,
+    totalCents: item.totalSellAmountCents,
+    serviceDate,
+    daysBeforeDeparture,
+    policyId: null,
+    policyVersionId: null,
+    policyVersion: null,
+    status: "manual_review",
+    reason,
+    result: null,
+  }
+}
+
+function daysBetween(asOf: Date, serviceDate: string): number {
+  const departure = Date.parse(`${serviceDate}T00:00:00.000Z`)
+  return Math.floor((departure - asOf.getTime()) / DAY_MS)
+}

--- a/packages/bookings/tests/unit/cancellation-consequences.test.ts
+++ b/packages/bookings/tests/unit/cancellation-consequences.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  type BookingCancellationConsequenceItemInput,
+  resolveBookingCancellationConsequences,
+} from "../../src/cancellation-consequences.js"
+
+const AS_OF = new Date("2026-08-01T00:00:00.000Z")
+
+function item(
+  overrides: Partial<BookingCancellationConsequenceItemInput> = {},
+): BookingCancellationConsequenceItemInput {
+  return {
+    id: "item_1",
+    title: "Hotel",
+    serviceDate: "2026-08-21",
+    startsAt: null,
+    sellCurrency: "EUR",
+    totalSellAmountCents: 20_000,
+    cancellationTermsSnapshot: {
+      schemaVersion: 1,
+      source: "booking_quote",
+      sourceId: "quote_1",
+      capturedAt: "2026-07-01T00:00:00.000Z",
+      policy: { schemaVersion: 1, policyVersionId: "polv_sale" },
+      sellCurrency: "EUR",
+      totalSellAmountCents: 20_000,
+      serviceDate: "2026-08-21",
+    },
+    ...overrides,
+  }
+}
+
+describe("resolveBookingCancellationConsequences", () => {
+  it("derives timing and amounts from each sold item and aggregates frozen evaluations", async () => {
+    const evaluate = vi.fn(async (snapshot: unknown, input: { totalCents: number }) => ({
+      status: "evaluated" as const,
+      policyId: "pol_cancel",
+      policyVersionId: (snapshot as { policyVersionId: string }).policyVersionId,
+      version: 1,
+      result: {
+        refundPercent: input.totalCents === 20_000 ? 8000 : 0,
+        refundCents: input.totalCents === 20_000 ? 16_000 : 0,
+        refundType: input.totalCents === 20_000 ? ("cash" as const) : ("none" as const),
+        appliedRule: { id: "rule_sale" },
+      },
+    }))
+
+    const result = await resolveBookingCancellationConsequences(
+      [item(), item({ id: "item_2", title: "Transfer", totalSellAmountCents: 5_000 })],
+      AS_OF,
+      evaluate,
+    )
+
+    expect(evaluate).toHaveBeenNthCalledWith(
+      1,
+      { schemaVersion: 1, policyVersionId: "polv_sale" },
+      { daysBeforeDeparture: 20, totalCents: 20_000, currency: "EUR" },
+    )
+    expect(result).toMatchObject({
+      status: "evaluated",
+      currency: "EUR",
+      totalCents: 25_000,
+      refundCents: 16_000,
+      knownRefundCents: 16_000,
+      refundPercent: 6400,
+      refundType: "cash",
+      reasons: [],
+    })
+  })
+
+  it("marks legacy items for manual review without inventing a zero refund", async () => {
+    const evaluate = vi.fn()
+    const result = await resolveBookingCancellationConsequences(
+      [item({ cancellationTermsSnapshot: null })],
+      AS_OF,
+      evaluate,
+    )
+
+    expect(evaluate).not.toHaveBeenCalled()
+    expect(result).toMatchObject({
+      status: "manual_review",
+      refundCents: null,
+      refundPercent: null,
+      refundType: "unknown",
+      reasons: ["policy_snapshot_missing"],
+      items: [{ status: "manual_review", reason: "policy_snapshot_missing", result: null }],
+    })
+  })
+
+  it("fails closed when frozen policy evaluation rejects the snapshot", async () => {
+    const result = await resolveBookingCancellationConsequences([item()], AS_OF, async () => ({
+      status: "unknown",
+      reason: "invalid_snapshot",
+    }))
+
+    expect(result).toMatchObject({
+      status: "manual_review",
+      refundCents: null,
+      knownRefundCents: 0,
+      reasons: ["policy_snapshot_invalid"],
+    })
+  })
+
+  it("does not aggregate different currencies into one entitlement", async () => {
+    const result = await resolveBookingCancellationConsequences(
+      [item(), item({ id: "item_2", sellCurrency: "USD" })],
+      AS_OF,
+      async (_snapshot, input) => ({
+        status: "evaluated",
+        policyId: "pol_cancel",
+        policyVersionId: "polv_sale",
+        version: 1,
+        result: {
+          refundPercent: 5000,
+          refundCents: input.totalCents / 2,
+          refundType: "cash",
+          appliedRule: null,
+        },
+      }),
+    )
+
+    expect(result).toMatchObject({
+      status: "manual_review",
+      currency: null,
+      refundCents: null,
+      reasons: ["mixed_currency"],
+    })
+  })
+})


### PR DESCRIPTION
## What changed

- adds a Booking-owned cancellation consequence resolver
- reads each item's authoritative amount, currency, service date, and frozen policy payload
- delegates only the frozen policy payload to an injected evaluator port
- returns per-item policy version, applied result, and aggregate entitlement
- fails closed to manual review for legacy/malformed evidence, missing facts, currency mismatch, or mixed currencies
- exposes the resolver through a deliberate package subpath for composition without a Legal↔Bookings dependency cycle

## Why

A proper cancellation intent tool must derive policy, timing, and amount from the Booking rather than accept those facts from a model. It must also distinguish unknown historic entitlement from a legitimate zero-refund policy.

This is Slice 3 of #4405 and prepares approval binding in the next slice.

## Validation

- focused Biome checks pass
- git diff --check passes
- focused unit coverage includes multi-item aggregation, legacy evidence, invalid snapshots, and mixed currencies
- GitHub CI provides executable tests, typecheck, package-export, and architecture validation
