### PR TITLE
feat(storefront): add live shopping adapters

### DIFF
--- a/.changeset/fuzzy-dodos-shop.md
+++ b/.changeset/fuzzy-dodos-shop.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/storefront": minor
+---
+
+Add the managed Storefront live-shopping adapter over flight and accommodation
+fan-outs plus a closed dynamic-package Connect source port.

--- a/packages/accommodations/tsconfig.build.json
+++ b/packages/accommodations/tsconfig.build.json
@@ -1945,6 +1945,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/live-provider": [
+        "../storefront/dist/shopping/live-provider.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
       ],

--- a/packages/accommodations/tsconfig.typecheck.json
+++ b/packages/accommodations/tsconfig.typecheck.json
@@ -1946,6 +1946,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/live-provider": [
+        "../storefront/dist/shopping/live-provider.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
       ],

--- a/packages/catalog/tsconfig.build.json
+++ b/packages/catalog/tsconfig.build.json
@@ -1897,6 +1897,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/live-provider": [
+        "../storefront/dist/shopping/live-provider.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
       ],

--- a/packages/catalog/tsconfig.typecheck.json
+++ b/packages/catalog/tsconfig.typecheck.json
@@ -1898,6 +1898,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/live-provider": [
+        "../storefront/dist/shopping/live-provider.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
       ],

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -1905,6 +1905,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/live-provider": [
+        "../storefront/dist/shopping/live-provider.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
       ],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -1899,6 +1899,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/live-provider": [
+        "../storefront/dist/shopping/live-provider.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
       ],

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -1950,6 +1950,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/live-provider": [
+        "../storefront/dist/shopping/live-provider.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
       ],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -1951,6 +1951,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/live-provider": [
+        "../storefront/dist/shopping/live-provider.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
       ],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -1954,6 +1954,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/live-provider": [
+        "../storefront/dist/shopping/live-provider.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
       ],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -1955,6 +1955,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/live-provider": [
+        "../storefront/dist/shopping/live-provider.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
       ],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -1986,6 +1986,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/live-provider": [
+        "../storefront/dist/shopping/live-provider.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
       ],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -1981,6 +1981,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/live-provider": [
+        "../storefront/dist/shopping/live-provider.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
       ],

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -1988,6 +1988,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/live-provider": [
+        "../storefront/dist/shopping/live-provider.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
       ],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -1989,6 +1989,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/live-provider": [
+        "../storefront/dist/shopping/live-provider.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
       ],

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -1986,6 +1986,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/live-provider": [
+        "../storefront/dist/shopping/live-provider.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
       ],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -1981,6 +1981,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/live-provider": [
+        "../storefront/dist/shopping/live-provider.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
       ],

--- a/packages/inventory/tsconfig.build.json
+++ b/packages/inventory/tsconfig.build.json
@@ -1918,6 +1918,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/live-provider": [
+        "../storefront/dist/shopping/live-provider.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
       ],

--- a/packages/inventory/tsconfig.typecheck.json
+++ b/packages/inventory/tsconfig.typecheck.json
@@ -1919,6 +1919,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/live-provider": [
+        "../storefront/dist/shopping/live-provider.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
       ],

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -1885,6 +1885,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/live-provider": [
+        "../storefront/dist/shopping/live-provider.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
       ],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -1880,6 +1880,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/live-provider": [
+        "../storefront/dist/shopping/live-provider.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
       ],

--- a/packages/storefront/package.json
+++ b/packages/storefront/package.json
@@ -18,6 +18,7 @@
     "./runtime-contributor": "./src/runtime-contributor.ts",
     "./runtime-port": "./src/runtime-port.ts",
     "./shopping": "./src/shopping/index.ts",
+    "./shopping/live-provider": "./src/shopping/live-provider.ts",
     "./shopping/managed-runtime": "./src/shopping/managed-runtime.ts",
     "./shopping/provider-ports": "./src/shopping/provider-ports.ts",
     "./shopping/runtime-port": "./src/shopping/runtime-port.ts",
@@ -83,6 +84,7 @@
     "@voyant-travel/db": "workspace:^",
     "@voyant-travel/data-sdk": "^0.8.0",
     "@voyant-travel/finance": "workspace:^",
+    "@voyant-travel/flights": "workspace:^",
     "@voyant-travel/hono": "workspace:^",
     "@voyant-travel/relationships-contracts": "workspace:^",
     "@voyant-travel/tools": "workspace:^",
@@ -197,6 +199,11 @@
         "types": "./dist/shopping/index.d.ts",
         "import": "./dist/shopping/index.js",
         "default": "./dist/shopping/index.js"
