### PR TITLE
feat(storefront): wire managed live shopping providers

### DIFF
--- a/.changeset/quiet-pandas-shop.md
+++ b/.changeset/quiet-pandas-shop.md
@@ -1,0 +1,8 @@
+---
+"@voyant-travel/voyant-connect-adapter": minor
+"@voyant-travel/catalog": patch
+"@voyant-travel/accommodations": patch
+---
+
+Wire admitted Voyant Connect dynamic-package search into the managed Storefront
+shopping provider without exposing connection or credential selectors.

--- a/packages/accommodations/src/catalog-runtime-extension.ts
+++ b/packages/accommodations/src/catalog-runtime-extension.ts
@@ -8,6 +8,7 @@ import {
   accommodationPropertyReferenceCatalogPolicy,
 } from "./catalog-policy-properties.js"
 import { createRoomTypeDocumentBuilder } from "./service-catalog-plane.js"
+import { getAccommodationContent } from "./service-content.js"
 import {
   createAccommodationPropertyDocumentBuilder,
   listAccommodationOffersReferencingProperty,
@@ -24,4 +25,35 @@ export const catalogAccommodationsRuntimeExtension = {
   registerOwnedAvailabilitySearchHandler(registry) {
     registry.register(createAccommodationOwnedSearchHandler({}))
   },
+  async presentAvailabilityCandidate({ db, registry, candidate, locale, market, currency }) {
+    const resolved = await getAccommodationContent(
+      db,
+      candidate.entity_id,
+      { preferredLocales: [locale], market, currency },
+      { registry },
+    )
+    if (!resolved) return undefined
+    const selection = record(candidate.selection)
+    const roomTypeId = string(selection?.roomTypeId)
+    const ratePlanId = string(selection?.ratePlanId)
+    const room = resolved.content.room_types.find(({ id }) => id === roomTypeId)
+    const ratePlan = resolved.content.rate_plans.find(({ id }) => id === ratePlanId)
+    const imageUrl = room?.images[0] ?? resolved.content.hotel.hero_image_url ?? undefined
+    return {
+      title: resolved.content.hotel.name,
+      ...(room?.name ? { roomName: room.name } : {}),
+      ...(ratePlan?.name ? { boardName: ratePlan.name } : {}),
+      ...(imageUrl ? { image: { url: imageUrl, alt: resolved.content.hotel.name } } : {}),
+    }
+  },
 } satisfies CatalogAccommodationsRuntimeExtension
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined
+}
+
+function string(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined
+}

--- a/packages/catalog/src/runtime-contracts.ts
+++ b/packages/catalog/src/runtime-contracts.ts
@@ -1,3 +1,4 @@
+import type { AvailabilityCandidate } from "@voyant-travel/catalog-contracts/adapter/contract"
 import type {
   OfferPreviewOutcomeV1,
   OfferPreviewRequestV1,
@@ -73,6 +74,22 @@ export interface CatalogAccommodationsRuntimeExtension extends CatalogPolicyRunt
     host: CatalogOwnedBookingHandlerHost,
   ): void
   registerOwnedAvailabilitySearchHandler(registry: OwnedAvailabilitySearchHandlerRegistry): void
+  presentAvailabilityCandidate?(input: {
+    db: AnyDrizzleDb
+    registry: SourceAdapterRegistry
+    candidate: AvailabilityCandidate
+    locale: string
+    market: string
+    currency: string
+  }): Promise<
+    | {
+        title: string
+        roomName?: string
+        boardName?: string
+        image?: { url: string; alt?: string }
+      }
+    | undefined
+  >
 }
 
 export interface CatalogChartersRuntimeExtension extends CatalogPolicyRuntimeExtension {}
@@ -327,6 +344,22 @@ export interface CatalogRuntimeServices {
   getOwnedHandlers(env: Readonly<Record<string, unknown>>): OwnedBookingHandlerRegistry
   getOwnedHandlersFromContext(context: unknown): OwnedBookingHandlerRegistry
   getOwnedAvailabilitySearchHandlers(): OwnedAvailabilitySearchHandlerRegistry
+  presentAvailabilityCandidate?(input: {
+    db: AnyDrizzleDb
+    registry: SourceAdapterRegistry
+    candidate: AvailabilityCandidate
+    locale: string
+    market: string
+    currency: string
+  }): Promise<
+    | {
+        title: string
+        roomName?: string
+        boardName?: string
+        image?: { url: string; alt?: string }
+      }
+    | undefined
+  >
   registerCompositeBookingSessionHandler?(handler: BookingSessionCompositeHandler): void
   getCompositeBookingSessionHandler?(): BookingSessionCompositeHandler | undefined
   buildEmbeddingProvider(env: Readonly<Record<string, unknown>>): EmbeddingProvider | undefined

--- a/packages/catalog/src/runtime.ts
+++ b/packages/catalog/src/runtime.ts
@@ -98,6 +98,7 @@ export function createCatalogRuntime(
     resolvePaymentAdapter: options.resolvePaymentAdapter,
     ...(options.analytics ? { analytics: options.analytics } : {}),
   })
