### PR TITLE
fix: make product lifecycle commands durable

### DIFF
--- a/.changeset/calm-products-replay.md
+++ b/.changeset/calm-products-replay.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/inventory": patch
+---
+
+Run approved product lifecycle tools through the handler-owned durable existing-target command protocol so an interrupted publication can be retried without losing its approval or applying the lifecycle mutation twice.

--- a/packages/inventory/src/mcp-runtime.ts
+++ b/packages/inventory/src/mcp-runtime.ts
@@ -2,6 +2,8 @@
 // service wiring, created-command execution, slug resolution, and content runtime
 // binding stay co-located until a dedicated runtime split preserves the public
 // contribution entry and its tests.
+
+import { executeAdmittedExistingTargetCommand } from "@voyant-travel/action-ledger"
 import {
   buildCreatedTargetCommandFingerprint,
   executeAdmittedCreatedTargetCommand,
@@ -174,6 +176,34 @@ export const voyantToolContextContribution = defineToolContextContribution({
           return { ...row, slug }
         }
         return row
+      },
+      async updateProductLifecycle(id, patch, admitted) {
+        const commandInput = { id, ...patch }
+        const idempotencyKey = await deriveCommandIdempotencyKey("product-lifecycle", commandInput)
+        const result = await executeAdmittedExistingTargetCommand(
+          {
+            db: asLedgerDb(db),
+            context: actionLedgerContext(c),
+            admitted: withServerResolvedIdempotencyKey(admitted, idempotencyKey),
+            commandInput,
+            evaluatedRisk: "high",
+          },
+          {
+            async prepare(tx) {
+              const row = await productsService.updateProduct(asPostgresDb(tx), id, patch)
+              if (!row) {
+                throw new ToolError(`No product exists with id "${id}".`, "NOT_FOUND", { id })
+              }
+            },
+            execute: () => loadProductById(id),
+            replay: () => loadProductById(id),
+          },
+        )
+        if (result.value) {
+          await eventBus?.emit("product.updated", { id })
+          await emitProductContentChanged(eventBus, { id, axis: "product" })
+        }
+        return result.value
       },
       async setProductOpenGraphImage(productId, mediaId) {
         try {

--- a/packages/inventory/src/tools.ts
+++ b/packages/inventory/src/tools.ts
@@ -126,6 +126,19 @@ export const COMPOSE_PRODUCT_HANDLER_POLICY = {
   },
 } as const satisfies HandlerActionPolicyExpectation
 
+export const PUBLISH_PRODUCT_HANDLER_POLICY = productLifecycleHandlerPolicy({
+  capabilityId: `${OWNER}#tool.publish-product`,
+  name: "publish_product",
+})
+export const UNPUBLISH_PRODUCT_HANDLER_POLICY = productLifecycleHandlerPolicy({
+  capabilityId: `${OWNER}#tool.unpublish-product`,
+  name: "unpublish_product",
+})
+export const ARCHIVE_PRODUCT_HANDLER_POLICY = productLifecycleHandlerPolicy({
+  capabilityId: `${OWNER}#tool.archive-product`,
+  name: "archive_product",
+})
+
 type ProductListQuery = z.infer<typeof productListQuerySchema>
 
 const productToolSchema = z
@@ -242,6 +255,11 @@ export interface InventoryToolServices {
     admitted: ToolHandlerActionPolicyContext,
   ): Promise<unknown>
   updateProduct(id: string, input: z.output<typeof updateProductSchema>): Promise<unknown | null>
+  updateProductLifecycle(
+    id: string,
+    input: z.output<typeof updateProductSchema>,
+    admitted: ToolHandlerActionPolicyContext,
+  ): Promise<unknown | null>
   setProductOpenGraphImage(productId: string, mediaId: string | null): Promise<unknown | null>
   listProductDays(productId: string): Promise<unknown[]>
   updateProductDay(input: UpdateProductDayInput): Promise<unknown | null>
@@ -501,6 +519,7 @@ export const publishProductTool = defineTool(
     description:
       "Make a product active. Inventory enforces scheduled-product departure readiness; effective channel publication controls where it is distributed.",
     patch: { status: "active" },
+    handlerPolicy: PUBLISH_PRODUCT_HANDLER_POLICY,
   }),
 )
 
@@ -511,6 +530,7 @@ export const unpublishProductTool = defineTool(
     description:
       "Return a product to draft without deleting authored history or its channel publication rules.",
     patch: { status: "draft" },
+    handlerPolicy: UNPUBLISH_PRODUCT_HANDLER_POLICY,
   }),
 )
 
@@ -520,6 +540,7 @@ export const archiveProductTool = defineTool(
     name: "archive_product",
     description: "Archive a product while preserving its history and owned records.",
     patch: { status: "archived" },
+    handlerPolicy: ARCHIVE_PRODUCT_HANDLER_POLICY,
   }),
 )
 
