### PR TITLE
perf(operator): reduce admin shell startup work

### DIFF
--- a/.changeset/fast-admin-shell-entry-operator.md
+++ b/.changeset/fast-admin-shell-entry-operator.md
@@ -1,12 +1,5 @@
 ---
-"@voyant-travel/auth-react": patch
-"@voyant-travel/operator-standard": patch
-"@voyant-travel/proposals-react": patch
-"@voyant-travel/reporting": patch
-"@voyant-travel/runtime": patch
-"@voyant-travel/storefront": patch
-"@voyant-travel/storefront-react": patch
-"@voyant-travel/vite-config": patch
+"operator": patch
 ---
 
 Reduce production admin-shell startup work by deferring lazy-route dependency preloads, keeping storefront presentation imports off the broad barrel, lazily loading public auth and proposal page implementations, loading Reporting admin routes on demand, and tightening the initial preload budget to 480 KiB gzip.

--- a/.changeset/fast-admin-shell-entry.md
+++ b/.changeset/fast-admin-shell-entry.md
@@ -1,0 +1,13 @@
+---
+"@voyant-travel/auth-react": patch
+"@voyant-travel/operator-standard": patch
+"@voyant-travel/proposals-react": patch
+"@voyant-travel/reporting": patch
+"@voyant-travel/runtime": patch
+"@voyant-travel/storefront": patch
+"@voyant-travel/storefront-react": patch
+"@voyant-travel/vite-config": patch
+"operator": patch
+---
+
+Reduce production admin-shell startup work by deferring lazy-route dependency preloads, keeping storefront presentation imports off the broad barrel, lazily loading public auth and proposal page implementations, loading Reporting admin routes on demand, and tightening the initial preload budget to 480 KiB gzip.

