### PR TITLE
fix(trips): make candidate selection durable

### DIFF
--- a/.changeset/calm-trip-candidates.md
+++ b/.changeset/calm-trip-candidates.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/trips": patch
+---
+
+Make approved trip candidate selection use durable existing-target command replay.

--- a/packages/trips/src/mcp-runtime.ts
+++ b/packages/trips/src/mcp-runtime.ts
@@ -1,3 +1,4 @@
+import { executeAdmittedExistingTargetCommand } from "@voyant-travel/action-ledger"
 import { executeAdmittedCreatedTargetCommand } from "@voyant-travel/action-ledger/created-command"
 import {
   type ActionLedgerRequestContextValues,
@@ -117,7 +118,29 @@ export const voyantToolContextContribution = defineToolContextContribution({
           ...input,
           organizationId: actionLedgerContext(c).organizationId ?? null,
         }),
-      selectCandidate: (input) => tripsService.selectCandidate(c.var.db, input),
+      selectCandidate: async (input, admitted) => {
+        let selected: Awaited<ReturnType<typeof tripsService.selectCandidate>> | undefined
+        const result = await executeAdmittedExistingTargetCommand(
+          {
+            db,
+            context: actionLedgerContext(c),
+            admitted,
+            commandInput: input,
+            evaluatedRisk: "medium",
+          },
+          {
+            async prepare(tx) {
+              selected = await tripsService.selectCandidate(tx, input)
+            },
+            execute() {
+              if (!selected) throw new Error("Trip candidate selection produced no result")
+              return Promise.resolve(selected)
+            },
+            replay: () => tripsService.getSelectedCandidateResult(db, input.requirementId),
+          },
+        )
+        return result
+      },
     }
     return { trips }
   },

--- a/packages/trips/src/service-requirements.ts
+++ b/packages/trips/src/service-requirements.ts
@@ -243,6 +243,28 @@ async function loadCandidate(db: AnyDrizzleDb, candidateId: string): Promise<Tri
   return candidate
 }
 
