### PR TITLE
fix: keep approval fingerprints server-owned

### DIFF
--- a/.changeset/calm-approvals-continue.md
+++ b/.changeset/calm-approvals-continue.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/tools": patch
+"@voyant-travel/action-ledger": patch
+---
+
+Keep approval command fingerprints server-owned for handler-managed tools while preserving exact-command validation against the approved ledger request.

--- a/packages/action-ledger/src/created-command-internal.ts
+++ b/packages/action-ledger/src/created-command-internal.ts
@@ -590,7 +590,7 @@ export async function executeAdmittedExistingTargetCommand<TValue, TCommandPaylo
           idempotencyKey,
           idempotencyFingerprint:
             input.admitted.invocation.idempotencyFingerprint?.trim() || fingerprint,
-          reasonCode: input.admitted.invocation.reasonCode ?? null,
+          reasonCode: approvalReasonCode,
         }
       : undefined
   const commandInput: ExecuteCreatedTargetCommandInput & { resultReferenceType: string } = {

--- a/packages/action-ledger/src/created-command-internal.ts
+++ b/packages/action-ledger/src/created-command-internal.ts
@@ -582,7 +582,8 @@ export async function executeAdmittedExistingTargetCommand<TValue, TCommandPaylo
       ? {
           approvalId: input.admitted.invocation.approvalId ?? "",
           idempotencyKey,
-          idempotencyFingerprint: input.admitted.invocation.idempotencyFingerprint ?? "",
+          idempotencyFingerprint:
+            input.admitted.invocation.idempotencyFingerprint?.trim() || fingerprint,
           reasonCode: input.admitted.invocation.reasonCode ?? null,
         }
       : undefined

--- a/packages/action-ledger/src/created-command-internal.ts
+++ b/packages/action-ledger/src/created-command-internal.ts
@@ -531,7 +531,13 @@ export async function executeAdmittedExistingTargetCommand<TValue, TCommandPaylo
   }
   const actionName = requiredValue(selected.capabilityId, "capability id")
   const approvalPolicy = selected.approval === "required" ? "required" : "none"
