### PR TITLE
Render authenticated workspace as a client shell

### DIFF
--- a/packages/operator-standard/src/standard-route-files.ts
+++ b/packages/operator-standard/src/standard-route-files.ts
@@ -114,7 +114,11 @@ import { operatorFrontend } from "../_lib/operator-frontend.js"
 const workspace = operatorFrontend.workspace
 
 export const Route = createFileRoute("/_workspace")({
-  ssr: "data-only",
+  // The authenticated workspace bootstrap is intentionally browser-owned.
+  // Running it during SSR holds the document stream open on a cold runtime,
+  // which also delays discovery of the hydration script until auth and data
+  // probes finish. Public/storefront routes remain SSR-enabled.
+  ssr: false,
   beforeLoad: ({ location, context }) => workspace.beforeLoad({ location, context }),
   loader: ({ context }) => ({ user: context.user }),
   pendingComponent: workspace.PendingComponent,

--- a/packages/operator-standard/tests/standard-route-files.test.ts
+++ b/packages/operator-standard/tests/standard-route-files.test.ts
@@ -123,6 +123,16 @@ describe("createStandardOperatorRouteFiles", () => {
     )
   })
 
+  it("keeps the authenticated workspace client-rendered without disabling public SSR", () => {
+    const files = createStandardOperatorRouteFiles({ presentations: [storefrontCustomer] })
+    const workspace = files.find((file) => file.path === "_workspace/route.tsx")
+    const storefront = files.find((file) => file.path === "(storefront)/route.tsx")
+
+    expect(workspace?.source).toContain("ssr: false")
+    expect(workspace?.source).toContain("workspace.beforeLoad")
+    expect(storefront?.source).not.toContain("ssr: false")
+  })
+
   it("emits routes for a presentation declared entirely outside operator-standard", () => {
     // The whole point of the refactor: a package that declares a presentation
     // with a contribution + routes gets admin route files emitted without any


### PR DESCRIPTION
## Summary

- render only the private `/_workspace` subtree as a client-owned shell
- keep public, storefront, auth, and portable Docker routes SSR-enabled
- add a route-generation regression test

## Evidence

This corrects the initial bundle hypothesis. Production emits 548 JS chunks, but the initial dashboard graph is only 36 depth-1 critical chunks (~2.707 MB raw). Signed-in Chrome showed document response start at ~220 ms, DOM interactive at 58.816 s, and all asset requests beginning around 58.45 s. SSR held the stream before the hydration script was discoverable; individual assets were not the dominant delay.

## Validation

- focused operator-standard tests passed
- Biome passed
- full operator production build passed
- before/after bundle graph unchanged (no rebundling regression)
- `git diff --check` passed

## Canary acceptance

- hydration scripts become discoverable immediately after the document begins
- private admin usable shell p75 <=2.5s and p95 <=4s on warm runtime
- unauthenticated access redirects correctly after client startup
- storefront/public SSR and self-host Docker behavior remain intact.