### PR TITLE
fix(mcp): bound discovery response cost

### DIFF
--- a/.changeset/tidy-amendment-outcomes.md
+++ b/.changeset/tidy-amendment-outcomes.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/bookings": patch
+---
+
+Return compact amendment references and consequence summaries from Booking Amendment Tools instead of full revision graphs.

--- a/apps/operator/tests/mcp-capability.test.ts
+++ b/apps/operator/tests/mcp-capability.test.ts
@@ -68,6 +68,7 @@ import {
   createGeneratedGraphRuntime,
   createGeneratedTestDeploymentResources,
 } from "./api/generated-project-runtime.js"
+import { measureResponseFormats } from "./support/mcp-response-format-metrics.js"
 import { fetchWithTransientRetry } from "./support/openai-response-retry.js"
 
 const TEST_DATABASE_URL = process.env.TEST_DATABASE_URL
@@ -1020,13 +1021,15 @@ function writeMachineReport(): void {
     .sort((left, right) => right.responseBytes - left.responseBytes)
     .slice(0, 10)
     .map((call) => ({ name: call.name, responseBytes: call.responseBytes, isError: call.isError }))
+  const allCalls = [...attempts.values()].flat().flatMap((attempt) => attempt.calls)
+  const responseFormats = measureResponseFormats(allCalls)
 
   mkdirSync(dirname(destination), { recursive: true })
   writeFileSync(
     destination,
     `${JSON.stringify(
       {
-        schemaVersion: 3,
+        schemaVersion: 4,
         generatedAt: new Date().toISOString(),
         model: MODEL,
         reasoningEffort: MODEL.startsWith("gpt-5") ? REASONING_EFFORT : null,
@@ -1060,6 +1063,7 @@ function writeMachineReport(): void {
           ),
         },
         largestResponses,
+        responseFormats,
       },
       null,
       2,

--- a/apps/operator/tests/mcp-response-format-metrics.test.ts
+++ b/apps/operator/tests/mcp-response-format-metrics.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest"
+
+import { measureResponseFormats } from "./support/mcp-response-format-metrics.js"
+
+describe("MCP response format metrics", () => {
+  it("measures explicit formats and an immediate detailed refetch", () => {
+    const result = measureResponseFormats([
+      { name: "search_tools", args: { query: "bookings" }, responseBytes: 120 },
+      {
+        name: "call_tool",
+        args: { name: "bookings_query", arguments: { resource: "bookings", limit: 10 } },
+        responseBytes: 400,
+      },
+      {
+        name: "call_tool",
+        args: {
+          name: "bookings_query",
+          arguments: { resource: "bookings", limit: 10, response_format: "detailed" },
+        },
+        responseBytes: 900,
+      },
+      { name: "describe_tool", args: { name: "bookings_query" }, responseBytes: 800 },
+    ])
+
+    expect(result).toEqual({
+      queryCalls: 2,
+      explicitConcise: 0,
+      explicitDetailed: 1,
+      defaultConcise: 1,
+      immediateDetailedRefetches: 1,
+      searchToolsMaxBytes: 120,
+      describeToolMaxBytes: 800,
+    })
+  })
+
+  it("does not call a non-adjacent detailed query a refetch", () => {
+    const result = measureResponseFormats([
+      { name: "inventory_query", args: { resource: "products" }, responseBytes: 100 },
+      { name: "search_tools", args: { query: "products" }, responseBytes: 100 },
+      {
+        name: "inventory_query",
+        args: { resource: "products", response_format: "detailed" },
+        responseBytes: 200,
+      },
+    ])
+    expect(result.immediateDetailedRefetches).toBe(0)
+  })
+})

--- a/apps/operator/tests/selected-graph-mcp-tool-surface.test.ts
+++ b/apps/operator/tests/selected-graph-mcp-tool-surface.test.ts
@@ -82,6 +82,12 @@ const ALL_TOOLS_AGGREGATE_CEILING_BYTES = 275_000
 
 const AGGREGATE_CEILING_BYTES = 130_000
 
+/** Real Terra max: 10,421 bytes; advanced exact-command Tools retain 40 KB headroom. */
+const DESCRIBE_RESPONSE_CEILING_BYTES = 40_000
+
+/** Real Terra max after domain-scoped fallback: 6,485 bytes. */
+const SEARCH_RESPONSE_CEILING_BYTES = 8_000
+
 /** Rough proxy for tokens. JSON schema tokenizes denser than prose, so this is a floor. */
 const BYTES_PER_TOKEN = 4
 
@@ -420,6 +426,52 @@ describe("selected-graph MCP tool surface cost", () => {
     expect(result?.returned).toBe(tools.length)
     expect(new Set(tools.map(({ domain }) => domain))).toEqual(new Set(["finance"]))
     expect(tools.map(({ name }) => name)).toContain("finance_query")
+  })
+
+  it("bounds the served discovery responses a model actually pays for", async () => {
+    const { app } = await mountSelectedGraphMcp()
+    const manifest = (await (await app.request("/manifest", {}, TEST_ENV, TEST_CTX)).json()) as {
+      tools: Array<{ name?: string }>
+    }
+    const names = new Set(manifest.tools.flatMap(({ name }) => (name ? [name] : [])))
+    for (const name of [
+      "accommodations_query",
+      "bookings_query",
+      "finance_query",
+      "inventory_query",
+      "operations_query",
+      "relationships_query",
+    ]) {
+      names.add(name)
+    }
+
+    let heaviest = { name: "", bytes: 0 }
+    for (const name of names) {
+      const response = await app.request(
+        "/",
+        rpc("tools/call", { name: "describe_tool", arguments: { name } }),
+        TEST_ENV,
+        TEST_CTX,
+      )
+      const bytes = Buffer.byteLength(await response.text(), "utf8")
+      if (bytes > heaviest.bytes) heaviest = { name, bytes }
+    }
+    expect(
+      heaviest.bytes,
+      `Largest served describe_tool response was ${heaviest.name} at ${heaviest.bytes} bytes`,
+    ).toBeLessThanOrEqual(DESCRIBE_RESPONSE_CEILING_BYTES)
+
+    const fallback = await app.request(
+      "/",
+      rpc("tools/call", {
+        name: "search_tools",
+        arguments: { query: "phrase guaranteed to have no exact capability match", limit: 50 },
+      }),
+      TEST_ENV,
+      TEST_CTX,
+    )
+    const fallbackBytes = Buffer.byteLength(await fallback.text(), "utf8")
+    expect(fallbackBytes).toBeLessThanOrEqual(SEARCH_RESPONSE_CEILING_BYTES)
   })
 
   it("still bounds EVERY selected tool's schema, writes included", async () => {

--- a/apps/operator/tests/support/mcp-response-format-metrics.ts
+++ b/apps/operator/tests/support/mcp-response-format-metrics.ts
@@ -1,0 +1,74 @@
+export interface RecordedMcpCall {
+  name: string
+  args: Record<string, unknown>
+  responseBytes: number
+}
+
+export interface ResponseFormatMetrics {
+  queryCalls: number
+  explicitConcise: number
+  explicitDetailed: number
+  defaultConcise: number
+  immediateDetailedRefetches: number
+  searchToolsMaxBytes: number
+  describeToolMaxBytes: number
+}
+
+export function measureResponseFormats(calls: readonly RecordedMcpCall[]): ResponseFormatMetrics {
+  const metrics: ResponseFormatMetrics = {
+    queryCalls: 0,
+    explicitConcise: 0,
+    explicitDetailed: 0,
+    defaultConcise: 0,
+    immediateDetailedRefetches: 0,
+    searchToolsMaxBytes: 0,
+    describeToolMaxBytes: 0,
+  }
+  let previousQuery: { fingerprint: string; format: string | undefined } | undefined
+
+  for (const call of calls) {
+    if (call.name === "search_tools") {
+      metrics.searchToolsMaxBytes = Math.max(metrics.searchToolsMaxBytes, call.responseBytes)
+    }
+    if (call.name === "describe_tool") {
+      metrics.describeToolMaxBytes = Math.max(metrics.describeToolMaxBytes, call.responseBytes)
+    }
+
+    const query = queryInvocation(call)
+    if (!query) {
+      previousQuery = undefined
+      continue
+    }
+    metrics.queryCalls += 1
+    if (query.format === "concise") metrics.explicitConcise += 1
+    else if (query.format === "detailed") metrics.explicitDetailed += 1
+    else metrics.defaultConcise += 1
+
+    if (
+      query.format === "detailed" &&
+      previousQuery?.fingerprint === query.fingerprint &&
+      previousQuery.format !== "detailed"
+    ) {
+      metrics.immediateDetailedRefetches += 1
+    }
+    previousQuery = query
+  }
+  return metrics
+}
+
+function queryInvocation(call: RecordedMcpCall) {
+  const toolName = call.name === "call_tool" ? call.args.name : call.name
+  const input = call.name === "call_tool" ? call.args.arguments : call.args
+  if (typeof toolName !== "string" || !toolName.endsWith("_query")) return undefined
+  if (!input || typeof input !== "object" || Array.isArray(input)) return undefined
+  const args = input as Record<string, unknown>
+  const format = typeof args.response_format === "string" ? args.response_format : undefined
+  const fingerprint = JSON.stringify(
+    Object.fromEntries(
+      Object.entries({ toolName, ...args })
+        .filter(([key]) => key !== "response_format")
+        .sort(([left], [right]) => left.localeCompare(right)),
+    ),
+  )
+  return { fingerprint, format }
+}

--- a/packages/bookings/src/tools.ts
+++ b/packages/bookings/src/tools.ts
@@ -303,7 +303,33 @@ export const reconcileBookingAmendmentToolInputSchema = z.object({
   idempotencyKey: amendmentCommandFields.idempotencyKey,
 })
 
-const acceptBookingAmendmentToolOutputSchema = z.discriminatedUnion("status", [
+const amendmentOutcomeReferenceSchema = z.object({
+  id: z.string(),
+  bookingId: z.string(),
+  status: z.string(),
+  resultBookingRevision: z.number().int().positive(),
+  nextActions: z.array(z.string()),
+  failureCode: z.string().nullable(),
+  priceDelta: z.object({
+    currency: z.string(),
+    amountCents: z.number().int(),
+    collectionAmountCents: z.number().int().nonnegative(),
+    refundAmountCents: z.number().int().nonnegative(),
+  }),
+  effects: z.object({
+    finance: z.string(),
+    legal: z.string(),
+    documents: z.string(),
+    fulfillment: z.string(),
+    supplier: z.string(),
+    allocation: z.string(),
+  }),
+})
+const amendmentPreviewToolOutputSchema = z.union([
+  z.object({ status: z.literal("ok"), amendment: amendmentOutcomeReferenceSchema }),
+  ...bookingAmendmentPreviewResultSchema.options.slice(1),
+])
+const acceptBookingAmendmentServiceResultSchema = z.discriminatedUnion("status", [
   z.object({ status: z.literal("ok"), amendment: bookingAmendmentSchema }),
   z.object({ status: z.literal("already_applied"), amendment: bookingAmendmentSchema }),
   z.object({ status: z.literal("not_found") }),
@@ -315,8 +341,65 @@ const acceptBookingAmendmentToolOutputSchema = z.discriminatedUnion("status", [
     currentBookingRevision: z.number().int().positive(),
   }),
 ])
+const acceptBookingAmendmentToolOutputSchema = z.union([
+  z.object({
+    status: z.enum(["ok", "already_applied"]),
+    amendment: amendmentOutcomeReferenceSchema,
+  }),
+  ...acceptBookingAmendmentServiceResultSchema.options.slice(2),
+])
+const amendmentOutcomeStatuses = [
+  "ok",
+  "supplier_pending",
+  "supplier_in_doubt",
+  "supplier_refused",
+  "manual_review",
+] as const
+const applyBookingAmendmentToolOutputSchema = z.union([
+  z.object({
+    status: z.enum(amendmentOutcomeStatuses),
+    amendment: amendmentOutcomeReferenceSchema,
+  }),
+  z.object({ status: z.literal("not_found") }),
+  z.object({ status: z.literal("revision_mismatch") }),
+  z.object({ status: z.literal("acceptance_required") }),
+  z.object({ status: z.literal("invalid_state") }),
+  z.object({ status: z.literal("idempotency_conflict") }),
+  z.object({ status: z.literal("quote_expired") }),
+  z.object({ status: z.literal("unsupported_capability") }),
+  z.object({ status: z.literal("availability_changed"), bookingItemId: z.string() }),
+  z.object({
+    status: z.literal("stale_revision"),
+    currentBookingRevision: z.number().int().positive(),
+  }),
+])
 
-const applyBookingAmendmentToolOutputSchema = bookingAmendmentApplyResultSchema
+function toAmendmentToolOutcome(value: unknown) {
+  const result = bookingAmendmentApplyResultSchema.parse(value)
+  if (!("amendment" in result)) return result
+  return {
+    status: result.status,
+    amendment: amendmentOutcomeReferenceSchema.parse(result.amendment),
+  }
+}
+
+function toAcceptAmendmentToolOutcome(value: unknown) {
+  const result = acceptBookingAmendmentServiceResultSchema.parse(value)
+  if (!("amendment" in result)) return result
+  return {
+    status: result.status,
+    amendment: amendmentOutcomeReferenceSchema.parse(result.amendment),
+  }
+}
+
+function toAmendmentPreviewToolOutcome(value: unknown) {
+  const result = bookingAmendmentPreviewResultSchema.parse(value)
+  if (!("amendment" in result)) return result
+  return {
+    status: result.status,
+    amendment: amendmentOutcomeReferenceSchema.parse(result.amendment),
+  }
+}
 
 const bookingAmendmentWriteRisk = {
   destructive: false,
@@ -334,7 +417,7 @@ export const previewTravelerCorrectionAmendmentTool = defineTool({
   description:
     "Create an immutable, idempotent before/proposed-after preview for a traveler correction without replacing the Booking.",
   inputSchema: previewTravelerCorrectionAmendmentToolInputSchema,
-  outputSchema: bookingAmendmentPreviewResultSchema,
+  outputSchema: amendmentPreviewToolOutputSchema,
   requiredScopes: ["bookings:write"],
   audience: { source: "grant", allowed: ["staff"] },
   tier: "write",
@@ -342,8 +425,8 @@ export const previewTravelerCorrectionAmendmentTool = defineTool({
   annotations: { idempotentHint: true },
   async handler(input, ctx: BookingsToolContext) {
     return parseJsonResult(
-      bookingAmendmentPreviewResultSchema,
-      await bookings(ctx).previewTravelerCorrectionAmendment(input),
+      amendmentPreviewToolOutputSchema,
+      toAmendmentPreviewToolOutcome(await bookings(ctx).previewTravelerCorrectionAmendment(input)),
     )
   },
 })
@@ -356,7 +439,7 @@ export const previewTravelerRosterChangeAmendmentTool = defineTool({
   description:
     "Quote an immutable traveler add/drop Amendment with server-calculated price, tax, inventory, supplier, and financial consequences.",
   inputSchema: previewTravelerRosterChangeAmendmentToolInputSchema,
-  outputSchema: bookingAmendmentPreviewResultSchema,
+  outputSchema: amendmentPreviewToolOutputSchema,
   requiredScopes: ["bookings:write"],
   audience: { source: "grant", allowed: ["staff"] },
   tier: "write",
@@ -364,8 +447,10 @@ export const previewTravelerRosterChangeAmendmentTool = defineTool({
   annotations: { idempotentHint: true },
   async handler(input, ctx: BookingsToolContext) {
     return parseJsonResult(
-      bookingAmendmentPreviewResultSchema,
-      await bookings(ctx).previewTravelerRosterChangeAmendment(input),
+      amendmentPreviewToolOutputSchema,
+      toAmendmentPreviewToolOutcome(
+        await bookings(ctx).previewTravelerRosterChangeAmendment(input),
+      ),
     )
   },
 })
@@ -387,7 +472,7 @@ export const acceptBookingAmendmentTool = defineTool({
   async handler(input, ctx: BookingsToolContext) {
     return parseJsonResult(
       acceptBookingAmendmentToolOutputSchema,
-      await bookings(ctx).acceptBookingAmendment(input),
+      toAcceptAmendmentToolOutcome(await bookings(ctx).acceptBookingAmendment(input)),
     )
   },
 })
@@ -409,7 +494,7 @@ export const applyBookingAmendmentTool = defineTool({
   async handler(input, ctx: BookingsToolContext) {
     return parseJsonResult(
       applyBookingAmendmentToolOutputSchema,
-      await bookings(ctx).applyBookingAmendment(input),
+      toAmendmentToolOutcome(await bookings(ctx).applyBookingAmendment(input)),
     )
   },
 })
@@ -431,7 +516,7 @@ export const reconcileBookingAmendmentTool = defineTool({
   async handler(input, ctx: BookingsToolContext) {
     return parseJsonResult(
       applyBookingAmendmentToolOutputSchema,
-      await bookings(ctx).reconcileBookingAmendment(input),
+      toAmendmentToolOutcome(await bookings(ctx).reconcileBookingAmendment(input)),
     )
   },
 })


### PR DESCRIPTION
Closes #3971.

- record real-model query format usage, immediate detailed refetches, and discovery maxima in the capability artifact
- bound every served `describe_tool` response and zero-hit `search_tools` fallback on the selected graph
- replace full Booking Amendment revision graphs with compact references and consequence summaries

Real five-run measurement: 75/75 attempts passed, 737 calls, 0 transport retries; 115 query calls comprised 82 explicit detailed, 10 explicit concise, and 23 default concise calls, with 0 immediate detailed refetches. Search max was 6,485 bytes and describe max 10,421 bytes.

Verification: `pnpm verify:fast`, focused operator response-budget tests, Bookings Tool tests and typecheck.