### PR TITLE
feat(flights): expose admitted Storefront shopping sources

### DIFF
--- a/.changeset/closed-storefront-flight-supply.md
+++ b/.changeset/closed-storefront-flight-supply.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/flights": minor
+"@voyant-travel/storefront": patch
+---
+
+Expose graph-admitted multi-connection flight shopping to the managed Storefront
+without accepting or returning provider and connection selectors.

--- a/docs/architecture/catalog-flights-architecture.md
+++ b/docs/architecture/catalog-flights-architecture.md
@@ -103,25 +103,18 @@ Default if omitted: `{ type: "hold" }`. Consumers declare their intent; the syst
 
 ## 4. Multi-connection fan-out and itinerary fingerprinting
 
-The flight orchestration layer fans out across all of an operator's flight connections in a single search call:
+The flight orchestration layer fans out across all admitted flight connections in a single search call. Admin composition may choose an operator-scoped connection set, but the public Storefront request never carries connection or provider selectors. Storefront passes only its server-resolved storefront, channel, market, locale, and currency to `FlightsRuntime.listAdmittedShoppingSources`; an empty enumeration is unavailable rather than a fallback to the admin adapter.
 
 ```
-POST /v1/{admin,public}/flights/search
-{
-  connectionIds?: string[],   // optional — defaults to all flight connections owned by the actor
-  slices: [...],
-  passengers: {...},
-  cabin: "...",
-  searchOptions: { directOnly?, maxStops?, includeCarriers?, excludeCarriers? },
-  limit?: number,
-  cursor?: string,
-  tier?: "browse" | "booking"
-}
+trusted Storefront context
+  -> listAdmittedShoppingSources({ storefrontId, channelId, marketId, locale, currency })
+  -> fanOutFlightSearch({ adapters: admittedSources, request: publicFlightIntent })
+  -> opaque single-use offer ref containing exact offer/connection ownership
 ```
 
 The orchestration layer:
 
-- **Filters connections to the actor's operator scope.** Cross-tenant connection ids are reported as `not_found` (true from the caller's perspective; reveals nothing about other operators).
+- **Filters connections inside the trusted runtime.** Public callers cannot probe cross-tenant connection ids because they cannot submit one.
 - **Parallel fan-out** with per-provider timeout (default 5s) and per-provider circuit breaker. One slow/failing provider doesn't tank the whole search.
 - **Partial success is the default.** Whatever providers responded come back; the rest are flagged in a `perConnection` status map.
 - **Deduplicates by itinerary fingerprint** — a deterministic key derived from segments (carrier codes + flight numbers + departure/arrival airports + times + cabin). Two providers selling the same flight produce identical fingerprints and merge into one `MergedFlightOffer` with a `cheapest` plus `alternates[]` and `sourceConnectionIds[]`.
@@ -239,7 +232,7 @@ Flight adapters (Hisky, Amadeus, Duffel, Sabre, Travelport NDC, an operator-buil
 - **`FlightConnectorAdapter`** — the provider-agnostic adapter interface for flight integrations, borrowed verbatim from voyant-cloud's `connect-flight-contract`. Five core methods plus capability-gated extras.
 - **Slice** — a single leg of a flight search request (`{ origin, destination, departureDate }`). One slice = one-way; two = round-trip; three or more = multi-city.
 - **Itinerary fingerprint** — deterministic hash derived from a `FlightOffer`'s segments (carrier codes + flight numbers + airports + times + cabin), used to deduplicate when the same flight is sold by multiple connections. Two providers selling the same flight produce identical fingerprints.
-- **`MergedFlightOffer`** — the deduplicated result of multi-connection fan-out: one `cheapest` offer plus `alternates[]` from other connections selling the same itinerary, with `sourceConnectionIds[]` for traceability.
+- **`MergedFlightOffer`** — the deduplicated result of multi-connection fan-out: one `cheapest` offer plus `alternates[]` from other connections selling the same itinerary, with aggregate `sourceConnectionIds[]` for traceability and exact aligned ownership (`cheapestSourceConnectionId` / `alternateSourceConnectionIds`) for opaque downstream offer resolution.
 - **`paymentIntent`** — discriminated union on `bookFlight` requests: `hold` / `card` / `ticket_on_credit`. Determines whether the booking returns held or ticketed.
 - **`ReferenceDataProvider`** — the swappable contract for global reference data (airlines, airports, aircraft, currencies, countries). Implementable at any layer, including the simplest case of plain Postgres tables in the operator's own Voyant database with no external dependency. Voyant Data is the hosted default; in-deployment local tables, static bundles, internal data lakes, third-party services (OAG, Cirium), and GDS-bundled implementations are all first-class alternatives. No implementer is privileged.
 

--- a/packages/flights/src/api-runtime.ts
+++ b/packages/flights/src/api-runtime.ts
@@ -470,5 +470,9 @@ export const createFlightsVoyantRuntime = defineGraphRuntimeFactory(async ({ get
   })
 })
 
