### PR TITLE
fix: recover failed approved Tool attempts

### DIFF
--- a/.changeset/gentle-approved-retries.md
+++ b/.changeset/gentle-approved-retries.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/action-ledger": patch
+---
+
+Allow one atomically claimed retry after a generic approved Tool attempt records a terminal failure, and report concurrent attempts as retryable in-progress work.

--- a/packages/action-ledger/src/tool-action-policy.ts
+++ b/packages/action-ledger/src/tool-action-policy.ts
@@ -156,7 +156,7 @@ export function createToolActionPolicyGate(
 
       const actionName = selected.capabilityId ?? selected.id
       let attempt = 1
-      let preflight
+      let preflight: Awaited<ReturnType<typeof appendActionLedgerMutation>>
       while (true) {
         preflight = await appendActionLedgerMutation(input.db, {
           context: input.requestContext,

--- a/packages/action-ledger/src/tool-action-policy.ts
+++ b/packages/action-ledger/src/tool-action-policy.ts
@@ -197,6 +197,23 @@ export function createToolActionPolicyGate(
           attempt += 1
           continue
         }
+        if (!terminal) {
+          throw new ToolError(
+            "This approved Tool execution is already in progress.",
+            "PROVIDER_UNAVAILABLE",
+            {
+              reason: "approved_execution_in_progress",
+              attempt,
+              actionId: preflight.entry.id,
+            },
+            undefined,
+            {
+              nextSteps: [
+                "Wait briefly, then retry the same approved command. Do not request another approval.",
+              ],
+            },
+          )
+        }
         throw duplicateDispatchError(preflight.entry.id, serverOwnedTarget, executionKey)
       }
 

--- a/packages/action-ledger/src/tool-action-policy.ts
+++ b/packages/action-ledger/src/tool-action-policy.ts
@@ -155,40 +155,49 @@ export function createToolActionPolicyGate(
           : null
 
       const actionName = selected.capabilityId ?? selected.id
-      const preflight = await appendActionLedgerMutation(input.db, {
-        context: input.requestContext,
-        actionName,
-        actionVersion: selected.version,
-        actionKind: "execute",
-        status: "requested",
-        evaluatedRisk: selected.risk,
-        targetType: selected.targetType,
-        targetId,
-        routeOrToolName: execution.capabilityId,
-        capabilityId: actionName,
-        capabilityVersion: selected.version,
-        authorizationSource: "selected_graph_mcp_gate",
-        causationActionId: approved?.requestedAction.id ?? null,
-        approvalId: approved?.approval.id ?? null,
-        idempotencyScope: approved
-          ? `${approved.approval.id}:mcp-execution-preflight`
-          : `${actionName}:${selected.version}:${targetId}:mcp-preflight`,
-        idempotencyKey: approved?.approval.id ?? executionKey,
-        idempotencyFingerprint: fingerprint,
-        mutationDetail: {
-          summary: `MCP Tool ${execution.canonicalName} passed selected action policy`,
-          reversalKind: "none",
-        },
-      })
-      if (preflight.replayed) {
-        throw new ToolError(
-          "This exact Tool execution has already been claimed; refusing duplicate dispatch.",
-          "AUTHORIZATION_DENIED",
-          {
-            actionId: preflight.entry.id,
-            ...(serverOwnedTarget ? { requestId: executionKey } : { idempotencyKey: executionKey }),
+      let attempt = 1
+      let preflight
+      while (true) {
+        preflight = await appendActionLedgerMutation(input.db, {
+          context: input.requestContext,
+          actionName,
+          actionVersion: selected.version,
+          actionKind: "execute",
+          status: "requested",
+          evaluatedRisk: selected.risk,
+          targetType: selected.targetType,
+          targetId,
+          routeOrToolName: execution.capabilityId,
+          capabilityId: actionName,
+          capabilityVersion: selected.version,
+          authorizationSource: "selected_graph_mcp_gate",
+          causationActionId: approved?.requestedAction.id ?? null,
+          approvalId: approved?.approval.id ?? null,
+          idempotencyScope: approved
+            ? `${approved.approval.id}:mcp-execution-preflight:${attempt}`
+            : `${actionName}:${selected.version}:${targetId}:mcp-preflight`,
+          idempotencyKey: approved?.approval.id ?? executionKey,
+          idempotencyFingerprint: fingerprint,
+          mutationDetail: {
+            summary: `MCP Tool ${execution.canonicalName} passed selected action policy`,
+            reversalKind: "none",
           },
-        )
+        })
+        if (!preflight.replayed) break
+        if (!approved) {
+          throw duplicateDispatchError(preflight.entry.id, serverOwnedTarget, executionKey)
+        }
+        const result = await actionLedgerService.listEntries(input.db, {
+          idempotencyScope: `${approved.approval.id}:execution:${attempt}`,
+          idempotencyKey: approved.approval.id,
+          limit: 1,
+        })
+        const terminal = result.entries[0]
+        if (terminal?.status === "failed") {
+          attempt += 1
+          continue
+        }
+        throw duplicateDispatchError(preflight.entry.id, serverOwnedTarget, executionKey)
       }
 
       try {
@@ -202,6 +211,7 @@ export function createToolActionPolicyGate(
           executionKey,
           fingerprint,
           preflightActionId: preflight.entry.id,
+          attempt,
           approved,
           status: "succeeded",
         })
@@ -216,6 +226,7 @@ export function createToolActionPolicyGate(
           executionKey,
           fingerprint,
           preflightActionId: preflight.entry.id,
+          attempt,
           approved,
           status: "failed",
         })
@@ -223,6 +234,21 @@ export function createToolActionPolicyGate(
       }
     },
   }
+}
+
+function duplicateDispatchError(
+  actionId: string,
+  serverOwnedTarget: boolean,
+  executionKey: string,
+) {
+  return new ToolError(
+    "This exact Tool execution has already been claimed; refusing duplicate dispatch.",
+    "AUTHORIZATION_DENIED",
+    {
+      actionId,
+      ...(serverOwnedTarget ? { requestId: executionKey } : { idempotencyKey: executionKey }),
+    },
+  )
 }
 
 function resolveSelectedAction(
@@ -628,6 +654,7 @@ async function appendExecutionResult(input: {
   executionKey: string
   fingerprint: string
   preflightActionId: string
+  attempt: number
   approved:
     | Awaited<ReturnType<typeof validateApproval>>
     | Awaited<ReturnType<typeof validateLegacyApproval>>
@@ -648,10 +675,10 @@ async function appendExecutionResult(input: {
     capabilityId: actionName,
     capabilityVersion: input.selected.version,
     authorizationSource: "selected_graph_mcp_gate",
-    causationActionId: input.approved?.requestedAction.id ?? input.preflightActionId,
+    causationActionId: input.preflightActionId,
     approvalId: input.approved?.approval.id ?? null,
     idempotencyScope: input.approved
-      ? `${input.approved.approval.id}:execution`
+      ? `${input.approved.approval.id}:execution:${input.attempt}`
       : `${actionName}:${input.selected.version}:${input.targetId}:mcp-result`,
     idempotencyKey: input.approved?.approval.id ?? input.executionKey,
     idempotencyFingerprint: input.fingerprint,

--- a/packages/action-ledger/tests/unit/tool-action-policy.test.ts
+++ b/packages/action-ledger/tests/unit/tool-action-policy.test.ts
@@ -303,7 +303,10 @@ describe("generic MCP action-policy gate", () => {
       requestedAction: { id: "requested_1", idempotencyKey: derivedRequestId },
       idempotencyFingerprint: fingerprint,
     } as never)
-    const entries = new Map<string, { id: string; status: string; idempotencyScope?: string | null }>()
+    const entries = new Map<
+      string,
+      { id: string; status: string; idempotencyScope?: string | null }
+    >()
     vi.spyOn(actionLedgerService, "appendEntry").mockImplementation(async (_db, input) => {
       const identity = `${input.idempotencyScope}:${input.idempotencyKey}`
       const existing = entries.get(identity)
@@ -312,12 +315,15 @@ describe("generic MCP action-policy gate", () => {
       entries.set(identity, entry)
       return { entry, replayed: false } as never
     })
-    vi.spyOn(actionLedgerService, "listEntries").mockImplementation(async (_db, input) => ({
-      entries: [...entries.values()].filter(
-        (entry) => entry.idempotencyScope === input.idempotencyScope,
-      ),
-      nextCursor: null,
-    }) as never)
+    vi.spyOn(actionLedgerService, "listEntries").mockImplementation(
+      async (_db, input) =>
+        ({
+          entries: [...entries.values()].filter(
+            (entry) => entry.idempotencyScope === input.idempotencyScope,
+          ),
+          nextCursor: null,
+        }) as never,
+    )
     let completeRetry!: (value: { ok: true }) => void
     const retryResult = new Promise<{ ok: true }>((resolve) => {
       completeRetry = resolve

--- a/packages/action-ledger/tests/unit/tool-action-policy.test.ts
+++ b/packages/action-ledger/tests/unit/tool-action-policy.test.ts
@@ -285,7 +285,7 @@ describe("generic MCP action-policy gate", () => {
       expect.objectContaining({ status: "requested", causationActionId: "requested_1" }),
       expect.objectContaining({
         status: "succeeded",
-        causationActionId: "requested_1",
+        causationActionId: "entry_1",
         approvalId: "approval_1",
         idempotencyFingerprint: fingerprint,
       }),

--- a/packages/action-ledger/tests/unit/tool-action-policy.test.ts
+++ b/packages/action-ledger/tests/unit/tool-action-policy.test.ts
@@ -292,6 +292,41 @@ describe("generic MCP action-policy gate", () => {
     ])
   })
 
+  it("allows one exact retry after an approved dispatch fails", async () => {
+    const selected = action({ approval: "required" })
+    const commandInput = { value: 1 }
+    const fingerprint = await exactFingerprint(selected, commandInput)
+    const derivedRequestId = `mcp-request:${fingerprint}`
+    vi.spyOn(actionLedgerService, "validateApprovedAction").mockResolvedValue({
+      ok: true,
+      approval: { id: "approval_1" },
+      requestedAction: { id: "requested_1", idempotencyKey: derivedRequestId },
+      idempotencyFingerprint: fingerprint,
+    } as never)
+    const entries = new Map<string, { id: string; status: string }>()
+    vi.spyOn(actionLedgerService, "appendEntry").mockImplementation(async (_db, input) => {
+      const identity = `${input.idempotencyScope}:${input.idempotencyKey}`
+      const existing = entries.get(identity)
+      if (existing) return { entry: existing, replayed: true } as never
+      const entry = { id: `entry_${entries.size + 1}`, ...input }
+      entries.set(identity, entry)
+      return { entry, replayed: false } as never
+    })
+    const dispatch = vi
+      .fn<() => Promise<{ ok: true }>>()
+      .mockRejectedValueOnce(new Error("readiness changed before publication"))
+      .mockResolvedValueOnce({ ok: true })
+    const invoke = () =>
+      gate(selected).execute(
+        execution(selected, { confirmed: true, approvalId: "approval_1" }, commandInput),
+        dispatch,
+      )
+
+    await expect(invoke()).rejects.toThrow("readiness changed before publication")
+    await expect(invoke()).resolves.toEqual({ ok: true })
+    expect(dispatch).toHaveBeenCalledTimes(2)
+  })
+
   it("rejects a package-resolved target that conflicts with the declared command target", async () => {
     const selected = action({ commandTargetField: "bookingId" })
     const dispatch = vi.fn(async () => ({ ok: true }))

--- a/packages/action-ledger/tests/unit/tool-action-policy.test.ts
+++ b/packages/action-ledger/tests/unit/tool-action-policy.test.ts
@@ -303,7 +303,7 @@ describe("generic MCP action-policy gate", () => {
       requestedAction: { id: "requested_1", idempotencyKey: derivedRequestId },
       idempotencyFingerprint: fingerprint,
     } as never)
-    const entries = new Map<string, { id: string; status: string }>()
+    const entries = new Map<string, { id: string; status: string; idempotencyScope?: string | null }>()
     vi.spyOn(actionLedgerService, "appendEntry").mockImplementation(async (_db, input) => {
       const identity = `${input.idempotencyScope}:${input.idempotencyKey}`
       const existing = entries.get(identity)
@@ -312,6 +312,12 @@ describe("generic MCP action-policy gate", () => {
       entries.set(identity, entry)
       return { entry, replayed: false } as never
     })
+    vi.spyOn(actionLedgerService, "listEntries").mockImplementation(async (_db, input) => ({
+      entries: [...entries.values()].filter(
+        (entry) => entry.idempotencyScope === input.idempotencyScope,
+      ),
+      nextCursor: null,
+    }) as never)
     const dispatch = vi
       .fn<() => Promise<{ ok: true }>>()
       .mockRejectedValueOnce(new Error("readiness changed before publication"))

--- a/packages/action-ledger/tests/unit/tool-action-policy.test.ts
+++ b/packages/action-ledger/tests/unit/tool-action-policy.test.ts
@@ -318,10 +318,14 @@ describe("generic MCP action-policy gate", () => {
       ),
       nextCursor: null,
     }) as never)
+    let completeRetry!: (value: { ok: true }) => void
+    const retryResult = new Promise<{ ok: true }>((resolve) => {
+      completeRetry = resolve
+    })
     const dispatch = vi
       .fn<() => Promise<{ ok: true }>>()
       .mockRejectedValueOnce(new Error("readiness changed before publication"))
-      .mockResolvedValueOnce({ ok: true })
+      .mockReturnValueOnce(retryResult)
     const invoke = () =>
       gate(selected).execute(
         execution(selected, { confirmed: true, approvalId: "approval_1" }, commandInput),
@@ -329,7 +333,15 @@ describe("generic MCP action-policy gate", () => {
       )
 
     await expect(invoke()).rejects.toThrow("readiness changed before publication")
-    await expect(invoke()).resolves.toEqual({ ok: true })
+    const retry = invoke()
+    await vi.waitFor(() => expect(dispatch).toHaveBeenCalledTimes(2))
+    await expect(invoke()).rejects.toMatchObject({
+      code: "PROVIDER_UNAVAILABLE",
+      retryable: true,
+      meta: { reason: "approved_execution_in_progress", attempt: 2 },
+    })
+    completeRetry({ ok: true })
+    await expect(retry).resolves.toEqual({ ok: true })
     expect(dispatch).toHaveBeenCalledTimes(2)
   })
 


### PR DESCRIPTION
## Summary

- give generic approved Tool executions attempt-specific durable claims and outcomes
- allow a terminally failed attempt to advance to one atomically claimed retry generation
- bind each terminal outcome causally to its own attempt claim
- report a concurrent retry as retryable in-progress work instead of authorization denial

## Safety

A retry never ignores an existing claim. It advances only after reading a terminal `failed` outcome for the prior generation. Concurrent callers choose the same next generation; only one inserts that claim and reaches domain dispatch. Successful or outcome-less attempts remain protected.

Lease recovery for a genuinely abandoned outcome-less attempt remains separately tracked in #4424.

## Verification

- generic action-policy unit suite: 14/14 pass
- failed dispatch -> exact approved retry -> success covered
- concurrent retry dispatches the domain operation once and returns actionable in-progress state to the loser
- Action Ledger typecheck: pass, zero TypeScript errors
- build: pass
- focused formatting/lint fixed

Part of #4424 and #4378.
