### PR TITLE
fix(mcp): derive settings command identity

### DIFF
--- a/.changeset/calm-operator-settings-command.md
+++ b/.changeset/calm-operator-settings-command.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/operator-settings": patch
+---
+
+Derive operator-settings update command identity in the handler so MCP callers only carry confirmation and server-issued approval continuations.

--- a/packages/operator-settings/src/mcp-runtime.ts
+++ b/packages/operator-settings/src/mcp-runtime.ts
@@ -3,8 +3,10 @@ import {
   executeAdmittedExistingTargetCommand,
 } from "@voyant-travel/action-ledger"
 import {
+  deriveCommandIdempotencyKey,
   defineToolContextContribution,
   type ToolHandlerActionPolicyContext,
+  withServerResolvedIdempotencyKey,
 } from "@voyant-travel/tools"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
@@ -27,13 +29,20 @@ export const voyantToolContextContribution = defineToolContextContribution({
           input: Parameters<typeof upsertOperatorSettings>[1],
           admitted: ToolHandlerActionPolicyContext,
         ) {
+          const commandInput = { settingsId: "operator-settings", patch: input }
+          const resolvedAdmitted = admitted.invocation.idempotencyKey?.trim()
+            ? admitted
+            : withServerResolvedIdempotencyKey(
+                admitted,
+                await deriveCommandIdempotencyKey("update-operator-settings", commandInput),
+              )
           let settings: Awaited<ReturnType<typeof upsertOperatorSettings>> | undefined
           const result = await executeAdmittedExistingTargetCommand(
             {
               db,
               context: actionLedgerContext(request as Context),
-              admitted,
-              commandInput: { settingsId: "operator-settings", patch: input },
+              admitted: resolvedAdmitted,
+              commandInput,
               evaluatedRisk: "high",
             },
             {

--- a/packages/operator-settings/src/tools.test.ts
+++ b/packages/operator-settings/src/tools.test.ts
@@ -99,5 +99,6 @@ describe("operator settings tools", () => {
       sideEffects: ["data-write"],
     })
     expect(updateOperatorSettingsTool.actionPolicyEnforcement).toBe("handler")
+    expect(updateOperatorSettingsTool.resolvesIdempotencyKeyServerSide).toBe(true)
   })
 })

--- a/packages/operator-settings/src/tools.ts
+++ b/packages/operator-settings/src/tools.ts
@@ -113,6 +113,7 @@ export const updateOperatorSettingsTool = defineTool<
   OperatorSettingsToolContext
 >({
   name: "update_operator_settings",
+  resolvesIdempotencyKeyServerSide: true,
   description:
     "Update operator identity/contact details, branding/locales, bank-transfer instructions, or payment defaults. supportedLocales and defaultLocale must be updated together, and defaultLocale must be included in supportedLocales. Requires confirmation because payment defaults affect future bookings and invoices.",
   inputSchema: updateOperatorSettingsSchema,


### PR DESCRIPTION
## Summary
- mark operator-settings updates as server-resolved commands
- derive a stable key from the semantic settings patch inside the handler
- stop advertising `_voyant.idempotencyKey` to MCP callers while preserving exact retry/approval replay

## Verification
- `pnpm --filter @voyant-travel/operator-settings test` (77 passed)
- `pnpm --filter @voyant-travel/operator-settings typecheck`
- `pnpm verify:tool-refinement-visibility`
- focused GPT-5.6 Terra journey passed with durable grading; the call carried only `_voyant.confirmed`, then the server-issued approval id

Artifact: `.agent-runs/mcp-capability/2026-08-10T09-26-04.727Z/`

Tracks #4378.