### PR TITLE
fix(proposals): make approved acceptance durable

### DIFF
--- a/.changeset/calm-proposal-acceptance.md
+++ b/.changeset/calm-proposal-acceptance.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/proposals": patch
+---
+
+Execute approved proposal-version acceptance through the handler-owned durable command-result protocol.

--- a/packages/proposals/src/mcp-runtime.ts
+++ b/packages/proposals/src/mcp-runtime.ts
@@ -20,6 +20,7 @@ import {
   ProposalAcceptanceError,
 } from "./service/proposal-acceptance.js"
 import { executeSnapshotAndSendProposalCommand } from "./service/proposal-delivery.js"
+import { executeAcceptProposalVersionCommand } from "./service/proposal-version-acceptance-command.js"
 
 export * from "./tools.js"
 
@@ -76,7 +77,15 @@ export const voyantToolContextContribution = defineToolContextContribution({
           id: string,
           input: Parameters<typeof proposalsService.sendProposalVersion>[2],
         ) => proposalsService.sendProposalVersion(db, id, input),
-        acceptProposalVersion: (id: string) => proposalsService.acceptProposalVersion(db, id),
+        async acceptProposalVersion(id: string, admitted: ToolHandlerActionPolicyContext) {
+          const result = await executeAcceptProposalVersionCommand({
+            db,
+            context: actionLedgerContext(c),
+            admitted,
+            proposalVersionId: id,
+          })
+          return result.value
+        },
         declineProposalVersion: (id: string) => proposalsService.declineProposalVersion(db, id),
       },
       proposalDelivery: {

--- a/packages/proposals/src/service/proposal-version-acceptance-command.ts
+++ b/packages/proposals/src/service/proposal-version-acceptance-command.ts
@@ -1,0 +1,86 @@
+import {
+  type ActionLedgerRequestContextValues,
+  executeAdmittedExistingTargetCommand,
+} from "@voyant-travel/action-ledger"
+import type { AnyDrizzleDb } from "@voyant-travel/db"
+import type { ToolHandlerActionPolicyContext } from "@voyant-travel/tools"
+import { and, eq, inArray, ne } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import { proposals, proposalVersions } from "../schema.js"
+import {
+  type AcceptProposalVersionResult,
+  ProposalVersionConflictError,
+  proposalVersionsService,
+} from "./proposal-versions.js"
+
+export interface ExecuteAcceptProposalVersionCommandInput {
+  db: AnyDrizzleDb
+  context: ActionLedgerRequestContextValues
+  admitted: ToolHandlerActionPolicyContext
+  proposalVersionId: string
+}
+
+/**
+ * Accept a proposal version under the handler-owned command claim. The claim,
+ * proposal/version lifecycle changes, and approval consumption commit in one
+ * transaction; exact retries resolve the already accepted state.
+ */
+export async function executeAcceptProposalVersionCommand(
+  input: ExecuteAcceptProposalVersionCommandInput,
+) {
+  const commandInput = { proposalVersionId: input.proposalVersionId }
+  let preparedValue: Awaited<ReturnType<typeof proposalVersionsService.acceptProposalVersion>> =
+    null
+  return executeAdmittedExistingTargetCommand(
+    {
+      db: input.db,
+      context: input.context,
+      admitted: input.admitted,
+      commandInput,
+      evaluatedRisk: "high",
+    },
+    {
+      async prepare(tx) {
+        preparedValue = await proposalVersionsService.acceptProposalVersion(
+          tx as PostgresJsDatabase,
+          input.proposalVersionId,
+        )
+      },
+      execute: () => Promise.resolve(preparedValue),
+      replay: () => resolveAcceptedProposalVersion(input.db, input.proposalVersionId),
+    },
+  )
+}
+
+async function resolveAcceptedProposalVersion(
+  db: AnyDrizzleDb,
+  proposalVersionId: string,
+): Promise<AcceptProposalVersionResult | null> {
+  const [accepted] = await db
+    .select({ proposal: proposals, proposalVersion: proposalVersions })
+    .from(proposalVersions)
+    .innerJoin(proposals, eq(proposalVersions.proposalId, proposals.id))
+    .where(eq(proposalVersions.id, proposalVersionId))
+    .limit(1)
+  if (!accepted) return null
+  if (
+    accepted.proposalVersion.status !== "accepted" ||
+    accepted.proposal.acceptedVersionId !== proposalVersionId
+  ) {
+    throw new ProposalVersionConflictError(
+      `Proposal Version ${proposalVersionId} no longer resolves to its accepted result`,
+    )
+  }
+  const closedProposalVersions = await db
+    .select()
+    .from(proposalVersions)
+    .where(
+      and(
+        eq(proposalVersions.proposalId, accepted.proposal.id),
+        ne(proposalVersions.id, proposalVersionId),
+        inArray(proposalVersions.status, ["declined", "superseded"]),
+      ),
+    )
+  return { ...accepted, closedProposalVersions }
+}

--- a/packages/proposals/src/tools.ts
+++ b/packages/proposals/src/tools.ts
@@ -60,7 +60,10 @@ export interface ProposalsToolServices {
     proposalVersionId: string,
     input: z.infer<typeof sendProposalVersionSchema>,
   ): Promise<unknown>
-  acceptProposalVersion(proposalVersionId: string): Promise<unknown>
+  acceptProposalVersion(
+    proposalVersionId: string,
+    admitted: ToolHandlerActionPolicyContext,
+  ): Promise<unknown>
   declineProposalVersion(proposalVersionId: string): Promise<unknown>
 }
 
