### PR TITLE
fix(settings): make operator updates durable

### DIFF
--- a/.changeset/neat-operator-settings.md
+++ b/.changeset/neat-operator-settings.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/operator-settings": patch
+---
+
+Make approved operator settings updates use durable singleton command replay.

--- a/packages/operator-settings/package.json
+++ b/packages/operator-settings/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@hono/zod-openapi": "catalog:",
+    "@voyant-travel/action-ledger": "workspace:^",
     "@voyant-travel/commerce": "workspace:^",
     "@voyant-travel/core": "workspace:^",
     "@voyant-travel/db": "workspace:^",

--- a/packages/operator-settings/src/mcp-runtime.ts
+++ b/packages/operator-settings/src/mcp-runtime.ts
@@ -1,4 +1,13 @@
-import { defineToolContextContribution } from "@voyant-travel/tools"
+import {
+  type ActionLedgerRequestContextValues,
+  executeAdmittedExistingTargetCommand,
+} from "@voyant-travel/action-ledger"
+import {
+  defineToolContextContribution,
+  type ToolHandlerActionPolicyContext,
+} from "@voyant-travel/tools"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import type { Context } from "hono"
 
 import { getOperatorSettings, upsertOperatorSettings } from "./service.js"
 import type { OperatorSettingsValue } from "./tools.js"
