### PR TITLE
perf(runtime): reuse full-host SSR handler

### DIFF
--- a/.changeset/soft-pumas-render.md
+++ b/.changeset/soft-pumas-render.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/runtime": patch
+---
+
+Reuse the portable full-host SSR handler across document requests.

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -622,6 +622,26 @@ async function createFullAdminHost(input: {
       (input.options.env?.NODE_ENV ?? process.env.NODE_ENV) === "production",
   )
   const { serveAdminHost } = await import("@voyant-travel/admin-host/serve")
+  type AdminSsrHandler = (
+    request: Request,
+    bindings: VoyantNodeRuntimeEnv,
+    ctx: import("hono").ExecutionContext,
+  ) => Response | Promise<Response>
+  let ssrHandlerPromise: Promise<AdminSsrHandler> | undefined
+  const loadSsrHandler = () => {
+    if (!ssrHandlerPromise) {
+      const attempt = import("@voyant-travel/admin-host/ssr").then(({ createAdminSsrHandler }) =>
+        createAdminSsrHandler<VoyantNodeRuntimeEnv>(),
+      )
+      ssrHandlerPromise = attempt
+      // A transient module/initialization failure must not poison every later
+      // document request in this otherwise healthy resident process.
+      void attempt.catch(() => {
+        if (ssrHandlerPromise === attempt) ssrHandlerPromise = undefined
+      })
+    }
+    return ssrHandlerPromise
+  }
   return serveAdminHost<VoyantNodeRuntimeEnv>({
     clientAssetsDir,
     app: async (request, bindings, ctx) => {
@@ -631,8 +651,7 @@ async function createFullAdminHost(input: {
       }
       const discovery = await input.resolveDiscovery(request, bindings)
       if (discovery) return discovery
-      const { createAdminSsrHandler } = await import("@voyant-travel/admin-host/ssr")
-      return createAdminSsrHandler<VoyantNodeRuntimeEnv>()(request, bindings, ctx)
+      return (await loadSsrHandler())(request, bindings, ctx)
     },
   })
 }

--- a/packages/runtime/src/runtime-composition.test-support.ts
+++ b/packages/runtime/src/runtime-composition.test-support.ts
@@ -9,6 +9,8 @@ interface RuntimeCompositionMocks {
     clientAssetsDir: string
     app(request: Request, env: unknown, ctx: unknown): Promise<Response>
   }>
+  adminSsrHandler: Mock
+  createAdminSsrHandler: Mock
   authRuntimeOptions: Array<Record<string, unknown>>
   createNodeServer: Mock
   postgresEnqueue: Mock
@@ -27,7 +29,7 @@ interface RuntimeCompositionMocks {
   deploymentProviders: Record<string, string>
   loadVoyantNodeRuntime: Mock
   nodeRuntime: {
-    env: { DATABASE_URL: string }
+    env: Record<string, string>
     deployment: { mode: string; providers: Record<string, string> }
     app: {
       ready: Mock
@@ -60,6 +62,8 @@ const mocks: RuntimeCompositionMocks = vi.hoisted(() => {
   const services = { has: vi.fn(() => false), register: vi.fn(), resolve: vi.fn() }
   const eventBus = { emit: vi.fn(), subscribe: vi.fn() }
   const runtimeFetch = vi.fn(async (request: Request) => new Response(request.url))
+  const adminSsrHandler = vi.fn(async (request: Request) => new Response(request.url))
+  const createAdminSsrHandler = vi.fn(() => adminSsrHandler)
   const nodeRuntime = {
     env: { DATABASE_URL: "postgres://example.invalid/voyant" },
     deployment: { mode: "self-hosted", providers: {} },
@@ -70,6 +74,8 @@ const mocks: RuntimeCompositionMocks = vi.hoisted(() => {
       clientAssetsDir: string
       app(request: Request, env: unknown, ctx: unknown): Promise<Response>
     }>,
+    adminSsrHandler,
+    createAdminSsrHandler,
     authRuntimeOptions: [] as Array<Record<string, unknown>>,
     createNodeServer: vi.fn(
       (options: { residentServices?: Array<{ start(): void; stop(): void | Promise<void> }> }) => {
@@ -100,7 +106,10 @@ const mocks: RuntimeCompositionMocks = vi.hoisted(() => {
       customerAuth: "better-auth",
       outboundWebhooks: "postgres",
     } as Record<string, string>,
-    loadVoyantNodeRuntime: vi.fn(async (_options: unknown) => nodeRuntime),
+    loadVoyantNodeRuntime: vi.fn(async (options: { env?: Record<string, string> }) => {
+      nodeRuntime.env = { ...nodeRuntime.env, ...options.env }
+      return nodeRuntime
+    }),
     nodeRuntime,
     resolveNodeDatabase: vi.fn(() => ({ kind: "database" })),
     runtimePortHosts: [] as Array<{
@@ -126,6 +135,10 @@ vi.mock("@voyant-travel/admin-host/serve", () => ({
       fetch: (request: Request, env: unknown, ctx: unknown) => options.app(request, env, ctx),
     }
   },
+}))
+
+vi.mock("@voyant-travel/admin-host/ssr", () => ({
+  createAdminSsrHandler: mocks.createAdminSsrHandler,
 }))
 
 vi.mock("@voyant-travel/apps", () => ({
@@ -161,6 +174,7 @@ vi.mock("@voyant-travel/auth/node-runtime", () => ({
       getCurrentUserForRequest: vi.fn(),
       hasAuthPermission: vi.fn(),
       resolveAuthRequest: vi.fn(),
+      resolveOAuthDiscoveryRequest: vi.fn(async () => null),
       validateApiTokenAccess: vi.fn(),
     }
   },
@@ -303,6 +317,8 @@ beforeEach(() => {
   mocks.adminHostOptions.length = 0
   mocks.authRuntimeOptions.length = 0
   mocks.runtimePortHosts.length = 0
+  mocks.nodeRuntime.env = { DATABASE_URL: "postgres://example.invalid/voyant" }
+  mocks.createAdminSsrHandler.mockImplementation(() => mocks.adminSsrHandler)
   mocks.deploymentProviders = {
     adminAuth: "better-auth",
     customerAuth: "better-auth",

--- a/packages/runtime/src/runtime-composition.test.ts
+++ b/packages/runtime/src/runtime-composition.test.ts
@@ -56,6 +56,48 @@ describe("Voyant project runtime composition", () => {
     )
   })
 
+  it("lazily constructs one SSR handler for concurrent and warm document requests", async () => {
+    const projectRoot = await createGeneratedProject()
+    const project = await loadVoyantProject({
+      projectRoot,
+      adminAssetsDir: path.join(projectRoot, "admin"),
+      env: { DATABASE_URL: "postgres://example.invalid/voyant" },
+    })
+
+    expect(mocks.createAdminSsrHandler).not.toHaveBeenCalled()
+    await project.fetch(new Request("https://operator.test/api/openapi.json"))
+    expect(mocks.createAdminSsrHandler).not.toHaveBeenCalled()
+
+    await Promise.all([
+      project.fetch(new Request("https://operator.test/products")),
+      project.fetch(new Request("https://operator.test/bookings")),
+    ])
+    await project.fetch(new Request("https://operator.test/settings"))
+
+    expect(mocks.createAdminSsrHandler).toHaveBeenCalledTimes(1)
+    expect(mocks.adminSsrHandler).toHaveBeenCalledTimes(3)
+  })
+
+  it("retries SSR handler initialization after a transient failure", async () => {
+    mocks.createAdminSsrHandler.mockImplementationOnce(() => {
+      throw new Error("temporary SSR initialization failure")
+    })
+    const projectRoot = await createGeneratedProject()
+    const project = await loadVoyantProject({
+      projectRoot,
+      adminAssetsDir: path.join(projectRoot, "admin"),
+      env: { DATABASE_URL: "postgres://example.invalid/voyant" },
+    })
+
+    await expect(project.fetch(new Request("https://operator.test/products"))).rejects.toThrow(
+      "temporary SSR initialization failure",
+    )
+    await expect(
+      project.fetch(new Request("https://operator.test/products")),
+    ).resolves.toBeInstanceOf(Response)
+    expect(mocks.createAdminSsrHandler).toHaveBeenCalledTimes(2)
+  })
+
   it("keeps the API-only profile out of the admin document host", async () => {
     const projectRoot = await createGeneratedProject()
     const project = await loadVoyantProject({


### PR DESCRIPTION
## Summary

- lazily construct one portable full-host SSR handler per host process
- single-flight concurrent first document requests and reuse the handler on warm requests
- leave API/health/OAuth discovery paths outside the SSR import path
- clear rejected initialization so transient failures can retry

Closes #4513.

## Scope

This is OSS/self-host parity and warm-document cleanup. The managed platform entry already caches its own SSR handler, and the API-only managed profile/global Cloudflare shell direction is unchanged.

## Verification

- `pnpm exec vitest run packages/runtime/src/runtime-composition.test.ts --maxWorkers=4` — 26/26 passed
- `pnpm --dir packages/runtime typecheck` — passed
- Biome on all changed files — passed
- `git diff --check` — passed
