### PR TITLE
Reduce admin shell startup payload

### DIFF
--- a/.changeset/fast-dashboard-charts.md
+++ b/.changeset/fast-dashboard-charts.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/admin": patch
+"@voyant-travel/finance-react": patch
+"@voyant-travel/vite-config": patch
+---
+
+Load dashboard charts after aggregate data arrives, defer public finance page bodies until their route is visited, and keep vendor chunks from absorbing shared dependencies so workspace chrome does not wait on Recharts or payment UI.

--- a/packages/admin/src/dashboard/dashboard-charts.tsx
+++ b/packages/admin/src/dashboard/dashboard-charts.tsx
@@ -1,0 +1,125 @@
+"use client"
+
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@voyant-travel/ui/components/chart"
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Pie,
+  PieChart,
+  XAxis,
+  YAxis,
+} from "recharts"
+
+import { formatCurrency } from "./dashboard-query-options.js"
+
+export interface RevenueTrendChartProps {
+  config: ChartConfig
+  currency: string
+  data: ReadonlyArray<{ month: string; revenue: number; bookings: number }>
+  className: string
+}
+
+export function RevenueTrendChart({ className, config, currency, data }: RevenueTrendChartProps) {
+  return (
+    <ChartContainer config={config} className={className}>
+      <AreaChart data={[...data]} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
+        <defs>
+          <linearGradient id="fillRevenue" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="5%" stopColor="var(--chart-1)" stopOpacity={0.3} />
+            <stop offset="95%" stopColor="var(--chart-1)" stopOpacity={0} />
+          </linearGradient>
+        </defs>
+        <CartesianGrid vertical={false} />
+        <XAxis dataKey="month" tickLine={false} axisLine={false} tickMargin={8} />
+        <YAxis
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          tickFormatter={(value: number) => `$${(value / 1000).toFixed(0)}k`}
+        />
+        <ChartTooltip
+          content={
+            <ChartTooltipContent
+              formatter={(value) =>
+                typeof value === "number" ? formatCurrency(value * 100, currency) : String(value)
+              }
+            />
+          }
+        />
+        <Area
+          type="monotone"
+          dataKey="revenue"
+          stroke="var(--chart-1)"
+          fill="url(#fillRevenue)"
+          strokeWidth={2}
+        />
+      </AreaChart>
+    </ChartContainer>
+  )
+}
+
+export interface BookingStatusChartProps {
+  config: ChartConfig
+  data: ReadonlyArray<{
+    status: string
+    count: number
+    fill: string
+  }>
+  className: string
+}
+
+export function BookingStatusChart({ className, config, data }: BookingStatusChartProps) {
+  return (
+    <ChartContainer config={config} className={className}>
+      <PieChart>
+        <ChartTooltip content={<ChartTooltipContent nameKey="status" hideLabel />} />
+        <Pie
+          data={[...data]}
+          dataKey="count"
+          nameKey="status"
+          cx="50%"
+          cy="50%"
+          innerRadius={60}
+          outerRadius={100}
+          paddingAngle={2}
+        >
+          {data.map((entry) => (
+            <Cell key={entry.status} fill={entry.fill} />
+          ))}
+        </Pie>
+        <ChartLegend content={<ChartLegendContent nameKey="status" />} />
+      </PieChart>
+    </ChartContainer>
+  )
+}
+
+export interface MonthlyBookingsChartProps {
+  config: ChartConfig
+  data: ReadonlyArray<{ month: string; count: number }>
+  className: string
+}
+
+export function MonthlyBookingsChart({ className, config, data }: MonthlyBookingsChartProps) {
+  return (
+    <ChartContainer config={config} className={className}>
+      <BarChart data={[...data]} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
+        <CartesianGrid vertical={false} />
+        <XAxis dataKey="month" tickLine={false} axisLine={false} tickMargin={8} />
+        <YAxis tickLine={false} axisLine={false} tickMargin={8} allowDecimals={false} />
+        <ChartTooltip content={<ChartTooltipContent />} />
+        <Bar dataKey="count" fill="var(--chart-1)" radius={[4, 4, 0, 0]} />
+      </BarChart>
+    </ChartContainer>
+  )
+}

