### PR TITLE
feat(storefront): add managed shopping runtime

### DIFF
--- a/.changeset/warm-storefront-shopping-runtime.md
+++ b/.changeset/warm-storefront-shopping-runtime.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/storefront": minor
+---
+
+Add the optional OSS managed storefront shopping provider, with active Commerce scope resolution, server-authored Catalog inspiration slices, closed live-search and opaque-reference ports, and shared presentation-currency normalization.

--- a/packages/accommodations/tsconfig.build.json
+++ b/packages/accommodations/tsconfig.build.json
@@ -1945,6 +1945,12 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/managed-runtime": [
+        "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/provider-ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/runtime-port": [
         "../storefront/dist/shopping/runtime-port.d.ts"
       ],

--- a/packages/accommodations/tsconfig.typecheck.json
+++ b/packages/accommodations/tsconfig.typecheck.json
@@ -1946,6 +1946,12 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/managed-runtime": [
+        "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/provider-ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/runtime-port": [
         "../storefront/dist/shopping/runtime-port.d.ts"
       ],

--- a/packages/catalog/tsconfig.build.json
+++ b/packages/catalog/tsconfig.build.json
@@ -1897,6 +1897,12 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/managed-runtime": [
+        "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/provider-ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/runtime-port": [
         "../storefront/dist/shopping/runtime-port.d.ts"
       ],

--- a/packages/catalog/tsconfig.typecheck.json
+++ b/packages/catalog/tsconfig.typecheck.json
@@ -1898,6 +1898,12 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/managed-runtime": [
+        "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/provider-ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/runtime-port": [
         "../storefront/dist/shopping/runtime-port.d.ts"
       ],

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -1905,6 +1905,12 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/managed-runtime": [
+        "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/provider-ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/runtime-port": [
         "../storefront/dist/shopping/runtime-port.d.ts"
       ],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -1899,6 +1899,12 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/managed-runtime": [
+        "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/provider-ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/runtime-port": [
         "../storefront/dist/shopping/runtime-port.d.ts"
       ],

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -1950,6 +1950,12 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/managed-runtime": [
+        "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/provider-ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/runtime-port": [
         "../storefront/dist/shopping/runtime-port.d.ts"
       ],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -1951,6 +1951,12 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/managed-runtime": [
+        "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/provider-ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/runtime-port": [
         "../storefront/dist/shopping/runtime-port.d.ts"
       ],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -1954,6 +1954,12 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/managed-runtime": [
+        "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/provider-ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/runtime-port": [
         "../storefront/dist/shopping/runtime-port.d.ts"
       ],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -1955,6 +1955,12 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/managed-runtime": [
+        "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/provider-ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/runtime-port": [
         "../storefront/dist/shopping/runtime-port.d.ts"
       ],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -1986,6 +1986,12 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/managed-runtime": [
+        "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/provider-ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/runtime-port": [
         "../storefront/dist/shopping/runtime-port.d.ts"
       ],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -1981,6 +1981,12 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/managed-runtime": [
+        "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/provider-ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/runtime-port": [
         "../storefront/dist/shopping/runtime-port.d.ts"
       ],

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -1988,6 +1988,12 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/managed-runtime": [
+        "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/provider-ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/runtime-port": [
         "../storefront/dist/shopping/runtime-port.d.ts"
       ],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -1989,6 +1989,12 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/managed-runtime": [
+        "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/provider-ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/runtime-port": [
         "../storefront/dist/shopping/runtime-port.d.ts"
       ],

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -1986,6 +1986,12 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/managed-runtime": [
+        "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/provider-ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/runtime-port": [
         "../storefront/dist/shopping/runtime-port.d.ts"
       ],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -1981,6 +1981,12 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/managed-runtime": [
+        "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/provider-ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/runtime-port": [
         "../storefront/dist/shopping/runtime-port.d.ts"
       ],

--- a/packages/inventory/tsconfig.build.json
+++ b/packages/inventory/tsconfig.build.json
@@ -1918,6 +1918,12 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/managed-runtime": [
+        "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/provider-ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/runtime-port": [
         "../storefront/dist/shopping/runtime-port.d.ts"
       ],

--- a/packages/inventory/tsconfig.typecheck.json
+++ b/packages/inventory/tsconfig.typecheck.json
@@ -1919,6 +1919,12 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/managed-runtime": [
+        "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/provider-ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/runtime-port": [
         "../storefront/dist/shopping/runtime-port.d.ts"
       ],

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -1885,6 +1885,12 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/managed-runtime": [
+        "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/provider-ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/runtime-port": [
         "../storefront/dist/shopping/runtime-port.d.ts"
       ],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -1880,6 +1880,12 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/managed-runtime": [
+        "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/provider-ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/runtime-port": [
         "../storefront/dist/shopping/runtime-port.d.ts"
       ],

--- a/packages/storefront/package.json
+++ b/packages/storefront/package.json
@@ -18,6 +18,8 @@
     "./runtime-contributor": "./src/runtime-contributor.ts",
     "./runtime-port": "./src/runtime-port.ts",
     "./shopping": "./src/shopping/index.ts",
+    "./shopping/managed-runtime": "./src/shopping/managed-runtime.ts",
+    "./shopping/provider-ports": "./src/shopping/provider-ports.ts",
     "./shopping/runtime-port": "./src/shopping/runtime-port.ts",
     "./service": "./src/service.ts",
     "./tools": "./src/mcp-runtime.ts",
@@ -195,6 +197,16 @@
         "types": "./dist/shopping/index.d.ts",
         "import": "./dist/shopping/index.js",
         "default": "./dist/shopping/index.js"
