### PR TITLE
fix(operator-settings): remove duplicate tool import

### DIFF
--- a/packages/operator-settings/src/mcp-runtime.ts
+++ b/packages/operator-settings/src/mcp-runtime.ts
@@ -3,7 +3,6 @@ import {
   executeAdmittedExistingTargetCommand,
 } from "@voyant-travel/action-ledger"
 import {
-  deriveCommandIdempotencyKey,
   defineToolContextContribution,
   deriveCommandIdempotencyKey,
   type ToolHandlerActionPolicyContext,


### PR DESCRIPTION
Fix the duplicate `deriveCommandIdempotencyKey` import introduced by #4530.

This restores the operator-settings build and repository Biome check on main.

Validation:
- focused Biome check passes
- the original CI error is a duplicate identifier at this exact import