### PR TITLE
Ready Node runtimes before accepting traffic

### DIFF
--- a/packages/framework/src/node-runtime.test.ts
+++ b/packages/framework/src/node-runtime.test.ts
@@ -1,5 +1,5 @@
 import type { EventEnvelope } from "@voyant-travel/core"
-import { definePort } from "@voyant-travel/core/project"
+import { defineGraphRuntimeFactory, definePort } from "@voyant-travel/core/project"
 import type { LazyRedisClient } from "@voyant-travel/utils/redis-client"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import type { VoyantDeploymentProviders } from "./deployment-types.js"
@@ -187,6 +187,58 @@ function emptyGraphRuntime(providers: VoyantDeploymentProviders) {
     graphHash: "sha256:0000000000000000000000000000000000000000000000000000000000000000",
     entries: {},
     modules: [],
+    plugins: [],
+    providerSelections: { ...providers },
+  })
+}
+
+function bootstrapGraphRuntime(
+  providers: VoyantDeploymentProviders,
+  bootstrap: () => Promise<void> | void,
+) {
+  const unitId = "@acme/bootstrap"
+  const entry = `${unitId}/runtime`
+  const referenceId = `${unitId}#api.admin:runtime`
+  const routeId = `${unitId}#api.admin`
+  return createVoyantGraphRuntime({
+    graphHash: "sha256:node-eager-readiness",
+    entries: {
+      [entry]: async () => ({
+        runtime: defineGraphRuntimeFactory(() => ({
+          module: { name: "bootstrap", bootstrap },
+        })),
+      }),
+    },
+    modules: [
+      {
+        id: unitId,
+        kind: "module",
+        packageName: unitId,
+        order: 0,
+        references: [
+          {
+            id: referenceId,
+            unitId,
+            facet: "api",
+            entityId: routeId,
+            runtime: { entry, export: "runtime" },
+            importEntry: entry,
+          },
+        ],
+        selectedIds: { routes: [routeId], tools: [], events: [], webhooks: [] },
+        routes: [
+          {
+            route: {
+              id: routeId,
+              surface: "admin",
+              runtime: { entry, export: "runtime" },
+            },
+            importEntry: entry,
+            referenceId,
+          },
+        ],
+      },
+    ],
     plugins: [],
     providerSelections: { ...providers },
   })
@@ -399,7 +451,59 @@ describe("createVoyantNodeEnv Redis namespace", () => {
   })
 })
 
