### PR TITLE
feat: audit approved cancellation entitlement

### DIFF
--- a/.changeset/audit-approved-cancellation-entitlement.md
+++ b/.changeset/audit-approved-cancellation-entitlement.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/bookings": patch
+"@voyant-travel/finance": patch
+---
+
+Carry the exact approved cancellation-policy entitlement into financial settlement and booking activity audit records.

--- a/packages/bookings/src/mcp-runtime.test.ts
+++ b/packages/bookings/src/mcp-runtime.test.ts
@@ -115,6 +115,18 @@ describe("bookings MCP runtime lifecycle detail", () => {
     expect(statusMutation).toHaveBeenCalledOnce()
     expect(statusMutation.mock.calls[0]?.[4]).toMatchObject({
       actionLedgerCausationActionId: "action_claim_1",
+      cancellationPolicyEntitlement: {
+        status: "evaluated",
+        asOf: expect.any(String),
+        refundCents: 500,
+        items: [
+          expect.objectContaining({
+            bookingItemId: "item_1",
+            policyVersionId: "polv_sale",
+            result: expect.objectContaining({ refundCents: 500 }),
+          }),
+        ],
+      },
       actionLedgerContext: {
         userId: "user_1",
         agentId: "agent_1",

--- a/packages/bookings/src/mcp-runtime.ts
+++ b/packages/bookings/src/mcp-runtime.ts
@@ -18,6 +18,7 @@ import {
 import { sql } from "drizzle-orm"
 import type { Context } from "hono"
 import {
+  type BookingCancellationConsequences,
   type BookingCancellationPolicyEvaluator,
   resolveBookingCancellationConsequences,
 } from "./cancellation-consequences.js"
@@ -364,6 +365,7 @@ async function executeBookingStatusToolCommand(input: {
           userId,
           {
             ...lifecycleRuntime,
+            cancellationPolicyEntitlement: cancellationPolicyEntitlement(currentPreview),
             closePaymentSchedulesForBooking: routeRuntime.closePaymentSchedulesForBooking,
             recordCancellationFinancialSettlement:
               routeRuntime.recordCancellationFinancialSettlement,
@@ -609,6 +611,20 @@ function policyEntitlementAsOf(preview: Record<string, unknown>): Date {
     })
   }
   return parsed
+}
+
+function cancellationPolicyEntitlement(
+  preview: Record<string, unknown>,
+): BookingCancellationConsequences {
+  const entitlement = preview.policyEntitlement
+  if (!isRecord(entitlement) || entitlement.status !== "evaluated") {
+    throw new ToolError(
+      "Cancellation policy entitlement requires manual review; no cancellation was written.",
+      "INVALID_INPUT",
+      { reason: "policy_manual_review_required" },
+    )
+  }
+  return entitlement as unknown as BookingCancellationConsequences
 }
 
 async function loadFinanceConsequenceTables(

--- a/packages/bookings/src/route-runtime.ts
+++ b/packages/bookings/src/route-runtime.ts
@@ -7,6 +7,7 @@ import {
   resolveMonthlyBookingLimit,
   selectMonthlyBookingLimit,
 } from "./booking-plan-limit.js"
+import type { BookingCancellationConsequences } from "./cancellation-consequences.js"
 import type { BookingTravelerSnapshot } from "./pii.js"
 import type { KmsBindings } from "./routes-shared.js"
 import type {
@@ -98,6 +99,7 @@ export type RecordCancellationFinancialSettlement = (
     previousStatus: Extract<BookingStatus, "confirmed" | "in_progress">
     reason: string | null
     actorId: string
+    cancellationPolicyEntitlement?: BookingCancellationConsequences
   },
 ) =>
   | Promise<Record<string, unknown> | null | undefined>

--- a/packages/bookings/src/service-core.ts
+++ b/packages/bookings/src/service-core.ts
@@ -44,6 +44,7 @@ import {
   assertMonthlyBookingLimitAvailable,
   BookingMonthlyLimitReachedError,
 } from "./booking-plan-limit.js"
+import type { BookingCancellationConsequences } from "./cancellation-consequences.js"
 import {
   type ConvertDayService,
   type ConvertDayServiceProvenance,
@@ -378,6 +379,7 @@ export interface BookingServiceRuntime {
   actionLedgerIdempotencyKey?: string | null
   actionLedgerIdempotencyFingerprint?: string | null
   actionLedgerRouteOrToolName?: string | null
+  cancellationPolicyEntitlement?: BookingCancellationConsequences
   expirePaymentSessionsForBooking?: (
     db: PostgresJsDatabase,
     bookingId: string,
@@ -395,6 +397,7 @@ export interface BookingServiceRuntime {
       previousStatus: BookingCancelledEvent["previousStatus"]
       reason: string | null
       actorId: string
+      cancellationPolicyEntitlement?: BookingCancellationConsequences
     },
   ) =>
     | Promise<Record<string, unknown> | null | undefined>
@@ -3150,6 +3153,9 @@ const bookingsServiceInternal = {
             previousStatus,
             reason: cancellationReason,
             actorId: userId ?? "system",
+            ...(runtime.cancellationPolicyEntitlement
+              ? { cancellationPolicyEntitlement: runtime.cancellationPolicyEntitlement }
+              : {}),
           },
         )
         const financialSettlementMessage =
@@ -3172,6 +3178,9 @@ const bookingsServiceInternal = {
             oldStatus: booking.status,
             newStatus: "cancelled",
             reason: cancellationReason,
+            ...(runtime.cancellationPolicyEntitlement
+              ? { cancellationPolicyEntitlement: runtime.cancellationPolicyEntitlement }
+              : {}),
             ...(financialSettlement ? { financialSettlement } : {}),
           },
         })

--- a/packages/finance/src/booking-lifecycle.ts
+++ b/packages/finance/src/booking-lifecycle.ts
@@ -9,6 +9,9 @@ export interface BookingCancellationSettlementInput {
   previousStatus: "confirmed" | "in_progress"
   reason: string | null
   actorId: string
+  cancellationPolicyEntitlement?: Parameters<
+    BookingFinancialLifecycle["recordCancellationFinancialSettlement"]
+  >[1]["cancellationPolicyEntitlement"]
 }
 
 interface PaidInvoice {
@@ -84,6 +87,9 @@ export async function recordPaidBookingCancellationSettlement(
     invoiceNumbers: paidInvoices.map((invoice) => invoice.invoiceNumber),
     financeNoteIds: noteIds,
     paidByCurrency: summarizePaidByCurrency(paidInvoices),
+    ...(input.cancellationPolicyEntitlement
+      ? { cancellationPolicyEntitlement: input.cancellationPolicyEntitlement }
+      : {}),
     message: "Paid booking cancelled; review refund, credit-note, or no-refund settlement.",
   }
 }

--- a/packages/finance/tests/unit/booking-lifecycle.test.ts
+++ b/packages/finance/tests/unit/booking-lifecycle.test.ts
@@ -24,12 +24,14 @@ describe("recordPaidBookingCancellationSettlement", () => {
       },
     ])
 
+    const cancellationPolicyEntitlement = evaluatedEntitlement()
     const settlement = await recordPaidBookingCancellationSettlement(db as never, {
       bookingId: "book_1",
       bookingNumber: "BK-1",
       previousStatus: "confirmed",
       reason: "Client requested",
       actorId: "user_1",
+      cancellationPolicyEntitlement,
     })
 
     expect(settlement).toMatchObject({
@@ -38,6 +40,7 @@ describe("recordPaidBookingCancellationSettlement", () => {
       invoiceIds: ["inv_1", "inv_2"],
       invoiceNumbers: ["INV-1", "INV-2"],
       paidByCurrency: { GBP: 15000 },
+      cancellationPolicyEntitlement,
     })
     expect(db.insertedNotes).toHaveLength(2)
     expect(db.insertedNotes[0]).toMatchObject({ invoiceId: "inv_1", authorId: "user_1" })
@@ -80,6 +83,41 @@ describe("recordPaidBookingCancellationSettlement", () => {
     ).not.toContain("Cancellation reason")
   })
 })
+
+function evaluatedEntitlement() {
+  return {
+    status: "evaluated" as const,
+    asOf: "2026-08-01T00:00:00.000Z",
+    currency: "GBP",
+    totalCents: 15000,
+    refundCents: 7500,
+    knownRefundCents: 7500,
+    refundPercent: 5000,
+    refundType: "cash" as const,
+    reasons: [],
+    items: [
+      {
+        bookingItemId: "item_1",
+        title: "Cruise",
+        currency: "GBP",
+        totalCents: 15000,
+        serviceDate: "2026-09-01",
+        daysBeforeDeparture: 31,
+        policyId: "pol_1",
+        policyVersionId: "polv_sale",
+        policyVersion: 1,
+        status: "evaluated" as const,
+        reason: null,
+        result: {
+          refundPercent: 5000,
+          refundCents: 7500,
+          refundType: "cash" as const,
+          appliedRule: { id: "rule_1" },
+        },
+      },
+    ],
+  }
+}
 
 interface FakePaidInvoice {
   id: string


### PR DESCRIPTION
## Summary
- pass the canonically revalidated cancellation-policy entitlement into the booking cancellation mutation
- persist the exact approved entitlement in booking activity metadata, independently of Finance settlement availability
- carry the same entitlement into paid-invoice settlement metadata for downstream operator decisions

## Why
Cancellation must be settled from the immutable sale-time policy evaluation approved by the operator or agent. The mutation must not dereference the policy current version or silently lose the contractual refund evidence.

## Verification
- Sprite: focused Biome check
- Sprite: `pnpm --filter @voyant-travel/bookings typecheck`
- Sprite: Bookings unit suite (470 passed)
- Sprite: `pnpm --filter @voyant-travel/finance typecheck`
- Sprite: Finance unit suite (562 passed)

Tracks #4405