--- a/apps/operator/tests/selected-graph-action-ledger-admin.test.ts
+++ b/apps/operator/tests/selected-graph-action-ledger-admin.test.ts
@@ -37,7 +37,7 @@ describe("selected-graph Action Ledger admin composition", () => {
       "finance",
       "flights",
       "legal",
-      "reporting",
+      "@voyant-travel/reporting",
       "notifications",
       "commerce",
       "trips",

--- a/packages/accommodations/tsconfig.build.json
+++ b/packages/accommodations/tsconfig.build.json
@@ -1911,6 +1911,12 @@
       "@voyant-travel/storefront-react/storefront": [
         "../storefront-react/dist/storefront/index.d.ts"
       ],
+      "@voyant-travel/storefront-react/storefront/messages": [
+        "../storefront-react/dist/storefront/messages.d.ts"
+      ],
+      "@voyant-travel/storefront-react/storefront/presentation-routes": [
+        "../storefront-react/dist/storefront/presentation-routes.d.ts"
+      ],
       "@voyant-travel/storefront-sdk": ["../storefront-sdk/dist/index.d.ts"],
       "@voyant-travel/storefront-sdk/booking-amendments": [
         "../storefront-sdk/dist/booking-amendments.d.ts"

--- a/packages/accommodations/tsconfig.typecheck.json
+++ b/packages/accommodations/tsconfig.typecheck.json
@@ -1912,6 +1912,12 @@
       "@voyant-travel/storefront-react/storefront": [
         "../storefront-react/dist/storefront/index.d.ts"
       ],
+      "@voyant-travel/storefront-react/storefront/messages": [
+        "../storefront-react/dist/storefront/messages.d.ts"
+      ],
+      "@voyant-travel/storefront-react/storefront/presentation-routes": [
+        "../storefront-react/dist/storefront/presentation-routes.d.ts"
+      ],
       "@voyant-travel/storefront-sdk": ["../storefront-sdk/dist/index.d.ts"],
       "@voyant-travel/storefront-sdk/booking-amendments": [
         "../storefront-sdk/dist/booking-amendments.d.ts"

--- a/packages/auth-react/src/local-auth-routes.tsx
+++ b/packages/auth-react/src/local-auth-routes.tsx
@@ -2,33 +2,56 @@ import { useMutation, useQuery } from "@tanstack/react-query"
 import { Outlet, redirect, useNavigate, useSearch } from "@tanstack/react-router"
 import { formatMessage } from "@voyant-travel/admin/lib/i18n"
 import type { AdminAuthMessages } from "@voyant-travel/i18n"
-import type { ReactNode } from "react"
+import { lazy, type ReactNode, Suspense } from "react"
 import { z } from "zod"
-import { AcceptInvitationPage } from "./components/accept-invitation-page.js"
-import { AuthLayout } from "./components/auth-layout.js"
-import {
-  ForgotPasswordPage,
-  type ForgotPasswordPageMessages,
-  ResetPasswordPage,
-  type ResetPasswordPageMessages,
+import type {
+  ForgotPasswordPageMessages,
+  ResetPasswordPageMessages,
 } from "./components/password-reset-pages.js"
-import {
-  RedeemInvitationPage,
-  type RedeemInvitationStatus,
-} from "./components/redeem-invitation-page.js"
-import {
-  SignInPage,
-  type SignInPageMessages,
-  type SignInSocialProvider,
-} from "./components/sign-in-page.js"
-import {
-  type SignUpEmailSubmitInput,
-  SignUpPage,
-  type SignUpPageMessages,
-  type SignUpSocialProvider,
+import type { RedeemInvitationStatus } from "./components/redeem-invitation-page.js"
+import type { SignInPageMessages, SignInSocialProvider } from "./components/sign-in-page.js"
+import type {
+  SignUpEmailSubmitInput,
+  SignUpPageMessages,
+  SignUpSocialProvider,
 } from "./components/sign-up-page.js"
-import { VerifyEmailPage, type VerifyEmailPageMessages } from "./components/verify-email-page.js"
+import type { VerifyEmailPageMessages } from "./components/verify-email-page.js"
 import { type LocalAuthRoute, resolveLocalAuthRedirect } from "./local-auth-bootstrap.js"
+
+const AcceptInvitationPage = lazy(() =>
+  import("./components/accept-invitation-page.js").then((module) => ({
+    default: module.AcceptInvitationPage,
+  })),
+)
+const AuthLayout = lazy(() =>
+  import("./components/auth-layout.js").then((module) => ({ default: module.AuthLayout })),
+)
+const ForgotPasswordPage = lazy(() =>
+  import("./components/password-reset-pages.js").then((module) => ({
+    default: module.ForgotPasswordPage,
+  })),
+)
+const ResetPasswordPage = lazy(() =>
+  import("./components/password-reset-pages.js").then((module) => ({
+    default: module.ResetPasswordPage,
+  })),
+)
+const RedeemInvitationPage = lazy(() =>
+  import("./components/redeem-invitation-page.js").then((module) => ({
+    default: module.RedeemInvitationPage,
+  })),
+)
+const SignInPage = lazy(() =>
+  import("./components/sign-in-page.js").then((module) => ({ default: module.SignInPage })),
+)
+const SignUpPage = lazy(() =>
+  import("./components/sign-up-page.js").then((module) => ({ default: module.SignUpPage })),
+)
+const VerifyEmailPage = lazy(() =>
+  import("./components/verify-email-page.js").then((module) => ({
+    default: module.VerifyEmailPage,
+  })),
+)
 
 export interface LocalAuthPresentationRuntime<TUser> {
   getCurrentUser: () => Promise<TUser | null>
@@ -389,9 +412,11 @@ export function createLocalAuthRouteContribution<TUser>(
 
 function LocalAuthLayout() {
   return (
-    <AuthLayout>
-      <Outlet />
-    </AuthLayout>
+    <Suspense fallback={<div className="min-h-screen bg-background" />}>
+      <AuthLayout>
+        <Outlet />
+      </AuthLayout>
+    </Suspense>
   )
 }
 

--- a/packages/catalog/tsconfig.build.json
+++ b/packages/catalog/tsconfig.build.json
@@ -1860,6 +1860,12 @@
       "@voyant-travel/storefront-react/storefront": [
         "../storefront-react/dist/storefront/index.d.ts"
       ],
+      "@voyant-travel/storefront-react/storefront/messages": [
+        "../storefront-react/dist/storefront/messages.d.ts"
+      ],
+      "@voyant-travel/storefront-react/storefront/presentation-routes": [
+        "../storefront-react/dist/storefront/presentation-routes.d.ts"
+      ],
       "@voyant-travel/storefront-sdk": ["../storefront-sdk/dist/index.d.ts"],
       "@voyant-travel/storefront-sdk/booking-amendments": [
         "../storefront-sdk/dist/booking-amendments.d.ts"

--- a/packages/catalog/tsconfig.typecheck.json
+++ b/packages/catalog/tsconfig.typecheck.json
@@ -1861,6 +1861,12 @@
       "@voyant-travel/storefront-react/storefront": [
         "../storefront-react/dist/storefront/index.d.ts"
       ],
+      "@voyant-travel/storefront-react/storefront/messages": [
+        "../storefront-react/dist/storefront/messages.d.ts"
+      ],
+      "@voyant-travel/storefront-react/storefront/presentation-routes": [
+        "../storefront-react/dist/storefront/presentation-routes.d.ts"
+      ],
       "@voyant-travel/storefront-sdk": ["../storefront-sdk/dist/index.d.ts"],
       "@voyant-travel/storefront-sdk/booking-amendments": [
         "../storefront-sdk/dist/booking-amendments.d.ts"

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -1871,6 +1871,12 @@
       "@voyant-travel/storefront-react/storefront": [
         "../storefront-react/dist/storefront/index.d.ts"
       ],
+      "@voyant-travel/storefront-react/storefront/messages": [
+        "../storefront-react/dist/storefront/messages.d.ts"
+      ],
+      "@voyant-travel/storefront-react/storefront/presentation-routes": [
+        "../storefront-react/dist/storefront/presentation-routes.d.ts"
+      ],
       "@voyant-travel/storefront-sdk": ["../storefront-sdk/dist/index.d.ts"],
       "@voyant-travel/storefront-sdk/booking-amendments": [
         "../storefront-sdk/dist/booking-amendments.d.ts"

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -1865,6 +1865,12 @@
       "@voyant-travel/storefront-react/storefront": [
         "../storefront-react/dist/storefront/index.d.ts"
       ],
+      "@voyant-travel/storefront-react/storefront/messages": [
+        "../storefront-react/dist/storefront/messages.d.ts"
+      ],
+      "@voyant-travel/storefront-react/storefront/presentation-routes": [
+        "../storefront-react/dist/storefront/presentation-routes.d.ts"
+      ],
       "@voyant-travel/storefront-sdk": ["../storefront-sdk/dist/index.d.ts"],
       "@voyant-travel/storefront-sdk/booking-amendments": [
         "../storefront-sdk/dist/booking-amendments.d.ts"

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -1916,6 +1916,12 @@
       "@voyant-travel/storefront-react/storefront": [
         "../storefront-react/dist/storefront/index.d.ts"
       ],
+      "@voyant-travel/storefront-react/storefront/messages": [
+        "../storefront-react/dist/storefront/messages.d.ts"
+      ],
+      "@voyant-travel/storefront-react/storefront/presentation-routes": [
+        "../storefront-react/dist/storefront/presentation-routes.d.ts"
+      ],
       "@voyant-travel/storefront-sdk": ["../storefront-sdk/dist/index.d.ts"],
       "@voyant-travel/storefront-sdk/booking-amendments": [
         "../storefront-sdk/dist/booking-amendments.d.ts"

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -1917,6 +1917,12 @@
       "@voyant-travel/storefront-react/storefront": [
         "../storefront-react/dist/storefront/index.d.ts"
       ],
+      "@voyant-travel/storefront-react/storefront/messages": [
+        "../storefront-react/dist/storefront/messages.d.ts"
+      ],
+      "@voyant-travel/storefront-react/storefront/presentation-routes": [
+        "../storefront-react/dist/storefront/presentation-routes.d.ts"
+      ],
       "@voyant-travel/storefront-sdk": ["../storefront-sdk/dist/index.d.ts"],
       "@voyant-travel/storefront-sdk/booking-amendments": [
         "../storefront-sdk/dist/booking-amendments.d.ts"

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -1920,6 +1920,12 @@
       "@voyant-travel/storefront-react/storefront": [
         "../storefront-react/dist/storefront/index.d.ts"
       ],
+      "@voyant-travel/storefront-react/storefront/messages": [
+        "../storefront-react/dist/storefront/messages.d.ts"
+      ],
+      "@voyant-travel/storefront-react/storefront/presentation-routes": [
+        "../storefront-react/dist/storefront/presentation-routes.d.ts"
+      ],
       "@voyant-travel/storefront-sdk": ["../storefront-sdk/dist/index.d.ts"],
       "@voyant-travel/storefront-sdk/booking-amendments": [
         "../storefront-sdk/dist/booking-amendments.d.ts"

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -1921,6 +1921,12 @@
       "@voyant-travel/storefront-react/storefront": [
         "../storefront-react/dist/storefront/index.d.ts"
       ],
+      "@voyant-travel/storefront-react/storefront/messages": [
+        "../storefront-react/dist/storefront/messages.d.ts"
+      ],
+      "@voyant-travel/storefront-react/storefront/presentation-routes": [
+        "../storefront-react/dist/storefront/presentation-routes.d.ts"
+      ],
       "@voyant-travel/storefront-sdk": ["../storefront-sdk/dist/index.d.ts"],
       "@voyant-travel/storefront-sdk/booking-amendments": [
         "../storefront-sdk/dist/booking-amendments.d.ts"

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -1952,6 +1952,12 @@
       "@voyant-travel/storefront-react/storefront": [
         "../storefront-react/dist/storefront/index.d.ts"
       ],
+      "@voyant-travel/storefront-react/storefront/messages": [
+        "../storefront-react/dist/storefront/messages.d.ts"
+      ],
+      "@voyant-travel/storefront-react/storefront/presentation-routes": [
+        "../storefront-react/dist/storefront/presentation-routes.d.ts"
+      ],
       "@voyant-travel/storefront-sdk": ["../storefront-sdk/dist/index.d.ts"],
       "@voyant-travel/storefront-sdk/booking-amendments": [
         "../storefront-sdk/dist/booking-amendments.d.ts"

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -1947,6 +1947,12 @@
       "@voyant-travel/storefront-react/storefront": [
         "../storefront-react/dist/storefront/index.d.ts"
       ],
+      "@voyant-travel/storefront-react/storefront/messages": [
+        "../storefront-react/dist/storefront/messages.d.ts"
+      ],
+      "@voyant-travel/storefront-react/storefront/presentation-routes": [
+        "../storefront-react/dist/storefront/presentation-routes.d.ts"
+      ],
       "@voyant-travel/storefront-sdk": ["../storefront-sdk/dist/index.d.ts"],
       "@voyant-travel/storefront-sdk/booking-amendments": [
         "../storefront-sdk/dist/booking-amendments.d.ts"

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -1954,6 +1954,12 @@
       "@voyant-travel/storefront-react/storefront": [
         "../storefront-react/dist/storefront/index.d.ts"
       ],
+      "@voyant-travel/storefront-react/storefront/messages": [
+        "../storefront-react/dist/storefront/messages.d.ts"
+      ],
+      "@voyant-travel/storefront-react/storefront/presentation-routes": [
+        "../storefront-react/dist/storefront/presentation-routes.d.ts"
+      ],
       "@voyant-travel/storefront-sdk": ["../storefront-sdk/dist/index.d.ts"],
       "@voyant-travel/storefront-sdk/booking-amendments": [
         "../storefront-sdk/dist/booking-amendments.d.ts"

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -1955,6 +1955,12 @@
       "@voyant-travel/storefront-react/storefront": [
         "../storefront-react/dist/storefront/index.d.ts"
       ],
+      "@voyant-travel/storefront-react/storefront/messages": [
+        "../storefront-react/dist/storefront/messages.d.ts"
+      ],
+      "@voyant-travel/storefront-react/storefront/presentation-routes": [
+        "../storefront-react/dist/storefront/presentation-routes.d.ts"
+      ],
       "@voyant-travel/storefront-sdk": ["../storefront-sdk/dist/index.d.ts"],
       "@voyant-travel/storefront-sdk/booking-amendments": [
         "../storefront-sdk/dist/booking-amendments.d.ts"

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -1952,6 +1952,12 @@
       "@voyant-travel/storefront-react/storefront": [
         "../storefront-react/dist/storefront/index.d.ts"
       ],
+      "@voyant-travel/storefront-react/storefront/messages": [
+        "../storefront-react/dist/storefront/messages.d.ts"
+      ],
+      "@voyant-travel/storefront-react/storefront/presentation-routes": [
+        "../storefront-react/dist/storefront/presentation-routes.d.ts"
+      ],
       "@voyant-travel/storefront-sdk": ["../storefront-sdk/dist/index.d.ts"],
       "@voyant-travel/storefront-sdk/booking-amendments": [
         "../storefront-sdk/dist/booking-amendments.d.ts"

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -1947,6 +1947,12 @@
       "@voyant-travel/storefront-react/storefront": [
         "../storefront-react/dist/storefront/index.d.ts"
       ],
+      "@voyant-travel/storefront-react/storefront/messages": [
+        "../storefront-react/dist/storefront/messages.d.ts"
+      ],
+      "@voyant-travel/storefront-react/storefront/presentation-routes": [
+        "../storefront-react/dist/storefront/presentation-routes.d.ts"
+      ],
       "@voyant-travel/storefront-sdk": ["../storefront-sdk/dist/index.d.ts"],
       "@voyant-travel/storefront-sdk/booking-amendments": [
         "../storefront-sdk/dist/booking-amendments.d.ts"

--- a/packages/inventory/tsconfig.build.json
+++ b/packages/inventory/tsconfig.build.json
@@ -1884,6 +1884,12 @@
       "@voyant-travel/storefront-react/storefront": [
         "../storefront-react/dist/storefront/index.d.ts"
       ],
+      "@voyant-travel/storefront-react/storefront/messages": [
+        "../storefront-react/dist/storefront/messages.d.ts"
+      ],
+      "@voyant-travel/storefront-react/storefront/presentation-routes": [
+        "../storefront-react/dist/storefront/presentation-routes.d.ts"
+      ],
       "@voyant-travel/storefront-sdk": ["../storefront-sdk/dist/index.d.ts"],
       "@voyant-travel/storefront-sdk/booking-amendments": [
         "../storefront-sdk/dist/booking-amendments.d.ts"

--- a/packages/inventory/tsconfig.typecheck.json
+++ b/packages/inventory/tsconfig.typecheck.json
@@ -1885,6 +1885,12 @@
       "@voyant-travel/storefront-react/storefront": [
         "../storefront-react/dist/storefront/index.d.ts"
       ],
+      "@voyant-travel/storefront-react/storefront/messages": [
+        "../storefront-react/dist/storefront/messages.d.ts"
+      ],
+      "@voyant-travel/storefront-react/storefront/presentation-routes": [
+        "../storefront-react/dist/storefront/presentation-routes.d.ts"
+      ],
       "@voyant-travel/storefront-sdk": ["../storefront-sdk/dist/index.d.ts"],
       "@voyant-travel/storefront-sdk/booking-amendments": [
         "../storefront-sdk/dist/booking-amendments.d.ts"

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -1850,6 +1850,12 @@
       "@voyant-travel/storefront-react/storefront": [
         "../storefront-react/dist/storefront/index.d.ts"
       ],
+      "@voyant-travel/storefront-react/storefront/messages": [
+        "../storefront-react/dist/storefront/messages.d.ts"
+      ],
+      "@voyant-travel/storefront-react/storefront/presentation-routes": [
+        "../storefront-react/dist/storefront/presentation-routes.d.ts"
+      ],
       "@voyant-travel/storefront-sdk": ["../storefront-sdk/dist/index.d.ts"],
       "@voyant-travel/storefront-sdk/booking-amendments": [
         "../storefront-sdk/dist/booking-amendments.d.ts"

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -1845,6 +1845,12 @@
       "@voyant-travel/storefront-react/storefront": [
         "../storefront-react/dist/storefront/index.d.ts"
       ],
+      "@voyant-travel/storefront-react/storefront/messages": [
+        "../storefront-react/dist/storefront/messages.d.ts"
+      ],
+      "@voyant-travel/storefront-react/storefront/presentation-routes": [
+        "../storefront-react/dist/storefront/presentation-routes.d.ts"
+      ],
       "@voyant-travel/storefront-sdk": ["../storefront-sdk/dist/index.d.ts"],
       "@voyant-travel/storefront-sdk/booking-amendments": [
         "../storefront-sdk/dist/booking-amendments.d.ts"

--- a/packages/operator-standard/src/standard-frontend.tsx
+++ b/packages/operator-standard/src/standard-frontend.tsx
@@ -46,13 +46,13 @@ import type {
   ProposalsPublicRouteRuntime,
 } from "@voyant-travel/proposals-react/public-routes"
 import { AdminWorkspaceRealtimeProvider } from "@voyant-travel/realtime-react"
+import { useStorefrontMessages } from "@voyant-travel/storefront-react/storefront/messages"
 import {
   createStorefrontMessagesProvider,
   type StorefrontComposerRouteProps,
   type StorefrontPresentationContribution,
   type StorefrontPresentationRuntime,
-  useStorefrontMessages,
-} from "@voyant-travel/storefront-react/storefront"
+} from "@voyant-travel/storefront-react/storefront/presentation-routes"
 import type { AccessCatalog } from "@voyant-travel/types/api-keys"
 import { ConfirmDialogHost, PromptDialogHost } from "@voyant-travel/ui/components"
 import { TooltipProvider } from "@voyant-travel/ui/components/tooltip"

--- a/packages/operator-standard/tests/standard-package-manifests.test.ts
+++ b/packages/operator-standard/tests/standard-package-manifests.test.ts
@@ -90,7 +90,7 @@ describe("standard package manifests", () => {
       {
         id: "@voyant-travel/storefront#presentation.customer",
         runtime: {
-          entry: "@voyant-travel/storefront-react/storefront",
+          entry: "@voyant-travel/storefront-react/storefront/presentation-routes",
           export: "createStorefrontPresentationContribution",
         },
         contribution: "storefront",

--- a/packages/proposals-react/src/public-routes.tsx
+++ b/packages/proposals-react/src/public-routes.tsx
@@ -1,9 +1,14 @@
 "use client"
 
 import { useParams } from "@tanstack/react-router"
-import type { ComponentType, ReactNode } from "react"
+import { type ComponentType, lazy, type ReactNode, Suspense } from "react"
 import type { PublicProposalPageMessages } from "./storefront/public-proposal-page.js"
-import { PublicProposalPage } from "./storefront/public-proposal-page.js"
+
+const PublicProposalPage = lazy(() =>
+  import("./storefront/public-proposal-page.js").then((module) => ({
+    default: module.PublicProposalPage,
+  })),
+)
 
 export interface ProposalsPublicRouteRuntime {
   getApiUrl(): string
@@ -15,7 +20,9 @@ export function createProposalsPublicRouteContribution(runtime: ProposalsPublicR
   function ProposalRoute() {
     return (
       <runtime.StorefrontMessagesProvider>
-        <ProposalRouteContent />
+        <Suspense fallback={<div className="min-h-screen bg-background" />}>
+          <ProposalRouteContent />
+        </Suspense>
       </runtime.StorefrontMessagesProvider>
     )
   }

--- a/packages/reporting/src/voyant-admin.ts
+++ b/packages/reporting/src/voyant-admin.ts
@@ -10,6 +10,7 @@ const reportingAdminRuntime = {
  */
 export const reportingVoyantAdmin = {
   compositionOrder: 60,
+  loading: "lazy-routes",
   runtime: {
     entry: "@voyant-travel/reporting-react/admin",
     export: "createSelectedReportingAdminExtension",

--- a/packages/runtime/src/tooling-internal.ts
+++ b/packages/runtime/src/tooling-internal.ts
@@ -266,6 +266,10 @@ export function createProjectViteConfig(options: ProjectViteConfigOptions): Inli
     appRootUrl: options.appRootUrl,
     nodeSsr: true,
     bundleWorkspaceSource: options.bundleWorkspaceSource ?? true,
+    // Production applications have hundreds of lazy route modules. Do not
+    // make the entry chunk parse their complete preload map before auth can
+    // begin; the requested route can fetch its edge-cached dependencies.
+    deferDynamicImportPreloads: options.bundleWorkspaceSource === false,
     plugins: [
       createDevelopmentReadinessPlugin(options.developmentReadiness),
       options.generatedRoutes.plugin,

--- a/packages/storefront-react/package.json
+++ b/packages/storefront-react/package.json
@@ -17,6 +17,8 @@
     "./query-keys": "./src/query-keys.ts",
     "./styles.css": "./src/styles.css",
     "./storefront": "./src/storefront/index.ts",
+    "./storefront/messages": "./src/storefront/messages.tsx",
+    "./storefront/presentation-routes": "./src/storefront/presentation-routes.tsx",
     "./customer-portal": "./src/customer-portal/index.ts",
     "./customer-portal/client": "./src/customer-portal/client.ts",
     "./customer-portal/hooks": "./src/customer-portal/hooks/index.ts",
@@ -136,6 +138,16 @@
         "types": "./dist/storefront/index.d.ts",
         "import": "./dist/storefront/index.js",
         "default": "./dist/storefront/index.js"
+      },
+      "./storefront/messages": {
+        "types": "./dist/storefront/messages.d.ts",
+        "import": "./dist/storefront/messages.js",
+        "default": "./dist/storefront/messages.js"
+      },
+      "./storefront/presentation-routes": {
+        "types": "./dist/storefront/presentation-routes.d.ts",
+        "import": "./dist/storefront/presentation-routes.js",
+        "default": "./dist/storefront/presentation-routes.js"
       },
       "./customer-portal": {
         "types": "./dist/customer-portal/index.d.ts",

--- a/packages/storefront/src/voyant.ts
+++ b/packages/storefront/src/voyant.ts
@@ -157,7 +157,7 @@ export const storefrontVoyantModule = defineModule({
     {
       id: "@voyant-travel/storefront#presentation.customer",
       runtime: {
-        entry: "@voyant-travel/storefront-react/storefront",
+        entry: "@voyant-travel/storefront-react/storefront/presentation-routes",
         export: "createStorefrontPresentationContribution",
       },
       contribution: "storefront",

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -1963,6 +1963,12 @@
       "@voyant-travel/storefront-react/storefront": [
         "../storefront-react/dist/storefront/index.d.ts"
       ],
+      "@voyant-travel/storefront-react/storefront/messages": [
+        "../storefront-react/dist/storefront/messages.d.ts"
+      ],
+      "@voyant-travel/storefront-react/storefront/presentation-routes": [
+        "../storefront-react/dist/storefront/presentation-routes.d.ts"
+      ],
       "@voyant-travel/storefront-sdk": ["../storefront-sdk/dist/index.d.ts"],
       "@voyant-travel/storefront-sdk/booking-amendments": [
         "../storefront-sdk/dist/booking-amendments.d.ts"

--- a/packages/vite-config/src/index.ts
+++ b/packages/vite-config/src/index.ts
@@ -307,6 +307,13 @@ export interface VoyantStartViteConfigOptions {
   /** Extra SSR optimizeDeps entries appended to the Voyant set. */
   ssrOptimizeDepsInclude?: readonly string[]
   /**
+   * Keep entry HTML preloads, but let lazy imports fetch their own dependency
+   * graph when they are actually requested. Large generated route graphs can
+   * otherwise make Vite embed hundreds of dependency URLs in the entry chunk,
+   * increasing parse and compile time before the application can authenticate.
+   */
+  deferDynamicImportPreloads?: boolean
+  /**
    * Build the SSR/server environment for a Node runtime (voyant#2966: Voyant
    * deployments are Node-only — no `@cloudflare/vite-plugin`). Adds the
    * load-bearing Node-SSR config the app would otherwise hand-merge:
@@ -364,6 +371,7 @@ export function voyantStartViteConfig(options: VoyantStartViteConfigOptions): Us
     extraManualChunks,
     nodeSsr,
     bundleWorkspaceSource = true,
+    deferDynamicImportPreloads = false,
   } = options
   const resolvableSsrDependencies = resolvableAppRootDependencies(
     appRootUrl,
@@ -377,6 +385,17 @@ export function voyantStartViteConfig(options: VoyantStartViteConfigOptions): Us
       allowedHosts,
     },
     build: {
+      ...(deferDynamicImportPreloads
+        ? {
+            modulePreload: {
+              resolveDependencies: (
+                _url: string,
+                dependencies: string[],
+                context: { hostType: "html" | "js" },
+              ) => (context.hostType === "js" ? [] : dependencies),
+            },
+          }
+        : {}),
       rollupOptions: {
         output: {
           ...voyantChunkOutput(

--- a/packages/vite-config/tests/vite-config.test.ts
+++ b/packages/vite-config/tests/vite-config.test.ts
@@ -212,6 +212,36 @@ describe("voyantStartViteConfig", () => {
     ])
   })
 
+  it("can defer only JavaScript-hosted dynamic import preloads", () => {
+    const config = voyantStartViteConfig({ ...base, deferDynamicImportPreloads: true })
+    const resolveDependencies = config.build?.modulePreload
+    if (
+      !resolveDependencies ||
+      typeof resolveDependencies === "boolean" ||
+      typeof resolveDependencies.resolveDependencies !== "function"
+    ) {
+      throw new Error("missing module preload dependency resolver")
+    }
+
+    const dependencies = ["assets/react.js", "assets/route.js"]
+    expect(
+      resolveDependencies.resolveDependencies("assets/index.js", dependencies, {
+        hostId: "index.html",
+        hostType: "html",
+      }),
+    ).toEqual(dependencies)
+    expect(
+      resolveDependencies.resolveDependencies("assets/route.js", dependencies, {
+        hostId: "assets/index.js",
+        hostType: "js",
+      }),
+    ).toEqual([])
+  })
+
+  it("keeps Vite's default preload behavior unless explicitly enabled", () => {
+    expect(voyantStartViteConfig(base).build?.modulePreload).toBeUndefined()
+  })
+
   it("layers extra manual chunks after the Voyant vendor rules", () => {
     const config = voyantStartViteConfig({
       ...base,

--- a/scripts/check-operator-product-ui-authority.mjs
+++ b/scripts/check-operator-product-ui-authority.mjs
@@ -126,7 +126,7 @@ const requiredTokens = new Map([
     [
       '"@voyant-travel/cruises-react/storefront"',
       '"@voyant-travel/inventory-react/storefront"',
-      '"@voyant-travel/storefront-react/storefront"',
+      '"@voyant-travel/storefront-react/storefront/presentation-routes"',
       '"@voyant-travel/trips-react/storefront"',
       "presentationFactories",
       '"@voyant-travel/storefront#presentation.customer"',

--- a/scripts/lib/storefront-presentation-authority.mjs
+++ b/scripts/lib/storefront-presentation-authority.mjs
@@ -117,7 +117,7 @@ export function checkStorefrontPresentationAuthority({
   for (const token of [
     "presentations: [",
     'id: "@voyant-travel/storefront#presentation.customer"',
-    'entry: "@voyant-travel/storefront-react/storefront"',
+    'entry: "@voyant-travel/storefront-react/storefront/presentation-routes"',
     'export: "createStorefrontPresentationContribution"',
   ]) {
     if (!graphDeclaration.includes(token)) {

--- a/scripts/measure-operator-application.mjs
+++ b/scripts/measure-operator-application.mjs
@@ -94,8 +94,8 @@ if (check) {
     failures.push("largest admin gzip chunk exceeds 2 MiB")
   }
   if (!report.portableShell) failures.push("portable admin shell is missing")
-  if ((report.portableShell?.initialPreloads.gzipBytes ?? 0) > 560 * 1024) {
-    failures.push("portable admin shell initial preloads exceed 560 KiB gzip")
+  if ((report.portableShell?.initialPreloads.gzipBytes ?? 0) > 480 * 1024) {
+    failures.push("portable admin shell initial preloads exceed 480 KiB gzip")
   }
   if (
     report.portableShell?.initialPreloads.paths.some((path) => /\/recharts-[^/]+\.js$/.test(path))


### PR DESCRIPTION
## What changed

- keep production entry HTML preloads while deferring dependency preloads for lazy JavaScript imports
- move the Storefront presentation onto a narrow import boundary instead of its broad page barrel
- lazy-load unauthenticated auth and public proposal page implementations
- load Reporting admin routes on demand
- tighten the portable-shell initial preload budget from 560 KiB to 480 KiB gzip

## Why

A real Pro Travel trace on 0.11.8 showed the document and initial assets arriving quickly, but the browser then spent about 8.5 seconds executing JavaScript and 4.5 seconds compiling before shell bootstrap began. The generated route/presentation graph was retaining unrelated public page implementations and hundreds of lazy dependency URLs in the initial entry.

## Measured impact

Compared with the deployed 0.11.8 artifact:

- entry JavaScript: 701,155 -> 515,712 bytes (-26.4%)
- entry gzip: about 195,834 -> 139,420 bytes (-28.8%)
- initial preload graph: 1,859,238 -> 1,548,355 bytes (-16.7%)
- initial preload gzip: 521,003 -> 438,691 bytes (-15.8%)
- direct modulepreloads: 36 -> 33

This is the first slice of #4439 and the OSS shell portion of voyant-travel/platform#1908. It does not yet claim the <=20-request target; remaining eager admin factories need separate import-cheap shell descriptors.

## Validation

- 84 focused Vite/runtime/auth/proposals/framework tests passed
- Storefront authority check passed
- Operator production build passed
- portable admin-shell identity verifier passed
- packaged browser smoke passed: deep-link loading shell, sign-in redirect, no console errors, no failed requests
- affected Operator manifest test passed after updating the expected narrow runtime entry

The repository-wide local hooks also traversed the broad monorepo graph. The first attempt encountered unrelated cached Bookings/Identity failures; the pre-push suite later exposed one relevant Storefront manifest expectation, which was fixed and rerun successfully. Depot CI remains the repository-wide gate.