### PR TITLE
Fix private document downloads

### DIFF
--- a/packages/storage/src/runtime.test.ts
+++ b/packages/storage/src/runtime.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
 import { createLocalStorageProvider } from "./providers/local.js"
 import { resolveDocumentDownloadUrl, type StorageRuntimeEnv } from "./runtime.js"
@@ -12,6 +12,32 @@ function env(overrides: StorageRuntimeEnv = {}): StorageRuntimeEnv {
 }
 
 describe("resolveDocumentDownloadUrl", () => {
+  it("prefers a time-limited HTTPS URL for private object storage", async () => {
+    const signedUrl = vi.fn(
+      async () => "https://storage.example.test/contracts/example.pdf?signature=private",
+    )
+
+    await expect(
+      resolveDocumentDownloadUrl(
+        env({ API_BASE_URL: "https://operator.example.test/api" }),
+        { ...storage, signedUrl },
+        "contracts/example.pdf",
+        120,
+      ),
+    ).resolves.toBe("https://storage.example.test/contracts/example.pdf?signature=private")
+    expect(signedUrl).toHaveBeenCalledWith("contracts/example.pdf", 120)
+  })
+
+  it("falls back to the authenticated stream for non-HTTP local URLs", async () => {
+    await expect(
+      resolveDocumentDownloadUrl(
+        env({ API_BASE_URL: "http://localhost:3300/api" }),
+        storage,
+        "contracts/example.pdf",
+      ),
+    ).resolves.toBe("http://localhost:3300/api/v1/admin/documents/files/contracts/example.pdf")
+  })
+
   it("uses API_BASE_URL so local admin redirects keep the /api mount prefix", async () => {
     await expect(
       resolveDocumentDownloadUrl(

--- a/packages/storage/src/runtime.ts
+++ b/packages/storage/src/runtime.ts
@@ -137,9 +137,13 @@ export async function resolveDocumentDownloadUrl(
   env: RuntimeEnv,
   storage: StorageProvider | null,
   storageKey: string,
-  _expiresIn?: number,
+  expiresIn = 300,
 ): Promise<string | null> {
   if (!storage) return null
+  if (storage.signedUrl) {
+    const signedUrl = await storage.signedUrl(storageKey, expiresIn)
+    if (isHttpUrl(signedUrl)) return signedUrl
+  }
   const apiBaseUrl = resolveDocumentDownloadApiBaseUrl(env)
   if (!apiBaseUrl) return null
   const keyPath = storageKey
@@ -147,6 +151,15 @@ export async function resolveDocumentDownloadUrl(
     .map((segment) => encodeURIComponent(segment))
     .join("/")
   return `${apiBaseUrl}/v1/admin/documents/files/${keyPath}`
+}
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const protocol = new URL(value).protocol
+    return protocol === "http:" || protocol === "https:"
+  } catch {
+    return false
+  }
 }
 
 /** Voyant Cloud one-shot video upload ticket provider. */


### PR DESCRIPTION
## Summary

- prefer the private storage provider’s time-limited HTTP(S) signed URL for document delivery
- retain the authenticated internal proxy for local and non-HTTP storage providers
- cover signed delivery, expiry forwarding, and local fallback

## Root cause

Automatic contract generation succeeds and stores the PDF, but document delivery ignored the configured private-store signer and routed every download through the raw-byte proxy. On the managed S3-compatible runtime that proxy returns HTTP 500 (live request ID `180f86bfe17f14cd7af1fc0d43e54d3e`).

## Validation

- `pnpm --filter @voyant-travel/storage test -- runtime.test.ts` (56 tests passed)
- `pnpm --filter @voyant-travel/storage typecheck`
- `pnpm --filter @voyant-travel/storage lint`
- `git diff --check`
- local repository push gate: 114/116 tasks passed; unrelated `flights-react` and `runtime` suites failed locally, so GitHub CI remains the full-repository merge gate
