### PR TITLE
fix(proposals): make booking acceptance durable

### DIFF
--- a/.changeset/kind-proposal-booking.md
+++ b/.changeset/kind-proposal-booking.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/proposals": patch
+---
+
+Bind approved proposal-to-booking acceptance to the handler-owned durable command-result protocol.

--- a/packages/proposals/src/mcp-runtime.ts
+++ b/packages/proposals/src/mcp-runtime.ts
@@ -15,10 +15,8 @@ import {
   proposalsPresentationRuntimePort,
 } from "./runtime-port.js"
 import { proposalsService } from "./service/index.js"
-import {
-  acceptProposalAndPrepareBooking,
-  ProposalAcceptanceError,
-} from "./service/proposal-acceptance.js"
+import { ProposalAcceptanceError } from "./service/proposal-acceptance.js"
+import { executeAcceptProposalForBookingCommand } from "./service/proposal-booking-acceptance-command.js"
 import { executeSnapshotAndSendProposalCommand } from "./service/proposal-delivery.js"
 import { executeAcceptProposalVersionCommand } from "./service/proposal-version-acceptance-command.js"
 
@@ -123,7 +121,10 @@ export const voyantToolContextContribution = defineToolContextContribution({
         },
       },
       proposalAcceptance: {
-        async acceptProposalForBooking(proposalVersionId: string) {
+        async acceptProposalForBooking(
+          proposalVersionId: string,
+          admitted: ToolHandlerActionPolicyContext,
+        ) {
           const proposal = await Promise.resolve(
             requireService(
               resources[proposalsPresentationRuntimePort.id] as
@@ -134,12 +135,15 @@ export const voyantToolContextContribution = defineToolContextContribution({
             ),
           )
           try {
-            return await acceptProposalAndPrepareBooking(
+            const result = await executeAcceptProposalForBookingCommand({
               db,
+              context: actionLedgerContext(c),
+              admitted,
               proposalVersionId,
-              (transactionalDb, input) =>
+              seedBookingSession: (transactionalDb, input) =>
                 proposal.seedAcceptedProposalBookingSession(transactionalDb, input, c),
-            )
+            })
+            return result.value
           } catch (error) {
             if (error instanceof ProposalAcceptanceError) {
               const code = error.code === "not_found" ? "NOT_FOUND" : "INVALID_INPUT"

--- a/packages/proposals/src/service/proposal-booking-acceptance-command.ts
+++ b/packages/proposals/src/service/proposal-booking-acceptance-command.ts
@@ -1,0 +1,57 @@
+import {
+  type ActionLedgerRequestContextValues,
+  executeAdmittedExistingTargetCommand,
+} from "@voyant-travel/action-ledger"
+import type { AnyDrizzleDb } from "@voyant-travel/db"
+import type { ToolHandlerActionPolicyContext } from "@voyant-travel/tools"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import {
+  type AcceptedProposalBookingSessionSeed,
+  type AcceptedProposalBookingSessionSeedResult,
+  acceptProposalAndPrepareBooking,
+} from "./proposal-acceptance.js"
+
+export interface ExecuteAcceptProposalForBookingCommandInput {
+  db: AnyDrizzleDb
+  context: ActionLedgerRequestContextValues
+  admitted: ToolHandlerActionPolicyContext
+  proposalVersionId: string
+  seedBookingSession: (
+    db: PostgresJsDatabase,
+    input: AcceptedProposalBookingSessionSeed,
+  ) => Promise<AcceptedProposalBookingSessionSeedResult>
+}
+
+/**
+ * Bind approved proposal acceptance and its Booking Session handoff to one
+ * handler-owned command claim. The domain workflow already keys the session by
+ * accepted Proposal Version, so replay resolves/reconciles that same session.
+ */
+export async function executeAcceptProposalForBookingCommand(
+  input: ExecuteAcceptProposalForBookingCommandInput,
+) {
+  const commandInput = { proposalVersionId: input.proposalVersionId }
+  let preparedValue: Awaited<ReturnType<typeof acceptProposalAndPrepareBooking>> | undefined
+  const executeWorkflow = (db: PostgresJsDatabase) =>
+    acceptProposalAndPrepareBooking(db, input.proposalVersionId, input.seedBookingSession)
+  return executeAdmittedExistingTargetCommand(
+    {
+      db: input.db,
+      context: input.context,
+      admitted: input.admitted,
+      commandInput,
+      evaluatedRisk: "high",
+    },
+    {
+      async prepare(tx) {
+        preparedValue = await executeWorkflow(tx as PostgresJsDatabase)
+      },
+      execute() {
+        if (!preparedValue) throw new Error("Proposal booking acceptance produced no result")
+        return Promise.resolve(preparedValue)
+      },
+      replay: () => executeWorkflow(input.db as PostgresJsDatabase),
+    },
+  )
+}

--- a/packages/proposals/src/tools.ts
+++ b/packages/proposals/src/tools.ts
@@ -75,7 +75,10 @@ export interface ProposalDeliveryToolServices {
 }
 
 export interface ProposalAcceptanceToolServices {
-  acceptProposalForBooking(proposalVersionId: string): Promise<unknown>
+  acceptProposalForBooking(
+    proposalVersionId: string,
+    admitted: ToolHandlerActionPolicyContext,
+  ): Promise<unknown>
 }
 
 export type ProposalsToolContext = ToolContext & {
@@ -165,6 +168,26 @@ export const ACCEPT_PROPOSAL_VERSION_HANDLER_POLICY = {
   actionPolicy: {
     id: `${OWNER}#action.accept-proposal-version`,
     capabilityId: `${OWNER}#action.accept-proposal-version`,
+    version: VERSION,
+    kind: "execute",
+    targetType: "proposal-version",
+    commandTargetField: "proposalVersionId",
+    targetLifecycle: "existing",
+    existingTarget: { durability: "handler-command-result-v1" },
+    risk: "high",
+    ledger: "required",
+    approval: "required",
+    reversible: false,
+  },
+} as const satisfies HandlerActionPolicyExpectation
+
+export const ACCEPT_PROPOSAL_FOR_BOOKING_HANDLER_POLICY = {
+  capabilityId: `${OWNER}#presentation-extension.tool.accept-proposal-for-booking`,
+  capabilityVersion: VERSION,
+  canonicalName: "accept_proposal_for_booking",
+  actionPolicy: {
+    id: `${OWNER}#presentation-extension.action.accept-proposal-for-booking`,
+    capabilityId: `${OWNER}#presentation-extension.action.accept-proposal-for-booking`,
     version: VERSION,
     kind: "execute",
     targetType: "proposal-version",
@@ -424,9 +447,12 @@ export const acceptProposalForBookingTool = defineTool({
   audience: STAFF_AUDIENCE,
   tier: "destructive",
   riskPolicy: proposalWriteRisk,
+  annotations: { idempotentHint: true },
+  actionPolicyEnforcement: "handler",
   async handler({ proposalVersionId }, ctx: ProposalsToolContext) {
+    const admitted = admitHandlerActionPolicy(ctx, ACCEPT_PROPOSAL_FOR_BOOKING_HANDLER_POLICY)
     return acceptProposalForBookingOutputSchema.parse(
-      await proposalAcceptance(ctx).acceptProposalForBooking(proposalVersionId),
+      await proposalAcceptance(ctx).acceptProposalForBooking(proposalVersionId, admitted),
     )
   },
 })

--- a/packages/proposals/src/voyant.ts
+++ b/packages/proposals/src/voyant.ts
@@ -502,6 +502,7 @@ export const proposalsPresentationVoyantExtension = defineExtension({
       targetType: "proposal-version",
       commandTargetField: "proposalVersionId",
       targetLifecycle: "existing",
+      existingTarget: { durability: "handler-command-result-v1" },
       effectBoundary: "local",
       resource: "proposals",
       action: "write",

--- a/packages/proposals/tests/tools.test.ts
+++ b/packages/proposals/tests/tools.test.ts
@@ -11,9 +11,12 @@ import {
   proposalsHandlerActionPolicyExpectation,
 } from "../src/created-target-policy.js"
 import {
+  ACCEPT_PROPOSAL_FOR_BOOKING_HANDLER_POLICY,
   ACCEPT_PROPOSAL_VERSION_HANDLER_POLICY,
+  acceptProposalForBookingTool,
   acceptProposalVersionTool,
   createProposalTool,
+  type ProposalAcceptanceToolServices,
   type ProposalDeliveryToolServices,
   type ProposalsToolServices,
   proposalsTools,
@@ -26,9 +29,11 @@ function ctx(
   actor: ToolContext["actor"] = "staff",
   delivery?: ProposalDeliveryToolServices,
   handlerActionPolicy: ToolHandlerActionPolicyContext = snapshotSendActionPolicy(),
+  acceptance?: ProposalAcceptanceToolServices,
 ): ToolContext & {
   proposals?: ProposalsToolServices
   proposalDelivery?: ProposalDeliveryToolServices
+  proposalAcceptance?: ProposalAcceptanceToolServices
 } {
   return {
     db: {},
@@ -39,6 +44,7 @@ function ctx(
     handlerActionPolicy,
     proposals: services as ProposalsToolServices | undefined,
     proposalDelivery: delivery,
+    proposalAcceptance: acceptance,
   }
 }
 
@@ -118,6 +124,29 @@ function acceptProposalActionPolicy(): ToolHandlerActionPolicyContext {
   }
 }
 
+function acceptProposalForBookingActionPolicy(): ToolHandlerActionPolicyContext {
+  return {
+    capabilityId: ACCEPT_PROPOSAL_FOR_BOOKING_HANDLER_POLICY.capabilityId,
+    capabilityVersion: ACCEPT_PROPOSAL_FOR_BOOKING_HANDLER_POLICY.capabilityVersion,
+    canonicalName: ACCEPT_PROPOSAL_FOR_BOOKING_HANDLER_POLICY.canonicalName,
+    actionPolicy: {
+      ...ACCEPT_PROPOSAL_FOR_BOOKING_HANDLER_POLICY.actionPolicy,
+      enforcement: "handler",
+      invocation: {
+        controlField: "_voyant",
+        requiredFields: ["idempotencyKey", "approvalId", "idempotencyFingerprint"],
+        optionalFields: ["reasonCode", "approvalId", "idempotencyFingerprint"],
+        fingerprintAlgorithm: "action-ledger-command-v1",
+      },
+    },
+    invocation: {
+      idempotencyKey: "proposal-booking-accept-1",
+      approvalId: "approval_1",
+      idempotencyFingerprint: "sha256:test",
+    },
+  }
+}
+
 function registry() {
   const registry = createToolRegistry()
   for (const tool of proposalsTools) {
@@ -128,6 +157,10 @@ function registry() {
     } else if (tool === acceptProposalVersionTool) {
       registry.register(tool, {
         actionPolicy: ACCEPT_PROPOSAL_VERSION_HANDLER_POLICY.actionPolicy,
+      })
+    } else if (tool === acceptProposalForBookingTool) {
+      registry.register(tool, {
+        actionPolicy: ACCEPT_PROPOSAL_FOR_BOOKING_HANDLER_POLICY.actionPolicy,
       })
     } else if (tool === createProposalTool) {
       registry.register(tool, {
@@ -281,6 +314,35 @@ describe("proposals Tools", () => {
     expect(result).toMatchObject({
       proposalUrl: `/proposal/${version.id}`,
       delivery: { id: "ndel_1", status: "pending" },
+    })
+  })
+
+  it("accepts a proposal for booking through one admitted durable command", async () => {
+    const acceptance: ProposalAcceptanceToolServices = {
+      async acceptProposalForBooking(proposalVersionId, admitted) {
+        expect(proposalVersionId).toBe(version.id)
+        expect(admitted.invocation.idempotencyKey).toBe("proposal-booking-accept-1")
+        return {
+          status: "accepted",
+          currency: "EUR",
+          totalAmountCents: 120_000,
+          bookingSession: {
+            id: "session_1",
+            state: "draft",
+            revision: 1,
+            expiresAt: "2026-09-01T00:00:00.000Z",
+          },
+        }
+      },
+    }
+    const result = await registry().dispatch(
+      "accept_proposal_for_booking",
+      { proposalVersionId: version.id },
+      ctx(undefined, "staff", undefined, acceptProposalForBookingActionPolicy(), acceptance),
+    )
+    expect(result).toMatchObject({
+      status: "accepted",
+      bookingSession: { id: "session_1" },
     })
   })
 

--- a/packages/proposals/tests/unit/mcp-runtime.test.ts
+++ b/packages/proposals/tests/unit/mcp-runtime.test.ts
@@ -2,15 +2,20 @@ import type { ToolHandlerActionPolicyContext } from "@voyant-travel/tools"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 const executeAcceptProposalVersionCommand = vi.hoisted(() => vi.fn())
+const executeAcceptProposalForBookingCommand = vi.hoisted(() => vi.fn())
 
 vi.mock("../../src/service/proposal-version-acceptance-command.js", () => ({
   executeAcceptProposalVersionCommand,
+}))
+vi.mock("../../src/service/proposal-booking-acceptance-command.js", () => ({
+  executeAcceptProposalForBookingCommand,
 }))
 
 import { voyantToolContextContribution } from "../../src/mcp-runtime.js"
 
 afterEach(() => {
   executeAcceptProposalVersionCommand.mockReset()
+  executeAcceptProposalForBookingCommand.mockReset()
 })
 
 describe("proposals MCP runtime", () => {
@@ -59,4 +64,49 @@ describe("proposals MCP runtime", () => {
       proposalVersionId: "version_1",
     })
   })
+
+  it("executes proposal-to-booking acceptance through the admitted durable command", async () => {
+    const db = {}
+    const admitted = {
+      invocation: { idempotencyKey: "booking-accept-1" },
+    } as ToolHandlerActionPolicyContext
+    const accepted = { status: "accepted", bookingSession: { id: "session_1" } }
+    executeAcceptProposalForBookingCommand.mockResolvedValue({ replayed: false, value: accepted })
+    const presentation = {
+      resolvePublicProposalBaseUrl: vi.fn(),
+      seedAcceptedProposalBookingSession: vi.fn(),
+    }
+    const contribution = voyantToolContextContribution.contribute({
+      request: request(db),
+      context: { db },
+      resources: { "proposals.presentation-runtime": presentation },
+    })
+    const acceptance = contribution.proposalAcceptance as {
+      acceptProposalForBooking(id: string, policy: ToolHandlerActionPolicyContext): Promise<unknown>
+    }
+
+    await expect(acceptance.acceptProposalForBooking("version_1", admitted)).resolves.toEqual(
+      accepted,
+    )
+    expect(executeAcceptProposalForBookingCommand).toHaveBeenCalledWith({
+      db,
+      context: expect.objectContaining({ organizationId: "org_1" }),
+      admitted,
+      proposalVersionId: "version_1",
+      seedBookingSession: expect.any(Function),
+    })
+  })
 })
+
+function request(db: object) {
+  return {
+    req: { header: () => "request_1" },
+    var: {
+      db,
+      userId: "user_1",
+      callerType: "session",
+      actor: "staff",
+      organizationId: "org_1",
+    },
+  }
+}

--- a/packages/proposals/tests/unit/voyant-manifest.test.ts
+++ b/packages/proposals/tests/unit/voyant-manifest.test.ts
@@ -271,6 +271,7 @@ describe("proposals deployment manifests", () => {
           version: "v1",
           commandTargetField: "proposalVersionId",
           targetLifecycle: "existing",
+          existingTarget: { durability: "handler-command-result-v1" },
           effectBoundary: "local",
           ledger: "required",
           approval: "required",


### PR DESCRIPTION
## Summary

- move `accept_proposal_for_booking` from generic approval preflight to handler-owned command-result durability
- commit approval consumption and the existing atomic proposal acceptance/Booking Session handoff under one command claim
- reconcile exact replay through the proposal-version-keyed Booking Session origin
- declare and verify selected-graph durability

## Why

This is an ordinary intent-level commercial workflow named in #4378, but it still used #4424's unsafe generic approved-dispatch path. The domain workflow was already atomic and its session handoff is idempotently keyed by accepted Proposal Version; this change binds that authority to the durable approval command.

## Verification

- `pnpm --filter @voyant-travel/proposals typecheck`
- `pnpm --filter @voyant-travel/proposals test` (105 passed)
- `pnpm --filter operator test -- tests/api/selected-graph-runtime.test.ts` (60 passed, 13 skipped)
- generated operator graph contains `existingTarget.durability = handler-command-result-v1`
- scoped Biome and `git diff --check`

Refs #4424
Refs #4378
