### PR TITLE
fix(finance): allow name-only booking contacts

### DIFF
--- a/.changeset/kind-finance-name-only-billing.md
+++ b/.changeset/kind-finance-name-only-billing.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/finance": patch
+---
+
+Allow a booking to persist a name-only billing person when the Storefront makes
+email and phone optional, while continuing to reject placeholder email values.

--- a/packages/finance/src/book-product.ts
+++ b/packages/finance/src/book-product.ts
@@ -268,26 +268,40 @@ export function mapBookProductIntentToCommand(
 export function collectBookProductIssues(
   input: BookProductInput,
 ): z.infer<typeof bookProductIssueSchema>[] | null {
+  const toolIssues: z.infer<typeof bookProductIssueSchema>[] = []
+  if (
+    input.personId &&
+    !input.billingContact?.email?.trim() &&
+    !input.billingContact?.phone?.trim()
+  ) {
+    toolIssues.push({
+      path: "billingContact.email",
+      message: "Set billingContact.email to a real address, or set billingContact.phone.",
+    })
+  }
+
   const candidate = mapBookProductIntentToCommand(input, "BK-PENDING-000000")
   const parsed = bookingCreateSchema.safeParse(candidate)
-  if (parsed.success) return null
-  return parsed.error.issues
-    .filter((issue) => !(issue.path.length === 1 && issue.path[0] === "bookingNumber"))
-    .map((issue) => {
-      const rawPath = issue.path.map((segment) => String(segment)).join(".")
-      const path = rawPath.startsWith("contact")
-        ? `billingContact.${rawPath.slice("contact".length, "contact".length + 1).toLowerCase()}${rawPath.slice("contact".length + 1)}`
-        : rawPath
-      const message =
-        rawPath === "personId"
-          ? "Set the TOP-LEVEL personId for a private client (or top-level organizationId for a company). Do not send a billingParty object."
-          : rawPath === "contactFirstName" || rawPath === "contactLastName"
-            ? "Set billingContact.firstName and billingContact.lastName for the private billing party."
-            : rawPath === "contactEmail"
-              ? "Set billingContact.email to a real address, or set billingContact.phone."
-              : issue.message
-      return { path, message }
-    })
+  if (parsed.success) return toolIssues.length > 0 ? toolIssues : null
+  return toolIssues.concat(
+    parsed.error.issues
+      .filter((issue) => !(issue.path.length === 1 && issue.path[0] === "bookingNumber"))
+      .map((issue) => {
+        const rawPath = issue.path.map((segment) => String(segment)).join(".")
+        const path = rawPath.startsWith("contact")
+          ? `billingContact.${rawPath.slice("contact".length, "contact".length + 1).toLowerCase()}${rawPath.slice("contact".length + 1)}`
+          : rawPath
+        const message =
+          rawPath === "personId"
+            ? "Set the TOP-LEVEL personId for a private client (or top-level organizationId for a company). Do not send a billingParty object."
+            : rawPath === "contactFirstName" || rawPath === "contactLastName"
+              ? "Set billingContact.firstName and billingContact.lastName for the private billing party."
+              : rawPath === "contactEmail"
+                ? "Set billingContact.email to a real address, or set billingContact.phone."
+                : issue.message
+        return { path, message }
+      }),
+  )
 }
 
 /**

--- a/packages/finance/src/service-booking-create.ts
+++ b/packages/finance/src/service-booking-create.ts
@@ -293,20 +293,12 @@ function requireCompleteBookingParty(
       })
     }
     const hasRealEmail = isRealEmail(value.contactEmail)
-    const hasPhone = Boolean(value.contactPhone?.trim())
 
     if (value.contactEmail && !hasRealEmail) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["contactEmail"],
         message: "Billing email cannot be a placeholder address",
-      })
-    }
-    if (!hasRealEmail && !hasPhone) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["contactEmail"],
-        message: "Billing person requires an email or phone number",
       })
     }
   } else if (value.contactEmail && !isRealEmail(value.contactEmail)) {

--- a/packages/finance/tests/integration/booking-create.test.ts
+++ b/packages/finance/tests/integration/booking-create.test.ts
@@ -580,6 +580,38 @@ describe.skipIf(!DB_AVAILABLE)("createBooking", () => {
     }
   }
 
+  it("creates a booking for a name-only billing person", async () => {
+    const { productId } = await seedProduct({ pax: null })
+
+    const outcome = await createBooking(db, {
+      productId,
+      bookingNumber: nextBookingNumber(),
+      ...bookingParty(),
+      contactEmail: null,
+      contactPhone: null,
+    })
+
+    expect(outcome.status).toBe("ok")
+    if (outcome.status !== "ok") return
+    const [booking] = await db
+      .select({
+        personId: bookings.personId,
+        contactFirstName: bookings.contactFirstName,
+        contactLastName: bookings.contactLastName,
+        contactEmail: bookings.contactEmail,
+        contactPhone: bookings.contactPhone,
+      })
+      .from(bookings)
+      .where(eq(bookings.id, outcome.result.booking.id))
+    expect(booking).toEqual({
+      personId: "pers_booking_create",
+      contactFirstName: "Alice",
+      contactLastName: "Lead",
+      contactEmail: null,
+      contactPhone: null,
+    })
+  })
+
   it("derives booking pax from travelers when pax is omitted", async () => {
     const { productId } = await seedProduct({ pax: null })
 

--- a/packages/finance/tests/unit/validation-booking-create.test.ts
+++ b/packages/finance/tests/unit/validation-booking-create.test.ts
@@ -128,14 +128,16 @@ describe("bookingCreateSchema", () => {
     expect(result.contactEmail).toBeNull()
   })
 
-  it("requires billing person email or phone", () => {
-    expect(() =>
-      bookingCreateSchema.parse({
-        ...valid,
-        contactEmail: null,
-        contactPhone: "   ",
-      }),
-    ).toThrow("Billing person requires an email or phone number")
+  it("accepts a name-only billing person when contact details are optional", () => {
+    const result = bookingCreateSchema.parse({
+      ...valid,
+      contactEmail: null,
+      contactPhone: null,
+    })
+
+    expect(result.personId).toBe("pers_123")
+    expect(result.contactEmail).toBeNull()
+    expect(result.contactPhone).toBeNull()
   })
 
   it("rejects placeholder billing emails", () => {


### PR DESCRIPTION
## Summary
- allow public booking creation to persist a billing person without email or phone when Storefront contact fields are optional
- preserve the stricter `book_product` agent-tool contract at the tool boundary
- add unit coverage plus a real-database booking integration test

## Validation
- `pnpm --filter @voyant-travel/finance test` (75 passed, 19 DB-gated skipped; 563 tests passed)
- `pnpm --filter @voyant-travel/finance typecheck`
- `pnpm turbo lint --filter=@voyant-travel/finance`
- `pnpm test` (116/116 tasks passed)

The DB CI lane is required to exercise the new integration case.