### PR TITLE
fix(finance): compact book product outcomes

### DIFF
--- a/.changeset/quiet-booking-outcomes.md
+++ b/.changeset/quiet-booking-outcomes.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/finance": patch
+---
+
+Return a compact `book_product` outcome with the committed booking reference and an executable `get_booking` follow-up instead of echoing the entire booking graph.

--- a/packages/finance/src/book-product.ts
+++ b/packages/finance/src/book-product.ts
@@ -18,7 +18,6 @@
  * work (reference allocation, the durable command) lives in `mcp-runtime.ts`,
  * which holds the request-scoped services.
  */
-import { bookingToolDetailSchema } from "@voyant-travel/bookings"
 import { z } from "zod"
 
 import { type BookingCreateInput, bookingCreateSchema } from "./service-booking-create.js"
@@ -187,7 +186,13 @@ export const bookProductToolOutputSchema = z.discriminatedUnion("status", [
     bookingId: z.string(),
     bookingNumber: z.string(),
     replayed: z.boolean(),
-    booking: bookingToolDetailSchema,
+    committedChanges: z.tuple([z.literal("booking_created")]),
+    nextActions: z.tuple([
+      z.object({
+        tool: z.literal("get_booking"),
+        input: z.object({ id: z.string() }),
+      }),
+    ]),
   }),
   z.object({
     status: z.literal("invalid"),

--- a/packages/finance/src/mcp-booking-runtime.ts
+++ b/packages/finance/src/mcp-booking-runtime.ts
@@ -115,18 +115,27 @@ export function financeBookingToolServices(
             : {}),
         },
       })
-      const detail = await readBookingCreateResult(db, c, result.value.bookingId, result.replayed)
+      const booking = await readBookingReference(db, result.value.bookingId)
       return {
         status: "created",
-        bookingId: detail.bookingId,
+        bookingId: booking.id,
         // The persisted reference — on an idempotent replay this is the ORIGINAL
         // booking's number, not the one just allocated and discarded.
-        bookingNumber: detail.booking.bookingNumber,
-        replayed: detail.replayed,
-        booking: detail.booking,
+        bookingNumber: booking.bookingNumber,
+        replayed: result.replayed,
+        committedChanges: ["booking_created"],
+        nextActions: [{ tool: "get_booking", input: { id: booking.id } }],
       }
     },
   }
+}
+
+async function readBookingReference(db: BookingRuntimeDb, bookingId: string) {
+  const booking = await bookingsService.getBookingById(db, bookingId)
+  if (!booking) {
+    throw new ToolError("The created booking could not be read back.", "NOT_FOUND", { bookingId })
+  }
+  return { id: booking.id, bookingNumber: booking.bookingNumber }
 }
 
 /**

--- a/packages/finance/tests/tools.test.ts
+++ b/packages/finance/tests/tools.test.ts
@@ -587,7 +587,8 @@ describe("finance tools", () => {
           bookingId: "booking_1",
           bookingNumber: "B-1",
           replayed: false,
-          booking: bookingDetail(),
+          committedChanges: ["booking_created"] as const,
+          nextActions: [{ tool: "get_booking" as const, input: { id: "booking_1" } }] as const,
         }
       },
     }
@@ -618,11 +619,15 @@ describe("finance tools", () => {
       }),
     )
 
-    expect(result).toMatchObject({
+    expect(result).toEqual({
       status: "created",
       bookingId: "booking_1",
       bookingNumber: "B-1",
+      replayed: false,
+      committedChanges: ["booking_created"],
+      nextActions: [{ tool: "get_booking", input: { id: "booking_1" } }],
     })
+    expect(Buffer.byteLength(JSON.stringify(result))).toBeLessThan(500)
     expect(receivedInput).toMatchObject({ productId: "product_1", personId: "person_1" })
   })
 


### PR DESCRIPTION
Advances #3971 and #4378.

`book_product` is the ordinary intent-level booking workflow, but its success response echoed the entire booking detail graph even though it already returned the durable booking id and number. That inflated every successful model turn and duplicated data available from `get_booking`.

This changes the success contract to a compact outcome:

- booking id and booking number
- whether the durable command replayed
- the committed change (`booking_created`)
- an executable `get_booking` next action for callers that actually need detail

The runtime now reloads only the authoritative booking reference on success/replay. The lower-level `create_booking` tool retains its detailed response for advanced callers.

Validation:
- Finance tests: 563 passed, 402 skipped
- Finance typecheck
- Biome check on changed sources/tests
- exact-result test plus a serialized outcome ratchet below 500 bytes
