### PR TITLE
perf(admin): defer selected route implementations

### DIFF
--- a/.changeset/lazy-admin-shell-descriptors.md
+++ b/.changeset/lazy-admin-shell-descriptors.md
@@ -1,0 +1,11 @@
+---
+"@voyant-travel/admin": patch
+"@voyant-travel/framework": patch
+"@voyant-travel/graph-contracts": patch
+"@voyant-travel/operations-react": patch
+"@voyant-travel/operations": patch
+---
+
+Allow graph-selected admin modules to expose an import-cheap shell descriptor
+while their route loaders and page implementations remain dynamically loaded,
+and apply the seam to the Operations admin surface.

--- a/docs/architecture/admin-architecture.md
+++ b/docs/architecture/admin-architecture.md
@@ -190,14 +190,19 @@ the first successful resolution.
 
 This is an explicit graph policy, not a heuristic. A package that owns setup,
 widgets, runtime navigation, or slots stays eager until those contributions have
-their own complete lightweight descriptors. Moving such a package behind the
-route-only boundary would silently remove shell behavior and is rejected by the
-artifact generator.
+their own complete lightweight descriptors. A lazy package may declare an
+import-cheap `admin.shellRuntime`; that factory must preserve every graph route's
+shell contract (redirects, search validation, destinations, SSR policy, copy),
+plus its navigation, setup, hooks, and widgets. The complete implementation
+factory remains dynamically imported for route loaders and pages. Shell/graph
+route drift fails during shell composition instead of silently changing behavior.
 
 Rule:
 
 Use `admin.loading: "lazy-routes"` only for descriptor-complete route/settings
-extensions. Never infer laziness from a filename or package category.
+extensions. Add `admin.shellRuntime` when the Module has shell-critical
+contributions, and keep that Interface import-cheap. Never infer laziness from a
+filename or package category.
 
 ## UI Layering
 

--- a/packages/accommodations/tsconfig.build.json
+++ b/packages/accommodations/tsconfig.build.json
@@ -1513,6 +1513,7 @@
       "@voyant-travel/operations": ["../operations/dist/index.d.ts"],
       "@voyant-travel/operations-react": ["../operations-react/dist/index.d.ts"],
       "@voyant-travel/operations-react/admin": ["../operations-react/dist/admin.d.ts"],
+      "@voyant-travel/operations-react/admin-shell": ["../operations-react/dist/admin-shell.d.ts"],
       "@voyant-travel/operations-react/availability": [
         "../operations-react/dist/availability/index.d.ts"
       ],

--- a/packages/accommodations/tsconfig.typecheck.json
+++ b/packages/accommodations/tsconfig.typecheck.json
@@ -1514,6 +1514,7 @@
       "@voyant-travel/operations": ["../operations/dist/index.d.ts"],
       "@voyant-travel/operations-react": ["../operations-react/dist/index.d.ts"],
       "@voyant-travel/operations-react/admin": ["../operations-react/dist/admin.d.ts"],
+      "@voyant-travel/operations-react/admin-shell": ["../operations-react/dist/admin-shell.d.ts"],
       "@voyant-travel/operations-react/availability": [
         "../operations-react/dist/availability/index.d.ts"
       ],

--- a/packages/admin/src/app/lazy-selected-extension.tsx
+++ b/packages/admin/src/app/lazy-selected-extension.tsx
@@ -5,9 +5,13 @@ import type {
   AdminRouteLoaderContext,
   AdminRoutePageModule,
   AdminSettingsPageContribution,
+  AdminShellExtension,
+  AdminShellRouteContribution,
+  AdminShellSettingsPageContribution,
   AdminUiRouteContribution,
   SelectedAdminExtensionFactory,
   SelectedAdminExtensionFactoryContext,
+  SelectedAdminShellFactory,
 } from "../extensions.js"
 import { adminRoutePageModule } from "../extensions.js"
 import { useOperatorAdminMessages } from "../providers/operator-admin-messages.js"
@@ -24,6 +28,7 @@ export interface LazySelectedAdminExtensionDescriptor {
   id: string
   moduleId: string
   load: () => Promise<SelectedAdminExtensionFactory>
+  shell?: SelectedAdminShellFactory
   routes: readonly LazySelectedAdminRouteDescriptor[]
 }
 
