### PR TITLE
perf(inventory): reuse products loader query

### DIFF
--- a/.changeset/quiet-products-first-paint.md
+++ b/.changeset/quiet-products-first-paint.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/inventory-react": patch
+---
+
+Reuse the products route-loader query when the initial products page mounts, and keep all product-list filters in the shared request serializer.

--- a/packages/inventory-react/src/admin/admin-extension.test.ts
+++ b/packages/inventory-react/src/admin/admin-extension.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from "vitest"
+import { QueryClient } from "@tanstack/react-query"
+import { describe, expect, it, vi } from "vitest"
 
 import { inventoryVoyantModule } from "../../../inventory/src/voyant.js"
+import { DEFAULT_PRODUCTS_LIST_FILTERS, getProductsQueryOptions } from "../query-options.js"
 import {
   createInventoryAdminExtension,
   createSelectedInventoryAdminExtension,
@@ -125,6 +127,31 @@ describe("createInventoryAdminExtension", () => {
       expect(typeof route.loader).toBe("function")
       expect(route.ssr).toBe("data-only")
     }
+  })
+
+  it("loads the exact first-page query that the products page mounts", async () => {
+    const fetcher = vi.fn(async () => Response.json({ data: [], total: 0, limit: 25, offset: 0 }))
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { staleTime: 30_000, retry: false } },
+    })
+    const route = createInventoryAdminExtension().routes?.find(
+      (candidate) => candidate.id === "products-index",
+    )
+
+    await route?.loader?.({
+      queryClient,
+      runtime: { baseUrl: "/api", fetcher },
+      params: {},
+    })
+    await queryClient.fetchQuery(
+      getProductsQueryOptions({ baseUrl: "/api", fetcher }, DEFAULT_PRODUCTS_LIST_FILTERS),
+    )
+
+    expect(fetcher).toHaveBeenCalledTimes(1)
+    expect(fetcher).toHaveBeenCalledWith(
+      "/api/v1/admin/products?sortBy=createdAt&sortDir=desc&limit=25&offset=0",
+      expect.any(Object),
+    )
   })
 
   it("annotates the route-backed destinations", () => {

--- a/packages/inventory-react/src/admin/index.tsx
+++ b/packages/inventory-react/src/admin/index.tsx
@@ -128,9 +128,11 @@ export function createInventoryAdminExtension(
         // would pin it into the workspace-chrome chunk that evaluates this
         // factory.
         loader: async ({ queryClient, runtime }: AdminRouteLoaderContext) => {
-          const { getProductsQueryOptions } = await import("../query-options.js")
+          const { DEFAULT_PRODUCTS_LIST_FILTERS, getProductsQueryOptions } = await import(
+            "../query-options.js"
+          )
           return queryClient.ensureQueryData(
-            getProductsQueryOptions(loaderClient(runtime), { limit: 25, offset: 0 }),
+            getProductsQueryOptions(loaderClient(runtime), DEFAULT_PRODUCTS_LIST_FILTERS),
           )
         },
         pendingComponent: ProductsListSkeleton,

--- a/packages/inventory-react/src/components/product-list.tsx
+++ b/packages/inventory-react/src/components/product-list.tsx
@@ -36,6 +36,7 @@ import {
   useProducts,
   useProductTypes,
 } from "../index.js"
+import { DEFAULT_PRODUCTS_LIST_FILTERS } from "../query-options.js"
 import { formatProductSubtype } from "./product-detail/product-detail-shared.js"
 import { ProductDialog } from "./product-dialog.js"
 import { ProductQuickStartDialog } from "./product-quick-start-dialog.js"
@@ -127,7 +128,10 @@ function formatListDuration(
   return messages.durationUnset
 }
 
-export function ProductList({ pageSize = 25, onSelectProduct }: ProductListProps = {}) {
+export function ProductList({
+  pageSize = DEFAULT_PRODUCTS_LIST_FILTERS.limit,
+  onSelectProduct,
+}: ProductListProps = {}) {
   const { locale, messages } = useProductsUiI18nOrDefault()
   const productMessages = messages.productList
   const { create } = useProductMutation()
@@ -148,9 +152,13 @@ export function ProductList({ pageSize = 25, onSelectProduct }: ProductListProps
   const [paxMax, setPaxMax] = React.useState<string>("")
   const [sellAmountMin, setSellAmountMin] = React.useState<string>("")
   const [sellAmountMax, setSellAmountMax] = React.useState<string>("")
-  const [sortBy, setSortBy] = React.useState<ProductsListSortField>("createdAt")
-  const [sortDir, setSortDir] = React.useState<ProductsListSortDir>("desc")
-  const [offset, setOffset] = React.useState(0)
+  const [sortBy, setSortBy] = React.useState<ProductsListSortField>(
+    DEFAULT_PRODUCTS_LIST_FILTERS.sortBy,
+  )
+  const [sortDir, setSortDir] = React.useState<ProductsListSortDir>(
+    DEFAULT_PRODUCTS_LIST_FILTERS.sortDir,
+  )
+  const [offset, setOffset] = React.useState<number>(DEFAULT_PRODUCTS_LIST_FILTERS.offset)
   const [filterPopoverOpen, setFilterPopoverOpen] = React.useState(false)
   const [dialogOpen, setDialogOpen] = React.useState(false)
   const [editing, setEditing] = React.useState<ProductRecord | undefined>(undefined)

--- a/packages/inventory-react/src/hooks/use-products.ts
+++ b/packages/inventory-react/src/hooks/use-products.ts
@@ -2,10 +2,9 @@
 
 import { useQuery } from "@tanstack/react-query"
 
-import { fetchWithValidation } from "../client.js"
 import { useVoyantProductsContext } from "../provider.js"
-import { type ProductsListFilters, productsQueryKeys } from "../query-keys.js"
-import { productListResponse } from "../schemas.js"
+import type { ProductsListFilters } from "../query-keys.js"
+import { getProductsQueryOptions } from "../query-options.js"
 
 export interface UseProductsOptions extends ProductsListFilters {
   enabled?: boolean
@@ -13,26 +12,10 @@ export interface UseProductsOptions extends ProductsListFilters {
 
 export function useProducts(options: UseProductsOptions = {}) {
   const { baseUrl, fetcher } = useVoyantProductsContext()
-  const { enabled = true, ...filters } = options
+  const { enabled = true } = options
 
   return useQuery({
-    queryKey: productsQueryKeys.productsList(filters),
-    queryFn: () => {
-      const params = new URLSearchParams()
-      if (filters.status) params.set("status", filters.status)
-      if (filters.bookingMode) params.set("bookingMode", filters.bookingMode)
-      if (filters.visibility) params.set("visibility", filters.visibility)
-      if (filters.activated !== undefined) params.set("activated", String(filters.activated))
-      if (filters.facilityId) params.set("facilityId", filters.facilityId)
-      if (filters.search) params.set("search", filters.search)
-      if (filters.limit !== undefined) params.set("limit", String(filters.limit))
-      if (filters.offset !== undefined) params.set("offset", String(filters.offset))
-      const qs = params.toString()
-      return fetchWithValidation(`/v1/admin/products${qs ? `?${qs}` : ""}`, productListResponse, {
-        baseUrl,
-        fetcher,
-      })
-    },
+    ...getProductsQueryOptions({ baseUrl, fetcher }, options),
     enabled,
   })
 }

--- a/packages/inventory-react/src/query-options.ts
+++ b/packages/inventory-react/src/query-options.ts
@@ -18,7 +18,7 @@ import type { UseProductTagsOptions } from "./hooks/use-product-tags.js"
 import type { UseProductTypesOptions } from "./hooks/use-product-types.js"
 import type { UseProductVersionsOptions } from "./hooks/use-product-versions.js"
 import type { UseProductsOptions } from "./hooks/use-products.js"
-import { productsQueryKeys } from "./query-keys.js"
+import { type ProductsListFilters, productsQueryKeys } from "./query-keys.js"
 import {
   optionUnitListResponse,
   optionUnitSingleResponse,
@@ -37,6 +37,18 @@ import {
   productTypeSingleResponse,
   productVersionsResponse,
 } from "./schemas.js"
+
+/**
+ * Canonical first-page state shared by the products route loader and page.
+ * Keeping one value is important: TanStack Query can only reuse the loader
+ * result when the mounted page asks for the exact same query key.
+ */
+export const DEFAULT_PRODUCTS_LIST_FILTERS = {
+  sortBy: "createdAt",
+  sortDir: "desc",
+  limit: 25,
+  offset: 0,
+} as const satisfies ProductsListFilters
 
 export function getProductsQueryOptions(
   client: FetchWithValidationOptions,


### PR DESCRIPTION
## Summary

- make the Products route loader and mounted page use one canonical first-page query key
- reuse the shared product-list request serializer from `useProducts`, including filters the hook previously keyed but did not send
- preserve the default `createdAt desc` page contract in one exported value

## Live evidence

Chrome DevTools traces against the signed-in managed sandbox showed the edge shell itself is fast, but the Products table is the LCP element:

- warm TTFB: 108–189 ms
- warm FCP: 258–317 ms
- Products-table LCP: 2.12–2.95 s
- CLS: 0.024
- main-thread blocking: 0–13 ms

Every reload issued the same `/api/v1/admin/products?limit=25&offset=0` request twice. The loader request began around 0.64–0.71 s; the page request began around 1.65–1.73 s and completed around 2.09–2.91 s, directly preceding the table LCP. The two requests had different React Query keys even though the old hook serialized them to the same URL.

## Validation

- focused inventory admin extension tests: 12/12 pass
- Biome on all changed source/test/changeset files: pass
- `git diff --check`: pass
- package typecheck reached the local 4 GB heap ceiling after ~2.5 minutes without diagnostics; CI has a 12 GB heap and is the authoritative typecheck lane

The new regression populates the loader cache and then requests the exact page query, proving only one fetch occurs and asserting the canonical sorted URL.