### PR TITLE
feat(flights): add provider-first booking lifecycle

### DIFF
--- a/.changeset/closed-flight-booking-lifecycle.md
+++ b/.changeset/closed-flight-booking-lifecycle.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/flights": minor
+"@voyant-travel/storefront": patch
+---
+
+Add a closed provider-first flight requote, hold, and idempotent commit lifecycle over exact Storefront offer/connection bindings.

--- a/docs/architecture/catalog-flights-architecture.md
+++ b/docs/architecture/catalog-flights-architecture.md
@@ -109,7 +109,8 @@ The flight orchestration layer fans out across all admitted flight connections i
 trusted Storefront context
   -> listAdmittedShoppingSources({ storefrontId, channelId, marketId, locale, currency })
   -> fanOutFlightSearch({ adapters: admittedSources, request: publicFlightIntent })
-  -> opaque single-use offer ref containing exact offer/connection ownership
+  -> opaque single-use offer ref containing exact offer/connection/scope ownership
+  -> server-side requote -> provider hold -> idempotent ticket commit
 ```
 
 The orchestration layer:
@@ -119,6 +120,38 @@ The orchestration layer:
 - **Partial success is the default.** Whatever providers responded come back; the rest are flagged in a `perConnection` status map.
 - **Deduplicates by itinerary fingerprint** — a deterministic key derived from segments (carrier codes + flight numbers + departure/arrival airports + times + cabin). Two providers selling the same flight produce identical fingerprints and merge into one `MergedFlightOffer` with a `cheapest` plus `alternates[]` and `sourceConnectionIds[]`.
 - **KV-cached at the `(sortedConnectionIds, requestHash)` level** with the `tier` parameter controlling cache participation: `"browse"` (default, ~15 min TTL — forgiving for browse pages) vs `"booking"` (skip cache, fresh prices before `priceOffer` / `bookFlight`).
+
+### 4.1 Storefront booking lifecycle boundary
+
+`createProviderFirstFlightBookingLifecycle` is the closed consumer of the
+server-only payload sealed into the opaque offer reference. It requires the
+deployment to revalidate the active storefront/channel and resolved market,
+locale, and currency, then re-enumerates admitted sources before requote, hold,
+and commit; a disabled channel, changed scope, disconnected connection, or
+out-of-scope connection therefore fails closed. The browser never submits a
+provider, connection, account, engine, or payment selector.
+
+The lifecycle requires a durable operation store to claim an idempotency key
+and request fingerprint before either supplier mutation. Reuse with changed
+passengers, offer, revision, or order is rejected. A price lock and hold each
+advance an optimistic revision and carry bounded expiry. Hold always sends the
+existing provider contract's `{ type: "hold" }` intent; commit only promotes
+that exact held order through `ticketOrder`. It does not introduce another
+payment session, checkout route, or booking engine.
+
+Flights whose provider does not declare `flight/holds` and implement
+`ticketOrder` are deliberately not bookable through this seam. An invalid
+provider hold is cancelled as compensation. Ambiguous supplier failures,
+failed compensation, and loss of durable settlement after a supplier effect
+are reported as `in_doubt` for operator reconciliation rather than guessed
+successful or retried against another connection.
+
+Catalog Booking Sessions remain the general quote/hold/commit and payment
+commitment authority. Trip remains the composite coordinator. A deployment
+integrating this seam must resolve the Trips-owned opaque reference on the
+server and persist lifecycle outcomes through those existing authorities; the
+standalone Flights admin `/price`, `/book`, and `/orders` routes are not a
+public Storefront bridge.
 
 This is the missing piece that makes "one API, many providers" true at the call level rather than just at the contract level. An agency wired to Hisky + Amadeus + a charter consolidator gets one merged result set without writing fan-out, dedupe, or partial-failure handling themselves.
 
@@ -226,6 +259,8 @@ Flight adapters (Hisky, Amadeus, Duffel, Sabre, Travelport NDC, an operator-buil
 2. **Whether an `IndexerAdapter` capability flag should advertise that flights are not indexed at all** (`supportsVerticals: string[]` excluding `"flights"`), or whether the `flights` vertical itself is structurally absent from any indexer-side code path. Lean toward the latter — flights bypass the indexer entirely; no flag is needed.
 3. **Pricing-cache TTL semantics under heavy regulatory variance.** The `tier: "browse"` 15-min TTL is borrowed from Connect's defaults. Markets with rapid currency or fare-rule shifts (e.g. competitive long-haul) may need shorter TTLs. Defer to deployment configuration.
 4. **First-party shipped `ReferenceDataProvider` implementations.** v1 of Phase 3 ships at minimum the in-deployment local-Postgres provider, the static-bundle provider, and the Voyant Data provider. Whether to ship a Cirium / OAG provider as first-party depends on whether operators commonly use those services; defer until concrete deployments demand it.
+5. **Provider hold coverage.** The public-safe lifecycle currently requires a real supplier hold and ticket promotion. Providers that only support immediate ticketing remain unavailable until an existing Booking Session payment policy can authorize that operation without allowing the browser to choose a payment or ticketing path.
+6. **Provider reconciliation evidence.** `getOrder` can confirm an ambiguously acknowledged ticket, but providers without idempotent booking/ticket semantics or a queryable order cannot automatically resolve every in-doubt operation. Their durable operation-store implementation must retain the claim for staff reconciliation; the lifecycle never falls back to another provider.
 
 ## 9. Glossary (Phase 3-specific)
 

--- a/packages/accommodations/tsconfig.build.json
+++ b/packages/accommodations/tsconfig.build.json
@@ -1134,6 +1134,9 @@
       ],
       "@voyant-travel/flights/runtime-contributor": ["../flights/dist/runtime-contributor.d.ts"],
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
+      "@voyant-travel/flights/storefront-booking-lifecycle": [
+        "../flights/dist/storefront-booking-lifecycle.d.ts"
+      ],
       "@voyant-travel/flights/tools": ["../flights/dist/mcp-runtime.d.ts"],
       "@voyant-travel/flights/voyant": ["../flights/dist/voyant.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
@@ -1950,6 +1953,9 @@
       ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
       ],
       "@voyant-travel/storefront/shopping/provider-ports": [
         "../storefront/dist/shopping/provider-ports.d.ts"

--- a/packages/accommodations/tsconfig.typecheck.json
+++ b/packages/accommodations/tsconfig.typecheck.json
@@ -1135,6 +1135,9 @@
       ],
       "@voyant-travel/flights/runtime-contributor": ["../flights/dist/runtime-contributor.d.ts"],
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
+      "@voyant-travel/flights/storefront-booking-lifecycle": [
+        "../flights/dist/storefront-booking-lifecycle.d.ts"
+      ],
       "@voyant-travel/flights/tools": ["../flights/dist/mcp-runtime.d.ts"],
       "@voyant-travel/flights/voyant": ["../flights/dist/voyant.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
@@ -1951,6 +1954,9 @@
       ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
       ],
       "@voyant-travel/storefront/shopping/provider-ports": [
         "../storefront/dist/shopping/provider-ports.d.ts"

--- a/packages/catalog/tsconfig.build.json
+++ b/packages/catalog/tsconfig.build.json
@@ -1086,6 +1086,9 @@
       ],
       "@voyant-travel/flights/runtime-contributor": ["../flights/dist/runtime-contributor.d.ts"],
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
+      "@voyant-travel/flights/storefront-booking-lifecycle": [
+        "../flights/dist/storefront-booking-lifecycle.d.ts"
+      ],
       "@voyant-travel/flights/tools": ["../flights/dist/mcp-runtime.d.ts"],
       "@voyant-travel/flights/voyant": ["../flights/dist/voyant.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
@@ -1902,6 +1905,9 @@
       ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
       ],
       "@voyant-travel/storefront/shopping/provider-ports": [
         "../storefront/dist/shopping/provider-ports.d.ts"

--- a/packages/catalog/tsconfig.typecheck.json
+++ b/packages/catalog/tsconfig.typecheck.json
@@ -1087,6 +1087,9 @@
       ],
       "@voyant-travel/flights/runtime-contributor": ["../flights/dist/runtime-contributor.d.ts"],
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
+      "@voyant-travel/flights/storefront-booking-lifecycle": [
+        "../flights/dist/storefront-booking-lifecycle.d.ts"
+      ],
       "@voyant-travel/flights/tools": ["../flights/dist/mcp-runtime.d.ts"],
       "@voyant-travel/flights/voyant": ["../flights/dist/voyant.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
@@ -1903,6 +1906,9 @@
       ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
       ],
       "@voyant-travel/storefront/shopping/provider-ports": [
         "../storefront/dist/shopping/provider-ports.d.ts"

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -1094,6 +1094,9 @@
       ],
       "@voyant-travel/flights/runtime-contributor": ["../flights/dist/runtime-contributor.d.ts"],
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
+      "@voyant-travel/flights/storefront-booking-lifecycle": [
+        "../flights/dist/storefront-booking-lifecycle.d.ts"
+      ],
       "@voyant-travel/flights/tools": ["../flights/dist/mcp-runtime.d.ts"],
       "@voyant-travel/flights/voyant": ["../flights/dist/voyant.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
@@ -1910,6 +1913,9 @@
       ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
       ],
       "@voyant-travel/storefront/shopping/provider-ports": [
         "../storefront/dist/shopping/provider-ports.d.ts"

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -1088,6 +1088,9 @@
       ],
       "@voyant-travel/flights/runtime-contributor": ["../flights/dist/runtime-contributor.d.ts"],
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
+      "@voyant-travel/flights/storefront-booking-lifecycle": [
+        "../flights/dist/storefront-booking-lifecycle.d.ts"
+      ],
       "@voyant-travel/flights/tools": ["../flights/dist/mcp-runtime.d.ts"],
       "@voyant-travel/flights/voyant": ["../flights/dist/voyant.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
@@ -1904,6 +1907,9 @@
       ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
       ],
       "@voyant-travel/storefront/shopping/provider-ports": [
         "../storefront/dist/shopping/provider-ports.d.ts"

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -1139,6 +1139,9 @@
       ],
       "@voyant-travel/flights/runtime-contributor": ["../flights/dist/runtime-contributor.d.ts"],
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
+      "@voyant-travel/flights/storefront-booking-lifecycle": [
+        "../flights/dist/storefront-booking-lifecycle.d.ts"
+      ],
       "@voyant-travel/flights/tools": ["../flights/dist/mcp-runtime.d.ts"],
       "@voyant-travel/flights/voyant": ["../flights/dist/voyant.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
@@ -1955,6 +1958,9 @@
       ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
       ],
       "@voyant-travel/storefront/shopping/provider-ports": [
         "../storefront/dist/shopping/provider-ports.d.ts"

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -1140,6 +1140,9 @@
       ],
       "@voyant-travel/flights/runtime-contributor": ["../flights/dist/runtime-contributor.d.ts"],
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
+      "@voyant-travel/flights/storefront-booking-lifecycle": [
+        "../flights/dist/storefront-booking-lifecycle.d.ts"
+      ],
       "@voyant-travel/flights/tools": ["../flights/dist/mcp-runtime.d.ts"],
       "@voyant-travel/flights/voyant": ["../flights/dist/voyant.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
@@ -1956,6 +1959,9 @@
       ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
       ],
       "@voyant-travel/storefront/shopping/provider-ports": [
         "../storefront/dist/shopping/provider-ports.d.ts"

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -1143,6 +1143,9 @@
       ],
       "@voyant-travel/flights/runtime-contributor": ["../flights/dist/runtime-contributor.d.ts"],
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
+      "@voyant-travel/flights/storefront-booking-lifecycle": [
+        "../flights/dist/storefront-booking-lifecycle.d.ts"
+      ],
       "@voyant-travel/flights/tools": ["../flights/dist/mcp-runtime.d.ts"],
       "@voyant-travel/flights/voyant": ["../flights/dist/voyant.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
@@ -1959,6 +1962,9 @@
       ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
       ],
       "@voyant-travel/storefront/shopping/provider-ports": [
         "../storefront/dist/shopping/provider-ports.d.ts"

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -1144,6 +1144,9 @@
       ],
       "@voyant-travel/flights/runtime-contributor": ["../flights/dist/runtime-contributor.d.ts"],
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
+      "@voyant-travel/flights/storefront-booking-lifecycle": [
+        "../flights/dist/storefront-booking-lifecycle.d.ts"
+      ],
       "@voyant-travel/flights/tools": ["../flights/dist/mcp-runtime.d.ts"],
       "@voyant-travel/flights/voyant": ["../flights/dist/voyant.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
@@ -1960,6 +1963,9 @@
       ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
       ],
       "@voyant-travel/storefront/shopping/provider-ports": [
         "../storefront/dist/shopping/provider-ports.d.ts"

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -1175,6 +1175,9 @@
       ],
       "@voyant-travel/flights/runtime-contributor": ["../flights/dist/runtime-contributor.d.ts"],
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
+      "@voyant-travel/flights/storefront-booking-lifecycle": [
+        "../flights/dist/storefront-booking-lifecycle.d.ts"
+      ],
       "@voyant-travel/flights/tools": ["../flights/dist/mcp-runtime.d.ts"],
       "@voyant-travel/flights/voyant": ["../flights/dist/voyant.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
@@ -1991,6 +1994,9 @@
       ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
       ],
       "@voyant-travel/storefront/shopping/provider-ports": [
         "../storefront/dist/shopping/provider-ports.d.ts"

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -1170,6 +1170,9 @@
       ],
       "@voyant-travel/flights/runtime-contributor": ["../flights/dist/runtime-contributor.d.ts"],
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
+      "@voyant-travel/flights/storefront-booking-lifecycle": [
+        "../flights/dist/storefront-booking-lifecycle.d.ts"
+      ],
       "@voyant-travel/flights/tools": ["../flights/dist/mcp-runtime.d.ts"],
       "@voyant-travel/flights/voyant": ["../flights/dist/voyant.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
@@ -1986,6 +1989,9 @@
       ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
       ],
       "@voyant-travel/storefront/shopping/provider-ports": [
         "../storefront/dist/shopping/provider-ports.d.ts"

--- a/packages/flights/package.json
+++ b/packages/flights/package.json
@@ -11,6 +11,7 @@
     "./durable-action-runtime-port": "./src/durable-action-runtime-port.ts",
     "./orchestration/fingerprint": "./src/orchestration/fingerprint.ts",
     "./orchestration/fan-out": "./src/orchestration/fan-out.ts",
+    "./storefront-booking-lifecycle": "./src/storefront-booking-lifecycle.ts",
     "./snapshot": "./src/snapshot.ts",
     "./reference/contract": "./src/reference/contract.ts",
     "./reference/fixtures": "./src/reference/fixtures.ts",
@@ -101,6 +102,11 @@
         "types": "./dist/orchestration/fan-out.d.ts",
         "import": "./dist/orchestration/fan-out.js",
         "default": "./dist/orchestration/fan-out.js"
+      },
+      "./storefront-booking-lifecycle": {
+        "types": "./dist/storefront-booking-lifecycle.d.ts",
+        "import": "./dist/storefront-booking-lifecycle.js",
+        "default": "./dist/storefront-booking-lifecycle.js"
       },
       "./snapshot": {
         "types": "./dist/snapshot.d.ts",

--- a/packages/flights/src/index.ts
+++ b/packages/flights/src/index.ts
@@ -107,3 +107,18 @@ export {
   type BuildFlightSnapshotInputOptions,
   buildFlightSnapshotInput,
 } from "./snapshot.js"
+export {
+  type BoundStorefrontFlightOffer,
+  createProviderFirstFlightBookingLifecycle,
+  type ProviderFirstFlightBookingLifecycle,
+  type ProviderFirstFlightBookingLifecycleOptions,
+  type StorefrontFlightCommitOutcome,
+  type StorefrontFlightHold,
+  type StorefrontFlightHoldOutcome,
+  StorefrontFlightLifecycleError,
+  type StorefrontFlightMutationOutcome,
+  type StorefrontFlightOperationClaim,
+  type StorefrontFlightOperationClaimInput,
+  type StorefrontFlightOperationStore,
+  type StorefrontFlightPriceLock,
+} from "./storefront-booking-lifecycle.js"

--- a/packages/flights/src/storefront-booking-lifecycle.test.ts
+++ b/packages/flights/src/storefront-booking-lifecycle.test.ts
@@ -1,0 +1,369 @@
+import { describe, expect, it, vi } from "vitest"
+
+import type { FlightConnectorAdapter } from "./contract/adapter.js"
+import type { FlightOffer, FlightOrder } from "./contract/types.js"
+import { FLIGHT_CAPABILITIES } from "./contract/types.js"
+import {
+  type BoundStorefrontFlightOffer,
+  createProviderFirstFlightBookingLifecycle,
+  StorefrontFlightLifecycleError,
+  type StorefrontFlightMutationOutcome,
+  type StorefrontFlightOperationClaimInput,
+  type StorefrontFlightOperationStore,
+} from "./storefront-booking-lifecycle.js"
+
+const now = new Date("2030-01-01T00:00:00.000Z")
+const authority = {
+  storefrontId: "storefront_1",
+  channelId: "channel_web",
+  marketId: "market_ro",
+  locale: "ro-RO",
+  currency: "EUR",
+}
+
+describe("provider-first Storefront flight booking lifecycle", () => {
+  it("requotes only the exact admitted offer/connection binding and rejects scope drift", async () => {
+    const adapter = adapterStub()
+    const list = vi.fn(async () => [
+      {
+        connectionId: "connection_exact",
+        adapter,
+        context: { connectionId: "attacker_override" } as never,
+      },
+    ])
+    const assertActiveStorefrontScope = vi.fn(async () => {})
+    const lifecycle = createProviderFirstFlightBookingLifecycle({
+      assertActiveStorefrontScope,
+      listAdmittedShoppingSources: list,
+      operations: operationStore(),
+      now: () => now,
+    })
+
+    const lock = await lifecycle.requote({
+      context: authority,
+      binding: binding(),
+      expectedRevision: 0,
+    })
+
+    expect(assertActiveStorefrontScope).toHaveBeenCalledWith(authority)
+    expect(list).toHaveBeenCalledWith(authority)
+    expect(adapter.priceOffer).toHaveBeenCalledWith(
+      expect.objectContaining({ connectionId: "connection_exact" }),
+      { offerId: "offer_secret", offer: offer() },
+    )
+    expect(lock).toMatchObject({
+      authority,
+      connectionId: "connection_exact",
+      revision: 1,
+      expiresAt: "2030-01-01T00:10:00.000Z",
+    })
+
+    await expect(
+      lifecycle.requote({
+        context: { ...authority, marketId: "market_other" },
+        binding: binding(),
+        expectedRevision: 0,
+      }),
+    ).rejects.toMatchObject({ code: "flight_scope_mismatch" })
+    expect(adapter.priceOffer).toHaveBeenCalledTimes(1)
+  })
+
+  it("holds with a hard-coded provider intent and replays the durable outcome", async () => {
+    const adapter = adapterStub()
+    const operations = operationStore()
+    const lifecycle = lifecycleFor(adapter, operations)
+    const lock = await lifecycle.requote({
+      context: authority,
+      binding: binding(),
+      expectedRevision: 0,
+    })
+    const request = {
+      context: authority,
+      lock,
+      expectedRevision: 1,
+      idempotencyKey: "hold_once",
+      passengers: [
+        {
+          passengerId: "pax_1",
+          type: "adult" as const,
+          firstName: "Ana",
+          lastName: "Test",
+          dateOfBirth: "1990-01-01",
+        },
+      ],
+    }
+
+    const first = await lifecycle.hold(request)
+    const replay = await lifecycle.hold(request)
+
+    expect(first).toMatchObject({
+      kind: "held",
+      hold: { orderId: "order_1", revision: 2, connectionId: "connection_exact" },
+    })
+    expect(replay).toEqual(first)
+    expect(adapter.bookFlight).toHaveBeenCalledTimes(1)
+    expect(adapter.bookFlight).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connectionId: "connection_exact",
+        idempotencyKey: "hold_once",
+      }),
+      expect.objectContaining({
+        offerId: "offer_secret",
+        offer: offer(),
+        paymentIntent: { type: "hold" },
+      }),
+    )
+  })
+
+  it("fails closed when the provider cannot hold and compensates an invalid hold", async () => {
+    const unsupported = adapterStub({ holds: false })
+    const unsupportedLifecycle = lifecycleFor(unsupported, operationStore())
+    const unsupportedLock = await unsupportedLifecycle.requote({
+      context: authority,
+      binding: binding(),
+      expectedRevision: 0,
+    })
+    await expect(
+      unsupportedLifecycle.hold({
+        context: authority,
+        lock: unsupportedLock,
+        expectedRevision: 1,
+        idempotencyKey: "unsupported",
+        passengers: [passenger()],
+      }),
+    ).rejects.toMatchObject({ code: "flight_hold_unsupported" })
+    expect(unsupported.bookFlight).not.toHaveBeenCalled()
+
+    const invalid = adapterStub({ order: ticketedOrder() })
+    const invalidLifecycle = lifecycleFor(invalid, operationStore())
+    const invalidLock = await invalidLifecycle.requote({
+      context: authority,
+      binding: binding(),
+      expectedRevision: 0,
+    })
+    await expect(
+      invalidLifecycle.hold({
+        context: authority,
+        lock: invalidLock,
+        expectedRevision: 1,
+        idempotencyKey: "invalid_hold",
+        passengers: [passenger()],
+      }),
+    ).resolves.toEqual({
+      kind: "compensated",
+      reason: "provider_did_not_return_a_live_hold",
+    })
+    expect(invalid.cancelOrder).toHaveBeenCalledWith(
+      expect.objectContaining({ connectionId: "connection_exact" }),
+      "order_1",
+      "operational",
+    )
+  })
+
+  it("commits the exact held order idempotently and reconciles an ambiguous provider response", async () => {
+    const ticketed = ticketedOrder()
+    const adapter = adapterStub({
+      ticketError: new TypeError("network"),
+      getOrderResult: ticketed,
+    })
+    const operations = operationStore()
+    const lifecycle = lifecycleFor(adapter, operations)
+    const lock = await lifecycle.requote({
+      context: authority,
+      binding: binding(),
+      expectedRevision: 0,
+    })
+    const held = await lifecycle.hold({
+      context: authority,
+      lock,
+      expectedRevision: 1,
+      idempotencyKey: "hold_1",
+      passengers: [passenger()],
+    })
+    if (held.kind !== "held") throw new Error("expected held fixture")
+
+    const first = await lifecycle.commit({
+      context: authority,
+      hold: held.hold,
+      expectedRevision: 2,
+      idempotencyKey: "commit_1",
+    })
+    const replay = await lifecycle.commit({
+      context: authority,
+      hold: held.hold,
+      expectedRevision: 2,
+      idempotencyKey: "commit_1",
+    })
+
+    expect(first).toEqual({ kind: "committed", order: ticketed })
+    expect(replay).toEqual(first)
+    expect(adapter.ticketOrder).toHaveBeenCalledTimes(1)
+    expect(adapter.getOrder).toHaveBeenCalledWith(
+      expect.objectContaining({ connectionId: "connection_exact" }),
+      "order_1",
+    )
+  })
+
+  it("rejects revision and idempotency drift before a second supplier mutation", async () => {
+    const adapter = adapterStub()
+    const operations = operationStore()
+    const lifecycle = lifecycleFor(adapter, operations)
+    const lock = await lifecycle.requote({
+      context: authority,
+      binding: binding(),
+      expectedRevision: 0,
+    })
+    await lifecycle.hold({
+      context: authority,
+      lock,
+      expectedRevision: 1,
+      idempotencyKey: "same_key",
+      passengers: [passenger()],
+    })
+
+    await expect(
+      lifecycle.hold({
+        context: authority,
+        lock,
+        expectedRevision: 1,
+        idempotencyKey: "same_key",
+        passengers: [{ ...passenger(), lastName: "Changed" }],
+      }),
+    ).rejects.toMatchObject({ code: "flight_idempotency_conflict" })
+    await expect(
+      lifecycle.hold({
+        context: authority,
+        lock,
+        expectedRevision: 0,
+        idempotencyKey: "other_key",
+        passengers: [passenger()],
+      }),
+    ).rejects.toBeInstanceOf(StorefrontFlightLifecycleError)
+    expect(adapter.bookFlight).toHaveBeenCalledTimes(1)
+  })
+})
+
+function lifecycleFor(adapter: FlightConnectorAdapter, operations: StorefrontFlightOperationStore) {
+  return createProviderFirstFlightBookingLifecycle({
+    assertActiveStorefrontScope: async () => {},
+    listAdmittedShoppingSources: async () => [{ connectionId: "connection_exact", adapter }],
+    operations,
+    now: () => now,
+  })
+}
+
+function binding(): BoundStorefrontFlightOffer {
+  return { authority, connectionId: "connection_exact", offer: offer(), revision: 0 }
+}
+
+function offer(): FlightOffer {
+  return {
+    offerId: "offer_secret",
+    source: "provider_secret",
+    itineraries: [
+      {
+        segments: [
+          {
+            segmentId: "segment_secret",
+            carrierCode: "RO",
+            flightNumber: "101",
+            departure: { iataCode: "OTP", at: "2030-02-01T08:00:00+02:00" },
+            arrival: { iataCode: "LHR", at: "2030-02-01T10:00:00+00:00" },
+            cabin: "economy",
+          },
+        ],
+      },
+    ],
+    fareBreakdowns: [],
+    totalPrice: { amount: "100.00", currency: "EUR" },
+    expiresAt: "2030-01-01T00:20:00.000Z",
+    providerData: { secret: true },
+  }
+}
+
+function passenger() {
+  return {
+    passengerId: "pax_1",
+    type: "adult" as const,
+    firstName: "Ana",
+    lastName: "Test",
+    dateOfBirth: "1990-01-01",
+  }
+}
+
+function order(overrides: Partial<FlightOrder> = {}): FlightOrder {
+  return {
+    orderId: "order_1",
+    status: "confirmed",
+    offer: offer(),
+    passengers: [passenger()],
+    totalPrice: offer().totalPrice,
+    paymentDeadline: "2030-01-01T00:15:00.000Z",
+    createdAt: "2030-01-01T00:00:01.000Z",
+    ...overrides,
+  }
+}
+
+function ticketedOrder(): FlightOrder {
+  const ticketed = order({ status: "ticketed" })
+  delete ticketed.paymentDeadline
+  return ticketed
+}
+
+function adapterStub(
+  options: {
+    holds?: boolean
+    order?: FlightOrder
+    getOrderResult?: FlightOrder
+    ticketError?: Error
+  } = {},
+): FlightConnectorAdapter {
+  const current = options.order ?? order()
+  return {
+    capabilities: {
+      provider: "provider_secret",
+      declared: options.holds === false ? [] : [FLIGHT_CAPABILITIES.HOLDS],
+    },
+    searchFlights: vi.fn(async () => ({ offers: [offer()] })),
+    priceOffer: vi.fn(async () => ({ offer: offer(), valid: true })),
+    bookFlight: vi.fn(async () => ({ order: current })),
+    getOrder: vi.fn(async () => ({ order: options.getOrderResult ?? current })),
+    cancelOrder: vi.fn(async () => ({ order: order({ status: "cancelled" }) })),
+    ticketOrder: vi.fn(async () => {
+      if (options.ticketError) throw options.ticketError
+      return { order: ticketedOrder() }
+    }),
+  }
+}
+
+function operationStore(): StorefrontFlightOperationStore {
+  const rows = new Map<
+    string,
+    { fingerprint: string; operationId: string; outcome?: StorefrontFlightMutationOutcome }
+  >()
+  return {
+    async claim(input: StorefrontFlightOperationClaimInput) {
+      const key = `${input.storefrontId}:${input.channelId}:${input.operation}:${input.idempotencyKey}`
+      const existing = rows.get(key)
+      if (existing) {
+        if (existing.fingerprint !== input.requestFingerprint)
+          return { status: "conflict" as const }
+        if (existing.outcome) return { status: "replay" as const, outcome: existing.outcome }
+        return { status: "in_progress" as const, operationId: existing.operationId }
+      }
+      const operationId = `operation_${rows.size + 1}`
+      rows.set(key, { fingerprint: input.requestFingerprint, operationId })
+      return { status: "claimed" as const, operationId }
+    },
+    async complete(operationId, outcome) {
+      for (const row of rows.values()) {
+        if (row.operationId === operationId) row.outcome = outcome
+      }
+    },
+    async markInDoubt(operationId, outcome) {
+      for (const row of rows.values()) {
+        if (row.operationId === operationId) row.outcome = outcome
+      }
+    },
+  }
+}

--- a/packages/flights/src/storefront-booking-lifecycle.ts
+++ b/packages/flights/src/storefront-booking-lifecycle.ts
@@ -1,0 +1,543 @@
+import type { FlightAdapterContext, FlightConnectorAdapter } from "./contract/adapter.js"
+import type {
+  AncillarySelection,
+  FlightOffer,
+  FlightOrder,
+  FlightPassenger,
+} from "./contract/types.js"
+import { FLIGHT_CAPABILITIES } from "./contract/types.js"
+import type {
+  AdmittedFlightShoppingSource,
+  FlightStorefrontShoppingContext,
+} from "./runtime-port.js"
+
+const DEFAULT_PRICE_LOCK_TTL_MS = 10 * 60_000
+
+/** Exact server-only authority sealed into a Storefront opaque offer ref. */
+export interface BoundStorefrontFlightOffer {
+  authority: FlightStorefrontShoppingContext
+  connectionId: string
+  offer: FlightOffer
+  revision: number
+}
+
+export interface StorefrontFlightPriceLock extends BoundStorefrontFlightOffer {
+  pricedAt: string
+  expiresAt: string
+}
+
+export interface StorefrontFlightHold {
+  authority: FlightStorefrontShoppingContext
+  connectionId: string
+  offerId: string
+  orderId: string
+  revision: number
+  expiresAt: string
+}
+
+export type StorefrontFlightHoldOutcome =
+  | { kind: "held"; hold: StorefrontFlightHold; order: FlightOrder }
+  | { kind: "compensated"; reason: string }
+  | { kind: "in_doubt"; operationId: string; reason: string }
+
+export type StorefrontFlightCommitOutcome =
+  | { kind: "committed"; order: FlightOrder }
+  | { kind: "in_doubt"; operationId: string; reason: string }
+
+export type StorefrontFlightMutationOutcome =
+  | StorefrontFlightHoldOutcome
+  | StorefrontFlightCommitOutcome
+
+export interface StorefrontFlightOperationClaimInput {
+  operation: "hold" | "commit"
+  storefrontId: string
+  channelId: string
+  idempotencyKey: string
+  requestFingerprint: string
+}
+
+export type StorefrontFlightOperationClaim =
+  | { status: "claimed"; operationId: string }
+  | { status: "replay"; outcome: StorefrontFlightMutationOutcome }
+  | { status: "conflict" }
+  | { status: "in_progress"; operationId: string }
+
+/**
+ * Durable server-owned operation store. Implementations must atomically claim
+ * `(storefront, channel, operation, idempotencyKey)` and persist the exact
+ * fingerprint before any supplier call.
+ */
+export interface StorefrontFlightOperationStore {
+  claim(input: StorefrontFlightOperationClaimInput): Promise<StorefrontFlightOperationClaim>
+  complete(operationId: string, outcome: StorefrontFlightMutationOutcome): Promise<void>
+  markInDoubt(
+    operationId: string,
+    outcome: Extract<StorefrontFlightMutationOutcome, { kind: "in_doubt" }>,
+  ): Promise<void>
+}
+
+export interface ProviderFirstFlightBookingLifecycleOptions {
+  /** Revalidate active storefront, channel, market, locale, and currency. */
+  assertActiveStorefrontScope(context: FlightStorefrontShoppingContext): Promise<void>
+  listAdmittedShoppingSources(
+    context: FlightStorefrontShoppingContext,
+  ): Promise<readonly AdmittedFlightShoppingSource[]>
+  operations: StorefrontFlightOperationStore
+  now?: () => Date
+  priceLockTtlMs?: number
+}
+
+export interface ProviderFirstFlightBookingLifecycle {
+  requote(input: {
+    context: FlightStorefrontShoppingContext
+    binding: BoundStorefrontFlightOffer
+    expectedRevision: number
+  }): Promise<StorefrontFlightPriceLock>
+  hold(input: {
+    context: FlightStorefrontShoppingContext
+    lock: StorefrontFlightPriceLock
+    expectedRevision: number
+    idempotencyKey: string
+    passengers: FlightPassenger[]
+    contact?: { email?: string; phone?: string }
+    ancillaries?: AncillarySelection
+  }): Promise<StorefrontFlightHoldOutcome>
+  commit(input: {
+    context: FlightStorefrontShoppingContext
+    hold: StorefrontFlightHold
+    expectedRevision: number
+    idempotencyKey: string
+  }): Promise<StorefrontFlightCommitOutcome>
+}
+
+/**
+ * Closed provider-first lifecycle for Storefront flight offers.
+ *
+ * This is not an HTTP API and accepts no provider, connection, payment, or
+ * booking-engine selector. Callers must resolve an opaque ref into the bound
+ * objects above on the server. Catalog Booking Sessions remain the general
+ * booking/payment commitment authority; this seam only performs the flight
+ * supplier operations they cannot model as indexed Catalog inventory.
+ */
+export function createProviderFirstFlightBookingLifecycle(
+  options: ProviderFirstFlightBookingLifecycleOptions,
+): ProviderFirstFlightBookingLifecycle {
+  const now = options.now ?? (() => new Date())
+  const priceLockTtlMs = options.priceLockTtlMs ?? DEFAULT_PRICE_LOCK_TTL_MS
+
+  return {
+    async requote(input) {
+      assertAuthority(input.context, input.binding.authority)
+      assertRevision(input.expectedRevision, input.binding.revision)
+      assertNotExpired(input.binding.offer.expiresAt, now(), "flight_offer_expired")
+      const source = await resolveAdmittedSource(options, input.context, input.binding.connectionId)
+      const response = await source.adapter.priceOffer(sourceContext(source), {
+        offerId: input.binding.offer.offerId,
+        offer: input.binding.offer,
+      })
+      if (!response.valid) {
+        throw new StorefrontFlightLifecycleError(
+          "flight_offer_unavailable",
+          response.invalidReason ?? "Provider rejected the selected flight offer.",
+        )
+      }
+      if (response.offer.offerId !== input.binding.offer.offerId) {
+        throw new StorefrontFlightLifecycleError(
+          "flight_offer_identity_changed",
+          "Provider changed the selected offer identity while repricing.",
+        )
+      }
+      const pricedAt = now()
+      const expiresAt = boundedExpiry(
+        pricedAt,
+        priceLockTtlMs,
+        response.offer.expiresAt,
+        "flight_price_lock_expired",
+      )
+      return {
+        authority: input.binding.authority,
+        connectionId: input.binding.connectionId,
+        offer: response.offer,
+        revision: input.binding.revision + 1,
+        pricedAt: pricedAt.toISOString(),
+        expiresAt: expiresAt.toISOString(),
+      }
+    },
+
+    async hold(input) {
+      assertAuthority(input.context, input.lock.authority)
+      assertRevision(input.expectedRevision, input.lock.revision)
+      assertNotExpired(input.lock.expiresAt, now(), "flight_price_lock_expired")
+      const source = await resolveAdmittedSource(options, input.context, input.lock.connectionId)
+      requireHoldCapability(source.adapter)
+      const fingerprint = await stableFingerprint({
+        authority: input.lock.authority,
+        connectionId: input.lock.connectionId,
+        offer: input.lock.offer,
+        revision: input.lock.revision,
+        passengers: input.passengers,
+        contact: input.contact,
+        ancillaries: input.ancillaries,
+      })
+      const claim = await options.operations.claim({
+        operation: "hold",
+        storefrontId: input.context.storefrontId,
+        channelId: input.context.channelId,
+        idempotencyKey: requiredKey(input.idempotencyKey),
+        requestFingerprint: fingerprint,
+      })
+      const replay = mutationClaimOutcome<StorefrontFlightHoldOutcome>(claim)
+      if (replay) return replay
+      const operationId = claimedOperationId(claim)
+
+      const adapterContext = sourceContext(source, input.idempotencyKey)
+      let order: FlightOrder
+      try {
+        order = (
+          await source.adapter.bookFlight(adapterContext, {
+            offerId: input.lock.offer.offerId,
+            offer: input.lock.offer,
+            passengers: input.passengers,
+            ...(input.contact ? { contact: input.contact } : {}),
+            ...(input.ancillaries ? { ancillaries: input.ancillaries } : {}),
+            paymentIntent: { type: "hold" },
+          })
+        ).order
+      } catch (error) {
+        const reason = safeErrorClass(error)
+        const outcome = { kind: "in_doubt", operationId, reason } as const
+        await options.operations.markInDoubt(operationId, outcome)
+        return outcome
+      }
+
+      const deadline = order.paymentDeadline
+      if (order.status !== "confirmed" || !deadline || isExpired(deadline, now())) {
+        const compensated = await compensateHold(source, adapterContext, order.orderId)
+        const outcome: StorefrontFlightHoldOutcome = compensated
+          ? { kind: "compensated", reason: "provider_did_not_return_a_live_hold" }
+          : {
+              kind: "in_doubt",
+              operationId,
+              reason: "invalid_hold_compensation_failed",
+            }
+        return (await settle(options.operations, operationId, outcome))
+          ? outcome
+          : settlementInDoubt(operationId)
+      }
+
+      const outcome: StorefrontFlightHoldOutcome = {
+        kind: "held",
+        hold: {
+          authority: input.lock.authority,
+          connectionId: input.lock.connectionId,
+          offerId: input.lock.offer.offerId,
+          orderId: order.orderId,
+          revision: input.lock.revision + 1,
+          expiresAt: deadline,
+        },
+        order,
+      }
+      const settled = await settle(options.operations, operationId, outcome, async () => {
+        await compensateHold(source, adapterContext, order.orderId)
+      })
+      return settled ? outcome : settlementInDoubt(operationId)
+    },
+
+    async commit(input) {
+      assertAuthority(input.context, input.hold.authority)
+      assertRevision(input.expectedRevision, input.hold.revision)
+      assertNotExpired(input.hold.expiresAt, now(), "flight_hold_expired")
+      const source = await resolveAdmittedSource(options, input.context, input.hold.connectionId)
+      requireHoldCapability(source.adapter)
+      const fingerprint = await stableFingerprint({
+        authority: input.hold.authority,
+        connectionId: input.hold.connectionId,
+        offerId: input.hold.offerId,
+        orderId: input.hold.orderId,
+        revision: input.hold.revision,
+      })
+      const claim = await options.operations.claim({
+        operation: "commit",
+        storefrontId: input.context.storefrontId,
+        channelId: input.context.channelId,
+        idempotencyKey: requiredKey(input.idempotencyKey),
+        requestFingerprint: fingerprint,
+      })
+      const replay = mutationClaimOutcome<StorefrontFlightCommitOutcome>(claim)
+      if (replay) return replay
+      const operationId = claimedOperationId(claim)
+
+      try {
+        const response = await source.adapter.ticketOrder!(
+          sourceContext(source, input.idempotencyKey),
+          input.hold.orderId,
+        )
+        if (response.order.status !== "ticketed") {
+          const outcome: StorefrontFlightCommitOutcome = {
+            kind: "in_doubt",
+            operationId,
+            reason: `provider_commit_status_${response.order.status}`,
+          }
+          return (await settle(options.operations, operationId, outcome))
+            ? outcome
+            : settlementInDoubt(operationId)
+        }
+        const outcome: StorefrontFlightCommitOutcome = {
+          kind: "committed",
+          order: response.order,
+        }
+        return (await settle(options.operations, operationId, outcome))
+          ? outcome
+          : settlementInDoubt(operationId)
+      } catch (error) {
+        const reason = safeErrorClass(error)
+        try {
+          const current = await source.adapter.getOrder(sourceContext(source), input.hold.orderId)
+          if (current.order.status === "ticketed") {
+            const outcome: StorefrontFlightCommitOutcome = {
+              kind: "committed",
+              order: current.order,
+            }
+            return (await settle(options.operations, operationId, outcome))
+              ? outcome
+              : settlementInDoubt(operationId)
+          }
+        } catch {
+          // The durable claim remains the reconciliation authority.
+        }
+        const outcome = { kind: "in_doubt", operationId, reason } as const
+        await options.operations.markInDoubt(operationId, outcome)
+        return outcome
+      }
+    },
+  }
+}
+
+export class StorefrontFlightLifecycleError extends Error {
+  constructor(
+    readonly code:
+      | "flight_scope_mismatch"
+      | "flight_revision_conflict"
+      | "flight_offer_expired"
+      | "flight_price_lock_expired"
+      | "flight_hold_expired"
+      | "flight_source_not_admitted"
+      | "flight_hold_unsupported"
+      | "flight_offer_unavailable"
+      | "flight_offer_identity_changed"
+      | "flight_idempotency_key_invalid"
+      | "flight_idempotency_conflict"
+      | "flight_operation_in_progress",
+    message: string,
+  ) {
+    super(message)
+    this.name = "StorefrontFlightLifecycleError"
+  }
+}
+
+async function resolveAdmittedSource(
+  options: ProviderFirstFlightBookingLifecycleOptions,
+  context: FlightStorefrontShoppingContext,
+  connectionId: string,
+): Promise<AdmittedFlightShoppingSource> {
+  assertContext(context)
+  await options.assertActiveStorefrontScope(context)
+  const sources = await options.listAdmittedShoppingSources(context)
+  const source = sources.find((candidate) => candidate.connectionId === connectionId)
+  if (!source) {
+    throw new StorefrontFlightLifecycleError(
+      "flight_source_not_admitted",
+      "The selected flight source is no longer admitted for this Storefront scope.",
+    )
+  }
+  return source
+}
+
+function sourceContext(
+  source: AdmittedFlightShoppingSource,
+  idempotencyKey?: string,
+): FlightAdapterContext {
+  return {
+    ...source.context,
+    connectionId: source.connectionId,
+    ...(idempotencyKey ? { idempotencyKey } : {}),
+  }
+}
+
+function requireHoldCapability(adapter: FlightConnectorAdapter): void {
+  if (
+    !adapter.capabilities.declared.includes(FLIGHT_CAPABILITIES.HOLDS) ||
+    typeof adapter.ticketOrder !== "function"
+  ) {
+    throw new StorefrontFlightLifecycleError(
+      "flight_hold_unsupported",
+      "The admitted provider cannot complete the required hold-then-ticket lifecycle.",
+    )
+  }
+}
+
+function assertAuthority(
+  actual: FlightStorefrontShoppingContext,
+  expected: FlightStorefrontShoppingContext,
+): void {
+  assertContext(actual)
+  if (
+    actual.storefrontId !== expected.storefrontId ||
+    actual.channelId !== expected.channelId ||
+    actual.marketId !== expected.marketId ||
+    actual.locale !== expected.locale ||
+    actual.currency !== expected.currency
+  ) {
+    throw new StorefrontFlightLifecycleError(
+      "flight_scope_mismatch",
+      "Opaque flight authority does not match the active Storefront scope.",
+    )
+  }
+}
+
+function assertContext(context: FlightStorefrontShoppingContext): void {
+  if (Object.values(context).some((value) => !value.trim())) {
+    throw new StorefrontFlightLifecycleError(
+      "flight_scope_mismatch",
+      "Storefront flight authority must be fully resolved server-side.",
+    )
+  }
+}
+
+function assertRevision(expected: number, actual: number): void {
+  if (!Number.isSafeInteger(expected) || expected < 0 || expected !== actual) {
+    throw new StorefrontFlightLifecycleError(
+      "flight_revision_conflict",
+      "Flight lifecycle revision changed after it was read.",
+    )
+  }
+}
+
+function assertNotExpired(
+  value: string | undefined,
+  now: Date,
+  code: StorefrontFlightLifecycleError["code"],
+): void {
+  if (value && isExpired(value, now)) {
+    throw new StorefrontFlightLifecycleError(code, "Flight lifecycle authority has expired.")
+  }
+}
+
+function boundedExpiry(
+  now: Date,
+  ttlMs: number,
+  upstream: string | undefined,
+  code: StorefrontFlightLifecycleError["code"],
+): Date {
+  const local = new Date(now.getTime() + ttlMs)
+  if (!upstream) return local
+  const parsed = new Date(upstream)
+  if (!Number.isFinite(parsed.getTime()) || parsed <= now) {
+    throw new StorefrontFlightLifecycleError(code, "Provider returned an expired flight offer.")
+  }
+  return parsed < local ? parsed : local
+}
+
+function isExpired(value: string, now: Date): boolean {
+  const parsed = Date.parse(value)
+  return !Number.isFinite(parsed) || parsed <= now.getTime()
+}
+
+function requiredKey(value: string): string {
+  if (!value.trim() || value !== value.trim() || value.length > 200) {
+    throw new StorefrontFlightLifecycleError(
+      "flight_idempotency_key_invalid",
+      "Flight lifecycle idempotency key is invalid.",
+    )
+  }
+  return value
+}
+
+function mutationClaimOutcome<T extends StorefrontFlightMutationOutcome>(
+  claim: StorefrontFlightOperationClaim,
+): T | undefined {
+  if (claim.status === "replay") return claim.outcome as T
+  if (claim.status === "conflict") {
+    throw new StorefrontFlightLifecycleError(
+      "flight_idempotency_conflict",
+      "Flight lifecycle idempotency key was reused for different input.",
+    )
+  }
+  if (claim.status === "in_progress") {
+    throw new StorefrontFlightLifecycleError(
+      "flight_operation_in_progress",
+      `Flight lifecycle operation ${claim.operationId} is already in progress.`,
+    )
+  }
+  return undefined
+}
+
+function claimedOperationId(claim: StorefrontFlightOperationClaim): string {
+  if (claim.status !== "claimed") throw new Error("flight_operation_claim_invalid")
+  return claim.operationId
+}
+
+async function settle(
+  operations: StorefrontFlightOperationStore,
+  operationId: string,
+  outcome: StorefrontFlightMutationOutcome,
+  compensate?: () => Promise<void>,
+): Promise<boolean> {
+  try {
+    await operations.complete(operationId, outcome)
+    return true
+  } catch {
+    if (compensate) {
+      try {
+        await compensate()
+      } catch {
+        // Failure to record after a supplier effect is necessarily in doubt.
+      }
+    }
+    const inDoubt = settlementInDoubt(operationId)
+    await operations.markInDoubt(operationId, inDoubt)
+    return false
+  }
+}
+
+function settlementInDoubt(operationId: string) {
+  return {
+    kind: "in_doubt",
+    operationId,
+    reason: "operation_settlement_failed",
+  } as const
+}
+
+async function compensateHold(
+  source: AdmittedFlightShoppingSource,
+  context: FlightAdapterContext,
+  orderId: string,
+): Promise<boolean> {
+  try {
+    const response = await source.adapter.cancelOrder(context, orderId, "operational")
+    return response.order.status === "cancelled"
+  } catch {
+    return false
+  }
+}
+
+async function stableFingerprint(value: unknown): Promise<string> {
+  const bytes = new TextEncoder().encode(stableJson(value))
+  const digest = await crypto.subtle.digest("SHA-256", bytes)
+  return `sha256:${Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("")}`
+}
+
+function stableJson(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value)
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`
+  return `{${Object.entries(value as Record<string, unknown>)
+    .filter(([, entry]) => entry !== undefined)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, entry]) => `${JSON.stringify(key)}:${stableJson(entry)}`)
+    .join(",")}}`
+}
+
+function safeErrorClass(error: unknown): string {
+  if (error instanceof Error && error.name.trim()) return error.name.slice(0, 100)
+  return "provider_operation_failed"
+}

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -1187,6 +1187,9 @@
       ],
       "@voyant-travel/flights/runtime-contributor": ["../flights/dist/runtime-contributor.d.ts"],
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
+      "@voyant-travel/flights/storefront-booking-lifecycle": [
+        "../flights/dist/storefront-booking-lifecycle.d.ts"
+      ],
       "@voyant-travel/flights/tools": ["../flights/dist/mcp-runtime.d.ts"],
       "@voyant-travel/flights/voyant": ["../flights/dist/voyant.d.ts"],
       "@voyant-travel/framework": ["./dist/index.d.ts"],
