### PR TITLE
fix(tools): reject unfenced approval dispatch

### DIFF
--- a/.changeset/strict-generic-approval.md
+++ b/.changeset/strict-generic-approval.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/tools": patch
+---
+
+Reject approval-required generic Tool execution at registration because arbitrary dispatch cannot be durably fenced, and stop advertising approval continuations for actions whose policy never requires approval.

--- a/.changeset/strict-generic-approval.md
+++ b/.changeset/strict-generic-approval.md
@@ -2,4 +2,4 @@
 "@voyant-travel/tools": patch
 ---
 
-Reject approval-required generic Tool execution at registration because arbitrary dispatch cannot be durably fenced, and stop advertising approval continuations for actions whose policy never requires approval.
+Reject approval-required generic Tool execution at registration because arbitrary dispatch cannot be durably fenced, stop advertising approval continuations for actions whose policy never requires approval, and tolerate explicit confirmation on execute commands where approval already supplies the required authorization.

--- a/apps/operator/tests/mcp-capability.test.ts
+++ b/apps/operator/tests/mcp-capability.test.ts
@@ -782,6 +782,11 @@ function selectedJourneys(mark: string): CapabilityJourney[] {
         : `Unknown MCP capability group: ${GROUP_FILTER}`,
     )
   }
+  if (JOURNEY_FILTER && selected[0]?.group === "commercial") {
+    throw new Error(
+      `Commercial journey ${JOURNEY_FILTER} depends on the preceding chain; run the commercial group instead of an isolated journey.`,
+    )
+  }
   return selected
 }
 

