### PR TITLE
feat(storefront): add provider-first shopping gateway

### DIFF
--- a/.changeset/bright-storefront-shopping.md
+++ b/.changeset/bright-storefront-shopping.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/storefront": minor
+---
+
+Add a provider-first storefront shopping contract for grouped indexed inspiration and live flight, stay, and flight-plus-stay searches. Add optional deployment ports for shopping and revision-checked opaque Trip selections, with server-resolved market, locale, currency, and presentation-money authority.

--- a/packages/accommodations/tsconfig.build.json
+++ b/packages/accommodations/tsconfig.build.json
@@ -1935,6 +1935,7 @@
       ],
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
+      "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"

--- a/packages/accommodations/tsconfig.typecheck.json
+++ b/packages/accommodations/tsconfig.typecheck.json
@@ -1936,6 +1936,7 @@
       ],
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
+      "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"

--- a/packages/catalog/tsconfig.build.json
+++ b/packages/catalog/tsconfig.build.json
@@ -1890,6 +1890,7 @@
       ],
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
+      "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"

--- a/packages/catalog/tsconfig.typecheck.json
+++ b/packages/catalog/tsconfig.typecheck.json
@@ -1891,6 +1891,7 @@
       ],
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
+      "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -1895,6 +1895,7 @@
       ],
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
+      "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -1889,6 +1889,7 @@
       ],
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
+      "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -1940,6 +1940,7 @@
       ],
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
+      "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -1941,6 +1941,7 @@
       ],
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
+      "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -1944,6 +1944,7 @@
       ],
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
+      "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -1945,6 +1945,7 @@
       ],
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
+      "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -1976,6 +1976,7 @@
       ],
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
+      "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -1971,6 +1971,7 @@
       ],
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
+      "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -1978,6 +1978,7 @@
       ],
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
+      "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -1979,6 +1979,7 @@
       ],
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
+      "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -1976,6 +1976,7 @@
       ],
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
+      "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -1971,6 +1971,7 @@
       ],
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
+      "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"

--- a/packages/inventory/tsconfig.build.json
+++ b/packages/inventory/tsconfig.build.json
@@ -1908,6 +1908,7 @@
       ],
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
+      "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"

--- a/packages/inventory/tsconfig.typecheck.json
+++ b/packages/inventory/tsconfig.typecheck.json
@@ -1909,6 +1909,7 @@
       ],
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
+      "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -1875,6 +1875,7 @@
       ],
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
+      "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -1870,6 +1870,7 @@
       ],
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
+      "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"

--- a/packages/storefront/README.md
+++ b/packages/storefront/README.md
@@ -20,8 +20,11 @@ Every browser object is strict. A browser may request only `marketId`, `locale`,
 and `currency`; it cannot choose a tenant, organization, storefront, channel,
 engine, provider, connection, or source. The host supplies trusted
 `storefrontId` and `channelId` context, resolves the request against active
-market configuration, and returns the selected scope plus the available values
-for pickers.
+market configuration, and may attach Voyant-managed `userId` and
+`buyerAccountId` ownership for a signed-in journey. Those identity values are
+nullable/absent for anonymous capability-owned journeys and are never accepted
+from the browser body. The runtime returns the selected scope plus the available
+values for pickers.
 
 Search prices carry both their supplier-native amount and their one selected
 presentation-currency amount. A currency conversion must include the server's

--- a/packages/storefront/README.md
+++ b/packages/storefront/README.md
@@ -3,6 +3,38 @@
 Public storefront routes and service helpers for checkout-adjacent product, departure,
 offer, and eligibility flows.
 
+## Shopping gateway
+
+`@voyant-travel/storefront/shopping` is the provider-first boundary for a
+theme or same-origin storefront BFF. It keeps three different kinds of work
+explicit instead of pretending they share one ranking or cursor:
+
+- grouped indexed inspiration for tours, excursions, experiences/activities,
+  stays, cruises, and charters; each group owns its result count and cursor;
+- discriminated live flight, stay, and flight-plus-stay package searches with
+  aggregate partial-provider coverage;
+- a separate, stateful Trip-selection seam with opaque references and
+  compare-and-swap revisions.
+
+Every browser object is strict. A browser may request only `marketId`, `locale`,
+and `currency`; it cannot choose a tenant, organization, storefront, channel,
+engine, provider, connection, or source. The host supplies trusted
+`storefrontId` and `channelId` context, resolves the request against active
+market configuration, and returns the selected scope plus the available values
+for pickers.
+
+Search prices carry both their supplier-native amount and their one selected
+presentation-currency amount. A currency conversion must include the server's
+FX authority, rate, and quote time. Themes format these values but never
+calculate exchange rates.
+
+Deployments may bind `storefront.shopping.runtime` and
+`storefront.trip-selections.runtime`. Both graph ports are optional so an
+operator without a provider continues to boot; attempts to use an unbound
+capability fail explicitly. Provider implementations keep connection and
+supplier identifiers behind the runtime boundary and return only opaque
+`offerRef`, `itemRef`, and `selectionRef` capabilities.
+
 ## Customer auth client
 
 `@voyant-travel/storefront/customer-auth-client` is the framework-neutral

--- a/packages/storefront/package.json
+++ b/packages/storefront/package.json
@@ -16,6 +16,7 @@
     "./public-routes": "./src/routes-public.ts",
     "./runtime-contributor": "./src/runtime-contributor.ts",
     "./runtime-port": "./src/runtime-port.ts",
