### PR TITLE
fix(finance): make invoice voiding durable

### DIFF
--- a/.changeset/tidy-finance-voids.md
+++ b/.changeset/tidy-finance-voids.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/finance": patch
+---
+
+Make approved invoice voiding use the handler-owned durable existing-target command protocol.

--- a/packages/finance/src/mcp-runtime.ts
+++ b/packages/finance/src/mcp-runtime.ts
@@ -1,4 +1,7 @@
-import { buildActionLedgerApprovedExecutionFields } from "@voyant-travel/action-ledger"
+import {
+  buildActionLedgerApprovedExecutionFields,
+  executeAdmittedExistingTargetCommand,
+} from "@voyant-travel/action-ledger"
 import {
   type BookingsCancellationPolicyRuntime,
   bookingsCancellationPolicyRuntimePort,
@@ -7,6 +10,7 @@ import {
   defineToolContextContribution,
   deriveCommandIdempotencyKey,
   ToolError,
+  type ToolHandlerActionPolicyContext,
 } from "@voyant-travel/tools"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
@@ -58,8 +62,34 @@ export const voyantToolContextContribution = defineToolContextContribution({
         getInvoiceById: (id: string) => financeService.getInvoiceById(db, id),
         getFinanceAggregates: (query: Parameters<typeof financeService.getFinanceAggregates>[1]) =>
           financeService.getFinanceAggregates(db, query),
-        voidInvoice: (id: string, input: { reason?: string }) =>
-          financeService.voidInvoice(db, id, input),
+        voidInvoice: async (
+          id: string,
+          input: { reason?: string },
+          admitted: ToolHandlerActionPolicyContext,
+        ) => {
+          let result: Awaited<ReturnType<typeof financeService.voidInvoice>> | undefined
+          const execute = (commandDb: PostgresJsDatabase) =>
+            financeService.voidInvoice(commandDb, id, input)
+          return executeAdmittedExistingTargetCommand(
+            {
+              db: db as PostgresJsDatabase,
+              context: financeToolActionLedgerContext(c),
+              admitted,
+              commandInput: { id, ...input },
+              evaluatedRisk: "critical",
+            },
+            {
+              async prepare(tx) {
+                result = await execute(tx as PostgresJsDatabase)
+              },
+              execute() {
+                if (!result) throw new Error("Invoice void produced no result")
+                return Promise.resolve(result)
+              },
+              replay: () => execute(db as PostgresJsDatabase),
+            },
+          )
+        },
         // create_booking + book_product (voyant#3933) — both compose the durable
         // booking-create command; book_product resolves reference and key server-side.
         ...financeBookingToolServices(db as PostgresJsDatabase, c, cancellationPolicy),

--- a/packages/finance/src/tools.ts
+++ b/packages/finance/src/tools.ts
@@ -8,9 +8,11 @@ import { bookingToolDetailSchema } from "@voyant-travel/bookings"
 import {
   admitHandlerActionPolicy,
   defineTool,
+  type HandlerActionPolicyExpectation,
   READ_ONLY_RISK,
   requireService,
   type ToolContext,
+  type ToolHandlerActionPolicyContext,
 } from "@voyant-travel/tools"
 import { listResponseSchema } from "@voyant-travel/types"
 import { z } from "zod"
@@ -60,7 +62,11 @@ export interface FinanceToolServices {
     to?: string
     outstandingTopLimit?: number
   }): Promise<unknown>
-  voidInvoice(id: string, input: { reason?: string }): Promise<unknown>
+  voidInvoice(
+    id: string,
+    input: { reason?: string },
+    admitted: ToolHandlerActionPolicyContext,
+  ): Promise<unknown>
   issueInvoiceRefund(input: {
     invoiceId: string
     creditNoteNumber: string
@@ -136,6 +142,26 @@ export const listInvoicesTool = defineTool<
 
 const getInvoiceArgs = z.object({ id: z.string().min(1).describe("The invoice id.") })
 
+export const VOID_INVOICE_HANDLER_POLICY = {
+  capabilityId: "@voyant-travel/finance#tool.void-invoice",
+  capabilityVersion: "v1",
+  canonicalName: "void_invoice",
+  actionPolicy: {
+    id: "@voyant-travel/finance#action.void-invoice",
+    capabilityId: "@voyant-travel/finance#action.void-invoice",
+    version: "v1",
+    kind: "execute",
+    targetType: "invoice",
+    commandTargetField: "id",
+    targetLifecycle: "existing",
+    existingTarget: { durability: "handler-command-result-v1" },
+    risk: "critical",
+    ledger: "required",
+    approval: "required",
+    reversible: false,
+  },
+} as const satisfies HandlerActionPolicyExpectation
+
 export const getInvoiceTool = defineTool<
   z.infer<typeof getInvoiceArgs>,
   unknown,
@@ -176,8 +202,14 @@ export const voidInvoiceTool = defineTool<
     dryRunSupported: false,
     confirmationRequired: true,
   },
+  annotations: { idempotentHint: true },
+  actionPolicyEnforcement: "handler",
   async handler({ id, reason }, ctx) {
-    return parseJsonResult(voidInvoiceResultSchema, await finance(ctx).voidInvoice(id, { reason }))
+    const admitted = admitHandlerActionPolicy(ctx, VOID_INVOICE_HANDLER_POLICY)
+    return parseJsonResult(
+      voidInvoiceResultSchema,
+      await finance(ctx).voidInvoice(id, { reason }, admitted),
+    )
   },
 })
 

--- a/packages/finance/src/voyant.ts
+++ b/packages/finance/src/voyant.ts
@@ -504,6 +504,7 @@ export const financeVoyantModule = defineModule({
   actions: [
     {
       id: "@voyant-travel/finance#action.void-invoice",
+      capabilityId: "@voyant-travel/finance#action.void-invoice",
       version: "v1",
       kind: "execute",
       targetType: "invoice",
@@ -518,6 +519,7 @@ export const financeVoyantModule = defineModule({
       availability: { status: "available" },
       effectBoundary: "local",
       targetLifecycle: "existing",
+      existingTarget: { durability: "handler-command-result-v1" },
       from: { tools: ["@voyant-travel/finance#tool.void-invoice"] },
     },
     {

--- a/packages/finance/tests/tools.test.ts
+++ b/packages/finance/tests/tools.test.ts
@@ -3,7 +3,7 @@ import {
   type ToolContext,
   type ToolHandlerActionPolicyContext,
 } from "@voyant-travel/tools"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import {
   FINANCE_BOOK_PRODUCT_HANDLER_POLICY,
   FINANCE_BOOKING_CREATE_HANDLER_POLICY,
@@ -18,8 +18,10 @@ import {
   issueInvoiceRefundInputSchema,
   issueInvoiceRefundTool,
   issueUnsyncedProformaFromBookingToolInputSchema,
+  VOID_INVOICE_HANDLER_POLICY,
+  voidInvoiceTool,
 } from "../src/tools.js"
-import { financeBookingsCreateVoyantPlugin } from "../src/voyant.js"
+import { financeBookingsCreateVoyantPlugin, financeVoyantModule } from "../src/voyant.js"
 
 function ctx(
   services?: Partial<FinanceToolServices>,
@@ -275,6 +277,7 @@ describe("finance tools", () => {
     expect(voidTool?.tier).toBe("destructive")
     expect(voidTool?.requiredScopes).toEqual(["finance:void"])
     expect(voidTool?.riskPolicy).toMatchObject({ destructive: true, confirmationRequired: true })
+    expect(voidInvoiceTool.actionPolicyEnforcement).toBe("handler")
     const refundTool = list.find((t) => t.name === "issue_invoice_refund")
     expect(refundTool).toMatchObject({
       tier: "destructive",
@@ -285,6 +288,48 @@ describe("finance tools", () => {
       expect(t.tier).toBe("read")
       expect(t.requiredScopes).toEqual(["finance:read"])
     }
+  })
+
+  it("passes the admitted durable action policy to invoice voiding", async () => {
+    const voidInvoice = vi.fn(async () => ({ status: "not_found" as const }))
+    const registry = createToolRegistry()
+    const action = financeVoyantModule.actions?.find(
+      (entry) => entry.id === VOID_INVOICE_HANDLER_POLICY.actionPolicy.id,
+    )
+    if (!action) throw new Error("void invoice action is missing")
+    registry.register(voidInvoiceTool, {
+      capabilityId: VOID_INVOICE_HANDLER_POLICY.capabilityId,
+      owner: "@voyant-travel/finance",
+      capabilityVersion: VOID_INVOICE_HANDLER_POLICY.capabilityVersion,
+      name: VOID_INVOICE_HANDLER_POLICY.canonicalName,
+      requiredScopes: ["finance:void"],
+      deploymentRisk: "critical",
+      actionPolicy: action,
+    })
+    const registeredPolicy = registry
+      .list()
+      .find((entry) => entry.name === "void_invoice")?.actionPolicy
+    if (!registeredPolicy) throw new Error("void invoice registered policy is missing")
+
+    await expect(
+      registry.dispatch(
+        "void_invoice",
+        { id: "inv_1", reason: "duplicate" },
+        ctx({ voidInvoice }, {
+          capabilityId: VOID_INVOICE_HANDLER_POLICY.capabilityId,
+          capabilityVersion: VOID_INVOICE_HANDLER_POLICY.capabilityVersion,
+          canonicalName: VOID_INVOICE_HANDLER_POLICY.canonicalName,
+          actionPolicy: registeredPolicy,
+          invocation: {
+            approvalId: "approval_1",
+            confirmed: true,
+            targetId: "inv_1",
+            idempotencyFingerprint: "fingerprint_1",
+          },
+        } as ToolHandlerActionPolicyContext),
+      ),
+    ).resolves.toEqual({ status: "not_found" })
+    expect(voidInvoice).toHaveBeenCalledWith("inv_1", { reason: "duplicate" }, expect.any(Object))
   })
 
   it("dispatches reads + void through the injected service", async () => {
@@ -455,12 +500,6 @@ describe("finance tools", () => {
     }
     expect(await registry.dispatch("get_invoice", { id: "inv_1" }, ctx(services))).toMatchObject({
       id: "inv_1",
-    })
-    expect(
-      await registry.dispatch("void_invoice", { id: "inv_2", reason: "dup" }, ctx(services)),
-    ).toMatchObject({
-      status: "voided",
-      invoice: { id: "inv_2", status: "void", voidReason: "dup" },
     })
     expect(
       await registry.dispatch(


### PR DESCRIPTION
Closes another unsafe generic approved-execution path from #4424.

- declares `void_invoice` as a handler-owned durable existing-target action
- binds approval admission, claim, invoice mutation, and result to the durable command protocol
- replays by reading the authoritative invoice state rather than redispatching through the generic preflight

Verification:
- `pnpm --filter @voyant-travel/finance exec vitest run tests/tools.test.ts --reporter=dot`
- `pnpm --filter @voyant-travel/finance typecheck`
- `pnpm --filter @voyant-travel/finance test` (563 passed, 401 skipped)
- `pnpm --filter operator prepare:verify`