--- a/packages/mcp/tests/server.test.ts
+++ b/packages/mcp/tests/server.test.ts
@@ -955,7 +955,8 @@ describe("createMcpApiRoutes", () => {
       | undefined
     const invocationSchema = listedTool?.inputSchema.properties?._voyant
     expect(invocationSchema?.properties).toHaveProperty("reasonCode")
-    expect(invocationSchema?.properties).not.toHaveProperty("confirmed")
+    expect(invocationSchema?.properties).toHaveProperty("confirmed")
+    expect(invocationSchema?.required ?? []).not.toContain("confirmed")
     expect(invocationSchema?.properties).not.toHaveProperty("targetId")
     expect(invocationSchema?.required ?? []).not.toContain("targetId")
     expect(listedTool?._meta).toMatchObject({

--- a/packages/mcp/tests/server.test.ts
+++ b/packages/mcp/tests/server.test.ts
@@ -1642,7 +1642,7 @@ describe("createMcpApiRoutes", () => {
           targetType: "notification",
           risk: "critical",
           ledger: "required",
-          approval: "required",
+          approval: "never",
         },
       },
     )
@@ -1685,7 +1685,7 @@ describe("createMcpApiRoutes", () => {
             invocation: {
               controlField: "_voyant",
               requiredFields: ["confirmed"],
-              optionalFields: ["reasonCode", "approvalId"],
+              optionalFields: ["reasonCode"],
               targetResolution: "package-resolver",
             },
           },
@@ -1702,7 +1702,6 @@ describe("createMcpApiRoutes", () => {
             message: "hello",
             _voyant: {
               confirmed: true,
-              approvalId: "approval_1",
             },
           },
         }),
@@ -1718,7 +1717,6 @@ describe("createMcpApiRoutes", () => {
         resolvedTargetId: "notification:hello",
         invocation: {
           confirmed: true,
-          approvalId: "approval_1",
         },
       }),
     ])

--- a/packages/operator-settings/src/mcp-runtime.ts
+++ b/packages/operator-settings/src/mcp-runtime.ts
@@ -3,7 +3,6 @@ import {
   executeAdmittedExistingTargetCommand,
 } from "@voyant-travel/action-ledger"
 import {
-  deriveCommandIdempotencyKey,
   defineToolContextContribution,
   deriveCommandIdempotencyKey,
   type ToolHandlerActionPolicyContext,

--- a/packages/tools/src/binding.ts
+++ b/packages/tools/src/binding.ts
@@ -105,6 +105,7 @@ export interface ToolActionInvocationPolicy {
   )[]
   optionalFields: readonly (
     | "reasonCode"
+    | "confirmed"
     | "approvalId"
     | "targetId"
     | "idempotencyKey"

--- a/packages/tools/src/registered-tool.ts
+++ b/packages/tools/src/registered-tool.ts
@@ -185,13 +185,17 @@ function deriveActionPolicy(
       : tool.resolvesIdempotencyKeyServerSide || serverOwnedGenericTarget
         ? (["approvalId"] as const)
         : (["approvalId", "idempotencyFingerprint"] as const)
+  const optionalConfirmationFields =
+    action.kind === "execute" && !requiredFields.includes("confirmed")
+      ? (["confirmed"] as const)
+      : []
   return {
     ...action,
     enforcement,
     invocation: {
       controlField: TOOL_ACTION_INVOCATION_FIELD,
       requiredFields,
-      optionalFields: ["reasonCode", ...optionalApprovalFields],
+      optionalFields: ["reasonCode", ...optionalConfirmationFields, ...optionalApprovalFields],
       fingerprintAlgorithm: "action-ledger-command-v1",
       ...targetResolution,
     },

--- a/packages/tools/src/registered-tool.ts
+++ b/packages/tools/src/registered-tool.ts
@@ -71,6 +71,11 @@ function deriveActionPolicy(
   action: ToolActionPolicyBinding,
 ): ToolActionPolicyManifest {
   const enforcement = tool.actionPolicyEnforcement ?? "generic"
+  if (action.kind === "execute" && action.approval === "required" && enforcement !== "handler") {
+    throw new Error(
+      `Tool "${tool.name}" action "${action.id}" approval-required execution requires handler-owned durable command enforcement`,
+    )
+  }
   if (action.targetLifecycle === "existing" && action.existingTarget) {
     if (action.kind !== "execute" || action.ledger !== "required") {
       throw new Error(
@@ -174,20 +179,19 @@ function deriveActionPolicy(
       }
     }
   }
+  const optionalApprovalFields =
+    action.approval === "never"
+      ? []
+      : tool.resolvesIdempotencyKeyServerSide || serverOwnedGenericTarget
+        ? (["approvalId"] as const)
+        : (["approvalId", "idempotencyFingerprint"] as const)
   return {
     ...action,
     enforcement,
     invocation: {
       controlField: TOOL_ACTION_INVOCATION_FIELD,
       requiredFields,
-      optionalFields:
-        enforcement === "generic"
-          ? serverOwnedGenericTarget
-            ? ["reasonCode", "approvalId"]
-            : ["reasonCode", "approvalId", "idempotencyFingerprint"]
-          : tool.resolvesIdempotencyKeyServerSide
-            ? ["reasonCode", "approvalId"]
-            : ["reasonCode", "approvalId", "idempotencyFingerprint"],
+      optionalFields: ["reasonCode", ...optionalApprovalFields],
       fingerprintAlgorithm: "action-ledger-command-v1",
       ...targetResolution,
     },

--- a/packages/tools/tests/registry.test.ts
+++ b/packages/tools/tests/registry.test.ts
@@ -475,7 +475,10 @@ describe("createToolRegistry", () => {
       commandTargetField: "recordId",
       existingTarget: { durability: "handler-command-result-v1" },
       enforcement: "handler",
-      invocation: { requiredFields: ["idempotencyKey"] },
+      invocation: {
+        requiredFields: ["idempotencyKey"],
+        optionalFields: ["reasonCode", "confirmed"],
+      },
     })
     expect(registry.list()[0]?.actionPolicy?.invocation.requiredFields).not.toContain("targetId")
 

--- a/packages/tools/tests/registry.test.ts
+++ b/packages/tools/tests/registry.test.ts
@@ -497,6 +497,44 @@ describe("createToolRegistry", () => {
     ).toThrow(/conditional approval is unsupported/)
   })
 
+  it("rejects approval-required generic execution because dispatch cannot be durably fenced", () => {
+    const definition = defineTool({
+      name: "publish_record",
+      description: "Publish a record.",
+      inputSchema: z.object({ recordId: z.string() }),
+      outputSchema: z.object({ id: z.string() }),
+      requiredScopes: ["records:write"],
+      tier: "write",
+      riskPolicy: {
+        destructive: false,
+        reversible: true,
+        dryRunSupported: false,
+        confirmationRequired: true,
+        sideEffects: ["data-write"],
+      },
+      async handler({ recordId }) {
+        return { id: recordId }
+      },
+    })
+
+    expect(() =>
+      createToolRegistry().register(definition, {
+        actionPolicy: {
+          id: "action.publish-record",
+          capabilityId: "@voyant-travel/test#action.publish-record",
+          version: "v1",
+          kind: "execute",
+          targetType: "record",
+          commandTargetField: "recordId",
+          targetLifecycle: "existing",
+          risk: "medium",
+          ledger: "required",
+          approval: "required",
+        },
+      }),
+    ).toThrow(/approval-required execution requires handler-owned durable command enforcement/)
+  })
+
   it("advertises package target resolution without exposing client-owned target metadata", async () => {
     const registry = createToolRegistry()
     const targetTool = defineTool({


### PR DESCRIPTION
## Summary
- fail registration for approval-required generic execute Tools because arbitrary dispatch cannot be lease-fenced safely
- require approval-gated execution to use handler-owned durable command enforcement
- omit approval continuation fields for policies that never require approval
- accept explicit `_voyant.confirmed: true` as an optional control when an execute command uses approval as its required authorization

This closes the remaining generic stranded-preflight class from #4424 by making it unreachable, rather than adding unsafe timeout redispatch. Current selected graph has zero callable approval-required generic actions. The real Terra smoke then exposed an avoidable `invoice_booking` retry because explicit confirmation was rejected after approval; the second commit removes that loop.

## Verification
- RED: new registry test failed before the generic-approval guard
- real GPT-5.6 Terra smoke: 15/15; exposed the invoice confirmation loop in `.agent-runs/mcp-capability/2026-08-10T09-45-51.883Z/`
- `pnpm --filter @voyant-travel/tools test` (83 passed)
- `pnpm --filter @voyant-travel/tools typecheck`
- `pnpm --filter @voyant-travel/mcp test` (101 passed)
- `pnpm --filter @voyant-travel/mcp typecheck`
- `pnpm --filter operator prepare:verify`
- focused Biome check

Tracks #4378 and #4424.