--- a/packages/admin/src/dashboard/dashboard-page.tsx
+++ b/packages/admin/src/dashboard/dashboard-page.tsx
@@ -12,27 +12,8 @@ import {
   CardTitle,
   SegmentedControl,
 } from "@voyant-travel/ui/components"
-import {
-  ChartContainer,
-  ChartLegend,
-  ChartLegendContent,
-  ChartTooltip,
-  ChartTooltipContent,
-} from "@voyant-travel/ui/components/chart"
 import { CalendarCheck, DollarSign, Package, Users } from "lucide-react"
-import { useState } from "react"
-import {
-  Area,
-  AreaChart,
-  Bar,
-  BarChart,
-  CartesianGrid,
-  Cell,
-  Pie,
-  PieChart,
-  XAxis,
-  YAxis,
-} from "recharts"
+import { lazy, Suspense, useState } from "react"
 
 import { AdminWidgetSlotRenderer } from "../components/admin-widget-slot.js"
 import { formatMessage } from "../lib/i18n.js"
@@ -70,6 +51,22 @@ import {
   DashboardPieChartSkeleton,
   DashboardUpcomingListSkeleton,
 } from "./dashboard-skeleton.js"
+
+const RevenueTrendChart = lazy(() =>
+  import("./dashboard-charts.js").then((module) => ({
+    default: module.RevenueTrendChart,
+  })),
+)
+const BookingStatusChart = lazy(() =>
+  import("./dashboard-charts.js").then((module) => ({
+    default: module.BookingStatusChart,
+  })),
+)
+const MonthlyBookingsChart = lazy(() =>
+  import("./dashboard-charts.js").then((module) => ({
+    default: module.MonthlyBookingsChart,
+  })),
+)
 
 export type {
   DashboardEmptyAction,
@@ -319,48 +316,14 @@ export function DashboardPage({ emptyStates = {} }: DashboardPageProps = {}) {
                 emptyState={resolvedEmptyStates.revenueTrend}
               />
             ) : (
-              <ChartContainer
-                config={revenueChartConfig}
-                className={`${DASHBOARD_CHART_TALL} w-full`}
-              >
-                <AreaChart
+              <Suspense fallback={<DashboardAreaChartSkeleton />}>
+                <RevenueTrendChart
+                  config={revenueChartConfig}
+                  currency={defaultCurrency}
                   data={monthlyRevenue}
-                  margin={{ top: 10, right: 10, left: 0, bottom: 0 }}
-                >
-                  <defs>
-                    <linearGradient id="fillRevenue" x1="0" y1="0" x2="0" y2="1">
-                      <stop offset="5%" stopColor="var(--chart-1)" stopOpacity={0.3} />
-                      <stop offset="95%" stopColor="var(--chart-1)" stopOpacity={0} />
-                    </linearGradient>
-                  </defs>
-                  <CartesianGrid vertical={false} />
-                  <XAxis dataKey="month" tickLine={false} axisLine={false} tickMargin={8} />
-                  <YAxis
-                    tickLine={false}
-                    axisLine={false}
-                    tickMargin={8}
-                    tickFormatter={(value: number) => `$${(value / 1000).toFixed(0)}k`}
-                  />
-                  <ChartTooltip
-                    content={
-                      <ChartTooltipContent
-                        formatter={(value) =>
-                          typeof value === "number"
-                            ? formatCurrency(value * 100, defaultCurrency)
-                            : String(value)
-                        }
-                      />
-                    }
-                  />
-                  <Area
-                    type="monotone"
-                    dataKey="revenue"
-                    stroke="var(--chart-1)"
-                    fill="url(#fillRevenue)"
-                    strokeWidth={2}
-                  />
-                </AreaChart>
-              </ChartContainer>
+                  className={`${DASHBOARD_CHART_TALL} w-full`}
+                />
+              </Suspense>
             )}
           </CardContent>
         </Card>
