### PR TITLE
fix(mcp): derive proposal acceptance identity

### DIFF
--- a/.changeset/bright-proposal-retries.md
+++ b/.changeset/bright-proposal-retries.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/proposals": patch
+---
+
+Resolve proposal-to-booking acceptance idempotency identity behind the Tool boundary.

--- a/apps/operator/tests/selected-graph-mcp-tool-surface.test.ts
+++ b/apps/operator/tests/selected-graph-mcp-tool-surface.test.ts
@@ -109,6 +109,7 @@ const INTENT_TOOL_NAMES = [
   "book_product",
   "invoice_booking",
   "cancel_booking",
+  "accept_proposal_for_booking",
 ] as const
 
 const CALLER_INVENTED_ACTION_FIELDS = [

--- a/packages/proposals/src/tools.ts
+++ b/packages/proposals/src/tools.ts
@@ -1,12 +1,14 @@
 import {
   admitHandlerActionPolicy,
   defineTool,
+  deriveCommandIdempotencyKey,
   type HandlerActionPolicyExpectation,
   READ_ONLY_RISK,
   requireService,
   type ToolContext,
   ToolError,
   type ToolHandlerActionPolicyContext,
+  withServerResolvedIdempotencyKey,
 } from "@voyant-travel/tools"
 import { listResponseSchema } from "@voyant-travel/types"
 import { z } from "zod"
@@ -449,8 +451,15 @@ export const acceptProposalForBookingTool = defineTool({
   riskPolicy: proposalWriteRisk,
   annotations: { idempotentHint: true },
   actionPolicyEnforcement: "handler",
+  resolvesIdempotencyKeyServerSide: true,
   async handler({ proposalVersionId }, ctx: ProposalsToolContext) {
-    const admitted = admitHandlerActionPolicy(ctx, ACCEPT_PROPOSAL_FOR_BOOKING_HANDLER_POLICY)
+    const idempotencyKey = await deriveCommandIdempotencyKey("accept-proposal-for-booking", {
+      proposalVersionId,
+    })
+    const admitted = withServerResolvedIdempotencyKey(
+      admitHandlerActionPolicy(ctx, ACCEPT_PROPOSAL_FOR_BOOKING_HANDLER_POLICY),
+      idempotencyKey,
+    )
     return acceptProposalForBookingOutputSchema.parse(
       await proposalAcceptance(ctx).acceptProposalForBooking(proposalVersionId, admitted),
     )

--- a/packages/proposals/tests/tools.test.ts
+++ b/packages/proposals/tests/tools.test.ts
@@ -321,7 +321,7 @@ describe("proposals Tools", () => {
     const acceptance: ProposalAcceptanceToolServices = {
       async acceptProposalForBooking(proposalVersionId, admitted) {
         expect(proposalVersionId).toBe(version.id)
-        expect(admitted.invocation.idempotencyKey).toBe("proposal-booking-accept-1")
+        expect(admitted.invocation.idempotencyKey).toMatch(/^accept-proposal-for-booking:v1:/)
         return {
           status: "accepted",
           currency: "EUR",


### PR DESCRIPTION
## Summary
- derive `accept_proposal_for_booking` command identity from its business input on the server
- stop advertising idempotency keys and fingerprints to the model
- extend the composed selected-graph intent-surface ratchet to proposal acceptance

## Verification
- `pnpm --filter @voyant-travel/proposals exec vitest run tests/tools.test.ts` (6 passed)
- selected-graph caller-invented identity assertion (1 passed)
- `pnpm --filter @voyant-travel/proposals typecheck`
- Biome check and `git diff --check`

Tracks #4378, #3933, and #3921.