### PR TITLE
feat(trips): provide storefront Trip selections

### DIFF
--- a/.changeset/green-storefront-trip-selections.md
+++ b/.changeset/green-storefront-trip-selections.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/trips": patch
+---
+
+Provide the Storefront Trip selection runtime with opaque capability and item references, owner- and scope-bound access, atomic revision checks, and an injected offer reference resolver.

--- a/packages/accommodations/tsconfig.build.json
+++ b/packages/accommodations/tsconfig.build.json
@@ -1936,6 +1936,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/runtime-port": [
+        "../storefront/dist/shopping/runtime-port.d.ts"
+      ],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"
@@ -1987,6 +1990,12 @@
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],
       "@voyant-travel/trips/sourcing-job": ["../trips/dist/sourcing-job.d.ts"],
+      "@voyant-travel/trips/storefront-trip-offer-resolver-port": [
+        "../trips/dist/storefront-trip-offer-resolver-port.d.ts"
+      ],
+      "@voyant-travel/trips/storefront-trip-selections-runtime": [
+        "../trips/dist/storefront-trip-selections-runtime.d.ts"
+      ],
       "@voyant-travel/trips/tools": ["../trips/dist/mcp-runtime.d.ts"],
       "@voyant-travel/trips/validation": ["../trips/dist/validation.d.ts"],
       "@voyant-travel/trips/voyant": ["../trips/dist/voyant.d.ts"],

--- a/packages/accommodations/tsconfig.typecheck.json
+++ b/packages/accommodations/tsconfig.typecheck.json
@@ -1937,6 +1937,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/runtime-port": [
+        "../storefront/dist/shopping/runtime-port.d.ts"
+      ],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"
@@ -1988,6 +1991,12 @@
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],
       "@voyant-travel/trips/sourcing-job": ["../trips/dist/sourcing-job.d.ts"],
+      "@voyant-travel/trips/storefront-trip-offer-resolver-port": [
+        "../trips/dist/storefront-trip-offer-resolver-port.d.ts"
+      ],
+      "@voyant-travel/trips/storefront-trip-selections-runtime": [
+        "../trips/dist/storefront-trip-selections-runtime.d.ts"
+      ],
       "@voyant-travel/trips/tools": ["../trips/dist/mcp-runtime.d.ts"],
       "@voyant-travel/trips/validation": ["../trips/dist/validation.d.ts"],
       "@voyant-travel/trips/voyant": ["../trips/dist/voyant.d.ts"],

--- a/packages/catalog/tsconfig.build.json
+++ b/packages/catalog/tsconfig.build.json
@@ -1891,6 +1891,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/runtime-port": [
+        "../storefront/dist/shopping/runtime-port.d.ts"
+      ],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"
@@ -1942,6 +1945,12 @@
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],
       "@voyant-travel/trips/sourcing-job": ["../trips/dist/sourcing-job.d.ts"],
+      "@voyant-travel/trips/storefront-trip-offer-resolver-port": [
+        "../trips/dist/storefront-trip-offer-resolver-port.d.ts"
+      ],
+      "@voyant-travel/trips/storefront-trip-selections-runtime": [
+        "../trips/dist/storefront-trip-selections-runtime.d.ts"
+      ],
       "@voyant-travel/trips/tools": ["../trips/dist/mcp-runtime.d.ts"],
       "@voyant-travel/trips/validation": ["../trips/dist/validation.d.ts"],
       "@voyant-travel/trips/voyant": ["../trips/dist/voyant.d.ts"],

--- a/packages/catalog/tsconfig.typecheck.json
+++ b/packages/catalog/tsconfig.typecheck.json
@@ -1892,6 +1892,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/runtime-port": [
+        "../storefront/dist/shopping/runtime-port.d.ts"
+      ],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"
@@ -1943,6 +1946,12 @@
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],
       "@voyant-travel/trips/sourcing-job": ["../trips/dist/sourcing-job.d.ts"],
+      "@voyant-travel/trips/storefront-trip-offer-resolver-port": [
+        "../trips/dist/storefront-trip-offer-resolver-port.d.ts"
+      ],
+      "@voyant-travel/trips/storefront-trip-selections-runtime": [
+        "../trips/dist/storefront-trip-selections-runtime.d.ts"
+      ],
       "@voyant-travel/trips/tools": ["../trips/dist/mcp-runtime.d.ts"],
       "@voyant-travel/trips/validation": ["../trips/dist/validation.d.ts"],
       "@voyant-travel/trips/voyant": ["../trips/dist/voyant.d.ts"],

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -1896,6 +1896,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/runtime-port": [
+        "../storefront/dist/shopping/runtime-port.d.ts"
+      ],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"
@@ -1947,6 +1950,12 @@
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],
       "@voyant-travel/trips/sourcing-job": ["../trips/dist/sourcing-job.d.ts"],
+      "@voyant-travel/trips/storefront-trip-offer-resolver-port": [
+        "../trips/dist/storefront-trip-offer-resolver-port.d.ts"
+      ],
+      "@voyant-travel/trips/storefront-trip-selections-runtime": [
+        "../trips/dist/storefront-trip-selections-runtime.d.ts"
+      ],
       "@voyant-travel/trips/tools": ["../trips/dist/mcp-runtime.d.ts"],
       "@voyant-travel/trips/validation": ["../trips/dist/validation.d.ts"],
       "@voyant-travel/trips/voyant": ["../trips/dist/voyant.d.ts"],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -1890,6 +1890,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/runtime-port": [
+        "../storefront/dist/shopping/runtime-port.d.ts"
+      ],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"
@@ -1941,6 +1944,12 @@
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],
       "@voyant-travel/trips/sourcing-job": ["../trips/dist/sourcing-job.d.ts"],
+      "@voyant-travel/trips/storefront-trip-offer-resolver-port": [
+        "../trips/dist/storefront-trip-offer-resolver-port.d.ts"
+      ],
+      "@voyant-travel/trips/storefront-trip-selections-runtime": [
+        "../trips/dist/storefront-trip-selections-runtime.d.ts"
+      ],
       "@voyant-travel/trips/tools": ["../trips/dist/mcp-runtime.d.ts"],
       "@voyant-travel/trips/validation": ["../trips/dist/validation.d.ts"],
       "@voyant-travel/trips/voyant": ["../trips/dist/voyant.d.ts"],

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -1941,6 +1941,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/runtime-port": [
+        "../storefront/dist/shopping/runtime-port.d.ts"
+      ],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"
@@ -1992,6 +1995,12 @@
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],
       "@voyant-travel/trips/sourcing-job": ["../trips/dist/sourcing-job.d.ts"],
+      "@voyant-travel/trips/storefront-trip-offer-resolver-port": [
+        "../trips/dist/storefront-trip-offer-resolver-port.d.ts"
+      ],
+      "@voyant-travel/trips/storefront-trip-selections-runtime": [
+        "../trips/dist/storefront-trip-selections-runtime.d.ts"
+      ],
       "@voyant-travel/trips/tools": ["../trips/dist/mcp-runtime.d.ts"],
       "@voyant-travel/trips/validation": ["../trips/dist/validation.d.ts"],
       "@voyant-travel/trips/voyant": ["../trips/dist/voyant.d.ts"],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -1942,6 +1942,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/runtime-port": [
+        "../storefront/dist/shopping/runtime-port.d.ts"
+      ],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"
@@ -1993,6 +1996,12 @@
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],
       "@voyant-travel/trips/sourcing-job": ["../trips/dist/sourcing-job.d.ts"],
+      "@voyant-travel/trips/storefront-trip-offer-resolver-port": [
+        "../trips/dist/storefront-trip-offer-resolver-port.d.ts"
+      ],
+      "@voyant-travel/trips/storefront-trip-selections-runtime": [
+        "../trips/dist/storefront-trip-selections-runtime.d.ts"
+      ],
       "@voyant-travel/trips/tools": ["../trips/dist/mcp-runtime.d.ts"],
       "@voyant-travel/trips/validation": ["../trips/dist/validation.d.ts"],
       "@voyant-travel/trips/voyant": ["../trips/dist/voyant.d.ts"],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -1945,6 +1945,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/runtime-port": [
+        "../storefront/dist/shopping/runtime-port.d.ts"
+      ],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"
@@ -1996,6 +1999,12 @@
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],
       "@voyant-travel/trips/sourcing-job": ["../trips/dist/sourcing-job.d.ts"],
+      "@voyant-travel/trips/storefront-trip-offer-resolver-port": [
+        "../trips/dist/storefront-trip-offer-resolver-port.d.ts"
+      ],
+      "@voyant-travel/trips/storefront-trip-selections-runtime": [
+        "../trips/dist/storefront-trip-selections-runtime.d.ts"
+      ],
       "@voyant-travel/trips/tools": ["../trips/dist/mcp-runtime.d.ts"],
       "@voyant-travel/trips/validation": ["../trips/dist/validation.d.ts"],
       "@voyant-travel/trips/voyant": ["../trips/dist/voyant.d.ts"],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -1946,6 +1946,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/runtime-port": [
+        "../storefront/dist/shopping/runtime-port.d.ts"
+      ],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"
@@ -1997,6 +2000,12 @@
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],
       "@voyant-travel/trips/sourcing-job": ["../trips/dist/sourcing-job.d.ts"],
+      "@voyant-travel/trips/storefront-trip-offer-resolver-port": [
+        "../trips/dist/storefront-trip-offer-resolver-port.d.ts"
+      ],
+      "@voyant-travel/trips/storefront-trip-selections-runtime": [
+        "../trips/dist/storefront-trip-selections-runtime.d.ts"
+      ],
       "@voyant-travel/trips/tools": ["../trips/dist/mcp-runtime.d.ts"],
       "@voyant-travel/trips/validation": ["../trips/dist/validation.d.ts"],
       "@voyant-travel/trips/voyant": ["../trips/dist/voyant.d.ts"],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -1977,6 +1977,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/runtime-port": [
