### PR TITLE
feat(connect): commit dynamic packages through provider holds

### DIFF
--- a/.changeset/calm-otters-hold.md
+++ b/.changeset/calm-otters-hold.md
@@ -1,0 +1,9 @@
+---
+"@voyant-travel/catalog": patch
+"@voyant-travel/catalog-contracts": patch
+"@voyant-travel/voyant-connect-adapter": patch
+---
+
+Commit sourced dynamic packages through a freshly validated Voyant Connect
+hold while preserving Catalog Booking Session quote and supplier-operation
+idempotency semantics.

--- a/docs/architecture/dynamic-packaging-rfc.md
+++ b/docs/architecture/dynamic-packaging-rfc.md
@@ -178,7 +178,32 @@ export function mergedFlightOfferToCandidate(o: MergedFlightOffer): Availability
 1. **Criteria-schema governance** — how `criteriaVersion` is versioned/deprecated across many adapters.
 2. **Candidate persistence depth** — persist (resume/re-rank/audit) vs cache-only. Lean: persist + reaper.
 3. **Sourced `releaseHold`** — sourced adapters only expose `cancel`; compensation falls back to cancel/staff-remediation until a release primitive lands (owned rows already have one).
+
 4. **Atomicity promise** — best-effort + staff remediation vs all-or-nothing. Lean: best-effort with strong compensation.
+
+### 6.1 Managed Storefront package-offer commitment
+
+Voyant Connect dynamic packages use the existing sourced Catalog Item path;
+they do not introduce a package booking engine. At Commit, Catalog adds the
+immutable Booking Session Quote total to the server-owned supplier request.
+The Connect adapter then re-resolves the exact package selection, rejects price
+or availability drift, creates a Connect hold, validates the held snapshot, and
+confirms it with Catalog's stable supplier-operation idempotency key. A changed
+hold is released. An ambiguous confirm is not released or blindly retried:
+Catalog retains the Supplier Operation in doubt for reconciliation. Confirmed
+bookings continue through the existing Booking, Allocation, snapshot, Trip
+component, cancellation, and compensation spine.
+
+The remaining Storefront integration gap is deliberately narrow: the managed
+opaque-reference store added by Storefront PR #4459 currently has an issuer but
+no owner/scope-bound consumer. Until that consumer exists, Storefront cannot
+turn a browser-held `package-offer` capability into the stable Catalog Item and
+public Booking Session selection (`departureDate`, pax, room/rate/board) that
+this adapter accepts. The consumer must validate purpose, storefront, channel,
+owner, scope, expiry, and single-use redemption; it must return only the stable
+selection and must never return or accept a connection/provider id on the
+browser boundary. No fallback may decode the capability in the browser or let
+the caller choose an adapter.
 
 ## 7. Success criteria
 

