### PR TITLE
fix(navigation): make organization preferences durable

### DIFF
--- a/.changeset/cool-navigation-preferences.md
+++ b/.changeset/cool-navigation-preferences.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/navigation-preferences": patch
+---
+
+Make approved organization navigation preferences use durable singleton command replay.

--- a/packages/navigation-preferences/package.json
+++ b/packages/navigation-preferences/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@hono/zod-openapi": "catalog:",
+    "@voyant-travel/action-ledger": "workspace:^",
     "@voyant-travel/core": "workspace:^",
     "@voyant-travel/db": "workspace:^",
     "@voyant-travel/hono": "workspace:^",

--- a/packages/navigation-preferences/src/mcp-runtime.ts
+++ b/packages/navigation-preferences/src/mcp-runtime.ts
@@ -1,6 +1,17 @@
-import { defineToolContextContribution, ToolError } from "@voyant-travel/tools"
+import {
+  type ActionLedgerRequestContextValues,
+  executeAdmittedExistingTargetCommand,
+} from "@voyant-travel/action-ledger"
+import {
+  defineToolContextContribution,
+  ToolError,
+  type ToolHandlerActionPolicyContext,
+} from "@voyant-travel/tools"
 import { hasApiKeyPermission, permissionStringsToPermissions } from "@voyant-travel/types/api-keys"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import type { Context } from "hono"
 
+import type { NavigationVisibilityMap } from "./contracts.js"
 import {
   getNavigationPreferences,
   setMemberNavigationPreferences,
@@ -13,7 +24,8 @@ export * from "./tools.js"
 export function createNavigationPreferencesToolServices(
   db: Parameters<typeof getNavigationPreferences>[0],
   memberId: string,
-  scopes: readonly string[] = [],
+  scopes: readonly string[],
+  request: Context,
 ): NavigationPreferencesToolServices {
   return {
     async get() {
@@ -26,7 +38,37 @@ export function createNavigationPreferencesToolServices(
         ),
       }
     },
-    setOrganization: (visibility) => setOrganizationNavigationPreferences(db, visibility),
+    async setOrganization(visibility, admitted: ToolHandlerActionPolicyContext) {
+      let updated: NavigationVisibilityMap | undefined
+      const result = await executeAdmittedExistingTargetCommand(
+        {
+          db,
+          context: actionLedgerContext(request),
+          admitted,
+          commandInput: {
+            preferencesId: "organization-navigation-preferences",
+            visibility,
+          },
+          evaluatedRisk: "high",
+        },
+        {
+          async prepare(tx) {
+            updated = await setOrganizationNavigationPreferences(
+              tx as PostgresJsDatabase,
+              visibility,
+            )
+          },
+          execute() {
+            if (!updated) throw new Error("Navigation preference update produced no result")
+            return Promise.resolve(updated)
+          },
+          async replay() {
+            return (await getNavigationPreferences(db, memberId)).organization
+          },
+        },
+      )
+      return result.value
+    },
     setMember: (visibility) => setMemberNavigationPreferences(db, memberId, visibility),
   }
 }
@@ -53,10 +95,30 @@ export const voyantToolContextContribution = defineToolContextContribution({
         context.db as Parameters<typeof getNavigationPreferences>[0],
         memberId,
         scopes,
+        request as Context,
       ),
     }
   },
 })
