### PR TITLE
fix(vite): keep chart bridge with recharts

### DIFF
--- a/.changeset/calm-dashboard-charts.md
+++ b/.changeset/calm-dashboard-charts.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/vite-config": patch
+---
+
+Co-locate the UI chart bridge with Recharts so portable admin dashboards cannot render an undefined chart component from a circular client-chunk import.

--- a/packages/vite-config/src/index.ts
+++ b/packages/vite-config/src/index.ts
@@ -45,6 +45,19 @@ export function voyantVendorChunk(id: string): string | undefined {
     return "tiptap"
   }
 
+  // ChartContainer imports Recharts while Recharts imports D3 helpers that
+  // Rolldown can otherwise place beside this first-party module. That creates
+  // a recharts <-> chart chunk cycle and leaves dashboard components undefined
+  // during browser evaluation. Keep only the UI bridge with the vendor; its D3
+  // dependencies can remain in their automatic, one-way dependency chunk.
+  if (
+    (normalizedId.includes("/packages/ui/") ||
+      normalizedId.includes("/node_modules/@voyant-travel/ui/")) &&
+    normalizedId.endsWith("/src/components/chart.tsx")
+  ) {
+    return "recharts"
+  }
+
   if (!normalizedId.includes("node_modules")) return undefined
 
   if (

--- a/packages/vite-config/tests/vite-config.test.ts
+++ b/packages/vite-config/tests/vite-config.test.ts
@@ -37,6 +37,10 @@ describe("voyantVendorChunk", () => {
         "/repo/node_modules/@voyant-travel/ui/src/components/rich-text-variable-extension.ts",
       ),
     ).toBe("tiptap")
+    expect(voyantVendorChunk("/repo/packages/ui/src/components/chart.tsx")).toBe("recharts")
+    expect(voyantVendorChunk("/repo/node_modules/@voyant-travel/ui/src/components/chart.tsx")).toBe(
+      "recharts",
+    )
     expect(voyantVendorChunk("/repo/node_modules/recharts/es6/index.js")).toBe("recharts")
     expect(voyantVendorChunk("/repo/node_modules/pdf-lib/cjs/index.js")).toBe("pdf-lib")
     expect(voyantVendorChunk("/repo/node_modules/@pdf-lib/fontkit/index.js")).toBe("pdf-lib")


### PR DESCRIPTION
## Summary

- co-locate the first-party chart bridge with the Recharts vendor chunk
- prevent the Recharts/chart circular chunk import that leaves dashboard components undefined
- cover workspace and installed-package paths

## Validation

- focused vite-config tests: 22/22
- operator production build
- packaged admin shell verification (612 files)
- initial preloads: 521,003 gzip bytes (limit 560 KiB)
- emitted client SCC scan: Recharts/chart cycle removed
- Chrome dynamic import: all three dashboard chart exports evaluate as functions