### PR TITLE
fix(accommodations): present sourced stay offers

### DIFF
--- a/.changeset/calm-stays-present.md
+++ b/.changeset/calm-stays-present.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/accommodations": patch
+---
+
+Resolve live sourced stay offers through their canonical Catalog identity before loading localized presentation content, with a closed adapter-content fallback for newly discovered inventory.

--- a/packages/accommodations/src/catalog-runtime-extension.ts
+++ b/packages/accommodations/src/catalog-runtime-extension.ts
@@ -1,4 +1,8 @@
+import type { SourceAdapterRegistry } from "@voyant-travel/catalog/booking-engine"
 import type { CatalogAccommodationsRuntimeExtension } from "@voyant-travel/catalog/runtime-contracts"
+import { readSourcedEntryBySource } from "@voyant-travel/catalog/services/sourced-entry"
+import type { AvailabilityCandidate } from "@voyant-travel/catalog-contracts/adapter/contract"
+import type { AnyDrizzleDb } from "@voyant-travel/db"
 
 import { registerAccommodationBookingHandler } from "./booking-engine/runtime.js"
 import { createAccommodationOwnedSearchHandler } from "./booking-engine/search-handler.js"
@@ -7,6 +11,7 @@ import {
   accommodationPropertyCatalogPolicy,
   accommodationPropertyReferenceCatalogPolicy,
 } from "./catalog-policy-properties.js"
+import { type AccommodationContent, accommodationContentSchema } from "./content-shape.js"
 import { createRoomTypeDocumentBuilder } from "./service-catalog-plane.js"
 import { getAccommodationContent } from "./service-content.js"
 import {
@@ -26,27 +31,99 @@ export const catalogAccommodationsRuntimeExtension = {
     registry.register(createAccommodationOwnedSearchHandler({}))
   },
   async presentAvailabilityCandidate({ db, registry, candidate, locale, market, currency }) {
+    const entityId = await resolveAvailabilityPresentationEntityId({
+      db,
+      registry,
+      candidate,
+    })
     const resolved = await getAccommodationContent(
       db,
-      candidate.entity_id,
+      entityId,
       { preferredLocales: [locale], market, currency },
       { registry },
     )
-    if (!resolved) return undefined
-    const selection = record(candidate.selection)
-    const roomTypeId = string(selection?.roomTypeId)
-    const ratePlanId = string(selection?.ratePlanId)
-    const room = resolved.content.room_types.find(({ id }) => id === roomTypeId)
-    const ratePlan = resolved.content.rate_plans.find(({ id }) => id === ratePlanId)
-    const imageUrl = room?.images[0] ?? resolved.content.hotel.hero_image_url ?? undefined
-    return {
-      title: resolved.content.hotel.name,
-      ...(room?.name ? { roomName: room.name } : {}),
-      ...(ratePlan?.name ? { boardName: ratePlan.name } : {}),
-      ...(imageUrl ? { image: { url: imageUrl, alt: resolved.content.hotel.name } } : {}),
-    }
+    const content =
+      resolved?.content ??
+      (await fetchUnindexedAvailabilityContent({
+        registry,
+        candidate,
+        locale,
+        market,
+        currency,
+      }))
+    if (!content) return undefined
+    return availabilityPresentation(content, candidate)
   },
 } satisfies CatalogAccommodationsRuntimeExtension