+      },
+      "./shopping/managed-runtime": {
+        "types": "./dist/shopping/managed-runtime.d.ts",
+        "import": "./dist/shopping/managed-runtime.js",
+        "default": "./dist/shopping/managed-runtime.js"
+      },
+      "./shopping/provider-ports": {
+        "types": "./dist/shopping/provider-ports.d.ts",
+        "import": "./dist/shopping/provider-ports.js",
+        "default": "./dist/shopping/provider-ports.js"
       },
       "./shopping/runtime-port": {
         "types": "./dist/shopping/runtime-port.d.ts",

--- a/packages/storefront/src/runtime-contributor.ts
+++ b/packages/storefront/src/runtime-contributor.ts
@@ -1,18 +1,44 @@
 import { customerBusinessAccountOnboardingRuntimePort } from "@voyant-travel/auth/customer-business-onboarding-runtime-port"
+import type { PresentationFxQuoter } from "@voyant-travel/catalog-contracts/presentation-money"
 import { createCommerceStorefrontOfferResolvers } from "@voyant-travel/commerce"
 import type { VoyantRuntimeHostPrimitives } from "@voyant-travel/core"
+import type { VoyantPort } from "@voyant-travel/core/project"
 import { createStorefrontCustomerBusinessOnboardingRuntime } from "./customer-business-onboarding-runtime.js"
 import { storefrontCustomerPortalRuntimePort, storefrontOffersRuntimePort } from "./runtime-port.js"
+import { createManagedStorefrontShoppingRuntime } from "./shopping/managed-runtime.js"
+import {
+  type StorefrontOpaqueReferenceIssuer,
+  type StorefrontShoppingCatalogProvider,
+  type StorefrontShoppingLiveProvider,
+  type StorefrontShoppingMarketProvider,
+  storefrontOpaqueReferenceIssuerPort,
+  storefrontPresentationFxProviderPort,
+  storefrontShoppingCatalogProviderPort,
+  storefrontShoppingLiveProviderPort,
+  storefrontShoppingMarketProviderPort,
+} from "./shopping/provider-ports.js"
+import { storefrontShoppingRuntimePort } from "./shopping/runtime-port.js"
 
 export interface StorefrontRuntimeContributorHost {
   primitives: VoyantRuntimeHostPrimitives
   hasRuntimePort?(port: { id: string }): boolean
+  getRuntimePort?<T>(port: Pick<VoyantPort<T>, "id">): T | Promise<T>
 }
 
 /** Storefront-owned adapters derived exclusively from generic Node primitives. */
 export function createStorefrontRuntimePortContribution(
   host: StorefrontRuntimeContributorHost,
 ): Readonly<Record<string, unknown>> {
+  const managedShoppingDependencies = [
+    storefrontShoppingMarketProviderPort,
+    storefrontShoppingCatalogProviderPort,
+    storefrontShoppingLiveProviderPort,
+    storefrontOpaqueReferenceIssuerPort,
+  ] as const
+  const canProvideManagedShopping =
+    host.getRuntimePort !== undefined &&
+    managedShoppingDependencies.every((port) => host.hasRuntimePort?.(port) === true)
+  const getRuntimePort = host.getRuntimePort
   return {
     [storefrontOffersRuntimePort.id]: createCommerceStorefrontOfferResolvers(),
     [storefrontCustomerPortalRuntimePort.id]: {
@@ -24,5 +50,30 @@ export function createStorefrontRuntimePortContribution(
           [customerBusinessAccountOnboardingRuntimePort.id]:
             createStorefrontCustomerBusinessOnboardingRuntime(),
         }),
+    ...(canProvideManagedShopping
+      ? {
+          [storefrontShoppingRuntimePort.id]: Promise.all([
+            getRuntimePort?.<StorefrontShoppingMarketProvider>(
+              storefrontShoppingMarketProviderPort,
+            ),
+            getRuntimePort?.<StorefrontShoppingCatalogProvider>(
+              storefrontShoppingCatalogProviderPort,
+            ),
+            getRuntimePort?.<StorefrontShoppingLiveProvider>(storefrontShoppingLiveProviderPort),
+            getRuntimePort?.<StorefrontOpaqueReferenceIssuer>(storefrontOpaqueReferenceIssuerPort),
+            host.hasRuntimePort?.(storefrontPresentationFxProviderPort)
+              ? getRuntimePort?.<PresentationFxQuoter>(storefrontPresentationFxProviderPort)
+              : undefined,
+          ]).then(([markets, catalog, live, references, quoteFx]) =>
+            createManagedStorefrontShoppingRuntime({
+              markets: markets as StorefrontShoppingMarketProvider,
+              catalog: catalog as StorefrontShoppingCatalogProvider,
+              live: live as StorefrontShoppingLiveProvider,
+              references: references as StorefrontOpaqueReferenceIssuer,
+              ...(quoteFx ? { quoteFx } : {}),
+            }),
+          ),
+        }
+      : {}),
   }
 }

--- a/packages/storefront/src/shopping/index.ts
+++ b/packages/storefront/src/shopping/index.ts
@@ -1,3 +1,5 @@
+export * from "./managed-runtime.js"
+export * from "./provider-ports.js"
 export * from "./routes-public.js"
 export * from "./runtime.js"
 export * from "./runtime-port.js"

--- a/packages/storefront/src/shopping/managed-runtime.ts
+++ b/packages/storefront/src/shopping/managed-runtime.ts
@@ -1,0 +1,436 @@
+import {
+  comparePresentationMoney,
+  normalizePresentationMoney,
+} from "@voyant-travel/catalog/search/presentation-money"
+import type { SearchFilter } from "@voyant-travel/catalog-contracts/indexer/contract"
+import type { PresentationFxQuoter } from "@voyant-travel/catalog-contracts/presentation-money"
+
+import type {
+  StorefrontCatalogSliceItem,
+  StorefrontLiveSearchPage,
+  StorefrontOpaqueReferenceIssuer,
+  StorefrontShoppingCatalogProvider,
+  StorefrontShoppingLiveProvider,
+  StorefrontShoppingMarketProvider,
+} from "./provider-ports.js"
+import type { StorefrontShoppingContext, StorefrontShoppingRuntime } from "./runtime-port.js"
+import type {
+  StorefrontRequestedScope,
+  StorefrontResolvedScope,
+  StorefrontShoppingIntent,
+  StorefrontShoppingResult,
+} from "./schemas.js"
+
+const OFFER_TTL_SECONDS = 15 * 60
+const ITEM_TTL_SECONDS = 15 * 60
+
+export class StorefrontShoppingScopeError extends Error {
+  readonly code = "storefront_shopping_scope_unsupported"
+  constructor(
+    readonly selector: "marketId" | "locale" | "currency" | "market",
+    readonly requested?: string,
+  ) {
+    super(`Unsupported storefront shopping ${selector}${requested ? `: ${requested}` : "."}`)
+    this.name = "StorefrontShoppingScopeError"
+  }
+}
+
+export interface ManagedStorefrontShoppingRuntimeOptions {
+  markets: StorefrontShoppingMarketProvider
+  catalog: StorefrontShoppingCatalogProvider
+  live: StorefrontShoppingLiveProvider
+  references: StorefrontOpaqueReferenceIssuer
+  quoteFx?: PresentationFxQuoter
+  now?: () => Date
+}
+
+/** Managed OSS implementation of the provider-first shopping runtime. */
+export function createManagedStorefrontShoppingRuntime(
+  options: ManagedStorefrontShoppingRuntimeOptions,
+): StorefrontShoppingRuntime {
+  const now = options.now ?? (() => new Date())
+
+  return {
+    async resolveScope(context, requested) {
+      return resolveActiveScope(options.markets, context, requested)
+    },
+    async search(context, input) {
+      switch (input.intent.kind) {
+        case "indexed-inspiration":
+          return searchInspiration(options, context, input.scope, input.intent, now)
+        case "flight":
+          return searchFlights(options, context, input.scope, input.intent, now)
+        case "stay":
+          return searchStays(options, context, input.scope, input.intent, now)
+        case "package":
+          return searchPackages(options, context, input.scope, input.intent, now)
+      }
+    },
+  }
+}
+
+async function resolveActiveScope(
+  provider: StorefrontShoppingMarketProvider,
+  context: StorefrontShoppingContext,
+  requested: StorefrontRequestedScope,
+): Promise<StorefrontResolvedScope> {
+  const markets = await provider.listActiveMarkets({
+    storefrontId: context.storefrontId,
+    channelId: context.channelId,
+  })
+  if (markets.length === 0) throw new StorefrontShoppingScopeError("market")
+  const market = requested.marketId
+    ? markets.find((candidate) => candidate.id === requested.marketId)
+    : (markets.find((candidate) => candidate.isDefault) ?? markets[0])
+  if (!market) throw new StorefrontShoppingScopeError("marketId", requested.marketId)
+
+  const locales = unique([market.defaultLocale, ...market.locales])
+  const currencies = unique([market.defaultCurrency, ...market.currencies].map(upperCurrency))
+  const locale = requested.locale ?? market.defaultLocale
+  const currency = upperCurrency(requested.currency ?? market.defaultCurrency)
+  if (!locales.includes(locale)) throw new StorefrontShoppingScopeError("locale", locale)
+  if (!currencies.includes(currency)) throw new StorefrontShoppingScopeError("currency", currency)
+
+  return {
+    marketId: market.id,
+    locale,
+    currency,
+    available: { marketIds: markets.map(({ id }) => id), locales, currencies },
+  }
+}
+
+type InspirationIntent = Extract<StorefrontShoppingIntent, { kind: "indexed-inspiration" }>
+
+export function inspirationCatalogSlice(group: InspirationIntent["groups"][number]["group"]): {
+  vertical: "products" | "accommodations" | "cruises" | "charters"
+  filters: SearchFilter[]
+} {
+  switch (group) {
+    case "tours":
+      return { vertical: "products", filters: [{ kind: "eq", field: "familyCode", value: "tour" }] }
+    case "activities":
+      return {
+        vertical: "products",
+        filters: [{ kind: "eq", field: "familyCode", value: "activity" }],
+      }
+    case "attractions":
+      return {
+        vertical: "products",
+        filters: [{ kind: "eq", field: "familyCode", value: "attraction" }],
+      }
+    case "experiences":
+      return {
+        vertical: "products",
+        filters: [
+          {
+            kind: "or",
+            clauses: [
+              { kind: "in", field: "categorySlugs", values: ["experience", "experiences"] },
+              { kind: "in", field: "subtypeCode", values: ["experience", "local-experience"] },
+            ],
+          },
+        ],
+      }
+    case "excursions":
+      return {
+        vertical: "products",
+        filters: [
+          {
+            kind: "in",
+            field: "subtypeCode",
+            values: ["excursion", "day-excursion", "shore-excursion"],
+          },
+        ],
+      }
+    case "stays":
+      return { vertical: "accommodations", filters: [] }
+    case "cruises":
+      return { vertical: "cruises", filters: [] }
+    case "charters":
+      return { vertical: "charters", filters: [] }
+  }
+}
+
+async function searchInspiration(
+  options: ManagedStorefrontShoppingRuntimeOptions,
+  context: StorefrontShoppingContext,
+  scope: StorefrontResolvedScope,
+  intent: InspirationIntent,
+  now: () => Date,
+): Promise<StorefrontShoppingResult> {
+  const groups = await Promise.all(
+    intent.groups.map(async (request) => {
+      const mapping = inspirationCatalogSlice(request.group)
+      const result = await options.catalog.searchSlice({
+        context,
+        scope,
+        vertical: mapping.vertical,
+        query: request.query ?? request.destination?.query ?? "",
+        filters: [...mapping.filters, ...destinationFilters(request.destination)],
+        pagination: request.pagination,
+      })
+      const normalized = await normalizePresentationMoney(
+        result.items.flatMap((item) => (item.nativePrice ? [item.nativePrice] : [])),
+        { targetCurrency: scope.currency, quoteFx: options.quoteFx },
+      )
+      let pricedIndex = 0
+      const items = await Promise.all(
+        result.items.map(async (item) => {
+          const priceFrom = item.nativePrice ? normalized.prices[pricedIndex++] : undefined
+          const issued = await issueBoundedReference(options.references, now, {
+            purpose: "catalog-item",
+            context,
+            scope,
+            payload: { entityModule: mapping.vertical, entityId: item.entityId },
+            replay: "multi-use",
+          })
+          return publicCatalogItem(item, issued.ref, priceFrom)
+        }),
+      )
+      return {
+        group: request.group,
+        items,
+        total: result.total,
+        ...(result.nextCursor ? { nextCursor: result.nextCursor } : {}),
+      }
+    }),
+  )
+  return { kind: "indexed-inspiration", scope, groups }
+}
+
+function publicCatalogItem(
+  item: StorefrontCatalogSliceItem,
+  itemRef: string,
+  priceFrom: Awaited<ReturnType<typeof normalizePresentationMoney>>["prices"][number],
+) {
+  return {
+    itemRef,
+    title: item.title,
+    ...(item.summary ? { summary: item.summary } : {}),
+    ...(item.href ? { href: item.href } : {}),
+    ...(item.image ? { image: item.image } : {}),
+    ...(priceFrom ? { priceFrom } : {}),
+  }
+}
+
+type FlightIntent = Extract<StorefrontShoppingIntent, { kind: "flight" }>
+type StayIntent = Extract<StorefrontShoppingIntent, { kind: "stay" }>
+type PackageIntent = Extract<StorefrontShoppingIntent, { kind: "package" }>
+
+async function searchFlights(
+  options: ManagedStorefrontShoppingRuntimeOptions,
+  context: StorefrontShoppingContext,
+  scope: StorefrontResolvedScope,
+  intent: FlightIntent,
+  now: () => Date,
+): Promise<StorefrontShoppingResult> {
+  const page = await options.live.searchFlights({ context, scope, intent })
+  const normalized = await normalizeLive(page, scope.currency, options.quoteFx)
+  const offers = await Promise.all(
+    normalized.items.map(async ({ item, price }) => {
+      const issued = await issueBoundedReference(options.references, now, {
+        purpose: "flight-offer",
+        context,
+        scope,
+        payload: { selection: item.selection, providerData: item.providerData },
+        replay: "single-use",
+      })
+      return {
+        offerRef: issued.ref,
+        itineraries: item.itineraries,
+        price,
+        expiresAt: earlierExpiry(issued.expiresAt, item.expiresAt),
+      }
+    }),
+  )
+  return { kind: "flight", scope, offers, coverage: coverage(page, normalized.dropped) }
+}
+
+async function searchStays(
+  options: ManagedStorefrontShoppingRuntimeOptions,
+  context: StorefrontShoppingContext,
+  scope: StorefrontResolvedScope,
+  intent: StayIntent,
+  now: () => Date,
+): Promise<StorefrontShoppingResult> {
+  const page = await options.live.searchStays({ context, scope, intent })
+  const normalized = await normalizeLive(page, scope.currency, options.quoteFx)
+  const offers = await Promise.all(
+    normalized.items.map(async ({ item, price }) => {
+      const [offer, accommodation] = await Promise.all([
+        issueBoundedReference(options.references, now, {
+          purpose: "stay-offer",
+          context,
+          scope,
+          payload: { selection: item.selection, providerData: item.providerData },
+          replay: "single-use",
+        }),
+        issueBoundedReference(options.references, now, {
+          purpose: "catalog-item",
+          context,
+          scope,
+          payload: { entityModule: "accommodations", selection: item.accommodationSelection },
+          replay: "multi-use",
+        }),
+      ])
+      return {
+        offerRef: offer.ref,
+        accommodationRef: accommodation.ref,
+        title: item.title,
+        checkIn: item.checkIn,
+        checkOut: item.checkOut,
+        ...(item.roomName ? { roomName: item.roomName } : {}),
+        ...(item.boardName ? { boardName: item.boardName } : {}),
+        ...(item.image ? { image: item.image } : {}),
+        price,
+        expiresAt: earlierExpiry(offer.expiresAt, item.expiresAt),
+      }
+    }),
+  )
+  return { kind: "stay", scope, offers, coverage: coverage(page, normalized.dropped) }
+}
+
+async function searchPackages(
+  options: ManagedStorefrontShoppingRuntimeOptions,
+  context: StorefrontShoppingContext,
+  scope: StorefrontResolvedScope,
+  intent: PackageIntent,
+  now: () => Date,
+): Promise<StorefrontShoppingResult> {
+  const page = await options.live.searchPackages({ context, scope, intent })
+  const normalized = await normalizeLive(page, scope.currency, options.quoteFx)
+  const offers = await Promise.all(
+    normalized.items.map(async ({ item, price }) => {
+      const issued = await issueBoundedReference(options.references, now, {
+        purpose: "package-offer",
+        context,
+        scope,
+        payload: { selection: item.selection, providerData: item.providerData },
+        replay: "single-use",
+      })
+      return {
+        offerRef: issued.ref,
+        title: item.title,
+        origin: item.origin,
+        destination: item.destination,
+        departureDate: item.departureDate,
+        nights: item.nights,
+        accommodationName: item.accommodationName,
+        ...(item.boardName ? { boardName: item.boardName } : {}),
+        ...(item.image ? { image: item.image } : {}),
+        price,
+        expiresAt: earlierExpiry(issued.expiresAt, item.expiresAt),
+      }
+    }),
+  )
+  return { kind: "package", scope, offers, coverage: coverage(page, normalized.dropped) }
+}
+
+async function normalizeLive<T extends { nativePrice: { amount: string; currency: string } }>(
+  page: StorefrontLiveSearchPage<T>,
+  currency: string,
+  quoteFx: PresentationFxQuoter | undefined,
+) {
+  const normalized = await normalizePresentationMoney(
+    page.items.map(({ nativePrice }) => nativePrice),
+    { targetCurrency: currency, quoteFx },
+  )
+  const items = page.items.flatMap((item, index) => {
+    const price = normalized.prices[index]
+    return price ? [{ item, price }] : []
+  })
+  if (
+    normalized.ranking.status === "ranked_native" ||
+    normalized.ranking.status === "ranked_presentation"
+  ) {
+    items.sort((left, right) => comparePresentationMoney(left.price, right.price))
+  }
+  return { items, dropped: page.items.length - items.length }
+}
+
+function coverage(page: StorefrontLiveSearchPage<unknown>, dropped: number) {
+  const succeeded = page.sources.filter(
+    ({ status }) => status === "ok" || status === "partial" || status === "empty",
+  ).length
+  const timedOut = page.sources.filter(({ status }) => status === "timeout").length
+  const failed = page.sources.length - succeeded - timedOut + (dropped > 0 ? 1 : 0)
+  return {
+    status:
+      succeeded === 0
+        ? failed > 0 || timedOut > 0
+          ? "unavailable"
+          : "complete"
+        : failed > 0 || timedOut > 0 || page.sources.some(({ status }) => status === "partial")
+          ? "partial"
+          : "complete",
+    succeeded,
+    failed,
+    timedOut,
+  } as const
+}
+
+async function issueBoundedReference(
+  issuer: StorefrontOpaqueReferenceIssuer,
+  now: () => Date,
+  input: {
+    purpose: "catalog-item" | "flight-offer" | "stay-offer" | "package-offer"
+    context: StorefrontShoppingContext
+    scope: StorefrontResolvedScope
+    payload: Readonly<Record<string, unknown>>
+    replay: "multi-use" | "single-use"
+  },
+) {
+  const issuedAt = now().getTime()
+  const issued = await issuer.issue({
+    purpose: input.purpose,
+    storefrontId: input.context.storefrontId,
+    channelId: input.context.channelId,
+    owner: {
+      userId: input.context.userId ?? null,
+      buyerAccountId: input.context.buyerAccountId ?? null,
+    },
+    scope: {
+      marketId: input.scope.marketId,
+      locale: input.scope.locale,
+      currency: input.scope.currency,
+    },
+    payload: input.payload,
+    ttlSeconds: input.purpose === "catalog-item" ? ITEM_TTL_SECONDS : OFFER_TTL_SECONDS,
+    replay: input.replay,
+  })
+  if (issued.ref.length < 16 || issued.ref.length > 512) throw new Error("opaque_reference_invalid")
+  const expiry = Date.parse(issued.expiresAt)
+  const max =
+    issuedAt + (input.purpose === "catalog-item" ? ITEM_TTL_SECONDS : OFFER_TTL_SECONDS) * 1000
+  if (!Number.isFinite(expiry) || expiry <= issuedAt || expiry > max) {
+    throw new Error("opaque_reference_expiry_invalid")
+  }
+  return issued
+}
+
+function destinationFilters(
+  destination: InspirationIntent["groups"][number]["destination"],
+): SearchFilter[] {
+  if (!destination) return []
+  const filters: SearchFilter[] = []
+  if (destination.countryCode) {
+    filters.push({ kind: "in", field: "countryCodes", values: [destination.countryCode] })
+  }
+  if (destination.city) {
+    filters.push({ kind: "in", field: "destinations", values: [destination.city] })
+  }
+  return filters
+}
+
+function earlierExpiry(issued: string, upstream: string | undefined): string {
+  if (!upstream) return issued
+  return Date.parse(upstream) < Date.parse(issued) ? upstream : issued
+}
+
+function unique(values: readonly string[]): string[] {
+  return [...new Set(values)]
+}
+
+function upperCurrency(value: string): string {
+  return value.trim().toUpperCase()
+}

--- a/packages/storefront/src/shopping/provider-ports.ts
+++ b/packages/storefront/src/shopping/provider-ports.ts
@@ -1,0 +1,199 @@
+import type { SearchFilter } from "@voyant-travel/catalog-contracts/indexer/contract"
+import type {
+  CatalogMoney,
+  PresentationFxQuoter,
+} from "@voyant-travel/catalog-contracts/presentation-money"
+import { definePort } from "@voyant-travel/core/project"
+
+import type { StorefrontShoppingContext } from "./runtime-port.js"
+import type { StorefrontResolvedScope, StorefrontShoppingIntent } from "./schemas.js"
+
+export interface StorefrontActiveMarket {
+  id: string
+  defaultLocale: string
+  defaultCurrency: string
+  locales: readonly string[]
+  currencies: readonly string[]
+  isDefault?: boolean
+}
+
+/**
+ * Closed trust-plane seam. Implementations return only active Commerce markets
+ * permitted for the already-authenticated storefront/channel pair.
+ */
+export interface StorefrontShoppingMarketProvider {
+  listActiveMarkets(input: {
+    storefrontId: string
+    channelId: string
+  }): Promise<readonly StorefrontActiveMarket[]>
+}
+
+export interface StorefrontCatalogSliceSearchInput {
+  /** Full server-derived ownership context; never populated from the request body. */
+  context: StorefrontShoppingContext
+  scope: StorefrontResolvedScope
+  vertical: "products" | "accommodations" | "cruises" | "charters"
+  query: string
+  filters: readonly SearchFilter[]
+  pagination?: { cursor?: string; limit?: number }
+}
+
+export interface StorefrontCatalogSliceItem {
+  entityId: string
+  title: string
+  summary?: string
+  href?: string
+  image?: { url: string; alt?: string }
+  nativePrice?: CatalogMoney
+}
+
+/** Adapter seam for the selected Catalog indexer; it is never an HTTP client. */
+export interface StorefrontShoppingCatalogProvider {
+  searchSlice(input: StorefrontCatalogSliceSearchInput): Promise<{
+    items: readonly StorefrontCatalogSliceItem[]
+    total: number
+    nextCursor?: string
+  }>
+}
+
+type FlightIntent = Extract<StorefrontShoppingIntent, { kind: "flight" }>
+type StayIntent = Extract<StorefrontShoppingIntent, { kind: "stay" }>
+type PackageIntent = Extract<StorefrontShoppingIntent, { kind: "package" }>
+
+export type StorefrontLiveSourceStatus =
+  | "ok"
+  | "partial"
+  | "empty"
+  | "timeout"
+  | "error"
+  | "unavailable"
+
+export interface StorefrontLiveSearchPage<T> {
+  /** Stable provider order. The managed provider sorts only after comparable FX normalization. */
+  items: readonly T[]
+  /** Deliberately contains no provider or connection identifiers. */
+  sources: readonly { status: StorefrontLiveSourceStatus }[]
+}
+
+interface InternalOffer {
+  nativePrice: CatalogMoney
+  /** Closed payload retained only inside the opaque reference store. */
+  selection: Readonly<Record<string, unknown>>
+  providerData?: Readonly<Record<string, unknown>>
+  expiresAt?: string
+}
+
+export interface StorefrontInternalFlightOffer extends InternalOffer {
+  itineraries: Array<{
+    segments: Array<{
+      origin: { code: string; at: string }
+      destination: { code: string; at: string }
+      marketingCarrier: string
+      flightNumber: string
+    }>
+    duration?: string
+  }>
+}
+
+export interface StorefrontInternalStayOffer extends InternalOffer {
+  accommodationSelection: Readonly<Record<string, unknown>>
+  title: string
+  checkIn: string
+  checkOut: string
+  roomName?: string
+  boardName?: string
+  image?: { url: string; alt?: string }
+}
+
+export interface StorefrontInternalPackageOffer extends InternalOffer {
+  title: string
+  origin: string
+  destination: string
+  departureDate: string
+  nights: number
+  accommodationName: string
+  boardName?: string
+  image?: { url: string; alt?: string }
+}
+
+/**
+ * Closed live-search adapter. Implementations call the owned/sourced flight and
+ * availability fan-outs directly and map their internal results here.
+ */
+export interface StorefrontShoppingLiveProvider {
+  searchFlights(input: {
+    context: StorefrontShoppingContext
+    scope: StorefrontResolvedScope
+    intent: FlightIntent
+  }): Promise<StorefrontLiveSearchPage<StorefrontInternalFlightOffer>>
+  searchStays(input: {
+    context: StorefrontShoppingContext
+    scope: StorefrontResolvedScope
+    intent: StayIntent
+  }): Promise<StorefrontLiveSearchPage<StorefrontInternalStayOffer>>
+  searchPackages(input: {
+    context: StorefrontShoppingContext
+    scope: StorefrontResolvedScope
+    intent: PackageIntent
+  }): Promise<StorefrontLiveSearchPage<StorefrontInternalPackageOffer>>
+}
+
+export interface StorefrontOpaqueReferenceIssuer {
+  /**
+   * The backing issuer MUST authenticate the same storefront/channel/scope and
+   * owner tuple when resolving the ref, and reject cross-owner replay. The
+   * managed shopping runtime never resolves or commits an offer itself.
+   */
+  issue(input: {
+    purpose: "catalog-item" | "flight-offer" | "stay-offer" | "package-offer"
+    storefrontId: string
+    channelId: string
+    /** Trusted capability owner binding. Anonymous owners are explicitly null. */
+    owner: { userId: string | null; buyerAccountId: string | null }
+    scope: Pick<StorefrontResolvedScope, "marketId" | "locale" | "currency">
+    payload: Readonly<Record<string, unknown>>
+    ttlSeconds: number
+    replay: "multi-use" | "single-use"
+  }): Promise<{ ref: string; expiresAt: string }>
+}
+
+function methodsPort<T>(id: string, methods: readonly string[]) {
+  return definePort<T>({
+    id,
+    test(provider) {
+      if (provider === null || typeof provider !== "object") {
+        throw new Error(`${id} provider must be an object.`)
+      }
+      for (const method of methods) {
+        if (typeof (provider as Record<string, unknown>)[method] !== "function") {
+          throw new Error(`${id} provider must implement ${method}().`)
+        }
+      }
+    },
+  })
+}
+
+export const storefrontShoppingMarketProviderPort = methodsPort<StorefrontShoppingMarketProvider>(
+  "storefront.shopping.market-provider",
+  ["listActiveMarkets"],
+)
+export const storefrontShoppingCatalogProviderPort = methodsPort<StorefrontShoppingCatalogProvider>(
+  "storefront.shopping.catalog-provider",
+  ["searchSlice"],
+)
+export const storefrontShoppingLiveProviderPort = methodsPort<StorefrontShoppingLiveProvider>(
+  "storefront.shopping.live-provider",
+  ["searchFlights", "searchStays", "searchPackages"],
+)
+export const storefrontOpaqueReferenceIssuerPort = methodsPort<StorefrontOpaqueReferenceIssuer>(
+  "storefront.shopping.opaque-reference-issuer",
+  ["issue"],
+)
+export const storefrontPresentationFxProviderPort = definePort<PresentationFxQuoter>({
+  id: "storefront.shopping.presentation-fx",
+  test(provider) {
+    if (typeof provider !== "function") {
+      throw new Error("storefront.shopping.presentation-fx provider must be a function.")
+    }
+  },
+})

--- a/packages/storefront/src/shopping/schemas.ts
+++ b/packages/storefront/src/shopping/schemas.ts
@@ -60,6 +60,7 @@ export const storefrontInspirationGroupSchema = z.enum([
   "excursions",
   "experiences",
   "activities",
+  "attractions",
   "stays",
   "cruises",
   "charters",
@@ -115,7 +116,7 @@ const inspirationGroupRequestSchema = z
 export const storefrontIndexedInspirationIntentSchema = z
   .object({
     kind: z.literal("indexed-inspiration"),
-    groups: z.array(inspirationGroupRequestSchema).min(1).max(7),
+    groups: z.array(inspirationGroupRequestSchema).min(1).max(8),
   })
   .strict()
   .superRefine((intent, ctx) => {

--- a/packages/storefront/src/voyant.ts
+++ b/packages/storefront/src/voyant.ts
@@ -19,6 +19,13 @@ import {
   storefrontVerificationRuntimePort,
 } from "./runtime-port.js"
 import {
+  storefrontOpaqueReferenceIssuerPort,
+  storefrontPresentationFxProviderPort,
+  storefrontShoppingCatalogProviderPort,
+  storefrontShoppingLiveProviderPort,
+  storefrontShoppingMarketProviderPort,
+} from "./shopping/provider-ports.js"
+import {
   storefrontShoppingRuntimePort,
   storefrontTripSelectionsRuntimePort,
 } from "./shopping/runtime-port.js"
@@ -410,6 +417,36 @@ export const storefrontCustomerPortalVoyantModule = defineModule({
   ],
   meta: {
     ownership: "package",
+  },
+})
+
+/**
+ * Optional OSS composition unit. Selecting it binds the managed shopping
+ * runtime only when all closed trust/supply/reference dependencies exist.
+ */
+export const storefrontShoppingProviderVoyantModule = defineModule({
+  id: "@voyant-travel/storefront#shopping-provider",
+  packageName: "@voyant-travel/storefront",
+  localId: "storefront.shopping-provider",
+  provides: { ports: [providePort(storefrontShoppingRuntimePort)] },
+  runtime: {
+    entry: "@voyant-travel/storefront/runtime-contributor",
+    export: "createStorefrontRuntimePortContribution",
+  },
+  runtimePorts: [
+    requirePort(storefrontShoppingMarketProviderPort),
+    requirePort(storefrontShoppingCatalogProviderPort),
+    requirePort(storefrontShoppingLiveProviderPort),
+    requirePort(storefrontOpaqueReferenceIssuerPort),
+    requirePort(storefrontPresentationFxProviderPort, { optional: true }),
+  ],
+  meta: {
+    ownership: "package",
+    agentTools: {
+      posture: "not-applicable",
+      rationale:
+        "This module binds managed customer shopping ports; product domains own agent-facing Tools.",
+    },
   },
 })
 

--- a/packages/storefront/tests/unit/customer-business-onboarding-runtime-contributor.test.ts
+++ b/packages/storefront/tests/unit/customer-business-onboarding-runtime-contributor.test.ts
@@ -2,6 +2,13 @@ import { customerBusinessAccountOnboardingRuntimePort } from "@voyant-travel/aut
 import { describe, expect, it, vi } from "vitest"
 
 import { createStorefrontRuntimePortContribution } from "../../src/runtime-contributor.js"
+import {
+  storefrontOpaqueReferenceIssuerPort,
+  storefrontShoppingCatalogProviderPort,
+  storefrontShoppingLiveProviderPort,
+  storefrontShoppingMarketProviderPort,
+} from "../../src/shopping/provider-ports.js"
+import { storefrontShoppingRuntimePort } from "../../src/shopping/runtime-port.js"
 
 function primitives() {
   return {
@@ -33,5 +40,34 @@ describe("storefront customer business onboarding runtime contribution", () => {
       hasRuntimePort: ({ id }) => id === customerBusinessAccountOnboardingRuntimePort.id,
     })
     expect(ports).not.toHaveProperty(customerBusinessAccountOnboardingRuntimePort.id)
+  })
+
+  it("keeps managed shopping absent until every closed dependency is configured", () => {
+    const ports = createStorefrontRuntimePortContribution({
+      primitives: primitives(),
+      hasRuntimePort: ({ id }) => id === storefrontShoppingMarketProviderPort.id,
+      getRuntimePort: vi.fn(),
+    })
+    expect(ports).not.toHaveProperty(storefrontShoppingRuntimePort.id)
+  })
+
+  it("contributes managed shopping after every closed dependency is configured", async () => {
+    const providers = new Map<string, unknown>([
+      [storefrontShoppingMarketProviderPort.id, { listActiveMarkets: vi.fn() }],
+      [storefrontShoppingCatalogProviderPort.id, { searchSlice: vi.fn() }],
+      [
+        storefrontShoppingLiveProviderPort.id,
+        { searchFlights: vi.fn(), searchStays: vi.fn(), searchPackages: vi.fn() },
+      ],
+      [storefrontOpaqueReferenceIssuerPort.id, { issue: vi.fn() }],
+    ])
+    const ports = createStorefrontRuntimePortContribution({
+      primitives: primitives(),
+      hasRuntimePort: ({ id }) => providers.has(id),
+      getRuntimePort: ({ id }) => providers.get(id) as never,
+    })
+    await expect(ports[storefrontShoppingRuntimePort.id]).resolves.toEqual(
+      expect.objectContaining({ resolveScope: expect.any(Function), search: expect.any(Function) }),
+    )
   })
 })

--- a/packages/storefront/tests/unit/managed-shopping-runtime.test.ts
+++ b/packages/storefront/tests/unit/managed-shopping-runtime.test.ts
@@ -1,0 +1,310 @@
+import { catalogInventoryRuntimeExtension } from "@voyant-travel/inventory/catalog-runtime-extension"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  createManagedStorefrontShoppingRuntime,
+  inspirationCatalogSlice,
+  type StorefrontInternalFlightOffer,
+  type StorefrontShoppingContext,
+  StorefrontShoppingScopeError,
+} from "../../src/shopping/index.js"
+
+const NOW = new Date("2026-08-08T10:00:00.000Z")
+const context = {
+  storefrontId: "storefront_public",
+  channelId: "channel_web",
+  userId: "user_private",
+  buyerAccountId: "buyer_private",
+} satisfies StorefrontShoppingContext
+
+const market = {
+  id: "market_ro",
+  defaultLocale: "ro-RO",
+  defaultCurrency: "RON",
+  locales: ["ro-RO", "en-GB"],
+  currencies: ["RON", "EUR"],
+  isDefault: true,
+}
+
+function dependencies(overrides: Record<string, unknown> = {}) {
+  let sequence = 0
+  return {
+    markets: {
+      listActiveMarkets: vi.fn(async () => [market]),
+    },
+    catalog: {
+      searchSlice: vi.fn(async () => ({ items: [], total: 0 })),
+    },
+    live: {
+      searchFlights: vi.fn(async () => ({ items: [], sources: [] })),
+      searchStays: vi.fn(async () => ({ items: [], sources: [] })),
+      searchPackages: vi.fn(async () => ({ items: [], sources: [] })),
+    },
+    references: {
+      issue: vi.fn(async () => ({
+        ref: `opaque-reference-${String(++sequence).padStart(6, "0")}`,
+        expiresAt: "2026-08-08T10:10:00.000Z",
+      })),
+    },
+    now: () => NOW,
+    ...overrides,
+  }
+}
+
+describe("managed storefront shopping scope", () => {
+  it("uses active trusted channel config, returns defaults/pickers, and passes no PII", async () => {
+    const deps = dependencies()
+    const runtime = createManagedStorefrontShoppingRuntime(deps)
+
+    await expect(runtime.resolveScope(context, {})).resolves.toEqual({
+      marketId: "market_ro",
+      locale: "ro-RO",
+      currency: "RON",
+      available: {
+        marketIds: ["market_ro"],
+        locales: ["ro-RO", "en-GB"],
+        currencies: ["RON", "EUR"],
+      },
+    })
+    expect(deps.markets.listActiveMarkets).toHaveBeenCalledWith({
+      storefrontId: "storefront_public",
+      channelId: "channel_web",
+    })
+    expect(JSON.stringify(deps.markets.listActiveMarkets.mock.calls)).not.toContain("user_private")
+    expect(JSON.stringify(deps.markets.listActiveMarkets.mock.calls)).not.toContain("buyer_private")
+  })
+
+  it.each([
+    ["marketId", { marketId: "market_inactive" }],
+    ["locale", { locale: "de-DE" }],
+    ["currency", { currency: "USD" }],
+  ] as const)("rejects an unsupported %s instead of trusting or silently switching it", async (_, requested) => {
+    const runtime = createManagedStorefrontShoppingRuntime(dependencies())
+    await expect(runtime.resolveScope(context, requested)).rejects.toBeInstanceOf(
+      StorefrontShoppingScopeError,
+    )
+  })
+})
+
+describe("managed indexed inspiration", () => {
+  it("maps product UX groups to server-authored Catalog slices and taxonomy", () => {
+    const customerFilterFields = new Set(
+      catalogInventoryRuntimeExtension.productFieldPolicy
+        .filter(
+          (policy) => policy.query === "indexed-column" && policy.visibility.includes("customer"),
+        )
+        .map((policy) => policy.path.replace(/\[\]$/, "")),
+    )
+    expect(customerFilterFields.has("familyCode")).toBe(true)
+    expect(customerFilterFields.has("subtypeCode")).toBe(true)
+    expect(customerFilterFields.has("categorySlugs")).toBe(true)
+    expect(inspirationCatalogSlice("tours")).toEqual({
+      vertical: "products",
+      filters: [{ kind: "eq", field: "familyCode", value: "tour" }],
+    })
+    expect(inspirationCatalogSlice("activities").filters).toContainEqual({
+      kind: "eq",
+      field: "familyCode",
+      value: "activity",
+    })
+    expect(inspirationCatalogSlice("attractions").filters).toContainEqual({
+      kind: "eq",
+      field: "familyCode",
+      value: "attraction",
+    })
+    expect(inspirationCatalogSlice("experiences")).toMatchObject({ vertical: "products" })
+    expect(inspirationCatalogSlice("excursions")).toMatchObject({ vertical: "products" })
+    expect(inspirationCatalogSlice("stays")).toEqual({ vertical: "accommodations", filters: [] })
+    expect(inspirationCatalogSlice("cruises")).toEqual({ vertical: "cruises", filters: [] })
+    expect(inspirationCatalogSlice("charters")).toEqual({ vertical: "charters", filters: [] })
+  })
+
+  it("preserves each Catalog group's total/cursor and does not invent a global cursor", async () => {
+    const deps = dependencies({
+      catalog: {
+        searchSlice: vi
+          .fn()
+          .mockResolvedValueOnce({
+            items: [{ entityId: "product_1", title: "Tour" }],
+            total: 12,
+            nextCursor: "catalog-cursor-products-0001",
+          })
+          .mockResolvedValueOnce({
+            items: [{ entityId: "cruise_1", title: "Cruise" }],
+            total: 4,
+            nextCursor: "catalog-cursor-cruises-0001",
+          }),
+      },
+    })
+    const runtime = createManagedStorefrontShoppingRuntime(deps)
+    const scope = await runtime.resolveScope(context, {})
+    const result = await runtime.search(context, {
+      scope,
+      intent: {
+        kind: "indexed-inspiration",
+        groups: [{ group: "tours" }, { group: "cruises" }],
+      },
+    })
+
+    expect(result).toMatchObject({
+      kind: "indexed-inspiration",
+      groups: [
+        { group: "tours", total: 12, nextCursor: "catalog-cursor-products-0001" },
+        { group: "cruises", total: 4, nextCursor: "catalog-cursor-cruises-0001" },
+      ],
+    })
+    expect(result).not.toHaveProperty("nextCursor")
+  })
+})
+
+describe("managed live shopping", () => {
+  const flightIntent = {
+    kind: "flight" as const,
+    slices: [{ origin: "OTP", destination: "LHR", departureDate: "2026-09-10" }],
+    travelers: { adults: 1 },
+  }
+
+  function flight(amount: string, currency: string, marker: string): StorefrontInternalFlightOffer {
+    return {
+      nativePrice: { amount, currency },
+      selection: { providerOffer: marker },
+      providerData: { connectionId: `connection_${marker}`, net: "secret" },
+      itineraries: [
+        {
+          segments: [
+            {
+              origin: { code: "OTP", at: "2026-09-10T08:00:00.000Z" },
+              destination: { code: "LHR", at: "2026-09-10T11:00:00.000Z" },
+              marketingCarrier: "RO",
+              flightNumber: marker,
+            },
+          ],
+        },
+      ],
+    }
+  }
+
+  it("normalizes mixed currency with shared FX, sorts comparably, and keeps provider data opaque", async () => {
+    const deps = dependencies({
+      live: {
+        searchFlights: vi.fn(async () => ({
+          items: [flight("100", "EUR", "100"), flight("450", "RON", "450")],
+          sources: [{ status: "ok" }, { status: "timeout" }],
+        })),
+        searchStays: vi.fn(),
+        searchPackages: vi.fn(),
+      },
+      quoteFx: vi.fn(async () => ({
+        rate: "5",
+        provider: "voyant-data-fx",
+        quotedAt: NOW.toISOString(),
+        validUntil: "2026-08-09T10:00:00.000Z",
+      })),
+    })
+    const runtime = createManagedStorefrontShoppingRuntime(deps)
+    const scope = await runtime.resolveScope(context, {})
+    const result = await runtime.search(context, { scope, intent: flightIntent })
+
+    expect(result.kind).toBe("flight")
+    if (result.kind !== "flight") return
+    expect(result.offers.map((offer) => offer.price.presentation.amount)).toEqual(["450", "500.00"])
+    expect(result.offers.map((offer) => Number(offer.price.presentation.amount))).toEqual(
+      [...result.offers]
+        .map((offer) => Number(offer.price.presentation.amount))
+        .sort((left, right) => left - right),
+    )
+    expect(result.offers.map((offer) => offer.itineraries[0]?.segments[0]?.flightNumber)).toEqual([
+      "450",
+      "100",
+    ])
+    expect(result.coverage).toEqual({ status: "partial", succeeded: 1, failed: 0, timedOut: 1 })
+    expect(JSON.stringify(result)).not.toContain("connection_")
+    expect(JSON.stringify(result)).not.toContain("secret")
+    expect(JSON.stringify(result)).not.toContain("user_private")
+    expect(JSON.stringify(result)).not.toContain("buyer_private")
+    expect(deps.references.issue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        purpose: "flight-offer",
+        ttlSeconds: 900,
+        replay: "single-use",
+        owner: { userId: "user_private", buyerAccountId: "buyer_private" },
+      }),
+    )
+  })
+
+  it("drops non-comparable prices without FX and marks partial instead of mixing currencies", async () => {
+    const deps = dependencies({
+      live: {
+        searchFlights: vi.fn(async () => ({
+          items: [flight("100", "EUR", "100"), flight("450", "RON", "450")],
+          sources: [{ status: "ok" }],
+        })),
+        searchStays: vi.fn(),
+        searchPackages: vi.fn(),
+      },
+    })
+    const runtime = createManagedStorefrontShoppingRuntime(deps)
+    const scope = await runtime.resolveScope(context, {})
+    const result = await runtime.search(context, { scope, intent: flightIntent })
+    expect(result.kind).toBe("flight")
+    if (result.kind !== "flight") return
+    expect(result.offers).toHaveLength(1)
+    expect(result.offers[0]?.price.presentation.currency).toBe("RON")
+    expect(result.coverage.status).toBe("partial")
+  })
+
+  it("forwards only trusted context and no body provider selectors to the live port", async () => {
+    const deps = dependencies()
+    const runtime = createManagedStorefrontShoppingRuntime(deps)
+    const scope = await runtime.resolveScope(context, {})
+    await runtime.search(context, { scope, intent: flightIntent })
+    const serialized = JSON.stringify(deps.live.searchFlights.mock.calls)
+    expect(serialized).not.toContain("providerId")
+    expect(serialized).not.toContain("connectionId")
+    expect(serialized).toContain("user_private")
+    expect(serialized).toContain("buyer_private")
+    expect(serialized).toContain("channel_web")
+  })
+
+  it("binds references to different trusted account owners", async () => {
+    const deps = dependencies({
+      live: {
+        searchFlights: vi.fn(async () => ({ items: [flight("450", "RON", "450")], sources: [] })),
+        searchStays: vi.fn(),
+        searchPackages: vi.fn(),
+      },
+    })
+    const runtime = createManagedStorefrontShoppingRuntime(deps)
+    const scope = await runtime.resolveScope(context, {})
+    await runtime.search(context, { scope, intent: flightIntent })
+    await runtime.search(
+      { ...context, userId: "user_other", buyerAccountId: "buyer_other" },
+      { scope, intent: flightIntent },
+    )
+    expect(deps.references.issue.mock.calls.map(([call]) => call.owner)).toEqual([
+      { userId: "user_private", buyerAccountId: "buyer_private" },
+      { userId: "user_other", buyerAccountId: "buyer_other" },
+    ])
+  })
+
+  it("rejects opaque references whose issuer exceeds the bounded TTL", async () => {
+    const deps = dependencies({
+      references: {
+        issue: vi.fn(async () => ({
+          ref: "opaque-reference-too-long-ttl",
+          expiresAt: "2026-08-08T11:00:00.000Z",
+        })),
+      },
+      live: {
+        searchFlights: vi.fn(async () => ({ items: [flight("450", "RON", "450")], sources: [] })),
+        searchStays: vi.fn(),
+        searchPackages: vi.fn(),
+      },
+    })
+    const runtime = createManagedStorefrontShoppingRuntime(deps)
+    const scope = await runtime.resolveScope(context, {})
+    await expect(runtime.search(context, { scope, intent: flightIntent })).rejects.toThrow(
+      "opaque_reference_expiry_invalid",
+    )
+  })
+})

