### PR TITLE
fix(framework): require approved tool target lifecycles

### DIFF
--- a/.changeset/safe-approved-tool-targets.md
+++ b/.changeset/safe-approved-tool-targets.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": patch
+---
+
+Require every available approval-required executable Tool action to declare a stable created or existing target lifecycle, closing the legacy path into generic non-atomic approved dispatch.

--- a/packages/framework/src/deployment-graph.test.ts
+++ b/packages/framework/src/deployment-graph.test.ts
@@ -1228,6 +1228,12 @@ describe("deployment graph v1", () => {
       ]),
     )
     expect(validateGraphUnitManifest(manifest({}))).toEqual([])
+    expect(validateGraphUnitManifest(manifest({ approval: "required" }))).toContainEqual(
+      expect.objectContaining({
+        facet: "actions[0].targetLifecycle",
+        message: expect.stringContaining("stable target anchor"),
+      }),
+    )
     expect(
       validateGraphUnitManifest(
         manifest({

--- a/packages/framework/src/deployment-graph.ts
+++ b/packages/framework/src/deployment-graph.ts
@@ -2105,7 +2105,7 @@ function validatePromotedFacets(
     const toolBound = isRecord(entry.from) && Array.isArray(entry.from.tools)
     if (
       effectivelyAvailable &&
-      safetyContractSelected &&
+      (safetyContractSelected || entry.approval === "required") &&
       entry.kind === "execute" &&
       toolBound &&
       entry.targetLifecycle === undefined


### PR DESCRIPTION
Closes #4424.

The generic approved-execution preflight is not atomic with arbitrary domain effects, so abandoned dispatch cannot be made safely retryable without fencing every possible handler. The durable direction has been to move selected actions onto handler-owned created/existing target commands.

This PR closes the remaining legacy escape hatch: every available approval-required executable Tool action must now declare a stable target lifecycle. Created targets already require `handler-command-claim-v1`; existing targets already require `handler-command-result-v1`; and the generic selected-graph gate fails closed for both. A validated deployment therefore cannot route an approved mutation through the unsafe generic dispatcher.

The current operator graph passes this stricter rule: all 26 exposed approval-required actions declare their target lifecycle and durable handler protocol.

Validation:
- red/green framework contract test
- deployment-graph suite: 61 passed
- Framework typecheck after rebuilding the local graph-contracts dependency
- operator artifact generation against the full selected graph