@@ -378,29 +341,13 @@ export function DashboardPage({ emptyStates = {} }: DashboardPageProps = {}) {
                 emptyState={resolvedEmptyStates.bookingStatus}
               />
             ) : (
-              <ChartContainer
-                config={bookingStatusConfig}
-                className={`mx-auto ${DASHBOARD_CHART_TALL} w-full`}
-              >
-                <PieChart>
-                  <ChartTooltip content={<ChartTooltipContent nameKey="status" hideLabel />} />
-                  <Pie
-                    data={localizedStatusBreakdown}
-                    dataKey="count"
-                    nameKey="status"
-                    cx="50%"
-                    cy="50%"
-                    innerRadius={60}
-                    outerRadius={100}
-                    paddingAngle={2}
-                  >
-                    {localizedStatusBreakdown.map((entry) => (
-                      <Cell key={entry.status} fill={entry.fill} />
-                    ))}
-                  </Pie>
-                  <ChartLegend content={<ChartLegendContent nameKey="status" />} />
-                </PieChart>
-              </ChartContainer>
+              <Suspense fallback={<DashboardPieChartSkeleton />}>
+                <BookingStatusChart
+                  config={bookingStatusConfig}
+                  data={localizedStatusBreakdown}
+                  className={`mx-auto ${DASHBOARD_CHART_TALL} w-full`}
+                />
+              </Suspense>
             )}
           </CardContent>
         </Card>
@@ -422,21 +369,13 @@ export function DashboardPage({ emptyStates = {} }: DashboardPageProps = {}) {
                 compact
               />
             ) : (
-              <ChartContainer
-                config={monthlyBookingsConfig}
-                className={`${DASHBOARD_CHART_SHORT} w-full`}
-              >
-                <BarChart
+              <Suspense fallback={<DashboardBarChartSkeleton />}>
+                <MonthlyBookingsChart
+                  config={monthlyBookingsConfig}
                   data={monthlyBookings}
-                  margin={{ top: 10, right: 10, left: 0, bottom: 0 }}
-                >
-                  <CartesianGrid vertical={false} />
-                  <XAxis dataKey="month" tickLine={false} axisLine={false} tickMargin={8} />
-                  <YAxis tickLine={false} axisLine={false} tickMargin={8} allowDecimals={false} />
-                  <ChartTooltip content={<ChartTooltipContent />} />
-                  <Bar dataKey="count" fill="var(--chart-1)" radius={[4, 4, 0, 0]} />
-                </BarChart>
-              </ChartContainer>
+                  className={`${DASHBOARD_CHART_SHORT} w-full`}
+                />
+              </Suspense>
             )}
           </CardContent>
         </Card>

--- a/packages/finance-react/src/public-routes.tsx
+++ b/packages/finance-react/src/public-routes.tsx
@@ -1,17 +1,30 @@
 "use client"
 
 import { Navigate, useParams, useSearch } from "@tanstack/react-router"
-import type { ComponentType, ReactNode } from "react"
+import { type ComponentType, lazy, type ReactNode, Suspense } from "react"
 import { z } from "zod"