+
+function actionLedgerContext(c: Context): ActionLedgerRequestContextValues {
+  const vars = c.var as Record<string, unknown>
+  return {
+    userId: (vars.userId as string | undefined) ?? null,
+    agentId: (vars.agentId as string | undefined) ?? null,
+    workflowPrincipalId: (vars.workflowPrincipalId as string | undefined) ?? null,
+    principalSubtype: (vars.principalSubtype as string | undefined) ?? null,
+    sessionId: (vars.sessionId as string | undefined) ?? null,
+    apiTokenId: ((vars.apiTokenId ?? vars.apiKeyId) as string | undefined) ?? null,
+    callerType: (vars.callerType as ActionLedgerRequestContextValues["callerType"]) ?? null,
+    actor: (vars.actor as ActionLedgerRequestContextValues["actor"]) ?? null,
+    isInternalRequest: (vars.isInternalRequest as boolean | undefined) ?? false,
+    organizationId: (vars.organizationId as string | undefined) ?? null,
+    workflowRunId: (vars.workflowRunId as string | undefined) ?? null,
+    workflowStepId: (vars.workflowStepId as string | undefined) ?? null,
+    correlationId: c.req.header("x-correlation-id") ?? c.req.header("x-request-id") ?? null,
+  }
+}
 
 function actingMemberRequiredNavigationPreferences(): NavigationPreferencesToolServices {
   const deny = async (): Promise<never> => {

--- a/packages/navigation-preferences/src/tools.ts
+++ b/packages/navigation-preferences/src/tools.ts
@@ -1,4 +1,12 @@
-import { defineTool, READ_ONLY_RISK, requireService, type ToolContext } from "@voyant-travel/tools"
+import {
+  admitHandlerActionPolicy,
+  defineTool,
+  type HandlerActionPolicyExpectation,
+  READ_ONLY_RISK,
+  requireService,
+  type ToolContext,
+  type ToolHandlerActionPolicyContext,
+} from "@voyant-travel/tools"
 import { z } from "zod"
 
 import {
@@ -11,9 +19,35 @@ import {
 
 const visibilityResultSchema = z.object({ visibility: navigationVisibilityMapSchema })
 
+export const SET_ORGANIZATION_NAVIGATION_PREFERENCES_HANDLER_POLICY = {
+  capabilityId:
+    "@voyant-travel/navigation-preferences#tool.set-organization-navigation-preferences",
+  capabilityVersion: "v1",
+  canonicalName: "set_organization_navigation_preferences",
+  actionPolicy: {
+    id: "@voyant-travel/navigation-preferences#action.set-organization-navigation-preferences",
+    capabilityId:
+      "@voyant-travel/navigation-preferences#action.set-organization-navigation-preferences",
+    version: "v1",
+    kind: "execute",
+    targetType: "organization-navigation-preferences",
+    commandTargetField: "preferencesId",
+    targetLifecycle: "existing",
+    existingTarget: { durability: "handler-command-result-v1" },
+    risk: "high",
+    ledger: "required",
+    approval: "required",
+    reversible: true,
+    allowedActorTypes: ["staff"],
+  },
+} as const satisfies HandlerActionPolicyExpectation
+
 export interface NavigationPreferencesToolServices {
   get(): Promise<NavigationPreferencesSnapshot>
-  setOrganization(visibility: NavigationVisibilityMap): Promise<NavigationVisibilityMap>
+  setOrganization(
+    visibility: NavigationVisibilityMap,
+    admitted: ToolHandlerActionPolicyContext,
+  ): Promise<NavigationVisibilityMap>
   setMember(visibility: NavigationVisibilityMap): Promise<NavigationVisibilityMap>
 }
 
@@ -66,8 +100,16 @@ export const setOrganizationNavigationPreferencesTool = defineTool<
     confirmationRequired: true,
     sideEffects: ["data-write"],
   },
+  annotations: { idempotentHint: true },
+  actionPolicyEnforcement: "handler",
   async handler({ visibility }, context) {
-    return { visibility: await navigationPreferences(context).setOrganization(visibility) }
+    const admitted = admitHandlerActionPolicy(
+      context,
+      SET_ORGANIZATION_NAVIGATION_PREFERENCES_HANDLER_POLICY,
+    )
+    return {
+      visibility: await navigationPreferences(context).setOrganization(visibility, admitted),
+    }
   },
 })
 

--- a/packages/navigation-preferences/src/voyant.ts
+++ b/packages/navigation-preferences/src/voyant.ts
@@ -119,9 +119,12 @@ export const navigationPreferencesVoyantModule = defineModule({
     },
     {
       id: "@voyant-travel/navigation-preferences#action.set-organization-navigation-preferences",
+      capabilityId:
+        "@voyant-travel/navigation-preferences#action.set-organization-navigation-preferences",
       version: "v1",
       kind: "execute",
       targetType: "organization-navigation-preferences",
+      commandTargetField: "preferencesId",
       resource: "admin-navigation",
       action: "write",
       requiredScopes: ["admin-navigation:write"],
@@ -133,6 +136,7 @@ export const navigationPreferencesVoyantModule = defineModule({
       availability: { status: "available" },
       effectBoundary: "local",
       targetLifecycle: "existing",
+      existingTarget: { durability: "handler-command-result-v1" },
       from: {
         tools: [
           "@voyant-travel/navigation-preferences#tool.set-organization-navigation-preferences",

--- a/packages/navigation-preferences/tests/unit/tools.test.ts
+++ b/packages/navigation-preferences/tests/unit/tools.test.ts
@@ -1,4 +1,8 @@
-import { createToolRegistry, type ToolContext } from "@voyant-travel/tools"
+import {
+  createToolRegistry,
+  type ToolContext,
+  type ToolHandlerActionPolicyContext,
+} from "@voyant-travel/tools"
 import { describe, expect, it, vi } from "vitest"
 
 import { voyantToolContextContribution } from "../../src/mcp-runtime.js"
@@ -7,6 +11,7 @@ import {
   type NavigationPreferencesToolContext,
   type NavigationPreferencesToolServices,
   navigationPreferencesTools,
+  SET_ORGANIZATION_NAVIGATION_PREFERENCES_HANDLER_POLICY,
   setMyNavigationPreferencesTool,
   setOrganizationNavigationPreferencesTool,
 } from "../../src/tools.js"
@@ -26,6 +31,7 @@ describe("navigation preference Tools", () => {
     expect(getNavigationPreferencesTool.audience?.allowed).toEqual(["staff"])
     expect(setOrganizationNavigationPreferencesTool.tier).toBe("sensitive")
     expect(setOrganizationNavigationPreferencesTool.riskPolicy.confirmationRequired).toBe(true)
+    expect(setOrganizationNavigationPreferencesTool.actionPolicyEnforcement).toBe("handler")
     expect(setMyNavigationPreferencesTool.tier).toBe("write")
   })
 
@@ -47,8 +53,36 @@ describe("navigation preference Tools", () => {
     }
 
     await expect(getNavigationPreferencesTool.handler({}, context)).resolves.toEqual(snapshot)
+    const registry = createToolRegistry()
+    registry.register(setOrganizationNavigationPreferencesTool, {
+      capabilityId: SET_ORGANIZATION_NAVIGATION_PREFERENCES_HANDLER_POLICY.capabilityId,
+      owner: "@voyant-travel/navigation-preferences",
+      capabilityVersion: SET_ORGANIZATION_NAVIGATION_PREFERENCES_HANDLER_POLICY.capabilityVersion,
+      name: SET_ORGANIZATION_NAVIGATION_PREFERENCES_HANDLER_POLICY.canonicalName,
+      requiredScopes: ["admin-navigation:write"],
+      deploymentRisk: "high",
+      actionPolicy: SET_ORGANIZATION_NAVIGATION_PREFERENCES_HANDLER_POLICY.actionPolicy,
+    })
+    const actionPolicy = registry.list()[0]?.actionPolicy
+    if (!actionPolicy) throw new Error("organization navigation action is missing")
     await expect(
-      setOrganizationNavigationPreferencesTool.handler({ visibility: { finance: false } }, context),
+      registry.dispatch(
+        "set_organization_navigation_preferences",
+        { visibility: { finance: false } },
+        {
+          ...context,
+          handlerActionPolicy: {
+            ...SET_ORGANIZATION_NAVIGATION_PREFERENCES_HANDLER_POLICY,
+            actionPolicy,
+            invocation: {
+              confirmed: true,
+              idempotencyKey: "navigation-update-1",
+              approvalId: "approval-1",
+              idempotencyFingerprint: "sha256:test",
+            },
+          } as ToolHandlerActionPolicyContext,
+        },
+      ),
     ).resolves.toEqual({ visibility: { finance: false } })
     await expect(
       setMyNavigationPreferencesTool.handler({ visibility: { finance: true } }, context),

--- a/packages/navigation-preferences/tests/unit/voyant-manifest.test.ts
+++ b/packages/navigation-preferences/tests/unit/voyant-manifest.test.ts
@@ -41,5 +41,8 @@ describe("navigation preferences manifest", () => {
       ["@voyant-travel/navigation-preferences#tool.set-organization-navigation-preferences"],
       ["@voyant-travel/navigation-preferences#tool.set-my-navigation-preferences"],
     ])
+    expect(navigationPreferencesVoyantModule.actions?.[1]).toMatchObject({
+      existingTarget: { durability: "handler-command-result-v1" },
+    })
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3870,6 +3870,9 @@ importers:
       '@hono/zod-openapi':
         specifier: 'catalog:'
         version: 1.4.0(hono@4.12.25)(zod@4.4.3)
+      '@voyant-travel/action-ledger':
+        specifier: workspace:^
+        version: link:../action-ledger
       '@voyant-travel/core':
         specifier: workspace:^
         version: link:../core


### PR DESCRIPTION
Continues #4424 by removing `set_organization_navigation_preferences` from generic approved execution.

- treats organization navigation defaults as a server-owned singleton target
- binds approval consumption, durable claim, and replacement write atomically
- exact retries return the authoritative organization visibility map

Verification:
- `pnpm --filter @voyant-travel/navigation-preferences typecheck`
- `pnpm --filter @voyant-travel/navigation-preferences test` (13 passed)
- `pnpm --filter operator prepare:verify`