### PR TITLE
Start checkout without optional contact details

### DIFF
--- a/.changeset/quiet-optional-checkout-contact.md
+++ b/.changeset/quiet-optional-checkout-contact.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/catalog": patch
+"@voyant-travel/finance": patch
+---
+
+Start a configured payment adapter when optional shopper contact details are absent, and carry missing email and name fields as null provider prefill instead of blocking checkout initiation.

--- a/packages/catalog/src/booking-engine/sessions-payment-production.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-payment-production.test.ts
@@ -186,6 +186,17 @@ describe("production Booking Session hosted-checkout initiation", () => {
 
     expect(startArgs().customerReference).toBeUndefined()
   })
+
+  it("starts checkout when optional contact details are absent", async () => {
+    await prepare({
+      locale: "en-GB",
+      departureDate: null,
+      omitContact: true,
+    })
+
+    expect(startPaymentAdapterCardPayment).toHaveBeenCalledOnce()
+    expect(startArgs().billing).toEqual({})
+  })
 })
 
 /**
@@ -322,6 +333,7 @@ async function prepare(input: {
   personId?: string
   actorKind?: string
   ownerPrincipalId?: string
+  omitContact?: boolean
   acceptedCheckoutHandoffs?: readonly ("redirect" | "embedded")[]
   refreshedCheckout?: Record<string, unknown>
   refreshedRedirectUrl?: string | null
@@ -367,12 +379,14 @@ async function prepare(input: {
       expiresAt: new Date("2026-08-06T00:00:00Z"),
       statePayload: {
         billing: {
-          contact: {
-            firstName: "Ana",
-            lastName: "Pop",
-            email: "ana@example.com",
-            ...(input.personId ? { personId: input.personId } : {}),
-          },
+          contact: input.omitContact
+            ? {}
+            : {
+                firstName: "Ana",
+                lastName: "Pop",
+                email: "ana@example.com",
+                ...(input.personId ? { personId: input.personId } : {}),
+              },
         },
       },
     },
@@ -410,6 +424,7 @@ function startArgs() {
     description?: string
     locale?: string
     customerReference?: string
+    billing?: Record<string, unknown>
     acceptedCheckoutHandoffs?: readonly ("redirect" | "embedded")[]
   }
 }

--- a/packages/catalog/src/booking-engine/sessions-payment-production.ts
+++ b/packages/catalog/src/booking-engine/sessions-payment-production.ts
@@ -142,7 +142,7 @@ export function createProductionBookingSessionPaymentPorts(
       }
 
       const adapter = await deps.resolvePaymentAdapter?.()
-      if (adapter && paymentSession.status === "pending" && contact.email && contact.firstName) {
+      if (adapter && paymentSession.status === "pending") {
         const reference = customerReference(session)
         await startPaymentAdapterCardPayment(
           adapter,
@@ -150,8 +150,8 @@ export function createProductionBookingSessionPaymentPorts(
             db: deps.db,
             sessionId: paymentSession.id,
             billing: {
-              email: contact.email,
-              firstName: contact.firstName,
+              ...(contact.email ? { email: contact.email } : {}),
+              ...(contact.firstName ? { firstName: contact.firstName } : {}),
               ...(contact.lastName ? { lastName: contact.lastName } : {}),
               ...(contact.phone ? { phone: contact.phone } : {}),
               ...(contact.country ? { country: contact.country } : {}),

--- a/packages/finance/src/card-payment.ts
+++ b/packages/finance/src/card-payment.ts
@@ -37,9 +37,9 @@ const PAYMENT_ADAPTER_INITIATION_STATE_KEY = "paymentAdapterInitiationState"
  * ISO string depending on the processor.
  */
 export interface CardPaymentBilling {
-  email: string
+  email?: string
   phone?: string
-  firstName: string
+  firstName?: string
   lastName?: string
   city?: string
   country?: number | string
@@ -219,9 +219,9 @@ export async function startPaymentAdapterCardPayment(
       idempotencyKey,
       customer: {
         reference: args.customerReference ?? null,
-        email: args.billing.email,
+        email: args.billing.email ?? null,
         phone: args.billing.phone ?? null,
-        firstName: args.billing.firstName,
+        firstName: args.billing.firstName ?? null,
         lastName: args.billing.lastName ?? null,
       },
       shipping: args.shipping,


### PR DESCRIPTION
## What changed

- start the configured payment adapter even when optional shopper contact fields are absent
- carry absent email and first name as nullable provider prefill instead of blocking initiation
- add regression coverage for a booking session with no billing contact

## Root cause

The booking-session payment port created a pending internal payment session, then gated processor initiation on both email and first name. Public checkout permits those fields to be omitted, leaving the payment session with no provider and no checkout handoff.

## Validation

- catalog tests: 764 passed, 52 skipped
- finance tests: 562 passed, 401 skipped
- catalog typecheck
- finance typecheck
- catalog and finance lint (one pre-existing catalog warning only)