@@ -1993,6 +1996,9 @@
       ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
       ],
       "@voyant-travel/storefront/shopping/provider-ports": [
         "../storefront/dist/shopping/provider-ports.d.ts"

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -1188,6 +1188,9 @@
       ],
       "@voyant-travel/flights/runtime-contributor": ["../flights/dist/runtime-contributor.d.ts"],
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
+      "@voyant-travel/flights/storefront-booking-lifecycle": [
+        "../flights/dist/storefront-booking-lifecycle.d.ts"
+      ],
       "@voyant-travel/flights/tools": ["../flights/dist/mcp-runtime.d.ts"],
       "@voyant-travel/flights/voyant": ["../flights/dist/voyant.d.ts"],
       "@voyant-travel/framework": ["./dist/index.d.ts"],
@@ -1994,6 +1997,9 @@
       ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
       ],
       "@voyant-travel/storefront/shopping/provider-ports": [
         "../storefront/dist/shopping/provider-ports.d.ts"

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -1193,6 +1193,9 @@
       ],
       "@voyant-travel/flights/runtime-contributor": ["../flights/dist/runtime-contributor.d.ts"],
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
+      "@voyant-travel/flights/storefront-booking-lifecycle": [
+        "../flights/dist/storefront-booking-lifecycle.d.ts"
+      ],
       "@voyant-travel/flights/tools": ["../flights/dist/mcp-runtime.d.ts"],
       "@voyant-travel/flights/voyant": ["../flights/dist/voyant.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
@@ -1991,6 +1994,9 @@
       ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
       ],
       "@voyant-travel/storefront/shopping/provider-ports": [
         "../storefront/dist/shopping/provider-ports.d.ts"

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -1188,6 +1188,9 @@
       ],
       "@voyant-travel/flights/runtime-contributor": ["../flights/dist/runtime-contributor.d.ts"],
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
+      "@voyant-travel/flights/storefront-booking-lifecycle": [
+        "../flights/dist/storefront-booking-lifecycle.d.ts"
+      ],
       "@voyant-travel/flights/tools": ["../flights/dist/mcp-runtime.d.ts"],
       "@voyant-travel/flights/voyant": ["../flights/dist/voyant.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
@@ -1986,6 +1989,9 @@
       ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
       ],
       "@voyant-travel/storefront/shopping/provider-ports": [
         "../storefront/dist/shopping/provider-ports.d.ts"

--- a/packages/inventory/tsconfig.build.json
+++ b/packages/inventory/tsconfig.build.json
@@ -1187,6 +1187,9 @@
       ],
       "@voyant-travel/flights/runtime-contributor": ["../flights/dist/runtime-contributor.d.ts"],
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
+      "@voyant-travel/flights/storefront-booking-lifecycle": [
+        "../flights/dist/storefront-booking-lifecycle.d.ts"
+      ],
       "@voyant-travel/flights/tools": ["../flights/dist/mcp-runtime.d.ts"],
       "@voyant-travel/flights/voyant": ["../flights/dist/voyant.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
@@ -1923,6 +1926,9 @@
       ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
       ],
       "@voyant-travel/storefront/shopping/provider-ports": [
         "../storefront/dist/shopping/provider-ports.d.ts"

--- a/packages/inventory/tsconfig.typecheck.json
+++ b/packages/inventory/tsconfig.typecheck.json
@@ -1188,6 +1188,9 @@
       ],
       "@voyant-travel/flights/runtime-contributor": ["../flights/dist/runtime-contributor.d.ts"],
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
+      "@voyant-travel/flights/storefront-booking-lifecycle": [
+        "../flights/dist/storefront-booking-lifecycle.d.ts"
+      ],
       "@voyant-travel/flights/tools": ["../flights/dist/mcp-runtime.d.ts"],
       "@voyant-travel/flights/voyant": ["../flights/dist/voyant.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
@@ -1924,6 +1927,9 @@
       ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
       ],
       "@voyant-travel/storefront/shopping/provider-ports": [
         "../storefront/dist/shopping/provider-ports.d.ts"

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -1193,6 +1193,9 @@
       ],
       "@voyant-travel/flights/runtime-contributor": ["../flights/dist/runtime-contributor.d.ts"],
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
+      "@voyant-travel/flights/storefront-booking-lifecycle": [
+        "../flights/dist/storefront-booking-lifecycle.d.ts"
+      ],
       "@voyant-travel/flights/tools": ["../flights/dist/mcp-runtime.d.ts"],
       "@voyant-travel/flights/voyant": ["../flights/dist/voyant.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
@@ -1890,6 +1893,9 @@
       ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
       ],
       "@voyant-travel/storefront/shopping/provider-ports": [
         "../storefront/dist/shopping/provider-ports.d.ts"

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -1188,6 +1188,9 @@
       ],
       "@voyant-travel/flights/runtime-contributor": ["../flights/dist/runtime-contributor.d.ts"],
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
+      "@voyant-travel/flights/storefront-booking-lifecycle": [
+        "../flights/dist/storefront-booking-lifecycle.d.ts"
+      ],
       "@voyant-travel/flights/tools": ["../flights/dist/mcp-runtime.d.ts"],
       "@voyant-travel/flights/voyant": ["../flights/dist/voyant.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
@@ -1885,6 +1888,9 @@
       ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
       ],
       "@voyant-travel/storefront/shopping/provider-ports": [
         "../storefront/dist/shopping/provider-ports.d.ts"

--- a/packages/storefront/package.json
+++ b/packages/storefront/package.json
@@ -20,6 +20,7 @@
     "./shopping": "./src/shopping/index.ts",
     "./shopping/live-provider": "./src/shopping/live-provider.ts",
     "./shopping/managed-runtime": "./src/shopping/managed-runtime.ts",
+    "./shopping/ports": "./src/shopping/provider-ports.ts",
     "./shopping/provider-ports": "./src/shopping/provider-ports.ts",
     "./shopping/runtime-port": "./src/shopping/runtime-port.ts",
     "./service": "./src/service.ts",
@@ -209,6 +210,11 @@
         "types": "./dist/shopping/managed-runtime.d.ts",
         "import": "./dist/shopping/managed-runtime.js",
         "default": "./dist/shopping/managed-runtime.js"
+      },
+      "./shopping/ports": {
+        "types": "./dist/shopping/provider-ports.d.ts",
+        "import": "./dist/shopping/provider-ports.js",
+        "default": "./dist/shopping/provider-ports.js"
       },
       "./shopping/provider-ports": {
         "types": "./dist/shopping/provider-ports.d.ts",

--- a/packages/storefront/src/shopping/live-provider.ts
+++ b/packages/storefront/src/shopping/live-provider.ts
@@ -98,7 +98,7 @@ export function createStorefrontShoppingLiveProvider(
           : {}),
       })
       return {
-        items: result.offers.flatMap(mapMergedFlightOffers),
+        items: result.offers.flatMap((offer) => mapMergedFlightOffers(offer, input)),
         sources: result.perConnection.map(({ status, count }) => ({
           status: mapFlightStatus(status, count),
         })),
@@ -234,7 +234,10 @@ function sourceScope(scope: StorefrontResolvedScope): AvailabilitySearchRequest[
   }
 }
 
