### PR TITLE
feat(storefront): add opaque live shopping continuations

### DIFF
--- a/.changeset/opaque-shopping-continuations.md
+++ b/.changeset/opaque-shopping-continuations.md
@@ -1,0 +1,9 @@
+---
+"@voyant-travel/catalog": patch
+"@voyant-travel/flights": patch
+"@voyant-travel/storefront": minor
+"@voyant-travel/trips": patch
+"@voyant-travel/voyant-connect-adapter": patch
+---
+
+Add bound opaque continuations for managed multi-source flight, stay, and package shopping.

--- a/packages/catalog/src/search/availability-fan-out.ts
+++ b/packages/catalog/src/search/availability-fan-out.ts
@@ -94,6 +94,11 @@ export interface FanOutAvailabilitySearchOptions {
   limit?: number
   /** Server-side display FX configuration. Credentials stay behind `quoteFx`. */
   presentation?: NormalizePresentationMoneyOptions
+  /** Server-only cursors keyed independently for sourced and owned supply. */
+  continuationCursors?: {
+    sourced?: Readonly<Record<string, string>>
+    owned?: Readonly<Record<string, string>>
+  }
 }
 
 interface SourceOutcome {
@@ -133,7 +138,11 @@ export async function fanOutAvailabilitySearch(
         return { status: "capability_missing" as const, candidates: [] }
       }
       const ctx: SourceAdapterContext = { connection_id: connectionId, ...context }
-      const result = await adapter.searchAvailability(ctx, request)
+      const cursor = options.continuationCursors?.sourced?.[connectionId]
+      const result = await adapter.searchAvailability(
+        ctx,
+        cursor ? { ...request, cursor } : request,
+      )
       // Stamp the dispatching connection as origin, unless the adapter already
       // set a more specific one (e.g. a cross-provider search per candidate).
       const candidates = result.candidates.map((c) =>
@@ -150,7 +159,11 @@ export async function fanOutAvailabilitySearch(
       if (handler.entityModule !== request.vertical) {
         return { status: "vertical_skipped" as const, candidates: [] }
       }
-      const result = await handler.searchAvailability(context, request)
+      const cursor = options.continuationCursors?.owned?.[handler.entityModule]
+      const result = await handler.searchAvailability(
+        context,
+        cursor ? { ...request, cursor } : request,
+      )
       const candidates = result.candidates.map((c) =>
         c.source ? c : { ...c, source: { kind: "owned" as const, module: handler.entityModule } },
       )

--- a/packages/flights/src/orchestration/fan-out.test.ts
+++ b/packages/flights/src/orchestration/fan-out.test.ts
@@ -44,6 +44,8 @@ function makeAdapter(
     delayMs?: number
     maxSlices?: number
     captureContext?: (ctx: FlightAdapterContext) => void
+    captureRequest?: (request: FlightSearchRequest) => void
+    nextCursor?: string
   } = {},
 ): FlightConnectorAdapter {
   return {
@@ -52,13 +54,25 @@ function makeAdapter(
       declared: [],
       maxSlicesPerSearch: behaviour.maxSlices,
     },
-    async searchFlights(ctx) {
+    async searchFlights(ctx, request) {
       behaviour.captureContext?.(ctx)
+      behaviour.captureRequest?.(request)
       if (behaviour.delayMs) {
         await new Promise((r) => setTimeout(r, behaviour.delayMs))
       }
       if (behaviour.throws) throw behaviour.throws
-      return { offers: behaviour.offers ?? [] }
+      return {
+        offers: behaviour.offers ?? [],
+        ...(behaviour.nextCursor
+          ? {
+              pagination: {
+                total: behaviour.offers?.length ?? 0,
+                hasMore: true,
+                cursor: behaviour.nextCursor,
+              },
+            }
+          : {}),
+      }
     },
     async priceOffer() {
       throw new Error("not implemented in test")
@@ -82,6 +96,36 @@ const oneSliceRequest: FlightSearchRequest = {
 }
 
 describe("fanOutFlightSearch", () => {
+  it("routes independent server-only continuations and returns aligned next cursors", async () => {
+    const requests: FlightSearchRequest[] = []
+    const result = await fanOutFlightSearch({
+      adapters: [
+        {
+          connectionId: "conn_a",
+          adapter: makeAdapter("a", {
+            captureRequest: (request) => requests.push(request),
+            nextCursor: "provider-a-page-3",
+          }),
+        },
+        {
+          connectionId: "conn_b",
+          adapter: makeAdapter("b", { captureRequest: (request) => requests.push(request) }),
+        },
+      ],
+      request: { ...oneSliceRequest, pagination: { limit: 10 } },
+      continuationCursors: { conn_a: "provider-a-page-2", conn_b: "provider-b-page-4" },
+    })
+
+    expect(requests.map(({ pagination }) => pagination?.cursor)).toEqual([
+      "provider-a-page-2",
+      "provider-b-page-4",
+    ])
+    expect(result.perConnection.map(({ nextCursor }) => nextCursor)).toEqual([
+      "provider-a-page-3",
+      undefined,
+    ])
+  })
+
   it("merges identical itineraries from multiple providers, keeping cheapest as primary", async () => {
     const result = await fanOutFlightSearch({
       adapters: [

--- a/packages/flights/src/orchestration/fan-out.ts
+++ b/packages/flights/src/orchestration/fan-out.ts
@@ -65,6 +65,7 @@ export interface ConnectionResult {
   count: number
   latencyMs: number
   errorMessage?: string
+  nextCursor?: string
 }
 
 export interface FanOutFlightSearchOptions {
@@ -89,6 +90,8 @@ export interface FanOutFlightSearchOptions {
   limit?: number
   /** Server-side display FX configuration. Credentials stay behind `quoteFx`. */
   presentation?: NormalizePresentationMoneyOptions
+  /** Server-only cursor keyed by admitted connection id. */
+  continuationCursors?: Readonly<Record<string, string>>
 }
 
 export interface FanOutFlightSearchResult {
@@ -131,8 +134,15 @@ export async function fanOutFlightSearch(
         // The admitted source owns its identity. Adapter context can enrich a
         // call but can never replace the enumerated connection id.
         const ctx: FlightAdapterContext = { ...context, connectionId }
+        const continuationCursor = options.continuationCursors?.[connectionId]
+        const request = continuationCursor
+          ? {
+              ...options.request,
+              pagination: { ...options.request.pagination, cursor: continuationCursor },
+            }
+          : options.request
         const response = await withTimeout(
-          adapter.searchFlights(ctx, options.request),
+          adapter.searchFlights(ctx, request),
           timeoutMs,
           `connection ${connectionId} timed out after ${timeoutMs}ms`,
         )
@@ -140,6 +150,7 @@ export async function fanOutFlightSearch(
           connectionId,
           status: "ok" as const,
           offers: response.offers,
+          nextCursor: response.pagination?.cursor,
           latencyMs: Date.now() - start,
         }
       } catch (err) {
@@ -163,6 +174,7 @@ export async function fanOutFlightSearch(
     count: r.offers.length,
     latencyMs: r.latencyMs,
     errorMessage: r.errorMessage,
+    nextCursor: "nextCursor" in r ? r.nextCursor : undefined,
   }))
 
   const flatOffers = settled.flatMap((result) => result.offers)

--- a/packages/storefront/src/shopping/live-provider.ts
+++ b/packages/storefront/src/shopping/live-provider.ts
@@ -14,6 +14,7 @@ import type {
   StorefrontDynamicPackageSourceProvider,
   StorefrontInternalPackageOffer,
   StorefrontInternalStayOffer,
+  StorefrontLiveContinuation,
   StorefrontLiveSearchPage,
   StorefrontLiveSourceStatus,
   StorefrontShoppingLiveProvider,
@@ -89,10 +90,25 @@ export function createStorefrontShoppingLiveProvider(
     async searchFlights(input) {
       if (!options.flights) return unavailablePage()
       const resolved = await options.flights.resolve(input)
-      if (resolved.adapters.length === 0) return unavailablePage()
+      const continued = continuationMap(input.continuation)
+      const adapters = input.continuation
+        ? resolved.adapters.filter(({ connectionId }) => continued.has(flightKey(connectionId)))
+        : resolved.adapters
+      if (adapters.length === 0) return unavailablePage()
       const result = await fanOutFlightSearch({
         ...resolved,
+        adapters,
         request: flightRequest(input.intent),
+        ...(input.continuation
+          ? {
+              continuationCursors: Object.fromEntries(
+                adapters.flatMap(({ connectionId }) => {
+                  const cursor = continued.get(flightKey(connectionId))
+                  return cursor ? [[connectionId, cursor]] : []
+                }),
+              ),
+            }
+          : {}),
         ...(options.perSourceTimeoutMs !== undefined
           ? { perConnectionTimeoutMs: options.perSourceTimeoutMs }
           : {}),
@@ -102,6 +118,13 @@ export function createStorefrontShoppingLiveProvider(
         sources: result.perConnection.map(({ status, count }) => ({
           status: mapFlightStatus(status, count),
         })),
+        ...continuationResult(
+          result.perConnection.flatMap(({ connectionId, status, nextCursor }) =>
+            status === "ok" && nextCursor
+              ? [{ key: flightKey(connectionId), cursor: nextCursor }]
+              : [],
+          ),
+        ),
       }
     },
 
@@ -109,12 +132,39 @@ export function createStorefrontShoppingLiveProvider(
       if (!options.stays) return unavailablePage()
       const stays = options.stays
       const resolved = await stays.resolve(input)
-      if ((resolved.adapters?.length ?? 0) + (resolved.ownedHandlers?.length ?? 0) === 0) {
+      const continued = continuationMap(input.continuation)
+      const adapters = (resolved.adapters ?? []).filter(
+        ({ connectionId }) => !input.continuation || continued.has(staySourcedKey(connectionId)),
+      )
+      const ownedHandlers = (resolved.ownedHandlers ?? []).filter(
+        ({ handler }) => !input.continuation || continued.has(stayOwnedKey(handler.entityModule)),
+      )
+      if (adapters.length + ownedHandlers.length === 0) {
         return unavailablePage()
       }
       const result = await fanOutAvailabilitySearch({
         ...resolved,
+        adapters,
+        ownedHandlers,
         request: stayRequest(input.scope, input.intent),
+        ...(input.continuation
+          ? {
+              continuationCursors: {
+                sourced: Object.fromEntries(
+                  adapters.flatMap(({ connectionId }) => {
+                    const cursor = continued.get(staySourcedKey(connectionId))
+                    return cursor ? [[connectionId, cursor]] : []
+                  }),
+                ),
+                owned: Object.fromEntries(
+                  ownedHandlers.flatMap(({ handler }) => {
+                    const cursor = continued.get(stayOwnedKey(handler.entityModule))
+                    return cursor ? [[handler.entityModule, cursor]] : []
+                  }),
+                ),
+              },
+            }
+          : {}),
         ...(options.perSourceTimeoutMs !== undefined
           ? { perConnectionTimeoutMs: options.perSourceTimeoutMs }
           : {}),
@@ -145,6 +195,18 @@ export function createStorefrontShoppingLiveProvider(
             status: dropped > 0 && (mapped === "ok" || mapped === "empty") ? "partial" : mapped,
           }
         }),
+        ...continuationResult(
+          result.perConnection.flatMap(({ source, kind, status, nextCursor }) =>
+            (status === "ok" || status === "partial" || status === "empty") && nextCursor
+              ? [
+                  {
+                    key: kind === "sourced" ? staySourcedKey(source) : stayOwnedKey(source),
+                    cursor: nextCursor,
+                  },
+                ]
+              : [],
+          ),
+        ),
       }
     },
 
@@ -155,12 +217,20 @@ export function createStorefrontShoppingLiveProvider(
         scope: input.scope,
         destination: input.intent.destination,
       })
-      if (sources.length === 0) return unavailablePage()
+      const continued = continuationMap(input.continuation)
+      const admittedSources = input.continuation
+        ? sources.filter(({ continuationKey }) => continued.has(packageKey(continuationKey)))
+        : sources
+      if (admittedSources.length === 0) return unavailablePage()
       const pages = await Promise.all(
-        sources.map((source) =>
+        admittedSources.map((source) =>
           runPackageSource(
             source,
-            packageRequest(input.scope, input.intent),
+            packageRequest(
+              input.scope,
+              input.intent,
+              continued.get(packageKey(source.continuationKey)),
+            ),
             options.perSourceTimeoutMs ?? 5_000,
           ),
         ),
@@ -168,6 +238,13 @@ export function createStorefrontShoppingLiveProvider(
       return {
         items: pages.flatMap(({ offers }) => offers),
         sources: pages.map(({ status }) => ({ status })),
+        ...continuationResult(
+          pages.flatMap(({ key, status, nextCursor }) =>
+            (status === "ok" || status === "partial" || status === "empty") && nextCursor
+              ? [{ key: packageKey(key), cursor: nextCursor }]
+              : [],
+          ),
+        ),
       }
     },
   }
@@ -310,7 +387,11 @@ function mapStay(
   }
 }
 
-function packageRequest(scope: StorefrontResolvedScope, intent: PackageIntent) {
+function packageRequest(
+  scope: StorefrontResolvedScope,
+  intent: PackageIntent,
+  continuationCursor?: string,
+) {
   return {
     origin: intent.origin,
     destination: intent.destination,
@@ -329,7 +410,14 @@ function packageRequest(scope: StorefrontResolvedScope, intent: PackageIntent) {
     },
     ...(intent.boards ? { boards: intent.boards } : {}),
     ...(intent.minStars !== undefined ? { minStars: intent.minStars } : {}),
-    ...(intent.pagination ? { pagination: intent.pagination } : {}),
+    ...(intent.pagination || continuationCursor
+      ? {
+          pagination: {
+            ...intent.pagination,
+            ...(continuationCursor ? { cursor: continuationCursor } : {}),
+          },
+        }
+      : {}),
     scope: { marketId: scope.marketId, locale: scope.locale, currency: scope.currency },
   }
 }
@@ -339,24 +427,55 @@ async function runPackageSource(
   request: Parameters<StorefrontDynamicPackageSource["search"]>[0],
   timeoutMs: number,
 ): Promise<{
+  key: string
   offers: readonly StorefrontInternalPackageOffer[]
   status: StorefrontLiveSourceStatus
+  nextCursor?: string
 }> {
   try {
     const result = await withTimeout(source.search(request), timeoutMs)
     return {
+      key: source.continuationKey,
       offers: result.offers.map((offer) => ({
         ...offer,
         selection: { ...offer.selection },
       })),
       status: result.status ?? (result.offers.length > 0 ? "ok" : "empty"),
+      ...(result.nextCursor ? { nextCursor: result.nextCursor } : {}),
     }
   } catch (error) {
     return {
+      key: source.continuationKey,
       offers: [],
       status: error instanceof SourceTimeoutError ? "timeout" : "error",
     }
   }
+}
+
+function continuationMap(
+  continuation: StorefrontLiveContinuation | undefined,
+): Map<string, string> {
+  return new Map(continuation?.sources.map(({ key, cursor }) => [key, cursor]) ?? [])
+}
+
+function continuationResult(sources: Array<{ key: string; cursor: string }>) {
+  return sources.length > 0 ? { continuation: { sources } } : {}
+}
+
+function flightKey(connectionId: string): string {
+  return `flight:${connectionId}`
+}
+
+function staySourcedKey(connectionId: string): string {
+  return `stay:sourced:${connectionId}`
+}
+
+function stayOwnedKey(entityModule: string): string {
+  return `stay:owned:${entityModule}`
+}
+
+function packageKey(sourceKey: string): string {
+  return `package:${sourceKey}`
 }
 
 class SourceTimeoutError extends Error {}

--- a/packages/storefront/src/shopping/managed-runtime.ts
+++ b/packages/storefront/src/shopping/managed-runtime.ts
@@ -4,9 +4,11 @@ import {
 } from "@voyant-travel/catalog/search/presentation-money"
 import type { SearchFilter } from "@voyant-travel/catalog-contracts/indexer/contract"
 import type { PresentationFxQuoter } from "@voyant-travel/catalog-contracts/presentation-money"
+import { sha256Hex } from "@voyant-travel/hono"
 
 import type {
   StorefrontCatalogSliceItem,
+  StorefrontLiveContinuation,
   StorefrontLiveSearchPage,
   StorefrontOpaqueReferenceIssuer,
   StorefrontShoppingCatalogProvider,
@@ -23,6 +25,11 @@ import type {
 
 const OFFER_TTL_SECONDS = 15 * 60
 const ITEM_TTL_SECONDS = 15 * 60
+const CONTINUATION_TTL_SECONDS = 5 * 60
+const MAX_CONTINUATION_PAGE = 100
+const MAX_CONTINUATION_SOURCES = 64
+const MAX_SOURCE_KEY_LENGTH = 256
+const MAX_SOURCE_CURSOR_LENGTH = 8_192
 
 export class StorefrontShoppingScopeError extends Error {
   readonly code = "storefront_shopping_scope_unsupported"
@@ -32,6 +39,14 @@ export class StorefrontShoppingScopeError extends Error {
   ) {
     super(`Unsupported storefront shopping ${selector}${requested ? `: ${requested}` : "."}`)
     this.name = "StorefrontShoppingScopeError"
+  }
+}
+
+export class StorefrontShoppingContinuationError extends Error {
+  readonly code = "storefront_shopping_continuation_unavailable"
+  constructor() {
+    super("Storefront shopping continuation is invalid, expired, consumed, or stale.")
+    this.name = "StorefrontShoppingContinuationError"
   }
 }
 
@@ -224,7 +239,13 @@ async function searchFlights(
   intent: FlightIntent,
   now: () => Date,
 ): Promise<StorefrontShoppingResult> {
-  const page = await options.live.searchFlights({ context, scope, intent })
+  const continuation = await resolveLiveContinuation(options.references, context, scope, intent)
+  const page = await options.live.searchFlights({
+    context,
+    scope,
+    intent: withoutLiveCursor(intent),
+    ...(continuation ? { continuation: continuation.state } : {}),
+  })
   const normalized = await normalizeLive(page, scope.currency, options.quoteFx)
   const offers = await Promise.all(
     normalized.items.map(async ({ item, price }) => {
@@ -243,7 +264,22 @@ async function searchFlights(
       }
     }),
   )
-  return { kind: "flight", scope, offers, coverage: coverage(page, normalized.dropped) }
+  const nextCursor = await issueLiveContinuation(
+    options.references,
+    now,
+    context,
+    scope,
+    intent,
+    page.continuation,
+    continuation?.page ?? 0,
+  )
+  return {
+    kind: "flight",
+    scope,
+    offers,
+    coverage: coverage(page, normalized.dropped),
+    ...(nextCursor ? { nextCursor } : {}),
+  }
 }
 
 async function searchStays(
@@ -253,7 +289,13 @@ async function searchStays(
   intent: StayIntent,
   now: () => Date,
 ): Promise<StorefrontShoppingResult> {
-  const page = await options.live.searchStays({ context, scope, intent })
+  const continuation = await resolveLiveContinuation(options.references, context, scope, intent)
+  const page = await options.live.searchStays({
+    context,
+    scope,
+    intent: withoutLiveCursor(intent),
+    ...(continuation ? { continuation: continuation.state } : {}),
+  })
   const normalized = await normalizeLive(page, scope.currency, options.quoteFx)
   const offers = await Promise.all(
     normalized.items.map(async ({ item, price }) => {
@@ -287,7 +329,22 @@ async function searchStays(
       }
     }),
   )
-  return { kind: "stay", scope, offers, coverage: coverage(page, normalized.dropped) }
+  const nextCursor = await issueLiveContinuation(
+    options.references,
+    now,
+    context,
+    scope,
+    intent,
+    page.continuation,
+    continuation?.page ?? 0,
+  )
+  return {
+    kind: "stay",
+    scope,
+    offers,
+    coverage: coverage(page, normalized.dropped),
+    ...(nextCursor ? { nextCursor } : {}),
+  }
 }
 
 async function searchPackages(
@@ -297,7 +354,13 @@ async function searchPackages(
   intent: PackageIntent,
   now: () => Date,
 ): Promise<StorefrontShoppingResult> {
-  const page = await options.live.searchPackages({ context, scope, intent })
+  const continuation = await resolveLiveContinuation(options.references, context, scope, intent)
+  const page = await options.live.searchPackages({
+    context,
+    scope,
+    intent: withoutLiveCursor(intent),
+    ...(continuation ? { continuation: continuation.state } : {}),
+  })
   const normalized = await normalizeLive(page, scope.currency, options.quoteFx)
   const offers = await Promise.all(
     normalized.items.map(async ({ item, price }) => {
@@ -323,7 +386,159 @@ async function searchPackages(
       }
     }),
   )
-  return { kind: "package", scope, offers, coverage: coverage(page, normalized.dropped) }
+  const nextCursor = await issueLiveContinuation(
+    options.references,
+    now,
+    context,
+    scope,
+    intent,
+    page.continuation,
+    continuation?.page ?? 0,
+  )
+  return {
+    kind: "package",
+    scope,
+    offers,
+    coverage: coverage(page, normalized.dropped),
+    ...(nextCursor ? { nextCursor } : {}),
+  }
+}
+
+type LiveIntent = FlightIntent | StayIntent | PackageIntent
+
+async function resolveLiveContinuation(
+  authority: StorefrontOpaqueReferenceIssuer,
+  context: StorefrontShoppingContext,
+  scope: StorefrontResolvedScope,
+  intent: LiveIntent,
+): Promise<{ state: StorefrontLiveContinuation; page: number } | undefined> {
+  const ref = intent.pagination?.cursor
+  if (!ref) return undefined
+  const expectedFingerprint = await liveIntentFingerprint(intent)
+  const resolved = await authority.redeem({
+    ref,
+    purpose: "live-continuation",
+    storefrontId: context.storefrontId,
+    channelId: context.channelId,
+    owner: owner(context),
+    scope: scopeBinding(scope),
+    kind: intent.kind,
+    intentFingerprint: expectedFingerprint,
+  })
+  if (!resolved) throw new StorefrontShoppingContinuationError()
+  const payload = resolved.payload
+  if (
+    payload.version !== 1 ||
+    payload.kind !== intent.kind ||
+    payload.intentFingerprint !== expectedFingerprint ||
+    typeof payload.page !== "number" ||
+    !Number.isInteger(payload.page) ||
+    (payload.page as number) < 1 ||
+    (payload.page as number) >= MAX_CONTINUATION_PAGE ||
+    !Array.isArray(payload.sources)
+  ) {
+    throw new StorefrontShoppingContinuationError()
+  }
+  const sources = payload.sources.flatMap((entry) => {
+    if (
+      entry === null ||
+      typeof entry !== "object" ||
+      typeof (entry as { key?: unknown }).key !== "string" ||
+      typeof (entry as { cursor?: unknown }).cursor !== "string"
+    ) {
+      return []
+    }
+    return [{ key: (entry as { key: string }).key, cursor: (entry as { cursor: string }).cursor }]
+  })
+  if (sources.length !== payload.sources.length || !validContinuationSources(sources)) {
+    throw new StorefrontShoppingContinuationError()
+  }
+  return { state: { sources }, page: payload.page as number }
+}
+
+async function issueLiveContinuation(
+  authority: StorefrontOpaqueReferenceIssuer,
+  now: () => Date,
+  context: StorefrontShoppingContext,
+  scope: StorefrontResolvedScope,
+  intent: LiveIntent,
+  continuation: StorefrontLiveContinuation | undefined,
+  currentPage: number,
+): Promise<string | undefined> {
+  if (!continuation || continuation.sources.length === 0) return undefined
+  if (!validContinuationSources(continuation.sources)) {
+    throw new StorefrontShoppingContinuationError()
+  }
+  const page = currentPage + 1
+  if (page >= MAX_CONTINUATION_PAGE) return undefined
+  const issuedAt = now().getTime()
+  const issued = await authority.issue({
+    purpose: "live-continuation",
+    storefrontId: context.storefrontId,
+    channelId: context.channelId,
+    owner: owner(context),
+    scope: scopeBinding(scope),
+    payload: {
+      version: 1,
+      kind: intent.kind,
+      intentFingerprint: await liveIntentFingerprint(intent),
+      page,
+      sources: continuation.sources,
+    },
+    ttlSeconds: CONTINUATION_TTL_SECONDS,
+    replay: "single-use",
+  })
+  validateIssuedReference(issued, issuedAt, CONTINUATION_TTL_SECONDS)
+  return issued.ref
+}
+
+function withoutLiveCursor<T extends LiveIntent>(intent: T): T {
+  if (!intent.pagination?.cursor) return intent
+  const { cursor: _cursor, ...pagination } = intent.pagination
+  return {
+    ...intent,
+    ...(Object.keys(pagination).length > 0 ? { pagination } : { pagination: undefined }),
+  } as T
+}
+
+async function liveIntentFingerprint(intent: LiveIntent): Promise<string> {
+  return sha256Hex(canonicalJson(withoutLiveCursor(intent)))
+}
+
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value) ?? "null"
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`
+  const record = value as Record<string, unknown>
+  return `{${Object.keys(record)
+    .filter((key) => record[key] !== undefined)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`)
+    .join(",")}}`
+}
+
+function validContinuationSources(sources: readonly { key: string; cursor: string }[]): boolean {
+  return (
+    sources.length <= MAX_CONTINUATION_SOURCES &&
+    new Set(sources.map(({ key }) => key)).size === sources.length &&
+    sources.every(
+      ({ key, cursor }) =>
+        key.length > 0 &&
+        key.length <= MAX_SOURCE_KEY_LENGTH &&
+        cursor.length > 0 &&
+        cursor.length <= MAX_SOURCE_CURSOR_LENGTH,
+    )
+  )
+}
+
+function owner(context: StorefrontShoppingContext) {
+  return {
+    userId: context.userId ?? null,
+    buyerAccountId: context.buyerAccountId ?? null,
+  }
+}
+
+function scopeBinding(scope: StorefrontResolvedScope) {
+  return { marketId: scope.marketId, locale: scope.locale, currency: scope.currency }
 }
 
 async function normalizeLive<T extends { nativePrice: { amount: string; currency: string } }>(
@@ -398,14 +613,25 @@ async function issueBoundedReference(
     ttlSeconds: input.purpose === "catalog-item" ? ITEM_TTL_SECONDS : OFFER_TTL_SECONDS,
     replay: input.replay,
   })
+  validateIssuedReference(
+    issued,
+    issuedAt,
+    input.purpose === "catalog-item" ? ITEM_TTL_SECONDS : OFFER_TTL_SECONDS,
+  )
+  return issued
+}
+
+function validateIssuedReference(
+  issued: { ref: string; expiresAt: string },
+  issuedAt: number,
+  ttlSeconds: number,
+): void {
   if (issued.ref.length < 16 || issued.ref.length > 512) throw new Error("opaque_reference_invalid")
   const expiry = Date.parse(issued.expiresAt)
-  const max =
-    issuedAt + (input.purpose === "catalog-item" ? ITEM_TTL_SECONDS : OFFER_TTL_SECONDS) * 1000
+  const max = issuedAt + ttlSeconds * 1000
   if (!Number.isFinite(expiry) || expiry <= issuedAt || expiry > max) {
     throw new Error("opaque_reference_expiry_invalid")
   }
-  return issued
 }
 
 function destinationFilters(

--- a/packages/storefront/src/shopping/provider-ports.ts
+++ b/packages/storefront/src/shopping/provider-ports.ts
@@ -103,6 +103,7 @@ export interface StorefrontDynamicPackageBookingSelection {
 
 export interface StorefrontDynamicPackageSource {
   /** The source is a closure over its admitted connection(s) and credentials. */
+  continuationKey: string
   search(input: {
     origin: string
     destination: PackageIntent["destination"]
@@ -117,6 +118,7 @@ export interface StorefrontDynamicPackageSource {
   }): Promise<{
     offers: readonly StorefrontDynamicPackageSourceOffer[]
     status?: "ok" | "partial" | "empty"
+    nextCursor?: string
   }>
 }
 
@@ -145,6 +147,13 @@ export interface StorefrontLiveSearchPage<T> {
   items: readonly T[]
   /** Deliberately contains no provider or connection identifiers. */
   sources: readonly { status: StorefrontLiveSourceStatus }[]
+  /** Closed continuation state persisted by the opaque-reference authority. */
+  continuation?: StorefrontLiveContinuation
+}
+
+export interface StorefrontLiveContinuation {
+  /** Stable server-only source key. Never serialized into the public result. */
+  sources: readonly { key: string; cursor: string }[]
 }
 
 interface InternalOffer {
@@ -197,16 +206,19 @@ export interface StorefrontShoppingLiveProvider {
     context: StorefrontShoppingContext
     scope: StorefrontResolvedScope
     intent: FlightIntent
+    continuation?: StorefrontLiveContinuation
   }): Promise<StorefrontLiveSearchPage<StorefrontInternalFlightOffer>>
   searchStays(input: {
     context: StorefrontShoppingContext
     scope: StorefrontResolvedScope
     intent: StayIntent
+    continuation?: StorefrontLiveContinuation
   }): Promise<StorefrontLiveSearchPage<StorefrontInternalStayOffer>>
   searchPackages(input: {
     context: StorefrontShoppingContext
     scope: StorefrontResolvedScope
     intent: PackageIntent
+    continuation?: StorefrontLiveContinuation
   }): Promise<StorefrontLiveSearchPage<StorefrontInternalPackageOffer>>
 }
 

--- a/packages/storefront/src/shopping/runtime-port.ts
+++ b/packages/storefront/src/shopping/runtime-port.ts
@@ -31,7 +31,7 @@ export interface StorefrontOpaqueReferenceIssuer {
    * managed shopping runtime never resolves or commits an offer itself.
    */
   issue(input: {
-    purpose: "catalog-item" | "flight-offer" | "stay-offer" | "package-offer"
+    purpose: "catalog-item" | "flight-offer" | "stay-offer" | "package-offer" | "live-continuation"
     storefrontId: string
     channelId: string
     /** Trusted capability owner binding. Anonymous owners are explicitly null. */
@@ -41,6 +41,21 @@ export interface StorefrontOpaqueReferenceIssuer {
     ttlSeconds: number
     replay: "multi-use" | "single-use"
   }): Promise<{ ref: string; expiresAt: string }>
+  /**
+   * Atomically redeems a server-stored capability against the complete trust
+   * boundary. Implementations return only its closed payload. Single-use
+   * references MUST be claimed with compare-and-set before returning it.
+   */
+  redeem(input: {
+    ref: string
+    purpose: "live-continuation"
+    storefrontId: string
+    channelId: string
+    owner: { userId: string | null; buyerAccountId: string | null }
+    scope: Pick<StorefrontResolvedScope, "marketId" | "locale" | "currency">
+    kind: "flight" | "stay" | "package"
+    intentFingerprint: string
+  }): Promise<{ payload: Readonly<Record<string, unknown>> } | null>
 }
 
 export interface StorefrontShoppingRuntime {
@@ -90,10 +105,11 @@ export const storefrontOpaqueReferenceIssuerPort = definePort<StorefrontOpaqueRe
     if (
       provider === null ||
       typeof provider !== "object" ||
-      typeof (provider as { issue?: unknown }).issue !== "function"
+      typeof (provider as { issue?: unknown }).issue !== "function" ||
+      typeof (provider as { redeem?: unknown }).redeem !== "function"
     ) {
       throw new Error(
-        "storefront.shopping.opaque-reference-issuer provider must implement issue().",
+        "storefront.shopping.opaque-reference-issuer provider must implement issue() and redeem().",
       )
     }
   },

--- a/packages/storefront/tests/unit/closed-live-provider.test.ts
+++ b/packages/storefront/tests/unit/closed-live-provider.test.ts
@@ -246,6 +246,9 @@ describe("closed Storefront live provider", () => {
       catalog: { searchSlice: async () => ({ items: [], total: 0 }) },
       live,
       references: {
+        async redeem() {
+          return null
+        },
         async issue(input) {
           issued.push(input as unknown as Record<string, unknown>)
           sequence += 1

--- a/packages/storefront/tests/unit/customer-business-onboarding-runtime-contributor.test.ts
+++ b/packages/storefront/tests/unit/customer-business-onboarding-runtime-contributor.test.ts
@@ -52,7 +52,7 @@ describe("storefront customer business onboarding runtime contribution", () => {
     const providers = new Map<string, unknown>([
       [catalogSearchRuntimePort.id, { resolveRuntime: vi.fn() }],
       [catalogRuntimeServicesPort.id, { fieldPolicyRegistries: vi.fn() }],
-      [storefrontOpaqueReferenceIssuerPort.id, { issue: vi.fn() }],
+      [storefrontOpaqueReferenceIssuerPort.id, { issue: vi.fn(), redeem: vi.fn() }],
     ])
     const ports = createStorefrontRuntimePortContribution({
       primitives: primitives(),

--- a/packages/storefront/tests/unit/live-shopping-provider.test.ts
+++ b/packages/storefront/tests/unit/live-shopping-provider.test.ts
@@ -246,6 +246,7 @@ describe("storefront live shopping provider", () => {
       catalog: { searchSlice: async () => ({ items: [], total: 0 }) },
       live: provider,
       references: {
+        redeem: async () => null,
         issue: async (input) => {
           issued.push(input as unknown as Record<string, unknown>)
           return {
@@ -256,7 +257,10 @@ describe("storefront live shopping provider", () => {
       },
       now: () => new Date("2026-08-08T10:00:00.000Z"),
     })
-    const publicResult = await runtime.search(context, { scope, intent })
+    const publicResult = await runtime.search(context, {
+      scope,
+      intent: { ...intent, pagination: { limit: 15 } },
+    })
     const serialized = JSON.stringify(publicResult)
     expect(serialized).not.toContain("connection_secret")
     expect(serialized).not.toContain("accommodation_secret")
@@ -290,8 +294,9 @@ describe("storefront live shopping provider", () => {
           expect(trustedContext).toBe(context)
           expect(trustedScope).toBe(scope)
           return [
-            { search },
+            { continuationKey: "packages-primary", search },
             {
+              continuationKey: "packages-failing",
               search: async () => {
                 throw new Error("second source failed")
               },
@@ -354,6 +359,7 @@ describe("storefront live shopping provider", () => {
       packages: {
         resolveSources: async () => [
           {
+            continuationKey: "packages-slow",
             search: async () => {
               await new Promise((resolve) => setTimeout(resolve, 20))
               return { offers: [] }

--- a/packages/storefront/tests/unit/managed-shopping-runtime.test.ts
+++ b/packages/storefront/tests/unit/managed-shopping-runtime.test.ts
@@ -41,6 +41,7 @@ function dependencies(overrides: Record<string, unknown> = {}) {
       searchPackages: vi.fn(async () => ({ items: [], sources: [] })),
     },
     references: {
+      redeem: vi.fn(async () => null),
       issue: vi.fn(async () => ({
         ref: `opaque-reference-${String(++sequence).padStart(6, "0")}`,
         expiresAt: "2026-08-08T10:10:00.000Z",
@@ -266,6 +267,71 @@ describe("managed live shopping", () => {
     expect(serialized).toContain("channel_web")
   })
 
+  it("seals per-source live cursors and redeems them only for the bound intent", async () => {
+    let continuationPayload: Readonly<Record<string, unknown>> | undefined
+    const redeem = vi.fn(async () =>
+      continuationPayload ? { payload: continuationPayload } : null,
+    )
+    const issue = vi.fn(async (input) => {
+      if (input.purpose === "live-continuation") continuationPayload = input.payload
+      return {
+        ref: "opaque-live-continuation-0001",
+        expiresAt: "2026-08-08T10:04:00.000Z",
+      }
+    })
+    const searchFlights = vi
+      .fn()
+      .mockResolvedValueOnce({
+        items: [],
+        sources: [{ status: "partial" }],
+        continuation: { sources: [{ key: "flight:connection_secret", cursor: "raw-page-2" }] },
+      })
+      .mockResolvedValueOnce({ items: [], sources: [{ status: "empty" }] })
+    const runtime = createManagedStorefrontShoppingRuntime(
+      dependencies({
+        references: { issue, redeem },
+        live: { searchFlights, searchStays: vi.fn(), searchPackages: vi.fn() },
+      }),
+    )
+    const scope = await runtime.resolveScope(context, {})
+    const first = await runtime.search(context, { scope, intent: flightIntent })
+    expect(first).toMatchObject({ nextCursor: "opaque-live-continuation-0001" })
+    expect(JSON.stringify(first)).not.toContain("connection_secret")
+    expect(JSON.stringify(first)).not.toContain("raw-page-2")
+
+    await runtime.search(context, {
+      scope,
+      intent: { ...flightIntent, pagination: { cursor: "opaque-live-continuation-0001" } },
+    })
+    expect(redeem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        purpose: "live-continuation",
+        storefrontId: "storefront_public",
+        channelId: "channel_web",
+        owner: { userId: "user_private", buyerAccountId: "buyer_private" },
+        scope: { marketId: "market_ro", locale: "ro-RO", currency: "RON" },
+      }),
+    )
+    expect(searchFlights.mock.calls[1]?.[0]).toMatchObject({
+      intent: flightIntent,
+      continuation: {
+        sources: [{ key: "flight:connection_secret", cursor: "raw-page-2" }],
+      },
+    })
+    expect(searchFlights.mock.calls[1]?.[0].intent.pagination).toBeUndefined()
+
+    await expect(
+      runtime.search(context, {
+        scope,
+        intent: {
+          ...flightIntent,
+          slices: [{ origin: "OTP", destination: "CDG", departureDate: "2026-09-10" }],
+          pagination: { cursor: "opaque-live-continuation-0001" },
+        },
+      }),
+    ).rejects.toThrow("Storefront shopping continuation is invalid")
+  })
+
   it("binds references to different trusted account owners", async () => {
     const deps = dependencies({
       live: {
@@ -290,6 +356,7 @@ describe("managed live shopping", () => {
   it("rejects opaque references whose issuer exceeds the bounded TTL", async () => {
     const deps = dependencies({
       references: {
+        redeem: vi.fn(async () => null),
         issue: vi.fn(async () => ({
           ref: "opaque-reference-too-long-ttl",
           expiresAt: "2026-08-08T11:00:00.000Z",

--- a/packages/trips/src/shopping-opaque-references.ts
+++ b/packages/trips/src/shopping-opaque-references.ts
@@ -4,7 +4,7 @@ import type {
   StorefrontOpaqueReferenceIssuer,
   StorefrontShoppingContext,
 } from "@voyant-travel/storefront/shopping"
-import { and, eq, gt, isNull } from "drizzle-orm"
+import { and, eq, gt, isNull, sql } from "drizzle-orm"
 import { z } from "zod"
 
 import type { TripShoppingReference } from "./schema.js"
@@ -16,7 +16,13 @@ import type {
 
 const MAX_REFERENCE_TTL_SECONDS = 24 * 60 * 60
 const referenceSchema = z.string().regex(/^sref_[a-f0-9]{64}$/)
-const purposeSchema = z.enum(["catalog-item", "flight-offer", "stay-offer", "package-offer"])
+const purposeSchema = z.enum([
+  "catalog-item",
+  "flight-offer",
+  "stay-offer",
+  "package-offer",
+  "live-continuation",
+])
 const replaySchema = z.enum(["multi-use", "single-use"])
 const scopeSchema = z
   .object({
@@ -79,6 +85,8 @@ export interface ShoppingReferenceBoundary {
   marketId: string
   locale: string
   currency: string
+  liveKind?: "flight" | "stay" | "package"
+  intentFingerprint?: string
   now: Date
 }
 
@@ -113,6 +121,10 @@ export function createTripShoppingReferenceRuntime(
             ...(options.createReference ? { createReference: options.createReference } : {}),
           }),
         ),
+      redeem: (input) =>
+        options.withTransaction((db) =>
+          redeemContinuation(postgresShoppingReferenceStore(db), input, now),
+        ),
     },
     offerResolver: {
       async resolve(context, input) {
@@ -140,12 +152,41 @@ export function createTripShoppingReferenceRuntimeWithStore(
           now,
           ...(options.createReference ? { createReference: options.createReference } : {}),
         }),
+      redeem: (input) => redeemContinuation(store, input, now),
     },
     offerResolver: {
       async resolve(context, input) {
         return resolveShoppingReference(store, context, input, now)
       },
     },
+  }
+}
+
+async function redeemContinuation(
+  store: TripShoppingReferenceStore,
+  input: Parameters<StorefrontOpaqueReferenceIssuer["redeem"]>[0],
+  now: () => Date,
+): Promise<{ payload: Readonly<Record<string, unknown>> } | null> {
+  const resolution = await redeemShoppingReference(store, input.ref, {
+    purpose: "live-continuation",
+    context: {
+      storefrontId: input.storefrontId,
+      channelId: input.channelId,
+      userId: input.owner.userId,
+      buyerAccountId: input.owner.buyerAccountId,
+    },
+    scope: input.scope,
+    continuationBinding: {
+      kind: input.kind,
+      intentFingerprint: input.intentFingerprint,
+    },
+    now,
+  })
+  if (!resolution.ok) return null
+  try {
+    return { payload: payloadSchema.parse(resolution.reference.payload) }
+  } catch {
+    return null
   }
 }
 
@@ -221,6 +262,10 @@ export async function redeemTripShoppingReference(
     purpose: ShoppingReferencePurpose
     context: StorefrontShoppingContext
     scope: { marketId: string; locale: string; currency: string }
+    continuationBinding?: {
+      kind: "flight" | "stay" | "package"
+      intentFingerprint: string
+    }
     now?: () => Date
   },
 ): Promise<ShoppingReferenceResolution> {
@@ -234,6 +279,10 @@ async function redeemShoppingReference(
     purpose: ShoppingReferencePurpose
     context: StorefrontShoppingContext
     scope: { marketId: string; locale: string; currency: string }
+    continuationBinding?: {
+      kind: "flight" | "stay" | "package"
+      intentFingerprint: string
+    }
     now?: () => Date
   },
 ): Promise<ShoppingReferenceResolution> {
@@ -256,6 +305,12 @@ async function redeemShoppingReference(
     marketId: scope.marketId,
     locale: scope.locale,
     currency: scope.currency,
+    ...(input.continuationBinding
+      ? {
+          liveKind: input.continuationBinding.kind,
+          intentFingerprint: input.continuationBinding.intentFingerprint,
+        }
+      : {}),
     now,
   }
 
@@ -281,6 +336,12 @@ function postgresShoppingReferenceStore(db: AnyDrizzleDb): TripShoppingReference
       eq(tripShoppingReferences.marketId, boundary.marketId),
       eq(tripShoppingReferences.locale, boundary.locale),
       eq(tripShoppingReferences.currency, boundary.currency),
+      boundary.liveKind
+        ? sql`${tripShoppingReferences.payload}->>'kind' = ${boundary.liveKind}`
+        : undefined,
+      boundary.intentFingerprint
+        ? sql`${tripShoppingReferences.payload}->>'intentFingerprint' = ${boundary.intentFingerprint}`
+        : undefined,
       gt(tripShoppingReferences.expiresAt, boundary.now),
     )
 

--- a/packages/trips/tests/shopping-opaque-references.test.ts
+++ b/packages/trips/tests/shopping-opaque-references.test.ts
@@ -20,6 +20,7 @@ const SCOPE = { marketId: "market_ro", locale: "ro-RO", currency: "EUR" }
 const FLIGHT_REF = `sref_${"a".repeat(64)}`
 const CATALOG_REF = `sref_${"b".repeat(64)}`
 const PACKAGE_REF = `sref_${"c".repeat(64)}`
+const CONTINUATION_REF = `sref_${"d".repeat(64)}`
 
 describe("durable shopping opaque references", () => {
   it("issues a 256-bit capability while persisting only its digest and bounded payload", async () => {
@@ -124,6 +125,64 @@ describe("durable shopping opaque references", () => {
     )
 
     expect(resolutions.filter((value) => value !== null)).toHaveLength(1)
+  })
+
+  it("atomically redeems a continuation payload without exposing its source cursor", async () => {
+    const store = new MemoryReferenceStore()
+    const runtime = createTripShoppingReferenceRuntimeWithStore(store, {
+      now: () => NOW,
+      createReference: () => CONTINUATION_REF,
+    })
+    await runtime.issuer.issue(continuationInput())
+
+    const input = {
+      ref: CONTINUATION_REF,
+      purpose: "live-continuation" as const,
+      storefrontId: CONTEXT.storefrontId,
+      channelId: CONTEXT.channelId,
+      owner: { userId: CONTEXT.userId, buyerAccountId: CONTEXT.buyerAccountId },
+      scope: SCOPE,
+      kind: "flight" as const,
+      intentFingerprint: "fingerprint",
+    }
+    const resolutions = await Promise.all(
+      Array.from({ length: 8 }, () => runtime.issuer.redeem(input)),
+    )
+
+    expect(resolutions.filter(Boolean)).toEqual([
+      {
+        payload: expect.objectContaining({
+          intentFingerprint: "fingerprint",
+          sources: [{ key: "flight:connection_secret", cursor: "provider-secret-cursor" }],
+        }),
+      },
+    ])
+    expect(JSON.stringify({ ref: CONTINUATION_REF })).not.toContain("provider-secret-cursor")
+  })
+
+  it("does not consume a continuation when its intent fingerprint does not match", async () => {
+    const store = new MemoryReferenceStore()
+    const runtime = createTripShoppingReferenceRuntimeWithStore(store, {
+      now: () => NOW,
+      createReference: () => CONTINUATION_REF,
+    })
+    await runtime.issuer.issue(continuationInput())
+    const boundary = {
+      ref: CONTINUATION_REF,
+      purpose: "live-continuation" as const,
+      storefrontId: CONTEXT.storefrontId,
+      channelId: CONTEXT.channelId,
+      owner: { userId: CONTEXT.userId, buyerAccountId: CONTEXT.buyerAccountId },
+      scope: SCOPE,
+      kind: "flight" as const,
+    }
+
+    await expect(
+      runtime.issuer.redeem({ ...boundary, intentFingerprint: "wrong-fingerprint" }),
+    ).resolves.toBeNull()
+    await expect(
+      runtime.issuer.redeem({ ...boundary, intentFingerprint: "fingerprint" }),
+    ).resolves.not.toBeNull()
   })
 
   it("turns one live package capability into stable Catalog booking pins exactly once", async () => {
@@ -253,6 +312,25 @@ function catalogInput(): Parameters<StorefrontOpaqueReferenceIssuer["issue"]>[0]
   }
 }
 
+function continuationInput(): Parameters<StorefrontOpaqueReferenceIssuer["issue"]>[0] {
+  return {
+    purpose: "live-continuation",
+    storefrontId: CONTEXT.storefrontId,
+    channelId: CONTEXT.channelId,
+    owner: { userId: CONTEXT.userId, buyerAccountId: CONTEXT.buyerAccountId },
+    scope: SCOPE,
+    payload: {
+      version: 1,
+      kind: "flight",
+      intentFingerprint: "fingerprint",
+      page: 1,
+      sources: [{ key: "flight:connection_secret", cursor: "provider-secret-cursor" }],
+    },
+    ttlSeconds: 5 * 60,
+    replay: "single-use",
+  }
+}
+
 function packageInput(
   offerExpiresAt = "2026-08-08T12:10:00.000Z",
 ): Parameters<StorefrontOpaqueReferenceIssuer["issue"]>[0] {
@@ -336,6 +414,11 @@ function matchesBoundary(
     reference.marketId === boundary.marketId &&
     reference.locale === boundary.locale &&
     reference.currency === boundary.currency &&
+    (boundary.liveKind === undefined ||
+      (reference.payload as { kind?: unknown }).kind === boundary.liveKind) &&
+    (boundary.intentFingerprint === undefined ||
+      (reference.payload as { intentFingerprint?: unknown }).intentFingerprint ===
+        boundary.intentFingerprint) &&
     reference.expiresAt > boundary.now
   )
 }

--- a/packages/voyant-connect-adapter/src/storefront-package-sources.ts
+++ b/packages/voyant-connect-adapter/src/storefront-package-sources.ts
@@ -30,6 +30,7 @@ export function createVoyantConnectStorefrontPackageSourceProvider(
       })
       return [
         {
+          continuationKey: "voyant-connect-packages",
           async search(input) {
             const query = packageQuery(input)
             const response = await client.packages.searchAcrossProviders(query, {
@@ -45,12 +46,24 @@ export function createVoyantConnectStorefrontPackageSourceProvider(
             return {
               offers: mapped,
               status: degraded ? "partial" : mapped.length > 0 ? "ok" : "empty",
+              ...connectContinuation(response),
             }
           },
         },
       ]
     },
   }
+}
+
+function connectContinuation(response: unknown): { nextCursor?: string } {
+  if (!response || typeof response !== "object") return {}
+  const value = response as {
+    nextCursor?: unknown
+    next_cursor?: unknown
+    pagination?: { cursor?: unknown }
+  }
+  const cursor = value.nextCursor ?? value.next_cursor ?? value.pagination?.cursor
+  return typeof cursor === "string" && cursor.length > 0 ? { nextCursor: cursor } : {}
 }
 
 type PackageSourceInput = Parameters<


### PR DESCRIPTION
## What changed

- issue one opaque live-shopping continuation over independent flight, stay, and package source cursors
- bind redemption to the trusted storefront, channel, managed user and buyer owner, resolved market/locale/currency, vertical, and canonical intent fingerprint
- use the existing Trips digest-only opaque-reference store for five-minute single-use CAS redemption
- keep source keys, connection identities, and raw provider cursors exclusively in the server-side payload
- continue only healthy sources that returned a next cursor; failed and terminal sources leave the continuation chain
- preserve indexed inspiration pagination as separate per-group Catalog cursors

## Security and page semantics

Continuation redemption is an atomic conditional claim. Tampered, expired, replayed, cross-owner, cross-scope, cross-vertical, or changed-intent references fail closed without returning payload. The payload is bounded to 64 sources, 8 KiB per cursor, and 100 pages. Stable source keys route each cursor only to its admitted source; newly admitted sources do not join an existing chain.

## Provider limitations

- suppliers that omit a next cursor are terminal after their current page
- failed/timed-out sources are not retried inside the chain, avoiding duplicate first pages; shoppers must restart the search to reincorporate them
- upstream cursors still inherit the supplier's own snapshot/stability guarantees
- Voyant Connect package pagination continues only when the installed SDK response exposes `nextCursor`, `next_cursor`, or `pagination.cursor`

## Validation

- Biome: 14 touched TypeScript files passed
- `git diff --check`: passed
- disposable Sprite focused suite: 60 passed; one stale fixture failed because it bypassed authority redemption, then was corrected in the pushed head
- Catalog typecheck on Sprite exceeded both 2 GiB and 4 GiB Node heaps before diagnostics; `lab1` was unavailable by SSH timeout
- full GitHub Actions CI on this draft is the clean-run gate

Stacked on #4461 after restacking it onto exact #4459 head `816fe3f1e58a43099dbc224aad821e5da3d6e8bb`.