-export type { FlightsRuntime } from "./runtime-port.js"
+export type {
+  AdmittedFlightShoppingSource,
+  FlightStorefrontShoppingContext,
+  FlightsRuntime,
+} from "./runtime-port.js"
 export { flightsRuntimePort } from "./runtime-port.js"

--- a/packages/flights/src/index.ts
+++ b/packages/flights/src/index.ts
@@ -3,11 +3,13 @@
 // Flight admin HTTP routes (module-owned; the deployment supplies connector +
 // payment options).
 export {
+  type AdmittedFlightShoppingSource,
   createFlightAdminRoutes,
   createFlightsApiModule,
   createFlightsVoyantRuntime,
   type FlightOrderPaymentSummary,
   type FlightPaymentIntegration,
+  type FlightStorefrontShoppingContext,
   type FlightsApiModuleOptions,
   type FlightsRouteOptions,
   type FlightsRuntime,

--- a/packages/flights/src/mcp-runtime.test.ts
+++ b/packages/flights/src/mcp-runtime.test.ts
@@ -16,6 +16,7 @@ describe("Flights MCP runtime", () => {
     }))
     const runtime = {
       resolveAdapter,
+      listAdmittedShoppingSources: vi.fn(async () => []),
       startCardPayment: vi.fn(),
     }
     const request = {

--- a/packages/flights/src/orchestration/availability-bridge.test.ts
+++ b/packages/flights/src/orchestration/availability-bridge.test.ts
@@ -23,7 +23,10 @@ function merged(overrides: Partial<MergedFlightOffer> = {}): MergedFlightOffer {
   return {
     itineraryFingerprint: overrides.itineraryFingerprint ?? "fp_lhr_jfk",
     cheapest: overrides.cheapest ?? offer(),
+    cheapestSourceConnectionId:
+      overrides.cheapestSourceConnectionId ?? overrides.sourceConnectionIds?.[0] ?? "conn_amadeus",
     alternates: overrides.alternates ?? [],
+    alternateSourceConnectionIds: overrides.alternateSourceConnectionIds ?? [],
     sourceConnectionIds: overrides.sourceConnectionIds ?? ["conn_amadeus"],
   }
 }
@@ -38,6 +41,8 @@ describe("mergedFlightOfferToCandidate", () => {
           providerData: { fareKey: "abc" },
         }),
         alternates: [offer({ offerId: "ofr_alt" })],
+        cheapestSourceConnectionId: "conn_amadeus",
+        alternateSourceConnectionIds: ["conn_sabre"],
         sourceConnectionIds: ["conn_amadeus", "conn_sabre"],
       }),
     )
@@ -48,7 +53,7 @@ describe("mergedFlightOfferToCandidate", () => {
     expect(candidate.price).toEqual({ amount: "600", currency: "USD" })
     expect(candidate.selection).toMatchObject({
       offerId: "ofr_99",
-      sourceConnectionIds: ["conn_amadeus", "conn_sabre"],
+      connectionId: "conn_amadeus",
     })
     expect(candidate.expiresAt).toEqual(new Date("2026-10-15T10:00:00Z"))
     expect(candidate.providerData).toMatchObject({ fareKey: "abc", alternateCount: 1 })

--- a/packages/flights/src/orchestration/availability-bridge.ts
+++ b/packages/flights/src/orchestration/availability-bridge.ts
@@ -21,7 +21,7 @@ export const FLIGHTS_ENTITY_MODULE = "flights" as const
  *
  * The candidate's `selection` carries what the flights booking path needs to
  * re-resolve and price the exact offer at reserve time (offer id + source +
- * the connections that returned it). The per-search `offerId` is not
+ * its exact owning connection). The per-search `offerId` is not
  * replay-safe, so callers re-price before booking — same rule as the generic
  * `AvailabilityCandidate.candidateRef`.
  */
@@ -35,7 +35,7 @@ export function mergedFlightOfferToCandidate(merged: MergedFlightOffer): Availab
       offerId: offer.offerId,
       source: offer.source,
       itineraryFingerprint: merged.itineraryFingerprint,
-      sourceConnectionIds: merged.sourceConnectionIds,
+      connectionId: merged.cheapestSourceConnectionId,
     },
     price: { amount: offer.totalPrice.amount, currency: offer.totalPrice.currency },
     expiresAt: offer.expiresAt ? new Date(offer.expiresAt) : undefined,

