### PR TITLE
fix(mcp): admit operator settings updates

### DIFF
--- a/apps/operator/tests/mcp-capability.test.ts
+++ b/apps/operator/tests/mcp-capability.test.ts
@@ -52,12 +52,14 @@ import { homedir } from "node:os"
 import { dirname, join, resolve } from "node:path"
 import { bookingActivityLog, bookings } from "@voyant-travel/bookings/schema"
 import { createDbClient } from "@voyant-travel/db"
+import { authAccount, authUser, userProfilesTable } from "@voyant-travel/db/schema/iam"
 import { dbClientDispose } from "@voyant-travel/db/transaction-capability"
 import { supplierDirectoryProjections, suppliers } from "@voyant-travel/distribution/schema"
 import { financeService } from "@voyant-travel/finance"
 import { invoices } from "@voyant-travel/finance/schema"
 import { composeVoyantGraphRuntime } from "@voyant-travel/framework"
 import { contractsService, policiesService } from "@voyant-travel/legal"
+import { operatorProfile } from "@voyant-travel/operator-settings/schema"
 import { proposalsService, tripSnapshotToProposalVersionApply } from "@voyant-travel/proposals"
 import { tripsService } from "@voyant-travel/trips"
 import { sql as sqlRaw } from "drizzle-orm"
@@ -97,6 +99,7 @@ const TEST_ENV = {
   DATABASE_URL: TEST_DATABASE_URL ?? "",
   VOYANT_API_KEY: "test",
   CATALOG_EMBEDDING_PROVIDER: "none",
+  "deployment.providers.adminAuth": "better-auth",
 } as never
 const TEST_CTX = { waitUntil() {}, passThroughOnException() {} } as never
 
@@ -336,7 +339,7 @@ const RUN_MARK = process.env.VOYANT_EVAL_MARK ?? String(Date.now()).slice(-6)
 
 interface CapabilityJourney {
   id: string
-  group: "commercial" | "supplier" | "contract"
+  group: "commercial" | "supplier" | "contract" | "team-admin"
   domain: string
   task: string
   expect: string
@@ -711,6 +714,37 @@ function buildJourneys(RUN_MARK: string): CapabilityJourney[] {
                and v.version = 2
                and v.body = t.body`,
     },
+    {
+      id: "admin-settings-read",
+      group: "team-admin",
+      domain: "settings",
+      task: "Report the operator's current name, contact email, default locale, and supported locales. If a value is not configured, say so explicitly.",
+      expect: "operator",
+      maxCalls: 10,
+      requiresDispatch: true,
+    },
+    {
+      id: "admin-settings-update",
+      group: "team-admin",
+      domain: "settings",
+      task: `Update the operator profile name to 'Capability Travel ${RUN_MARK}', contact email to 'office.${RUN_MARK}@capability.example', and set both the supported locales and default locale to English. Preserve all other settings. Complete any required approval and confirm the saved values.`,
+      expect: `capability travel ${RUN_MARK}`,
+      maxCalls: 16,
+      verify: `select 1 from operator_profile
+             where name = 'Capability Travel ${RUN_MARK}'
+               and email = 'office.${RUN_MARK}@capability.example'
+               and default_locale = 'en'
+               and supported_locales = '["en"]'::jsonb`,
+    },
+    {
+      id: "team-roster-read",
+      group: "team-admin",
+      domain: "team",
+      task: "List the current staff team roster and report each member's role and access status.",
+      expect: "capability.eval@example.com",
+      maxCalls: 10,
+      requiresDispatch: true,
+    },
   ]
 }
 
@@ -853,6 +887,52 @@ async function seedContractJourney(journeyId: string, mark: string): Promise<voi
     active: true,
   })
   if (!template?.currentVersionId) throw new Error(`Cannot seed ${journeyId}`)
+}
+
+/** Staff authority and ordinary operator configuration for isolated admin jobs. */
+async function seedTeamAdminJourney(journeyId: string): Promise<void> {
+  if (!verifyDb) throw new Error("Capability eval database is not mounted")
+  const now = new Date()
+  await verifyDb
+    .insert(authUser)
+    .values({
+      id: "user_capability_eval",
+      name: "Capability Evaluator",
+      email: "capability.eval@example.com",
+      emailVerified: true,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoNothing()
+  await verifyDb
+    .insert(userProfilesTable)
+    .values({
+      id: "user_capability_eval",
+      firstName: "Capability",
+      lastName: "Evaluator",
+      isSuperAdmin: true,
+      permissions: ["*"],
+    })
+    .onConflictDoNothing()
+  await verifyDb
+    .insert(authAccount)
+    .values({
+      id: "account_capability_eval",
+      accountId: "user_capability_eval",
+      providerId: "credential",
+      userId: "user_capability_eval",
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoNothing()
+  if (journeyId === "admin-settings-read") {
+    await verifyDb.insert(operatorProfile).values({
+      name: "Capability Operator",
+      email: "operator@capability.example",
+      supportedLocales: ["en"],
+      defaultLocale: "en",
+    })
+  }
 }
 
 /**
@@ -1329,6 +1409,7 @@ describe.skipIf(!enabled)("MCP capability — a travel agent's job", () => {
         for (const journey of journeys) {
           if (journey.group === "supplier") await seedSupplierJourney(journey.id, mark)
           if (journey.group === "contract") await seedContractJourney(journey.id, mark)
+          if (journey.group === "team-admin") await seedTeamAdminJourney(journey.id)
           if (journey.id === "proposal-accept") await seedProposalAcceptance(mark)
           if (journey.id === "paid-refund") await seedPaidCancellationRefund(mark)
           let run: JourneyRun

--- a/packages/operator-settings/src/tools.ts
+++ b/packages/operator-settings/src/tools.ts
@@ -64,6 +64,7 @@ export const UPDATE_OPERATOR_SETTINGS_HANDLER_POLICY = {
     risk: "high",
     ledger: "required",
     approval: "required",
+    policy: "operator-settings.update.v1",
     reversible: true,
   },
 } as const satisfies HandlerActionPolicyExpectation

--- a/packages/operator-settings/src/voyant.ts
+++ b/packages/operator-settings/src/voyant.ts
@@ -159,6 +159,7 @@ export const operatorSettingsVoyantModule = defineModule({
       risk: "high",
       ledger: "required",
       approval: "required",
+      policy: "operator-settings.update.v1",
       reversible: true,
       availability: { status: "available" },
       effectBoundary: "local",


### PR DESCRIPTION
## Summary
- add a real-model team/admin capability group for settings reads, settings updates, and roster reads
- provide the selected Better Auth deployment binding and durable acting-user fixtures
- bind operator-settings updates to their approval policy so handler-owned approval can execute correctly

## Verification
- `pnpm --filter @voyant-travel/operator-settings typecheck`
- `pnpm --filter @voyant-travel/operator-settings test` (77 passed)
- `pnpm --filter operator typecheck`
- real GPT-5.6 Terra settings update journey: 1/1, 11 calls, durable result
- real GPT-5.6 Terra team roster journey: 1/1, 6 calls, zero tool errors

Tracks #4378.