### PR TITLE
test(mcp): cover database lookup safety

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,6 +365,8 @@ jobs:
                 tests/integration/created-target-tools.test.ts
               pnpm --filter @voyant-travel/inventory exec vitest run \
                 tests/integration/conservative-family-backfill.test.ts
+              pnpm --filter @voyant-travel/inventory exec vitest run \
+                tests/integration/mcp-lookup.test.ts
               pnpm --filter @voyant-travel/finance exec vitest run \
                 tests/integration/booking-create.test.ts
               pnpm --filter @voyant-travel/finance exec vitest run \
@@ -379,6 +381,8 @@ jobs:
                 tests/integration/booking-amendments.test.ts
               pnpm --filter @voyant-travel/bookings exec vitest run \
                 tests/integration/frozen-supplier-statuses.test.ts
+              pnpm --filter @voyant-travel/bookings exec vitest run \
+                tests/integration/mcp-lookup.test.ts
               pnpm --filter @voyant-travel/operations exec vitest run \
                 tests/availability/integration/auto-allocate-concurrency.test.ts
               pnpm --filter @voyant-travel/operations exec vitest run \

--- a/packages/bookings/tests/integration/mcp-lookup.test.ts
+++ b/packages/bookings/tests/integration/mcp-lookup.test.ts
@@ -1,0 +1,96 @@
+import { createDbClient } from "@voyant-travel/db"
+import { cleanupTestDb } from "@voyant-travel/db/test-utils"
+import { createToolRegistry } from "@voyant-travel/tools"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { voyantToolContextContribution } from "../../src/mcp-runtime.js"
+import { bookings, bookingTravelers } from "../../src/schema.js"
+import { bookingsTools } from "../../src/tools.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+type ClosableTestDb = PostgresJsDatabase & {
+  $client: { end(options?: { timeout?: number | null }): Promise<unknown> }
+}
+
+describe.skipIf(!DB_AVAILABLE)("Bookings MCP lookup", () => {
+  let db: ClosableTestDb
+
+  beforeAll(() => {
+    db = createDbClient(process.env.TEST_DATABASE_URL as string, {
+      adapter: "node",
+      nodeMaxConnections: 2,
+      timeouts: { statementMs: false, queryMs: false, connectMs: false },
+    }) as ClosableTestDb
+  })
+  beforeEach(() => cleanupTestDb(db))
+  afterAll(() => db.$client.end({ timeout: 0 }))
+
+  async function toolContext() {
+    const request = {
+      env: {},
+      var: {
+        db,
+        userId: "user_1",
+        agentId: "agent_1",
+        callerType: "agent",
+        actor: "staff",
+        scopes: ["bookings:read"],
+        isInternalRequest: false,
+      },
+      req: { header: () => undefined },
+      get(key: string) {
+        return this.var[key as keyof typeof this.var]
+      },
+    }
+    const base = {
+      db,
+      actor: "staff" as const,
+      audience: "staff" as const,
+      tenantId: "default",
+      resolverScope: {
+        locale: "en",
+        market: "default",
+        audience: "staff" as const,
+        actor: "staff" as const,
+      },
+    }
+    const contributed = await voyantToolContextContribution.contribute({
+      request,
+      context: base,
+      resources: {},
+    })
+    return { ...base, ...contributed }
+  }
+
+  it("redacts traveler identity when get_booking resolves by booking number", async () => {
+    const [booking] = await db
+      .insert(bookings)
+      .values({ bookingNumber: "BK-MCP-PII-001", sellCurrency: "EUR" })
+      .returning({ id: bookings.id })
+    await db.insert(bookingTravelers).values({
+      bookingId: booking.id,
+      participantType: "traveler",
+      firstName: "Ana",
+      lastName: "Traveler",
+      email: "ana@example.test",
+      phone: "+40123456789",
+    })
+
+    const registry = createToolRegistry()
+    registry.registerAll(bookingsTools)
+    const result = await registry.dispatch<{ travelers: Record<string, unknown>[] }>(
+      "get_booking",
+      { bookingNumber: "BK-MCP-PII-001" },
+      await toolContext(),
+    )
+
+    expect(result.travelers).toHaveLength(1)
+    expect(result.travelers[0]).toMatchObject({
+      firstName: "***",
+      lastName: "***",
+      email: "a***a@example.test",
+      phone: "***6789",
+    })
+  })
+})