@@ -615,6 +636,7 @@ function productLifecycleToolDefinition(input: {
   name: string
   description: string
   patch: z.output<typeof updateProductSchema>
+  handlerPolicy: HandlerActionPolicyExpectation
 }) {
   return {
     capabilityId: input.capabilityId,
@@ -628,9 +650,11 @@ function productLifecycleToolDefinition(input: {
     tier: "write",
     riskPolicy: PRODUCT_LIFECYCLE_RISK,
     annotations: { idempotentHint: true },
+    actionPolicyEnforcement: "handler",
     async handler({ id }: z.infer<typeof productIdArgs>, ctx: InventoryToolContext) {
       try {
-        const product = await inventory(ctx).updateProduct(id, input.patch)
+        const admitted = admitHandlerActionPolicy(ctx, input.handlerPolicy)
+        const product = await inventory(ctx).updateProductLifecycle(id, input.patch, admitted)
         if (!product) {
           // A lifecycle mutation returning `null` is not success. The live GPT
           // client supplied a run-marker suffix as the id, received
@@ -649,6 +673,29 @@ function productLifecycleToolDefinition(input: {
       }
     },
   } as const
+}
+
+function productLifecycleHandlerPolicy(input: { capabilityId: string; name: string }) {
+  return {
+    capabilityId: input.capabilityId,
+    capabilityVersion: VERSION,
+    canonicalName: input.name,
+    actionPolicy: {
+      id: input.capabilityId.replace("#tool.", "#action."),
+      capabilityId: input.capabilityId.replace("#tool.", "#action."),
+      version: VERSION,
+      kind: "execute",
+      targetType: "product",
+      commandTargetField: "id",
+      targetLifecycle: "existing",
+      existingTarget: { durability: "handler-command-result-v1" },
+      risk: "high",
+      ledger: "required",
+      approval: "required",
+      reversible: true,
+      allowedActorTypes: ["staff"],
+    },
+  } as const satisfies HandlerActionPolicyExpectation
 }
 
 /**

--- a/packages/inventory/src/voyant.ts
+++ b/packages/inventory/src/voyant.ts
@@ -499,6 +499,7 @@ export const inventoryVoyantModule = defineModule({
       availability: { status: "available" },
       effectBoundary: "local",
       targetLifecycle: "existing",
+      existingTarget: { durability: "handler-command-result-v1" },
       from: { tools: ["@voyant-travel/inventory#tool.publish-product"] },
     },
     {
@@ -516,6 +517,7 @@ export const inventoryVoyantModule = defineModule({
       availability: { status: "available" },
       effectBoundary: "local",
       targetLifecycle: "existing",
+      existingTarget: { durability: "handler-command-result-v1" },
       from: { tools: ["@voyant-travel/inventory#tool.unpublish-product"] },
     },
     {
@@ -533,6 +535,7 @@ export const inventoryVoyantModule = defineModule({
       availability: { status: "available" },
       effectBoundary: "local",
       targetLifecycle: "existing",
+      existingTarget: { durability: "handler-command-result-v1" },
       from: { tools: ["@voyant-travel/inventory#tool.archive-product"] },
     },
     ...(

--- a/packages/inventory/tests/tools.test.ts
+++ b/packages/inventory/tests/tools.test.ts
@@ -2,6 +2,7 @@ import { createToolRegistry, type ToolContext } from "@voyant-travel/tools"
 import { describe, expect, it } from "vitest"
 
 import {
+  ARCHIVE_PRODUCT_HANDLER_POLICY,
   COMPOSE_PRODUCT_HANDLER_POLICY,
   CREATE_PRODUCT_HANDLER_POLICY,
   type InventoryAuthoringToolServices,
@@ -9,11 +10,15 @@ import {
   type InventoryContentToolServices,
   type InventoryToolServices,
   inventoryTools,
-  publishProductTool,
+  PUBLISH_PRODUCT_HANDLER_POLICY,
+  UNPUBLISH_PRODUCT_HANDLER_POLICY,
 } from "../src/tools.js"
 
 function admitted(
-  expected: typeof CREATE_PRODUCT_HANDLER_POLICY | typeof COMPOSE_PRODUCT_HANDLER_POLICY,
+  expected:
+    | typeof CREATE_PRODUCT_HANDLER_POLICY
+    | typeof COMPOSE_PRODUCT_HANDLER_POLICY
+    | typeof PUBLISH_PRODUCT_HANDLER_POLICY,
 ): ToolContext["handlerActionPolicy"] {
   return {
     capabilityId: expected.capabilityId,
@@ -92,6 +97,12 @@ function makeRegistry() {
       registry.register(tool, { actionPolicy: COMPOSE_PRODUCT_HANDLER_POLICY.actionPolicy })
     } else if (tool.name === "update_product_day") {
       registry.register(tool, { actionPolicy: UPDATE_PRODUCT_DAY_ACTION_POLICY })
+    } else if (tool.name === "publish_product") {
+      registry.register(tool, { actionPolicy: PUBLISH_PRODUCT_HANDLER_POLICY.actionPolicy })
+    } else if (tool.name === "unpublish_product") {
+      registry.register(tool, { actionPolicy: UNPUBLISH_PRODUCT_HANDLER_POLICY.actionPolicy })
+    } else if (tool.name === "archive_product") {
+      registry.register(tool, { actionPolicy: ARCHIVE_PRODUCT_HANDLER_POLICY.actionPolicy })
     } else {
       registry.register(tool)
     }
@@ -482,12 +493,16 @@ describe("inventory tools", () => {
       { id: "prod_1" },
       ctxWith(
         {
-          async updateProduct(_id, input) {
+          async updateProductLifecycle(_id, input) {
             forwarded = input
             return product(input)
           },
         },
-        { actor: "staff", audience: "staff" },
+        {
+          actor: "staff",
+          audience: "staff",
+          handlerActionPolicy: admitted(PUBLISH_PRODUCT_HANDLER_POLICY),
+        },
       ),
     )
     expect(forwarded).toEqual({ status: "active" })
@@ -534,14 +549,22 @@ describe("inventory tools", () => {
       ],
     })
 
-    const error = await publishProductTool
-      .handler(
+    const error = await makeRegistry()
+      .dispatch(
+        "publish_product",
         { id: "prod_1" },
-        ctxWith({
-          async updateProduct() {
-            throw readinessError
+        ctxWith(
+          {
+            async updateProductLifecycle() {
+              throw readinessError
+            },
+          } as never,
+          {
+            actor: "staff",
+            audience: "staff",
+            handlerActionPolicy: admitted(PUBLISH_PRODUCT_HANDLER_POLICY),
           },
-        } as never),
+        ),
       )
       .catch((thrown: unknown) => thrown as { code?: string; nextSteps?: string[] })
 
@@ -554,14 +577,22 @@ describe("inventory tools", () => {
   })
 
   it("refuses a missing lifecycle target instead of reporting null success", async () => {
-    const error = await publishProductTool
-      .handler(
+    const error = await makeRegistry()
+      .dispatch(
+        "publish_product",
         { id: "8014752" },
-        ctxWith({
-          async updateProduct() {
-            return null
+        ctxWith(
+          {
+            async updateProductLifecycle() {
+              return null
+            },
+          } as never,
+          {
+            actor: "staff",
+            audience: "staff",
+            handlerActionPolicy: admitted(PUBLISH_PRODUCT_HANDLER_POLICY),
           },
-        } as never),
+        ),
       )
       .catch((thrown: unknown) => thrown as { code?: string; message?: string })
 
@@ -575,14 +606,25 @@ describe("inventory tools", () => {
     // failure with a confident, wrong remediation.
     const other = new Error("connection reset")
     await expect(
-      publishProductTool.handler(
+      makeRegistry().dispatch(
+        "publish_product",
         { id: "prod_1" },
-        ctxWith({
-          async updateProduct() {
-            throw other
+        ctxWith(
+          {
+            async updateProductLifecycle() {
+              throw other
+            },
+          } as never,
+          {
+            actor: "staff",
+            audience: "staff",
+            handlerActionPolicy: admitted(PUBLISH_PRODUCT_HANDLER_POLICY),
           },
-        } as never),
+        ),
       ),
-    ).rejects.toBe(other)
+    ).rejects.toMatchObject({
+      code: "PROVIDER_ERROR",
+      message: 'Tool "publish_product" failed: connection reset',
+    })
   })
 })

--- a/packages/inventory/tests/unit/voyant-manifest.test.ts
+++ b/packages/inventory/tests/unit/voyant-manifest.test.ts
@@ -183,6 +183,7 @@ describe("inventory deployment manifests", () => {
           ledger: "required",
           approval: "required",
           allowedActorTypes: ["staff"],
+          existingTarget: { durability: "handler-command-result-v1" },
         }),
         expect.objectContaining({
           id: "@voyant-travel/inventory#action.set-product-open-graph-image",


### PR DESCRIPTION
## Summary

- route product publish, unpublish, and archive Tools through the existing handler-owned durable existing-target command protocol
- atomically claim the approved command and apply the local lifecycle mutation in the same transaction
- derive the lifecycle idempotency key server-side so approval retries do not depend on model-generated opaque tokens
- replay the product result and repair content projection events after an interrupted response

## Why

A generic preflight cannot safely recover an abandoned in-flight command: after process loss it cannot know whether an arbitrary side effect occurred. Product lifecycle is a local transactional mutation, so it can use the repository's established handler-command-result-v1 protocol and eliminate that ambiguity.

## Verification

- focused Biome check: pass
- inventory Tool and manifest tests: 24/24 pass on lab1
- package typecheck was attempted on lab1, but this package exhausted both the default 2 GB heap and an 8 GB heap without producing TypeScript diagnostics; CI will run the repository's normal affected-graph typecheck lane

Part of #4424 and #4378.