--- a/packages/flights/src/orchestration/fan-out.test.ts
+++ b/packages/flights/src/orchestration/fan-out.test.ts
@@ -110,6 +110,8 @@ describe("fanOutFlightSearch", () => {
     expect(result.offers[0]?.cheapest.source).toBe("hisky")
     expect(result.offers[0]?.alternates).toHaveLength(1)
     expect(result.offers[0]?.alternates[0]?.source).toBe("amadeus")
+    expect(result.offers[0]?.cheapestSourceConnectionId).toBe("conn_hisky")
+    expect(result.offers[0]?.alternateSourceConnectionIds).toEqual(["conn_amadeus"])
     expect(result.offers[0]?.sourceConnectionIds.sort()).toEqual(["conn_amadeus", "conn_hisky"])
   })
 
@@ -296,6 +298,25 @@ describe("fanOutFlightSearch", () => {
       environment: "sandbox",
     })
     expect(captured[0]?.signal).toBe(controller.signal)
+  })
+
+  it("keeps the admitted source identity authoritative over adapter context", async () => {
+    const captured: FlightAdapterContext[] = []
+
+    await fanOutFlightSearch({
+      adapters: [
+        {
+          connectionId: "conn_admitted",
+          adapter: makeAdapter("a", {
+            captureContext: (ctx) => captured.push(ctx),
+          }),
+          context: { connectionId: "conn_injected" } as never,
+        },
+      ],
+      request: oneSliceRequest,
+    })
+
+    expect(captured[0]?.connectionId).toBe("conn_admitted")
   })
 
   it("does not choose a fake cheapest offer across unconverted currencies", async () => {

--- a/packages/flights/src/orchestration/fan-out.ts
+++ b/packages/flights/src/orchestration/fan-out.ts
@@ -39,10 +39,14 @@ export interface MergedFlightOffer {
    * when FX is unavailable. The property name is retained for compatibility.
    */
   cheapest: FlightOffer
+  /** Exact server-only owner of `cheapest`; keep behind an opaque public ref. */
+  cheapestSourceConnectionId: string
   /** Native + shopper-selected money for `cheapest`, when presentation succeeded. */
   cheapestPresentationPrice?: PresentationMoney
   /** Other offers, price-sorted only when `priceRanking` is ranked. */
   alternates: FlightOffer[]
+  /** Exact owners aligned by index with `alternates`. */
+  alternateSourceConnectionIds: string[]
   /** Presentation prices aligned by index with `alternates`. */
   alternatePresentationPrices?: Array<PresentationMoney | undefined>
   /** Connection ids that returned an offer for this itinerary. */
@@ -69,7 +73,7 @@ export interface FanOutFlightSearchOptions {
     connectionId: string
     adapter: FlightConnectorAdapter
     /** Optional override for the adapter context per connection. */
-    context?: Partial<FlightAdapterContext>
+    context?: Omit<Partial<FlightAdapterContext>, "connectionId">
   }>
   request: FlightSearchRequest
   /**
@@ -124,7 +128,9 @@ export async function fanOutFlightSearch(
           }
         }
 
-        const ctx: FlightAdapterContext = { connectionId, ...context }
+        // The admitted source owns its identity. Adapter context can enrich a
+        // call but can never replace the enumerated connection id.
+        const ctx: FlightAdapterContext = { ...context, connectionId }
         const response = await withTimeout(
           adapter.searchFlights(ctx, options.request),
           timeoutMs,
@@ -240,8 +246,10 @@ function mergeByFingerprint(
     merged.push({
       itineraryFingerprint: fingerprint,
       cheapest: cheapestEntry.offer,
+      cheapestSourceConnectionId: cheapestEntry.connectionId,
       cheapestPresentationPrice: presentedByOffer.get(cheapestEntry.offer),
       alternates: alternateEntries.map((entry) => entry.offer),
+      alternateSourceConnectionIds: alternateEntries.map((entry) => entry.connectionId),
       alternatePresentationPrices: alternateEntries.map((entry) =>
         presentedByOffer.get(entry.offer),
       ),

--- a/packages/flights/src/runtime-port.ts
+++ b/packages/flights/src/runtime-port.ts
@@ -1,12 +1,39 @@
 import { definePort } from "@voyant-travel/core/project"
 import type { Context } from "hono"
 
-import type { FlightConnectorAdapter } from "./contract/adapter.js"
+import type { FlightAdapterContext, FlightConnectorAdapter } from "./contract/adapter.js"
 import type { FlightCardBilling } from "./payment-integration.js"
+
+/**
+ * Trusted Storefront authority used to enumerate flight supply. Every field is
+ * resolved server-side; no provider or connection selector is accepted.
+ */
+export interface FlightStorefrontShoppingContext {
+  storefrontId: string
+  channelId: string
+  marketId: string
+  locale: string
+  currency: string
+}
+
+/** One graph-admitted connection, closed over its adapter credentials/context. */
+export interface AdmittedFlightShoppingSource {
+  connectionId: string
+  adapter: FlightConnectorAdapter
+  context?: Omit<Partial<FlightAdapterContext>, "connectionId">
+}
 
 /** Node-host behavior required by the package-owned Flights runtime factory. */
 export interface FlightsRuntime {
   resolveAdapter(c: Context): FlightConnectorAdapter
+  /**
+   * Enumerate every source admitted for the trusted Storefront scope. Returning
+   * an empty array fails public shopping closed; callers must never fall back to
+   * `resolveAdapter()` or infer supply from credentials.
+   */
+  listAdmittedShoppingSources(
+    context: FlightStorefrontShoppingContext,
+  ): Promise<readonly AdmittedFlightShoppingSource[]>
   startCardPayment(c: Context, sessionId: string, billing: FlightCardBilling): Promise<void>
 }
 
@@ -17,7 +44,11 @@ export const flightsRuntimePort = definePort<FlightsRuntime>({
     if (provider === null || typeof provider !== "object") {
       throw new Error("flights.runtime provider must be an options object.")
     }
-    for (const method of ["resolveAdapter", "startCardPayment"] as const) {
+    for (const method of [
+      "resolveAdapter",
+      "listAdmittedShoppingSources",
+      "startCardPayment",
+    ] as const) {
       if (typeof provider[method] !== "function") {
         throw new Error(`flights.runtime provider must implement ${method}().`)
       }

--- a/packages/flights/src/runtime.ts
+++ b/packages/flights/src/runtime.ts
@@ -10,6 +10,9 @@ export function createFlightsRuntime(primitives: VoyantRuntimeHostPrimitives): F
         "Flight connector is not configured. Provide a flights.runtime port from project customization or an installed connector integration.",
       )
     },
+    async listAdmittedShoppingSources() {
+      return []
+    },
     async startCardPayment() {
       return
     },

--- a/packages/flights/src/voyant.test.ts
+++ b/packages/flights/src/voyant.test.ts
@@ -204,6 +204,7 @@ describe("flights deployment manifest", () => {
     }
     const provider = {
       resolveAdapter: vi.fn(() => adapter),
+      listAdmittedShoppingSources: vi.fn(async () => []),
       startCardPayment: vi.fn(async () => {}),
     }
 

--- a/packages/framework/src/runtime-composition.ts
+++ b/packages/framework/src/runtime-composition.ts
@@ -159,6 +159,7 @@ function runtimePortStub(id: string): unknown {
     resolveDynamicHotelIds: unavailableAsync,
     resolveAirportLabels: unavailableAsync,
     resolveAdapter: unavailable,
+    listAdmittedShoppingSources: () => [],
     startCardPayment: unavailableAsync,
     resolveStorage: unavailable,
     resolvePrinter: unavailable,

--- a/packages/storefront/src/runtime-contributor.ts
+++ b/packages/storefront/src/runtime-contributor.ts
@@ -11,6 +11,7 @@ import type { PresentationFxQuoter } from "@voyant-travel/catalog-contracts/pres
 import { createCommerceStorefrontOfferResolvers } from "@voyant-travel/commerce"
 import type { VoyantRuntimeHostPrimitives } from "@voyant-travel/core"
 import type { VoyantPort } from "@voyant-travel/core/project"
+import { type FlightsRuntime, flightsRuntimePort } from "@voyant-travel/flights"
 import { createStorefrontCustomerBusinessOnboardingRuntime } from "./customer-business-onboarding-runtime.js"
 import { storefrontCustomerPortalRuntimePort, storefrontOffersRuntimePort } from "./runtime-port.js"
 import { createClosedStorefrontShoppingLiveProvider } from "./shopping/closed-live-provider.js"
@@ -70,6 +71,9 @@ export function createStorefrontRuntimePortContribution(
                   storefrontDynamicPackageSourceProviderPort,
                 )
               : undefined,
+            host.hasRuntimePort?.(flightsRuntimePort)
+              ? getRuntimePort?.<FlightsRuntime>(flightsRuntimePort)
+              : undefined,
             getRuntimePort?.<StorefrontOpaqueReferenceIssuer>(storefrontOpaqueReferenceIssuerPort),
             host.hasRuntimePort?.(storefrontPresentationFxProviderPort)
               ? getRuntimePort?.<PresentationFxQuoter>(storefrontPresentationFxProviderPort)
@@ -80,6 +84,7 @@ export function createStorefrontRuntimePortContribution(
               catalogServices,
               configuredLive,
               packageSources,
+              flights,
               references,
               quoteFx,
             ]) => {
@@ -94,6 +99,7 @@ export function createStorefrontRuntimePortContribution(
                   primitives: host.primitives,
                   catalogServices: catalogServices as CatalogRuntimeServices,
                   markets: adapters.markets,
+                  ...(flights ? { flights: flights as FlightsRuntime } : {}),
                   ...(packageSources
                     ? { packages: packageSources as StorefrontDynamicPackageSourceProvider }
                     : {}),

--- a/packages/storefront/src/shopping/closed-live-provider.ts
+++ b/packages/storefront/src/shopping/closed-live-provider.ts
@@ -1,5 +1,6 @@
 import type { CatalogRuntimeServices } from "@voyant-travel/catalog/runtime-contracts"
 import type { VoyantRuntimeHostPrimitives } from "@voyant-travel/core"
+import type { FlightsRuntime } from "@voyant-travel/flights"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import { createStorefrontShoppingLiveProvider } from "./live-provider.js"
@@ -16,22 +17,42 @@ export interface ClosedStorefrontShoppingLiveProviderOptions {
   primitives: VoyantRuntimeHostPrimitives
   catalogServices: CatalogRuntimeServices
   markets: StorefrontShoppingMarketProvider
+  flights?: Pick<FlightsRuntime, "listAdmittedShoppingSources">
   packages?: StorefrontDynamicPackageSourceProvider
   loadStayPresentation?: CatalogRuntimeServices["presentAvailabilityCandidate"]
 }
 
 /**
  * Production live-shopping composition over the graph-admitted Catalog
- * runtime. Flights deliberately remain absent: Flights currently exposes a
- * request-bound single adapter, not an admitted multi-adapter discovery seam.
+ * runtime. Flight supply is enumerated only through the graph-admitted Flights
+ * runtime and only after the trusted storefront/channel/scope is revalidated.
  */
 export function createClosedStorefrontShoppingLiveProvider(
   options: ClosedStorefrontShoppingLiveProviderOptions,
 ): StorefrontShoppingLiveProvider {
   const present =
     options.loadStayPresentation ?? options.catalogServices.presentAvailabilityCandidate
+  const flights = options.flights
 
   return createStorefrontShoppingLiveProvider({
+    ...(flights
+      ? {
+          flights: {
+            async resolve(input) {
+              await assertActiveScope(options.markets, input.context, input.scope)
+              return {
+                adapters: await flights.listAdmittedShoppingSources({
+                  storefrontId: input.context.storefrontId,
+                  channelId: input.context.channelId,
+                  marketId: input.scope.marketId,
+                  locale: input.scope.locale,
+                  currency: input.scope.currency,
+                }),
+              }
+            },
+          },
+        }
+      : {}),
     stays: {
       async resolve(input) {
         await assertActiveScope(options.markets, input.context, input.scope)

--- a/packages/storefront/src/shopping/live-provider.ts
+++ b/packages/storefront/src/shopping/live-provider.ts
@@ -235,29 +235,39 @@ function sourceScope(scope: StorefrontResolvedScope): AvailabilitySearchRequest[
 }
 
 function mapMergedFlightOffers(merged: MergedFlightOffer) {
-  return [merged.cheapest, ...merged.alternates].map((offer) => ({
-    nativePrice: offer.totalPrice,
-    itineraries: offer.itineraries.map((itinerary) => ({
-      segments: itinerary.segments.map((segment) => ({
-        origin: { code: segment.departure.iataCode, at: segment.departure.at },
-        destination: { code: segment.arrival.iataCode, at: segment.arrival.at },
-        marketingCarrier: segment.carrierCode,
-        flightNumber: segment.flightNumber,
-      })),
-      ...(itinerary.duration ? { duration: itinerary.duration } : {}),
+  const ownedOffers = [
+    { offer: merged.cheapest, connectionId: merged.cheapestSourceConnectionId },
+    ...merged.alternates.map((offer, index) => ({
+      offer,
+      connectionId: merged.alternateSourceConnectionIds[index],
     })),
-    selection: {
-      offerId: offer.offerId,
-      source: offer.source,
-      itineraryFingerprint: merged.itineraryFingerprint,
-      sourceConnectionIds: merged.sourceConnectionIds,
-    },
-    providerData: {
-      sourceConnectionIds: merged.sourceConnectionIds,
-      ...(offer.providerData ?? {}),
-    },
-    ...(offer.expiresAt ? { expiresAt: offer.expiresAt } : {}),
-  }))
+  ]
+  return ownedOffers.flatMap(({ offer, connectionId }) =>
+    connectionId
+      ? [
+          {
+            nativePrice: offer.totalPrice,
+            itineraries: offer.itineraries.map((itinerary) => ({
+              segments: itinerary.segments.map((segment) => ({
+                origin: { code: segment.departure.iataCode, at: segment.departure.at },
+                destination: { code: segment.arrival.iataCode, at: segment.arrival.at },
+                marketingCarrier: segment.carrierCode,
+                flightNumber: segment.flightNumber,
+              })),
+              ...(itinerary.duration ? { duration: itinerary.duration } : {}),
+            })),
+            selection: {
+              offerId: offer.offerId,
+              source: offer.source,
+              itineraryFingerprint: merged.itineraryFingerprint,
+              connectionId,
+            },
+            ...(offer.providerData ? { providerData: offer.providerData } : {}),
+            ...(offer.expiresAt ? { expiresAt: offer.expiresAt } : {}),
+          },
+        ]
+      : [],
+  )
 }
 
 function mapStay(

--- a/packages/storefront/src/voyant.ts
+++ b/packages/storefront/src/voyant.ts
@@ -9,6 +9,7 @@ import { defineModule, providePort, requirePort } from "@voyant-travel/core/proj
 // Search route contracts are intentionally not imported into this import-cheap
 // manifest; the runtime contributor resolves the real typed port.
 const catalogSearchRuntimePortReference = { id: "catalog.search-runtime" } as const
+const flightsRuntimePortReference = { id: "flights.runtime" } as const
 
 // Lightweight reference (id only) so the deployment-graph manifest stays
 // import-cheap — importing the real port from @voyant-travel/payments would
@@ -442,6 +443,7 @@ export const storefrontShoppingProviderVoyantModule = defineModule({
   runtimePorts: [
     catalogSearchRuntimePortReference,
     requirePort(catalogRuntimeServicesPort),
+    { ...flightsRuntimePortReference, optional: true },
     requirePort(storefrontShoppingLiveProviderPort, { optional: true }),
     requirePort(storefrontDynamicPackageSourceProviderPort, { optional: true }),
     requirePort(storefrontOpaqueReferenceIssuerPort),

--- a/packages/storefront/tests/unit/closed-live-provider.test.ts
+++ b/packages/storefront/tests/unit/closed-live-provider.test.ts
@@ -1,6 +1,8 @@
+import type { FlightConnectorAdapter, FlightOffer } from "@voyant-travel/flights"
 import { describe, expect, it, vi } from "vitest"
 
 import { createClosedStorefrontShoppingLiveProvider } from "../../src/shopping/closed-live-provider.js"
+import { createManagedStorefrontShoppingRuntime } from "../../src/shopping/managed-runtime.js"
 
 const context = { storefrontId: "sf_1", channelId: "ch_1" }
 const scope = {
@@ -35,6 +37,51 @@ function markets(active = true) {
           ]
         : [],
     ),
+  }
+}
+
+function flightOffer(amount: string): FlightOffer {
+  return {
+    offerId: "shared_provider_offer",
+    source: "provider_internal",
+    itineraries: [
+      {
+        segments: [
+          {
+            segmentId: "segment_internal",
+            carrierCode: "RO",
+            flightNumber: "101",
+            departure: { iataCode: "OTP", at: "2026-09-10T08:00:00+03:00" },
+            arrival: { iataCode: "FCO", at: "2026-09-10T09:30:00+02:00" },
+            cabin: "economy",
+          },
+        ],
+      },
+    ],
+    fareBreakdowns: [],
+    totalPrice: { amount, currency: amount === "100.00" ? "EUR" : "RON" },
+    providerData: { locator: `secret_${amount}` },
+  }
+}
+
+function flightAdapter(
+  searchFlights: FlightConnectorAdapter["searchFlights"],
+): FlightConnectorAdapter {
+  return {
+    capabilities: { provider: "provider_internal", declared: [] },
+    searchFlights,
+    async priceOffer() {
+      throw new Error("not used")
+    },
+    async bookFlight() {
+      throw new Error("not used")
+    },
+    async getOrder() {
+      throw new Error("not used")
+    },
+    async cancelOrder() {
+      throw new Error("not used")
+    },
   }
 }
 
@@ -141,11 +188,13 @@ describe("closed Storefront live provider", () => {
     expect(ensureSourceRegistry).not.toHaveBeenCalled()
   })
 
-  it("keeps flights unavailable while no admitted flight adapter resolver exists", async () => {
+  it("fails flight search closed when the admitted runtime returns no sources", async () => {
+    const listAdmittedShoppingSources = vi.fn(async () => [])
     const provider = createClosedStorefrontShoppingLiveProvider({
       primitives: primitives(),
       catalogServices: {} as never,
       markets: markets(),
+      flights: { listAdmittedShoppingSources },
     })
     await expect(
       provider.searchFlights({
@@ -158,5 +207,83 @@ describe("closed Storefront live provider", () => {
         },
       }),
     ).resolves.toEqual({ items: [], sources: [{ status: "unavailable" }] })
+    expect(listAdmittedShoppingSources).toHaveBeenCalledWith({
+      storefrontId: "sf_1",
+      channelId: "ch_1",
+      marketId: "market_ro",
+      locale: "ro-RO",
+      currency: "EUR",
+    })
+  })
+
+  it("keeps exact offer ownership opaque across partial multi-source flight search", async () => {
+    const listAdmittedShoppingSources = vi.fn(async () => [
+      {
+        connectionId: "connection_eur",
+        adapter: flightAdapter(async () => ({ offers: [flightOffer("100.00")] })),
+      },
+      {
+        connectionId: "connection_ron",
+        adapter: flightAdapter(async () => ({ offers: [flightOffer("450.00")] })),
+      },
+      {
+        connectionId: "connection_failed",
+        adapter: flightAdapter(async () => {
+          throw new Error("supplier unavailable")
+        }),
+      },
+    ])
+    const live = createClosedStorefrontShoppingLiveProvider({
+      primitives: primitives(),
+      catalogServices: {} as never,
+      markets: markets(),
+      flights: { listAdmittedShoppingSources },
+    })
+    const issued: Array<Record<string, unknown>> = []
+    let sequence = 0
+    const runtime = createManagedStorefrontShoppingRuntime({
+      markets: markets(),
+      catalog: { searchSlice: async () => ({ items: [], total: 0 }) },
+      live,
+      references: {
+        async issue(input) {
+          issued.push(input as unknown as Record<string, unknown>)
+          sequence += 1
+          return {
+            ref: `opaque-flight-offer-${String(sequence).padStart(4, "0")}`,
+            expiresAt: "2026-08-08T10:15:00.000Z",
+          }
+        },
+      },
+      now: () => new Date("2026-08-08T10:00:00.000Z"),
+      quoteFx: async () => ({
+        rate: "0.2",
+        provider: "server-fx",
+        quotedAt: "2026-08-08T10:00:00.000Z",
+      }),
+    })
+
+    const result = await runtime.search(context, {
+      scope,
+      intent: {
+        kind: "flight",
+        slices: [{ origin: "OTP", destination: "FCO", departureDate: "2026-09-10" }],
+        travelers: { adults: 1 },
+      },
+    })
+
+    expect(result.kind).toBe("flight")
+    if (result.kind !== "flight") return
+    expect(result.offers.map(({ price }) => price.presentation.amount)).toEqual(["90.00", "100.00"])
+    expect(result.coverage).toEqual({ status: "partial", succeeded: 2, failed: 1, timedOut: 0 })
+    expect(
+      issued.map(
+        (entry) =>
+          (entry.payload as { selection: { connectionId: string } }).selection.connectionId,
+      ),
+    ).toEqual(["connection_ron", "connection_eur"])
+    expect(JSON.stringify(result)).not.toContain("connection_")
+    expect(JSON.stringify(result)).not.toContain("provider_internal")
+    expect(JSON.stringify(result)).not.toContain("secret_")
   })
 })

--- a/packages/storefront/tests/unit/voyant-manifest.test.ts
+++ b/packages/storefront/tests/unit/voyant-manifest.test.ts
@@ -47,6 +47,7 @@ describe("storefront deployment manifest", () => {
       runtimePorts: [
         { id: "catalog.search-runtime" },
         { id: catalogRuntimeServicesPort.id },
+        { id: "flights.runtime", optional: true },
         { id: storefrontShoppingLiveProviderPort.id, optional: true },
         { id: storefrontDynamicPackageSourceProviderPort.id, optional: true },
         { id: storefrontOpaqueReferenceIssuerPort.id },

--- a/scripts/check-flights-runtime-authority.mjs
+++ b/scripts/check-flights-runtime-authority.mjs
@@ -53,7 +53,7 @@ if (
 ) {
   violations.push("Flights must assemble routes and payment sessions inside its graph factory")
 }
-for (const method of ["resolveAdapter", "startCardPayment"]) {
+for (const method of ["resolveAdapter", "listAdmittedShoppingSources", "startCardPayment"]) {
   if (!runtimePort.includes(`"${method}"`)) {
     violations.push(`flights.runtime conformance must require ${method}()`)
   }
@@ -82,6 +82,7 @@ if (
 }
 for (const token of [
   "resolveAdapter()",
+  "listAdmittedShoppingSources",
   "startCardPayment",
   "Flight connector is not configured",
 ]) {

--- a/scripts/tests/check-flights-runtime-authority.test.mjs
+++ b/scripts/tests/check-flights-runtime-authority.test.mjs
@@ -28,11 +28,12 @@ async function createFixture(overrides = {}) {
       'runtimePorts: [\nrequirePort(flightsRuntimePort),\nrequirePort(durableFlightActionRuntimePort, { optional: true }),\n]\nrequires: { capabilities: ["finance.payment-sessions"] }\nexport: "createFlightsVoyantRuntime"\n',
     "flights/src/api-runtime.ts":
       'defineGraphRuntimeFactory(({ getPort }) => getPort(flightsRuntimePort))\ncreateOrderPaymentSessions({ targetType: "flight_order" })\n',
-    "flights/src/runtime-port.ts": '["resolveAdapter", "startCardPayment"]\n',
+    "flights/src/runtime-port.ts":
+      '["resolveAdapter", "listAdmittedShoppingSources", "startCardPayment"]\n',
     "flights/src/runtime-contributor.ts":
       "primitives: VoyantRuntimeHostPrimitives\ncreateFlightsRuntime(host.primitives)\n",
     "flights/src/runtime.ts":
-      'resolveAdapter() {}\nstartCardPayment() {}\nthrow new Error("Flight connector is not configured")\n',
+      'resolveAdapter() {}\nlistAdmittedShoppingSources() {}\nstartCardPayment() {}\nthrow new Error("Flight connector is not configured")\n',
     "runtime/src/deployment-resources.ts":
       "function createDeploymentPortResources() { return options.createRuntimePorts({ primitives }) }\n",
     ...overrides,


### PR DESCRIPTION
## Summary

- add a closed `FlightsRuntime.listAdmittedShoppingSources` seam keyed only by trusted storefront, channel, market, locale, and currency context
- wire the graph-admitted Flights runtime into the managed Storefront live provider, failing closed when it enumerates no sources
- preserve exact per-offer connection ownership through fan-out ordering and seal it inside the Storefront's single-use opaque offer reference
- keep provider/connection identities, credentials, provider data, customer state, payment state, and theme state out of public flight results
- preserve managed Storefront server-side presentation-FX normalization and partial-provider coverage

## Focused coverage

- admitted source identity cannot be overridden by adapter context
- identical provider offer ids retain exact cheapest/alternate connection ownership
- partial supplier failure returns healthy-source offers and identity-free coverage
- no admitted source returns unavailable without falling back to the admin adapter
- opaque references receive exact offer ownership while public results contain no connection/provider identity

## Residual gaps

- **Price/requote:** the opaque offer reference records exact connection ownership, but no public-safe reference consumer or price/requote command is added here.
- **Hold/commit:** no public hold, ticket, booking, payment, or commit port is introduced. Flight offers are search-only in this slice.
- **Pagination:** the Storefront intent still forwards one opaque cursor to every admitted adapter. There is no signed aggregate cursor carrying independent per-source continuations, and the fan-out does not return a merged next cursor.
- **Order lifecycle:** reserve/order-status/cancellation remain unavailable to public Storefront flight shopping.

## Validation

- source formatting completed with the repository Biome binary
- `git diff --check` passed before commit
- `lab1` validation was attempted but SSH timed out; no local heavy fallback was run
- GitHub Actions is the authoritative clean-run validation for this draft

Stacked on #4459 because that PR owns the managed closed live-provider composition this seam completes.