+export async function getSelectedCandidateResult(
+  db: AnyDrizzleDb,
+  requirementId: string,
+): Promise<{ requirement: TripRequirement; candidate: TripCandidate; component: TripComponent }> {
+  const requirement = await loadRequirement(db, requirementId)
+  if (!requirement.selectedCandidateId || !requirement.resolvedComponentId) {
+    throw new TripsInvariantError(`Trip requirement ${requirementId} has no selected candidate`)
+  }
+  const candidate = await loadCandidate(db, requirement.selectedCandidateId)
+  const [component] = (await db
+    .select()
+    .from(tripComponents)
+    .where(eq(tripComponents.id, requirement.resolvedComponentId))
+    .limit(1)) as TripComponent[]
+  if (!component) {
+    throw new TripsInvariantError(
+      `Trip requirement ${requirementId} resolved component was not found`,
+    )
+  }
+  return { requirement, candidate, component }
+}
+
 async function nextComponentSequence(db: AnyDrizzleDb, envelopeId: string): Promise<number> {
   const rows = (await db
     .select()

--- a/packages/trips/src/service.ts
+++ b/packages/trips/src/service.ts
@@ -39,6 +39,7 @@ export {
   assertRequiredRequirementsResolved,
   availabilityCandidateToRow,
   expireStaleTripCandidates,
+  getSelectedCandidateResult,
   isTripCandidateExpired,
   listEnvelopeRequirements,
   pinnedComponentValuesFromCandidate,
@@ -112,6 +113,7 @@ import { priceTrip } from "./service-pricing.js"
 import {
   addRequirement,
   expireStaleTripCandidates,
+  getSelectedCandidateResult,
   listEnvelopeRequirements,
   selectCandidate,
 } from "./service-requirements.js"
@@ -158,5 +160,6 @@ export const tripsService = {
   listEnvelopeRequirements,
   getTripRequirementSourcingOperation,
   selectCandidate,
+  getSelectedCandidateResult,
   expireStaleTripCandidates,
 }

--- a/packages/trips/src/tools.ts
+++ b/packages/trips/src/tools.ts
@@ -170,6 +170,27 @@ export const RESERVE_TRIP_HANDLER_POLICY = {
   },
 } as const satisfies HandlerActionPolicyExpectation
 
+export const SELECT_TRIP_CANDIDATE_HANDLER_POLICY = {
+  capabilityId: `${OWNER}#tool.select-candidate`,
+  capabilityVersion: VERSION,
+  canonicalName: "select_trip_candidate",
+  actionPolicy: {
+    id: `${OWNER}#action.select-candidate`,
+    capabilityId: `${OWNER}#action.select-candidate`,
+    version: VERSION,
+    kind: "execute",
+    targetType: "trip-requirement",
+    commandTargetField: "requirementId",
+    targetLifecycle: "existing",
+    existingTarget: { durability: "handler-command-result-v1" },
+    risk: "medium",
+    ledger: "required",
+    approval: "required",
+    reversible: true,
+    allowedActorTypes: ["staff"],
+  },
+} as const satisfies HandlerActionPolicyExpectation
+
 /** The trips service surface a deployment binds into the tool context. */
 export interface TripsToolServices {
   createTrip(
@@ -198,7 +219,10 @@ export interface TripsToolServices {
   getRequirementSourcingOperation(
     input: z.infer<typeof getRequirementSourcingOperationSchema>,
   ): Promise<unknown | null>
-  selectCandidate(input: z.infer<typeof selectCandidateSchema>): Promise<unknown>
+  selectCandidate(
+    input: z.infer<typeof selectCandidateSchema>,
+    admitted: ToolHandlerActionPolicyContext,
+  ): Promise<unknown>
   listTrips(input: ListTripsArgs): Promise<unknown>
   getTrip(envelopeId: string): Promise<unknown | null>
 }
@@ -478,8 +502,14 @@ export const selectTripCandidateTool = defineTool({
   audience: STAFF_AUDIENCE,
   tier: "write",
   riskPolicy: CANDIDATE_SELECTION_RISK,
+  annotations: { idempotentHint: true },
+  actionPolicyEnforcement: "handler",
   async handler(input, ctx: TripsToolContext) {
-    return parseJsonResult(selectTripCandidateResultSchema, await trips(ctx).selectCandidate(input))
+    const admitted = admitHandlerActionPolicy(ctx, SELECT_TRIP_CANDIDATE_HANDLER_POLICY)
+    return parseJsonResult(
+      selectTripCandidateResultSchema,
+      await trips(ctx).selectCandidate(input, admitted),
+    )
   },
 })
 

--- a/packages/trips/src/voyant.ts
+++ b/packages/trips/src/voyant.ts
@@ -513,6 +513,7 @@ export const tripsVoyantModule = defineModule({
     },
     {
       id: "@voyant-travel/trips#action.select-candidate",
+      capabilityId: "@voyant-travel/trips#action.select-candidate",
       version: "v1",
       kind: "execute",
       targetType: "trip-requirement",
@@ -526,6 +527,7 @@ export const tripsVoyantModule = defineModule({
       availability: { status: "available" },
       effectBoundary: "local",
       targetLifecycle: "existing",
+      existingTarget: { durability: "handler-command-result-v1" },
       from: { tools: ["@voyant-travel/trips#tool.select-candidate"] },
     },
   ],

--- a/packages/trips/tests/tools.test.ts
+++ b/packages/trips/tests/tools.test.ts
@@ -11,7 +11,9 @@ import {
   priceTripTool,
   RESERVE_TRIP_HANDLER_POLICY,
   reserveTripTool,
+  SELECT_TRIP_CANDIDATE_HANDLER_POLICY,
   SOURCE_REQUIREMENT_CANDIDATES_HANDLER_POLICY,
+  selectTripCandidateTool,
   sourceTripRequirementCandidatesTool,
   type TripsToolServices,
   tripsTools,
@@ -52,6 +54,10 @@ function makeRegistry() {
     } else if (tool === sourceTripRequirementCandidatesTool) {
       registry.register(tool, {
         actionPolicy: SOURCE_REQUIREMENT_CANDIDATES_HANDLER_POLICY.actionPolicy,
+      })
+    } else if (tool === selectTripCandidateTool) {
+      registry.register(tool, {
+        actionPolicy: SELECT_TRIP_CANDIDATE_HANDLER_POLICY.actionPolicy,
       })
     } else {
       registry.register(tool)
@@ -129,6 +135,7 @@ describe("trips tools", () => {
       requiredScopes: ["trips:write"],
       deploymentRisk: "medium",
     })
+    expect(selectTripCandidateTool.actionPolicyEnforcement).toBe("handler")
     expect(price?.riskPolicy).toMatchObject({
       confirmationRequired: true,
       sideEffects: ["data-write"],

--- a/packages/trips/tests/voyant-manifest.test.ts
+++ b/packages/trips/tests/voyant-manifest.test.ts
@@ -315,6 +315,7 @@ describe("trips deployment manifest", () => {
           ledger: "required",
           approval: "required",
           allowedActorTypes: ["staff"],
+          existingTarget: { durability: "handler-command-result-v1" },
         }),
       ]),
     )


### PR DESCRIPTION
Continues #4424 by removing `select_trip_candidate` from the unsafe generic approved-execution path.

- declares handler-owned durable existing-target execution
- commits the command claim, approval consumption, candidate selection, and pinned component in one transaction
- replays the authoritative selected requirement/candidate/component without repeating the mutation

Verification:
- `pnpm --filter @voyant-travel/trips typecheck`
- `pnpm --filter @voyant-travel/trips test` (172 passed, 12 skipped)
- `pnpm --filter operator prepare:verify`