### PR TITLE
fix(storefront): resolve shopping scope across markets

### DIFF
--- a/.changeset/calm-shopping-scope.md
+++ b/.changeset/calm-shopping-scope.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/storefront": patch
+---
+
+Resolve base-language and presentation-currency preferences against all active storefront markets, and return unsupported shopping scopes as bounded client errors.

--- a/packages/storefront/src/shopping/managed-runtime.ts
+++ b/packages/storefront/src/shopping/managed-runtime.ts
@@ -7,6 +7,7 @@ import type { PresentationFxQuoter } from "@voyant-travel/catalog-contracts/pres
 import { sha256Hex } from "@voyant-travel/hono"
 
 import type {
+  StorefrontActiveMarket,
   StorefrontCatalogSliceItem,
   StorefrontLiveContinuation,
   StorefrontLiveSearchPage,
@@ -96,24 +97,87 @@ async function resolveActiveScope(
     channelId: context.channelId,
   })
   if (markets.length === 0) throw new StorefrontShoppingScopeError("market")
+  const availableLocales = unique(
+    markets.flatMap((market) => [market.defaultLocale, ...market.locales]),
+  )
+  const availableCurrencies = unique(
+    markets.flatMap((market) => [market.defaultCurrency, ...market.currencies]).map(upperCurrency),
+  )
+  const requestedCurrency = requested.currency ? upperCurrency(requested.currency) : undefined
+  const eligible = markets.filter(
+    (candidate) =>
+      (!requested.locale || resolveSupportedLocale(candidate, requested.locale)) &&
+      (!requestedCurrency || marketCurrencies(candidate).includes(requestedCurrency)),
+  )
   const market = requested.marketId
     ? markets.find((candidate) => candidate.id === requested.marketId)
-    : (markets.find((candidate) => candidate.isDefault) ?? markets[0])
-  if (!market) throw new StorefrontShoppingScopeError("marketId", requested.marketId)
+    : (eligible.find((candidate) => candidate.isDefault) ?? eligible[0])
+  if (!market) {
+    if (requested.marketId) {
+      throw new StorefrontShoppingScopeError("marketId", requested.marketId)
+    }
+    if (requested.locale && !availableLocale(availableLocales, requested.locale)) {
+      throw new StorefrontShoppingScopeError("locale", requested.locale)
+    }
+    if (requestedCurrency && !availableCurrencies.includes(requestedCurrency)) {
+      throw new StorefrontShoppingScopeError("currency", requestedCurrency)
+    }
+    throw new StorefrontShoppingScopeError("market")
+  }
 
-  const locales = unique([market.defaultLocale, ...market.locales])
-  const currencies = unique([market.defaultCurrency, ...market.currencies].map(upperCurrency))
-  const locale = requested.locale ?? market.defaultLocale
-  const currency = upperCurrency(requested.currency ?? market.defaultCurrency)
-  if (!locales.includes(locale)) throw new StorefrontShoppingScopeError("locale", locale)
-  if (!currencies.includes(currency)) throw new StorefrontShoppingScopeError("currency", currency)
+  const locale = requested.locale
+    ? resolveSupportedLocale(market, requested.locale)
+    : market.defaultLocale
+  const currencies = marketCurrencies(market)
+  const currency = requestedCurrency ?? upperCurrency(market.defaultCurrency)
+  if (!locale) throw new StorefrontShoppingScopeError("locale", requested.locale)
+  if (!currencies.includes(currency)) {
+    throw new StorefrontShoppingScopeError("currency", currency)
+  }
 
   return {
     marketId: market.id,
     locale,
     currency,
-    available: { marketIds: markets.map(({ id }) => id), locales, currencies },
+    available: {
+      marketIds: markets.map(({ id }) => id),
+      locales: availableLocales,
+      currencies: availableCurrencies,
+    },
   }
+}
+
+function marketLocales(market: StorefrontActiveMarket): string[] {
+  return unique([market.defaultLocale, ...market.locales])
+}
+
+function marketCurrencies(market: StorefrontActiveMarket): string[] {
+  return unique([market.defaultCurrency, ...market.currencies].map(upperCurrency))
+}
+
+function baseLanguageRange(locale: string): string | null {
+  try {
+    const parsed = new Intl.Locale(locale)
+    return parsed.region || parsed.script ? null : parsed.language
+  } catch {
+    return null
+  }
+}
+
+function availableLocale(locales: readonly string[], requested: string): string | undefined {
+  const exact = locales.find((locale) => locale === requested)
+  if (exact) return exact
+  const language = baseLanguageRange(requested)
+  return language
+    ? locales.find((locale) => new Intl.Locale(locale).language === language)
+    : undefined
+}
+
+function resolveSupportedLocale(
+  market: StorefrontActiveMarket,
+  requested: string,
+): string | undefined {
+  return availableLocale(marketLocales(market), requested)
 }
 
 type InspirationIntent = Extract<StorefrontShoppingIntent, { kind: "indexed-inspiration" }>

--- a/packages/storefront/src/shopping/routes-public.ts
+++ b/packages/storefront/src/shopping/routes-public.ts
@@ -341,6 +341,14 @@ function isRevisionConflict(value: unknown): boolean {
   )
 }
 
