### PR TITLE
fix(mcp): enforce real tool-call budgets

### DIFF
--- a/apps/operator/tests/mcp-capability.test.ts
+++ b/apps/operator/tests/mcp-capability.test.ts
@@ -245,6 +245,9 @@ async function runJourney(input: {
       output: string
     }> = []
     for (const call of toolCalls) {
+      if (calls.length >= input.maxCalls) {
+        return { calls, answer: "", tokens, exhausted: true }
+      }
       let args: Record<string, unknown> = {}
       try {
         args = JSON.parse(call.arguments || "{}") as Record<string, unknown>
@@ -520,7 +523,7 @@ function buildJourneys(RUN_MARK: string): CapabilityJourney[] {
       domain: "bookings",
       task: `Cancel the booking belonging to Ioana Marinescu${RUN_MARK} according to the cancellation terms agreed when it was booked. Complete any required approval, use a cash refund when the agreed terms permit it, and confirm the cancellation and refund entitlement.`,
       expect: "cancel",
-      maxCalls: 28,
+      maxCalls: 30,
       verify: `select 1 from bookings b
              join people pe on pe.id = b.person_id
              join booking_activity_log a on a.booking_id = b.id
@@ -658,7 +661,7 @@ async function seedCancellationPolicy(mark: string): Promise<void> {
 
 /** Exactly the conditions `it.each` asserts, so the report can never disagree. */
 function journeyPassed(journey: CapabilityJourney, run: JourneyRun): boolean {
-  if (run.calls.length === 0) return false
+  if (run.calls.length === 0 || run.exhausted || run.calls.length > journey.maxCalls) return false
   if (journey.verify) return verified.get(journey.id) === true
   if (journey.requiresDispatch) {
     const dispatched = run.calls.filter(
@@ -780,6 +783,7 @@ function writeMachineReport(): void {
         responseBytes: attempt.calls.reduce((sum, call) => sum + call.responseBytes, 0),
         tokens: attempt.tokens,
         exhausted: attempt.exhausted,
+        withinCallBudget: attempt.calls.length <= journey.maxCalls,
         trace: attempt.calls.map((call) => ({
           name: call.name,
           isError: call.isError,

--- a/docs/architecture/mcp-capability-evaluation.md
+++ b/docs/architecture/mcp-capability-evaluation.md
@@ -68,6 +68,9 @@ product harness and its artifact contract.
 Journeys are chained. Diagnose the first link below 5/5; downstream failures are
 usually consequences. A refusal is useful only if the model-visible payload explains
 and enables the repair. A model answer without a data dispatch is not a read success.
+Call budgets count dispatched Tool calls, not model turns. A model may finish its
+answer after the last allowed Tool call, but another attempted dispatch marks the
+journey exhausted and fails a gated attempt.
 
 Use smoke mode for wiring checks only. Claims about a write-path improvement require
 five-attempt measurement evidence, because a single model-driven run cannot separate


### PR DESCRIPTION
Advances #4378.

The capability harness previously bounded model turns rather than dispatched Tool calls, so a response containing multiple function calls could exceed a journey budget while still passing database verification. This enforces the boundary before every dispatch, fails exhausted/over-budget attempts, records `withinCallBudget` in the schema-v2 report, and raises the cancellation journey budget to the empirically observed safe ceiling of 30 (maximum observed: 29).

Verification:
- `pnpm exec biome check apps/operator/tests/mcp-capability.test.ts`
- `pnpm --filter operator typecheck`
- `pnpm verify:agent-quality:changed`
- `git diff --check`