### PR TITLE
fix(finance): allow credits on paid invoices

### DIFF
--- a/.changeset/kind-paid-refunds.md
+++ b/.changeset/kind-paid-refunds.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/finance": patch
+---
+
+Allow refund credit notes on paid invoices while continuing to reject aggregate credits above the original invoice total.

--- a/packages/finance/src/service-invoice-credit-notes.ts
+++ b/packages/finance/src/service-invoice-credit-notes.ts
@@ -49,7 +49,7 @@ function creditAmountInInvoiceCurrency(
   )
 }
 
-async function assertCreditNotesDoNotExceedInvoiceBalance(
+async function assertCreditNotesDoNotExceedInvoiceTotal(
   db: PostgresJsDatabase,
   invoice: typeof invoices.$inferSelect,
   candidate: typeof creditNotes.$inferSelect,
@@ -65,16 +65,20 @@ async function assertCreditNotesDoNotExceedInvoiceBalance(
   const attemptedCreditedCents =
     existingCreditedCents + creditAmountInInvoiceCurrency(invoice, candidate)
 
-  if (attemptedCreditedCents <= invoice.balanceDueCents) return
+  // Payments settle the receivable; they do not reduce the amount that may be
+  // reversed. A fully paid invoice has a zero balance due and is precisely the
+  // ordinary case where a refund credit note is needed. Bound credits by the
+  // invoiced total, less other credit notes, independently of payment state.
+  if (attemptedCreditedCents <= invoice.totalCents) return
 
   throw new InvoiceValidationError(
-    "Credit notes cannot exceed the invoice balance due",
+    "Credit notes cannot exceed the invoice total",
     {
       invoiceId: invoice.id,
       invoiceCurrency: invoice.currency,
-      invoiceBalanceDueCents: invoice.balanceDueCents,
+      invoiceTotalCents: invoice.totalCents,
       attemptedCreditedCents,
-      excessCents: attemptedCreditedCents - invoice.balanceDueCents,
+      excessCents: attemptedCreditedCents - invoice.totalCents,
     },
     { status: 409, code: "invoice_overcredited" },
   )
@@ -142,7 +146,7 @@ export const financeInvoiceCreditNoteService = {
         .returning()
 
       if (row) {
-        await assertCreditNotesDoNotExceedInvoiceBalance(tx, invoice, row)
+        await assertCreditNotesDoNotExceedInvoiceTotal(tx, invoice, row)
       }
 
       if (row && runtime.actionLedgerContext) {
@@ -204,7 +208,7 @@ export const financeInvoiceCreditNoteService = {
         .limit(1)
 
       if (invoice) {
-        await assertCreditNotesDoNotExceedInvoiceBalance(writer, invoice, row)
+        await assertCreditNotesDoNotExceedInvoiceTotal(writer, invoice, row)
       }
 
       return invoice ? { invoice, creditNote: row } : null

--- a/packages/finance/tests/integration/routes.test.ts
+++ b/packages/finance/tests/integration/routes.test.ts
@@ -2958,15 +2958,43 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
       expect(res.status).toBe(404)
     })
 
-    it("rejects credit notes that exceed the invoice balance due", async () => {
-      const booking = await seedBooking()
+    it("allows a credit note on a fully paid invoice", async () => {
+      const booking = await seedBooking({ status: "confirmed" })
+      const inv = await seedInvoice(booking.id, { totalCents: 10000, balanceDueCents: 10000 })
+      const payment = await app.request(`/invoices/${inv.id}/payments`, {
+        method: "POST",
+        ...json({
+          amountCents: 10000,
+          currency: "USD",
+          paymentMethod: "bank_transfer",
+          status: "completed",
+          paymentDate: "2025-06-02",
+        }),
+      })
+      expect(payment.status).toBe(201)
+
+      const res = await app.request(`/invoices/${inv.id}/credit-notes`, {
+        method: "POST",
+        ...json({
+          creditNoteNumber: nextCreditNoteNumber(),
+          amountCents: 5000,
+          currency: "USD",
+          reason: "Paid booking cancellation",
+        }),
+      })
+
+      expect(res.status).toBe(201)
+    })
+
+    it("rejects credit notes that exceed the invoice total", async () => {
+      const booking = await seedBooking({ status: "confirmed" })
       const inv = await seedInvoice(booking.id, { totalCents: 10000, balanceDueCents: 8000 })
 
       const res = await app.request(`/invoices/${inv.id}/credit-notes`, {
         method: "POST",
         ...json({
           creditNoteNumber: nextCreditNoteNumber(),
-          amountCents: 8001,
+          amountCents: 10001,
           currency: "USD",
           reason: "Too much credit",
         }),
@@ -2978,8 +3006,8 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
       })
     })
 
-    it("rejects credit note updates that exceed the invoice balance due", async () => {
-      const booking = await seedBooking()
+    it("rejects credit note updates that exceed the invoice total", async () => {
+      const booking = await seedBooking({ status: "confirmed" })
       const inv = await seedInvoice(booking.id, { totalCents: 10000, balanceDueCents: 8000 })
 
       const createRes = await app.request(`/invoices/${inv.id}/credit-notes`, {
@@ -2995,7 +3023,7 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
 
       const res = await app.request(`/invoices/${inv.id}/credit-notes/${cn.id}`, {
         method: "PATCH",
-        ...json({ amountCents: 8001 }),
+        ...json({ amountCents: 10001 }),
       })
 
       expect(res.status).toBe(409)


### PR DESCRIPTION
## Summary
- bound aggregate credit notes by the original invoice total rather than its remaining receivable balance
- allow the ordinary paid-invoice cancellation refund case
- preserve create and update rejection when aggregate credits exceed the invoice total

## Evidence
The paid-refund capability trace reached the correct Finance tools but a fully paid invoice (`balanceDueCents = 0`) rejected every credit note, making an actual refund impossible. The new integration case reproduces that paid state.

## Verification
- focused Finance integration tests: 3 passed
- formatting and whitespace checks

Refs #4378
