### PR TITLE
Expose installed product-job wake producers

### DIFF
--- a/.changeset/calm-jobs-wake.md
+++ b/.changeset/calm-jobs-wake.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/framework": minor
+"@voyant-travel/runtime": minor
+---
+
+Expose provider-neutral, release-scoped attestations for automatic product-job wake producers installed by the active runtime host.

--- a/packages/framework/src/node-job-host.test.ts
+++ b/packages/framework/src/node-job-host.test.ts
@@ -1,3 +1,4 @@
+// agent-quality: file-size exception -- owner: framework; product-job host inventory, invocation, retry, wake, scheduling, and health cases share one fixture-rich contract suite.
 import { describe, expect, it, vi } from "vitest"
 
 import {
@@ -117,6 +118,38 @@ describe("Voyant Node product job host", () => {
         jobs: [{ ...inventory()[0]!, id: "notifications.detached" }],
       }),
     ).toThrow('provisioning job "notifications.detached" has no matching runtime job')
+  })
+
+  it("rejects a durable wake producer for an unknown job", () => {
+    expect(() =>
+      createVoyantNodeJobHost({
+        runtime: jobRuntime(() => {}),
+        jobs: inventory(),
+        jobWakeProducers: [
+          {
+            id: "notifications.outbox",
+            jobIds: ["notifications.missing"],
+            guarantee: "durable-work-before-wake",
+          },
+        ],
+      }),
+    ).toThrow('wake producer "notifications.outbox" targets unknown job "notifications.missing"')
+  })
+
+  it("rejects a durable wake producer for a non-wakeable job", () => {
+    expect(() =>
+      createVoyantNodeJobHost({
+        runtime: jobRuntime(() => {}, undefined, false),
+        jobs: inventory(undefined, false),
+        jobWakeProducers: [
+          {
+            id: "notifications.outbox",
+            jobIds: [jobId],
+            guarantee: "durable-work-before-wake",
+          },
+        ],
+      }),
+    ).toThrow(`wake producer "notifications.outbox" targets non-wakeable job "${jobId}"`)
   })
 
   it("authenticates fixed payload-free HTTP invocation and returns 202 promptly", async () => {
@@ -403,6 +436,49 @@ describe("Voyant Node product job host", () => {
     )
     expect(response?.status).toBe(200)
     await expect(response?.json()).resolves.toEqual({ provisioning: { jobs: inventory() } })
+  })
+
+  it("returns wake producer attestations in canonical identity order", async () => {
+    const host = createVoyantNodeJobHost({
+      runtime: jobRuntime(() => {}),
+      jobs: inventory(),
+      jobWakeProducers: [
+        {
+          id: "z-last",
+          jobIds: [jobId],
+          guarantee: "durable-work-before-wake",
+        },
+        {
+          id: "a-first",
+          jobIds: [jobId],
+          guarantee: "durable-work-before-wake",
+        },
+      ],
+      originTrustSecret: "secret",
+    })
+    const response = await host.handleRequest(
+      new Request(`https://operator.test${VOYANT_PRODUCT_JOB_ROUTE}`, {
+        headers: { "x-voyant-origin-trust": "secret" },
+      }),
+    )
+
+    await expect(response?.json()).resolves.toEqual({
+      provisioning: {
+        jobs: inventory(),
+        jobWakeProducers: [
+          {
+            id: "a-first",
+            jobIds: [jobId],
+            guarantee: "durable-work-before-wake",
+          },
+          {
+            id: "z-last",
+            jobIds: [jobId],
+            guarantee: "durable-work-before-wake",
+          },
+        ],
+      },
+    })
   })
 
   it("reports terminal health best-effort without repeating completed domain work", async () => {

--- a/packages/framework/src/node-job-host.ts
+++ b/packages/framework/src/node-job-host.ts
@@ -1,3 +1,4 @@
+// agent-quality: file-size exception -- owner: framework; product-job admission, invocation, scheduling, retry, wake idempotency, and health reporting share one host state machine.
 import { verifyOriginTrust } from "@voyant-travel/runtime-core"
 
 import type { VoyantGraphProvisionedJob } from "./deployment-graph.js"
@@ -49,10 +50,24 @@ export interface VoyantNodeJobHostRetryOptions {
   maxBackoffMs?: number
 }
 
+/**
+ * Release-scoped attestation emitted by a host that actually installed an
+ * automatic product-job wake source. The guarantee is deliberately transport
+ * neutral: Queue, Pub/Sub, HTTP, and an in-process host all share the same
+ * durable-work-before-signal contract.
+ */
+export interface VoyantProductJobWakeProducer {
+  id: string
+  jobIds: readonly string[]
+  guarantee: "durable-work-before-wake"
+}
+
 export interface CreateVoyantNodeJobHostOptions {
   runtime: VoyantGraphRuntime
   /** Immutable host inventory copied from resolved provisioning.jobs. */
   jobs: readonly VoyantGraphProvisionedJob[]
+  /** Automatic wake sources installed by this exact runtime release. */
+  jobWakeProducers?: readonly VoyantProductJobWakeProducer[]
   ports?: VoyantGraphRuntimePorts
   /** Concrete deployment bindings passed to fixed product-job runtimes. */
   bindings?: unknown
@@ -141,6 +156,7 @@ export function createVoyantNodeJobHost(
   const inventory = options.jobs.map((job) => structuredClone(job))
   const jobsById = new Map(inventory.map((job) => [job.id, job]))
   assertRuntimeInventoryParity(options.runtime, inventory)
+  const jobWakeProducers = normalizeJobWakeProducers(options.jobWakeProducers ?? [], jobsById)
 
   const maxAttempts = positiveInteger(options.retry?.maxAttempts ?? 3, "retry.maxAttempts")
   const initialBackoffMs = nonNegativeNumber(
@@ -385,7 +401,12 @@ export function createVoyantNodeJobHost(
       if (url.search || (await requestHasBodyBytes(request))) {
         return new Response("Product job inventory requests do not accept input", { status: 400 })
       }
-      return Response.json({ provisioning: { jobs: inventory } })
+      return Response.json({
+        provisioning: {
+          jobs: inventory,
+          ...(jobWakeProducers.length > 0 ? { jobWakeProducers } : {}),
+        },
+      })
     }
     if (request.method !== "POST") return new Response("Method Not Allowed", { status: 405 })
     if (url.search || (await requestHasBodyBytes(request))) {
@@ -471,6 +492,67 @@ export function createVoyantNodeJobHost(
       armedWakes.clear()
     },
   }
+}
+
+function normalizeJobWakeProducers(
+  producers: readonly VoyantProductJobWakeProducer[],
+  jobsById: ReadonlyMap<string, VoyantGraphProvisionedJob>,
+): readonly VoyantProductJobWakeProducer[] {
+  const producerIds = new Set<string>()
+  return producers
+    .map((producer, index) => {
+      if (!producer || typeof producer !== "object" || Array.isArray(producer)) {
+        throw new Error(`Voyant Node job host: wake producer at index ${index} must be an object.`)
+      }
+      const unexpectedKeys = Object.keys(producer).filter(
+        (key) => !["id", "jobIds", "guarantee"].includes(key),
+      )
+      if (unexpectedKeys.length > 0) {
+        throw new Error(
+          `Voyant Node job host: wake producer at index ${index} has unsupported keys: ${unexpectedKeys.join(", ")}.`,
+        )
+      }
+      const id = typeof producer.id === "string" ? producer.id.trim() : ""
+      if (!id) {
+        throw new Error(`Voyant Node job host: wake producer at index ${index} requires an id.`)
+      }
+      if (producerIds.has(id)) {
+        throw new Error(`Voyant Node job host: duplicate wake producer id "${id}".`)
+      }
+      producerIds.add(id)
+      if (producer.guarantee !== "durable-work-before-wake") {
+        throw new Error(`Voyant Node job host: wake producer "${id}" has an unsupported guarantee.`)
+      }
+      if (!Array.isArray(producer.jobIds) || producer.jobIds.length === 0) {
+        throw new Error(`Voyant Node job host: wake producer "${id}" requires target jobs.`)
+      }
+      const jobIds = producer.jobIds.map((value) => (typeof value === "string" ? value.trim() : ""))
+      if (jobIds.some((jobId) => !jobId)) {
+        throw new Error(`Voyant Node job host: wake producer "${id}" has an invalid target job.`)
+      }
+      if (new Set(jobIds).size !== jobIds.length) {
+        throw new Error(`Voyant Node job host: wake producer "${id}" has duplicate target jobs.`)
+      }
+      for (const jobId of jobIds) {
+        const job = jobsById.get(jobId)
+        if (!job) {
+          throw new Error(
+            `Voyant Node job host: wake producer "${id}" targets unknown job "${jobId}".`,
+          )
+        }
+        if (!job.wakeup) {
+          throw new Error(
+            `Voyant Node job host: wake producer "${id}" targets non-wakeable job "${jobId}".`,
+          )
+        }
+      }
+      return {
+        id,
+        jobIds: [...jobIds].sort(),
+        guarantee: "durable-work-before-wake" as const,
+      }
+    })
+    .sort((left, right) => left.id.localeCompare(right.id))
 }
 
 interface ManagedWakeRequest {
@@ -567,18 +649,18 @@ async function readManagedWakeRequest(request: Request): Promise<ManagedWakeRequ
   if (Object.keys(record).some((key) => !allowed.has(key))) {
     return managedWakeFailure(400, "invalid_request", false)
   }
-  for (const key of allowed) {
-    const field = record[key]
-    if (
-      typeof field !== "string" ||
-      field.trim() !== field ||
-      field.length < 1 ||
-      field.length > 255
-    ) {
-      return managedWakeFailure(400, "invalid_request", false)
-    }
+  const boundedString = (field: unknown): string | null =>
+    typeof field === "string" && field.trim() === field && field.length >= 1 && field.length <= 255
+      ? field
+      : null
+  const deploymentId = boundedString(record.deploymentId)
+  const jobId = boundedString(record.jobId)
+  const eventId = boundedString(record.eventId)
+  const idempotencyKey = boundedString(record.idempotencyKey)
+  if (!deploymentId || !jobId || !eventId || !idempotencyKey) {
+    return managedWakeFailure(400, "invalid_request", false)
   }
-  return record as unknown as ManagedWakeRequest
+  return { deploymentId, jobId, eventId, idempotencyKey }
 }
 
 async function readBoundedRequestBytes(

--- a/packages/framework/src/node-runtime.test.ts
+++ b/packages/framework/src/node-runtime.test.ts
@@ -1,3 +1,4 @@
+// agent-quality: file-size exception -- owner: framework; Node boot, provider posture, readiness, event delivery, and managed job inventory share one runtime harness.
 import type { EventEnvelope } from "@voyant-travel/core"
 import { defineGraphRuntimeFactory, definePort } from "@voyant-travel/core/project"
 import type { LazyRedisClient } from "@voyant-travel/utils/redis-client"
@@ -590,6 +591,53 @@ describe("loadVoyantNodeRuntime", () => {
 
     expect(response.status).toBe(200)
     await expect(response.json()).resolves.toEqual({ provisioning: { jobs: [] } })
+  })
+
+  it("reports only host-installed durable wake producers in release inventory", async () => {
+    const runtime = await loadVoyantNodeRuntime({
+      graphRuntime: outboxJobRuntime(BASE_PROVIDERS, async () => {}),
+      jobs: [
+        {
+          id: OUTBOX_JOB_ID,
+          unitId: "@voyant-travel/db",
+          packageName: "@voyant-travel/db",
+          wakeup: true,
+        },
+      ],
+      jobWakeProducers: [
+        {
+          id: "managed.mutation-outbox",
+          jobIds: [OUTBOX_JOB_ID],
+          guarantee: "durable-work-before-wake",
+        },
+      ],
+      deployment: {
+        mode: "self-hosted",
+        providers: BASE_PROVIDERS,
+        redis: DEDICATED_TRUSTED_REDIS,
+      },
+      deploymentRequirements: { resources: [] },
+      env: { ORIGIN_TRUST_SECRET: "secret" },
+    })
+
+    const response = await runtime.fetch(
+      new Request("https://operator.test/__voyant/jobs", {
+        headers: { "x-voyant-origin-trust": "secret" },
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      provisioning: {
+        jobWakeProducers: [
+          {
+            id: "managed.mutation-outbox",
+            jobIds: [OUTBOX_JOB_ID],
+            guarantee: "durable-work-before-wake",
+          },
+        ],
+      },
+    })
   })
 
   it("requires REDIS_NAMESPACE when managed shared state uses Redis", async () => {

--- a/packages/framework/src/node-runtime.ts
+++ b/packages/framework/src/node-runtime.ts
@@ -56,7 +56,11 @@ import {
   VOYANT_PRODUCT_JOB_ROUTE,
   type VoyantNodeJobHealth,
   type VoyantNodeJobHost,
+  type VoyantProductJobWakeProducer,
 } from "./node-job-host.js"
+
+export type { VoyantProductJobWakeProducer } from "./node-job-host.js"
+
 import {
   resolveVoyantNodeProviderPlan,
   type VoyantNodeDeploymentPostureInput,
@@ -225,6 +229,8 @@ export interface VoyantNodeRuntimeOptions {
   graphRuntime: VoyantGraphRuntime
   /** Resolved, immutable provisioning.jobs inventory from the admitted graph. */
   jobs: readonly VoyantGraphProvisionedJob[]
+  /** Automatic wake sources installed by this exact host/runtime composition. */
+  jobWakeProducers?: readonly VoyantProductJobWakeProducer[]
   deployment: VoyantNodeRuntimeDeployment
   deploymentRequirements: VoyantGraphDeploymentRequirements
   runtimePorts?: import("./runtime-composition.js").VoyantGraphRuntimePorts
@@ -376,6 +382,7 @@ export async function loadVoyantNodeRuntime(
   const jobHost = createVoyantNodeJobHost({
     runtime: options.graphRuntime,
     jobs: options.jobs,
+    ...(options.jobWakeProducers ? { jobWakeProducers: options.jobWakeProducers } : {}),
     bindings: env,
     ...(runtimePorts ? { ports: runtimePorts } : {}),
     ...(env.ORIGIN_TRUST_SECRET ? { originTrustSecret: env.ORIGIN_TRUST_SECRET } : {}),

--- a/packages/framework/src/worker-job-host.test.ts
+++ b/packages/framework/src/worker-job-host.test.ts
@@ -187,7 +187,18 @@ describe("Voyant Worker product job host", () => {
           "acme.database": contributorPrimitives.database.resolve(undefined),
         }),
       },
-      { scheduleAuthority: "managed-http", primitives, originTrustSecret: "secret" },
+      {
+        scheduleAuthority: "managed-http",
+        primitives,
+        originTrustSecret: "secret",
+        jobWakeProducers: [
+          {
+            id: "worker.database-commit",
+            jobIds: ["acme.database-job"],
+            guarantee: "durable-work-before-wake",
+          },
+        ],
+      },
     )
     const pending: Promise<unknown>[] = []
     const accepted = await host.fetch(
@@ -200,6 +211,24 @@ describe("Voyant Worker product job host", () => {
     expect(accepted?.status).toBe(202)
     await Promise.all(pending)
     expect(observed).toHaveBeenCalledWith("from-worker-binding")
+
+    const inventoryResponse = await host.fetch(
+      new Request("https://worker.test/__voyant/jobs", {
+        headers: { "x-voyant-origin-trust": "secret" },
+      }),
+      { waitUntil: () => {} },
+    )
+    await expect(inventoryResponse?.json()).resolves.toMatchObject({
+      provisioning: {
+        jobWakeProducers: [
+          {
+            id: "worker.database-commit",
+            jobIds: ["acme.database-job"],
+            guarantee: "durable-work-before-wake",
+          },
+        ],
+      },
+    })
   })
 
   it("fans one Cron Trigger out to every graph job with that exact cron", async () => {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -50,6 +50,7 @@ import {
   resolveVoyantNodeProviderPlan,
   type VoyantNodeRuntime,
   type VoyantNodeRuntimeEnv,
+  type VoyantProductJobWakeProducer,
   validateVoyantNodeProviderPlanEnv,
 } from "@voyant-travel/framework/node-runtime"
 import { consoleReporter } from "@voyant-travel/hono/observability/reporter"
@@ -124,6 +125,8 @@ export interface LoadVoyantProjectOptions {
   host?: {
     config?: Readonly<Record<string, unknown>>
     deliverEvent?: (event: unknown, bindings: unknown) => Promise<unknown>
+    /** Automatic wake sources installed by this exact host/runtime composition. */
+    jobWakeProducers?: readonly VoyantProductJobWakeProducer[]
     /** Project-owned provider overrides keyed by their published runtime-port id. */
     runtimePorts?: VoyantGraphRuntimePorts
     storage?: StorageProviderResolver
@@ -454,6 +457,7 @@ export async function loadVoyantProject(
     applicationId: path.basename(projectRoot),
     graphRuntime: activatedGraphRuntime,
     jobs: graph.jobs,
+    ...(options.host?.jobWakeProducers ? { jobWakeProducers: options.host.jobWakeProducers } : {}),
     deployment: {
       ...(deployment.mode ? { mode: deployment.mode } : {}),
       providers: deployment.providers,

--- a/packages/runtime/src/runtime-composition.test.ts
+++ b/packages/runtime/src/runtime-composition.test.ts
@@ -1,3 +1,4 @@
+// agent-quality: file-size exception -- owner: runtime; generated project boot, host overrides, and provider composition share one integration harness.
 import { mkdir, writeFile } from "node:fs/promises"
 import path from "node:path"
 import { customerBusinessAccountOnboardingRuntimePort } from "@voyant-travel/auth/customer-business-onboarding-runtime-port"
@@ -33,6 +34,28 @@ vi.mock("@voyant-travel/auth/storefront-channel-binding-provider", () => ({
 const mocks = getRuntimeCompositionMocks()
 
 describe("Voyant project runtime composition", () => {
+  it("forwards host-installed wake producers to the release inventory boundary", async () => {
+    const projectRoot = await createGeneratedProject()
+    const jobWakeProducers = [
+      {
+        id: "managed.mutation-outbox",
+        jobIds: ["infrastructure.event-outbox-drain"],
+        guarantee: "durable-work-before-wake" as const,
+      },
+    ]
+
+    await loadVoyantProject({
+      projectRoot,
+      adminAssetsDir: path.join(projectRoot, "admin"),
+      env: { DATABASE_URL: "postgres://example.invalid/voyant" },
+      host: { jobWakeProducers },
+    })
+
+    expect(mocks.loadVoyantNodeRuntime).toHaveBeenCalledWith(
+      expect.objectContaining({ jobWakeProducers }),
+    )
+  })
+
   it("keeps the API-only profile out of the admin document host", async () => {
     const projectRoot = await createGeneratedProject()
     const project = await loadVoyantProject({


### PR DESCRIPTION
## Summary

- add a provider-neutral `VoyantProductJobWakeProducer` host contract
- validate producer identity, guarantee, exact targets, wakeability, duplicate identities, duplicate targets, and unsupported metadata at runtime boot
- expose only installed producer attestations from the exact release's authenticated `GET /__voyant/jobs` inventory
- forward managed/self-host host registrations through `loadVoyantProject`
- preserve the existing response byte-for-byte when no producer is installed
- support the same contract in the Node and Worker job hosts without a Cloudflare dependency

This is the OSS/runtime half of voyant-travel/platform#2032. It does not declare any producer itself; the concrete host must attest only sources it actually installed. That means existing self-hosted Docker deployments remain conservative and portable.

## Verification

- framework product-job host/runtime/Worker suites: 54 tests
- runtime composition suite: 25 tests
- framework typecheck
- runtime typecheck
- full pre-commit affected-package lint/build/typecheck: 224/224 tasks
- agent-quality and secretlint gates

## Rollout

Platform parser/admission is staged separately in voyant-travel/platform#2033. After both contracts are available, the managed runtime can advertise its installed Queue-backed producers release-by-release; old runtimes and absent registries continue using the 15-minute recovery floor.
