### PR TITLE
feat(storefront): close shopping market and catalog adapters

### DIFF
--- a/.changeset/closed-storefront-shopping-adapters.md
+++ b/.changeset/closed-storefront-shopping-adapters.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/storefront": patch
+---
+
+Compose storefront market discovery and indexed inspiration directly from the
+active Commerce market configuration and customer-scoped Catalog runtime.

--- a/packages/storefront/src/runtime-contributor.ts
+++ b/packages/storefront/src/runtime-contributor.ts
@@ -1,21 +1,26 @@
 import { customerBusinessAccountOnboardingRuntimePort } from "@voyant-travel/auth/customer-business-onboarding-runtime-port"
+import {
+  type CatalogSearchRuntimeOptions,
+  catalogSearchRuntimePort,
+} from "@voyant-travel/catalog/api-runtime-ports"
+import {
+  type CatalogRuntimeServices,
+  catalogRuntimeServicesPort,
+} from "@voyant-travel/catalog/runtime-contracts"
 import type { PresentationFxQuoter } from "@voyant-travel/catalog-contracts/presentation-money"
 import { createCommerceStorefrontOfferResolvers } from "@voyant-travel/commerce"
 import type { VoyantRuntimeHostPrimitives } from "@voyant-travel/core"
 import type { VoyantPort } from "@voyant-travel/core/project"
 import { createStorefrontCustomerBusinessOnboardingRuntime } from "./customer-business-onboarding-runtime.js"
 import { storefrontCustomerPortalRuntimePort, storefrontOffersRuntimePort } from "./runtime-port.js"
+import { createClosedStorefrontShoppingAdapters } from "./shopping/closed-provider-adapters.js"
 import { createManagedStorefrontShoppingRuntime } from "./shopping/managed-runtime.js"
 import {
   type StorefrontOpaqueReferenceIssuer,
-  type StorefrontShoppingCatalogProvider,
   type StorefrontShoppingLiveProvider,
-  type StorefrontShoppingMarketProvider,
   storefrontOpaqueReferenceIssuerPort,
   storefrontPresentationFxProviderPort,
-  storefrontShoppingCatalogProviderPort,
   storefrontShoppingLiveProviderPort,
-  storefrontShoppingMarketProviderPort,
 } from "./shopping/provider-ports.js"
 import { storefrontShoppingRuntimePort } from "./shopping/runtime-port.js"
 
@@ -30,8 +35,8 @@ export function createStorefrontRuntimePortContribution(
   host: StorefrontRuntimeContributorHost,
 ): Readonly<Record<string, unknown>> {
   const managedShoppingDependencies = [
-    storefrontShoppingMarketProviderPort,
-    storefrontShoppingCatalogProviderPort,
+    catalogSearchRuntimePort,
+    catalogRuntimeServicesPort,
     storefrontShoppingLiveProviderPort,
     storefrontOpaqueReferenceIssuerPort,
   ] as const
@@ -53,26 +58,26 @@ export function createStorefrontRuntimePortContribution(
     ...(canProvideManagedShopping
       ? {
           [storefrontShoppingRuntimePort.id]: Promise.all([
-            getRuntimePort?.<StorefrontShoppingMarketProvider>(
-              storefrontShoppingMarketProviderPort,
-            ),
-            getRuntimePort?.<StorefrontShoppingCatalogProvider>(
-              storefrontShoppingCatalogProviderPort,
-            ),
+            getRuntimePort?.<CatalogSearchRuntimeOptions>(catalogSearchRuntimePort),
+            getRuntimePort?.<CatalogRuntimeServices>(catalogRuntimeServicesPort),
             getRuntimePort?.<StorefrontShoppingLiveProvider>(storefrontShoppingLiveProviderPort),
             getRuntimePort?.<StorefrontOpaqueReferenceIssuer>(storefrontOpaqueReferenceIssuerPort),
             host.hasRuntimePort?.(storefrontPresentationFxProviderPort)
               ? getRuntimePort?.<PresentationFxQuoter>(storefrontPresentationFxProviderPort)
               : undefined,
-          ]).then(([markets, catalog, live, references, quoteFx]) =>
-            createManagedStorefrontShoppingRuntime({
-              markets: markets as StorefrontShoppingMarketProvider,
-              catalog: catalog as StorefrontShoppingCatalogProvider,
+          ]).then(([catalogSearch, catalogServices, live, references, quoteFx]) => {
+            const adapters = createClosedStorefrontShoppingAdapters({
+              primitives: host.primitives,
+              catalogSearch: catalogSearch as CatalogSearchRuntimeOptions,
+              catalogServices: catalogServices as CatalogRuntimeServices,
+            })
+            return createManagedStorefrontShoppingRuntime({
+              ...adapters,
               live: live as StorefrontShoppingLiveProvider,
               references: references as StorefrontOpaqueReferenceIssuer,
               ...(quoteFx ? { quoteFx } : {}),
-            }),
-          ),
+            })
+          }),
         }
       : {}),
   }

