### PR TITLE
Generate contracts when bookings are confirmed

### DIFF
--- a/.changeset/bright-dodos-confirm-contracts.md
+++ b/.changeset/bright-dodos-confirm-contracts.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/legal": patch
+---
+
+Generate the customer contract document automatically and idempotently when a booking is confirmed, using the selected Legal artifact provider and the durable action-ledger-backed operation.

--- a/packages/accommodations/tsconfig.build.json
+++ b/packages/accommodations/tsconfig.build.json
@@ -1346,6 +1346,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-confirmed-subscriber": [
+        "../legal/dist/booking-contract-confirmed-subscriber.d.ts"
+      ],
       "@voyant-travel/legal/contract-document-job": ["../legal/dist/contract-document-job.d.ts"],
       "@voyant-travel/legal/contract-document-routes": [
         "../legal/dist/contract-document-routes.d.ts"

--- a/packages/accommodations/tsconfig.typecheck.json
+++ b/packages/accommodations/tsconfig.typecheck.json
@@ -1347,6 +1347,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-confirmed-subscriber": [
+        "../legal/dist/booking-contract-confirmed-subscriber.d.ts"
+      ],
       "@voyant-travel/legal/contract-document-job": ["../legal/dist/contract-document-job.d.ts"],
       "@voyant-travel/legal/contract-document-routes": [
         "../legal/dist/contract-document-routes.d.ts"

--- a/packages/catalog/tsconfig.build.json
+++ b/packages/catalog/tsconfig.build.json
@@ -1301,6 +1301,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-confirmed-subscriber": [
+        "../legal/dist/booking-contract-confirmed-subscriber.d.ts"
+      ],
       "@voyant-travel/legal/contract-document-job": ["../legal/dist/contract-document-job.d.ts"],
       "@voyant-travel/legal/contract-document-routes": [
         "../legal/dist/contract-document-routes.d.ts"

--- a/packages/catalog/tsconfig.typecheck.json
+++ b/packages/catalog/tsconfig.typecheck.json
@@ -1302,6 +1302,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-confirmed-subscriber": [
+        "../legal/dist/booking-contract-confirmed-subscriber.d.ts"
+      ],
       "@voyant-travel/legal/contract-document-job": ["../legal/dist/contract-document-job.d.ts"],
       "@voyant-travel/legal/contract-document-routes": [
         "../legal/dist/contract-document-routes.d.ts"

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -1306,6 +1306,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-confirmed-subscriber": [
+        "../legal/dist/booking-contract-confirmed-subscriber.d.ts"
+      ],
       "@voyant-travel/legal/contract-document-job": ["../legal/dist/contract-document-job.d.ts"],
       "@voyant-travel/legal/contract-document-routes": [
         "../legal/dist/contract-document-routes.d.ts"

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -1300,6 +1300,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-confirmed-subscriber": [
+        "../legal/dist/booking-contract-confirmed-subscriber.d.ts"
+      ],
       "@voyant-travel/legal/contract-document-job": ["../legal/dist/contract-document-job.d.ts"],
       "@voyant-travel/legal/contract-document-routes": [
         "../legal/dist/contract-document-routes.d.ts"

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -1351,6 +1351,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-confirmed-subscriber": [
+        "../legal/dist/booking-contract-confirmed-subscriber.d.ts"
+      ],
       "@voyant-travel/legal/contract-document-job": ["../legal/dist/contract-document-job.d.ts"],
       "@voyant-travel/legal/contract-document-routes": [
         "../legal/dist/contract-document-routes.d.ts"

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -1352,6 +1352,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-confirmed-subscriber": [
+        "../legal/dist/booking-contract-confirmed-subscriber.d.ts"
+      ],
       "@voyant-travel/legal/contract-document-job": ["../legal/dist/contract-document-job.d.ts"],
       "@voyant-travel/legal/contract-document-routes": [
         "../legal/dist/contract-document-routes.d.ts"

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -1355,6 +1355,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-confirmed-subscriber": [
+        "../legal/dist/booking-contract-confirmed-subscriber.d.ts"
+      ],
       "@voyant-travel/legal/contract-document-job": ["../legal/dist/contract-document-job.d.ts"],
       "@voyant-travel/legal/contract-document-routes": [
         "../legal/dist/contract-document-routes.d.ts"

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -1356,6 +1356,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-confirmed-subscriber": [
+        "../legal/dist/booking-contract-confirmed-subscriber.d.ts"
+      ],
       "@voyant-travel/legal/contract-document-job": ["../legal/dist/contract-document-job.d.ts"],
       "@voyant-travel/legal/contract-document-routes": [
         "../legal/dist/contract-document-routes.d.ts"

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -1387,6 +1387,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-confirmed-subscriber": [
+        "../legal/dist/booking-contract-confirmed-subscriber.d.ts"
+      ],
       "@voyant-travel/legal/contract-document-job": ["../legal/dist/contract-document-job.d.ts"],
       "@voyant-travel/legal/contract-document-routes": [
         "../legal/dist/contract-document-routes.d.ts"

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -1382,6 +1382,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-confirmed-subscriber": [
+        "../legal/dist/booking-contract-confirmed-subscriber.d.ts"
+      ],
       "@voyant-travel/legal/contract-document-job": ["../legal/dist/contract-document-job.d.ts"],
       "@voyant-travel/legal/contract-document-routes": [
         "../legal/dist/contract-document-routes.d.ts"

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -1389,6 +1389,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-confirmed-subscriber": [
+        "../legal/dist/booking-contract-confirmed-subscriber.d.ts"
+      ],
       "@voyant-travel/legal/contract-document-job": ["../legal/dist/contract-document-job.d.ts"],
       "@voyant-travel/legal/contract-document-routes": [
         "../legal/dist/contract-document-routes.d.ts"

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -1390,6 +1390,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-confirmed-subscriber": [
+        "../legal/dist/booking-contract-confirmed-subscriber.d.ts"
+      ],
       "@voyant-travel/legal/contract-document-job": ["../legal/dist/contract-document-job.d.ts"],
       "@voyant-travel/legal/contract-document-routes": [
         "../legal/dist/contract-document-routes.d.ts"

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -1387,6 +1387,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-confirmed-subscriber": [
+        "../legal/dist/booking-contract-confirmed-subscriber.d.ts"
+      ],
       "@voyant-travel/legal/contract-document-job": ["../legal/dist/contract-document-job.d.ts"],
       "@voyant-travel/legal/contract-document-routes": [
         "../legal/dist/contract-document-routes.d.ts"

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -1382,6 +1382,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-confirmed-subscriber": [
+        "../legal/dist/booking-contract-confirmed-subscriber.d.ts"
+      ],
       "@voyant-travel/legal/contract-document-job": ["../legal/dist/contract-document-job.d.ts"],
       "@voyant-travel/legal/contract-document-routes": [
         "../legal/dist/contract-document-routes.d.ts"

--- a/packages/inventory/tsconfig.build.json
+++ b/packages/inventory/tsconfig.build.json
@@ -1319,6 +1319,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-confirmed-subscriber": [
+        "../legal/dist/booking-contract-confirmed-subscriber.d.ts"
+      ],
       "@voyant-travel/legal/contract-document-job": ["../legal/dist/contract-document-job.d.ts"],
       "@voyant-travel/legal/contract-document-routes": [
         "../legal/dist/contract-document-routes.d.ts"

--- a/packages/inventory/tsconfig.typecheck.json
+++ b/packages/inventory/tsconfig.typecheck.json
@@ -1320,6 +1320,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-confirmed-subscriber": [
+        "../legal/dist/booking-contract-confirmed-subscriber.d.ts"
+      ],
       "@voyant-travel/legal/contract-document-job": ["../legal/dist/contract-document-job.d.ts"],
       "@voyant-travel/legal/contract-document-routes": [
         "../legal/dist/contract-document-routes.d.ts"

--- a/packages/legal/README.md
+++ b/packages/legal/README.md
@@ -77,6 +77,14 @@ attachment with the immutable result and deterministic outbox event. The prior
 canonical attachment remains readable until that final transaction; deletion
 of its old object is an idempotent, resumable cleanup checkpoint.
 
+When a deployment selects a conformant Legal document-artifact provider, the
+Legal `booking.confirmed` subscriber automatically selects the active default
+customer template, records a system action-ledger claim, and admits that same
+durable document operation. Redelivery is idempotent per booking. Deployments
+without a provider remain inert, and a missing applicable template or required
+booking data skips generation without inventing customer data. Public booking
+commands do not expose or require a document-generation switch.
+
 The previous direct generator/reset routes have been removed:
 
 - `POST /v1/admin/legal/contracts/bookings/:bookingId/generate-document`

--- a/packages/legal/package.json
+++ b/packages/legal/package.json
@@ -9,6 +9,7 @@
     "./standard-links": "./src/standard-links.ts",
     "./contract-document-routes": "./src/contract-document-routes.ts",
     "./contract-document-job": "./src/contract-document-job.ts",
+    "./booking-contract-confirmed-subscriber": "./src/booking-contract-confirmed-subscriber.ts",
     "./schema": "./src/schema.ts",
     "./contracts": "./src/contracts/index.ts",
     "./contracts/linkables": "./src/contracts/linkables.ts",
@@ -109,6 +110,11 @@
         "types": "./dist/contract-document-job.d.ts",
         "import": "./dist/contract-document-job.js",
         "default": "./dist/contract-document-job.js"
+      },
+      "./booking-contract-confirmed-subscriber": {
+        "types": "./dist/booking-contract-confirmed-subscriber.d.ts",
+        "import": "./dist/booking-contract-confirmed-subscriber.js",
+        "default": "./dist/booking-contract-confirmed-subscriber.js"
       },
       "./schema": {
         "types": "./dist/schema.d.ts",

--- a/packages/legal/src/booking-contract-confirmed-subscriber.ts
+++ b/packages/legal/src/booking-contract-confirmed-subscriber.ts
@@ -1,0 +1,66 @@
+import type { EventEnvelope, SubscriberRuntimeDescriptor } from "@voyant-travel/core"
+import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import { generateBookingContractOnConfirmation } from "./booking-contract-confirmed.js"
+import { legalContractDocumentJobRuntimePort } from "./contract-document-job-runtime-port.js"
+import {
+  type LegalDocumentArtifactProvider,
+  legalDocumentArtifactProviderPort,
+} from "./contracts/document-artifact-provider.js"
+
+export const LEGAL_BOOKING_CONTRACT_CONFIRMED_SUBSCRIBER_ID =
+  "@voyant-travel/legal#subscriber.booking-contract-confirmed"
+
+export interface LegalBookingConfirmedPayload {
+  bookingId: string
+  bookingNumber: string
+  actorId: string | null
+  suppressNotifications?: boolean
+}
+
+export type LegalBookingConfirmedEvent = EventEnvelope<LegalBookingConfirmedPayload>
+
+export interface LegalBookingContractConfirmedSubscriberOptions {
+  resolveDb(): PostgresJsDatabase | Promise<PostgresJsDatabase>
+  provider?: LegalDocumentArtifactProvider
+  generate?: (input: {
+    db: PostgresJsDatabase
+    event: LegalBookingConfirmedEvent
+  }) => Promise<unknown>
+}
+
+/** Register the durable Legal projection of the booking confirmation event. */
+export function createLegalBookingContractConfirmedSubscriber(
+  options: LegalBookingContractConfirmedSubscriberOptions,
+): SubscriberRuntimeDescriptor {
+  return {
+    id: LEGAL_BOOKING_CONTRACT_CONFIRMED_SUBSCRIBER_ID,
+    eventType: "booking.confirmed",
+    register: ({ eventBus }) => {
+      eventBus.subscribe<LegalBookingConfirmedPayload>("booking.confirmed", async (event) => {
+        if (!options.provider && !options.generate) return
+        const db = await options.resolveDb()
+        if (options.generate) {
+          await options.generate({ db, event })
+          return
+        }
+        await generateBookingContractOnConfirmation({ db, event, provider: options.provider! })
+      })
+    },
+  }
+}
+
+/** Resolve only graph-selected runtime ports; a deployment without a renderer remains inert. */
+export const createLegalBookingContractConfirmedSubscriberGraphRuntime = defineGraphRuntimeFactory(
+  async ({ getPort, hasPort }) => {
+    const runtime = await getPort(legalContractDocumentJobRuntimePort)
+    const provider = hasPort(legalDocumentArtifactProviderPort)
+      ? await getPort(legalDocumentArtifactProviderPort)
+      : undefined
+    return createLegalBookingContractConfirmedSubscriber({
+      resolveDb: runtime.resolveDb,
+      ...(provider ? { provider } : {}),
+    })
+  },
+)

--- a/packages/legal/src/booking-contract-confirmed.ts
+++ b/packages/legal/src/booking-contract-confirmed.ts
@@ -1,0 +1,448 @@
+import {
+  actionLedgerService,
+  buildActionApprovalCommandFingerprint,
+  buildActionLedgerMutationEntryInput,
+  buildExistingTargetIdempotencyScope,
+} from "@voyant-travel/action-ledger"
+import { bookingItems, bookingOrigins, bookings } from "@voyant-travel/bookings/schema"
+import type { EventEnvelope } from "@voyant-travel/core"
+import { and, desc, eq, sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import type {
+  LegalBookingConfirmedEvent,
+  LegalBookingConfirmedPayload,
+} from "./booking-contract-confirmed-subscriber.js"
+import {
+  bookingContractCustomerVariables,
+  bookingContractPrerequisites,
+  bookingContractReviewSnapshot,
+  bookingContractTemplateMatchesChannel,
+  resolveBookingContractLanguage,
+} from "./booking-contract-review.js"
+import type {
+  LegalDocumentArtifactProvider,
+  LegalDocumentRenderDescriptor,
+} from "./contracts/document-artifact-provider.js"
+import { createLegalDocumentOperationEngine } from "./contracts/document-operation.js"
+import {
+  contractAttachments,
+  contracts,
+  contractTemplates,
+  contractTemplateVersions,
+} from "./contracts/schema.js"
+import { contractsService, validateTemplateVariables } from "./contracts/service.js"
+
+export const LEGAL_BOOKING_CONTRACT_CONFIRMED_ACTION_ID =
+  "@voyant-travel/legal#action.generate-booking-contract-on-confirmation"
+const BOOKING_CONFIRMED_EVENT_ID = "@voyant-travel/bookings#event.booking.confirmed"
+const SYSTEM_PRINCIPAL_ID = "legal-booking-contract-confirmed"
+
+export type BookingContractConfirmationResult =
+  | { status: "generated"; contractId: string; attachmentId: string; replayed: boolean }
+  | { status: "pending"; contractId: string; operationId: string; replayed: boolean }
+  | { status: "already_generated"; contractId: string; attachmentId: string }
+  | {
+      status: "skipped"
+      reason:
+        | "booking_not_found"
+        | "template_not_found"
+        | "template_version_missing"
+        | "contract_not_mutable"
+        | "missing_prerequisites"
+      missingPrerequisites?: string[]
+    }
+
+interface GenerateBookingContractOnConfirmationInput {
+  db: PostgresJsDatabase
+  event: LegalBookingConfirmedEvent
+  provider: LegalDocumentArtifactProvider
+}
+
+interface PreparedTarget {
+  bookingId: string
+  contractId: string
+  organizationId: string | null
+  descriptor: LegalDocumentRenderDescriptor
+}
+
+/**
+ * Project one booking confirmation into one ledgered, durable Legal document
+ * operation. The booking id is the idempotency key, so outbox redelivery and a
+ * repeated confirmation cannot create a second canonical contract document.
+ */
+export async function generateBookingContractOnConfirmation(
+  input: GenerateBookingContractOnConfirmationInput,
+): Promise<BookingContractConfirmationResult> {
+  const engine = createLegalDocumentOperationEngine({ provider: input.provider })
+  const prepared = await input.db.transaction(async (rawTx) => {
+    const tx = rawTx as PostgresJsDatabase
+    const bookingId = input.event.data.bookingId
+    // agent-quality: raw-sql reviewed -- owner: legal; the booking id is parameterized and the transaction-scoped advisory lock serializes idempotent confirmation delivery.
+    await tx.execute(
+      sql`select pg_advisory_xact_lock(hashtext(${`legal:booking-confirmed:${bookingId}`}))`,
+    )
+
+    const target = await prepareBookingContractTarget(tx, bookingId)
+    if (target.status !== "prepared") return target
+
+    const sourceEventId = resolveSourceEventId(input.event)
+    const commandPayload = { bookingId, sourceEventId }
+    const idempotencyKey = `booking-confirmed:${bookingId}`
+    const idempotencyFingerprint = await buildActionApprovalCommandFingerprint({
+      actionName: LEGAL_BOOKING_CONTRACT_CONFIRMED_ACTION_ID,
+      actionVersion: "v1",
+      targetType: "booking",
+      targetId: bookingId,
+      commandInput: commandPayload,
+      approvalPolicy: "none",
+      capabilityId: LEGAL_BOOKING_CONTRACT_CONFIRMED_ACTION_ID,
+      capabilityVersion: "v1",
+      evaluatedRisk: "high",
+      reasonCode: null,
+    })
+    const idempotencyScope = await buildExistingTargetIdempotencyScope({
+      actionName: LEGAL_BOOKING_CONTRACT_CONFIRMED_ACTION_ID,
+      actionVersion: "v1",
+      principalType: "system",
+      principalId: SYSTEM_PRINCIPAL_ID,
+      organizationId: target.organizationId,
+    })
+    const context = {
+      userId: SYSTEM_PRINCIPAL_ID,
+      actor: "system",
+      callerType: "internal",
+      isInternalRequest: true,
+      organizationId: target.organizationId,
+      correlationId: sourceEventId,
+    } as const
+    const claim = await actionLedgerService.appendEntry(
+      tx,
+      buildActionLedgerMutationEntryInput({
+        context,
+        actionName: LEGAL_BOOKING_CONTRACT_CONFIRMED_ACTION_ID,
+        actionVersion: "v1",
+        actionKind: "execute",
+        status: "requested",
+        evaluatedRisk: "high",
+        targetType: "booking",
+        targetId: bookingId,
+        routeOrToolName: BOOKING_CONFIRMED_EVENT_ID,
+        capabilityId: LEGAL_BOOKING_CONTRACT_CONFIRMED_ACTION_ID,
+        capabilityVersion: "v1",
+        authorizationSource: "selected_graph_event",
+        idempotencyScope,
+        idempotencyKey,
+        idempotencyFingerprint,
+        mutationDetail: {
+          summary: "Generate the customer contract after booking confirmation",
+          reversalKind: "none",
+        },
+      }),
+    )
+    const admission = await engine.admit({
+      db: tx,
+      bookingId,
+      mode: "generate",
+      idempotencyKey,
+      requestFingerprint: idempotencyFingerprint,
+      principal: {
+        type: "system",
+        id: SYSTEM_PRINCIPAL_ID,
+        organizationId: target.organizationId,
+      },
+      claim: {
+        actionId: claim.entry.id,
+        actionName: LEGAL_BOOKING_CONTRACT_CONFIRMED_ACTION_ID,
+        actionVersion: "v1",
+        targetType: "booking",
+        targetId: bookingId,
+        idempotencyScope,
+        idempotencyKey,
+        idempotencyFingerprint,
+        commandPayload,
+      },
+      prepareTarget: async () => target,
+    })
+    return {
+      status: "admitted" as const,
+      contractId: target.contractId,
+      operationId: admission.operationId,
+      replayed: claim.replayed || admission.replayed,
+    }
+  })
+
+  if (prepared.status !== "admitted") return prepared
+  const result = await engine.run(input.db, prepared.operationId)
+  return result
+    ? {
+        status: "generated",
+        contractId: result.contractId,
+        attachmentId: result.attachmentId,
+        replayed: prepared.replayed,
+      }
+    : {
+        status: "pending",
+        contractId: prepared.contractId,
+        operationId: prepared.operationId,
+        replayed: prepared.replayed,
+      }
+}
+
+async function prepareBookingContractTarget(
+  db: PostgresJsDatabase,
+  bookingId: string,
+): Promise<
+  | ({ status: "prepared" } & PreparedTarget)
+  | Exclude<BookingContractConfirmationResult, { status: "generated" | "pending" }>
+> {
+  const [booking] = await db.select().from(bookings).where(eq(bookings.id, bookingId)).limit(1)
+  if (!booking) return { status: "skipped", reason: "booking_not_found" }
+
+  const existingContracts = await db
+    .select()
+    .from(contracts)
+    .where(and(eq(contracts.bookingId, bookingId), eq(contracts.scope, "customer")))
+    .orderBy(desc(contracts.createdAt), desc(contracts.id))
+  if (existingContracts.length > 0) {
+    const existingIds = existingContracts.map(({ id }) => id)
+    const [canonical] = await db
+      .select({ attachment: contractAttachments, contract: contracts })
+      .from(contractAttachments)
+      .innerJoin(contracts, eq(contracts.id, contractAttachments.contractId))
+      .where(
+        and(
+          eq(contractAttachments.kind, "document"),
+          eq(contracts.bookingId, bookingId),
+          eq(contracts.scope, "customer"),
+        ),
+      )
+      .orderBy(desc(contractAttachments.createdAt))
+      .limit(1)
+    if (canonical && existingIds.includes(canonical.contract.id)) {
+      return {
+        status: "already_generated",
+        contractId: canonical.contract.id,
+        attachmentId: canonical.attachment.id,
+      }
+    }
+  }
+
+  const [origin] = await db
+    .select()
+    .from(bookingOrigins)
+    .where(eq(bookingOrigins.bookingId, bookingId))
+    .limit(1)
+  const items = await db.select().from(bookingItems).where(eq(bookingItems.bookingId, bookingId))
+  const language = resolveBookingContractLanguage(booking)
+  const reusable = existingContracts.find((contract) => {
+    const metadata = record(contract.metadata)
+    return (
+      contract.status === "draft" &&
+      (metadata.autoGenerated === true ||
+        record(metadata).acceptance !== undefined ||
+        record(metadata).bookingContractWorkflow !== undefined)
+    )
+  })
+
+  const selected = await resolveTemplateSelection(db, {
+    reusable,
+    language,
+    channelId: origin?.channelId ?? null,
+  })
+  if (selected.status !== "selected") return selected
+
+  const variables = bookingContractVariables(booking, items)
+  const missingPrerequisites = bookingContractPrerequisites({
+    templateApplicable:
+      reusable?.templateVersionId === selected.version.id ||
+      (selected.template.active &&
+        selected.template.scope === "customer" &&
+        selected.template.currentVersionId === selected.version.id &&
+        selected.template.language === language &&
+        bookingContractTemplateMatchesChannel(
+          selected.template.channelId,
+          origin?.channelId ?? null,
+        )),
+    totalAmountCents: booking.sellAmountCents,
+    itemCount: items.length,
+    missingRequiredVariables: validateTemplateVariables(
+      selected.version.variableSchema ?? selected.template.variableSchema,
+      variables,
+    ),
+  })
+  if (missingPrerequisites.length > 0) {
+    return { status: "skipped", reason: "missing_prerequisites", missingPrerequisites }
+  }
+
+  const reviewSnapshot = bookingContractReviewSnapshot({
+    booking,
+    items,
+    template: selected.template,
+    version: selected.version,
+    language,
+    commercialTerms: record(variables.commercial),
+  })
+  const renderedBody = contractsService.renderPreview({
+    body: selected.version.body,
+    variables,
+  })
+  const metadata = {
+    ...record(reusable?.metadata),
+    autoGenerated: true,
+    trigger: "booking.confirmed",
+    bookingContractWorkflow: {
+      revision: 1,
+      previousRevisionId: null,
+      reviewOnly: true,
+      reviewSnapshot,
+    },
+  }
+
+  const contract = reusable
+    ? await db
+        .update(contracts)
+        .set({
+          title: reusable.title || `${selected.template.name} — ${booking.bookingNumber}`,
+          templateVersionId: selected.version.id,
+          personId: reusable.personId ?? booking.personId,
+          organizationId: reusable.organizationId ?? booking.organizationId,
+          channelId: reusable.channelId ?? origin?.channelId ?? null,
+          language,
+          variables,
+          renderedBody,
+          renderedBodyFormat: "html",
+          metadata,
+          updatedAt: new Date(),
+        })
+        .where(and(eq(contracts.id, reusable.id), eq(contracts.status, "draft")))
+        .returning()
+        .then(([row]) => row ?? null)
+    : await contractsService.createContract(
+        db,
+        {
+          scope: "customer",
+          status: "draft",
+          title: `${selected.template.name} — ${booking.bookingNumber}`,
+          templateVersionId: selected.version.id,
+          seriesId: null,
+          bookingId,
+          personId: booking.personId,
+          organizationId: booking.organizationId,
+          channelId: origin?.channelId ?? null,
+          language,
+          variables,
+          renderedBody,
+          renderedBodyFormat: "html",
+          metadata,
+        },
+        { allowBookingContractWorkflow: true },
+      )
+  if (!contract) return { status: "skipped", reason: "contract_not_mutable" }
+
+  return {
+    status: "prepared",
+    bookingId,
+    contractId: contract.id,
+    organizationId: booking.organizationId,
+    descriptor: {
+      contractId: contract.id,
+      bookingId,
+      templateVersionId: selected.version.id,
+      contractNumber: contract.contractNumber,
+      body: renderedBody,
+      bodyFormat: "html",
+      variables,
+    },
+  }
+}
+
+async function resolveTemplateSelection(
+  db: PostgresJsDatabase,
+  input: {
+    reusable: typeof contracts.$inferSelect | undefined
+    language: string
+    channelId: string | null
+  },
+): Promise<
+  | {
+      status: "selected"
+      template: typeof contractTemplates.$inferSelect
+      version: typeof contractTemplateVersions.$inferSelect
+    }
+  | Extract<BookingContractConfirmationResult, { status: "skipped" }>
+> {
+  if (input.reusable?.templateVersionId) {
+    const [selection] = await db
+      .select({ template: contractTemplates, version: contractTemplateVersions })
+      .from(contractTemplateVersions)
+      .innerJoin(contractTemplates, eq(contractTemplates.id, contractTemplateVersions.templateId))
+      .where(eq(contractTemplateVersions.id, input.reusable.templateVersionId))
+      .limit(1)
+    if (selection) return { status: "selected", ...selection }
+  }
+
+  const template = await contractsService.getDefaultTemplate(db, {
+    scope: "customer",
+    language: input.language,
+    channelId: input.channelId ?? undefined,
+    fallbackLanguages: input.language === "en" ? [] : ["en"],
+  })
+  if (!template) return { status: "skipped", reason: "template_not_found" }
+  if (!template.currentVersionId) {
+    return { status: "skipped", reason: "template_version_missing" }
+  }
+  const [version] = await db
+    .select()
+    .from(contractTemplateVersions)
+    .where(eq(contractTemplateVersions.id, template.currentVersionId))
+    .limit(1)
+  return version
+    ? { status: "selected", template, version }
+    : { status: "skipped", reason: "template_version_missing" }
+}
+
+function bookingContractVariables(
+  booking: typeof bookings.$inferSelect,
+  items: readonly (typeof bookingItems.$inferSelect)[],
+): Record<string, unknown> {
+  const primaryProduct = items[0]
+  const normalizedItems = items.map((item) => ({
+    title: item.productNameSnapshot ?? item.title,
+    quantity: item.quantity,
+    amountCents: item.totalSellAmountCents,
+    currency: item.sellCurrency,
+  }))
+  return {
+    booking: {
+      id: booking.id,
+      bookingId: booking.id,
+      reference: booking.bookingNumber,
+      bookingNumber: booking.bookingNumber,
+      startDate: booking.startDate,
+      endDate: booking.endDate,
+      productName: primaryProduct?.productNameSnapshot ?? primaryProduct?.title ?? null,
+      items: normalizedItems,
+    },
+    customer: bookingContractCustomerVariables(booking),
+    commercial: {
+      currency: booking.sellCurrency,
+      totalAmountCents: booking.sellAmountCents,
+    },
+    product: {
+      title: primaryProduct?.productNameSnapshot ?? primaryProduct?.title ?? null,
+    },
+  }
+}
+
+function resolveSourceEventId(event: EventEnvelope<LegalBookingConfirmedPayload>): string {
+  const eventId = event.metadata?.eventId
+  return typeof eventId === "string" && eventId.trim()
+    ? eventId
+    : `booking.confirmed:${event.data.bookingId}`
+}
+
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {}
+}

--- a/packages/legal/src/booking-contract-confirmed.ts
+++ b/packages/legal/src/booking-contract-confirmed.ts
@@ -298,45 +298,54 @@ async function prepareBookingContractTarget(
     },
   }
 
