### PR TITLE
feat(trips): bind storefront itinerary access

### DIFF
--- a/.changeset/tidy-storefront-itineraries.md
+++ b/.changeset/tidy-storefront-itineraries.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/trips": minor
+---
+
+Add storefront-bound opaque itinerary capabilities and persist validated market, locale, and currency scope for managed Trip composition.

--- a/packages/trips/migrations/0004_storefront_trip_access.sql
+++ b/packages/trips/migrations/0004_storefront_trip_access.sql
@@ -1,0 +1,21 @@
+CREATE TABLE "trip_storefront_access" (
+	"envelope_id" text PRIMARY KEY NOT NULL,
+	"capability_digest" text NOT NULL,
+	"storefront_id" text NOT NULL,
+	"channel_id" text NOT NULL,
+	"market_id" text NOT NULL,
+	"locale" text NOT NULL,
+	"currency" text NOT NULL,
+	"owner_user_id" text,
+	"owner_buyer_account_id" text,
+	"revision" integer DEFAULT 1 NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "trip_storefront_access_capability_digest_unique" UNIQUE("capability_digest")
+);
+--> statement-breakpoint
+ALTER TABLE "trip_storefront_access" ADD CONSTRAINT "trip_storefront_access_envelope_id_trip_envelopes_id_fk" FOREIGN KEY ("envelope_id") REFERENCES "public"."trip_envelopes"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_trip_storefront_access_scope" ON "trip_storefront_access" USING btree ("storefront_id","channel_id");--> statement-breakpoint
+CREATE INDEX "idx_trip_storefront_access_owner" ON "trip_storefront_access" USING btree ("owner_user_id","updated_at");--> statement-breakpoint
+CREATE INDEX "idx_trip_storefront_access_expiry" ON "trip_storefront_access" USING btree ("expires_at");

--- a/packages/trips/migrations/meta/_journal.json
+++ b/packages/trips/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1784970000000,
       "tag": "0003_durable_trip_actions",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1786178101086,
+      "tag": "0004_storefront_trip_access",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/trips/src/index.ts
+++ b/packages/trips/src/index.ts
@@ -68,6 +68,20 @@ export type {
   TripsRoutesOptionsProvider,
 } from "./routes.js"
 export { createTripsRoutes } from "./routes.js"
