### PR TITLE
fix(mcp): keep cancellation eval financially valid

### DIFF
--- a/apps/operator/tests/mcp-capability.test.ts
+++ b/apps/operator/tests/mcp-capability.test.ts
@@ -521,20 +521,16 @@ function buildJourneys(RUN_MARK: string): CapabilityJourney[] {
       // approves, applies, and audits those exact terms rather than today's policy.
       id: "booking-cancel",
       domain: "bookings",
-      task: `Cancel the booking belonging to Ioana Marinescu${RUN_MARK} according to the cancellation terms agreed when it was booked. Complete any required approval, use a cash refund when the agreed terms permit it, and confirm the cancellation and refund entitlement.`,
+      task: `Cancel the booking belonging to Ioana Marinescu${RUN_MARK} according to the cancellation terms agreed when it was booked. Complete any required approval and confirm the cancellation and refund entitlement. Inspect the related invoice before taking any finance action; do not record money as paid back when no customer payment was received.`,
       expect: "cancel",
-      maxCalls: 36,
+      maxCalls: 30,
       verify: `select 1 from bookings b
              join people pe on pe.id = b.person_id
              join booking_activity_log a on a.booking_id = b.id
              where pe.last_name ilike '%marinescu${RUN_MARK}%'
                and b.status = 'cancelled'
                and a.metadata->'cancellationPolicyEntitlement'->>'status' = 'evaluated'
-               and (a.metadata->'cancellationPolicyEntitlement'->>'refundCents')::int > 0
-               and exists (
-                 select 1 from refund_settlements rs
-                 where rs.booking_id = b.id and rs.method = 'cash'
-               )`,
+               and (a.metadata->'cancellationPolicyEntitlement'->>'refundCents')::int > 0`,
     },
     {
       id: "contracts-read",


### PR DESCRIPTION
Advances #4378.

The stricter five-run proved the previous cancellation prompt was financially invalid: it demanded a cash payout after issuing only an unpaid proforma. Terra correctly refused to record money as paid back in 4/5 attempts; the sole SQL pass fabricated a cash settlement despite €0 received.

This keeps the real cancellation-policy assertion (booking cancelled, sale-time entitlement evaluated, positive refund entitlement), explicitly requires invoice inspection, and forbids recording a payout when no customer payment was received. The real-call budget returns to 30. The separate cash-refund workflow must be evaluated from a paid-invoice fixture.

Evidence: invoice issuance is now 5/5; cancellation itself and entitlement were 5/5; the invalid cash-settlement requirement was 1/5. Cleanup succeeded.

Verification:
- `pnpm exec biome check apps/operator/tests/mcp-capability.test.ts`
- `pnpm --filter operator typecheck`
- `pnpm verify:agent-quality:changed`
- `git diff --check`