--- a/packages/catalog-contracts/src/booking-engine/selection-contracts.ts
+++ b/packages/catalog-contracts/src/booking-engine/selection-contracts.ts
@@ -105,6 +105,10 @@ export const bookingSelectionPublicV1 = z.object({
     .object({
       departureSlotId: z.string().optional(),
       departureDate: z.string().optional(), // ISO yyyy-MM-dd
+      /** Package origin pin. This is travel intent, never an adapter selector. */
+      departureAirportCode: z.string().length(3).optional(),
+      /** Exact package duration selected from the live offer. */
+      nights: z.number().int().positive().optional(),
       departureTime: z.string().optional(), // ISO HH:mm
       // Pax counts keyed by band code — `paxBandCodeSchema` lists the
       // canonical codes but the wizard learns the active bands off the

--- a/packages/catalog/openapi/admin/catalog-booking.json
+++ b/packages/catalog/openapi/admin/catalog-booking.json
@@ -14351,6 +14351,15 @@
                           "departureDate": {
                             "type": "string"
                           },
+                          "departureAirportCode": {
+                            "type": "string",
+                            "minLength": 3,
+                            "maxLength": 3
+                          },
+                          "nights": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0
+                          },
                           "departureTime": {
                             "type": "string"
                           },

--- a/packages/catalog/openapi/storefront/catalog-booking.json
+++ b/packages/catalog/openapi/storefront/catalog-booking.json
@@ -14351,6 +14351,15 @@
                           "departureDate": {
                             "type": "string"
                           },
+                          "departureAirportCode": {
+                            "type": "string",
+                            "minLength": 3,
+                            "maxLength": 3
+                          },
+                          "nights": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0
+                          },
                           "departureTime": {
                             "type": "string"
                           },

--- a/packages/catalog/src/booking-engine/quote-support.test.ts
+++ b/packages/catalog/src/booking-engine/quote-support.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest"
+
+import { engineParametersFromSelection } from "./quote-support.js"
+
+describe("Connect package Booking Session parameters", () => {
+  it("projects stable package pins without accepting a provider selector", () => {
+    const parameters = engineParametersFromSelection(
+      undefined,
+      {
+        configure: {
+          departureDate: "2026-09-10",
+          departureAirportCode: "OTP",
+          nights: 5,
+          pax: { adult: 2 },
+          roomTypeId: "room_1",
+          ratePlanId: "rate_1:AI",
+          board: "AI",
+        },
+      },
+      { entityModule: "products", sourceKind: "voyant-connect" },
+    )
+
+    expect(parameters).toMatchObject({
+      connectRoute: "packages",
+      departureDate: "2026-09-10",
+      departureAirportCode: "OTP",
+      nights: 5,
+      paxCount: 2,
+      roomTypeId: "room_1",
+      ratePlanId: "rate_1:AI",
+      board: "AI",
+    })
+    expect(parameters).not.toHaveProperty("connectionId")
+    expect(parameters).not.toHaveProperty("providerId")
+  })
+})

--- a/packages/catalog/src/booking-engine/quote-support.ts
+++ b/packages/catalog/src/booking-engine/quote-support.ts
@@ -17,6 +17,9 @@ export function engineParametersFromSelection(
   const selection = asRecord(selectionPayload)
   const configure = asRecord(selection?.configure)
   const departureSlotId = stringValue(configure?.departureSlotId)
+  const departureDate = stringValue(configure?.departureDate)
+  const departureAirportCode = stringValue(configure?.departureAirportCode)
+  const nights = positiveInteger(configure?.nights)
   const paxCount = sumPax(configure?.pax)
   const next: Record<string, unknown> = {
     ...(parameters ?? {}),
@@ -28,6 +31,11 @@ export function engineParametersFromSelection(
     if (next.departure_id == null) next.departure_id = departureSlotId
     if (next.slotId == null) next.slotId = departureSlotId
   }
+  if (departureDate && next.departureDate == null) next.departureDate = departureDate
+  if (departureAirportCode && next.departureAirportCode == null) {
+    next.departureAirportCode = departureAirportCode
+  }
+  if (nights && next.nights == null) next.nights = nights
   if (paxCount > 0 && next.paxCount == null) next.paxCount = paxCount
   for (const key of ["roomTypeId", "ratePlanId", "board"] as const) {
     const value = stringValue(configure?.[key])
@@ -184,6 +192,10 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
 
 function stringValue(value: unknown): string | null {
   return typeof value === "string" && value.length > 0 ? value : null
+}
+
+function positiveInteger(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : null
 }
 
 function sumPax(value: unknown): number {

--- a/packages/catalog/src/booking-engine/sessions-production.ts
+++ b/packages/catalog/src/booking-engine/sessions-production.ts
@@ -336,7 +336,16 @@ async function commitSourcedBooking(
     repository: createDrizzleSupplierOperationRepository(deps.db),
     registry,
   })
-  const parameters = sourcedParameters(input.session.statePayload, sourced)
+  const parameters = {
+    ...sourcedParameters(input.session.statePayload, sourced),
+    // Server-owned commit evidence. Adapters that perform a provider-side hold
+    // can compare the held total to the immutable Session Quote immediately
+    // before commitment. This is never accepted from a browser selection.
+    bookingQuote: {
+      currency: input.quote.pricing.currency,
+      totalAmountMinor: input.quote.pricing.total,
+    },
+  }
   const request = {
     entity_module: sourced.entityModule,
     entity_id: sourced.entityId,

--- a/packages/voyant-connect-adapter/src/index.ts
+++ b/packages/voyant-connect-adapter/src/index.ts
@@ -19,6 +19,7 @@ export {
   type GeoNameResolver,
   type GeoNameResolverOptions,
 } from "./geo-resolver.js"
+export { withConnectPackageBookingLifecycle } from "./package-booking.js"
 export {
   type ConnectProductPackageSourceAdapterOptions,
   createConnectProductPackageSourceAdapter,

--- a/packages/voyant-connect-adapter/src/package-booking.test.ts
+++ b/packages/voyant-connect-adapter/src/package-booking.test.ts
@@ -1,0 +1,201 @@
+import type {
+  ReserveRequest,
+  SourceAdapter,
+} from "@voyant-travel/catalog-contracts/adapter/contract"
+import { ReservationDispatchError } from "@voyant-travel/catalog-contracts/adapter/contract"
+import type { PackageOffer, VoyantConnectClient } from "@voyant-travel/connect-sdk"
+import { describe, expect, it, vi } from "vitest"
+
+import { withConnectPackageBookingLifecycle } from "./package-booking.js"
+
+const expectedPrice = { currency: "EUR", totalAmountMinor: 100_000 }
+
+describe("Voyant Connect package booking lifecycle", () => {
+  it("revalidates, locks, and confirms through the server-resolved connection", async () => {
+    const current = offer()
+    const { adapter, client } = fixture(current)
+
+    await expect(
+      adapter.reserve?.({ connection_id: "conn_server" }, request()),
+    ).resolves.toMatchObject({
+      upstream_ref: "package:booking_1",
+      status: "confirmed",
+    })
+
+    expect(client.packages.lock).toHaveBeenCalledWith("conn_server", current)
+    expect(client.packages.search).toHaveBeenCalledWith(
+      "conn_server",
+      expect.objectContaining({
+        departure: { airportCodes: ["OTP"] },
+        departureDateFrom: "2026-09-10",
+        departureDateTo: "2026-09-10",
+        nights: { min: 5, max: 5 },
+      }),
+    )
+    expect(client.packages.confirm).toHaveBeenCalledWith(
+      "conn_server",
+      expect.objectContaining({ holdId: "hold_1" }),
+      { idempotencyKey: "bses_1:commit_1:reserve" },
+    )
+    expect(client.packages.lock).not.toHaveBeenCalledWith("conn_browser", expect.anything())
+  })
+
+  it("fails before hold when the provider price moved from the immutable Session Quote", async () => {
+    const { adapter, client } = fixture(
+      offer({ pricing: { ...offer().pricing, total: money(100_001) } }),
+    )
+
+    await expect(adapter.reserve?.({ connection_id: "conn_server" }, request())).resolves.toEqual({
+      upstream_ref: "package-offer:product_1",
+      status: "failed",
+      upstream_payload: { reason: "package_price_changed" },
+    })
+    expect(client.packages.lock).not.toHaveBeenCalled()
+    expect(client.packages.confirm).not.toHaveBeenCalled()
+  })
+
+  it("releases a hold whose provider snapshot changed before confirmation", async () => {
+    const { adapter, client } = fixture(offer(), {
+      heldOffer: offer({ stay: { ...offer().stay, board: "HB" } }),
+    })
+
+    await expect(adapter.reserve?.({ connection_id: "conn_server" }, request())).resolves.toEqual({
+      upstream_ref: "package-offer:product_1",
+      status: "failed",
+      upstream_payload: { reason: "package_hold_changed" },
+    })
+    expect(client.packages.releaseLock).toHaveBeenCalledWith("conn_server", "hold_1")
+    expect(client.packages.confirm).not.toHaveBeenCalled()
+  })
+
+  it("does not release an ambiguous confirmation and reports possibly-sent certainty", async () => {
+    const { adapter, client } = fixture(offer(), { confirmError: new Error("timeout") })
+
+    const error = await adapter
+      .reserve?.({ connection_id: "conn_server" }, request())
+      .catch((value) => value)
+
+    expect(error).toBeInstanceOf(ReservationDispatchError)
+    expect(error).toMatchObject({
+      certainty: "possibly_sent",
+      errorClass: "package_confirmation_in_doubt",
+    })
+    expect(client.packages.releaseLock).not.toHaveBeenCalled()
+  })
+
+  it("fails closed without a server-resolved connection", async () => {
+    const { adapter, client } = fixture(offer())
+
+    const error = await adapter.reserve?.({ connection_id: "engine" }, request()).catch((e) => e)
+
+    expect(error).toMatchObject({
+      certainty: "not_sent",
+      errorClass: "package_connection_unavailable",
+    })
+    expect(client.packages.lock).not.toHaveBeenCalled()
+  })
+
+  it("fails closed when the stable package selection is incomplete", async () => {
+    const { adapter, client } = fixture(offer())
+    const incomplete = request()
+    delete incomplete.parameters.departureAirportCode
+
+    await expect(adapter.reserve?.({ connection_id: "conn_server" }, incomplete)).resolves.toEqual({
+      upstream_ref: "package-offer:product_1",
+      status: "failed",
+      upstream_payload: { reason: "package_offer_unavailable" },
+    })
+    expect(client.packages.lock).not.toHaveBeenCalled()
+  })
+})
+
+function fixture(
+  currentOffer: PackageOffer,
+  options: { heldOffer?: PackageOffer; confirmError?: Error } = {},
+) {
+  const liveResolve = vi.fn(async () => ({
+    values: { product_1: { offer: currentOffer } },
+  }))
+  const base: SourceAdapter = {
+    kind: "voyant-connect",
+    capabilities: {
+      verticals: ["products"],
+      supportsLiveResolution: true,
+      supportsDriftDetection: false,
+      supportsBookingForwarding: true,
+      postBookOperations: ["cancel", "status"],
+    },
+    liveResolve,
+    reserve: vi.fn(),
+  }
+  const confirm = options.confirmError
+    ? vi.fn().mockRejectedValue(options.confirmError)
+    : vi.fn().mockResolvedValue({ id: "booking_1", status: "confirmed" })
+  const client = {
+    packages: {
+      search: vi.fn().mockResolvedValue({ offers: [currentOffer] }),
+      lock: vi.fn().mockResolvedValue({
+        id: "hold_1",
+        offerSnapshot: options.heldOffer ?? currentOffer,
+        status: "active",
+        expiresAt: "2099-01-01T00:00:00.000Z",
+      }),
+      releaseLock: vi.fn().mockResolvedValue({}),
+      confirm,
+    },
+  } as unknown as VoyantConnectClient
+  return { adapter: withConnectPackageBookingLifecycle(base, client), client }
+}
+
+function request(): ReserveRequest {
+  return {
+    entity_module: "products",
+    entity_id: "product_1",
+    source_ref: "product_1",
+    scope: { locale: "ro-RO", market: "market_ro", audience: "customer", currency: "EUR" },
+    parameters: {
+      connectRoute: "packages",
+      bookingQuote: expectedPrice,
+      // A browser-supplied selector must not override SourceAdapterContext.
+      connectionId: "conn_browser",
+      departureDate: "2026-09-10",
+      departureAirportCode: "OTP",
+      nights: 5,
+      roomTypeId: "room_1",
+      ratePlanId: "rate_1:AI",
+      board: "AI",
+      travelers: [{ category: "adult", firstName: "Ana", lastName: "Pop", isPrimary: true }],
+      leadTraveler: { category: "adult", firstName: "Ana", lastName: "Pop", isPrimary: true },
+    },
+    party: { contact: { email: "ana@example.test" } },
+    idempotency_key: "bses_1:commit_1:reserve",
+  }
+}
+
+function money(amountMinor: number) {
+  return { amountMinor, currency: "EUR", currencyPrecision: 2 }
+}
+
+function offer(overrides: Partial<PackageOffer> = {}): PackageOffer {
+  return {
+    id: "offer_1",
+    connectionId: "conn_server",
+    supplierId: "supplier_1",
+    productRef: { entityModule: "products", entityId: "product_1" },
+    stay: {
+      ref: { entityModule: "accommodations", entityId: "hotel_1" },
+      roomTypeId: "room_1",
+      ratePlanId: "rate_1:AI",
+      board: "AI",
+      checkIn: "2026-09-10",
+      checkOut: "2026-09-15",
+      nights: 5,
+      occupancy: { adults: 2 },
+    },
+    flights: [{ origin: "OTP", destination: "FCO" }],
+    pricing: { perPerson: money(50_000), total: money(100_000) },
+    cancellationPolicy: { deadlines: [] },
+    expiresAt: "2099-01-01T00:00:00.000Z",
+    ...overrides,
+  }
+}

--- a/packages/voyant-connect-adapter/src/package-booking.ts
+++ b/packages/voyant-connect-adapter/src/package-booking.ts
@@ -1,0 +1,360 @@
+import type {
+  LiveResolveRequest,
+  ReserveRequest,
+  SourceAdapter,
+  SourceAdapterContext,
+} from "@voyant-travel/catalog-contracts/adapter/contract"
+import { ReservationDispatchError } from "@voyant-travel/catalog-contracts/adapter/contract"
+import type {
+  PackageConfirmInput,
+  PackageHold,
+  PackageOffer,
+  PackageSearchQuery,
+  Traveler,
+  VoyantConnectClient,
+} from "@voyant-travel/connect-sdk"
+
+import { recordValue, stringValue } from "./utils.js"
+
+interface ExpectedPackagePrice {
+  currency: string
+  totalAmountMinor: number
+}
+
+/**
+ * Add Connect's Offer -> Hold -> Booking ladder to the generic Catalog source
+ * adapter. Catalog remains the lifecycle owner: this wrapper only translates
+ * one already-admitted sourced Product reservation into provider operations.
+ */
+export function withConnectPackageBookingLifecycle(
+  base: SourceAdapter,
+  client: VoyantConnectClient,
+): SourceAdapter {
+  return {
+    ...base,
+    async liveResolve(ctx, request) {
+      if (request.parameters?.connectRoute === "packages") {
+        return liveResolvePackage(client, ctx, request)
+      }
+      if (!base.liveResolve) return { values: {}, failed: missing(request.ids) }
+      return base.liveResolve(ctx, request)
+    },
+    async reserve(ctx, request) {
+      if (request.parameters.connectRoute !== "packages") {
+        if (!base.reserve) {
+          throw new ReservationDispatchError(
+            "Voyant Connect booking forwarding is unavailable",
+            "not_sent",
+            "booking_forwarding_unavailable",
+          )
+        }
+        return base.reserve(ctx, request)
+      }
+      return reservePackage(client, ctx, request)
+    },
+  }
+}
+
+async function reservePackage(
+  client: VoyantConnectClient,
+  ctx: SourceAdapterContext,
+  request: ReserveRequest,
+) {
+  const connectionId = requiredConnectionId(ctx)
+  let resolved: PackageOffer | null
+  try {
+    resolved = await resolveExactOffer(client, ctx, request)
+  } catch (error) {
+    throw new ReservationDispatchError(
+      message(error, "Voyant Connect package revalidation failed"),
+      "not_sent",
+      "package_quote_unavailable",
+    )
+  }
+  if (!resolved) {
+    return failedPackageResult(request.entity_id, "package_offer_unavailable")
+  }
+  if (resolved.connectionId !== connectionId || Date.parse(resolved.expiresAt) <= Date.now()) {
+    return failedPackageResult(request.entity_id, "package_offer_unavailable")
+  }
+  const expected = expectedPackagePrice(request.parameters)
+  if (!expected || !samePrice(resolved, expected)) {
+    return failedPackageResult(request.entity_id, "package_price_changed")
+  }
+
+  let hold: PackageHold
+  try {
+    hold = await client.packages.lock(connectionId, resolved)
+  } catch (error) {
+    throw new ReservationDispatchError(
+      message(error, "Voyant Connect package hold failed"),
+      "not_sent",
+      "package_hold_failed",
+    )
+  }
+
+  const heldOffer = hold.offerSnapshot
+  if (
+    hold.status !== "active" ||
+    Date.parse(hold.expiresAt) <= Date.now() ||
+    !samePackageSelection(resolved, heldOffer) ||
+    !samePrice(heldOffer, expected)
+  ) {
+    await releaseFailedHold(client, connectionId, hold.id)
+    return failedPackageResult(request.entity_id, "package_hold_changed")
+  }
+
+  const confirm = packageConfirmInput(request, hold.id)
+  if (!confirm) {
+    await releaseFailedHold(client, connectionId, hold.id)
+    return failedPackageResult(request.entity_id, "package_party_incomplete")
+  }
+
+  try {
+    const booking = await client.packages.confirm(connectionId, confirm, {
+      idempotencyKey: request.idempotency_key,
+    })
+    return {
+      upstream_ref: `package:${booking.id}`,
+      status:
+        booking.status === "confirmed"
+          ? ("confirmed" as const)
+          : booking.status === "pending"
+            ? ("held" as const)
+            : ("failed" as const),
+      upstream_payload: booking as unknown as Record<string, unknown>,
+    }
+  } catch (error) {
+    // The request may have reached Connect. Releasing here could cancel the
+    // capacity behind a successfully-created booking, so Catalog must retain
+    // its supplier operation in doubt and reconcile by the stable write key.
+    throw new ReservationDispatchError(
+      message(error, "Voyant Connect package confirmation is in doubt"),
+      "possibly_sent",
+      "package_confirmation_in_doubt",
+    )
+  }
+}
+
+async function resolveExactOffer(
+  client: VoyantConnectClient,
+  ctx: SourceAdapterContext,
+  request: ReserveRequest,
+): Promise<PackageOffer | null> {
+  const liveRequest: LiveResolveRequest = {
+    ids: [request.entity_id],
+    ...(request.source_ref ? { source_refs: { [request.entity_id]: request.source_ref } } : {}),
+    scope: request.scope ?? { locale: "en", market: "default", audience: "customer" },
+    parameters: withoutBookingQuote(request.parameters),
+  }
+  const result = await liveResolvePackage(client, ctx, liveRequest)
+  if (result.failed?.[request.entity_id]) return null
+  const value = recordValue(result.values[request.entity_id])
+  return packageOffer(value?.offer)
+}
+
+async function liveResolvePackage(
+  client: VoyantConnectClient,
+  ctx: SourceAdapterContext,
+  request: LiveResolveRequest,
+) {
+  const connectionId = requiredConnectionId(ctx)
+  const parameters = request.parameters ?? {}
+  const departureDate = stringValue(parameters.departureDate)
+  if (!departureDate) return { values: {}, failed: missing(request.ids) }
+  const pax = recordValue(recordValue(parameters.draft)?.configure)?.pax
+  const paxRecord = recordValue(pax)
+  const adults = integer(paxRecord?.adults) ?? integer(parameters.paxCount) ?? 2
+  const children = integer(paxRecord?.children)
+  const nights = integer(parameters.nights)
+  const departureAirportCode = stringValue(parameters.departureAirportCode)
+  if (
+    !departureAirportCode ||
+    nights === undefined ||
+    (!stringValue(parameters.roomTypeId) &&
+      !stringValue(parameters.ratePlanId) &&
+      !stringValue(parameters.board))
+  ) {
+    return { values: {}, failed: missing(request.ids) }
+  }
+  const query: PackageSearchQuery = {
+    departure: { airportCodes: [departureAirportCode] },
+    accommodationIds: [...new Set(request.ids.map((id) => id.replace(/^[^:]+:/, "")))],
+    departureDateFrom: departureDate,
+    departureDateTo: departureDate,
+    occupancy: { adults, ...(children !== undefined ? { children } : {}) },
+    nights: { min: nights, max: nights },
+    ...(request.scope.locale ? { locale: request.scope.locale } : {}),
+    limit: 100,
+  }
+  const response = await client.packages.search(connectionId, query)
+  const chosen = new Map<string, PackageOffer>()
+  for (const offer of response.offers) {
+    const id = offer.productRef.entityId
+    if (!request.ids.includes(id) || offer.connectionId !== connectionId) continue
+    const current = chosen.get(id)
+    if (!current || (matchesPin(offer, parameters) && !matchesPin(current, parameters))) {
+      chosen.set(id, offer)
+    }
+  }
+  const values: Record<string, Record<string, unknown>> = {}
+  for (const [id, offer] of chosen) {
+    if (Date.parse(offer.expiresAt) <= Date.now()) continue
+    values[id] = {
+      available: true,
+      offer: offer as unknown as Record<string, unknown>,
+      priceCents: offer.pricing.total.amountMinor,
+      currency: offer.pricing.total.currency,
+      expires_at: offer.expiresAt,
+      cancellationPolicy: offer.cancellationPolicy,
+    }
+  }
+  const failed = missing(request.ids.filter((id) => !values[id]))
+  return Object.keys(failed).length > 0 ? { values, failed } : { values }
+}
+
+function matchesPin(offer: PackageOffer, parameters: Record<string, unknown>): boolean {
+  const roomTypeId = stringValue(parameters.roomTypeId)
+  const ratePlanId = stringValue(parameters.ratePlanId)
+  const board = stringValue(parameters.board)
+  return (
+    (!roomTypeId || offer.stay.roomTypeId === roomTypeId) &&
+    (!ratePlanId || offer.stay.ratePlanId === ratePlanId) &&
+    (!board || offer.stay.board === board)
+  )
+}
+
+function missing(ids: readonly string[]): Record<string, "not_found"> {
+  return Object.fromEntries(ids.map((id) => [id, "not_found"]))
+}
+
+function integer(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : undefined
+}
+
+function packageConfirmInput(request: ReserveRequest, holdId: string): PackageConfirmInput | null {
+  const travelers = Array.isArray(request.parameters.travelers)
+    ? request.parameters.travelers.flatMap((value) => {
+        const traveler = packageTraveler(value)
+        return traveler ? [traveler] : []
+      })
+    : []
+  const lead = packageTraveler(request.parameters.leadTraveler) ?? travelers[0]
+  const partyContact = recordValue(request.party)?.contact
+  const contact = recordValue(partyContact) ?? recordValue(request.parameters.contact)
+  const email = stringValue(contact?.email)
+  const phone = stringValue(contact?.phone)
+  if (!lead || travelers.length === 0 || !email) return null
+  return {
+    holdId,
+    leadTraveler: lead,
+    travelers,
+    contact: {
+      email,
+      ...(phone ? { phone } : {}),
+    },
+  }
+}
+
+function packageTraveler(value: unknown): Traveler | null {
+  const row = recordValue(value)
+  const firstName = stringValue(row?.firstName)
+  const lastName = stringValue(row?.lastName)
+  if (!firstName || !lastName) return null
+  const category = row?.category
+  return {
+    category:
+      category === "child" || category === "infant" || category === "senior" || category === "adult"
+        ? category
+        : "adult",
+    firstName,
+    lastName,
+    ...(typeof row?.dateOfBirth === "string" ? { dateOfBirth: row.dateOfBirth } : {}),
+    ...(typeof row?.isPrimary === "boolean" ? { isPrimary: row.isPrimary } : {}),
+  }
+}
+
+function expectedPackagePrice(parameters: Record<string, unknown>): ExpectedPackagePrice | null {
+  const quote = recordValue(parameters.bookingQuote)
+  const currency = stringValue(quote?.currency)
+  const totalAmountMinor = quote?.totalAmountMinor
+  return currency && typeof totalAmountMinor === "number" && Number.isInteger(totalAmountMinor)
+    ? { currency, totalAmountMinor }
+    : null
+}
+
+function samePrice(offer: PackageOffer, expected: ExpectedPackagePrice): boolean {
+  return (
+    offer.pricing.total.currency === expected.currency &&
+    offer.pricing.total.amountMinor === expected.totalAmountMinor
+  )
+}
+
+function samePackageSelection(left: PackageOffer, right: PackageOffer): boolean {
+  return (
+    left.connectionId === right.connectionId &&
+    left.productRef.entityId === right.productRef.entityId &&
+    left.stay.ref.entityId === right.stay.ref.entityId &&
+    left.stay.roomTypeId === right.stay.roomTypeId &&
+    left.stay.ratePlanId === right.stay.ratePlanId &&
+    left.stay.board === right.stay.board &&
+    left.stay.checkIn === right.stay.checkIn &&
+    left.stay.checkOut === right.stay.checkOut
+  )
+}
+
+function packageOffer(value: unknown): PackageOffer | null {
+  const row = recordValue(value)
+  const pricing = recordValue(row?.pricing)
+  const total = recordValue(pricing?.total)
+  const productRef = recordValue(row?.productRef)
+  const stay = recordValue(row?.stay)
+  if (
+    !stringValue(row?.id) ||
+    !stringValue(row?.connectionId) ||
+    !stringValue(productRef?.entityId) ||
+    !stringValue(stay?.checkIn) ||
+    !stringValue(stay?.checkOut) ||
+    !stringValue(total?.currency) ||
+    typeof total?.amountMinor !== "number"
+  ) {
+    return null
+  }
+  return value as PackageOffer
+}
+
+function withoutBookingQuote(parameters: Record<string, unknown>): Record<string, unknown> {
+  const { bookingQuote: _bookingQuote, ...selection } = parameters
+  return selection
+}
+
+async function releaseFailedHold(
+  client: VoyantConnectClient,
+  connectionId: string,
+  holdId: string,
+): Promise<void> {
+  await client.packages.releaseLock(connectionId, holdId).catch(() => undefined)
+}
+
+function failedPackageResult(entityId: string, reason: string) {
+  return {
+    upstream_ref: `package-offer:${entityId}`,
+    status: "failed" as const,
+    upstream_payload: { reason },
+  }
+}
+
+function requiredConnectionId(ctx: SourceAdapterContext): string {
+  if (!ctx.connection_id || ctx.connection_id === "engine") {
+    throw new ReservationDispatchError(
+      "Voyant Connect package booking requires a server-resolved connection",
+      "not_sent",
+      "package_connection_unavailable",
+    )
+  }
+  return ctx.connection_id
+}
+
+function message(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback
+}

--- a/packages/voyant-connect-adapter/src/sources.ts
+++ b/packages/voyant-connect-adapter/src/sources.ts
@@ -16,6 +16,7 @@ import {
   type DestinationNameResolver,
   type GeoNameResolver,
 } from "./geo-resolver.js"
+import { withConnectPackageBookingLifecycle } from "./package-booking.js"
 import { createConnectProductPackageSourceAdapter } from "./package-products.js"
 import { positiveInteger, recordValue, stringValue } from "./utils.js"
 
@@ -115,13 +116,16 @@ function createDefaultSources(
   return [
     {
       role: "generic",
-      adapter: createVoyantConnectSourceAdapter({
-        client: options.client,
-        operatorId: options.operatorId,
-        market: options.market,
-        discoverLimit: options.discoverLimit,
-        mapDocument: skipCruiseConnectDocuments,
-      }),
+      adapter: withConnectPackageBookingLifecycle(
+        createVoyantConnectSourceAdapter({
+          client: options.client,
+          operatorId: options.operatorId,
+          market: options.market,
+          discoverLimit: options.discoverLimit,
+          mapDocument: skipCruiseConnectDocuments,
+        }),
+        options.client,
+      ),
     },
     {
       role: "cruises",
@@ -153,15 +157,18 @@ function createConnectionScopedSources(
       connectionId: connection.id,
       role: "generic",
       sourceProvider,
-      adapter: createVoyantConnectSourceAdapter({
-        client: options.client,
-        operatorId: options.operatorId,
-        sourceProvider,
-        connectionIds: [connection.id],
-        market: options.market,
-        discoverLimit: options.discoverLimit,
-        mapDocument: skipCruiseConnectDocuments,
-      }),
+      adapter: withConnectPackageBookingLifecycle(
+        createVoyantConnectSourceAdapter({
+          client: options.client,
+          operatorId: options.operatorId,
+          sourceProvider,
+          connectionIds: [connection.id],
+          market: options.market,
+          discoverLimit: options.discoverLimit,
+          mapDocument: skipCruiseConnectDocuments,
+        }),
+        options.client,
+      ),
     },
     {
       connectionId: `${connection.id}:cruises`,


### PR DESCRIPTION
## What changed

- carry the immutable Booking Session Quote total into sourced supplier requests as server-owned commit evidence
- wrap Voyant Connect catalog sources with an exact dynamic-package revalidation path that pins origin, date, duration, room/rate/board, and the server-resolved connection
- execute Connect's provider-first `search -> lock -> confirm` ladder inside the existing Catalog Supplier Operation / Booking Session spine
- release changed or incomplete holds, but retain ambiguous confirmation attempts in doubt for reconciliation
- preserve the existing Connect package cancellation/retrieval path and Catalog/Trip booking materialization
- document the exact remaining Storefront opaque-reference consumer gap from #4459

## Security and lifecycle posture

- browser input cannot select a connection or provider; adapter dispatch uses only `SourceAdapterContext.connection_id`
- quote/hold price drift and held-selection drift fail closed
- confirmation uses Catalog's stable supplier-operation idempotency key
- ambiguous confirms are never blindly retried or compensated by releasing potentially-booked capacity

## Validation

- focused Biome check passed for the 8 touched TypeScript files
- `git diff --check` passed
- focused tests added for exact search pins, server-owned connection selection, price drift, hold compensation, ambiguous confirmation, incomplete selections, and Booking Session parameter projection
- lab1 validation was attempted but SSH port 22 timed out; no local test/typecheck fallback was run. GitHub Actions is the validation lane for this draft.

## Remaining provider gap

Storefront #4459 issues single-use `package-offer` capabilities but does not yet expose an owner/scope-bound consumer. A follow-up must redeem that ref server-side and map it to the stable public Booking Session selection (`departureDate`, `departureAirportCode`, `nights`, pax, room/rate/board). It must validate purpose, storefront, channel, owner, scope, expiry, and single-use state, and must never expose or accept connection/provider identifiers at the browser boundary.
