### PR TITLE
Add closed live cruise storefront commerce

### DIFF
--- a/.changeset/live-cruise-storefront.md
+++ b/.changeset/live-cruise-storefront.md
@@ -1,0 +1,9 @@
+---
+"@voyant-travel/storefront": minor
+"@voyant-travel/cruises": patch
+"@voyant-travel/trips": patch
+"@voyant-travel/catalog-contracts": minor
+"@voyant-travel/catalog": patch
+---
+
+Add a closed provider-first live cruise shopping seam with exact admitted-source ownership, managed presentation FX, opaque offer references, and Catalog Booking Session reservation/reconciliation payloads.

--- a/docs/architecture/storefront-live-cruise-commerce.md
+++ b/docs/architecture/storefront-live-cruise-commerce.md
@@ -1,0 +1,13 @@
+# Storefront live cruise commerce
+
+The live cruise slice is a closed managed Storefront path. A browser may send only the cruise search vocabulary and an operator-enabled market, locale, and presentation currency. The response contains public sailing/cabin presentation plus a single-use opaque offer reference. Supplier, connection, source, credential, booking, payment, and FX authority never enters the theme contract.
+
+Only Catalog-admitted cruise source adapters are considered. A source must support live resolution, booking forwarding, and lookup by the stable supplier idempotency key. Sources without reconciliation are excluded. Request-only, wait-list, sold-out, and other non-reservable fare policies are excluded from sellable results. Per-source timeout and failure remain anonymous coverage counts.
+
+The opaque payload pins the exact Catalog source connection, encoded source reference, sailing, cabin, occupancy, fare, and supplier terms used at search time. The managed consumer must redeem it against the same storefront, channel, owner, market, locale, and currency; then create/quote/commit the existing Catalog Booking Session. Catalog revalidates through the same source adapter and its supplier-operation workflow owns idempotency and ambiguous-outcome reconciliation. Themes never reserve inventory or process payment.
+
+## Stack and remaining gates
+
+This change stacks immediately after the merged managed shopping provider wiring. Its `cruise-offer` redemption mapping must be added while restacking the opaque package consumer, before flight/package lifecycle and generic opaque-pagination stacks are consolidated. After those land, release Storefront and pin it in Platform's managed bridge before enabling `cruise.sailing.v1`, `cruise.pricing.v1`, or `cruise.quote.v1`.
+
+This OSS seam does not complete Themes Slice 6 by itself. The reference theme still needs live cruise search-to-checkout rendering, a second substantially different first-party theme must render tours and cruises through the same contract, and stable `v1` remains blocked on cross-theme/cross-vertical conformance and browser evidence.