+      },
+      "./shopping/live-provider": {
+        "types": "./dist/shopping/live-provider.d.ts",
+        "import": "./dist/shopping/live-provider.js",
+        "default": "./dist/shopping/live-provider.js"
       },
       "./shopping/managed-runtime": {
         "types": "./dist/shopping/managed-runtime.d.ts",

--- a/packages/storefront/src/shopping/index.ts
+++ b/packages/storefront/src/shopping/index.ts
@@ -1,4 +1,5 @@
 export * from "./closed-provider-adapters.js"
+export * from "./live-provider.js"
 export * from "./managed-runtime.js"
 export * from "./provider-ports.js"
 export * from "./routes-public.js"

--- a/packages/storefront/src/shopping/live-provider.ts
+++ b/packages/storefront/src/shopping/live-provider.ts
@@ -1,0 +1,424 @@
+import {
+  type FanOutAvailabilitySearchOptions,
+  fanOutAvailabilitySearch,
+  type PresentedAvailabilityCandidate,
+} from "@voyant-travel/catalog"
+import type { AvailabilitySearchRequest } from "@voyant-travel/catalog-contracts/adapter/contract"
+import {
+  type FanOutFlightSearchOptions,
+  fanOutFlightSearch,
+  type MergedFlightOffer,
+} from "@voyant-travel/flights"
+import type {
+  StorefrontInternalPackageOffer,
+  StorefrontInternalStayOffer,
+  StorefrontLiveSearchPage,
+  StorefrontLiveSourceStatus,
+  StorefrontShoppingLiveProvider,
+} from "./provider-ports.js"
+import type { StorefrontShoppingContext } from "./runtime-port.js"
+import type { StorefrontResolvedScope, StorefrontShoppingIntent } from "./schemas.js"
+
+type FlightIntent = Extract<StorefrontShoppingIntent, { kind: "flight" }>
+type StayIntent = Extract<StorefrontShoppingIntent, { kind: "stay" }>
+type PackageIntent = Extract<StorefrontShoppingIntent, { kind: "package" }>
+
+interface TrustedShoppingInput<TIntent> {
+  context: StorefrontShoppingContext
+  scope: StorefrontResolvedScope
+  intent: TIntent
+}
+
+export interface StorefrontStayPresentation {
+  title: string
+  roomName?: string
+  boardName?: string
+  image?: { url: string; alt?: string }
+}
+
+/**
+ * Closed deployment seam for source discovery. The resolver authenticates the
+ * trusted storefront/channel tuple and returns only sources admitted to the
+ * resolved market. Connection ids remain inside the fan-out invocation.
+ */
+export interface StorefrontLiveFlightFanOutResolver {
+  resolve(
+    input: Omit<TrustedShoppingInput<FlightIntent>, "intent">,
+  ): Promise<Omit<FanOutFlightSearchOptions, "request" | "presentation">>
+}
+
+/** Closed equivalent for owned + sourced accommodation availability. */
+export interface StorefrontLiveStayFanOutResolver {
+  resolve(
+    input: Omit<TrustedShoppingInput<StayIntent>, "intent">,
+  ): Promise<Omit<FanOutAvailabilitySearchOptions, "request" | "presentation">>
+  present(
+    input: Omit<TrustedShoppingInput<StayIntent>, "intent"> & {
+      candidate: PresentedAvailabilityCandidate
+    },
+  ): Promise<StorefrontStayPresentation | undefined>
+}
+
+export interface StorefrontDynamicPackageSourceOffer {
+  nativePrice: { amount: string; currency: string }
+  title: string
+  origin: string
+  destination: string
+  departureDate: string
+  nights: number
+  accommodationName: string
+  boardName?: string
+  image?: { url: string; alt?: string }
+  expiresAt?: string
+  selection: Readonly<Record<string, unknown>>
+  providerData?: Readonly<Record<string, unknown>>
+}
+
+export interface StorefrontDynamicPackageSource {
+  /** The source is a closure over its Connect connection and credentials. */
+  search(input: {
+    origin: string
+    destination: PackageIntent["destination"]
+    departureDateFrom: string
+    departureDateTo: string
+    nights: { min: number; max: number }
+    occupancy: { adults: number; children?: number; childrenAges?: number[]; infants?: number }
+    boards?: string[]
+    minStars?: number
+    pagination?: { cursor?: string; limit?: number }
+    scope: Pick<StorefrontResolvedScope, "marketId" | "locale" | "currency">
+  }): Promise<{
+    offers: readonly StorefrontDynamicPackageSourceOffer[]
+    status?: "ok" | "partial" | "empty"
+  }>
+}
+
+/**
+ * Closed Connect source resolver. No connection, provider, operator, or vendor
+ * selector is accepted from the shopping intent.
+ */
+export interface StorefrontDynamicPackageConnectPort {
+  resolveSources(
+    input: Omit<TrustedShoppingInput<PackageIntent>, "intent"> & {
+      destination: PackageIntent["destination"]
+    },
+  ): Promise<readonly StorefrontDynamicPackageSource[]>
+}
+
+export interface CreateStorefrontShoppingLiveProviderOptions {
+  flights?: StorefrontLiveFlightFanOutResolver
+  stays?: StorefrontLiveStayFanOutResolver
+  packages?: StorefrontDynamicPackageConnectPort
+  perSourceTimeoutMs?: number
+}
+
+/**
+ * Maps the existing domain fan-outs onto Storefront's identity-free live page.
+ * FX is deliberately not configured here: the managed Storefront runtime is
+ * the sole presentation-money authority after all live verticals are mapped.
+ */
+export function createStorefrontShoppingLiveProvider(
+  options: CreateStorefrontShoppingLiveProviderOptions,
+): StorefrontShoppingLiveProvider {
+  return {
+    async searchFlights(input) {
+      if (!options.flights) return unavailablePage()
+      const resolved = await options.flights.resolve(input)
+      if (resolved.adapters.length === 0) return unavailablePage()
+      const result = await fanOutFlightSearch({
+        ...resolved,
+        request: flightRequest(input.intent),
+        ...(options.perSourceTimeoutMs !== undefined
+          ? { perConnectionTimeoutMs: options.perSourceTimeoutMs }
+          : {}),
+      })
+      return {
+        items: result.offers.flatMap(mapMergedFlightOffers),
+        sources: result.perConnection.map(({ status, count }) => ({
+          status: mapFlightStatus(status, count),
+        })),
+      }
+    },
+
+    async searchStays(input) {
+      if (!options.stays) return unavailablePage()
+      const stays = options.stays
+      const resolved = await stays.resolve(input)
+      if ((resolved.adapters?.length ?? 0) + (resolved.ownedHandlers?.length ?? 0) === 0) {
+        return unavailablePage()
+      }
+      const result = await fanOutAvailabilitySearch({
+        ...resolved,
+        request: stayRequest(input.scope, input.intent),
+        ...(options.perSourceTimeoutMs !== undefined
+          ? { perConnectionTimeoutMs: options.perSourceTimeoutMs }
+          : {}),
+      })
+      const items = (
+        await Promise.all(
+          result.candidates.map(async (candidate) => {
+            try {
+              const presentation = await stays.present({
+                context: input.context,
+                scope: input.scope,
+                candidate,
+              })
+              if (!presentation) return undefined
+              return mapStay(candidate, input.intent, presentation)
+            } catch {
+              return undefined
+            }
+          }),
+        )
+      ).filter((item): item is StorefrontInternalStayOffer => item !== undefined)
+      const dropped = result.candidates.length - items.length
+      return {
+        items,
+        sources: result.perConnection.map(({ status }) => {
+          const mapped = mapAvailabilityStatus(status)
+          return {
+            status: dropped > 0 && (mapped === "ok" || mapped === "empty") ? "partial" : mapped,
+          }
+        }),
+      }
+    },
+
+    async searchPackages(input) {
+      if (!options.packages) return unavailablePage()
+      const sources = await options.packages.resolveSources({
+        context: input.context,
+        scope: input.scope,
+        destination: input.intent.destination,
+      })
+      if (sources.length === 0) return unavailablePage()
+      const pages = await Promise.all(
+        sources.map((source) =>
+          runPackageSource(
+            source,
+            packageRequest(input.scope, input.intent),
+            options.perSourceTimeoutMs ?? 5_000,
+          ),
+        ),
+      )
+      return {
+        items: pages.flatMap(({ offers }) => offers),
+        sources: pages.map(({ status }) => ({ status })),
+      }
+    },
+  }
+}
+
+function flightRequest(intent: FlightIntent): FanOutFlightSearchOptions["request"] {
+  const childrenAges = intent.travelers.childrenAges
+  return {
+    slices: intent.slices,
+    passengers: {
+      adults: intent.travelers.adults,
+      ...(childrenAges?.length ? { children: childrenAges.length } : {}),
+      ...(intent.travelers.infants !== undefined ? { infants: intent.travelers.infants } : {}),
+    },
+    ...(intent.cabin ? { cabin: intent.cabin } : {}),
+    ...(intent.directOnly !== undefined
+      ? { searchOptions: { directOnly: intent.directOnly } }
+      : {}),
+    ...(intent.pagination ? { pagination: intent.pagination } : {}),
+  }
+}
+
+function stayRequest(
+  scope: StorefrontResolvedScope,
+  intent: StayIntent,
+): AvailabilitySearchRequest {
+  const destination = {
+    ...(intent.destination.query ? { query: intent.destination.query } : {}),
+    ...(intent.destination.countryCode ? { countryCode: intent.destination.countryCode } : {}),
+    ...(intent.destination.city ? { city: intent.destination.city } : {}),
+  }
+  const near =
+    intent.destination.latitude !== undefined && intent.destination.longitude !== undefined
+      ? { latitude: intent.destination.latitude, longitude: intent.destination.longitude }
+      : undefined
+  return {
+    vertical: "accommodations",
+    criteria: {
+      ...(Object.keys(destination).length > 0 ? { destination } : {}),
+      ...(near ? { near } : {}),
+      checkIn: intent.checkIn,
+      checkOut: intent.checkOut,
+      rooms: intent.rooms.map((room) => ({
+        adults: room.adults,
+        ...(room.childrenAges?.length
+          ? { children: room.childrenAges.length, childrenAges: room.childrenAges }
+          : {}),
+      })),
+      ...(intent.minStars !== undefined ? { minStars: intent.minStars } : {}),
+    },
+    criteriaVersion: "accommodations.v1",
+    scope: sourceScope(scope),
+    ...(intent.pagination?.cursor ? { cursor: intent.pagination.cursor } : {}),
+    ...(intent.pagination?.limit !== undefined ? { limit: intent.pagination.limit } : {}),
+  }
+}
+
+function sourceScope(scope: StorefrontResolvedScope): AvailabilitySearchRequest["scope"] {
+  return {
+    locale: scope.locale,
+    audience: "storefront",
+    market: scope.marketId,
+    currency: scope.currency,
+  }
+}
+
+function mapMergedFlightOffers(merged: MergedFlightOffer) {
+  return [merged.cheapest, ...merged.alternates].map((offer) => ({
+    nativePrice: offer.totalPrice,
+    itineraries: offer.itineraries.map((itinerary) => ({
+      segments: itinerary.segments.map((segment) => ({
+        origin: { code: segment.departure.iataCode, at: segment.departure.at },
+        destination: { code: segment.arrival.iataCode, at: segment.arrival.at },
+        marketingCarrier: segment.carrierCode,
+        flightNumber: segment.flightNumber,
+      })),
+      ...(itinerary.duration ? { duration: itinerary.duration } : {}),
+    })),
+    selection: {
+      offerId: offer.offerId,
+      source: offer.source,
+      itineraryFingerprint: merged.itineraryFingerprint,
+      sourceConnectionIds: merged.sourceConnectionIds,
+    },
+    providerData: {
+      sourceConnectionIds: merged.sourceConnectionIds,
+      ...(offer.providerData ?? {}),
+    },
+    ...(offer.expiresAt ? { expiresAt: offer.expiresAt } : {}),
+  }))
+}
+
+function mapStay(
+  candidate: PresentedAvailabilityCandidate,
+  intent: StayIntent,
+  presentation: StorefrontStayPresentation,
+): StorefrontInternalStayOffer {
+  return {
+    nativePrice: candidate.price,
+    selection: {
+      entityModule: candidate.entity_module,
+      entityId: candidate.entity_id,
+      selection: candidate.selection,
+      source: candidate.source,
+    },
+    accommodationSelection: {
+      entityModule: candidate.entity_module,
+      entityId: candidate.entity_id,
+    },
+    providerData: candidate.providerData,
+    title: presentation.title,
+    checkIn: intent.checkIn,
+    checkOut: intent.checkOut,
+    ...(presentation.roomName ? { roomName: presentation.roomName } : {}),
+    ...(presentation.boardName ? { boardName: presentation.boardName } : {}),
+    ...(presentation.image ? { image: presentation.image } : {}),
+    ...(candidate.expiresAt ? { expiresAt: candidate.expiresAt.toISOString() } : {}),
+  }
+}
+
+function packageRequest(scope: StorefrontResolvedScope, intent: PackageIntent) {
+  return {
+    origin: intent.origin,
+    destination: intent.destination,
+    departureDateFrom: intent.departureDateFrom,
+    departureDateTo: intent.departureDateTo,
+    nights: intent.nights,
+    occupancy: {
+      adults: intent.travelers.adults,
+      ...(intent.travelers.childrenAges?.length
+        ? {
+            children: intent.travelers.childrenAges.length,
+            childrenAges: intent.travelers.childrenAges,
+          }
+        : {}),
+      ...(intent.travelers.infants !== undefined ? { infants: intent.travelers.infants } : {}),
+    },
+    ...(intent.boards ? { boards: intent.boards } : {}),
+    ...(intent.minStars !== undefined ? { minStars: intent.minStars } : {}),
+    ...(intent.pagination ? { pagination: intent.pagination } : {}),
+    scope: { marketId: scope.marketId, locale: scope.locale, currency: scope.currency },
+  }
+}
+
+async function runPackageSource(
+  source: StorefrontDynamicPackageSource,
+  request: Parameters<StorefrontDynamicPackageSource["search"]>[0],
+  timeoutMs: number,
+): Promise<{
+  offers: readonly StorefrontInternalPackageOffer[]
+  status: StorefrontLiveSourceStatus
+}> {
+  try {
+    const result = await withTimeout(source.search(request), timeoutMs)
+    return {
+      offers: result.offers,
+      status: result.status ?? (result.offers.length > 0 ? "ok" : "empty"),
+    }
+  } catch (error) {
+    return {
+      offers: [],
+      status: error instanceof SourceTimeoutError ? "timeout" : "error",
+    }
+  }
+}
+
+class SourceTimeoutError extends Error {}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new SourceTimeoutError("dynamic package source timed out")),
+          timeoutMs,
+        )
+      }),
+    ])
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout)
+  }
+}
+
+function mapFlightStatus(
+  status: "ok" | "timeout" | "error" | "not_found" | "capability_missing",
+  count: number,
+): StorefrontLiveSourceStatus {
+  if (status === "ok") return count > 0 ? "ok" : "empty"
+  if (status === "timeout") return "timeout"
+  if (status === "error") return "error"
+  return "unavailable"
+}
+
+function mapAvailabilityStatus(
+  status:
+    | "ok"
+    | "partial"
+    | "empty"
+    | "unsupported"
+    | "timeout"
+    | "error"
+    | "capability_missing"
+    | "vertical_skipped",
+): StorefrontLiveSourceStatus {
+  if (
+    status === "unsupported" ||
+    status === "capability_missing" ||
+    status === "vertical_skipped"
+  ) {
+    return "unavailable"
+  }
+  return status
+}
+
+function unavailablePage<T>(): StorefrontLiveSearchPage<T> {
+  return { items: [], sources: [{ status: "unavailable" }] }
+}

