### PR TITLE
fix(storefront): make invoice payment links durable

### DIFF
--- a/.changeset/calm-links-replay.md
+++ b/.changeset/calm-links-replay.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/storefront": patch
+---
+
+Claim approved invoice payment-link commands in the handler transaction and reload the idempotent session on exact replay.

--- a/packages/storefront/package.json
+++ b/packages/storefront/package.json
@@ -71,6 +71,7 @@
     "db:generate": "drizzle-kit generate --config=drizzle.migrations.config.ts --name=storefront_baseline && node ../../scripts/migrations/guard-create-type.mjs ./migrations && node ../../scripts/migrations/ensure-extensions.mjs ./migrations"
   },
   "dependencies": {
+    "@voyant-travel/action-ledger": "workspace:^",
     "@voyant-travel/auth": "workspace:^",
     "@hono/zod-openapi": "catalog:",
     "@voyant-travel/bookings": "workspace:^",

--- a/packages/storefront/src/mcp-runtime.ts
+++ b/packages/storefront/src/mcp-runtime.ts
@@ -1,3 +1,5 @@
+import { executeAdmittedExistingTargetCommand } from "@voyant-travel/action-ledger"
+import type { ActionLedgerRequestContextValues } from "@voyant-travel/action-ledger/request-context"
 import { buildPaymentLinkUrl, financeService } from "@voyant-travel/finance"
 import {
   type CustomerBuyerContext,
@@ -5,7 +7,12 @@ import {
   requireCustomerBuyerContext,
   requireCustomerIdentityContext,
 } from "@voyant-travel/hono"
-import { defineToolContextContribution, requireService, ToolError } from "@voyant-travel/tools"
+import {
+  defineToolContextContribution,
+  requireService,
+  ToolError,
+  type ToolHandlerActionPolicyContext,
+} from "@voyant-travel/tools"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
 
@@ -324,15 +331,70 @@ export function createPaymentLinkToolServices(input: {
   }
 
   return {
-    async createFromInvoice({ invoiceId, ...command }) {
-      const row = await financeService.createPaymentSessionFromInvoice(input.db, invoiceId, command)
-      if (!row)
-        throw new ToolError(`Invoice "${invoiceId}" was not found.`, "NOT_FOUND", { invoiceId })
-      return toDto(row)
+    async createFromInvoice({ invoiceId, ...command }, admitted) {
+      let created: Awaited<ReturnType<typeof financeService.createPaymentSessionFromInvoice>>
+      const result = await executeAdmittedExistingTargetCommand(
+        {
+          db: input.db,
+          context: actionLedgerContext(input.request),
+          admitted: admitted as ToolHandlerActionPolicyContext,
+          commandInput: { invoiceId, ...command },
+          evaluatedRisk: "high",
+        },
+        {
+          async prepare(tx) {
+            created = await financeService.createPaymentSessionFromInvoice(
+              tx as PostgresJsDatabase,
+              invoiceId,
+              command,
+            )
+            if (!created) {
+              throw new ToolError(`Invoice "${invoiceId}" was not found.`, "NOT_FOUND", {
+                invoiceId,
+              })
+            }
+          },
+          execute() {
+            if (!created) throw new Error("Payment link creation produced no session")
+            return Promise.resolve(toDto(created))
+          },
+          async replay() {
+            const page = await financeService.listPaymentSessions(input.db, {
+              invoiceId,
+              idempotencyKey: command.idempotencyKey,
+              limit: 2,
+              offset: 0,
+            })
+            const row = page.data[0]
+            if (!row) throw new ToolError("Payment link was not found.", "NOT_FOUND")
+            return toDto(row)
+          },
+        },
+      )
+      return result.value
     },
     async get(sessionId) {
       return toDto(await financeService.getPaymentSessionById(input.db, sessionId))
     },
+  }
+}
+
+function actionLedgerContext(c: Context): ActionLedgerRequestContextValues {
+  const vars = c.var as Record<string, unknown>
+  return {
+    userId: (vars.userId as string | undefined) ?? null,
+    agentId: (vars.agentId as string | undefined) ?? null,
+    workflowPrincipalId: (vars.workflowPrincipalId as string | undefined) ?? null,
+    principalSubtype: (vars.principalSubtype as string | undefined) ?? null,
+    sessionId: (vars.sessionId as string | undefined) ?? null,
+    apiTokenId: ((vars.apiTokenId ?? vars.apiKeyId) as string | undefined) ?? null,
+    callerType: (vars.callerType as ActionLedgerRequestContextValues["callerType"]) ?? null,
+    actor: (vars.actor as ActionLedgerRequestContextValues["actor"]) ?? null,
+    isInternalRequest: (vars.isInternalRequest as boolean | undefined) ?? false,
+    organizationId: (vars.organizationId as string | undefined) ?? null,
+    workflowRunId: (vars.workflowRunId as string | undefined) ?? null,
+    workflowStepId: (vars.workflowStepId as string | undefined) ?? null,
+    correlationId: c.req.header("x-correlation-id") ?? c.req.header("x-request-id") ?? null,
   }
 }
 

--- a/packages/storefront/src/tools.ts
+++ b/packages/storefront/src/tools.ts
@@ -1,5 +1,7 @@
 import {
+  admitHandlerActionPolicy,
   defineTool,
+  type HandlerActionPolicyExpectation,
   READ_ONLY_RISK,
   requireService,
   type ToolContext,
@@ -139,6 +141,7 @@ export interface StorefrontCustomerPortalToolServices {
 export interface StorefrontPaymentLinkToolServices {
   createFromInvoice(
     input: z.infer<typeof createInvoicePaymentLinkInputSchema>,
+    admitted: import("@voyant-travel/tools").ToolHandlerActionPolicyContext,
   ): Promise<z.infer<typeof paymentLinkSchema>>
   get(sessionId: string): Promise<z.infer<typeof paymentLinkSchema>>
 }
@@ -361,6 +364,27 @@ export const getPaymentLinkTool = defineTool({
   outputSchema: paymentLinkSchema,
   handler: ({ sessionId }, ctx: StorefrontToolContext) => paymentLink(ctx).get(sessionId),
 })
+export const CREATE_INVOICE_PAYMENT_LINK_HANDLER_POLICY = {
+  capabilityId: `${OWNER}#tool.create-invoice-payment-link`,
+  capabilityVersion: VERSION,
+  canonicalName: "create_invoice_payment_link",
+  actionPolicy: {
+    id: `${OWNER}#action.create-invoice-payment-link`,
+    capabilityId: `${OWNER}#action.create-invoice-payment-link`,
+    version: VERSION,
+    kind: "execute",
+    targetType: "invoice",
+    commandTargetField: "invoiceId",
+    targetLifecycle: "existing",
+    existingTarget: { durability: "handler-command-result-v1" },
+    risk: "high",
+    ledger: "required",
+    approval: "required",
+    reversible: true,
+    allowedActorTypes: ["staff"],
+  },
+} as const satisfies HandlerActionPolicyExpectation
+
 export const createInvoicePaymentLinkTool = defineTool({
   owner: PAYMENT_LINK_OWNER,
   capabilityVersion: VERSION,
@@ -380,7 +404,13 @@ export const createInvoicePaymentLinkTool = defineTool({
     confirmationRequired: true,
     sideEffects: ["data-write"],
   },
-  handler: (input, ctx: StorefrontToolContext) => paymentLink(ctx).createFromInvoice(input),
+  actionPolicyEnforcement: "handler",
+  annotations: { idempotentHint: true },
+  handler: (input, ctx: StorefrontToolContext) =>
+    paymentLink(ctx).createFromInvoice(
+      input,
+      admitHandlerActionPolicy(ctx, CREATE_INVOICE_PAYMENT_LINK_HANDLER_POLICY),
+    ),
 })
 
 const verificationReadWrite = {

--- a/packages/storefront/src/voyant.ts
+++ b/packages/storefront/src/voyant.ts
@@ -607,6 +607,7 @@ export const storefrontPaymentLinkVoyantModule = defineModule({
       ledger: "required",
       approval: "required",
       reversible: true,
+      existingTarget: { durability: "handler-command-result-v1" },
       allowedActorTypes: ["staff"],
       availability: { status: "available" },
       effectBoundary: "local",

--- a/packages/storefront/tests/unit/mcp-runtime-payment-link.test.ts
+++ b/packages/storefront/tests/unit/mcp-runtime-payment-link.test.ts
@@ -1,0 +1,82 @@
+import type { ToolHandlerActionPolicyContext } from "@voyant-travel/tools"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+const executeAdmittedExistingTargetCommand = vi.hoisted(() => vi.fn())
+
+vi.mock("@voyant-travel/action-ledger", () => ({ executeAdmittedExistingTargetCommand }))
+
+import { financeService } from "@voyant-travel/finance"
+import { createPaymentLinkToolServices } from "../../src/mcp-runtime.js"
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  executeAdmittedExistingTargetCommand.mockReset()
+})
+
+describe("invoice payment-link durable command", () => {
+  it("creates once and reloads the session by invoice and idempotency key on replay", async () => {
+    const row = {
+      id: "pays_1",
+      status: "pending",
+      invoiceId: "inv_1",
+      bookingId: null,
+      currency: "EUR",
+      amountCents: 12500,
+      paymentMethod: "credit_card",
+      provider: "stripe",
+      redirectUrl: null,
+      expiresAt: null,
+      createdAt: new Date("2026-08-08T10:00:00.000Z"),
+      updatedAt: new Date("2026-08-08T10:00:00.000Z"),
+    }
+    const create = vi
+      .spyOn(financeService, "createPaymentSessionFromInvoice")
+      .mockResolvedValue(row as never)
+    const list = vi.spyOn(financeService, "listPaymentSessions").mockResolvedValue({
+      data: [row],
+      total: 1,
+      limit: 2,
+      offset: 0,
+    } as never)
+    let completed = false
+    executeAdmittedExistingTargetCommand.mockImplementation(async (_input, handlers) => {
+      if (!completed) {
+        await handlers.prepare({})
+        completed = true
+        return { replayed: false, value: await handlers.execute() }
+      }
+      return { replayed: true, value: await handlers.replay() }
+    })
+    const services = createPaymentLinkToolServices({
+      db: {} as never,
+      request: {
+        var: { actor: "staff", organizationId: "org_1" },
+        req: { header: () => null },
+      } as never,
+      runtime: {
+        resolvePublicCheckoutBaseUrl: () => "https://pay.example.test",
+      } as never,
+    })
+    const command = {
+      invoiceId: "inv_1",
+      idempotencyKey: "invoice-inv_1-v1",
+      paymentMethod: "credit_card" as const,
+    }
+    const admitted = {} as ToolHandlerActionPolicyContext
+
+    await expect(services.createFromInvoice(command, admitted)).resolves.toMatchObject({
+      id: "pays_1",
+      invoiceId: "inv_1",
+    })
+    await expect(services.createFromInvoice(command, admitted)).resolves.toMatchObject({
+      id: "pays_1",
+      invoiceId: "inv_1",
+    })
+
+    expect(create).toHaveBeenCalledTimes(1)
+    expect(list).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ invoiceId: "inv_1", idempotencyKey: "invoice-inv_1-v1" }),
+    )
+  })
+})

--- a/packages/storefront/tests/unit/mcp-runtime-payment-link.test.ts
+++ b/packages/storefront/tests/unit/mcp-runtime-payment-link.test.ts
@@ -3,7 +3,10 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 
 const executeAdmittedExistingTargetCommand = vi.hoisted(() => vi.fn())
 
-vi.mock("@voyant-travel/action-ledger", () => ({ executeAdmittedExistingTargetCommand }))
+vi.mock("@voyant-travel/action-ledger", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@voyant-travel/action-ledger")>()),
+  executeAdmittedExistingTargetCommand,
+}))
 
 import { financeService } from "@voyant-travel/finance"
 import { createPaymentLinkToolServices } from "../../src/mcp-runtime.js"

--- a/packages/storefront/tests/unit/voyant-manifest.test.ts
+++ b/packages/storefront/tests/unit/voyant-manifest.test.ts
@@ -346,6 +346,7 @@ describe("storefront deployment manifest", () => {
           targetLifecycle: "existing",
           allowedActorTypes: ["staff"],
           approval: "required",
+          existingTarget: { durability: "handler-command-result-v1" },
         }),
       ]),
     )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5536,6 +5536,9 @@ importers:
       '@hono/zod-openapi':
         specifier: 'catalog:'
         version: 1.4.0(hono@4.12.25)(zod@4.4.3)
+      '@voyant-travel/action-ledger':
+        specifier: workspace:^
+        version: link:../action-ledger
       '@voyant-travel/auth':
         specifier: workspace:^
         version: link:../auth


### PR DESCRIPTION
## Summary
- move approved invoice payment-link creation behind the handler-owned existing-target command claim
- create the session inside the claim transaction and reload it by invoice plus idempotency key on exact replay
- declare the durable result contract in the module graph

## Verification
- `pnpm --filter @voyant-travel/storefront test` (187 passed, 33 skipped)
- `pnpm --filter @voyant-travel/storefront typecheck`
- `pnpm --filter operator prepare:verify`

Continues #4424.