### PR TITLE
Defer storefront page bundles from the admin shell

### DIFF
--- a/.changeset/lazy-storefront-routes.md
+++ b/.changeset/lazy-storefront-routes.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/operator-standard": patch
+"@voyant-travel/storefront-react": patch
+---
+
+Load storefront page bodies and product renderers only when a customer route visits them, keeping the admin shell entry focused on workspace chrome.

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "verify:relationships-runtime-authority": "node --test scripts/tests/check-relationships-runtime-authority.test.mjs && node scripts/check-relationships-runtime-authority.mjs",
     "verify:flights-runtime-authority": "node --test scripts/tests/check-flights-runtime-authority.test.mjs && node scripts/check-flights-runtime-authority.mjs",
     "verify:distribution-channel-push-runtime-authority": "node --test scripts/tests/check-distribution-channel-push-runtime-authority.test.mjs && node scripts/check-distribution-channel-push-runtime-authority.mjs",
-    "verify:operator-product-ui-authority": "node scripts/check-operator-product-ui-authority.mjs",
+    "verify:operator-product-ui-authority": "node --test scripts/tests/check-operator-product-ui-authority.test.mjs && node scripts/check-operator-product-ui-authority.mjs",
     "verify:operator-frontend-shell-authority": "node --test scripts/tests/check-operator-frontend-shell-authority.test.mjs && node scripts/check-operator-frontend-shell-authority.mjs",
     "verify:operator-admin-presentation-authority": "node scripts/check-operator-admin-presentation-authority.mjs",
     "verify:admin-presentation-fallback-authority": "node --test scripts/tests/check-admin-presentation-fallback-authority.test.mjs && node scripts/check-admin-presentation-fallback-authority.mjs",

--- a/packages/operator-standard/src/standard-frontend.tsx
+++ b/packages/operator-standard/src/standard-frontend.tsx
@@ -36,12 +36,10 @@ import type { McpConsentRouteContribution } from "@voyant-travel/auth-react/mcp-
 import type { RedeemInvitationStatus } from "@voyant-travel/auth-react/ui"
 import { RealtimeChannel } from "@voyant-travel/cloud-sdk"
 import type { VoyantGraphJsonValue } from "@voyant-travel/core/project"
-import { CruiseDetailPage } from "@voyant-travel/cruises-react/storefront"
 import type {
   createFinancePublicRouteContribution,
   FinancePublicRouteRuntime,
 } from "@voyant-travel/finance-react/public-routes"
