### PR TITLE
feat(storefront): expose provider-first public shopping gateway

### DIFF
--- a/packages/hono/src/middleware/body-size.ts
+++ b/packages/hono/src/middleware/body-size.ts
@@ -72,11 +72,13 @@ export function requestBodyLimit(options: RequestBodyLimitOptions): MiddlewareHa
 }
 
 function tooLargeResponse(c: Context, maxBytes: number): Response {
+  const requestId = c.get("requestId" as never) as string | undefined
   return c.json(
     {
       error: "Request body too large",
       code: "request_body_too_large",
       maxBytes,
+      requestId,
     },
     413,
   )

--- a/packages/hono/src/middleware/error-boundary.ts
+++ b/packages/hono/src/middleware/error-boundary.ts
@@ -129,6 +129,8 @@ export function handleApiError(
       status: statusCode,
       headers: {
         "content-type": "application/json",
+        "cache-control": "private, no-store",
+        vary: "Cookie, Authorization",
         // Carry the correlation id on the error response too — `onError`
         // replaces `c.res`, which would otherwise drop the header set by the
         // `requestId` middleware (RFC #1553).

--- a/packages/hono/src/middleware/public-cache.ts
+++ b/packages/hono/src/middleware/public-cache.ts
@@ -400,10 +400,10 @@ export function publicResponseCache<TBindings extends VoyantBindings>(
     const isBodyKeyed = c.req.method === "POST" && bodyKeyedPaths.has(normalizePath(path))
     if (c.req.method !== "GET" && !isBodyKeyed) return next()
     if (!prefixes.some((prefix) => path.startsWith(prefix))) return next()
-    // A credentialed request is outside the shared representation contract:
+    // A credentialed or cookie-bearing request is outside the shared representation contract:
     // it is neither served from nor stored into an entry other requesters
     // can read. `Set-Cookie` on the response opts out on the way back.
-    if (c.req.header("authorization")) return next()
+    if (c.req.header("authorization") || c.req.header("cookie")) return next()
     // Standard escape hatch: a requester (or a debugging operator) can
     // force revalidation with `Cache-Control: no-cache`.
     const requestDirective = c.req.header("cache-control")?.toLowerCase() ?? ""

--- a/packages/hono/tests/unit/public-cache.test.ts
+++ b/packages/hono/tests/unit/public-cache.test.ts
@@ -184,6 +184,27 @@ describe("publicResponseCache (KV fallback — no Cache API in the test runtime)
     expect(handler).toHaveBeenCalledTimes(2)
   })
 
+  it("never serves an anonymous cached copy to a cookie-bearing request", async () => {
+    const kv = fakeKv()
+    let call = 0
+    const handler = vi.fn(
+      () =>
+        new Response(JSON.stringify({ call: ++call }), {
+          status: 200,
+          headers: { "cache-control": "public, s-maxage=60" },
+        }),
+    )
+    const app = buildApp(kv, handler)
+
+    expect(await (await app.request("/v1/public/products")).json()).toEqual({ call: 1 })
+    expect(
+      await (
+        await app.request("/v1/public/products", { headers: { cookie: "session=opaque" } })
+      ).json(),
+    ).toEqual({ call: 2 })
+    expect(handler).toHaveBeenCalledTimes(2)
+  })
+
   it("clamps KV expirationTtl to the 60s KV minimum", async () => {
     const kv = fakeKv()
     const handler = vi.fn(

--- a/packages/storefront/openapi/storefront/storefront.json
+++ b/packages/storefront/openapi/storefront/storefront.json
@@ -3271,6 +3271,2035 @@
         "x-voyant-unit-id": "@voyant-travel/storefront",
         "x-voyant-package-name": "@voyant-travel/storefront"
       }
+    },
+    "/v1/public/shopping/search": {
+      "post": {
+        "x-voyant-api-id": "@voyant-travel/storefront#api.public",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "scope": {
+                    "type": "object",
+                    "properties": {
+                      "marketId": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 128
+                      },
+                      "locale": {
+                        "type": "string",
+                        "pattern": "^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$"
+                      },
+                      "currency": {
+                        "type": "string",
+                        "pattern": "^[A-Z]{3}$"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "intent": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "enum": ["indexed-inspiration"]
+                          },
+                          "groups": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "group": {
+                                  "type": "string",
+                                  "enum": [
+                                    "tours",
+                                    "excursions",
+                                    "experiences",
+                                    "activities",
+                                    "stays",
+                                    "cruises",
+                                    "charters"
+                                  ]
+                                },
+                                "query": {
+                                  "type": "string",
+                                  "maxLength": 300
+                                },
+                                "destination": {
+                                  "type": "object",
+                                  "properties": {
+                                    "query": {
+                                      "type": "string",
+                                      "minLength": 1,
+                                      "maxLength": 200
+                                    },
+                                    "countryCode": {
+                                      "type": "string",
+                                      "minLength": 2,
+                                      "maxLength": 2
+                                    },
+                                    "city": {
+                                      "type": "string",
+                                      "minLength": 1,
+                                      "maxLength": 120
+                                    },
+                                    "latitude": {
+                                      "type": "number",
+                                      "minimum": -90,
+                                      "maximum": 90
+                                    },
+                                    "longitude": {
+                                      "type": "number",
+                                      "minimum": -180,
+                                      "maximum": 180
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                },
+                                "fromDate": {
+                                  "type": "string",
+                                  "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                                },
+                                "toDate": {
+                                  "type": "string",
+                                  "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                                },
+                                "pagination": {
+                                  "type": "object",
+                                  "properties": {
+                                    "cursor": {
+                                      "type": "string",
+                                      "minLength": 16,
+                                      "maxLength": 512
+                                    },
+                                    "limit": {
+                                      "type": "integer",
+                                      "minimum": 1,
+                                      "maximum": 100
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": ["group"],
+                              "additionalProperties": false
+                            },
+                            "minItems": 1,
+                            "maxItems": 7
+                          }
+                        },
+                        "required": ["kind", "groups"],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "enum": ["flight"]
+                          },
+                          "slices": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "origin": {
+                                  "type": "string",
+                                  "minLength": 3,
+                                  "maxLength": 3
+                                },
+                                "destination": {
+                                  "type": "string",
+                                  "minLength": 3,
+                                  "maxLength": 3
+                                },
+                                "departureDate": {
+                                  "type": "string",
+                                  "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                                }
+                              },
+                              "required": ["origin", "destination", "departureDate"],
+                              "additionalProperties": false
+                            },
+                            "minItems": 1,
+                            "maxItems": 6
+                          },
+                          "travelers": {
+                            "type": "object",
+                            "properties": {
+                              "adults": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "maximum": 20
+                              },
+                              "childrenAges": {
+                                "type": "array",
+                                "items": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 17
+                                },
+                                "maxItems": 20
+                              },
+                              "infants": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "maximum": 10
+                              }
+                            },
+                            "required": ["adults"],
+                            "additionalProperties": false
+                          },
+                          "cabin": {
+                            "type": "string",
+                            "enum": ["economy", "premium_economy", "business", "first"]
+                          },
+                          "directOnly": {
+                            "type": "boolean"
+                          },
+                          "pagination": {
+                            "type": "object",
+                            "properties": {
+                              "cursor": {
+                                "type": "string",
+                                "minLength": 16,
+                                "maxLength": 512
+                              },
+                              "limit": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "maximum": 100
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": ["kind", "slices", "travelers"],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "enum": ["stay"]
+                          },
+                          "destination": {
+                            "type": "object",
+                            "properties": {
+                              "query": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 200
+                              },
+                              "countryCode": {
+                                "type": "string",
+                                "minLength": 2,
+                                "maxLength": 2
+                              },
+                              "city": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 120
+                              },
+                              "latitude": {
+                                "type": "number",
+                                "minimum": -90,
+                                "maximum": 90
+                              },
+                              "longitude": {
+                                "type": "number",
+                                "minimum": -180,
+                                "maximum": 180
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "checkIn": {
+                            "type": "string",
+                            "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                          },
+                          "checkOut": {
+                            "type": "string",
+                            "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                          },
+                          "rooms": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "adults": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 20
+                                },
+                                "childrenAges": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "maximum": 17
+                                  },
+                                  "maxItems": 20
+                                }
+                              },
+                              "required": ["adults"],
+                              "additionalProperties": false
+                            },
+                            "minItems": 1,
+                            "maxItems": 10
+                          },
+                          "minStars": {
+                            "type": "number",
+                            "minimum": 1,
+                            "maximum": 5
+                          },
+                          "pagination": {
+                            "type": "object",
+                            "properties": {
+                              "cursor": {
+                                "type": "string",
+                                "minLength": 16,
+                                "maxLength": 512
+                              },
+                              "limit": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "maximum": 100
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": ["kind", "destination", "checkIn", "checkOut", "rooms"],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "enum": ["package"]
+                          },
+                          "origin": {
+                            "type": "string",
+                            "minLength": 3,
+                            "maxLength": 3
+                          },
+                          "destination": {
+                            "type": "object",
+                            "properties": {
+                              "query": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 200
+                              },
+                              "countryCode": {
+                                "type": "string",
+                                "minLength": 2,
+                                "maxLength": 2
+                              },
+                              "city": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 120
+                              },
+                              "latitude": {
+                                "type": "number",
+                                "minimum": -90,
+                                "maximum": 90
+                              },
+                              "longitude": {
+                                "type": "number",
+                                "minimum": -180,
+                                "maximum": 180
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "departureDateFrom": {
+                            "type": "string",
+                            "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                          },
+                          "departureDateTo": {
+                            "type": "string",
+                            "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                          },
+                          "nights": {
+                            "type": "object",
+                            "properties": {
+                              "min": {
+                                "type": "integer",
+                                "minimum": 1
+                              },
+                              "max": {
+                                "type": "integer",
+                                "minimum": 1
+                              }
+                            },
+                            "required": ["min", "max"],
+                            "additionalProperties": false
+                          },
+                          "travelers": {
+                            "type": "object",
+                            "properties": {
+                              "adults": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "maximum": 20
+                              },
+                              "childrenAges": {
+                                "type": "array",
+                                "items": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 17
+                                },
+                                "maxItems": 20
+                              },
+                              "infants": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "maximum": 10
+                              }
+                            },
+                            "required": ["adults"],
+                            "additionalProperties": false
+                          },
+                          "boards": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "minLength": 1,
+                              "maxLength": 80
+                            },
+                            "maxItems": 20
+                          },
+                          "minStars": {
+                            "type": "number",
+                            "minimum": 1,
+                            "maximum": 5
+                          },
+                          "pagination": {
+                            "type": "object",
+                            "properties": {
+                              "cursor": {
+                                "type": "string",
+                                "minLength": 16,
+                                "maxLength": 512
+                              },
+                              "limit": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "maximum": 100
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "origin",
+                          "destination",
+                          "departureDateFrom",
+                          "departureDateTo",
+                          "nights",
+                          "travelers"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
+                },
+                "required": ["scope", "intent"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "A provider-neutral Storefront shopping result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "kind": {
+                              "type": "string",
+                              "enum": ["indexed-inspiration"]
+                            },
+                            "scope": {
+                              "type": "object",
+                              "properties": {
+                                "marketId": {
+                                  "type": "string",
+                                  "minLength": 1,
+                                  "maxLength": 128
+                                },
+                                "locale": {
+                                  "type": "string",
+                                  "pattern": "^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$"
+                                },
+                                "currency": {
+                                  "type": "string",
+                                  "pattern": "^[A-Z]{3}$"
+                                },
+                                "available": {
+                                  "type": "object",
+                                  "properties": {
+                                    "marketIds": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string",
+                                        "minLength": 1,
+                                        "maxLength": 128
+                                      },
+                                      "minItems": 1
+                                    },
+                                    "locales": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string",
+                                        "pattern": "^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$"
+                                      },
+                                      "minItems": 1
+                                    },
+                                    "currencies": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string",
+                                        "pattern": "^[A-Z]{3}$"
+                                      },
+                                      "minItems": 1
+                                    }
+                                  },
+                                  "required": ["marketIds", "locales", "currencies"],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": ["marketId", "locale", "currency", "available"],
+                              "additionalProperties": false
+                            },
+                            "groups": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "group": {
+                                    "type": "string",
+                                    "enum": [
+                                      "tours",
+                                      "excursions",
+                                      "experiences",
+                                      "activities",
+                                      "stays",
+                                      "cruises",
+                                      "charters"
+                                    ]
+                                  },
+                                  "items": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "itemRef": {
+                                          "type": "string",
+                                          "minLength": 16,
+                                          "maxLength": 512
+                                        },
+                                        "title": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        },
+                                        "summary": {
+                                          "type": "string"
+                                        },
+                                        "href": {
+                                          "type": "string",
+                                          "minLength": 1
+                                        },
+                                        "image": {
+                                          "type": "object",
+                                          "properties": {
+                                            "url": {
+                                              "type": "string",
+                                              "format": "uri"
+                                            },
+                                            "alt": {
+                                              "type": "string",
+                                              "maxLength": 300
+                                            }
+                                          },
+                                          "required": ["url"],
+                                          "additionalProperties": false
+                                        },
+                                        "priceFrom": {
+                                          "type": "object",
+                                          "properties": {
+                                            "native": {
+                                              "type": "object",
+                                              "properties": {
+                                                "amount": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                },
+                                                "currency": {
+                                                  "type": "string",
+                                                  "pattern": "^[A-Z]{3}$"
+                                                }
+                                              },
+                                              "required": ["amount", "currency"],
+                                              "additionalProperties": false
+                                            },
+                                            "presentation": {
+                                              "type": "object",
+                                              "properties": {
+                                                "amount": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                },
+                                                "currency": {
+                                                  "type": "string",
+                                                  "pattern": "^[A-Z]{3}$"
+                                                }
+                                              },
+                                              "required": ["amount", "currency"],
+                                              "additionalProperties": false
+                                            },
+                                            "fx": {
+                                              "type": "object",
+                                              "properties": {
+                                                "authority": {
+                                                  "type": "string",
+                                                  "minLength": 1,
+                                                  "maxLength": 128
+                                                },
+                                                "rate": {
+                                                  "type": "string",
+                                                  "minLength": 1
+                                                },
+                                                "quotedAt": {
+                                                  "type": "string",
+                                                  "format": "date-time"
+                                                },
+                                                "validUntil": {
+                                                  "type": "string",
+                                                  "format": "date-time"
+                                                }
+                                              },
+                                              "required": ["authority", "rate", "quotedAt"],
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "required": ["native", "presentation"],
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "required": ["itemRef", "title"],
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "total": {
+                                    "type": "integer",
+                                    "minimum": 0
+                                  },
+                                  "nextCursor": {
+                                    "type": "string",
+                                    "minLength": 16,
+                                    "maxLength": 512
+                                  }
+                                },
+                                "required": ["group", "items", "total"],
+                                "additionalProperties": false
+                              }
+                            }
+                          },
+                          "required": ["kind", "scope", "groups"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "kind": {
+                              "type": "string",
+                              "enum": ["flight"]
+                            },
+                            "scope": {
+                              "type": "object",
+                              "properties": {
+                                "marketId": {
+                                  "type": "string",
+                                  "minLength": 1,
+                                  "maxLength": 128
+                                },
+                                "locale": {
+                                  "type": "string",
+                                  "pattern": "^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$"
+                                },
+                                "currency": {
+                                  "type": "string",
+                                  "pattern": "^[A-Z]{3}$"
+                                },
+                                "available": {
+                                  "type": "object",
+                                  "properties": {
+                                    "marketIds": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string",
+                                        "minLength": 1,
+                                        "maxLength": 128
+                                      },
+                                      "minItems": 1
+                                    },
+                                    "locales": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string",
+                                        "pattern": "^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$"
+                                      },
+                                      "minItems": 1
+                                    },
+                                    "currencies": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string",
+                                        "pattern": "^[A-Z]{3}$"
+                                      },
+                                      "minItems": 1
+                                    }
+                                  },
+                                  "required": ["marketIds", "locales", "currencies"],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": ["marketId", "locale", "currency", "available"],
+                              "additionalProperties": false
+                            },
+                            "offers": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "offerRef": {
+                                    "type": "string",
+                                    "minLength": 16,
+                                    "maxLength": 512
+                                  },
+                                  "itineraries": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "segments": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "origin": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "code": {
+                                                    "type": "string",
+                                                    "minLength": 3,
+                                                    "maxLength": 3
+                                                  },
+                                                  "at": {
+                                                    "type": "string",
+                                                    "format": "date-time"
+                                                  }
+                                                },
+                                                "required": ["code", "at"],
+                                                "additionalProperties": false
+                                              },
+                                              "destination": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "code": {
+                                                    "type": "string",
+                                                    "minLength": 3,
+                                                    "maxLength": 3
+                                                  },
+                                                  "at": {
+                                                    "type": "string",
+                                                    "format": "date-time"
+                                                  }
+                                                },
+                                                "required": ["code", "at"],
+                                                "additionalProperties": false
+                                              },
+                                              "marketingCarrier": {
+                                                "type": "string",
+                                                "minLength": 2,
+                                                "maxLength": 3
+                                              },
+                                              "flightNumber": {
+                                                "type": "string",
+                                                "minLength": 1,
+                                                "maxLength": 12
+                                              }
+                                            },
+                                            "required": [
+                                              "origin",
+                                              "destination",
+                                              "marketingCarrier",
+                                              "flightNumber"
+                                            ],
+                                            "additionalProperties": false
+                                          },
+                                          "minItems": 1
+                                        },
+                                        "duration": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": ["segments"],
+                                      "additionalProperties": false
+                                    },
+                                    "minItems": 1
+                                  },
+                                  "price": {
+                                    "type": "object",
+                                    "properties": {
+                                      "native": {
+                                        "type": "object",
+                                        "properties": {
+                                          "amount": {
+                                            "type": "string",
+                                            "minLength": 1
+                                          },
+                                          "currency": {
+                                            "type": "string",
+                                            "pattern": "^[A-Z]{3}$"
+                                          }
+                                        },
+                                        "required": ["amount", "currency"],
+                                        "additionalProperties": false
+                                      },
+                                      "presentation": {
+                                        "type": "object",
+                                        "properties": {
+                                          "amount": {
+                                            "type": "string",
+                                            "minLength": 1
+                                          },
+                                          "currency": {
+                                            "type": "string",
+                                            "pattern": "^[A-Z]{3}$"
+                                          }
+                                        },
+                                        "required": ["amount", "currency"],
+                                        "additionalProperties": false
+                                      },
+                                      "fx": {
+                                        "type": "object",
+                                        "properties": {
+                                          "authority": {
+                                            "type": "string",
+                                            "minLength": 1,
+                                            "maxLength": 128
+                                          },
+                                          "rate": {
+                                            "type": "string",
+                                            "minLength": 1
+                                          },
+                                          "quotedAt": {
+                                            "type": "string",
+                                            "format": "date-time"
+                                          },
+                                          "validUntil": {
+                                            "type": "string",
+                                            "format": "date-time"
+                                          }
+                                        },
+                                        "required": ["authority", "rate", "quotedAt"],
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "required": ["native", "presentation"],
+                                    "additionalProperties": false
+                                  },
+                                  "expiresAt": {
+                                    "type": "string",
+                                    "format": "date-time"
+                                  }
+                                },
+                                "required": ["offerRef", "itineraries", "price"],
+                                "additionalProperties": false
+                              }
+                            },
+                            "coverage": {
+                              "type": "object",
+                              "properties": {
+                                "status": {
+                                  "type": "string",
+                                  "enum": ["complete", "partial", "unavailable"]
+                                },
+                                "succeeded": {
+                                  "type": "integer",
+                                  "minimum": 0
+                                },
+                                "failed": {
+                                  "type": "integer",
+                                  "minimum": 0
+                                },
+                                "timedOut": {
+                                  "type": "integer",
+                                  "minimum": 0
+                                }
+                              },
+                              "required": ["status", "succeeded", "failed", "timedOut"],
+                              "additionalProperties": false
+                            },
+                            "nextCursor": {
+                              "type": "string",
+                              "minLength": 16,
+                              "maxLength": 512
+                            }
+                          },
+                          "required": ["kind", "scope", "offers", "coverage"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "kind": {
+                              "type": "string",
+                              "enum": ["stay"]
+                            },
+                            "scope": {
+                              "type": "object",
+                              "properties": {
+                                "marketId": {
+                                  "type": "string",
+                                  "minLength": 1,
+                                  "maxLength": 128
+                                },
+                                "locale": {
+                                  "type": "string",
+                                  "pattern": "^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$"
+                                },
+                                "currency": {
+                                  "type": "string",
+                                  "pattern": "^[A-Z]{3}$"
+                                },
+                                "available": {
+                                  "type": "object",
+                                  "properties": {
+                                    "marketIds": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string",
+                                        "minLength": 1,
+                                        "maxLength": 128
+                                      },
+                                      "minItems": 1
+                                    },
+                                    "locales": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string",
+                                        "pattern": "^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$"
+                                      },
+                                      "minItems": 1
+                                    },
+                                    "currencies": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string",
+                                        "pattern": "^[A-Z]{3}$"
+                                      },
+                                      "minItems": 1
+                                    }
+                                  },
+                                  "required": ["marketIds", "locales", "currencies"],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": ["marketId", "locale", "currency", "available"],
+                              "additionalProperties": false
+                            },
+                            "offers": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "offerRef": {
+                                    "type": "string",
+                                    "minLength": 16,
+                                    "maxLength": 512
+                                  },
+                                  "accommodationRef": {
+                                    "type": "string",
+                                    "minLength": 16,
+                                    "maxLength": 512
+                                  },
+                                  "title": {
+                                    "type": "string",
+                                    "minLength": 1
+                                  },
+                                  "checkIn": {
+                                    "type": "string",
+                                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                                  },
+                                  "checkOut": {
+                                    "type": "string",
+                                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                                  },
+                                  "roomName": {
+                                    "type": "string"
+                                  },
+                                  "boardName": {
+                                    "type": "string"
+                                  },
+                                  "image": {
+                                    "type": "object",
+                                    "properties": {
+                                      "url": {
+                                        "type": "string",
+                                        "format": "uri"
+                                      },
+                                      "alt": {
+                                        "type": "string",
+                                        "maxLength": 300
+                                      }
+                                    },
+                                    "required": ["url"],
+                                    "additionalProperties": false
+                                  },
+                                  "price": {
+                                    "type": "object",
+                                    "properties": {
+                                      "native": {
+                                        "type": "object",
+                                        "properties": {
+                                          "amount": {
+                                            "type": "string",
+                                            "minLength": 1
+                                          },
+                                          "currency": {
+                                            "type": "string",
+                                            "pattern": "^[A-Z]{3}$"
+                                          }
+                                        },
+                                        "required": ["amount", "currency"],
+                                        "additionalProperties": false
+                                      },
+                                      "presentation": {
+                                        "type": "object",
+                                        "properties": {
+                                          "amount": {
+                                            "type": "string",
+                                            "minLength": 1
+                                          },
+                                          "currency": {
+                                            "type": "string",
+                                            "pattern": "^[A-Z]{3}$"
+                                          }
+                                        },
+                                        "required": ["amount", "currency"],
+                                        "additionalProperties": false
+                                      },
+                                      "fx": {
+                                        "type": "object",
+                                        "properties": {
+                                          "authority": {
+                                            "type": "string",
+                                            "minLength": 1,
+                                            "maxLength": 128
+                                          },
+                                          "rate": {
+                                            "type": "string",
+                                            "minLength": 1
+                                          },
+                                          "quotedAt": {
+                                            "type": "string",
+                                            "format": "date-time"
+                                          },
+                                          "validUntil": {
+                                            "type": "string",
+                                            "format": "date-time"
+                                          }
+                                        },
+                                        "required": ["authority", "rate", "quotedAt"],
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "required": ["native", "presentation"],
+                                    "additionalProperties": false
+                                  },
+                                  "expiresAt": {
+                                    "type": "string",
+                                    "format": "date-time"
+                                  }
+                                },
+                                "required": [
+                                  "offerRef",
+                                  "accommodationRef",
+                                  "title",
+                                  "checkIn",
+                                  "checkOut",
+                                  "price"
+                                ],
+                                "additionalProperties": false
+                              }
+                            },
+                            "coverage": {
+                              "type": "object",
+                              "properties": {
+                                "status": {
+                                  "type": "string",
+                                  "enum": ["complete", "partial", "unavailable"]
+                                },
+                                "succeeded": {
+                                  "type": "integer",
+                                  "minimum": 0
+                                },
+                                "failed": {
+                                  "type": "integer",
+                                  "minimum": 0
+                                },
+                                "timedOut": {
+                                  "type": "integer",
+                                  "minimum": 0
+                                }
+                              },
+                              "required": ["status", "succeeded", "failed", "timedOut"],
+                              "additionalProperties": false
+                            },
+                            "nextCursor": {
+                              "type": "string",
+                              "minLength": 16,
+                              "maxLength": 512
+                            }
+                          },
+                          "required": ["kind", "scope", "offers", "coverage"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "kind": {
+                              "type": "string",
+                              "enum": ["package"]
+                            },
+                            "scope": {
+                              "type": "object",
+                              "properties": {
+                                "marketId": {
+                                  "type": "string",
+                                  "minLength": 1,
+                                  "maxLength": 128
+                                },
+                                "locale": {
+                                  "type": "string",
+                                  "pattern": "^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$"
+                                },
+                                "currency": {
+                                  "type": "string",
+                                  "pattern": "^[A-Z]{3}$"
+                                },
+                                "available": {
+                                  "type": "object",
+                                  "properties": {
+                                    "marketIds": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string",
+                                        "minLength": 1,
+                                        "maxLength": 128
+                                      },
+                                      "minItems": 1
+                                    },
+                                    "locales": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string",
+                                        "pattern": "^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$"
+                                      },
+                                      "minItems": 1
+                                    },
+                                    "currencies": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string",
+                                        "pattern": "^[A-Z]{3}$"
+                                      },
+                                      "minItems": 1
+                                    }
+                                  },
+                                  "required": ["marketIds", "locales", "currencies"],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": ["marketId", "locale", "currency", "available"],
+                              "additionalProperties": false
+                            },
+                            "offers": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "offerRef": {
+                                    "type": "string",
+                                    "minLength": 16,
+                                    "maxLength": 512
+                                  },
+                                  "title": {
+                                    "type": "string",
+                                    "minLength": 1
+                                  },
+                                  "origin": {
+                                    "type": "string",
+                                    "minLength": 3,
+                                    "maxLength": 3
+                                  },
+                                  "destination": {
+                                    "type": "string",
+                                    "minLength": 1
+                                  },
+                                  "departureDate": {
+                                    "type": "string",
+                                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                                  },
+                                  "nights": {
+                                    "type": "integer",
+                                    "minimum": 1
+                                  },
+                                  "accommodationName": {
+                                    "type": "string",
+                                    "minLength": 1
+                                  },
+                                  "boardName": {
+                                    "type": "string"
+                                  },
+                                  "image": {
+                                    "type": "object",
+                                    "properties": {
+                                      "url": {
+                                        "type": "string",
+                                        "format": "uri"
+                                      },
+                                      "alt": {
+                                        "type": "string",
+                                        "maxLength": 300
+                                      }
+                                    },
+                                    "required": ["url"],
+                                    "additionalProperties": false
+                                  },
+                                  "price": {
+                                    "type": "object",
+                                    "properties": {
+                                      "native": {
+                                        "type": "object",
+                                        "properties": {
+                                          "amount": {
+                                            "type": "string",
+                                            "minLength": 1
+                                          },
+                                          "currency": {
+                                            "type": "string",
+                                            "pattern": "^[A-Z]{3}$"
+                                          }
+                                        },
+                                        "required": ["amount", "currency"],
+                                        "additionalProperties": false
+                                      },
+                                      "presentation": {
+                                        "type": "object",
+                                        "properties": {
+                                          "amount": {
+                                            "type": "string",
+                                            "minLength": 1
+                                          },
+                                          "currency": {
+                                            "type": "string",
+                                            "pattern": "^[A-Z]{3}$"
+                                          }
+                                        },
+                                        "required": ["amount", "currency"],
+                                        "additionalProperties": false
+                                      },
+                                      "fx": {
+                                        "type": "object",
+                                        "properties": {
+                                          "authority": {
+                                            "type": "string",
+                                            "minLength": 1,
+                                            "maxLength": 128
+                                          },
+                                          "rate": {
+                                            "type": "string",
+                                            "minLength": 1
+                                          },
+                                          "quotedAt": {
+                                            "type": "string",
+                                            "format": "date-time"
+                                          },
+                                          "validUntil": {
+                                            "type": "string",
+                                            "format": "date-time"
+                                          }
+                                        },
+                                        "required": ["authority", "rate", "quotedAt"],
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "required": ["native", "presentation"],
+                                    "additionalProperties": false
+                                  },
+                                  "expiresAt": {
+                                    "type": "string",
+                                    "format": "date-time"
+                                  }
+                                },
+                                "required": [
+                                  "offerRef",
+                                  "title",
+                                  "origin",
+                                  "destination",
+                                  "departureDate",
+                                  "nights",
+                                  "accommodationName",
+                                  "price"
+                                ],
+                                "additionalProperties": false
+                              }
+                            },
+                            "coverage": {
+                              "type": "object",
+                              "properties": {
+                                "status": {
+                                  "type": "string",
+                                  "enum": ["complete", "partial", "unavailable"]
+                                },
+                                "succeeded": {
+                                  "type": "integer",
+                                  "minimum": 0
+                                },
+                                "failed": {
+                                  "type": "integer",
+                                  "minimum": 0
+                                },
+                                "timedOut": {
+                                  "type": "integer",
+                                  "minimum": 0
+                                }
+                              },
+                              "required": ["status", "succeeded", "failed", "timedOut"],
+                              "additionalProperties": false
+                            },
+                            "nextCursor": {
+                              "type": "string",
+                              "minLength": 16,
+                              "maxLength": 512
+                            }
+                          },
+                          "required": ["kind", "scope", "offers", "coverage"],
+                          "additionalProperties": false
+                        }
+                      ]
+                    }
+                  },
+                  "required": ["data"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The strict shopping request was invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "An active server-resolved Storefront Channel is required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "The shopping request body exceeded 64 KiB",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string",
+                      "enum": ["request_body_too_large"]
+                    },
+                    "maxBytes": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["error", "code", "maxBytes"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "No shopping runtime is bound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postPublicShoppingSearch",
+        "summary": "POST /v1/public/shopping/search",
+        "tags": ["shopping"],
+        "x-voyant-module": "shopping",
+        "x-voyant-surface": "storefront",
+        "x-voyant-package-name": "@voyant-travel/storefront"
+      }
+    },
+    "/v1/public/shopping/trip-selections": {
+      "post": {
+        "x-voyant-api-id": "@voyant-travel/storefront#api.public",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "scope": {
+                    "type": "object",
+                    "properties": {
+                      "marketId": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 128
+                      },
+                      "locale": {
+                        "type": "string",
+                        "pattern": "^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$"
+                      },
+                      "currency": {
+                        "type": "string",
+                        "pattern": "^[A-Z]{3}$"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "offers": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "kind": {
+                          "type": "string",
+                          "enum": ["product", "flight", "stay", "package"]
+                        },
+                        "offerRef": {
+                          "type": "string",
+                          "minLength": 16,
+                          "maxLength": 512
+                        },
+                        "quantity": {
+                          "type": "integer",
+                          "minimum": 1,
+                          "maximum": 99
+                        }
+                      },
+                      "required": ["kind", "offerRef"],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1,
+                    "maxItems": 100
+                  }
+                },
+                "required": ["scope", "offers"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "A newly created opaque Trip selection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "selectionRef": {
+                          "type": "string",
+                          "minLength": 16,
+                          "maxLength": 512
+                        },
+                        "revision": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "scope": {
+                          "type": "object",
+                          "properties": {
+                            "marketId": {
+                              "type": "string",
+                              "minLength": 1,
+                              "maxLength": 128
+                            },
+                            "locale": {
+                              "type": "string",
+                              "pattern": "^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$"
+                            },
+                            "currency": {
+                              "type": "string",
+                              "pattern": "^[A-Z]{3}$"
+                            },
+                            "available": {
+                              "type": "object",
+                              "properties": {
+                                "marketIds": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "minLength": 1,
+                                    "maxLength": 128
+                                  },
+                                  "minItems": 1
+                                },
+                                "locales": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "pattern": "^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$"
+                                  },
+                                  "minItems": 1
+                                },
+                                "currencies": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "pattern": "^[A-Z]{3}$"
+                                  },
+                                  "minItems": 1
+                                }
+                              },
+                              "required": ["marketIds", "locales", "currencies"],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": ["marketId", "locale", "currency", "available"],
+                          "additionalProperties": false
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "itemRef": {
+                                "type": "string",
+                                "minLength": 16,
+                                "maxLength": 512
+                              },
+                              "kind": {
+                                "type": "string",
+                                "enum": ["product", "flight", "stay", "package"]
+                              },
+                              "quantity": {
+                                "type": "integer",
+                                "minimum": 1
+                              }
+                            },
+                            "required": ["itemRef", "kind", "quantity"],
+                            "additionalProperties": false
+                          },
+                          "maxItems": 100
+                        }
+                      },
+                      "required": ["selectionRef", "revision", "scope", "items"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["data"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The strict Trip-selection request was invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The active Storefront Channel or same-origin mutation proof is missing",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "The Trip-selection request body exceeded 64 KiB",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string",
+                      "enum": ["request_body_too_large"]
+                    },
+                    "maxBytes": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["error", "code", "maxBytes"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "A required shopping or Trip-selection runtime is not bound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postPublicShoppingTripSelections",
+        "summary": "POST /v1/public/shopping/trip-selections",
+        "tags": ["shopping"],
+        "x-voyant-module": "shopping",
+        "x-voyant-surface": "storefront",
+        "x-voyant-package-name": "@voyant-travel/storefront"
+      },
+      "patch": {
+        "x-voyant-api-id": "@voyant-travel/storefront#api.public",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "selectionRef": {
+                    "type": "string",
+                    "minLength": 16,
+                    "maxLength": 512
+                  },
+                  "expectedRevision": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "mutation": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "enum": ["add"]
+                          },
+                          "offer": {
+                            "type": "object",
+                            "properties": {
+                              "kind": {
+                                "type": "string",
+                                "enum": ["product", "flight", "stay", "package"]
+                              },
+                              "offerRef": {
+                                "type": "string",
+                                "minLength": 16,
+                                "maxLength": 512
+                              },
+                              "quantity": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "maximum": 99
+                              }
+                            },
+                            "required": ["kind", "offerRef"],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": ["kind", "offer"],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "enum": ["remove"]
+                          },
+                          "itemRef": {
+                            "type": "string",
+                            "minLength": 16,
+                            "maxLength": 512
+                          }
+                        },
+                        "required": ["kind", "itemRef"],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "enum": ["reorder"]
+                          },
+                          "itemRefs": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "minLength": 16,
+                              "maxLength": 512
+                            },
+                            "minItems": 1,
+                            "maxItems": 100
+                          }
+                        },
+                        "required": ["kind", "itemRefs"],
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
+                },
+                "required": ["selectionRef", "expectedRevision", "mutation"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The compare-and-swap updated Trip selection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "selectionRef": {
+                          "type": "string",
+                          "minLength": 16,
+                          "maxLength": 512
+                        },
+                        "revision": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "scope": {
+                          "type": "object",
+                          "properties": {
+                            "marketId": {
+                              "type": "string",
+                              "minLength": 1,
+                              "maxLength": 128
+                            },
+                            "locale": {
+                              "type": "string",
+                              "pattern": "^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$"
+                            },
+                            "currency": {
+                              "type": "string",
+                              "pattern": "^[A-Z]{3}$"
+                            },
+                            "available": {
+                              "type": "object",
+                              "properties": {
+                                "marketIds": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "minLength": 1,
+                                    "maxLength": 128
+                                  },
+                                  "minItems": 1
+                                },
+                                "locales": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "pattern": "^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$"
+                                  },
+                                  "minItems": 1
+                                },
+                                "currencies": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "pattern": "^[A-Z]{3}$"
+                                  },
+                                  "minItems": 1
+                                }
+                              },
+                              "required": ["marketIds", "locales", "currencies"],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": ["marketId", "locale", "currency", "available"],
+                          "additionalProperties": false
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "itemRef": {
+                                "type": "string",
+                                "minLength": 16,
+                                "maxLength": 512
+                              },
+                              "kind": {
+                                "type": "string",
+                                "enum": ["product", "flight", "stay", "package"]
+                              },
+                              "quantity": {
+                                "type": "integer",
+                                "minimum": 1
+                              }
+                            },
+                            "required": ["itemRef", "kind", "quantity"],
+                            "additionalProperties": false
+                          },
+                          "maxItems": 100
+                        }
+                      },
+                      "required": ["selectionRef", "revision", "scope", "items"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["data"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The strict Trip-selection mutation was invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The active Storefront Channel or same-origin mutation proof is missing",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The Trip-selection revision changed after it was read",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "The Trip-selection mutation body exceeded 64 KiB",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string",
+                      "enum": ["request_body_too_large"]
+                    },
+                    "maxBytes": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["error", "code", "maxBytes"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "No Trip-selection runtime is bound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "operationId": "patchPublicShoppingTripSelections",
+        "summary": "PATCH /v1/public/shopping/trip-selections",
+        "tags": ["shopping"],
+        "x-voyant-module": "shopping",
+        "x-voyant-surface": "storefront",
+        "x-voyant-package-name": "@voyant-travel/storefront"
+      }
     }
   },
   "webhooks": {}