--- a/packages/storefront/tests/unit/live-shopping-provider.test.ts
+++ b/packages/storefront/tests/unit/live-shopping-provider.test.ts
@@ -1,0 +1,473 @@
+import type {
+  AvailabilityCandidate,
+  SourceAdapter,
+} from "@voyant-travel/catalog-contracts/adapter/contract"
+import type { FlightConnectorAdapter, FlightOffer } from "@voyant-travel/flights"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  createManagedStorefrontShoppingRuntime,
+  createStorefrontShoppingLiveProvider,
+  type StorefrontResolvedScope,
+  type StorefrontShoppingContext,
+} from "../../src/shopping/index.js"
+
+const context = {
+  storefrontId: "storefront_trusted",
+  channelId: "channel_trusted",
+  userId: "user_trusted",
+  buyerAccountId: "buyer_trusted",
+} satisfies StorefrontShoppingContext
+
+const scope = {
+  marketId: "market_ro",
+  locale: "ro-RO",
+  currency: "EUR",
+  available: {
+    marketIds: ["market_ro"],
+    locales: ["ro-RO"],
+    currencies: ["EUR"],
+  },
+} satisfies StorefrontResolvedScope
+
+function flightOffer(overrides: Partial<FlightOffer> = {}): FlightOffer {
+  return {
+    offerId: "provider_offer_secret",
+    source: "provider_secret",
+    itineraries: [
+      {
+        duration: "PT2H30M",
+        segments: [
+          {
+            segmentId: "segment_secret",
+            carrierCode: "RO",
+            flightNumber: "101",
+            departure: { iataCode: "OTP", at: "2026-09-10T08:00:00+03:00" },
+            arrival: { iataCode: "FCO", at: "2026-09-10T09:30:00+02:00" },
+            cabin: "economy",
+          },
+        ],
+      },
+    ],
+    fareBreakdowns: [],
+    totalPrice: { amount: "125.00", currency: "EUR" },
+    expiresAt: "2026-08-08T10:04:00.000Z",
+    providerData: { vendorLocator: "vendor_secret" },
+    ...overrides,
+  }
+}
+
+function flightAdapter(search: FlightConnectorAdapter["searchFlights"]): FlightConnectorAdapter {
+  return {
+    capabilities: { provider: "secret-provider", declared: [] },
+    searchFlights: search,
+    async priceOffer() {
+      throw new Error("not used")
+    },
+    async bookFlight() {
+      throw new Error("not used")
+    },
+    async getOrder() {
+      throw new Error("not used")
+    },
+    async cancelOrder() {
+      throw new Error("not used")
+    },
+  }
+}
+
+function stayAdapter(searchAvailability: NonNullable<SourceAdapter["searchAvailability"]>) {
+  return {
+    kind: "secret-stay-source",
+    capabilities: {
+      verticals: ["accommodations"],
+      supportsLiveResolution: true,
+      supportsAvailabilitySearch: true,
+      supportsDriftDetection: false,
+      supportsBookingForwarding: false,
+      postBookOperations: [],
+    },
+    searchAvailability,
+  } satisfies SourceAdapter
+}
+
+describe("storefront live shopping provider", () => {
+  it("maps flight criteria, fans out admitted sources, and retains partial health + expiry", async () => {
+    const search = vi.fn(async () => ({ offers: [flightOffer()] }))
+    const resolve = vi.fn(async () => ({
+      adapters: [
+        { connectionId: "connection_secret_ok", adapter: flightAdapter(search) },
+        {
+          connectionId: "connection_secret_failed",
+          adapter: flightAdapter(async () => {
+            throw new Error("upstream failed")
+          }),
+        },
+      ],
+    }))
+    const provider = createStorefrontShoppingLiveProvider({ flights: { resolve } })
+
+    const page = await provider.searchFlights({
+      context,
+      scope,
+      intent: {
+        kind: "flight",
+        slices: [{ origin: "OTP", destination: "FCO", departureDate: "2026-09-10" }],
+        travelers: { adults: 2, childrenAges: [7, 12], infants: 1 },
+        cabin: "business",
+        directOnly: true,
+        pagination: { cursor: "opaque-cursor-0001", limit: 25 },
+      },
+    })
+
+    expect(resolve).toHaveBeenCalledWith({
+      context,
+      scope,
+      intent: {
+        kind: "flight",
+        slices: [{ origin: "OTP", destination: "FCO", departureDate: "2026-09-10" }],
+        travelers: { adults: 2, childrenAges: [7, 12], infants: 1 },
+        cabin: "business",
+        directOnly: true,
+        pagination: { cursor: "opaque-cursor-0001", limit: 25 },
+      },
+    })
+    expect(search).toHaveBeenCalledWith(
+      { connectionId: "connection_secret_ok" },
+      {
+        slices: [{ origin: "OTP", destination: "FCO", departureDate: "2026-09-10" }],
+        passengers: { adults: 2, children: 2, infants: 1 },
+        cabin: "business",
+        searchOptions: { directOnly: true },
+        pagination: { cursor: "opaque-cursor-0001", limit: 25 },
+      },
+    )
+    expect(page.sources).toEqual([{ status: "ok" }, { status: "error" }])
+    expect(page.items[0]).toMatchObject({
+      nativePrice: { amount: "125.00", currency: "EUR" },
+      expiresAt: "2026-08-08T10:04:00.000Z",
+      itineraries: [
+        {
+          segments: [
+            {
+              origin: { code: "OTP", at: "2026-09-10T08:00:00+03:00" },
+              destination: { code: "FCO", at: "2026-09-10T09:30:00+02:00" },
+              marketingCarrier: "RO",
+              flightNumber: "101",
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it("maps trusted scope and stay criteria across sourced availability without public identity leakage", async () => {
+    const searchAvailability = vi.fn(async () => ({
+      status: "partial" as const,
+      candidates: [
+        {
+          candidateRef: "candidate_secret",
+          entity_module: "accommodations",
+          entity_id: "accommodation_secret",
+          selection: { ratePlanId: "rate_secret", roomTypeId: "room_secret" },
+          price: { amount: "450.00", currency: "EUR" },
+          source: { kind: "sourced" as const, connectionId: "connection_secret" },
+          expiresAt: new Date("2026-08-08T10:03:00.000Z"),
+          providerData: { net: "300.00", supplierRef: "supplier_secret" },
+        },
+      ],
+    }))
+    const provider = createStorefrontShoppingLiveProvider({
+      stays: {
+        resolve: vi.fn(async () => ({
+          adapters: [
+            {
+              connectionId: "connection_secret",
+              adapter: stayAdapter(searchAvailability),
+            },
+          ],
+        })),
+        present: vi.fn(async () => ({
+          title: "Hotel Public",
+          roomName: "Family room",
+          boardName: "Breakfast",
+        })),
+      },
+    })
+    const intent = {
+      kind: "stay" as const,
+      destination: { countryCode: "IT", city: "Rome", latitude: 41.9, longitude: 12.5 },
+      checkIn: "2026-09-10",
+      checkOut: "2026-09-15",
+      rooms: [{ adults: 2, childrenAges: [6] }],
+      minStars: 4,
+      pagination: { cursor: "opaque-cursor-0002", limit: 15 },
+    }
+
+    const page = await provider.searchStays({ context, scope, intent })
+
+    expect(searchAvailability).toHaveBeenCalledWith(
+      { connection_id: "connection_secret" },
+      {
+        vertical: "accommodations",
+        criteriaVersion: "accommodations.v1",
+        criteria: {
+          destination: { countryCode: "IT", city: "Rome" },
+          near: { latitude: 41.9, longitude: 12.5 },
+          checkIn: "2026-09-10",
+          checkOut: "2026-09-15",
+          rooms: [{ adults: 2, children: 1, childrenAges: [6] }],
+          minStars: 4,
+        },
+        scope: { locale: "ro-RO", audience: "storefront", market: "market_ro", currency: "EUR" },
+        cursor: "opaque-cursor-0002",
+        limit: 15,
+      },
+    )
+    expect(page.sources).toEqual([{ status: "partial" }])
+    expect(page.items[0]).toMatchObject({
+      title: "Hotel Public",
+      expiresAt: "2026-08-08T10:03:00.000Z",
+    })
+
+    const issued: Array<Record<string, unknown>> = []
+    const runtime = createManagedStorefrontShoppingRuntime({
+      markets: {
+        listActiveMarkets: async () => [
+          {
+            id: scope.marketId,
+            defaultLocale: scope.locale,
+            defaultCurrency: scope.currency,
+            locales: [scope.locale],
+            currencies: [scope.currency],
+          },
+        ],
+      },
+      catalog: { searchSlice: async () => ({ items: [], total: 0 }) },
+      live: provider,
+      references: {
+        issue: async (input) => {
+          issued.push(input as unknown as Record<string, unknown>)
+          return {
+            ref: `opaque-reference-${issued.length.toString().padStart(4, "0")}`,
+            expiresAt: "2026-08-08T10:05:00.000Z",
+          }
+        },
+      },
+      now: () => new Date("2026-08-08T10:00:00.000Z"),
+    })
+    const publicResult = await runtime.search(context, { scope, intent })
+    const serialized = JSON.stringify(publicResult)
+    expect(serialized).not.toContain("connection_secret")
+    expect(serialized).not.toContain("accommodation_secret")
+    expect(serialized).not.toContain("supplier_secret")
+    expect(serialized).not.toContain("providerData")
+    expect(issued).toHaveLength(2)
+    expect(JSON.stringify(issued)).toContain("supplier_secret")
+  })
+
+  it("fans out closed dynamic-package sources, maps occupancy, and hides source health identities", async () => {
+    const search = vi.fn(async () => ({
+      status: "partial" as const,
+      offers: [
+        {
+          nativePrice: { amount: "999.00", currency: "EUR" },
+          title: "Rome escape",
+          origin: "OTP",
+          destination: "Rome",
+          departureDate: "2026-09-10",
+          nights: 5,
+          accommodationName: "Hotel Public",
+          expiresAt: "2026-08-08T10:02:00.000Z",
+          selection: { upstreamOfferId: "package_offer_secret" },
+          providerData: { connectionId: "connection_secret" },
+        },
+      ],
+    }))
+    const provider = createStorefrontShoppingLiveProvider({
+      packages: {
+        resolveSources: vi.fn(async ({ context: trustedContext, scope: trustedScope }) => {
+          expect(trustedContext).toBe(context)
+          expect(trustedScope).toBe(scope)
+          return [
+            { search },
+            {
+              search: async () => {
+                throw new Error("second source failed")
+              },
+            },
+          ]
+        }),
+      },
+    })
+    const intent = {
+      kind: "package" as const,
+      origin: "OTP",
+      destination: { countryCode: "IT", city: "Rome" },
+      departureDateFrom: "2026-09-01",
+      departureDateTo: "2026-09-30",
+      nights: { min: 5, max: 7 },
+      travelers: { adults: 2, childrenAges: [9], infants: 1 },
+      boards: ["AI"],
+      minStars: 4,
+      pagination: { cursor: "opaque-cursor-0003", limit: 30 },
+    }
+
+    const page = await provider.searchPackages({ context, scope, intent })
+
+    expect(search).toHaveBeenCalledWith({
+      origin: "OTP",
+      destination: { countryCode: "IT", city: "Rome" },
+      departureDateFrom: "2026-09-01",
+      departureDateTo: "2026-09-30",
+      nights: { min: 5, max: 7 },
+      occupancy: { adults: 2, children: 1, childrenAges: [9], infants: 1 },
+      boards: ["AI"],
+      minStars: 4,
+      pagination: { cursor: "opaque-cursor-0003", limit: 30 },
+      scope: { marketId: "market_ro", locale: "ro-RO", currency: "EUR" },
+    })
+    expect(page.sources).toEqual([{ status: "partial" }, { status: "error" }])
+    expect(page.items[0]).toMatchObject({
+      title: "Rome escape",
+      expiresAt: "2026-08-08T10:02:00.000Z",
+    })
+    expect(JSON.stringify(page.sources)).not.toContain("connection_secret")
+  })
+
+  it("fails unavailable for unconfigured live domains and reports package timeouts without identities", async () => {
+    const unavailable = createStorefrontShoppingLiveProvider({})
+    await expect(
+      unavailable.searchFlights({
+        context,
+        scope,
+        intent: {
+          kind: "flight",
+          slices: [{ origin: "OTP", destination: "FCO", departureDate: "2026-09-10" }],
+          travelers: { adults: 1 },
+        },
+      }),
+    ).resolves.toEqual({ items: [], sources: [{ status: "unavailable" }] })
+
+    const timed = createStorefrontShoppingLiveProvider({
+      perSourceTimeoutMs: 1,
+      packages: {
+        resolveSources: async () => [
+          {
+            search: async () => {
+              await new Promise((resolve) => setTimeout(resolve, 20))
+              return { offers: [] }
+            },
+          },
+        ],
+      },
+    })
+    const page = await timed.searchPackages({
+      context,
+      scope,
+      intent: {
+        kind: "package",
+        origin: "OTP",
+        destination: { city: "Rome" },
+        departureDateFrom: "2026-09-01",
+        departureDateTo: "2026-09-30",
+        nights: { min: 5, max: 7 },
+        travelers: { adults: 2 },
+      },
+    })
+    expect(page).toEqual({ items: [], sources: [{ status: "timeout" }] })
+  })
+
+  it("fails unavailable when configured resolvers admit no live sources", async () => {
+    const provider = createStorefrontShoppingLiveProvider({
+      flights: { resolve: async () => ({ adapters: [] }) },
+      stays: { resolve: async () => ({}), present: async () => undefined },
+      packages: { resolveSources: async () => [] },
+    })
+
+    await expect(
+      provider.searchFlights({
+        context,
+        scope,
+        intent: {
+          kind: "flight",
+          slices: [{ origin: "OTP", destination: "FCO", departureDate: "2026-09-10" }],
+          travelers: { adults: 1 },
+        },
+      }),
+    ).resolves.toEqual({ items: [], sources: [{ status: "unavailable" }] })
+    await expect(
+      provider.searchStays({
+        context,
+        scope,
+        intent: {
+          kind: "stay",
+          destination: { city: "Rome" },
+          checkIn: "2026-09-10",
+          checkOut: "2026-09-15",
+          rooms: [{ adults: 1 }],
+        },
+      }),
+    ).resolves.toEqual({ items: [], sources: [{ status: "unavailable" }] })
+    await expect(
+      provider.searchPackages({
+        context,
+        scope,
+        intent: {
+          kind: "package",
+          origin: "OTP",
+          destination: { city: "Rome" },
+          departureDateFrom: "2026-09-01",
+          departureDateTo: "2026-09-30",
+          nights: { min: 5, max: 7 },
+          travelers: { adults: 2 },
+        },
+      }),
+    ).resolves.toEqual({ items: [], sources: [{ status: "unavailable" }] })
+  })
+
+  it("drops a stay whose presentation fails without aborting the live page", async () => {
+    const candidate = {
+      candidateRef: "candidate_secret",
+      entity_module: "accommodations",
+      entity_id: "accommodation_secret",
+      selection: { ratePlanId: "rate_secret" },
+      price: { amount: "450.00", currency: "EUR" },
+      source: { kind: "sourced" as const, connectionId: "connection_secret" },
+    } satisfies AvailabilityCandidate
+    const provider = createStorefrontShoppingLiveProvider({
+      stays: {
+        resolve: async () => ({
+          adapters: [
+            {
+              connectionId: "connection_secret",
+              adapter: stayAdapter(async () => ({
+                status: "ok",
+                candidates: [candidate, { ...candidate, candidateRef: "candidate_failed" }],
+              })),
+            },
+          ],
+        }),
+        present: async ({ candidate: presented }) => {
+          if (presented.candidateRef === "candidate_failed") throw new Error("catalog unavailable")
+          return { title: "Hotel Public" }
+        },
+      },
+    })
+
+    const page = await provider.searchStays({
+      context,
+      scope,
+      intent: {
+        kind: "stay",
+        destination: { city: "Rome" },
+        checkIn: "2026-09-10",
+        checkOut: "2026-09-15",
+        rooms: [{ adults: 1 }],
+      },
+    })
+
+    expect(page.items).toHaveLength(1)
+    expect(page.sources).toEqual([{ status: "partial" }])
+  })
+})

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -1997,6 +1997,9 @@
       "@voyant-travel/storefront/runtime-port": ["../storefront/dist/runtime-port.d.ts"],
       "@voyant-travel/storefront/service": ["../storefront/dist/service.d.ts"],
       "@voyant-travel/storefront/shopping": ["../storefront/dist/shopping/index.d.ts"],
+      "@voyant-travel/storefront/shopping/live-provider": [
+        "../storefront/dist/shopping/live-provider.d.ts"
+      ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
       ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5563,6 +5563,9 @@ importers:
       '@voyant-travel/finance':
         specifier: workspace:^
         version: link:../finance
+      '@voyant-travel/flights':
+        specifier: workspace:^
+        version: link:../flights
       '@voyant-travel/hono':
         specifier: workspace:^
         version: link:../hono


### PR DESCRIPTION
## Summary
- adapt admitted flight connections through `fanOutFlightSearch` without browser-selectable provider identifiers
- adapt owned and sourced accommodation availability through `fanOutAvailabilitySearch`, retaining opaque selection/provider data only for reference issuance
- add a closed source-closure Connect mechanic for dynamic flight+stay package fan-out, including partial/error/timeout health with no source identities
- keep presentation FX out of the adapters so the managed Storefront runtime remains the shared normalization authority

## Coverage
- criteria and resolved-scope mapping for flights, stays, and packages
- partial/error/timeout/unavailable source health
- upstream expiry propagation and managed reference bounding
- public DTO leakage checks for connection, accommodation, supplier, and provider data

## Validation
- `git diff --check 26a70e400d3aa401ac8c7f6e6ca7ec375b85f32e..HEAD`
- lab1 validation blocked: SSH to lab1 timed out, and two `agent-run` dispatch attempts stopped after pushing the already-current base without starting a job
- local typecheck/test/lint intentionally not run because this task requires those commands through lab1/approved remote execution

## Stack
- pinned base branch: `agent/storefront-shopping-runtime-26a70e4` at `26a70e400d3aa401ac8c7f6e6ca7ec375b85f32e`
- implementation branch: `agent/storefront-shopping-live-adapters` at `29797653049ac6beb2fd2dcad8ac0cbf955f60e8`
- the shared `agent/storefront-shopping-runtime` branch moved during implementation, so this non-moving anchor preserves the requested exact parent

## Residual provider wiring
- deployments must supply the trusted flight and stay fan-out source resolvers
- Connect-backed package deployments must supply source closures that encapsulate connection resolution, credentials, hotel discovery, and raw response normalization; the OSS domain currently has no safe request-independent package-search primitive