@@ -7,20 +16,63 @@ export * from "./tools.js"
 
 export const voyantToolContextContribution = defineToolContextContribution({
   context: ["operatorSettings"],
-  contribute: ({ context }) => {
+  contribute: ({ context, request }) => {
     const db = context.db as Parameters<typeof getOperatorSettings>[0]
     return {
       operatorSettings: {
         async getSettings() {
           return serializeSettings(await getOperatorSettings(db))
         },
-        async updateSettings(input: Parameters<typeof upsertOperatorSettings>[1]) {
-          return serializeSettings(await upsertOperatorSettings(db, input))
+        async updateSettings(
+          input: Parameters<typeof upsertOperatorSettings>[1],
+          admitted: ToolHandlerActionPolicyContext,
+        ) {
+          let settings: Awaited<ReturnType<typeof upsertOperatorSettings>> | undefined
+          const result = await executeAdmittedExistingTargetCommand(
+            {
+              db,
+              context: actionLedgerContext(request as Context),
+              admitted,
+              commandInput: { settingsId: "operator-settings", patch: input },
+              evaluatedRisk: "high",
+            },
+            {
+              async prepare(tx) {
+                settings = await upsertOperatorSettings(tx as PostgresJsDatabase, input)
+              },
+              execute() {
+                return Promise.resolve(serializeSettings(settings ?? null))
+              },
+              async replay() {
+                return serializeSettings(await getOperatorSettings(db))
+              },
+            },
+          )
+          return result.value
         },
       },
     }
   },
 })
+
+function actionLedgerContext(c: Context): ActionLedgerRequestContextValues {
+  const vars = c.var as Record<string, unknown>
+  return {
+    userId: (vars.userId as string | undefined) ?? null,
+    agentId: (vars.agentId as string | undefined) ?? null,
+    workflowPrincipalId: (vars.workflowPrincipalId as string | undefined) ?? null,
+    principalSubtype: (vars.principalSubtype as string | undefined) ?? null,
+    sessionId: (vars.sessionId as string | undefined) ?? null,
+    apiTokenId: ((vars.apiTokenId ?? vars.apiKeyId) as string | undefined) ?? null,
+    callerType: (vars.callerType as ActionLedgerRequestContextValues["callerType"]) ?? null,
+    actor: (vars.actor as ActionLedgerRequestContextValues["actor"]) ?? null,
+    isInternalRequest: (vars.isInternalRequest as boolean | undefined) ?? false,
+    organizationId: (vars.organizationId as string | undefined) ?? null,
+    workflowRunId: (vars.workflowRunId as string | undefined) ?? null,
+    workflowStepId: (vars.workflowStepId as string | undefined) ?? null,
+    correlationId: c.req.header("x-correlation-id") ?? c.req.header("x-request-id") ?? null,
+  }
+}
 
 function serializeSettings(
   settings: Awaited<ReturnType<typeof getOperatorSettings>>,

--- a/packages/operator-settings/src/tools.test.ts
+++ b/packages/operator-settings/src/tools.test.ts
@@ -1,7 +1,12 @@
+import { createToolRegistry, type ToolHandlerActionPolicyContext } from "@voyant-travel/tools"
 import { describe, expect, it, vi } from "vitest"
 
 import type { OperatorSettingsToolContext } from "./tools.js"
-import { getOperatorSettingsTool, updateOperatorSettingsTool } from "./tools.js"
+import {
+  getOperatorSettingsTool,
+  UPDATE_OPERATOR_SETTINGS_HANDLER_POLICY,
+  updateOperatorSettingsTool,
+} from "./tools.js"
 
 const settings = {
   name: "Voyant Travel",
@@ -46,12 +51,40 @@ describe("operator settings tools", () => {
 
   it("updates settings through the injected service", async () => {
     const updateSettings = vi.fn(async () => settings)
-    const ctx = context({ updateSettings })
+    const registry = createToolRegistry()
+    registry.register(updateOperatorSettingsTool, {
+      capabilityId: UPDATE_OPERATOR_SETTINGS_HANDLER_POLICY.capabilityId,
+      owner: "@voyant-travel/operator-settings",
+      capabilityVersion: UPDATE_OPERATOR_SETTINGS_HANDLER_POLICY.capabilityVersion,
+      name: UPDATE_OPERATOR_SETTINGS_HANDLER_POLICY.canonicalName,
+      requiredScopes: ["settings:write"],
+      deploymentRisk: "high",
+      actionPolicy: UPDATE_OPERATOR_SETTINGS_HANDLER_POLICY.actionPolicy,
+    })
+    const actionPolicy = registry.list()[0]?.actionPolicy
+    if (!actionPolicy) throw new Error("registered operator settings action is missing")
+    const handlerActionPolicy = {
+      ...UPDATE_OPERATOR_SETTINGS_HANDLER_POLICY,
+      actionPolicy,
+      invocation: {
+        confirmed: true,
+        idempotencyKey: "settings-update-1",
+        approvalId: "approval-1",
+        idempotencyFingerprint: "sha256:test",
+      },
+    } as ToolHandlerActionPolicyContext
 
     await expect(
-      updateOperatorSettingsTool.handler({ name: "Voyant Travel" }, ctx),
+      registry.dispatch(
+        "update_operator_settings",
+        { name: "Voyant Travel" },
+        {
+          ...context({ updateSettings }),
+          handlerActionPolicy,
+        },
+      ),
     ).resolves.toEqual({ settings })
-    expect(updateSettings).toHaveBeenCalledWith({ name: "Voyant Travel" })
+    expect(updateSettings).toHaveBeenCalledWith({ name: "Voyant Travel" }, expect.any(Object))
   })
 
   it("publishes typed schemas and guarded write risk", () => {
@@ -65,5 +98,6 @@ describe("operator settings tools", () => {
       reversible: true,
       sideEffects: ["data-write"],
     })
+    expect(updateOperatorSettingsTool.actionPolicyEnforcement).toBe("handler")
   })
 })

--- a/packages/operator-settings/src/tools.ts
+++ b/packages/operator-settings/src/tools.ts
@@ -5,7 +5,15 @@
  * not the underlying storage tables. A deployment injects the service through
  * the Tool context so this surface stays transport-neutral.
  */
-import { defineTool, READ_ONLY_RISK, requireService, type ToolContext } from "@voyant-travel/tools"
+import {
+  admitHandlerActionPolicy,
+  defineTool,
+  type HandlerActionPolicyExpectation,
+  READ_ONLY_RISK,
+  requireService,
+  type ToolContext,
+  type ToolHandlerActionPolicyContext,
+} from "@voyant-travel/tools"
 import { z } from "zod"
 
 import { paymentPolicySchema, updateOperatorSettingsSchema } from "./service.js"
@@ -40,13 +48,36 @@ export const operatorSettingsValueSchema = z.object({
 export type OperatorSettingsValue = z.infer<typeof operatorSettingsValueSchema>
 export type UpdateOperatorSettingsToolInput = z.infer<typeof updateOperatorSettingsSchema>
 
+export const UPDATE_OPERATOR_SETTINGS_HANDLER_POLICY = {
+  capabilityId: "@voyant-travel/operator-settings#tool.update-operator-settings",
+  capabilityVersion: "v1",
+  canonicalName: "update_operator_settings",
+  actionPolicy: {
+    id: "@voyant-travel/operator-settings#action.update-operator-settings",
+    capabilityId: "@voyant-travel/operator-settings#action.update-operator-settings",
+    version: "v1",
+    kind: "execute",
+    targetType: "operator-settings",
+    commandTargetField: "settingsId",
+    targetLifecycle: "existing",
+    existingTarget: { durability: "handler-command-result-v1" },
+    risk: "high",
+    ledger: "required",
+    approval: "required",
+    reversible: true,
+  },
+} as const satisfies HandlerActionPolicyExpectation
+
 const operatorSettingsResultSchema = z.object({
   settings: operatorSettingsValueSchema.nullable(),
 })
 
 export interface OperatorSettingsToolServices {
   getSettings(): Promise<OperatorSettingsValue | null>
-  updateSettings(input: UpdateOperatorSettingsToolInput): Promise<OperatorSettingsValue | null>
+  updateSettings(
+    input: UpdateOperatorSettingsToolInput,
+    admitted: ToolHandlerActionPolicyContext,
+  ): Promise<OperatorSettingsValue | null>
 }
 
 export type OperatorSettingsToolContext = ToolContext & {
@@ -94,8 +125,11 @@ export const updateOperatorSettingsTool = defineTool<
     confirmationRequired: true,
     sideEffects: ["data-write"],
   },
+  annotations: { idempotentHint: true },
+  actionPolicyEnforcement: "handler",
   async handler(input, ctx) {
-    return { settings: await operatorSettings(ctx).updateSettings(input) }
+    const admitted = admitHandlerActionPolicy(ctx, UPDATE_OPERATOR_SETTINGS_HANDLER_POLICY)
+    return { settings: await operatorSettings(ctx).updateSettings(input, admitted) }
   },
 })
 

--- a/packages/operator-settings/src/voyant.ts
+++ b/packages/operator-settings/src/voyant.ts
@@ -148,9 +148,11 @@ export const operatorSettingsVoyantModule = defineModule({
   actions: [
     {
       id: "@voyant-travel/operator-settings#action.update-operator-settings",
+      capabilityId: "@voyant-travel/operator-settings#action.update-operator-settings",
       version: "v1",
       kind: "execute",
       targetType: "operator-settings",
+      commandTargetField: "settingsId",
       resource: "settings",
       action: "write",
       requiredScopes: ["settings:write"],
@@ -161,6 +163,7 @@ export const operatorSettingsVoyantModule = defineModule({
       availability: { status: "available" },
       effectBoundary: "local",
       targetLifecycle: "existing",
+      existingTarget: { durability: "handler-command-result-v1" },
       from: { tools: ["@voyant-travel/operator-settings#tool.update-operator-settings"] },
     },
   ],

--- a/packages/operator-settings/tests/unit/voyant-manifest.test.ts
+++ b/packages/operator-settings/tests/unit/voyant-manifest.test.ts
@@ -70,6 +70,7 @@ describe("operator-settings deployment manifest", () => {
           action: "write",
           ledger: "required",
           approval: "required",
+          existingTarget: { durability: "handler-command-result-v1" },
           from: { tools: ["@voyant-travel/operator-settings#tool.update-operator-settings"] },
         },
       ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4260,6 +4260,9 @@ importers:
       '@hono/zod-openapi':
         specifier: 'catalog:'
         version: 1.4.0(hono@4.12.25)(zod@4.4.3)
+      '@voyant-travel/action-ledger':
+        specifier: workspace:^
+        version: link:../action-ledger
       '@voyant-travel/commerce':
         specifier: workspace:^
         version: link:../commerce


### PR DESCRIPTION
Continues #4424 by removing `update_operator_settings` from generic approved execution.

- treats the operator settings aggregate as a server-owned singleton target
- binds approval consumption, durable claim, and all aggregate writes in one transaction
- exact retries replay the authoritative combined settings snapshot

Verification:
- `pnpm --filter @voyant-travel/operator-settings typecheck`
- `pnpm --filter @voyant-travel/operator-settings test` (45 passed)
- `pnpm --filter operator prepare:verify`