### PR TITLE
fix: derive cancellation command identity server-side

### DIFF
--- a/packages/bookings/src/tools.ts
+++ b/packages/bookings/src/tools.ts
@@ -22,12 +22,14 @@ import {
 import {
   admitHandlerActionPolicy,
   defineTool,
+  deriveCommandIdempotencyKey,
   type HandlerActionPolicyExpectation,
   READ_ONLY_RISK,
   requireService,
   type ToolContext,
   ToolError,
   type ToolHandlerActionPolicyContext,
+  withServerResolvedIdempotencyKey,
 } from "@voyant-travel/tools"
 import { listResponseSchema } from "@voyant-travel/types"
 import { z } from "zod"
@@ -90,7 +92,7 @@ export interface BookingsToolServices {
     upcomingLimit?: number
   }): Promise<unknown>
   cancelBooking(
-    input: z.infer<typeof cancelBookingToolInputSchema>,
+    input: z.infer<typeof cancelBookingToolInputSchema> & { idempotencyKey: string },
     admitted: ToolHandlerActionPolicyContext,
   ): Promise<unknown>
   previewTravelerCorrectionAmendment(
@@ -183,11 +185,6 @@ export const cancelBookingToolInputSchema = z.object({
     .boolean()
     .optional()
     .describe("Keep customer email and SMS suppressed for this booking lifecycle."),
-  idempotencyKey: z
-    .string()
-    .trim()
-    .min(1)
-    .describe("Stable key used when requesting approval and replaying the command."),
 })
 
 const completedCancelledBookingActionSchema = z.object({
@@ -245,9 +242,16 @@ export const cancelBookingTool = defineTool<
   },
   annotations: { idempotentHint: true },
   actionPolicyEnforcement: "handler",
+  resolvesIdempotencyKeyServerSide: true,
   async handler(input, ctx) {
-    const admitted = admitHandlerActionPolicy(ctx, CANCEL_BOOKING_HANDLER_POLICY)
-    return cancelBookingToolOutputSchema.parse(await bookings(ctx).cancelBooking(input, admitted))
+    const idempotencyKey = await deriveCommandIdempotencyKey("cancel-booking", input)
+    const admitted = withServerResolvedIdempotencyKey(
+      admitHandlerActionPolicy(ctx, CANCEL_BOOKING_HANDLER_POLICY),
+      idempotencyKey,
+    )
+    return cancelBookingToolOutputSchema.parse(
+      await bookings(ctx).cancelBooking({ ...input, idempotencyKey }, admitted),
+    )
   },
 })
 

--- a/packages/bookings/tests/tools.test.ts
+++ b/packages/bookings/tests/tools.test.ts
@@ -147,9 +147,9 @@ describe("bookings tools", () => {
       requiredScopes: ["bookings:write"],
       riskPolicy: { destructive: true, reversible: false, confirmationRequired: true },
     })
-    expect(
-      bookingsTools.find((tool) => tool.name === "cancel_booking"),
-    ).toMatchObject({ resolvesIdempotencyKeyServerSide: true })
+    expect(bookingsTools.find((tool) => tool.name === "cancel_booking")).toMatchObject({
+      resolvesIdempotencyKeyServerSide: true,
+    })
     expect(
       bookingsTools
         .find((tool) => tool.name === "cancel_booking")

--- a/packages/bookings/tests/tools.test.ts
+++ b/packages/bookings/tests/tools.test.ts
@@ -146,10 +146,10 @@ describe("bookings tools", () => {
       tier: "destructive",
       requiredScopes: ["bookings:write"],
       riskPolicy: { destructive: true, reversible: false, confirmationRequired: true },
-      actionPolicy: {
-        invocation: { requiredFields: expect.not.arrayContaining(["idempotencyKey"]) },
-      },
     })
+    expect(
+      bookingsTools.find((tool) => tool.name === "cancel_booking"),
+    ).toMatchObject({ resolvesIdempotencyKeyServerSide: true })
     expect(
       bookingsTools
         .find((tool) => tool.name === "cancel_booking")
@@ -175,7 +175,7 @@ describe("bookings tools", () => {
         ...CANCEL_BOOKING_HANDLER_POLICY.actionPolicy,
         enforcement: "handler",
         invocation: {
-          requiredFields: ["confirmed", "idempotencyKey"],
+          requiredFields: ["confirmed"],
           optionalFields: ["reasonCode", "approvalId", "idempotencyFingerprint"],
         },
       },
@@ -185,14 +185,14 @@ describe("bookings tools", () => {
       {
         id: "bk_1",
         note: "operator request",
-        idempotencyKey: "cancel-bk-1",
         approvalId: "dead-top-level-field",
       },
       ctx(
         {
           async cancelBooking(_input, admitted) {
             expect(_input).not.toHaveProperty("approvalId")
-            expect(admitted.invocation.idempotencyKey).toBe("cancel-bk-1")
+            expect(admitted.invocation.idempotencyKey).toMatch(/^cancel-booking:v1:/)
+            expect(_input.idempotencyKey).toBe(admitted.invocation.idempotencyKey)
             expect(admitted.invocation.approvalId).toBe("approval-reserved")
             expect(admitted.invocation.idempotencyFingerprint).toBe("sha256:reserved")
             return {
@@ -210,13 +210,12 @@ describe("bookings tools", () => {
             ...CANCEL_BOOKING_HANDLER_POLICY.actionPolicy,
             enforcement: "handler",
             invocation: {
-              requiredFields: ["confirmed", "idempotencyKey"],
+              requiredFields: ["confirmed"],
               optionalFields: ["reasonCode", "approvalId", "idempotencyFingerprint"],
             },
           },
           invocation: {
             confirmed: true,
-            idempotencyKey: "cancel-bk-1",
             approvalId: "approval-reserved",
             idempotencyFingerprint: "sha256:reserved",
           },

--- a/packages/bookings/tests/tools.test.ts
+++ b/packages/bookings/tests/tools.test.ts
@@ -146,13 +146,15 @@ describe("bookings tools", () => {
       tier: "destructive",
       requiredScopes: ["bookings:write"],
       riskPolicy: { destructive: true, reversible: false, confirmationRequired: true },
+      actionPolicy: {
+        invocation: { requiredFields: expect.not.arrayContaining(["idempotencyKey"]) },
+      },
     })
     expect(
       bookingsTools
         .find((tool) => tool.name === "cancel_booking")
         ?.inputSchema.parse({
           id: "bk_1",
-          idempotencyKey: "cancel-bk-1",
           approvalId: "dead-top-level-field",
         }),
     ).not.toHaveProperty("approvalId")


### PR DESCRIPTION
## Summary

- remove the caller-facing cancellation idempotency key
- derive a stable durable-command identity from the cancellation business input
- re-mint the authenticated handler admission with that server-owned key
- keep exact-command replay and changed-command rejection in the existing action-ledger protocol

## Evidence

The real cancellation trace completed correctly but still made the caller carry duplicate protocol identity. This removes that field from the domain schema and from the handler invocation requirements without weakening approval fingerprint validation.

## Verification

- focused Bookings Tool tests: 10/10 pass
- Bookings typecheck: pass, 0 TypeScript errors
- focused Biome check: pass after formatting

Closes part of #4378 and #3933.
