### PR TITLE
feat(storefront): book opaque Trip itineraries

### DIFF
--- a/.changeset/calm-itineraries-book.md
+++ b/.changeset/calm-itineraries-book.md
@@ -1,0 +1,10 @@
+---
+"@voyant-travel/catalog-contracts": minor
+"@voyant-travel/catalog": minor
+"@voyant-travel/storefront": minor
+"@voyant-travel/trips": minor
+---
+
+Convert an exact opaque Storefront Trip selection revision into a server-priced
+composite Catalog Booking Session without exposing Trip or supplier authority
+identifiers to browser clients.

--- a/packages/accommodations/tsconfig.build.json
+++ b/packages/accommodations/tsconfig.build.json
@@ -463,6 +463,9 @@
         "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
       ],
       "@voyant-travel/catalog/catalog-runtime": ["../catalog/dist/runtime/catalog-runtime.d.ts"],
+      "@voyant-travel/catalog/composite-booking-session-runtime-port": [
+        "../catalog/dist/composite-booking-session-runtime-port.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/accommodations/tsconfig.typecheck.json
+++ b/packages/accommodations/tsconfig.typecheck.json
@@ -464,6 +464,9 @@
         "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
       ],
       "@voyant-travel/catalog/catalog-runtime": ["../catalog/dist/runtime/catalog-runtime.d.ts"],
+      "@voyant-travel/catalog/composite-booking-session-runtime-port": [
+        "../catalog/dist/composite-booking-session-runtime-port.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/catalog-contracts/src/booking-engine/session-contracts.ts
+++ b/packages/catalog-contracts/src/booking-engine/session-contracts.ts
@@ -37,6 +37,25 @@ export const bookingSessionTargetV1 = z.discriminatedUnion("kind", [
 ])
 export type BookingSessionTargetV1 = z.infer<typeof bookingSessionTargetV1>
 
+/**
+ * Public projection of a Session target. Composite Trip identifiers stay on
+ * the server: a storefront needs to know only that the Session is managed as
+ * one composite itinerary.
+ */
+export const bookingSessionPublicTargetV1 = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("product"), productId: z.string().min(1) }).strict(),
+  z.object({ kind: z.literal("catalog_item"), catalogItemId: z.string().min(1) }).strict(),
+  z
+    .object({
+      kind: z.literal("owned_entity"),
+      entityModule: z.string().min(1),
+      entityId: z.string().min(1),
+    })
+    .strict(),
+  z.object({ kind: z.literal("managed_itinerary") }).strict(),
+])
+export type BookingSessionPublicTargetV1 = z.infer<typeof bookingSessionPublicTargetV1>
+
 /** Server-owned provenance. Public Session-create callers cannot supply this. */
 export const bookingSessionOriginV1 = z.discriminatedUnion("kind", [
   z.object({
@@ -116,7 +135,7 @@ export type BookingSessionCapabilityActionV1 = z.infer<typeof bookingSessionCapa
 
 export const bookingSessionRecordV1 = z.object({
   id: z.string().min(1),
-  target: bookingSessionTargetV1,
+  target: bookingSessionPublicTargetV1,
   origin: bookingSessionOriginV1.optional(),
   actorKind: bookingSessionActorKindV1,
   state: bookingSessionStateV1,
@@ -262,7 +281,7 @@ export const bookingHoldRecordV1 = z.object({
   id: z.string().min(1),
   sessionId: z.string().min(1),
   quoteId: z.string().min(1),
-  target: bookingSessionTargetV1,
+  target: bookingSessionPublicTargetV1,
   quantity: z.number().int().positive(),
   state: bookingHoldStateV1,
   expiresAt: z.string().datetime(),

--- a/packages/catalog-contracts/src/booking-engine/session-contracts.ts
+++ b/packages/catalog-contracts/src/booking-engine/session-contracts.ts
@@ -52,6 +52,13 @@ export const bookingSessionPublicTargetV1 = z.discriminatedUnion("kind", [
       entityId: z.string().min(1),
     })
     .strict(),
+  z
+    .object({
+      kind: z.literal("trip_snapshot"),
+      tripSnapshotId: z.string().min(1),
+      tripEnvelopeId: z.string().min(1),
+    })
+    .strict(),
   z.object({ kind: z.literal("managed_itinerary") }).strict(),
 ])
 export type BookingSessionPublicTargetV1 = z.infer<typeof bookingSessionPublicTargetV1>

--- a/packages/catalog/openapi/admin/catalog-booking.json
+++ b/packages/catalog/openapi/admin/catalog-booking.json
@@ -98,6 +98,17 @@
                         },
                         "required": ["kind", "tripSnapshotId", "tripEnvelopeId"],
                         "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "enum": ["managed_itinerary"]
+                          }
+                        },
+                        "required": ["kind"],
+                        "additionalProperties": false
                       }
                     ]
                   },
@@ -1045,6 +1056,17 @@
                         },
                         "required": ["kind", "tripSnapshotId", "tripEnvelopeId"],
                         "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "enum": ["managed_itinerary"]
+                          }
+                        },
+                        "required": ["kind"],
+                        "additionalProperties": false
                       }
                     ]
                   },
@@ -1991,6 +2013,17 @@
                           }
                         },
                         "required": ["kind", "tripSnapshotId", "tripEnvelopeId"],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "enum": ["managed_itinerary"]
+                          }
+                        },
+                        "required": ["kind"],
                         "additionalProperties": false
                       }
                     ]
@@ -2948,6 +2981,17 @@
                         },
                         "required": ["kind", "tripSnapshotId", "tripEnvelopeId"],
                         "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "enum": ["managed_itinerary"]
+                          }
+                        },
+                        "required": ["kind"],
+                        "additionalProperties": false
                       }
                     ]
                   },
@@ -3904,6 +3948,17 @@
                         },
                         "required": ["kind", "tripSnapshotId", "tripEnvelopeId"],
                         "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "enum": ["managed_itinerary"]
+                          }
+                        },
+                        "required": ["kind"],
+                        "additionalProperties": false
                       }
                     ]
                   },
@@ -4851,6 +4906,17 @@
                         },
                         "required": ["kind", "tripSnapshotId", "tripEnvelopeId"],
                         "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "enum": ["managed_itinerary"]
+                          }
+                        },
+                        "required": ["kind"],
+                        "additionalProperties": false
                       }
                     ]
                   },
@@ -5797,6 +5863,17 @@
                           }
                         },
                         "required": ["kind", "tripSnapshotId", "tripEnvelopeId"],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "enum": ["managed_itinerary"]
+                          }
+                        },
+                        "required": ["kind"],
                         "additionalProperties": false
                       }
                     ]
@@ -7684,6 +7761,17 @@
                         },
                         "required": ["kind", "tripSnapshotId", "tripEnvelopeId"],
                         "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "enum": ["managed_itinerary"]
+                          }
+                        },
+                        "required": ["kind"],
+                        "additionalProperties": false
                       }
                     ]
                   },
@@ -8628,6 +8716,17 @@
                           }
                         },
                         "required": ["kind", "tripSnapshotId", "tripEnvelopeId"],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "enum": ["managed_itinerary"]
+                          }
+                        },
+                        "required": ["kind"],
                         "additionalProperties": false
                       }
                     ]

--- a/packages/catalog/openapi/storefront/catalog-booking.json
+++ b/packages/catalog/openapi/storefront/catalog-booking.json
@@ -98,6 +98,17 @@
                         },
                         "required": ["kind", "tripSnapshotId", "tripEnvelopeId"],
                         "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "enum": ["managed_itinerary"]
+                          }
+                        },
+                        "required": ["kind"],
+                        "additionalProperties": false
                       }
                     ]
                   },
@@ -1045,6 +1056,17 @@
                         },
                         "required": ["kind", "tripSnapshotId", "tripEnvelopeId"],
                         "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "enum": ["managed_itinerary"]
+                          }
+                        },
+                        "required": ["kind"],
+                        "additionalProperties": false
                       }
                     ]
                   },
@@ -1991,6 +2013,17 @@
                           }
                         },
                         "required": ["kind", "tripSnapshotId", "tripEnvelopeId"],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "enum": ["managed_itinerary"]
+                          }
+                        },
+                        "required": ["kind"],
                         "additionalProperties": false
                       }
                     ]
@@ -2948,6 +2981,17 @@
                         },
                         "required": ["kind", "tripSnapshotId", "tripEnvelopeId"],
                         "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "enum": ["managed_itinerary"]
+                          }
+                        },
+                        "required": ["kind"],
+                        "additionalProperties": false
                       }
                     ]
                   },
@@ -3904,6 +3948,17 @@
                         },
                         "required": ["kind", "tripSnapshotId", "tripEnvelopeId"],
                         "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "enum": ["managed_itinerary"]
+                          }
+                        },
+                        "required": ["kind"],
+                        "additionalProperties": false
                       }
                     ]
                   },
@@ -4851,6 +4906,17 @@
                         },
                         "required": ["kind", "tripSnapshotId", "tripEnvelopeId"],
                         "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "enum": ["managed_itinerary"]
+                          }
+                        },
+                        "required": ["kind"],
+                        "additionalProperties": false
                       }
                     ]
                   },
@@ -5797,6 +5863,17 @@
                           }
                         },
                         "required": ["kind", "tripSnapshotId", "tripEnvelopeId"],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "enum": ["managed_itinerary"]
+                          }
+                        },
+                        "required": ["kind"],
                         "additionalProperties": false
                       }
                     ]
@@ -7684,6 +7761,17 @@
                         },
                         "required": ["kind", "tripSnapshotId", "tripEnvelopeId"],
                         "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "enum": ["managed_itinerary"]
+                          }
+                        },
+                        "required": ["kind"],
+                        "additionalProperties": false
                       }
                     ]
                   },
@@ -8628,6 +8716,17 @@
                           }
                         },
                         "required": ["kind", "tripSnapshotId", "tripEnvelopeId"],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "enum": ["managed_itinerary"]
+                          }
+                        },
+                        "required": ["kind"],
                         "additionalProperties": false
                       }
                     ]