+        "../storefront/dist/shopping/runtime-port.d.ts"
+      ],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"
@@ -2028,6 +2031,12 @@
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],
       "@voyant-travel/trips/sourcing-job": ["../trips/dist/sourcing-job.d.ts"],
+      "@voyant-travel/trips/storefront-trip-offer-resolver-port": [
+        "../trips/dist/storefront-trip-offer-resolver-port.d.ts"
+      ],
+      "@voyant-travel/trips/storefront-trip-selections-runtime": [
+        "../trips/dist/storefront-trip-selections-runtime.d.ts"
+      ],
       "@voyant-travel/trips/tools": ["../trips/dist/mcp-runtime.d.ts"],
       "@voyant-travel/trips/validation": ["../trips/dist/validation.d.ts"],
       "@voyant-travel/trips/voyant": ["../trips/dist/voyant.d.ts"],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -1972,6 +1972,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/runtime-port": [
+        "../storefront/dist/shopping/runtime-port.d.ts"
+      ],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"
@@ -2023,6 +2026,12 @@
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],
       "@voyant-travel/trips/sourcing-job": ["../trips/dist/sourcing-job.d.ts"],
+      "@voyant-travel/trips/storefront-trip-offer-resolver-port": [
+        "../trips/dist/storefront-trip-offer-resolver-port.d.ts"
+      ],
+      "@voyant-travel/trips/storefront-trip-selections-runtime": [
+        "../trips/dist/storefront-trip-selections-runtime.d.ts"
+      ],
       "@voyant-travel/trips/tools": ["../trips/dist/mcp-runtime.d.ts"],
       "@voyant-travel/trips/validation": ["../trips/dist/validation.d.ts"],
       "@voyant-travel/trips/voyant": ["../trips/dist/voyant.d.ts"],

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -1979,6 +1979,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/runtime-port": [
+        "../storefront/dist/shopping/runtime-port.d.ts"
+      ],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"
@@ -2030,6 +2033,12 @@
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],
       "@voyant-travel/trips/sourcing-job": ["../trips/dist/sourcing-job.d.ts"],
+      "@voyant-travel/trips/storefront-trip-offer-resolver-port": [
+        "../trips/dist/storefront-trip-offer-resolver-port.d.ts"
+      ],
+      "@voyant-travel/trips/storefront-trip-selections-runtime": [
+        "../trips/dist/storefront-trip-selections-runtime.d.ts"
+      ],
       "@voyant-travel/trips/tools": ["../trips/dist/mcp-runtime.d.ts"],
       "@voyant-travel/trips/validation": ["../trips/dist/validation.d.ts"],
       "@voyant-travel/trips/voyant": ["../trips/dist/voyant.d.ts"],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -1980,6 +1980,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/runtime-port": [
+        "../storefront/dist/shopping/runtime-port.d.ts"
+      ],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"
@@ -2031,6 +2034,12 @@
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],
       "@voyant-travel/trips/sourcing-job": ["../trips/dist/sourcing-job.d.ts"],
+      "@voyant-travel/trips/storefront-trip-offer-resolver-port": [
+        "../trips/dist/storefront-trip-offer-resolver-port.d.ts"
+      ],
+      "@voyant-travel/trips/storefront-trip-selections-runtime": [
+        "../trips/dist/storefront-trip-selections-runtime.d.ts"
+      ],
       "@voyant-travel/trips/tools": ["../trips/dist/mcp-runtime.d.ts"],
       "@voyant-travel/trips/validation": ["../trips/dist/validation.d.ts"],
       "@voyant-travel/trips/voyant": ["../trips/dist/voyant.d.ts"],

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -1977,6 +1977,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/runtime-port": [
+        "../storefront/dist/shopping/runtime-port.d.ts"
+      ],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"
@@ -2028,6 +2031,12 @@
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],
       "@voyant-travel/trips/sourcing-job": ["../trips/dist/sourcing-job.d.ts"],
+      "@voyant-travel/trips/storefront-trip-offer-resolver-port": [
+        "../trips/dist/storefront-trip-offer-resolver-port.d.ts"
+      ],
+      "@voyant-travel/trips/storefront-trip-selections-runtime": [
+        "../trips/dist/storefront-trip-selections-runtime.d.ts"
+      ],
       "@voyant-travel/trips/tools": ["../trips/dist/mcp-runtime.d.ts"],
       "@voyant-travel/trips/validation": ["../trips/dist/validation.d.ts"],
       "@voyant-travel/trips/voyant": ["../trips/dist/voyant.d.ts"],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -1972,6 +1972,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/runtime-port": [
+        "../storefront/dist/shopping/runtime-port.d.ts"
+      ],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"
@@ -2023,6 +2026,12 @@
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],
       "@voyant-travel/trips/sourcing-job": ["../trips/dist/sourcing-job.d.ts"],
+      "@voyant-travel/trips/storefront-trip-offer-resolver-port": [
+        "../trips/dist/storefront-trip-offer-resolver-port.d.ts"
+      ],
+      "@voyant-travel/trips/storefront-trip-selections-runtime": [
+        "../trips/dist/storefront-trip-selections-runtime.d.ts"
+      ],
       "@voyant-travel/trips/tools": ["../trips/dist/mcp-runtime.d.ts"],
       "@voyant-travel/trips/validation": ["../trips/dist/validation.d.ts"],
       "@voyant-travel/trips/voyant": ["../trips/dist/voyant.d.ts"],

--- a/packages/inventory/tsconfig.build.json
+++ b/packages/inventory/tsconfig.build.json
@@ -1909,6 +1909,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/runtime-port": [
+        "../storefront/dist/shopping/runtime-port.d.ts"
+      ],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"
@@ -1960,6 +1963,12 @@
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],
       "@voyant-travel/trips/sourcing-job": ["../trips/dist/sourcing-job.d.ts"],
+      "@voyant-travel/trips/storefront-trip-offer-resolver-port": [
+        "../trips/dist/storefront-trip-offer-resolver-port.d.ts"
+      ],
+      "@voyant-travel/trips/storefront-trip-selections-runtime": [
+        "../trips/dist/storefront-trip-selections-runtime.d.ts"
+      ],
       "@voyant-travel/trips/tools": ["../trips/dist/mcp-runtime.d.ts"],
       "@voyant-travel/trips/validation": ["../trips/dist/validation.d.ts"],
       "@voyant-travel/trips/voyant": ["../trips/dist/voyant.d.ts"],

--- a/packages/inventory/tsconfig.typecheck.json
+++ b/packages/inventory/tsconfig.typecheck.json
@@ -1910,6 +1910,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/runtime-port": [
+        "../storefront/dist/shopping/runtime-port.d.ts"
+      ],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"
@@ -1961,6 +1964,12 @@
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],
       "@voyant-travel/trips/sourcing-job": ["../trips/dist/sourcing-job.d.ts"],
+      "@voyant-travel/trips/storefront-trip-offer-resolver-port": [
+        "../trips/dist/storefront-trip-offer-resolver-port.d.ts"
+      ],
+      "@voyant-travel/trips/storefront-trip-selections-runtime": [
+        "../trips/dist/storefront-trip-selections-runtime.d.ts"
+      ],
       "@voyant-travel/trips/tools": ["../trips/dist/mcp-runtime.d.ts"],
       "@voyant-travel/trips/validation": ["../trips/dist/validation.d.ts"],
       "@voyant-travel/trips/voyant": ["../trips/dist/voyant.d.ts"],

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -1876,6 +1876,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/runtime-port": [
+        "../storefront/dist/shopping/runtime-port.d.ts"
+      ],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"
@@ -1927,6 +1930,12 @@
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],
       "@voyant-travel/trips/sourcing-job": ["../trips/dist/sourcing-job.d.ts"],
+      "@voyant-travel/trips/storefront-trip-offer-resolver-port": [
+        "../trips/dist/storefront-trip-offer-resolver-port.d.ts"
+      ],
+      "@voyant-travel/trips/storefront-trip-selections-runtime": [
+        "../trips/dist/storefront-trip-selections-runtime.d.ts"
+      ],
       "@voyant-travel/trips/tools": ["../trips/dist/mcp-runtime.d.ts"],
       "@voyant-travel/trips/validation": ["../trips/dist/validation.d.ts"],
       "@voyant-travel/trips/voyant": ["../trips/dist/voyant.d.ts"],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -1871,6 +1871,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/runtime-port": [
+        "../storefront/dist/shopping/runtime-port.d.ts"
+      ],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"
@@ -1922,6 +1925,12 @@
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],
       "@voyant-travel/trips/sourcing-job": ["../trips/dist/sourcing-job.d.ts"],
+      "@voyant-travel/trips/storefront-trip-offer-resolver-port": [
+        "../trips/dist/storefront-trip-offer-resolver-port.d.ts"
+      ],
+      "@voyant-travel/trips/storefront-trip-selections-runtime": [
+        "../trips/dist/storefront-trip-selections-runtime.d.ts"
+      ],
       "@voyant-travel/trips/tools": ["../trips/dist/mcp-runtime.d.ts"],
       "@voyant-travel/trips/validation": ["../trips/dist/validation.d.ts"],
       "@voyant-travel/trips/voyant": ["../trips/dist/voyant.d.ts"],

