### PR TITLE
fix(vite): keep rich-text editor in the Tiptap chunk

### DIFF
--- a/.changeset/safe-admin-shell-chunks.md
+++ b/.changeset/safe-admin-shell-chunks.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/vite-config": patch
+---
+
+Preserve module execution order across explicit Vite 8 vendor chunks so portable admin-shell documents cannot observe uninitialized circular imports.

--- a/.changeset/safe-admin-shell-chunks.md
+++ b/.changeset/safe-admin-shell-chunks.md
@@ -2,4 +2,4 @@
 "@voyant-travel/vite-config": patch
 ---
 
-Preserve module execution order across explicit Vite 8 vendor chunks so portable admin-shell documents cannot observe uninitialized circular imports.
+Co-locate the rich-text editor with its Tiptap vendor graph so portable admin-shell documents cannot observe uninitialized circular imports without increasing the initial preload closure.

--- a/packages/vite-config/src/index.ts
+++ b/packages/vite-config/src/index.ts
@@ -62,6 +62,12 @@ export function voyantChunkOutput(viteMajor: number, extraManualChunks?: ExtraMa
   const chunkName = (id: string) => voyantVendorChunk(id) ?? extraManualChunks?.(id)
   if (viteMajor >= 8) {
     return {
+      // Explicit groups can leave order-sensitive dependencies in automatic
+      // chunks. Rolldown then permits circular chunk imports, and the portable
+      // admin document can choose a different evaluation order than SSR. Keep
+      // the smaller explicit groups, but preserve the source module order so a
+      // cycle cannot observe an uninitialized export.
+      strictExecutionOrder: true,
       codeSplitting: {
         // Keep named vendor chunks from absorbing their transitive dependencies.
         // In particular, Recharts shares small helpers with workspace chrome;

--- a/packages/vite-config/src/index.ts
+++ b/packages/vite-config/src/index.ts
@@ -30,6 +30,21 @@ function isNodeModulePackage(id: string, packageName: string): boolean {
 
 export function voyantVendorChunk(id: string): string | undefined {
   const normalizedId = id.replaceAll("\\", "/")
+
+  // The editor imports Tiptap, but Rolldown can place modules shared by that
+  // vendor graph into the editor's automatic chunk. Keep the two editor entry
+  // modules with Tiptap so Rolldown cannot emit a circular
+  // tiptap <-> rich-text-editor chunk pair. Match both workspace sources and
+  // the installed package layout used by portable starters.
+  if (
+    (normalizedId.includes("/packages/ui/") ||
+      normalizedId.includes("/node_modules/@voyant-travel/ui/")) &&
+    (normalizedId.endsWith("/src/components/rich-text-editor.tsx") ||
+      normalizedId.endsWith("/src/components/rich-text-variable-extension.ts"))
+  ) {
+    return "tiptap"
+  }
+
   if (!normalizedId.includes("node_modules")) return undefined
 
   if (
@@ -62,12 +77,6 @@ export function voyantChunkOutput(viteMajor: number, extraManualChunks?: ExtraMa
   const chunkName = (id: string) => voyantVendorChunk(id) ?? extraManualChunks?.(id)
   if (viteMajor >= 8) {
     return {
-      // Explicit groups can leave order-sensitive dependencies in automatic
-      // chunks. Rolldown then permits circular chunk imports, and the portable
-      // admin document can choose a different evaluation order than SSR. Keep
-      // the smaller explicit groups, but preserve the source module order so a
-      // cycle cannot observe an uninitialized export.
-      strictExecutionOrder: true,
       codeSplitting: {
         // Keep named vendor chunks from absorbing their transitive dependencies.
         // In particular, Recharts shares small helpers with workspace chrome;

--- a/packages/vite-config/tests/vite-config.test.ts
+++ b/packages/vite-config/tests/vite-config.test.ts
@@ -68,8 +68,9 @@ describe("voyantVendorChunk", () => {
 })
 
 describe("voyantChunkOutput", () => {
-  it("uses explicit Rolldown dependency boundaries on Vite 8", () => {
+  it("preserves execution order across explicit Rolldown boundaries on Vite 8", () => {
     const output = voyantChunkOutput(8)
+    expect("strictExecutionOrder" in output && output.strictExecutionOrder).toBe(true)
     expect("codeSplitting" in output && output.codeSplitting.includeDependenciesRecursively).toBe(
       false,
     )

--- a/packages/vite-config/tests/vite-config.test.ts
+++ b/packages/vite-config/tests/vite-config.test.ts
@@ -29,6 +29,14 @@ describe("voyantVendorChunk", () => {
   it("isolates the heavy editor, chart, and pdf vendors", () => {
     expect(voyantVendorChunk("/repo/node_modules/@tiptap/core/index.js")).toBe("tiptap")
     expect(voyantVendorChunk("/repo/node_modules/prosemirror-state/index.js")).toBe("tiptap")
+    expect(voyantVendorChunk("/repo/packages/ui/src/components/rich-text-editor.tsx")).toBe(
+      "tiptap",
+    )
+    expect(
+      voyantVendorChunk(
+        "/repo/node_modules/@voyant-travel/ui/src/components/rich-text-variable-extension.ts",
+      ),
+    ).toBe("tiptap")
     expect(voyantVendorChunk("/repo/node_modules/recharts/es6/index.js")).toBe("recharts")
     expect(voyantVendorChunk("/repo/node_modules/pdf-lib/cjs/index.js")).toBe("pdf-lib")
     expect(voyantVendorChunk("/repo/node_modules/@pdf-lib/fontkit/index.js")).toBe("pdf-lib")
@@ -68,9 +76,8 @@ describe("voyantVendorChunk", () => {
 })
 
 describe("voyantChunkOutput", () => {
-  it("preserves execution order across explicit Rolldown boundaries on Vite 8", () => {
+  it("uses explicit Rolldown dependency boundaries on Vite 8", () => {
     const output = voyantChunkOutput(8)
-    expect("strictExecutionOrder" in output && output.strictExecutionOrder).toBe(true)
     expect("codeSplitting" in output && output.codeSplitting.includeDependenciesRecursively).toBe(
       false,
     )


### PR DESCRIPTION
## Summary

- co-locate the rich-text editor entry modules with their Tiptap/ProseMirror vendor graph
- prevent Rolldown from emitting the crashing `tiptap <-> rich-text-editor` circular chunk pair
- retain explicit dependency boundaries and the portable-shell preload budget

## Production evidence

The 0.11.6 admin shell attached to managed runtime 0.80.6 failed on `/products` with an uninitialized circular import. Importing the published Tiptap chunk reproduces the failure. The rebuilt graph has no separate rich-text-editor chunk, and its Tiptap chunk imports successfully in Chrome with no page errors.

## Performance guard

A global `strictExecutionOrder` fix was rejected because Depot measured 712,065 bytes gzip of initial preloads against the 560 KiB limit. The scoped graph fix measures 521,026 bytes gzip locally and keeps Tiptap out of the initial preload closure.

## Validation

- focused vite-config tests: 22/22
- vite-config typecheck
- Biome and diff check
- full operator production build
- packaged admin-shell verifier: 612 files
- published-vs-rebuilt generated chunk import in Chrome
- repository-wide pre-push test graph