### PR TITLE
perf(inventory): prefetch product filter data

### DIFF
--- a/.changeset/early-product-type-filters.md
+++ b/.changeset/early-product-type-filters.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/inventory-react": patch
+---
+
+Start product-type filter data alongside the first products request without delaying route admission.

--- a/packages/inventory-react/src/admin/admin-extension.test.ts
+++ b/packages/inventory-react/src/admin/admin-extension.test.ts
@@ -2,7 +2,11 @@ import { QueryClient } from "@tanstack/react-query"
 import { describe, expect, it, vi } from "vitest"
 
 import { inventoryVoyantModule } from "../../../inventory/src/voyant.js"
-import { DEFAULT_PRODUCTS_LIST_FILTERS, getProductsQueryOptions } from "../query-options.js"
+import {
+  DEFAULT_PRODUCTS_LIST_FILTERS,
+  getProductsQueryOptions,
+  getProductTypesQueryOptions,
+} from "../query-options.js"
 import {
   createInventoryAdminExtension,
   createSelectedInventoryAdminExtension,
@@ -129,7 +133,7 @@ describe("createInventoryAdminExtension", () => {
     }
   })
 
-  it("loads the exact first-page query that the products page mounts", async () => {
+  it("loads the exact first-page query and prefetches the mounted type filter", async () => {
     const fetcher = vi.fn(async () => Response.json({ data: [], total: 0, limit: 25, offset: 0 }))
     const queryClient = new QueryClient({
       defaultOptions: { queries: { staleTime: 30_000, retry: false } },
@@ -143,14 +147,53 @@ describe("createInventoryAdminExtension", () => {
       runtime: { baseUrl: "/api", fetcher },
       params: {},
     })
-    await queryClient.fetchQuery(
-      getProductsQueryOptions({ baseUrl: "/api", fetcher }, DEFAULT_PRODUCTS_LIST_FILTERS),
-    )
+    await Promise.all([
+      queryClient.fetchQuery(
+        getProductsQueryOptions({ baseUrl: "/api", fetcher }, DEFAULT_PRODUCTS_LIST_FILTERS),
+      ),
+      queryClient.fetchQuery(
+        getProductTypesQueryOptions({ baseUrl: "/api", fetcher }, { limit: 100 }),
+      ),
+    ])
 
-    expect(fetcher).toHaveBeenCalledTimes(1)
-    expect(fetcher).toHaveBeenCalledWith(
+    expect(fetcher).toHaveBeenCalledTimes(2)
+    expect(fetcher).toHaveBeenNthCalledWith(
+      1,
+      "/api/v1/admin/products/product-types?limit=100",
+      expect.any(Object),
+    )
+    expect(fetcher).toHaveBeenNthCalledWith(
+      2,
       "/api/v1/admin/products?sortBy=createdAt&sortDir=desc&limit=25&offset=0",
       expect.any(Object),
+    )
+  })
+
+  it("does not fail route admission when the type-filter prefetch fails", async () => {
+    const fetcher = vi.fn(async (url: string) => {
+      if (url.includes("/product-types")) throw new Error("type filters unavailable")
+      return Response.json({ data: [], total: 0, limit: 25, offset: 0 })
+    })
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { staleTime: 30_000, retry: false } },
+    })
+    const route = createInventoryAdminExtension().routes?.find(
+      (candidate) => candidate.id === "products-index",
+    )
+
+    await expect(
+      route?.loader?.({
+        queryClient,
+        runtime: { baseUrl: "/api", fetcher },
+        params: {},
+      }),
+    ).resolves.toMatchObject({ data: [] })
+    await vi.waitFor(() =>
+      expect(
+        queryClient.getQueryState(
+          getProductTypesQueryOptions({ baseUrl: "/api", fetcher }, { limit: 100 }).queryKey,
+        )?.status,
+      ).toBe("error"),
     )
   })
 

--- a/packages/inventory-react/src/admin/index.tsx
+++ b/packages/inventory-react/src/admin/index.tsx
@@ -128,11 +128,19 @@ export function createInventoryAdminExtension(
         // would pin it into the workspace-chrome chunk that evaluates this
         // factory.
         loader: async ({ queryClient, runtime }: AdminRouteLoaderContext) => {
-          const { DEFAULT_PRODUCTS_LIST_FILTERS, getProductsQueryOptions } = await import(
-            "../query-options.js"
-          )
+          const {
+            DEFAULT_PRODUCTS_LIST_FILTERS,
+            getProductsQueryOptions,
+            getProductTypesQueryOptions,
+          } = await import("../query-options.js")
+          const client = loaderClient(runtime)
+          // The product-type filter is useful as soon as the page mounts, but
+          // it must not delay the route or make the list unavailable when the
+          // secondary request fails. Start it alongside the critical list and
+          // let the mounted query consume the fresh cache entry when ready.
+          void queryClient.prefetchQuery(getProductTypesQueryOptions(client, { limit: 100 }))
           return queryClient.ensureQueryData(
-            getProductsQueryOptions(loaderClient(runtime), DEFAULT_PRODUCTS_LIST_FILTERS),
+            getProductsQueryOptions(client, DEFAULT_PRODUCTS_LIST_FILTERS),
           )
         },
         pendingComponent: ProductsListSkeleton,


### PR DESCRIPTION
## Summary

- start the product-type filter query alongside the critical first products query
- keep filter prefetch failure isolated from Products route admission
- let the mounted filter query consume the same fresh React Query cache entry

## Evidence

Live managed-shell traces showed product types did not begin until the lazy Products page mounted at roughly 1.65–1.73 s, then completed around 2.09–2.21 s. The route loader already has the API client and query-options module around 0.64–0.71 s, so this moves the secondary request roughly one second earlier without adding it to the critical await path.

## Validation

- focused inventory admin extension tests: 13/13 pass
- success regression proves the loader-prefetched products and product types are each fetched exactly once when their mounted queries run
- failure regression proves a rejected product-type prefetch does not reject critical route admission
- Biome: pass
- `git diff --check`: pass

This follows the existing non-blocking detail-page prefetch pattern.