### PR TITLE
fix(webhooks): canonicalize persisted payloads

### DIFF
--- a/.changeset/calm-webhooks-hash.md
+++ b/.changeset/calm-webhooks-hash.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/webhook-delivery": patch
+"@voyant-travel/apps": patch
+---
+
+Serialize durable webhook payloads canonically so PostgreSQL jsonb key reordering cannot invalidate their persisted integrity hash before delivery.

--- a/packages/apps/src/webhook-delivery.ts
+++ b/packages/apps/src/webhook-delivery.ts
@@ -15,6 +15,7 @@ import {
   type ExternalWebhookEventContract,
   hashWebhookPayload,
   isAppWebhookDeliveryEnvelope,
+  serializeWebhookPayload,
   type WebhookDeliveryStore,
   type WebhookDeliveryWorker,
   type WebhookEnqueueOutcome,
@@ -444,7 +445,7 @@ function replayInput(
     idempotencyKey: `app-webhook-replay:${original.id}:${deliveryId}`,
     originalDeliveryId: original.id,
   })
-  const body = JSON.stringify(replay)
+  const body = serializeWebhookPayload(replay)
   return {
     id: deliveryId,
     sourceModule: "apps",

--- a/packages/webhook-delivery/src/admin-service.ts
+++ b/packages/webhook-delivery/src/admin-service.ts
@@ -24,6 +24,7 @@ import {
 import {
   assertOutboundWebhookEndpointUrl,
   hashWebhookPayload,
+  serializeWebhookPayload,
   webhookBodyExcerpt,
 } from "./security.js"
 import { generateWebhookTestPayload } from "./test-payload.js"
@@ -327,7 +328,7 @@ function deliveryInput(input: {
 }): EnqueueWebhookAttemptInput {
   const id = newId("webhook_deliveries")
   const idempotencyKey = `${input.idempotencyPrefix}:${id}`
-  const body = JSON.stringify(input.event)
+  const body = serializeWebhookPayload(input.event)
   return {
     id,
     sourceModule: "operator-webhooks",

--- a/packages/webhook-delivery/src/index.ts
+++ b/packages/webhook-delivery/src/index.ts
@@ -39,6 +39,7 @@ export {
   assertOutboundWebhookEndpointUrl,
   hashWebhookPayload,
   redactWebhookHeaders,
+  serializeWebhookPayload,
   signWebhookPayload,
   verifyWebhookPayloadSignature,
   webhookBodyExcerpt,

--- a/packages/webhook-delivery/src/security.ts
+++ b/packages/webhook-delivery/src/security.ts
@@ -7,3 +7,36 @@
  * routes.
  */
 export * from "@voyant-travel/webhook-delivery-contracts"
+
+/**
+ * Serialize a persisted webhook payload deterministically.
+ *
+ * PostgreSQL `jsonb` does not preserve object-key insertion order. Hashing a
+ * plain `JSON.stringify` result before insert and then stringifying the
+ * hydrated row can therefore produce different bytes for the same payload.
+ * Webhook hashes and signatures must cover the exact bytes the worker sends,
+ * so every enqueue, retry, replay, and dispatch path uses this serializer.
+ */
+export function serializeWebhookPayload(value: unknown): string {
+  const serialized = JSON.stringify(sortJsonValue(value))
+  if (serialized === undefined) {
+    throw new Error("Webhook payload must be JSON serializable.")
+  }
+  return serialized
+}
+
+function sortJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortJsonValue)
+  if (value === null || typeof value !== "object") return value
+
+  const toJSON = (value as { toJSON?: () => unknown }).toJSON
+  if (typeof toJSON === "function") return sortJsonValue(toJSON.call(value))
+
+  const record = value as Record<string, unknown>
+  return Object.fromEntries(
+    Object.keys(record)
+      .sort()
+      .filter((key) => record[key] !== undefined)
+      .map((key) => [key, sortJsonValue(record[key])]),
+  )
+}

--- a/packages/webhook-delivery/src/selected-queue.ts
+++ b/packages/webhook-delivery/src/selected-queue.ts
@@ -4,7 +4,7 @@ import { newId } from "@voyant-travel/db/lib/typeid"
 
 import { createAppWebhookDeliveryEnvelope } from "./app-envelope.js"
 import { type ExternalWebhookEventContract, prepareExternalWebhookEvent } from "./contracts.js"
-import { hashWebhookPayload, webhookBodyExcerpt } from "./security.js"
+import { hashWebhookPayload, serializeWebhookPayload, webhookBodyExcerpt } from "./security.js"
 import type {
   SelectedExternalWebhookQueue,
   WebhookDeliveryStore,
@@ -55,7 +55,7 @@ export function createSelectedExternalWebhookQueue(
                   idempotencyKey,
                 })
               : event
-            const body = JSON.stringify(payload)
+            const body = serializeWebhookPayload(payload)
             const enqueued = await options.store.enqueueAttempt({
               id: deliveryId,
               sourceModule:

--- a/packages/webhook-delivery/src/worker.ts
+++ b/packages/webhook-delivery/src/worker.ts
@@ -21,6 +21,7 @@ import {
   assertOutboundWebhookEndpointUrl,
   hashWebhookPayload,
   redactWebhookHeaders,
+  serializeWebhookPayload,
   signWebhookPayload,
   webhookBodyExcerpt,
 } from "./security.js"
@@ -92,7 +93,7 @@ export function createWebhookDeliveryWorker(
       return abandon(delivery, startedAt, "webhook subscription is unavailable or inactive")
     }
 
-    const body = JSON.stringify(hydrated.payload)
+    const body = serializeWebhookPayload(hydrated.payload)
     if (hashWebhookPayload(body) !== delivery.requestBodyHash) {
       return abandon(delivery, startedAt, "persisted webhook payload hash does not match")
     }
@@ -424,7 +425,7 @@ function retryInput(
         parentDeliveryId: delivery.id,
       })
     : payload
-  const body = JSON.stringify(retryPayload)
+  const body = serializeWebhookPayload(retryPayload)
   return {
     id: deliveryId,
     sourceModule: delivery.sourceModule,

--- a/packages/webhook-delivery/tests/worker.test.ts
+++ b/packages/webhook-delivery/tests/worker.test.ts
@@ -104,6 +104,27 @@ describe("durable external webhook delivery", () => {
     )
   })
 
+  it("keeps the payload hash stable when jsonb reorders object keys", async () => {
+    const store = new MemoryWebhookDeliveryStore([APP_SUBSCRIPTION])
+    await createSelectedExternalWebhookQueue({ contracts: [CONTRACT], store }).enqueue(EVENT)
+    const queued = store.records[0]
+    if (!queued) throw new Error("Expected a queued webhook delivery")
+
+    // PostgreSQL jsonb normalizes object keys instead of preserving the
+    // insertion order used by the enqueueing process. Model that round trip
+    // without changing the payload's JSON value.
+    queued.requestPayload = reorderObjectKeys(queued.requestPayload)
+
+    const fetch = vi.fn(async () => new Response(null, { status: 204 }))
+    const worker = createWebhookDeliveryWorker({
+      store,
+      fetch: fetch as typeof globalThis.fetch,
+    })
+
+    await expect(worker.runNext()).resolves.toMatchObject({ status: "succeeded" })
+    expect(fetch).toHaveBeenCalledOnce()
+  })
+
   it("delivers installed app subscriptions with the RFC envelope and signing key id", async () => {
     const store = new MemoryWebhookDeliveryStore([APP_SUBSCRIPTION])
     await createSelectedExternalWebhookQueue({ contracts: [CONTRACT], store }).enqueue(EVENT)
@@ -284,6 +305,16 @@ describe("durable external webhook delivery", () => {
     expect(fetch).not.toHaveBeenCalled()
   })
 })
+
+function reorderObjectKeys(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(reorderObjectKeys)
+  if (value === null || typeof value !== "object") return value
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .reverse()
+      .map(([key, nested]) => [key, reorderObjectKeys(nested)]),
+  )
+}
 
 async function queuedStore(): Promise<MemoryWebhookDeliveryStore> {
   const store = new MemoryWebhookDeliveryStore([SUBSCRIPTION])


### PR DESCRIPTION
## Summary
- serialize durable webhook payloads with stable object-key ordering
- use the same bytes for enqueue integrity hashes, retries, replays, signing, and dispatch
- add a regression test that models PostgreSQL jsonb key reordering

## Root cause
PostgreSQL jsonb normalizes object-key order. The queue hashed insertion-order JSON before persistence, while the worker hashed JSON reconstructed from jsonb. Equivalent app webhook payloads therefore failed the integrity check and were abandoned before HTTP dispatch.

## Validation
- `pnpm --filter @voyant-travel/webhook-delivery test` (57 passed)
- `pnpm --filter @voyant-travel/apps test` (143 passed, 15 skipped)
- both package typechecks and lints passed
- changed-file quality and secret scan passed

The full local monorepo commit typecheck was attempted after a complete install but hit existing cross-package declaration-order failures in unrelated React packages; GitHub CI remains the authoritative full-suite gate.