-import { ProductDetailPageProducts } from "@voyant-travel/inventory-react/storefront"
 import { navigationPreferencesQueryKey } from "@voyant-travel/navigation-preferences-react"
 import type {
   createProposalsPublicRouteContribution,
@@ -49,22 +47,45 @@ import type {
 } from "@voyant-travel/proposals-react/public-routes"
 import { AdminWorkspaceRealtimeProvider } from "@voyant-travel/realtime-react"
 import {
-  AccommodationDetailPage,
   createStorefrontMessagesProvider,
   type StorefrontComposerRouteProps,
   type StorefrontPresentationContribution,
   type StorefrontPresentationRuntime,
   useStorefrontMessages,
 } from "@voyant-travel/storefront-react/storefront"
-import { StorefrontComposerPage } from "@voyant-travel/trips-react/storefront"
 import type { AccessCatalog } from "@voyant-travel/types/api-keys"
 import { ConfirmDialogHost, PromptDialogHost } from "@voyant-travel/ui/components"
 import { TooltipProvider } from "@voyant-travel/ui/components/tooltip"
 import { emailOTPClient, organizationClient } from "better-auth/client/plugins"
 import { createAuthClient } from "better-auth/react"
 import type { ComponentType, ReactNode } from "react"
-import { useMemo } from "react"
+import { lazy, Suspense, useMemo } from "react"
 import { createApiDocsRouteOptions, type OpenApiSpecLoaders } from "./standard-api-docs.js"
+
+const AccommodationDetailPage = lazy(() =>
+  import("@voyant-travel/storefront-react/storefront").then((module) => ({
+    default: module.AccommodationDetailPage,
+  })),
+)
+const CruiseDetailPage = lazy(() =>
+  import("@voyant-travel/cruises-react/storefront").then((module) => ({
+    default: module.CruiseDetailPage,
+  })),
+)
+const ProductDetailPageProducts = lazy(() =>
+  import("@voyant-travel/inventory-react/storefront").then((module) => ({
+    default: module.ProductDetailPageProducts,
+  })),
+)
+const StorefrontComposerPage = lazy(() =>
+  import("@voyant-travel/trips-react/storefront").then((module) => ({
+    default: module.StorefrontComposerPage,
+  })),
+)
+
+function StorefrontPageFallback() {
+  return <div className="min-h-48" />
+}
 
 export {
   AdminRootErrorBoundary,
@@ -328,11 +349,17 @@ function createPresentationRuntime(
     ComposerPage: StandardStorefrontComposerPage,
     getApiUrl: getAdminApiUrl,
     projectFetcher: adminFetcher,
-    renderProductDetail: (entityModule, entityId) => {
-      if (entityModule === "accommodations") return <AccommodationDetailPage entityId={entityId} />
-      if (entityModule === "cruises") return <CruiseDetailPage entityId={entityId} />
-      return <ProductDetailPageProducts entityModule={entityModule} entityId={entityId} />
-    },
+    renderProductDetail: (entityModule, entityId) => (
+      <Suspense fallback={<StorefrontPageFallback />}>
+        {entityModule === "accommodations" ? (
+          <AccommodationDetailPage entityId={entityId} />
+        ) : entityModule === "cruises" ? (
+          <CruiseDetailPage entityId={entityId} />
+        ) : (
+          <ProductDetailPageProducts entityModule={entityModule} entityId={entityId} />
+        )}
+      </Suspense>
+    ),
     requestEmailCode: async (email) => {
       const result = await customerAuthClient.emailOtp.sendVerificationOtp({
         email,
@@ -527,9 +554,11 @@ type ProposalsPublicPresentationFactory = (
 
 function StandardStorefrontComposerPage(props: StorefrontComposerRouteProps) {
   return (
-    <StorefrontComposerPage
-      {...props}
-      messages={useOperatorAdminMessages().trips.storefrontComposer}
-    />
+    <Suspense fallback={<StorefrontPageFallback />}>
+      <StorefrontComposerPage
+        {...props}
+        messages={useOperatorAdminMessages().trips.storefrontComposer}
+      />
+    </Suspense>
   )
 }

--- a/packages/storefront-react/src/storefront/browse-page.tsx
+++ b/packages/storefront-react/src/storefront/browse-page.tsx
@@ -5,13 +5,13 @@ import { Card, CardContent, CardHeader, CardTitle } from "@voyant-travel/ui/comp
 import { Input } from "@voyant-travel/ui/components/input"
 import { Skeleton } from "@voyant-travel/ui/components/skeleton"
 import { useState } from "react"
-import { z } from "zod"
+import type { z } from "zod"
 
-import {
-  getStorefrontCustomerProductDetailRoute,
-  storefrontCustomerBookableProductVerticals,
-} from "../routing.js"
+import { getStorefrontCustomerProductDetailRoute } from "../routing.js"
 import { StorefrontLink, useStorefrontUi } from "./context.js"
+import type { shopSearchSchema } from "./shop-search.js"
+
+export { shopSearchSchema } from "./shop-search.js"
 
 /**
  * Storefront landing — real catalog browser backed by
@@ -28,11 +28,6 @@ import { StorefrontLink, useStorefrontUi } from "./context.js"
  * detail pages, and `.catch(undefined)` gracefully drops any stale/crafted
  * unsupported vertical URL back to the default vertical instead of erroring.
  */
-export const shopSearchSchema = z.object({
-  q: z.string().optional(),
-  vertical: z.enum(storefrontCustomerBookableProductVerticals).optional().catch(undefined),
-})
-
 export function StorefrontBrowsePage({
   search,
 }: {

--- a/packages/storefront-react/src/storefront/index.ts
+++ b/packages/storefront-react/src/storefront/index.ts
@@ -1,5 +1,5 @@
 export { AccommodationDetailPage } from "./accommodation-detail-page.js"
-export { StorefrontBrowsePage, shopSearchSchema } from "./browse-page.js"
+export { StorefrontBrowsePage } from "./browse-page.js"
 export {
   type BuyerAccountContextValue,
   type BuyerAccountPolicy,
@@ -78,3 +78,4 @@ export {
   useStorefrontScope,
 } from "./scope.js"
 export { StorefrontShell } from "./shell.js"
+export { shopSearchSchema } from "./shop-search.js"

--- a/packages/storefront-react/src/storefront/presentation-routes.tsx
+++ b/packages/storefront-react/src/storefront/presentation-routes.tsx
@@ -2,22 +2,15 @@
 
 import { Outlet, useNavigate, useParams, useSearch } from "@tanstack/react-router"
 import { Card, CardContent, CardHeader, CardTitle } from "@voyant-travel/ui/components/card"
-import type { ComponentType, ReactNode } from "react"
+import { type ComponentType, lazy, type ReactNode, Suspense } from "react"
 import { z } from "zod"
 import type { VoyantFetcher } from "../customer-portal/client.js"
 import { getStorefrontCustomerProductDetailRoute } from "../routing.js"
-import { StorefrontBrowsePage, shopSearchSchema } from "./browse-page.js"
-import { type StorefrontConfirmationKind, StorefrontConfirmationPage } from "./confirmation-page.js"
+import type { StorefrontConfirmationKind } from "./confirmation-page.js"
 import { type StorefrontUiNavigation, StorefrontUiProvider } from "./context.js"
-import { CustomerAccountPage } from "./customer-account-page.js"
 import { CustomerAccountProvider } from "./customer-account-provider.js"
 import { useCustomerAuthConfig } from "./customer-auth-config.js"
-import {
-  CustomerSignInPage,
-  CustomerSignUpPage,
-  type CustomerSocialAuthProvider,
-  CustomerVerifyEmailPage,
-} from "./customer-auth-pages.js"
+import type { CustomerSocialAuthProvider } from "./customer-auth-pages.js"
 import {
   type StorefrontMessages,
   StorefrontMessagesProvider,
@@ -25,6 +18,36 @@ import {
 } from "./messages.js"
 import { StorefrontScopeProvider, useStorefrontScope } from "./scope.js"
 import { StorefrontShell } from "./shell.js"
+import { shopSearchSchema } from "./shop-search.js"
+
+const StorefrontBrowsePage = lazy(() =>
+  import("./browse-page.js").then((module) => ({ default: module.StorefrontBrowsePage })),
+)
+const StorefrontConfirmationPage = lazy(() =>
+  import("./confirmation-page.js").then((module) => ({
+    default: module.StorefrontConfirmationPage,
+  })),
+)
+const CustomerAccountPage = lazy(() =>
+  import("./customer-account-page.js").then((module) => ({
+    default: module.CustomerAccountPage,
+  })),
+)
+const CustomerSignInPage = lazy(() =>
+  import("./customer-auth-pages.js").then((module) => ({ default: module.CustomerSignInPage })),
+)
+const CustomerSignUpPage = lazy(() =>
+  import("./customer-auth-pages.js").then((module) => ({ default: module.CustomerSignUpPage })),
+)
+const CustomerVerifyEmailPage = lazy(() =>
+  import("./customer-auth-pages.js").then((module) => ({
+    default: module.CustomerVerifyEmailPage,
+  })),
+)
+
+function StorefrontRouteFallback() {
+  return <div className="min-h-48" />
+}
 
 const accountSignInSearchSchema = z.object({
   next: z.string().optional(),
@@ -132,7 +155,9 @@ export function createStorefrontPresentationContribution(
           navigate: (navigation: StorefrontUiNavigation) => void navigate(navigation as never),
         }}
       >
-        <StorefrontBrowsePage search={search} />
+        <Suspense fallback={<StorefrontRouteFallback />}>
+          <StorefrontBrowsePage search={search} />
+        </Suspense>
       </StorefrontUiProvider>
     )
   }
@@ -152,15 +177,17 @@ export function createStorefrontPresentationContribution(
     }
     if (authConfig.error || !authConfig.config) return <CustomerAuthUnavailable />
     return (
-      <CustomerSignInPage
-        methods={authConfig.config.methods}
-        redirectTo={redirectTo}
-        verified={Boolean(verify)}
-        requestEmailCode={runtime.requestEmailCode}
-        signInWithEmailCode={runtime.signInWithEmailCode}
-        signInWithSocial={runtime.signInWithSocial}
-        onNavigate={(to) => void navigate({ to })}
-      />
+      <Suspense fallback={<StorefrontRouteFallback />}>
+        <CustomerSignInPage
+          methods={authConfig.config.methods}
+          redirectTo={redirectTo}
+          verified={Boolean(verify)}
+          requestEmailCode={runtime.requestEmailCode}
+          signInWithEmailCode={runtime.signInWithEmailCode}
+          signInWithSocial={runtime.signInWithSocial}
+          onNavigate={(to) => void navigate({ to })}
+        />
+      </Suspense>
     )
   }
 
@@ -181,17 +208,19 @@ export function createStorefrontPresentationContribution(
       return null
     }
     return (
-      <CustomerSignUpPage
-        methods={authConfig.config.methods}
-        redirectTo={redirectTo}
-        signInWithSocial={runtime.signInWithSocial}
-        onNavigateToVerify={(email) =>
-          void navigate({
-            to: "/shop/account/verify-email",
-            search: { email, next: redirectTo },
-          })
-        }
-      />
+      <Suspense fallback={<StorefrontRouteFallback />}>
+        <CustomerSignUpPage
+          methods={authConfig.config.methods}
+          redirectTo={redirectTo}
+          signInWithSocial={runtime.signInWithSocial}
+          onNavigateToVerify={(email) =>
+            void navigate({
+              to: "/shop/account/verify-email",
+              search: { email, next: redirectTo },
+            })
+          }
+        />
+      </Suspense>
     )
   }
 
@@ -219,12 +248,14 @@ export function createStorefrontPresentationContribution(
       return null
     }
     return (
-      <CustomerAccountPage
-        onSignOut={async () => {
-          await runtime.signOut()
-          void navigate({ to: "/shop" })
-        }}
-      />
+      <Suspense fallback={<StorefrontRouteFallback />}>
+        <CustomerAccountPage
+          onSignOut={async () => {
+            await runtime.signOut()
+            void navigate({ to: "/shop" })
+          }}
+        />
+      </Suspense>
     )
   }
 
@@ -235,22 +266,24 @@ export function createStorefrontPresentationContribution(
     >
     const redirectTo = next || "/shop/account"
     return (
-      <CustomerVerifyEmailPage
-        email={email}
-        redirectTo={redirectTo}
-        onCompleted={async () => {
-          await runtime.signOut()
-        }}
-        onResendVerification={async (verificationEmail) => {
-          await runtime.resendVerification(verificationEmail)
-        }}
-        onNavigateToSignIn={() =>
-          void navigate({
-            to: "/shop/account/sign-in",
-            search: { next: redirectTo, verify: "1" },
-          })
-        }
-      />
+      <Suspense fallback={<StorefrontRouteFallback />}>
+        <CustomerVerifyEmailPage
+          email={email}
+          redirectTo={redirectTo}
+          onCompleted={async () => {
+            await runtime.signOut()
+          }}
+          onResendVerification={async (verificationEmail) => {
+            await runtime.resendVerification(verificationEmail)
+          }}
+          onNavigateToSignIn={() =>
+            void navigate({
+              to: "/shop/account/sign-in",
+              search: { next: redirectTo, verify: "1" },
+            })
+          }
+        />
+      </Suspense>
     )
   }
 
@@ -271,12 +304,14 @@ export function createStorefrontPresentationContribution(
     const { bookingId } = useParams({ strict: false }) as { bookingId: string }
     const search = useSearch({ strict: false }) as z.infer<typeof confirmationSearchSchema>
     return (
-      <StorefrontConfirmationPage
-        apiUrl={runtime.getApiUrl()}
-        bookingId={bookingId}
-        kind={search.kind as StorefrontConfirmationKind | undefined}
-        paymentRef={search.session ?? search.orderId ?? search.ref}
-      />
+      <Suspense fallback={<StorefrontRouteFallback />}>
+        <StorefrontConfirmationPage
+          apiUrl={runtime.getApiUrl()}
+          bookingId={bookingId}
+          kind={search.kind as StorefrontConfirmationKind | undefined}
+          paymentRef={search.session ?? search.orderId ?? search.ref}
+        />
+      </Suspense>
     )
   }
 

--- a/packages/storefront-react/src/storefront/shop-search.ts
+++ b/packages/storefront-react/src/storefront/shop-search.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+import { storefrontCustomerBookableProductVerticals } from "../routing.js"
+
+export const shopSearchSchema = z.object({
+  q: z.string().optional(),
+  vertical: z.enum(storefrontCustomerBookableProductVerticals).optional().catch(undefined),
+})

--- a/scripts/check-operator-product-ui-authority.mjs
+++ b/scripts/check-operator-product-ui-authority.mjs
@@ -124,10 +124,10 @@ const requiredTokens = new Map([
   [
     "packages/operator-standard/src/standard-frontend.tsx",
     [
-      'from "@voyant-travel/cruises-react/storefront"',
-      'from "@voyant-travel/inventory-react/storefront"',
-      'from "@voyant-travel/storefront-react/storefront"',
-      'from "@voyant-travel/trips-react/storefront"',
+      '"@voyant-travel/cruises-react/storefront"',
+      '"@voyant-travel/inventory-react/storefront"',
+      '"@voyant-travel/storefront-react/storefront"',
+      '"@voyant-travel/trips-react/storefront"',
       "presentationFactories",
       '"@voyant-travel/storefront#presentation.customer"',
       "createFinancePublicRouteContribution",

--- a/scripts/measure-operator-application.mjs
+++ b/scripts/measure-operator-application.mjs
@@ -94,8 +94,8 @@ if (check) {
     failures.push("largest admin gzip chunk exceeds 2 MiB")
   }
   if (!report.portableShell) failures.push("portable admin shell is missing")
-  if ((report.portableShell?.initialPreloads.gzipBytes ?? 0) > 640 * 1024) {
-    failures.push("portable admin shell initial preloads exceed 640 KiB gzip")
+  if ((report.portableShell?.initialPreloads.gzipBytes ?? 0) > 560 * 1024) {
+    failures.push("portable admin shell initial preloads exceed 560 KiB gzip")
   }
   if (
     report.portableShell?.initialPreloads.paths.some((path) => /\/recharts-[^/]+\.js$/.test(path))

--- a/scripts/tests/check-operator-product-ui-authority.test.mjs
+++ b/scripts/tests/check-operator-product-ui-authority.test.mjs
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict"
+import { execFileSync } from "node:child_process"
+import { test } from "node:test"
+
+test("standard product UI authority accepts package-owned lazy imports", () => {
+  const output = execFileSync(
+    process.execPath,
+    ["scripts/check-operator-product-ui-authority.mjs"],
+    { encoding: "utf8" },
+  )
+
+  assert.match(output, /Operator product UI authority: OK/)
+})


### PR DESCRIPTION
## Summary
- lazy-load storefront browse, customer account/auth, confirmation, composer, and product-detail bodies when their routes render
- move the shop search schema into a lightweight module so route validation stays eager without importing the browse page
- tighten the portable-shell initial preload budget from 640 KiB to 560 KiB gzip

## Measured impact
After #4470 → this build:
- initial raw preload bytes: 2,077,117 → 1,875,858 (-9.7%)
- initial gzip preload bytes: 586,246 → 521,915 (-11.0%)
- entry chunk: 855,980 → 757,729 raw bytes (-11.5%)

Original 0.11.4 shell → both optimizations:
- initial raw preload bytes: 2,704,844 → 1,875,858 (-30.6%)
- initial gzip preload bytes: 755,900 → 521,915 (-31.0%)

## Validation
- storefront-react: 33/33 tests, typecheck
- operator-standard: 20/20 tests, typecheck (10 GiB bounded heap)
- full Operator production build
- portable shell: 35 preloads / 521,915 gzip bytes / no eager Recharts
- performance measurement fixture passes