### PR TITLE
fix: clarify server-issued approval discovery

### DIFF
--- a/.changeset/wise-approval-discovery.md
+++ b/.changeset/wise-approval-discovery.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/action-ledger": patch
+"@voyant-travel/mcp": patch
+---
+
+Tell agents to invoke governed domain tools before requesting approval so handler-owned commands can issue the approval bound to their exact command.

--- a/packages/action-ledger/src/tools.ts
+++ b/packages/action-ledger/src/tools.ts
@@ -428,7 +428,7 @@ export const getActionDelegationTool = defineTool({
 export const requestActionApprovalTool = defineTool({
   name: "request_action_approval",
   description:
-    "Request approval for an exact write Tool action admitted by the selected graph with approval=required. Action identity, canonical Tool capability, risk, target type, and policy are derived server-side; conditional and absent policies fail closed.",
+    "Request approval only when the original domain Tool explicitly directs you here. Call the domain Tool first: handler-owned Tools issue their own approval bound to the exact command, and an independently requested approval cannot authorize them. For generic approval-required actions, identity, canonical capability, risk, target type, and policy are derived server-side; conditional and absent policies fail closed.",
   inputSchema: requestApprovalInputSchema,
   outputSchema: z.object({
     requestedAction: actionLedgerEntryDtoSchema,

--- a/packages/mcp/src/guide.ts
+++ b/packages/mcp/src/guide.ts
@@ -417,7 +417,11 @@ function confirmationSection(scope: GuideScope): string {
     "- requestId — a UUID identifying the request, required by generic guarded " +
     "actions.\n" +
     "- approvalId — an approval identifier some ledgered actions require before they " +
-    "will dispatch; supply it when the Tool's policy lists it.\n" +
+    "will dispatch. Call the domain Tool first with its other required controls. " +
+    "Handler-owned Tools create a server-issued approval bound to that exact command; " +
+    "approve the returned id and retry exactly as instructed. Do NOT call " +
+    "request_action_approval first unless the domain Tool explicitly tells you to — " +
+    "an independently requested approval will not authorize a handler-owned command.\n" +
     "- reasonCode — an optional human-meaningful reason recorded on the ledger.\n" +
     "- idempotencyKey — for handler-owned/created-target actions, the key that makes " +
     "a retry safe (the same key returns the same result rather than acting twice).\n\n" +

--- a/packages/mcp/src/schema-projection.ts
+++ b/packages/mcp/src/schema-projection.ts
@@ -58,7 +58,7 @@ const actionInvocationFields = {
     .trim()
     .min(1)
     .describe(
-      "Approval authorising this exact command. Get one with request_action_approval, then approve_action_approval — a pending approval is rejected.",
+      "Approval authorising this exact command. Call the domain Tool first: handler-owned Tools issue their own bound approval and tell you which id to approve. Use request_action_approval only when that Tool explicitly instructs you to; an unrelated approval is rejected.",
     ),
   reasonCode: z.string().trim().min(1).describe("Optional reason recorded with the action."),
   // Compatibility fields used by handler-owned policies and generic actions

--- a/packages/mcp/tests/guide.test.ts
+++ b/packages/mcp/tests/guide.test.ts
@@ -221,6 +221,8 @@ describe("MCP guide layer", () => {
     expect(confirmation).toContain("_voyant")
     expect(confirmation).toMatch(/confirmed/)
     expect(confirmation).toMatch(/approvalId/)
+    expect(confirmation).toMatch(/call the domain Tool first/i)
+    expect(confirmation).toMatch(/do NOT call request_action_approval first/i)
   })
 
   it("filters the glossary by term", async () => {


### PR DESCRIPTION
## Summary

- tell agents to call a governed domain Tool before requesting approval
- explain that handler-owned Tools issue an approval bound to the exact command
- warn that independently requested approvals cannot authorize handler-owned commands
- apply the guidance in `_voyant.approvalId`, the confirmation guide, and `request_action_approval` discovery

## Evidence

The merged-main GPT-5.6 Terra harness passed 13/13, but publication spent eight error calls on unrelated manually requested approvals before recovering through the server-issued path. This change puts the correct fork in every discovery surface the model used.

Part of #4424 and #4378.