### PR TITLE
perf(catalog): reduce booking session database round trips

### DIFF
--- a/.changeset/quiet-sessions-travel.md
+++ b/.changeset/quiet-sessions-travel.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/catalog": patch
+---
+
+Reduce booking-session mutation database round trips by reusing the transaction-locked Session and superseding active Quotes with one set-based write.

--- a/packages/catalog/src/booking-engine/sessions-drizzle.ts
+++ b/packages/catalog/src/booking-engine/sessions-drizzle.ts
@@ -217,6 +217,17 @@ export function createDrizzleBookingSessionRepository(
         )
       return rows.map(mapQuote)
     },
+    async supersedeActiveQuotes(sessionId) {
+      await resolveDb()
+        .update(bookingSessionQuotesTable)
+        .set({ state: "superseded" })
+        .where(
+          and(
+            eq(bookingSessionQuotesTable.sessionId, sessionId),
+            eq(bookingSessionQuotesTable.state, "active"),
+          ),
+        )
+    },
     async getQuote(quoteId) {
       const [row] = await resolveDb()
         .select()
@@ -443,10 +454,13 @@ export function createDrizzleBookingSessionRepository(
       }
       return db.transaction(async (tx) =>
         txStore.run(tx as PostgresJsDatabase, async () => {
-          await resolveDb().execute(
-            sql`select id from booking_sessions where id = ${sessionId} for update`,
-          )
-          return operation(tx)
+          const [row] = await resolveDb()
+            .select()
+            .from(bookingSessionsTable)
+            .where(eq(bookingSessionsTable.id, sessionId))
+            .for("update")
+            .limit(1)
+          return operation(tx, row ? mapSession(row) : null)
         }),
       )
     },

--- a/packages/catalog/src/booking-engine/sessions-memory.ts
+++ b/packages/catalog/src/booking-engine/sessions-memory.ts
@@ -91,6 +91,13 @@ export function createInMemoryBookingSessionRepository(): InMemoryBookingSession
         .filter((quote) => quote.sessionId === sessionId && quote.state === "active")
         .map(cloneQuote)
     },