--- a/packages/storefront/package.json
+++ b/packages/storefront/package.json
@@ -61,6 +61,7 @@
     "typecheck": "tsc -p tsconfig.typecheck.json",
     "lint": "biome check src/",
     "test": "vitest run",
+    "generate:shopping-openapi": "tsx scripts/generate-shopping-openapi.ts",
     "verify:openapi-authority": "node scripts/check-openapi-authority.mjs",
     "build": "pnpm run clean && tsc -p tsconfig.build.json",
     "clean": "rm -rf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",

--- a/packages/storefront/scripts/generate-shopping-openapi.ts
+++ b/packages/storefront/scripts/generate-shopping-openapi.ts
@@ -1,0 +1,63 @@
+import { execFile } from "node:child_process"
+import { readFile, writeFile } from "node:fs/promises"
+import { fileURLToPath } from "node:url"
+import { promisify } from "node:util"
+
+import { stampOpenApiRegistryApiId } from "@voyant-travel/hono"
+import {
+  generateOpenApiDocument,
+  type OpenApiDocument,
+  stampModuleMetadata,
+} from "@voyant-travel/hono/openapi"
+
+import { createStorefrontShoppingPublicRoutes } from "../src/shopping/routes-public.js"
+
+const documentUrl = new URL("../openapi/storefront/storefront.json", import.meta.url)
+const current = JSON.parse(await readFile(documentUrl, "utf8")) as OpenApiDocument
+const routes = stampOpenApiRegistryApiId(
+  createStorefrontShoppingPublicRoutes(),
+  "@voyant-travel/storefront#api.public",
+)
+const generated = generateOpenApiDocument(routes, {
+  info: current.info,
+  servers: current.servers,
+})
+const prefixed = stampModuleMetadata(
+  {
+    ...generated,
+    paths: Object.fromEntries(
+      Object.entries(generated.paths ?? {}).map(([path, item]) => [
+        `/v1/public/shopping${path}`,
+        item,
+      ]),
+    ),
+  },
+  new Map(),
+)
+
+const operationMethods = ["get", "post", "put", "patch", "delete", "head", "options"]
+for (const pathItem of Object.values(prefixed.paths ?? {})) {
+  if (!pathItem || typeof pathItem !== "object") continue
+  for (const method of operationMethods) {
+    const operation = (pathItem as Record<string, unknown>)[method]
+    if (!operation || typeof operation !== "object") continue
+    Object.assign(operation, {
+      "x-voyant-api-id": "@voyant-travel/storefront#api.public",
+      "x-voyant-package-name": "@voyant-travel/storefront",
+    })
+  }
+}
+
+const shoppingPaths = Object.fromEntries(
+  Object.entries(current.paths ?? {}).filter(([path]) => !path.startsWith("/v1/public/shopping")),
+)
+const next = {
+  ...current,
+  paths: { ...shoppingPaths, ...prefixed.paths },
+}
+
+await writeFile(documentUrl, `${JSON.stringify(next, null, 2)}\n`)
+// Keep the committed document's canonical formatting. Without this step,
+// JSON.stringify expands every existing compact array and hides the two-path
+// semantic change inside thousands of formatting-only lines.
+await promisify(execFile)("biome", ["format", "--write", fileURLToPath(documentUrl)])

