### PR TITLE
fix(mcp): scope discovery fallbacks by domain

### DIFF
--- a/.changeset/calm-domain-fallbacks.md
+++ b/.changeset/calm-domain-fallbacks.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/mcp": patch
+---
+
+Keep zero-hit Tool discovery fallbacks inside a recognized domain and report the fallback count accurately.

--- a/apps/operator/tests/selected-graph-mcp-tool-surface.test.ts
+++ b/apps/operator/tests/selected-graph-mcp-tool-surface.test.ts
@@ -336,6 +336,39 @@ describe("selected-graph MCP tool surface cost", () => {
     ).toBeLessThanOrEqual(AGGREGATE_CEILING_BYTES)
   })
 
+  it("keeps a zero-hit fallback inside a recognized domain", async () => {
+    const { app } = await mountSelectedGraphMcp()
+    const searched = await readRpc(
+      await app.request(
+        "/",
+        rpc("tools/call", {
+          name: "search_tools",
+          arguments: {
+            query: "cash refund booking entitlement phrase with no exact tool match",
+            domain: "finance",
+            limit: 50,
+          },
+        }),
+        TEST_ENV,
+        TEST_CTX,
+      ),
+    )
+    const result = (
+      searched.result as {
+        structuredContent?: {
+          returned?: number
+          tools?: Array<{ name: string; domain: string }>
+        }
+      }
+    ).structuredContent
+    const tools = result?.tools ?? []
+
+    expect(tools.length).toBeGreaterThan(0)
+    expect(result?.returned).toBe(tools.length)
+    expect(new Set(tools.map(({ domain }) => domain))).toEqual(new Set(["finance"]))
+    expect(tools.map(({ name }) => name)).toContain("finance_query")
+  })
+
   it("still bounds EVERY selected tool's schema, writes included", async () => {
     // The query-tool bound above covers the collapsed READ surface only. Writes
     // are deliberately not collapsed (voyant#3921: per-action risk, confirmation,

--- a/packages/mcp/src/meta-tools.ts
+++ b/packages/mcp/src/meta-tools.ts
@@ -1,3 +1,4 @@
+// agent-quality: file-size exception -- owner: mcp; remove when discovery, descriptor projection, and lazy dispatch are split without duplicating the shared authorized-surface rules.
 /**
  * Progressive disclosure (voyant#3927): the eager MCP surface is a small tier-0
  * of meta-tools; the long tail of domain tools is discovered and dispatched on
@@ -294,12 +295,17 @@ function searchTools(
   // back to the query tools, which is the answer to "where do I look for a
   // record" in the only vocabulary the caller is already using.
   const fellBack = matches.length === 0
-  const fallback = fellBack ? queryToolCandidates(projection) : []
+  const allFallbacks = fellBack ? queryToolCandidates(projection) : []
+  const domainFallbacks = domain
+    ? allFallbacks.filter((candidate) => candidate.domain.toLowerCase() === domain)
+    : []
+  const fallbackPool = domainFallbacks.length > 0 ? domainFallbacks : allFallbacks
+  const fallback = fallbackPool.slice(0, limit)
 
   const payload = {
     total: matches.length,
-    returned: returned.length,
-    truncated: matches.length > returned.length,
+    returned: fellBack ? fallback.length : returned.length,
+    truncated: fellBack ? fallbackPool.length > fallback.length : matches.length > returned.length,
     tools: fellBack ? fallback : returned.map(({ score: _score, ...tool }) => tool),
     ...(ignoredDomain ? { ignoredDomain: args.domain } : {}),
     ...(fellBack ? { howToFindARecord: recordLookupGuidance() } : {}),


### PR DESCRIPTION
Advances #3971 and #4378.

The final GPT-5.6 Terra report showed `search_tools` zero-hit fallback payloads at ~14.2 KB. Even when the caller supplied a recognized domain such as `finance`, fallback returned every domain query tool and reported `returned: 0` despite a non-empty `tools` array.

This keeps the recovery mechanism for record-name searches, but scopes fallback query tools to a recognized domain, honors the requested limit, and reports fallback counts/truncation consistently. A real selected-graph regression covers the Finance case.

Verification:
- `pnpm --filter @voyant-travel/mcp test` (99 tests)
- `pnpm --filter @voyant-travel/mcp typecheck`
- selected operator graph surface test (7 tests)
- `pnpm verify:agent-quality:changed`
- `git diff --check`