--- a/packages/storefront/src/shopping/closed-provider-adapters.ts
+++ b/packages/storefront/src/shopping/closed-provider-adapters.ts
@@ -1,0 +1,246 @@
+import type { CatalogSearchRuntimeOptions } from "@voyant-travel/catalog/api-runtime-ports"
+import type { FieldPolicyRegistry } from "@voyant-travel/catalog/contract"
+import type { CatalogRuntimeServices } from "@voyant-travel/catalog/runtime-contracts"
+import type {
+  IndexerDocument,
+  IndexerSlice,
+  SearchFilter,
+} from "@voyant-travel/catalog-contracts/indexer/contract"
+import { indexFieldNameForPolicyPath } from "@voyant-travel/catalog-contracts/indexer/contract"
+import { listPublicMarkets, type PublicMarket } from "@voyant-travel/commerce"
+import type { VoyantRuntimeHostPrimitives } from "@voyant-travel/core"
+import { sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import type {
+  StorefrontActiveMarket,
+  StorefrontCatalogSliceItem,
+  StorefrontShoppingCatalogProvider,
+  StorefrontShoppingMarketProvider,
+} from "./provider-ports.js"
+import { StorefrontShoppingUnavailableError } from "./runtime.js"
+import type { StorefrontShoppingContext } from "./runtime-port.js"
+
+interface StorefrontChannelBindingDatabase {
+  execute(query: ReturnType<typeof sql>): Promise<unknown>
+}
+
+export interface ClosedStorefrontShoppingAdapterOptions {
+  primitives: VoyantRuntimeHostPrimitives
+  catalogSearch: CatalogSearchRuntimeOptions
+  catalogServices: Pick<CatalogRuntimeServices, "fieldPolicyRegistries">
+  listMarkets?: (db: PostgresJsDatabase) => Promise<PublicMarket[]>
+  isActiveStorefrontChannel?: (
+    db: PostgresJsDatabase,
+    context: Pick<StorefrontShoppingContext, "storefrontId" | "channelId">,
+  ) => Promise<boolean>
+}
+
+export interface ClosedStorefrontShoppingAdapters {
+  markets: StorefrontShoppingMarketProvider
+  catalog: StorefrontShoppingCatalogProvider
+}
+
+/**
+ * Compose the two read-only shopping adapters from the operator's own Commerce
+ * and Catalog runtimes. No request body, tenant selector, provider selector, or
+ * HTTP/admin route participates in this path.
+ */
+export function createClosedStorefrontShoppingAdapters(
+  options: ClosedStorefrontShoppingAdapterOptions,
+): ClosedStorefrontShoppingAdapters {
+  const loadMarkets = options.listMarkets ?? listPublicMarkets
+  const isActiveStorefrontChannel =
+    options.isActiveStorefrontChannel ?? defaultIsActiveStorefrontChannel
+
+  const markets: StorefrontShoppingMarketProvider = {
+    async listActiveMarkets(context) {
+      const trusted = trustedStorefrontContext(context)
+      const db = options.primitives.database.resolve<PostgresJsDatabase>(undefined)
+      if (!(await isActiveStorefrontChannel(db, trusted))) {
+        throw new StorefrontShoppingUnavailableError("active storefront channel")
+      }
+      return (await loadMarkets(db)).map(toActiveMarket)
+    },
+  }
+
+  const catalog: StorefrontShoppingCatalogProvider = {
+    async searchSlice(input) {
+      const trusted = trustedStorefrontContext(input.context)
+      await assertActiveScope(markets, trusted, input.scope)
+
+      const registry = options.catalogServices.fieldPolicyRegistries().get(input.vertical)
+      if (!registry) throw new StorefrontShoppingUnavailableError("catalog field policy")
+      assertCustomerSearchFilters(registry, input.filters)
+
+      const runtime = options.catalogSearch.resolveRuntime(
+        catalogRuntimeContext(options.primitives, trusted),
+      )
+      if (!runtime.indexer) throw new StorefrontShoppingUnavailableError("catalog indexer")
+
+      const slice: IndexerSlice = {
+        vertical: input.vertical,
+        locale: input.scope.locale,
+        audience: "customer",
+        market: input.scope.marketId,
+        channel: trusted.channelId,
+      }
+      const result = await runtime.indexer.search(slice, {
+        query: input.query,
+        mode: "keyword",
+        filters: [...input.filters],
+        pagination: input.pagination,
+      })
+
+      return {
+        items: result.hits.map(({ document }) => catalogItem(document, registry)),
+        total: result.total,
+        ...(result.next_cursor ? { nextCursor: result.next_cursor } : {}),
+      }
+    },
+  }
+
+  return { markets, catalog }
+}
+
+function trustedStorefrontContext(
+  context: Pick<StorefrontShoppingContext, "storefrontId" | "channelId">,
+): Pick<StorefrontShoppingContext, "storefrontId" | "channelId"> {
+  const storefrontId = context.storefrontId.trim()
+  const channelId = context.channelId.trim()
+  if (!storefrontId || !channelId) {
+    throw new StorefrontShoppingUnavailableError("trusted storefront channel context")
+  }
+  return { storefrontId, channelId }
+}
+
+async function assertActiveScope(
+  provider: StorefrontShoppingMarketProvider,
+  context: Pick<StorefrontShoppingContext, "storefrontId" | "channelId">,
+  scope: { marketId: string; locale: string; currency: string },
+): Promise<void> {
+  const active = await provider.listActiveMarkets(context)
+  const market = active.find(({ id }) => id === scope.marketId)
+  if (
+    !market?.locales.includes(scope.locale) ||
+    !market.currencies.includes(scope.currency.trim().toUpperCase())
+  ) {
+    throw new StorefrontShoppingUnavailableError("active market scope")
+  }
+}
+
+function toActiveMarket(market: PublicMarket): StorefrontActiveMarket {
+  const locales = market.locales.map(({ languageTag }) => languageTag)
+  const currencies = market.currencies.map(({ currencyCode }) => currencyCode.toUpperCase())
+  return {
+    id: market.id,
+    defaultLocale: market.defaultLocale,
+    defaultCurrency: market.defaultCurrency.toUpperCase(),
+    locales,
+    currencies,
+  }
+}
+
+function catalogRuntimeContext(
+  primitives: VoyantRuntimeHostPrimitives,
+  context: Pick<StorefrontShoppingContext, "storefrontId" | "channelId">,
+): never {
+  return {
+    env: primitives.env(undefined),
+    get(key: string) {
+      if (key !== "storefrontChannel") return undefined
+      return { ...context, channelStatus: "active" }
+    },
+  } as never
+}
+
+function assertCustomerSearchFilters(
+  registry: FieldPolicyRegistry,
+  filters: readonly SearchFilter[],
+): void {
+  for (const filter of filters) {
+    if (filter.kind === "and" || filter.kind === "or") {
+      assertCustomerSearchFilters(registry, filter.clauses)
+      continue
+    }
+    const policy = registry.policies.find(
+      ({ path }) => indexFieldNameForPolicyPath(path) === filter.field,
+    )
+    if (!policy || policy.query === "blob-only" || !policy.visibility.includes("customer")) {
+      throw new StorefrontShoppingUnavailableError(
+        `customer catalog field policy for ${filter.field}`,
+      )
+    }
+  }
+}
+
+function catalogItem(
+  document: IndexerDocument,
+  registry: FieldPolicyRegistry,
+): StorefrontCatalogSliceItem {
+  const field = (name: string): unknown =>
+    customerVisibleField(registry, name) ? document.fields[name] : undefined
+  const title = firstString(field("name"), field("title"))
+  if (!title) throw new StorefrontShoppingUnavailableError("customer catalog title")
+  const summary = firstString(field("description"), field("summary"))
+  const slug = firstString(field("slug"))
+  const imageUrl = firstString(
+    field("thumbnailUrl"),
+    field("primaryMediaUrl"),
+    field("coverMediaUrl"),
+  )
+  const priceAmountCents = firstNumber(field("priceFromAmountCents"), field("sellAmountCents"))
+  const priceCurrency = firstString(field("priceFromCurrency"), field("sellCurrency"))
+  return {
+    entityId: document.id,
+    title,
+    ...(summary ? { summary } : {}),
+    ...(slug ? { href: `/catalog/${encodeURIComponent(slug)}` } : {}),
+    ...(imageUrl ? { image: { url: imageUrl, alt: title } } : {}),
+    ...(priceAmountCents !== undefined && priceCurrency
+      ? {
+          nativePrice: {
+            amount: (priceAmountCents / 100).toFixed(2),
+            currency: priceCurrency.trim().toUpperCase(),
+          },
+        }
+      : {}),
+  }
+}
+
+function customerVisibleField(registry: FieldPolicyRegistry, field: string): boolean {
+  const policy = registry.policies.find(({ path }) => indexFieldNameForPolicyPath(path) === field)
+  return policy?.visibility.includes("customer") === true
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  return values.find((value): value is string => typeof value === "string" && value.length > 0)
+}
+
+function firstNumber(...values: unknown[]): number | undefined {
+  return values.find(
+    (value): value is number => typeof value === "number" && Number.isFinite(value),
+  )
+}
+
+async function defaultIsActiveStorefrontChannel(
+  db: PostgresJsDatabase,
+  context: Pick<StorefrontShoppingContext, "storefrontId" | "channelId">,
+): Promise<boolean> {
+  const result = await (db as unknown as StorefrontChannelBindingDatabase).execute(
+    sql`SELECT EXISTS (
+       SELECT 1
+       FROM auth_storefront_distribution_channel AS binding
+       INNER JOIN channels AS channel ON channel.id = binding.channel_id
+       WHERE binding.storefront_id = ${context.storefrontId}
+         AND binding.channel_id = ${context.channelId}
+         AND binding.deleted_at IS NULL
+         AND channel.status = 'active'
+     ) AS active`,
+  )
+  const rows = Array.isArray(result)
+    ? result
+    : ((result as { rows?: readonly unknown[] } | null)?.rows ?? [])
+  const row = rows[0] as { active?: unknown } | undefined
+  return row?.active === true || row?.active === "true" || row?.active === 1
+}

--- a/packages/storefront/src/shopping/index.ts
+++ b/packages/storefront/src/shopping/index.ts
@@ -1,3 +1,4 @@
+export * from "./closed-provider-adapters.js"
 export * from "./managed-runtime.js"
 export * from "./provider-ports.js"
 export * from "./routes-public.js"

--- a/packages/storefront/src/shopping/runtime.ts
+++ b/packages/storefront/src/shopping/runtime.ts
@@ -17,7 +17,18 @@ import {
 export class StorefrontShoppingUnavailableError extends Error {
   readonly code = "storefront_shopping_unavailable"
 
-  constructor(capability: "shopping" | "trip-selections") {
+  constructor(
+    capability:
+      | "shopping"
+      | "trip-selections"
+      | "active storefront channel"
+      | "trusted storefront channel context"
+      | "active market scope"
+      | "catalog field policy"
+      | "catalog indexer"
+      | "customer catalog title"
+      | `customer catalog field policy for ${string}`,
+  ) {
     super(`Storefront ${capability} runtime is not configured.`)
     this.name = "StorefrontShoppingUnavailableError"
   }

--- a/packages/storefront/src/voyant.ts
+++ b/packages/storefront/src/voyant.ts
@@ -1,7 +1,14 @@
 // agent-quality: file-size exception -- storefront graph facets stay co-located so one import-cheap manifest remains authoritative.
 import { customerBusinessAccountOnboardingRuntimePort } from "@voyant-travel/auth/ports"
-import { catalogPublicationRuntimePort } from "@voyant-travel/catalog/ports"
+import {
+  catalogPublicationRuntimePort,
+  catalogRuntimeServicesPort,
+} from "@voyant-travel/catalog/ports"
 import { defineModule, providePort, requirePort } from "@voyant-travel/core/project"
+
+// Search route contracts are intentionally not imported into this import-cheap
+// manifest; the runtime contributor resolves the real typed port.
+const catalogSearchRuntimePortReference = { id: "catalog.search-runtime" } as const
 
 // Lightweight reference (id only) so the deployment-graph manifest stays
 // import-cheap — importing the real port from @voyant-travel/payments would
@@ -21,9 +28,7 @@ import {
 import {
   storefrontOpaqueReferenceIssuerPort,
   storefrontPresentationFxProviderPort,
-  storefrontShoppingCatalogProviderPort,
   storefrontShoppingLiveProviderPort,
-  storefrontShoppingMarketProviderPort,
 } from "./shopping/provider-ports.js"
 import {
   storefrontShoppingRuntimePort,
@@ -434,8 +439,8 @@ export const storefrontShoppingProviderVoyantModule = defineModule({
     export: "createStorefrontRuntimePortContribution",
   },
   runtimePorts: [
-    requirePort(storefrontShoppingMarketProviderPort),
-    requirePort(storefrontShoppingCatalogProviderPort),
+    catalogSearchRuntimePortReference,
+    requirePort(catalogRuntimeServicesPort),
     requirePort(storefrontShoppingLiveProviderPort),
     requirePort(storefrontOpaqueReferenceIssuerPort),
     requirePort(storefrontPresentationFxProviderPort, { optional: true }),

--- a/packages/storefront/tests/unit/closed-shopping-provider-adapters.test.ts
+++ b/packages/storefront/tests/unit/closed-shopping-provider-adapters.test.ts
@@ -1,0 +1,364 @@
+import { createFieldPolicyRegistry, type FieldPolicy } from "@voyant-travel/catalog/contract"
+import type { IndexerAdapter } from "@voyant-travel/catalog-contracts/indexer/contract"
+import type { SQL } from "drizzle-orm"
+import { PgDialect } from "drizzle-orm/pg-core"
+import { describe, expect, it, vi } from "vitest"
+
+import { createClosedStorefrontShoppingAdapters } from "../../src/shopping/closed-provider-adapters.js"
+import { StorefrontShoppingUnavailableError } from "../../src/shopping/runtime.js"
+
+const storefront = { storefrontId: "sf_alpha", channelId: "channel_web" }
+const dialect = new PgDialect()
+const activeMarket = {
+  id: "market_ro",
+  code: "RO",
+  name: "Romania",
+  regionCode: "EU",
+  countryCode: "RO",
+  defaultLocale: "ro-RO",
+  defaultCurrency: "RON",
+  locales: [
+    { languageTag: "ro-RO", isDefault: true },
+    { languageTag: "en-GB", isDefault: false },
+  ],
+  currencies: [
+    { currencyCode: "RON", isDefault: true },
+    { currencyCode: "EUR", isDefault: false },
+  ],
+}
+
+function policy(path: string, overrides: Partial<FieldPolicy> = {}): FieldPolicy {
+  return {
+    path,
+    class: "structural",
+    merge: "source-only",
+    drift: "low",
+    reindex: "entry",
+    snapshot: "never",
+    query: "indexed-column",
+    localized: false,
+    visibility: ["customer"],
+    editRole: "none",
+    overrideFriction: "none",
+    sourceFreshness: "sync",
+    ...overrides,
+  }
+}
+
+function createIndexer(search = vi.fn(async () => ({ hits: [], total: 0 }))): IndexerAdapter {
+  return {
+    capabilities: {
+      supportsKeywordSearch: true,
+      supportsHybridSearch: false,
+      supportsVectorFields: false,
+      vectorDimensions: null,
+      maxVectorsPerDocument: null,
+      supportsCrossAudienceFederation: false,
+      supportsAdminDenormalization: false,
+    },
+    ensureCollection: vi.fn(),
+    upsert: vi.fn(),
+    delete: vi.fn(),
+    search,
+    bulkReindex: vi.fn(),
+  }
+}
+
+function adapters(
+  input: {
+    active?: (context: typeof storefront) => boolean
+    indexer?: IndexerAdapter
+    policies?: FieldPolicy[]
+  } = {},
+) {
+  const indexer = input.indexer ?? createIndexer()
+  return createClosedStorefrontShoppingAdapters({
+    primitives: {
+      env: vi.fn(() => ({ TENANT_ID: "operator_server_owned" })),
+      database: { resolve: vi.fn(() => ({ server: "db" })) },
+    } as never,
+    catalogSearch: {
+      resolveRuntime: vi.fn(() => ({
+        indexer,
+        defaultScope: { locale: "ignored", audience: "staff", market: "ignored" },
+      })),
+    },
+    catalogServices: {
+      fieldPolicyRegistries: () =>
+        new Map([
+          [
+            "products",
+            createFieldPolicyRegistry(
+              input.policies ?? [
+                policy("name"),
+                policy("description", { query: "blob-only" }),
+                policy("slug"),
+                policy("thumbnailUrl"),
+                policy("priceFromAmountCents"),
+                policy("priceFromCurrency"),
+                policy("familyCode"),
+              ],
+            ),
+          ],
+        ]),
+    },
+    listMarkets: vi.fn(async () => [activeMarket]),
+    isActiveStorefrontChannel: vi.fn(async (_db, context) =>
+      input.active ? input.active(context as typeof storefront) : true,
+    ),
+  })
+}
+
+describe("closed storefront shopping market adapter", () => {
+  it("ignores a soft-deleted storefront channel binding", async () => {
+    const statements: Array<{ sql: string; params: unknown[] }> = []
+    const provider = createClosedStorefrontShoppingAdapters({
+      primitives: {
+        env: vi.fn(() => ({})),
+        database: {
+          resolve: vi.fn(() => ({
+            execute(query: SQL) {
+              const statement = dialect.sqlToQuery(query)
+              statements.push({ sql: statement.sql, params: statement.params })
+              return Promise.resolve([{ active: false }])
+            },
+          })),
+        },
+      } as never,
+      catalogSearch: {
+        resolveRuntime: vi.fn(() => ({
+          defaultScope: { locale: "ignored", audience: "staff", market: "ignored" },
+        })),
+      },
+      catalogServices: { fieldPolicyRegistries: () => new Map() },
+      listMarkets: vi.fn(async () => [activeMarket]),
+    }).markets
+
+    await expect(provider.listActiveMarkets(storefront)).rejects.toThrow(
+      "active storefront channel",
+    )
+    expect(statements).toHaveLength(1)
+    expect(statements[0]?.sql).toContain("binding.deleted_at IS NULL")
+    expect(statements[0]?.params).toEqual([storefront.storefrontId, storefront.channelId])
+  })
+
+  it("keeps an active channel binding isolated to its trusted storefront", async () => {
+    const provider = adapters({
+      active: (context) =>
+        context.storefrontId === storefront.storefrontId &&
+        context.channelId === storefront.channelId,
+    }).markets
+
+    await expect(provider.listActiveMarkets(storefront)).resolves.toHaveLength(1)
+    await expect(
+      provider.listActiveMarkets({ ...storefront, storefrontId: "sf_other" }),
+    ).rejects.toBeInstanceOf(StorefrontShoppingUnavailableError)
+  })
+
+  it("fails closed for an inactive channel", async () => {
+    await expect(
+      adapters({ active: () => false }).markets.listActiveMarkets(storefront),
+    ).rejects.toThrow("active storefront channel")
+  })
+})
+
+describe("closed storefront shopping catalog adapter", () => {
+  it.each([
+    ["disabled locale", { marketId: "market_ro", locale: "de-DE", currency: "RON" }],
+    ["disabled currency", { marketId: "market_ro", locale: "ro-RO", currency: "USD" }],
+    ["inactive market", { marketId: "market_other", locale: "ro-RO", currency: "RON" }],
+  ])("rejects %s before touching Catalog", async (_label, scope) => {
+    const indexer = createIndexer()
+    const provider = adapters({ indexer }).catalog
+
+    await expect(
+      provider.searchSlice({
+        context: storefront,
+        scope: { ...scope, available: { marketIds: [], locales: [], currencies: [] } },
+        vertical: "products",
+        query: "",
+        filters: [],
+      }),
+    ).rejects.toThrow("active market scope")
+    expect(indexer.search).not.toHaveBeenCalled()
+  })
+
+  it("uses the exact customer Catalog slice and maps only customer-policy fields", async () => {
+    const search = vi.fn(async () => ({
+      hits: [
+        {
+          id: "product_1",
+          score: 1,
+          document: {
+            id: "product_1",
+            fields: {
+              name: "Danube tour",
+              description: "Seven nights",
+              slug: "danube-tour",
+              thumbnailUrl: "https://media.example/danube.jpg",
+              priceFromAmountCents: 12345,
+              priceFromCurrency: "ron",
+              supplierSecret: "must-not-leak",
+            },
+          },
+        },
+      ],
+      total: 1,
+      next_cursor: "cursor_2",
+    }))
+    const provider = adapters({
+      indexer: createIndexer(search),
+      policies: [
+        policy("name"),
+        policy("description", { query: "blob-only" }),
+        policy("slug"),
+        policy("thumbnailUrl"),
+        policy("priceFromAmountCents"),
+        policy("priceFromCurrency"),
+        policy("familyCode"),
+        policy("supplierSecret", { visibility: ["staff"] }),
+      ],
+    }).catalog
+
+    await expect(
+      provider.searchSlice({
+        context: storefront,
+        scope: {
+          marketId: "market_ro",
+          locale: "ro-RO",
+          currency: "RON",
+          available: { marketIds: [], locales: [], currencies: [] },
+        },
+        vertical: "products",
+        query: "danube",
+        filters: [{ kind: "eq", field: "familyCode", value: "tour" }],
+        pagination: { limit: 12, cursor: "cursor_1" },
+      }),
+    ).resolves.toEqual({
+      items: [
+        {
+          entityId: "product_1",
+          title: "Danube tour",
+          summary: "Seven nights",
+          href: "/catalog/danube-tour",
+          image: { url: "https://media.example/danube.jpg", alt: "Danube tour" },
+          nativePrice: { amount: "123.45", currency: "RON" },
+        },
+      ],
+      total: 1,
+      nextCursor: "cursor_2",
+    })
+    expect(search).toHaveBeenCalledWith(
+      {
+        vertical: "products",
+        locale: "ro-RO",
+        audience: "customer",
+        market: "market_ro",
+        channel: "channel_web",
+      },
+      {
+        query: "danube",
+        mode: "keyword",
+        filters: [{ kind: "eq", field: "familyCode", value: "tour" }],
+        pagination: { limit: 12, cursor: "cursor_1" },
+      },
+    )
+  })
+
+  it.each([
+    ["undeclared", "providerConnectionId"],
+    ["staff-only", "supplierSecret"],
+    ["blob-only", "description"],
+  ])("refuses a %s Catalog filter under the exact field policy", async (_label, field) => {
+    const indexer = createIndexer()
+    const provider = adapters({
+      indexer,
+      policies: [
+        policy("description", { query: "blob-only" }),
+        policy("supplierSecret", { visibility: ["staff"] }),
+      ],
+    }).catalog
+
+    await expect(
+      provider.searchSlice({
+        context: storefront,
+        scope: {
+          marketId: "market_ro",
+          locale: "ro-RO",
+          currency: "RON",
+          available: { marketIds: [], locales: [], currencies: [] },
+        },
+        vertical: "products",
+        query: "",
+        filters: [{ kind: "eq", field, value: "browser-selected" }],
+      }),
+    ).rejects.toThrow(`customer catalog field policy for ${field}`)
+    expect(indexer.search).not.toHaveBeenCalled()
+  })
+
+  it("does not expose a raw entity id when the customer title is unavailable", async () => {
+    const privateEntityId = "product_internal_1"
+    const indexer = createIndexer(
+      vi.fn(async () => ({
+        hits: [
+          {
+            id: privateEntityId,
+            score: 1,
+            document: { id: privateEntityId, fields: {} },
+          },
+        ],
+        total: 1,
+      })),
+    )
+    const provider = adapters({ indexer, policies: [policy("name")] }).catalog
+
+    await expect(
+      provider.searchSlice({
+        context: storefront,
+        scope: {
+          marketId: "market_ro",
+          locale: "ro-RO",
+          currency: "RON",
+          available: { marketIds: [], locales: [], currencies: [] },
+        },
+        vertical: "products",
+        query: "",
+        filters: [],
+      }),
+    ).rejects.toThrow("customer catalog title")
+  })
+
+  it("fails unavailable when the selected Catalog runtime has no indexer", async () => {
+    const noIndexerProvider = createClosedStorefrontShoppingAdapters({
+      primitives: {
+        env: vi.fn(() => ({})),
+        database: { resolve: vi.fn(() => ({})) },
+      } as never,
+      catalogSearch: {
+        resolveRuntime: () => ({
+          defaultScope: { locale: "ignored", audience: "staff", market: "ignored" },
+        }),
+      },
+      catalogServices: {
+        fieldPolicyRegistries: () =>
+          new Map([["products", createFieldPolicyRegistry([policy("familyCode")])]]),
+      },
+      listMarkets: async () => [activeMarket],
+      isActiveStorefrontChannel: async () => true,
+    }).catalog
+    await expect(
+      noIndexerProvider.searchSlice({
+        context: storefront,
+        scope: {
+          marketId: "market_ro",
+          locale: "ro-RO",
+          currency: "RON",
+          available: { marketIds: [], locales: [], currencies: [] },
+        },
+        vertical: "products",
+        query: "",
+        filters: [],
+      }),
+    ).rejects.toThrow("catalog indexer")
+  })
+})

--- a/packages/storefront/tests/unit/customer-business-onboarding-runtime-contributor.test.ts
+++ b/packages/storefront/tests/unit/customer-business-onboarding-runtime-contributor.test.ts
@@ -1,12 +1,12 @@
 import { customerBusinessAccountOnboardingRuntimePort } from "@voyant-travel/auth/customer-business-onboarding-runtime-port"
+import { catalogSearchRuntimePort } from "@voyant-travel/catalog/api-runtime-ports"
+import { catalogRuntimeServicesPort } from "@voyant-travel/catalog/runtime-contracts"
 import { describe, expect, it, vi } from "vitest"
 
 import { createStorefrontRuntimePortContribution } from "../../src/runtime-contributor.js"
 import {
   storefrontOpaqueReferenceIssuerPort,
-  storefrontShoppingCatalogProviderPort,
   storefrontShoppingLiveProviderPort,
-  storefrontShoppingMarketProviderPort,
 } from "../../src/shopping/provider-ports.js"
 import { storefrontShoppingRuntimePort } from "../../src/shopping/runtime-port.js"
 
@@ -45,7 +45,7 @@ describe("storefront customer business onboarding runtime contribution", () => {
   it("keeps managed shopping absent until every closed dependency is configured", () => {
     const ports = createStorefrontRuntimePortContribution({
       primitives: primitives(),
-      hasRuntimePort: ({ id }) => id === storefrontShoppingMarketProviderPort.id,
+      hasRuntimePort: ({ id }) => id === catalogSearchRuntimePort.id,
       getRuntimePort: vi.fn(),
     })
     expect(ports).not.toHaveProperty(storefrontShoppingRuntimePort.id)
@@ -53,8 +53,8 @@ describe("storefront customer business onboarding runtime contribution", () => {
 
   it("contributes managed shopping after every closed dependency is configured", async () => {
     const providers = new Map<string, unknown>([
-      [storefrontShoppingMarketProviderPort.id, { listActiveMarkets: vi.fn() }],
-      [storefrontShoppingCatalogProviderPort.id, { searchSlice: vi.fn() }],
+      [catalogSearchRuntimePort.id, { resolveRuntime: vi.fn() }],
+      [catalogRuntimeServicesPort.id, { fieldPolicyRegistries: vi.fn() }],
       [
         storefrontShoppingLiveProviderPort.id,
         { searchFlights: vi.fn(), searchStays: vi.fn(), searchPackages: vi.fn() },

--- a/packages/storefront/tests/unit/voyant-manifest.test.ts
+++ b/packages/storefront/tests/unit/voyant-manifest.test.ts
@@ -1,4 +1,7 @@
-import { catalogPublicationRuntimePort } from "@voyant-travel/catalog/runtime-contracts"
+import {
+  catalogPublicationRuntimePort,
+  catalogRuntimeServicesPort,
+} from "@voyant-travel/catalog/runtime-contracts"
 import { Hono } from "hono"
 import { describe, expect, it, vi } from "vitest"
 import { createStorefrontVoyantRuntime } from "../../src/index.js"
@@ -12,9 +15,7 @@ import {
 import {
   storefrontOpaqueReferenceIssuerPort,
   storefrontPresentationFxProviderPort,
-  storefrontShoppingCatalogProviderPort,
   storefrontShoppingLiveProviderPort,
-  storefrontShoppingMarketProviderPort,
 } from "../../src/shopping/provider-ports.js"
 import {
   storefrontShoppingRuntimePort,
@@ -43,8 +44,8 @@ describe("storefront deployment manifest", () => {
       id: "@voyant-travel/storefront#shopping-provider",
       provides: { ports: [{ id: storefrontShoppingRuntimePort.id }] },
       runtimePorts: [
-        { id: storefrontShoppingMarketProviderPort.id },
-        { id: storefrontShoppingCatalogProviderPort.id },
+        { id: "catalog.search-runtime" },
+        { id: catalogRuntimeServicesPort.id },
         { id: storefrontShoppingLiveProviderPort.id },
         { id: storefrontOpaqueReferenceIssuerPort.id },
         { id: storefrontPresentationFxProviderPort.id, optional: true },


### PR DESCRIPTION
## Summary

- compose `StorefrontShoppingMarketProvider` directly from Commerce active public market configuration
- compose `StorefrontShoppingCatalogProvider` directly from the Catalog search runtime and exact customer-visible/indexed field policies
- bind every read to the trusted storefront/channel pair and recheck active market, locale, currency, and channel before indexer access
- contribute the optional managed shopping runtime only when Catalog search/services plus live/reference dependencies exist

## Trust boundary

The adapters do not call HTTP/admin routes and do not accept tenant, channel, or provider selectors from browser input. The storefront/channel pair is checked against `auth_storefront_distribution_channel` joined to an active Distribution channel. Catalog search always uses the fixed `customer` slice with server-derived market, locale, and channel.

## Tests

Added focused coverage for cross-storefront isolation, inactive channel, inactive market, disabled locale/currency, fixed customer Catalog slice, exact field-policy filtering/mapping, and missing-indexer unavailability. Existing managed-runtime tests cover the UX-group-to-Catalog-slice mappings.

Validation run `s3b7pznkqf` was cancelled on request before completion; architecture checks had started without a reported failure. Exact narrow commands still required:

```sh
pnpm --filter @voyant-travel/storefront exec vitest run tests/unit/closed-shopping-provider-adapters.test.ts tests/unit/managed-shopping-runtime.test.ts tests/unit/customer-business-onboarding-runtime-contributor.test.ts tests/unit/voyant-manifest.test.ts
pnpm --filter @voyant-travel/storefront typecheck
pnpm --filter @voyant-travel/storefront lint
```

## Stack

- base PR: #4443 (`agent/storefront-shopping-runtime`)
- exact base commit: `26a70e400d3aa401ac8c7f6e6ca7ec375b85f32e`
- isolated top commit: `64883779cdefd7bc06c693b64680a6b472b6409b`

Do not merge before the stack is restacked onto the merged gateway line and the narrow validation commands are green.