-  const approvalReasonCode = input.admitted.invocation.reasonCode ?? null
+  const approvalId = input.admitted.invocation.approvalId?.trim()
+  const approvalReasonCode =
+    input.admitted.invocation.reasonCode ??
+    (approvalId && !input.admitted.invocation.idempotencyFingerprint
+      ? ((await actionLedgerService.getApproval(input.db, approvalId))?.requestedAction?.entry
+          .reasonCode ?? null)
+      : null)
   const fingerprint = await buildActionApprovalCommandFingerprint({
     actionName,
     actionVersion: selected.version,
@@ -557,7 +563,7 @@ export async function executeAdmittedExistingTargetCommand<TValue, TCommandPaylo
   ) {
     throw new ActionLedgerCreatedCommandProtocolError("forged_approval_linkage")
   }
-  if (selected.approval === "required" && !input.admitted.invocation.approvalId?.trim()) {
+  if (selected.approval === "required" && !approvalId) {
     await throwHandlerApprovalRequired({
       db: input.db,
       context: input.context,
@@ -580,7 +586,7 @@ export async function executeAdmittedExistingTargetCommand<TValue, TCommandPaylo
   const approvalControls =
     selected.approval === "required"
       ? {
-          approvalId: input.admitted.invocation.approvalId ?? "",
+          approvalId: approvalId ?? "",
           idempotencyKey,
           idempotencyFingerprint:
             input.admitted.invocation.idempotencyFingerprint?.trim() || fingerprint,

--- a/packages/action-ledger/src/created-command-internal.ts
+++ b/packages/action-ledger/src/created-command-internal.ts
@@ -535,8 +535,7 @@ export async function executeAdmittedExistingTargetCommand<TValue, TCommandPaylo
   const approvalReasonCode =
     input.admitted.invocation.reasonCode ??
     (approvalId && !input.admitted.invocation.idempotencyFingerprint
-      ? ((await actionLedgerService.getApproval(input.db, approvalId))?.requestedAction?.entry
-          .reasonCode ?? null)
+      ? ((await actionLedgerService.getApproval(input.db, approvalId))?.approval.reasonCode ?? null)
       : null)
   const fingerprint = await buildActionApprovalCommandFingerprint({
     actionName,

--- a/packages/action-ledger/tests/unit/created-command.test.ts
+++ b/packages/action-ledger/tests/unit/created-command.test.ts
@@ -1473,7 +1473,6 @@ function mockApprovedExistingCommand(
     approvalId: "appr_existing",
     idempotencyKey: "price_1",
     idempotencyFingerprint: fingerprint,
-    reasonCode: "operator_approved",
   })
   vi.spyOn(actionLedgerService, "validateApprovedAction").mockImplementation(async (_db, input) =>
     input.organizationId !== requestedAction.organizationId

--- a/packages/action-ledger/tests/unit/created-command.test.ts
+++ b/packages/action-ledger/tests/unit/created-command.test.ts
@@ -532,7 +532,10 @@ describe("existing-target durable command protocol", () => {
         },
         handlers,
       ),
-    ).rejects.toMatchObject({ code: "ACTION_POLICY_REQUIRED" })
+    ).rejects.toMatchObject({
+      name: "ActionLedgerIdempotencyConflictError",
+      message: "Action ledger idempotency key was reused with a different fingerprint",
+    })
   })
 
   it("rolls back the claim and package intent when intent preparation fails", async () => {

--- a/packages/action-ledger/tests/unit/created-command.test.ts
+++ b/packages/action-ledger/tests/unit/created-command.test.ts
@@ -482,7 +482,6 @@ describe("existing-target durable command protocol", () => {
       invocation: {
         idempotencyKey: "price_1",
         approvalId: "appr_existing",
-        idempotencyFingerprint: fingerprint,
         reasonCode: "operator_approved",
       },
     })
@@ -524,6 +523,15 @@ describe("existing-target durable command protocol", () => {
     }
     await expect(
       executeAdmittedExistingTargetCommand(existingCommandInput(harness.db, changedKey), handlers),
+    ).rejects.toMatchObject({ code: "ACTION_POLICY_REQUIRED" })
+    await expect(
+      executeAdmittedExistingTargetCommand(
+        {
+          ...existingCommandInput(harness.db, admitted),
+          commandInput: { tripId: "trip_1", currency: "USD" },
+        },
+        handlers,
+      ),
     ).rejects.toMatchObject({ code: "ACTION_POLICY_REQUIRED" })
   })
 

--- a/packages/action-ledger/tests/unit/created-command.test.ts
+++ b/packages/action-ledger/tests/unit/created-command.test.ts
@@ -482,7 +482,6 @@ describe("existing-target durable command protocol", () => {
       invocation: {
         idempotencyKey: "price_1",
         approvalId: "appr_existing",
-        reasonCode: "operator_approved",
       },
     })
     const scope = await buildExistingTargetIdempotencyScope({
@@ -1474,6 +1473,7 @@ function mockApprovedExistingCommand(
     approvalId: "appr_existing",
     idempotencyKey: "price_1",
     idempotencyFingerprint: fingerprint,
+    reasonCode: "operator_approved",
   })
   vi.spyOn(actionLedgerService, "validateApprovedAction").mockImplementation(async (_db, input) =>
     input.organizationId !== requestedAction.organizationId

--- a/packages/tools/src/registered-tool.ts
+++ b/packages/tools/src/registered-tool.ts
@@ -168,7 +168,10 @@ function deriveActionPolicy(
       requiredFields.push("idempotencyKey")
     }
     if (action.approval === "required") {
-      requiredFields.push("approvalId", "idempotencyFingerprint")
+      requiredFields.push("approvalId")
+      if (!tool.resolvesIdempotencyKeyServerSide) {
+        requiredFields.push("idempotencyFingerprint")
+      }
     }
   }
   return {
@@ -182,7 +185,9 @@ function deriveActionPolicy(
           ? serverOwnedGenericTarget
             ? ["reasonCode", "approvalId"]
             : ["reasonCode", "approvalId", "idempotencyFingerprint"]
-          : ["reasonCode", "approvalId", "idempotencyFingerprint"],
+          : tool.resolvesIdempotencyKeyServerSide
+            ? ["reasonCode", "approvalId"]
+            : ["reasonCode", "approvalId", "idempotencyFingerprint"],
       fingerprintAlgorithm: "action-ledger-command-v1",
       ...targetResolution,
     },

--- a/packages/tools/tests/registered-tool.test.ts
+++ b/packages/tools/tests/registered-tool.test.ts
@@ -59,4 +59,58 @@ describe("server-resolved idempotency keys", () => {
     expect(required).toContain("confirmed")
     expect(required).not.toContain("idempotencyKey")
   })
+
+  it("advertises an approval id without making callers echo the server fingerprint", () => {
+    const registry = createToolRegistry()
+    registry.register(
+      defineTool({
+        capabilityId: "@test#tool.cancel",
+        owner: "@test",
+        name: "cancel_thing",
+        description: "Cancel one existing thing after approval.",
+        inputSchema: z.object({ id: z.string() }),
+        outputSchema: z.object({ id: z.string() }),
+        requiredScopes: [],
+        tier: "destructive",
+        riskPolicy: {
+          destructive: true,
+          reversible: false,
+          dryRunSupported: false,
+          confirmationRequired: true,
+          sideEffects: ["data-write"],
+        },
+        actionPolicyEnforcement: "handler",
+        resolvesIdempotencyKeyServerSide: true,
+        async handler({ id }) {
+          return { id }
+        },
+      }),
+      {
+        actionPolicy: {
+          id: "@test#action.cancel",
+          capabilityId: "@test#action.cancel",
+          version: "v1",
+          kind: "execute",
+          targetType: "thing",
+          commandTargetField: "id",
+          targetLifecycle: "existing",
+          risk: "high",
+          ledger: "required",
+          approval: "required",
+          policy: "thing-cancellation-v1",
+          reversible: false,
+          existingTarget: { durability: "handler-command-result-v1" },
+        },
+      },
+    )
+
+    const required =
+      registry.list().find(({ name }) => name === "cancel_thing")?.actionPolicy?.invocation
+        .requiredFields ?? []
+
+    expect(required).toContain("confirmed")
+    expect(required).toContain("approvalId")
+    expect(required).not.toContain("idempotencyKey")
+    expect(required).not.toContain("idempotencyFingerprint")
+  })
 })


### PR DESCRIPTION
## Summary

- stop advertising approval fingerprints for handler-managed Tools that derive command identity server-side
- compute the fingerprint from the exact canonical business command inside Action Ledger when the caller does not provide a legacy value
- retain approval ID as the continuation handle
- preserve persisted approval validation and changed-command rejection

## Safety properties

The fingerprint is still computed independently from the execution command and compared with the fingerprint on the approved requested action. A changed command using the same durable key fails as an explicit idempotency fingerprint conflict before mutation.

Legacy handler Tools that still advertise a caller fingerprint retain their current supplied-fingerprint validation.

## Verification

- focused Tools and Action Ledger tests: 77/77 pass
- Tools typecheck: pass, zero TypeScript errors
- Action Ledger typecheck: pass, zero TypeScript errors
- focused Biome check: pass

Advances #4378.