+  const presentAvailabilityCandidate = extensions.accommodations.presentAvailabilityCandidate
   const services: CatalogRuntimeServices = {
     defaultSlices: DEFAULT_SLICES,
     ensureSourceRegistry: (env) => ensureBookingEngineRegistry(env as never),
@@ -107,6 +108,11 @@ export function createCatalogRuntime(
     getOwnedHandlersFromContext: (context) =>
       getOwnedBookingHandlerRegistryFromContext(context as never),
     getOwnedAvailabilitySearchHandlers: () => ownedAvailabilitySearchHandlers,
+    ...(presentAvailabilityCandidate
+      ? {
+          presentAvailabilityCandidate: (input) => presentAvailabilityCandidate(input),
+        }
+      : {}),
     registerCompositeBookingSessionHandler(handler) {
       if (compositeBookingSessionHandler && compositeBookingSessionHandler !== handler) {
         throw new Error("A composite Booking Session handler is already registered")

--- a/packages/storefront/src/runtime-contributor.ts
+++ b/packages/storefront/src/runtime-contributor.ts
@@ -13,11 +13,14 @@ import type { VoyantRuntimeHostPrimitives } from "@voyant-travel/core"
 import type { VoyantPort } from "@voyant-travel/core/project"
 import { createStorefrontCustomerBusinessOnboardingRuntime } from "./customer-business-onboarding-runtime.js"
 import { storefrontCustomerPortalRuntimePort, storefrontOffersRuntimePort } from "./runtime-port.js"
+import { createClosedStorefrontShoppingLiveProvider } from "./shopping/closed-live-provider.js"
 import { createClosedStorefrontShoppingAdapters } from "./shopping/closed-provider-adapters.js"
 import { createManagedStorefrontShoppingRuntime } from "./shopping/managed-runtime.js"
 import {
+  type StorefrontDynamicPackageSourceProvider,
   type StorefrontOpaqueReferenceIssuer,
   type StorefrontShoppingLiveProvider,
+  storefrontDynamicPackageSourceProviderPort,
   storefrontOpaqueReferenceIssuerPort,
   storefrontPresentationFxProviderPort,
   storefrontShoppingLiveProviderPort,
@@ -37,7 +40,6 @@ export function createStorefrontRuntimePortContribution(
   const managedShoppingDependencies = [
     catalogSearchRuntimePort,
     catalogRuntimeServicesPort,
-    storefrontShoppingLiveProviderPort,
     storefrontOpaqueReferenceIssuerPort,
   ] as const
   const canProvideManagedShopping =
@@ -60,24 +62,50 @@ export function createStorefrontRuntimePortContribution(
           [storefrontShoppingRuntimePort.id]: Promise.all([
             getRuntimePort?.<CatalogSearchRuntimeOptions>(catalogSearchRuntimePort),
             getRuntimePort?.<CatalogRuntimeServices>(catalogRuntimeServicesPort),
-            getRuntimePort?.<StorefrontShoppingLiveProvider>(storefrontShoppingLiveProviderPort),
+            host.hasRuntimePort?.(storefrontShoppingLiveProviderPort)
+              ? getRuntimePort?.<StorefrontShoppingLiveProvider>(storefrontShoppingLiveProviderPort)
+              : undefined,
+            host.hasRuntimePort?.(storefrontDynamicPackageSourceProviderPort)
+              ? getRuntimePort?.<StorefrontDynamicPackageSourceProvider>(
+                  storefrontDynamicPackageSourceProviderPort,
+                )
+              : undefined,
             getRuntimePort?.<StorefrontOpaqueReferenceIssuer>(storefrontOpaqueReferenceIssuerPort),
             host.hasRuntimePort?.(storefrontPresentationFxProviderPort)
               ? getRuntimePort?.<PresentationFxQuoter>(storefrontPresentationFxProviderPort)
               : undefined,
-          ]).then(([catalogSearch, catalogServices, live, references, quoteFx]) => {
-            const adapters = createClosedStorefrontShoppingAdapters({
-              primitives: host.primitives,
-              catalogSearch: catalogSearch as CatalogSearchRuntimeOptions,
-              catalogServices: catalogServices as CatalogRuntimeServices,
-            })
-            return createManagedStorefrontShoppingRuntime({
-              ...adapters,
-              live: live as StorefrontShoppingLiveProvider,
-              references: references as StorefrontOpaqueReferenceIssuer,
-              ...(quoteFx ? { quoteFx } : {}),
-            })
-          }),
+          ]).then(
+            ([
+              catalogSearch,
+              catalogServices,
+              configuredLive,
+              packageSources,
+              references,
+              quoteFx,
+            ]) => {
+              const adapters = createClosedStorefrontShoppingAdapters({
+                primitives: host.primitives,
+                catalogSearch: catalogSearch as CatalogSearchRuntimeOptions,
+                catalogServices: catalogServices as CatalogRuntimeServices,
+              })
+              const live =
+                configuredLive ??
+                createClosedStorefrontShoppingLiveProvider({
+                  primitives: host.primitives,
+                  catalogServices: catalogServices as CatalogRuntimeServices,
+                  markets: adapters.markets,
+                  ...(packageSources
+                    ? { packages: packageSources as StorefrontDynamicPackageSourceProvider }
+                    : {}),
+                })
+              return createManagedStorefrontShoppingRuntime({
+                ...adapters,
+                live,
+                references: references as StorefrontOpaqueReferenceIssuer,
+                ...(quoteFx ? { quoteFx } : {}),
+              })
+            },
+          ),
         }
       : {}),
   }

--- a/packages/storefront/src/shopping/closed-live-provider.ts
+++ b/packages/storefront/src/shopping/closed-live-provider.ts
@@ -1,0 +1,117 @@
+import type { CatalogRuntimeServices } from "@voyant-travel/catalog/runtime-contracts"
+import type { VoyantRuntimeHostPrimitives } from "@voyant-travel/core"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import { createStorefrontShoppingLiveProvider } from "./live-provider.js"
+import type {
+  StorefrontDynamicPackageSourceProvider,
+  StorefrontShoppingLiveProvider,
+  StorefrontShoppingMarketProvider,
+} from "./provider-ports.js"
+import { StorefrontShoppingUnavailableError } from "./runtime.js"
+import type { StorefrontShoppingContext } from "./runtime-port.js"
+import type { StorefrontResolvedScope } from "./schemas.js"
+
+export interface ClosedStorefrontShoppingLiveProviderOptions {
+  primitives: VoyantRuntimeHostPrimitives
+  catalogServices: CatalogRuntimeServices
+  markets: StorefrontShoppingMarketProvider
+  packages?: StorefrontDynamicPackageSourceProvider
+  loadStayPresentation?: CatalogRuntimeServices["presentAvailabilityCandidate"]
+}
+
+/**
+ * Production live-shopping composition over the graph-admitted Catalog
+ * runtime. Flights deliberately remain absent: Flights currently exposes a
+ * request-bound single adapter, not an admitted multi-adapter discovery seam.
+ */
+export function createClosedStorefrontShoppingLiveProvider(
+  options: ClosedStorefrontShoppingLiveProviderOptions,
+): StorefrontShoppingLiveProvider {
+  const present =
+    options.loadStayPresentation ?? options.catalogServices.presentAvailabilityCandidate
+
+  return createStorefrontShoppingLiveProvider({
+    stays: {
+      async resolve(input) {
+        await assertActiveScope(options.markets, input.context, input.scope)
+        const env = options.primitives.env(undefined)
+        const registry = await options.catalogServices.ensureSourceRegistry(env)
+        const adapters = registry.connections().flatMap((connectionId) => {
+          const adapter = registry.resolveByConnection(connectionId)
+          if (
+            !adapter?.capabilities.verticals.includes("accommodations") ||
+            adapter.capabilities.supportsAvailabilitySearch !== true ||
+            typeof adapter.searchAvailability !== "function"
+          ) {
+            return []
+          }
+          return [{ connectionId, adapter }]
+        })
+        const owned = options.catalogServices.getOwnedAvailabilitySearchHandlers()
+        const db = options.primitives.database.resolve<PostgresJsDatabase>(undefined)
+        return {
+          adapters,
+          ownedHandlers: owned.modules().flatMap((entityModule) => {
+            if (entityModule !== "accommodations") return []
+            const handler = owned.resolve(entityModule)
+            return handler
+              ? [
+                  {
+                    handler,
+                    context: {
+                      db,
+                      adapterContext: { connection_id: `owned:${entityModule}` },
+                    },
+                  },
+                ]
+              : []
+          }),
+        }
+      },
+      async present(input) {
+        if (!present) return undefined
+        await assertActiveScope(options.markets, input.context, input.scope)
+        const registry = await options.catalogServices.ensureSourceRegistry(
+          options.primitives.env(undefined),
+        )
+        return present({
+          db: options.primitives.database.resolve<PostgresJsDatabase>(undefined),
+          registry,
+          candidate: input.candidate,
+          locale: input.scope.locale,
+          market: input.scope.marketId,
+          currency: input.scope.currency,
+        })
+      },
+    },
+    ...(options.packages
+      ? {
+          packages: {
+            async resolveSources(input) {
+              await assertActiveScope(options.markets, input.context, input.scope)
+              return options.packages?.resolveSources(input) ?? []
+            },
+          },
+        }
+      : {}),
+  })
+}
+
+async function assertActiveScope(
+  markets: StorefrontShoppingMarketProvider,
+  context: StorefrontShoppingContext,
+  scope: StorefrontResolvedScope,
+): Promise<void> {
+  const active = await markets.listActiveMarkets({
+    storefrontId: context.storefrontId,
+    channelId: context.channelId,
+  })
+  const market = active.find(({ id }) => id === scope.marketId)
+  if (
+    !market?.locales.includes(scope.locale) ||
+    !market.currencies.map((currency) => currency.toUpperCase()).includes(scope.currency)
+  ) {
+    throw new StorefrontShoppingUnavailableError("active market scope")
+  }
+}

--- a/packages/storefront/src/shopping/index.ts
+++ b/packages/storefront/src/shopping/index.ts
@@ -1,3 +1,4 @@
+export * from "./closed-live-provider.js"
 export * from "./closed-provider-adapters.js"
 export * from "./live-provider.js"
 export * from "./managed-runtime.js"

--- a/packages/storefront/src/shopping/live-provider.ts
+++ b/packages/storefront/src/shopping/live-provider.ts
@@ -10,6 +10,8 @@ import {
   type MergedFlightOffer,
 } from "@voyant-travel/flights"
 import type {
+  StorefrontDynamicPackageSource,
+  StorefrontDynamicPackageSourceProvider,
   StorefrontInternalPackageOffer,
   StorefrontInternalStayOffer,
   StorefrontLiveSearchPage,
@@ -18,6 +20,12 @@ import type {
 } from "./provider-ports.js"
 import type { StorefrontShoppingContext } from "./runtime-port.js"
 import type { StorefrontResolvedScope, StorefrontShoppingIntent } from "./schemas.js"
+
+export type {
+  StorefrontDynamicPackageSource,
+  StorefrontDynamicPackageSourceOffer,
+  StorefrontDynamicPackageSourceProvider,
+} from "./provider-ports.js"
 
 type FlightIntent = Extract<StorefrontShoppingIntent, { kind: "flight" }>
 type StayIntent = Extract<StorefrontShoppingIntent, { kind: "stay" }>
@@ -59,56 +67,13 @@ export interface StorefrontLiveStayFanOutResolver {
   ): Promise<StorefrontStayPresentation | undefined>
 }
 
-export interface StorefrontDynamicPackageSourceOffer {
-  nativePrice: { amount: string; currency: string }
-  title: string
-  origin: string
-  destination: string
-  departureDate: string
-  nights: number
-  accommodationName: string
-  boardName?: string
-  image?: { url: string; alt?: string }
-  expiresAt?: string
-  selection: Readonly<Record<string, unknown>>
-  providerData?: Readonly<Record<string, unknown>>
-}
-
-export interface StorefrontDynamicPackageSource {
-  /** The source is a closure over its Connect connection and credentials. */
-  search(input: {
-    origin: string
-    destination: PackageIntent["destination"]
-    departureDateFrom: string
-    departureDateTo: string
-    nights: { min: number; max: number }
-    occupancy: { adults: number; children?: number; childrenAges?: number[]; infants?: number }
-    boards?: string[]
-    minStars?: number
-    pagination?: { cursor?: string; limit?: number }
-    scope: Pick<StorefrontResolvedScope, "marketId" | "locale" | "currency">
-  }): Promise<{
-    offers: readonly StorefrontDynamicPackageSourceOffer[]
-    status?: "ok" | "partial" | "empty"
-  }>
-}
-
-/**
- * Closed Connect source resolver. No connection, provider, operator, or vendor
- * selector is accepted from the shopping intent.
- */
-export interface StorefrontDynamicPackageConnectPort {
-  resolveSources(
-    input: Omit<TrustedShoppingInput<PackageIntent>, "intent"> & {
-      destination: PackageIntent["destination"]
-    },
-  ): Promise<readonly StorefrontDynamicPackageSource[]>
-}
+/** @deprecated Use the provider-neutral source-provider name. */
+export type StorefrontDynamicPackageConnectPort = StorefrontDynamicPackageSourceProvider
 
 export interface CreateStorefrontShoppingLiveProviderOptions {
   flights?: StorefrontLiveFlightFanOutResolver
   stays?: StorefrontLiveStayFanOutResolver
-  packages?: StorefrontDynamicPackageConnectPort
+  packages?: StorefrontDynamicPackageSourceProvider
   perSourceTimeoutMs?: number
 }
 

--- a/packages/storefront/src/shopping/provider-ports.ts
+++ b/packages/storefront/src/shopping/provider-ports.ts
@@ -65,6 +65,52 @@ type FlightIntent = Extract<StorefrontShoppingIntent, { kind: "flight" }>
 type StayIntent = Extract<StorefrontShoppingIntent, { kind: "stay" }>
 type PackageIntent = Extract<StorefrontShoppingIntent, { kind: "package" }>
 
+export interface StorefrontDynamicPackageSourceOffer {
+  nativePrice: { amount: string; currency: string }
+  title: string
+  origin: string
+  destination: string
+  departureDate: string
+  nights: number
+  accommodationName: string
+  boardName?: string
+  image?: { url: string; alt?: string }
+  expiresAt?: string
+  selection: Readonly<Record<string, unknown>>
+  providerData?: Readonly<Record<string, unknown>>
+}
+
+export interface StorefrontDynamicPackageSource {
+  /** The source is a closure over its admitted connection(s) and credentials. */
+  search(input: {
+    origin: string
+    destination: PackageIntent["destination"]
+    departureDateFrom: string
+    departureDateTo: string
+    nights: { min: number; max: number }
+    occupancy: { adults: number; children?: number; childrenAges?: number[]; infants?: number }
+    boards?: string[]
+    minStars?: number
+    pagination?: { cursor?: string; limit?: number }
+    scope: Pick<StorefrontResolvedScope, "marketId" | "locale" | "currency">
+  }): Promise<{
+    offers: readonly StorefrontDynamicPackageSourceOffer[]
+    status?: "ok" | "partial" | "empty"
+  }>
+}
+
+/**
+ * Closed deployment source resolver. Implementations derive their operator,
+ * connection admission, and credentials from server-owned configuration.
+ */
+export interface StorefrontDynamicPackageSourceProvider {
+  resolveSources(input: {
+    context: StorefrontShoppingContext
+    scope: StorefrontResolvedScope
+    destination: PackageIntent["destination"]
+  }): Promise<readonly StorefrontDynamicPackageSource[]>
+}
+
 export type StorefrontLiveSourceStatus =
   | "ok"
   | "partial"
@@ -171,6 +217,11 @@ export const storefrontShoppingLiveProviderPort = methodsPort<StorefrontShopping
   "storefront.shopping.live-provider",
   ["searchFlights", "searchStays", "searchPackages"],
 )
+export const storefrontDynamicPackageSourceProviderPort =
+  methodsPort<StorefrontDynamicPackageSourceProvider>(
+    "storefront.shopping.dynamic-package-source-provider",
+    ["resolveSources"],
+  )
 export const storefrontPresentationFxProviderPort = definePort<PresentationFxQuoter>({
   id: "storefront.shopping.presentation-fx",
   test(provider) {

--- a/packages/storefront/src/shopping/runtime-port.ts
+++ b/packages/storefront/src/shopping/runtime-port.ts
@@ -10,6 +10,10 @@ import type {
   StorefrontTripSelectionUpdate,
 } from "./schemas.js"
 
+// Package manifests consume graph-safe provider contracts through this
+// dedicated runtime-port surface rather than the runtime-heavy provider module.
+export { storefrontDynamicPackageSourceProviderPort } from "./provider-ports.js"
+
 /** Server-derived authority. It must never be accepted from a browser body. */
 export interface StorefrontShoppingContext {
   storefrontId: string

--- a/packages/storefront/src/voyant.ts
+++ b/packages/storefront/src/voyant.ts
@@ -26,6 +26,7 @@ import {
   storefrontVerificationRuntimePort,
 } from "./runtime-port.js"
 import {
+  storefrontDynamicPackageSourceProviderPort,
   storefrontOpaqueReferenceIssuerPort,
   storefrontPresentationFxProviderPort,
   storefrontShoppingLiveProviderPort,
@@ -441,7 +442,8 @@ export const storefrontShoppingProviderVoyantModule = defineModule({
   runtimePorts: [
     catalogSearchRuntimePortReference,
     requirePort(catalogRuntimeServicesPort),
-    requirePort(storefrontShoppingLiveProviderPort),
+    requirePort(storefrontShoppingLiveProviderPort, { optional: true }),
+    requirePort(storefrontDynamicPackageSourceProviderPort, { optional: true }),
     requirePort(storefrontOpaqueReferenceIssuerPort),
     requirePort(storefrontPresentationFxProviderPort, { optional: true }),
   ],

--- a/packages/storefront/tests/unit/closed-live-provider.test.ts
+++ b/packages/storefront/tests/unit/closed-live-provider.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { createClosedStorefrontShoppingLiveProvider } from "../../src/shopping/closed-live-provider.js"
+
+const context = { storefrontId: "sf_1", channelId: "ch_1" }
+const scope = {
+  marketId: "market_ro",
+  locale: "ro-RO",
+  currency: "EUR",
+  available: { marketIds: ["market_ro"], locales: ["ro-RO"], currencies: ["EUR"] },
+}
+
+function primitives() {
+  return {
+    env: vi.fn(() => ({ SERVER_SECRET: "credential_secret" })),
+    database: { resolve: vi.fn(() => ({ id: "db" })) },
+    storage: {},
+    events: {},
+    config: {},
+  } as never
+}
+
+function markets(active = true) {
+  return {
+    listActiveMarkets: vi.fn(async () =>
+      active
+        ? [
+            {
+              id: "market_ro",
+              defaultLocale: "ro-RO",
+              defaultCurrency: "EUR",
+              locales: ["ro-RO"],
+              currencies: ["EUR"],
+            },
+          ]
+        : [],
+    ),
+  }
+}
+
+describe("closed Storefront live provider", () => {
+  it("fans out only admitted stay-capable adapters and the owned accommodations handler", async () => {
+    const sourcedSearch = vi.fn(async () => ({
+      status: "ok" as const,
+      candidates: [
+        {
+          candidateRef: "stay_1",
+          entity_module: "accommodations",
+          entity_id: "hotel_1",
+          selection: { roomTypeId: "room_1", ratePlanId: "rate_1" },
+          price: { amount: "300.00", currency: "EUR" },
+        },
+      ],
+    }))
+    const ignoredSearch = vi.fn()
+    const ownedSearch = vi.fn(async () => ({ candidates: [], status: "empty" as const }))
+    const adapters = new Map([
+      [
+        "stay_connection",
+        {
+          capabilities: {
+            verticals: ["accommodations"],
+            supportsAvailabilitySearch: true,
+          },
+          searchAvailability: sourcedSearch,
+        },
+      ],
+      [
+        "cruise_connection",
+        {
+          capabilities: { verticals: ["cruises"], supportsAvailabilitySearch: true },
+          searchAvailability: ignoredSearch,
+        },
+      ],
+    ])
+    const registry = {
+      connections: () => [...adapters.keys()],
+      resolveByConnection: (id: string) => adapters.get(id),
+    }
+    const catalogServices = {
+      ensureSourceRegistry: vi.fn(async () => registry),
+      getOwnedAvailabilitySearchHandlers: () => ({
+        modules: () => ["accommodations"],
+        resolve: () => ({ entityModule: "accommodations", searchAvailability: ownedSearch }),
+      }),
+    }
+    const provider = createClosedStorefrontShoppingLiveProvider({
+      primitives: primitives(),
+      catalogServices: catalogServices as never,
+      markets: markets(),
+      loadStayPresentation: vi.fn(async () => ({
+        title: "Hotel Public",
+        roomName: "Public room",
+      })),
+    })
+
+    const result = await provider.searchStays({
+      context,
+      scope,
+      intent: {
+        kind: "stay",
+        destination: { city: "Rome" },
+        checkIn: "2026-09-10",
+        checkOut: "2026-09-15",
+        rooms: [{ adults: 2 }],
+      },
+    })
+
+    expect(sourcedSearch).toHaveBeenCalledOnce()
+    expect(ownedSearch).toHaveBeenCalledOnce()
+    expect(ignoredSearch).not.toHaveBeenCalled()
+    expect(result.items).toEqual([
+      expect.objectContaining({ title: "Hotel Public", roomName: "Public room" }),
+    ])
+    expect(JSON.stringify(result)).not.toContain("credential_secret")
+  })
+
+  it("rejects an inactive storefront/channel before resolving supply", async () => {
+    const ensureSourceRegistry = vi.fn()
+    const provider = createClosedStorefrontShoppingLiveProvider({
+      primitives: primitives(),
+      catalogServices: {
+        ensureSourceRegistry,
+        getOwnedAvailabilitySearchHandlers: vi.fn(),
+      } as never,
+      markets: markets(false),
+    })
+    await expect(
+      provider.searchStays({
+        context,
+        scope,
+        intent: {
+          kind: "stay",
+          destination: { city: "Rome" },
+          checkIn: "2026-09-10",
+          checkOut: "2026-09-15",
+          rooms: [{ adults: 2 }],
+        },
+      }),
+    ).rejects.toThrow("active market scope")
+    expect(ensureSourceRegistry).not.toHaveBeenCalled()
+  })
+
+  it("keeps flights unavailable while no admitted flight adapter resolver exists", async () => {
+    const provider = createClosedStorefrontShoppingLiveProvider({
+      primitives: primitives(),
+      catalogServices: {} as never,
+      markets: markets(),
+    })
+    await expect(
+      provider.searchFlights({
+        context,
+        scope,
+        intent: {
+          kind: "flight",
+          slices: [{ origin: "OTP", destination: "FCO", departureDate: "2026-09-10" }],
+          travelers: { adults: 2 },
+        },
+      }),
+    ).resolves.toEqual({ items: [], sources: [{ status: "unavailable" }] })
+  })
+})

--- a/packages/storefront/tests/unit/customer-business-onboarding-runtime-contributor.test.ts
+++ b/packages/storefront/tests/unit/customer-business-onboarding-runtime-contributor.test.ts
@@ -4,10 +4,7 @@ import { catalogRuntimeServicesPort } from "@voyant-travel/catalog/runtime-contr
 import { describe, expect, it, vi } from "vitest"
 
 import { createStorefrontRuntimePortContribution } from "../../src/runtime-contributor.js"
-import {
-  storefrontOpaqueReferenceIssuerPort,
-  storefrontShoppingLiveProviderPort,
-} from "../../src/shopping/provider-ports.js"
+import { storefrontOpaqueReferenceIssuerPort } from "../../src/shopping/provider-ports.js"
 import { storefrontShoppingRuntimePort } from "../../src/shopping/runtime-port.js"
 
 function primitives() {
@@ -51,14 +48,10 @@ describe("storefront customer business onboarding runtime contribution", () => {
     expect(ports).not.toHaveProperty(storefrontShoppingRuntimePort.id)
   })
 
-  it("contributes managed shopping after every closed dependency is configured", async () => {
+  it("contributes the closed live provider without a browser-selected provider port", async () => {
     const providers = new Map<string, unknown>([
       [catalogSearchRuntimePort.id, { resolveRuntime: vi.fn() }],
       [catalogRuntimeServicesPort.id, { fieldPolicyRegistries: vi.fn() }],
-      [
-        storefrontShoppingLiveProviderPort.id,
-        { searchFlights: vi.fn(), searchStays: vi.fn(), searchPackages: vi.fn() },
-      ],
       [storefrontOpaqueReferenceIssuerPort.id, { issue: vi.fn() }],
     ])
     const ports = createStorefrontRuntimePortContribution({

--- a/packages/storefront/tests/unit/voyant-manifest.test.ts
+++ b/packages/storefront/tests/unit/voyant-manifest.test.ts
@@ -13,6 +13,7 @@ import {
   storefrontPaymentReconciliationJobRuntimePort,
 } from "../../src/runtime-port.js"
 import {
+  storefrontDynamicPackageSourceProviderPort,
   storefrontOpaqueReferenceIssuerPort,
   storefrontPresentationFxProviderPort,
   storefrontShoppingLiveProviderPort,
@@ -46,7 +47,8 @@ describe("storefront deployment manifest", () => {
       runtimePorts: [
         { id: "catalog.search-runtime" },
         { id: catalogRuntimeServicesPort.id },
-        { id: storefrontShoppingLiveProviderPort.id },
+        { id: storefrontShoppingLiveProviderPort.id, optional: true },
+        { id: storefrontDynamicPackageSourceProviderPort.id, optional: true },
         { id: storefrontOpaqueReferenceIssuerPort.id },
         { id: storefrontPresentationFxProviderPort.id, optional: true },
       ],

--- a/packages/voyant-connect-adapter/package.json
+++ b/packages/voyant-connect-adapter/package.json
@@ -38,8 +38,10 @@
     "@voyant-travel/connect-adapter": "^0.5.0",
     "@voyant-travel/connect-cruises": "^0.6.2",
     "@voyant-travel/connect-sdk": "^0.10.0",
+    "@voyant-travel/core": "workspace:^",
     "@voyant-travel/data-sdk": "^0.8.0",
-    "@voyant-travel/graph-contracts": "workspace:^"
+    "@voyant-travel/graph-contracts": "workspace:^",
+    "@voyant-travel/storefront": "workspace:^"
   },
   "peerDependencies": {
     "@voyant-travel/catalog": "workspace:^",

--- a/packages/voyant-connect-adapter/src/index.ts
+++ b/packages/voyant-connect-adapter/src/index.ts
@@ -32,3 +32,4 @@ export {
   type VoyantConnectSourceRegistration,
   type VoyantConnectSourcesOptions,
 } from "./sources.js"
+export { createVoyantConnectStorefrontPackageSourceProvider } from "./storefront-package-sources.js"

--- a/packages/voyant-connect-adapter/src/runtime-contributor.ts
+++ b/packages/voyant-connect-adapter/src/runtime-contributor.ts
@@ -1,10 +1,21 @@
 import { catalogSourcesRuntimeExtensionPort } from "@voyant-travel/catalog/runtime-contracts"
+import type { VoyantRuntimeHostPrimitives } from "@voyant-travel/core"
+import { storefrontDynamicPackageSourceProviderPort } from "@voyant-travel/storefront/shopping/provider-ports"
 
 import { createVoyantConnectCatalogSourcesExtension } from "./catalog-sources-extension.js"
+import { createVoyantConnectStorefrontPackageSourceProvider } from "./storefront-package-sources.js"
+
+export interface VoyantConnectRuntimeContributorHost {
+  primitives: VoyantRuntimeHostPrimitives
+}
 
 /** Bind Voyant Connect as the deployment's catalog inventory channel. */
-export function createVoyantConnectRuntimePortContribution(): Readonly<Record<string, unknown>> {
+export function createVoyantConnectRuntimePortContribution(
+  host: VoyantConnectRuntimeContributorHost,
+): Readonly<Record<string, unknown>> {
   return {
     [catalogSourcesRuntimeExtensionPort.id]: createVoyantConnectCatalogSourcesExtension(),
+    [storefrontDynamicPackageSourceProviderPort.id]:
+      createVoyantConnectStorefrontPackageSourceProvider(host.primitives),
   }
 }

--- a/packages/voyant-connect-adapter/src/storefront-package-sources.test.ts
+++ b/packages/voyant-connect-adapter/src/storefront-package-sources.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const searchAcrossProviders = vi.fn()
+
+vi.mock("@voyant-travel/connect-sdk", () => ({
+  createVoyantConnectClient: vi.fn(() => ({ packages: { searchAcrossProviders } })),
+}))
+
+import { createVoyantConnectStorefrontPackageSourceProvider } from "./storefront-package-sources.js"
+
+function primitives(env: Record<string, unknown>) {
+  return {
+    env: vi.fn(() => env),
+    database: {},
+    storage: {},
+    events: {},
+    config: {},
+  } as never
+}
+
+const input = {
+  origin: "OTP",
+  destination: { countryCode: "IT", city: "Rome" },
+  departureDateFrom: "2026-09-01",
+  departureDateTo: "2026-09-30",
+  nights: { min: 5, max: 7 },
+  occupancy: { adults: 2, children: 1, childrenAges: [9] },
+  boards: ["AI"],
+  pagination: { cursor: "opaque-cursor", limit: 20 },
+  scope: {
+    marketId: "market_ro",
+    locale: "ro-RO",
+    currency: "EUR",
+    available: {
+      marketIds: ["market_ro"],
+      locales: ["ro-RO"],
+      currencies: ["EUR"],
+    },
+  },
+}
+
+describe("Voyant Connect Storefront package sources", () => {
+  beforeEach(() => searchAcrossProviders.mockReset())
+
+  it("keeps credentials and connection identity behind the opaque selection", async () => {
+    searchAcrossProviders.mockResolvedValue({
+      offers: [
+        {
+          id: "offer_secret",
+          connectionId: "connection_secret",
+          supplierId: "supplier_secret",
+          productRef: { entityModule: "products", entityId: "product_secret" },
+          title: "Rome escape",
+          stay: {
+            ref: { entityModule: "accommodations", entityId: "hotel_secret" },
+            name: "Hotel Public",
+            board: "AI",
+            checkIn: "2026-09-10",
+            checkOut: "2026-09-15",
+            nights: 5,
+            occupancy: { adults: 2 },
+          },
+          flights: [
+            {
+              origin: "OTP",
+              destination: "FCO",
+              departureAt: "2026-09-10T07:00:00.000Z",
+            },
+          ],
+          pricing: {
+            perPerson: { amountMinor: 50000, currency: "EUR", currencyPrecision: 2 },
+            total: { amountMinor: 100000, currency: "EUR", currencyPrecision: 2 },
+          },
+          cancellationPolicy: { refundable: false, penalties: [] },
+          expiresAt: "2026-08-08T10:05:00.000Z",
+        },
+      ],
+      connectionDiagnostics: [{ connectionId: "connection_secret", status: "ok" }],
+    })
+    const provider = createVoyantConnectStorefrontPackageSourceProvider(
+      primitives({ VOYANT_API_KEY: "credential_secret", VOYANT_CONNECT_OPERATOR_ID: "op_1" }),
+    )
+    const sources = await provider.resolveSources({
+      context: { storefrontId: "sf_1", channelId: "ch_1" },
+      scope: input.scope,
+      destination: input.destination,
+    })
+    const result = await sources[0]?.search(input)
+
+    expect(searchAcrossProviders).toHaveBeenCalledWith(
+      expect.objectContaining({
+        departure: { airportCodes: ["OTP"] },
+        destination: { countryCode: "IT", city: "Rome" },
+        flightIncluded: true,
+      }),
+      { operatorId: "op_1" },
+    )
+    expect(result).toMatchObject({
+      status: "ok",
+      offers: [
+        {
+          nativePrice: { amount: "1000.00", currency: "EUR" },
+          title: "Rome escape",
+          accommodationName: "Hotel Public",
+          boardName: "AI",
+        },
+      ],
+    })
+    expect(JSON.stringify(result)).not.toContain("credential_secret")
+    expect(result?.offers[0]).not.toHaveProperty("providerData")
+    expect(result?.offers[0]?.selection).toMatchObject({ connectionId: "connection_secret" })
+  })
+
+  it("fails closed when Connect cannot enforce the requested package filter", async () => {
+    const provider = createVoyantConnectStorefrontPackageSourceProvider(
+      primitives({ VOYANT_API_KEY: "key", VOYANT_CONNECT_OPERATOR_ID: "op_1" }),
+    )
+    const [source] = await provider.resolveSources({
+      context: { storefrontId: "sf_1", channelId: "ch_1" },
+      scope: input.scope,
+      destination: input.destination,
+    })
+    await expect(source?.search({ ...input, minStars: 4 })).rejects.toThrow(
+      "does not support a minimum-stars constraint",
+    )
+    expect(searchAcrossProviders).not.toHaveBeenCalled()
+  })
+
+  it("returns no source when server-owned Connect configuration is absent", async () => {
+    const provider = createVoyantConnectStorefrontPackageSourceProvider(primitives({}))
+    await expect(
+      provider.resolveSources({
+        context: { storefrontId: "sf_1", channelId: "ch_1" },
+        scope: input.scope,
+        destination: input.destination,
+      }),
+    ).resolves.toEqual([])
+  })
+})

--- a/packages/voyant-connect-adapter/src/storefront-package-sources.ts
+++ b/packages/voyant-connect-adapter/src/storefront-package-sources.ts
@@ -1,0 +1,132 @@
+import {
+  createVoyantConnectClient,
+  type PackageOffer,
+  type PackageSearchQuery,
+} from "@voyant-travel/connect-sdk"
+import type { VoyantRuntimeHostPrimitives } from "@voyant-travel/core"
+import type {
+  StorefrontDynamicPackageSourceOffer,
+  StorefrontDynamicPackageSourceProvider,
+} from "@voyant-travel/storefront/shopping/provider-ports"
+
+import { resolveVoyantConnectEnv } from "./env.js"
+
+const BOARD_CODES = new Set(["RO", "BB", "HB", "FB", "AI"])
+
+/** Connect's admitted cross-provider package search behind Storefront's closed port. */
+export function createVoyantConnectStorefrontPackageSourceProvider(
+  primitives: VoyantRuntimeHostPrimitives,
+): StorefrontDynamicPackageSourceProvider {
+  return {
+    async resolveSources() {
+      const config = resolveVoyantConnectEnv(primitives.env(undefined), {
+        warn: (message) => console.warn(`[voyant-connect] ${message}`),
+      })
+      if (!config) return []
+      const client = createVoyantConnectClient({
+        apiKey: config.apiKey,
+        operatorId: config.operatorId,
+        ...(config.baseUrl ? { baseUrl: config.baseUrl } : {}),
+      })
+      return [
+        {
+          async search(input) {
+            const query = packageQuery(input)
+            const response = await client.packages.searchAcrossProviders(query, {
+              operatorId: config.operatorId,
+            })
+            const mapped = response.offers.flatMap((offer) => {
+              const value = packageOffer(offer, input)
+              return value ? [value] : []
+            })
+            const degraded =
+              mapped.length !== response.offers.length ||
+              response.connectionDiagnostics?.some(({ status }) => status !== "ok") === true
+            return {
+              offers: mapped,
+              status: degraded ? "partial" : mapped.length > 0 ? "ok" : "empty",
+            }
+          },
+        },
+      ]
+    },
+  }
+}
+
+type PackageSourceInput = Parameters<
+  Awaited<ReturnType<StorefrontDynamicPackageSourceProvider["resolveSources"]>>[number]["search"]
+>[0]
+
+function packageQuery(input: PackageSourceInput): PackageSearchQuery {
+  if (input.minStars !== undefined) {
+    throw new Error("Connect package search does not support a minimum-stars constraint")
+  }
+  if (input.destination.query || input.destination.latitude || input.destination.longitude) {
+    throw new Error("Connect package search requires a country or city destination")
+  }
+  const boards = input.boards?.map((board) => board.toUpperCase())
+  if (boards?.some((board) => !BOARD_CODES.has(board))) {
+    throw new Error("Connect package search received an unsupported board code")
+  }
+  return {
+    departure: { airportCodes: [input.origin] },
+    destination: {
+      ...(input.destination.countryCode
+        ? { countryCode: input.destination.countryCode.toUpperCase() }
+        : {}),
+      ...(input.destination.city ? { city: input.destination.city } : {}),
+    },
+    departureDateFrom: input.departureDateFrom,
+    departureDateTo: input.departureDateTo,
+    nights: input.nights,
+    occupancy: input.occupancy,
+    ...(boards ? { boards: boards as PackageSearchQuery["boards"] } : {}),
+    flightIncluded: true,
+    locale: input.scope.locale,
+    ...(input.pagination?.limit !== undefined ? { limit: input.pagination.limit } : {}),
+    ...(input.pagination?.cursor ? { cursor: input.pagination.cursor } : {}),
+  }
+}
+
+function packageOffer(
+  offer: PackageOffer,
+  input: PackageSourceInput,
+): StorefrontDynamicPackageSourceOffer | undefined {
+  const accommodationName = offer.stay.name ?? offer.stay.ref.label ?? undefined
+  if (!accommodationName || offer.flights.length === 0) return undefined
+  const firstFlight = offer.flights[0]
+  const lastFlight = offer.flights.at(-1)
+  const destination =
+    input.destination.city ?? input.destination.countryCode ?? lastFlight?.destination
+  if (!firstFlight || !destination) return undefined
+  return {
+    nativePrice: money(offer.pricing.total),
+    title: offer.title ?? `${accommodationName} package`,
+    origin: firstFlight.origin,
+    destination,
+    departureDate: firstFlight.departureAt?.slice(0, 10) ?? input.departureDateFrom,
+    nights: offer.stay.nights,
+    accommodationName,
+    boardName: offer.stay.board,
+    expiresAt: offer.expiresAt,
+    // This payload is issued only into the server-side opaque reference store.
+    // The public result receives the resulting capability ref, never this offer.
+    selection: { connectionId: offer.connectionId, offer },
+  }
+}
+
+function money(input: { amountMinor: number; currency: string; currencyPrecision: number }): {
+  amount: string
+  currency: string
+} {
+  const precision = input.currencyPrecision
+  if (precision <= 0) return { amount: String(input.amountMinor), currency: input.currency }
+  const negative = input.amountMinor < 0
+  const digits = Math.abs(input.amountMinor)
+    .toString()
+    .padStart(precision + 1, "0")
+  return {
+    amount: `${negative ? "-" : ""}${digits.slice(0, -precision)}.${digits.slice(-precision)}`,
+    currency: input.currency,
+  }
+}

--- a/packages/voyant-connect-adapter/src/voyant.ts
+++ b/packages/voyant-connect-adapter/src/voyant.ts
@@ -1,5 +1,6 @@
 import { catalogSourcesRuntimeExtensionPort } from "@voyant-travel/catalog/ports"
 import { defineAdapter, providePort } from "@voyant-travel/graph-contracts"
+import { storefrontDynamicPackageSourceProviderPort } from "@voyant-travel/storefront/shopping/runtime-port"
 
 /**
  * Voyant Connect as one catalog inventory channel.
@@ -13,7 +14,10 @@ export const voyantConnectAdapter = defineAdapter({
   packageName: "@voyant-travel/voyant-connect-adapter",
   localId: "voyant-connect",
   provides: {
-    ports: [providePort(catalogSourcesRuntimeExtensionPort)],
+    ports: [
+      providePort(catalogSourcesRuntimeExtensionPort),
+      providePort(storefrontDynamicPackageSourceProviderPort),
+    ],
   },
   meta: {
     ownership: "package",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6144,12 +6144,18 @@ importers:
       '@voyant-travel/connect-sdk':
         specifier: ^0.10.0
         version: 0.10.0
+      '@voyant-travel/core':
+        specifier: workspace:^
+        version: link:../core
       '@voyant-travel/data-sdk':
         specifier: ^0.8.0
         version: 0.8.0
       '@voyant-travel/graph-contracts':
         specifier: workspace:^
         version: link:../graph-contracts
+      '@voyant-travel/storefront':
+        specifier: workspace:^
+        version: link:../storefront
     devDependencies:
       '@voyant-travel/catalog':
         specifier: workspace:^


### PR DESCRIPTION
## What changed

- compose the managed Storefront live provider when no deployment override is selected
- admit active, stay-capable Catalog source adapters plus the owned Accommodations search handler only after the trusted storefront/channel/market check
- resolve stay presentation through Catalog's graph-admitted Accommodations extension
- provide a Voyant Connect cross-provider dynamic-package source from server-owned operator credentials
- keep connection ids and full upstream offers inside opaque-reference payloads; public source health remains identity-free

## Fail-closed gaps

- Flight search remains unavailable. The OSS Flights runtime exposes only `resolveAdapter(Context)`, not admitted multi-adapter enumeration or an exact offer-to-connection ownership resolver.
- Package hold/confirm/commit remains unavailable because Storefront has no opaque-reference consumer/commit port for Connect package offers.
- Live multi-source pagination remains unavailable because no opaque cursor issuer/consumer represents per-source cursors.
- This does not claim customer accounts, booking-engine ownership, payments, or theme-owned FX.

## Validation

- Biome check: 23 touched source/test files
- Vitest: 5 files, 24 tests passed, max 2 workers
- Sequential lab1 typecheck dispatch was blocked before execution by an SSH timeout; no local heavy fallback was run.

Stacked on `agent/storefront-shopping-live-adapters` (`eaaf21fb3f`).
