### PR TITLE
perf(admin): consolidate initial shell chunks

### DIFF
--- a/.changeset/quick-admin-shell-operator.md
+++ b/.changeset/quick-admin-shell-operator.md
@@ -1,5 +1,5 @@
 ---
-"@voyant-travel/vite-config": patch
+"operator": patch
 ---
 
 Consolidate the admin shell's required UI primitives into one production chunk and enforce a 20-request initial preload budget.

--- a/.changeset/quick-admin-shell-ui.md
+++ b/.changeset/quick-admin-shell-ui.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/vite-config": patch
+"operator": patch
+---
+
+Consolidate the admin shell's required UI primitives into one production chunk and enforce a 20-request initial preload budget.

--- a/packages/vite-config/src/index.ts
+++ b/packages/vite-config/src/index.ts
@@ -28,6 +28,60 @@ function isNodeModulePackage(id: string, packageName: string): boolean {
   return id.includes(`/node_modules/${packageName}/`)
 }
 
+const ADMIN_SHELL_UI_MODULES = new Set([
+  "alert",
+  "badge",
+  "button",
+  "card",
+  "input",
+  "label",
+  "separator",
+  "skeleton",
+  "table",
+  "textarea",
+])
+
+function voyantAdminShellUiChunk(id: string): string | undefined {
+  const normalizedId = id.replaceAll("\\", "/")
+  if (
+    !normalizedId.includes("/packages/ui/") &&
+    !normalizedId.includes("/node_modules/@voyant-travel/ui/")
+  ) {
+    return undefined
+  }
+
+  if (normalizedId.endsWith("/src/lib/utils.ts") || normalizedId.endsWith("/dist/lib/utils.js")) {
+    return "admin-shell-ui"
+  }
+
+  const match = normalizedId.match(/\/(?:src|dist)\/components\/([^/]+)\.(?:ts|tsx|js)$/)
+  return match?.[1] && ADMIN_SHELL_UI_MODULES.has(match[1]) ? "admin-shell-ui" : undefined
+}
+
+const ADMIN_SHELL_LUCIDE_ICONS = new Set(["check", "file-text", "loader-circle", "search"])
+const ADMIN_SHELL_LUCIDE_CORE = new Set([
+  "Icon.mjs",
+  "context.mjs",
+  "createLucideIcon.mjs",
+  "defaultAttributes.mjs",
+  "shared/src/utils/hasA11yProp.mjs",
+  "shared/src/utils/mergeClasses.mjs",
+  "shared/src/utils/toKebabCase.mjs",
+  "shared/src/utils/toPascalCase.mjs",
+])
+
+function voyantAdminShellLucideChunk(id: string): string | undefined {
+  const normalizedId = id.replaceAll("\\", "/")
+  if (!isNodeModulePackage(normalizedId, "lucide-react")) return undefined
+
+  const relativePath = normalizedId.split("/lucide-react/dist/esm/")[1]
+  if (!relativePath) return undefined
+  if (ADMIN_SHELL_LUCIDE_CORE.has(relativePath)) return "admin-shell-lucide"
+
+  const icon = relativePath.match(/^icons\/([^/]+)\.mjs$/)?.[1]
+  return icon && ADMIN_SHELL_LUCIDE_ICONS.has(icon) ? "admin-shell-lucide" : undefined
+}
+
 export function voyantVendorChunk(id: string): string | undefined {
   const normalizedId = id.replaceAll("\\", "/")
 
@@ -87,7 +141,11 @@ export function voyantVendorChunk(id: string): string | undefined {
 type ExtraManualChunks = (id: string) => string | undefined
 
 export function voyantChunkOutput(viteMajor: number, extraManualChunks?: ExtraManualChunks) {
-  const chunkName = (id: string) => voyantVendorChunk(id) ?? extraManualChunks?.(id)
+  const chunkName = (id: string) =>
+    voyantVendorChunk(id) ??
+    voyantAdminShellUiChunk(id) ??
+    voyantAdminShellLucideChunk(id) ??
+    extraManualChunks?.(id)
   if (viteMajor >= 8) {
     return {
       codeSplitting: {

--- a/packages/vite-config/tests/vite-config.test.ts
+++ b/packages/vite-config/tests/vite-config.test.ts
@@ -257,6 +257,22 @@ describe("voyantStartViteConfig", () => {
     if (typeof chunkName !== "function") throw new Error("missing chunk name function")
 
     expect(chunkName("/repo/node_modules/react/index.js", {} as never)).toBe("react")
+    expect(chunkName("/repo/packages/ui/src/components/button.tsx", {} as never)).toBe(
+      "admin-shell-ui",
+    )
+    expect(
+      chunkName("/repo/node_modules/@voyant-travel/ui/dist/components/button.js", {} as never),
+    ).toBe("admin-shell-ui")
+    expect(chunkName("/repo/packages/ui/src/components/date-picker.tsx", {} as never)).toBeNull()
+    expect(
+      chunkName("/repo/node_modules/lucide-react/dist/esm/icons/loader-circle.mjs", {} as never),
+    ).toBe("admin-shell-lucide")
+    expect(
+      chunkName("/repo/node_modules/lucide-react/dist/esm/createLucideIcon.mjs", {} as never),
+    ).toBe("admin-shell-lucide")
+    expect(
+      chunkName("/repo/node_modules/lucide-react/dist/esm/icons/settings.mjs", {} as never),
+    ).toBeNull()
     expect(chunkName("/repo/node_modules/lodash/index.js", {} as never)).toBe("lodash")
     expect(chunkName("/repo/node_modules/zod/index.js", {} as never)).toBeNull()
   })

--- a/scripts/measure-operator-application.mjs
+++ b/scripts/measure-operator-application.mjs
@@ -97,6 +97,9 @@ if (check) {
   if ((report.portableShell?.initialPreloads.gzipBytes ?? 0) > 430 * 1024) {
     failures.push("portable admin shell initial preloads exceed 430 KiB gzip")
   }
+  if ((report.portableShell?.initialPreloads.files ?? Number.POSITIVE_INFINITY) > 20) {
+    failures.push("portable admin shell initial preloads exceed 20 JavaScript requests")
+  }
   if (
     report.portableShell?.initialPreloads.paths.some((path) => /\/recharts-[^/]+\.js$/.test(path))
   ) {


### PR DESCRIPTION
## Summary

- consolidate only the UI primitives already required by the initial admin shell
- consolidate the four shell Lucide icons and their shared core without pulling route-only icons forward
- enforce a maximum of 20 initial JavaScript preload requests

## Measured result

Compared with the parent branch:

- initial JS requests: 33 -> 20
- initial raw JS: 1,515,878 -> 1,507,276 bytes
- initial gzip JS: 432,483 -> 426,456 bytes
- largest gzip chunk: 133,212 -> 132,989 bytes

## Safety

- production Operator client and SSR build passes
- no new circular-chunk warnings
- Vite config tests: 24/24 pass
- Vite config typecheck passes
- measurement script node:test passes
- Biome and diff checks pass
- browser module-evaluation smoke has no page errors; the only console failure is the expected static-server 404 for /auth/shell-bootstrap, matching the parent build

Stacked on #4502, which is stacked on #4500.