### PR TITLE
fix: include confirmation in approval remediation

### DIFF
--- a/.changeset/brave-approval-confirmation.md
+++ b/.changeset/brave-approval-confirmation.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/action-ledger": patch
+---
+
+Include the required confirmation control in server-issued approval decision remediation so agents can approve without a preventable failed call.

--- a/packages/action-ledger/src/created-command-internal.ts
+++ b/packages/action-ledger/src/created-command-internal.ts
@@ -1158,7 +1158,7 @@ async function throwHandlerApprovalRequired(input: {
       // request_action_approval" first step sends the caller to mint a second
       // one and loop on the first. See that site for the measured trace.
       nextSteps: [
-        `1. Call approve_action_approval with approvalId "${result.approval.id}". This approval already exists and is PENDING — do NOT call request_action_approval, which would create a different one and leave this one blocking.`,
+        `1. Call approve_action_approval with arguments {"approvalId": "${result.approval.id}", "_voyant": {"confirmed": true}}. This approval already exists and is PENDING — do NOT call request_action_approval, which would create a different one and leave this one blocking.`,
         // Confirmation is re-asserted on the approved retry too — see the note at
         // the matching step in tool-action-policy.ts.
         `2. Re-call this tool with the nested control object "_voyant": {"confirmed": true, "approvalId": "${result.approval.id}"}, and the command otherwise unchanged. Do not send flat keys such as "_voyant.confirmed". Both fields must be present on the same call.`,

--- a/packages/action-ledger/src/tool-action-policy.ts
+++ b/packages/action-ledger/src/tool-action-policy.ts
@@ -649,7 +649,7 @@ async function requestApprovalPreflight(input: {
       // reason as the invoice payload: an id the caller has to go and find is an
       // id the caller can get wrong.
       nextSteps: [
-        `1. Call approve_action_approval with approvalId "${result.approval.id}". This approval already exists and is PENDING — do NOT call request_action_approval, which would create a different one and leave this one blocking.`,
+        `1. Call approve_action_approval with arguments {"approvalId": "${result.approval.id}", "_voyant": {"confirmed": true}}. This approval already exists and is PENDING — do NOT call request_action_approval, which would create a different one and leave this one blocking.`,
         // "keep _voyant.confirmed=true" is not padding. assertConfirmation runs on
         // EVERY dispatch, the approved retry included, so a caller that rebuilds
         // the control block with only approvalId loses its confirmation and is

--- a/packages/action-ledger/tests/unit/tool-action-policy.test.ts
+++ b/packages/action-ledger/tests/unit/tool-action-policy.test.ts
@@ -153,6 +153,7 @@ describe("generic MCP action-policy gate", () => {
     // The concrete id, not a description of where to find it.
     expect(error.nextSteps?.[0]).toContain("approve_action_approval")
     expect(error.nextSteps?.[0]).toContain("approval_1")
+    expect(error.nextSteps?.[0]).toContain('"_voyant": {"confirmed": true}')
     expect(error.nextSteps?.[1]).toContain('"approvalId": "approval_1"')
     expect(error.nextSteps?.[1]).toContain("approval_1")
     // Confirmation is asserted on the approved retry too, so the retry step has


### PR DESCRIPTION
## Summary

- include `_voyant.confirmed: true` in the concrete `approve_action_approval` call emitted by both generic and handler-owned approval flows
- retain the exact server-issued approval id and retry instructions
- cover the public remediation text test-first

## Verification

- RED: focused action-policy test failed because the approval step omitted confirmation
- GREEN: 89 focused action-ledger tests pass on lab1
- real Terra baseline after #4430: product publication improved from 29 calls/8 errors/exhausted to 20 calls/2 errors; this removes the remaining preventable confirmation error

Part of #4424 and #4378.