-describe("loadVoyantNodeRuntime Redis URL validation", () => {
+describe("loadVoyantNodeRuntime", () => {
+  it("does not resolve until selected application bootstraps are ready", async () => {
+    let releaseBootstrap!: () => void
+    const bootstrapGate = new Promise<void>((resolve) => {
+      releaseBootstrap = resolve
+    })
+    const bootstrap = vi.fn(() => bootstrapGate)
+    let loaded = false
+
+    const loading = loadVoyantNodeRuntime({
+      graphRuntime: bootstrapGraphRuntime(BASE_PROVIDERS, bootstrap),
+      jobs: [],
+      deployment: {
+        mode: "managed-cloud",
+        providers: BASE_PROVIDERS,
+        redis: DEDICATED_TRUSTED_REDIS,
+      },
+      deploymentRequirements: { resources: [] },
+    }).then((runtime) => {
+      loaded = true
+      return runtime
+    })
+
+    await vi.waitFor(() => expect(bootstrap).toHaveBeenCalledTimes(1))
+    expect(loaded).toBe(false)
+    releaseBootstrap()
+    const runtime = await loading
+
+    await Promise.all([runtime.app.ready(runtime.env), runtime.app.ready(runtime.env)])
+    expect(bootstrap).toHaveBeenCalledTimes(1)
+  })
+
+  it("rejects runtime loading when an application bootstrap fails", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const failure = new Error("bootstrap dependency unavailable")
+
+    await expect(
+      loadVoyantNodeRuntime({
+        graphRuntime: bootstrapGraphRuntime(BASE_PROVIDERS, () => {
+          throw failure
+        }),
+        jobs: [],
+        deployment: {
+          mode: "managed-cloud",
+          providers: BASE_PROVIDERS,
+          redis: DEDICATED_TRUSTED_REDIS,
+        },
+        deploymentRequirements: { resources: [] },
+      }),
+    ).rejects.toThrow(/module:bootstrap/)
+    errorSpy.mockRestore()
+  })
+
   it("delivers outbox events through the composed internal subscriber bus", async () => {
     const originalDeliver = vi.fn(async (_envelope: EventEnvelope) => ({
       attempted: 0,

--- a/packages/framework/src/node-runtime.ts
+++ b/packages/framework/src/node-runtime.ts
@@ -442,6 +442,14 @@ export async function loadVoyantNodeRuntime(
     ),
   })
 
+  // A Node runtime is not loadable until every selected app bootstrap has
+  // completed. Managed Cloud warms this boundary before binding its listener,
+  // while self-hosted and cell callers receive the same no-first-request-work
+  // guarantee. Explicit readiness rejects on bootstrap failure, so a broken
+  // runtime fails startup/admission instead of leaking the failure and latency
+  // into the first authenticated request.
+  await app.ready(env)
+
   // A package asks for a wake on the request path that wrote the work — a
   // checkout placing a hold, say. `wakeAt` rejects a job the graph did not
   // select or declare wakeable, which is a real manifest bug, but failing the

--- a/packages/hono/src/app.ts
+++ b/packages/hono/src/app.ts
@@ -125,7 +125,8 @@ export interface VoyantAppExtensions<TBindings = unknown> {
   services: import("@voyant-travel/core").ModuleContainer
   /**
    * Resolves once the lazy bootstrap completes. Idempotent — multiple
-   * calls share the same promise. Use from tests + node sibling
+   * calls share the same promise. Rejects after every selected bootstrap has
+   * had a chance to run when any bootstrap failed. Use from tests + node sibling
    * processes where no request will arrive to trigger boot. See
    * architecture doc §18 + §18.1.
    *
@@ -402,6 +403,8 @@ export function mountApp<TBindings extends VoyantBindings>(
   }
 
   let bootstrapPromise: Promise<void> | null = null
+  let readinessPromise: Promise<void> | null = null
+  const bootstrapFailures: Array<{ label: string; error: unknown }> = []
   function ensureRuntimeBootstrapped(bindings: TBindings) {
     if (!bootstrapPromise) {
       bootstrapPromise = (async () => {
@@ -414,6 +417,7 @@ export function mountApp<TBindings extends VoyantBindings>(
           try {
             await fn(ctx)
           } catch (error) {
+            bootstrapFailures.push({ label, error })
             const message = error instanceof Error ? error.message : String(error)
             console.error(`[voyant] bootstrap failed for ${label}: ${message}`)
             // Bootstrap failures are startup-critical but silent today — surface
@@ -448,6 +452,19 @@ export function mountApp<TBindings extends VoyantBindings>(
     }
 
     return bootstrapPromise
+  }
+
+  function ensureRuntimeReady(bindings: TBindings): Promise<void> {
+    if (!readinessPromise) {
+      readinessPromise = ensureRuntimeBootstrapped(bindings).then(() => {
+        if (bootstrapFailures.length === 0) return
+        throw new AggregateError(
+          bootstrapFailures.map(({ error }) => error),
+          `Voyant app bootstrap failed for ${bootstrapFailures.map(({ label }) => label).join(", ")}`,
+        )
+      })
+    }
+    return readinessPromise
   }
 
   // Request ID header
@@ -856,19 +873,17 @@ export function mountApp<TBindings extends VoyantBindings>(
 
   // Attach `ready()` directly to the Hono instance. Fires the lazy
   // bootstrap with the supplied bindings (or `{}` for back-compat with
-  // node / InMemory drivers that ignore them). Production code never
-  // calls `ready()` — the first request triggers the same boot via
-  // `ensureRuntimeBootstrapped(c.env)`. Tests + node sibling processes
-  // use this so the time wheel + manifest registration happen without
-  // traffic. Binding-dependent drivers that want eager boot must pass
-  // the real `env`.
+  // node / InMemory drivers that ignore them). The Node host calls `ready()`
+  // before exposing a loaded runtime; request-driven/Worker hosts retain the
+  // same lazy boot via `ensureRuntimeBootstrapped(c.env)`. Tests + node sibling
+  // processes also use this so the time wheel + manifest registration happen
+  // without traffic. Binding-dependent drivers must pass the real `env`.
   const augmented = app as Hono<MountEnv<TBindings>> & VoyantAppExtensions<TBindings>
   augmented.services = container
   augmented.eventBus = eventBus
   augmented.lazyMounts = lazyMounts
   augmented.moduleMounts = moduleMounts
-  augmented.ready = (bindings?: TBindings) =>
-    ensureRuntimeBootstrapped(bindings ?? ({} as TBindings))
+  augmented.ready = (bindings?: TBindings) => ensureRuntimeReady(bindings ?? ({} as TBindings))
   return augmented
 }
 

--- a/packages/hono/tests/unit/bundle.test.ts
+++ b/packages/hono/tests/unit/bundle.test.ts
@@ -362,6 +362,29 @@ describe("mountApp with plugins", () => {
     expect(calls).toEqual(["plugin", "module", "extension"])
   })
 
+  it("keeps concurrent first requests off the bootstrap path after explicit readiness", async () => {
+    const bootstrap = vi.fn(async () => undefined)
+    const mod: ApiModule = {
+      module: { name: "ready", bootstrap },
+      adminRoutes: new Hono().get("/ping", (c) => c.json({ ok: true })),
+    }
+    const app = mountApp({
+      // biome-ignore lint/suspicious/noExplicitAny: test doesn't use db -- owner: hono; existing suppression is intentional pending typed cleanup.
+      db: () => ({}) as any,
+      modules: [mod],
+      auth: { resolve: () => ({ userId: "u1", actor: "staff", realm: "admin" }) },
+    })
+
+    await app.ready(TEST_ENV)
+    const responses = await Promise.all([
+      app.request("/v1/admin/ready/ping", {}, TEST_ENV, TEST_CTX),
+      app.request("/v1/admin/ready/ping", {}, TEST_ENV, TEST_CTX),
+    ])
+
+    expect(responses.map(({ status }) => status)).toEqual([200, 200])
+    expect(bootstrap).toHaveBeenCalledTimes(1)
+  })
+
   it("isolates bootstrap failures — a throwing plugin must not break unrelated routes", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
     const goodModule: ApiModule = {

--- a/packages/hono/tests/unit/observability.test.ts
+++ b/packages/hono/tests/unit/observability.test.ts
@@ -288,7 +288,7 @@ describe("non-HTTP catch points route to the reporter (RFC #1553)", () => {
     })
 
     // `ready()` fires the lazy bootstrap without needing a request.
-    await app.ready({})
+    await expect(app.ready({})).rejects.toThrow(/module:flaky/)
 
     const bootEvent = events.find((e) => e.context?.surface === "bootstrap")
     expect(bootEvent).toBeDefined()


### PR DESCRIPTION
## Summary

- await `app.ready(env)` before a Node runtime is considered loaded
- make explicit readiness reject after reporting all selected bootstrap failures
- preserve request-path fail-open behavior for Worker/request-host compatibility
- share one readiness promise across concurrent callers
- cover deferred startup, failed startup, idempotency, and concurrent first requests

## Why

Managed startup composed the graph before binding but did not run Hono package bootstraps. The first admitted authenticated request therefore paid bootstrap latency and could encounter a startup-critical failure after readiness was already green.

## Validation

- focused framework/Hono tests: 55 passed
- framework typecheck passed
- Hono typecheck passed
- Biome passed
- disposable validation environment exited cleanly

## Acceptance

- managed listener/readiness cannot become healthy before all selected bootstraps complete
- first post-deploy authenticated API request performs no bootstrap work
- bootstrap failure prevents startup/admission with useful labels
- self-host and cell Node hosts retain the same portable runtime surface.