### PR TITLE
fix(mcp): keep publish identity server-owned

### DIFF
--- a/.changeset/quiet-publish-identities.md
+++ b/.changeset/quiet-publish-identities.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/inventory": patch
+---
+
+Keep product lifecycle idempotency identity server-owned in MCP action metadata.

--- a/apps/operator/tests/selected-graph-mcp-tool-surface.test.ts
+++ b/apps/operator/tests/selected-graph-mcp-tool-surface.test.ts
@@ -100,6 +100,23 @@ interface SerializedTool {
   name: string
 }
 
+const INTENT_TOOL_NAMES = [
+  "create_person",
+  "create_product",
+  "create_option_unit",
+  "create_departure",
+  "publish_product",
+  "book_product",
+  "invoice_booking",
+  "cancel_booking",
+] as const
+
+const CALLER_INVENTED_ACTION_FIELDS = [
+  "targetId",
+  "idempotencyKey",
+  "idempotencyFingerprint",
+] as const
+
 function rpc(method: string, params: unknown) {
   return {
     method: "POST",
@@ -205,6 +222,41 @@ describe("selected-graph MCP tool surface cost", () => {
     expect(manifest.tools.length).toBeGreaterThan(200)
     const unnamed = manifest.tools.filter(({ name }) => !name || name.length === 0)
     expect(unnamed).toEqual([])
+  })
+
+  it("does not make intent tools expose caller-invented action-ledger identity", async () => {
+    const { app } = await mountSelectedGraphMcp()
+    const manifest = (await (await app.request("/manifest", {}, TEST_ENV, TEST_CTX)).json()) as {
+      tools: Array<{
+        name?: string
+        actionPolicy?: {
+          invocation?: {
+            requiredFields?: readonly string[]
+            optionalFields?: readonly string[]
+          }
+        }
+      }>
+    }
+    const byName = new Map(manifest.tools.map((tool) => [tool.name, tool]))
+
+    for (const name of INTENT_TOOL_NAMES) {
+      const tool = byName.get(name)
+      expect(tool, `${name} was missing from the selected MCP manifest`).toBeDefined()
+      expect(tool?.actionPolicy, `${name} did not publish its action policy`).toBeDefined()
+
+      const invocation = tool?.actionPolicy?.invocation
+      const exposed = [...(invocation?.requiredFields ?? []), ...(invocation?.optionalFields ?? [])]
+      expect(
+        exposed.filter((field) =>
+          CALLER_INVENTED_ACTION_FIELDS.includes(
+            field as (typeof CALLER_INVENTED_ACTION_FIELDS)[number],
+          ),
+        ),
+        `${name} leaks action-ledger identity into the MCP protocol. Intent tools may ask ` +
+          "for confirmation and may carry a server-issued approvalId, but target and " +
+          "idempotency identity must be resolved behind the tool boundary.",
+      ).toEqual([])
+    }
   })
 
   it("registers every staff-audience tool the selected graph declares", async () => {

--- a/packages/inventory/src/tools.ts
+++ b/packages/inventory/src/tools.ts
@@ -651,6 +651,10 @@ function productLifecycleToolDefinition(input: {
     riskPolicy: PRODUCT_LIFECYCLE_RISK,
     annotations: { idempotentHint: true },
     actionPolicyEnforcement: "handler",
+    // `updateProductLifecycle` derives a stable key from the product id and
+    // requested lifecycle patch before executing the admitted command. Keep
+    // that server-owned identity out of the caller-facing MCP protocol.
+    resolvesIdempotencyKeyServerSide: true,
     async handler({ id }: z.infer<typeof productIdArgs>, ctx: InventoryToolContext) {
       try {
         const admitted = admitHandlerActionPolicy(ctx, input.handlerPolicy)

--- a/packages/inventory/tests/tools.test.ts
+++ b/packages/inventory/tests/tools.test.ts
@@ -159,6 +159,12 @@ describe("inventory tools", () => {
       confirmationRequired: true,
       reversible: true,
     })
+    expect(
+      manifest.find(({ name }) => name === "publish_product")?.actionPolicy?.invocation,
+    ).toMatchObject({
+      requiredFields: ["confirmed", "approvalId"],
+      optionalFields: ["reasonCode", "approvalId"],
+    })
   })
 
   it("sets or clears the explicit product Open Graph image", async () => {


### PR DESCRIPTION
## Summary
- stop advertising product lifecycle idempotency keys and fingerprints to MCP callers
- rely on the existing server-side lifecycle command derivation
- ratchet the composed selected-graph intent surface against caller-invented action identity

## Verification
- `pnpm --filter @voyant-travel/inventory exec vitest run tests/tools.test.ts` (18 passed)
- `pnpm --filter operator exec vitest run --config .voyant/vitest.config.ts tests/selected-graph-mcp-tool-surface.test.ts -t "does not make intent tools expose"` (1 passed)
- `pnpm --filter @voyant-travel/inventory typecheck`
- `pnpm --filter operator typecheck`
- Biome check and `git diff --check`

Tracks #4378 and #3921.