--- a/packages/storefront/tests/unit/voyant-manifest.test.ts
+++ b/packages/storefront/tests/unit/voyant-manifest.test.ts
@@ -10,12 +10,20 @@ import {
   storefrontPaymentReconciliationJobRuntimePort,
 } from "../../src/runtime-port.js"
 import {
+  storefrontOpaqueReferenceIssuerPort,
+  storefrontPresentationFxProviderPort,
+  storefrontShoppingCatalogProviderPort,
+  storefrontShoppingLiveProviderPort,
+  storefrontShoppingMarketProviderPort,
+} from "../../src/shopping/provider-ports.js"
+import {
   storefrontShoppingRuntimePort,
   storefrontTripSelectionsRuntimePort,
 } from "../../src/shopping/runtime-port.js"
 import {
   storefrontCustomerPortalVoyantModule,
   storefrontPaymentLinkVoyantModule,
+  storefrontShoppingProviderVoyantModule,
   storefrontVerificationVoyantModule,
   storefrontVoyantModule,
 } from "../../src/voyant.js"
@@ -27,6 +35,21 @@ describe("storefront deployment manifest", () => {
     expect(storefrontPaymentReconciliationJobRuntimePort.id).toBe(
       "storefront.payment-reconciliation-job.runtime",
     )
+  })
+
+  it("declares the optional OSS shopping provider graph", () => {
+    expect(storefrontShoppingProviderVoyantModule).toMatchObject({
+      schemaVersion: "voyant.module.v1",
+      id: "@voyant-travel/storefront#shopping-provider",
+      provides: { ports: [{ id: storefrontShoppingRuntimePort.id }] },
+      runtimePorts: [
+        { id: storefrontShoppingMarketProviderPort.id },
+        { id: storefrontShoppingCatalogProviderPort.id },
+        { id: storefrontShoppingLiveProviderPort.id },
+        { id: storefrontOpaqueReferenceIssuerPort.id },
+        { id: storefrontPresentationFxProviderPort.id, optional: true },
+      ],
+    })
   })
 
   it("owns the base runtime, persistence, and verification link facets", () => {

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -1997,6 +1997,12 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/managed-runtime": [
+        "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/provider-ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/runtime-port": [
         "../storefront/dist/shopping/runtime-port.d.ts"
       ],


### PR DESCRIPTION
## Summary

- add the optional OSS managed `StorefrontShoppingRuntime` composition over closed trusted-market, Catalog-slice, live-search, opaque-reference, and presentation-FX ports
- resolve active channel-scoped Commerce markets strictly, preserve per-group Catalog totals/cursors, and map inspiration groups to real product/accommodation/cruise/charter slices
- normalize live flight/stay/package money into one selected presentation currency, strip provider internals, and bind bounded opaque refs to the trusted storefront/channel/scope/account owner
- add graph declarations, package exports, changeset, and focused security/runtime tests

## Validation

- `git diff --check agent/storefront-display-money...HEAD` — passed
- narrow Biome check — passed before commit
- typecheck/Vitest commands prepared but not completed: `lab1` was non-responsive; no local fallback was run under the inherited execution constraint

Commands to run:

```sh
pnpm --filter @voyant-travel/storefront typecheck
pnpm --filter @voyant-travel/storefront exec vitest run tests/unit/managed-shopping-runtime.test.ts tests/unit/shopping-gateway.test.ts tests/unit/voyant-manifest.test.ts tests/unit/customer-business-onboarding-runtime-contributor.test.ts
```

## Intentional provider gaps

The OSS runtime remains unavailable (gateway 503) unless the optional shopping-provider unit is selected and all closed market, Catalog, live fan-out, and opaque-reference dependencies are configured. The new live port is the public-safety boundary for adapters over existing owned/sourced mechanics; this change does not add customer accounts, booking/payment/supplier commit, Trip persistence, or admin-HTTP calls.