### PR TITLE
feat(storefront): redeem dynamic package offers

### DIFF
--- a/.changeset/opaque-package-consumer.md
+++ b/.changeset/opaque-package-consumer.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/storefront": patch
+"@voyant-travel/trips": patch
+"@voyant-travel/voyant-connect-adapter": patch
+---
+
+Redeem bound Storefront package capabilities into stable sourced Catalog booking selections.

--- a/docs/architecture/dynamic-packaging-rfc.md
+++ b/docs/architecture/dynamic-packaging-rfc.md
@@ -194,16 +194,15 @@ Catalog retains the Supplier Operation in doubt for reconciliation. Confirmed
 bookings continue through the existing Booking, Allocation, snapshot, Trip
 component, cancellation, and compensation spine.
 
-The remaining Storefront integration gap is deliberately narrow: the managed
-opaque-reference store added by Storefront PR #4459 currently has an issuer but
-no owner/scope-bound consumer. Until that consumer exists, Storefront cannot
-turn a browser-held `package-offer` capability into the stable Catalog Item and
-public Booking Session selection (`departureDate`, pax, room/rate/board) that
-this adapter accepts. The consumer must validate purpose, storefront, channel,
-owner, scope, expiry, and single-use redemption; it must return only the stable
-selection and must never return or accept a connection/provider id on the
-browser boundary. No fallback may decode the capability in the browser or let
-the caller choose an adapter.
+The Storefront integration closes through Trips' durable opaque-reference
+consumer. It validates purpose, storefront, channel, owner, scope, reference
+expiry, and the supplier offer's own expiry, then atomically redeems the
+single-use capability inside the Trip-selection mutation. The resulting Trip
+component contains only the stable Catalog Item and Booking Session pins
+(`departureDate`, pax, room/rate/board). Connection identity remains
+server-derived behind the capability and is never returned or accepted on the
+browser boundary; no fallback decodes the capability or lets the caller choose
+an adapter.
 
 ## 7. Success criteria
 

--- a/packages/storefront/src/shopping/live-provider.ts
+++ b/packages/storefront/src/shopping/live-provider.ts
@@ -323,7 +323,10 @@ async function runPackageSource(
   try {
     const result = await withTimeout(source.search(request), timeoutMs)
     return {
-      offers: result.offers,
+      offers: result.offers.map((offer) => ({
+        ...offer,
+        selection: { ...offer.selection },
+      })),
       status: result.status ?? (result.offers.length > 0 ? "ok" : "empty"),
     }
   } catch (error) {

--- a/packages/storefront/src/shopping/provider-ports.ts
+++ b/packages/storefront/src/shopping/provider-ports.ts
@@ -76,8 +76,29 @@ export interface StorefrontDynamicPackageSourceOffer {
   boardName?: string
   image?: { url: string; alt?: string }
   expiresAt?: string
-  selection: Readonly<Record<string, unknown>>
+  /** Server-only stable booking target and pins persisted behind the opaque ref. */
+  selection: StorefrontDynamicPackageBookingSelection
   providerData?: Readonly<Record<string, unknown>>
+}
+
+export interface StorefrontDynamicPackageBookingSelection {
+  target: {
+    entityModule: string
+    entityId: string
+    sourceKind: string
+    sourceConnectionId: string
+    sourceRef: string
+  }
+  configure: {
+    departureDate: string
+    departureAirportCode: string
+    nights: number
+    pax: Readonly<Record<string, number>>
+    roomTypeId?: string
+    ratePlanId?: string
+    board?: string
+  }
+  offerExpiresAt: string
 }
 
 export interface StorefrontDynamicPackageSource {

--- a/packages/storefront/src/shopping/runtime.ts
+++ b/packages/storefront/src/shopping/runtime.ts
@@ -24,6 +24,7 @@ export class StorefrontShoppingUnavailableError extends Error {
       | "active storefront channel"
       | "trusted storefront channel context"
       | "active market scope"
+      | "active live-shopping scope"
       | "catalog field policy"
       | "catalog indexer"
       | "customer catalog title"

--- a/packages/trips/src/shopping-opaque-references.ts
+++ b/packages/trips/src/shopping-opaque-references.ts
@@ -9,8 +9,10 @@ import { z } from "zod"
 
 import type { TripShoppingReference } from "./schema.js"
 import { tripShoppingReferences } from "./schema.js"
-import type { StorefrontTripOfferResolver } from "./storefront-trip-offer-resolver-port.js"
-import type { CreateTripComponentBodyInput } from "./validation.js"
+import type {
+  StorefrontTripOfferComponent,
+  StorefrontTripOfferResolver,
+} from "./storefront-trip-offer-resolver-port.js"
 
 const MAX_REFERENCE_TTL_SECONDS = 24 * 60 * 60
 const referenceSchema = z.string().regex(/^sref_[a-f0-9]{64}$/)
@@ -24,6 +26,36 @@ const scopeSchema = z
   })
   .strict()
 const payloadSchema = z.record(z.string(), z.unknown())
+const packageSelectionSchema = z
+  .object({
+    target: z
+      .object({
+        entityModule: z.literal("products"),
+        entityId: z.string().min(1),
+        sourceKind: z.string().min(1),
+        sourceConnectionId: z.string().min(1),
+        sourceRef: z.string().min(1),
+      })
+      .strict(),
+    configure: z
+      .object({
+        departureDate: z.iso.date(),
+        departureAirportCode: z.string().regex(/^[A-Z]{3}$/),
+        nights: z.number().int().positive(),
+        pax: z.record(z.string(), z.number().int().nonnegative()),
+        roomTypeId: z.string().min(1).optional(),
+        ratePlanId: z.string().min(1).optional(),
+        board: z.string().min(1).optional(),
+      })
+      .strict()
+      .refine(
+        (value) => Boolean(value.roomTypeId || value.ratePlanId || value.board),
+        "package rate pin required",
+      )
+      .refine((value) => (value.pax.adult ?? 0) > 0, "package adult pax required"),
+    offerExpiresAt: z.string().datetime({ offset: true }),
+  })
+  .strict()
 
 export type ShoppingReferencePurpose = z.infer<typeof purposeSchema>
 
@@ -84,17 +116,12 @@ export function createTripShoppingReferenceRuntime(
     },
     offerResolver: {
       async resolve(context, input) {
-        const purpose = purposeForSelectionKind(input.kind)
-        const resolution = await options.withTransaction((db) =>
-          redeemShoppingReference(postgresShoppingReferenceStore(db), input.offerRef, {
-            purpose,
-            context,
-            scope: input.scope,
-            now,
-          }),
+        return options.withTransaction((db) =>
+          resolveShoppingReference(postgresShoppingReferenceStore(db), context, input, now),
         )
-        if (!resolution.ok) return null
-        return resolvedComponent(resolution.reference)
+      },
+      async resolveInTransaction(db, context, input) {
+        return resolveShoppingReference(postgresShoppingReferenceStore(db), context, input, now)
       },
     },
   }
@@ -116,13 +143,7 @@ export function createTripShoppingReferenceRuntimeWithStore(
     },
     offerResolver: {
       async resolve(context, input) {
-        const resolution = await redeemShoppingReference(store, input.offerRef, {
-          purpose: purposeForSelectionKind(input.kind),
-          context,
-          scope: input.scope,
-          now,
-        })
-        return resolution.ok ? resolvedComponent(resolution.reference) : null
+        return resolveShoppingReference(store, context, input, now)
       },
     },
   }
@@ -298,7 +319,26 @@ function postgresShoppingReferenceStore(db: AnyDrizzleDb): TripShoppingReference
   }
 }
 