-  const contract = reusable
-    ? await db
-        .update(contracts)
-        .set({
-          title: reusable.title || `${selected.template.name} — ${booking.bookingNumber}`,
-          templateVersionId: selected.version.id,
-          personId: reusable.personId ?? booking.personId,
-          organizationId: reusable.organizationId ?? booking.organizationId,
-          channelId: reusable.channelId ?? origin?.channelId ?? null,
-          language,
-          variables,
-          renderedBody,
-          renderedBodyFormat: "html",
-          metadata,
-          updatedAt: new Date(),
-        })
-        .where(and(eq(contracts.id, reusable.id), eq(contracts.status, "draft")))
-        .returning()
-        .then(([row]) => row ?? null)
-    : await contractsService.createContract(
-        db,
-        {
-          scope: "customer",
-          status: "draft",
-          title: `${selected.template.name} — ${booking.bookingNumber}`,
-          templateVersionId: selected.version.id,
-          seriesId: null,
-          bookingId,
-          personId: booking.personId,
-          organizationId: booking.organizationId,
-          channelId: origin?.channelId ?? null,
-          language,
-          variables,
-          renderedBody,
-          renderedBodyFormat: "html",
-          metadata,
-        },
-        { allowBookingContractWorkflow: true },
-      )
+  let contract: typeof contracts.$inferSelect | null
+  if (reusable) {
+    contract = await db
+      .update(contracts)
+      .set({
+        title: reusable.title || `${selected.template.name} — ${booking.bookingNumber}`,
+        templateVersionId: selected.version.id,
+        personId: reusable.personId ?? booking.personId,
+        organizationId: reusable.organizationId ?? booking.organizationId,
+        channelId: reusable.channelId ?? origin?.channelId ?? null,
+        language,
+        variables,
+        renderedBody,
+        renderedBodyFormat: "html",
+        metadata,
+        updatedAt: new Date(),
+      })
+      .where(and(eq(contracts.id, reusable.id), eq(contracts.status, "draft")))
+      .returning()
+      .then(([row]) => row ?? null)
+  } else {
+    const created = await contractsService.createContract(
+      db,
+      {
+        scope: "customer",
+        status: "draft",
+        title: `${selected.template.name} — ${booking.bookingNumber}`,
+        templateVersionId: selected.version.id,
+        seriesId: null,
+        bookingId,
+        personId: booking.personId,
+        organizationId: booking.organizationId,
+        channelId: origin?.channelId ?? null,
+        language,
+        variables,
+        metadata,
+      },
+      { allowBookingContractWorkflow: true },
+    )
+    contract = created
+      ? await db
+          .update(contracts)
+          .set({ renderedBody, renderedBodyFormat: "html", updatedAt: new Date() })
+          .where(eq(contracts.id, created.id))
+          .returning()
+          .then(([row]) => row ?? null)
+      : null
+  }
   if (!contract) return { status: "skipped", reason: "contract_not_mutable" }
 
   return {

--- a/packages/legal/src/booking-contract-confirmed.ts
+++ b/packages/legal/src/booking-contract-confirmed.ts
@@ -4,7 +4,7 @@ import {
   buildActionLedgerMutationEntryInput,
   buildExistingTargetIdempotencyScope,
 } from "@voyant-travel/action-ledger"
-import { bookingItems, bookingOrigins, bookings } from "@voyant-travel/bookings/schema"
+import { bookingsService, getBookingOriginByBookingId } from "@voyant-travel/bookings"
 import type { EventEnvelope } from "@voyant-travel/core"
 import { and, desc, eq, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
@@ -64,6 +64,8 @@ interface PreparedTarget {
   organizationId: string | null
   descriptor: LegalDocumentRenderDescriptor
 }
+
+type BookingContractReviewInput = Parameters<typeof bookingContractReviewSnapshot>[0]
 
 /**
  * Project one booking confirmation into one ledgered, durable Legal document
@@ -195,7 +197,7 @@ async function prepareBookingContractTarget(
   | ({ status: "prepared" } & PreparedTarget)
   | Exclude<BookingContractConfirmationResult, { status: "generated" | "pending" }>
 > {
-  const [booking] = await db.select().from(bookings).where(eq(bookings.id, bookingId)).limit(1)
+  const booking = await bookingsService.getBookingById(db, bookingId)
   if (!booking) return { status: "skipped", reason: "booking_not_found" }
 
   const existingContracts = await db
@@ -227,12 +229,8 @@ async function prepareBookingContractTarget(
     }
   }
 
-  const [origin] = await db
-    .select()
-    .from(bookingOrigins)
-    .where(eq(bookingOrigins.bookingId, bookingId))
-    .limit(1)
-  const items = await db.select().from(bookingItems).where(eq(bookingItems.bookingId, bookingId))
+  const origin = await getBookingOriginByBookingId(db, bookingId)
+  const items = await bookingsService.listItems(db, bookingId)
   const language = resolveBookingContractLanguage(booking)
   const reusable = existingContracts.find((contract) => {
     const metadata = record(contract.metadata)
@@ -411,8 +409,8 @@ async function resolveTemplateSelection(
 }
 
 function bookingContractVariables(
-  booking: typeof bookings.$inferSelect,
-  items: readonly (typeof bookingItems.$inferSelect)[],
+  booking: BookingContractReviewInput["booking"],
+  items: BookingContractReviewInput["items"],
 ): Record<string, unknown> {
   const primaryProduct = items[0]
   const normalizedItems = items.map((item) => ({

--- a/packages/legal/src/voyant.ts
+++ b/packages/legal/src/voyant.ts
@@ -69,6 +69,40 @@ const contractDocumentTools = [
 
 const contractDocumentActions = [
   {
+    id: "@voyant-travel/legal#action.generate-booking-contract-on-confirmation",
+    version: "v1",
+    kind: "execute" as const,
+    targetType: "booking",
+    commandTargetField: "bookingId",
+    targetLifecycle: "existing" as const,
+    existingTarget: { durability: "handler-command-result-v1" as const },
+    availability: {
+      status: "unavailable" as const,
+      reasonCode: "provider-not-conformant",
+      enableWhen: {
+        selectedProviderPorts: {
+          mode: "all" as const,
+          ports: [legalDocumentArtifactProviderPort.id],
+        },
+      },
+    },
+    effectBoundary: "multistage" as const,
+    durability: {
+      strategy: "outbox" as const,
+      testReference: "packages/legal/tests/integration/booking-contract-confirmed.test.ts",
+    },
+    resource: "legal",
+    action: "write",
+    requiredScopes: ["legal:write"],
+    risk: "high" as const,
+    ledger: "required" as const,
+    approval: "never" as const,
+    policy: "legal.booking-contract-confirmed.v1",
+    reversible: false,
+    allowedActorTypes: ["system" as const],
+    from: { events: ["@voyant-travel/bookings#event.booking.confirmed"] },
+  },
+  {
     id: "@voyant-travel/legal#action.generate-booking-contract-document",
     version: "v1",
     kind: "execute" as const,
@@ -398,6 +432,17 @@ export const legalVoyantModule = defineModule({
       payloadSchema: contractDocumentGeneratedEventPayloadSchema,
       visibility: "internal",
       audit: { sourceModule: "legal", category: "domain" },
+    },
+  ],
+  subscribers: [
+    {
+      id: "@voyant-travel/legal#subscriber.booking-contract-confirmed",
+      eventType: "booking.confirmed",
+      source: "@voyant-travel/legal/booking-contract-confirmed-subscriber",
+      runtime: {
+        entry: "@voyant-travel/legal/booking-contract-confirmed-subscriber",
+        export: "createLegalBookingContractConfirmedSubscriberGraphRuntime",
+      },
     },
   ],
   access: {

--- a/packages/legal/tests/integration/booking-contract-confirmed.test.ts
+++ b/packages/legal/tests/integration/booking-contract-confirmed.test.ts
@@ -1,0 +1,200 @@
+import { actionLedgerEntries } from "@voyant-travel/action-ledger/schema"
+import { bookingItems, bookings } from "@voyant-travel/bookings/schema"
+import { createEventBus } from "@voyant-travel/core"
+import { createDbClient } from "@voyant-travel/db"
+import { cleanupTestDb } from "@voyant-travel/db/test-utils"
+import { eq } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+import { LEGAL_BOOKING_CONTRACT_CONFIRMED_ACTION_ID } from "../../src/booking-contract-confirmed.js"
+import {
+  createLegalBookingContractConfirmedSubscriber,
+  type LegalBookingConfirmedPayload,
+} from "../../src/booking-contract-confirmed-subscriber.js"
+import {
+  checksumLegalDocumentBytes,
+  LEGAL_DOCUMENT_ARTIFACT_PROVIDER_PROTOCOL,
+  type LegalDocumentArtifactProvider,
+} from "../../src/contracts/document-artifact-provider.js"
+import {
+  contractAttachments,
+  contractDocumentOperations,
+  contracts,
+  contractTemplates,
+  contractTemplateVersions,
+} from "../../src/contracts/schema.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+type TestDb = PostgresJsDatabase & {
+  $client: { end(options?: { timeout?: number | null }): Promise<unknown> }
+}
+
+function provider(): LegalDocumentArtifactProvider {
+  const objects = new Map<string, Uint8Array>()
+  return {
+    identity: {
+      id: "test.booking-confirmed-contract",
+      version: "1",
+      protocol: LEGAL_DOCUMENT_ARTIFACT_PROVIDER_PROTOCOL,
+    },
+    async render(descriptor) {
+      const bytes = new TextEncoder().encode(descriptor.body)
+      return {
+        bytes,
+        checksumSha256: await checksumLegalDocumentBytes(bytes),
+        name: "booking-contract.pdf",
+        contentType: "application/pdf",
+      }
+    },
+    async put(input) {
+      objects.set(input.operationKey, input.artifact.bytes.slice())
+      return {
+        key: input.operationKey,
+        checksumSha256: input.artifact.checksumSha256,
+        byteLength: input.artifact.bytes.byteLength,
+      }
+    },
+    async inspect(key) {
+      const bytes = objects.get(key)
+      return bytes
+        ? {
+            status: "present" as const,
+            key,
+            checksumSha256: await checksumLegalDocumentBytes(bytes),
+            byteLength: bytes.byteLength,
+          }
+        : { status: "absent" as const }
+    },
+    async get(key) {
+      return objects.get(key)?.slice() ?? null
+    },
+    async deleteIfPresent(key) {
+      objects.delete(key)
+    },
+  }
+}
+
+describe.skipIf(!DB_AVAILABLE)("booking-confirmed contract generation", () => {
+  let db: TestDb
+
+  beforeAll(() => {
+    db = createDbClient(process.env.TEST_DATABASE_URL as string, {
+      adapter: "node",
+      nodeMaxConnections: 4,
+      timeouts: { statementMs: false, queryMs: false, connectMs: false },
+    }) as TestDb
+  })
+  beforeEach(() => cleanupTestDb(db))
+  afterAll(async () => db.$client.end({ timeout: 0 }))
+
+  it("turns booking.confirmed into one ledgered canonical contract document", async () => {
+    const [booking] = await db
+      .insert(bookings)
+      .values({
+        bookingNumber: "BK-AUTO-CONTRACT-1",
+        status: "confirmed",
+        contactFirstName: "Ana",
+        contactLastName: "Pop",
+        contactEmail: "ana@example.test",
+        contactPreferredLanguage: "en",
+        sellCurrency: "EUR",
+        sellAmountCents: 120_00,
+        startDate: "2026-09-01",
+        endDate: "2026-09-07",
+      })
+      .returning()
+    await db.insert(bookingItems).values({
+      bookingId: booking!.id,
+      title: "Autumn tour",
+      status: "confirmed",
+      productNameSnapshot: "Autumn tour",
+      quantity: 2,
+      sellCurrency: "EUR",
+      totalSellAmountCents: 120_00,
+    })
+    const [template] = await db
+      .insert(contractTemplates)
+      .values({
+        name: "Customer agreement",
+        slug: "customer-agreement-auto",
+        scope: "customer",
+        language: "en",
+        body: "Hello {{ customer.name }}, booking {{ booking.reference }}",
+        active: true,
+        isDefault: true,
+      })
+      .returning()
+    const [version] = await db
+      .insert(contractTemplateVersions)
+      .values({
+        templateId: template!.id,
+        version: 1,
+        body: "Hello {{ customer.name }}, booking {{ booking.reference }}",
+        variableSchema: { required: ["customer.name", "booking.reference"] },
+      })
+      .returning()
+    await db
+      .update(contractTemplates)
+      .set({ currentVersionId: version!.id })
+      .where(eq(contractTemplates.id, template!.id))
+
+    const eventBus = createEventBus({ handlerTimeoutMs: false })
+    await createLegalBookingContractConfirmedSubscriber({
+      resolveDb: async () => db,
+      provider: provider(),
+    }).register({ bindings: {}, container: {} as never, eventBus })
+    const payload: LegalBookingConfirmedPayload = {
+      bookingId: booking!.id,
+      bookingNumber: booking!.bookingNumber,
+      actorId: null,
+    }
+
+    await eventBus.emit("booking.confirmed", payload, {
+      eventId: `evt_finance_booking_confirmed_${booking!.id}`,
+      category: "domain",
+      source: "service",
+    })
+    await eventBus.emit("booking.confirmed", payload, {
+      eventId: `evt_finance_booking_confirmed_${booking!.id}`,
+      category: "domain",
+      source: "service",
+    })
+
+    const contractRows = await db
+      .select()
+      .from(contracts)
+      .where(eq(contracts.bookingId, booking!.id))
+    const attachmentRows = await db.select().from(contractAttachments)
+    const operationRows = await db
+      .select()
+      .from(contractDocumentOperations)
+      .where(eq(contractDocumentOperations.bookingId, booking!.id))
+    const ledgerRows = await db
+      .select()
+      .from(actionLedgerEntries)
+      .where(eq(actionLedgerEntries.actionName, LEGAL_BOOKING_CONTRACT_CONFIRMED_ACTION_ID))
+
+    expect(contractRows).toHaveLength(1)
+    expect(contractRows[0]).toMatchObject({
+      bookingId: booking!.id,
+      templateVersionId: version!.id,
+      renderedBody: "Hello Ana Pop, booking BK-AUTO-CONTRACT-1",
+    })
+    expect(attachmentRows).toHaveLength(1)
+    expect(attachmentRows[0]).toMatchObject({
+      contractId: contractRows[0]!.id,
+      kind: "document",
+      name: "booking-contract.pdf",
+    })
+    expect(operationRows).toHaveLength(1)
+    expect(operationRows[0]).toMatchObject({ status: "completed", principalType: "system" })
+    expect(ledgerRows).toHaveLength(1)
+    expect(ledgerRows[0]).toMatchObject({
+      targetType: "booking",
+      targetId: booking!.id,
+      principalType: "system",
+      status: "requested",
+      authorizationSource: "selected_graph_event",
+    })
+  })
+})

--- a/packages/legal/tests/unit/booking-contract-confirmed-subscriber.test.ts
+++ b/packages/legal/tests/unit/booking-contract-confirmed-subscriber.test.ts
@@ -1,0 +1,77 @@
+import type { EventEnvelope } from "@voyant-travel/core"
+import { createContainer, createEventBus } from "@voyant-travel/core"
+import { createDbClient } from "@voyant-travel/db"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  createLegalBookingContractConfirmedSubscriber,
+  LEGAL_BOOKING_CONTRACT_CONFIRMED_SUBSCRIBER_ID,
+} from "../../src/booking-contract-confirmed-subscriber.js"
+
+const UNIT_DATABASE_URL = ["postgres", "://", "unit", "@", "127.0.0.1:1/unit"].join("")
+
+const confirmed = {
+  name: "booking.confirmed",
+  data: {
+    bookingId: "book_1",
+    bookingNumber: "BK-1",
+    actorId: null,
+    suppressNotifications: true,
+  },
+  emittedAt: "2026-08-08T00:00:00.000Z",
+  metadata: {
+    eventId: "evt_finance_booking_confirmed_book_1",
+    category: "domain" as const,
+    source: "service" as const,
+  },
+} satisfies EventEnvelope
+
+function captureHandler() {
+  const eventBus = createEventBus()
+  let handler: ((event: EventEnvelope) => Promise<void> | void) | undefined
+  vi.spyOn(eventBus, "subscribe").mockImplementation((_eventType, registeredHandler) => {
+    handler = registeredHandler as typeof handler
+    return { unsubscribe: vi.fn() }
+  })
+  return { eventBus, handler: () => handler }
+}
+
+describe("Legal booking contract confirmation subscriber", () => {
+  it("runs generation for every delivery and relies on the command's durable replay", async () => {
+    const db = createDbClient(UNIT_DATABASE_URL, { adapter: "node" })
+    const resolveDb = vi.fn(async () => db)
+    const generate = vi.fn(async () => ({ status: "generated" as const }))
+    const { eventBus, handler } = captureHandler()
+    const descriptor = createLegalBookingContractConfirmedSubscriber({ resolveDb, generate })
+
+    await descriptor.register({ bindings: {}, container: createContainer(), eventBus })
+    await handler()?.(confirmed)
+    await handler()?.(confirmed)
+
+    expect({ id: descriptor.id, eventType: descriptor.eventType }).toEqual({
+      id: LEGAL_BOOKING_CONTRACT_CONFIRMED_SUBSCRIBER_ID,
+      eventType: "booking.confirmed",
+    })
+    expect(resolveDb).toHaveBeenCalledTimes(2)
+    expect(generate).toHaveBeenCalledTimes(2)
+    expect(generate).toHaveBeenNthCalledWith(1, {
+      db,
+      event: confirmed,
+    })
+  })
+
+  it("lets durable delivery observe generation failures", async () => {
+    const failure = new Error("database unavailable")
+    const db = createDbClient(UNIT_DATABASE_URL, { adapter: "node" })
+    const { eventBus, handler } = captureHandler()
+    const descriptor = createLegalBookingContractConfirmedSubscriber({
+      resolveDb: async () => db,
+      generate: async () => {
+        throw failure
+      },
+    })
+    await descriptor.register({ bindings: {}, container: createContainer(), eventBus })
+
+    await expect(handler()?.(confirmed)).rejects.toBe(failure)
+  })
+})

--- a/packages/legal/tests/unit/package-exports.test.ts
+++ b/packages/legal/tests/unit/package-exports.test.ts
@@ -22,6 +22,17 @@ describe("@voyant-travel/legal package exports", () => {
     })
   })
 
+  it("publishes the booking-confirmed durable subscriber", () => {
+    expect(packageJson.exports["./booking-contract-confirmed-subscriber"]).toBe(
+      "./src/booking-contract-confirmed-subscriber.ts",
+    )
+    expect(packageJson.publishConfig.exports["./booking-contract-confirmed-subscriber"]).toEqual({
+      types: "./dist/booking-contract-confirmed-subscriber.d.ts",
+      import: "./dist/booking-contract-confirmed-subscriber.js",
+      default: "./dist/booking-contract-confirmed-subscriber.js",
+    })
+  })
+
   it("does not publish retired document-generation runtime subpaths", () => {
     for (const subpath of [
       "./booking-contract-subscriber",

--- a/packages/legal/tests/unit/voyant-manifest.test.ts
+++ b/packages/legal/tests/unit/voyant-manifest.test.ts
@@ -116,6 +116,32 @@ describe("legal deployment manifest", () => {
       commandTargetField: "bookingId",
       targetLifecycle: "existing",
     })
+    expect(legalVoyantModule.subscribers).toContainEqual({
+      id: "@voyant-travel/legal#subscriber.booking-contract-confirmed",
+      eventType: "booking.confirmed",
+      source: "@voyant-travel/legal/booking-contract-confirmed-subscriber",
+      runtime: {
+        entry: "@voyant-travel/legal/booking-contract-confirmed-subscriber",
+        export: "createLegalBookingContractConfirmedSubscriberGraphRuntime",
+      },
+    })
+    expect(
+      legalVoyantModule.actions?.find(
+        ({ id }) => id === "@voyant-travel/legal#action.generate-booking-contract-on-confirmation",
+      ),
+    ).toMatchObject({
+      kind: "execute",
+      targetType: "booking",
+      risk: "high",
+      ledger: "required",
+      approval: "never",
+      allowedActorTypes: ["system"],
+      from: { events: ["@voyant-travel/bookings#event.booking.confirmed"] },
+      durability: {
+        strategy: "outbox",
+        testReference: "packages/legal/tests/integration/booking-contract-confirmed.test.ts",
+      },
+    })
     expect(legalVoyantModule.meta?.agentTools).toBeUndefined()
   })
 

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -1405,6 +1405,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-confirmed-subscriber": [
+        "../legal/dist/booking-contract-confirmed-subscriber.d.ts"
+      ],
       "@voyant-travel/legal/contract-document-job": ["../legal/dist/contract-document-job.d.ts"],
       "@voyant-travel/legal/contract-document-routes": [
         "../legal/dist/contract-document-routes.d.ts"

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -1400,6 +1400,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-confirmed-subscriber": [
+        "../legal/dist/booking-contract-confirmed-subscriber.d.ts"
+      ],
       "@voyant-travel/legal/contract-document-job": ["../legal/dist/contract-document-job.d.ts"],
       "@voyant-travel/legal/contract-document-routes": [
         "../legal/dist/contract-document-routes.d.ts"

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -1398,6 +1398,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-confirmed-subscriber": [
+        "../legal/dist/booking-contract-confirmed-subscriber.d.ts"
+      ],
       "@voyant-travel/legal/contract-document-job": ["../legal/dist/contract-document-job.d.ts"],
       "@voyant-travel/legal/contract-document-routes": [
         "../legal/dist/contract-document-routes.d.ts"


### PR DESCRIPTION
## Summary

- subscribe Legal to `booking.confirmed` and automatically select the default customer template
- ledger the system action and admit the existing durable canonical document operation
- make redelivery idempotent so a booking receives one customer contract and document
- keep public booking commands free of an operator-only document-generation flag

## Verification

- real Postgres integration: duplicate confirmation produces one contract, attachment, operation, and ledger claim
- focused Legal unit tests: 11 passed
- graph conformance, Legal subscriber authority, Legal document runtime authority, public-surface, agent-quality, Biome, and secret scanning pass
- package typecheck passed before manifest/test-only additions; the repository-wide TypeScript sweep was stopped after pathological memory/runtime growth and remains gated by CI