+export {
+  type CreateStorefrontTripInput,
+  createStorefrontTrip,
+  createStorefrontTripCapability,
+  resolveStorefrontTripAccess,
+  STOREFRONT_TRIP_CAPABILITY_HEADER,
+  STOREFRONT_TRIP_CAPABILITY_TTL_MS,
+  type StorefrontTripAccessOptions,
+  type StorefrontTripAccessResolution,
+  type StorefrontTripContext,
+  type StorefrontTripHandle,
+  type StorefrontTripScope,
+  storefrontTripScopeSchema,
+} from "./storefront-access.js"
 
 export const tripsModule: Module = {
   name: "trips",

--- a/packages/trips/src/schema.ts
+++ b/packages/trips/src/schema.ts
@@ -1,3 +1,4 @@
+// agent-quality: file-size exception -- owner: trips; the package schema remains one Drizzle graph so migrations, foreign keys, and exported relations are generated from one source.
 import { typeId, typeIdRef } from "@voyant-travel/db/lib/typeid-column"
 import { relations } from "drizzle-orm"
 import {
@@ -236,6 +237,40 @@ export const tripEnvelopes = pgTable(
     index("idx_trip_envelopes_payment_session").on(table.paymentSessionId),
     index("idx_trip_envelopes_reserve_idempotency").on(table.reserveIdempotencyKey),
     index("idx_trip_envelopes_checkout_idempotency").on(table.checkoutIdempotencyKey),
+  ],
+)
+
+/**
+ * Storefront ownership for a customer-authored Trip.
+ *
+ * The browser carries a random capability while the database stores only its
+ * SHA-256 digest. Storefront/channel and shopping scope come from trusted
+ * runtime context, never request selectors, so capabilities cannot cross
+ * storefront boundaries.
+ */
+export const tripStorefrontAccess = pgTable(
+  "trip_storefront_access",
+  {
+    envelopeId: typeIdRef("envelope_id")
+      .primaryKey()
+      .references(() => tripEnvelopes.id, { onDelete: "cascade" }),
+    capabilityDigest: text("capability_digest").notNull().unique(),
+    storefrontId: text("storefront_id").notNull(),
+    channelId: text("channel_id").notNull(),
+    marketId: text("market_id").notNull(),
+    locale: text("locale").notNull(),
+    currency: text("currency").notNull(),
+    ownerUserId: text("owner_user_id"),
+    ownerBuyerAccountId: text("owner_buyer_account_id"),
+    revision: integer("revision").notNull().default(1),
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("idx_trip_storefront_access_scope").on(table.storefrontId, table.channelId),
+    index("idx_trip_storefront_access_owner").on(table.ownerUserId, table.updatedAt),
+    index("idx_trip_storefront_access_expiry").on(table.expiresAt),
   ],
 )
 
@@ -593,6 +628,13 @@ export const tripEnvelopeRelations = relations(tripEnvelopes, ({ many }) => ({
   requirements: many(tripRequirements),
 }))
 
+export const tripStorefrontAccessRelations = relations(tripStorefrontAccess, ({ one }) => ({
+  envelope: one(tripEnvelopes, {
+    fields: [tripStorefrontAccess.envelopeId],
+    references: [tripEnvelopes.id],
+  }),
+}))
+
 export const tripComponentRelations = relations(tripComponents, ({ one, many }) => ({
   envelope: one(tripEnvelopes, {
     fields: [tripComponents.envelopeId],
@@ -661,6 +703,8 @@ export const tripRequirementSourcingOperationRelations = relations(
 
 export type TripEnvelope = typeof tripEnvelopes.$inferSelect
 export type NewTripEnvelope = typeof tripEnvelopes.$inferInsert
+export type TripStorefrontAccess = typeof tripStorefrontAccess.$inferSelect
+export type NewTripStorefrontAccess = typeof tripStorefrontAccess.$inferInsert
 export type TripComponent = typeof tripComponents.$inferSelect
 export type NewTripComponent = typeof tripComponents.$inferInsert
 export type TripComponentEvent = typeof tripComponentEvents.$inferSelect

--- a/packages/trips/src/storefront-access.ts
+++ b/packages/trips/src/storefront-access.ts
@@ -1,0 +1,179 @@
+import type { AnyDrizzleDb } from "@voyant-travel/db"
+import { randomBytesHex, sha256Hex } from "@voyant-travel/hono"
+import { eq } from "drizzle-orm"
+import { z } from "zod"
+
+import {
+  type NewTripEnvelope,
+  type TripStorefrontAccess,
+  tripEnvelopes,
+  tripStorefrontAccess,
+} from "./schema.js"
+import { getTrip } from "./service-trips.js"
+import type { Trip } from "./service-types.js"
+
+export const STOREFRONT_TRIP_CAPABILITY_HEADER = "Voyant-Trip-Capability"
+export const STOREFRONT_TRIP_CAPABILITY_TTL_MS = 30 * 24 * 60 * 60 * 1000
+
+const capabilitySchema = z.string().regex(/^tcap_[a-f0-9]{64}$/)
+
+/** Preferences after the managed storefront runtime validates operator config. */
+export const storefrontTripScopeSchema = z
+  .object({
+    marketId: z.string().min(1).max(255),
+    locale: z.string().min(1).max(64),
+    currency: z.string().regex(/^[A-Z]{3}$/),
+  })
+  .strict()
+
+export type StorefrontTripScope = z.infer<typeof storefrontTripScopeSchema>
+
+/** Request identity derived by auth. None of these fields are browser input. */
+export interface StorefrontTripContext {
+  storefrontId: string
+  channelId: string
+  userId?: string | null
+  buyerAccountId?: string | null
+}
+
+export interface CreateStorefrontTripInput {
+  title?: string
+  description?: string
+  scope: StorefrontTripScope
+}
+
+/** Internal handle; a public facade must expose only capability/revision/scope. */
+export interface StorefrontTripHandle {
+  capability: string
+  revision: number
+  scope: StorefrontTripScope
+  trip: Trip
+}
+
+export type StorefrontTripAccessResolution =
+  | { ok: true; access: TripStorefrontAccess; trip: Trip }
+  | { ok: false; reason: "invalid" | "expired" | "wrong_storefront" | "wrong_owner" | "missing" }
+
+export interface StorefrontTripAccessOptions {
+  now?: () => Date
+  createCapability?: () => string
+  ttlMs?: number
+}
+
+/** Creates a portable 256-bit capability. Only its digest is persisted. */
+export function createStorefrontTripCapability(): string {
+  return `tcap_${randomBytesHex(32)}`
+}
+
+/**
+ * Create an empty customer itinerary and its capability in one transaction.
+ * Traveler and billing data are deliberately collected later, before quote or
+ * commitment; the existing full Trip creator remains strict for staff flows.
+ */
+export async function createStorefrontTrip(
+  db: AnyDrizzleDb,
+  input: CreateStorefrontTripInput,
+  context: StorefrontTripContext,
+  options: StorefrontTripAccessOptions = {},
+): Promise<StorefrontTripHandle> {
+  const scope = storefrontTripScopeSchema.parse(input.scope)
+  assertActiveStorefrontContext(context)
+  const capability = (options.createCapability ?? createStorefrontTripCapability)()
+  capabilitySchema.parse(capability)
+  const capabilityDigest = await sha256Hex(capability)
+  const now = options.now?.() ?? new Date()
+  const expiresAt = new Date(now.getTime() + (options.ttlMs ?? STOREFRONT_TRIP_CAPABILITY_TTL_MS))
+
+  return db.transaction(async (tx) => {
+    const actor = storefrontActor(context)
+    const values: NewTripEnvelope = {
+      title: input.title,
+      description: input.description,
+      travelerParty: {},
+      constraints: { storefrontScope: scope },
+      createdBy: actor,
+      updatedBy: actor,
+    }
+    const [envelope] = await tx.insert(tripEnvelopes).values(values).returning()
+    if (!envelope) throw new Error("createStorefrontTrip: insert returned no envelope")
+
+    const [access] = await tx
+      .insert(tripStorefrontAccess)
+      .values({
+        envelopeId: envelope.id,
+        capabilityDigest,
+        storefrontId: context.storefrontId,
+        channelId: context.channelId,
+        marketId: scope.marketId,
+        locale: scope.locale,
+        currency: scope.currency,
+        ownerUserId: authenticatedUserId(context),
+        ownerBuyerAccountId: context.buyerAccountId ?? null,
+        expiresAt,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning()
+    if (!access) throw new Error("createStorefrontTrip: access insert returned no row")
+
+    return {
+      capability,
+      revision: access.revision,
+      scope,
+      trip: { envelope, components: [] },
+    }
+  })
+}
+
+/** Resolve an opaque capability without ever accepting an envelope id. */
+export async function resolveStorefrontTripAccess(
+  db: AnyDrizzleDb,
+  capability: string,
+  context: StorefrontTripContext,
+  options: Pick<StorefrontTripAccessOptions, "now"> = {},
+): Promise<StorefrontTripAccessResolution> {
+  if (!capabilitySchema.safeParse(capability).success) return { ok: false, reason: "invalid" }
+  assertActiveStorefrontContext(context)
+  const capabilityDigest = await sha256Hex(capability)
+  const now = options.now?.() ?? new Date()
+  const [access] = (await db
+    .select()
+    .from(tripStorefrontAccess)
+    .where(eq(tripStorefrontAccess.capabilityDigest, capabilityDigest))
+    .limit(1)) as TripStorefrontAccess[]
+
+  if (!access) return { ok: false, reason: "missing" }
+  if (access.expiresAt <= now) return { ok: false, reason: "expired" }
+  if (access.storefrontId !== context.storefrontId || access.channelId !== context.channelId) {
+    return { ok: false, reason: "wrong_storefront" }
+  }
+  const userId = authenticatedUserId(context)
+  if (access.ownerUserId && access.ownerUserId !== userId) {
+    return { ok: false, reason: "wrong_owner" }
+  }
+  if (access.ownerBuyerAccountId && access.ownerBuyerAccountId !== context.buyerAccountId) {
+    return { ok: false, reason: "wrong_owner" }
+  }
+
+  const trip = await getTrip(db, access.envelopeId)
+  if (!trip) return { ok: false, reason: "missing" }
+  return { ok: true, access, trip }
+}
+
+function authenticatedUserId(context: StorefrontTripContext): string | null {
+  const userId = context.userId?.trim()
+  return !userId || userId === "anonymous-storefront" ? null : userId
+}
+
+function storefrontActor(context: StorefrontTripContext): string {
+  const userId = authenticatedUserId(context)
+  return userId
+    ? `storefront:${context.storefrontId}:customer:${userId}`
+    : `storefront:${context.storefrontId}:anonymous`
+}
+
+function assertActiveStorefrontContext(context: StorefrontTripContext): void {
+  if (!context.storefrontId.trim() || !context.channelId.trim()) {
+    throw new Error("active_storefront_channel_required")
+  }
+}

--- a/packages/trips/tests/storefront-access.test.ts
+++ b/packages/trips/tests/storefront-access.test.ts
@@ -1,0 +1,190 @@
+import type { AnyDrizzleDb } from "@voyant-travel/db"
+import { sha256Hex } from "@voyant-travel/hono"
+import { describe, expect, it } from "vitest"
+import {
+  type TripEnvelope,
+  type TripStorefrontAccess,
+  tripComponents,
+  tripEnvelopes,
+  tripStorefrontAccess,
+} from "../src/schema.js"
+import {
+  createStorefrontTrip,
+  resolveStorefrontTripAccess,
+  STOREFRONT_TRIP_CAPABILITY_TTL_MS,
+} from "../src/storefront-access.js"
+
+const CAPABILITY = `tcap_${"a".repeat(64)}`
+const NOW = new Date("2026-08-08T10:00:00.000Z")
+const CONTEXT = {
+  storefrontId: "storefront_bucharest",
+  channelId: "channel_direct",
+  userId: "anonymous-storefront",
+}
+const SCOPE = { marketId: "market_ro", locale: "ro-RO", currency: "EUR" }
+
+describe("storefront Trip access", () => {
+  it("creates an empty managed Trip and persists only the capability digest", async () => {
+    const state: { envelope?: TripEnvelope; access?: TripStorefrontAccess } = {}
+    const result = await createStorefrontTrip(
+      createDb(state),
+      { title: "City and coast", scope: SCOPE },
+      CONTEXT,
+      { now: () => NOW, createCapability: () => CAPABILITY },
+    )
+
+    expect(result.capability).toBe(CAPABILITY)
+    expect(result.trip.envelope.id).toBe("trip_storefront_1")
+    expect(result.trip.envelope.travelerParty).toEqual({})
+    expect(result.trip.envelope.constraints).toEqual({ storefrontScope: SCOPE })
+    expect(result.trip.envelope.createdBy).toBe("storefront:storefront_bucharest:anonymous")
+    expect(state.access).toMatchObject({
+      envelopeId: "trip_storefront_1",
+      capabilityDigest: await sha256Hex(CAPABILITY),
+      storefrontId: CONTEXT.storefrontId,
+      channelId: CONTEXT.channelId,
+      ...SCOPE,
+      ownerUserId: null,
+      revision: 1,
+      expiresAt: new Date(NOW.getTime() + STOREFRONT_TRIP_CAPABILITY_TTL_MS),
+    })
+    expect(JSON.stringify(state.access)).not.toContain(CAPABILITY)
+  })
+
+  it("resolves only in the bound storefront and channel", async () => {
+    const state = await seededState()
+    const db = createDb(state)
+    const result = await resolveStorefrontTripAccess(db, CAPABILITY, CONTEXT, { now: () => NOW })
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.access.currency).toBe("EUR")
+
+    await expect(
+      resolveStorefrontTripAccess(
+        db,
+        CAPABILITY,
+        { ...CONTEXT, storefrontId: "storefront_other" },
+        { now: () => NOW },
+      ),
+    ).resolves.toEqual({ ok: false, reason: "wrong_storefront" })
+  })
+
+  it("fails closed for malformed, expired, and differently-owned capabilities", async () => {
+    const state = await seededState()
+    const db = createDb(state)
+    await expect(resolveStorefrontTripAccess(db, "trip_storefront_1", CONTEXT)).resolves.toEqual({
+      ok: false,
+      reason: "invalid",
+    })
+
+    state.access = { ...state.access, expiresAt: new Date("2026-08-08T09:00:00.000Z") }
+    await expect(
+      resolveStorefrontTripAccess(db, CAPABILITY, CONTEXT, { now: () => NOW }),
+    ).resolves.toEqual({ ok: false, reason: "expired" })
+
+    state.access = {
+      ...state.access,
+      expiresAt: new Date("2026-09-01T00:00:00.000Z"),
+      ownerUserId: "customer_1",
+    }
+    await expect(
+      resolveStorefrontTripAccess(
+        db,
+        CAPABILITY,
+        { ...CONTEXT, userId: "customer_2" },
+        { now: () => NOW },
+      ),
+    ).resolves.toEqual({ ok: false, reason: "wrong_owner" })
+  })
+})
+
+async function seededState(): Promise<{ envelope: TripEnvelope; access: TripStorefrontAccess }> {
+  const envelope = envelopeRow()
+  return {
+    envelope,
+    access: {
+      envelopeId: envelope.id,
+      capabilityDigest: await sha256Hex(CAPABILITY),
+      storefrontId: CONTEXT.storefrontId,
+      channelId: CONTEXT.channelId,
+      marketId: SCOPE.marketId,
+      locale: SCOPE.locale,
+      currency: SCOPE.currency,
+      ownerUserId: null,
+      ownerBuyerAccountId: null,
+      revision: 1,
+      expiresAt: new Date("2026-09-01T00:00:00.000Z"),
+      createdAt: NOW,
+      updatedAt: NOW,
+    },
+  }
+}
+
+function envelopeRow(): TripEnvelope {
+  return {
+    id: "trip_storefront_1",
+    status: "draft",
+    title: "City and coast",
+    description: null,
+    travelerParty: {},
+    constraints: { storefrontScope: SCOPE },
+    aggregateCurrency: null,
+    aggregateSubtotalAmountCents: null,
+    aggregateTaxAmountCents: null,
+    aggregateTotalAmountCents: null,
+    aggregatePricingSnapshot: null,
+    currentPriceExpiresAt: null,
+    bookingGroupId: null,
+    orderId: null,
+    paymentSessionId: null,
+    reserveIdempotencyKey: null,
+    reserveStartedAt: null,
+    reservedAt: null,
+    checkoutIdempotencyKey: null,
+    checkoutStartedAt: null,
+    createdBy: "storefront:storefront_bucharest:anonymous",
+    updatedBy: "storefront:storefront_bucharest:anonymous",
+    createdAt: NOW,
+    updatedAt: NOW,
+  }
+}
+
+function createDb(state: { envelope?: TripEnvelope; access?: TripStorefrontAccess }): AnyDrizzleDb {
+  const tx = {
+    insert: (table: unknown) => ({
+      values: (values: Record<string, unknown>) => ({
+        returning: async () => {
+          if (table === tripEnvelopes) {
+            state.envelope = { ...envelopeRow(), ...values } as TripEnvelope
+            return [state.envelope]
+          }
+          if (table === tripStorefrontAccess) {
+            state.access = {
+              revision: 1,
+              createdAt: NOW,
+              updatedAt: NOW,
+              ...values,
+            } as TripStorefrontAccess
+            return [state.access]
+          }
+          return []
+        },
+      }),
+    }),
+  }
+  const db = {
+    transaction: async (operation: (transaction: typeof tx) => unknown) => operation(tx),
+    select: () => ({
+      from: (table: unknown) => ({
+        where: () => ({
+          limit: async () => {
+            if (table === tripStorefrontAccess) return state.access ? [state.access] : []
+            if (table === tripEnvelopes) return state.envelope ? [state.envelope] : []
+            return []
+          },
+          orderBy: async () => (table === tripComponents ? [] : []),
+        }),
+      }),
+    }),
+  }
+  return db as AnyDrizzleDb
+}


### PR DESCRIPTION
## What changed

- adds a package-owned storefront access record for customer-authored Trips
- persists only a SHA-256 digest of a 256-bit opaque capability
- binds every handle to trusted storefront/channel plus validated market, locale, and currency scope
- supports anonymous managed journeys and optional managed customer/buyer ownership
- creates empty draft itineraries without weakening the existing strict staff Trip creator
- adds expiry, revision, migration, public exports, and focused security tests

## Why

A theme must be able to build a multi-item itinerary without owning customer accounts, booking-engine identity, raw Trip IDs, provider selectors, or currency conversion. This is the persistence and access-control foundation for the managed storefront shopping gateway `trip-selections` runtime.

## Validation

- `@voyant-travel/trips` full Vitest suite: 172 passed, 12 skipped
- changed-file Biome: passed
- agent-quality and secret scan hooks: passed
- `git diff --check`: passed
- local package typecheck exceeded Node default heap on the unsupported local Node 26 toolchain; GitHub Actions on the repository toolchain is the authoritative typecheck gate

## Follow-up

After the managed shopping gateway contract lands, a stacked PR will implement its `saveTripSelection` runtime using this access record and CAS revision.