-function mapMergedFlightOffers(merged: MergedFlightOffer) {
+function mapMergedFlightOffers(
+  merged: MergedFlightOffer,
+  input: Omit<TrustedShoppingInput<FlightIntent>, "intent">,
+) {
   const ownedOffers = [
     { offer: merged.cheapest, connectionId: merged.cheapestSourceConnectionId },
     ...merged.alternates.map((offer, index) => ({
@@ -261,6 +264,15 @@ function mapMergedFlightOffers(merged: MergedFlightOffer) {
               source: offer.source,
               itineraryFingerprint: merged.itineraryFingerprint,
               connectionId,
+              authority: {
+                storefrontId: input.context.storefrontId,
+                channelId: input.context.channelId,
+                marketId: input.scope.marketId,
+                locale: input.scope.locale,
+                currency: input.scope.currency,
+              },
+              offer,
+              revision: 0,
             },
             ...(offer.providerData ? { providerData: offer.providerData } : {}),
             ...(offer.expiresAt ? { expiresAt: offer.expiresAt } : {}),

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -1186,6 +1186,9 @@
       ],
       "@voyant-travel/flights/runtime-contributor": ["../flights/dist/runtime-contributor.d.ts"],
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
+      "@voyant-travel/flights/storefront-booking-lifecycle": [
+        "../flights/dist/storefront-booking-lifecycle.d.ts"
+      ],
       "@voyant-travel/flights/tools": ["../flights/dist/mcp-runtime.d.ts"],
       "@voyant-travel/flights/voyant": ["../flights/dist/voyant.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
@@ -2002,6 +2005,9 @@
       ],
       "@voyant-travel/storefront/shopping/managed-runtime": [
         "../storefront/dist/shopping/managed-runtime.d.ts"
+      ],
+      "@voyant-travel/storefront/shopping/ports": [
+        "../storefront/dist/shopping/provider-ports.d.ts"
       ],
       "@voyant-travel/storefront/shopping/provider-ports": [
         "../storefront/dist/shopping/provider-ports.d.ts"


### PR DESCRIPTION
## Summary

- seal the exact searched `FlightOffer`, admitted connection id, resolved Storefront scope, and initial revision inside the existing single-use opaque offer reference
- add a Flights-owned provider-first requote → hold → ticket-commit orchestrator that revalidates active Storefront scope and source admission before every provider call
- require a deployment-supplied durable operation store to claim idempotency keys and request fingerprints before supplier mutations, with replay/conflict handling
- compensate invalid holds through the same bound adapter and surface ambiguous provider, compensation, and settlement failures as `in_doubt`
- keep payment intent server-owned (`hold`) and leave Catalog Booking Sessions and Trip composite coordination as the existing booking/payment authorities

## Security and lifecycle coverage

- browser-visible results contain only opaque refs; provider, connection, account, engine, payment, full offer, and provider data remain in the server-only reference payload
- exact storefront/channel/market/locale/currency authority, connection admission, expiry, and revision are checked before provider dispatch
- adapter context cannot override the admitted connection id
- idempotency replay returns the stored outcome; changed input with the same key is rejected before a second supplier mutation
- providers without `flight/holds` plus `ticketOrder` fail closed
- invalid holds are cancelled; ambiguous ticket acknowledgements are reconciled once through `getOrder` and otherwise remain in doubt

## Existing authority boundaries audited

- Flights admin `/price`, `/book`, and `/orders` routes remain operator-facing and are not reused as a public Storefront bridge
- Catalog Booking Sessions remain the general quote/hold/commit and payment lifecycle
- Trip remains the composite coordinator; its current single-admin-adapter flight placeholder path is not used for multi-provider Storefront offers
- Trips-owned opaque-reference persistence can resolve the sealed binding server-side without exposing selectors to the browser

## Provider capability gaps

- immediate-ticket-only providers remain unavailable until an existing Booking Session payment policy can authorize that path without accepting a browser payment/ticket selector
- providers without idempotent mutation semantics or queryable order status may require staff reconciliation for an in-doubt operation; the lifecycle never falls back to another connection

## Validation

- repository Biome formatting passed for all changed TypeScript/JSON files
- `git diff --check` passed
- manual GitHub Actions CI on the exact top passed the changed test graph (including all five focused lifecycle tests), changed build graph, package-artifact verification, and operator image impact check
- the repository-wide quality job stops during global Biome lint on an existing unrelated baseline before reaching its typecheck step; every changed TypeScript/JSON file passes the same formatter/linter
- the architecture job accepts the dedicated Storefront shopping port boundary added here, then stops later on unrelated stale `packages/framework` dependency-path artifacts; see [CI run 31285289107](https://github.com/voyant-travel/voyant/actions/runs/31285289107)
- `lab1` SSH timed out twice; no local heavy fallback was used

Stacked directly on #4461 (`agent/flight-storefront-provider-stack`).
