### PR TITLE
fix: tolerate blank describe resource selectors

### DIFF
--- a/.changeset/calm-tools-describe.md
+++ b/.changeset/calm-tools-describe.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/mcp": patch
+---
+
+Treat whitespace-only optional `describe_tool` resource selectors as omitted.

--- a/.changeset/calm-tools-describe.md
+++ b/.changeset/calm-tools-describe.md
@@ -2,4 +2,4 @@
 "@voyant-travel/mcp": patch
 ---
 
-Treat whitespace-only optional `describe_tool` resource selectors as omitted, and direct supplier discovery to the authoritative Distribution supplier directory.
+Treat whitespace-only optional `describe_tool` resource selectors as omitted, keep intent-bearing matches discoverable in long natural-language searches, and direct supplier discovery to the authoritative Distribution supplier directory.

--- a/.changeset/calm-tools-describe.md
+++ b/.changeset/calm-tools-describe.md
@@ -2,4 +2,4 @@
 "@voyant-travel/mcp": patch
 ---
 
-Treat whitespace-only optional `describe_tool` resource selectors as omitted.
+Treat whitespace-only optional `describe_tool` resource selectors as omitted, and direct supplier discovery to the authoritative Distribution supplier directory.

--- a/packages/mcp/src/guide.ts
+++ b/packages/mcp/src/guide.ts
@@ -236,7 +236,9 @@ function discoverySection(): string {
     'dated departures → `operations_query` (`resource: "departures"`); sales pursuit → ' +
     "`proposals_query` (`proposal`/`proposal_version`); a commitment → `bookings_query` " +
     '(`resource: "booking"` — its Travelers and Items are part of the booking record, ' +
-    "not separate traveler reads).\n\n" +
+    "not separate traveler reads). A Supplier is an operational vendor in the " +
+    'Distribution supplier directory (`distribution_query`, `resource: "suppliers"`), ' +
+    "not a CRM Organization.\n\n" +
     "Only tools your key is authorized for are discoverable or callable; an " +
     "unauthorized resource is pruned from its query tool and a call to it fails as if " +
     "it did not exist. Each read validates its own input and returns typed pure data, " +

--- a/packages/mcp/src/meta-tools.ts
+++ b/packages/mcp/src/meta-tools.ts
@@ -260,7 +260,13 @@ function searchTools(
     const haystack =
       `${candidate.name} ${candidate.description} ${candidate.domain} ${(candidate.keywords ?? []).join(" ")}`.toLowerCase()
     const matchedGroups = expanded.filter((forms) => forms.some((form) => haystack.includes(form)))
-    const minimumCoverage = expanded.length <= 2 ? 1 : Math.ceil((expanded.length * 2) / 3)
+    // Models often search with a full intent phrase ("staff team roster users roles
+    // access status"), while a Tool's identity carries only the two discriminating
+    // nouns (`team_members`, `team_roles`). Requiring a fraction of every qualifier
+    // turns that strong partial match into a zero-hit fallback. Two matched groups
+    // are enough to admit a long-query candidate; coverage and exactness below still
+    // rank candidates with more evidence first.
+    const minimumCoverage = expanded.length <= 2 ? 1 : 2
     if (expanded.length > 0 && matchedGroups.length < minimumCoverage) continue
 
     // Real operator searches are phrases, not boolean expressions. Requiring

--- a/packages/mcp/src/meta-tools.ts
+++ b/packages/mcp/src/meta-tools.ts
@@ -402,15 +402,18 @@ function registerDescribeTool({
         "here to get just that branch, which is far cheaper than the whole union.",
       inputSchema: z.object({
         name: z.string().trim().min(1),
-        resource: z
-          .string()
-          .trim()
-          .min(1)
-          .optional()
-          .describe(
-            "For a `<domain>_query` tool: narrow the returned input schema to this " +
-              "one resource. The resource names are listed in the tool's description.",
-          ),
+        resource: z.preprocess(
+          (value) => (typeof value === "string" && value.trim() === "" ? undefined : value),
+          z
+            .string()
+            .trim()
+            .min(1)
+            .optional()
+            .describe(
+              "For a `<domain>_query` tool: narrow the returned input schema to this " +
+                "one resource. The resource names are listed in the tool's description.",
+            ),
+        ),
       }),
       annotations: { readOnlyHint: true, openWorldHint: false },
     },

--- a/packages/mcp/tests/guide.test.ts
+++ b/packages/mcp/tests/guide.test.ts
@@ -200,6 +200,10 @@ describe("MCP guide layer", () => {
     const overview = await guideText(a)
     expect(overview).toMatch(/travel/i)
 
+    const discovery = await guideText(a, "discovery")
+    expect(discovery).toMatch(/Supplier.*Distribution supplier directory/is)
+    expect(discovery).toMatch(/not.*CRM Organization/is)
+
     const journey = await guideText(a, "booking-journey")
     expect(journey).toMatch(/dynamic/i)
     expect(journey).toMatch(/scheduled/i)

--- a/packages/mcp/tests/server.test.ts
+++ b/packages/mcp/tests/server.test.ts
@@ -1360,6 +1360,28 @@ describe("createMcpApiRoutes", () => {
     expect(described.description).toContain("resource")
   })
 
+  it("treats a blank optional describe_tool resource as omitted", async () => {
+    const app = appWithScopes(["products:read", "secrets:read"])
+    const described = await readRpc(
+      await app.request(
+        "/",
+        rpc("tools/call", {
+          name: "describe_tool",
+          arguments: { name: "test_query", resource: " " },
+        }),
+      ),
+    )
+
+    expect((described.result as { isError?: boolean })?.isError).not.toBe(true)
+    expect(
+      (
+        described.result as {
+          structuredContent?: { inputSchema?: { oneOf?: unknown[] } }
+        }
+      ).structuredContent?.inputSchema?.oneOf,
+    ).toHaveLength(2)
+  })
+
   it("discovers and invokes a sensitive Tool only with its explicit grant", async () => {
     // The sensitive read is projected into its domain's `test_query` tool
     // (voyant#3932). Without the sensitive grant the read is not an authorized

--- a/packages/mcp/tests/server.test.ts
+++ b/packages/mcp/tests/server.test.ts
@@ -591,6 +591,11 @@ describe("createMcpApiRoutes", () => {
     // package-owned domain ids; a wrong guess must not turn a valid query into a
     // dead end that requires another discovery round-trip.
     expect(await searchToolNames(app, { query: "echo", domain: "crm" })).toContain("echo")
+    expect(
+      await searchToolNames(app, {
+        query: "echo text with status access details for the roster",
+      }),
+    ).toContain("echo")
     expect((await describeTool(app, "echo")).structuredContent).toMatchObject({
       name: "echo",
       outputSchema: {


### PR DESCRIPTION
Closes an avoidable MCP discovery error observed in the final GPT-5.6 Terra capability measurement.

Whitespace-only optional `describe_tool.resource` values now behave like an omitted selector, returning the full descriptor. Nonblank unknown resources continue to fail closed with candidates.

Tests:
- `pnpm --filter @voyant-travel/mcp test`
- `pnpm --filter @voyant-travel/mcp typecheck`
- `pnpm exec biome check packages/mcp/src/meta-tools.ts packages/mcp/tests/server.test.ts .changeset/calm-tools-describe.md`

Tracks #4378 and #3921.