### PR TITLE
fix(mcp): enforce Tool protocol ownership

### DIFF
--- a/.changeset/calm-tool-protocol.md
+++ b/.changeset/calm-tool-protocol.md
@@ -1,0 +1,8 @@
+---
+"@voyant-travel/finance": patch
+"@voyant-travel/inventory": patch
+"@voyant-travel/operations": patch
+"@voyant-travel/relationships": patch
+---
+
+Hide server-owned idempotency keys from six MCP Tool inputs and enforce an exact inventory of retained caller-owned protocol fields.

--- a/packages/finance/src/tools.ts
+++ b/packages/finance/src/tools.ts
@@ -377,14 +377,6 @@ export const financeBookingsCreateTools = [createBookingTool, bookProductTool] a
 
 export const issueInvoiceFromBookingToolInputSchema = z.object({
   command: invoiceFromBookingSchema.describe("The exact invoice or proforma issue command."),
-  idempotencyKey: z
-    .string()
-    .trim()
-    .min(1)
-    .optional()
-    .describe(
-      "Optional. Leave this out — the platform derives a stable key from the command itself. Only send one to override that.",
-    ),
 })
 
 export const issueInvoiceFromBookingToolOutputSchema = z.union([

--- a/packages/inventory/src/mcp-runtime.ts
+++ b/packages/inventory/src/mcp-runtime.ts
@@ -136,7 +136,7 @@ export const voyantToolContextContribution = defineToolContextContribution({
         return productId ? loadProductById(productId) : null
       },
       getProductAggregates: (query) => productsService.getProductAggregates(db, query),
-      async createProduct({ idempotencyKey: legacyIdempotencyKey, ...input }, admitted) {
+      async createProduct(input, admitted) {
         const draft = insertProductSchema.parse({
           ...input,
           status: "draft",
@@ -148,8 +148,7 @@ export const voyantToolContextContribution = defineToolContextContribution({
         // the model to invent an opaque token made this fail on first attempt with
         // ACTION_POLICY_REQUIRED, on a requirement absent from the input schema —
         // the agent could only discover it by failing and reading the guide.
-        const resolvedIdempotencyKey =
-          legacyIdempotencyKey ?? (await deriveCommandIdempotencyKey("create-product", draft))
+        const resolvedIdempotencyKey = await deriveCommandIdempotencyKey("create-product", draft)
         const result = await executeProductCreateCommand({
           c,
           db: asLedgerDb(db),
@@ -422,15 +421,16 @@ export const voyantToolContextContribution = defineToolContextContribution({
           input: Parameters<InventoryOptionToolServices["createProductOption"]>[0],
           admitted: ToolHandlerActionPolicyContext,
         ) => {
-          const { idempotencyKey, productId, ...data } = input
+          const { productId, ...data } = input
           // voyant#3921: derive server-side, matching create_person/product/
           // departure. Paired with `resolvesIdempotencyKeyServerSide` on the Tool
           // so the caller is never asked for a key it would then misuse across a
           // retry. Both halves are required: deriving without declaring leaves the
           // admission demanding a key, declaring without deriving leaves it absent.
-          const resolvedIdempotencyKey =
-            idempotencyKey ??
-            (await deriveCommandIdempotencyKey("create-product-option", { productId, ...data }))
+          const resolvedIdempotencyKey = await deriveCommandIdempotencyKey(
+            "create-product-option",
+            { productId, ...data },
+          )
           return executeInventoryGeneratedChild({
             c,
             db: asLedgerDb(db),
@@ -486,14 +486,15 @@ export const voyantToolContextContribution = defineToolContextContribution({
           input: Parameters<InventoryOptionToolServices["createOptionUnit"]>[0],
           admitted: ToolHandlerActionPolicyContext,
         ) => {
-          const { idempotencyKey, optionId, ...data } = input
+          const { optionId, ...data } = input
           // voyant#3921: derive server-side, paired with the Tool's
           // `resolvesIdempotencyKeyServerSide` declaration. This is the last write
           // in the product-setup chain, so until it landed a product could not
           // reach a bookable state through MCP at all.
-          const resolvedIdempotencyKey =
-            idempotencyKey ??
-            (await deriveCommandIdempotencyKey("create-option-unit", { optionId, ...data }))
+          const resolvedIdempotencyKey = await deriveCommandIdempotencyKey("create-option-unit", {
+            optionId,
+            ...data,
+          })
           return executeInventoryGeneratedChild({
             c,
             db: asLedgerDb(db),

--- a/packages/inventory/src/option-tools.ts
+++ b/packages/inventory/src/option-tools.ts
@@ -93,8 +93,6 @@ const optionUnitValueSchema = z.object({
   updatedAt: isoTimestamp,
 })
 
-const idempotencyKeySchema = z.string().trim().min(1).max(255).optional()
-
 export const createProductOptionInputSchema = insertProductOptionSchema.safeExtend({
   productId: z
     .string()
@@ -102,7 +100,6 @@ export const createProductOptionInputSchema = insertProductOptionSchema.safeExte
     .describe(
       "Id of the product this option belongs to. Resolve it with `list_products`, or create the product first with `create_product`.",
     ),
-  idempotencyKey: idempotencyKeySchema,
 })
 
 export const createOptionUnitInputSchema = insertOptionUnitSchema.safeExtend({
@@ -121,7 +118,6 @@ export const createOptionUnitInputSchema = insertOptionUnitSchema.safeExtend({
     .describe(
       "How many travellers one unit sleeps or seats, at minimum. REQUIRED (and ≥ 1) when unitType is `room` or `vehicle` — storefront pricing multiplies occupancy by quantity, so omitting it silently under-charges the booking.",
     ),
-  idempotencyKey: idempotencyKeySchema,
 })
 
 const updateProductOptionToolSchema = updateProductOptionSchema.safeExtend({

--- a/packages/inventory/src/tools.ts
+++ b/packages/inventory/src/tools.ts
@@ -198,13 +198,11 @@ const getProductContentArgs = z.object({
   forceFresh: z.boolean().default(false),
 })
 
-export const createProductToolSchema = z
-  .object(
-    (({ status: _status, visibility: _visibility, activated: _activated, ...shape }) => shape)(
-      insertProductSchema.shape,
-    ),
-  )
-  .extend({ idempotencyKey: z.string().trim().min(1).max(255).optional() })
+export const createProductToolSchema = z.object(
+  (({ status: _status, visibility: _visibility, activated: _activated, ...shape }) => shape)(
+    insertProductSchema.shape,
+  ),
+)
 const updateProductToolSchema = z.object({
   id: z.string().min(1),
   ...updateProductSchema.shape,

--- a/packages/inventory/tests/tools.test.ts
+++ b/packages/inventory/tests/tools.test.ts
@@ -1,3 +1,4 @@
+// agent-quality: file-size exception -- owner: inventory; Tool registry behavior stays co-located while shared protocol fixtures are tightened.
 import { createToolRegistry, type ToolContext } from "@voyant-travel/tools"
 import { describe, expect, it } from "vitest"
 
@@ -473,7 +474,7 @@ describe("inventory tools", () => {
     let forwarded: unknown
     const result = await makeRegistry().dispatch<{ productId: string }>(
       "create_product",
-      { name: "Cairo discovery", sellCurrency: "EUR", idempotencyKey: "product-create-1" },
+      { name: "Cairo discovery", sellCurrency: "EUR" },
       ctxWith(
         {
           async createProduct(input) {
@@ -488,7 +489,7 @@ describe("inventory tools", () => {
         },
       ),
     )
-    expect(forwarded).toMatchObject({ idempotencyKey: "product-create-1" })
+    expect(forwarded).not.toHaveProperty("idempotencyKey")
     expect(result).toEqual({ productId: "prod_1" })
   })
 

--- a/packages/operations/src/tools.ts
+++ b/packages/operations/src/tools.ts
@@ -1,3 +1,4 @@
+// agent-quality: file-size exception -- owner: operations; departure Tool schemas and definitions remain co-located pending a domain-aligned extraction.
 import { bookingActionSyncSummarySchema } from "@voyant-travel/bookings-contracts/booking-actions"
 import {
   admitHandlerActionPolicy,
@@ -521,17 +522,7 @@ export const RELEASE_DEPARTURE_ROOM_BLOCK_HANDLER_POLICY = {
   },
 } as const satisfies HandlerActionPolicyExpectation
 
-const createDepartureArgs = availabilitySlotCoreSchema
-  .extend({
-    idempotencyKey: z
-      .string()
-      .trim()
-      .min(1)
-      .max(255)
-      .optional()
-      .describe("Stable retry key. Must match the admitted Tool invocation idempotency key."),
-  })
-  .strict()
+const createDepartureArgs = availabilitySlotCoreSchema.strict()
 
 // Preserve the original update Tool contract: callers commonly round-trip a
 // get_departure snapshot, so known compatibility fields remain accepted and

--- a/packages/operations/tests/tools.test.ts
+++ b/packages/operations/tests/tools.test.ts
@@ -1,3 +1,4 @@
+// agent-quality: file-size exception -- owner: operations; Tool registry behavior stays co-located while shared protocol fixtures are tightened.
 import { createToolRegistry, type ToolContext } from "@voyant-travel/tools"
 import { describe, expect, it } from "vitest"
 
@@ -74,7 +75,7 @@ function registry() {
 }
 
 describe("Operations tools", () => {
-  it("creates a lossless departure through the admitted idempotent command surface", async () => {
+  it("creates a lossless departure while keeping command identity server-owned", async () => {
     const writeRegistry = createToolRegistry()
     writeRegistry.register(createDepartureTool, {
       actionPolicy: CREATE_DEPARTURE_HANDLER_POLICY.actionPolicy,
@@ -95,12 +96,11 @@ describe("Operations tools", () => {
         nights: 2,
         days: 3,
         notes: "Meet at the station",
-        idempotencyKey: "bucharest-2026-10-12-v1",
       },
       {
         ...contextWith({
           async createDeparture(input) {
-            expect(input.idempotencyKey).toBe("bucharest-2026-10-12-v1")
+            expect(input).not.toHaveProperty("idempotencyKey")
             return {
               replayed: false,
               departure: {

--- a/packages/relationships/src/tools.ts
+++ b/packages/relationships/src/tools.ts
@@ -118,13 +118,6 @@ export const createPersonToolInputSchema = insertPersonSchema
       .describe(
         "Removed compatibility field. Omit it; use list_people before create_person when resolving an existing person.",
       ),
-    idempotencyKey: z
-      .string()
-      .trim()
-      .min(1)
-      .max(255)
-      .optional()
-      .describe("Compatibility copy of the admitted created-command idempotency key."),
   })
 
 export const updatePersonToolInputSchema = updatePersonSchema

--- a/scripts/check-tool-refinement-visibility.ts
+++ b/scripts/check-tool-refinement-visibility.ts
@@ -11,7 +11,8 @@
 import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs"
 import path from "node:path"
 import { fileURLToPath, pathToFileURL } from "node:url"
-
+import type { z } from "zod"
+import { inspectToolProtocolFieldInventory } from "./lib/tool-protocol-field-inventory.mjs"
 import {
   entryId,
   findRefinementPaths,
@@ -19,6 +20,7 @@ import {
 } from "./lib/tool-refinement-inventory.mjs"
 
 const INVENTORY_PATH = "scripts/tool-refinement-inventory.json"
+const PROTOCOL_INVENTORY_PATH = "scripts/tool-protocol-field-inventory.json"
 
 void main()
 
@@ -30,13 +32,16 @@ async function main() {
       : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
   const write = process.argv.includes("--write")
 
-  const { found, unknownTypes } = await collectRefinements(repoRoot)
+  const { found, protocolFields, unknownTypes } = await collectRefinements(repoRoot)
 
   if (process.argv.includes("--report")) {
     for (const item of found) {
       console.log(`\n${item.id}`)
       console.log(`  tool: ${collapse(item.toolDescription)}`)
       console.log(`  path: ${collapse(item.pathDescription)}`)
+    }
+    for (const item of protocolFields) {
+      console.log(`\n${item.id} (${item.serverResolved ? "server-owned" : "caller-owned"})`)
     }
     return
   }
@@ -86,10 +91,21 @@ async function main() {
 
   const inventory = JSON.parse(readFileSync(inventoryFile, "utf8")) as Inventory
   const result = inspectRefinementInventory(found, inventory)
+  const protocolInventoryFile = path.join(repoRoot, PROTOCOL_INVENTORY_PATH)
+  if (!existsSync(protocolInventoryFile)) {
+    console.error(`Tool refinement visibility failed — ${PROTOCOL_INVENTORY_PATH} is missing.`)
+    process.exitCode = 1
+    return
+  }
+  const protocolResult = inspectToolProtocolFieldInventory(
+    protocolFields,
+    JSON.parse(readFileSync(protocolInventoryFile, "utf8")),
+  )
 
-  if (result.diagnostics.length > 0) {
+  if (result.diagnostics.length > 0 || protocolResult.diagnostics.length > 0) {
     console.error("Tool refinement visibility failed:\n")
     for (const diagnostic of result.diagnostics) console.error(`- ${diagnostic}`)
+    for (const diagnostic of protocolResult.diagnostics) console.error(`- ${diagnostic}`)
     process.exitCode = 1
     return
   }
@@ -98,6 +114,7 @@ async function main() {
     `Tool refinement visibility: OK (${result.total} refinements, ` +
       `${result.documented} documented, ${result.undocumented} undocumented)`,
   )
+  console.log(`Tool protocol field inventory: OK (${protocolResult.total} classified fields)`)
 }
 
 function collapse(text: string) {
@@ -156,6 +173,7 @@ async function collectRefinements(root: string) {
     pathDescription: string
   }[] = []
   const unknownTypes: string[] = []
+  const protocolFields: { id: string; serverResolved: boolean }[] = []
   const packagesRoot = path.join(root, "packages")
 
   for (const packageDirectory of findPackageDirectories(packagesRoot)) {
@@ -183,11 +201,19 @@ async function collectRefinements(root: string) {
           )
         }
         const toolModule = await importFile(packageDirectory, target, packageJson.name)
-        const definition = toolModule[tool.export] as { inputSchema?: unknown } | undefined
+        const definition = toolModule[tool.export] as
+          | { inputSchema?: z.ZodType; resolvesIdempotencyKeyServerSide?: boolean }
+          | undefined
         if (!definition?.inputSchema) {
           throw new Error(
             `${packageJson.name}: "${tool.export}" is not an exported Tool with an inputSchema`,
           )
+        }
+        if (hasTopLevelField(definition.inputSchema, "idempotencyKey")) {
+          protocolFields.push({
+            id: `${packageJson.name}:${tool.name}:input.idempotencyKey`,
+            serverResolved: definition.resolvesIdempotencyKeyServerSide === true,
+          })
         }
         const walked = findRefinementPaths(definition.inputSchema)
         for (const entry of walked.unknownTypes) {
@@ -211,7 +237,25 @@ async function collectRefinements(root: string) {
   // human classifies once, so collapse them.
   const byId = new Map(found.map((item) => [item.id, item]))
   const unique = [...byId.values()].sort((left, right) => left.id.localeCompare(right.id))
-  return { found: unique, unknownTypes }
+  const uniqueProtocolFields = [
+    ...new Map(protocolFields.map((item) => [item.id, item])).values(),
+  ].sort((left, right) => left.id.localeCompare(right.id))
+  return { found: unique, protocolFields: uniqueProtocolFields, unknownTypes }
+}
+
+function hasTopLevelField(schema: unknown, field: string, depth = 0): boolean {
+  if (depth > 12 || !schema || typeof schema !== "object") return false
+  const def = (schema as { _zod?: { def?: Record<string, unknown> } })._zod?.def
+  if (!def) return false
+  const shape = typeof def.shape === "function" ? def.shape() : def.shape
+  if (shape && typeof shape === "object" && field in shape) return true
+  for (const key of ["left", "right", "innerType", "in", "out"]) {
+    if (hasTopLevelField(def[key], field, depth + 1)) return true
+  }
+  if (Array.isArray(def.options)) {
+    return def.options.some((option) => hasTopLevelField(option, field, depth + 1))
+  }
+  return false
 }
 
 function manifestTools(value: unknown) {

--- a/scripts/lib/tool-protocol-field-inventory.mjs
+++ b/scripts/lib/tool-protocol-field-inventory.mjs
@@ -1,0 +1,53 @@
+export function inspectToolProtocolFieldInventory(observed, inventory) {
+  const diagnostics = []
+  const frameworkControls = inventory?.frameworkControls ?? []
+  if (
+    frameworkControls.length !== 1 ||
+    frameworkControls[0]?.field !== "_voyant" ||
+    frameworkControls[0]?.ownership !== "server-issued-continuation"
+  ) {
+    diagnostics.push(
+      'frameworkControls must classify exactly "_voyant" as server-issued-continuation',
+    )
+  }
+  const entries = Array.isArray(inventory?.entries) ? inventory.entries : []
+  const observedIds = [...new Set(observed.map((entry) => entry.id))].sort()
+  const inventoryIds = entries.map((entry) => entry.id)
+
+  if (new Set(inventoryIds).size !== inventoryIds.length) {
+    diagnostics.push("inventory contains duplicate ids")
+  }
+  if (JSON.stringify(inventoryIds) !== JSON.stringify([...inventoryIds].sort())) {
+    diagnostics.push("inventory entries must be sorted by id")
+  }
+
+  const inventoryById = new Map(entries.map((entry) => [entry.id, entry]))
+  for (const id of observedIds) {
+    const entry = inventoryById.get(id)
+    if (!entry) {
+      diagnostics.push(`unclassified caller-facing protocol field: ${id}`)
+      continue
+    }
+    if (!["caller-owned-command-identity", "server-owned"].includes(entry.ownership)) {
+      diagnostics.push(`${id} has invalid ownership classification`)
+    }
+    const observedEntry = observed.find((item) => item.id === id)
+    if (observedEntry?.serverResolved) {
+      diagnostics.push(`${id} is server-owned and must not be advertised to callers`)
+    }
+    const expectedOwnership = observedEntry?.serverResolved
+      ? "server-owned"
+      : "caller-owned-command-identity"
+    if (entry.ownership !== expectedOwnership) {
+      diagnostics.push(`${id} must be classified ${expectedOwnership}`)
+    }
+    if (typeof entry.rationale !== "string" || entry.rationale.trim().length < 20) {
+      diagnostics.push(`${id} must explain its business rationale`)
+    }
+  }
+  for (const id of inventoryIds) {
+    if (!observedIds.includes(id)) diagnostics.push(`stale inventory entry: ${id}`)
+  }
+
+  return { diagnostics, total: observedIds.length }
+}

--- a/scripts/tests/check-tool-protocol-field-inventory.test.mjs
+++ b/scripts/tests/check-tool-protocol-field-inventory.test.mjs
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import { inspectToolProtocolFieldInventory } from "../lib/tool-protocol-field-inventory.mjs"
+
+const observed = [
+  { id: "@voyant-travel/example:create_thing:input.idempotencyKey", serverResolved: false },
+]
+const classified = {
+  frameworkControls: [
+    {
+      field: "_voyant",
+      ownership: "server-issued-continuation",
+      rationale: "Carries confirmation and an approval id issued by the platform.",
+    },
+  ],
+  entries: [
+    {
+      id: observed[0].id,
+      ownership: "caller-owned-command-identity",
+      rationale: "The caller chooses the stable identity of this retryable business command.",
+    },
+  ],
+}
+
+describe("tool protocol field inventory", () => {
+  it("accepts an exact classified inventory", () => {
+    assert.deepEqual(inspectToolProtocolFieldInventory(observed, classified), {
+      diagnostics: [],
+      total: 1,
+    })
+  })
+
+  it("fails closed when a new field is not classified", () => {
+    const result = inspectToolProtocolFieldInventory(observed, {
+      frameworkControls: classified.frameworkControls,
+      entries: [],
+    })
+    assert.match(result.diagnostics[0], /unclassified caller-facing protocol field/)
+  })
+
+  it("rejects stale entries and missing rationale", () => {
+    const result = inspectToolProtocolFieldInventory([], {
+      frameworkControls: classified.frameworkControls,
+      entries: [{ id: observed[0].id, ownership: "server-owned", rationale: "short" }],
+    })
+    assert.ok(result.diagnostics.some((message) => message.includes("stale inventory entry")))
+  })
+
+  it("rejects a server-owned key even when someone classifies it", () => {
+    const result = inspectToolProtocolFieldInventory([{ ...observed[0], serverResolved: true }], {
+      frameworkControls: classified.frameworkControls,
+      entries: [
+        {
+          ...classified.entries[0],
+          ownership: "server-owned",
+        },
+      ],
+    })
+    assert.ok(result.diagnostics.some((message) => message.includes("must not be advertised")))
+  })
+})

--- a/scripts/tool-protocol-field-inventory.json
+++ b/scripts/tool-protocol-field-inventory.json
@@ -1,0 +1,166 @@
+{
+  "frameworkControls": [
+    {
+      "field": "_voyant",
+      "ownership": "server-issued-continuation",
+      "rationale": "Carries caller confirmation and platform-issued approval ids; command identity remains server-owned."
+    }
+  ],
+  "entries": [
+    {
+      "id": "@voyant-travel/accommodations:create_room_block:input.idempotencyKey",
+      "ownership": "caller-owned-command-identity",
+      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
+    },
+    {
+      "id": "@voyant-travel/action-ledger:request_action_approval:input.idempotencyKey",
+      "ownership": "caller-owned-command-identity",
+      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
+    },
+    {
+      "id": "@voyant-travel/bookings:accept_booking_amendment:input.idempotencyKey",
+      "ownership": "caller-owned-command-identity",
+      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
+    },
+    {
+      "id": "@voyant-travel/bookings:apply_booking_amendment:input.idempotencyKey",
+      "ownership": "caller-owned-command-identity",
+      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
+    },
+    {
+      "id": "@voyant-travel/bookings:create_booking_extra:input.idempotencyKey",
+      "ownership": "caller-owned-command-identity",
+      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
+    },
+    {
+      "id": "@voyant-travel/bookings:preview_traveler_correction_amendment:input.idempotencyKey",
+      "ownership": "caller-owned-command-identity",
+      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
+    },
+    {
+      "id": "@voyant-travel/bookings:preview_traveler_roster_change_amendment:input.idempotencyKey",
+      "ownership": "caller-owned-command-identity",
+      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
+    },
+    {
+      "id": "@voyant-travel/bookings:reconcile_booking_amendment:input.idempotencyKey",
+      "ownership": "caller-owned-command-identity",
+      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
+    },
+    {
+      "id": "@voyant-travel/charters:create_charter_product:input.idempotencyKey",
+      "ownership": "caller-owned-command-identity",
+      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
+    },
+    {
+      "id": "@voyant-travel/charters:create_charter_yacht:input.idempotencyKey",
+      "ownership": "caller-owned-command-identity",
+      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
+    },
+    {
+      "id": "@voyant-travel/commerce:create_cancellation_policy:input.idempotencyKey",
+      "ownership": "caller-owned-command-identity",
+      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
+    },
+    {
+      "id": "@voyant-travel/commerce:create_price_catalog:input.idempotencyKey",
+      "ownership": "caller-owned-command-identity",
+      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
+    },
+    {
+      "id": "@voyant-travel/commerce:create_promotion:input.idempotencyKey",
+      "ownership": "caller-owned-command-identity",
+      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
+    },
+    {
+      "id": "@voyant-travel/cruises:create_cruise:input.idempotencyKey",
+      "ownership": "caller-owned-command-identity",
+      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
+    },
+    {
+      "id": "@voyant-travel/cruises:create_cruise_ship:input.idempotencyKey",
+      "ownership": "caller-owned-command-identity",
+      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
+    },
+    {
+      "id": "@voyant-travel/distribution:create_distribution_channel:input.idempotencyKey",
+      "ownership": "caller-owned-command-identity",
+      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
+    },
+    {
+      "id": "@voyant-travel/distribution:create_external_reference:input.idempotencyKey",
+      "ownership": "caller-owned-command-identity",
+      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
+    },
+    {
+      "id": "@voyant-travel/distribution:create_supplier:input.idempotencyKey",
+      "ownership": "caller-owned-command-identity",
+      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
+    },
+    {
+      "id": "@voyant-travel/finance:issue_invoice_refund:input.idempotencyKey",
+      "ownership": "caller-owned-command-identity",
+      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
+    },
+    {
+      "id": "@voyant-travel/finance:issue_unsynced_proforma_from_booking:input.idempotencyKey",
+      "ownership": "caller-owned-command-identity",
+      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
+    },
+    {
+      "id": "@voyant-travel/finance:record_refund_settlement:input.idempotencyKey",
+      "ownership": "caller-owned-command-identity",
+      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
+    },
+    {
+      "id": "@voyant-travel/identity:create_identity_address:input.idempotencyKey",
+      "ownership": "caller-owned-command-identity",
+      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
+    },
+    {
+      "id": "@voyant-travel/identity:create_identity_contact_point:input.idempotencyKey",
+      "ownership": "caller-owned-command-identity",
+      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
+    },
+    {
+      "id": "@voyant-travel/identity:create_identity_named_contact:input.idempotencyKey",
+      "ownership": "caller-owned-command-identity",
+      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
+    },
+    {
+      "id": "@voyant-travel/inventory:compose_product:input.idempotencyKey",
+      "ownership": "caller-owned-command-identity",
+      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
+    },
+    {
+      "id": "@voyant-travel/inventory:create_option_extra_config:input.idempotencyKey",
+      "ownership": "caller-owned-command-identity",
+      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
+    },
+    {
+      "id": "@voyant-travel/inventory:create_product_extra:input.idempotencyKey",
+      "ownership": "caller-owned-command-identity",
+      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
+    },
+    {
+      "id": "@voyant-travel/legal:create_legal_contract_draft:input.idempotencyKey",
+      "ownership": "caller-owned-command-identity",
+      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
+    },
+    {
+      "id": "@voyant-travel/mice:create_mice_program:input.idempotencyKey",
+      "ownership": "caller-owned-command-identity",
+      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
+    },
+    {
+      "id": "@voyant-travel/relationships:create_organization:input.idempotencyKey",
+      "ownership": "caller-owned-command-identity",
+      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
+    },
+    {
+      "id": "@voyant-travel/storefront:create_invoice_payment_link:input.idempotencyKey",
+      "ownership": "caller-owned-command-identity",
+      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
+    }
+  ]
+}


### PR DESCRIPTION
Closes part of #4378.

- inventory every retained caller-facing `idempotencyKey` by exact Tool id and rationale
- classify `_voyant` as the server-issued approval/confirmation continuation channel
- reject new, stale, misclassified, or server-owned caller fields
- remove six server-owned idempotency keys from advertised Tool schemas and derive them exclusively in handlers

Verification:
- `pnpm verify:fast`
- affected finance, inventory, operations, and relationships package tests
- focused checker unit tests