--- a/packages/bookings/tests/integration/mcp-lookup.test.ts
+++ b/packages/bookings/tests/integration/mcp-lookup.test.ts
@@ -66,7 +66,11 @@ describe.skipIf(!DB_AVAILABLE)("Bookings MCP lookup", () => {
   it("redacts traveler identity when get_booking resolves by booking number", async () => {
     const [booking] = await db
       .insert(bookings)
-      .values({ bookingNumber: "BK-MCP-PII-001", sellCurrency: "EUR" })
+      .values({
+        bookingNumber: "BK-MCP-PII-001",
+        status: "confirmed",
+        sellCurrency: "EUR",
+      })
       .returning({ id: bookings.id })
     await db.insert(bookingTravelers).values({
       bookingId: booking.id,

--- a/packages/inventory/tests/integration/mcp-lookup.test.ts
+++ b/packages/inventory/tests/integration/mcp-lookup.test.ts
@@ -1,0 +1,97 @@
+import { createDbClient } from "@voyant-travel/db"
+import { cleanupTestDb } from "@voyant-travel/db/test-utils"
+import { createToolRegistry } from "@voyant-travel/tools"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { voyantToolContextContribution } from "../../src/mcp-runtime.js"
+import { products, productTranslations } from "../../src/schema.js"
+import { inventoryTools } from "../../src/tools.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+type ClosableTestDb = PostgresJsDatabase & {
+  $client: { end(options?: { timeout?: number | null }): Promise<unknown> }
+}
+
+describe.skipIf(!DB_AVAILABLE)("Inventory MCP lookup", () => {
+  let db: ClosableTestDb
+
+  beforeAll(() => {
+    db = createDbClient(process.env.TEST_DATABASE_URL as string, {
+      adapter: "node",
+      nodeMaxConnections: 2,
+      timeouts: { statementMs: false, queryMs: false, connectMs: false },
+    }) as ClosableTestDb
+  })
+  beforeEach(() => cleanupTestDb(db))
+  afterAll(() => db.$client.end({ timeout: 0 }))
+
+  async function toolContext() {
+    const request = {
+      env: {},
+      var: {
+        db,
+        userId: "user_1",
+        agentId: "agent_1",
+        callerType: "agent",
+        actor: "staff",
+      },
+      req: { header: () => undefined },
+      get(key: string) {
+        return this.var[key as keyof typeof this.var]
+      },
+    }
+    const base = {
+      db,
+      actor: "staff" as const,
+      audience: "staff" as const,
+      tenantId: "default",
+      resolverScope: {
+        locale: "en",
+        market: "default",
+        audience: "staff" as const,
+        actor: "staff" as const,
+      },
+    }
+    const contributed = await voyantToolContextContribution.contribute({
+      request,
+      context: base,
+      resources: {},
+    })
+    return { ...base, ...contributed }
+  }
+
+  it("fails closed when a catalog slug belongs to more than one product", async () => {
+    const [first, second] = await db
+      .insert(products)
+      .values([
+        { name: "First product", sellCurrency: "EUR" },
+        { name: "Second product", sellCurrency: "EUR" },
+      ])
+      .returning({ id: products.id })
+    await db.insert(productTranslations).values([
+      {
+        productId: first.id,
+        languageTag: "en",
+        slug: "shared-trip",
+        name: "First product",
+      },
+      {
+        productId: second.id,
+        languageTag: "en",
+        slug: "shared-trip",
+        name: "Second product",
+      },
+    ])
+
+    const registry = createToolRegistry()
+    registry.registerAll(inventoryTools)
+
+    await expect(
+      registry.dispatch("get_product", { slug: "shared-trip" }, await toolContext()),
+    ).rejects.toMatchObject({
+      code: "INVALID_INPUT",
+      meta: { slug: "shared-trip", candidates: expect.arrayContaining([first.id, second.id]) },
+    })
+  })
+})


### PR DESCRIPTION
Closes #3951.

Adds real PostgreSQL-backed MCP dispatch coverage for two lookup guarantees that previously rested only on implementation structure:

- `get_product` fails closed when a non-unique catalog slug belongs to multiple products and returns the matching product ids instead of silently choosing one.
- `get_booking` resolved by `bookingNumber` applies the same traveler-identity redaction as the id lookup when the caller lacks the PII scope.

Both tests are explicitly included in the database-integration CI lane, so they execute after the operator migration rather than passing as environment-skipped package tests.

Local validation:
- `@voyant-travel/inventory` typecheck
- `@voyant-travel/bookings` typecheck
- both new test modules import and skip cleanly without `TEST_DATABASE_URL`
- Biome check on both new test files