-import { AccountantPortal } from "./components/accountant-portal.js"
-import {
-  type PaymentLinkResolverMessages,
-  PaymentLinkResolverPage,
-} from "./storefront/payment-link-resolver-page.js"
-import {
-  PublicPaymentLinkPage,
-  type PublicPaymentLinkPageMessages,
-} from "./storefront/public-payment-link-page.js"
+import type { PaymentLinkResolverMessages } from "./storefront/payment-link-resolver-page.js"
+import type { PublicPaymentLinkPageMessages } from "./storefront/public-payment-link-page.js"
+
+const AccountantPortal = lazy(() =>
+  import("./components/accountant-portal.js").then((module) => ({
+    default: module.AccountantPortal,
+  })),
+)
+const PaymentLinkResolverPage = lazy(() =>
+  import("./storefront/payment-link-resolver-page.js").then((module) => ({
+    default: module.PaymentLinkResolverPage,
+  })),
+)
+const PublicPaymentLinkPage = lazy(() =>
+  import("./storefront/public-payment-link-page.js").then((module) => ({
+    default: module.PublicPaymentLinkPage,
+  })),
+)
+
+function PublicFinanceRouteFallback() {
+  return <div className="min-h-screen bg-background" />
+}
 
 const paymentSearchSchema = z.object({
   orderID: z.string().optional(),
@@ -30,7 +43,9 @@ export function createFinancePublicRouteContribution(runtime: FinancePublicRoute
   function PayRoute() {
     return (
       <runtime.StorefrontMessagesProvider>
-        <PayRouteContent />
+        <Suspense fallback={<PublicFinanceRouteFallback />}>
+          <PayRouteContent />
+        </Suspense>
       </runtime.StorefrontMessagesProvider>
     )
   }
@@ -53,7 +68,9 @@ export function createFinancePublicRouteContribution(runtime: FinancePublicRoute
   function PaymentLinkRoute() {
     return (
       <runtime.StorefrontMessagesProvider>
-        <PaymentLinkRouteContent />
+        <Suspense fallback={<PublicFinanceRouteFallback />}>
+          <PaymentLinkRouteContent />
+        </Suspense>
       </runtime.StorefrontMessagesProvider>
     )
   }
@@ -75,7 +92,9 @@ export function createFinancePublicRouteContribution(runtime: FinancePublicRoute
     const { token } = useParams({ strict: false }) as { token: string }
     return (
       <div className="min-h-screen bg-background">
-        <AccountantPortal token={token} apiBaseUrl={runtime.getApiUrl()} />
+        <Suspense fallback={<PublicFinanceRouteFallback />}>
+          <AccountantPortal token={token} apiBaseUrl={runtime.getApiUrl()} />
+        </Suspense>
       </div>
     )
   }

--- a/packages/vite-config/src/index.ts
+++ b/packages/vite-config/src/index.ts
@@ -11,7 +11,7 @@ import {
 import { createRequire } from "node:module"
 import { dirname, join, resolve } from "node:path"
 import { fileURLToPath, URL } from "node:url"
-import type { Plugin, PluginOption, UserConfig } from "vite"
+import { type Plugin, type PluginOption, type UserConfig, version as viteVersion } from "vite"
 
 /**
  * Force heavy vendor libs into their own chunks so they're only downloaded
@@ -54,6 +54,28 @@ export function voyantVendorChunk(id: string): string | undefined {
     return "pdf-lib"
   }
   return undefined
+}
+
+type ExtraManualChunks = (id: string) => string | undefined
+
+export function voyantChunkOutput(viteMajor: number, extraManualChunks?: ExtraManualChunks) {
+  const chunkName = (id: string) => voyantVendorChunk(id) ?? extraManualChunks?.(id)
+  if (viteMajor >= 8) {
+    return {
+      codeSplitting: {
+        // Keep named vendor chunks from absorbing their transitive dependencies.
+        // In particular, Recharts shares small helpers with workspace chrome;
+        // absorbing those helpers made every route import the full chart bundle.
+        includeDependenciesRecursively: false,
+        groups: [{ name: (id: string) => chunkName(id) ?? null }],
+      },
+    }
+  }
+  return {
+    // Rollup 4's equivalent. Vite 6 and 7 use Rollup rather than Rolldown.
+    onlyExplicitManualChunks: true,
+    manualChunks: chunkName,
+  }
 }
 
 /**
@@ -329,10 +351,11 @@ export function voyantStartViteConfig(options: VoyantStartViteConfigOptions): Us
     build: {
       rollupOptions: {
         output: {
-          manualChunks(id: string) {
-            return voyantVendorChunk(id) ?? extraManualChunks?.(id)
-          },
-        },
+          ...voyantChunkOutput(
+            Number.parseInt(viteVersion.split(".")[0] ?? "0", 10),
+            extraManualChunks,
+          ),
+        } as never,
       },
     },
     resolve: {

--- a/packages/vite-config/tests/vite-config.test.ts
+++ b/packages/vite-config/tests/vite-config.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest"
 import {
   VOYANT_ROUTE_FILE_IGNORE_PATTERN,
   VOYANT_SSR_OPTIMIZE_DEPS,
+  voyantChunkOutput,
   voyantGeneratedRoutes,
   voyantStartViteConfig,
   voyantVendorChunk,
@@ -63,6 +64,23 @@ describe("voyantVendorChunk", () => {
     expect(
       voyantVendorChunk("/repo/node_modules/@better-auth/utils/dist/client/react/error-codes.js"),
     ).toBeUndefined()
+  })
+})
+
+describe("voyantChunkOutput", () => {
+  it("uses explicit Rolldown dependency boundaries on Vite 8", () => {
+    const output = voyantChunkOutput(8)
+    expect("codeSplitting" in output && output.codeSplitting.includeDependenciesRecursively).toBe(
+      false,
+    )
+  })
+
+  it("uses Rollup's explicit manual chunks on Vite 6 and 7", () => {
+    const output = voyantChunkOutput(7)
+    expect("onlyExplicitManualChunks" in output && output.onlyExplicitManualChunks).toBe(true)
+    expect(
+      "manualChunks" in output && output.manualChunks("/repo/node_modules/react/index.js"),
+    ).toBe("react")
   })
 })
 
@@ -188,13 +206,17 @@ describe("voyantStartViteConfig", () => {
       extraManualChunks: (id) => (id.includes("/lodash/") ? "lodash" : undefined),
     })
     const output = config.build?.rollupOptions?.output
-    const manualChunks = (Array.isArray(output) ? output[0] : output)?.manualChunks as (
-      id: string,
-    ) => string | undefined
+    const codeSplitting = (Array.isArray(output) ? output[0] : output)?.codeSplitting
+    expect(codeSplitting).not.toBe(false)
+    expect(codeSplitting).not.toBe(true)
+    if (!codeSplitting || typeof codeSplitting !== "object") throw new Error("missing chunk config")
+    expect(codeSplitting.includeDependenciesRecursively).toBe(false)
+    const chunkName = codeSplitting.groups?.[0]?.name
+    if (typeof chunkName !== "function") throw new Error("missing chunk name function")
 
-    expect(manualChunks("/repo/node_modules/react/index.js")).toBe("react")
-    expect(manualChunks("/repo/node_modules/lodash/index.js")).toBe("lodash")
-    expect(manualChunks("/repo/node_modules/zod/index.js")).toBeUndefined()
+    expect(chunkName("/repo/node_modules/react/index.js", {} as never)).toBe("react")
+    expect(chunkName("/repo/node_modules/lodash/index.js", {} as never)).toBe("lodash")
+    expect(chunkName("/repo/node_modules/zod/index.js", {} as never)).toBeNull()
   })
 
   it("appends app-specific SSR optimizeDeps to the Voyant set", () => {

--- a/scripts/measure-operator-application.mjs
+++ b/scripts/measure-operator-application.mjs
@@ -15,6 +15,7 @@ const requireBuild = process.argv.includes("--require-build") || process.argv.in
 const check = process.argv.includes("--check")
 const serverEntry = join(operatorRoot, "dist/server/server.js")
 const clientRoot = join(operatorRoot, "dist/client")
+const portableShellEntry = join(operatorRoot, "dist/admin-shell/client/index.html")
 
 if (requireBuild && (!existsSync(serverEntry) || !existsSync(clientRoot))) {
   console.error(
@@ -70,6 +71,7 @@ const report = {
   server: summarize(serverFiles),
   admin: summarize(adminChunks),
   client: summarize(clientFiles),
+  portableShell: existsSync(portableShellEntry) ? summarizePortableShell(portableShellEntry) : null,
   boot: existsSync(serverEntry) ? measureBoot(serverEntry) : null,
 }
 
@@ -90,6 +92,15 @@ if (check) {
   if (report.admin.gzipBytes > 15 * 1024 * 1024) failures.push("admin gzip chunks exceed 15 MiB")
   if (report.admin.largestGzipBytes > 2 * 1024 * 1024) {
     failures.push("largest admin gzip chunk exceeds 2 MiB")
+  }
+  if (!report.portableShell) failures.push("portable admin shell is missing")
+  if ((report.portableShell?.initialPreloads.gzipBytes ?? 0) > 640 * 1024) {
+    failures.push("portable admin shell initial preloads exceed 640 KiB gzip")
+  }
+  if (
+    report.portableShell?.initialPreloads.paths.some((path) => /\/recharts-[^/]+\.js$/.test(path))
+  ) {
+    failures.push("portable admin shell eagerly preloads Recharts")
   }
   if (!report.boot?.ok || report.boot.milliseconds > 5_000) {
     failures.push("cold Node module boot exceeds 5000 ms or failed")
@@ -129,6 +140,24 @@ function summarize(files) {
     bytes: entries.reduce((total, entry) => total + entry.bytes, 0),
     gzipBytes: entries.reduce((total, entry) => total + entry.gzipBytes, 0),
     largestGzipBytes: Math.max(0, ...entries.map((entry) => entry.gzipBytes)),
+  }
+}
+
+function summarizePortableShell(entryDocument) {
+  const document = readFileSync(entryDocument, "utf8")
+  const hrefs = [...document.matchAll(/<link[^>]+rel="modulepreload"[^>]+href="([^"]+\.js)"/g)].map(
+    (match) => match[1],
+  )
+  const files = hrefs.map((href) => {
+    const file = join(dirname(entryDocument), href.startsWith("/") ? href.slice(1) : href)
+    if (!existsSync(file)) throw new Error(`portable shell preload is missing: ${href}`)
+    return file
+  })
+  return {
+    initialPreloads: {
+      ...summarize(files),
+      paths: files.map((file) => relative(operatorRoot, file)).sort(),
+    },
   }
 }
 

--- a/scripts/tests/measure-operator-application.test.mjs
+++ b/scripts/tests/measure-operator-application.test.mjs
@@ -24,6 +24,16 @@ test("measures a built Operator application without starting a listener", () => 
     }
     write(root, "apps/operator/dist/server/server.js", "export default { fetch() {} }\n")
     write(root, "apps/operator/dist/client/assets/admin-page.js", "export const page = true\n")
+    write(
+      root,
+      "apps/operator/dist/admin-shell/client/assets/index.js",
+      "export const shell = true\n",
+    )
+    write(
+      root,
+      "apps/operator/dist/admin-shell/client/index.html",
+      '<link rel="modulepreload" href="/assets/index.js">\n',
+    )
 
     const output = execFileSync(
       process.execPath,
@@ -37,6 +47,11 @@ test("measures a built Operator application without starting a listener", () => 
     assert.equal(report.metadata.generated.files, 4)
     assert.equal(report.server.files, 1)
     assert.equal(report.admin.files, 1)
+    assert.equal(report.portableShell.initialPreloads.files, 1)
+    assert.equal(
+      report.portableShell.initialPreloads.paths[0],
+      "dist/admin-shell/client/assets/index.js",
+    )
     assert.equal(report.boot.ok, true)
     assert.ok(report.boot.milliseconds >= 0)
   } finally {


### PR DESCRIPTION
## Summary
- lazy-load dashboard chart rendering after aggregate data arrives
- lazy-load finance public route bodies so accountant and payment UI stay off the admin entry path
- use explicit dependency boundaries for Vite 8 Rolldown and Vite 6/7 Rollup vendor chunks
- enforce a 640 KiB gzip portable-shell preload budget and reject eager Recharts preloads

## Measured impact
Published 0.11.4 shell baseline → this build:
- initial module preloads: 35 → 34
- raw preload bytes: 2,704,844 → 2,077,117 (-23.2%)
- gzip preload bytes: 755,900 → 586,246 (-22.4%)
- Recharts: 411,277-byte eager preload → deferred until dashboard chart data renders

## Validation
- `pnpm --filter @voyant-travel/vite-config test` (22/22)
- `pnpm --filter @voyant-travel/vite-config typecheck`
- `pnpm --filter @voyant-travel/finance-react test` (64/64)
- `pnpm --filter @voyant-travel/finance-react typecheck`
- `pnpm --filter @voyant-travel/admin typecheck`
- `node --test scripts/tests/measure-operator-application.test.mjs`
- full `pnpm --filter operator build`
- portable shell measurement: 34 preloads / 586,246 gzip bytes / no Recharts preload

The local aggregate `measure --check` boot probe cannot resolve unbuilt workspace package `.js` exports in this source worktree; the new portable-shell measurement and all source/full-build checks pass. CI builds the package closure first.