--- a/packages/storefront/package.json
+++ b/packages/storefront/package.json
@@ -17,6 +17,7 @@
     "./runtime-contributor": "./src/runtime-contributor.ts",
     "./runtime-port": "./src/runtime-port.ts",
     "./shopping": "./src/shopping/index.ts",
+    "./shopping/runtime-port": "./src/shopping/runtime-port.ts",
     "./service": "./src/service.ts",
     "./tools": "./src/mcp-runtime.ts",
     "./transport-eligibility": "./src/transport-eligibility.ts",
@@ -185,6 +186,11 @@
         "types": "./dist/shopping/index.d.ts",
         "import": "./dist/shopping/index.js",
         "default": "./dist/shopping/index.js"
+      },
+      "./shopping/runtime-port": {
+        "types": "./dist/shopping/runtime-port.d.ts",
+        "import": "./dist/shopping/runtime-port.js",
+        "default": "./dist/shopping/runtime-port.js"
       },
       "./service": {
         "types": "./dist/service.d.ts",

--- a/packages/storefront/tests/unit/package-exports.test.ts
+++ b/packages/storefront/tests/unit/package-exports.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+
+interface PackageJson {
+  exports: Record<string, string>
+  publishConfig: {
+    exports: Record<string, { types: string; import: string; default: string }>
+  }
+}
+
+const packageJson = JSON.parse(
+  readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
+) as PackageJson
+
+describe("@voyant-travel/storefront package exports", () => {
+  it("publishes the dependency-cheap shopping runtime port", () => {
+    expect(packageJson.exports["./shopping/runtime-port"]).toBe("./src/shopping/runtime-port.ts")
+    expect(packageJson.publishConfig.exports["./shopping/runtime-port"]).toEqual({
+      types: "./dist/shopping/runtime-port.d.ts",
+      import: "./dist/shopping/runtime-port.js",
+      default: "./dist/shopping/runtime-port.js",
+    })
+  })
+})

--- a/packages/trips/package.json
+++ b/packages/trips/package.json
@@ -21,6 +21,8 @@
     "./routes": "./src/routes.ts",
     "./runtime-contributor": "./src/runtime-contributor.ts",
     "./runtime-port": "./src/runtime-port.ts",
+    "./storefront-trip-offer-resolver-port": "./src/storefront-trip-offer-resolver-port.ts",
+    "./storefront-trip-selections-runtime": "./src/storefront-trip-selections-runtime.ts",
     "./voyant": "./src/voyant.ts",
     "./openapi/admin": "./openapi/admin/trips.json",
     "./openapi/storefront": "./openapi/storefront/trips.json"
@@ -179,6 +181,16 @@
         "types": "./dist/runtime-port.d.ts",
         "import": "./dist/runtime-port.js",
         "default": "./dist/runtime-port.js"
+      },
+      "./storefront-trip-offer-resolver-port": {
+        "types": "./dist/storefront-trip-offer-resolver-port.d.ts",
+        "import": "./dist/storefront-trip-offer-resolver-port.js",
+        "default": "./dist/storefront-trip-offer-resolver-port.js"
+      },
+      "./storefront-trip-selections-runtime": {
+        "types": "./dist/storefront-trip-selections-runtime.d.ts",
+        "import": "./dist/storefront-trip-selections-runtime.js",
+        "default": "./dist/storefront-trip-selections-runtime.js"
       },
       "./voyant": {
         "types": "./dist/voyant.d.ts",

--- a/packages/trips/src/index.ts
+++ b/packages/trips/src/index.ts
@@ -82,6 +82,19 @@ export {
   type StorefrontTripScope,
   storefrontTripScopeSchema,
 } from "./storefront-access.js"
+export {
+  type StorefrontTripOfferResolutionInput,
+  type StorefrontTripOfferResolver,
+  storefrontTripOfferResolverPort,
+} from "./storefront-trip-offer-resolver-port.js"
+export {
+  createStorefrontTripSelectionsRuntime,
+  StorefrontTripSelectionAccessError,
+  StorefrontTripSelectionConflictError,
+  StorefrontTripSelectionMutationError,
+  type StorefrontTripSelectionsRuntimeOptions,
+  StorefrontTripSelectionUnavailableError,
+} from "./storefront-trip-selections-runtime.js"
 
 export const tripsModule: Module = {
   name: "trips",

--- a/packages/trips/src/runtime-contributor.ts
+++ b/packages/trips/src/runtime-contributor.ts
@@ -12,12 +12,14 @@ import {
 } from "@voyant-travel/commerce/runtime-port"
 import type { VoyantRuntimeHostPrimitives } from "@voyant-travel/core"
 import type { VoyantPort } from "@voyant-travel/core/project"
+import type { AnyDrizzleDb } from "@voyant-travel/db"
 import { type FlightsRuntime, flightsRuntimePort } from "@voyant-travel/flights"
 import { type PaymentAdapter, paymentAdapterRuntimePort } from "@voyant-travel/payments"
 import {
   storefrontPaymentLinkRuntimePort,
   storefrontPaymentReconciliationJobRuntimePort,
 } from "@voyant-travel/storefront"
+import { storefrontTripSelectionsRuntimePort } from "@voyant-travel/storefront/shopping"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { createTripBookingSessionCompositeHandler } from "./booking-session-composite-handler.js"
 import type { TripsRoutesOptionsProvider } from "./routes.js"
@@ -32,6 +34,11 @@ import {
   createCommerceCardPaymentRuntime,
   createStandardPaymentLinkRouteOptions,
 } from "./storefront-payment-link-runtime.js"
+import {
+  type StorefrontTripOfferResolver,
+  storefrontTripOfferResolverPort,
+} from "./storefront-trip-offer-resolver-port.js"
+import { createStorefrontTripSelectionsRuntime } from "./storefront-trip-selections-runtime.js"
 
 type RuntimePortValue<T> = T | Promise<T>
 
@@ -91,6 +98,10 @@ export function createTripsRuntimePortContribution(
     withDb: (bindings, operation) =>
       host.primitives.database.transaction(bindings, (database) => operation(database as never)),
   }
+  const storefrontOfferResolver =
+    host.hasRuntimePort?.(storefrontTripOfferResolverPort) === true
+      ? host.getRuntimePort<StorefrontTripOfferResolver>(storefrontTripOfferResolverPort)
+      : null
   const contribution: Record<string, unknown> = {
     [storefrontPaymentLinkRuntimePort.id]: createStandardPaymentLinkRouteOptions(paymentAdapter),
     [storefrontPaymentReconciliationJobRuntimePort.id]: {
@@ -102,6 +113,21 @@ export function createTripsRuntimePortContribution(
     },
     [tripsRoutesRuntimePort.id]: tripsRoutes,
     [tripsDatabaseRuntimePort.id]: tripsDatabase,
+    [storefrontTripSelectionsRuntimePort.id]: createStorefrontTripSelectionsRuntime({
+      withTransaction: (operation) =>
+        host.primitives.database.transaction(undefined, (database) =>
+          operation(database as AnyDrizzleDb),
+        ),
+      ...(storefrontOfferResolver
+        ? {
+            offerResolver: {
+              async resolve(context, input) {
+                return (await storefrontOfferResolver).resolve(context, input)
+              },
+            },
+          }
+        : {}),
+    }),
     [tripsSourcingJobRuntimePort.id]: {
       resolveDb: (bindings: unknown) =>
         host.primitives.database.resolve<PostgresJsDatabase>(bindings),

--- a/packages/trips/src/storefront-access.ts
+++ b/packages/trips/src/storefront-access.ts
@@ -76,6 +76,18 @@ export async function createStorefrontTrip(
   context: StorefrontTripContext,
   options: StorefrontTripAccessOptions = {},
 ): Promise<StorefrontTripHandle> {
+  return db.transaction((tx) =>
+    createStorefrontTripInTransaction(tx as unknown as AnyDrizzleDb, input, context, options),
+  )
+}
+
+/** Package-internal transaction primitive used by the Storefront selection provider. */
+export async function createStorefrontTripInTransaction(
+  db: AnyDrizzleDb,
+  input: CreateStorefrontTripInput,
+  context: StorefrontTripContext,
+  options: StorefrontTripAccessOptions = {},
+): Promise<StorefrontTripHandle> {
   const scope = storefrontTripScopeSchema.parse(input.scope)
   assertActiveStorefrontContext(context)
   const capability = (options.createCapability ?? createStorefrontTripCapability)()
@@ -84,45 +96,43 @@ export async function createStorefrontTrip(
   const now = options.now?.() ?? new Date()
   const expiresAt = new Date(now.getTime() + (options.ttlMs ?? STOREFRONT_TRIP_CAPABILITY_TTL_MS))
 
-  return db.transaction(async (tx) => {
-    const actor = storefrontActor(context)
-    const values: NewTripEnvelope = {
-      title: input.title,
-      description: input.description,
-      travelerParty: {},
-      constraints: { storefrontScope: scope },
-      createdBy: actor,
-      updatedBy: actor,
-    }
-    const [envelope] = await tx.insert(tripEnvelopes).values(values).returning()
-    if (!envelope) throw new Error("createStorefrontTrip: insert returned no envelope")
+  const actor = storefrontActor(context)
+  const values: NewTripEnvelope = {
+    title: input.title,
+    description: input.description,
+    travelerParty: {},
+    constraints: { storefrontScope: scope },
+    createdBy: actor,
+    updatedBy: actor,
+  }
+  const [envelope] = await db.insert(tripEnvelopes).values(values).returning()
+  if (!envelope) throw new Error("createStorefrontTrip: insert returned no envelope")
 
-    const [access] = await tx
-      .insert(tripStorefrontAccess)
-      .values({
-        envelopeId: envelope.id,
-        capabilityDigest,
-        storefrontId: context.storefrontId,
-        channelId: context.channelId,
-        marketId: scope.marketId,
-        locale: scope.locale,
-        currency: scope.currency,
-        ownerUserId: authenticatedUserId(context),
-        ownerBuyerAccountId: context.buyerAccountId ?? null,
-        expiresAt,
-        createdAt: now,
-        updatedAt: now,
-      })
-      .returning()
-    if (!access) throw new Error("createStorefrontTrip: access insert returned no row")
+  const [access] = await db
+    .insert(tripStorefrontAccess)
+    .values({
+      envelopeId: envelope.id,
+      capabilityDigest,
+      storefrontId: context.storefrontId,
+      channelId: context.channelId,
+      marketId: scope.marketId,
+      locale: scope.locale,
+      currency: scope.currency,
+      ownerUserId: authenticatedUserId(context),
+      ownerBuyerAccountId: context.buyerAccountId ?? null,
+      expiresAt,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning()
+  if (!access) throw new Error("createStorefrontTrip: access insert returned no row")
 
-    return {
-      capability,
-      revision: access.revision,
-      scope,
-      trip: { envelope, components: [] },
-    }
-  })
+  return {
+    capability,
+    revision: access.revision,
+    scope,
+    trip: { envelope, components: [] },
+  }
 }
 
 /** Resolve an opaque capability without ever accepting an envelope id. */

--- a/packages/trips/src/storefront-trip-offer-resolver-port.ts
+++ b/packages/trips/src/storefront-trip-offer-resolver-port.ts
@@ -1,0 +1,39 @@
+import { definePort } from "@voyant-travel/core/project"
+import type {
+  StorefrontShoppingContext,
+  StorefrontTripSelectionCreate,
+} from "@voyant-travel/storefront/shopping"
+
+import type { StorefrontTripScope } from "./storefront-access.js"
+import type { CreateTripComponentBodyInput } from "./validation.js"
+
+type StorefrontOfferSelection = StorefrontTripSelectionCreate["offers"][number]
+
+export interface StorefrontTripOfferResolutionInput extends StorefrontOfferSelection {
+  scope: StorefrontTripScope
+}
+
+/**
+ * Closed trust-plane seam from a gateway-issued offerRef to a Trips component.
+ * Deployments may resolve only the opaque offerRef plus trusted context/scope;
+ * raw entity, connection, source, or provider selectors never cross this port.
+ */
+export interface StorefrontTripOfferResolver {
+  resolve(
+    context: StorefrontShoppingContext,
+    input: StorefrontTripOfferResolutionInput,
+  ): Promise<{ component: CreateTripComponentBodyInput } | null>
+}
+
+export const storefrontTripOfferResolverPort = definePort<StorefrontTripOfferResolver>({
+  id: "trips.storefront-offer-resolver.runtime",
+  test(provider) {
+    if (
+      provider === null ||
+      typeof provider !== "object" ||
+      typeof (provider as { resolve?: unknown }).resolve !== "function"
+    ) {
+      throw new Error("trips.storefront-offer-resolver.runtime provider must implement resolve().")
+    }
+  },
+})

--- a/packages/trips/src/storefront-trip-selections-runtime.ts
+++ b/packages/trips/src/storefront-trip-selections-runtime.ts
@@ -1,0 +1,457 @@
+import type { AnyDrizzleDb } from "@voyant-travel/db"
+import { randomBytesHex } from "@voyant-travel/hono"
+import {
+  type StorefrontResolvedScope,
+  type StorefrontShoppingContext,
+  type StorefrontTripSelection,
+  type StorefrontTripSelectionCreate,
+  type StorefrontTripSelectionsRuntime,
+  type StorefrontTripSelectionUpdate,
+  storefrontResolvedScopeSchema,
+} from "@voyant-travel/storefront/shopping"
+import { and, eq, isNull } from "drizzle-orm"
+import { z } from "zod"
+
+import type { TripComponent, TripStorefrontAccess } from "./schema.js"
+import { tripStorefrontAccess } from "./schema.js"
+import {
+  addComponent,
+  getTrip,
+  removeComponent,
+  reorderComponents,
+  updateTrip,
+} from "./service-trips.js"
+import type { Trip } from "./service-types.js"
+import {
+  createStorefrontTripInTransaction,
+  resolveStorefrontTripAccess,
+  type StorefrontTripScope,
+} from "./storefront-access.js"
+import type { StorefrontTripOfferResolver } from "./storefront-trip-offer-resolver-port.js"
+import { type CreateTripComponentBodyInput, createTripComponentBodySchema } from "./validation.js"
+
+const storefrontSelectionItemMetadataSchema = z
+  .object({
+    version: z.literal(1),
+    itemRef: z.string().regex(/^tsi_[a-f0-9]{64}$/),
+    kind: z.enum(["product", "flight", "stay", "package"]),
+    quantity: z.number().int().min(1).max(99),
+  })
+  .strict()
+
+type StorefrontOfferSelection = StorefrontTripSelectionCreate["offers"][number]
+
+export class StorefrontTripSelectionUnavailableError extends Error {
+  readonly code = "storefront_trip_selection_unavailable"
+
+  constructor(reason = "offer_resolution_unavailable") {
+    super(`Storefront Trip selection is unavailable: ${reason}.`)
+    this.name = "StorefrontTripSelectionUnavailableError"
+  }
+}
+
+export class StorefrontTripSelectionAccessError extends Error {
+  readonly code = "storefront_trip_selection_not_found"
+
+  constructor() {
+    super("Storefront Trip selection was not found.")
+    this.name = "StorefrontTripSelectionAccessError"
+  }
+}
+
+export class StorefrontTripSelectionConflictError extends Error {
+  readonly code = "storefront_trip_selection_revision_conflict"
+
+  constructor(
+    readonly expectedRevision: number,
+    readonly actualRevision: number,
+  ) {
+    super(
+      `Storefront Trip selection revision conflict: expected ${expectedRevision}, actual ${actualRevision}.`,
+    )
+    this.name = "StorefrontTripSelectionConflictError"
+  }
+}
+
+export class StorefrontTripSelectionMutationError extends Error {
+  readonly code = "storefront_trip_selection_invalid_mutation"
+
+  constructor(message: string) {
+    super(message)
+    this.name = "StorefrontTripSelectionMutationError"
+  }
+}
+
+export interface StorefrontTripSelectionsRuntimeOptions {
+  withTransaction<T>(operation: (db: AnyDrizzleDb) => Promise<T>): Promise<T>
+  offerResolver?: StorefrontTripOfferResolver
+  now?: () => Date
+  createSelectionRef?: () => string
+  createItemRef?: () => string
+}
+
+/** Trips-owned provider for the Storefront gateway's stateful selection port. */
+export function createStorefrontTripSelectionsRuntime(
+  options: StorefrontTripSelectionsRuntimeOptions,
+): StorefrontTripSelectionsRuntime {
+  const createItemRef = options.createItemRef ?? (() => `tsi_${randomBytesHex(32)}`)
+
+  return {
+    async create(context, input) {
+      const offers = await resolveOffers(options.offerResolver, context, input.scope, input.offers)
+      const itemRefs = offers.map(() =>
+        storefrontSelectionItemMetadataSchema.shape.itemRef.parse(createItemRef()),
+      )
+
+      return options.withTransaction(async (db) => {
+        const handle = await createStorefrontTripInTransaction(
+          db,
+          { scope: coreScope(input.scope) },
+          context,
+          {
+            ...(options.now ? { now: options.now } : {}),
+            ...(options.createSelectionRef ? { createCapability: options.createSelectionRef } : {}),
+          },
+        )
+        await updateTrip(db, handle.trip.envelope.id, {
+          constraints: {
+            storefrontScope: handle.scope,
+            storefrontResolvedScope: input.scope,
+          },
+        })
+        const components: TripComponent[] = []
+        for (const [sequence, resolved] of offers.entries()) {
+          components.push(
+            await addComponent(db, {
+              ...resolved.component,
+              envelopeId: handle.trip.envelope.id,
+              sequence,
+              metadata: withSelectionMetadata(
+                resolved.component.metadata,
+                itemRefs[sequence] as string,
+                input.offers[sequence] as StorefrontOfferSelection,
+              ),
+            }),
+          )
+        }
+        return selectionResult(handle.capability, handle.revision, input.scope, components)
+      })
+    },
+
+    async update(context, input) {
+      return options.withTransaction(async (db) => {
+        const resolved = await resolveAuthorizedSelection(
+          db,
+          input.selectionRef,
+          context,
+          options.now,
+        )
+        const components = selectionComponents(resolved.trip)
+        if (resolved.access.revision !== input.expectedRevision) {
+          throw new StorefrontTripSelectionConflictError(
+            input.expectedRevision,
+            resolved.access.revision,
+          )
+        }
+
+        const mutation = await prepareMutation(
+          options.offerResolver,
+          context,
+          accessScope(resolved.access),
+          input,
+          components,
+          createItemRef,
+          resolved.trip.components.reduce(
+            (maximum, component) => Math.max(maximum, component.sequence),
+            -1,
+          ) + 1,
+        )
+        const nextRevision = await compareAndSwapRevision(
+          db,
+          resolved.access,
+          input.expectedRevision,
+          options.now?.() ?? new Date(),
+        )
+
+        if (mutation.kind === "add") {
+          await addComponent(db, {
+            ...mutation.component,
+            envelopeId: resolved.access.envelopeId,
+            sequence: mutation.sequence,
+            metadata: withSelectionMetadata(
+              mutation.component.metadata,
+              mutation.itemRef,
+              mutation.offer,
+            ),
+          })
+        } else if (mutation.kind === "remove") {
+          await removeComponent(db, mutation.component.id)
+        } else {
+          await reorderComponents(db, {
+            envelopeId: resolved.access.envelopeId,
+            componentIds: mutation.components.map((component) => component.id),
+          })
+        }
+
+        const trip = await getTrip(db, resolved.access.envelopeId)
+        if (!trip) throw new StorefrontTripSelectionAccessError()
+        return selectionResult(
+          input.selectionRef,
+          nextRevision,
+          resolvedScope(resolved.access, trip),
+          selectionComponents(trip),
+        )
+      })
+    },
+  }
+}
+
+async function resolveOffers(
+  resolver: StorefrontTripOfferResolver | undefined,
+  context: StorefrontShoppingContext,
+  scope: StorefrontResolvedScope,
+  offers: StorefrontTripSelectionCreate["offers"],
+): Promise<Array<{ component: CreateTripComponentBodyInput }>> {
+  const resolved: Array<{ component: CreateTripComponentBodyInput }> = []
+  for (const offer of offers) {
+    resolved.push(await resolveOffer(resolver, context, coreScope(scope), offer))
+  }
+  return resolved
+}
+
+async function resolveOffer(
+  resolver: StorefrontTripOfferResolver | undefined,
+  context: StorefrontShoppingContext,
+  scope: StorefrontTripScope,
+  offer: StorefrontOfferSelection,
+): Promise<{ component: CreateTripComponentBodyInput }> {
+  if (!resolver) throw new StorefrontTripSelectionUnavailableError()
+  const resolution = await resolver.resolve(context, { ...offer, scope })
+  if (!resolution) throw new StorefrontTripSelectionUnavailableError("offer_unavailable")
+  return { component: createTripComponentBodySchema.parse(resolution.component) }
+}
+
+async function resolveAuthorizedSelection(
+  db: AnyDrizzleDb,
+  selectionRef: string,
+  context: StorefrontShoppingContext,
+  now: (() => Date) | undefined,
+): Promise<{ access: TripStorefrontAccess; trip: Trip }> {
+  const resolution = await resolveStorefrontTripAccess(db, selectionRef, context, {
+    ...(now ? { now } : {}),
+  })
+  if (!resolution.ok) throw new StorefrontTripSelectionAccessError()
+  assertScopeIntegrity(resolution.access, resolution.trip)
+  return resolution
+}
+
+function assertScopeIntegrity(access: TripStorefrontAccess, trip: Trip): void {
+  const constraints = trip.envelope.constraints
+  const stored =
+    constraints && typeof constraints === "object" && !Array.isArray(constraints)
+      ? (constraints as Record<string, unknown>).storefrontScope
+      : undefined
+  const parsed = z
+    .object({ marketId: z.string(), locale: z.string(), currency: z.string() })
+    .strict()
+    .safeParse(stored)
+  if (
+    !parsed.success ||
+    parsed.data.marketId !== access.marketId ||
+    parsed.data.locale !== access.locale ||
+    parsed.data.currency !== access.currency
+  ) {
+    throw new StorefrontTripSelectionAccessError()
+  }
+  resolvedScope(access, trip)
+}
+
+type PreparedMutation =
+  | {
+      kind: "add"
+      offer: StorefrontOfferSelection
+      itemRef: string
+      sequence: number
+      component: CreateTripComponentBodyInput
+    }
+  | { kind: "remove"; component: TripComponent }
+  | { kind: "reorder"; components: TripComponent[] }
+
+async function prepareMutation(
+  resolver: StorefrontTripOfferResolver | undefined,
+  context: StorefrontShoppingContext,
+  scope: StorefrontTripScope,
+  input: StorefrontTripSelectionUpdate,
+  components: TripComponent[],
+  createItemRef: () => string,
+  nextSequence: number,
+): Promise<PreparedMutation> {
+  const byItemRef = new Map(
+    components.map((component) => [selectionItem(component).itemRef, component]),
+  )
+  if (input.mutation.kind === "add") {
+    const resolved = await resolveOffer(resolver, context, scope, input.mutation.offer)
+    return {
+      kind: "add",
+      offer: input.mutation.offer,
+      itemRef: storefrontSelectionItemMetadataSchema.shape.itemRef.parse(createItemRef()),
+      sequence: nextSequence,
+      component: resolved.component,
+    }
+  }
+  if (input.mutation.kind === "remove") {
+    const component = byItemRef.get(input.mutation.itemRef)
+    if (!component) {
+      throw new StorefrontTripSelectionMutationError("Selection item was not found.")
+    }
+    return { kind: "remove", component }
+  }
+
+  if (
+    input.mutation.itemRefs.length !== components.length ||
+    new Set(input.mutation.itemRefs).size !== components.length
+  ) {
+    throw new StorefrontTripSelectionMutationError(
+      "Reorder must contain every selection item exactly once.",
+    )
+  }
+  const reordered = input.mutation.itemRefs.map((itemRef) => byItemRef.get(itemRef))
+  if (reordered.some((component) => component === undefined)) {
+    throw new StorefrontTripSelectionMutationError(
+      "Reorder must contain every selection item exactly once.",
+    )
+  }
+  return { kind: "reorder", components: reordered as TripComponent[] }
+}
+
+async function compareAndSwapRevision(
+  db: AnyDrizzleDb,
+  access: TripStorefrontAccess,
+  expectedRevision: number,
+  now: Date,
+): Promise<number> {
+  const nextRevision = expectedRevision + 1
+  const [updated] = (await db
+    .update(tripStorefrontAccess)
+    .set({ revision: nextRevision, updatedAt: now })
+    .where(
+      and(
+        eq(tripStorefrontAccess.envelopeId, access.envelopeId),
+        eq(tripStorefrontAccess.capabilityDigest, access.capabilityDigest),
+        eq(tripStorefrontAccess.storefrontId, access.storefrontId),
+        eq(tripStorefrontAccess.channelId, access.channelId),
+        eq(tripStorefrontAccess.marketId, access.marketId),
+        eq(tripStorefrontAccess.locale, access.locale),
+        eq(tripStorefrontAccess.currency, access.currency),
+        access.ownerUserId === null
+          ? isNull(tripStorefrontAccess.ownerUserId)
+          : eq(tripStorefrontAccess.ownerUserId, access.ownerUserId),
+        access.ownerBuyerAccountId === null
+          ? isNull(tripStorefrontAccess.ownerBuyerAccountId)
+          : eq(tripStorefrontAccess.ownerBuyerAccountId, access.ownerBuyerAccountId),
+        eq(tripStorefrontAccess.revision, expectedRevision),
+      ),
+    )
+    .returning()) as TripStorefrontAccess[]
+  if (updated) return updated.revision
+
+  const [actual] = (await db
+    .select()
+    .from(tripStorefrontAccess)
+    .where(eq(tripStorefrontAccess.envelopeId, access.envelopeId))
+    .limit(1)) as TripStorefrontAccess[]
+  if (!actual) throw new StorefrontTripSelectionAccessError()
+  if (!sameAccessBoundary(access, actual)) throw new StorefrontTripSelectionAccessError()
+  throw new StorefrontTripSelectionConflictError(expectedRevision, actual.revision)
+}
+
+function sameAccessBoundary(expected: TripStorefrontAccess, actual: TripStorefrontAccess): boolean {
+  return (
+    expected.capabilityDigest === actual.capabilityDigest &&
+    expected.storefrontId === actual.storefrontId &&
+    expected.channelId === actual.channelId &&
+    expected.marketId === actual.marketId &&
+    expected.locale === actual.locale &&
+    expected.currency === actual.currency &&
+    expected.ownerUserId === actual.ownerUserId &&
+    expected.ownerBuyerAccountId === actual.ownerBuyerAccountId
+  )
+}
+
+function selectionComponents(trip: Trip): TripComponent[] {
+  const active = trip.components.filter(
+    (component) => component.status !== "removed" && component.status !== "cancelled",
+  )
+  for (const component of active) selectionItem(component)
+  return active.sort((left, right) => left.sequence - right.sequence)
+}
+
+function selectionItem(
+  component: TripComponent,
+): z.infer<typeof storefrontSelectionItemMetadataSchema> {
+  const parsed = storefrontSelectionItemMetadataSchema.safeParse(
+    (component.metadata as Record<string, unknown>).storefrontSelection,
+  )
+  if (!parsed.success) {
+    throw new StorefrontTripSelectionAccessError()
+  }
+  return parsed.data
+}
+
+function withSelectionMetadata(
+  metadata: Record<string, unknown>,
+  itemRef: string,
+  offer: StorefrontOfferSelection,
+): Record<string, unknown> {
+  return {
+    ...metadata,
+    storefrontSelection: {
+      version: 1,
+      itemRef,
+      kind: offer.kind,
+      quantity: offer.quantity ?? 1,
+    },
+  }
+}
+
+function selectionResult(
+  selectionRef: string,
+  revision: number,
+  scope: StorefrontResolvedScope,
+  components: TripComponent[],
+): StorefrontTripSelection {
+  return {
+    selectionRef,
+    revision,
+    scope,
+    items: components.map((component) => {
+      const item = selectionItem(component)
+      return { itemRef: item.itemRef, kind: item.kind, quantity: item.quantity }
+    }),
+  }
+}
+
+function coreScope(scope: StorefrontResolvedScope): StorefrontTripScope {
+  return { marketId: scope.marketId, locale: scope.locale, currency: scope.currency }
+}
+
+function accessScope(access: TripStorefrontAccess): StorefrontTripScope {
+  return { marketId: access.marketId, locale: access.locale, currency: access.currency }
+}
+
+function resolvedScope(access: TripStorefrontAccess, trip: Trip): StorefrontResolvedScope {
+  const constraints = trip.envelope.constraints as Record<string, unknown>
+  const scope = storefrontResolvedScopeSchema.safeParse(constraints.storefrontResolvedScope)
+  if (!scope.success || !sameScope(access, scope.data)) {
+    throw new StorefrontTripSelectionAccessError()
+  }
+  return scope.data
+}
+
+function sameScope(access: TripStorefrontAccess, scope: StorefrontTripScope): boolean {
+  return (
+    access.marketId === scope.marketId &&
+    access.locale === scope.locale &&
+    access.currency === scope.currency
+  )
+}

--- a/packages/trips/src/voyant.ts
+++ b/packages/trips/src/voyant.ts
@@ -4,9 +4,11 @@ import {
   storefrontPaymentLinkRuntimePort,
   storefrontPaymentReconciliationJobRuntimePort,
 } from "@voyant-travel/storefront/runtime-port"
+import { storefrontTripSelectionsRuntimePort } from "@voyant-travel/storefront/shopping/runtime-port"
 import { durableTripActionRuntimePort } from "./durable-action-runtime-port.js"
 import { tripsDatabaseRuntimePort, tripsRoutesRuntimePort } from "./runtime-port.js"
 import { tripsSourcingJobRuntimePort } from "./sourcing-job-runtime-port.js"
+import { storefrontTripOfferResolverPort } from "./storefront-trip-offer-resolver-port.js"
 
 const catalogRuntimeServicesPortReference = { id: "catalog.runtime-services" } as const
 const catalogCheckoutApiRuntimePortReference = { id: "commerce.checkout-api-options" } as const
@@ -107,6 +109,7 @@ export const tripsVoyantModule = defineModule({
       providePort(commerceCardPaymentRuntimePort),
       providePort(storefrontPaymentLinkRuntimePort),
       providePort(storefrontPaymentReconciliationJobRuntimePort),
+      providePort(storefrontTripSelectionsRuntimePort),
       providePort(tripsRoutesRuntimePort),
       providePort(tripsDatabaseRuntimePort),
       providePort(tripsSourcingJobRuntimePort),
@@ -118,6 +121,7 @@ export const tripsVoyantModule = defineModule({
     requirePort(tripsDatabaseRuntimePort),
     requirePort(tripsSourcingJobRuntimePort),
     requirePort(durableTripActionRuntimePort, { optional: true }),
+    requirePort(storefrontTripOfferResolverPort, { optional: true }),
     { ...paymentAdapterRuntimePortReference, optional: true },
     catalogRuntimeServicesPortReference,
     catalogCheckoutApiRuntimePortReference,

--- a/packages/trips/tests/package-exports.test.ts
+++ b/packages/trips/tests/package-exports.test.ts
@@ -19,6 +19,25 @@ const packageJson = JSON.parse(
 ) as PackageJson
 
 describe("@voyant-travel/trips package exports", () => {
+  it("publishes the Storefront Trip selections provider subpath", () => {
+    expect(packageJson.exports["./storefront-trip-offer-resolver-port"]).toBe(
+      "./src/storefront-trip-offer-resolver-port.ts",
+    )
+    expect(packageJson.publishConfig.exports["./storefront-trip-offer-resolver-port"]).toEqual({
+      types: "./dist/storefront-trip-offer-resolver-port.d.ts",
+      import: "./dist/storefront-trip-offer-resolver-port.js",
+      default: "./dist/storefront-trip-offer-resolver-port.js",
+    })
+    expect(packageJson.exports["./storefront-trip-selections-runtime"]).toBe(
+      "./src/storefront-trip-selections-runtime.ts",
+    )
+    expect(packageJson.publishConfig.exports["./storefront-trip-selections-runtime"]).toEqual({
+      types: "./dist/storefront-trip-selections-runtime.d.ts",
+      import: "./dist/storefront-trip-selections-runtime.js",
+      default: "./dist/storefront-trip-selections-runtime.js",
+    })
+  })
+
   it("publishes the payment subscriber runtime subpath", () => {
     expect(packageJson.exports["./payment-subscribers"]).toBe("./src/payment-subscriber-runtime.ts")
     expect(packageJson.publishConfig.exports["./payment-subscribers"]).toEqual({

--- a/packages/trips/tests/storefront-trip-selections-runtime.test.ts
+++ b/packages/trips/tests/storefront-trip-selections-runtime.test.ts
@@ -1,0 +1,520 @@
+import type { AnyDrizzleDb } from "@voyant-travel/db"
+import { sha256Hex } from "@voyant-travel/hono"
+import type { StorefrontShoppingContext } from "@voyant-travel/storefront/shopping"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  type TripComponent,
+  type TripEnvelope,
+  type TripStorefrontAccess,
+  tripComponents,
+  tripEnvelopes,
+  tripStorefrontAccess,
+} from "../src/schema.js"
+import type { StorefrontTripOfferResolutionInput } from "../src/storefront-trip-offer-resolver-port.js"
+import {
+  createStorefrontTripSelectionsRuntime,
+  StorefrontTripSelectionAccessError,
+  StorefrontTripSelectionConflictError,
+  StorefrontTripSelectionUnavailableError,
+} from "../src/storefront-trip-selections-runtime.js"
+
+const NOW = new Date("2026-08-08T10:00:00.000Z")
+const CAPABILITY = `tcap_${"a".repeat(64)}`
+const ITEM_ONE = `tsi_${"b".repeat(64)}`
+const ITEM_TWO = `tsi_${"c".repeat(64)}`
+const CONTEXT = {
+  storefrontId: "storefront_bucharest",
+  channelId: "channel_direct",
+  userId: "customer_1",
+  buyerAccountId: "buyer_1",
+}
+const SCOPE = {
+  marketId: "market_ro",
+  locale: "ro-RO",
+  currency: "EUR",
+  available: {
+    marketIds: ["market_ro"],
+    locales: ["ro-RO"],
+    currencies: ["EUR"],
+  },
+}
+
+describe("Storefront Trip selections runtime", () => {
+  it("fails unavailable without an offerRef resolver and never treats a Trip id as a selection", async () => {
+    const state = await seededState()
+    const runtime = createStorefrontTripSelectionsRuntime({
+      withTransaction: (operation) => operation(createDb(state)),
+      now: () => NOW,
+    })
+
+    await expect(
+      runtime.create(CONTEXT, {
+        scope: SCOPE,
+        offers: [{ kind: "product", offerRef: "offer-public-ref-0001" }],
+      }),
+    ).rejects.toBeInstanceOf(StorefrontTripSelectionUnavailableError)
+    await expect(
+      runtime.update(CONTEXT, {
+        selectionRef: "trip_storefront_internal_0001",
+        expectedRevision: 1,
+        mutation: { kind: "remove", itemRef: ITEM_ONE },
+      }),
+    ).rejects.toBeInstanceOf(StorefrontTripSelectionAccessError)
+  })
+
+  it("creates and mutates only through opaque references with deterministic ordering", async () => {
+    const state = emptyState()
+    const resolver = {
+      resolve: vi.fn(
+        async (_context: StorefrontShoppingContext, input: StorefrontTripOfferResolutionInput) => ({
+          component: {
+            kind: "catalog_booking" as const,
+            catalogRef: {
+              entityModule: input.kind === "stay" ? "accommodations" : "products",
+              entityId: `internal_${input.offerRef}`,
+              sourceKind: "owned",
+            },
+            metadata:
+              input.kind === "stay"
+                ? {
+                    bookingDraftV1: {
+                      configure: {
+                        dateRange: { checkIn: "2026-09-01", checkOut: "2026-09-03" },
+                      },
+                    },
+                  }
+                : {},
+          },
+        }),
+      ),
+    }
+    const itemRefs = [ITEM_ONE, ITEM_TWO]
+    const runtime = createStorefrontTripSelectionsRuntime({
+      withTransaction: (operation) => operation(createDb(state)),
+      offerResolver: resolver,
+      now: () => NOW,
+      createSelectionRef: () => CAPABILITY,
+      createItemRef: () => itemRefs.shift() as string,
+    })
+
+    const created = await runtime.create(CONTEXT, {
+      scope: SCOPE,
+      offers: [{ kind: "product", offerRef: "offer-public-ref-0001", quantity: 2 }],
+    })
+    const added = await runtime.update(CONTEXT, {
+      selectionRef: created.selectionRef,
+      expectedRevision: created.revision,
+      mutation: { kind: "add", offer: { kind: "stay", offerRef: "offer-public-ref-0002" } },
+    })
+    const reordered = await runtime.update(CONTEXT, {
+      selectionRef: added.selectionRef,
+      expectedRevision: added.revision,
+      mutation: { kind: "reorder", itemRefs: [ITEM_TWO, ITEM_ONE] },
+    })
+    const removed = await runtime.update(CONTEXT, {
+      selectionRef: reordered.selectionRef,
+      expectedRevision: reordered.revision,
+      mutation: { kind: "remove", itemRef: ITEM_ONE },
+    })
+
+    expect(created).toMatchObject({
+      selectionRef: CAPABILITY,
+      revision: 1,
+      items: [{ itemRef: ITEM_ONE, kind: "product", quantity: 2 }],
+    })
+    expect(added.items.map((item) => item.itemRef)).toEqual([ITEM_ONE, ITEM_TWO])
+    expect(reordered.items.map((item) => item.itemRef)).toEqual([ITEM_TWO, ITEM_ONE])
+    expect(removed.items.map((item) => item.itemRef)).toEqual([ITEM_TWO])
+    expect(removed.revision).toBe(4)
+    expect(resolver.resolve).toHaveBeenNthCalledWith(1, CONTEXT, {
+      kind: "product",
+      offerRef: "offer-public-ref-0001",
+      quantity: 2,
+      scope: { marketId: "market_ro", locale: "ro-RO", currency: "EUR" },
+    })
+    expect(JSON.stringify(created)).not.toContain("internal_offer")
+    expect(JSON.stringify(state.access)).not.toContain(CAPABILITY)
+  })
+
+  it("rejects replayed and concurrently stale mutations without applying them", async () => {
+    const state = await seededState()
+    const resolve = vi.fn(async () => ({
+      component: { kind: "catalog_booking" as const, metadata: {} },
+    }))
+    const runtime = createStorefrontTripSelectionsRuntime({
+      withTransaction: (operation) => operation(createDb(state)),
+      offerResolver: { resolve },
+      now: () => NOW,
+      createItemRef: () => ITEM_TWO,
+    })
+    const request = {
+      selectionRef: CAPABILITY,
+      expectedRevision: 1,
+      mutation: {
+        kind: "add" as const,
+        offer: { kind: "flight" as const, offerRef: "flight-offer-ref-001" },
+      },
+    }
+
+    await expect(runtime.update(CONTEXT, request)).resolves.toMatchObject({ revision: 2 })
+    await expect(runtime.update(CONTEXT, request)).rejects.toMatchObject({
+      code: "storefront_trip_selection_revision_conflict",
+      expectedRevision: 1,
+      actualRevision: 2,
+    })
+    expect(resolve).toHaveBeenCalledOnce()
+    expect(state.components).toHaveLength(2)
+
+    const concurrent = await seededState()
+    concurrent.forceCasConflictRevision = 2
+    const concurrentRuntime = createStorefrontTripSelectionsRuntime({
+      withTransaction: (operation) => operation(createDb(concurrent)),
+      now: () => NOW,
+    })
+    await expect(
+      concurrentRuntime.update(CONTEXT, {
+        selectionRef: CAPABILITY,
+        expectedRevision: 1,
+        mutation: { kind: "remove", itemRef: ITEM_ONE },
+      }),
+    ).rejects.toEqual(new StorefrontTripSelectionConflictError(1, 2))
+    expect(concurrent.components[0]?.status).toBe("draft")
+  })
+
+  it("keeps the revision unchanged when add, remove, or reorder validation fails", async () => {
+    const state = await seededState()
+    const runtime = createStorefrontTripSelectionsRuntime({
+      withTransaction: (operation) => operation(createDb(state)),
+      now: () => NOW,
+    })
+
+    await expect(
+      runtime.update(CONTEXT, {
+        selectionRef: CAPABILITY,
+        expectedRevision: 1,
+        mutation: {
+          kind: "add",
+          offer: { kind: "flight", offerRef: "flight-offer-ref-001" },
+        },
+      }),
+    ).rejects.toBeInstanceOf(StorefrontTripSelectionUnavailableError)
+    expect(state.access?.revision).toBe(1)
+
+    await expect(
+      runtime.update(CONTEXT, {
+        selectionRef: CAPABILITY,
+        expectedRevision: 1,
+        mutation: { kind: "remove", itemRef: ITEM_TWO },
+      }),
+    ).rejects.toMatchObject({ code: "storefront_trip_selection_invalid_mutation" })
+    expect(state.access?.revision).toBe(1)
+
+    await expect(
+      runtime.update(CONTEXT, {
+        selectionRef: CAPABILITY,
+        expectedRevision: 1,
+        mutation: { kind: "reorder", itemRefs: [ITEM_ONE, ITEM_ONE] },
+      }),
+    ).rejects.toMatchObject({ code: "storefront_trip_selection_invalid_mutation" })
+    expect(state.access?.revision).toBe(1)
+    expect(state.components[0]?.status).toBe("draft")
+  })
+
+  it("rejects an expired selection before mutation", async () => {
+    const state = await seededState()
+    state.access = {
+      ...(state.access as TripStorefrontAccess),
+      expiresAt: new Date("2026-08-08T09:59:59.000Z"),
+    }
+    const runtime = createStorefrontTripSelectionsRuntime({
+      withTransaction: (operation) => operation(createDb(state)),
+      now: () => NOW,
+    })
+
+    await expect(
+      runtime.update(CONTEXT, {
+        selectionRef: CAPABILITY,
+        expectedRevision: 1,
+        mutation: { kind: "remove", itemRef: ITEM_ONE },
+      }),
+    ).rejects.toBeInstanceOf(StorefrontTripSelectionAccessError)
+    expect(state.access?.revision).toBe(1)
+  })
+
+  it.each([
+    { context: { ...CONTEXT, storefrontId: "storefront_other" }, boundary: "storefront" },
+    { context: { ...CONTEXT, channelId: "channel_other" }, boundary: "channel" },
+    { context: { ...CONTEXT, userId: "customer_other" }, boundary: "customer" },
+    { context: { ...CONTEXT, buyerAccountId: "buyer_other" }, boundary: "buyer account" },
+  ])("isolates selections from a different $boundary", async ({ context }) => {
+    const state = await seededState()
+    const runtime = createStorefrontTripSelectionsRuntime({
+      withTransaction: (operation) => operation(createDb(state)),
+      now: () => NOW,
+    })
+
+    await expect(
+      runtime.update(context, {
+        selectionRef: CAPABILITY,
+        expectedRevision: 1,
+        mutation: { kind: "remove", itemRef: ITEM_ONE },
+      }),
+    ).rejects.toBeInstanceOf(StorefrontTripSelectionAccessError)
+    expect(state.access?.revision).toBe(1)
+    expect(state.components[0]?.status).toBe("draft")
+  })
+
+  it("fails closed when persisted access and Trip scope drift", async () => {
+    const state = await seededState()
+    state.envelope = {
+      ...state.envelope,
+      constraints: {
+        storefrontScope: { marketId: "market_ro", locale: "ro-RO", currency: "USD" },
+      },
+    }
+    const runtime = createStorefrontTripSelectionsRuntime({
+      withTransaction: (operation) => operation(createDb(state)),
+      now: () => NOW,
+    })
+
+    await expect(
+      runtime.update(CONTEXT, {
+        selectionRef: CAPABILITY,
+        expectedRevision: 1,
+        mutation: { kind: "remove", itemRef: ITEM_ONE },
+      }),
+    ).rejects.toBeInstanceOf(StorefrontTripSelectionAccessError)
+  })
+})
+
+interface State {
+  envelope?: TripEnvelope
+  access?: TripStorefrontAccess
+  components: TripComponent[]
+  nextComponent: number
+  forceCasConflictRevision?: number
+}
+
+function emptyState(): State {
+  return { components: [], nextComponent: 1 }
+}
+
+async function seededState(): Promise<State> {
+  return {
+    envelope: envelopeRow(),
+    access: {
+      envelopeId: "trip_storefront_1",
+      capabilityDigest: await sha256Hex(CAPABILITY),
+      storefrontId: CONTEXT.storefrontId,
+      channelId: CONTEXT.channelId,
+      marketId: SCOPE.marketId,
+      locale: SCOPE.locale,
+      currency: SCOPE.currency,
+      ownerUserId: CONTEXT.userId,
+      ownerBuyerAccountId: CONTEXT.buyerAccountId,
+      revision: 1,
+      expiresAt: new Date("2026-09-01T00:00:00.000Z"),
+      createdAt: NOW,
+      updatedAt: NOW,
+    },
+    components: [
+      componentRow({
+        id: "trip_component_internal_1",
+        metadata: {
+          storefrontSelection: {
+            version: 1,
+            itemRef: ITEM_ONE,
+            kind: "product",
+            quantity: 1,
+          },
+        },
+      }),
+    ],
+    nextComponent: 2,
+  }
+}
+
+function createDb(state: State): AnyDrizzleDb {
+  const db = {
+    transaction: async (operation: (transaction: unknown) => unknown) => operation(db),
+    insert: (table: unknown) => ({
+      values: (values: Record<string, unknown>) => ({
+        returning: async () => {
+          if (table === tripEnvelopes) {
+            state.envelope = { ...envelopeRow(), ...(values as Partial<TripEnvelope>) }
+            return [state.envelope]
+          }
+          if (table === tripStorefrontAccess) {
+            state.access = {
+              envelopeId: state.envelope?.id ?? "trip_storefront_1",
+              capabilityDigest: "",
+              storefrontId: "",
+              channelId: "",
+              marketId: "",
+              locale: "",
+              currency: "",
+              ownerUserId: null,
+              ownerBuyerAccountId: null,
+              revision: 1,
+              expiresAt: NOW,
+              createdAt: NOW,
+              updatedAt: NOW,
+              ...(values as Partial<TripStorefrontAccess>),
+            } as TripStorefrontAccess
+            return [state.access]
+          }
+          if (table === tripComponents) {
+            const component = componentRow({
+              ...(values as Partial<TripComponent>),
+              id: `trip_component_internal_${state.nextComponent++}`,
+            })
+            state.components.push(component)
+            return [component]
+          }
+          return []
+        },
+      }),
+    }),
+    select: () => ({
+      from: (table: unknown) => ({
+        where: () => {
+          const rows =
+            table === tripStorefrontAccess
+              ? state.access
+                ? [state.access]
+                : []
+              : table === tripEnvelopes
+                ? state.envelope
+                  ? [state.envelope]
+                  : []
+                : table === tripComponents
+                  ? state.components
+                  : []
+          return Object.assign(Promise.resolve(rows), {
+            limit: async () => {
+              if (table === tripStorefrontAccess) return state.access ? [state.access] : []
+              if (table === tripEnvelopes) return state.envelope ? [state.envelope] : []
+              if (table === tripComponents) {
+                return state.components.length > 0 ? [state.components[0]] : []
+              }
+              return []
+            },
+            orderBy: async () =>
+              table === tripComponents
+                ? [...state.components].sort((left, right) => left.sequence - right.sequence)
+                : [],
+          })
+        },
+      }),
+    }),
+    update: (table: unknown) => ({
+      set: (values: Record<string, unknown>) => ({
+        where: () => ({
+          returning: async () => {
+            if (table === tripStorefrontAccess) {
+              if (state.forceCasConflictRevision !== undefined) {
+                state.access = {
+                  ...(state.access as TripStorefrontAccess),
+                  revision: state.forceCasConflictRevision,
+                }
+                state.forceCasConflictRevision = undefined
+                return []
+              }
+              if (!state.access || state.access.revision !== Number(values.revision) - 1) return []
+              state.access = { ...state.access, ...values }
+              return [state.access]
+            }
+            if (table === tripComponents) {
+              const component =
+                values.sequence === undefined
+                  ? state.components[0]
+                  : [...state.components].reverse()[Number(values.sequence)]
+              if (!component) return []
+              Object.assign(component, values)
+              return [component]
+            }
+            if (table === tripEnvelopes && state.envelope) {
+              state.envelope = { ...state.envelope, ...(values as Partial<TripEnvelope>) }
+              return [state.envelope]
+            }
+            return []
+          },
+        }),
+      }),
+    }),
+  }
+  return db as AnyDrizzleDb
+}
+
+function envelopeRow(): TripEnvelope {
+  return {
+    id: "trip_storefront_1",
+    status: "draft",
+    title: null,
+    description: null,
+    travelerParty: {},
+    constraints: {
+      storefrontScope: { marketId: "market_ro", locale: "ro-RO", currency: "EUR" },
+      storefrontResolvedScope: SCOPE,
+    },
+    aggregateCurrency: null,
+    aggregateSubtotalAmountCents: null,
+    aggregateTaxAmountCents: null,
+    aggregateTotalAmountCents: null,
+    aggregatePricingSnapshot: null,
+    currentPriceExpiresAt: null,
+    bookingGroupId: null,
+    orderId: null,
+    paymentSessionId: null,
+    reserveIdempotencyKey: null,
+    reserveStartedAt: null,
+    reservedAt: null,
+    checkoutIdempotencyKey: null,
+    checkoutStartedAt: null,
+    createdBy: `storefront:${CONTEXT.storefrontId}:customer:${CONTEXT.userId}`,
+    updatedBy: `storefront:${CONTEXT.storefrontId}:customer:${CONTEXT.userId}`,
+    createdAt: NOW,
+    updatedAt: NOW,
+  }
+}
+
+function componentRow(overrides: Partial<TripComponent>): TripComponent {
+  return {
+    id: "trip_component_internal_1",
+    envelopeId: "trip_storefront_1",
+    sequence: 0,
+    kind: "catalog_booking",
+    status: "draft",
+    title: null,
+    description: null,
+    entityModule: null,
+    entityId: null,
+    sourceKind: null,
+    sourceConnectionId: null,
+    sourceRef: null,
+    bookingDraftId: null,
+    catalogQuoteId: null,
+    bookingId: null,
+    bookingGroupId: null,
+    orderId: null,
+    paymentSessionId: null,
+    providerRef: null,
+    supplierRef: null,
+    componentCurrency: null,
+    componentSubtotalAmountCents: null,
+    componentTaxAmountCents: null,
+    componentTotalAmountCents: null,
+    pricingSnapshot: null,
+    taxLines: [],
+    cancellationSnapshot: null,
+    holdToken: null,
+    holdExpiresAt: null,
+    priceExpiresAt: null,
+    warningCodes: [],
+    metadata: {},
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  }
+}

--- a/packages/trips/tests/voyant-manifest.test.ts
+++ b/packages/trips/tests/voyant-manifest.test.ts
@@ -8,10 +8,12 @@ import {
   type PaymentAdapter,
   paymentAdapterRuntimePort,
 } from "@voyant-travel/payments"
+import { storefrontTripSelectionsRuntimePort } from "@voyant-travel/storefront/shopping"
 import { describe, expect, it, vi } from "vitest"
 
 import {
   createTripsVoyantRuntime,
+  storefrontTripOfferResolverPort,
   type TripsDatabaseRuntime,
   tripsDatabaseRuntimePort,
   tripsRoutesRuntimePort,
@@ -32,6 +34,7 @@ describe("trips deployment manifest", () => {
           { id: "commerce.card-payment.runtime" },
           { id: "storefront.payment-link.runtime" },
           { id: "storefront.payment-reconciliation-job.runtime" },
+          { id: "storefront.trip-selections.runtime" },
           { id: "trips.routes-runtime" },
           { id: "trips.database-runtime" },
           { id: "trips.sourcing-job-runtime" },
@@ -43,6 +46,7 @@ describe("trips deployment manifest", () => {
         { id: "trips.database-runtime" },
         { id: "trips.sourcing-job-runtime" },
         { id: "trips.durable-action-runtime", optional: true },
+        { id: "trips.storefront-offer-resolver.runtime", optional: true },
         { id: "payments.adapter.runtime", optional: true },
         { id: "catalog.runtime-services" },
         { id: "commerce.checkout-api-options" },
@@ -140,6 +144,21 @@ describe("trips deployment manifest", () => {
     expect(withAdapter).toHaveProperty(commerceCardPaymentRuntimePort.id)
   })
 
+  it("publishes the Storefront Trip selection runtime and resolves offers only through its port", async () => {
+    const resolve = vi.fn(async () => null)
+    const contribution = createTripsRuntimePortContribution({
+      primitives: { database: { transaction: vi.fn() } } as never,
+      hasRuntimePort: (port) => port.id === storefrontTripOfferResolverPort.id,
+      getRuntimePort: ((port: { id: string }) => {
+        if (port.id === storefrontTripOfferResolverPort.id) return { resolve }
+        return stubRequiredRuntimePortResolver()(port as never)
+      }) as never,
+    })
+
+    expect(contribution).toHaveProperty(storefrontTripSelectionsRuntimePort.id)
+    expect(() => storefrontTripOfferResolverPort.test({} as never)).toThrow(/resolve/)
+  })
+
   it("does not resolve the optional flights runtime when flights are not selected", async () => {
     const registerCompositeBookingSessionHandler = vi.fn()
     const getRuntimePort = vi.fn((port: { id: string }) => {
@@ -149,7 +168,8 @@ describe("trips deployment manifest", () => {
     })
     const contribution = createTripsRuntimePortContribution({
       primitives: { database: { transaction: vi.fn() } } as never,
-      hasRuntimePort: (port) => port.id !== "flights.runtime",
+      hasRuntimePort: (port) =>
+        port.id !== "flights.runtime" && port.id !== storefrontTripOfferResolverPort.id,
       getRuntimePort: getRuntimePort as never,
     })
 

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -1988,6 +1988,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/runtime-port": [
+        "../storefront/dist/shopping/runtime-port.d.ts"
+      ],
       "@voyant-travel/storefront/tools": ["../storefront/dist/mcp-runtime.d.ts"],
       "@voyant-travel/storefront/transport-eligibility": [
         "../storefront/dist/transport-eligibility.d.ts"
@@ -2039,6 +2042,12 @@
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],
       "@voyant-travel/trips/sourcing-job": ["../trips/dist/sourcing-job.d.ts"],
+      "@voyant-travel/trips/storefront-trip-offer-resolver-port": [
+        "../trips/dist/storefront-trip-offer-resolver-port.d.ts"
+      ],
+      "@voyant-travel/trips/storefront-trip-selections-runtime": [
+        "../trips/dist/storefront-trip-selections-runtime.d.ts"
+      ],
       "@voyant-travel/trips/tools": ["../trips/dist/mcp-runtime.d.ts"],
       "@voyant-travel/trips/validation": ["../trips/dist/validation.d.ts"],
       "@voyant-travel/trips/voyant": ["../trips/dist/voyant.d.ts"],

--- a/scripts/checks/graph/graph-conformance.json
+++ b/scripts/checks/graph/graph-conformance.json
@@ -17,6 +17,8 @@
       "portIds": [
         "trips.routes-runtime",
         "trips.database-runtime",
+        "storefront.trip-selections.runtime",
+        "trips.storefront-offer-resolver.runtime",
         "catalog.runtime-services",
         "commerce.checkout-api-options",
         "flights.runtime"


### PR DESCRIPTION
## What changed

- provide `storefront.trip-selections.runtime` from Trips using the existing Storefront Trip capability and component services
- bind selection access to trusted storefront/channel plus optional managed user and buyer-account identity, with persisted scope integrity checks
- add opaque item references and atomic expected-revision CAS for create/add/remove/reorder semantics
- define an optional closed offerRef resolver port that fails unavailable instead of accepting raw Trip, source, connection, or provider selectors
- wire the provider through the Trips graph manifest and publish the provider/resolver subpaths

## Why

The managed Storefront shopping gateway defines an opaque stateful selection contract, while OSS Trips owns durable itinerary composition. This adapter joins those surfaces without moving customer-account, booking-engine, payment, or FX authority into themes or browser input.

## Verification

- targeted Biome check on all changed Trips source/test/manifest files (pass)
- `git diff --check` / committed patch check (pass)
- remote narrow test/typecheck dispatch was attempted but lab1 returned no job/result; package typecheck/tests remain to be confirmed

## Stack

Base: #4436 (`feat/storefront-shopping-gateway`, `1322f5694f338946543f4470f5ee0ec15db29086`).