+    "./shopping": "./src/shopping/index.ts",
     "./service": "./src/service.ts",
     "./tools": "./src/mcp-runtime.ts",
     "./transport-eligibility": "./src/transport-eligibility.ts",
@@ -179,6 +180,11 @@
         "types": "./dist/runtime-port.d.ts",
         "import": "./dist/runtime-port.js",
         "default": "./dist/runtime-port.js"
+      },
+      "./shopping": {
+        "types": "./dist/shopping/index.d.ts",
+        "import": "./dist/shopping/index.js",
+        "default": "./dist/shopping/index.js"
       },
       "./service": {
         "types": "./dist/service.d.ts",

--- a/packages/storefront/src/index.ts
+++ b/packages/storefront/src/index.ts
@@ -283,3 +283,23 @@ export {
   storefrontPaymentReconciliationJobRuntimePort,
   storefrontVerificationRuntimePort,
 } from "./runtime-port.js"
+export type {
+  StorefrontRequestedScope,
+  StorefrontResolvedScope,
+  StorefrontShoppingContext,
+  StorefrontShoppingGateway,
+  StorefrontShoppingIntent,
+  StorefrontShoppingRequest,
+  StorefrontShoppingResult,
+  StorefrontShoppingRuntime,
+  StorefrontTripSelection,
+  StorefrontTripSelectionCreate,
+  StorefrontTripSelectionsRuntime,
+  StorefrontTripSelectionUpdate,
+} from "./shopping/index.js"
+export {
+  createStorefrontShoppingGateway,
+  StorefrontShoppingUnavailableError,
+  storefrontShoppingRuntimePort,
+  storefrontTripSelectionsRuntimePort,
+} from "./shopping/index.js"

--- a/packages/storefront/src/shopping/index.ts
+++ b/packages/storefront/src/shopping/index.ts
@@ -1,0 +1,3 @@
+export * from "./runtime.js"
+export * from "./runtime-port.js"
+export * from "./schemas.js"

--- a/packages/storefront/src/shopping/runtime-port.ts
+++ b/packages/storefront/src/shopping/runtime-port.ts
@@ -14,6 +14,10 @@ import type {
 export interface StorefrontShoppingContext {
   storefrontId: string
   channelId: string
+  /** Voyant-managed customer identity; absent/null for an anonymous capability owner. */
+  userId?: string | null
+  /** Voyant-managed buyer account selected for the journey, never browser-derived. */
+  buyerAccountId?: string | null
 }
 
 export interface StorefrontShoppingRuntime {

--- a/packages/storefront/src/shopping/runtime-port.ts
+++ b/packages/storefront/src/shopping/runtime-port.ts
@@ -1,0 +1,68 @@
+import { definePort } from "@voyant-travel/core/project"
+
+import type {
+  StorefrontRequestedScope,
+  StorefrontResolvedScope,
+  StorefrontShoppingIntent,
+  StorefrontShoppingResult,
+  StorefrontTripSelection,
+  StorefrontTripSelectionCreate,
+  StorefrontTripSelectionUpdate,
+} from "./schemas.js"
+
+/** Server-derived authority. It must never be accepted from a browser body. */
+export interface StorefrontShoppingContext {
+  storefrontId: string
+  channelId: string
+}
+
+export interface StorefrontShoppingRuntime {
+  resolveScope(
+    context: StorefrontShoppingContext,
+    requested: StorefrontRequestedScope,
+  ): Promise<StorefrontResolvedScope>
+  search(
+    context: StorefrontShoppingContext,
+    input: { scope: StorefrontResolvedScope; intent: StorefrontShoppingIntent },
+  ): Promise<StorefrontShoppingResult>
+}
+
+/** Separate stateful seam: shopping remains read-only and stateless. */
+export interface StorefrontTripSelectionsRuntime {
+  create(
+    context: StorefrontShoppingContext,
+    input: Omit<StorefrontTripSelectionCreate, "scope"> & { scope: StorefrontResolvedScope },
+  ): Promise<StorefrontTripSelection>
+  update(
+    context: StorefrontShoppingContext,
+    input: StorefrontTripSelectionUpdate,
+  ): Promise<StorefrontTripSelection>
+}
+
+function requireMethods(id: string, provider: object, methods: readonly string[]): void {
+  for (const method of methods) {
+    if (typeof (provider as Record<string, unknown>)[method] !== "function") {
+      throw new Error(`${id} provider must implement ${method}().`)
+    }
+  }
+}
+
+export const storefrontShoppingRuntimePort = definePort<StorefrontShoppingRuntime>({
+  id: "storefront.shopping.runtime",
+  test(provider) {
+    if (provider === null || typeof provider !== "object") {
+      throw new Error("storefront.shopping.runtime provider must be an options object.")
+    }
+    requireMethods("storefront.shopping.runtime", provider, ["resolveScope", "search"])
+  },
+})
+
+export const storefrontTripSelectionsRuntimePort = definePort<StorefrontTripSelectionsRuntime>({
+  id: "storefront.trip-selections.runtime",
+  test(provider) {
+    if (provider === null || typeof provider !== "object") {
+      throw new Error("storefront.trip-selections.runtime provider must be an options object.")
+    }
+    requireMethods("storefront.trip-selections.runtime", provider, ["create", "update"])
+  },
+})

--- a/packages/storefront/src/shopping/runtime.ts
+++ b/packages/storefront/src/shopping/runtime.ts
@@ -1,0 +1,103 @@
+import type {
+  StorefrontShoppingContext,
+  StorefrontShoppingRuntime,
+  StorefrontTripSelectionsRuntime,
+} from "./runtime-port.js"
+import {
+  type StorefrontShoppingResult,
+  type StorefrontTripSelection,
+  storefrontResolvedScopeSchema,
+  storefrontShoppingRequestSchema,
+  storefrontShoppingResultSchema,
+  storefrontTripSelectionCreateSchema,
+  storefrontTripSelectionSchema,
+  storefrontTripSelectionUpdateSchema,
+} from "./schemas.js"
+
+export class StorefrontShoppingUnavailableError extends Error {
+  readonly code = "storefront_shopping_unavailable"
+
+  constructor(capability: "shopping" | "trip-selections") {
+    super(`Storefront ${capability} runtime is not configured.`)
+    this.name = "StorefrontShoppingUnavailableError"
+  }
+}
+
+export interface StorefrontShoppingGateway {
+  search(context: StorefrontShoppingContext, request: unknown): Promise<StorefrontShoppingResult>
+  createTripSelection(
+    context: StorefrontShoppingContext,
+    request: unknown,
+  ): Promise<StorefrontTripSelection>
+  updateTripSelection(
+    context: StorefrontShoppingContext,
+    request: unknown,
+  ): Promise<StorefrontTripSelection>
+}
+
+/**
+ * Strict validation boundary in front of deployment-provided implementations.
+ * Optional ports keep existing deployments bootable; calls fail explicitly
+ * until the corresponding managed or self-hosted provider is installed.
+ */
+export function createStorefrontShoppingGateway(options: {
+  shopping?: StorefrontShoppingRuntime
+  tripSelections?: StorefrontTripSelectionsRuntime
+}): StorefrontShoppingGateway {
+  return {
+    async search(context, rawRequest) {
+      const shopping = options.shopping
+      if (!shopping) throw new StorefrontShoppingUnavailableError("shopping")
+      const request = storefrontShoppingRequestSchema.parse(rawRequest)
+      const scope = storefrontResolvedScopeSchema.parse(
+        await shopping.resolveScope(context, request.scope),
+      )
+      const result = storefrontShoppingResultSchema.parse(
+        await shopping.search(context, { scope, intent: request.intent }),
+      )
+      assertSameResolvedScope(scope, result.scope)
+      if (result.kind !== request.intent.kind) {
+        throw new Error(
+          `Storefront shopping runtime returned ${result.kind} for ${request.intent.kind} intent.`,
+        )
+      }
+      return result
+    },
+
+    async createTripSelection(context, rawRequest) {
+      const shopping = options.shopping
+      if (!shopping) throw new StorefrontShoppingUnavailableError("shopping")
+      const tripSelections = options.tripSelections
+      if (!tripSelections) throw new StorefrontShoppingUnavailableError("trip-selections")
+      const request = storefrontTripSelectionCreateSchema.parse(rawRequest)
+      const scope = storefrontResolvedScopeSchema.parse(
+        await shopping.resolveScope(context, request.scope),
+      )
+      const result = storefrontTripSelectionSchema.parse(
+        await tripSelections.create(context, { scope, offers: request.offers }),
+      )
+      assertSameResolvedScope(scope, result.scope)
+      return result
+    },
+
+    async updateTripSelection(context, rawRequest) {
+      const tripSelections = options.tripSelections
+      if (!tripSelections) throw new StorefrontShoppingUnavailableError("trip-selections")
+      const request = storefrontTripSelectionUpdateSchema.parse(rawRequest)
+      return storefrontTripSelectionSchema.parse(await tripSelections.update(context, request))
+    },
+  }
+}
+
+function assertSameResolvedScope(
+  expected: { marketId: string; locale: string; currency: string },
+  actual: { marketId: string; locale: string; currency: string },
+): void {
+  if (
+    expected.marketId !== actual.marketId ||
+    expected.locale !== actual.locale ||
+    expected.currency !== actual.currency
+  ) {
+    throw new Error("Storefront runtime returned a result outside the resolved shopping scope.")
+  }
+}

--- a/packages/storefront/src/shopping/schemas.ts
+++ b/packages/storefront/src/shopping/schemas.ts
@@ -1,0 +1,435 @@
+import { z } from "zod"
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/
+const CURRENCY = /^[A-Z]{3}$/
+const LANGUAGE_TAG = /^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$/
+
+const opaqueRefSchema = z.string().min(16).max(512)
+const isoDateSchema = z.string().regex(ISO_DATE, "Expected an ISO 8601 calendar date (YYYY-MM-DD)")
+const currencyCodeSchema = z.string().regex(CURRENCY, "Expected an ISO 4217 currency code")
+const localeSchema = z.string().regex(LANGUAGE_TAG, "Expected a BCP 47 language tag")
+
+/** Values a browser may request. Deployment and supply selectors are deliberately absent. */
+export const storefrontRequestedScopeSchema = z
+  .object({
+    marketId: z.string().min(1).max(128).optional(),
+    locale: localeSchema.optional(),
+    currency: currencyCodeSchema.optional(),
+  })
+  .strict()
+
+/**
+ * Server-authoritative scope after validation against the active operator market.
+ * `available` is suitable for language/currency pickers and proves which values
+ * were considered while resolving defaults or clamping stale browser choices.
+ */
+export const storefrontResolvedScopeSchema = z
+  .object({
+    marketId: z.string().min(1).max(128),
+    locale: localeSchema,
+    currency: currencyCodeSchema,
+    available: z
+      .object({
+        marketIds: z.array(z.string().min(1).max(128)).min(1),
+        locales: z.array(localeSchema).min(1),
+        currencies: z.array(currencyCodeSchema).min(1),
+      })
+      .strict(),
+  })
+  .strict()
+
+export const storefrontNativeMoneySchema = z
+  .object({ amount: z.string().min(1), currency: currencyCodeSchema })
+  .strict()
+
+export const storefrontFxQuoteSchema = z
+  .object({
+    authority: z.string().min(1).max(128),
+    rate: z.string().min(1),
+    quotedAt: z.string().datetime({ offset: true }),
+    validUntil: z.string().datetime({ offset: true }).optional(),
+  })
+  .strict()
+
+/** Native supplier amount plus server-normalized display amount. Themes never calculate FX. */
+export const storefrontPresentationMoneySchema = z
+  .object({
+    native: storefrontNativeMoneySchema,
+    presentation: storefrontNativeMoneySchema,
+    fx: storefrontFxQuoteSchema.optional(),
+  })
+  .strict()
+  .superRefine((money, ctx) => {
+    if (money.native.currency !== money.presentation.currency && !money.fx) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["fx"],
+        message: "FX provenance is required when native and presentation currencies differ",
+      })
+    }
+  })
+
+export const storefrontInspirationGroupSchema = z.enum([
+  "tours",
+  "excursions",
+  "experiences",
+  "activities",
+  "stays",
+  "cruises",
+  "charters",
+])
+
+const destinationSchema = z
+  .object({
+    query: z.string().min(1).max(200).optional(),
+    countryCode: z.string().length(2).optional(),
+    city: z.string().min(1).max(120).optional(),
+    latitude: z.number().min(-90).max(90).optional(),
+    longitude: z.number().min(-180).max(180).optional(),
+  })
+  .strict()
+  .superRefine((destination, ctx) => {
+    if (
+      destination.query === undefined &&
+      destination.countryCode === undefined &&
+      destination.city === undefined &&
+      destination.latitude === undefined
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "At least one destination criterion is required",
+      })
+    }
+    if ((destination.latitude === undefined) !== (destination.longitude === undefined)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "latitude and longitude must be supplied together",
+      })
+    }
+  })
+
+const paginationSchema = z
+  .object({
+    cursor: opaqueRefSchema.optional(),
+    limit: z.number().int().min(1).max(100).optional(),
+  })
+  .strict()
+
+const inspirationGroupRequestSchema = z
+  .object({
+    group: storefrontInspirationGroupSchema,
+    query: z.string().max(300).optional(),
+    destination: destinationSchema.optional(),
+    fromDate: isoDateSchema.optional(),
+    toDate: isoDateSchema.optional(),
+    pagination: paginationSchema.optional(),
+  })
+  .strict()
+
+export const storefrontIndexedInspirationIntentSchema = z
+  .object({
+    kind: z.literal("indexed-inspiration"),
+    groups: z.array(inspirationGroupRequestSchema).min(1).max(7),
+  })
+  .strict()
+  .superRefine((intent, ctx) => {
+    const seen = new Set<string>()
+    for (const [index, group] of intent.groups.entries()) {
+      if (seen.has(group.group)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["groups", index, "group"],
+          message: "Each inspiration group may be requested only once",
+        })
+      }
+      seen.add(group.group)
+    }
+  })
+
+const travelersSchema = z
+  .object({
+    adults: z.number().int().min(1).max(20),
+    childrenAges: z.array(z.number().int().min(0).max(17)).max(20).optional(),
+    infants: z.number().int().min(0).max(10).optional(),
+  })
+  .strict()
+
+const flightSliceSchema = z
+  .object({
+    origin: z.string().length(3),
+    destination: z.string().length(3),
+    departureDate: isoDateSchema,
+  })
+  .strict()
+
+export const storefrontFlightSearchIntentSchema = z
+  .object({
+    kind: z.literal("flight"),
+    slices: z.array(flightSliceSchema).min(1).max(6),
+    travelers: travelersSchema,
+    cabin: z.enum(["economy", "premium_economy", "business", "first"]).optional(),
+    directOnly: z.boolean().optional(),
+    pagination: paginationSchema.optional(),
+  })
+  .strict()
+
+const stayRoomSchema = z
+  .object({
+    adults: z.number().int().min(1).max(20),
+    childrenAges: z.array(z.number().int().min(0).max(17)).max(20).optional(),
+  })
+  .strict()
+
+export const storefrontStaySearchIntentSchema = z
+  .object({
+    kind: z.literal("stay"),
+    destination: destinationSchema,
+    checkIn: isoDateSchema,
+    checkOut: isoDateSchema,
+    rooms: z.array(stayRoomSchema).min(1).max(10),
+    minStars: z.number().min(1).max(5).optional(),
+    pagination: paginationSchema.optional(),
+  })
+  .strict()
+  .superRefine((intent, ctx) => {
+    if (intent.checkOut <= intent.checkIn) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["checkOut"],
+        message: "checkOut must be after checkIn",
+      })
+    }
+  })
+
+export const storefrontPackageSearchIntentSchema = z
+  .object({
+    kind: z.literal("package"),
+    origin: z.string().length(3),
+    destination: destinationSchema,
+    departureDateFrom: isoDateSchema,
+    departureDateTo: isoDateSchema,
+    nights: z.object({ min: z.number().int().min(1), max: z.number().int().min(1) }).strict(),
+    travelers: travelersSchema,
+    boards: z.array(z.string().min(1).max(80)).max(20).optional(),
+    minStars: z.number().min(1).max(5).optional(),
+    pagination: paginationSchema.optional(),
+  })
+  .strict()
+  .superRefine((intent, ctx) => {
+    if (intent.departureDateTo < intent.departureDateFrom) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["departureDateTo"],
+        message: "departureDateTo must not be before departureDateFrom",
+      })
+    }
+    if (intent.nights.max < intent.nights.min) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["nights", "max"],
+        message: "nights.max must not be less than nights.min",
+      })
+    }
+  })
+
+export const storefrontShoppingIntentSchema = z.discriminatedUnion("kind", [
+  storefrontIndexedInspirationIntentSchema,
+  storefrontFlightSearchIntentSchema,
+  storefrontStaySearchIntentSchema,
+  storefrontPackageSearchIntentSchema,
+])
+
+/** Complete browser request. `.strict()` at every object boundary rejects trust-plane selectors. */
+export const storefrontShoppingRequestSchema = z
+  .object({ scope: storefrontRequestedScopeSchema, intent: storefrontShoppingIntentSchema })
+  .strict()
+
+const coverageSchema = z
+  .object({
+    status: z.enum(["complete", "partial", "unavailable"]),
+    succeeded: z.number().int().min(0),
+    failed: z.number().int().min(0),
+    timedOut: z.number().int().min(0),
+  })
+  .strict()
+
+const imageSchema = z
+  .object({ url: z.string().url(), alt: z.string().max(300).optional() })
+  .strict()
+
+const inspirationItemSchema = z
+  .object({
+    itemRef: opaqueRefSchema,
+    title: z.string().min(1),
+    summary: z.string().optional(),
+    href: z.string().min(1).optional(),
+    image: imageSchema.optional(),
+    priceFrom: storefrontPresentationMoneySchema.optional(),
+  })
+  .strict()
+
+const inspirationGroupResultSchema = z
+  .object({
+    group: storefrontInspirationGroupSchema,
+    items: z.array(inspirationItemSchema),
+    total: z.number().int().min(0),
+    nextCursor: opaqueRefSchema.optional(),
+  })
+  .strict()
+
+export const storefrontIndexedInspirationResultSchema = z
+  .object({
+    kind: z.literal("indexed-inspiration"),
+    scope: storefrontResolvedScopeSchema,
+    groups: z.array(inspirationGroupResultSchema),
+  })
+  .strict()
+
+const airportStopSchema = z
+  .object({ code: z.string().length(3), at: z.string().datetime({ offset: true }) })
+  .strict()
+const flightSegmentResultSchema = z
+  .object({
+    origin: airportStopSchema,
+    destination: airportStopSchema,
+    marketingCarrier: z.string().min(2).max(3),
+    flightNumber: z.string().min(1).max(12),
+  })
+  .strict()
+const flightItinerarySchema = z
+  .object({ segments: z.array(flightSegmentResultSchema).min(1), duration: z.string().optional() })
+  .strict()
+
+const flightOfferSchema = z
+  .object({
+    offerRef: opaqueRefSchema,
+    itineraries: z.array(flightItinerarySchema).min(1),
+    price: storefrontPresentationMoneySchema,
+    expiresAt: z.string().datetime({ offset: true }).optional(),
+  })
+  .strict()
+
+export const storefrontFlightSearchResultSchema = z
+  .object({
+    kind: z.literal("flight"),
+    scope: storefrontResolvedScopeSchema,
+    offers: z.array(flightOfferSchema),
+    coverage: coverageSchema,
+    nextCursor: opaqueRefSchema.optional(),
+  })
+  .strict()
+
+const stayOfferSchema = z
+  .object({
+    offerRef: opaqueRefSchema,
+    accommodationRef: opaqueRefSchema,
+    title: z.string().min(1),
+    checkIn: isoDateSchema,
+    checkOut: isoDateSchema,
+    roomName: z.string().optional(),
+    boardName: z.string().optional(),
+    image: imageSchema.optional(),
+    price: storefrontPresentationMoneySchema,
+    expiresAt: z.string().datetime({ offset: true }).optional(),
+  })
+  .strict()
+
+export const storefrontStaySearchResultSchema = z
+  .object({
+    kind: z.literal("stay"),
+    scope: storefrontResolvedScopeSchema,
+    offers: z.array(stayOfferSchema),
+    coverage: coverageSchema,
+    nextCursor: opaqueRefSchema.optional(),
+  })
+  .strict()
+
+const packageOfferSchema = z
+  .object({
+    offerRef: opaqueRefSchema,
+    title: z.string().min(1),
+    origin: z.string().length(3),
+    destination: z.string().min(1),
+    departureDate: isoDateSchema,
+    nights: z.number().int().min(1),
+    accommodationName: z.string().min(1),
+    boardName: z.string().optional(),
+    image: imageSchema.optional(),
+    price: storefrontPresentationMoneySchema,
+    expiresAt: z.string().datetime({ offset: true }).optional(),
+  })
+  .strict()
+
+export const storefrontPackageSearchResultSchema = z
+  .object({
+    kind: z.literal("package"),
+    scope: storefrontResolvedScopeSchema,
+    offers: z.array(packageOfferSchema),
+    coverage: coverageSchema,
+    nextCursor: opaqueRefSchema.optional(),
+  })
+  .strict()
+
+export const storefrontShoppingResultSchema = z.discriminatedUnion("kind", [
+  storefrontIndexedInspirationResultSchema,
+  storefrontFlightSearchResultSchema,
+  storefrontStaySearchResultSchema,
+  storefrontPackageSearchResultSchema,
+])
+
+const tripOfferSelectionSchema = z
+  .object({
+    kind: z.enum(["product", "flight", "stay", "package"]),
+    offerRef: opaqueRefSchema,
+    quantity: z.number().int().min(1).max(99).optional(),
+  })
+  .strict()
+
+export const storefrontTripSelectionCreateSchema = z
+  .object({
+    scope: storefrontRequestedScopeSchema,
+    offers: z.array(tripOfferSelectionSchema).min(1).max(100),
+  })
+  .strict()
+
+const tripSelectionMutationSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("add"), offer: tripOfferSelectionSchema }).strict(),
+  z.object({ kind: z.literal("remove"), itemRef: opaqueRefSchema }).strict(),
+  z
+    .object({ kind: z.literal("reorder"), itemRefs: z.array(opaqueRefSchema).min(1).max(100) })
+    .strict(),
+])
+
+export const storefrontTripSelectionUpdateSchema = z
+  .object({
+    selectionRef: opaqueRefSchema,
+    expectedRevision: z.number().int().min(0),
+    mutation: tripSelectionMutationSchema,
+  })
+  .strict()
+
+const tripSelectionItemSchema = z
+  .object({
+    itemRef: opaqueRefSchema,
+    kind: z.enum(["product", "flight", "stay", "package"]),
+    quantity: z.number().int().min(1),
+  })
+  .strict()
+
+export const storefrontTripSelectionSchema = z
+  .object({
+    selectionRef: opaqueRefSchema,
+    revision: z.number().int().min(0),
+    scope: storefrontResolvedScopeSchema,
+    items: z.array(tripSelectionItemSchema).max(100),
+  })
+  .strict()
+
+export type StorefrontRequestedScope = z.infer<typeof storefrontRequestedScopeSchema>
+export type StorefrontResolvedScope = z.infer<typeof storefrontResolvedScopeSchema>
+export type StorefrontShoppingIntent = z.infer<typeof storefrontShoppingIntentSchema>
+export type StorefrontShoppingRequest = z.infer<typeof storefrontShoppingRequestSchema>
+export type StorefrontShoppingResult = z.infer<typeof storefrontShoppingResultSchema>
+export type StorefrontTripSelectionCreate = z.infer<typeof storefrontTripSelectionCreateSchema>
+export type StorefrontTripSelectionUpdate = z.infer<typeof storefrontTripSelectionUpdateSchema>
+export type StorefrontTripSelection = z.infer<typeof storefrontTripSelectionSchema>