@@ -146,6 +149,26 @@ export const SNAPSHOT_AND_SEND_PROPOSAL_HANDLER_POLICY = {
     kind: "execute",
     targetType: "proposal",
     commandTargetField: "proposalId",
+    targetLifecycle: "existing",
+    existingTarget: { durability: "handler-command-result-v1" },
+    risk: "high",
+    ledger: "required",
+    approval: "required",
+    reversible: false,
+  },
+} as const satisfies HandlerActionPolicyExpectation
+
+export const ACCEPT_PROPOSAL_VERSION_HANDLER_POLICY = {
+  capabilityId: `${OWNER}#tool.accept-proposal-version`,
+  capabilityVersion: VERSION,
+  canonicalName: "accept_proposal_version",
+  actionPolicy: {
+    id: `${OWNER}#action.accept-proposal-version`,
+    capabilityId: `${OWNER}#action.accept-proposal-version`,
+    version: VERSION,
+    kind: "execute",
+    targetType: "proposal-version",
+    commandTargetField: "proposalVersionId",
     targetLifecycle: "existing",
     existingTarget: { durability: "handler-command-result-v1" },
     risk: "high",
@@ -364,10 +387,13 @@ export const acceptProposalVersionTool = defineTool({
   audience: STAFF_AUDIENCE,
   tier: "write",
   riskPolicy: proposalWriteRisk,
+  annotations: { idempotentHint: true },
+  actionPolicyEnforcement: "handler",
   async handler({ proposalVersionId }, ctx: ProposalsToolContext) {
+    const admitted = admitHandlerActionPolicy(ctx, ACCEPT_PROPOSAL_VERSION_HANDLER_POLICY)
     return parseJsonResult(
       acceptProposalVersionResultSchema.nullable(),
-      await proposals(ctx).acceptProposalVersion(proposalVersionId),
+      await proposals(ctx).acceptProposalVersion(proposalVersionId, admitted),
     )
   },
 })

--- a/packages/proposals/src/voyant.ts
+++ b/packages/proposals/src/voyant.ts
@@ -358,6 +358,7 @@ export const proposalsVoyantModule = defineModule({
       availability: { status: "available" },
       effectBoundary: "local",
       targetLifecycle: "existing",
+      existingTarget: { durability: "handler-command-result-v1" },
       from: { tools: ["@voyant-travel/proposals#tool.accept-proposal-version"] },
     },
     {

--- a/packages/proposals/tests/tools.test.ts
+++ b/packages/proposals/tests/tools.test.ts
@@ -11,6 +11,8 @@ import {
   proposalsHandlerActionPolicyExpectation,
 } from "../src/created-target-policy.js"
 import {
+  ACCEPT_PROPOSAL_VERSION_HANDLER_POLICY,
+  acceptProposalVersionTool,
   createProposalTool,
   type ProposalDeliveryToolServices,
   type ProposalsToolServices,
@@ -93,12 +95,39 @@ function snapshotSendActionPolicy(): ToolHandlerActionPolicyContext {
   }
 }
 
+function acceptProposalActionPolicy(): ToolHandlerActionPolicyContext {
+  return {
+    capabilityId: ACCEPT_PROPOSAL_VERSION_HANDLER_POLICY.capabilityId,
+    capabilityVersion: ACCEPT_PROPOSAL_VERSION_HANDLER_POLICY.capabilityVersion,
+    canonicalName: ACCEPT_PROPOSAL_VERSION_HANDLER_POLICY.canonicalName,
+    actionPolicy: {
+      ...ACCEPT_PROPOSAL_VERSION_HANDLER_POLICY.actionPolicy,
+      enforcement: "handler",
+      invocation: {
+        controlField: "_voyant",
+        requiredFields: ["idempotencyKey", "approvalId", "idempotencyFingerprint"],
+        optionalFields: ["reasonCode", "approvalId", "idempotencyFingerprint"],
+        fingerprintAlgorithm: "action-ledger-command-v1",
+      },
+    },
+    invocation: {
+      idempotencyKey: "proposal-accept-1",
+      approvalId: "approval_1",
+      idempotencyFingerprint: "sha256:test",
+    },
+  }
+}
+
 function registry() {
   const registry = createToolRegistry()
   for (const tool of proposalsTools) {
     if (tool === snapshotAndSendProposalTool) {
       registry.register(tool, {
         actionPolicy: SNAPSHOT_AND_SEND_PROPOSAL_HANDLER_POLICY.actionPolicy,
+      })
+    } else if (tool === acceptProposalVersionTool) {
+      registry.register(tool, {
+        actionPolicy: ACCEPT_PROPOSAL_VERSION_HANDLER_POLICY.actionPolicy,
       })
     } else if (tool === createProposalTool) {
       registry.register(tool, {
@@ -280,7 +309,8 @@ describe("proposals Tools", () => {
           sentAt: timestamp,
         }
       },
-      async acceptProposalVersion(id) {
+      async acceptProposalVersion(id, admitted) {
+        expect(admitted.invocation.idempotencyKey).toBe("proposal-accept-1")
         calls.push(`accept:${id}`)
         return {
           proposal: { ...proposal, status: "won", acceptedVersionId: id, closedAt: timestamp },
@@ -307,7 +337,7 @@ describe("proposals Tools", () => {
     const accepted = await toolRegistry.dispatch<{ proposalVersion: Record<string, unknown> }>(
       "accept_proposal_version",
       { proposalVersionId: version.id },
-      ctx(services),
+      ctx(services, "staff", undefined, acceptProposalActionPolicy()),
     )
     const declined = await toolRegistry.dispatch<Record<string, unknown>>(
       "decline_proposal_version",

--- a/packages/proposals/tests/unit/mcp-runtime.test.ts
+++ b/packages/proposals/tests/unit/mcp-runtime.test.ts
@@ -1,0 +1,62 @@
+import type { ToolHandlerActionPolicyContext } from "@voyant-travel/tools"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+const executeAcceptProposalVersionCommand = vi.hoisted(() => vi.fn())
+
+vi.mock("../../src/service/proposal-version-acceptance-command.js", () => ({
+  executeAcceptProposalVersionCommand,
+}))
+
+import { voyantToolContextContribution } from "../../src/mcp-runtime.js"
+
+afterEach(() => {
+  executeAcceptProposalVersionCommand.mockReset()
+})
+
+describe("proposals MCP runtime", () => {
+  it("executes proposal acceptance through the admitted durable command", async () => {
+    const db = {}
+    const admitted = {
+      invocation: { idempotencyKey: "accept-1" },
+    } as ToolHandlerActionPolicyContext
+    const accepted = { proposal: { id: "proposal_1" }, proposalVersion: { id: "version_1" } }
+    executeAcceptProposalVersionCommand.mockResolvedValue({ replayed: false, value: accepted })
+    const request = {
+      req: {
+        header(name: string) {
+          return name === "x-request-id" ? "request_1" : undefined
+        },
+      },
+      var: {
+        db,
+        userId: "user_1",
+        callerType: "session",
+        actor: "staff",
+        organizationId: "org_1",
+      },
+    }
+
+    const contribution = voyantToolContextContribution.contribute({
+      request,
+      context: { db },
+      resources: {},
+    })
+    const proposals = contribution.proposals as {
+      acceptProposalVersion(id: string, policy: ToolHandlerActionPolicyContext): Promise<unknown>
+    }
+
+    await expect(proposals.acceptProposalVersion("version_1", admitted)).resolves.toEqual(accepted)
+    expect(executeAcceptProposalVersionCommand).toHaveBeenCalledWith({
+      db,
+      context: expect.objectContaining({
+        userId: "user_1",
+        callerType: "session",
+        actor: "staff",
+        organizationId: "org_1",
+        correlationId: "request_1",
+      }),
+      admitted,
+      proposalVersionId: "version_1",
+    })
+  })
+})

--- a/packages/proposals/tests/unit/voyant-manifest.test.ts
+++ b/packages/proposals/tests/unit/voyant-manifest.test.ts
@@ -225,7 +225,12 @@ describe("proposals deployment manifests", () => {
       proposalsVoyantModule.actions?.find(
         ({ id }) => id === "@voyant-travel/proposals#action.accept-proposal-version",
       ),
-    ).toMatchObject({ risk: "high", approval: "required" })
+    ).toMatchObject({
+      risk: "high",
+      approval: "required",
+      targetLifecycle: "existing",
+      existingTarget: { durability: "handler-command-result-v1" },
+    })
   })
 
   it("owns the cross-module proposal snapshot and notification action", () => {


### PR DESCRIPTION
## Summary

- move `accept_proposal_version` from the generic approval preflight to the handler-owned existing-target command-result protocol
- commit approval consumption, the durable command claim, and proposal/version lifecycle changes in one transaction
- resolve exact replays from accepted durable state without redispatching the mutation
- declare and verify the selected graph durability contract

## Why

#4424 proved that a generic preflight claim cannot safely recover an abandoned dispatch without fencing the domain mutation. Product lifecycle and booking cancellation already use handler-owned durable execution. Proposal acceptance was still an ordinary approval-required workflow on the unsafe generic path.

## Verification

- `pnpm --filter @voyant-travel/proposals typecheck`
- `pnpm --filter @voyant-travel/proposals test` (103 passed)
- `pnpm --filter operator test -- tests/api/selected-graph-runtime.test.ts` (60 passed, 13 skipped)
- generated operator graph contains `existingTarget.durability = handler-command-result-v1`
- scoped Biome and `git diff --check`

Refs #4424
Refs #4378
