### PR TITLE
feat(trips): redeem durable opaque shopping references

### DIFF
--- a/.changeset/tough-shopping-opaque-references.md
+++ b/.changeset/tough-shopping-opaque-references.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/trips": minor
+---
+
+Add a durable, digest-only Storefront shopping reference issuer and Trips redemption adapter with scope, owner, expiry, and atomic replay enforcement.

--- a/packages/storefront/src/shopping/provider-ports.ts
+++ b/packages/storefront/src/shopping/provider-ports.ts
@@ -8,6 +8,11 @@ import { definePort } from "@voyant-travel/core/project"
 import type { StorefrontShoppingContext } from "./runtime-port.js"
 import type { StorefrontResolvedScope, StorefrontShoppingIntent } from "./schemas.js"
 
+export {
+  type StorefrontOpaqueReferenceIssuer,
+  storefrontOpaqueReferenceIssuerPort,
+} from "./runtime-port.js"
+
 export interface StorefrontActiveMarket {
   id: string
   defaultLocale: string
@@ -138,25 +143,6 @@ export interface StorefrontShoppingLiveProvider {
   }): Promise<StorefrontLiveSearchPage<StorefrontInternalPackageOffer>>
 }
 
-export interface StorefrontOpaqueReferenceIssuer {
-  /**
-   * The backing issuer MUST authenticate the same storefront/channel/scope and
-   * owner tuple when resolving the ref, and reject cross-owner replay. The
-   * managed shopping runtime never resolves or commits an offer itself.
-   */
-  issue(input: {
-    purpose: "catalog-item" | "flight-offer" | "stay-offer" | "package-offer"
-    storefrontId: string
-    channelId: string
-    /** Trusted capability owner binding. Anonymous owners are explicitly null. */
-    owner: { userId: string | null; buyerAccountId: string | null }
-    scope: Pick<StorefrontResolvedScope, "marketId" | "locale" | "currency">
-    payload: Readonly<Record<string, unknown>>
-    ttlSeconds: number
-    replay: "multi-use" | "single-use"
-  }): Promise<{ ref: string; expiresAt: string }>
-}
-
 function methodsPort<T>(id: string, methods: readonly string[]) {
   return definePort<T>({
     id,
@@ -184,10 +170,6 @@ export const storefrontShoppingCatalogProviderPort = methodsPort<StorefrontShopp
 export const storefrontShoppingLiveProviderPort = methodsPort<StorefrontShoppingLiveProvider>(
   "storefront.shopping.live-provider",
   ["searchFlights", "searchStays", "searchPackages"],
-)
-export const storefrontOpaqueReferenceIssuerPort = methodsPort<StorefrontOpaqueReferenceIssuer>(
-  "storefront.shopping.opaque-reference-issuer",
-  ["issue"],
 )
 export const storefrontPresentationFxProviderPort = definePort<PresentationFxQuoter>({
   id: "storefront.shopping.presentation-fx",

--- a/packages/storefront/src/shopping/runtime-port.ts
+++ b/packages/storefront/src/shopping/runtime-port.ts
@@ -20,6 +20,25 @@ export interface StorefrontShoppingContext {
   buyerAccountId?: string | null
 }
 
+export interface StorefrontOpaqueReferenceIssuer {
+  /**
+   * The backing issuer MUST authenticate the same storefront/channel/scope and
+   * owner tuple when resolving the ref, and reject cross-owner replay. The
+   * managed shopping runtime never resolves or commits an offer itself.
+   */
+  issue(input: {
+    purpose: "catalog-item" | "flight-offer" | "stay-offer" | "package-offer"
+    storefrontId: string
+    channelId: string
+    /** Trusted capability owner binding. Anonymous owners are explicitly null. */
+    owner: { userId: string | null; buyerAccountId: string | null }
+    scope: Pick<StorefrontResolvedScope, "marketId" | "locale" | "currency">
+    payload: Readonly<Record<string, unknown>>
+    ttlSeconds: number
+    replay: "multi-use" | "single-use"
+  }): Promise<{ ref: string; expiresAt: string }>
+}
+
 export interface StorefrontShoppingRuntime {
   resolveScope(
     context: StorefrontShoppingContext,
@@ -58,6 +77,21 @@ export const storefrontShoppingRuntimePort = definePort<StorefrontShoppingRuntim
       throw new Error("storefront.shopping.runtime provider must be an options object.")
     }
     requireMethods("storefront.shopping.runtime", provider, ["resolveScope", "search"])
+  },
+})
+
+export const storefrontOpaqueReferenceIssuerPort = definePort<StorefrontOpaqueReferenceIssuer>({
+  id: "storefront.shopping.opaque-reference-issuer",
+  test(provider) {
+    if (
+      provider === null ||
+      typeof provider !== "object" ||
+      typeof (provider as { issue?: unknown }).issue !== "function"
+    ) {
+      throw new Error(
+        "storefront.shopping.opaque-reference-issuer provider must implement issue().",
+      )
+    }
   },
 })
 

--- a/packages/trips/migrations/0005_shopping_opaque_references.sql
+++ b/packages/trips/migrations/0005_shopping_opaque_references.sql
@@ -1,0 +1,25 @@
+CREATE TABLE "trip_shopping_references" (
+	"reference_digest" text PRIMARY KEY NOT NULL,
+	"purpose" text NOT NULL,
+	"storefront_id" text NOT NULL,
+	"channel_id" text NOT NULL,
+	"owner_user_id" text,
+	"owner_buyer_account_id" text,
+	"market_id" text NOT NULL,
+	"locale" text NOT NULL,
+	"currency" text NOT NULL,
+	"replay" text NOT NULL,
+	"payload" jsonb NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"consumed_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "trip_shopping_references_purpose_check" CHECK ("purpose" IN ('catalog-item', 'flight-offer', 'stay-offer', 'package-offer')),
+	CONSTRAINT "trip_shopping_references_replay_check" CHECK ("replay" IN ('multi-use', 'single-use')),
+	CONSTRAINT "trip_shopping_references_currency_check" CHECK ("currency" ~ '^[A-Z]{3}$')
+);
+--> statement-breakpoint
+CREATE INDEX "idx_trip_shopping_references_expiry" ON "trip_shopping_references" USING btree ("expires_at");
+--> statement-breakpoint
+CREATE INDEX "idx_trip_shopping_references_scope" ON "trip_shopping_references" USING btree ("storefront_id", "channel_id", "market_id");
+--> statement-breakpoint
+CREATE INDEX "idx_trip_shopping_references_owner" ON "trip_shopping_references" USING btree ("owner_user_id", "owner_buyer_account_id", "expires_at");

--- a/packages/trips/migrations/meta/_journal.json
+++ b/packages/trips/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1786178101086,
       "tag": "0004_storefront_trip_access",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1786194000000,
+      "tag": "0005_shopping_opaque_references",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/trips/src/index.ts
+++ b/packages/trips/src/index.ts
@@ -69,6 +69,18 @@ export type {
 } from "./routes.js"
 export { createTripsRoutes } from "./routes.js"
 export {
+  createTripShoppingReferenceRuntime,
+  createTripShoppingReferenceRuntimeWithStore,
+  issueTripShoppingReference,
+  redeemTripShoppingReference,
+  type ShoppingReferenceBoundary,
+  type ShoppingReferencePurpose,
+  type ShoppingReferenceResolution,
+  type TripShoppingReferenceRuntime,
+  type TripShoppingReferenceRuntimeOptions,
+  type TripShoppingReferenceStore,
+} from "./shopping-opaque-references.js"
+export {
   type CreateStorefrontTripInput,
   createStorefrontTrip,
   createStorefrontTripCapability,

--- a/packages/trips/src/runtime-contributor.ts
+++ b/packages/trips/src/runtime-contributor.ts
@@ -19,7 +19,10 @@ import {
   storefrontPaymentLinkRuntimePort,
   storefrontPaymentReconciliationJobRuntimePort,
 } from "@voyant-travel/storefront"
-import { storefrontTripSelectionsRuntimePort } from "@voyant-travel/storefront/shopping"
+import {
+  storefrontOpaqueReferenceIssuerPort,
+  storefrontTripSelectionsRuntimePort,
+} from "@voyant-travel/storefront/shopping"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { createTripBookingSessionCompositeHandler } from "./booking-session-composite-handler.js"
 import type { TripsRoutesOptionsProvider } from "./routes.js"
@@ -29,15 +32,13 @@ import {
   tripsDatabaseRuntimePort,
   tripsRoutesRuntimePort,
 } from "./runtime-port.js"
+import { createTripShoppingReferenceRuntime } from "./shopping-opaque-references.js"
 import { tripsSourcingJobRuntimePort } from "./sourcing-job-runtime-port.js"
 import {
   createCommerceCardPaymentRuntime,
   createStandardPaymentLinkRouteOptions,
 } from "./storefront-payment-link-runtime.js"
-import {
-  type StorefrontTripOfferResolver,
-  storefrontTripOfferResolverPort,
-} from "./storefront-trip-offer-resolver-port.js"
+import { storefrontTripOfferResolverPort } from "./storefront-trip-offer-resolver-port.js"
 import { createStorefrontTripSelectionsRuntime } from "./storefront-trip-selections-runtime.js"
 
 type RuntimePortValue<T> = T | Promise<T>
@@ -98,10 +99,12 @@ export function createTripsRuntimePortContribution(
     withDb: (bindings, operation) =>
       host.primitives.database.transaction(bindings, (database) => operation(database as never)),
   }
-  const storefrontOfferResolver =
-    host.hasRuntimePort?.(storefrontTripOfferResolverPort) === true
-      ? host.getRuntimePort<StorefrontTripOfferResolver>(storefrontTripOfferResolverPort)
-      : null
+  const shoppingReferences = createTripShoppingReferenceRuntime({
+    withTransaction: (operation) =>
+      host.primitives.database.transaction(undefined, (database) =>
+        operation(database as AnyDrizzleDb),
+      ),
+  })
   const contribution: Record<string, unknown> = {
     [storefrontPaymentLinkRuntimePort.id]: createStandardPaymentLinkRouteOptions(paymentAdapter),
     [storefrontPaymentReconciliationJobRuntimePort.id]: {
@@ -113,20 +116,14 @@ export function createTripsRuntimePortContribution(
     },
     [tripsRoutesRuntimePort.id]: tripsRoutes,
     [tripsDatabaseRuntimePort.id]: tripsDatabase,
+    [storefrontOpaqueReferenceIssuerPort.id]: shoppingReferences.issuer,
+    [storefrontTripOfferResolverPort.id]: shoppingReferences.offerResolver,
     [storefrontTripSelectionsRuntimePort.id]: createStorefrontTripSelectionsRuntime({
       withTransaction: (operation) =>
         host.primitives.database.transaction(undefined, (database) =>
           operation(database as AnyDrizzleDb),
         ),
-      ...(storefrontOfferResolver
-        ? {
-            offerResolver: {
-              async resolve(context, input) {
-                return (await storefrontOfferResolver).resolve(context, input)
-              },
-            },
-          }
-        : {}),
+      offerResolver: shoppingReferences.offerResolver,
     }),
     [tripsSourcingJobRuntimePort.id]: {
       resolveDb: (bindings: unknown) =>

--- a/packages/trips/src/schema.ts
+++ b/packages/trips/src/schema.ts
@@ -274,6 +274,47 @@ export const tripStorefrontAccess = pgTable(
   ],
 )
 
+/**
+ * Server-only shopping capabilities issued to public Storefront clients.
+ *
+ * The raw 256-bit capability is never persisted. `referenceDigest` is its
+ * SHA-256 digest and `payload` is intentionally absent from every public Trip
+ * projection. Exact trust and shopping-scope columns make redemption a single
+ * fail-closed database predicate rather than an application-side comparison.
+ */
+export const tripShoppingReferences = pgTable(
+  "trip_shopping_references",
+  {
+    referenceDigest: text("reference_digest").primaryKey(),
+    purpose: text("purpose").notNull(),
+    storefrontId: text("storefront_id").notNull(),
+    channelId: text("channel_id").notNull(),
+    ownerUserId: text("owner_user_id"),
+    ownerBuyerAccountId: text("owner_buyer_account_id"),
+    marketId: text("market_id").notNull(),
+    locale: text("locale").notNull(),
+    currency: text("currency").notNull(),
+    replay: text("replay").notNull(),
+    payload: jsonb("payload").$type<Readonly<Record<string, unknown>>>().notNull(),
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+    consumedAt: timestamp("consumed_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("idx_trip_shopping_references_expiry").on(table.expiresAt),
+    index("idx_trip_shopping_references_scope").on(
+      table.storefrontId,
+      table.channelId,
+      table.marketId,
+    ),
+    index("idx_trip_shopping_references_owner").on(
+      table.ownerUserId,
+      table.ownerBuyerAccountId,
+      table.expiresAt,
+    ),
+  ],
+)
+
 export const tripComponents = pgTable(
   "trip_components",
   {
@@ -705,6 +746,8 @@ export type TripEnvelope = typeof tripEnvelopes.$inferSelect
 export type NewTripEnvelope = typeof tripEnvelopes.$inferInsert
 export type TripStorefrontAccess = typeof tripStorefrontAccess.$inferSelect
 export type NewTripStorefrontAccess = typeof tripStorefrontAccess.$inferInsert
+export type TripShoppingReference = typeof tripShoppingReferences.$inferSelect
+export type NewTripShoppingReference = typeof tripShoppingReferences.$inferInsert
 export type TripComponent = typeof tripComponents.$inferSelect
 export type NewTripComponent = typeof tripComponents.$inferInsert
 export type TripComponentEvent = typeof tripComponentEvents.$inferSelect

--- a/packages/trips/src/shopping-opaque-references.ts
+++ b/packages/trips/src/shopping-opaque-references.ts
@@ -1,0 +1,388 @@
+import type { AnyDrizzleDb } from "@voyant-travel/db"
+import { randomBytesHex, sha256Hex } from "@voyant-travel/hono"
+import type {
+  StorefrontOpaqueReferenceIssuer,
+  StorefrontShoppingContext,
+} from "@voyant-travel/storefront/shopping"
+import { and, eq, gt, isNull } from "drizzle-orm"
+import { z } from "zod"
+
+import type { TripShoppingReference } from "./schema.js"
+import { tripShoppingReferences } from "./schema.js"
+import type { StorefrontTripOfferResolver } from "./storefront-trip-offer-resolver-port.js"
+import type { CreateTripComponentBodyInput } from "./validation.js"
+
+const MAX_REFERENCE_TTL_SECONDS = 24 * 60 * 60
+const referenceSchema = z.string().regex(/^sref_[a-f0-9]{64}$/)
+const purposeSchema = z.enum(["catalog-item", "flight-offer", "stay-offer", "package-offer"])
+const replaySchema = z.enum(["multi-use", "single-use"])
+const scopeSchema = z
+  .object({
+    marketId: z.string().min(1).max(128),
+    locale: z.string().min(1).max(64),
+    currency: z.string().regex(/^[A-Z]{3}$/),
+  })
+  .strict()
+const payloadSchema = z.record(z.string(), z.unknown())
+
+export type ShoppingReferencePurpose = z.infer<typeof purposeSchema>
+
+export type ShoppingReferenceResolution =
+  | { ok: true; reference: TripShoppingReference }
+  | { ok: false; reason: "invalid" | "unavailable" }
+
+export interface TripShoppingReferenceRuntimeOptions {
+  withTransaction<T>(operation: (db: AnyDrizzleDb) => Promise<T>): Promise<T>
+  now?: () => Date
+  createReference?: () => string
+}
+
+export interface ShoppingReferenceBoundary {
+  referenceDigest: string
+  purpose: ShoppingReferencePurpose
+  storefrontId: string
+  channelId: string
+  ownerUserId: string | null
+  ownerBuyerAccountId: string | null
+  marketId: string
+  locale: string
+  currency: string
+  now: Date
+}
+
+/** Narrow persistence contract; claimSingle must be an atomic compare-and-set. */
+export interface TripShoppingReferenceStore {
+  insert(reference: TripShoppingReference): Promise<void>
+  claimSingle(boundary: ShoppingReferenceBoundary): Promise<TripShoppingReference | null>
+  readMulti(boundary: ShoppingReferenceBoundary): Promise<TripShoppingReference | null>
+}
+
+export interface TripShoppingReferenceRuntime {
+  issuer: StorefrontOpaqueReferenceIssuer
+  offerResolver: StorefrontTripOfferResolver
+}
+
+/**
+ * Durable Storefront issuer plus Trips redemption adapter. The adapter returns
+ * only a Trips component; it never returns the stored row or provider payload
+ * through a public Storefront result.
+ */
+export function createTripShoppingReferenceRuntime(
+  options: TripShoppingReferenceRuntimeOptions,
+): TripShoppingReferenceRuntime {
+  const now = options.now ?? (() => new Date())
+
+  return {
+    issuer: {
+      issue: (input) =>
+        options.withTransaction((db) =>
+          issueShoppingReference(postgresShoppingReferenceStore(db), input, {
+            now,
+            ...(options.createReference ? { createReference: options.createReference } : {}),
+          }),
+        ),
+    },
+    offerResolver: {
+      async resolve(context, input) {
+        const purpose = purposeForSelectionKind(input.kind)
+        const resolution = await options.withTransaction((db) =>
+          redeemShoppingReference(postgresShoppingReferenceStore(db), input.offerRef, {
+            purpose,
+            context,
+            scope: input.scope,
+            now,
+          }),
+        )
+        if (!resolution.ok) return null
+        return resolvedComponent(resolution.reference)
+      },
+    },
+  }
+}
+
+/** Store-injected variant used by alternative durable adapters and concurrency tests. */
+export function createTripShoppingReferenceRuntimeWithStore(
+  store: TripShoppingReferenceStore,
+  options: Omit<TripShoppingReferenceRuntimeOptions, "withTransaction"> = {},
+): TripShoppingReferenceRuntime {
+  const now = options.now ?? (() => new Date())
+  return {
+    issuer: {
+      issue: (input) =>
+        issueShoppingReference(store, input, {
+          now,
+          ...(options.createReference ? { createReference: options.createReference } : {}),
+        }),
+    },
+    offerResolver: {
+      async resolve(context, input) {
+        const resolution = await redeemShoppingReference(store, input.offerRef, {
+          purpose: purposeForSelectionKind(input.kind),
+          context,
+          scope: input.scope,
+          now,
+        })
+        return resolution.ok ? resolvedComponent(resolution.reference) : null
+      },
+    },
+  }
+}
+
+/** Creates a 256-bit capability and persists only its SHA-256 digest. */
+export async function issueTripShoppingReference(
+  db: AnyDrizzleDb,
+  rawInput: Parameters<StorefrontOpaqueReferenceIssuer["issue"]>[0],
+  options: { now?: () => Date; createReference?: () => string } = {},
+): Promise<{ ref: string; expiresAt: string }> {
+  return issueShoppingReference(postgresShoppingReferenceStore(db), rawInput, options)
+}
+
+async function issueShoppingReference(
+  store: TripShoppingReferenceStore,
+  rawInput: Parameters<StorefrontOpaqueReferenceIssuer["issue"]>[0],
+  options: { now?: () => Date; createReference?: () => string } = {},
+): Promise<{ ref: string; expiresAt: string }> {
+  const purpose = purposeSchema.parse(rawInput.purpose)
+  const replay = replaySchema.parse(rawInput.replay)
+  const scope = scopeSchema.parse(rawInput.scope)
+  const payload = payloadSchema.parse(rawInput.payload)
+  const ttlSeconds = z
+    .number()
+    .int()
+    .min(1)
+    .max(MAX_REFERENCE_TTL_SECONDS)
+    .parse(rawInput.ttlSeconds)
+  const storefrontId = requiredBinding(rawInput.storefrontId)
+  const channelId = requiredBinding(rawInput.channelId)
+  const ownerUserId = managedUserId(rawInput.owner.userId)
+  const ownerBuyerAccountId = optionalBinding(rawInput.owner.buyerAccountId)
+  const ref = referenceSchema.parse(
+    (options.createReference ?? (() => `sref_${randomBytesHex(32)}`))(),
+  )
+  const referenceDigest = await sha256Hex(ref)
+  const createdAt = options.now?.() ?? new Date()
+  const expiresAt = new Date(createdAt.getTime() + ttlSeconds * 1000)
+
+  try {
+    await store.insert({
+      referenceDigest,
+      purpose,
+      storefrontId,
+      channelId,
+      ownerUserId,
+      ownerBuyerAccountId,
+      marketId: scope.marketId,
+      locale: scope.locale,
+      currency: scope.currency,
+      replay,
+      payload,
+      expiresAt,
+      consumedAt: null,
+      createdAt,
+    })
+  } catch {
+    // Do not let a driver error carrying bound JSON parameters reach request
+    // logging or a public error serializer.
+    throw new Error("shopping_reference_issue_failed")
+  }
+
+  return { ref, expiresAt: expiresAt.toISOString() }
+}
+
+/**
+ * Redeems against the complete trust boundary. Single-use rows are claimed by
+ * one conditional UPDATE, so concurrent callers cannot both receive payload.
+ */
+export async function redeemTripShoppingReference(
+  db: AnyDrizzleDb,
+  rawReference: string,
+  input: {
+    purpose: ShoppingReferencePurpose
+    context: StorefrontShoppingContext
+    scope: { marketId: string; locale: string; currency: string }
+    now?: () => Date
+  },
+): Promise<ShoppingReferenceResolution> {
+  return redeemShoppingReference(postgresShoppingReferenceStore(db), rawReference, input)
+}
+
+async function redeemShoppingReference(
+  store: TripShoppingReferenceStore,
+  rawReference: string,
+  input: {
+    purpose: ShoppingReferencePurpose
+    context: StorefrontShoppingContext
+    scope: { marketId: string; locale: string; currency: string }
+    now?: () => Date
+  },
+): Promise<ShoppingReferenceResolution> {
+  if (!referenceSchema.safeParse(rawReference).success) return { ok: false, reason: "invalid" }
+  const purpose = purposeSchema.parse(input.purpose)
+  const scope = scopeSchema.parse(input.scope)
+  const storefrontId = requiredBinding(input.context.storefrontId)
+  const channelId = requiredBinding(input.context.channelId)
+  const ownerUserId = managedUserId(input.context.userId)
+  const ownerBuyerAccountId = optionalBinding(input.context.buyerAccountId)
+  const referenceDigest = await sha256Hex(rawReference)
+  const now = input.now?.() ?? new Date()
+  const boundary: ShoppingReferenceBoundary = {
+    referenceDigest,
+    purpose,
+    storefrontId,
+    channelId,
+    ownerUserId,
+    ownerBuyerAccountId,
+    marketId: scope.marketId,
+    locale: scope.locale,
+    currency: scope.currency,
+    now,
+  }
+
+  const singleUse = await store.claimSingle(boundary)
+  if (singleUse) return { ok: true, reference: singleUse }
+  const multiUse = await store.readMulti(boundary)
+  return multiUse ? { ok: true, reference: multiUse } : { ok: false, reason: "unavailable" }
+}
+
+function postgresShoppingReferenceStore(db: AnyDrizzleDb): TripShoppingReferenceStore {
+  const whereBoundary = (boundary: ShoppingReferenceBoundary) =>
+    and(
+      eq(tripShoppingReferences.referenceDigest, boundary.referenceDigest),
+      eq(tripShoppingReferences.purpose, boundary.purpose),
+      eq(tripShoppingReferences.storefrontId, boundary.storefrontId),
+      eq(tripShoppingReferences.channelId, boundary.channelId),
+      boundary.ownerUserId === null
+        ? isNull(tripShoppingReferences.ownerUserId)
+        : eq(tripShoppingReferences.ownerUserId, boundary.ownerUserId),
+      boundary.ownerBuyerAccountId === null
+        ? isNull(tripShoppingReferences.ownerBuyerAccountId)
+        : eq(tripShoppingReferences.ownerBuyerAccountId, boundary.ownerBuyerAccountId),
+      eq(tripShoppingReferences.marketId, boundary.marketId),
+      eq(tripShoppingReferences.locale, boundary.locale),
+      eq(tripShoppingReferences.currency, boundary.currency),
+      gt(tripShoppingReferences.expiresAt, boundary.now),
+    )
+
+  return {
+    async insert(reference) {
+      await db.insert(tripShoppingReferences).values(reference)
+    },
+    async claimSingle(boundary) {
+      const [claimed] = (await db
+        .update(tripShoppingReferences)
+        .set({ consumedAt: boundary.now })
+        .where(
+          and(
+            whereBoundary(boundary),
+            eq(tripShoppingReferences.replay, "single-use"),
+            isNull(tripShoppingReferences.consumedAt),
+          ),
+        )
+        .returning()) as TripShoppingReference[]
+      return claimed ?? null
+    },
+    async readMulti(boundary) {
+      const [reference] = (await db
+        .select()
+        .from(tripShoppingReferences)
+        .where(
+          and(
+            whereBoundary(boundary),
+            eq(tripShoppingReferences.replay, "multi-use"),
+            isNull(tripShoppingReferences.consumedAt),
+          ),
+        )
+        .limit(1)) as TripShoppingReference[]
+      return reference ?? null
+    },
+  }
+}
+
+function componentFromReference(reference: TripShoppingReference): CreateTripComponentBodyInput {
+  const payload = payloadSchema.parse(reference.payload)
+  if (reference.purpose === "catalog-item") {
+    const catalog = z
+      .object({ entityModule: z.string().min(1), entityId: z.string().min(1) })
+      .passthrough()
+      .parse(payload)
+    return {
+      // The selection runtime replaces this placeholder with the final ordered position.
+      sequence: 0,
+      kind: "catalog_booking",
+      catalogRef: {
+        entityModule: catalog.entityModule,
+        entityId: catalog.entityId,
+        sourceKind: "owned",
+      },
+      metadata: {},
+    }
+  }
+
+  const offer = z
+    .object({
+      selection: z.record(z.string(), z.unknown()),
+      providerData: z.record(z.string(), z.unknown()).optional(),
+    })
+    .strict()
+    .parse(payload)
+  const durableSelection = {
+    version: 1,
+    purpose: reference.purpose,
+    selection: offer.selection,
+    ...(offer.providerData ? { providerData: offer.providerData } : {}),
+  }
+  return reference.purpose === "flight-offer"
+    ? {
+        // The selection runtime replaces this placeholder with the final ordered position.
+        sequence: 0,
+        kind: "flight_placeholder",
+        metadata: {
+          flightDraft: { selectedOffer: offer.selection },
+          storefrontShopping: durableSelection,
+        },
+      }
+    : {
+        // The selection runtime replaces this placeholder with the final ordered position.
+        sequence: 0,
+        kind: "catalog_booking",
+        metadata: { storefrontShopping: durableSelection },
+      }
+}
+
+function resolvedComponent(
+  reference: TripShoppingReference,
+): { component: CreateTripComponentBodyInput } | null {
+  try {
+    return { component: componentFromReference(reference) }
+  } catch {
+    // Persisted provider/source payload is never attached to a thrown parse
+    // error that could cross into request logging.
+    return null
+  }
+}
+
+function purposeForSelectionKind(kind: "product" | "flight" | "stay" | "package") {
+  const purposes = {
+    product: "catalog-item",
+    flight: "flight-offer",
+    stay: "stay-offer",
+    package: "package-offer",
+  } as const
+  return purposes[kind]
+}
+
+function requiredBinding(value: string): string {
+  const normalized = value.trim()
+  if (!normalized) throw new Error("active_storefront_channel_required")
+  return normalized
+}
+
+function optionalBinding(value: string | null | undefined): string | null {
+  const normalized = value?.trim()
+  return normalized ? normalized : null
+}
+
+function managedUserId(value: string | null | undefined): string | null {
+  const normalized = optionalBinding(value)
+  return normalized === "anonymous-storefront" ? null : normalized
+}

--- a/packages/trips/src/voyant.ts
+++ b/packages/trips/src/voyant.ts
@@ -4,7 +4,10 @@ import {
   storefrontPaymentLinkRuntimePort,
   storefrontPaymentReconciliationJobRuntimePort,
 } from "@voyant-travel/storefront/runtime-port"
-import { storefrontTripSelectionsRuntimePort } from "@voyant-travel/storefront/shopping/runtime-port"
+import {
+  storefrontOpaqueReferenceIssuerPort,
+  storefrontTripSelectionsRuntimePort,
+} from "@voyant-travel/storefront/shopping/runtime-port"
 import { durableTripActionRuntimePort } from "./durable-action-runtime-port.js"
 import { tripsDatabaseRuntimePort, tripsRoutesRuntimePort } from "./runtime-port.js"
 import { tripsSourcingJobRuntimePort } from "./sourcing-job-runtime-port.js"
@@ -109,6 +112,8 @@ export const tripsVoyantModule = defineModule({
       providePort(commerceCardPaymentRuntimePort),
       providePort(storefrontPaymentLinkRuntimePort),
       providePort(storefrontPaymentReconciliationJobRuntimePort),
+      providePort(storefrontOpaqueReferenceIssuerPort),
+      providePort(storefrontTripOfferResolverPort),
       providePort(storefrontTripSelectionsRuntimePort),
       providePort(tripsRoutesRuntimePort),
       providePort(tripsDatabaseRuntimePort),
@@ -121,7 +126,6 @@ export const tripsVoyantModule = defineModule({
     requirePort(tripsDatabaseRuntimePort),
     requirePort(tripsSourcingJobRuntimePort),
     requirePort(durableTripActionRuntimePort, { optional: true }),
-    requirePort(storefrontTripOfferResolverPort, { optional: true }),
     { ...paymentAdapterRuntimePortReference, optional: true },
     catalogRuntimeServicesPortReference,
     catalogCheckoutApiRuntimePortReference,

--- a/packages/trips/tests/shopping-opaque-references.test.ts
+++ b/packages/trips/tests/shopping-opaque-references.test.ts
@@ -1,0 +1,241 @@
+import { sha256Hex } from "@voyant-travel/hono"
+import type { StorefrontOpaqueReferenceIssuer } from "@voyant-travel/storefront/shopping"
+import { describe, expect, it } from "vitest"
+
+import type { TripShoppingReference } from "../src/schema.js"
+import {
+  createTripShoppingReferenceRuntimeWithStore,
+  type ShoppingReferenceBoundary,
+  type TripShoppingReferenceStore,
+} from "../src/shopping-opaque-references.js"
+
+const NOW = new Date("2026-08-08T12:00:00.000Z")
+const CONTEXT = {
+  storefrontId: "storefront_ro",
+  channelId: "direct",
+  userId: "user_1",
+  buyerAccountId: "account_1",
+}
+const SCOPE = { marketId: "market_ro", locale: "ro-RO", currency: "EUR" }
+const FLIGHT_REF = `sref_${"a".repeat(64)}`
+const CATALOG_REF = `sref_${"b".repeat(64)}`
+
+describe("durable shopping opaque references", () => {
+  it("issues a 256-bit capability while persisting only its digest and bounded payload", async () => {
+    const store = new MemoryReferenceStore()
+    const runtime = createTripShoppingReferenceRuntimeWithStore(store, {
+      now: () => NOW,
+      createReference: () => FLIGHT_REF,
+    })
+
+    const issued = await runtime.issuer.issue(flightInput())
+    const persisted = [...store.references.values()][0]
+
+    expect(issued).toEqual({ ref: FLIGHT_REF, expiresAt: "2026-08-08T12:15:00.000Z" })
+    expect(issued.ref).toMatch(/^sref_[a-f0-9]{64}$/)
+    expect(persisted?.referenceDigest).toBe(await sha256Hex(FLIGHT_REF))
+    expect(JSON.stringify(persisted)).not.toContain(FLIGHT_REF)
+    expect(JSON.stringify(issued)).not.toContain("provider-secret")
+  })
+
+  it.each([
+    ["storefront", { context: { ...CONTEXT, storefrontId: "storefront_other" } }],
+    ["channel", { context: { ...CONTEXT, channelId: "partner" } }],
+    ["managed user", { context: { ...CONTEXT, userId: "user_other" } }],
+    ["buyer account", { context: { ...CONTEXT, buyerAccountId: "account_other" } }],
+    ["market", { scope: { ...SCOPE, marketId: "market_us" } }],
+    ["locale", { scope: { ...SCOPE, locale: "en-US" } }],
+    ["currency", { scope: { ...SCOPE, currency: "USD" } }],
+  ])("rejects a cross-boundary %s redemption without consuming it", async (_label, override) => {
+    const { runtime, store } = await issuedFlightRuntime()
+    const resolution = await runtime.offerResolver.resolve(
+      "context" in override ? override.context : CONTEXT,
+      {
+        kind: "flight",
+        offerRef: FLIGHT_REF,
+        scope: "scope" in override ? override.scope : SCOPE,
+      },
+    )
+
+    expect(resolution).toBeNull()
+    expect([...store.references.values()][0]?.consumedAt).toBeNull()
+    await expect(
+      runtime.offerResolver.resolve(CONTEXT, {
+        kind: "flight",
+        offerRef: FLIGHT_REF,
+        scope: SCOPE,
+      }),
+    ).resolves.not.toBeNull()
+  })
+
+  it("rejects expiry and kind/purpose substitution without consuming the offer", async () => {
+    let clock = NOW
+    const { runtime, store } = await issuedFlightRuntime(() => clock)
+
+    await expect(
+      runtime.offerResolver.resolve(CONTEXT, {
+        kind: "stay",
+        offerRef: FLIGHT_REF,
+        scope: SCOPE,
+      }),
+    ).resolves.toBeNull()
+    expect([...store.references.values()][0]?.consumedAt).toBeNull()
+    clock = new Date("2026-08-08T12:15:00.000Z")
+    await expect(
+      runtime.offerResolver.resolve(CONTEXT, {
+        kind: "flight",
+        offerRef: FLIGHT_REF,
+        scope: SCOPE,
+      }),
+    ).resolves.toBeNull()
+  })
+
+  it("keeps catalog references multi-use and makes offers single-use", async () => {
+    const store = new MemoryReferenceStore()
+    const catalog = createTripShoppingReferenceRuntimeWithStore(store, {
+      now: () => NOW,
+      createReference: () => CATALOG_REF,
+    })
+    await catalog.issuer.issue(catalogInput())
+
+    const product = { kind: "product" as const, offerRef: CATALOG_REF, scope: SCOPE }
+    await expect(catalog.offerResolver.resolve(CONTEXT, product)).resolves.toMatchObject({
+      component: { kind: "catalog_booking", catalogRef: { entityId: "product_1" } },
+    })
+    await expect(catalog.offerResolver.resolve(CONTEXT, product)).resolves.not.toBeNull()
+
+    const flight = createTripShoppingReferenceRuntimeWithStore(store, {
+      now: () => NOW,
+      createReference: () => FLIGHT_REF,
+    })
+    await flight.issuer.issue(flightInput())
+    const offer = { kind: "flight" as const, offerRef: FLIGHT_REF, scope: SCOPE }
+    await expect(flight.offerResolver.resolve(CONTEXT, offer)).resolves.not.toBeNull()
+    await expect(flight.offerResolver.resolve(CONTEXT, offer)).resolves.toBeNull()
+  })
+
+  it("atomically allows only one concurrent single-use redemption", async () => {
+    const { runtime } = await issuedFlightRuntime()
+    const input = { kind: "flight" as const, offerRef: FLIGHT_REF, scope: SCOPE }
+
+    const resolutions = await Promise.all(
+      Array.from({ length: 8 }, () => runtime.offerResolver.resolve(CONTEXT, input)),
+    )
+
+    expect(resolutions.filter((value) => value !== null)).toHaveLength(1)
+  })
+
+  it("sanitizes persistence and payload-shape failures before they can reach request logs", async () => {
+    const failing = createTripShoppingReferenceRuntimeWithStore(
+      {
+        insert: async () => {
+          throw new Error("driver params include provider-secret")
+        },
+        claimSingle: async () => null,
+        readMulti: async () => null,
+      },
+      { now: () => NOW, createReference: () => FLIGHT_REF },
+    )
+    const persistenceError = await failing.issuer.issue(flightInput()).catch((error) => error)
+    expect(persistenceError).toEqual(new Error("shopping_reference_issue_failed"))
+    expect(JSON.stringify(persistenceError)).not.toContain("provider-secret")
+
+    const store = new MemoryReferenceStore()
+    const malformed = createTripShoppingReferenceRuntimeWithStore(store, {
+      now: () => NOW,
+      createReference: () => FLIGHT_REF,
+    })
+    await malformed.issuer.issue({
+      ...flightInput(),
+      payload: { unexpectedProviderSecret: "never-serialized" },
+    })
+    await expect(
+      malformed.offerResolver.resolve(CONTEXT, {
+        kind: "flight",
+        offerRef: FLIGHT_REF,
+        scope: SCOPE,
+      }),
+    ).resolves.toBeNull()
+  })
+})
+
+function flightInput(): Parameters<StorefrontOpaqueReferenceIssuer["issue"]>[0] {
+  return {
+    purpose: "flight-offer",
+    storefrontId: CONTEXT.storefrontId,
+    channelId: CONTEXT.channelId,
+    owner: { userId: CONTEXT.userId, buyerAccountId: CONTEXT.buyerAccountId },
+    scope: SCOPE,
+    payload: {
+      selection: { offerId: "internal-offer" },
+      providerData: { token: "provider-secret" },
+    },
+    ttlSeconds: 15 * 60,
+    replay: "single-use",
+  }
+}
+
+function catalogInput(): Parameters<StorefrontOpaqueReferenceIssuer["issue"]>[0] {
+  return {
+    purpose: "catalog-item",
+    storefrontId: CONTEXT.storefrontId,
+    channelId: CONTEXT.channelId,
+    owner: { userId: CONTEXT.userId, buyerAccountId: CONTEXT.buyerAccountId },
+    scope: SCOPE,
+    payload: { entityModule: "products", entityId: "product_1" },
+    ttlSeconds: 15 * 60,
+    replay: "multi-use",
+  }
+}
+
+async function issuedFlightRuntime(now = () => NOW) {
+  const store = new MemoryReferenceStore()
+  const runtime = createTripShoppingReferenceRuntimeWithStore(store, {
+    now,
+    createReference: () => FLIGHT_REF,
+  })
+  await runtime.issuer.issue(flightInput())
+  return { runtime, store }
+}
+
+class MemoryReferenceStore implements TripShoppingReferenceStore {
+  references = new Map<string, TripShoppingReference>()
+
+  async insert(reference: TripShoppingReference): Promise<void> {
+    if (this.references.has(reference.referenceDigest)) throw new Error("duplicate_reference")
+    this.references.set(reference.referenceDigest, structuredClone(reference))
+  }
+
+  async claimSingle(boundary: ShoppingReferenceBoundary): Promise<TripShoppingReference | null> {
+    const reference = this.references.get(boundary.referenceDigest)
+    if (reference?.replay !== "single-use" || reference.consumedAt) return null
+    if (!matchesBoundary(reference, boundary)) return null
+    const claimed = { ...reference, consumedAt: boundary.now }
+    this.references.set(reference.referenceDigest, claimed)
+    return structuredClone(claimed)
+  }
+
+  async readMulti(boundary: ShoppingReferenceBoundary): Promise<TripShoppingReference | null> {
+    const reference = this.references.get(boundary.referenceDigest)
+    return reference && reference.replay === "multi-use" && matchesBoundary(reference, boundary)
+      ? structuredClone(reference)
+      : null
+  }
+}
+
+function matchesBoundary(
+  reference: TripShoppingReference,
+  boundary: ShoppingReferenceBoundary,
+): boolean {
+  return (
+    reference.purpose === boundary.purpose &&
+    reference.storefrontId === boundary.storefrontId &&
+    reference.channelId === boundary.channelId &&
+    reference.ownerUserId === boundary.ownerUserId &&
+    reference.ownerBuyerAccountId === boundary.ownerBuyerAccountId &&
+    reference.marketId === boundary.marketId &&
+    reference.locale === boundary.locale &&
+    reference.currency === boundary.currency &&
+    reference.expiresAt > boundary.now
+  )
+}

--- a/packages/trips/tests/voyant-manifest.test.ts
+++ b/packages/trips/tests/voyant-manifest.test.ts
@@ -8,7 +8,10 @@ import {
   type PaymentAdapter,
   paymentAdapterRuntimePort,
 } from "@voyant-travel/payments"
-import { storefrontTripSelectionsRuntimePort } from "@voyant-travel/storefront/shopping"
+import {
+  storefrontOpaqueReferenceIssuerPort,
+  storefrontTripSelectionsRuntimePort,
+} from "@voyant-travel/storefront/shopping"
 import { describe, expect, it, vi } from "vitest"
 
 import {
@@ -34,6 +37,8 @@ describe("trips deployment manifest", () => {
           { id: "commerce.card-payment.runtime" },
           { id: "storefront.payment-link.runtime" },
           { id: "storefront.payment-reconciliation-job.runtime" },
+          { id: "storefront.shopping.opaque-reference-issuer" },
+          { id: "trips.storefront-offer-resolver.runtime" },
           { id: "storefront.trip-selections.runtime" },
           { id: "trips.routes-runtime" },
           { id: "trips.database-runtime" },
@@ -46,7 +51,6 @@ describe("trips deployment manifest", () => {
         { id: "trips.database-runtime" },
         { id: "trips.sourcing-job-runtime" },
         { id: "trips.durable-action-runtime", optional: true },
-        { id: "trips.storefront-offer-resolver.runtime", optional: true },
         { id: "payments.adapter.runtime", optional: true },
         { id: "catalog.runtime-services" },
         { id: "commerce.checkout-api-options" },
@@ -144,17 +148,15 @@ describe("trips deployment manifest", () => {
     expect(withAdapter).toHaveProperty(commerceCardPaymentRuntimePort.id)
   })
 
-  it("publishes the Storefront Trip selection runtime and resolves offers only through its port", async () => {
-    const resolve = vi.fn(async () => null)
+  it("publishes the durable shopping issuer, resolver, and Trip selection runtime", () => {
     const contribution = createTripsRuntimePortContribution({
       primitives: { database: { transaction: vi.fn() } } as never,
-      hasRuntimePort: (port) => port.id === storefrontTripOfferResolverPort.id,
-      getRuntimePort: ((port: { id: string }) => {
-        if (port.id === storefrontTripOfferResolverPort.id) return { resolve }
-        return stubRequiredRuntimePortResolver()(port as never)
-      }) as never,
+      hasRuntimePort: () => false,
+      getRuntimePort: stubRequiredRuntimePortResolver(),
     })
 
+    expect(contribution).toHaveProperty(storefrontOpaqueReferenceIssuerPort.id)
+    expect(contribution).toHaveProperty(storefrontTripOfferResolverPort.id)
     expect(contribution).toHaveProperty(storefrontTripSelectionsRuntimePort.id)
     expect(() => storefrontTripOfferResolverPort.test({} as never)).toThrow(/resolve/)
   })
@@ -168,8 +170,7 @@ describe("trips deployment manifest", () => {
     })
     const contribution = createTripsRuntimePortContribution({
       primitives: { database: { transaction: vi.fn() } } as never,
-      hasRuntimePort: (port) =>
-        port.id !== "flights.runtime" && port.id !== storefrontTripOfferResolverPort.id,
+      hasRuntimePort: (port) => port.id !== "flights.runtime",
       getRuntimePort: getRuntimePort as never,
     })
 

--- a/scripts/checks/graph/graph-conformance.json
+++ b/scripts/checks/graph/graph-conformance.json
@@ -17,6 +17,7 @@
       "portIds": [
         "trips.routes-runtime",
         "trips.database-runtime",
+        "storefront.shopping.opaque-reference-issuer",
         "storefront.trip-selections.runtime",
         "trips.storefront-offer-resolver.runtime",
         "catalog.runtime-services",


### PR DESCRIPTION
## Summary

- reapply the Storefront Trip selections provider from the exact requested #4441 inspection point `0d8c726addea2faa5ab9bd59577b114d03290ccb` onto the exact provider-runtime base
- add a durable Trips-owned Storefront opaque-reference issuer and resolver adapter without a reverse Storefront dependency
- persist only SHA-256 reference digests with exact storefront, channel, optional managed user/buyer account, market, locale, currency, purpose, TTL, and replay bindings
- atomically consume single-use flight/stay/package offers while keeping catalog-item references multi-use
- keep provider/source payload inside server-only persistence, sanitize persistence/parse errors, and return only public opaque references / minimal Trip selection projections
- add migration `0005_shopping_opaque_references.sql` and focused isolation, expiry, replay, concurrency, and error-redaction coverage

## Stack

Base: `agent/storefront-shopping-runtime-26a70e4` at `26a70e400d3aa401ac8c7f6e6ca7ec375b85f32e`

1. `d7baad062d` — reapplied exact #4441 contract commit
2. `e54ecda49b` — durable issuer/store and Trips resolver adapter

The current rebased #4441 head `1d572e535c` carries the same Trip-provider patch as the supplied exact inspection head; this stack retains the supplied base/order.

## Validation

- `git diff --check` passed
- worktree is clean
- PR security checks passed on the prior revision and reran after the final update
- package typecheck/tests were not run locally because this worktree has no installed dependencies and the active execution policy requires tests through an approved remote lane
- `lab1` is unreachable: both the fleet capacity query and direct SSH timed out; no Sprite fallback was used
