### PR TITLE
fix(storefront): validate offer expiry after issuance

### DIFF
--- a/.changeset/calm-shopping-clocks.md
+++ b/.changeset/calm-shopping-clocks.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/storefront": patch
+---
+
+Validate opaque shopping-reference expiry after asynchronous issuance so normal persistence latency cannot reject correctly bounded live offers.

--- a/packages/storefront/src/shopping/managed-runtime.ts
+++ b/packages/storefront/src/shopping/managed-runtime.ts
@@ -538,7 +538,6 @@ async function issueLiveContinuation(
   }
   const page = currentPage + 1
   if (page >= MAX_CONTINUATION_PAGE) return undefined
-  const issuedAt = now().getTime()
   const issued = await authority.issue({
     purpose: "live-continuation",
     storefrontId: context.storefrontId,
@@ -555,7 +554,7 @@ async function issueLiveContinuation(
     ttlSeconds: CONTINUATION_TTL_SECONDS,
     replay: "single-use",
   })
-  validateIssuedReference(issued, issuedAt, CONTINUATION_TTL_SECONDS)
+  validateIssuedReference(issued, now().getTime(), CONTINUATION_TTL_SECONDS)
   return issued.ref
 }
 
@@ -702,7 +701,6 @@ async function issueBoundedReference(
     replay: "multi-use" | "single-use"
   },
 ) {
-  const issuedAt = now().getTime()
   const issued = await issuer.issue({
     purpose: input.purpose,
     storefrontId: input.context.storefrontId,
@@ -722,7 +720,7 @@ async function issueBoundedReference(
   })
   validateIssuedReference(
     issued,
-    issuedAt,
+    now().getTime(),
     input.purpose === "catalog-item" ? ITEM_TTL_SECONDS : OFFER_TTL_SECONDS,
   )
   return issued

--- a/packages/storefront/tests/unit/managed-shopping-runtime.test.ts
+++ b/packages/storefront/tests/unit/managed-shopping-runtime.test.ts
@@ -437,4 +437,34 @@ describe("managed live shopping", () => {
       "opaque_reference_expiry_invalid",
     )
   })
+
+  it("accepts the bounded TTL when reference persistence advances the clock", async () => {
+    let currentTime = NOW.getTime()
+    const deps = dependencies({
+      now: () => new Date(currentTime),
+      references: {
+        redeem: vi.fn(async () => null),
+        issue: vi.fn(async (input: { ttlSeconds: number }) => {
+          currentTime += 50
+          return {
+            ref: "opaque-reference-after-persistence",
+            expiresAt: new Date(currentTime + input.ttlSeconds * 1_000).toISOString(),
+          }
+        }),
+      },
+      live: {
+        searchFlights: vi.fn(async () => ({ items: [flight("450", "RON", "450")], sources: [] })),
+        searchStays: vi.fn(),
+        searchPackages: vi.fn(),
+        searchCruises: vi.fn(),
+      },
+    })
+    const runtime = createManagedStorefrontShoppingRuntime(deps)
+    const scope = await runtime.resolveScope(context, {})
+
+    await expect(runtime.search(context, { scope, intent: flightIntent })).resolves.toMatchObject({
+      kind: "flight",
+      offers: [{ offerRef: "opaque-reference-after-persistence" }],
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- validate bounded opaque-reference expiry against the clock after async issuance
- preserve the strict maximum TTL while tolerating normal persistence latency
- add a regression test where issuance advances the clock

## Validation
- `pnpm --filter @voyant-travel/storefront exec vitest run tests/unit/managed-shopping-runtime.test.ts --maxWorkers=2` — 14/14 passed
- targeted Biome and `git diff --check` passed
- package typecheck exceeded the local Node 4 GiB heap; GitHub CI remains the typecheck authority

## Live evidence
This fixes the sandbox package-search 500 `opaque_reference_expiry_invalid`, where the durable issuer correctly based expiry on its later insertion timestamp.
