### PR TITLE
Fix automatic contract template variables

### DIFF
--- a/packages/legal/src/booking-contract-confirmed.ts
+++ b/packages/legal/src/booking-contract-confirmed.ts
@@ -230,7 +230,10 @@ async function prepareBookingContractTarget(
   }
 
   const origin = await getBookingOriginByBookingId(db, bookingId)
-  const items = await bookingsService.listItems(db, bookingId)
+  const [items, travelers] = await Promise.all([
+    bookingsService.listItems(db, bookingId),
+    bookingsService.listTravelers(db, bookingId),
+  ])
   const language = resolveBookingContractLanguage(booking)
   const reusable = existingContracts.find((contract) => {
     const metadata = record(contract.metadata)
@@ -249,7 +252,7 @@ async function prepareBookingContractTarget(
   })
   if (selected.status !== "selected") return selected
 
-  const variables = bookingContractVariables(booking, items)
+  const variables = bookingContractVariables(booking, items, travelers)
   const missingPrerequisites = bookingContractPrerequisites({
     templateApplicable:
       reusable?.templateVersionId === selected.version.id ||
@@ -408,32 +411,94 @@ async function resolveTemplateSelection(
     : { status: "skipped", reason: "template_version_missing" }
 }
 
-function bookingContractVariables(
+export function bookingContractVariables(
   booking: BookingContractReviewInput["booking"],
   items: BookingContractReviewInput["items"],
+  travelers: Awaited<ReturnType<typeof bookingsService.listTravelers>>,
+  now = new Date(),
 ): Record<string, unknown> {
   const primaryProduct = items[0]
+  const today = now.toISOString().slice(0, 10)
   const normalizedItems = items.map((item) => ({
     title: item.productNameSnapshot ?? item.title,
     quantity: item.quantity,
     amountCents: item.totalSellAmountCents,
     currency: item.sellCurrency,
   }))
+  const normalizedTravelers = travelers.map((traveler) => ({
+    id: traveler.id,
+    firstName: traveler.firstName,
+    lastName: traveler.lastName,
+    fullName: [traveler.firstName, traveler.lastName].filter(Boolean).join(" "),
+    email: traveler.email,
+    phone: traveler.phone,
+    category: traveler.travelerCategory,
+    isPrimary: traveler.isPrimary,
+  }))
+  const leadTraveler =
+    normalizedTravelers.find((traveler) => traveler.isPrimary) ?? normalizedTravelers[0] ?? null
+  const customerName = [booking.contactFirstName, booking.contactLastName].filter(Boolean).join(" ")
+  const pax = booking.pax ?? (normalizedTravelers.length > 0 ? normalizedTravelers.length : null)
   return {
+    today,
+    currentDate: today,
+    currentDateTime: now.toISOString(),
+    currentTime: now.toISOString().slice(11, 19),
+    contract: {
+      contractNumber: "",
+      number: "",
+      contractDate: today,
+      date: today,
+      signedAt: "",
+      isManual: false,
+      series: "",
+      channel: "storefront",
+      source: "self_service",
+    },
     booking: {
       id: booking.id,
       bookingId: booking.id,
       reference: booking.bookingNumber,
       bookingNumber: booking.bookingNumber,
+      number: booking.bookingNumber,
+      status: booking.status,
       startDate: booking.startDate,
       endDate: booking.endDate,
       productName: primaryProduct?.productNameSnapshot ?? primaryProduct?.title ?? null,
+      pax,
+      paxTotal: pax,
+      sellCurrency: booking.sellCurrency,
+      currency: booking.sellCurrency,
+      sellAmountCents: booking.sellAmountCents,
+      totalAmountCents: booking.sellAmountCents,
       items: normalizedItems,
     },
-    customer: bookingContractCustomerVariables(booking),
+    customer: {
+      ...bookingContractCustomerVariables(booking),
+      firstName: booking.contactFirstName,
+      lastName: booking.contactLastName,
+      fullName: customerName || null,
+      type: booking.contactPartyType === "company" ? "B2B" : "B2C",
+      address: {
+        line1: booking.contactAddressLine1,
+        line2: booking.contactAddressLine2,
+        city: booking.contactCity,
+        region: booking.contactRegion,
+        postal: booking.contactPostalCode,
+        country: booking.contactCountry,
+      },
+    },
+    leadTraveler,
+    travelers: normalizedTravelers,
+    passengers: normalizedTravelers,
+    items: normalizedItems,
     commercial: {
       currency: booking.sellCurrency,
       totalAmountCents: booking.sellAmountCents,
+    },
+    payment: {
+      amountCents: booking.sellAmountCents,
+      currency: booking.sellCurrency,
     },
     product: {
       title: primaryProduct?.productNameSnapshot ?? primaryProduct?.title ?? null,

--- a/packages/legal/tests/integration/booking-contract-confirmed.test.ts
+++ b/packages/legal/tests/integration/booking-contract-confirmed.test.ts
@@ -1,5 +1,5 @@
 import { actionLedgerEntries } from "@voyant-travel/action-ledger/schema"
-import { bookingItems, bookings } from "@voyant-travel/bookings/schema"
+import { bookingItems, bookings, bookingTravelers } from "@voyant-travel/bookings/schema"
 import { createEventBus } from "@voyant-travel/core"
 import { createDbClient } from "@voyant-travel/db"
 import { cleanupTestDb } from "@voyant-travel/db/test-utils"
@@ -101,6 +101,7 @@ describe.skipIf(!DB_AVAILABLE)("booking-confirmed contract generation", () => {
         sellAmountCents: 120_00,
         startDate: "2026-09-01",
         endDate: "2026-09-07",
+        pax: 2,
       })
       .returning()
     await db.insert(bookingItems).values({
@@ -112,6 +113,22 @@ describe.skipIf(!DB_AVAILABLE)("booking-confirmed contract generation", () => {
       sellCurrency: "EUR",
       totalSellAmountCents: 120_00,
     })
+    await db.insert(bookingTravelers).values([
+      {
+        bookingId: booking!.id,
+        firstName: "Ana",
+        lastName: "Pop",
+        email: "ana@example.test",
+        travelerCategory: "adult",
+        isPrimary: true,
+      },
+      {
+        bookingId: booking!.id,
+        firstName: "Mara",
+        lastName: "Pop",
+        travelerCategory: "child",
+      },
+    ])
     const [template] = await db
       .insert(contractTemplates)
       .values({
@@ -119,7 +136,7 @@ describe.skipIf(!DB_AVAILABLE)("booking-confirmed contract generation", () => {
         slug: "customer-agreement-auto",
         scope: "customer",
         language: "en",
-        body: "Hello {{ customer.name }}, booking {{ booking.reference }}",
+        body: "Booking {{ booking.number }} for {{ leadTraveler.fullName }} and {{ travelers.size }} travellers: {{ booking.totalAmountCents | cents: booking.currency }} on {{ contract.date }}",
         active: true,
         isDefault: true,
       })
@@ -129,8 +146,16 @@ describe.skipIf(!DB_AVAILABLE)("booking-confirmed contract generation", () => {
       .values({
         templateId: template!.id,
         version: 1,
-        body: "Hello {{ customer.name }}, booking {{ booking.reference }}",
-        variableSchema: { required: ["customer.name", "booking.reference"] },
+        body: "Booking {{ booking.number }} for {{ leadTraveler.fullName }} and {{ travelers.size }} travellers: {{ booking.totalAmountCents | cents: booking.currency }} on {{ contract.date }}",
+        variableSchema: {
+          required: [
+            "booking.number",
+            "leadTraveler.fullName",
+            "booking.totalAmountCents",
+            "booking.currency",
+            "contract.date",
+          ],
+        },
       })
       .returning()
     await db
@@ -178,7 +203,9 @@ describe.skipIf(!DB_AVAILABLE)("booking-confirmed contract generation", () => {
     expect(contractRows[0]).toMatchObject({
       bookingId: booking!.id,
       templateVersionId: version!.id,
-      renderedBody: "Hello Ana Pop, booking BK-AUTO-CONTRACT-1",
+      renderedBody: expect.stringMatching(
+        /^Booking BK-AUTO-CONTRACT-1 for Ana Pop and 2 travellers: €120\.00 on \d{4}-\d{2}-\d{2}$/,
+      ),
     })
     expect(attachmentRows).toHaveLength(1)
     expect(attachmentRows[0]).toMatchObject({

--- a/packages/legal/tests/unit/booking-contract-confirmed.test.ts
+++ b/packages/legal/tests/unit/booking-contract-confirmed.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest"
+import { bookingContractVariables } from "../../src/booking-contract-confirmed.js"
+import { contractsService } from "../../src/contracts/service.js"
+
+describe("automatic booking contract variables", () => {
+  it("renders the documented customer-sales-agreement aliases from persisted booking data", () => {
+    const variables = bookingContractVariables(
+      {
+        id: "book_1",
+        bookingNumber: "BK-AUTO-1",
+        status: "confirmed",
+        contactFirstName: "Ana",
+        contactLastName: "Pop",
+        contactEmail: "ana@example.test",
+        contactPhone: "+40123456789",
+        contactPartyType: "individual",
+        contactAddressLine1: "1 Main Street",
+        contactAddressLine2: null,
+        contactCity: "Bucharest",
+        contactRegion: "Bucharest",
+        contactPostalCode: "010101",
+        contactCountry: "RO",
+        sellCurrency: "EUR",
+        sellAmountCents: 120_00,
+        pax: 2,
+        startDate: "2026-09-01",
+        endDate: "2026-09-07",
+      } as never,
+      [
+        {
+          title: "Autumn tour",
+          productNameSnapshot: "Autumn tour",
+          quantity: 2,
+          sellCurrency: "EUR",
+          totalSellAmountCents: 120_00,
+        },
+      ] as never,
+      [
+        {
+          id: "trav_1",
+          firstName: "Ana",
+          lastName: "Pop",
+          email: "ana@example.test",
+          phone: null,
+          travelerCategory: "adult",
+          isPrimary: true,
+        },
+        {
+          id: "trav_2",
+          firstName: "Mara",
+          lastName: "Pop",
+          email: null,
+          phone: null,
+          travelerCategory: "child",
+          isPrimary: false,
+        },
+      ] as never,
+      new Date("2026-08-08T06:45:12.000Z"),
+    )
+
+    expect(variables).toMatchObject({
+      today: "2026-08-08",
+      contract: { date: "2026-08-08" },
+      booking: {
+        number: "BK-AUTO-1",
+        totalAmountCents: 120_00,
+        currency: "EUR",
+        pax: 2,
+      },
+      customer: {
+        fullName: "Ana Pop",
+        email: "ana@example.test",
+      },
+      leadTraveler: { fullName: "Ana Pop", email: "ana@example.test" },
+    })
+
+    expect(
+      contractsService.renderPreview({
+        body: "Booking {{ booking.number }} for {{ leadTraveler.fullName }} and {{ travelers.size }} travellers: {{ booking.totalAmountCents | cents: booking.currency }} on {{ contract.date }}",
+        variables,
+      }),
+    ).toBe("Booking BK-AUTO-1 for Ana Pop and 2 travellers: €120.00 on 2026-08-08")
+  })
+})


### PR DESCRIPTION
## Summary

- make automatic `booking.confirmed` contract generation honor the documented Legal template-variable aliases
- hydrate persisted travelers and expose the lead traveler, traveler/passenger collections, customer address, booking totals/currency/pax, items, payment, and render clocks
- keep customer and traveler contact data exactly as persisted; no email or identity synthesis

## Root cause

The automatic backend generator introduced in #4419 emitted a smaller canonical shape than the existing Legal template contract. Sandbox’s default customer agreement therefore rendered blank booking numbers, missing travelers, `TBD` pax, and a missing total even though document generation itself succeeded.

## Validation

- exact unit render of the sandbox template fields passes
- Legal typecheck passes with an 8 GB Node heap
- Biome check passes for all changed files
- integration database test now exercises the same aliases and two persisted travelers
- `git diff --check`
