### PR TITLE
feat(storefront): book sourced stays safely

### DIFF
--- a/.changeset/bright-stays-book.md
+++ b/.changeset/bright-stays-book.md
@@ -1,0 +1,10 @@
+---
+"@voyant-travel/accommodations": patch
+"@voyant-travel/catalog": patch
+"@voyant-travel/catalog-contracts": patch
+"@voyant-travel/storefront": patch
+"@voyant-travel/trips": patch
+"@voyant-travel/voyant-connect-adapter": patch
+---
+
+Carry server-resolved sourced-stay identities and exact date, room, rate, and occupancy pins through opaque Trip selections, then revalidate price, lock, and confirm through the managed Connect lifecycle without exposing supplier authority to storefront clients.

--- a/packages/accommodations/src/catalog-runtime-extension.ts
+++ b/packages/accommodations/src/catalog-runtime-extension.ts
@@ -31,14 +31,14 @@ export const catalogAccommodationsRuntimeExtension = {
     registry.register(createAccommodationOwnedSearchHandler({}))
   },
   async presentAvailabilityCandidate({ db, registry, candidate, locale, market, currency }) {
-    const entityId = await resolveAvailabilityPresentationEntityId({
+    const bookingTarget = await resolveAvailabilityPresentationTarget({
       db,
       registry,
       candidate,
     })
     const resolved = await getAccommodationContent(
       db,
-      entityId,
+      bookingTarget.entityId,
       { preferredLocales: [locale], market, currency },
       { registry },
     )
@@ -52,7 +52,7 @@ export const catalogAccommodationsRuntimeExtension = {
         currency,
       }))
     if (!content) return undefined
-    return availabilityPresentation(content, candidate)
+    return { ...availabilityPresentation(content, candidate), bookingTarget }
   },
 } satisfies CatalogAccommodationsRuntimeExtension
 
@@ -100,18 +100,36 @@ async function fetchUnindexedAvailabilityContent(input: {
   return parsed.success ? parsed.data : undefined
 }
 
-export async function resolveAvailabilityPresentationEntityId(input: {
+export async function resolveAvailabilityPresentationTarget(input: {
   db: AnyDrizzleDb
   registry: SourceAdapterRegistry
   candidate: AvailabilityCandidate
   readBySource?: typeof readSourcedEntryBySource
-}): Promise<string> {
+}): Promise<{
+  entityModule: "accommodations"
+  entityId: string
+  sourceKind: string
+  sourceConnectionId?: string
+  sourceRef?: string
+}> {
   if (input.candidate.source?.kind !== "sourced") {
-    return input.candidate.entity_id
+    return {
+      entityModule: "accommodations",
+      entityId: input.candidate.entity_id,
+      sourceKind: "owned",
+    }
   }
   const connectionId = input.candidate.source.connectionId
   const adapter = input.registry.resolveByConnection(connectionId)
-  if (!adapter) return input.candidate.entity_id
+  if (!adapter) {
+    return {
+      entityModule: "accommodations",
+      entityId: input.candidate.entity_id,
+      sourceKind: "unknown",
+      sourceConnectionId: connectionId,
+      sourceRef: input.candidate.entity_id,
+    }
+  }
 
   // Live Connect search returns the source accommodation reference. Catalog
   // content is keyed by its canonical sourced-entry id. Resolve that identity
@@ -122,7 +140,13 @@ export async function resolveAvailabilityPresentationEntityId(input: {
     sourceConnectionId: connectionId,
     sourceRef: input.candidate.entity_id,
   })
-  return sourced?.entity_id ?? input.candidate.entity_id
+  return {
+    entityModule: "accommodations",
+    entityId: sourced?.entity_id ?? input.candidate.entity_id,
+    sourceKind: sourced?.source_kind ?? adapter.kind,
+    sourceConnectionId: sourced?.source_connection_id ?? connectionId,
+    sourceRef: sourced?.source_ref ?? input.candidate.entity_id,
+  }
 }
 
 function record(value: unknown): Record<string, unknown> | undefined {

--- a/packages/accommodations/tests/catalog-runtime-extension.test.ts
+++ b/packages/accommodations/tests/catalog-runtime-extension.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, it, vi } from "vitest"
 
-import { resolveAvailabilityPresentationEntityId } from "../src/catalog-runtime-extension.js"
+import { resolveAvailabilityPresentationTarget } from "../src/catalog-runtime-extension.js"
 
 describe("availability presentation identity", () => {
   it("maps a sourced live offer reference to the canonical catalog entity", async () => {
-    const readBySource = vi.fn(async () => ({ entity_id: "acc_canonical" }))
-    const result = await resolveAvailabilityPresentationEntityId({
+    const readBySource = vi.fn(async () => ({
+      entity_id: "acc_canonical",
+      source_kind: "voyant-connect",
+      source_connection_id: "conn_1",
+      source_ref: "hotel_source_ref",
+    }))
+    const result = await resolveAvailabilityPresentationTarget({
       db: {} as never,
       registry: {
         resolveByConnection: () => ({ kind: "voyant-connect" }),
@@ -21,7 +26,13 @@ describe("availability presentation identity", () => {
       readBySource: readBySource as never,
     })
 
-    expect(result).toBe("acc_canonical")
+    expect(result).toEqual({
+      entityModule: "accommodations",
+      entityId: "acc_canonical",
+      sourceKind: "voyant-connect",
+      sourceConnectionId: "conn_1",
+      sourceRef: "hotel_source_ref",
+    })
     expect(readBySource).toHaveBeenCalledWith(
       {},
       {
@@ -43,13 +54,17 @@ describe("availability presentation identity", () => {
       price: { amount: "100.00", currency: "EUR" },
     }
     await expect(
-      resolveAvailabilityPresentationEntityId({
+      resolveAvailabilityPresentationTarget({
         db: {} as never,
         registry: {} as never,
         candidate: { ...base, source: { kind: "owned", module: "accommodations" } },
         readBySource: readBySource as never,
       }),
-    ).resolves.toBe("acc_owned")
+    ).resolves.toEqual({
+      entityModule: "accommodations",
+      entityId: "acc_owned",
+      sourceKind: "owned",
+    })
     expect(readBySource).not.toHaveBeenCalled()
   })
 })

--- a/packages/catalog-contracts/src/booking-engine/selection-contracts.ts
+++ b/packages/catalog-contracts/src/booking-engine/selection-contracts.ts
@@ -243,6 +243,18 @@ export const bookingSelectionPublicV1 = z.object({
            *  requires this before the Accommodation step is
            *  considered complete. */
           ratePlanId: z.string().optional(),
+          /** Exact per-room occupancy selected from a live stay offer. The
+           * managed engine uses it for supplier revalidation; it carries no
+           * provider or connection authority. */
+          occupancy: z
+            .object({
+              adults: z.number().int().positive(),
+              children: z.number().int().nonnegative().optional(),
+              childrenAges: z.array(z.number().int().nonnegative()).optional(),
+              infants: z.number().int().nonnegative().optional(),
+            })
+            .strict()
+            .optional(),
         }),
       ),
       travelerAssignments: z.record(z.string(), z.string()).default({}),

--- a/packages/catalog/openapi/admin/catalog-booking.json
+++ b/packages/catalog/openapi/admin/catalog-booking.json
@@ -14767,6 +14767,32 @@
                                 },
                                 "ratePlanId": {
                                   "type": "string"
+                                },
+                                "occupancy": {
+                                  "type": "object",
+                                  "properties": {
+                                    "adults": {
+                                      "type": "integer",
+                                      "exclusiveMinimum": 0
+                                    },
+                                    "children": {
+                                      "type": "integer",
+                                      "minimum": 0
+                                    },
+                                    "childrenAges": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "integer",
+                                        "minimum": 0
+                                      }
+                                    },
+                                    "infants": {
+                                      "type": "integer",
+                                      "minimum": 0
+                                    }
+                                  },
+                                  "required": ["adults"],
+                                  "additionalProperties": false
                                 }
                               },
                               "required": ["optionUnitId", "quantity"]

--- a/packages/catalog/openapi/storefront/catalog-booking.json
+++ b/packages/catalog/openapi/storefront/catalog-booking.json
@@ -14767,6 +14767,32 @@
                                 },
                                 "ratePlanId": {
                                   "type": "string"
+                                },
+                                "occupancy": {
+                                  "type": "object",
+                                  "properties": {
+                                    "adults": {
+                                      "type": "integer",
+                                      "exclusiveMinimum": 0
+                                    },
+                                    "children": {
+                                      "type": "integer",
+                                      "minimum": 0
+                                    },
+                                    "childrenAges": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "integer",
+                                        "minimum": 0
+                                      }
+                                    },
+                                    "infants": {
+                                      "type": "integer",
+                                      "minimum": 0
+                                    }
+                                  },
+                                  "required": ["adults"],
+                                  "additionalProperties": false
                                 }
                               },
                               "required": ["optionUnitId", "quantity"]

--- a/packages/catalog/src/booking-engine/quote-support.test.ts
+++ b/packages/catalog/src/booking-engine/quote-support.test.ts
@@ -59,4 +59,36 @@ describe("Connect package Booking Session parameters", () => {
     expect(parameters).not.toHaveProperty("connectionId")
     expect(parameters).not.toHaveProperty("providerId")
   })
+
+  it("projects sourced stay dates, room pins, and occupancy without source authority", () => {
+    const parameters = engineParametersFromSelection(
+      undefined,
+      {
+        configure: {
+          pax: { adult: 2, child: 1 },
+          dateRange: { checkIn: "2026-09-10", checkOut: "2026-09-15" },
+          roomTypeId: "room_1",
+          ratePlanId: "rate_1",
+        },
+        accommodation: {
+          rooms: [{ optionUnitId: "room_1", ratePlanId: "rate_1", quantity: 1 }],
+        },
+      },
+      { entityModule: "accommodations", sourceKind: "voyant-connect" },
+    )
+
+    expect(parameters).toMatchObject({
+      connectRoute: "stays",
+      checkIn: "2026-09-10",
+      checkOut: "2026-09-15",
+      rooms: [
+        {
+          roomTypeId: "room_1",
+          ratePlanId: "rate_1",
+          occupancy: { adults: 2, children: 1 },
+        },
+      ],
+    })
+    expect(parameters).not.toHaveProperty("connectionId")
+  })
 })