+function isShoppingScopeError(value: unknown): boolean {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { code?: unknown }).code === "storefront_shopping_scope_unsupported"
+  )
+}
+
 export function createStorefrontShoppingPublicRoutes(
   options: StorefrontShoppingPublicRoutesOptions = {},
 ): OpenAPIHono<Env> {
@@ -364,6 +372,15 @@ export function createStorefrontShoppingPublicRoutes(
         await setSafeIndexedCacheHeaders(c, result, options)
         return c.json({ data: result }, 200)
       } catch (cause) {
+        if (isShoppingScopeError(cause)) {
+          return c.json(
+            {
+              error: "storefront_shopping_scope_unsupported",
+              requestId: requestId(c),
+            },
+            400,
+          )
+        }
         if (cause instanceof StorefrontShoppingUnavailableError) {
           return c.json({ error: "storefront_shopping_unavailable", requestId: requestId(c) }, 503)
         }

--- a/packages/storefront/tests/unit/managed-shopping-runtime.test.ts
+++ b/packages/storefront/tests/unit/managed-shopping-runtime.test.ts
@@ -76,6 +76,64 @@ describe("managed storefront shopping scope", () => {
     expect(JSON.stringify(deps.markets.listActiveMarkets.mock.calls)).not.toContain("buyer_private")
   })
 
+  it("resolves language ranges and currency choices across active markets", async () => {
+    const markets = [
+      {
+        id: "market_eu",
+        defaultLocale: "en-GB",
+        defaultCurrency: "EUR",
+        locales: ["en-GB", "fr-FR", "it-IT"],
+        currencies: ["EUR"],
+        isDefault: true,
+      },
+      {
+        id: "market_ro",
+        defaultLocale: "ro-RO",
+        defaultCurrency: "RON",
+        locales: ["ro-RO", "en-GB"],
+        currencies: ["RON", "EUR"],
+      },
+      {
+        id: "market_uk",
+        defaultLocale: "en-GB",
+        defaultCurrency: "GBP",
+        locales: ["en-GB"],
+        currencies: ["GBP", "EUR"],
+      },
+    ]
+    const runtime = createManagedStorefrontShoppingRuntime(
+      dependencies({ markets: { listActiveMarkets: vi.fn(async () => markets) } }),
+    )
+
+    await expect(runtime.resolveScope(context, { locale: "en" })).resolves.toMatchObject({
+      marketId: "market_eu",
+      locale: "en-GB",
+      currency: "EUR",
+      available: {
+        marketIds: ["market_eu", "market_ro", "market_uk"],
+        locales: ["en-GB", "fr-FR", "it-IT", "ro-RO"],
+        currencies: ["EUR", "RON", "GBP"],
+      },
+    })
+    await expect(runtime.resolveScope(context, { locale: "ro" })).resolves.toMatchObject({
+      marketId: "market_ro",
+      locale: "ro-RO",
+      currency: "RON",
+    })
+    await expect(runtime.resolveScope(context, { currency: "GBP" })).resolves.toMatchObject({
+      marketId: "market_uk",
+      locale: "en-GB",
+      currency: "GBP",
+    })
+    await expect(
+      runtime.resolveScope(context, { locale: "fr-FR", currency: "RON" }),
+    ).rejects.toMatchObject({ code: "storefront_shopping_scope_unsupported" })
+    await expect(runtime.resolveScope(context, { locale: "en-US" })).rejects.toMatchObject({
+      code: "storefront_shopping_scope_unsupported",
+      selector: "locale",
+    })
+  })
+
   it.each([
     ["marketId", { marketId: "market_inactive" }],
     ["locale", { locale: "de-DE" }],

--- a/packages/storefront/tests/unit/shopping-public-routes.test.ts
+++ b/packages/storefront/tests/unit/shopping-public-routes.test.ts
@@ -152,6 +152,25 @@ describe("Storefront shopping public routes", () => {
     expect(response.headers.get("x-request-id")).toBeTruthy()
   })
 
+  it("returns a bounded 400 for an unsupported managed scope", async () => {
+    const shopping = runtime()
+    vi.mocked(shopping.search).mockRejectedValueOnce({
+      code: "storefront_shopping_scope_unsupported",
+      selector: "locale",
+      requested: "en",
+    })
+    const response = await app({ shopping }).request(
+      jsonRequest("/v1/public/shopping/search", searchBody),
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: "storefront_shopping_scope_unsupported",
+      requestId: expect.any(String),
+    })
+    expect(response.headers.get("cache-control")).toBe("private, no-store")
+  })
+
   it("bounds JSON bodies with absent or misleading Content-Length before provider invocation", async () => {
     const shopping = runtime()
     const oversizedBody = { ...searchBody, padding: "x".repeat(65 * 1024) }


### PR DESCRIPTION
## Summary
- resolve base language ranges such as `en` and `ro` to exact configured regional locales without silently remapping one regional locale to another
- when `marketId` is omitted, select an active market that satisfies the requested locale and/or presentation currency
- return the union of operator-enabled locales and currencies across active markets so one shared storefront picker can discover EUR, RON, GBP, and configured languages
- return unsupported managed scopes as bounded private 400 responses instead of uncaught 500s

## Authority boundaries
- active storefront/channel and market configuration remain server-resolved
- browsers still cannot supply tenant, engine, provider, source, payment, or FX authority
- Storefront returns presentation money; themes perform no FX math

## Sandbox evidence
The managed Bucharest preview reaches the live gateway. `{scope:{}}` resolves successfully to `en-GB/EUR`; `{scope:{locale:"en"}}` currently returns 500 because market locales are regional. The default market exposes EUR, the RO market RON/EUR, and the UK market GBP/EUR.

## Validation
- Storefront focused tests: 22/22
- targeted Biome and diff checks
- package typecheck was attempted locally twice; TypeScript 6 exceeded both 4 GiB and 6 GiB heaps after several minutes with no diagnostic. CI remains the authoritative typecheck gate.