--- a/packages/storefront/src/voyant.ts
+++ b/packages/storefront/src/voyant.ts
@@ -1,3 +1,4 @@
+// agent-quality: file-size exception -- storefront graph facets stay co-located so one import-cheap manifest remains authoritative.
 import { customerBusinessAccountOnboardingRuntimePort } from "@voyant-travel/auth/ports"
 import { catalogPublicationRuntimePort } from "@voyant-travel/catalog/ports"
 import { defineModule, providePort, requirePort } from "@voyant-travel/core/project"
@@ -17,6 +18,10 @@ import {
   storefrontPaymentReconciliationJobRuntimePort,
   storefrontVerificationRuntimePort,
 } from "./runtime-port.js"
+import {
+  storefrontShoppingRuntimePort,
+  storefrontTripSelectionsRuntimePort,
+} from "./shopping/runtime-port.js"
 
 /** Import-cheap deployment declarations owned by the storefront package. */
 export const storefrontVoyantModule = defineModule({
@@ -35,6 +40,8 @@ export const storefrontVoyantModule = defineModule({
     requirePort(storefrontOffersRuntimePort),
     requirePort(storefrontIntakeRuntimePort),
     requirePort(catalogPublicationRuntimePort),
+    requirePort(storefrontShoppingRuntimePort, { optional: true }),
+    requirePort(storefrontTripSelectionsRuntimePort, { optional: true }),
   ],
   subscribers: [
     {

--- a/packages/storefront/tests/unit/shopping-gateway.test.ts
+++ b/packages/storefront/tests/unit/shopping-gateway.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest"
 import {
   createStorefrontShoppingGateway,
   type StorefrontResolvedScope,
+  type StorefrontShoppingContext,
   type StorefrontShoppingResult,
   StorefrontShoppingUnavailableError,
   storefrontPresentationMoneySchema,
@@ -12,7 +13,12 @@ import {
   storefrontTripSelectionUpdateSchema,
 } from "../../src/shopping/index.js"
 
-const context = { storefrontId: "storefront_public", channelId: "channel_web" }
+const context = {
+  storefrontId: "storefront_public",
+  channelId: "channel_web",
+  userId: "user_managed_123",
+  buyerAccountId: "buyer_account_123",
+} satisfies StorefrontShoppingContext
 const scope: StorefrontResolvedScope = {
   marketId: "market_ro",
   locale: "ro-RO",
@@ -42,6 +48,8 @@ describe("storefront shopping schemas", () => {
     "connectionId",
     "source",
     "sourceId",
+    "userId",
+    "buyerAccountId",
   ])("rejects browser trust selector %s", (selector) => {
     expect(() =>
       storefrontShoppingRequestSchema.parse({

--- a/packages/storefront/tests/unit/shopping-gateway.test.ts
+++ b/packages/storefront/tests/unit/shopping-gateway.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  createStorefrontShoppingGateway,
+  type StorefrontResolvedScope,
+  type StorefrontShoppingResult,
+  StorefrontShoppingUnavailableError,
+  storefrontPresentationMoneySchema,
+  storefrontShoppingRequestSchema,
+  storefrontShoppingRuntimePort,
+  storefrontTripSelectionsRuntimePort,
+  storefrontTripSelectionUpdateSchema,
+} from "../../src/shopping/index.js"
+
+const context = { storefrontId: "storefront_public", channelId: "channel_web" }
+const scope: StorefrontResolvedScope = {
+  marketId: "market_ro",
+  locale: "ro-RO",
+  currency: "RON",
+  available: {
+    marketIds: ["market_ro", "market_gb"],
+    locales: ["ro-RO", "en-GB"],
+    currencies: ["RON", "EUR"],
+  },
+}
+
+describe("storefront shopping schemas", () => {
+  it.each([
+    "tenant",
+    "tenantId",
+    "organization",
+    "organizationId",
+    "engine",
+    "engineId",
+    "storefront",
+    "storefrontId",
+    "storefrontChannel",
+    "channel",
+    "channelId",
+    "provider",
+    "providerId",
+    "connectionId",
+    "source",
+    "sourceId",
+  ])("rejects browser trust selector %s", (selector) => {
+    expect(() =>
+      storefrontShoppingRequestSchema.parse({
+        scope: { currency: "EUR", [selector]: "attacker-controlled" },
+        intent: {
+          kind: "flight",
+          slices: [{ origin: "OTP", destination: "LHR", departureDate: "2026-09-01" }],
+          travelers: { adults: 1 },
+        },
+      }),
+    ).toThrow()
+  })
+
+  it("models indexed inspiration as independently paginated groups", () => {
+    const request = storefrontShoppingRequestSchema.parse({
+      scope: {},
+      intent: {
+        kind: "indexed-inspiration",
+        groups: [
+          { group: "tours", query: "Danube", pagination: { cursor: "tour-cursor-0000001" } },
+          { group: "activities", destination: { city: "Bucharest" } },
+          { group: "stays", destination: { countryCode: "RO" } },
+        ],
+      },
+    })
+
+    expect(request.intent).toMatchObject({ kind: "indexed-inspiration" })
+    expect(() =>
+      storefrontShoppingRequestSchema.parse({
+        scope: {},
+        intent: {
+          kind: "indexed-inspiration",
+          groups: [{ group: "tours" }],
+          cursor: "fake-global-cursor",
+        },
+      }),
+    ).toThrow()
+  })
+
+  it("requires Voyant Data FX provenance for converted presentation money", () => {
+    expect(() =>
+      storefrontPresentationMoneySchema.parse({
+        native: { amount: "100.00", currency: "EUR" },
+        presentation: { amount: "497.50", currency: "RON" },
+      }),
+    ).toThrow(/FX provenance/)
+
+    expect(
+      storefrontPresentationMoneySchema.parse({
+        native: { amount: "100.00", currency: "EUR" },
+        presentation: { amount: "497.50", currency: "RON" },
+        fx: {
+          authority: "voyant-data",
+          rate: "4.975",
+          quotedAt: "2026-08-08T10:00:00+00:00",
+        },
+      }),
+    ).toBeTruthy()
+  })
+})
+
+describe("storefront shopping gateway", () => {
+  it("resolves scope server-side and preserves vertical discrimination", async () => {
+    const resolveScope = vi.fn(async () => scope)
+    const search = vi.fn(
+      async (_context, input): Promise<StorefrontShoppingResult> => ({
+        kind: "flight",
+        scope: input.scope,
+        offers: [],
+        coverage: { status: "partial", succeeded: 1, failed: 1, timedOut: 0 },
+      }),
+    )
+    const gateway = createStorefrontShoppingGateway({ shopping: { resolveScope, search } })
+
+    const result = await gateway.search(context, {
+      scope: { marketId: "market_ro", locale: "ro-RO", currency: "RON" },
+      intent: {
+        kind: "flight",
+        slices: [{ origin: "OTP", destination: "LHR", departureDate: "2026-09-01" }],
+        travelers: { adults: 2 },
+      },
+    })
+
+    expect(result.kind).toBe("flight")
+    expect(resolveScope).toHaveBeenCalledWith(context, {
+      marketId: "market_ro",
+      locale: "ro-RO",
+      currency: "RON",
+    })
+    expect(search).toHaveBeenCalledWith(context, expect.objectContaining({ scope }))
+  })
+
+  it("rejects provider results outside the resolved scope", async () => {
+    const gateway = createStorefrontShoppingGateway({
+      shopping: {
+        resolveScope: async () => scope,
+        search: async (_context, input) => ({
+          kind: "stay",
+          scope: { ...input.scope, currency: "EUR" },
+          offers: [],
+          coverage: { status: "complete", succeeded: 1, failed: 0, timedOut: 0 },
+        }),
+      },
+    })
+
+    await expect(
+      gateway.search(context, {
+        scope: {},
+        intent: {
+          kind: "stay",
+          destination: { city: "Bucharest" },
+          checkIn: "2026-09-01",
+          checkOut: "2026-09-03",
+          rooms: [{ adults: 2 }],
+        },
+      }),
+    ).rejects.toThrow(/outside the resolved shopping scope/)
+  })
+
+  it("keeps Trip selection mutations opaque and revision checked", async () => {
+    const create = vi.fn(async (_context, input) => ({
+      selectionRef: "selection-ref-00000001",
+      revision: 0,
+      scope: input.scope,
+      items: [{ itemRef: "selection-item-000001", kind: "flight" as const, quantity: 1 }],
+    }))
+    const update = vi.fn(async (_context, input) => ({
+      selectionRef: input.selectionRef,
+      revision: input.expectedRevision + 1,
+      scope,
+      items: [],
+    }))
+    const gateway = createStorefrontShoppingGateway({
+      shopping: { resolveScope: async () => scope, search: vi.fn() },
+      tripSelections: { create, update },
+    })
+
+    const created = await gateway.createTripSelection(context, {
+      scope: { currency: "RON" },
+      offers: [{ kind: "flight", offerRef: "flight-offer-000001" }],
+    })
+    const updated = await gateway.updateTripSelection(context, {
+      selectionRef: created.selectionRef,
+      expectedRevision: created.revision,
+      mutation: { kind: "remove", itemRef: created.items[0]?.itemRef },
+    })
+
+    expect(updated.revision).toBe(1)
+    expect(update).toHaveBeenCalledWith(
+      context,
+      expect.objectContaining({ expectedRevision: 0, selectionRef: created.selectionRef }),
+    )
+    expect(() =>
+      storefrontTripSelectionUpdateSchema.parse({
+        selectionRef: created.selectionRef,
+        mutation: { kind: "remove", itemRef: "selection-item-000001" },
+      }),
+    ).toThrow()
+  })
+
+  it("fails explicitly when optional deployment providers are absent", async () => {
+    const gateway = createStorefrontShoppingGateway({})
+    await expect(gateway.search(context, {})).rejects.toBeInstanceOf(
+      StorefrontShoppingUnavailableError,
+    )
+  })
+})
+
+describe("storefront shopping graph ports", () => {
+  it("validate provider method surfaces", () => {
+    expect(() => storefrontShoppingRuntimePort.test({} as never)).toThrow(/resolveScope/)
+    expect(() => storefrontTripSelectionsRuntimePort.test({} as never)).toThrow(/create/)
+  })
+})

--- a/packages/storefront/tests/unit/voyant-manifest.test.ts
+++ b/packages/storefront/tests/unit/voyant-manifest.test.ts
@@ -10,6 +10,10 @@ import {
   storefrontPaymentReconciliationJobRuntimePort,
 } from "../../src/runtime-port.js"
 import {
+  storefrontShoppingRuntimePort,
+  storefrontTripSelectionsRuntimePort,
+} from "../../src/shopping/runtime-port.js"
+import {
   storefrontCustomerPortalVoyantModule,
   storefrontPaymentLinkVoyantModule,
   storefrontVerificationVoyantModule,
@@ -42,6 +46,8 @@ describe("storefront deployment manifest", () => {
         { id: "storefront.offers.runtime" },
         { id: "storefront.intake.runtime" },
         { id: catalogPublicationRuntimePort.id },
+        { id: storefrontShoppingRuntimePort.id, optional: true },
+        { id: storefrontTripSelectionsRuntimePort.id, optional: true },
       ],
       api: [
         {

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -1987,6 +1987,7 @@
       ],
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
+      "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"


### PR DESCRIPTION
## Summary

- export strict `@voyant-travel/storefront/shopping` schemas for independently paginated indexed inspiration groups and discriminated live flight, stay, and flight-plus-stay searches
- resolve market, locale, and currency through a server-owned runtime, preserve native and presentation money with FX provenance, and reject browser-controlled tenant, organization, engine, storefront, channel, provider, connection, source, user, and buyer-account selectors
- carry optional nullable `userId` and `buyerAccountId` only in trusted server-derived context so logged-in itineraries bind to Voyant-managed customer ownership
- add optional graph ports for shopping and a separate compare-and-swap Trip-selection runtime using opaque offer, item, and selection references
- keep deployments without either provider bootable and fail capability calls explicitly

## Architecture

Indexed groups retain independent totals and cursors; the contract does not create a fake cross-vertical rank or cursor. Live results preserve their vertical discriminator and aggregate partial-provider coverage without exposing provider identifiers. Trip composition remains behind the Trips storefront authority merged in #4434; this PR defines only the separate provider seam and does not absorb Trip internals.

Managed customer identity is never accepted by any browser request schema. `userId` and `buyerAccountId` can enter only through `StorefrontShoppingContext`, supplied by the trusted server integration and passed unchanged to the provider.

## Validation

- repository pre-commit affected graph: 224/224 lint, build, and typecheck tasks passed
- `pnpm --filter @voyant-travel/storefront test`: 27 files passed, 8 skipped; 163 tests passed, 33 skipped
- focused shopping + manifest tests after managed identity coverage: 32 passed
- bounded standalone strict TypeScript check for shopping source and tests: passed
- `pnpm verify:graph-conformance`: passed
- `pnpm verify:public-surface`: passed
- `pnpm verify:dep-paths`: passed
- `pnpm verify:dist-configs`: passed

Full GitHub Actions checks are requested as the authoritative clean-run validation.