### PR TITLE
fix(storefront): use FX provider in cache keys

### DIFF
--- a/.changeset/quiet-cats-fix-storefront.md
+++ b/.changeset/quiet-cats-fix-storefront.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/storefront": patch
+---
+
+Use the standardized FX provider provenance field when deriving public shopping cache keys.

--- a/packages/storefront/src/shopping/routes-public.ts
+++ b/packages/storefront/src/shopping/routes-public.ts
@@ -247,7 +247,7 @@ function convertedFxFreshness(result: z.infer<typeof storefrontShoppingResultSch
       if (!Number.isFinite(expires)) return { keys: [], validUntil: null }
       validUntil = validUntil === null ? expires : Math.min(validUntil, expires)
       keys.push(
-        [money.fx.authority, money.fx.quotedAt, money.fx.validUntil, money.fx.rate].join(":"),
+        [money.fx.provider, money.fx.quotedAt, money.fx.validUntil, money.fx.rate].join(":"),
       )
     }
   }


### PR DESCRIPTION
## Summary
- repair the main-branch storefront build after FX provenance renamed `authority` to `provider`
- preserve provider-sensitive cache-key derivation

## Verification
- `pnpm --filter @voyant-travel/storefront build` (exit 0, 0 TypeScript errors)

Fixes the shared CI blocker observed while executing #4424.