-function componentFromReference(reference: TripShoppingReference): CreateTripComponentBodyInput {
+async function resolveShoppingReference(
+  store: TripShoppingReferenceStore,
+  context: StorefrontShoppingContext,
+  input: Parameters<StorefrontTripOfferResolver["resolve"]>[1],
+  now: () => Date,
+): Promise<{ component: StorefrontTripOfferComponent } | null> {
+  const resolvedAt = now()
+  const resolution = await redeemShoppingReference(store, input.offerRef, {
+    purpose: purposeForSelectionKind(input.kind),
+    context,
+    scope: input.scope,
+    now: () => resolvedAt,
+  })
+  return resolution.ok ? resolvedComponent(resolution.reference, resolvedAt) : null
+}
+
+function componentFromReference(
+  reference: TripShoppingReference,
+  now: Date,
+): StorefrontTripOfferComponent {
   const payload = payloadSchema.parse(reference.payload)
   if (reference.purpose === "catalog-item") {
     const catalog = z
@@ -306,8 +346,6 @@ function componentFromReference(reference: TripShoppingReference): CreateTripCom
       .passthrough()
       .parse(payload)
     return {
-      // The selection runtime replaces this placeholder with the final ordered position.
-      sequence: 0,
       kind: "catalog_booking",
       catalogRef: {
         entityModule: catalog.entityModule,
@@ -315,6 +353,33 @@ function componentFromReference(reference: TripShoppingReference): CreateTripCom
         sourceKind: "owned",
       },
       metadata: {},
+    }
+  }
+
+  if (reference.purpose === "package-offer") {
+    const payload = z
+      .object({ selection: packageSelectionSchema, providerData: z.never().optional() })
+      .strict()
+      .parse(reference.payload)
+    if (Date.parse(payload.selection.offerExpiresAt) <= now.getTime()) {
+      throw new Error("package_offer_expired")
+    }
+    const { target, configure } = payload.selection
+    return {
+      kind: "catalog_booking",
+      catalogRef: target,
+      metadata: {
+        bookingDraftV1: {
+          entity: {
+            module: target.entityModule,
+            id: target.entityId,
+            sourceKind: target.sourceKind,
+            sourceConnectionId: target.sourceConnectionId,
+            sourceRef: target.sourceRef,
+          },
+          configure,
+        },
+      },
     }
   }
 
@@ -333,8 +398,6 @@ function componentFromReference(reference: TripShoppingReference): CreateTripCom
   }
   return reference.purpose === "flight-offer"
     ? {
-        // The selection runtime replaces this placeholder with the final ordered position.
-        sequence: 0,
         kind: "flight_placeholder",
         metadata: {
           flightDraft: { selectedOffer: offer.selection },
@@ -342,8 +405,6 @@ function componentFromReference(reference: TripShoppingReference): CreateTripCom
         },
       }
     : {
-        // The selection runtime replaces this placeholder with the final ordered position.
-        sequence: 0,
         kind: "catalog_booking",
         metadata: { storefrontShopping: durableSelection },
       }
@@ -351,9 +412,10 @@ function componentFromReference(reference: TripShoppingReference): CreateTripCom
 
 function resolvedComponent(
   reference: TripShoppingReference,
-): { component: CreateTripComponentBodyInput } | null {
+  now: Date,
+): { component: StorefrontTripOfferComponent } | null {
   try {
-    return { component: componentFromReference(reference) }
+    return { component: componentFromReference(reference, now) }
   } catch {
     // Persisted provider/source payload is never attached to a thrown parse
     // error that could cross into request logging.

--- a/packages/trips/src/storefront-trip-offer-resolver-port.ts
+++ b/packages/trips/src/storefront-trip-offer-resolver-port.ts
@@ -1,4 +1,5 @@
 import { definePort } from "@voyant-travel/core/project"
+import type { AnyDrizzleDb } from "@voyant-travel/db"
 import type {
   StorefrontShoppingContext,
   StorefrontTripSelectionCreate,
@@ -13,6 +14,9 @@ export interface StorefrontTripOfferResolutionInput extends StorefrontOfferSelec
   scope: StorefrontTripScope
 }
 
+/** Sequence is owned by the Trip selection mutation, never by an offer payload. */
+export type StorefrontTripOfferComponent = Omit<CreateTripComponentBodyInput, "sequence">
+
 /**
  * Closed trust-plane seam from a gateway-issued offerRef to a Trips component.
  * Deployments may resolve only the opaque offerRef plus trusted context/scope;
@@ -22,7 +26,13 @@ export interface StorefrontTripOfferResolver {
   resolve(
     context: StorefrontShoppingContext,
     input: StorefrontTripOfferResolutionInput,
-  ): Promise<{ component: CreateTripComponentBodyInput } | null>
+  ): Promise<{ component: StorefrontTripOfferComponent } | null>
+  /** Keep one-time redemption inside the selection mutation transaction. */
+  resolveInTransaction?(
+    db: AnyDrizzleDb,
+    context: StorefrontShoppingContext,
+    input: StorefrontTripOfferResolutionInput,
+  ): Promise<{ component: StorefrontTripOfferComponent } | null>
 }
 
 export const storefrontTripOfferResolverPort = definePort<StorefrontTripOfferResolver>({

--- a/packages/trips/src/storefront-trip-selections-runtime.ts
+++ b/packages/trips/src/storefront-trip-selections-runtime.ts
@@ -98,12 +98,17 @@ export function createStorefrontTripSelectionsRuntime(
 
   return {
     async create(context, input) {
-      const offers = await resolveOffers(options.offerResolver, context, input.scope, input.offers)
-      const itemRefs = offers.map(() =>
-        storefrontSelectionItemMetadataSchema.shape.itemRef.parse(createItemRef()),
-      )
-
       return options.withTransaction(async (db) => {
+        const offers = await resolveOffers(
+          options.offerResolver,
+          db,
+          context,
+          input.scope,
+          input.offers,
+        )
+        const itemRefs = offers.map(() =>
+          storefrontSelectionItemMetadataSchema.shape.itemRef.parse(createItemRef()),
+        )
         const handle = await createStorefrontTripInTransaction(
           db,
           { scope: coreScope(input.scope) },
@@ -156,6 +161,7 @@ export function createStorefrontTripSelectionsRuntime(
 
         const mutation = await prepareMutation(
           options.offerResolver,
+          db,
           context,
           accessScope(resolved.access),
           input,
@@ -208,25 +214,30 @@ export function createStorefrontTripSelectionsRuntime(
 
 async function resolveOffers(
   resolver: StorefrontTripOfferResolver | undefined,
+  db: AnyDrizzleDb,
   context: StorefrontShoppingContext,
   scope: StorefrontResolvedScope,
   offers: StorefrontTripSelectionCreate["offers"],
 ): Promise<Array<{ component: CreateTripComponentBodyInput }>> {
   const resolved: Array<{ component: CreateTripComponentBodyInput }> = []
   for (const offer of offers) {
-    resolved.push(await resolveOffer(resolver, context, coreScope(scope), offer))
+    resolved.push(await resolveOffer(resolver, db, context, coreScope(scope), offer))
   }
   return resolved
 }
 
 async function resolveOffer(
   resolver: StorefrontTripOfferResolver | undefined,
+  db: AnyDrizzleDb,
   context: StorefrontShoppingContext,
   scope: StorefrontTripScope,
   offer: StorefrontOfferSelection,
 ): Promise<{ component: CreateTripComponentBodyInput }> {
   if (!resolver) throw new StorefrontTripSelectionUnavailableError()
-  const resolution = await resolver.resolve(context, { ...offer, scope })
+  const input = { ...offer, scope }
+  const resolution = resolver.resolveInTransaction
+    ? await resolver.resolveInTransaction(db, context, input)
+    : await resolver.resolve(context, input)
   if (!resolution) throw new StorefrontTripSelectionUnavailableError("offer_unavailable")
   return { component: createTripComponentBodySchema.parse(resolution.component) }
 }
@@ -279,6 +290,7 @@ type PreparedMutation =
 
 async function prepareMutation(
   resolver: StorefrontTripOfferResolver | undefined,
+  db: AnyDrizzleDb,
   context: StorefrontShoppingContext,
   scope: StorefrontTripScope,
   input: StorefrontTripSelectionUpdate,
@@ -290,7 +302,7 @@ async function prepareMutation(
     components.map((component) => [selectionItem(component).itemRef, component]),
   )
   if (input.mutation.kind === "add") {
-    const resolved = await resolveOffer(resolver, context, scope, input.mutation.offer)
+    const resolved = await resolveOffer(resolver, db, context, scope, input.mutation.offer)
     return {
       kind: "add",
       offer: input.mutation.offer,

--- a/packages/trips/tests/booking-session-composite-handler.test.ts
+++ b/packages/trips/tests/booking-session-composite-handler.test.ts
@@ -126,6 +126,147 @@ describe("accepted Proposal Version Booking Session composite", () => {
     expect(consumeSources).toHaveBeenCalledTimes(2)
   })
 
+  it("quotes and commits a redeemed package through the sourced supplier-operation leaf", async () => {
+    const selectedPackage = component({
+      sourceKind: "voyant-connect",
+      sourceConnectionId: "connection_server",
+      sourceRef: "product_1",
+      metadata: {
+        bookingDraftV1: {
+          entity: {
+            module: "products",
+            id: "prod_1",
+            sourceKind: "voyant-connect",
+            sourceConnectionId: "connection_server",
+            sourceRef: "product_1",
+          },
+          configure: {
+            departureDate: "2026-09-10",
+            departureAirportCode: "OTP",
+            nights: 5,
+            pax: { adult: 2 },
+            roomTypeId: "room_1",
+            ratePlanId: "rate_1:AI",
+            board: "AI",
+          },
+        },
+      },
+    })
+    const state = harness([selectedPackage])
+    const commitSourced = vi.fn(async (input) => {
+      expect(input.session.target).toEqual({ kind: "catalog_item", catalogItemId: "prod_1" })
+      expect(input.session.statePayload).toMatchObject({
+        configure: {
+          departureDate: "2026-09-10",
+          departureAirportCode: "OTP",
+          roomTypeId: "room_1",
+          ratePlanId: "rate_1:AI",
+          board: "AI",
+        },
+      })
+      await input.consumeSources(state.db, "book_package", ["ball_package"], "suop_package")
+      return {
+        kind: "committed" as const,
+        bookingId: "book_package",
+        allocationIds: ["ball_package"],
+        supplierOperationId: "suop_package",
+      }
+    })
+    const leaf = leafRuntime({ commitSourced })
+    const handler = createTripBookingSessionCompositeHandler(state.persistence)
+    const quote = await createQuote(handler, state.session, leaf, state.db)
+
+    await expect(
+      handler.placeCapacityHold({
+        session: state.session,
+        quote,
+        holdId: "bshd_package",
+        capacityKey: "trip_snapshot:trsn_1",
+        quantity: 1,
+        expiresAt: new Date("2026-08-02T10:15:00.000Z"),
+        access: ACCESS,
+        now: NOW,
+        tx: state.db,
+        leaf,
+      }),
+    ).resolves.toBe("held")
+
+    await expect(
+      handler.commit({
+        session: state.session,
+        quote,
+        idempotencyKey: "commit_package",
+        requestFingerprint: "fp_package",
+        access: ACCESS,
+        now: NOW,
+        consumeSources: async () => {},
+        leaf,
+        db: state.db,
+      }),
+    ).resolves.toEqual({
+      kind: "committed",
+      bookings: [
+        {
+          componentId: selectedPackage.id,
+          bookingId: "book_package",
+          allocationIds: ["ball_package"],
+          supplierOperationId: "suop_package",
+        },
+      ],
+    })
+    expect(commitSourced).toHaveBeenCalledWith(
+      expect.objectContaining({
+        supplierOperationScope: selectedPackage.id,
+        idempotencyKey: `commit_package:${selectedPackage.id}`,
+      }),
+    )
+  })
+
+  it("keeps an ambiguous package confirmation in doubt without materializing a booking", async () => {
+    const selectedPackage = component({
+      sourceKind: "voyant-connect",
+      sourceConnectionId: "connection_server",
+      sourceRef: "product_1",
+    })
+    const state = harness([selectedPackage])
+    const consumeSources = vi.fn(async () => {})
+    const handler = createTripBookingSessionCompositeHandler(state.persistence)
+    const leaf = leafRuntime({
+      commitSourced: vi.fn(async () => ({
+        kind: "supplier_in_doubt" as const,
+        nextAction: "reconcile_supplier_operation" as const,
+        supplierOperationId: "suop_package",
+        operatorBackedRiskAccepted: false,
+      })),
+    })
+    const quote = await createQuote(handler, state.session, leaf, state.db)
+
+    await expect(
+      handler.commit({
+        session: state.session,
+        quote,
+        idempotencyKey: "commit_package",
+        requestFingerprint: "fp_package",
+        access: ACCESS,
+        now: NOW,
+        consumeSources,
+        leaf,
+        db: state.db,
+      }),
+    ).resolves.toEqual({
+      kind: "component_commit_pending",
+      nextAction: "continue_component_commit",
+      components: [
+        {
+          componentId: selectedPackage.id,
+          state: "supplier_in_doubt",
+          supplierOperationId: "suop_package",
+        },
+      ],
+    })
+    expect(consumeSources).not.toHaveBeenCalled()
+  })
+
   it("keeps manual placeholders honest and leaves the aggregate pending", async () => {
     const live = component({ id: "tcmp_cruise", entityId: "crus_1", sourceKind: "direct:cruise" })
     const manual = component({

--- a/packages/trips/tests/shopping-opaque-references.test.ts
+++ b/packages/trips/tests/shopping-opaque-references.test.ts
@@ -19,6 +19,7 @@ const CONTEXT = {
 const SCOPE = { marketId: "market_ro", locale: "ro-RO", currency: "EUR" }
 const FLIGHT_REF = `sref_${"a".repeat(64)}`
 const CATALOG_REF = `sref_${"b".repeat(64)}`
+const PACKAGE_REF = `sref_${"c".repeat(64)}`
 
 describe("durable shopping opaque references", () => {
   it("issues a 256-bit capability while persisting only its digest and bounded payload", async () => {
@@ -125,6 +126,70 @@ describe("durable shopping opaque references", () => {
     expect(resolutions.filter((value) => value !== null)).toHaveLength(1)
   })
 
+  it("turns one live package capability into stable Catalog booking pins exactly once", async () => {
+    const store = new MemoryReferenceStore()
+    const runtime = createTripShoppingReferenceRuntimeWithStore(store, {
+      now: () => NOW,
+      createReference: () => PACKAGE_REF,
+    })
+    await runtime.issuer.issue(packageInput())
+    const input = { kind: "package" as const, offerRef: PACKAGE_REF, scope: SCOPE }
+
+    await expect(runtime.offerResolver.resolve(CONTEXT, input)).resolves.toEqual({
+      component: {
+        kind: "catalog_booking",
+        catalogRef: {
+          entityModule: "products",
+          entityId: "product_1",
+          sourceKind: "voyant-connect",
+          sourceConnectionId: "connection_server",
+          sourceRef: "product_1",
+        },
+        metadata: {
+          bookingDraftV1: {
+            entity: {
+              module: "products",
+              id: "product_1",
+              sourceKind: "voyant-connect",
+              sourceConnectionId: "connection_server",
+              sourceRef: "product_1",
+            },
+            configure: {
+              departureDate: "2026-09-10",
+              departureAirportCode: "OTP",
+              nights: 5,
+              pax: { adult: 2 },
+              roomTypeId: "room_1",
+              ratePlanId: "rate_1:AI",
+              board: "AI",
+            },
+          },
+        },
+      },
+    })
+    await expect(runtime.offerResolver.resolve(CONTEXT, input)).resolves.toBeNull()
+  })
+
+  it("rejects and consumes a package capability after its supplier offer expires", async () => {
+    const store = new MemoryReferenceStore()
+    const runtime = createTripShoppingReferenceRuntimeWithStore(store, {
+      now: () => new Date("2026-08-08T12:06:00.000Z"),
+      createReference: () => PACKAGE_REF,
+    })
+    await runtime.issuer.issue(packageInput("2026-08-08T12:05:00.000Z"))
+
+    await expect(
+      runtime.offerResolver.resolve(CONTEXT, {
+        kind: "package",
+        offerRef: PACKAGE_REF,
+        scope: SCOPE,
+      }),
+    ).resolves.toBeNull()
+    expect([...store.references.values()][0]?.consumedAt).toEqual(
+      new Date("2026-08-08T12:06:00.000Z"),
+    )
+  })
+
   it("sanitizes persistence and payload-shape failures before they can reach request logs", async () => {
     const failing = createTripShoppingReferenceRuntimeWithStore(
       {
@@ -185,6 +250,41 @@ function catalogInput(): Parameters<StorefrontOpaqueReferenceIssuer["issue"]>[0]
     payload: { entityModule: "products", entityId: "product_1" },
     ttlSeconds: 15 * 60,
     replay: "multi-use",
+  }
+}
+
+function packageInput(
+  offerExpiresAt = "2026-08-08T12:10:00.000Z",
+): Parameters<StorefrontOpaqueReferenceIssuer["issue"]>[0] {
+  return {
+    purpose: "package-offer",
+    storefrontId: CONTEXT.storefrontId,
+    channelId: CONTEXT.channelId,
+    owner: { userId: CONTEXT.userId, buyerAccountId: CONTEXT.buyerAccountId },
+    scope: SCOPE,
+    payload: {
+      selection: {
+        target: {
+          entityModule: "products",
+          entityId: "product_1",
+          sourceKind: "voyant-connect",
+          sourceConnectionId: "connection_server",
+          sourceRef: "product_1",
+        },
+        configure: {
+          departureDate: "2026-09-10",
+          departureAirportCode: "OTP",
+          nights: 5,
+          pax: { adult: 2 },
+          roomTypeId: "room_1",
+          ratePlanId: "rate_1:AI",
+          board: "AI",
+        },
+        offerExpiresAt,
+      },
+    },
+    ttlSeconds: 15 * 60,
+    replay: "single-use",
   }
 }
 

--- a/packages/trips/tests/storefront-trip-selections-runtime.test.ts
+++ b/packages/trips/tests/storefront-trip-selections-runtime.test.ts
@@ -63,6 +63,47 @@ describe("Storefront Trip selections runtime", () => {
     ).rejects.toBeInstanceOf(StorefrontTripSelectionAccessError)
   })
 
+  it("redeems one-time offers inside the same transaction that creates the selection", async () => {
+    const state = emptyState()
+    const db = createDb(state)
+    const resolve = vi.fn(async () => {
+      throw new Error("standalone redemption must not run")
+    })
+    const resolveInTransaction = vi.fn(async () => ({
+      component: {
+        kind: "catalog_booking" as const,
+        catalogRef: {
+          entityModule: "products",
+          entityId: "product_1",
+          sourceKind: "voyant-connect",
+          sourceConnectionId: "connection_server",
+          sourceRef: "product_1",
+        },
+        metadata: {},
+      },
+    }))
+    const runtime = createStorefrontTripSelectionsRuntime({
+      withTransaction: (operation) => operation(db),
+      offerResolver: { resolve, resolveInTransaction },
+      now: () => NOW,
+      createSelectionRef: () => CAPABILITY,
+      createItemRef: () => ITEM_ONE,
+    })
+
+    await expect(
+      runtime.create(CONTEXT, {
+        scope: SCOPE,
+        offers: [{ kind: "package", offerRef: "package-offer-ref-001" }],
+      }),
+    ).resolves.toMatchObject({ revision: 1, items: [{ kind: "package" }] })
+    expect(resolve).not.toHaveBeenCalled()
+    expect(resolveInTransaction).toHaveBeenCalledWith(
+      db,
+      CONTEXT,
+      expect.objectContaining({ kind: "package", offerRef: "package-offer-ref-001" }),
+    )
+  })
+
   it("creates and mutates only through opaque references with deterministic ordering", async () => {
     const state = emptyState()
     const resolver = {

--- a/packages/voyant-connect-adapter/src/package-booking.test.ts
+++ b/packages/voyant-connect-adapter/src/package-booking.test.ts
@@ -27,6 +27,7 @@ describe("Voyant Connect package booking lifecycle", () => {
       "conn_server",
       expect.objectContaining({
         departure: { airportCodes: ["OTP"] },
+        accommodationIds: ["hotel_1"],
         departureDateFrom: "2026-09-10",
         departureDateTo: "2026-09-10",
         nights: { min: 5, max: 5 },
@@ -38,6 +39,34 @@ describe("Voyant Connect package booking lifecycle", () => {
       { idempotencyKey: "bses_1:commit_1:reserve" },
     )
     expect(client.packages.lock).not.toHaveBeenCalledWith("conn_browser", expect.anything())
+  })
+
+  it("revalidates canonical traveler bands without widening children into adults", async () => {
+    const { adapter, client } = fixture(offer())
+    const mixedParty = request()
+    mixedParty.parameters.draft = {
+      configure: { pax: { adult: 2, "child:pricing_1": 1, infant: 1 } },
+    }
+
+    await adapter.reserve?.({ connection_id: "conn_server" }, mixedParty)
+
+    expect(client.packages.search).toHaveBeenCalledWith(
+      "conn_server",
+      expect.objectContaining({ occupancy: { adults: 2, children: 1, infants: 1 } }),
+    )
+  })
+
+  it("fails closed before hold when no offer matches the stable rate pins", async () => {
+    const { adapter, client } = fixture(
+      offer({ stay: { ...offer().stay, ratePlanId: "rate_changed" } }),
+    )
+
+    await expect(adapter.reserve?.({ connection_id: "conn_server" }, request())).resolves.toEqual({
+      upstream_ref: "package-offer:product_1",
+      status: "failed",
+      upstream_payload: { reason: "package_offer_unavailable" },
+    })
+    expect(client.packages.lock).not.toHaveBeenCalled()
   })
 
   it("fails before hold when the provider price moved from the immutable Session Quote", async () => {
@@ -151,7 +180,7 @@ function request(): ReserveRequest {
   return {
     entity_module: "products",
     entity_id: "product_1",
-    source_ref: "product_1",
+    source_ref: "hotel_1",
     scope: { locale: "ro-RO", market: "market_ro", audience: "customer", currency: "EUR" },
     parameters: {
       connectRoute: "packages",

--- a/packages/voyant-connect-adapter/src/package-booking.ts
+++ b/packages/voyant-connect-adapter/src/package-booking.ts
@@ -5,6 +5,7 @@ import type {
   SourceAdapterContext,
 } from "@voyant-travel/catalog-contracts/adapter/contract"
 import { ReservationDispatchError } from "@voyant-travel/catalog-contracts/adapter/contract"
+import { paxBandBaseCode } from "@voyant-travel/catalog-contracts/booking-engine/requirements-defaults"
 import type {
   PackageConfirmInput,
   PackageHold,
@@ -162,14 +163,12 @@ async function liveResolvePackage(
   const parameters = request.parameters ?? {}
   const departureDate = stringValue(parameters.departureDate)
   if (!departureDate) return { values: {}, failed: missing(request.ids) }
-  const pax = recordValue(recordValue(parameters.draft)?.configure)?.pax
-  const paxRecord = recordValue(pax)
-  const adults = integer(paxRecord?.adults) ?? integer(parameters.paxCount) ?? 2
-  const children = integer(paxRecord?.children)
+  const occupancy = packageOccupancy(parameters)
   const nights = integer(parameters.nights)
   const departureAirportCode = stringValue(parameters.departureAirportCode)
   if (
     !departureAirportCode ||
+    !occupancy ||
     nights === undefined ||
     (!stringValue(parameters.roomTypeId) &&
       !stringValue(parameters.ratePlanId) &&
@@ -179,10 +178,12 @@ async function liveResolvePackage(
   }
   const query: PackageSearchQuery = {
     departure: { airportCodes: [departureAirportCode] },
-    accommodationIds: [...new Set(request.ids.map((id) => id.replace(/^[^:]+:/, "")))],
+    accommodationIds: [
+      ...new Set(request.ids.map((id) => request.source_refs?.[id] ?? id.replace(/^[^:]+:/, ""))),
+    ],
     departureDateFrom: departureDate,
     departureDateTo: departureDate,
-    occupancy: { adults, ...(children !== undefined ? { children } : {}) },
+    occupancy,
     nights: { min: nights, max: nights },
     ...(request.scope.locale ? { locale: request.scope.locale } : {}),
     limit: 100,
@@ -191,11 +192,15 @@ async function liveResolvePackage(
   const chosen = new Map<string, PackageOffer>()
   for (const offer of response.offers) {
     const id = offer.productRef.entityId
-    if (!request.ids.includes(id) || offer.connectionId !== connectionId) continue
-    const current = chosen.get(id)
-    if (!current || (matchesPin(offer, parameters) && !matchesPin(current, parameters))) {
-      chosen.set(id, offer)
+    if (
+      !request.ids.includes(id) ||
+      offer.connectionId !== connectionId ||
+      !matchesPin(offer, parameters)
+    ) {
+      continue
     }
+    const current = chosen.get(id)
+    if (!current) chosen.set(id, offer)
   }
   const values: Record<string, Record<string, unknown>> = {}
   for (const [id, offer] of chosen) {
@@ -224,12 +229,42 @@ function matchesPin(offer: PackageOffer, parameters: Record<string, unknown>): b
   )
 }
 
+function packageOccupancy(
+  parameters: Record<string, unknown>,
+): PackageSearchQuery["occupancy"] | null {
+  const pax = recordValue(recordValue(recordValue(parameters.draft)?.configure)?.pax)
+  if (!pax) return { adults: positiveInteger(parameters.paxCount) ?? 2 }
+
+  let adults = 0
+  let children = 0
+  let infants = 0
+  for (const [band, value] of Object.entries(pax)) {
+    const count = integer(value)
+    if (count === undefined) return null
+    const category = paxBandBaseCode(band)
+    if (category === "adult" || category === "senior") adults += count
+    else if (category === "child") children += count
+    else if (category === "infant") infants += count
+  }
+  if (adults < 1) return null
+  return {
+    adults,
+    ...(children > 0 ? { children } : {}),
+    ...(infants > 0 ? { infants } : {}),
+  }
+}
+
 function missing(ids: readonly string[]): Record<string, "not_found"> {
   return Object.fromEntries(ids.map((id) => [id, "not_found"]))
 }
 
 function integer(value: unknown): number | undefined {
   return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : undefined
+}
+
+function positiveInteger(value: unknown): number | undefined {
+  const parsed = integer(value)
+  return parsed !== undefined && parsed > 0 ? parsed : undefined
 }
 
 function packageConfirmInput(request: ReserveRequest, holdId: string): PackageConfirmInput | null {
@@ -299,7 +334,10 @@ function samePackageSelection(left: PackageOffer, right: PackageOffer): boolean 
     left.stay.ratePlanId === right.stay.ratePlanId &&
     left.stay.board === right.stay.board &&
     left.stay.checkIn === right.stay.checkIn &&
-    left.stay.checkOut === right.stay.checkOut
+    left.stay.checkOut === right.stay.checkOut &&
+    left.stay.nights === right.stay.nights &&
+    JSON.stringify(left.stay.occupancy) === JSON.stringify(right.stay.occupancy) &&
+    JSON.stringify(left.flights) === JSON.stringify(right.flights)
   )
 }
 

--- a/packages/voyant-connect-adapter/src/storefront-package-sources.test.ts
+++ b/packages/voyant-connect-adapter/src/storefront-package-sources.test.ts
@@ -108,7 +108,25 @@ describe("Voyant Connect Storefront package sources", () => {
     })
     expect(JSON.stringify(result)).not.toContain("credential_secret")
     expect(result?.offers[0]).not.toHaveProperty("providerData")
-    expect(result?.offers[0]?.selection).toMatchObject({ connectionId: "connection_secret" })
+    expect(result?.offers[0]?.selection).toEqual({
+      target: {
+        entityModule: "products",
+        entityId: "product_secret",
+        sourceKind: "voyant-connect",
+        sourceConnectionId: "connection_secret",
+        sourceRef: "hotel_secret",
+      },
+      configure: {
+        departureDate: "2026-09-10",
+        departureAirportCode: "OTP",
+        nights: 5,
+        pax: { adult: 2 },
+        board: "AI",
+      },
+      offerExpiresAt: "2026-08-08T10:05:00.000Z",
+    })
+    expect(JSON.stringify(result?.offers[0]?.selection)).not.toContain("offer_secret")
+    expect(JSON.stringify(result?.offers[0]?.selection)).not.toContain("supplier_secret")
   })
 
   it("fails closed when Connect cannot enforce the requested package filter", async () => {

--- a/packages/voyant-connect-adapter/src/storefront-package-sources.ts
+++ b/packages/voyant-connect-adapter/src/storefront-package-sources.ts
@@ -109,9 +109,32 @@ function packageOffer(
     accommodationName,
     boardName: offer.stay.board,
     expiresAt: offer.expiresAt,
-    // This payload is issued only into the server-side opaque reference store.
-    // The public result receives the resulting capability ref, never this offer.
-    selection: { connectionId: offer.connectionId, offer },
+    // Persist only stable re-resolution pins behind the opaque capability. The
+    // broad short-lived provider offer never becomes Trip state.
+    selection: {
+      target: {
+        entityModule: offer.productRef.entityModule,
+        entityId: offer.productRef.entityId,
+        sourceKind: "voyant-connect",
+        sourceConnectionId: offer.connectionId,
+        sourceRef: offer.stay.ref.entityId,
+      },
+      configure: {
+        departureDate: firstFlight.departureAt?.slice(0, 10) ?? offer.stay.checkIn,
+        departureAirportCode: firstFlight.origin,
+        nights: offer.stay.nights,
+        pax: {
+          adult: offer.stay.occupancy.adults,
+          ...(offer.stay.occupancy.children !== undefined
+            ? { child: offer.stay.occupancy.children }
+            : {}),
+        },
+        ...(offer.stay.roomTypeId ? { roomTypeId: offer.stay.roomTypeId } : {}),
+        ...(offer.stay.ratePlanId ? { ratePlanId: offer.stay.ratePlanId } : {}),
+        ...(offer.stay.board ? { board: offer.stay.board } : {}),
+      },
+      offerExpiresAt: offer.expiresAt,
+    },
   }
 }
 


### PR DESCRIPTION
## What changed

- redeem owner/storefront/channel/scope-bound package capabilities into stable sourced Catalog Item selections
- persist only stable package re-resolution pins; browser responses never expose or accept provider or connection selectors
- keep one-time redemption inside the Trip-selection transaction and enforce both capability and supplier-offer expiry
- route composite quote, hold, and commit through Catalog's sourced supplier-operation lifecycle with component-scoped idempotency
- fail closed on stale/malformed capabilities, changed rate or party pins, unavailable server-resolved connections, and ambiguous confirmation
- preserve compensation for definitively changed holds while retaining possibly-sent confirmation as in doubt for reconciliation

## Why

The managed Storefront could issue opaque package offer references, but Trips redeemed them into metadata-only components. Those components were not Catalog-backed, so the Trip/Booking Session composite could not reach the revalidate, hold, and confirm lifecycle.

## Validation

- `git diff --check`
- focused Biome checks on all changed source and test files
- exact-head GitHub Actions CI: https://github.com/voyant-travel/voyant/actions/runs/31290003639
  - build, tests, lint/typecheck, architecture, packaged acceptance, operator image smoke, and all DB lanes passed

## Stack

Base: #4459 (`290b87d477`). This draft is exactly one commit (`c58d76a47c`) on the current provider-wiring head. The opaque-reference and Connect lifecycle prerequisites are now merged into that base.

## Remaining boundary

No additional Storefront package/Trip/Booking ownership is introduced. Runtime success still requires the sourced Catalog Product and its server-admitted Connect connection to exist; absence fails closed. A possibly-sent supplier confirmation remains in Catalog's existing in-doubt reconciliation/manual-resolution workflow rather than being blindly retried or compensated.