### PR TITLE
perf(admin): defer deployment access catalog

### DIFF
--- a/.changeset/lazy-admin-access-catalog.md
+++ b/.changeset/lazy-admin-access-catalog.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/admin-app": patch
+"@voyant-travel/admin-host": patch
+"@voyant-travel/operator-standard": patch
+---
+
+Keep the deployment access catalog out of the initial admin shell and load it only when the API Tokens settings page is opened.

--- a/packages/admin-app/src/core-extension/index.tsx
+++ b/packages/admin-app/src/core-extension/index.tsx
@@ -86,8 +86,8 @@ export interface AdminCoreAccountOptions {
 export interface AdminCoreSettingsOptions {
   /** Mount path of the settings area. Default `/settings`. */
   basePath?: string
-  /** Deployment-selected catalog supplied to API-token and member permission editors. */
-  accessCatalog?: AccessCatalog
+  /** Lazily load the deployment-selected catalog for permission-editing pages. */
+  loadAccessCatalog?: () => Promise<AccessCatalog>
   /**
    * Where the settings index redirects. Default `<basePath>/channels`
    * (skipped automatically when `channels` is omitted — then the first
@@ -193,7 +193,7 @@ function createSettingsContribution(options: AdminCoreSettingsOptions): AdminUiR
       title: "Settings",
       redirectTo: indexRedirectTo,
     },
-    ...entries.map((entry) => createBuiltInSettingsPage(entry.id, options.accessCatalog)),
+    ...entries.map((entry) => createBuiltInSettingsPage(entry.id, options.loadAccessCatalog)),
     ...extraPages.map((page) => ({
       id: `core-settings-${page.id}`,
       path: page.path,
@@ -233,7 +233,7 @@ function uniqueExtraSettingsPages(
 
 function createBuiltInSettingsPage(
   id: AdminCoreSettingsPageId,
-  accessCatalog?: AccessCatalog,
+  loadAccessCatalog?: () => Promise<AccessCatalog>,
 ): AdminUiRouteContribution {
   const entry = adminCoreSettingsNavEntries.find((candidate) => candidate.id === id)
   if (!entry) {
@@ -250,7 +250,10 @@ function createBuiltInSettingsPage(
             default: module.AuthUiMessagesProvider,
           })),
         page: () =>
-          import("@voyant-travel/auth-react/components/service-api-keys-page").then((module) => {
+          Promise.all([
+            import("@voyant-travel/auth-react/components/service-api-keys-page"),
+            loadAccessCatalog?.(),
+          ]).then(([module, accessCatalog]) => {
             function ApiTokensPage() {
               return <module.ApiTokensPage accessCatalog={accessCatalog} />
             }

--- a/packages/admin-app/tests/admin-app.test.ts
+++ b/packages/admin-app/tests/admin-app.test.ts
@@ -65,6 +65,25 @@ describe("createAdminCoreExtension", async () => {
     expect(settings?.children?.[0]?.redirectTo).toBe("/settings/api-tokens")
   })
 
+  it("does not load the access catalog until the API tokens page is requested", async () => {
+    const accessCatalog = { resources: [], presets: [] }
+    let loadCount = 0
+    const core = createAdminCoreExtensionShim({
+      settings: {
+        loadAccessCatalog: async () => {
+          loadCount += 1
+          return accessCatalog
+        },
+      },
+    })
+    const settings = core.routes?.find((route) => route.id === "core-settings")
+    const apiTokens = settings?.children?.find((child) => child.id === "core-settings-api-tokens")
+
+    expect(loadCount).toBe(0)
+    await apiTokens?.page?.()
+    expect(loadCount).toBe(1)
+  }, 15_000)
+
   it("binds app-supplied extra settings pages as child contributions", () => {
     const core = createAdminCoreExtensionShim({
       settings: {

--- a/packages/admin-host/src/admin-presentation.ts
+++ b/packages/admin-host/src/admin-presentation.ts
@@ -39,7 +39,7 @@ export interface CreateAdminHostExtensionsOptions {
 }
 
 export interface CreateAdminHostPresentationOptions {
-  accessCatalog: AccessCatalog
+  loadAccessCatalog: () => Promise<AccessCatalog>
   selected: SelectedExtensionsFactory
   project?: Record<string, unknown>
 }
@@ -104,7 +104,7 @@ function uniqueExtensionsById(
 
 /** Build the standard selected-graph presentation with optional project-local extensions. */
 export function createAdminHostPresentation({
-  accessCatalog,
+  loadAccessCatalog,
   selected,
   project = {},
 }: CreateAdminHostPresentationOptions): AdminHostPresentation {
@@ -114,7 +114,7 @@ export function createAdminHostPresentation({
       core: (settingsPages, setup) =>
         createAdminCoreExtension({
           dashboard: { loader: (context) => loadAdminDashboard(context, setup) },
-          settings: { accessCatalog, extraPages: settingsPages },
+          settings: { loadAccessCatalog, extraPages: settingsPages },
         }),
       selected,
       navMessages,

--- a/packages/operator-standard/src/standard-frontend.tsx
+++ b/packages/operator-standard/src/standard-frontend.tsx
@@ -118,7 +118,7 @@ type StandardOperatorShellBootstrap = Omit<
 }
 
 export interface CreateStandardOperatorFrontendOptions {
-  accessCatalog: AccessCatalog
+  loadAccessCatalog: () => Promise<AccessCatalog>
   selected: Parameters<typeof createAdminHostPresentation>[0]["selected"]
   presentations: Readonly<Record<string, StandardOperatorPresentationFactory>>
   project?: Record<string, unknown>

--- a/packages/operator-standard/src/standard-route-files.ts
+++ b/packages/operator-standard/src/standard-route-files.ts
@@ -46,9 +46,11 @@ const standardOperatorRouteFiles: readonly VoyantGeneratedRouteFile[] = [
     path: "_lib/operator-frontend.tsx",
     source: `
 import { createStandardOperatorFrontend } from ${JSON.stringify(standardFrontendImport)}
-import { accessCatalog } from "../../access/selected-access-catalog.generated.js"
 import { createSelectedGraphAdminExtensions } from "../../admin/selected-graph-admin.generated.js"
 import { selectedGraphPresentationFactories } from "../../presentations/selected-graph-presentations.generated.js"
+
+const loadAccessCatalog = () =>
+  import("../../access/selected-access-catalog.generated.js").then((module) => module.accessCatalog)
 
 const workspaceSpecs = import.meta.glob<{ default: Record<string, unknown> }>(
   "../../../../../packages/*/openapi/{admin,storefront}/*.json",
@@ -58,7 +60,7 @@ const installedSpecs = import.meta.glob<{ default: Record<string, unknown> }>(
 )
 
 export const operatorFrontend = createStandardOperatorFrontend({
-  accessCatalog,
+  loadAccessCatalog,
   selected: createSelectedGraphAdminExtensions,
   presentations: selectedGraphPresentationFactories,
   project: import.meta.glob("../../../src/admin/*/index.tsx", { eager: true }),

--- a/packages/operator-standard/tests/standard-route-files.test.ts
+++ b/packages/operator-standard/tests/standard-route-files.test.ts
@@ -69,6 +69,10 @@ describe("createStandardOperatorRouteFiles", () => {
     )
     expect(runtime?.source).toContain("createStandardOperatorFrontend")
     expect(runtime?.source).toContain("selectedGraphPresentationFactories")
+    expect(runtime?.source).toContain('import("../../access/selected-access-catalog.generated.js")')
+    expect(runtime?.source).not.toContain(
+      'import { accessCatalog } from "../../access/selected-access-catalog.generated.js"',
+    )
     expect(runtime?.source).toContain('import.meta.glob("../../../src/admin/*/index.tsx"')
     expect(runtime?.source).toContain("packages/*/openapi/{admin,storefront}/*.json")
 

--- a/scripts/measure-operator-application.mjs
+++ b/scripts/measure-operator-application.mjs
@@ -94,8 +94,8 @@ if (check) {
     failures.push("largest admin gzip chunk exceeds 2 MiB")
   }
   if (!report.portableShell) failures.push("portable admin shell is missing")
-  if ((report.portableShell?.initialPreloads.gzipBytes ?? 0) > 480 * 1024) {
-    failures.push("portable admin shell initial preloads exceed 480 KiB gzip")
+  if ((report.portableShell?.initialPreloads.gzipBytes ?? 0) > 430 * 1024) {
+    failures.push("portable admin shell initial preloads exceed 430 KiB gzip")
   }
   if (
     report.portableShell?.initialPreloads.paths.some((path) => /\/recharts-[^/]+\.js$/.test(path))


### PR DESCRIPTION
## Summary

Stacked on #4500.

The generated deployment access catalog was statically imported by the shared operator frontend, so every admin, auth, and public route parsed it at startup even though only the lazy API Tokens settings page consumes it.

This change:
- replaces the eager catalog value with a lazy loader through the standard frontend/admin presentation interface
- resolves the catalog alongside the API Tokens page module only when that route opens
- adds focused coverage proving composition does not load the catalog eagerly
- ratchets the portable-shell preload budget from 480 KiB to 430 KiB gzip

## Production artifact measurement

Parent #4500:
- 33 direct preloads
- 1,548,355 raw bytes
- 438,691 gzip bytes
- entry: 515,712 raw / 139,420 gzip

This branch:
- 33 direct preloads
- 1,515,878 raw bytes
- 432,483 gzip bytes
- entry: 483,235 raw / 133,212 gzip
- catalog emitted as a separate 32,646-byte route-local chunk

Delta:
- initial graph: -32,477 raw / -6,208 gzip
- entry: -32,477 raw / -6,208 gzip
- no request-count or chunking regression

## Validation

- 13 focused tests pass
- changed-file Biome passes
- admin-app typecheck passes
- admin-host typecheck passes
- production Operator client + SSR build passes
- portable-shell measurement passes at 432,483 bytes under the new 430 KiB budget
- measure-operator-application test passes

The standalone operator-standard typecheck exceeded Node's default 4 GiB heap, then remained CPU-bound without diagnostics under the repository's 8 GiB setting; it was stopped before the production build. Depot CI is the authoritative full typecheck lane.

Part of #4439 and platform#1908.