--- a/packages/storefront/src/index.ts
+++ b/packages/storefront/src/index.ts
@@ -10,6 +10,10 @@ import type { ApiModule } from "@voyant-travel/hono/module"
 import { createStorefrontAdminRoutes } from "./routes-admin.js"
 import { createStorefrontPublicRoutes } from "./routes-public.js"
 import { storefrontIntakeRuntimePort, storefrontOffersRuntimePort } from "./runtime-port.js"
+import {
+  storefrontShoppingRuntimePort,
+  storefrontTripSelectionsRuntimePort,
+} from "./shopping/runtime-port.js"
 
 export {
   createStorefrontAvailabilityReadModelInvalidationSubscriber,
@@ -203,6 +207,7 @@ export const storefrontAnonymousPublicPaths = [
   "/leads",
   "/newsletter",
   "/offers",
+  "/shopping",
   "/settings",
 ] as const
 // These guest-facing route families still need the customer-auth resolver to
@@ -216,6 +221,7 @@ export const storefrontOptionalCustomerAuthPaths = [
   "/newsletter",
   "/offers",
   "/products",
+  "/shopping",
   "/settings",
 ] as const
 
@@ -237,43 +243,57 @@ export function createStorefrontApiModule(options?: StorefrontApiModuleOptions):
     ),
     anonymous: storefrontAnonymousPublicPaths,
     optionalCustomerAuth: storefrontOptionalCustomerAuthPaths,