--- a/packages/catalog/src/booking-engine/quote-support.ts
+++ b/packages/catalog/src/booking-engine/quote-support.ts
@@ -56,8 +56,68 @@ export function engineParametersFromSelection(
   const promotionCode = stringValue(selection?.promotionCode)
   if (promotionCode && next.promotionCode == null) next.promotionCode = promotionCode
   applyConnectPackageConfirmParameters(next, selection, context)
+  applyConnectStayParameters(next, selection, context)
 
   return next
+}
+
+function applyConnectStayParameters(
+  parameters: Record<string, unknown>,
+  selection: Record<string, unknown> | undefined,
+  context: { entityModule?: string; sourceKind?: string },
+): void {
+  if (!selection || context.sourceKind !== "voyant-connect") return
+  const entityModule = context.entityModule ?? stringValue(asRecord(selection.entity)?.module)
+  if (entityModule !== "accommodations") return
+  const configure = asRecord(selection.configure)
+  const range = asRecord(configure?.dateRange)
+  const checkIn = stringValue(range?.checkIn)
+  const checkOut = stringValue(range?.checkOut)
+  const accommodation = asRecord(selection.accommodation)
+  const selectedRooms = Array.isArray(accommodation?.rooms) ? accommodation.rooms : []
+  const fallbackOccupancy = paxOccupancy(configure?.pax)
+  const rooms = selectedRooms.flatMap((value) => {
+    const room = asRecord(value)
+    const roomTypeId = stringValue(room?.optionUnitId)
+    const ratePlanId = stringValue(room?.ratePlanId)
+    const quantity = positiveInteger(room?.quantity) ?? 1
+    if (!roomTypeId || !ratePlanId) return []
+    const occupancy = stayOccupancy(room?.occupancy) ?? fallbackOccupancy
+    return Array.from({ length: quantity }, () => ({ roomTypeId, ratePlanId, occupancy }))
+  })
+  if (!checkIn || !checkOut || rooms.length === 0) return
+  if (parameters.connectRoute == null) parameters.connectRoute = "stays"
+  if (parameters.checkIn == null) parameters.checkIn = checkIn
+  if (parameters.checkOut == null) parameters.checkOut = checkOut
+  if (parameters.rooms == null) parameters.rooms = rooms
+}
+
+function stayOccupancy(value: unknown): Record<string, unknown> | undefined {
+  const occupancy = asRecord(value)
+  const adults = positiveInteger(occupancy?.adults)
+  if (!adults) return undefined
+  const children = nonnegativeInteger(occupancy?.children)
+  const infants = nonnegativeInteger(occupancy?.infants)
+  const childrenAges = Array.isArray(occupancy?.childrenAges)
+    ? occupancy.childrenAges.filter(
+        (age): age is number => typeof age === "number" && Number.isInteger(age) && age >= 0,
+      )
+    : []
+  return {
+    adults,
+    ...(children ? { children } : {}),
+    ...(childrenAges.length > 0 ? { childrenAges } : {}),
+    ...(infants ? { infants } : {}),
+  }
+}
+
+function paxOccupancy(value: unknown): Record<string, unknown> {
+  const pax = asRecord(value)
+  return {
+    adults: positiveInteger(pax?.adult) ?? 1,
+    ...((positiveInteger(pax?.child) ?? 0) > 0 ? { children: positiveInteger(pax?.child) } : {}),
+    ...((positiveInteger(pax?.infant) ?? 0) > 0 ? { infants: positiveInteger(pax?.infant) } : {}),
+  }
 }
 
 function applyConnectPackageConfirmParameters(
@@ -197,6 +257,10 @@ function stringValue(value: unknown): string | null {
 
 function positiveInteger(value: unknown): number | null {
   return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : null
+}
+
+function nonnegativeInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : undefined
 }
 
 function sumPax(value: unknown): number {

--- a/packages/catalog/src/runtime-contracts.ts
+++ b/packages/catalog/src/runtime-contracts.ts
@@ -61,6 +61,21 @@ export interface CatalogPolicyRuntimeExtension {
   readonly fieldPolicy: readonly FieldPolicy[]
 }
 
+export interface CatalogAvailabilityPresentation {
+  title: string
+  roomName?: string
+  boardName?: string
+  image?: { url: string; alt?: string }
+  /** Server-resolved booking identity; never accepted from Storefront input. */
+  bookingTarget?: {
+    entityModule: "accommodations"
+    entityId: string
+    sourceKind: string
+    sourceConnectionId?: string
+    sourceRef?: string
+  }
+}
+
 export interface CatalogAccommodationsRuntimeExtension extends CatalogPolicyRuntimeExtension {
   readonly propertyFieldPolicy: readonly FieldPolicy[]
   createDocumentBuilder(input: { db: AnyDrizzleDb; sellerOperatorId: string }): DocumentBuilder
@@ -81,15 +96,7 @@ export interface CatalogAccommodationsRuntimeExtension extends CatalogPolicyRunt
     locale: string
     market: string
     currency: string
-  }): Promise<
-    | {
-        title: string
-        roomName?: string
-        boardName?: string
-        image?: { url: string; alt?: string }
-      }
-    | undefined
-  >
+  }): Promise<CatalogAvailabilityPresentation | undefined>
 }
 
 export interface CatalogChartersRuntimeExtension extends CatalogPolicyRuntimeExtension {}