--- a/packages/catalog-contracts/src/booking-engine/selection-contracts.test.ts
+++ b/packages/catalog-contracts/src/booking-engine/selection-contracts.test.ts
@@ -12,6 +12,38 @@ const ENTITY = {
 const CONTACT = { firstName: "Test", lastName: "Traveler", email: "test@example.com" }
 
 describe("booking selection contracts", () => {
+  it("preserves sourced cruise merchandise choices without provider authority", () => {
+    const parsed = bookingSelectionV1.parse({
+      entity: {
+        module: "cruises",
+        id: "cruise_1",
+        sourceKind: "cruise:provider",
+        sourceConnectionId: "server_connection",
+        sourceRef: "cruise_ref",
+      },
+      configure: {
+        pax: { adult: 2 },
+        sailingId: "encoded_sailing_ref",
+        cabinCategoryId: "encoded_cabin_ref",
+        occupancy: 2,
+        passengerComposition: { adults: 2 },
+        fareCode: "FLEX",
+        fareVariant: "cruise_only",
+        bookingTerms: { refundable: true },
+      },
+    })
+
+    expect(parsed.configure).toMatchObject({
+      sailingId: "encoded_sailing_ref",
+      cabinCategoryId: "encoded_cabin_ref",
+      occupancy: 2,
+      passengerComposition: { adults: 2 },
+      fareCode: "FLEX",
+      fareVariant: "cruise_only",
+      bookingTerms: { refundable: true },
+    })
+  })
+
   it("rejects malformed billing contact emails", () => {
     const parsed = bookingSelectionV1.safeParse({
       entity: ENTITY,

--- a/packages/catalog-contracts/src/booking-engine/selection-contracts.ts
+++ b/packages/catalog-contracts/src/booking-engine/selection-contracts.ts
@@ -128,6 +128,24 @@ export const bookingSelectionPublicV1 = z.object({
         )
         .optional(),
       cabinCategoryId: z.string().optional(),
+      /** Opaque cruise sailing choice. The target's server-owned source
+       * connection remains authoritative; this value cannot select a provider. */
+      sailingId: z.string().optional(),
+      /** Exact occupancy and passenger mix used to revalidate a sourced cruise fare. */
+      occupancy: z.number().int().positive().optional(),
+      passengerComposition: z
+        .object({
+          adults: z.number().int().nonnegative(),
+          children: z.number().int().nonnegative().optional(),
+          childAges: z.array(z.number().int().nonnegative()).optional(),
+          infants: z.number().int().nonnegative().optional(),
+          seniors: z.number().int().nonnegative().optional(),
+        })
+        .optional(),
+      fareCode: z.string().optional().nullable(),
+      fareVariant: z.enum(["cruise_only", "air_inclusive"]).optional().nullable(),
+      /** Supplier terms captured with the opaque offer and revalidated at commit. */
+      bookingTerms: z.record(z.string(), z.unknown()).optional().nullable(),
       cabinNumberId: z.string().optional(),
       // Sourced stays/package rate pin. The chosen room + rate plan (and its
       // `board` suffix) so the connect adapter re-resolves the EXACT offer the

--- a/packages/catalog/openapi/admin/catalog-booking.json
+++ b/packages/catalog/openapi/admin/catalog-booking.json
@@ -14501,6 +14501,53 @@
                           "cabinCategoryId": {
                             "type": "string"
                           },
+                          "sailingId": {
+                            "type": "string"
+                          },
+                          "occupancy": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0
+                          },
+                          "passengerComposition": {
+                            "type": "object",
+                            "properties": {
+                              "adults": {
+                                "type": "integer",
+                                "minimum": 0
+                              },
+                              "children": {
+                                "type": "integer",
+                                "minimum": 0
+                              },
+                              "childAges": {
+                                "type": "array",
+                                "items": {
+                                  "type": "integer",
+                                  "minimum": 0
+                                }
+                              },
+                              "infants": {
+                                "type": "integer",
+                                "minimum": 0
+                              },
+                              "seniors": {
+                                "type": "integer",
+                                "minimum": 0
+                              }
+                            },
+                            "required": ["adults"]
+                          },
+                          "fareCode": {
+                            "type": ["string", "null"]
+                          },
+                          "fareVariant": {
+                            "type": ["string", "null"],
+                            "enum": ["cruise_only", "air_inclusive", null]
+                          },
+                          "bookingTerms": {
+                            "type": ["object", "null"],
+                            "additionalProperties": {}
+                          },
                           "cabinNumberId": {
                             "type": "string"
                           },

--- a/packages/catalog/openapi/storefront/catalog-booking.json
+++ b/packages/catalog/openapi/storefront/catalog-booking.json
@@ -14501,6 +14501,53 @@
                           "cabinCategoryId": {
                             "type": "string"
                           },
+                          "sailingId": {
+                            "type": "string"
+                          },
+                          "occupancy": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0
+                          },
+                          "passengerComposition": {
+                            "type": "object",
+                            "properties": {
+                              "adults": {
+                                "type": "integer",
+                                "minimum": 0
+                              },
+                              "children": {
+                                "type": "integer",
+                                "minimum": 0
+                              },
+                              "childAges": {
+                                "type": "array",
+                                "items": {
+                                  "type": "integer",
+                                  "minimum": 0
+                                }
+                              },
+                              "infants": {
+                                "type": "integer",
+                                "minimum": 0
+                              },
+                              "seniors": {
+                                "type": "integer",
+                                "minimum": 0
+                              }
+                            },
+                            "required": ["adults"]
+                          },
+                          "fareCode": {
+                            "type": ["string", "null"]
+                          },
+                          "fareVariant": {
+                            "type": ["string", "null"],
+                            "enum": ["cruise_only", "air_inclusive", null]
+                          },
+                          "bookingTerms": {
+                            "type": ["object", "null"],
+                            "additionalProperties": {}
+                          },
                           "cabinNumberId": {
                             "type": "string"
                           },

--- a/packages/catalog/src/booking-engine/quote-support.test.ts
+++ b/packages/catalog/src/booking-engine/quote-support.test.ts
@@ -3,6 +3,32 @@ import { describe, expect, it } from "vitest"
 import { engineParametersFromSelection } from "./quote-support.js"
 
 describe("Connect package Booking Session parameters", () => {
+  it("forwards exact cruise choices and terms without source authority", () => {
+    const parameters = engineParametersFromSelection(undefined, {
+      configure: {
+        sailingId: "sailing_ref",
+        cabinCategoryId: "cabin_ref",
+        occupancy: 2,
+        passengerComposition: { adults: 2 },
+        fareCode: "FLEX",
+        fareVariant: "cruise_only",
+        bookingTerms: { refundable: true },
+      },
+    })
+
+    expect(parameters).toMatchObject({
+      sailingId: "sailing_ref",
+      cabinCategoryId: "cabin_ref",
+      occupancy: 2,
+      passengerComposition: { adults: 2 },
+      fareCode: "FLEX",
+      fareVariant: "cruise_only",
+      bookingTerms: { refundable: true },
+    })
+    expect(parameters).not.toHaveProperty("connectionId")
+    expect(parameters).not.toHaveProperty("providerId")
+  })
+
   it("projects stable package pins without accepting a provider selector", () => {
     const parameters = engineParametersFromSelection(
       undefined,

--- a/packages/catalog/src/booking-engine/quote-support.ts
+++ b/packages/catalog/src/booking-engine/quote-support.ts
@@ -49,6 +49,7 @@ export function engineParametersFromSelection(
     "passengerComposition",
     "fareCode",
     "fareVariant",
+    "bookingTerms",
   ] as const) {
     if (configure?.[key] != null && next[key] == null) next[key] = configure[key]
   }

--- a/packages/catalog/src/booking-engine/sessions-production.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-production.test.ts
@@ -110,6 +110,30 @@ async function createAnonymousSession(
 }
 
 describe("normalizeProductSelection", () => {
+  it("normalizes sourced cruise choices while preserving passenger ages and terms", () => {
+    const normalized = normalizeProductSelection(PRODUCT_TARGET, {
+      configure: {
+        sailingId: " encoded_sailing_ref ",
+        cabinCategoryId: " encoded_cabin_ref ",
+        occupancy: 3,
+        passengerComposition: { adults: 2, children: 1, childAges: [9] },
+        fareCode: " FLEX ",
+        fareVariant: "cruise_only",
+        bookingTerms: { refundable: true },
+      },
+    })
+
+    expect(normalized.configure).toEqual({
+      sailingId: "encoded_sailing_ref",
+      cabinCategoryId: "encoded_cabin_ref",
+      occupancy: 3,
+      passengerComposition: { adults: 2, children: 1, childAges: [9] },
+      fareCode: "FLEX",
+      fareVariant: "cruise_only",
+      bookingTerms: { refundable: true },
+    })
+  })
+
   it("projects product selections to the server-owned booking session shape", () => {
     const normalized = normalizeProductSelection(PRODUCT_TARGET, {
       configure: {

--- a/packages/catalog/src/booking-engine/sessions-production.ts
+++ b/packages/catalog/src/booking-engine/sessions-production.ts
@@ -1027,12 +1027,15 @@ export function normalizeBookingSelection(
       cabinCategoryId: stringValue(configure?.cabinCategoryId),
       cabinCategoryRef: normalizeSourceRef(configure?.cabinCategoryRef),
       occupancy: positiveInteger(configure?.occupancy),
-      passengerComposition: normalizeStringNumberMap(asRecord(configure?.passengerComposition)),
+      passengerComposition: normalizePassengerComposition(
+        asRecord(configure?.passengerComposition),
+      ),
       fareCode: stringValue(configure?.fareCode),
       fareVariant:
         configure?.fareVariant === "cruise_only" || configure?.fareVariant === "air_inclusive"
           ? configure.fareVariant
           : undefined,
+      bookingTerms: asRecord(configure?.bookingTerms),
     }),
     billing: pruneEmpty({
       buyerType:
@@ -1268,6 +1271,19 @@ function normalizeStringNumberMap(record: Record<string, unknown> | undefined) {
   )
 }
 
+function normalizePassengerComposition(record: Record<string, unknown> | undefined) {
+  if (!record) return undefined
+  return pruneEmpty({
+    adults: nonnegativeInteger(record.adults),
+    children: nonnegativeInteger(record.children),
+    childAges: arrayValue(record.childAges)
+      ?.map(nonnegativeInteger)
+      .filter((value): value is number => value != null),
+    infants: nonnegativeInteger(record.infants),
+    seniors: nonnegativeInteger(record.seniors),
+  })
+}
+
 function normalizeStringMap(record: Record<string, unknown> | undefined) {
   if (!record) return undefined
   return pruneEmpty(
@@ -1306,6 +1322,10 @@ function stringValue(value: unknown): string | undefined {
 
 function positiveInteger(value: unknown): number | undefined {
   return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : undefined
+}
+
+function nonnegativeInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : undefined
 }
 
 function numberValue(value: unknown): number | undefined {

--- a/packages/cruises/src/adapters/index.ts
+++ b/packages/cruises/src/adapters/index.ts
@@ -396,6 +396,7 @@ export {
 
 // ---------- catalog SourceAdapter shim ----------
 
+export { encodeSourceRef } from "../lib/key.js"
 export {
   type CompatibilityMappingResult,
   type ConnectCabinRoomType,
@@ -409,7 +410,6 @@ export {
   mapConnectInclusionKind,
   mapConnectPriceComponentKind,
 } from "./connect-compat.js"
-
 export {
   type CruiseSourceAdapterShim,
   type CruiseSourceAdapterShimOptions,

--- a/packages/storefront/package.json
+++ b/packages/storefront/package.json
@@ -82,6 +82,7 @@
     "@voyant-travel/catalog-contracts": "workspace:^",
     "@voyant-travel/commerce": "workspace:^",
     "@voyant-travel/core": "workspace:^",
+    "@voyant-travel/cruises": "workspace:^",
     "@voyant-travel/db": "workspace:^",
     "@voyant-travel/data-sdk": "^0.8.0",
     "@voyant-travel/finance": "workspace:^",

--- a/packages/storefront/src/shopping/closed-live-provider.ts
+++ b/packages/storefront/src/shopping/closed-live-provider.ts
@@ -1,10 +1,22 @@
 import type { CatalogRuntimeServices } from "@voyant-travel/catalog/runtime-contracts"
 import type { VoyantRuntimeHostPrimitives } from "@voyant-travel/core"
+import {
+  type CruiseAdapter,
+  type CruiseSourceAdapterShim,
+  type ExternalCabinCategory,
+  type ExternalPriceRow,
+  type ExternalSailing,
+  encodeSourceRef,
+  type SourceRef,
+} from "@voyant-travel/cruises/adapters"
+import { composeQuote } from "@voyant-travel/cruises/service-pricing"
 import type { FlightsRuntime } from "@voyant-travel/flights"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import { createStorefrontShoppingLiveProvider } from "./live-provider.js"
 import type {
+  StorefrontCruiseSource,
+  StorefrontCruiseSourceOffer,
   StorefrontDynamicPackageSourceProvider,
   StorefrontShoppingLiveProvider,
   StorefrontShoppingMarketProvider,
@@ -116,7 +128,227 @@ export function createClosedStorefrontShoppingLiveProvider(
           },
         }
       : {}),
+    cruises: {
+      async resolveSources(input) {
+        await assertActiveScope(options.markets, input.context, input.scope)
+        const registry = await options.catalogServices.ensureSourceRegistry(
+          options.primitives.env(undefined),
+        )
+        return registry.connections().flatMap((connectionId) => {
+          const adapter = registry.resolveByConnection(connectionId)
+          if (!isAdmittedCruiseShim(adapter)) return []
+          return [cruiseSource(connectionId, adapter)]
+        })
+      },
+    },
   })
+}
+
+function isAdmittedCruiseShim(value: unknown): value is CruiseSourceAdapterShim {
+  if (!value || typeof value !== "object") return false
+  const adapter = value as Partial<CruiseSourceAdapterShim>
+  return (
+    adapter.capabilities?.verticals.includes("cruises") === true &&
+    adapter.capabilities.supportsLiveResolution === true &&
+    adapter.capabilities.supportsBookingForwarding === true &&
+    typeof adapter.liveResolve === "function" &&
+    typeof adapter.reserve === "function" &&
+    typeof adapter.cruiseAdapter?.listEntries === "function" &&
+    typeof adapter.cruiseAdapter?.getBookingByIdempotencyKey === "function"
+  )
+}
+
+function cruiseSource(
+  connectionId: string,
+  sourceAdapter: CruiseSourceAdapterShim,
+): StorefrontCruiseSource {
+  const adapter = sourceAdapter.cruiseAdapter
+  return {
+    commitPolicy: "reserve_with_idempotent_reconciliation",
+    async search(input) {
+      const page = await adapter.listEntries({ limit: Math.min(100, input.limit * 5) })
+      const offers = []
+      let degraded = page.nextCursor !== undefined
+      for (const entry of page.entries) {
+        if (offers.length >= input.limit) break
+        if (!matchesCruiseQuery(entry, input.query, input.cruiseTypes)) continue
+        try {
+          const sailings = await adapter.listSailingsForCruise(entry.sourceRef)
+          for (const sailing of sailings) {
+            if (offers.length >= input.limit) break
+            if (!matchesSailing(sailing, input.departureDateFrom, input.departureDateTo)) continue
+            const offer = await cruiseOffer({
+              adapter,
+              sourceAdapter,
+              connectionId,
+              entry,
+              sailing,
+              travelers: input.travelers,
+            })
+            if (offer) offers.push(offer)
+          }
+        } catch {
+          degraded = true
+        }
+      }
+      return {
+        offers,
+        status: degraded ? "partial" : offers.length > 0 ? "ok" : "empty",
+      }
+    },
+  }
+}
+
+async function cruiseOffer(input: {
+  adapter: CruiseAdapter
+  sourceAdapter: CruiseSourceAdapterShim
+  connectionId: string
+  entry: Awaited<ReturnType<CruiseAdapter["listEntries"]>>["entries"][number]
+  sailing: ExternalSailing
+  travelers: {
+    adults: number
+    childrenAges?: number[]
+    infants?: number
+    seniors?: number
+  }
+}): Promise<StorefrontCruiseSourceOffer | undefined> {
+  const occupancy =
+    input.travelers.adults +
+    (input.travelers.childrenAges?.length ?? 0) +
+    (input.travelers.infants ?? 0) +
+    (input.travelers.seniors ?? 0)
+  const [prices, ship] = await Promise.all([
+    input.adapter.fetchSailingPricing(input.sailing.sourceRef),
+    input.adapter.fetchShip(input.sailing.shipRef),
+  ])
+  if (!ship) return undefined
+  const bookable = prices.flatMap((price) => {
+    const cabin = ship.categories?.find(({ sourceRef }) =>
+      sourceRefsMatch(sourceRef, price.cabinCategoryRef),
+    )
+    if (!cabin || !isBookablePrice(price, occupancy, cabin)) return []
+    const quote = externalQuote(price, occupancy)
+    return [{ price, cabin, quote }]
+  })
+  bookable.sort(
+    (left, right) => Number(left.quote.totalForCabin) - Number(right.quote.totalForCabin),
+  )
+  const selected = bookable[0]
+  if (!selected) return undefined
+  const passengerComposition = {
+    adults: input.travelers.adults,
+    ...(input.travelers.childrenAges?.length
+      ? {
+          children: input.travelers.childrenAges.length,
+          childAges: input.travelers.childrenAges,
+        }
+      : {}),
+    ...(input.travelers.infants ? { infants: input.travelers.infants } : {}),
+    ...(input.travelers.seniors ? { seniors: input.travelers.seniors } : {}),
+  }
+  return {
+    nativePrice: { amount: selected.quote.totalForCabin, currency: selected.quote.currency },
+    title: input.entry.name,
+    cruiseType: input.entry.cruiseType,
+    lineName: input.entry.lineName,
+    shipName: ship.name,
+    departureDate: input.sailing.departureDate,
+    returnDate: input.sailing.returnDate,
+    nights: input.entry.nights,
+    ...(input.sailing.embarkPortName ? { embarkPortName: input.sailing.embarkPortName } : {}),
+    ...(input.sailing.disembarkPortName
+      ? { disembarkPortName: input.sailing.disembarkPortName }
+      : {}),
+    cabinName: selected.cabin.name,
+    availability: selected.price.availability,
+    ...(input.entry.heroImageUrl
+      ? { image: { url: input.entry.heroImageUrl, alt: input.entry.name } }
+      : {}),
+    selection: {
+      target: {
+        entityModule: "cruises",
+        entityId: `cruise:${input.entry.sourceRef.externalId}`,
+        sourceKind: input.sourceAdapter.kind,
+        sourceConnectionId: input.connectionId,
+        sourceRef: encodeSourceRef(input.entry.sourceRef),
+      },
+      configure: {
+        sailingId: encodeSourceRef(input.sailing.sourceRef),
+        cabinCategoryId: encodeSourceRef(selected.price.cabinCategoryRef),
+        occupancy,
+        passengerComposition,
+        fareCode: selected.price.fareCode ?? null,
+        fareVariant: selected.price.fareVariant ?? "cruise_only",
+        bookingTerms: selected.price.bookingTerms ?? null,
+      },
+    },
+  }
+}
+
+function matchesCruiseQuery(
+  entry: Awaited<ReturnType<CruiseAdapter["listEntries"]>>["entries"][number],
+  query: string | undefined,
+  cruiseTypes: readonly string[] | undefined,
+): boolean {
+  if (cruiseTypes && !cruiseTypes.includes(entry.cruiseType)) return false
+  if (!query) return true
+  const needle = query.trim().toLocaleLowerCase()
+  return [entry.name, entry.lineName, entry.shipName]
+    .filter((value): value is string => typeof value === "string")
+    .some((value) => value.toLocaleLowerCase().includes(needle))
+}
+
+function matchesSailing(
+  sailing: ExternalSailing,
+  from: string | undefined,
+  to: string | undefined,
+): boolean {
+  if (from && sailing.departureDate < from) return false
+  if (to && sailing.departureDate > to) return false
+  return sailing.salesStatus === undefined || sailing.salesStatus === "open"
+}
+
+function isBookablePrice(
+  price: ExternalPriceRow,
+  occupancy: number,
+  cabin: ExternalCabinCategory,
+): price is ExternalPriceRow & { availability: "available" | "limited" } {
+  return (
+    price.occupancy === occupancy &&
+    occupancy >= cabin.minOccupancy &&
+    occupancy <= cabin.maxOccupancy &&
+    (price.availability === "available" || price.availability === "limited") &&
+    price.requiresRequest !== true
+  )
+}
+
+function externalQuote(price: ExternalPriceRow, occupancy: number) {
+  return composeQuote({
+    price: {
+      pricePerPerson: price.pricePerPerson,
+      originalPricePerPerson: price.originalPricePerPerson ?? null,
+      secondGuestPricePerPerson: price.secondGuestPricePerPerson ?? null,
+      singlePricePerPerson: price.singlePricePerPerson ?? null,
+      singleSupplementPercent: price.singleSupplementPercent ?? null,
+      currency: price.currency,
+      fareCode: price.fareCode ?? null,
+      fareCodeName: price.fareCodeName ?? null,
+      fareVariant: price.fareVariant ?? "cruise_only",
+      earlyBookingDeadline: price.earlyBookingDeadline ?? null,
+      earlyBookingBonusDescription: price.earlyBookingBonusDescription ?? null,
+    },
+    components: (price.components ?? []).map((component) => ({
+      ...component,
+      label: component.label ?? null,
+    })),
+    occupancy,
+    guestCount: occupancy,
+    ...(price.bookingTerms !== undefined ? { bookingTerms: price.bookingTerms } : {}),
+  })
+}
+
+function sourceRefsMatch(left: SourceRef, right: SourceRef): boolean {
+  return encodeSourceRef(left) === encodeSourceRef(right)
 }
 
 async function assertActiveScope(

--- a/packages/storefront/src/shopping/live-provider.ts
+++ b/packages/storefront/src/shopping/live-provider.ts
@@ -10,8 +10,11 @@ import {
   type MergedFlightOffer,
 } from "@voyant-travel/flights"
 import type {
+  StorefrontCruiseSource,
+  StorefrontCruiseSourceProvider,
   StorefrontDynamicPackageSource,
   StorefrontDynamicPackageSourceProvider,
+  StorefrontInternalCruiseOffer,
   StorefrontInternalPackageOffer,
   StorefrontInternalStayOffer,
   StorefrontLiveContinuation,
@@ -75,6 +78,7 @@ export interface CreateStorefrontShoppingLiveProviderOptions {
   flights?: StorefrontLiveFlightFanOutResolver
   stays?: StorefrontLiveStayFanOutResolver
   packages?: StorefrontDynamicPackageSourceProvider
+  cruises?: StorefrontCruiseSourceProvider
   perSourceTimeoutMs?: number
 }
 
@@ -245,6 +249,47 @@ export function createStorefrontShoppingLiveProvider(
               : [],
           ),
         ),
+      }
+    },
+
+    async searchCruises(input) {
+      if (!options.cruises) return unavailablePage()
+      const sources = await options.cruises.resolveSources({
+        context: input.context,
+        scope: input.scope,
+      })
+      const admitted = sources.filter(
+        ({ commitPolicy }) => commitPolicy === "reserve_with_idempotent_reconciliation",
+      )
+      if (admitted.length === 0) return unavailablePage()
+      const pages = await Promise.all(
+        admitted.map((source) =>
+          runCruiseSource(
+            source,
+            {
+              ...(input.intent.query ? { query: input.intent.query } : {}),
+              ...(input.intent.departureDateFrom
+                ? { departureDateFrom: input.intent.departureDateFrom }
+                : {}),
+              ...(input.intent.departureDateTo
+                ? { departureDateTo: input.intent.departureDateTo }
+                : {}),
+              travelers: input.intent.travelers,
+              ...(input.intent.cruiseTypes ? { cruiseTypes: input.intent.cruiseTypes } : {}),
+              limit: input.intent.limit ?? 20,
+              scope: {
+                marketId: input.scope.marketId,
+                locale: input.scope.locale,
+                currency: input.scope.currency,
+              },
+            },
+            options.perSourceTimeoutMs ?? 5_000,
+          ),
+        ),
+      )
+      return {
+        items: pages.flatMap(({ offers }) => offers),
+        sources: pages.map(({ status }) => ({ status })),
       }
     },
   }
@@ -476,6 +521,25 @@ function stayOwnedKey(entityModule: string): string {
 
 function packageKey(sourceKey: string): string {
   return `package:${sourceKey}`
+}
+
+async function runCruiseSource(
+  source: StorefrontCruiseSource,
+  request: Parameters<StorefrontCruiseSource["search"]>[0],
+  timeoutMs: number,
+): Promise<{
+  offers: readonly StorefrontInternalCruiseOffer[]
+  status: StorefrontLiveSourceStatus
+}> {
+  try {
+    const result = await withTimeout(source.search(request), timeoutMs)
+    return {
+      offers: result.offers.map((offer) => ({ ...offer })),
+      status: result.status ?? (result.offers.length > 0 ? "ok" : "empty"),
+    }
+  } catch (error) {
+    return { offers: [], status: error instanceof SourceTimeoutError ? "timeout" : "error" }
+  }
 }
 
 class SourceTimeoutError extends Error {}

--- a/packages/storefront/src/shopping/managed-runtime.ts
+++ b/packages/storefront/src/shopping/managed-runtime.ts
@@ -79,6 +79,8 @@ export function createManagedStorefrontShoppingRuntime(
           return searchStays(options, context, input.scope, input.intent, now)
         case "package":
           return searchPackages(options, context, input.scope, input.intent, now)
+        case "cruise":
+          return searchCruises(options, context, input.scope, input.intent, now)
       }
     },
   }
@@ -231,6 +233,7 @@ function publicCatalogItem(
 type FlightIntent = Extract<StorefrontShoppingIntent, { kind: "flight" }>
 type StayIntent = Extract<StorefrontShoppingIntent, { kind: "stay" }>
 type PackageIntent = Extract<StorefrontShoppingIntent, { kind: "package" }>
+type CruiseIntent = Extract<StorefrontShoppingIntent, { kind: "cruise" }>
 
 async function searchFlights(
   options: ManagedStorefrontShoppingRuntimeOptions,
@@ -541,6 +544,46 @@ function scopeBinding(scope: StorefrontResolvedScope) {
   return { marketId: scope.marketId, locale: scope.locale, currency: scope.currency }
 }
 
+async function searchCruises(
+  options: ManagedStorefrontShoppingRuntimeOptions,
+  context: StorefrontShoppingContext,
+  scope: StorefrontResolvedScope,
+  intent: CruiseIntent,
+  now: () => Date,
+): Promise<StorefrontShoppingResult> {
+  const page = await options.live.searchCruises({ context, scope, intent })
+  const normalized = await normalizeLive(page, scope.currency, options.quoteFx)
+  const offers = await Promise.all(
+    normalized.items.map(async ({ item, price }) => {
+      const issued = await issueBoundedReference(options.references, now, {
+        purpose: "cruise-offer",
+        context,
+        scope,
+        payload: { selection: item.selection, providerData: item.providerData },
+        replay: "single-use",
+      })
+      return {
+        offerRef: issued.ref,
+        title: item.title,
+        cruiseType: item.cruiseType,
+        lineName: item.lineName,
+        shipName: item.shipName,
+        departureDate: item.departureDate,
+        returnDate: item.returnDate,
+        nights: item.nights,
+        ...(item.embarkPortName ? { embarkPortName: item.embarkPortName } : {}),
+        ...(item.disembarkPortName ? { disembarkPortName: item.disembarkPortName } : {}),
+        cabinName: item.cabinName,
+        availability: item.availability,
+        ...(item.image ? { image: item.image } : {}),
+        price,
+        expiresAt: earlierExpiry(issued.expiresAt, item.expiresAt),
+      }
+    }),
+  )
+  return { kind: "cruise", scope, offers, coverage: coverage(page, normalized.dropped) }
+}
+
 async function normalizeLive<T extends { nativePrice: { amount: string; currency: string } }>(
   page: StorefrontLiveSearchPage<T>,
   currency: string,
@@ -588,7 +631,7 @@ async function issueBoundedReference(
   issuer: StorefrontOpaqueReferenceIssuer,
   now: () => Date,
   input: {
-    purpose: "catalog-item" | "flight-offer" | "stay-offer" | "package-offer"
+    purpose: "catalog-item" | "flight-offer" | "stay-offer" | "package-offer" | "cruise-offer"
     context: StorefrontShoppingContext
     scope: StorefrontResolvedScope
     payload: Readonly<Record<string, unknown>>

--- a/packages/storefront/src/shopping/provider-ports.ts
+++ b/packages/storefront/src/shopping/provider-ports.ts
@@ -64,6 +64,7 @@ export interface StorefrontShoppingCatalogProvider {
 type FlightIntent = Extract<StorefrontShoppingIntent, { kind: "flight" }>
 type StayIntent = Extract<StorefrontShoppingIntent, { kind: "stay" }>
 type PackageIntent = Extract<StorefrontShoppingIntent, { kind: "package" }>
+type CruiseIntent = Extract<StorefrontShoppingIntent, { kind: "cruise" }>
 
 export interface StorefrontDynamicPackageSourceOffer {
   nativePrice: { amount: string; currency: string }
@@ -134,6 +135,49 @@ export interface StorefrontDynamicPackageSourceProvider {
   }): Promise<readonly StorefrontDynamicPackageSource[]>
 }
 
+export interface StorefrontCruiseSourceOffer {
+  nativePrice: CatalogMoney
+  title: string
+  cruiseType: "ocean" | "river" | "expedition" | "coastal"
+  lineName: string
+  shipName: string
+  departureDate: string
+  returnDate: string
+  nights: number
+  embarkPortName?: string
+  disembarkPortName?: string
+  cabinName: string
+  availability: "available" | "limited"
+  image?: { url: string; alt?: string }
+  /** Exact admitted source ownership and booking configuration; opaque outside the server. */
+  selection: Readonly<Record<string, unknown>>
+}
+
+export interface StorefrontCruiseSource {
+  /** Only sources with this exact commit/reconciliation policy may be admitted. */
+  commitPolicy: "reserve_with_idempotent_reconciliation"
+  search(input: {
+    query?: string
+    departureDateFrom?: string
+    departureDateTo?: string
+    travelers: CruiseIntent["travelers"]
+    cruiseTypes?: CruiseIntent["cruiseTypes"]
+    limit: number
+    scope: Pick<StorefrontResolvedScope, "marketId" | "locale" | "currency">
+  }): Promise<{
+    offers: readonly StorefrontCruiseSourceOffer[]
+    status?: "ok" | "partial" | "empty"
+  }>
+}
+
+/** Closed resolver over Catalog-admitted cruise connections and credentials. */
+export interface StorefrontCruiseSourceProvider {
+  resolveSources(input: {
+    context: StorefrontShoppingContext
+    scope: StorefrontResolvedScope
+  }): Promise<readonly StorefrontCruiseSource[]>
+}
+
 export type StorefrontLiveSourceStatus =
   | "ok"
   | "partial"
@@ -197,6 +241,21 @@ export interface StorefrontInternalPackageOffer extends InternalOffer {
   image?: { url: string; alt?: string }
 }
 
+export interface StorefrontInternalCruiseOffer extends InternalOffer {
+  title: string
+  cruiseType: "ocean" | "river" | "expedition" | "coastal"
+  lineName: string
+  shipName: string
+  departureDate: string
+  returnDate: string
+  nights: number
+  embarkPortName?: string
+  disembarkPortName?: string
+  cabinName: string
+  availability: "available" | "limited"
+  image?: { url: string; alt?: string }
+}
+
 /**
  * Closed live-search adapter. Implementations call the owned/sourced flight and
  * availability fan-outs directly and map their internal results here.
@@ -220,6 +279,11 @@ export interface StorefrontShoppingLiveProvider {
     intent: PackageIntent
     continuation?: StorefrontLiveContinuation
   }): Promise<StorefrontLiveSearchPage<StorefrontInternalPackageOffer>>
+  searchCruises(input: {
+    context: StorefrontShoppingContext
+    scope: StorefrontResolvedScope
+    intent: CruiseIntent
+  }): Promise<StorefrontLiveSearchPage<StorefrontInternalCruiseOffer>>
 }
 
 function methodsPort<T>(id: string, methods: readonly string[]) {
@@ -248,7 +312,7 @@ export const storefrontShoppingCatalogProviderPort = methodsPort<StorefrontShopp
 )
 export const storefrontShoppingLiveProviderPort = methodsPort<StorefrontShoppingLiveProvider>(
   "storefront.shopping.live-provider",
-  ["searchFlights", "searchStays", "searchPackages"],
+  ["searchFlights", "searchStays", "searchPackages", "searchCruises"],
 )
 export const storefrontDynamicPackageSourceProviderPort =
   methodsPort<StorefrontDynamicPackageSourceProvider>(

--- a/packages/storefront/src/shopping/runtime-port.ts
+++ b/packages/storefront/src/shopping/runtime-port.ts
@@ -33,7 +33,13 @@ export interface StorefrontOpaqueReferenceIssuer {
    * managed shopping runtime never resolves or commits an offer itself.
    */
   issue(input: {
-    purpose: "catalog-item" | "flight-offer" | "stay-offer" | "package-offer" | "live-continuation"
+    purpose:
+      | "catalog-item"
+      | "flight-offer"
+      | "stay-offer"
+      | "package-offer"
+      | "cruise-offer"
+      | "live-continuation"
     storefrontId: string
     channelId: string
     /** Trusted capability owner binding. Anonymous owners are explicitly null. */

--- a/packages/storefront/src/shopping/schemas.ts
+++ b/packages/storefront/src/shopping/schemas.ts
@@ -220,11 +220,40 @@ export const storefrontPackageSearchIntentSchema = z
     }
   })
 
+export const storefrontCruiseSearchIntentSchema = z
+  .object({
+    kind: z.literal("cruise"),
+    query: z.string().min(1).max(300).optional(),
+    departureDateFrom: isoDateSchema.optional(),
+    departureDateTo: isoDateSchema.optional(),
+    travelers: travelersSchema.extend({ seniors: z.number().int().min(0).max(20).optional() }),
+    cruiseTypes: z
+      .array(z.enum(["ocean", "river", "expedition", "coastal"]))
+      .max(4)
+      .optional(),
+    limit: z.number().int().min(1).max(50).optional(),
+  })
+  .strict()
+  .superRefine((intent, ctx) => {
+    if (
+      intent.departureDateFrom !== undefined &&
+      intent.departureDateTo !== undefined &&
+      intent.departureDateTo < intent.departureDateFrom
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["departureDateTo"],
+        message: "departureDateTo must not be before departureDateFrom",
+      })
+    }
+  })
+
 export const storefrontShoppingIntentSchema = z.discriminatedUnion("kind", [
   storefrontIndexedInspirationIntentSchema,
   storefrontFlightSearchIntentSchema,
   storefrontStaySearchIntentSchema,
   storefrontPackageSearchIntentSchema,
+  storefrontCruiseSearchIntentSchema,
 ])
 
 /** Complete browser request. `.strict()` at every object boundary rejects trust-plane selectors. */
@@ -358,16 +387,46 @@ export const storefrontPackageSearchResultSchema = z
   })
   .strict()
 
+const cruiseOfferSchema = z
+  .object({
+    offerRef: opaqueRefSchema,
+    title: z.string().min(1),
+    cruiseType: z.enum(["ocean", "river", "expedition", "coastal"]),
+    lineName: z.string().min(1),
+    shipName: z.string().min(1),
+    departureDate: isoDateSchema,
+    returnDate: isoDateSchema,
+    nights: z.number().int().min(1),
+    embarkPortName: z.string().optional(),
+    disembarkPortName: z.string().optional(),
+    cabinName: z.string().min(1),
+    availability: z.enum(["available", "limited"]),
+    image: imageSchema.optional(),
+    price: storefrontPresentationMoneySchema,
+    expiresAt: z.string().datetime({ offset: true }),
+  })
+  .strict()
+
+export const storefrontCruiseSearchResultSchema = z
+  .object({
+    kind: z.literal("cruise"),
+    scope: storefrontResolvedScopeSchema,
+    offers: z.array(cruiseOfferSchema),
+    coverage: coverageSchema,
+  })
+  .strict()
+
 export const storefrontShoppingResultSchema = z.discriminatedUnion("kind", [
   storefrontIndexedInspirationResultSchema,
   storefrontFlightSearchResultSchema,
   storefrontStaySearchResultSchema,
   storefrontPackageSearchResultSchema,
+  storefrontCruiseSearchResultSchema,
 ])
 
 const tripOfferSelectionSchema = z
   .object({
-    kind: z.enum(["product", "flight", "stay", "package"]),
+    kind: z.enum(["product", "flight", "stay", "package", "cruise"]),
     offerRef: opaqueRefSchema,
     quantity: z.number().int().min(1).max(99).optional(),
   })
@@ -399,7 +458,7 @@ export const storefrontTripSelectionUpdateSchema = z
 const tripSelectionItemSchema = z
   .object({
     itemRef: opaqueRefSchema,
-    kind: z.enum(["product", "flight", "stay", "package"]),
+    kind: z.enum(["product", "flight", "stay", "package", "cruise"]),
     quantity: z.number().int().min(1),
   })
   .strict()

--- a/packages/storefront/tests/unit/cruise-live-shopping.test.ts
+++ b/packages/storefront/tests/unit/cruise-live-shopping.test.ts
@@ -1,0 +1,290 @@
+import { type CruiseAdapter, cruiseAdapterToSourceAdapter } from "@voyant-travel/cruises/adapters"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  createClosedStorefrontShoppingLiveProvider,
+  createManagedStorefrontShoppingRuntime,
+  type StorefrontResolvedScope,
+  type StorefrontShoppingContext,
+} from "../../src/shopping/index.js"
+
+const NOW = new Date("2026-08-09T10:00:00.000Z")
+const context = {
+  storefrontId: "storefront_trusted",
+  channelId: "channel_trusted",
+  userId: "user_trusted",
+  buyerAccountId: "buyer_trusted",
+} satisfies StorefrontShoppingContext
+const scope = {
+  marketId: "market_ro",
+  locale: "ro-RO",
+  currency: "EUR",
+  available: { marketIds: ["market_ro"], locales: ["ro-RO"], currencies: ["EUR"] },
+} satisfies StorefrontResolvedScope
+const intent = {
+  kind: "cruise" as const,
+  query: "Danube",
+  departureDateFrom: "2027-04-01",
+  departureDateTo: "2027-04-30",
+  travelers: { adults: 2 },
+  cruiseTypes: ["river" as const],
+}
+
+function primitives() {
+  return {
+    env: vi.fn(() => ({ CRUISE_TOKEN: "credential_secret" })),
+    database: { resolve: vi.fn(() => ({ id: "db" })) },
+    storage: {},
+    events: {},
+    config: {},
+  } as never
+}
+
+function markets() {
+  return {
+    listActiveMarkets: vi.fn(async () => [
+      {
+        id: scope.marketId,
+        defaultLocale: scope.locale,
+        defaultCurrency: scope.currency,
+        locales: [scope.locale],
+        currencies: [scope.currency],
+      },
+    ]),
+  }
+}
+
+function cruiseAdapter(overrides: Partial<CruiseAdapter> = {}): CruiseAdapter {
+  const cruiseRef = { connectionId: "provider_connection_secret", externalId: "cruise_secret" }
+  const sailingRef = { connectionId: "provider_connection_secret", externalId: "sailing_secret" }
+  const shipRef = { connectionId: "provider_connection_secret", externalId: "ship_secret" }
+  const cabinRef = { connectionId: "provider_connection_secret", externalId: "cabin_secret" }
+  return {
+    name: "provider-secret",
+    version: "1.0.0",
+    async listEntries() {
+      return {
+        entries: [
+          {
+            sourceRef: cruiseRef,
+            name: "Danube Discovery",
+            slug: "danube-discovery",
+            cruiseType: "river",
+            lineName: "Public Cruise Line",
+            shipName: "Public Ship",
+            nights: 7,
+            heroImageUrl: "https://images.example.test/danube.jpg",
+          },
+        ],
+      }
+    },
+    async *searchProjection() {},
+    async fetchCruise() {
+      return null
+    },
+    async fetchSailing() {
+      return null
+    },
+    async fetchSailingPricing() {
+      return [
+        {
+          cabinCategoryRef: cabinRef,
+          occupancy: 2,
+          fareCode: "PUBLIC",
+          fareVariant: "cruise_only",
+          currency: "RON",
+          pricePerPerson: "2500.00",
+          availability: "limited",
+          bookingTerms: { paymentTerms: { depositPercent: "20" } },
+        },
+      ]
+    },
+    async fetchSailingItinerary() {
+      return []
+    },
+    async fetchShip() {
+      return {
+        sourceRef: shipRef,
+        name: "Public Ship",
+        slug: "public-ship",
+        shipType: "river",
+        categories: [
+          {
+            sourceRef: cabinRef,
+            code: "BAL",
+            name: "Balcony cabin",
+            roomType: "balcony",
+            minOccupancy: 1,
+            maxOccupancy: 2,
+          },
+        ],
+      }
+    },
+    async listSailingsForCruise() {
+      return [
+        {
+          sourceRef: sailingRef,
+          cruiseRef,
+          shipRef,
+          departureDate: "2027-04-12",
+          returnDate: "2027-04-19",
+          embarkPortName: "Budapest",
+          disembarkPortName: "Bucharest",
+          salesStatus: "open",
+        },
+      ]
+    },
+    async createBooking() {
+      return { connectorBookingRef: "booking_secret", connectorStatus: "confirmed" }
+    },
+    async getBookingByIdempotencyKey() {
+      return null
+    },
+    ...overrides,
+  }
+}
+
+function closedProvider(
+  adapters: Array<[string, ReturnType<typeof cruiseAdapterToSourceAdapter>]>,
+) {
+  const registry = {
+    connections: () => adapters.map(([id]) => id),
+    resolveByConnection: (id: string) => adapters.find(([candidate]) => candidate === id)?.[1],
+  }
+  return createClosedStorefrontShoppingLiveProvider({
+    primitives: primitives(),
+    catalogServices: {
+      ensureSourceRegistry: vi.fn(async () => registry),
+      getOwnedAvailabilitySearchHandlers: () => ({ modules: () => [], resolve: () => undefined }),
+    } as never,
+    markets: markets(),
+  })
+}
+
+describe("closed live cruise commerce", () => {
+  it("issues only scope/owner-bound opaque refs and normalizes presentation money managed-side", async () => {
+    const source = cruiseAdapterToSourceAdapter(cruiseAdapter(), { sourceKind: "cruise:private" })
+    const live = closedProvider([["connection_private", source]])
+    const issued: Record<string, unknown>[] = []
+    const runtime = createManagedStorefrontShoppingRuntime({
+      markets: markets(),
+      catalog: { searchSlice: async () => ({ items: [], total: 0 }) },
+      live,
+      references: {
+        async issue(input) {
+          issued.push(input as unknown as Record<string, unknown>)
+          return {
+            ref: "opaque-cruise-offer-0000000000000001",
+            expiresAt: "2026-08-09T10:15:00.000Z",
+          }
+        },
+      },
+      quoteFx: async () => ({
+        rate: "0.2",
+        provider: "voyant-data-fx",
+        quotedAt: NOW.toISOString(),
+        validUntil: "2026-08-10T10:00:00.000Z",
+      }),
+      now: () => NOW,
+    })
+
+    const result = await runtime.search(context, { scope, intent })
+
+    expect(result).toMatchObject({
+      kind: "cruise",
+      offers: [
+        {
+          offerRef: "opaque-cruise-offer-0000000000000001",
+          title: "Danube Discovery",
+          departureDate: "2027-04-12",
+          cabinName: "Balcony cabin",
+          availability: "limited",
+          price: {
+            native: { amount: "5000.00", currency: "RON" },
+            presentation: { amount: "1000.00", currency: "EUR" },
+          },
+          expiresAt: "2026-08-09T10:15:00.000Z",
+        },
+      ],
+    })
+    const serialized = JSON.stringify(result)
+    expect(serialized).not.toContain("connection_private")
+    expect(serialized).not.toContain("provider_connection_secret")
+    expect(serialized).not.toContain("cruise_secret")
+    expect(serialized).not.toContain("credential_secret")
+    expect(issued[0]).toMatchObject({
+      purpose: "cruise-offer",
+      storefrontId: context.storefrontId,
+      channelId: context.channelId,
+      owner: { userId: context.userId, buyerAccountId: context.buyerAccountId },
+      scope: { marketId: "market_ro", locale: "ro-RO", currency: "EUR" },
+      payload: {
+        selection: {
+          configure: {
+            sailingId: expect.stringMatching(/^sr_/),
+            cabinCategoryId: expect.stringMatching(/^sr_/),
+          },
+        },
+      },
+      ttlSeconds: 900,
+      replay: "single-use",
+    })
+    expect(JSON.stringify(issued[0])).toContain("sourceConnectionId")
+    expect(JSON.stringify(issued[0])).not.toContain("sailing_secret")
+    expect(JSON.stringify(issued[0])).not.toContain("cabin_secret")
+  })
+
+  it("fails closed without idempotency reconciliation or for request-only fares", async () => {
+    const withoutReconciliation = cruiseAdapter()
+    withoutReconciliation.getBookingByIdempotencyKey = undefined
+    const unsupportedFare = cruiseAdapter({
+      async fetchSailingPricing() {
+        const row = await cruiseAdapter().fetchSailingPricing({ externalId: "sailing_secret" })
+        return row.map((price) => ({ ...price, requiresRequest: true }))
+      },
+    })
+    const live = closedProvider([
+      ["no_reconciliation", cruiseAdapterToSourceAdapter(withoutReconciliation)],
+      ["request_only", cruiseAdapterToSourceAdapter(unsupportedFare)],
+    ])
+
+    await expect(live.searchCruises({ context, scope, intent })).resolves.toEqual({
+      items: [],
+      sources: [{ status: "empty" }],
+    })
+  })
+
+  it("retains partial source coverage without leaking source health identity", async () => {
+    const healthy = cruiseAdapterToSourceAdapter(cruiseAdapter())
+    const failing = cruiseAdapterToSourceAdapter(
+      cruiseAdapter({
+        async listEntries() {
+          throw new Error("provider secret outage")
+        },
+      }),
+    )
+    const result = await closedProvider([
+      ["healthy_secret", healthy],
+      ["failing_secret", failing],
+    ]).searchCruises({ context, scope, intent })
+
+    expect(result.items).toHaveLength(1)
+    expect(result.sources).toEqual([{ status: "ok" }, { status: "error" }])
+    expect(JSON.stringify(result.sources)).not.toContain("secret")
+  })
+
+  it("rejects a cross-market/locale/currency scope before supplier discovery", async () => {
+    const listEntries = vi.fn(cruiseAdapter().listEntries)
+    const source = cruiseAdapterToSourceAdapter(cruiseAdapter({ listEntries }))
+    const live = closedProvider([["admitted", source]])
+
+    await expect(
+      live.searchCruises({
+        context,
+        scope: { ...scope, locale: "en-GB", currency: "USD", marketId: "market_other" },
+        intent,
+      }),
+    ).rejects.toThrow("active market scope")
+    expect(listEntries).not.toHaveBeenCalled()
+  })
+})

--- a/packages/storefront/tests/unit/managed-shopping-runtime.test.ts
+++ b/packages/storefront/tests/unit/managed-shopping-runtime.test.ts
@@ -39,6 +39,7 @@ function dependencies(overrides: Record<string, unknown> = {}) {
       searchFlights: vi.fn(async () => ({ items: [], sources: [] })),
       searchStays: vi.fn(async () => ({ items: [], sources: [] })),
       searchPackages: vi.fn(async () => ({ items: [], sources: [] })),
+      searchCruises: vi.fn(async () => ({ items: [], sources: [] })),
     },
     references: {
       redeem: vi.fn(async () => null),
@@ -194,6 +195,7 @@ describe("managed live shopping", () => {
         })),
         searchStays: vi.fn(),
         searchPackages: vi.fn(),
+        searchCruises: vi.fn(),
       },
       quoteFx: vi.fn(async () => ({
         rate: "5",
@@ -242,6 +244,7 @@ describe("managed live shopping", () => {
         })),
         searchStays: vi.fn(),
         searchPackages: vi.fn(),
+        searchCruises: vi.fn(),
       },
     })
     const runtime = createManagedStorefrontShoppingRuntime(deps)
@@ -338,6 +341,7 @@ describe("managed live shopping", () => {
         searchFlights: vi.fn(async () => ({ items: [flight("450", "RON", "450")], sources: [] })),
         searchStays: vi.fn(),
         searchPackages: vi.fn(),
+        searchCruises: vi.fn(),
       },
     })
     const runtime = createManagedStorefrontShoppingRuntime(deps)
@@ -366,6 +370,7 @@ describe("managed live shopping", () => {
         searchFlights: vi.fn(async () => ({ items: [flight("450", "RON", "450")], sources: [] })),
         searchStays: vi.fn(),
         searchPackages: vi.fn(),
+        searchCruises: vi.fn(),
       },
     })
     const runtime = createManagedStorefrontShoppingRuntime(deps)

--- a/packages/trips/src/shopping-opaque-references.ts
+++ b/packages/trips/src/shopping-opaque-references.ts
@@ -22,6 +22,7 @@ const purposeSchema = z.enum([
   "stay-offer",
   "package-offer",
   "live-continuation",
+  "cruise-offer",
 ])
 const replaySchema = z.enum(["multi-use", "single-use"])
 const scopeSchema = z
@@ -60,6 +61,39 @@ const packageSelectionSchema = z
       )
       .refine((value) => (value.pax.adult ?? 0) > 0, "package adult pax required"),
     offerExpiresAt: z.string().datetime({ offset: true }),
+  })
+  .strict()
+
+const cruiseSelectionSchema = z
+  .object({
+    target: z
+      .object({
+        entityModule: z.literal("cruises"),
+        entityId: z.string().min(1),
+        sourceKind: z.string().min(1),
+        sourceConnectionId: z.string().min(1),
+        sourceRef: z.string().min(1),
+      })
+      .strict(),
+    configure: z
+      .object({
+        sailingId: z.string().min(1),
+        cabinCategoryId: z.string().min(1),
+        occupancy: z.number().int().positive(),
+        passengerComposition: z
+          .object({
+            adults: z.number().int().nonnegative(),
+            children: z.number().int().nonnegative().optional(),
+            childAges: z.array(z.number().int().nonnegative()).optional(),
+            infants: z.number().int().nonnegative().optional(),
+            seniors: z.number().int().nonnegative().optional(),
+          })
+          .strict(),
+        fareCode: z.string().min(1).nullable(),
+        fareVariant: z.enum(["cruise_only", "air_inclusive"]),
+        bookingTerms: z.record(z.string(), z.unknown()).nullable(),
+      })
+      .strict(),
   })
   .strict()
 
@@ -444,6 +478,35 @@ function componentFromReference(
     }
   }
 
+  if (reference.purpose === "cruise-offer") {
+    const payload = z
+      .object({ selection: cruiseSelectionSchema, providerData: z.never().optional() })
+      .strict()
+      .parse(reference.payload)
+    const { target, configure } = payload.selection
+    return {
+      kind: "catalog_booking",
+      catalogRef: target,
+      metadata: {
+        bookingDraftV1: {
+          entity: {
+            module: target.entityModule,
+            id: target.entityId,
+            sourceKind: target.sourceKind,
+            sourceConnectionId: target.sourceConnectionId,
+            sourceRef: target.sourceRef,
+          },
+          configure,
+        },
+        storefrontShopping: {
+          version: 1,
+          purpose: reference.purpose,
+          selection: payload.selection,
+        },
+      },
+    }
+  }
+
   const offer = z
     .object({
       selection: z.record(z.string(), z.unknown()),
@@ -484,12 +547,13 @@ function resolvedComponent(
   }
 }
 
-function purposeForSelectionKind(kind: "product" | "flight" | "stay" | "package") {
+function purposeForSelectionKind(kind: "product" | "flight" | "stay" | "package" | "cruise") {
   const purposes = {
     product: "catalog-item",
     flight: "flight-offer",
     stay: "stay-offer",
     package: "package-offer",
+    cruise: "cruise-offer",
   } as const
   return purposes[kind]
 }

--- a/packages/trips/tests/catalog-component-adapter.test.ts
+++ b/packages/trips/tests/catalog-component-adapter.test.ts
@@ -103,6 +103,48 @@ describe("catalog component adapter", () => {
     expect(draft.configure.pax).toEqual({ adult: 2 })
   })
 
+  it("preserves server-pinned cruise choices for composite booking sessions", () => {
+    const draft = bookingDraftFromComponent(
+      component({
+        entityModule: "cruises",
+        entityId: "cruise_1",
+        sourceKind: "cruise:provider",
+        sourceConnectionId: "connection_server",
+        sourceRef: "cruise_ref",
+        metadata: {
+          bookingDraftV1: {
+            entity: {
+              module: "cruises",
+              id: "cruise_1",
+              sourceKind: "cruise:provider",
+              sourceConnectionId: "connection_server",
+              sourceRef: "cruise_ref",
+            },
+            configure: {
+              sailingId: "sailing_ref",
+              cabinCategoryId: "cabin_ref",
+              occupancy: 2,
+              passengerComposition: { adults: 2 },
+              fareCode: "FLEX",
+              fareVariant: "cruise_only",
+              bookingTerms: { refundable: true },
+            },
+          },
+        },
+      }),
+    )
+
+    expect(draft.configure).toMatchObject({
+      sailingId: "sailing_ref",
+      cabinCategoryId: "cabin_ref",
+      occupancy: 2,
+      passengerComposition: { adults: 2 },
+      fareCode: "FLEX",
+      fareVariant: "cruise_only",
+      bookingTerms: { refundable: true },
+    })
+  })
+
   it("requires accommodation catalog components to carry a valid stay date range", () => {
     expect(() =>
       assertCatalogComponentBookingDraftReady(

--- a/packages/trips/tests/shopping-opaque-references.test.ts
+++ b/packages/trips/tests/shopping-opaque-references.test.ts
@@ -21,6 +21,7 @@ const FLIGHT_REF = `sref_${"a".repeat(64)}`
 const CATALOG_REF = `sref_${"b".repeat(64)}`
 const PACKAGE_REF = `sref_${"c".repeat(64)}`
 const CONTINUATION_REF = `sref_${"d".repeat(64)}`
+const CRUISE_REF = `sref_${"e".repeat(64)}`
 
 describe("durable shopping opaque references", () => {
   it("issues a 256-bit capability while persisting only its digest and bounded payload", async () => {
@@ -249,6 +250,59 @@ describe("durable shopping opaque references", () => {
     )
   })
 
+  it("redeems a cruise offer only for its exact managed owner and shopping scope", async () => {
+    const store = new MemoryReferenceStore()
+    const runtime = createTripShoppingReferenceRuntimeWithStore(store, {
+      now: () => NOW,
+      createReference: () => CRUISE_REF,
+    })
+    await runtime.issuer.issue(cruiseInput())
+
+    await expect(
+      runtime.offerResolver.resolve(CONTEXT, {
+        kind: "cruise",
+        offerRef: CRUISE_REF,
+        scope: { ...SCOPE, currency: "USD" },
+      }),
+    ).resolves.toBeNull()
+    await expect(
+      runtime.offerResolver.resolve(CONTEXT, {
+        kind: "cruise",
+        offerRef: CRUISE_REF,
+        scope: SCOPE,
+      }),
+    ).resolves.toMatchObject({
+      component: {
+        kind: "catalog_booking",
+        catalogRef: {
+          entityModule: "cruises",
+          entityId: "cruise_secret",
+          sourceKind: "cruise:provider",
+          sourceConnectionId: "connection_secret",
+          sourceRef: "source_ref_secret",
+        },
+        metadata: {
+          bookingDraftV1: {
+            configure: {
+              sailingId: "sailing_secret",
+              cabinCategoryId: "cabin_secret",
+              occupancy: 2,
+            },
+          },
+          storefrontShopping: {
+            purpose: "cruise-offer",
+            selection: {
+              target: {
+                entityModule: "cruises",
+                sourceConnectionId: "connection_secret",
+              },
+            },
+          },
+        },
+      },
+    })
+  })
+
   it("sanitizes persistence and payload-shape failures before they can reach request logs", async () => {
     const failing = createTripShoppingReferenceRuntimeWithStore(
       {
@@ -359,6 +413,38 @@ function packageInput(
           board: "AI",
         },
         offerExpiresAt,
+      },
+    },
+    ttlSeconds: 15 * 60,
+    replay: "single-use",
+  }
+}
+
+function cruiseInput(): Parameters<StorefrontOpaqueReferenceIssuer["issue"]>[0] {
+  return {
+    purpose: "cruise-offer",
+    storefrontId: CONTEXT.storefrontId,
+    channelId: CONTEXT.channelId,
+    owner: { userId: CONTEXT.userId, buyerAccountId: CONTEXT.buyerAccountId },
+    scope: SCOPE,
+    payload: {
+      selection: {
+        target: {
+          entityModule: "cruises",
+          entityId: "cruise_secret",
+          sourceKind: "cruise:provider",
+          sourceConnectionId: "connection_secret",
+          sourceRef: "source_ref_secret",
+        },
+        configure: {
+          sailingId: "sailing_secret",
+          cabinCategoryId: "cabin_secret",
+          occupancy: 2,
+          passengerComposition: { adults: 2 },
+          fareCode: null,
+          fareVariant: "cruise_only",
+          bookingTerms: null,
+        },
       },
     },
     ttlSeconds: 15 * 60,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5554,6 +5554,9 @@ importers:
       '@voyant-travel/core':
         specifier: workspace:^
         version: link:../core
+      '@voyant-travel/cruises':
+        specifier: workspace:^
+        version: link:../cruises
       '@voyant-travel/data-sdk':
         specifier: ^0.8.0
         version: 0.8.0


### PR DESCRIPTION
## Summary

- add a cruise-specific managed shopping intent/result with live sailing/cabin availability and managed Voyant Data FX presentation money
- admit only Catalog-registered cruise source adapters that support booking forwarding and idempotency-key reconciliation
- keep exact connection/source/sailing/cabin/fare/terms ownership inside a single-use, owner/storefront/channel/scope-bound opaque reference
- redeem the opaque cruise offer into a catalog-backed Trip component with the canonical Booking Session draft, so Book all revalidates, quotes, holds, commits, and reconciles through the existing Catalog supplier-operation spine
- fail closed for missing admitted supply, request-only/wait-list/sold-out policy, unsupported occupancy, malformed or replayed references, and sources without ambiguous-outcome reconciliation

Themes remain render-only: no customer-account authority, provider selectors, booking engine, payment processing, or FX math is added to the browser contract.

## Stack and release gates

Base: Voyant main after merged live providers, package/flight lifecycle, opaque pagination, and Trip Book all (#4459, #4465, #4464, #4467, #4468).

After merge, regenerate the aggregate OSS release PR and publish the exact Storefront/Catalog/Trips/Cruises package set before Platform enables these capabilities.

This does not complete Platform #1671 by itself. Remaining gates are the Platform live capability pin, reference-theme live cruise search-to-managed-checkout UX, a second substantially different first-party theme rendering tours and cruises through the same contract, cross-theme/cross-vertical conformance, and stable-v1 browser evidence.

## Validation

- local focused Vitest: 82 tests passed across Catalog Contracts, Catalog normalization/parameter mapping, Trips opaque redemption/booking drafts, and Storefront cruise shopping
- local typechecks: Catalog Contracts, Catalog, Storefront, Trips, and Cruises passed on Node 22 with bounded sequential execution
- Biome on all changed TypeScript files: passed
- git diff --check: passed
- exact-head GitHub Actions: running on a191d086d45b8549b72cea2b84e84054f8c63212