+    bodyKeyedCache: ["/shopping/search"],
   }
 }
 
-export const createStorefrontVoyantRuntime = defineGraphRuntimeFactory(async ({ api, getPort }) => {
-  const [offers, persistence, publication] = await Promise.all([
-    getPort(storefrontOffersRuntimePort),
-    getPort(storefrontIntakeRuntimePort),
-    getPort<CatalogPublicationRuntime>(catalogPublicationRuntimePort),
-  ])
-  const configured = createStorefrontApiModule({
-    offers,
-    intake: { persistence },
-    publication: {
-      isProductPublished: ({ productId, context }) => {
-        if (!context.db || !context.channelId) return false
-        return publication.isProductPublished({
-          db: context.db,
-          productId,
-          channelId: context.channelId,
-        })
+export const createStorefrontVoyantRuntime = defineGraphRuntimeFactory(
+  async ({ api, getPort, hasPort }) => {
+    const [offers, persistence, publication] = await Promise.all([
+      getPort(storefrontOffersRuntimePort),
+      getPort(storefrontIntakeRuntimePort),
+      getPort<CatalogPublicationRuntime>(catalogPublicationRuntimePort),
+    ])
+    const configured = createStorefrontApiModule({
+      offers,
+      intake: { persistence },
+      publication: {
+        isProductPublished: ({ productId, context }) => {
+          if (!context.db || !context.channelId) return false
+          return publication.isProductPublished({
+            db: context.db,
+            productId,
+            channelId: context.channelId,
+          })
+        },
       },
-    },
-  })
-  const selected: ApiModule = { module: configured.module }
-  if (api.some(({ surface }) => surface === "admin") && configured.adminRoutes) {
-    selected.adminRoutes = configured.adminRoutes
-  }
-  if (api.some(({ surface }) => surface === "public") && configured.publicRoutes) {
-    selected.publicRoutes = configured.publicRoutes
-    if (configured.publicPath !== undefined) selected.publicPath = configured.publicPath
-    if (configured.anonymous !== undefined) selected.anonymous = configured.anonymous
-    if (configured.optionalCustomerAuth !== undefined) {
-      selected.optionalCustomerAuth = configured.optionalCustomerAuth
+      shoppingGateway: {
+        shopping: hasPort(storefrontShoppingRuntimePort)
+          ? await getPort(storefrontShoppingRuntimePort)
+          : undefined,
+        tripSelections: hasPort(storefrontTripSelectionsRuntimePort)
+          ? await getPort(storefrontTripSelectionsRuntimePort)
+          : undefined,
+      },
+    })
+    const selected: ApiModule = { module: configured.module }
+    if (api.some(({ surface }) => surface === "admin") && configured.adminRoutes) {
+      selected.adminRoutes = configured.adminRoutes
     }
-  }
-  return selected
-})
+    if (api.some(({ surface }) => surface === "public") && configured.publicRoutes) {
+      selected.publicRoutes = configured.publicRoutes
+      if (configured.publicPath !== undefined) selected.publicPath = configured.publicPath
+      if (configured.anonymous !== undefined) selected.anonymous = configured.anonymous
+      if (configured.optionalCustomerAuth !== undefined) {
+        selected.optionalCustomerAuth = configured.optionalCustomerAuth
+      }
+      if (configured.bodyKeyedCache !== undefined) {
+        selected.bodyKeyedCache = configured.bodyKeyedCache
+      }
+    }
+    return selected
+  },
+)
 
 export {
   storefrontCustomerPortalRuntimePort,

--- a/packages/storefront/src/routes-public.ts
+++ b/packages/storefront/src/routes-public.ts
@@ -10,6 +10,10 @@ import {
 import type { Context, Next } from "hono"
 
 import { departuresDocKey, readThroughDepartures } from "./departures-read-model.js"
+import {
+  createStorefrontShoppingPublicRoutes,
+  type StorefrontShoppingPublicRoutesOptions,
+} from "./shopping/routes-public.js"
 
 export { departuresDocKey, readThroughDepartures }
 
@@ -376,7 +380,11 @@ const subscribeNewsletterRoute = createRoute({
   },
 })
 
-export function createStorefrontPublicRoutes(options?: StorefrontServiceOptions) {
+export type StorefrontPublicRoutesOptions = StorefrontServiceOptions & {
+  shoppingGateway?: StorefrontShoppingPublicRoutesOptions
+}
+
+export function createStorefrontPublicRoutes(options?: StorefrontPublicRoutesOptions) {
   const storefrontService = createStorefrontService(options)
 
   function getRequestContext(c: Context<Env>): StorefrontRequestContext {
@@ -475,7 +483,7 @@ export function createStorefrontPublicRoutes(options?: StorefrontServiceOptions)
   app.use("/leads", requireActiveChannel)
   app.use("/newsletter/*", requireActiveChannel)
 
-  return app
+  const routes = app
     .openapi(listProductOffersRoute, async (c) => {
       const query = c.req.valid("query")
       const offers = await storefrontService.listApplicableOffers({
@@ -684,6 +692,9 @@ export function createStorefrontPublicRoutes(options?: StorefrontServiceOptions)
         }),
       })
     })
+
+  routes.route("/shopping", createStorefrontShoppingPublicRoutes(options?.shoppingGateway))
+  return routes
 }
 
 export type StorefrontPublicRoutes = ReturnType<typeof createStorefrontPublicRoutes>

--- a/packages/storefront/src/shopping/index.ts
+++ b/packages/storefront/src/shopping/index.ts
@@ -1,3 +1,4 @@
+export * from "./routes-public.js"
 export * from "./runtime.js"
 export * from "./runtime-port.js"
 export * from "./schemas.js"

--- a/packages/storefront/src/shopping/routes-public.ts
+++ b/packages/storefront/src/shopping/routes-public.ts
@@ -1,0 +1,379 @@
+import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
+import {
+  openApiValidationHook,
+  type VoyantBindings,
+  type VoyantVariables,
+} from "@voyant-travel/hono"
+import type { Context, MiddlewareHandler } from "hono"
+
+import {
+  createStorefrontShoppingGateway,
+  type StorefrontShoppingGateway,
+  StorefrontShoppingUnavailableError,
+  StorefrontTripSelectionRevisionConflictError,
+} from "./runtime.js"
+import type {
+  StorefrontShoppingContext,
+  StorefrontShoppingRuntime,
+  StorefrontTripSelectionsRuntime,
+} from "./runtime-port.js"
+import {
+  storefrontShoppingRequestSchema,
+  storefrontShoppingResultSchema,
+  storefrontTripSelectionCreateSchema,
+  storefrontTripSelectionSchema,
+  storefrontTripSelectionUpdateSchema,
+} from "./schemas.js"
+
+const MAX_SHOPPING_BODY_BYTES = 64 * 1024
+const PRIVATE_NO_STORE = "private, no-store"
+const PUBLIC_INDEXED_CACHE_SECONDS = 60
+
+type Env = {
+  Bindings: VoyantBindings & { NODE_ENV?: string }
+  Variables: VoyantVariables
+}
+
+const errorResponseSchema = z
+  .object({ error: z.string(), requestId: z.string().optional() })
+  .strict()
+const tooLargeResponseSchema = errorResponseSchema
+  .extend({ code: z.literal("request_body_too_large"), maxBytes: z.number().int() })
+  .strict()
+const shoppingEnvelopeSchema = z.object({ data: storefrontShoppingResultSchema }).strict()
+const tripSelectionEnvelopeSchema = z.object({ data: storefrontTripSelectionSchema }).strict()
+
+function jsonBody<T extends z.ZodType>(schema: T) {
+  return { required: true, content: { "application/json": { schema } } }
+}
+
+const searchRoute = createRoute({
+  method: "post",
+  path: "/search",
+  request: { body: jsonBody(storefrontShoppingRequestSchema) },
+  responses: {
+    200: {
+      description: "A provider-neutral Storefront shopping result",
+      content: { "application/json": { schema: shoppingEnvelopeSchema } },
+    },
+    400: {
+      description: "The strict shopping request was invalid",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "An active server-resolved Storefront Channel is required",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    413: {
+      description: "The shopping request body exceeded 64 KiB",
+      content: { "application/json": { schema: tooLargeResponseSchema } },
+    },
+    503: {
+      description: "No shopping runtime is bound",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+const createTripSelectionRoute = createRoute({
+  method: "post",
+  path: "/trip-selections",
+  request: { body: jsonBody(storefrontTripSelectionCreateSchema) },
+  responses: {
+    201: {
+      description: "A newly created opaque Trip selection",
+      content: { "application/json": { schema: tripSelectionEnvelopeSchema } },
+    },
+    400: {
+      description: "The strict Trip-selection request was invalid",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "The active Storefront Channel or same-origin mutation proof is missing",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    413: {
+      description: "The Trip-selection request body exceeded 64 KiB",
+      content: { "application/json": { schema: tooLargeResponseSchema } },
+    },
+    503: {
+      description: "A required shopping or Trip-selection runtime is not bound",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+const updateTripSelectionRoute = createRoute({
+  method: "patch",
+  path: "/trip-selections",
+  request: { body: jsonBody(storefrontTripSelectionUpdateSchema) },
+  responses: {
+    200: {
+      description: "The compare-and-swap updated Trip selection",
+      content: { "application/json": { schema: tripSelectionEnvelopeSchema } },
+    },
+    400: {
+      description: "The strict Trip-selection mutation was invalid",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "The active Storefront Channel or same-origin mutation proof is missing",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    409: {
+      description: "The Trip-selection revision changed after it was read",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    413: {
+      description: "The Trip-selection mutation body exceeded 64 KiB",
+      content: { "application/json": { schema: tooLargeResponseSchema } },
+    },
+    503: {
+      description: "No Trip-selection runtime is bound",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+export interface StorefrontShoppingPublicRoutesOptions {
+  shopping?: StorefrontShoppingRuntime
+  tripSelections?: StorefrontTripSelectionsRuntime
+  /** Test seam only; production defaults to the deployment's NODE_ENV. */
+  production?: boolean
+  now?: () => Date
+}
+
+function requestId(c: Context<Env>): string | undefined {
+  return c.get("requestId")
+}
+
+function boundedJsonBody(maxBytes: number): MiddlewareHandler<Env> {
+  return async (c, next) => {
+    const declaredLength = Number(c.req.header("content-length"))
+    if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+      return requestBodyTooLarge(c, maxBytes)
+    }
+
+    const body = c.req.raw.body
+    if (!body) return next()
+    const reader = body.getReader()
+    const decoder = new TextDecoder()
+    let bytesRead = 0
+    let text = ""
+    while (true) {
+      const chunk = await reader.read()
+      if (chunk.done) break
+      bytesRead += chunk.value.byteLength
+      if (bytesRead > maxBytes) {
+        await reader.cancel().catch(() => {})
+        return requestBodyTooLarge(c, maxBytes)
+      }
+      text += decoder.decode(chunk.value, { stream: true })
+    }
+    text += decoder.decode()
+
+    // OpenAPI validation reads through HonoRequest.json(), whose first cache
+    // key is `text`. Supplying the bounded buffer there prevents a second raw
+    // stream read while preserving the normal validator and handler contract.
+    // Hono's runtime body cache stores promises, although its public type
+    // currently describes the resolved values. Seed the runtime shape so a
+    // later `.json()` converts this already-bounded text instead of rereading
+    // the consumed request stream.
+    c.req.bodyCache.text = Promise.resolve(text) as unknown as string
+    return next()
+  }
+}
+
+function requestBodyTooLarge(c: Context<Env>, maxBytes: number): Response {
+  return c.json(
+    {
+      error: "Request body too large",
+      code: "request_body_too_large" as const,
+      maxBytes,
+      requestId: requestId(c),
+    },
+    413,
+  )
+}
+
+function activeShoppingContext(c: Context<Env>): StorefrontShoppingContext | null {
+  const channel = c.get("storefrontChannel")
+  if (!channel?.storefrontId || !channel.channelId || channel.channelStatus !== "active")
+    return null
+  return {
+    storefrontId: channel.storefrontId,
+    channelId: channel.channelId,
+    userId: c.get("userId") ?? null,
+    buyerAccountId: c.get("buyerAccountId") ?? null,
+  }
+}
+
+function requireSameOriginMutation(c: Context<Env>): boolean {
+  if (c.req.header("sec-fetch-site") === "cross-site") return false
+  const origin = c.req.header("origin")?.trim()
+  if (!origin) return false
+  try {
+    return new URL(origin).origin === new URL(c.req.url).origin
+  } catch {
+    return false
+  }
+}
+
+function setPrivateNoStore(c: Context<Env>): void {
+  c.header("Cache-Control", PRIVATE_NO_STORE)
+  c.header("Vary", "Cookie", { append: true })
+  c.header("Vary", "Authorization", { append: true })
+}
+
+function processNodeEnv(): string | undefined {
+  return (
+    globalThis as typeof globalThis & { process?: { env?: Record<string, string | undefined> } }
+  ).process?.env?.NODE_ENV
+}
+
+function convertedFxFreshness(result: z.infer<typeof storefrontShoppingResultSchema>): {
+  keys: string[]
+  validUntil: number | null
+} {
+  if (result.kind !== "indexed-inspiration") return { keys: [], validUntil: null }
+  const keys: string[] = []
+  let validUntil: number | null = null
+  for (const group of result.groups) {
+    for (const item of group.items) {
+      const money = item.priceFrom
+      if (!money || money.native.currency === money.presentation.currency) continue
+      if (!money.fx?.validUntil) return { keys: [], validUntil: null }
+      const expires = Date.parse(money.fx.validUntil)
+      if (!Number.isFinite(expires)) return { keys: [], validUntil: null }
+      validUntil = validUntil === null ? expires : Math.min(validUntil, expires)
+      keys.push(
+        [money.fx.authority, money.fx.quotedAt, money.fx.validUntil, money.fx.rate].join(":"),
+      )
+    }
+  }
+  return { keys: keys.sort(), validUntil }
+}
+
+async function setSafeIndexedCacheHeaders(
+  c: Context<Env>,
+  result: z.infer<typeof storefrontShoppingResultSchema>,
+  options: StorefrontShoppingPublicRoutesOptions,
+): Promise<void> {
+  const runtimeNodeEnv = (c.env as { NODE_ENV?: string } | undefined)?.NODE_ENV
+  const production = options.production ?? runtimeNodeEnv === "production"
+  const isProduction =
+    production || (runtimeNodeEnv === undefined && processNodeEnv() === "production")
+  if (
+    !isProduction ||
+    result.kind !== "indexed-inspiration" ||
+    c.get("isAnonymousRequest") !== true ||
+    !c.req.header("x-api-key") ||
+    c.req.header("cookie") ||
+    c.req.header("authorization")
+  ) {
+    setPrivateNoStore(c)
+    return
+  }
+
+  const freshness = convertedFxFreshness(result)
+  const now = (options.now?.() ?? new Date()).getTime()
+  const seconds = freshness.validUntil
+    ? Math.min(PUBLIC_INDEXED_CACHE_SECONDS, Math.floor((freshness.validUntil - now) / 1000))
+    : PUBLIC_INDEXED_CACHE_SECONDS
+  if (seconds < 1) {
+    setPrivateNoStore(c)
+    return
+  }
+
+  const scopeKey = [result.scope.marketId, result.scope.locale, result.scope.currency].join(":")
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(JSON.stringify([scopeKey, freshness.keys])),
+  )
+  const cacheTag = Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+  c.header("Cache-Control", `public, s-maxage=${seconds}`)
+  c.header("Cache-Tag", `storefront-shopping-${cacheTag}`)
+}
+
+function isRevisionConflict(value: unknown): boolean {
+  return (
+    value instanceof StorefrontTripSelectionRevisionConflictError ||
+    (typeof value === "object" &&
+      value !== null &&
+      (value as { code?: unknown }).code === "trip_selection_revision_conflict")
+  )
+}
+
+export function createStorefrontShoppingPublicRoutes(
+  options: StorefrontShoppingPublicRoutesOptions = {},
+): OpenAPIHono<Env> {
+  const gateway: StorefrontShoppingGateway = createStorefrontShoppingGateway(options)
+  const app = new OpenAPIHono<Env>({ defaultHook: openApiValidationHook })
+
+  app.use("*", async (c, next) => {
+    await next()
+    if (!c.res.headers.has("Cache-Control")) setPrivateNoStore(c)
+  })
+  app.use("*", boundedJsonBody(MAX_SHOPPING_BODY_BYTES))
+
+  return app
+    .openapi(searchRoute, async (c) => {
+      const context = activeShoppingContext(c)
+      if (!context) {
+        return c.json({ error: "active_storefront_channel_required", requestId: requestId(c) }, 403)
+      }
+      try {
+        const result = await gateway.search(context, c.req.valid("json"))
+        await setSafeIndexedCacheHeaders(c, result, options)
+        return c.json({ data: result }, 200)
+      } catch (cause) {
+        if (cause instanceof StorefrontShoppingUnavailableError) {
+          return c.json({ error: "storefront_shopping_unavailable", requestId: requestId(c) }, 503)
+        }
+        throw cause
+      }
+    })
+    .openapi(createTripSelectionRoute, async (c) => {
+      const context = activeShoppingContext(c)
+      if (!context) {
+        return c.json({ error: "active_storefront_channel_required", requestId: requestId(c) }, 403)
+      }
+      if (!requireSameOriginMutation(c)) {
+        return c.json({ error: "same_origin_required", requestId: requestId(c) }, 403)
+      }
+      try {
+        const result = await gateway.createTripSelection(context, c.req.valid("json"))
+        setPrivateNoStore(c)
+        return c.json({ data: result }, 201)
+      } catch (cause) {
+        if (cause instanceof StorefrontShoppingUnavailableError) {
+          return c.json({ error: "storefront_shopping_unavailable", requestId: requestId(c) }, 503)
+        }
+        throw cause
+      }
+    })
+    .openapi(updateTripSelectionRoute, async (c) => {
+      const context = activeShoppingContext(c)
+      if (!context) {
+        return c.json({ error: "active_storefront_channel_required", requestId: requestId(c) }, 403)
+      }
+      if (!requireSameOriginMutation(c)) {
+        return c.json({ error: "same_origin_required", requestId: requestId(c) }, 403)
+      }
+      try {
+        const result = await gateway.updateTripSelection(context, c.req.valid("json"))
+        setPrivateNoStore(c)
+        return c.json({ data: result }, 200)
+      } catch (cause) {
+        if (cause instanceof StorefrontShoppingUnavailableError) {
+          return c.json({ error: "storefront_shopping_unavailable", requestId: requestId(c) }, 503)
+        }
+        if (isRevisionConflict(cause)) {
+          return c.json({ error: "trip_selection_revision_conflict", requestId: requestId(c) }, 409)
+        }
+        throw cause
+      }
+    })
+}

--- a/packages/storefront/src/shopping/runtime.ts
+++ b/packages/storefront/src/shopping/runtime.ts
@@ -23,6 +23,16 @@ export class StorefrontShoppingUnavailableError extends Error {
   }
 }
 
+/** Provider-neutral compare-and-swap failure surfaced by Trip-selection runtimes. */
+export class StorefrontTripSelectionRevisionConflictError extends Error {
+  readonly code = "trip_selection_revision_conflict"
+
+  constructor() {
+    super("Trip selection changed after it was read.")
+    this.name = "StorefrontTripSelectionRevisionConflictError"
+  }
+}
+
 export interface StorefrontShoppingGateway {
   search(context: StorefrontShoppingContext, request: unknown): Promise<StorefrontShoppingResult>
   createTripSelection(

--- a/packages/storefront/src/voyant.ts
+++ b/packages/storefront/src/voyant.ts
@@ -71,7 +71,15 @@ export const storefrontVoyantModule = defineModule({
       mount: "/",
       resource: "storefront",
       openapi: { document: "storefront" },
-      anonymous: ["/bookings", "/departures", "/leads", "/newsletter", "/offers", "/settings"],
+      anonymous: [
+        "/bookings",
+        "/departures",
+        "/leads",
+        "/newsletter",
+        "/offers",
+        "/shopping",
+        "/settings",
+      ],
       runtime: {
         entry: "@voyant-travel/storefront",
         export: "createStorefrontApiModule",

--- a/packages/storefront/tests/unit/api-module.test.ts
+++ b/packages/storefront/tests/unit/api-module.test.ts
@@ -19,6 +19,7 @@ describe("createStorefrontApiModule", () => {
       "/leads",
       "/newsletter",
       "/offers",
+      "/shopping",
       "/settings",
     ])
     expect(assembleAnonymousPaths([module], [])).toEqual([
@@ -28,6 +29,7 @@ describe("createStorefrontApiModule", () => {
       "/v1/public/newsletter",
       "/v1/public/offers",
       "/v1/public/settings",
+      "/v1/public/shopping",
     ])
     expect(module.optionalCustomerAuth).toBe(storefrontOptionalCustomerAuthPaths)
     expect(module.optionalCustomerAuth).toEqual([
@@ -37,8 +39,10 @@ describe("createStorefrontApiModule", () => {
       "/newsletter",
       "/offers",
       "/products",
+      "/shopping",
       "/settings",
     ])
+    expect(module.bodyKeyedCache).toEqual(["/shopping/search"])
 
     const anonymouslyMatchedDepartureAndSettingsRoutes = new Set(
       module.publicRoutes?.routes

--- a/packages/storefront/tests/unit/shopping-public-routes.test.ts
+++ b/packages/storefront/tests/unit/shopping-public-routes.test.ts
@@ -1,0 +1,252 @@
+import { handleApiError, requestId } from "@voyant-travel/hono"
+import { Hono } from "hono"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  createStorefrontShoppingPublicRoutes,
+  type StorefrontShoppingRuntime,
+  StorefrontTripSelectionRevisionConflictError,
+  type StorefrontTripSelectionsRuntime,
+} from "../../src/shopping/index.js"
+
+const scope = {
+  marketId: "default",
+  locale: "en-GB",
+  currency: "EUR",
+  available: { marketIds: ["default"], locales: ["en-GB"], currencies: ["EUR"] },
+}
+
+const searchBody = {
+  scope: { locale: "en-GB", currency: "EUR" },
+  intent: { kind: "indexed-inspiration" as const, groups: [{ group: "tours" as const }] },
+}
+
+function runtime(): StorefrontShoppingRuntime {
+  return {
+    resolveScope: vi.fn(async () => scope),
+    search: vi.fn(async () => ({
+      kind: "indexed-inspiration" as const,
+      scope,
+      groups: [{ group: "tours" as const, items: [], total: 0 }],
+    })),
+  }
+}
+
+function tripRuntime(): StorefrontTripSelectionsRuntime {
+  return {
+    create: vi.fn(async (_context, input) => ({
+      selectionRef: "selection_ref_123456789",
+      revision: 0,
+      scope: input.scope,
+      items: [],
+    })),
+    update: vi.fn(async (_context, input) => ({
+      selectionRef: input.selectionRef,
+      revision: input.expectedRevision + 1,
+      scope,
+      items: [],
+    })),
+  }
+}
+
+function app(
+  options: Parameters<typeof createStorefrontShoppingPublicRoutes>[0] = {},
+  context: {
+    active?: boolean
+    anonymous?: boolean
+    userId?: string
+    buyerAccountId?: string
+  } = {},
+) {
+  const root = new Hono()
+  root.use("*", requestId)
+  root.use("*", async (c, next) => {
+    c.set(
+      "storefrontChannel" as never,
+      {
+        storefrontId: "sf_server",
+        channelId: "chan_server",
+        channelStatus: context.active === false ? "inactive" : "active",
+      } as never,
+    )
+    c.set("isAnonymousRequest" as never, (context.anonymous ?? true) as never)
+    if (context.userId) c.set("userId" as never, context.userId as never)
+    if (context.buyerAccountId) c.set("buyerAccountId" as never, context.buyerAccountId as never)
+    await next()
+  })
+  root.onError((cause, c) => handleApiError(cause, c))
+  root.route("/v1/public/shopping", createStorefrontShoppingPublicRoutes(options))
+  return root
+}
+
+function jsonRequest(path: string, body: unknown, init: RequestInit = {}) {
+  return new Request(`https://shop.example${path}`, {
+    ...init,
+    method: init.method ?? "POST",
+    headers: { "content-type": "application/json", ...init.headers },
+    body: JSON.stringify(body),
+  })
+}
+
+describe("Storefront shopping public routes", () => {
+  it("keeps the canonical public capability paths in the OpenAPI registry", () => {
+    const routes = createStorefrontShoppingPublicRoutes()
+    expect([
+      ...new Set(
+        routes.routes
+          .filter(({ method }) => method !== "ALL")
+          .map(({ method, path }) => `${method} ${path}`),
+      ),
+    ]).toEqual(["POST /search", "POST /trip-selections", "PATCH /trip-selections"])
+  })
+
+  it("requires an active server-resolved Storefront Channel and ignores no browser selector", async () => {
+    const shopping = runtime()
+    const response = await app({ shopping }, { active: false }).request(
+      jsonRequest("/v1/public/shopping/search", searchBody),
+    )
+    expect(response.status).toBe(403)
+    expect(shopping.search).not.toHaveBeenCalled()
+
+    const spoofed = await app({ shopping }).request(
+      jsonRequest("/v1/public/shopping/search", { ...searchBody, providerId: "provider_browser" }),
+    )
+    expect(spoofed.status).toBe(400)
+    expect(await spoofed.json()).toMatchObject({
+      code: "invalid_request",
+      requestId: expect.any(String),
+    })
+  })
+
+  it("returns an explicit PII-free 503 when optional runtimes are unbound", async () => {
+    const response = await app().request(jsonRequest("/v1/public/shopping/search", searchBody))
+    expect(response.status).toBe(503)
+    expect(await response.json()).toEqual({
+      error: "storefront_shopping_unavailable",
+      requestId: expect.any(String),
+    })
+    expect(response.headers.get("cache-control")).toBe("private, no-store")
+    expect(response.headers.get("vary")).toContain("Cookie")
+    expect(response.headers.get("x-request-id")).toBeTruthy()
+  })
+
+  it("bounds JSON bodies with absent or misleading Content-Length before provider invocation", async () => {
+    const shopping = runtime()
+    const oversizedBody = { ...searchBody, padding: "x".repeat(65 * 1024) }
+    const absentLength = await app({ shopping }).request(
+      jsonRequest("/v1/public/shopping/search", oversizedBody),
+    )
+    expect(absentLength.status).toBe(413)
+    expect(absentLength.headers.get("cache-control")).toBe("private, no-store")
+    expect(await absentLength.json()).toMatchObject({
+      code: "request_body_too_large",
+      maxBytes: 64 * 1024,
+      requestId: expect.any(String),
+    })
+
+    const misleadingLength = await app({ shopping }).request(
+      jsonRequest("/v1/public/shopping/search", oversizedBody, {
+        headers: { "content-length": "1" },
+      }),
+    )
+    expect(misleadingLength.status).toBe(413)
+    expect(shopping.search).not.toHaveBeenCalled()
+  })
+
+  it("propagates only managed customer ownership from request auth context", async () => {
+    const shopping = runtime()
+    const response = await app(
+      { shopping },
+      { anonymous: false, userId: "usr_managed", buyerAccountId: "buyer_managed" },
+    ).request(jsonRequest("/v1/public/shopping/search", searchBody))
+    expect(response.status).toBe(200)
+    expect(shopping.search).toHaveBeenCalledWith(
+      {
+        storefrontId: "sf_server",
+        channelId: "chan_server",
+        userId: "usr_managed",
+        buyerAccountId: "buyer_managed",
+      },
+      expect.anything(),
+    )
+    expect(response.headers.get("cache-control")).toBe("private, no-store")
+  })
+
+  it("shares only production anonymous indexed inspiration with a presentation/FX cache tag", async () => {
+    const publicResponse = await app({ shopping: runtime(), production: true }).request(
+      jsonRequest("/v1/public/shopping/search", searchBody, {
+        headers: { "x-api-key": "storefront_key" },
+      }),
+    )
+    expect(publicResponse.status).toBe(200)
+    expect(publicResponse.headers.get("cache-control")).toBe("public, s-maxage=60")
+    expect(publicResponse.headers.get("cache-tag")).toMatch(/^storefront-shopping-[a-f0-9]{64}$/)
+    expect(publicResponse.headers.get("vary")).toBeNull()
+
+    const cookieResponse = await app({ shopping: runtime(), production: true }).request(
+      jsonRequest("/v1/public/shopping/search", searchBody, {
+        headers: { cookie: "voyant.customer_session=opaque" },
+      }),
+    )
+    expect(cookieResponse.headers.get("cache-control")).toBe("private, no-store")
+    expect(cookieResponse.headers.get("vary")).toContain("Cookie")
+
+    const liveBody = {
+      scope: {},
+      intent: {
+        kind: "flight",
+        slices: [{ origin: "OTP", destination: "LHR", departureDate: "2026-09-01" }],
+        travelers: { adults: 1 },
+      },
+    }
+    const liveShopping: StorefrontShoppingRuntime = {
+      resolveScope: async () => scope,
+      search: async () => ({
+        kind: "flight",
+        scope,
+        offers: [],
+        coverage: { status: "complete", succeeded: 1, failed: 0, timedOut: 0 },
+      }),
+    }
+    const live = await app({ shopping: liveShopping, production: true }).request(
+      jsonRequest("/v1/public/shopping/search", liveBody),
+    )
+    expect(live.headers.get("cache-control")).toBe("private, no-store")
+  })
+
+  it("rejects cross-site Trip mutations and maps provider CAS conflicts to 409", async () => {
+    const trips = tripRuntime()
+    const createBody = {
+      scope: {},
+      offers: [{ kind: "product", offerRef: "offer_ref_123456789" }],
+    }
+    const crossSite = await app({ shopping: runtime(), tripSelections: trips }).request(
+      jsonRequest("/v1/public/shopping/trip-selections", createBody, {
+        headers: { origin: "https://evil.example", "sec-fetch-site": "cross-site" },
+      }),
+    )
+    expect(crossSite.status).toBe(403)
+    expect(trips.create).not.toHaveBeenCalled()
+
+    trips.update = vi.fn(async () => {
+      throw new StorefrontTripSelectionRevisionConflictError()
+    })
+    const conflict = await app({ shopping: runtime(), tripSelections: trips }).request(
+      jsonRequest(
+        "/v1/public/shopping/trip-selections",
+        {
+          selectionRef: "selection_ref_123456789",
+          expectedRevision: 3,
+          mutation: { kind: "remove", itemRef: "selection_item_123456" },
+        },
+        { method: "PATCH", headers: { origin: "https://shop.example" } },
+      ),
+    )
+    expect(conflict.status).toBe(409)
+    expect(await conflict.json()).toMatchObject({
+      error: "trip_selection_revision_conflict",
+      requestId: expect.any(String),
+    })
+    expect(conflict.headers.get("cache-control")).toBe("private, no-store")
+  })
+})

--- a/packages/storefront/tests/unit/voyant-manifest.test.ts
+++ b/packages/storefront/tests/unit/voyant-manifest.test.ts
@@ -66,7 +66,15 @@ describe("storefront deployment manifest", () => {
           mount: "/",
           resource: "storefront",
           openapi: { document: "storefront" },
-          anonymous: ["/bookings", "/departures", "/leads", "/newsletter", "/offers", "/settings"],
+          anonymous: [
+            "/bookings",
+            "/departures",
+            "/leads",
+            "/newsletter",
+            "/offers",
+            "/shopping",
+            "/settings",
+          ],
           runtime: {
             entry: "@voyant-travel/storefront",
             export: "createStorefrontApiModule",


### PR DESCRIPTION
## Summary

- expose the provider-first shopping runtime at `POST /v1/public/shopping/search` and opaque Trip selections at `POST|PATCH /v1/public/shopping/trip-selections`
- require a server-resolved active Storefront Channel and propagate only managed request-context `userId` / `buyerAccountId`; strict schemas reject browser tenant, organization, runtime, provider, source, channel, and ownership selectors
- fail closed with explicit 503 responses when optional runtimes are unbound; map provider-neutral revision conflicts to 409
- enforce a streaming 64 KiB JSON ceiling before OpenAPI validation and exact same-origin proof for state-changing Trip-selection calls
- keep live, authenticated/cookie-bearing, Trip state, and errors private/no-store with `Vary: Cookie, Authorization`; allow only production anonymous indexed inspiration into the canonical body-keyed cache, scoped by the Storefront key and presentation/FX freshness tag/TTL
- wire optional graph ports, anonymous optional customer auth, body-keyed cache participation, request IDs, and PII-free error contracts

## Scope

This PR is stacked on #4436 (`feat/storefront-shopping-gateway`). It does not implement provider fanout, FX calculation, or Trip persistence/composition internals.

## Validation status

Static checks completed:

- `biome check --write` on all touched source/test files: passed
- `git diff --check 1322f5694f..HEAD`: passed
- exact base merge-base: `1322f5694f338946543f4470f5ee0ec15db29086`

The latest streaming-body-limit revision still needs narrow runtime validation. `lab1` was unreachable (SSH timeout), and the remote job was stopped rather than falling back to an unapproved lane. Run:

```sh
pnpm --filter @voyant-travel/storefront exec vitest run tests/unit/shopping-public-routes.test.ts tests/unit/api-module.test.ts tests/unit/voyant-manifest.test.ts --maxWorkers=4
pnpm --filter @voyant-travel/hono exec vitest run tests/unit/public-cache.test.ts --maxWorkers=4
pnpm --filter @voyant-travel/storefront typecheck
pnpm --filter @voyant-travel/hono typecheck
pnpm --filter @voyant-travel/storefront generate:shopping-openapi
pnpm --filter @voyant-travel/storefront verify:openapi-authority
```

After generation, commit `packages/storefront/openapi/storefront/storefront.json` and verify the only new paths are `/v1/public/shopping/search` and `/v1/public/shopping/trip-selections`.