--- a/packages/catalog/package.json
+++ b/packages/catalog/package.json
@@ -57,6 +57,7 @@
     "./subscriber-runtime-ports": "./src/subscriber-runtime-ports.ts",
     "./booking-engine/operator-routes": "./src/booking-engine/operator-routes.ts",
     "./runtime-port": "./src/content-runtime-port.ts",
+    "./composite-booking-session-runtime-port": "./src/composite-booking-session-runtime-port.ts",
     "./booking-session-maintenance-job": "./src/booking-session-maintenance-job.ts",
     "./reindex-job": "./src/reindex-job.ts",
     "./sources-sync-job": "./src/sources-sync-job.ts",
@@ -377,6 +378,11 @@
         "types": "./dist/content-runtime-port.d.ts",
         "import": "./dist/content-runtime-port.js",
         "default": "./dist/content-runtime-port.js"
+      },
+      "./composite-booking-session-runtime-port": {
+        "types": "./dist/composite-booking-session-runtime-port.d.ts",
+        "import": "./dist/composite-booking-session-runtime-port.js",
+        "default": "./dist/composite-booking-session-runtime-port.js"
       },
       "./booking-session-maintenance-job": {
         "types": "./dist/booking-session-maintenance-job.d.ts",

--- a/packages/catalog/src/booking-engine/sessions-production.ts
+++ b/packages/catalog/src/booking-engine/sessions-production.ts
@@ -105,7 +105,13 @@ export function createProductionBookingSessionModule(
         if (session.target.kind === "trip_snapshot") {
           const handler = await deps.resolveCompositeHandler?.()
           return (
-            (handler ? await handler.composeRequirements({ ...input, leaf }) : undefined) ?? {
+            (handler
+              ? await handler.composeRequirements({
+                  ...input,
+                  tx: input.tx ?? deps.db,
+                  leaf,
+                })
+              : undefined) ?? {
               status: "unavailable",
               reason: "target_not_bookable",
               nextAction: "contact_operator",
@@ -119,7 +125,9 @@ export function createProductionBookingSessionModule(
         if (session.target.kind === "trip_snapshot") {
           const handler = await deps.resolveCompositeHandler?.()
           return (
-            (handler ? await handler.composeQuote({ ...input, leaf }) : undefined) ?? {
+            (handler
+              ? await handler.composeQuote({ ...input, tx: input.tx ?? deps.db, leaf })
+              : undefined) ?? {
               status: "unavailable",
               reason: "target_not_bookable",
               nextAction: "contact_operator",
@@ -133,7 +141,7 @@ export function createProductionBookingSessionModule(
         if (session.target.kind === "trip_snapshot") {
           const handler = await deps.resolveCompositeHandler?.()
           if (!handler) return "unavailable"
-          return handler.placeCapacityHold({ ...input, leaf })
+          return handler.placeCapacityHold({ ...input, tx: input.tx ?? deps.db, leaf })
         }
         return leaf.placeCapacityHold(input)
       },
@@ -141,7 +149,7 @@ export function createProductionBookingSessionModule(
         const { session } = input
         if (session.target.kind === "trip_snapshot") {
           const handler = await deps.resolveCompositeHandler?.()
-          await handler?.releaseCapacityHold({ ...input, leaf })
+          await handler?.releaseCapacityHold({ ...input, tx: input.tx ?? deps.db, leaf })
           return
         }
         await leaf.releaseCapacityHold(input)

--- a/packages/catalog/src/booking-engine/sessions-service.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-service.test.ts
@@ -562,7 +562,7 @@ describe("Booking Session v1 owned tracer", () => {
     expect(harness.repository.sessions.size).toBe(1)
   })
 
-  it("seeds exactly one Trip Snapshot Session with accepted Proposal Version provenance", async () => {
+  it("seeds exactly one Trip Snapshot Session without exposing its internal target publicly", async () => {
     const harness = createHarness()
     const input = {
       idempotencyKey: "proposal_session_seed",
@@ -579,20 +579,39 @@ describe("Booking Session v1 owned tracer", () => {
     expect(first).toMatchObject({
       kind: "session_created",
       session: {
+        target: { kind: "managed_itinerary" },
+      },
+    })
+    expect(JSON.stringify(first)).not.toMatch(/trsn_frozen|trip_composed|prps_accepted/)
+    expect(harness.repository.sessions.values().next().value).toMatchObject({
+      target: {
+        kind: "trip_snapshot",
+        tripSnapshotId: "trsn_frozen",
+        tripEnvelopeId: "trip_composed",
+      },
+    })
+    expect(replay).toEqual(first)
+    expect(harness.repository.sessions.size).toBe(1)
+  })
+
+  it("prices a server-owned composite target before creating its Session", async () => {
+    const harness = createHarness()
+    const outcome = await harness.module.createCompositeSession(
+      {
+        idempotencyKey: "managed_trip_create",
         target: {
           kind: "trip_snapshot",
           tripSnapshotId: "trsn_frozen",
           tripEnvelopeId: "trip_composed",
         },
-        origin: {
-          kind: "accepted_proposal_version",
-          proposalId: "prps_accepted",
-          proposalVersionId: "prvr_accepted",
-          tripSnapshotId: "trsn_frozen",
-        },
       },
+      ANONYMOUS_ACCESS,
+    )
+
+    expect(outcome).toMatchObject({
+      kind: "session_created",
+      session: { target: { kind: "managed_itinerary" } },
     })
-    expect(replay).toEqual(first)
     expect(harness.repository.sessions.size).toBe(1)
   })
 

--- a/packages/catalog/src/booking-engine/sessions-service.ts
+++ b/packages/catalog/src/booking-engine/sessions-service.ts
@@ -791,7 +791,7 @@ export function createBookingSessionModule(
       updatedAt: at,
     }
     if (validateCompositePricing) {
-      const priced = await options.ports.composeQuote({ session, now: at })
+      const priced = await options.ports.composeQuote({ session, now: at, tx: undefined })
       if (priced.status === "unavailable") return quoteUnavailable(priced)
     }
     const created = await repository.createSession(session)

--- a/packages/catalog/src/booking-engine/sessions-service.ts
+++ b/packages/catalog/src/booking-engine/sessions-service.ts
@@ -574,6 +574,17 @@ export class BookingSessionCommitRejectedError extends Error {
 }
 
 export interface BookingSessionModule {
+  /** Server-only composite create; public callers can never submit internal Trip identifiers. */
+  createCompositeSession(
+    input: {
+      idempotencyKey: string
+      target: Extract<BookingSessionTargetV1, { kind: "trip_snapshot" }>
+      selection?: Record<string, unknown>
+      scope?: BookingSessionScopeV1
+      capabilityScopes?: BookingSessionCapabilityActionV1[]
+    },
+    access: BookingSessionAccessContext,
+  ): Promise<BookingSessionOutcomeV1>
   createAcceptedProposalSession(
     input: CreateAcceptedProposalBookingSessionV1,
     access: BookingSessionAccessContext,
@@ -701,6 +712,7 @@ export function createBookingSessionModule(
     },
     access: BookingSessionAccessContext,
     origin?: BookingSessionOriginV1,
+    validateCompositePricing = false,
   ): Promise<BookingSessionOutcomeV1> {
     const at = now()
     if (access.actorKind !== "anonymous" && !access.principalId?.trim()) {
@@ -742,7 +754,7 @@ export function createBookingSessionModule(
       }
       return {
         kind: "session_created",
-        session: serializeSession(existing, await sessionRequirements(existing, at)),
+        session: serializeSession(existing, await sessionRequirements(existing, at), access),
       }
     }
     let statePayload: Record<string, unknown>
@@ -778,6 +790,10 @@ export function createBookingSessionModule(
       createdAt: at,
       updatedAt: at,
     }
+    if (validateCompositePricing) {
+      const priced = await options.ports.composeQuote({ session, now: at })
+      if (priced.status === "unavailable") return quoteUnavailable(priced)
+    }
     const created = await repository.createSession(session)
     if (created.id !== session.id) {
       if (created.createRequestFingerprint !== createRequestFingerprint) {
@@ -785,16 +801,19 @@ export function createBookingSessionModule(
       }
       return {
         kind: "session_created",
-        session: serializeSession(created, await sessionRequirements(created, at)),
+        session: serializeSession(created, await sessionRequirements(created, at), access),
       }
     }
     return {
       kind: "session_created",
-      session: serializeSession(session, await sessionRequirements(session, at)),
+      session: serializeSession(session, await sessionRequirements(session, at), access),
     }
   }
 
   const bookingSessionModule: BookingSessionModule = {
+    createCompositeSession(input, access) {
+      return createSessionRecord(input, access, undefined, true)
+    },
     createSession(input, access) {
       return createSessionRecord(input, access)
     },
@@ -965,7 +984,7 @@ export function createBookingSessionModule(
         })
         const outcome: BookingSessionOutcomeV1 = {
           kind: "session_renewed",
-          session: serializeSession(session),
+          session: serializeSession(session, undefined, access),
         }
         await repository.completeOperation({ id: claim.id, outcome })
         return outcome
@@ -1015,7 +1034,7 @@ export function createBookingSessionModule(
         await appendSessionAudit(repository, session, "update", access, at)
         const outcome: BookingSessionOutcomeV1 = {
           kind: "session_updated",
-          session: serializeSession(session, await sessionRequirements(session, at, tx)),
+          session: serializeSession(session, await sessionRequirements(session, at, tx), access),
         }
         await repository.completeOperation({ id: claim.id, outcome })
         return outcome
@@ -1078,7 +1097,7 @@ export function createBookingSessionModule(
           kind: "quote_created",
           // The compose call already derived requirements for this target;
           // publish those rather than re-deriving them for the record.
-          session: serializeSession(session, requirements),
+          session: serializeSession(session, requirements, access),
           quote: serializeQuote(quote),
         }
         await repository.completeOperation({ id: claim.id, outcome })
@@ -1176,8 +1195,8 @@ export function createBookingSessionModule(
         })
         const outcome: BookingSessionOutcomeV1 = {
           kind: "hold_created",
-          session: serializeSession(session),
-          hold: serializeHold(hold),
+          session: serializeSession(session, undefined, access),
+          hold: serializeHold(hold, access),
         }
         await repository.completeOperation({ id: claim.id, outcome })
         return outcome
@@ -1236,7 +1255,7 @@ export function createBookingSessionModule(
         await appendSessionAudit(repository, session, "abandon", access, at)
         const outcome: BookingSessionOutcomeV1 = {
           kind: "session_abandoned",
-          session: serializeSession(session),
+          session: serializeSession(session, undefined, access),
         }
         await repository.completeOperation({ id: claim.id, outcome })
         return outcome
@@ -2521,11 +2540,13 @@ function resolveSessionScope(scope: BookingSessionScopeV1 | undefined): BookingS
 function serializeSession(
   session: BookingSessionInternalRecord,
   requirements?: BookingRequirementsV1,
+  access?: BookingSessionAccessContext,
 ): BookingSessionRecordV1 {
+  const redactComposite = session.target.kind === "trip_snapshot" && access?.actorKind !== "staff"
   return {
     id: session.id,
-    target: session.target,
-    ...(session.origin ? { origin: session.origin } : {}),
+    target: redactComposite ? { kind: "managed_itinerary" } : session.target,
+    ...(session.origin && !redactComposite ? { origin: session.origin } : {}),
     actorKind: session.actorKind,
     state: session.state,
     revision: session.revision,
@@ -2542,7 +2563,7 @@ function serializeSessionView(
   access: BookingSessionAccessContext,
   requirements?: BookingRequirementsV1,
 ): BookingSessionViewV1 {
-  const record = serializeSession(session, requirements)
+  const record = serializeSession(session, requirements, access)
   if (access.actorKind === "staff") {
     return { ...record, redaction: "selection_omitted" }
   }
@@ -2563,12 +2584,18 @@ function serializeQuote(quote: BookingQuoteInternalRecord): BookingQuoteRecordV1
   }
 }
 
-function serializeHold(hold: BookingHoldInternalRecord): BookingHoldRecordV1 {
+function serializeHold(
+  hold: BookingHoldInternalRecord,
+  access: BookingSessionAccessContext,
+): BookingHoldRecordV1 {
   return {
     id: hold.id,
     sessionId: hold.sessionId,
     quoteId: hold.quoteId,
-    target: hold.target,
+    target:
+      hold.target.kind === "trip_snapshot" && access.actorKind !== "staff"
+        ? { kind: "managed_itinerary" }
+        : hold.target,
     quantity: hold.quantity,
     state: hold.state,
     expiresAt: hold.expiresAt.toISOString(),

--- a/packages/catalog/src/composite-booking-session-runtime-port.ts
+++ b/packages/catalog/src/composite-booking-session-runtime-port.ts
@@ -1,0 +1,26 @@
+import type { BookingSessionOutcomeV1 } from "@voyant-travel/catalog-contracts/booking-engine/session-contracts"
+import { definePort } from "@voyant-travel/core/project"
+import type { AnyDrizzleDb } from "@voyant-travel/db"
+
+export interface CatalogCompositeBookingSessionRuntime {
+  createValidatedTripSnapshotSession(input: {
+    db: AnyDrizzleDb
+    idempotencyKey: string
+    tripSnapshotId: string
+    tripEnvelopeId: string
+    capability: string
+    ownerUserId: string | null
+    storefront: { storefrontId: string; channelId: string }
+    scope: { locale: string; market: string; currency: string }
+  }): Promise<BookingSessionOutcomeV1>
+}
+
+export const catalogCompositeBookingSessionRuntimePort =
+  definePort<CatalogCompositeBookingSessionRuntime>({
+    id: "catalog.composite-booking-session.runtime",
+    test(runtime) {
+      if (!runtime || typeof runtime.createValidatedTripSnapshotSession !== "function") {
+        throw new Error("catalog.composite-booking-session.runtime provider is incomplete.")
+      }
+    },
+  })

--- a/packages/catalog/src/runtime-contributor.ts
+++ b/packages/catalog/src/runtime-contributor.ts
@@ -59,6 +59,10 @@ import {
   catalogBookingSessionSettlementRuntimePort,
 } from "./booking-session-settlement-runtime-port.js"
 import {
+  type CatalogCompositeBookingSessionRuntime,
+  catalogCompositeBookingSessionRuntimePort,
+} from "./composite-booking-session-runtime-port.js"
+import {
   type CatalogReindexCheckpoint,
   type CatalogReindexClaim,
   catalogReindexJobRuntimePort,
@@ -208,8 +212,8 @@ export function createCatalogRuntimePortContribution(
       return services.ensureSourceRegistry(host.primitives.env(bindings))
     },
   }
-  const resolveBookingSessionModule = async () => {
-    const db = host.primitives.database.resolve(undefined) as PostgresJsDatabase
+  const resolveBookingSessionModule = async (dbOverride?: AnyDrizzleDb) => {
+    const db = (dbOverride ?? host.primitives.database.resolve(undefined)) as PostgresJsDatabase
     const runtime = await contribution
     const services = await runtime.services
     const [, , , distribution, , inventory, , , settings] = await dependencies
@@ -248,6 +252,33 @@ export function createCatalogRuntimePortContribution(
         return (await resolveBookingSessionModule()).commitPaidSession(input)
       },
     } satisfies CatalogBookingSessionSettlementRuntime,
+    [catalogCompositeBookingSessionRuntimePort.id]: {
+      async createValidatedTripSnapshotSession(input) {
+        const module = await resolveBookingSessionModule(input.db)
+        return module.createCompositeSession(
+          {
+            idempotencyKey: input.idempotencyKey,
+            target: {
+              kind: "trip_snapshot",
+              tripSnapshotId: input.tripSnapshotId,
+              tripEnvelopeId: input.tripEnvelopeId,
+            },
+            scope: input.scope,
+          },
+          input.ownerUserId
+            ? {
+                actorKind: "customer",
+                principalId: input.ownerUserId,
+                storefront: input.storefront,
+              }
+            : {
+                actorKind: "anonymous",
+                capability: input.capability,
+                storefront: input.storefront,
+              },
+        )
+      },
+    } satisfies CatalogCompositeBookingSessionRuntime,
     [catalogRuntimeServicesPort.id]: contribution.then((runtime) => runtime.services),
     [bookingsSupplierAmendmentRuntimePort.id]: createCatalogBookingAmendmentRuntime({
       async resolveRegistry() {

--- a/packages/catalog/src/voyant.ts
+++ b/packages/catalog/src/voyant.ts
@@ -23,6 +23,7 @@ import {
 import { catalogBookingSessionMaintenanceJobRuntimePort } from "./booking-session-maintenance-job-runtime-port.js"
 import { catalogBookingSessionSettlementRuntimePort } from "./booking-session-settlement-runtime-port.js"
 import { catalogBookingSnapshotSubscriberDeclaration } from "./booking-snapshot-subscriber-declaration.js"
+import { catalogCompositeBookingSessionRuntimePort } from "./composite-booking-session-runtime-port.js"
 import { catalogContentRuntimePort } from "./content-runtime-port.js"
 import { catalogIndexSubscriberDeclarations } from "./index-subscriber-declarations.js"
 import { catalogIndexerProviderPort } from "./indexer/provider.js"
@@ -101,6 +102,7 @@ export const catalogVoyantModule = defineModule({
       providePort(catalogBookingSnapshotRuntimePort),
       providePort(catalogBookingSessionMaintenanceJobRuntimePort),
       providePort(catalogBookingSessionSettlementRuntimePort),
+      providePort(catalogCompositeBookingSessionRuntimePort),
       providePort(catalogRuntimeServicesPort),
       providePort(catalogReindexJobRuntimePort),
       providePort(catalogSourcesSyncJobRuntimePort),
@@ -115,6 +117,7 @@ export const catalogVoyantModule = defineModule({
     requirePort(catalogBookingSnapshotRuntimePort),
     requirePort(catalogBookingSessionMaintenanceJobRuntimePort),
     requirePort(catalogBookingSessionSettlementRuntimePort),
+    requirePort(catalogCompositeBookingSessionRuntimePort),
     requirePort(catalogReindexJobRuntimePort),
     requirePort(catalogSourcesSyncJobRuntimePort),
   ],

--- a/packages/catalog/tests/unit/voyant-manifest.test.ts
+++ b/packages/catalog/tests/unit/voyant-manifest.test.ts
@@ -26,6 +26,7 @@ describe("catalog deployment manifest", () => {
           { id: "catalog.booking-snapshot-runtime" },
           { id: "catalog.booking-session-maintenance-job" },
           { id: "catalog.booking-session-settlement-runtime" },
+          { id: "catalog.composite-booking-session.runtime" },
           { id: "catalog.runtime-services" },
           { id: "catalog.reindex-products-job" },
           { id: "catalog.sources-sync-job" },
@@ -115,6 +116,7 @@ describe("catalog deployment manifest", () => {
       { id: "catalog.booking-snapshot-runtime" },
       { id: "catalog.booking-session-maintenance-job" },
       { id: "catalog.booking-session-settlement-runtime" },
+      { id: "catalog.composite-booking-session.runtime" },
       { id: "catalog.reindex-products-job" },
       { id: "catalog.sources-sync-job" },
     ])

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -523,6 +523,9 @@
         "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
       ],
       "@voyant-travel/catalog/catalog-runtime": ["../catalog/dist/runtime/catalog-runtime.d.ts"],
+      "@voyant-travel/catalog/composite-booking-session-runtime-port": [
+        "../catalog/dist/composite-booking-session-runtime-port.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -517,6 +517,9 @@
         "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
       ],
       "@voyant-travel/catalog/catalog-runtime": ["../catalog/dist/runtime/catalog-runtime.d.ts"],
+      "@voyant-travel/catalog/composite-booking-session-runtime-port": [
+        "../catalog/dist/composite-booking-session-runtime-port.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -516,6 +516,9 @@
         "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
       ],
       "@voyant-travel/catalog/catalog-runtime": ["../catalog/dist/runtime/catalog-runtime.d.ts"],
+      "@voyant-travel/catalog/composite-booking-session-runtime-port": [
+        "../catalog/dist/composite-booking-session-runtime-port.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -517,6 +517,9 @@
         "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
       ],
       "@voyant-travel/catalog/catalog-runtime": ["../catalog/dist/runtime/catalog-runtime.d.ts"],
+      "@voyant-travel/catalog/composite-booking-session-runtime-port": [
+        "../catalog/dist/composite-booking-session-runtime-port.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -516,6 +516,9 @@
         "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
       ],
       "@voyant-travel/catalog/catalog-runtime": ["../catalog/dist/runtime/catalog-runtime.d.ts"],
+      "@voyant-travel/catalog/composite-booking-session-runtime-port": [
+        "../catalog/dist/composite-booking-session-runtime-port.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -517,6 +517,9 @@
         "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
       ],
       "@voyant-travel/catalog/catalog-runtime": ["../catalog/dist/runtime/catalog-runtime.d.ts"],
+      "@voyant-travel/catalog/composite-booking-session-runtime-port": [
+        "../catalog/dist/composite-booking-session-runtime-port.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -522,6 +522,9 @@
         "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
       ],
       "@voyant-travel/catalog/catalog-runtime": ["../catalog/dist/runtime/catalog-runtime.d.ts"],
+      "@voyant-travel/catalog/composite-booking-session-runtime-port": [
+        "../catalog/dist/composite-booking-session-runtime-port.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -517,6 +517,9 @@
         "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
       ],
       "@voyant-travel/catalog/catalog-runtime": ["../catalog/dist/runtime/catalog-runtime.d.ts"],
+      "@voyant-travel/catalog/composite-booking-session-runtime-port": [
+        "../catalog/dist/composite-booking-session-runtime-port.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -516,6 +516,9 @@
         "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
       ],
       "@voyant-travel/catalog/catalog-runtime": ["../catalog/dist/runtime/catalog-runtime.d.ts"],
+      "@voyant-travel/catalog/composite-booking-session-runtime-port": [
+        "../catalog/dist/composite-booking-session-runtime-port.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -517,6 +517,9 @@
         "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
       ],
       "@voyant-travel/catalog/catalog-runtime": ["../catalog/dist/runtime/catalog-runtime.d.ts"],
+      "@voyant-travel/catalog/composite-booking-session-runtime-port": [
+        "../catalog/dist/composite-booking-session-runtime-port.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -522,6 +522,9 @@
         "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
       ],
       "@voyant-travel/catalog/catalog-runtime": ["../catalog/dist/runtime/catalog-runtime.d.ts"],
+      "@voyant-travel/catalog/composite-booking-session-runtime-port": [
+        "../catalog/dist/composite-booking-session-runtime-port.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -517,6 +517,9 @@
         "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
       ],
       "@voyant-travel/catalog/catalog-runtime": ["../catalog/dist/runtime/catalog-runtime.d.ts"],
+      "@voyant-travel/catalog/composite-booking-session-runtime-port": [
+        "../catalog/dist/composite-booking-session-runtime-port.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/inventory/tsconfig.build.json
+++ b/packages/inventory/tsconfig.build.json
@@ -516,6 +516,9 @@
         "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
       ],
       "@voyant-travel/catalog/catalog-runtime": ["../catalog/dist/runtime/catalog-runtime.d.ts"],
+      "@voyant-travel/catalog/composite-booking-session-runtime-port": [
+        "../catalog/dist/composite-booking-session-runtime-port.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/inventory/tsconfig.typecheck.json
+++ b/packages/inventory/tsconfig.typecheck.json
@@ -517,6 +517,9 @@
         "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
       ],
       "@voyant-travel/catalog/catalog-runtime": ["../catalog/dist/runtime/catalog-runtime.d.ts"],
+      "@voyant-travel/catalog/composite-booking-session-runtime-port": [
+        "../catalog/dist/composite-booking-session-runtime-port.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -522,6 +522,9 @@
         "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
       ],
       "@voyant-travel/catalog/catalog-runtime": ["../catalog/dist/runtime/catalog-runtime.d.ts"],
+      "@voyant-travel/catalog/composite-booking-session-runtime-port": [
+        "../catalog/dist/composite-booking-session-runtime-port.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -517,6 +517,9 @@
         "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
       ],
       "@voyant-travel/catalog/catalog-runtime": ["../catalog/dist/runtime/catalog-runtime.d.ts"],
+      "@voyant-travel/catalog/composite-booking-session-runtime-port": [
+        "../catalog/dist/composite-booking-session-runtime-port.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/storefront/src/shopping/routes-public.ts
+++ b/packages/storefront/src/shopping/routes-public.ts
@@ -20,6 +20,8 @@ import type {
 import {
   storefrontShoppingRequestSchema,
   storefrontShoppingResultSchema,
+  storefrontTripBookingCreateSchema,
+  storefrontTripBookingSchema,
   storefrontTripSelectionCreateSchema,
   storefrontTripSelectionSchema,
   storefrontTripSelectionUpdateSchema,
@@ -42,6 +44,7 @@ const tooLargeResponseSchema = errorResponseSchema
   .strict()
 const shoppingEnvelopeSchema = z.object({ data: storefrontShoppingResultSchema }).strict()
 const tripSelectionEnvelopeSchema = z.object({ data: storefrontTripSelectionSchema }).strict()
+const tripBookingEnvelopeSchema = z.object({ data: storefrontTripBookingSchema }).strict()
 
 function jsonBody<T extends z.ZodType>(schema: T) {
   return { required: true, content: { "application/json": { schema } } }
@@ -130,6 +133,38 @@ const updateTripSelectionRoute = createRoute({
     },
     503: {
       description: "No Trip-selection runtime is bound",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+const bookTripSelectionRoute = createRoute({
+  method: "post",
+  path: "/trip-selections/book",
+  request: { body: jsonBody(storefrontTripBookingCreateSchema) },
+  responses: {
+    200: {
+      description: "A managed composite Booking Session for the exact Trip revision",
+      content: { "application/json": { schema: tripBookingEnvelopeSchema } },
+    },
+    400: {
+      description: "The Trip could not be frozen and priced",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    403: {
+      description: "The Trip capability, owner, channel, or same-origin proof is invalid",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    409: {
+      description: "The Trip revision or idempotent request conflicts",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    413: {
+      description: "The request body exceeded 64 KiB",
+      content: { "application/json": { schema: tooLargeResponseSchema } },
+    },
+    503: {
+      description: "The managed Trip booking runtime is unavailable",
       content: { "application/json": { schema: errorResponseSchema } },
     },
   },
@@ -376,4 +411,42 @@ export function createStorefrontShoppingPublicRoutes(
         throw cause
       }
     })
+    .openapi(bookTripSelectionRoute, async (c) => {
+      const context = activeShoppingContext(c)
+      if (!context) {
+        return c.json({ error: "active_storefront_channel_required", requestId: requestId(c) }, 403)
+      }
+      if (!requireSameOriginMutation(c)) {
+        return c.json({ error: "same_origin_required", requestId: requestId(c) }, 403)
+      }
+      try {
+        const result = await gateway.bookTripSelection(context, c.req.valid("json"))
+        setPrivateNoStore(c)
+        return c.json({ data: result }, 200)
+      } catch (cause) {
+        if (cause instanceof StorefrontShoppingUnavailableError) {
+          return c.json({ error: "storefront_shopping_unavailable", requestId: requestId(c) }, 503)
+        }
+        if (isRevisionConflict(cause)) {
+          return c.json({ error: "trip_selection_revision_conflict", requestId: requestId(c) }, 409)
+        }
+        const code = errorCode(cause)
+        if (code === "storefront_trip_selection_not_found") {
+          return c.json({ error: code, requestId: requestId(c) }, 403)
+        }
+        if (code === "storefront_trip_booking_idempotency_conflict") {
+          return c.json({ error: code, requestId: requestId(c) }, 409)
+        }
+        if (code?.startsWith("storefront_trip_booking_")) {
+          return c.json({ error: code, requestId: requestId(c) }, 400)
+        }
+        throw cause
+      }
+    })
+}
+
+function errorCode(value: unknown): string | undefined {
+  if (!value || typeof value !== "object") return undefined
+  const code = (value as { code?: unknown }).code
+  return typeof code === "string" ? code : undefined
 }

--- a/packages/storefront/src/shopping/runtime-port.ts
+++ b/packages/storefront/src/shopping/runtime-port.ts
@@ -5,6 +5,8 @@ import type {
   StorefrontResolvedScope,
   StorefrontShoppingIntent,
   StorefrontShoppingResult,
+  StorefrontTripBooking,
+  StorefrontTripBookingCreate,
   StorefrontTripSelection,
   StorefrontTripSelectionCreate,
   StorefrontTripSelectionUpdate,
@@ -79,6 +81,10 @@ export interface StorefrontTripSelectionsRuntime {
     context: StorefrontShoppingContext,
     input: StorefrontTripSelectionUpdate,
   ): Promise<StorefrontTripSelection>
+  book(
+    context: StorefrontShoppingContext,
+    input: StorefrontTripBookingCreate,
+  ): Promise<StorefrontTripBooking>
 }
 
 function requireMethods(id: string, provider: object, methods: readonly string[]): void {
@@ -121,6 +127,6 @@ export const storefrontTripSelectionsRuntimePort = definePort<StorefrontTripSele
     if (provider === null || typeof provider !== "object") {
       throw new Error("storefront.trip-selections.runtime provider must be an options object.")
     }
-    requireMethods("storefront.trip-selections.runtime", provider, ["create", "update"])
+    requireMethods("storefront.trip-selections.runtime", provider, ["create", "update", "book"])
   },
 })

--- a/packages/storefront/src/shopping/runtime.ts
+++ b/packages/storefront/src/shopping/runtime.ts
@@ -5,10 +5,13 @@ import type {
 } from "./runtime-port.js"
 import {
   type StorefrontShoppingResult,
+  type StorefrontTripBooking,
   type StorefrontTripSelection,
   storefrontResolvedScopeSchema,
   storefrontShoppingRequestSchema,
   storefrontShoppingResultSchema,
+  storefrontTripBookingCreateSchema,
+  storefrontTripBookingSchema,
   storefrontTripSelectionCreateSchema,
   storefrontTripSelectionSchema,
   storefrontTripSelectionUpdateSchema,
@@ -55,6 +58,10 @@ export interface StorefrontShoppingGateway {
     context: StorefrontShoppingContext,
     request: unknown,
   ): Promise<StorefrontTripSelection>
+  bookTripSelection(
+    context: StorefrontShoppingContext,
+    request: unknown,
+  ): Promise<StorefrontTripBooking>
 }
 
 /**
@@ -107,6 +114,13 @@ export function createStorefrontShoppingGateway(options: {
       if (!tripSelections) throw new StorefrontShoppingUnavailableError("trip-selections")
       const request = storefrontTripSelectionUpdateSchema.parse(rawRequest)
       return storefrontTripSelectionSchema.parse(await tripSelections.update(context, request))
+    },
+
+    async bookTripSelection(context, rawRequest) {
+      const tripSelections = options.tripSelections
+      if (!tripSelections) throw new StorefrontShoppingUnavailableError("trip-selections")
+      const request = storefrontTripBookingCreateSchema.parse(rawRequest)
+      return storefrontTripBookingSchema.parse(await tripSelections.book(context, request))
     },
   }
 }

--- a/packages/storefront/src/shopping/schemas.ts
+++ b/packages/storefront/src/shopping/schemas.ts
@@ -1,3 +1,4 @@
+import { bookingSessionOutcomeV1 } from "@voyant-travel/catalog-contracts/booking-engine/session-contracts"
 import {
   type CatalogMoney,
   catalogMoneySchema,
@@ -412,6 +413,24 @@ export const storefrontTripSelectionSchema = z
   })
   .strict()
 
+export const storefrontTripBookingCreateSchema = z
+  .object({
+    selectionRef: opaqueRefSchema,
+    expectedRevision: z.number().int().min(0),
+    idempotencyKey: z.string().min(8).max(128),
+  })
+  .strict()
+
+export const storefrontTripBookingSchema = z
+  .object({
+    bookingSessionCapability: z
+      .string()
+      .regex(/^bcap_[A-Za-z0-9_-]{43,}$/)
+      .optional(),
+    outcome: bookingSessionOutcomeV1,
+  })
+  .strict()
+
 export type StorefrontRequestedScope = z.infer<typeof storefrontRequestedScopeSchema>
 export type StorefrontResolvedScope = z.infer<typeof storefrontResolvedScopeSchema>
 export type StorefrontShoppingIntent = z.infer<typeof storefrontShoppingIntentSchema>
@@ -420,3 +439,5 @@ export type StorefrontShoppingResult = z.infer<typeof storefrontShoppingResultSc
 export type StorefrontTripSelectionCreate = z.infer<typeof storefrontTripSelectionCreateSchema>
 export type StorefrontTripSelectionUpdate = z.infer<typeof storefrontTripSelectionUpdateSchema>
 export type StorefrontTripSelection = z.infer<typeof storefrontTripSelectionSchema>
+export type StorefrontTripBookingCreate = z.infer<typeof storefrontTripBookingCreateSchema>
+export type StorefrontTripBooking = z.infer<typeof storefrontTripBookingSchema>

--- a/packages/storefront/tests/unit/shopping-gateway.test.ts
+++ b/packages/storefront/tests/unit/shopping-gateway.test.ts
@@ -184,7 +184,13 @@ describe("storefront shopping gateway", () => {
     }))
     const gateway = createStorefrontShoppingGateway({
       shopping: { resolveScope: async () => scope, search: vi.fn() },
-      tripSelections: { create, update },
+      tripSelections: {
+        create,
+        update,
+        book: async () => {
+          throw new Error("not used")
+        },
+      },
     })
 
     const created = await gateway.createTripSelection(context, {

--- a/packages/storefront/tests/unit/shopping-public-routes.test.ts
+++ b/packages/storefront/tests/unit/shopping-public-routes.test.ts
@@ -46,6 +46,9 @@ function tripRuntime(): StorefrontTripSelectionsRuntime {
       scope,
       items: [],
     })),
+    book: vi.fn(async () => {
+      throw new Error("not used")
+    }),
   }
 }
 
@@ -97,7 +100,12 @@ describe("Storefront shopping public routes", () => {
           .filter(({ method }) => method !== "ALL")
           .map(({ method, path }) => `${method} ${path}`),
       ),
-    ]).toEqual(["POST /search", "POST /trip-selections", "PATCH /trip-selections"])
+    ]).toEqual([
+      "POST /search",
+      "POST /trip-selections",
+      "PATCH /trip-selections",
+      "POST /trip-selections/book",
+    ])
   })
 
   it("requires an active server-resolved Storefront Channel and ignores no browser selector", async () => {

--- a/packages/storefront/tests/unit/shopping-public-routes.test.ts
+++ b/packages/storefront/tests/unit/shopping-public-routes.test.ts
@@ -46,9 +46,23 @@ function tripRuntime(): StorefrontTripSelectionsRuntime {
       scope,
       items: [],
     })),
-    book: vi.fn(async () => {
-      throw new Error("not used")
-    }),
+    book: vi.fn(async () => ({
+      bookingSessionCapability: `bcap_${"a".repeat(43)}`,
+      outcome: {
+        kind: "session_created" as const,
+        session: {
+          id: "booking_sessions_public_1",
+          target: { kind: "managed_itinerary" as const },
+          actorKind: "anonymous" as const,
+          state: "active" as const,
+          revision: 1,
+          scope: { locale: "ro-RO", market: "market_ro", currency: "EUR" },
+          expiresAt: "2026-08-08T10:30:00.000Z",
+          createdAt: "2026-08-08T10:00:00.000Z",
+          updatedAt: "2026-08-08T10:00:00.000Z",
+        },
+      },
+    })),
   }
 }
 
@@ -256,5 +270,39 @@ describe("Storefront shopping public routes", () => {
       requestId: expect.any(String),
     })
     expect(conflict.headers.get("cache-control")).toBe("private, no-store")
+  })
+
+  it("creates a managed itinerary Session without accepting authority selectors", async () => {
+    const trips = tripRuntime()
+    const request = {
+      selectionRef: "selection_ref_123456789",
+      expectedRevision: 3,
+      idempotencyKey: "book_trip_once",
+    }
+    const response = await app({ shopping: runtime(), tripSelections: trips }).request(
+      jsonRequest("/v1/public/shopping/trip-selections/book", request, {
+        headers: { origin: "https://shop.example" },
+      }),
+    )
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      data: {
+        bookingSessionCapability: expect.stringMatching(/^bcap_/),
+        outcome: {
+          kind: "session_created",
+          session: { target: { kind: "managed_itinerary" } },
+        },
+      },
+    })
+
+    const injected = await app({ shopping: runtime(), tripSelections: trips }).request(
+      jsonRequest(
+        "/v1/public/shopping/trip-selections/book",
+        { ...request, providerId: "provider_browser" },
+        { headers: { origin: "https://shop.example" } },
+      ),
+    )
+    expect(injected.status).toBe(400)
+    expect(trips.book).toHaveBeenCalledOnce()
   })
 })

--- a/packages/trips/migrations/0006_storefront_trip_booking_operations.sql
+++ b/packages/trips/migrations/0006_storefront_trip_booking_operations.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "trip_storefront_booking_operations" (
+	"operation_digest" text PRIMARY KEY NOT NULL,
+	"envelope_id" text NOT NULL,
+	"request_fingerprint" text NOT NULL,
+	"snapshot_id" text,
+	"booking_session_id" text,
+	"outcome" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "trip_storefront_booking_operations_envelope_id_trip_envelopes_id_fk" FOREIGN KEY ("envelope_id") REFERENCES "public"."trip_envelopes"("id") ON DELETE cascade ON UPDATE no action,
+	CONSTRAINT "trip_storefront_booking_operations_snapshot_id_trip_snapshots_id_fk" FOREIGN KEY ("snapshot_id") REFERENCES "public"."trip_snapshots"("id") ON DELETE restrict ON UPDATE no action
+);
+--> statement-breakpoint
+CREATE INDEX "idx_trip_storefront_booking_operations_envelope" ON "trip_storefront_booking_operations" USING btree ("envelope_id");

--- a/packages/trips/migrations/meta/_journal.json
+++ b/packages/trips/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1786194000000,
       "tag": "0005_shopping_opaque_references",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1786262400000,
+      "tag": "0006_storefront_trip_booking_operations",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/trips/src/runtime-contributor.ts
+++ b/packages/trips/src/runtime-contributor.ts
@@ -1,4 +1,8 @@
 import {
+  type CatalogCompositeBookingSessionRuntime,
+  catalogCompositeBookingSessionRuntimePort,
+} from "@voyant-travel/catalog/composite-booking-session-runtime-port"
+import {
   type CatalogRuntimeServices,
   catalogRuntimeServicesPort,
 } from "@voyant-travel/catalog/runtime-contracts"
@@ -124,6 +128,9 @@ export function createTripsRuntimePortContribution(
           operation(database as AnyDrizzleDb),
         ),
       offerResolver: shoppingReferences.offerResolver,
+      compositeBookingSessions: host.getRuntimePort<CatalogCompositeBookingSessionRuntime>(
+        catalogCompositeBookingSessionRuntimePort,
+      ),
     }),
     [tripsSourcingJobRuntimePort.id]: {
       resolveDb: (bindings: unknown) =>

--- a/packages/trips/src/schema.ts
+++ b/packages/trips/src/schema.ts
@@ -1,4 +1,6 @@
 // agent-quality: file-size exception -- owner: trips; the package schema remains one Drizzle graph so migrations, foreign keys, and exported relations are generated from one source.
+
+import type { BookingSessionOutcomeV1 } from "@voyant-travel/catalog-contracts/booking-engine/session-contracts"
 import { typeId, typeIdRef } from "@voyant-travel/db/lib/typeid-column"
 import { relations } from "drizzle-orm"
 import {
@@ -313,6 +315,26 @@ export const tripShoppingReferences = pgTable(
       table.expiresAt,
     ),
   ],
+)
+
+/** Durable, digest-only idempotency authority for Storefront Trip conversion. */
+export const tripStorefrontBookingOperations = pgTable(
+  "trip_storefront_booking_operations",
+  {
+    operationDigest: text("operation_digest").primaryKey(),
+    envelopeId: typeIdRef("envelope_id")
+      .notNull()
+      .references(() => tripEnvelopes.id, { onDelete: "cascade" }),
+    requestFingerprint: text("request_fingerprint").notNull(),
+    snapshotId: typeIdRef("snapshot_id").references(() => tripSnapshots.id, {
+      onDelete: "restrict",
+    }),
+    bookingSessionId: text("booking_session_id"),
+    outcome: jsonb("outcome").$type<BookingSessionOutcomeV1>(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [index("idx_trip_storefront_booking_operations_envelope").on(table.envelopeId)],
 )
 
 export const tripComponents = pgTable(
@@ -748,6 +770,7 @@ export type TripStorefrontAccess = typeof tripStorefrontAccess.$inferSelect
 export type NewTripStorefrontAccess = typeof tripStorefrontAccess.$inferInsert
 export type TripShoppingReference = typeof tripShoppingReferences.$inferSelect
 export type NewTripShoppingReference = typeof tripShoppingReferences.$inferInsert
+export type TripStorefrontBookingOperation = typeof tripStorefrontBookingOperations.$inferSelect
 export type TripComponent = typeof tripComponents.$inferSelect
 export type NewTripComponent = typeof tripComponents.$inferInsert
 export type TripComponentEvent = typeof tripComponentEvents.$inferSelect

--- a/packages/trips/src/storefront-trip-selections-runtime.ts
+++ b/packages/trips/src/storefront-trip-selections-runtime.ts
@@ -322,7 +322,7 @@ async function bookAuthorizedSelection(
         : "storefront_trip_booking_session_rejected",
     )
   }
-  await db
+  const [completed] = (await db
     .update(tripStorefrontBookingOperations)
     .set({
       snapshotId: snapshot.id,
@@ -331,6 +331,10 @@ async function bookAuthorizedSelection(
       updatedAt: now?.() ?? new Date(),
     })
     .where(eq(tripStorefrontBookingOperations.operationDigest, operationDigest))
+    .returning()) as TripStorefrontBookingOperation[]
+  if (!completed) {
+    throw new StorefrontTripBookingError("storefront_trip_booking_session_rejected")
+  }
   return bookingResult(input.selectionRef, resolved.access.ownerUserId, outcome)
 }
 

--- a/packages/trips/src/storefront-trip-selections-runtime.ts
+++ b/packages/trips/src/storefront-trip-selections-runtime.ts
@@ -1,8 +1,11 @@
+import type { CatalogCompositeBookingSessionRuntime } from "@voyant-travel/catalog/composite-booking-session-runtime-port"
 import type { AnyDrizzleDb } from "@voyant-travel/db"
-import { randomBytesHex } from "@voyant-travel/hono"
+import { randomBytesHex, sha256Hex } from "@voyant-travel/hono"
 import {
   type StorefrontResolvedScope,
   type StorefrontShoppingContext,
+  type StorefrontTripBooking,
+  type StorefrontTripBookingCreate,
   type StorefrontTripSelection,
   type StorefrontTripSelectionCreate,
   type StorefrontTripSelectionsRuntime,
@@ -13,7 +16,12 @@ import { and, eq, isNull } from "drizzle-orm"
 import { z } from "zod"
 
 import type { TripComponent, TripStorefrontAccess } from "./schema.js"
-import { tripStorefrontAccess } from "./schema.js"
+import {
+  type TripStorefrontBookingOperation,
+  tripStorefrontAccess,
+  tripStorefrontBookingOperations,
+} from "./schema.js"
+import { freezeTripSnapshot } from "./service-snapshots.js"
 import {
   addComponent,
   getTrip,
@@ -82,12 +90,27 @@ export class StorefrontTripSelectionMutationError extends Error {
   }
 }
 
+export class StorefrontTripBookingError extends Error {
+  constructor(
+    readonly code:
+      | "storefront_trip_booking_idempotency_conflict"
+      | "storefront_trip_booking_pricing_unavailable"
+      | "storefront_trip_booking_session_rejected",
+  ) {
+    super(code)
+    this.name = "StorefrontTripBookingError"
+  }
+}
+
 export interface StorefrontTripSelectionsRuntimeOptions {
   withTransaction<T>(operation: (db: AnyDrizzleDb) => Promise<T>): Promise<T>
   offerResolver?: StorefrontTripOfferResolver
   now?: () => Date
   createSelectionRef?: () => string
   createItemRef?: () => string
+  compositeBookingSessions?:
+    | CatalogCompositeBookingSessionRuntime
+    | Promise<CatalogCompositeBookingSessionRuntime>
 }
 
 /** Trips-owned provider for the Storefront gateway's stateful selection port. */
@@ -209,7 +232,163 @@ export function createStorefrontTripSelectionsRuntime(
         )
       })
     },
+
+    async book(context, input) {
+      if (!options.compositeBookingSessions) {
+        throw new StorefrontTripBookingError("storefront_trip_booking_session_rejected")
+      }
+      const catalog = await options.compositeBookingSessions
+      return options.withTransaction(async (db) =>
+        bookAuthorizedSelection(db, catalog, context, input, options.now),
+      )
+    },
   }
+}
+
+async function bookAuthorizedSelection(
+  db: AnyDrizzleDb,
+  catalog: CatalogCompositeBookingSessionRuntime,
+  context: StorefrontShoppingContext,
+  input: StorefrontTripBookingCreate,
+  now: (() => Date) | undefined,
+): Promise<StorefrontTripBooking> {
+  const resolved = await resolveAuthorizedSelection(db, input.selectionRef, context, now)
+  if (resolved.access.revision !== input.expectedRevision) {
+    throw new StorefrontTripSelectionConflictError(input.expectedRevision, resolved.access.revision)
+  }
+  const components = selectionComponents(resolved.trip)
+  if (components.length === 0 || components.some((component) => !component.pricingSnapshot)) {
+    throw new StorefrontTripBookingError("storefront_trip_booking_pricing_unavailable")
+  }
+
+  const operationDigest = await sha256Hex(
+    ["storefront-trip-booking-v1", resolved.access.capabilityDigest, input.idempotencyKey].join(
+      ":",
+    ),
+  )
+  const requestFingerprint = await sha256Hex(
+    JSON.stringify({
+      version: 1,
+      capabilityDigest: resolved.access.capabilityDigest,
+      revision: input.expectedRevision,
+      storefrontId: resolved.access.storefrontId,
+      channelId: resolved.access.channelId,
+      ownerUserId: resolved.access.ownerUserId,
+      ownerBuyerAccountId: resolved.access.ownerBuyerAccountId,
+      scope: accessScope(resolved.access),
+    }),
+  )
+  const operation = await claimBookingOperation(db, {
+    operationDigest,
+    envelopeId: resolved.access.envelopeId,
+    requestFingerprint,
+  })
+  if (!operation.claimed) {
+    if (operation.record.requestFingerprint !== requestFingerprint) {
+      throw new StorefrontTripBookingError("storefront_trip_booking_idempotency_conflict")
+    }
+    if (!operation.record.outcome) {
+      throw new StorefrontTripBookingError("storefront_trip_booking_session_rejected")
+    }
+    return bookingResult(input.selectionRef, resolved.access.ownerUserId, operation.record.outcome)
+  }
+
+  const snapshot = await freezeTripSnapshot(db, {
+    envelopeId: resolved.access.envelopeId,
+    createdBy: resolved.access.ownerUserId ?? undefined,
+  })
+  const capability = await deriveBookingCapability(input.selectionRef)
+  const outcome = await catalog.createValidatedTripSnapshotSession({
+    db,
+    idempotencyKey: input.idempotencyKey,
+    tripSnapshotId: snapshot.id,
+    tripEnvelopeId: resolved.access.envelopeId,
+    capability,
+    ownerUserId: resolved.access.ownerUserId,
+    storefront: {
+      storefrontId: resolved.access.storefrontId,
+      channelId: resolved.access.channelId,
+    },
+    scope: {
+      locale: resolved.access.locale,
+      market: resolved.access.marketId,
+      currency: resolved.access.currency,
+    },
+  })
+  if (outcome.kind !== "session_created") {
+    throw new StorefrontTripBookingError(
+      outcome.kind === "rejected" && outcome.error.kind === "quote_unavailable"
+        ? "storefront_trip_booking_pricing_unavailable"
+        : "storefront_trip_booking_session_rejected",
+    )
+  }
+  await db
+    .update(tripStorefrontBookingOperations)
+    .set({
+      snapshotId: snapshot.id,
+      bookingSessionId: outcome.session.id,
+      outcome,
+      updatedAt: now?.() ?? new Date(),
+    })
+    .where(eq(tripStorefrontBookingOperations.operationDigest, operationDigest))
+  return bookingResult(input.selectionRef, resolved.access.ownerUserId, outcome)
+}
+
+async function claimBookingOperation(
+  db: AnyDrizzleDb,
+  input: { operationDigest: string; envelopeId: string; requestFingerprint: string },
+): Promise<
+  | { claimed: true; record: TripStorefrontBookingOperation }
+  | { claimed: false; record: TripStorefrontBookingOperation }
+> {
+  const [claimed] = (await db
+    .insert(tripStorefrontBookingOperations)
+    .values(input)
+    .onConflictDoNothing()
+    .returning()) as TripStorefrontBookingOperation[]
+  if (claimed) return { claimed: true, record: claimed }
+  const [existing] = (await db
+    .select()
+    .from(tripStorefrontBookingOperations)
+    .where(eq(tripStorefrontBookingOperations.operationDigest, input.operationDigest))
+    .limit(1)) as TripStorefrontBookingOperation[]
+  if (!existing) throw new StorefrontTripBookingError("storefront_trip_booking_session_rejected")
+  return { claimed: false, record: existing }
+}
+
+async function bookingResult(
+  selectionRef: string,
+  ownerUserId: string | null,
+  outcome: StorefrontTripBooking["outcome"],
+): Promise<StorefrontTripBooking> {
+  return {
+    ...(!ownerUserId
+      ? { bookingSessionCapability: await deriveBookingCapability(selectionRef) }
+      : {}),
+    outcome,
+  }
+}
+
+async function deriveBookingCapability(selectionRef: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(selectionRef),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  )
+  const digest = new Uint8Array(
+    await crypto.subtle.sign(
+      "HMAC",
+      key,
+      new TextEncoder().encode("voyant:storefront:trip-booking-capability:v1"),
+    ),
+  )
+  const encoded = btoa(String.fromCharCode(...digest))
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/, "")
+  return `bcap_${encoded}`
 }
 
 async function resolveOffers(

--- a/packages/trips/src/voyant.ts
+++ b/packages/trips/src/voyant.ts
@@ -14,6 +14,9 @@ import { tripsSourcingJobRuntimePort } from "./sourcing-job-runtime-port.js"
 import { storefrontTripOfferResolverPort } from "./storefront-trip-offer-resolver-port.js"
 
 const catalogRuntimeServicesPortReference = { id: "catalog.runtime-services" } as const
+const catalogCompositeBookingSessionRuntimePortReference = {
+  id: "catalog.composite-booking-session.runtime",
+} as const
 const catalogCheckoutApiRuntimePortReference = { id: "commerce.checkout-api-options" } as const
 const flightsRuntimePortReference = { id: "flights.runtime" } as const
 const paymentAdapterRuntimePortReference = { id: "payments.adapter.runtime" } as const
@@ -128,6 +131,7 @@ export const tripsVoyantModule = defineModule({
     requirePort(durableTripActionRuntimePort, { optional: true }),
     { ...paymentAdapterRuntimePortReference, optional: true },
     catalogRuntimeServicesPortReference,
+    catalogCompositeBookingSessionRuntimePortReference,
     catalogCheckoutApiRuntimePortReference,
     { ...flightsRuntimePortReference, optional: true },
   ],

--- a/packages/trips/tests/storefront-trip-selections-runtime.test.ts
+++ b/packages/trips/tests/storefront-trip-selections-runtime.test.ts
@@ -6,14 +6,19 @@ import { describe, expect, it, vi } from "vitest"
 import {
   type TripComponent,
   type TripEnvelope,
+  type TripSnapshot,
   type TripStorefrontAccess,
+  type TripStorefrontBookingOperation,
   tripComponents,
   tripEnvelopes,
+  tripSnapshots,
   tripStorefrontAccess,
+  tripStorefrontBookingOperations,
 } from "../src/schema.js"
 import type { StorefrontTripOfferResolutionInput } from "../src/storefront-trip-offer-resolver-port.js"
 import {
   createStorefrontTripSelectionsRuntime,
+  StorefrontTripBookingError,
   StorefrontTripSelectionAccessError,
   StorefrontTripSelectionConflictError,
   StorefrontTripSelectionUnavailableError,
@@ -316,6 +321,7 @@ describe("Storefront Trip selections runtime", () => {
     }
     const runtime = createStorefrontTripSelectionsRuntime({
       withTransaction: (operation) => operation(createDb(state)),
+      compositeBookingSessions: { createValidatedTripSnapshotSession: vi.fn() },
       now: () => NOW,
     })
 
@@ -326,6 +332,163 @@ describe("Storefront Trip selections runtime", () => {
         mutation: { kind: "remove", itemRef: ITEM_ONE },
       }),
     ).rejects.toBeInstanceOf(StorefrontTripSelectionAccessError)
+    await expect(
+      runtime.book(CONTEXT, {
+        selectionRef: CAPABILITY,
+        expectedRevision: 1,
+        idempotencyKey: "book_scope_drift",
+      }),
+    ).rejects.toBeInstanceOf(StorefrontTripSelectionAccessError)
+  })
+
+  it("fails before Catalog conversion when the exact revision is stale or unpriced", async () => {
+    const state = await seededState()
+    const createValidatedTripSnapshotSession = vi.fn()
+    const runtime = createStorefrontTripSelectionsRuntime({
+      withTransaction: (operation) => operation(createDb(state)),
+      compositeBookingSessions: { createValidatedTripSnapshotSession },
+      now: () => NOW,
+    })
+
+    await expect(
+      runtime.book(CONTEXT, {
+        selectionRef: CAPABILITY,
+        expectedRevision: 0,
+        idempotencyKey: "book_stale_revision",
+      }),
+    ).rejects.toBeInstanceOf(StorefrontTripSelectionConflictError)
+    await expect(
+      runtime.book(CONTEXT, {
+        selectionRef: CAPABILITY,
+        expectedRevision: 1,
+        idempotencyKey: "book_missing_price",
+      }),
+    ).rejects.toEqual(new StorefrontTripBookingError("storefront_trip_booking_pricing_unavailable"))
+    expect(createValidatedTripSnapshotSession).not.toHaveBeenCalled()
+    expect(state.snapshots).toHaveLength(0)
+    expect(state.bookingOperations).toHaveLength(0)
+  })
+
+  it.each([
+    { context: { ...CONTEXT, storefrontId: "storefront_other" }, boundary: "storefront" },
+    { context: { ...CONTEXT, channelId: "channel_other" }, boundary: "channel" },
+    { context: { ...CONTEXT, userId: "customer_other" }, boundary: "owner" },
+  ])("rejects Trip booking replay across a different $boundary", async ({ context }) => {
+    const state = await pricedState()
+    state.access = {
+      ...(state.access as TripStorefrontAccess),
+      ownerUserId: CONTEXT.userId,
+      ownerBuyerAccountId: CONTEXT.buyerAccountId,
+    }
+    const createValidatedTripSnapshotSession = vi.fn()
+    const runtime = createStorefrontTripSelectionsRuntime({
+      withTransaction: transactional(state),
+      compositeBookingSessions: { createValidatedTripSnapshotSession },
+      now: () => NOW,
+    })
+
+    await expect(
+      runtime.book(context, {
+        selectionRef: CAPABILITY,
+        expectedRevision: 1,
+        idempotencyKey: "book_wrong_boundary",
+      }),
+    ).rejects.toBeInstanceOf(StorefrontTripSelectionAccessError)
+    expect(createValidatedTripSnapshotSession).not.toHaveBeenCalled()
+    expect(state.snapshots).toHaveLength(0)
+  })
+
+  it("atomically freezes once and returns the same opaque Session on an idempotent retry", async () => {
+    const state = await pricedState()
+    const createValidatedTripSnapshotSession = vi.fn(async () => ({
+      kind: "session_created" as const,
+      session: bookingSessionRecord(),
+    }))
+    const runtime = createStorefrontTripSelectionsRuntime({
+      withTransaction: transactional(state),
+      compositeBookingSessions: { createValidatedTripSnapshotSession },
+      now: () => NOW,
+    })
+    const request = {
+      selectionRef: CAPABILITY,
+      expectedRevision: 1,
+      idempotencyKey: "book_trip_retry",
+    }
+
+    const first = await runtime.book({ ...CONTEXT, userId: null, buyerAccountId: null }, request)
+    const replay = await runtime.book({ ...CONTEXT, userId: null, buyerAccountId: null }, request)
+
+    expect(replay).toEqual(first)
+    expect(first).toMatchObject({
+      bookingSessionCapability: expect.stringMatching(/^bcap_[A-Za-z0-9_-]{43}$/),
+      outcome: {
+        kind: "session_created",
+        session: { target: { kind: "managed_itinerary" } },
+      },
+    })
+    expect(JSON.stringify(first)).not.toMatch(/trip_storefront_1|trip_component_internal/)
+    expect(createValidatedTripSnapshotSession).toHaveBeenCalledOnce()
+    expect(state.snapshots).toHaveLength(1)
+    expect(state.bookingOperations).toHaveLength(1)
+  })
+
+  it("conflicts on a reused key with a different exact Trip revision", async () => {
+    const state = await pricedState()
+    const createValidatedTripSnapshotSession = vi.fn(async () => ({
+      kind: "session_created" as const,
+      session: bookingSessionRecord(),
+    }))
+    const runtime = createStorefrontTripSelectionsRuntime({
+      withTransaction: transactional(state),
+      compositeBookingSessions: { createValidatedTripSnapshotSession },
+      now: () => NOW,
+    })
+    await runtime.book(CONTEXT, {
+      selectionRef: CAPABILITY,
+      expectedRevision: 1,
+      idempotencyKey: "book_trip_conflict",
+    })
+    state.access = { ...(state.access as TripStorefrontAccess), revision: 2 }
+
+    await expect(
+      runtime.book(CONTEXT, {
+        selectionRef: CAPABILITY,
+        expectedRevision: 2,
+        idempotencyKey: "book_trip_conflict",
+      }),
+    ).rejects.toEqual(
+      new StorefrontTripBookingError("storefront_trip_booking_idempotency_conflict"),
+    )
+    expect(createValidatedTripSnapshotSession).toHaveBeenCalledOnce()
+    expect(state.snapshots).toHaveLength(1)
+  })
+
+  it("rolls back the snapshot and idempotency claim when Catalog rejects creation", async () => {
+    const state = await pricedState()
+    const runtime = createStorefrontTripSelectionsRuntime({
+      withTransaction: transactional(state),
+      compositeBookingSessions: {
+        createValidatedTripSnapshotSession: vi.fn(async () => ({
+          kind: "rejected" as const,
+          error: {
+            kind: "quote_unavailable" as const,
+            reason: "price_unavailable" as const,
+            nextAction: "select_alternative_inventory" as const,
+          },
+        })),
+      },
+      now: () => NOW,
+    })
+
+    await expect(
+      runtime.book(CONTEXT, {
+        selectionRef: CAPABILITY,
+        expectedRevision: 1,
+        idempotencyKey: "book_trip_rejected",
+      }),
+    ).rejects.toEqual(new StorefrontTripBookingError("storefront_trip_booking_pricing_unavailable"))
+    expect(state.snapshots).toHaveLength(0)
+    expect(state.bookingOperations).toHaveLength(0)
   })
 })
 
@@ -335,10 +498,12 @@ interface State {
   components: TripComponent[]
   nextComponent: number
   forceCasConflictRevision?: number
+  snapshots: TripSnapshot[]
+  bookingOperations: TripStorefrontBookingOperation[]
 }
 
 function emptyState(): State {
-  return { components: [], nextComponent: 1 }
+  return { components: [], nextComponent: 1, snapshots: [], bookingOperations: [] }
 }
 
 async function seededState(): Promise<State> {
@@ -373,15 +538,37 @@ async function seededState(): Promise<State> {
       }),
     ],
     nextComponent: 2,
+    snapshots: [],
+    bookingOperations: [],
   }
+}
+
+async function pricedState(): Promise<State> {
+  const state = await seededState()
+  state.access = {
+    ...(state.access as TripStorefrontAccess),
+    ownerUserId: null,
+    ownerBuyerAccountId: null,
+  }
+  state.components[0] = componentRow({
+    ...state.components[0],
+    status: "priced",
+    pricingSnapshot: {
+      currency: "EUR",
+      subtotalAmountCents: 10_000,
+      taxAmountCents: 1_900,
+      totalAmountCents: 11_900,
+    },
+  })
+  return state
 }
 
 function createDb(state: State): AnyDrizzleDb {
   const db = {
     transaction: async (operation: (transaction: unknown) => unknown) => operation(db),
     insert: (table: unknown) => ({
-      values: (values: Record<string, unknown>) => ({
-        returning: async () => {
+      values: (values: Record<string, unknown>) => {
+        const returning = async () => {
           if (table === tripEnvelopes) {
             state.envelope = { ...envelopeRow(), ...(values as Partial<TripEnvelope>) }
             return [state.envelope]
@@ -413,9 +600,38 @@ function createDb(state: State): AnyDrizzleDb {
             state.components.push(component)
             return [component]
           }
+          if (table === tripSnapshots) {
+            const snapshot = {
+              id: `trip_snapshots_${state.snapshots.length + 1}`,
+              createdAt: NOW,
+              ...values,
+            } as TripSnapshot
+            state.snapshots.push(snapshot)
+            return [snapshot]
+          }
+          if (table === tripStorefrontBookingOperations) {
+            const existing = state.bookingOperations.find(
+              (operation) => operation.operationDigest === values.operationDigest,
+            )
+            if (existing) return []
+            const operation = {
+              snapshotId: null,
+              bookingSessionId: null,
+              outcome: null,
+              createdAt: NOW,
+              updatedAt: NOW,
+              ...values,
+            } as TripStorefrontBookingOperation
+            state.bookingOperations.push(operation)
+            return [operation]
+          }
           return []
-        },
-      }),
+        }
+        return {
+          returning,
+          onConflictDoNothing: () => ({ returning }),
+        }
+      },
     }),
     select: () => ({
       from: (table: unknown) => ({
@@ -431,13 +647,18 @@ function createDb(state: State): AnyDrizzleDb {
                   : []
                 : table === tripComponents
                   ? state.components
-                  : []
+                  : table === tripStorefrontBookingOperations
+                    ? state.bookingOperations
+                    : []
           return Object.assign(Promise.resolve(rows), {
             limit: async () => {
               if (table === tripStorefrontAccess) return state.access ? [state.access] : []
               if (table === tripEnvelopes) return state.envelope ? [state.envelope] : []
               if (table === tripComponents) {
                 return state.components.length > 0 ? [state.components[0]] : []
+              }
+              if (table === tripStorefrontBookingOperations) {
+                return state.bookingOperations.length > 0 ? [state.bookingOperations[0]] : []
               }
               return []
             },
@@ -479,6 +700,12 @@ function createDb(state: State): AnyDrizzleDb {
               state.envelope = { ...state.envelope, ...(values as Partial<TripEnvelope>) }
               return [state.envelope]
             }
+            if (table === tripStorefrontBookingOperations) {
+              const operation = state.bookingOperations[0]
+              if (!operation) return []
+              Object.assign(operation, values)
+              return [operation]
+            }
             return []
           },
         }),
@@ -486,6 +713,32 @@ function createDb(state: State): AnyDrizzleDb {
     }),
   }
   return db as AnyDrizzleDb
+}
+
+function transactional(state: State) {
+  return async <T>(operation: (db: AnyDrizzleDb) => Promise<T>): Promise<T> => {
+    const before = structuredClone(state)
+    try {
+      return await operation(createDb(state))
+    } catch (error) {
+      Object.assign(state, before)
+      throw error
+    }
+  }
+}
+
+function bookingSessionRecord() {
+  return {
+    id: "booking_sessions_public_1",
+    target: { kind: "managed_itinerary" as const },
+    actorKind: "anonymous" as const,
+    state: "active" as const,
+    revision: 1,
+    scope: { locale: "ro-RO", market: "market_ro", currency: "EUR" },
+    expiresAt: "2026-08-08T10:30:00.000Z",
+    createdAt: NOW.toISOString(),
+    updatedAt: NOW.toISOString(),
+  }
 }
 
 function envelopeRow(): TripEnvelope {

--- a/packages/trips/tests/voyant-manifest.test.ts
+++ b/packages/trips/tests/voyant-manifest.test.ts
@@ -53,6 +53,7 @@ describe("trips deployment manifest", () => {
         { id: "trips.durable-action-runtime", optional: true },
         { id: "payments.adapter.runtime", optional: true },
         { id: "catalog.runtime-services" },
+        { id: "catalog.composite-booking-session.runtime" },
         { id: "commerce.checkout-api-options" },
         { id: "flights.runtime", optional: true },
       ],
@@ -165,6 +166,9 @@ describe("trips deployment manifest", () => {
     const registerCompositeBookingSessionHandler = vi.fn()
     const getRuntimePort = vi.fn((port: { id: string }) => {
       if (port.id === "catalog.runtime-services") return { registerCompositeBookingSessionHandler }
+      if (port.id === "catalog.composite-booking-session.runtime") {
+        return { createValidatedTripSnapshotSession: vi.fn() }
+      }
       if (port.id === "commerce.checkout-api-options") return () => ({})
       throw new Error(`unexpected runtime port ${port.id}`)
     })
@@ -457,6 +461,9 @@ function publicOperationApiIds(document: unknown): unknown[] {
 function stubRequiredRuntimePortResolver(paymentAdapter?: PaymentAdapter) {
   return vi.fn((port: { id: string }) => {
     if (port.id === "catalog.runtime-services") return {}
+    if (port.id === "catalog.composite-booking-session.runtime") {
+      return { createValidatedTripSnapshotSession: vi.fn() }
+    }
     if (port.id === "commerce.checkout-api-options") return () => ({})
     if (port.id === paymentAdapterRuntimePort.id && paymentAdapter) return paymentAdapter
     throw new Error(`unexpected runtime port ${port.id}`)

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -515,6 +515,9 @@
         "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
       ],
       "@voyant-travel/catalog/catalog-runtime": ["../catalog/dist/runtime/catalog-runtime.d.ts"],
+      "@voyant-travel/catalog/composite-booking-session-runtime-port": [
+        "../catalog/dist/composite-booking-session-runtime-port.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],


### PR DESCRIPTION
## Summary
- add `POST /v1/public/shopping/trip-selections/book` with the strict browser contract `{ selectionRef, expectedRevision, idempotencyKey }`
- resolve and validate the owner/storefront/channel/scope-bound Trip capability inside one Trips transaction, claim digest-only idempotency, freeze the exact revision, and invoke a narrow Catalog server-only composite Booking Session runtime
- require Catalog's existing composite quote authority to revalidate/price the frozen itinerary before persisting the Session
- return the standard Booking Session outcome plus anonymous capability material while redacting Trip snapshot/envelope/origin identifiers as `managed_itinerary` on non-staff outcomes
- keep Holds, Commit, payments, managed checkout, customer adoption, supplier operations, and compensation in the existing Catalog Booking Session lifecycle

## Authority / security properties
- no browser account, booking-engine, payment, provider, connection, source, or FX selectors
- same-origin mutation proof plus trusted active Storefront Channel context
- Trip capability resolution binds owner, buyer account, storefront, channel, market, locale, and currency
- exact revision is checked before idempotency claim, freeze, or Catalog invocation
- booking capability uses HMAC-SHA256 keyed by the 256-bit Trip capability and a domain-separated message; raw capabilities are never persisted
- idempotency claim stores only digests and binds capability digest + exact revision + owner + channel + scope
- snapshot, idempotency outcome, and Catalog Session use the same injected DB transaction; rejection/throw rolls the snapshot and claim back

## Stack ordering
This PR is based directly on current `main` at implementation start (`e06888cded`) and does not import code from #4459/#4461/#4464/#4465. It is independently reviewable. For a genuinely live production itinerary, merge after the provider wiring/consumer stack because those PRs supply the live flight/package redemption and booking implementations that this composite lifecycle coordinates.

## Validation
- [x] Biome formatted changed TypeScript files
- [x] `git diff --check`
- [x] focused changed-graph tests, lint/typecheck, and build in GitHub Actions
- [x] architecture checks with generated OpenAPI, dependency paths, and package dist configs synchronized
- [x] production operator image migration/smoke and packaged starter acceptance
- [x] database union, integration, and migration replay (Postgres 17 and 18)
- [x] exact-head full CI: [run 31294987369](https://github.com/voyant-travel/voyant/actions/runs/31294987369)
- [x] deterministic generators ran through Depot CI (`c3sdjsrd8r`, `ptsxgv95g1`, `psmzvz53pj`)