@@ -351,15 +358,7 @@ export interface CatalogRuntimeServices {
     locale: string
     market: string
     currency: string
-  }): Promise<
-    | {
-        title: string
-        roomName?: string
-        boardName?: string
-        image?: { url: string; alt?: string }
-      }
-    | undefined
-  >
+  }): Promise<CatalogAvailabilityPresentation | undefined>
   registerCompositeBookingSessionHandler?(handler: BookingSessionCompositeHandler): void
   getCompositeBookingSessionHandler?(): BookingSessionCompositeHandler | undefined
   buildEmbeddingProvider(env: Readonly<Record<string, unknown>>): EmbeddingProvider | undefined

--- a/packages/storefront/src/shopping/live-provider.ts
+++ b/packages/storefront/src/shopping/live-provider.ts
@@ -46,6 +46,13 @@ export interface StorefrontStayPresentation {
   roomName?: string
   boardName?: string
   image?: { url: string; alt?: string }
+  bookingTarget?: {
+    entityModule: "accommodations"
+    entityId: string
+    sourceKind: string
+    sourceConnectionId?: string
+    sourceRef?: string
+  }
 }
 
 /**
@@ -409,19 +416,70 @@ function mapStay(
   intent: StayIntent,
   presentation: StorefrontStayPresentation,
 ): StorefrontInternalStayOffer {
+  if (!presentation.bookingTarget) {
+    throw new Error("stay_booking_target_unavailable")
+  }
+  const candidateSelection = record(candidate.selection)
+  const nestedRooms = Array.isArray(candidateSelection?.rooms)
+    ? candidateSelection.rooms.flatMap((value) => {
+        const room = record(value)
+        const roomTypeId = nonEmptyString(room?.roomTypeId)
+        const ratePlanId = nonEmptyString(room?.ratePlanId)
+        if (!roomTypeId || !ratePlanId) return []
+        return [
+          {
+            roomTypeId,
+            ratePlanId,
+            ...(record(room?.occupancy) ? { occupancy: record(room?.occupancy) } : {}),
+          },
+        ]
+      })
+    : []
+  const flatRoomTypeId = nonEmptyString(candidateSelection?.roomTypeId)
+  const flatRatePlanId = nonEmptyString(candidateSelection?.ratePlanId)
+  const selectedRooms =
+    nestedRooms.length > 0
+      ? nestedRooms
+      : flatRoomTypeId && flatRatePlanId
+        ? [
+            {
+              roomTypeId: flatRoomTypeId,
+              ratePlanId: flatRatePlanId,
+              occupancy: {
+                adults: intent.rooms[0]?.adults ?? 1,
+                ...(intent.rooms[0]?.childrenAges?.length
+                  ? { children: intent.rooms[0].childrenAges.length }
+                  : {}),
+              },
+            },
+          ]
+        : []
+  if (selectedRooms.length === 0) throw new Error("stay_rate_pin_unavailable")
+  const firstRoom = selectedRooms[0]
+  const pax = intent.rooms.reduce(
+    (counts, room) => ({
+      adult: counts.adult + room.adults,
+      child: counts.child + (room.childrenAges?.length ?? 0),
+    }),
+    { adult: 0, child: 0 },
+  )
   return {
     nativePrice: candidate.price,
     selection: {
-      entityModule: candidate.entity_module,
-      entityId: candidate.entity_id,
-      selection: candidate.selection,
-      source: candidate.source,
+      target: presentation.bookingTarget,
+      configure: {
+        dateRange: { checkIn: intent.checkIn, checkOut: intent.checkOut },
+        pax,
+        ...(firstRoom
+          ? { roomTypeId: firstRoom.roomTypeId, ratePlanId: firstRoom.ratePlanId }
+          : {}),
+      },
+      rooms: selectedRooms,
     },
     accommodationSelection: {
-      entityModule: candidate.entity_module,
-      entityId: candidate.entity_id,
+      entityModule: presentation.bookingTarget.entityModule,
+      entityId: presentation.bookingTarget.entityId,
     },
-    providerData: candidate.providerData,
     title: presentation.title,
     checkIn: intent.checkIn,
     checkOut: intent.checkOut,
@@ -430,6 +488,16 @@ function mapStay(
     ...(presentation.image ? { image: presentation.image } : {}),
     ...(candidate.expiresAt ? { expiresAt: candidate.expiresAt.toISOString() } : {}),
   }
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined
 }
 
 function packageRequest(

--- a/packages/storefront/src/shopping/managed-runtime.ts
+++ b/packages/storefront/src/shopping/managed-runtime.ts
@@ -371,14 +371,14 @@ async function searchStays(
           purpose: "stay-offer",
           context,
           scope,
-          payload: { selection: item.selection, providerData: item.providerData },
+          payload: { selection: item.selection },
           replay: "single-use",
         }),
         issueBoundedReference(options.references, now, {
           purpose: "catalog-item",
           context,
           scope,
-          payload: { entityModule: "accommodations", selection: item.accommodationSelection },
+          payload: item.accommodationSelection,
           replay: "multi-use",
         }),
       ])

--- a/packages/storefront/tests/unit/closed-live-provider.test.ts
+++ b/packages/storefront/tests/unit/closed-live-provider.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest"
 
 import { createClosedStorefrontShoppingLiveProvider } from "../../src/shopping/closed-live-provider.js"
 import { createManagedStorefrontShoppingRuntime } from "../../src/shopping/managed-runtime.js"
+import type { StorefrontOpaqueReferenceIssuer } from "../../src/shopping/runtime-port.js"
 
 const context = { storefrontId: "sf_1", channelId: "ch_1" }
 const scope = {
@@ -138,6 +139,13 @@ describe("closed Storefront live provider", () => {
       loadStayPresentation: vi.fn(async () => ({
         title: "Hotel Public",
         roomName: "Public room",
+        bookingTarget: {
+          entityModule: "accommodations" as const,
+          entityId: "catalog_item_1",
+          sourceKind: "voyant-connect",
+          sourceConnectionId: "stay_connection",
+          sourceRef: "hotel_1",
+        },
       })),
     })
 
@@ -239,7 +247,7 @@ describe("closed Storefront live provider", () => {
       markets: markets(),
       flights: { listAdmittedShoppingSources },
     })
-    const issued: Array<Record<string, unknown>> = []
+    const issued: Array<Parameters<StorefrontOpaqueReferenceIssuer["issue"]>[0]> = []
     let sequence = 0
     const runtime = createManagedStorefrontShoppingRuntime({
       markets: markets(),
@@ -250,7 +258,7 @@ describe("closed Storefront live provider", () => {
           return null
         },
         async issue(input) {
-          issued.push(input as unknown as Record<string, unknown>)
+          issued.push(input)
           sequence += 1
           return {
             ref: `opaque-flight-offer-${String(sequence).padStart(4, "0")}`,

--- a/packages/storefront/tests/unit/live-shopping-provider.test.ts
+++ b/packages/storefront/tests/unit/live-shopping-provider.test.ts
@@ -169,7 +169,15 @@ describe("storefront live shopping provider", () => {
           candidateRef: "candidate_secret",
           entity_module: "accommodations",
           entity_id: "accommodation_secret",
-          selection: { ratePlanId: "rate_secret", roomTypeId: "room_secret" },
+          selection: {
+            rooms: [
+              {
+                ratePlanId: "rate_secret",
+                roomTypeId: "room_secret",
+                occupancy: { adults: 2, children: 1 },
+              },
+            ],
+          },
           price: { amount: "450.00", currency: "EUR" },
           source: { kind: "sourced" as const, connectionId: "connection_secret" },
           expiresAt: new Date("2026-08-08T10:03:00.000Z"),
@@ -191,6 +199,13 @@ describe("storefront live shopping provider", () => {
           title: "Hotel Public",
           roomName: "Family room",
           boardName: "Breakfast",
+          bookingTarget: {
+            entityModule: "accommodations",
+            entityId: "accommodation_canonical",
+            sourceKind: "voyant-connect",
+            sourceConnectionId: "connection_secret",
+            sourceRef: "accommodation_secret",
+          },
         })),
       },
     })
@@ -267,7 +282,22 @@ describe("storefront live shopping provider", () => {
     expect(serialized).not.toContain("supplier_secret")
     expect(serialized).not.toContain("providerData")
     expect(issued).toHaveLength(2)
-    expect(JSON.stringify(issued)).toContain("supplier_secret")
+    expect(JSON.stringify(issued)).not.toContain("supplier_secret")
+    expect(issued).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          purpose: "stay-offer",
+          payload: {
+            selection: expect.objectContaining({
+              target: expect.objectContaining({ entityId: "accommodation_canonical" }),
+              configure: expect.objectContaining({
+                dateRange: { checkIn: "2026-09-10", checkOut: "2026-09-15" },
+              }),
+            }),
+          },
+        }),
+      ]),
+    )
   })
 
   it("fans out closed dynamic-package sources, maps occupancy, and hides source health identities", async () => {
@@ -437,7 +467,9 @@ describe("storefront live shopping provider", () => {
       candidateRef: "candidate_secret",
       entity_module: "accommodations",
       entity_id: "accommodation_secret",
-      selection: { ratePlanId: "rate_secret" },
+      selection: {
+        rooms: [{ roomTypeId: "room_secret", ratePlanId: "rate_secret", occupancy: { adults: 1 } }],
+      },
       price: { amount: "450.00", currency: "EUR" },
       source: { kind: "sourced" as const, connectionId: "connection_secret" },
     } satisfies AvailabilityCandidate
@@ -456,7 +488,16 @@ describe("storefront live shopping provider", () => {
         }),
         present: async ({ candidate: presented }) => {
           if (presented.candidateRef === "candidate_failed") throw new Error("catalog unavailable")
-          return { title: "Hotel Public" }
+          return {
+            title: "Hotel Public",
+            bookingTarget: {
+              entityModule: "accommodations",
+              entityId: "accommodation_canonical",
+              sourceKind: "voyant-connect",
+              sourceConnectionId: "connection_secret",
+              sourceRef: "accommodation_secret",
+            },
+          }
         },
       },
     })

--- a/packages/trips/src/shopping-opaque-references.ts
+++ b/packages/trips/src/shopping-opaque-references.ts
@@ -64,6 +64,52 @@ const packageSelectionSchema = z
   })
   .strict()
 
+const staySelectionSchema = z
+  .object({
+    target: z
+      .object({
+        entityModule: z.literal("accommodations"),
+        entityId: z.string().min(1),
+        sourceKind: z.string().min(1),
+        sourceConnectionId: z.string().min(1).optional(),
+        sourceRef: z.string().min(1).optional(),
+      })
+      .strict()
+      .superRefine((target, ctx) => {
+        if (target.sourceKind !== "owned" && (!target.sourceConnectionId || !target.sourceRef)) {
+          ctx.addIssue({ code: "custom", message: "sourced stay identity required" })
+        }
+      }),
+    configure: z
+      .object({
+        dateRange: z.object({ checkIn: z.iso.date(), checkOut: z.iso.date() }).strict(),
+        pax: z.record(z.string(), z.number().int().nonnegative()),
+        roomTypeId: z.string().min(1).optional(),
+        ratePlanId: z.string().min(1).optional(),
+      })
+      .strict(),
+    rooms: z
+      .array(
+        z
+          .object({
+            roomTypeId: z.string().min(1),
+            ratePlanId: z.string().min(1),
+            occupancy: z
+              .object({
+                adults: z.number().int().positive(),
+                children: z.number().int().nonnegative().optional(),
+                childrenAges: z.array(z.number().int().nonnegative()).optional(),
+                infants: z.number().int().nonnegative().optional(),
+              })
+              .strict()
+              .optional(),
+          })
+          .strict(),
+      )
+      .min(1),
+  })
+  .strict()
+
 const cruiseSelectionSchema = z
   .object({
     target: z
@@ -473,6 +519,39 @@ function componentFromReference(
             sourceRef: target.sourceRef,
           },
           configure,
+        },
+      },
+    }
+  }
+
+  if (reference.purpose === "stay-offer") {
+    const payload = z
+      .object({ selection: staySelectionSchema, providerData: z.never().optional() })
+      .strict()
+      .parse(reference.payload)
+    const { target, configure, rooms } = payload.selection
+    return {
+      kind: "catalog_booking",
+      catalogRef: target,
+      metadata: {
+        bookingDraftV1: {
+          entity: {
+            module: target.entityModule,
+            id: target.entityId,
+            sourceKind: target.sourceKind,
+            sourceConnectionId: target.sourceConnectionId,
+            sourceRef: target.sourceRef,
+          },
+          configure,
+          accommodation: {
+            rooms: rooms.map(({ roomTypeId, ratePlanId, occupancy }) => ({
+              optionUnitId: roomTypeId,
+              ratePlanId,
+              quantity: 1,
+              ...(occupancy ? { occupancy } : {}),
+            })),
+            travelerAssignments: {},
+          },
         },
       },
     }

--- a/packages/trips/tests/shopping-opaque-references.test.ts
+++ b/packages/trips/tests/shopping-opaque-references.test.ts
@@ -22,6 +22,7 @@ const CATALOG_REF = `sref_${"b".repeat(64)}`
 const PACKAGE_REF = `sref_${"c".repeat(64)}`
 const CONTINUATION_REF = `sref_${"d".repeat(64)}`
 const CRUISE_REF = `sref_${"e".repeat(64)}`
+const STAY_REF = `sref_${"f".repeat(64)}`
 
 describe("durable shopping opaque references", () => {
   it("issues a 256-bit capability while persisting only its digest and bounded payload", async () => {
@@ -250,6 +251,62 @@ describe("durable shopping opaque references", () => {
     )
   })
 
+  it("turns a sourced stay capability into a date- and rate-pinned Catalog component", async () => {
+    const store = new MemoryReferenceStore()
+    const runtime = createTripShoppingReferenceRuntimeWithStore(store, {
+      now: () => NOW,
+      createReference: () => STAY_REF,
+    })
+    await runtime.issuer.issue(stayInput())
+
+    await expect(
+      runtime.offerResolver.resolve(CONTEXT, {
+        kind: "stay",
+        offerRef: STAY_REF,
+        scope: SCOPE,
+      }),
+    ).resolves.toEqual({
+      component: {
+        kind: "catalog_booking",
+        catalogRef: {
+          entityModule: "accommodations",
+          entityId: "acc_canonical",
+          sourceKind: "voyant-connect",
+          sourceConnectionId: "connection_server",
+          sourceRef: "hotel_source",
+        },
+        metadata: {
+          bookingDraftV1: {
+            entity: {
+              module: "accommodations",
+              id: "acc_canonical",
+              sourceKind: "voyant-connect",
+              sourceConnectionId: "connection_server",
+              sourceRef: "hotel_source",
+            },
+            configure: {
+              dateRange: { checkIn: "2026-09-10", checkOut: "2026-09-15" },
+              pax: { adult: 2 },
+              roomTypeId: "room_1",
+              ratePlanId: "rate_1",
+            },
+            accommodation: {
+              rooms: [
+                {
+                  optionUnitId: "room_1",
+                  ratePlanId: "rate_1",
+                  quantity: 1,
+                  occupancy: { adults: 2 },
+                },
+              ],
+              travelerAssignments: {},
+            },
+          },
+        },
+      },
+    })
+  })
+
   it("redeems a cruise offer only for its exact managed owner and shopping scope", async () => {
     const store = new MemoryReferenceStore()
     const runtime = createTripShoppingReferenceRuntimeWithStore(store, {
@@ -445,6 +502,36 @@ function cruiseInput(): Parameters<StorefrontOpaqueReferenceIssuer["issue"]>[0] 
           fareVariant: "cruise_only",
           bookingTerms: null,
         },
+      },
+    },
+    ttlSeconds: 15 * 60,
+    replay: "single-use",
+  }
+}
+
+function stayInput(): Parameters<StorefrontOpaqueReferenceIssuer["issue"]>[0] {
+  return {
+    purpose: "stay-offer",
+    storefrontId: CONTEXT.storefrontId,
+    channelId: CONTEXT.channelId,
+    owner: { userId: CONTEXT.userId, buyerAccountId: CONTEXT.buyerAccountId },
+    scope: SCOPE,
+    payload: {
+      selection: {
+        target: {
+          entityModule: "accommodations",
+          entityId: "acc_canonical",
+          sourceKind: "voyant-connect",
+          sourceConnectionId: "connection_server",
+          sourceRef: "hotel_source",
+        },
+        configure: {
+          dateRange: { checkIn: "2026-09-10", checkOut: "2026-09-15" },
+          pax: { adult: 2 },
+          roomTypeId: "room_1",
+          ratePlanId: "rate_1",
+        },
+        rooms: [{ roomTypeId: "room_1", ratePlanId: "rate_1", occupancy: { adults: 2 } }],
       },
     },
     ttlSeconds: 15 * 60,

--- a/packages/voyant-connect-adapter/src/sources.ts
+++ b/packages/voyant-connect-adapter/src/sources.ts
@@ -18,6 +18,7 @@ import {
 } from "./geo-resolver.js"
 import { withConnectPackageBookingLifecycle } from "./package-booking.js"
 import { createConnectProductPackageSourceAdapter } from "./package-products.js"
+import { withConnectStayBookingLifecycle } from "./stay-booking.js"
 import { positiveInteger, recordValue, stringValue } from "./utils.js"
 
 export interface VoyantConnectSourceConnection {
@@ -116,14 +117,17 @@ function createDefaultSources(
   return [
     {
       role: "generic",
-      adapter: withConnectPackageBookingLifecycle(
-        createVoyantConnectSourceAdapter({
-          client: options.client,
-          operatorId: options.operatorId,
-          market: options.market,
-          discoverLimit: options.discoverLimit,
-          mapDocument: skipCruiseConnectDocuments,
-        }),
+      adapter: withConnectStayBookingLifecycle(
+        withConnectPackageBookingLifecycle(
+          createVoyantConnectSourceAdapter({
+            client: options.client,
+            operatorId: options.operatorId,
+            market: options.market,
+            discoverLimit: options.discoverLimit,
+            mapDocument: skipCruiseConnectDocuments,
+          }),
+          options.client,
+        ),
         options.client,
       ),
     },
@@ -157,16 +161,19 @@ function createConnectionScopedSources(
       connectionId: connection.id,
       role: "generic",
       sourceProvider,
-      adapter: withConnectPackageBookingLifecycle(
-        createVoyantConnectSourceAdapter({
-          client: options.client,
-          operatorId: options.operatorId,
-          sourceProvider,
-          connectionIds: [connection.id],
-          market: options.market,
-          discoverLimit: options.discoverLimit,
-          mapDocument: skipCruiseConnectDocuments,
-        }),
+      adapter: withConnectStayBookingLifecycle(
+        withConnectPackageBookingLifecycle(
+          createVoyantConnectSourceAdapter({
+            client: options.client,
+            operatorId: options.operatorId,
+            sourceProvider,
+            connectionIds: [connection.id],
+            market: options.market,
+            discoverLimit: options.discoverLimit,
+            mapDocument: skipCruiseConnectDocuments,
+          }),
+          options.client,
+        ),
         options.client,
       ),
     },

--- a/packages/voyant-connect-adapter/src/stay-booking.test.ts
+++ b/packages/voyant-connect-adapter/src/stay-booking.test.ts
@@ -1,0 +1,164 @@
+import type {
+  ReserveRequest,
+  SourceAdapter,
+} from "@voyant-travel/catalog-contracts/adapter/contract"
+import { ReservationDispatchError } from "@voyant-travel/catalog-contracts/adapter/contract"
+import type { StayOffer, VoyantConnectClient } from "@voyant-travel/connect-sdk"
+import { describe, expect, it, vi } from "vitest"
+
+import { withConnectStayBookingLifecycle } from "./stay-booking.js"
+
+describe("Voyant Connect stay booking lifecycle", () => {
+  it("re-searches, locks, and confirms the exact server-owned stay", async () => {
+    const { adapter, client, current } = fixture()
+
+    await expect(adapter.reserve?.({ connection_id: "conn_server" }, request())).resolves.toEqual(
+      expect.objectContaining({ upstream_ref: "stay:booking_1", status: "confirmed" }),
+    )
+    expect(client.stays.search).toHaveBeenCalledWith("conn_server", {
+      accommodationIds: ["hotel_source"],
+      checkIn: "2026-09-10",
+      checkOut: "2026-09-15",
+      rooms: [{ adults: 2 }],
+      locale: "ro-RO",
+      limit: 100,
+    })
+    expect(client.stays.lock).toHaveBeenCalledWith("conn_server", current)
+    expect(client.stays.confirm).toHaveBeenCalledWith(
+      "conn_server",
+      expect.objectContaining({
+        holdId: "hold_1",
+        guestsByRoom: [[expect.any(Object), expect.any(Object)]],
+      }),
+      { idempotencyKey: "bses_1:commit_1:reserve" },
+    )
+  })
+
+  it("fails before hold when the immutable Session quote moved", async () => {
+    const { adapter, client } = fixture({ current: offer(100_001) })
+
+    await expect(adapter.reserve?.({ connection_id: "conn_server" }, request())).resolves.toEqual({
+      upstream_ref: "stay-offer:acc_canonical",
+      status: "failed",
+      upstream_payload: { reason: "stay_price_changed" },
+    })
+    expect(client.stays.lock).not.toHaveBeenCalled()
+  })
+
+  it("releases a changed hold and never confirms it", async () => {
+    const changed = offer(100_000)
+    changed.rooms[0]!.ratePlanId = "rate_changed"
+    const { adapter, client } = fixture({ held: changed })
+
+    await expect(adapter.reserve?.({ connection_id: "conn_server" }, request())).resolves.toEqual(
+      expect.objectContaining({
+        status: "failed",
+        upstream_payload: { reason: "stay_hold_changed" },
+      }),
+    )
+    expect(client.stays.releaseLock).toHaveBeenCalledWith("conn_server", "hold_1")
+    expect(client.stays.confirm).not.toHaveBeenCalled()
+  })
+
+  it("does not release an ambiguous confirmation", async () => {
+    const { adapter, client } = fixture({ confirmError: new Error("timeout") })
+
+    const error = await adapter
+      .reserve?.({ connection_id: "conn_server" }, request())
+      .catch((value) => value)
+
+    expect(error).toBeInstanceOf(ReservationDispatchError)
+    expect(error).toMatchObject({
+      certainty: "possibly_sent",
+      errorClass: "stay_confirmation_in_doubt",
+    })
+    expect(client.stays.releaseLock).not.toHaveBeenCalled()
+  })
+})
+
+function fixture(options: { current?: StayOffer; held?: StayOffer; confirmError?: Error } = {}) {
+  const current = options.current ?? offer(100_000)
+  const confirm = options.confirmError
+    ? vi.fn().mockRejectedValue(options.confirmError)
+    : vi.fn().mockResolvedValue({ id: "booking_1", status: "confirmed" })
+  const client = {
+    stays: {
+      search: vi.fn().mockResolvedValue({ offers: [current] }),
+      lock: vi.fn().mockResolvedValue({
+        id: "hold_1",
+        offerSnapshot: options.held ?? current,
+        status: "active",
+        expiresAt: "2099-01-01T00:00:00.000Z",
+      }),
+      releaseLock: vi.fn().mockResolvedValue({}),
+      confirm,
+    },
+  } as unknown as VoyantConnectClient
+  const base: SourceAdapter = {
+    kind: "voyant-connect",
+    capabilities: {
+      verticals: ["accommodations"],
+      supportsLiveResolution: true,
+      supportsDriftDetection: false,
+      supportsBookingForwarding: true,
+      postBookOperations: ["cancel", "status"],
+    },
+    reserve: vi.fn(),
+  }
+  return { current, client, adapter: withConnectStayBookingLifecycle(base, client) }
+}
+
+function request(): ReserveRequest {
+  return {
+    entity_module: "accommodations",
+    entity_id: "acc_canonical",
+    source_ref: "hotel_source",
+    scope: { locale: "ro-RO", market: "market_ro", audience: "customer", currency: "EUR" },
+    parameters: {
+      connectRoute: "stays",
+      bookingQuote: { currency: "EUR", totalAmountMinor: 100_000 },
+      checkIn: "2026-09-10",
+      checkOut: "2026-09-15",
+      rooms: [{ roomTypeId: "room_1", ratePlanId: "rate_1", occupancy: { adults: 2 } }],
+      connectionId: "conn_browser",
+    },
+    party: {
+      contact: { email: "ana@example.test" },
+      passengers: [
+        { travelerCategory: "adult", firstName: "Ana", lastName: "Pop", email: "ana@example.test" },
+        { travelerCategory: "adult", firstName: "Ion", lastName: "Pop" },
+      ],
+    },
+    idempotency_key: "bses_1:commit_1:reserve",
+  }
+}
+
+function offer(amountMinor: number): StayOffer {
+  const money = { amountMinor, currency: "EUR", currencyPrecision: 2 }
+  return {
+    id: "offer_1",
+    connectionId: "conn_server",
+    accommodationId: "hotel_source",
+    rooms: [
+      {
+        roomTypeId: "room_1",
+        ratePlanId: "rate_1",
+        occupancy: { adults: 2 },
+        nights: 5,
+        nightlyBreakdown: [],
+        subtotal: money,
+        taxes: { ...money, amountMinor: 0 },
+        fees: { ...money, amountMinor: 0 },
+        total: money,
+        cancellationPolicy: { deadlines: [] },
+      },
+    ],
+    totals: {
+      subtotal: money,
+      taxes: { ...money, amountMinor: 0 },
+      fees: { ...money, amountMinor: 0 },
+      total: money,
+    },
+    expiresAt: "2099-01-01T00:00:00.000Z",
+  }
+}

--- a/packages/voyant-connect-adapter/src/stay-booking.ts
+++ b/packages/voyant-connect-adapter/src/stay-booking.ts
@@ -1,0 +1,280 @@
+import type {
+  ReserveRequest,
+  SourceAdapter,
+  SourceAdapterContext,
+} from "@voyant-travel/catalog-contracts/adapter/contract"
+import { ReservationDispatchError } from "@voyant-travel/catalog-contracts/adapter/contract"
+import type {
+  Guest,
+  StayConfirmInput,
+  StayHold,
+  StayOffer,
+  StaySearchQuery,
+  VoyantConnectClient,
+} from "@voyant-travel/connect-sdk"
+
+import { recordValue, stringValue } from "./utils.js"
+
+/** Exact search -> quote check -> hold -> confirm lifecycle for sourced stays. */
+export function withConnectStayBookingLifecycle(
+  base: SourceAdapter,
+  client: VoyantConnectClient,
+): SourceAdapter {
+  return {
+    ...base,
+    async reserve(ctx, request) {
+      if (request.parameters.connectRoute !== "stays") {
+        if (!base.reserve) {
+          throw new ReservationDispatchError(
+            "Voyant Connect booking forwarding is unavailable",
+            "not_sent",
+            "booking_forwarding_unavailable",
+          )
+        }
+        return base.reserve(ctx, request)
+      }
+      return reserveStay(client, ctx, request)
+    },
+  }
+}
+
+async function reserveStay(
+  client: VoyantConnectClient,
+  ctx: SourceAdapterContext,
+  request: ReserveRequest,
+) {
+  const connectionId = requiredConnectionId(ctx)
+  const resolvedSearch = staySearchQuery(request)
+  if (!resolvedSearch) return failed(request.entity_id, "stay_selection_incomplete")
+
+  let offer: StayOffer | undefined
+  try {
+    const response = await client.stays.search(connectionId, resolvedSearch.query)
+    offer = response.offers.find(
+      (candidate) =>
+        candidate.connectionId === connectionId &&
+        candidate.accommodationId === (request.source_ref ?? request.entity_id) &&
+        matchesRooms(candidate, resolvedSearch.pins),
+    )
+  } catch (error) {
+    throw notSent(error, "stay_quote_unavailable")
+  }
+  if (!offer || Date.parse(offer.expiresAt) <= Date.now()) {
+    return failed(request.entity_id, "stay_offer_unavailable")
+  }
+  const quote = expectedPrice(request.parameters)
+  if (!quote || !samePrice(offer, quote)) return failed(request.entity_id, "stay_price_changed")
+
+  let hold: StayHold
+  try {
+    hold = await client.stays.lock(connectionId, offer)
+  } catch (error) {
+    throw notSent(error, "stay_hold_failed")
+  }
+  if (
+    hold.status !== "active" ||
+    Date.parse(hold.expiresAt) <= Date.now() ||
+    !sameSelection(offer, hold.offerSnapshot) ||
+    !samePrice(hold.offerSnapshot, quote)
+  ) {
+    await release(client, connectionId, hold.id)
+    return failed(request.entity_id, "stay_hold_changed")
+  }
+
+  const confirmation = confirmationInput(request, hold.id, hold.offerSnapshot)
+  if (!confirmation) {
+    await release(client, connectionId, hold.id)
+    return failed(request.entity_id, "stay_party_incomplete")
+  }
+  try {
+    const booking = await client.stays.confirm(connectionId, confirmation, {
+      idempotencyKey: request.idempotency_key,
+    })
+    return {
+      upstream_ref: `stay:${booking.id}`,
+      status: booking.status === "confirmed" ? ("confirmed" as const) : ("held" as const),
+      upstream_payload: booking as unknown as Record<string, unknown>,
+    }
+  } catch (error) {
+    // Confirmation may have reached the supplier. Never release or retry it
+    // blindly; Catalog's existing supplier-operation reconciliation owns it.
+    throw new ReservationDispatchError(
+      message(error, "Voyant Connect stay confirmation is in doubt"),
+      "possibly_sent",
+      "stay_confirmation_in_doubt",
+    )
+  }
+}
+
+function staySearchQuery(request: ReserveRequest): {
+  query: StaySearchQuery
+  pins: Array<{ roomTypeId: string; ratePlanId: string }>
+} | null {
+  const p = request.parameters
+  const checkIn = stringValue(p.checkIn)
+  const checkOut = stringValue(p.checkOut)
+  const rooms = Array.isArray(p.rooms)
+    ? p.rooms.flatMap((value) => {
+        const room = recordValue(value)
+        const roomTypeId = stringValue(room?.roomTypeId)
+        const ratePlanId = stringValue(room?.ratePlanId)
+        const occupancy = stayOccupancy(room?.occupancy)
+        return roomTypeId && ratePlanId && occupancy ? [{ roomTypeId, ratePlanId, occupancy }] : []
+      })
+    : []
+  if (!checkIn || !checkOut || rooms.length === 0) return null
+  return {
+    query: {
+      accommodationIds: [request.source_ref ?? request.entity_id],
+      checkIn,
+      checkOut,
+      rooms: rooms.map(({ occupancy }) => occupancy),
+      ...(request.scope?.locale ? { locale: request.scope.locale } : {}),
+      limit: 100,
+    },
+    pins: rooms.map(({ roomTypeId, ratePlanId }) => ({ roomTypeId, ratePlanId })),
+  }
+}
+
+function matchesRooms(
+  offer: StayOffer,
+  pins: Array<{ roomTypeId: string; ratePlanId: string }>,
+): boolean {
+  if (pins.length !== offer.rooms.length) return false
+  return pins.every(
+    (pin, index) =>
+      offer.rooms[index]?.roomTypeId === pin.roomTypeId &&
+      offer.rooms[index]?.ratePlanId === pin.ratePlanId,
+  )
+}
+
+function confirmationInput(
+  request: ReserveRequest,
+  holdId: string,
+  offer: StayOffer,
+): StayConfirmInput | null {
+  const party = recordValue(request.party)
+  const contact = recordValue(party?.contact)
+  const email = stringValue(contact?.email)
+  const phone = stringValue(contact?.phone)
+  const passengers = Array.isArray(party?.passengers)
+    ? party.passengers.flatMap((value) => {
+        const guest = mapGuest(value)
+        return guest ? [guest] : []
+      })
+    : []
+  if (!email || passengers.length === 0) return null
+  let offset = 0
+  const guestsByRoom = offer.rooms.map((room) => {
+    const count =
+      room.occupancy.adults + (room.occupancy.children ?? 0) + (room.occupancy.infants ?? 0)
+    const guests = passengers.slice(offset, offset + count)
+    offset += count
+    return guests
+  })
+  if (offset !== passengers.length || guestsByRoom.some((guests) => guests.length === 0))
+    return null
+  return {
+    holdId,
+    leadGuest: passengers.find((guest) => guest.email === email) ?? passengers[0]!,
+    contact: { email, ...(phone ? { phone } : {}) },
+    guestsByRoom,
+  }
+}
+
+function mapGuest(value: unknown): Guest | null {
+  const row = recordValue(value)
+  const firstName = stringValue(row?.firstName)
+  const lastName = stringValue(row?.lastName)
+  if (!firstName || !lastName) return null
+  const category = row?.travelerCategory
+  return {
+    type: category === "child" || category === "infant" ? category : "adult",
+    firstName,
+    lastName,
+    ...(stringValue(row?.email) ? { email: stringValue(row?.email) } : {}),
+    ...(stringValue(row?.phone) ? { phone: stringValue(row?.phone) } : {}),
+  }
+}
+
+function stayOccupancy(value: unknown): StaySearchQuery["rooms"][number] | null {
+  const row = recordValue(value)
+  const adults = positiveInteger(row?.adults)
+  if (!adults) return null
+  const children = nonnegativeInteger(row?.children)
+  const infants = nonnegativeInteger(row?.infants)
+  return {
+    adults,
+    ...(children ? { children } : {}),
+    ...(infants ? { infants } : {}),
+  }
+}
+
+function expectedPrice(parameters: Record<string, unknown>) {
+  const row = recordValue(parameters.bookingQuote)
+  const currency = stringValue(row?.currency)
+  const totalAmountMinor = row?.totalAmountMinor
+  return currency && typeof totalAmountMinor === "number" && Number.isInteger(totalAmountMinor)
+    ? { currency, totalAmountMinor }
+    : null
+}
+
+function samePrice(offer: StayOffer, expected: { currency: string; totalAmountMinor: number }) {
+  return (
+    offer.totals.total.currency === expected.currency &&
+    offer.totals.total.amountMinor === expected.totalAmountMinor
+  )
+}
+
+function sameSelection(left: StayOffer, right: StayOffer) {
+  return (
+    left.connectionId === right.connectionId &&
+    left.accommodationId === right.accommodationId &&
+    JSON.stringify(left.rooms) === JSON.stringify(right.rooms)
+  )
+}
+
+function requiredConnectionId(ctx: SourceAdapterContext) {
+  const value = stringValue(ctx.connection_id)
+  if (!value || value === "engine") {
+    throw new ReservationDispatchError(
+      "Voyant Connect stay connection unavailable",
+      "not_sent",
+      "stay_connection_unavailable",
+    )
+  }
+  return value
+}
+
+async function release(client: VoyantConnectClient, connectionId: string, holdId: string) {
+  try {
+    await client.stays.releaseLock(connectionId, holdId)
+  } catch {
+    // Confirmation is still blocked. The expired/changed hold remains visible
+    // to provider reconciliation even when best-effort release fails.
+  }
+}
+
+function failed(entityId: string, reason: string) {
+  return {
+    upstream_ref: `stay-offer:${entityId}`,
+    status: "failed" as const,
+    upstream_payload: { reason },
+  }
+}
+
+function notSent(error: unknown, errorClass: string) {
+  return new ReservationDispatchError(message(error, errorClass), "not_sent", errorClass)
+}
+
+function message(error: unknown, fallback: string) {
+  return error instanceof Error && error.message ? error.message : fallback
+}
+
+function positiveInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : undefined
+}
+
+function nonnegativeInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : undefined
+}


### PR DESCRIPTION
## Summary
- carry canonical sourced accommodation identity plus exact dates, room/rate pins, and per-room occupancy through managed opaque stay references
- materialize a valid Catalog-backed Trip component without raw provider payloads
- re-search, verify immutable Session price, lock, validate the held snapshot, and confirm through Voyant Connect with ambiguity-safe reconciliation

## Safety boundaries
- browser inputs cannot choose provider, connection, source, engine, account, payment, or FX authority
- sourced identity is resolved server-side from Catalog provenance
- provider payloads and offer bodies are not persisted in the public opaque-reference payload
- ambiguous confirmation is never released or blindly retried

## Validation
- focused Catalog Contracts, Catalog, Storefront, Trips, Accommodations, and Connect lifecycle tests pass (63 tests total)
- targeted Biome and git diff checks pass
- package typechecks are running locally with bounded execution; full CI remains the merge gate