### PR TITLE
fix(operator-settings): remove duplicate tool import

### DIFF
--- a/packages/operator-settings/src/mcp-runtime.ts
+++ b/packages/operator-settings/src/mcp-runtime.ts
@@ -3,7 +3,6 @@ import {
   executeAdmittedExistingTargetCommand,
 } from "@voyant-travel/action-ledger"
 import {
-  deriveCommandIdempotencyKey,
   defineToolContextContribution,
   deriveCommandIdempotencyKey,
   type ToolHandlerActionPolicyContext,


### PR DESCRIPTION
## Summary
- remove the duplicate import introduced when the #4530 follow-up was auto-merged on top of #4529
- retain the Biome-required import order

## Verification
- `pnpm exec biome check packages/operator-settings/src/mcp-runtime.ts`

Fixes the quality-lane failure on current `main`.