+    async supersedeActiveQuotes(sessionId) {
+      for (const [id, quote] of repository.quotes) {
+        if (quote.sessionId === sessionId && quote.state === "active") {
+          repository.quotes.set(id, { ...cloneQuote(quote), state: "superseded" })
+        }
+      }
+    },
     async getQuote(quoteId) {
       const quote = repository.quotes.get(quoteId)
       return quote ? cloneQuote(quote) : null
@@ -217,7 +224,8 @@ export function createInMemoryBookingSessionRepository(): InMemoryBookingSession
         auditEvents: cloneMap(repository.auditEvents, cloneAudit),
       }
       try {
-        return await operation(undefined)
+        const session = repository.sessions.get(sessionId)
+        return await operation(undefined, session ? cloneSession(session) : null)
       } catch (error) {
         repository.sessions = snapshot.sessions
         repository.quotes = snapshot.quotes

--- a/packages/catalog/src/booking-engine/sessions-service.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-service.test.ts
@@ -848,6 +848,40 @@ describe("Booking Session v1 owned tracer", () => {
     expect(harness.inventory.bookingIds).toEqual([])
   })
 
+  it("reuses the transaction-locked Session and supersedes Quotes in one repository operation", async () => {
+    const { harness, session, capability, quote } = await createQuoteAndHold()
+    let getSessionCalls = 0
+    let supersedeCalls = 0
+    const getSession = harness.repository.getSession.bind(harness.repository)
+    const supersedeActiveQuotes = harness.repository.supersedeActiveQuotes!.bind(harness.repository)
+    harness.repository.getSession = async (sessionId) => {
+      getSessionCalls += 1
+      return getSession(sessionId)
+    }
+    harness.repository.supersedeActiveQuotes = async (sessionId) => {
+      supersedeCalls += 1
+      return supersedeActiveQuotes(sessionId)
+    }
+    harness.repository.listActiveQuotes = async () => {
+      throw new Error("update should not load Quotes before superseding them")
+    }
+
+    const updated = await harness.module.updateSession(
+      session.id,
+      {
+        idempotencyKey: "update_bulk_supersede",
+        expectedRevision: session.revision,
+        selection: { departureSlotId: "slot_later" },
+      },
+      { ...ANONYMOUS_ACCESS, capability },
+    )
+
+    expect(updated).toMatchObject({ kind: "session_updated", session: { revision: 2 } })
+    expect(getSessionCalls).toBe(0)
+    expect(supersedeCalls).toBe(1)
+    expect(harness.repository.quotes.get(quote.id)?.state).toBe("superseded")
+  })
+
   it("checks Hold expiry synchronously at Commit", async () => {
     const { harness, session, capability, quote, hold } = await createQuoteAndHold()
     harness.advance(61_000)

--- a/packages/catalog/src/booking-engine/sessions-service.ts
+++ b/packages/catalog/src/booking-engine/sessions-service.ts
@@ -182,6 +182,7 @@ export interface BookingSessionRepository {
   }): Promise<BookingSessionInternalRecord[]>
   purgeSessionArtifacts(sessionId: string): Promise<void>
   listActiveQuotes(sessionId: string): Promise<BookingQuoteInternalRecord[]>
+  supersedeActiveQuotes?(sessionId: string): Promise<void>
   getQuote(quoteId: string): Promise<BookingQuoteInternalRecord | null>
   saveQuote(record: BookingQuoteInternalRecord): Promise<void>
   getHold(holdId: string): Promise<BookingHoldInternalRecord | null>
@@ -213,7 +214,10 @@ export interface BookingSessionRepository {
     now: Date
   }): Promise<void>
   withTransactionContext<T>(tx: unknown, operation: () => Promise<T>): Promise<T>
-  withSessionTransaction<T>(sessionId: string, operation: (tx: unknown) => Promise<T>): Promise<T>
+  withSessionTransaction<T>(
+    sessionId: string,
+    operation: (tx: unknown, session?: BookingSessionInternalRecord | null) => Promise<T>,
+  ): Promise<T>
 }
 
 export interface ComposeBookingQuoteInput {
@@ -831,8 +835,8 @@ export function createBookingSessionModule(
     },
 
     async resumeSession(sessionId, access) {
-      return repository.withSessionTransaction(sessionId, async (tx) => {
-        const session = await loadSession(sessionId)
+      return repository.withSessionTransaction(sessionId, async (tx, lockedSession) => {
+        const session = lockedSession === undefined ? await loadSession(sessionId) : lockedSession
         if (!session) return { kind: "rejected", error: { kind: "session_expired" } }
         const authorized = await authorizeSessionAccess(session, access, "read")
         if (authorized) return authorized
@@ -915,8 +919,8 @@ export function createBookingSessionModule(
     },
 
     async renewSession(sessionId, input, access) {
-      return repository.withSessionTransaction(sessionId, async (tx) => {
-        const session = await loadSession(sessionId)
+      return repository.withSessionTransaction(sessionId, async (tx, lockedSession) => {
+        const session = lockedSession === undefined ? await loadSession(sessionId) : lockedSession
         if (!session) return { kind: "rejected", error: { kind: "session_expired" } }
         const authorized = await authorizeSessionAccess(session, access, "renew")
         if (authorized) return authorized
@@ -951,10 +955,7 @@ export function createBookingSessionModule(
         }
 
         await releaseLiveHolds(repository, options.ports, session, access, at, tx)
-        for (const quote of await repository.listActiveQuotes(session.id)) {
-          quote.state = "superseded"
-          await repository.saveQuote(quote)
-        }
+        await supersedeActiveQuotes(repository, session.id)
         session.expiresAt = renewedExpiry
         session.revision += 1
         session.updatedAt = at
@@ -972,8 +973,8 @@ export function createBookingSessionModule(
     },
 
     async updateSession(sessionId, input, access) {
-      return repository.withSessionTransaction(sessionId, async (tx) => {
-        const session = await loadSession(sessionId)
+      return repository.withSessionTransaction(sessionId, async (tx, lockedSession) => {
+        const session = lockedSession === undefined ? await loadSession(sessionId) : lockedSession
         if (!session) return { kind: "rejected", error: { kind: "session_expired" } }
         const authorized = await authorizeSessionAccess(session, access, "update")
         if (authorized) return authorized
@@ -1009,10 +1010,7 @@ export function createBookingSessionModule(
         session.statePayload = statePayload
         session.revision += 1
         session.updatedAt = at
-        for (const quote of await repository.listActiveQuotes(session.id)) {
-          quote.state = "superseded"
-          await repository.saveQuote(quote)
-        }
+        await supersedeActiveQuotes(repository, session.id)
         await repository.saveSession(session)
         await appendSessionAudit(repository, session, "update", access, at)
         const outcome: BookingSessionOutcomeV1 = {
@@ -1025,8 +1023,8 @@ export function createBookingSessionModule(
     },
 
     async quoteSession(sessionId, input, access) {
-      return repository.withSessionTransaction(sessionId, async (tx) => {
-        const session = await loadSession(sessionId)
+      return repository.withSessionTransaction(sessionId, async (tx, lockedSession) => {
+        const session = lockedSession === undefined ? await loadSession(sessionId) : lockedSession
         if (!session) return { kind: "rejected", error: { kind: "session_expired" } }
         const authorized = await authorizeSessionAccess(session, access, "quote")
         if (authorized) return authorized
@@ -1046,10 +1044,7 @@ export function createBookingSessionModule(
         if (revisionRejected) return completeAndReturn(repository, claim.id, revisionRejected)
 
         await releaseLiveHolds(repository, options.ports, session, access, at, tx)
-        for (const quote of await repository.listActiveQuotes(session.id)) {
-          quote.state = "superseded"
-          await repository.saveQuote(quote)
-        }
+        await supersedeActiveQuotes(repository, session.id)
 
         const composed = await options.ports.composeQuote({ session, now: at, tx })
         if (composed.status === "unavailable") {
@@ -2214,6 +2209,20 @@ function commitRejectionNextAction(
       return "request_fresh_quote"
     case "incomplete_draft":
       return "update_selection"
+  }
+}
+
+async function supersedeActiveQuotes(
+  repository: BookingSessionRepository,
+  sessionId: string,
+): Promise<void> {
+  if (repository.supersedeActiveQuotes) {
+    await repository.supersedeActiveQuotes(sessionId)
+    return
+  }
+  for (const quote of await repository.listActiveQuotes(sessionId)) {
+    quote.state = "superseded"
+    await repository.saveQuote(quote)
   }
 }
 


### PR DESCRIPTION
## Outcome

Reduce serial SQL work in the booking-session update, quote, renew, and resume paths.

## Changes

- Return the locked Session from the existing SELECT FOR UPDATE instead of immediately issuing a second read.
- Supersede all active Quotes with one set-based UPDATE instead of SELECT plus N writes.
- Preserve compatibility for custom repositories through optional fast-path seams and existing fallback behavior.
- Keep transaction, idempotency, audit, and hold-release ordering unchanged.

## Validation

- Focused booking-session lifecycle tests: 45/45 passed.
- Biome on all changed TypeScript files: passed.
- git diff --check: passed.
- Package typecheck was attempted locally but Node reached its default 4 GB heap ceiling after about 89 seconds; Depot CI is the authoritative typecheck lane.

## Performance expectation

For a normal update with no active holds, this removes one guaranteed Session read and replaces Quote supersession from two or more round trips with one UPDATE.