+
+function availabilityPresentation(content: AccommodationContent, candidate: AvailabilityCandidate) {
+  const selection = record(candidate.selection)
+  const roomTypeId = string(selection?.roomTypeId)
+  const ratePlanId = string(selection?.ratePlanId)
+  const rooms = Array.isArray(selection?.rooms) ? selection.rooms : []
+  const firstRoom = record(rooms[0])
+  const selectedRoomTypeId = roomTypeId ?? string(firstRoom?.roomTypeId)
+  const selectedRatePlanId = ratePlanId ?? string(firstRoom?.ratePlanId)
+  const room = content.room_types.find(({ id }) => id === selectedRoomTypeId)
+  const ratePlan = content.rate_plans.find(({ id }) => id === selectedRatePlanId)
+  const imageUrl = room?.images[0] ?? content.hotel.hero_image_url ?? undefined
+  return {
+    title: content.hotel.name,
+    ...(room?.name ? { roomName: room.name } : {}),
+    ...(ratePlan?.name ? { boardName: ratePlan.name } : {}),
+    ...(imageUrl ? { image: { url: imageUrl, alt: content.hotel.name } } : {}),
+  }
+}
+
+async function fetchUnindexedAvailabilityContent(input: {
+  registry: SourceAdapterRegistry
+  candidate: AvailabilityCandidate
+  locale: string
+  market: string
+  currency: string
+}): Promise<AccommodationContent | undefined> {
+  if (input.candidate.source?.kind !== "sourced") return undefined
+  const connectionId = input.candidate.source.connectionId
+  const adapter = input.registry.resolveByConnection(connectionId)
+  if (!adapter?.getContent) return undefined
+  const fresh = await adapter.getContent(
+    { connection_id: connectionId },
+    {
+      entity_module: "accommodations",
+      entity_id: input.candidate.entity_id,
+      locale: input.locale,
+      market: input.market,
+      currency: input.currency,
+    },
+  )
+  const parsed = accommodationContentSchema.safeParse(fresh.content)
+  return parsed.success ? parsed.data : undefined
+}
+
+export async function resolveAvailabilityPresentationEntityId(input: {
+  db: AnyDrizzleDb
+  registry: SourceAdapterRegistry
+  candidate: AvailabilityCandidate
+  readBySource?: typeof readSourcedEntryBySource
+}): Promise<string> {
+  if (input.candidate.source?.kind !== "sourced") {
+    return input.candidate.entity_id
+  }
+  const connectionId = input.candidate.source.connectionId
+  const adapter = input.registry.resolveByConnection(connectionId)
+  if (!adapter) return input.candidate.entity_id
+
+  // Live Connect search returns the source accommodation reference. Catalog
+  // content is keyed by its canonical sourced-entry id. Resolve that identity
+  // boundary before presentation; never expose or accept it from the browser.
+  const sourced = await (input.readBySource ?? readSourcedEntryBySource)(input.db, {
+    entityModule: "accommodations",
+    sourceKind: adapter.kind,
+    sourceConnectionId: connectionId,
+    sourceRef: input.candidate.entity_id,
+  })
+  return sourced?.entity_id ?? input.candidate.entity_id
+}
 
 function record(value: unknown): Record<string, unknown> | undefined {
   return value !== null && typeof value === "object" && !Array.isArray(value)

--- a/packages/accommodations/tests/catalog-runtime-extension.test.ts
+++ b/packages/accommodations/tests/catalog-runtime-extension.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { resolveAvailabilityPresentationEntityId } from "../src/catalog-runtime-extension.js"
+
+describe("availability presentation identity", () => {
+  it("maps a sourced live offer reference to the canonical catalog entity", async () => {
+    const readBySource = vi.fn(async () => ({ entity_id: "acc_canonical" }))
+    const result = await resolveAvailabilityPresentationEntityId({
+      db: {} as never,
+      registry: {
+        resolveByConnection: () => ({ kind: "voyant-connect" }),
+      } as never,
+      candidate: {
+        candidateRef: "stay_offer",
+        entity_module: "accommodations",
+        entity_id: "hotel_source_ref",
+        selection: {},
+        source: { kind: "sourced", connectionId: "conn_1" },
+        price: { amount: "100.00", currency: "EUR" },
+      },
+      readBySource: readBySource as never,
+    })
+
+    expect(result).toBe("acc_canonical")
+    expect(readBySource).toHaveBeenCalledWith(
+      {},
+      {
+        entityModule: "accommodations",
+        sourceKind: "voyant-connect",
+        sourceConnectionId: "conn_1",
+        sourceRef: "hotel_source_ref",
+      },
+    )
+  })
+
+  it("keeps owned and unmapped candidates on their canonical input id", async () => {
+    const readBySource = vi.fn()
+    const base = {
+      candidateRef: "stay_offer",
+      entity_module: "accommodations",
+      entity_id: "acc_owned",
+      selection: {},
+      price: { amount: "100.00", currency: "EUR" },
+    }
+    await expect(
+      resolveAvailabilityPresentationEntityId({
+        db: {} as never,
+        registry: {} as never,
+        candidate: { ...base, source: { kind: "owned", module: "accommodations" } },
+        readBySource: readBySource as never,
+      }),
+    ).resolves.toBe("acc_owned")
+    expect(readBySource).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

- resolve a live sourced stay's provider accommodation reference to its canonical Catalog entry before presentation
- fall back through the already-admitted source adapter for newly discovered inventory that has not completed an index sync
- read room/rate labels from Connect's nested room selection shape

## Root cause

Voyant Connect already returned valid stay candidates, but Storefront presentation passed the provider accommodation reference into a service keyed by Voyant's canonical entity ID. Presentation returned no content and the managed runtime safely dropped every otherwise valid offer.

## Impact

Managed storefronts can display real sourced stay offers without exposing provider or connection identifiers to the browser. The theme remains presentation-only; Catalog and the admitted adapter retain identity, content, and supplier authority.

## Validation

- focused Accommodations regression: 2/2 passed
- targeted Biome check passed
- `git diff --check` passed
- package-wide local TypeScript exhausted Node's 4 GB heap; full changed-graph validation is delegated to GitHub CI