@@ -43,6 +48,8 @@ export function createLazySelectedAdminExtension(
   descriptor: LazySelectedAdminExtensionDescriptor,
   context: SelectedAdminExtensionFactoryContext,
 ): AdminExtension {
+  const shell: AdminShellExtension | undefined = descriptor.shell?.(context)
+  if (shell) assertShellRouteCoverage(descriptor, shell)
   let loaded: Promise<AdminExtension> | undefined
   const load = () =>
     (loaded ??= descriptor.load().then((factory) => {
@@ -56,34 +63,67 @@ export function createLazySelectedAdminExtension(
   const settingsPages: AdminSettingsPageContribution[] = []
   for (const route of descriptor.routes) {
     if (route.path.startsWith("/settings/")) {
-      settingsPages.push(lazySettingsPage(descriptor, route, load))
+      const relativePath = route.path.slice("/settings".length)
+      const shellPage = shell?.settingsPages?.find((candidate) => candidate.path === relativePath)
+      settingsPages.push(lazySettingsPage(descriptor, route, load, shellPage))
     } else {
-      routes.push(lazyRoute(descriptor, route, load))
+      const shellRoute = findShellRouteByPath(shell?.routes ?? [], route.path)
+      routes.push(lazyRoute(descriptor, route, load, shellRoute))
     }
   }
 
   return {
-    id: descriptor.id,
-    ...(routes.length ? { routes } : {}),
-    ...(settingsPages.length ? { settingsPages } : {}),
+    ...shell,
+    id: shell?.id ?? descriptor.id,
+    ...(routes.length ? { routes } : { routes: undefined }),
+    ...(settingsPages.length ? { settingsPages } : { settingsPages: undefined }),
   }
+}
+
+function assertShellRouteCoverage(
+  descriptor: LazySelectedAdminExtensionDescriptor,
+  shell: AdminShellExtension,
+): void {
+  const expected = new Set(descriptor.routes.map((route) => route.path))
+  const actual = new Set([
+    ...flattenShellRoutes(shell.routes ?? []).map((route) => route.path),
+    ...(shell.settingsPages ?? []).map((page) => `/settings${page.path}`),
+  ])
+  const missing = [...expected].filter((path) => !actual.has(path))
+  const extra = [...actual].filter((path) => !expected.has(path))
+  if (missing.length || extra.length) {
+    throw new Error(
+      `Admin shell routes for "${descriptor.id}" do not match its graph routes` +
+        `${missing.length ? `; missing: ${missing.join(", ")}` : ""}` +
+        `${extra.length ? `; extra: ${extra.join(", ")}` : ""}.`,
+    )
+  }
+}
+
+function flattenShellRoutes(
+  routes: readonly AdminShellRouteContribution[],
+): AdminShellRouteContribution[] {
+  return routes.flatMap((route) => [route, ...flattenShellRoutes(route.children ?? [])])
 }
 
 function lazyRoute(
   descriptor: LazySelectedAdminExtensionDescriptor,
   route: LazySelectedAdminRouteDescriptor,
   load: () => Promise<AdminExtension>,
+  shellRoute?: AdminShellRouteContribution,
 ): AdminUiRouteContribution {
+  if (shellRoute?.redirectTo) return { ...shellRoute, id: route.id, path: route.path }
   return {
+    ...shellRoute,
     id: route.id,
     path: route.path,
-    title: route.title,
+    title: shellRoute?.title ?? route.title,
     page: () => loadRoutePage(load, route.path),
     loader: (loaderContext) => loadRouteData(descriptor, load, route.path, loaderContext),
-    pendingComponent: LazyAdminExtensionPending,
-    errorComponent: LazyAdminExtensionError,
-    preload: "intent",
-    ssr: "data-only",
+    pendingComponent: shellRoute?.pendingComponent ?? LazyAdminExtensionPending,
+    errorComponent: shellRoute?.errorComponent ?? LazyAdminExtensionError,
+    preload: shellRoute?.preload ?? "intent",
+    ssr: shellRoute?.ssr ?? "data-only",
   }
 }
 
@@ -91,16 +131,30 @@ function lazySettingsPage(
   descriptor: LazySelectedAdminExtensionDescriptor,
   route: LazySelectedAdminRouteDescriptor,
   load: () => Promise<AdminExtension>,
+  shellPage?: AdminShellSettingsPageContribution,
 ): AdminSettingsPageContribution {
   return {
+    ...shellPage,
     id: route.id,
     path: route.path.slice("/settings".length),
-    title: route.title,
-    label: route.title,
+    title: shellPage?.title ?? route.title,
+    label: shellPage?.label ?? route.title,
     page: () => loadRoutePage(load, route.path),
     loader: (loaderContext) => loadRouteData(descriptor, load, route.path, loaderContext),
     ssr: "data-only",
   }
+}
+
+function findShellRouteByPath(
+  routes: readonly AdminShellRouteContribution[],
+  path: string,
+): AdminShellRouteContribution | undefined {
+  for (const route of routes) {
+    if (route.path === path) return route
+    const child = findShellRouteByPath(route.children ?? [], path)
+    if (child) return child
+  }
+  return undefined
 }
 
 async function loadRouteData(

--- a/packages/admin/src/extensions.ts
+++ b/packages/admin/src/extensions.ts
@@ -17,6 +17,31 @@ export type SelectedAdminExtensionFactory = (
   context: SelectedAdminExtensionFactoryContext,
 ) => AdminExtension
 
+/** Route metadata required by the shell before its implementation is downloaded. */
+export type AdminShellRouteContribution = Omit<
+  AdminUiRouteContribution,
+  "children" | "component" | "loader" | "page"
+> & {
+  children?: ReadonlyArray<AdminShellRouteContribution>
+}
+
+/** Settings metadata required by the shell before its implementation is downloaded. */
+export type AdminShellSettingsPageContribution = Omit<
+  AdminSettingsPageContribution,
+  "loader" | "page"
+>
+
+/** Shell-critical half of a selected admin extension; route implementations stay separate. */
+export type AdminShellExtension = Omit<AdminExtension, "routes" | "settingsPages"> & {
+  routes?: ReadonlyArray<AdminShellRouteContribution>
+  settingsPages?: ReadonlyArray<AdminShellSettingsPageContribution>
+}
+
+/** Import-cheap factory used alongside a dynamically loaded route implementation. */
+export type SelectedAdminShellFactory = (
+  context: SelectedAdminExtensionFactoryContext,
+) => AdminShellExtension
+
 /**
  * App-supplied runtime handed to route loaders: where the API lives and how
  * to reach it (the host's cookie-forwarding fetcher in SSR setups).

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -146,6 +146,9 @@ export {
   type AdminSetupStepActionProps,
   type AdminSetupStepContribution,
   type AdminSetupStepMessages,
+  type AdminShellExtension,
+  type AdminShellRouteContribution,
+  type AdminShellSettingsPageContribution,
   type AdminUiRouteContribution,
   type AdminWidgetContribution,
   type AdminWidgetSlot,
@@ -170,6 +173,7 @@ export {
   resolveAdminWidgets,
   type SelectedAdminExtensionFactory,
   type SelectedAdminExtensionFactoryContext,
+  type SelectedAdminShellFactory,
   storeAdminSetupPrefill,
 } from "./extensions.js"
 export {

--- a/packages/admin/tests/app/lazy-selected-extension.test.tsx
+++ b/packages/admin/tests/app/lazy-selected-extension.test.tsx
@@ -8,6 +8,107 @@ import {
 } from "../../src/app/lazy-selected-extension.js"
 
 describe("createLazySelectedAdminExtension", () => {
+  it("composes import-cheap shell contributions without loading route implementations", () => {
+    const implementationLoader = vi.fn()
+    const shell = vi.fn(() => ({
+      id: "catalog",
+      navigation: [{ items: [{ id: "catalog", title: "Catalog", url: "/catalog" }] }],
+      routes: [{ id: "catalog-index", path: "/catalog", title: "Catalog" }],
+    }))
+
+    const extension = createLazySelectedAdminExtension(
+      {
+        id: "catalog",
+        moduleId: "catalog",
+        shell,
+        load: implementationLoader,
+        routes: [{ id: "catalog-index", path: "/catalog", title: "Catalog" }],
+      },
+      { navMessages: { catalog: "Catalog" } },
+    )
+
+    expect(shell).toHaveBeenCalledOnce()
+    expect(extension.id).toBe("catalog")
+    expect(extension.navigation?.[0]?.items[0]).toMatchObject({ id: "catalog", title: "Catalog" })
+    expect(extension.routes).toHaveLength(1)
+    expect(implementationLoader).not.toHaveBeenCalled()
+  })
+
+  it("preserves shell route contracts while delegating implementation fields", async () => {
+    const validateSearch = vi.fn((search) => search)
+    const implementationLoader = vi.fn(async () => () => ({
+      id: "catalog",
+      routes: [
+        {
+          id: "catalog-products",
+          path: "/catalog/products",
+          title: "Products",
+          page: async () => ({ default: () => null }),
+        },
+      ],
+    }))
+    const extension = createLazySelectedAdminExtension(
+      {
+        id: "@voyant-travel/catalog",
+        moduleId: "catalog",
+        shell: () => ({
+          id: "catalog",
+          routes: [
+            {
+              id: "catalog-products",
+              path: "/catalog/products",
+              title: "Products",
+              validateSearch,
+              destination: "catalog.browse" as never,
+            },
+            {
+              id: "catalog-index",
+              path: "/catalog",
+              title: "Catalog",
+              redirectTo: "/catalog/products",
+            },
+          ],
+        }),
+        load: implementationLoader,
+        routes: [
+          { id: "graph-products", path: "/catalog/products", title: "Products" },
+          { id: "graph-index", path: "/catalog", title: "Catalog" },
+        ],
+      },
+      { navMessages: {} },
+    )
+
+    expect(extension.routes?.[0]).toMatchObject({
+      id: "graph-products",
+      validateSearch,
+      destination: "catalog.browse",
+    })
+    expect(extension.routes?.[1]).toMatchObject({
+      id: "graph-index",
+      redirectTo: "/catalog/products",
+    })
+    expect(extension.routes?.[1]?.page).toBeUndefined()
+    expect(implementationLoader).not.toHaveBeenCalled()
+  })
+
+  it("fails loudly when shell and graph route ownership drift", () => {
+    expect(() =>
+      createLazySelectedAdminExtension(
+        {
+          id: "operations",
+          moduleId: "operations",
+          shell: () => ({
+            id: "operations",
+            routes: [{ id: "resources", path: "/operations/resources", title: "Resources" }],
+          }),
+          load: vi.fn(),
+          routes: [{ id: "availability", path: "/operations/availability", title: "Availability" }],
+        },
+        { navMessages: {} },
+      ),
+    ).toThrow("missing: /operations/availability; extra: /operations/resources")
+  })
+
   it("does not import the implementation until its route is used and caches it", async () => {
     const page = () => null
     const implementationLoader = vi.fn(async () => () => ({

--- a/packages/catalog/tsconfig.build.json
+++ b/packages/catalog/tsconfig.build.json
@@ -1462,6 +1462,7 @@
       "@voyant-travel/operations": ["../operations/dist/index.d.ts"],
       "@voyant-travel/operations-react": ["../operations-react/dist/index.d.ts"],
       "@voyant-travel/operations-react/admin": ["../operations-react/dist/admin.d.ts"],
+      "@voyant-travel/operations-react/admin-shell": ["../operations-react/dist/admin-shell.d.ts"],
       "@voyant-travel/operations-react/availability": [
         "../operations-react/dist/availability/index.d.ts"
       ],

--- a/packages/catalog/tsconfig.typecheck.json
+++ b/packages/catalog/tsconfig.typecheck.json
@@ -1463,6 +1463,7 @@
       "@voyant-travel/operations": ["../operations/dist/index.d.ts"],
       "@voyant-travel/operations-react": ["../operations-react/dist/index.d.ts"],
       "@voyant-travel/operations-react/admin": ["../operations-react/dist/admin.d.ts"],
+      "@voyant-travel/operations-react/admin-shell": ["../operations-react/dist/admin-shell.d.ts"],
       "@voyant-travel/operations-react/availability": [
         "../operations-react/dist/availability/index.d.ts"
       ],

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -1473,6 +1473,7 @@
       "@voyant-travel/operations": ["../operations/dist/index.d.ts"],
       "@voyant-travel/operations-react": ["../operations-react/dist/index.d.ts"],
       "@voyant-travel/operations-react/admin": ["../operations-react/dist/admin.d.ts"],
+      "@voyant-travel/operations-react/admin-shell": ["../operations-react/dist/admin-shell.d.ts"],
       "@voyant-travel/operations-react/availability": [
         "../operations-react/dist/availability/index.d.ts"
       ],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -1467,6 +1467,7 @@
       "@voyant-travel/operations": ["../operations/dist/index.d.ts"],
       "@voyant-travel/operations-react": ["../operations-react/dist/index.d.ts"],
       "@voyant-travel/operations-react/admin": ["../operations-react/dist/admin.d.ts"],
+      "@voyant-travel/operations-react/admin-shell": ["../operations-react/dist/admin-shell.d.ts"],
       "@voyant-travel/operations-react/availability": [
         "../operations-react/dist/availability/index.d.ts"
       ],

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -1518,6 +1518,7 @@
       "@voyant-travel/operations": ["../operations/dist/index.d.ts"],
       "@voyant-travel/operations-react": ["../operations-react/dist/index.d.ts"],
       "@voyant-travel/operations-react/admin": ["../operations-react/dist/admin.d.ts"],
+      "@voyant-travel/operations-react/admin-shell": ["../operations-react/dist/admin-shell.d.ts"],
       "@voyant-travel/operations-react/availability": [
         "../operations-react/dist/availability/index.d.ts"
       ],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -1519,6 +1519,7 @@
       "@voyant-travel/operations": ["../operations/dist/index.d.ts"],
       "@voyant-travel/operations-react": ["../operations-react/dist/index.d.ts"],
       "@voyant-travel/operations-react/admin": ["../operations-react/dist/admin.d.ts"],
+      "@voyant-travel/operations-react/admin-shell": ["../operations-react/dist/admin-shell.d.ts"],
       "@voyant-travel/operations-react/availability": [
         "../operations-react/dist/availability/index.d.ts"
       ],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -1522,6 +1522,7 @@
       "@voyant-travel/operations": ["../operations/dist/index.d.ts"],
       "@voyant-travel/operations-react": ["../operations-react/dist/index.d.ts"],
       "@voyant-travel/operations-react/admin": ["../operations-react/dist/admin.d.ts"],
+      "@voyant-travel/operations-react/admin-shell": ["../operations-react/dist/admin-shell.d.ts"],
       "@voyant-travel/operations-react/availability": [
         "../operations-react/dist/availability/index.d.ts"
       ],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -1523,6 +1523,7 @@
       "@voyant-travel/operations": ["../operations/dist/index.d.ts"],
       "@voyant-travel/operations-react": ["../operations-react/dist/index.d.ts"],
       "@voyant-travel/operations-react/admin": ["../operations-react/dist/admin.d.ts"],
+      "@voyant-travel/operations-react/admin-shell": ["../operations-react/dist/admin-shell.d.ts"],
       "@voyant-travel/operations-react/availability": [
         "../operations-react/dist/availability/index.d.ts"
       ],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -1554,6 +1554,7 @@
       "@voyant-travel/operations": ["../operations/dist/index.d.ts"],
       "@voyant-travel/operations-react": ["../operations-react/dist/index.d.ts"],
       "@voyant-travel/operations-react/admin": ["../operations-react/dist/admin.d.ts"],
+      "@voyant-travel/operations-react/admin-shell": ["../operations-react/dist/admin-shell.d.ts"],
       "@voyant-travel/operations-react/availability": [
         "../operations-react/dist/availability/index.d.ts"
       ],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -1549,6 +1549,7 @@
       "@voyant-travel/operations": ["../operations/dist/index.d.ts"],
       "@voyant-travel/operations-react": ["../operations-react/dist/index.d.ts"],
       "@voyant-travel/operations-react/admin": ["../operations-react/dist/admin.d.ts"],
+      "@voyant-travel/operations-react/admin-shell": ["../operations-react/dist/admin-shell.d.ts"],
       "@voyant-travel/operations-react/availability": [
         "../operations-react/dist/availability/index.d.ts"
       ],

--- a/packages/framework/src/deployment-artifacts.test.ts
+++ b/packages/framework/src/deployment-artifacts.test.ts
@@ -426,6 +426,43 @@ describe("deployment graph artifacts", () => {
     expect(() => buildGraphAdminBundleModule({ graph })).toThrow("lazy-routes cannot carry nav")
   })
 
+  it("statically lowers an explicit shell while keeping its routes dynamic", async () => {
+    const graph = await graphWithSelectedUnits([
+      defineModule({
+        id: "@acme/catalog",
+        localId: "catalog",
+        admin: {
+          loading: "lazy-routes",
+          runtime: { entry: "./admin", export: "createCatalogAdminExtension" },
+          shellRuntime: { entry: "./admin-shell", export: "createCatalogAdminShell" },
+          routes: [
+            {
+              id: "@acme/catalog#admin.route.index",
+              path: "/catalog",
+              runtime: { entry: "./admin", export: "createCatalogAdminExtension" },
+            },
+          ],
+          nav: [
+            {
+              id: "@acme/catalog#admin.nav.index",
+              routeId: "@acme/catalog#admin.route.index",
+              label: { namespace: "catalog", key: "title" },
+            },
+          ],
+        },
+      }),
+    ])
+
+    const source = buildGraphAdminBundleModule({ graph })
+
+    expect(source).toContain(
+      'import { createCatalogAdminShell as selectedAdminShellFactory0 } from "@acme/catalog/admin-shell"',
+    )
+    expect(source).toContain("shell: selectedAdminShellFactory0")
+    expect(source).toContain('load: () => import("@acme/catalog/admin")')
+    expect(source).not.toContain("import { createCatalogAdminExtension")
+  })
+
   it("lowers only selected presentation factories in deterministic id order", async () => {
     const graph = await graphWithSelectedUnits([
       defineModule({

--- a/packages/framework/src/deployment-artifacts.ts
+++ b/packages/framework/src/deployment-artifacts.ts
@@ -224,6 +224,7 @@ export function buildGraphAdminBundleModule(input: BuildGraphAdminBundleModuleIn
   const units = selectedGraphAdminUnits(input.graph)
   const eagerUnits = units.filter((unit) => unit.admin?.loading !== "lazy-routes")
   const lazyUnits = units.filter((unit) => unit.admin?.loading === "lazy-routes")
+  const lazyShellUnits = lazyUnits.filter((unit) => unit.admin?.shellRuntime)
   for (const unit of lazyUnits) assertLazyAdminUnit(unit)
   const command = input.command ?? "voyant project resolve"
   const imports = eagerUnits.map((unit, index) => {
@@ -238,6 +239,17 @@ export function buildGraphAdminBundleModule(input: BuildGraphAdminBundleModuleIn
   const factories = eagerUnits.map(
     (unit, index) => `  ${quote(unit.id)}: selectedAdminFactory${index},`,
   )
+  const shellImports = lazyShellUnits.map((unit, index) => {
+    const runtime = unit.admin?.shellRuntime
+    if (!runtime?.export) {
+      throw new Error(
+        `buildGraphAdminBundleModule: ${unit.id} admin.shellRuntime requires an export.`,
+      )
+    }
+    const entry = lowerAdminRuntimeEntry(unit, runtime.entry)
+    const importEntry = input.runtimeEntryOverrides?.[entry] ?? entry
+    return `import { ${runtime.export} as selectedAdminShellFactory${index} } from ${quote(importEntry)}`
+  })
   const lazyDescriptors = lazyUnits.map((unit) => {
     const runtime = unit.admin?.runtime
     if (!runtime?.export) {
@@ -251,10 +263,11 @@ export function buildGraphAdminBundleModule(input: BuildGraphAdminBundleModuleIn
       title: adminRouteTitle(route.path),
       ...(route.requiredScopes?.length ? { requiredScopes: route.requiredScopes } : {}),
     }))
+    const shellIndex = lazyShellUnits.indexOf(unit)
     return `  ${quote(unit.id)}: {
     id: ${quote(unit.id)},
     moduleId: ${quote(unit.localId ?? unit.id)},
-    routes: ${formatGeneratedValue(routes, 4)},
+    ${shellIndex >= 0 ? `shell: selectedAdminShellFactory${shellIndex},\n    ` : ""}routes: ${formatGeneratedValue(routes, 4)},
     load: () => import(${quote(importEntry)}).then((module) => module[${quote(runtime.export)}]),
   },`
   })
@@ -267,7 +280,7 @@ export function buildGraphAdminBundleModule(input: BuildGraphAdminBundleModuleIn
 // Contains only graph-selected, import-cheap admin factories. Page bodies stay lazy in package UI exports.
 
 ${lazyUnits.length > 0 ? 'import { createLazySelectedAdminExtension } from "@voyant-travel/admin/app"\n' : ""}
-${imports.join("\n")}${imports.length > 0 ? "\n" : ""}
+${[...imports, ...shellImports].join("\n")}${imports.length + shellImports.length > 0 ? "\n" : ""}
 export const GENERATED_SELECTED_GRAPH_ADMIN_HASH = ${quote(input.graph.contentHash)}
 export const GENERATED_SELECTED_GRAPH_ADMIN_UNIT_IDS = ${formatGeneratedValue(
     units.map((unit) => unit.id),
@@ -339,9 +352,14 @@ function assertLazyAdminUnit(unit: ResolvedVoyantGraphUnit): void {
     admin.slots?.length ? "slots" : undefined,
     admin.nav?.length ? "nav" : undefined,
   ].filter(Boolean)
-  if (unsafe.length) {
+  if (unsafe.length && !admin.shellRuntime) {
     throw new Error(
       `buildGraphAdminBundleModule: ${unit.id} lazy-routes cannot carry ${unsafe.join(", ")}.`,
+    )
+  }
+  if (admin.shellRuntime && !admin.shellRuntime.export) {
+    throw new Error(
+      `buildGraphAdminBundleModule: ${unit.id} admin.shellRuntime requires an export.`,
     )
   }
 }

--- a/packages/framework/src/deployment-graph.ts
+++ b/packages/framework/src/deployment-graph.ts
@@ -1395,6 +1395,7 @@ function resolveUnit(
       ? {
           admin: {
             ...(unit.admin.runtime ? { runtime: unit.admin.runtime } : {}),
+            ...(unit.admin.shellRuntime ? { shellRuntime: unit.admin.shellRuntime } : {}),
             ...(unit.admin.loading ? { loading: unit.admin.loading } : {}),
             ...(unit.admin.compositionOrder !== undefined
               ? { compositionOrder: unit.admin.compositionOrder }
@@ -2585,6 +2586,9 @@ function validateAdminFacet(
   }
   if (value.runtime !== undefined) {
     validateRuntimeReference(value.runtime, "admin.runtime", source, diagnostics)
+  }
+  if (value.shellRuntime !== undefined) {
+    validateRuntimeReference(value.shellRuntime, "admin.shellRuntime", source, diagnostics)
   }
   if (value.loading !== undefined && value.loading !== "lazy-routes") {
     invalidFacet(
@@ -4613,6 +4617,7 @@ function validateRuntimeReferenceAdmission(
       add(`providers.runtime.${provider.id}.entry`, provider.runtime)
     }
     add("admin.runtime.entry", unit.admin?.runtime)
+    add("admin.shellRuntime.entry", unit.admin?.shellRuntime)
     for (const copy of unit.admin?.copy ?? []) {
       add(`admin.copy.runtime.${copy.id}.entry`, copy.runtime)
     }

--- a/packages/framework/src/graph-lifecycle.ts
+++ b/packages/framework/src/graph-lifecycle.ts
@@ -28,6 +28,7 @@ export type VoyantGraphLifecycleFacet =
   | "access-resource"
   | "access-role"
   | "admin-runtime"
+  | "admin-shell-runtime"
   | "admin-copy"
   | "admin-route"
   | "admin-nav"
@@ -503,6 +504,9 @@ function unitFacetEntities(
   add("access-role", unit.access?.roles)
   if (unit.admin?.runtime) {
     entities.push({ facet: "admin-runtime", entityId: `${unit.id}#admin.runtime` })
+  }
+  if (unit.admin?.shellRuntime) {
+    entities.push({ facet: "admin-shell-runtime", entityId: `${unit.id}#admin.shellRuntime` })
   }
   add("admin-copy", unit.admin?.copy)
   add("admin-route", unit.admin?.routes)

--- a/packages/framework/src/project-resolver.ts
+++ b/packages/framework/src/project-resolver.ts
@@ -564,6 +564,7 @@ function runtimePackageReferences(
     for (const secret of unit.secrets ?? []) add(unit, secret.validator)
     for (const provider of unit.providers ?? []) add(unit, provider.runtime)
     add(unit, unit.admin?.runtime)
+    add(unit, unit.admin?.shellRuntime)
     for (const copy of unit.admin?.copy ?? []) add(unit, copy.runtime)
     for (const route of unit.admin?.routes ?? []) add(unit, route.runtime)
     for (const contribution of unit.admin?.contributions ?? []) add(unit, contribution.runtime)

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -1556,6 +1556,7 @@
       "@voyant-travel/operations": ["../operations/dist/index.d.ts"],
       "@voyant-travel/operations-react": ["../operations-react/dist/index.d.ts"],
       "@voyant-travel/operations-react/admin": ["../operations-react/dist/admin.d.ts"],
+      "@voyant-travel/operations-react/admin-shell": ["../operations-react/dist/admin-shell.d.ts"],
       "@voyant-travel/operations-react/availability": [
         "../operations-react/dist/availability/index.d.ts"
       ],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -1557,6 +1557,7 @@
       "@voyant-travel/operations": ["../operations/dist/index.d.ts"],
       "@voyant-travel/operations-react": ["../operations-react/dist/index.d.ts"],
       "@voyant-travel/operations-react/admin": ["../operations-react/dist/admin.d.ts"],
+      "@voyant-travel/operations-react/admin-shell": ["../operations-react/dist/admin-shell.d.ts"],
       "@voyant-travel/operations-react/availability": [
         "../operations-react/dist/availability/index.d.ts"
       ],

--- a/packages/graph-contracts/src/facets.ts
+++ b/packages/graph-contracts/src/facets.ts
@@ -137,6 +137,11 @@ export interface VoyantGraphAdminDeclaration {
   /** Import-cheap factory for this unit's complete nav/route/page extension. */
   runtime?: VoyantGraphRuntimeReference
   /**
+   * Import-cheap factory for shell-critical contributions (navigation, setup,
+   * runtime hooks, and widgets) when the complete route implementation is lazy.
+   */
+  shellRuntime?: VoyantGraphRuntimeReference
+  /**
    * Keep a route-only implementation behind a dynamic import. Use only when
    * every shell-critical contribution is represented by lightweight graph
    * metadata; setup flows, widgets, slots, and runtime nav remain eager.

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -1554,6 +1554,7 @@
       "@voyant-travel/operations": ["../operations/dist/index.d.ts"],
       "@voyant-travel/operations-react": ["../operations-react/dist/index.d.ts"],
       "@voyant-travel/operations-react/admin": ["../operations-react/dist/admin.d.ts"],
+      "@voyant-travel/operations-react/admin-shell": ["../operations-react/dist/admin-shell.d.ts"],
       "@voyant-travel/operations-react/availability": [
         "../operations-react/dist/availability/index.d.ts"
       ],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -1549,6 +1549,7 @@
       "@voyant-travel/operations": ["../operations/dist/index.d.ts"],
       "@voyant-travel/operations-react": ["../operations-react/dist/index.d.ts"],
       "@voyant-travel/operations-react/admin": ["../operations-react/dist/admin.d.ts"],
+      "@voyant-travel/operations-react/admin-shell": ["../operations-react/dist/admin-shell.d.ts"],
       "@voyant-travel/operations-react/availability": [
         "../operations-react/dist/availability/index.d.ts"
       ],

--- a/packages/inventory/tsconfig.build.json
+++ b/packages/inventory/tsconfig.build.json
@@ -1486,6 +1486,7 @@
       "@voyant-travel/operations": ["../operations/dist/index.d.ts"],
       "@voyant-travel/operations-react": ["../operations-react/dist/index.d.ts"],
       "@voyant-travel/operations-react/admin": ["../operations-react/dist/admin.d.ts"],
+      "@voyant-travel/operations-react/admin-shell": ["../operations-react/dist/admin-shell.d.ts"],
       "@voyant-travel/operations-react/availability": [
         "../operations-react/dist/availability/index.d.ts"
       ],

--- a/packages/inventory/tsconfig.typecheck.json
+++ b/packages/inventory/tsconfig.typecheck.json
@@ -1487,6 +1487,7 @@
       "@voyant-travel/operations": ["../operations/dist/index.d.ts"],
       "@voyant-travel/operations-react": ["../operations-react/dist/index.d.ts"],
       "@voyant-travel/operations-react/admin": ["../operations-react/dist/admin.d.ts"],
+      "@voyant-travel/operations-react/admin-shell": ["../operations-react/dist/admin-shell.d.ts"],
       "@voyant-travel/operations-react/availability": [
         "../operations-react/dist/availability/index.d.ts"
       ],

--- a/packages/operations-react/package.json
+++ b/packages/operations-react/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./admin": "./src/admin.ts",
+    "./admin-shell": "./src/admin-shell.tsx",
     "./styles.css": "./src/styles.css",
     "./availability": "./src/availability/index.ts",
     "./availability/provider": "./src/availability/provider.tsx",
@@ -151,6 +152,11 @@
         "types": "./dist/admin.d.ts",
         "import": "./dist/admin.js",
         "default": "./dist/admin.js"
+      },
+      "./admin-shell": {
+        "types": "./dist/admin-shell.d.ts",
+        "import": "./dist/admin-shell.js",
+        "default": "./dist/admin-shell.js"
       },
       "./styles.css": {
         "default": "./src/styles.css"

--- a/packages/operations-react/src/admin-shell.tsx
+++ b/packages/operations-react/src/admin-shell.tsx
@@ -1,0 +1,143 @@
+import {
+  type AdminShellExtension,
+  type AdminShellRouteContribution,
+  type AdminWidgetContribution,
+  composeAdminRouteMessagesProviders,
+  type SelectedAdminExtensionFactoryContext,
+} from "@voyant-travel/admin"
+import {
+  type ProductDetailOptionExtrasSlotContext,
+  productDetailOptionExtrasSlot,
+} from "@voyant-travel/inventory-react/admin"
+import { CalendarDays, Wrench } from "lucide-react"
+import { createElement, lazy, Suspense } from "react"
+
+import type {} from "./admin.js"
+
+const LazyOptionResourceTemplatesPanel = lazy(() =>
+  import("./availability/admin/option-resource-templates-panel.js").then((module) => ({
+    default: module.OptionResourceTemplatesPanel,
+  })),
+)
+
+function ProductOptionResourceTemplates(props: ProductDetailOptionExtrasSlotContext) {
+  return createElement(
+    Suspense,
+    { fallback: null },
+    createElement(LazyOptionResourceTemplatesPanel, props),
+  )
+}
+
+const operationsRouteMessagesProvider = composeAdminRouteMessagesProviders(
+  () =>
+    import("./availability/i18n/index.js").then((module) => ({
+      default: module.AvailabilityUiMessagesProvider,
+    })),
+  () =>
+    import("./availability/allocation/i18n/index.js").then((module) => ({
+      default: module.AllocationUiMessagesProvider,
+    })),
+  () =>
+    import("./resources/i18n/index.js").then((module) => ({
+      default: module.ResourcesUiMessagesProvider,
+    })),
+)
+
+/** Import-cheap Operations chrome and route contracts. */
+export function createSelectedOperationsAdminShellExtension({
+  navMessages,
+}: SelectedAdminExtensionFactoryContext): AdminShellExtension {
+  const availability = navMessages.availability ?? "Availability"
+  const resources = navMessages.resources ?? "Resources"
+  const route = (
+    id: string,
+    path: string,
+    title: string,
+    extra: Partial<AdminShellRouteContribution> = {},
+  ): AdminShellRouteContribution => ({
+    id,
+    path,
+    title,
+    routeMessagesProvider: operationsRouteMessagesProvider,
+    ...extra,
+  })
+
+  return {
+    id: "operations",
+    navigation: [
+      {
+        order: -110,
+        items: [
+          {
+            id: "availability",
+            title: availability,
+            url: "/operations/availability",
+            icon: CalendarDays,
+          },
+        ],
+      },
+      {
+        order: -60,
+        items: [
+          {
+            id: "resources",
+            title: resources,
+            url: "/operations/resources",
+            icon: Wrench,
+          },
+        ],
+      },
+    ],
+    routes: [
+      route("availability-index", "/operations/availability", availability, {
+        destination: "availabilitySlot.list",
+        ssr: "data-only",
+      }),
+      route("availability-slot-detail", "/operations/availability/$id", availability, {
+        destination: "availabilitySlot.detail",
+        destinationParams: { id: "slotId" },
+      }),
+      route("availability-rule-detail", "/operations/availability/rules/$id", availability),
+      route(
+        "availability-start-time-detail",
+        "/operations/availability/start-times/$id",
+        availability,
+        {
+          destination: "availabilityStartTime.detail",
+          destinationParams: { id: "startTimeId" },
+        },
+      ),
+      route("resources-index", "/operations/resources", resources, {
+        destination: "resource.list",
+        ssr: "data-only",
+      }),
+      route("resources-detail", "/operations/resources/$id", resources, {
+        destination: "resource.detail",
+        destinationParams: { id: "resourceId" },
+        ssr: "data-only",
+      }),
+      route("resources-pool-detail", "/operations/resources/pools/$id", resources, {
+        destination: "resourcePool.detail",
+        destinationParams: { id: "poolId" },
+        ssr: "data-only",
+      }),
+      route("resources-assignment-detail", "/operations/resources/assignments/$id", resources, {
+        destination: "resourceAssignment.detail",
+        destinationParams: { id: "assignmentId" },
+        ssr: "data-only",
+      }),
+      route("resources-allocation-detail", "/operations/resources/allocations/$id", resources, {
+        destination: "resourceAllocation.detail",
+        destinationParams: { id: "allocationId" },
+        ssr: "data-only",
+      }),
+    ],
+    widgets: [
+      {
+        id: "operations-product-option-resource-templates",
+        slot: productDetailOptionExtrasSlot,
+        component: ProductOptionResourceTemplates,
+      } satisfies AdminWidgetContribution<ProductDetailOptionExtrasSlotContext>,
+    ],
+  }
+}

--- a/packages/operations-react/src/admin.test.ts
+++ b/packages/operations-react/src/admin.test.ts
@@ -1,8 +1,39 @@
 import { describe, expect, it } from "vitest"
 
 import { createSelectedOperationsAdminExtension } from "./admin.js"
+import { createSelectedOperationsAdminShellExtension } from "./admin-shell.js"
 
 describe("createSelectedOperationsAdminExtension", () => {
+  it("keeps the import-cheap shell contract aligned with the full extension", () => {
+    const context = { navMessages: { availability: "Disponibilitate", resources: "Resurse" } }
+    const shell = createSelectedOperationsAdminShellExtension(context)
+    const extension = createSelectedOperationsAdminExtension(context)
+
+    expect(shell.navigation).toEqual(extension.navigation)
+    expect(shell.widgets?.map(({ id, slot }) => ({ id, slot }))).toEqual(
+      extension.widgets?.map(({ id, slot }) => ({ id, slot })),
+    )
+    expect(
+      shell.routes?.map(({ id, path, title, destination, destinationParams, ssr }) => ({
+        id,
+        path,
+        title,
+        destination,
+        destinationParams,
+        ssr,
+      })),
+    ).toEqual(
+      extension.routes?.map(({ id, path, title, destination, destinationParams, ssr }) => ({
+        id,
+        path,
+        title,
+        destination,
+        destinationParams,
+        ssr,
+      })),
+    )
+  })
+
   it("preserves the standard Availability and Resources navigation slots", () => {
     const extension = createSelectedOperationsAdminExtension({
       navMessages: { availability: "Disponibilitate", resources: "Resurse" },

--- a/packages/operations/src/voyant.ts
+++ b/packages/operations/src/voyant.ts
@@ -705,6 +705,11 @@ export const operationsVoyantModule = defineModule({
   ],
   admin: {
     compositionOrder: 10,
+    loading: "lazy-routes",
+    shellRuntime: {
+      entry: "@voyant-travel/operations-react/admin-shell",
+      export: "createSelectedOperationsAdminShellExtension",
+    },
     runtime: {
       entry: "@voyant-travel/operations-react/admin",
       export: "createSelectedOperationsAdminExtension",

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -1565,6 +1565,7 @@
       "@voyant-travel/operations": ["../operations/dist/index.d.ts"],
       "@voyant-travel/operations-react": ["../operations-react/dist/index.d.ts"],
       "@voyant-travel/operations-react/admin": ["../operations-react/dist/admin.d.ts"],
+      "@voyant-travel/operations-react/admin-shell": ["../operations-react/dist/admin-shell.d.ts"],
       "@voyant-travel/operations-react/availability": [
         "../operations-react/dist/availability/index.d.ts"
       ],


### PR DESCRIPTION
## What changed

- add an explicit `admin.shellRuntime` Interface for import-cheap navigation, route contracts, setup, hooks, and widgets
- keep the complete selected-admin implementation behind a cached dynamic import
- fail shell composition when graph and shell route ownership drift
- migrate Operations while preserving its nine route contracts, navigation, i18n providers, destinations, SSR policy, and inventory widget

## Why

Selected admin factories are evaluated with workspace chrome even when their page bodies are lazy. This seam keeps shell-critical behavior eager while deferring route clients, skeletons, loaders, and page implementation code until an Operations route is used. The all-in-one Docker and self-hosted runtime remain unchanged.

## Measured impact

Exact production Operator build against the rebased parent:

- initial raw preloads: 1,876,665 -> 1,858,952 bytes (-17,713; -0.94%)
- initial gzip preloads: 522,402 -> 520,952 bytes (-1,450; -0.28%)
- largest initial gzip chunk: 197,944 -> 195,783 bytes (-2,161; -1.09%)

Catalog was tested and intentionally not migrated because its shell adapter added more than it removed.

## Validation

- 43 focused admin/framework/Operations tests pass
- 69 deployment graph and project resolver tests pass
- admin, framework, and graph-contracts typechecks pass
- production Operator client and SSR build passes
- Operations package typecheck is left to Depot CI: the existing program exhausted an 8 GB local TypeScript heap without emitting a diagnostic