### PR TITLE
fix: wire Operator catalog search provider

### DIFF
--- a/.changeset/tidy-operator-search.md
+++ b/.changeset/tidy-operator-search.md
@@ -1,0 +1,5 @@
+---
+"operator": patch
+---
+
+Select the Postgres Catalog indexer in the Operator deployment and wire a deterministic cursor-signing key into isolated runtime tests and MCP capability evaluations.

--- a/apps/operator/tests/api/generated-project-runtime.ts
+++ b/apps/operator/tests/api/generated-project-runtime.ts
@@ -31,7 +31,10 @@ export const {
   GENERATED_GRAPH_RUNTIME_PLUGIN_IDS,
 } = generatedRuntime
 
-const TEST_DEPLOYMENT_VALUES = { DATABASE_URL: "postgres://test" }
+const TEST_DEPLOYMENT_VALUES = {
+  DATABASE_URL: "postgres://test",
+  POSTGRES_SEARCH_CURSOR_SIGNING_KEY: "operator-test-catalog-cursor-signing-key",
+}
 const TEST_DOCUMENT_STORAGE = createLocalStorageProvider({
   name: "operator-test:documents",
   baseUrl: "test://documents/",

--- a/apps/operator/tests/api/selected-graph-runtime.test.ts
+++ b/apps/operator/tests/api/selected-graph-runtime.test.ts
@@ -16,6 +16,7 @@ import {
   catalogOffersRuntimePort,
   catalogSearchRuntimePort,
 } from "@voyant-travel/catalog/graph-runtime"
+import { catalogIndexerProviderPort } from "@voyant-travel/catalog/indexer/provider"
 import { BULK_REINDEX_SERVICE_KEY } from "@voyant-travel/commerce"
 import { catalogCheckoutApiRuntimePort } from "@voyant-travel/commerce/catalog-checkout-subscribers"
 import { bookingMaintenanceRuntimePort } from "@voyant-travel/commerce/checkout"
@@ -88,6 +89,12 @@ async function composeOperatorGraph(runtime = createGeneratedGraphRuntime()) {
 }
 
 describe("selected Operator graph runtime composition", () => {
+  it("selects a real Catalog indexer for the exposed catalog search Tool", async () => {
+    const selected = await createGeneratedTestDeploymentResources()
+
+    expect(selected.ports).toHaveProperty(catalogIndexerProviderPort.id)
+  })
+
   it("activates selected Legal document actions and rejects stale unactivated composition", async () => {
     const staleRuntime = createGeneratedGraphRuntime()
     const selected = await createGeneratedTestDeploymentResources(staleRuntime)

--- a/apps/operator/voyant.config.ts
+++ b/apps/operator/voyant.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     target: "node",
     providers: {
       database: "postgres",
+      search: "postgres",
     },
   },
 })

--- a/scripts/run-mcp-capability-eval.mjs
+++ b/scripts/run-mcp-capability-eval.mjs
@@ -169,6 +169,9 @@ async function main() {
       ...process.env,
       DATABASE_URL: databaseUrl,
       TEST_DATABASE_URL: databaseUrl,
+      POSTGRES_SEARCH_CURSOR_SIGNING_KEY:
+        process.env.POSTGRES_SEARCH_CURSOR_SIGNING_KEY ??
+        "mcp-capability-eval-catalog-cursor-signing-key",
       VOYANT_EVAL_MODEL: options.model,
       VOYANT_EVAL_REPORT_FILE: path.join(artifactDir, "report.json"),
       VOYANT_EVAL_RUNS: options.mode === "measure" ? "5" : "1",


### PR DESCRIPTION
## Summary

- select the built-in Postgres Catalog indexer in the Operator deployment
- provide isolated cursor-signing keys to generated runtime tests and the MCP capability harness
- assert the generated selected graph exposes the real `catalog.indexer` provider

## Verification

- RED: selected Operator runtime test failed because `catalog.indexer` was absent
- GREEN: 19/19 selected-graph runtime tests pass on lab1
- real Terra evidence before this fix: 13/13 journeys passed, but booking discovery hit `MISSING_SERVICE: Catalog search indexer is not configured`

Part of #4378.