### PR TITLE
fix(catalog): support keyword-only deployments

### DIFF
--- a/.changeset/bright-keyword-catalog.md
+++ b/.changeset/bright-keyword-catalog.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/catalog": patch
+---
+
+Allow keyword-only catalog deployments to explicitly disable embeddings even when a Voyant Cloud API key is configured.

--- a/apps/operator/tests/agent-journey-real-surface.test.ts
+++ b/apps/operator/tests/agent-journey-real-surface.test.ts
@@ -38,7 +38,11 @@ const MCP_HEADERS = {
   "content-type": "application/json",
   accept: "application/json, text/event-stream",
 }
-const TEST_ENV = { DATABASE_URL: "postgres://test", VOYANT_API_KEY: "test" } as never
+const TEST_ENV = {
+  DATABASE_URL: "postgres://test",
+  VOYANT_API_KEY: "test",
+  CATALOG_EMBEDDING_PROVIDER: "none",
+} as never
 const TEST_CTX = { waitUntil() {}, passThroughOnException() {} } as never
 
 /** Response-bytes ÷ 4 token proxy — a floor; see the mcp harness docblock. */

--- a/apps/operator/tests/mcp-capability.test.ts
+++ b/apps/operator/tests/mcp-capability.test.ts
@@ -85,7 +85,11 @@ const enabled = Boolean(TEST_DATABASE_URL && apiKey)
 /** A live model turn plus a real dispatch is slow; the default would time out on latency. */
 const JOURNEY_TIMEOUT_MS = 180_000
 
-const TEST_ENV = { DATABASE_URL: TEST_DATABASE_URL ?? "", VOYANT_API_KEY: "test" } as never
+const TEST_ENV = {
+  DATABASE_URL: TEST_DATABASE_URL ?? "",
+  VOYANT_API_KEY: "test",
+  CATALOG_EMBEDDING_PROVIDER: "none",
+} as never
 const TEST_CTX = { waitUntil() {}, passThroughOnException() {} } as never
 
 let rpcSeq = 0

--- a/apps/operator/tests/selected-graph-mcp-tool-surface.test.ts
+++ b/apps/operator/tests/selected-graph-mcp-tool-surface.test.ts
@@ -89,7 +89,11 @@ const MCP_HEADERS = {
   "content-type": "application/json",
   accept: "application/json, text/event-stream",
 }
-const TEST_ENV = { DATABASE_URL: "postgres://test", VOYANT_API_KEY: "test" } as never
+const TEST_ENV = {
+  DATABASE_URL: "postgres://test",
+  VOYANT_API_KEY: "test",
+  CATALOG_EMBEDDING_PROVIDER: "none",
+} as never
 const TEST_CTX = { waitUntil() {}, passThroughOnException() {} } as never
 
 interface SerializedTool {

--- a/packages/catalog/src/runtime-support.test.ts
+++ b/packages/catalog/src/runtime-support.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@voyant-travel/catalog-contracts/indexer/contract"
 import { describe, expect, it, vi } from "vitest"
 import {
+  buildCatalogEmbeddingProvider,
   buildCatalogSlices,
   createCatalogOffersSearchResolvers,
   DEFAULT_CATALOG_SLICES,
@@ -22,6 +23,17 @@ const scope = withoutCatalogScopeChannel({
   audience: "staff",
   market: "ro",
   channel: "website",
+})
+
+describe("catalog embedding provider selection", () => {
+  it("allows keyword-only deployments to explicitly disable embeddings", () => {
+    expect(
+      buildCatalogEmbeddingProvider({
+        VOYANT_API_KEY: "cloud-api-key",
+        CATALOG_EMBEDDING_PROVIDER: "none",
+      }),
+    ).toBeUndefined()
+  })
 })
 
 function createIndexer(search: IndexerAdapter["search"]): IndexerAdapter {

--- a/packages/catalog/src/runtime-support.ts
+++ b/packages/catalog/src/runtime-support.ts
@@ -184,13 +184,16 @@ export interface CatalogRuntimeEnv {
    * at collection creation and `ensureCollection` does not migrate it, so a
    * Typesense-backed deployment must recreate/migrate the vector field before
    * enabling a provider whose model dimension differs.
+   * Keyword-only indexers select `none` explicitly; the legacy default remains
+   * Gemini when a Voyant Cloud API key is present.
    */
-  CATALOG_EMBEDDING_PROVIDER?: "openai" | "gemini"
+  CATALOG_EMBEDDING_PROVIDER?: "none" | "openai" | "gemini"
 }
 
 export function buildCatalogEmbeddingProvider(
   env: CatalogRuntimeEnv,
 ): EmbeddingProvider | undefined {
+  if (env.CATALOG_EMBEDDING_PROVIDER === "none") return undefined
   const apiKey = env.VOYANT_API_KEY ?? env.VOYANT_CLOUD_API_KEY
   if (!apiKey) return undefined
   const cloudBase = (env.VOYANT_CLOUD_API_URL ?? "https://api.voyant.travel").replace(/\/$/, "")


### PR DESCRIPTION
## Why

The Operator now selects the first-party Postgres catalog indexer, whose safe default is keyword-only. Its real MCP harness also supplies a Voyant API key for authenticated runtime behavior, which implicitly enables Gemini embeddings and makes runtime composition reject the incompatible indexer before any MCP tools can load.

## What

- add an explicit `CATALOG_EMBEDDING_PROVIDER=none` selection
- use it in the real Operator MCP capability environment
- preserve the legacy Gemini default for existing deployments
- cover the API-key-plus-explicit-none behavior

Tracks #4378 and #4424.

## Verification

- `pnpm --filter @voyant-travel/catalog exec vitest run src/runtime-support.test.ts` (6/6)
- Catalog typecheck currently reaches an unrelated main regression in `sessions-payment-production.ts`: optional checkout email is incompatible with required `CardPaymentBilling.email`.