### PR TITLE
Fence resident cell tenant contexts

### DIFF
--- a/.changeset/calm-context-fences.md
+++ b/.changeset/calm-context-fences.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": minor
+---
+
+Fence resident application-cell runtimes with an immutable tenant context digest.

--- a/docs/adr/0001-tenant-scoping.md
+++ b/docs/adr/0001-tenant-scoping.md
@@ -84,6 +84,11 @@ wakes, the deployment identity in the authenticated contract into one frozen
 tenant context before domain code runs. Unknown, stale, or conflicting mappings
 fail closed and emit security telemetry. The context owns server-only database
 credentials; it is never serialized into responses or deployment manifests.
+It also carries a canonical `sha256:` version over the complete server-side
+configuration, including assignment generation. A resident runtime is reused
+only for the same digest; hosts create and drain cell generations instead of
+mutating resident tenant contexts. The digest is an identity, never a
+serialization of credentials, and it never reaches the browser.
 
 Each resident tenant gets its own composed module and extension registries,
 in-memory caches, authorization integration, event bus, job host, timers, and

--- a/packages/framework/src/node-cell-runtime.test.ts
+++ b/packages/framework/src/node-cell-runtime.test.ts
@@ -8,6 +8,7 @@ function context(tenantId: string): VoyantTenantContext {
     tenantId,
     deploymentId: `deployment-${tenantId}`,
     hostname: `${tenantId}.example.test`,
+    contextVersion: `sha256:${(tenantId === "alpha" ? "a" : "b").repeat(64)}`,
     env: {
       DATABASE_URL: `postgres://db/${tenantId}`,
       DATABASE_MAX_CONNECTIONS: "2",
@@ -148,5 +149,86 @@ describe("createVoyantNodeCellRuntime", () => {
     )
     expect(response.status).toBe(421)
     expect(telemetry).toHaveBeenCalledWith(expect.objectContaining({ type: "unknown_mapping" }))
+  })
+
+  it("refuses to reuse a resident runtime after its immutable context changes", async () => {
+    let resolved = context("alpha")
+    const telemetry = vi.fn()
+    const loadRuntime = vi.fn(
+      async (options: VoyantNodeRuntimeOptions) =>
+        ({
+          env: options.env,
+          fetch: async () => new Response("ok"),
+          jobs: { invoke: vi.fn() },
+        }) as unknown as VoyantNodeRuntime,
+    )
+    const cell = createVoyantNodeCellRuntime({
+      runtime: runtimeOptions(),
+      resolver: { resolve: async () => resolved },
+      securityTelemetry: telemetry,
+      loadRuntime,
+    })
+
+    expect((await cell.fetch(new Request("https://alpha.example.test/"))).status).toBe(200)
+    resolved = {
+      ...resolved,
+      contextVersion: `sha256:${"c".repeat(64)}`,
+      env: { ...resolved.env, REDIS_NAMESPACE: "changed" },
+    }
+    expect((await cell.fetch(new Request("https://alpha.example.test/"))).status).toBe(503)
+    expect(loadRuntime).toHaveBeenCalledTimes(1)
+    expect(telemetry).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type: "conflicting_mapping" }),
+    )
+  })
+
+  it("does not join an in-flight runtime load for a different context version", async () => {
+    let resolved = context("alpha")
+    let releaseLoad = () => {}
+    let markStarted = () => {}
+    const loadGate = new Promise<void>((resolve) => {
+      releaseLoad = resolve
+    })
+    const loadStarted = new Promise<void>((resolve) => {
+      markStarted = resolve
+    })
+    const loadRuntime = vi.fn(async (options: VoyantNodeRuntimeOptions) => {
+      markStarted()
+      await loadGate
+      return {
+        env: options.env,
+        fetch: async () => new Response("ok"),
+        jobs: { invoke: vi.fn() },
+      } as unknown as VoyantNodeRuntime
+    })
+    const cell = createVoyantNodeCellRuntime({
+      runtime: runtimeOptions(),
+      resolver: { resolve: async () => resolved },
+      loadRuntime,
+    })
+
+    const first = cell.fetch(new Request("https://alpha.example.test/"))
+    await loadStarted
+    resolved = { ...resolved, contextVersion: `sha256:${"c".repeat(64)}` }
+    expect((await cell.fetch(new Request("https://alpha.example.test/"))).status).toBe(503)
+    releaseLoad()
+    expect((await first).status).toBe(200)
+    expect(loadRuntime).toHaveBeenCalledTimes(1)
+  })
+
+  it("rejects a malformed context version before runtime composition", async () => {
+    const invalid = { ...context("alpha"), contextVersion: "latest" }
+    const telemetry = vi.fn()
+    const loadRuntime = vi.fn()
+    const cell = createVoyantNodeCellRuntime({
+      runtime: runtimeOptions(),
+      resolver: { resolve: async () => invalid },
+      securityTelemetry: telemetry,
+      loadRuntime,
+    })
+
+    expect((await cell.fetch(new Request("https://alpha.example.test/"))).status).toBe(421)
+    expect(loadRuntime).not.toHaveBeenCalled()
+    expect(telemetry).toHaveBeenCalledWith(expect.objectContaining({ type: "stale_mapping" }))
   })
 })

--- a/packages/framework/src/node-cell-runtime.ts
+++ b/packages/framework/src/node-cell-runtime.ts
@@ -18,9 +18,13 @@ export interface VoyantTenantContext {
   readonly tenantId: string
   readonly deploymentId: string
   readonly hostname: string
+  /** Digest of the complete canonical server-side context, including assignment generation. */
+  readonly contextVersion: string
   /** Server-only bindings. They must never be serialized into a response or edge manifest. */
   readonly env: VoyantNodeRuntimeEnv
 }
+
+export const VOYANT_TENANT_CONTEXT_VERSION_PATTERN = /^sha256:[0-9a-f]{64}$/u
 
 export interface VoyantTenantContextResolver {
   resolve(input: {
@@ -62,6 +66,11 @@ interface ResidentTenant {
   releaseDatabase: () => void
 }
 
+interface PendingTenant {
+  context: VoyantTenantContext
+  promise: Promise<ResidentTenant>
+}
+
 /**
  * Host a bounded set of database-per-tenant runtimes in one regional process.
  * Domain code still sees one deployment-static environment and one database;
@@ -73,7 +82,7 @@ export function createVoyantNodeCellRuntime(
   const maximum = positiveInteger(options.maxTenants, 16, "maxTenants")
   const idleMs = positiveInteger(options.idleTenantMs, 300_000, "idleTenantMs")
   const residents = new Map<string, ResidentTenant>()
-  const pending = new Map<string, Promise<ResidentTenant>>()
+  const pending = new Map<string, PendingTenant>()
   const databaseOwners = new Map<string, string>()
   const load = options.loadRuntime ?? loadVoyantNodeRuntime
 
@@ -88,7 +97,13 @@ export function createVoyantNodeCellRuntime(
       report({ type: "unknown_mapping", ...identity })
       return null
     }
-    const context = freezeContext(resolved)
+    let context: VoyantTenantContext
+    try {
+      context = freezeContext(resolved)
+    } catch {
+      report({ type: "stale_mapping", ...identity })
+      return null
+    }
     if (
       identity.hostname &&
       normalizeHostname(context.hostname) !== normalizeHostname(identity.hostname)
@@ -122,7 +137,17 @@ export function createVoyantNodeCellRuntime(
       return current
     }
     const loading = pending.get(context.deploymentId)
-    if (loading) return loading
+    if (loading) {
+      if (!sameContext(loading.context, context)) {
+        report({
+          type: "conflicting_mapping",
+          hostname: context.hostname,
+          deploymentId: context.deploymentId,
+        })
+        throw new CellAdmissionError("Tenant mapping changed while loading.")
+      }
+      return loading.promise
+    }
     const contextDatabase = databaseIdentity(context.env)
     const databaseOwner = databaseOwners.get(contextDatabase)
     if (databaseOwner && databaseOwner !== context.deploymentId) {
@@ -169,7 +194,7 @@ export function createVoyantNodeCellRuntime(
       residents.set(context.deploymentId, resident)
       return resident
     })()
-    pending.set(context.deploymentId, promise)
+    pending.set(context.deploymentId, { context, promise })
     try {
       return await promise
     } finally {
@@ -240,6 +265,7 @@ function freezeContext(context: VoyantTenantContext): VoyantTenantContext {
     tenantId: required(context.tenantId, "tenantId"),
     deploymentId: required(context.deploymentId, "deploymentId"),
     hostname: normalizeHostname(required(context.hostname, "hostname")),
+    contextVersion: immutableContextVersion(context.contextVersion),
     env: Object.freeze({ ...context.env }),
   })
 }
@@ -249,6 +275,7 @@ function sameContext(left: VoyantTenantContext, right: VoyantTenantContext): boo
     left.tenantId === right.tenantId &&
     left.deploymentId === right.deploymentId &&
     left.hostname === right.hostname &&
+    left.contextVersion === right.contextVersion &&
     left.env.DATABASE_URL === right.env.DATABASE_URL &&
     left.env.DATABASE_URL_DIRECT === right.env.DATABASE_URL_DIRECT
   )
@@ -296,6 +323,14 @@ function normalizeHostname(hostname: string): string {
 function required(value: string, name: string): string {
   const normalized = value.trim()
   if (!normalized) throw new Error(`Tenant context ${name} is required.`)
+  return normalized
+}
+
+function immutableContextVersion(value: string): string {
+  const normalized = required(value, "contextVersion")
+  if (!VOYANT_TENANT_CONTEXT_VERSION_PATTERN.test(normalized)) {
+    throw new Error("Tenant context contextVersion must be an exact sha256 digest.")
+  }
   return normalized
 }
 


### PR DESCRIPTION
Closes #4516. Supports voyant-travel/platform#2036.

## Summary
- require a canonical `sha256:` version for every server-only cell tenant context
- include the version in resident runtime identity so settings/bindings/auth/module changes cannot silently reuse stale composition
- reject malformed resolver output before database/runtime composition
- fence the in-flight single-flight path too: a changed context cannot join an older pending runtime load
- document that the host hashes the complete canonical context including assignment generation, without serializing credentials to clients

The dedicated and portable single-tenant runtime paths are unchanged.

## Validation
- focused Node cell runtime tests: 6/6
- Framework typecheck
- Biome and diff check