### PR TITLE
fix: harden model failure reporting and Tool search

### DIFF
--- a/.changeset/quiet-domain-search.md
+++ b/.changeset/quiet-domain-search.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/mcp": patch
+---
+
+Keep relevant long-form Tool searches within a recognized domain while retaining cross-domain recovery for incorrect domain hints.

--- a/apps/operator/tests/mcp-capability.test.ts
+++ b/apps/operator/tests/mcp-capability.test.ts
@@ -182,6 +182,12 @@ interface JourneyRun {
   tokens: number
   exhausted: boolean
   modelTransportRetries: number
+  fatal?: {
+    source: "model_transport" | "harness"
+    status: number | null
+    code: string | null
+    message: string
+  }
 }
 
 async function runJourney(input: {
@@ -235,7 +241,17 @@ async function runJourney(input: {
         },
       },
     )
-    if (!res.ok) throw new Error(`OpenAI ${res.status}: ${(await res.text()).slice(0, 300)}`)
+    if (!res.ok) {
+      const failure = parseModelFailure(res.status, await res.text())
+      return {
+        calls,
+        answer: `FATAL: ${failure.message}`,
+        tokens,
+        exhausted: true,
+        modelTransportRetries,
+        fatal: failure,
+      }
+    }
     const body = (await res.json()) as {
       id?: string
       output_text?: string
@@ -305,6 +321,21 @@ async function runJourney(input: {
     nextInput = functionOutputs
   }
   return { calls, answer: "", tokens, exhausted: true, modelTransportRetries }
+}
+
+function parseModelFailure(status: number, responseText: string): NonNullable<JourneyRun["fatal"]> {
+  let code: string | null = null
+  let message = responseText.slice(0, 300)
+  try {
+    const body = JSON.parse(responseText) as {
+      error?: { code?: string | null; type?: string; message?: string }
+    }
+    code = body.error?.code ?? body.error?.type ?? null
+    message = body.error?.message?.slice(0, 300) ?? message
+  } catch {
+    // Preserve the bounded raw response when the provider did not return JSON.
+  }
+  return { source: "model_transport", status, code, message: `OpenAI ${status}: ${message}` }
 }
 
 /**
@@ -1208,6 +1239,11 @@ function report(): string {
       }`,
     )
     if (!done) lines.push(`      answer: ${run.answer.slice(0, 220)}`)
+    if (run.fatal) {
+      lines.push(
+        `      fatal: ${run.fatal.source} status=${run.fatal.status ?? "none"} code=${run.fatal.code ?? "none"}`,
+      )
+    }
     for (const failed of run.calls.filter((c) => c.isError)) {
       lines.push(`      ✗ ${failed.name}: ${failed.snippet.slice(0, 200)}`)
       // The error tells us which guard refused; the arguments tell us why. This
@@ -1279,6 +1315,7 @@ function writeMachineReport(): void {
         responseBytes: attempt.calls.reduce((sum, call) => sum + call.responseBytes, 0),
         tokens: attempt.tokens,
         modelTransportRetries: attempt.modelTransportRetries,
+        fatal: attempt.fatal ?? null,
         exhausted: attempt.exhausted,
         withinCallBudget: attempt.calls.length <= journey.maxCalls,
         trace: attempt.calls.map((call) => ({
@@ -1306,7 +1343,7 @@ function writeMachineReport(): void {
     destination,
     `${JSON.stringify(
       {
-        schemaVersion: 4,
+        schemaVersion: 5,
         generatedAt: new Date().toISOString(),
         model: MODEL,
         reasoningEffort: MODEL.startsWith("gpt-5") ? REASONING_EFFORT : null,
@@ -1433,6 +1470,12 @@ describe.skipIf(!enabled)("MCP capability — a travel agent's job", () => {
               tokens: 0,
               exhausted: true,
               modelTransportRetries: 0,
+              fatal: {
+                source: "harness",
+                status: null,
+                code: null,
+                message: String(err).slice(0, 300),
+              },
             }
           }
           attempts.set(journey.id, [...(attempts.get(journey.id) ?? []), run])

--- a/apps/operator/tests/mcp-openai-retry.test.ts
+++ b/apps/operator/tests/mcp-openai-retry.test.ts
@@ -25,4 +25,45 @@ describe("MCP capability model transport retry", () => {
     expect(response.status).toBe(400)
     expect(request).toHaveBeenCalledTimes(1)
   })
+
+  it("does not retry an OpenAI insufficient-quota 429", async () => {
+    const request = vi.fn(async () =>
+      Response.json(
+        {
+          error: {
+            message: "You have no credits remaining.",
+            type: "insufficient_quota",
+            code: "insufficient_quota",
+          },
+        },
+        { status: 429 },
+      ),
+    )
+    const delay = vi.fn(async () => undefined)
+
+    const response = await fetchWithTransientRetry(request, { delay })
+
+    expect(response.status).toBe(429)
+    expect(request).toHaveBeenCalledTimes(1)
+    expect(delay).not.toHaveBeenCalled()
+  })
+
+  it("still retries a transient OpenAI rate-limit 429", async () => {
+    const request = vi
+      .fn<() => Promise<Response>>()
+      .mockResolvedValueOnce(
+        Response.json(
+          { error: { type: "rate_limit_error", code: "rate_limit_exceeded" } },
+          { status: 429 },
+        ),
+      )
+      .mockResolvedValueOnce(new Response('{"id":"response_1"}', { status: 200 }))
+    const delay = vi.fn(async () => undefined)
+
+    const response = await fetchWithTransientRetry(request, { delay })
+
+    expect(response.status).toBe(200)
+    expect(request).toHaveBeenCalledTimes(2)
+    expect(delay).toHaveBeenCalledTimes(1)
+  })
 })

--- a/apps/operator/tests/selected-graph-mcp-tool-surface.test.ts
+++ b/apps/operator/tests/selected-graph-mcp-tool-surface.test.ts
@@ -395,7 +395,7 @@ describe("selected-graph MCP tool surface cost", () => {
     ).toBeLessThanOrEqual(AGGREGATE_CEILING_BYTES)
   })
 
-  it("keeps a zero-hit fallback inside a recognized domain", async () => {
+  it("keeps long natural-language matches inside a recognized domain", async () => {
     const { app } = await mountSelectedGraphMcp()
     const searched = await readRpc(
       await app.request(
@@ -407,6 +407,35 @@ describe("selected-graph MCP tool surface cost", () => {
             domain: "finance",
             limit: 50,
           },
+        }),
+        TEST_ENV,
+        TEST_CTX,
+      ),
+    )
+    const result = (
+      searched.result as {
+        structuredContent?: {
+          returned?: number
+          tools?: Array<{ name: string; domain: string }>
+        }
+      }
+    ).structuredContent
+    const tools = result?.tools ?? []
+
+    expect(tools.length).toBeGreaterThan(0)
+    expect(result?.returned).toBe(tools.length)
+    expect(new Set(tools.map(({ domain }) => domain))).toEqual(new Set(["finance"]))
+    expect(tools.map(({ name }) => name)).toContain("refund_cancelled_booking")
+  })
+
+  it("keeps a zero-hit fallback inside a recognized domain", async () => {
+    const { app } = await mountSelectedGraphMcp()
+    const searched = await readRpc(
+      await app.request(
+        "/",
+        rpc("tools/call", {
+          name: "search_tools",
+          arguments: { query: "quokka zephyr", domain: "finance", limit: 50 },
         }),
         TEST_ENV,
         TEST_CTX,

--- a/apps/operator/tests/support/openai-response-retry.ts
+++ b/apps/operator/tests/support/openai-response-retry.ts
@@ -22,6 +22,7 @@ export async function fetchWithTransientRetry(
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     try {
       const response = await request()
+      if (await isTerminalQuotaResponse(response)) return response
       if (!TRANSIENT_STATUS.has(response.status) || attempt === maxAttempts) return response
       const delayMs = retryDelayMs(attempt, response.headers.get("retry-after"))
       options.onRetry?.({ attempt, maxAttempts, status: response.status, delayMs })
@@ -37,6 +38,20 @@ export async function fetchWithTransientRetry(
   }
 
   throw lastError ?? new Error("Transient model request retry exhausted")
+}
+
+async function isTerminalQuotaResponse(response: Response): Promise<boolean> {
+  if (response.status !== 429) return false
+  try {
+    const body = (await response.clone().json()) as {
+      error?: { type?: string; code?: string | null }
+    }
+    return [body.error?.type, body.error?.code].some(
+      (value) => value === "insufficient_quota" || value === "billing_hard_limit_reached",
+    )
+  } catch {
+    return false
+  }
 }
 
 function retryDelayMs(attempt: number, retryAfter: string | null) {

--- a/packages/mcp/src/meta-tools.ts
+++ b/packages/mcp/src/meta-tools.ts
@@ -285,13 +285,18 @@ function searchTools(
       score: matchedGroups.length * 10 + relevance + domainBonus,
     })
   }
-  const ignoredDomain =
-    domain !== undefined &&
-    matches.length > 0 &&
-    !matches.some((candidate) => candidate.domain.toLowerCase() === domain)
+  const domainMatches = domain
+    ? matches.filter((candidate) => candidate.domain.toLowerCase() === domain)
+    : []
+  // A recognized domain is useful when that domain has relevant matches: keep
+  // incidental words in a long phrase from pulling in every other product area.
+  // If the caller guessed the domain vocabulary incorrectly, keep the established
+  // cross-domain recovery behavior and return the real matches instead.
+  const rankedMatches = domainMatches.length > 0 ? domainMatches : matches
+  const ignoredDomain = domain !== undefined && matches.length > 0 && domainMatches.length === 0
 
-  matches.sort((a, b) => b.score - a.score || a.name.localeCompare(b.name))
-  const returned = matches.slice(0, limit)
+  rankedMatches.sort((a, b) => b.score - a.score || a.name.localeCompare(b.name))
+  const returned = rankedMatches.slice(0, limit)
 
   // A zero-hit search used to return a bare `{ total: 0, tools: [] }`, which a
   // model reads as "the thing you asked about does not exist".
@@ -308,7 +313,7 @@ function searchTools(
   // TOOLS, in the field it already knows how to read — so a no-hit search falls
   // back to the query tools, which is the answer to "where do I look for a
   // record" in the only vocabulary the caller is already using.
-  const fellBack = matches.length === 0
+  const fellBack = rankedMatches.length === 0
   const allFallbacks = fellBack ? queryToolCandidates(projection) : []
   const domainFallbacks = domain
     ? allFallbacks.filter((candidate) => candidate.domain.toLowerCase() === domain)
@@ -317,9 +322,11 @@ function searchTools(
   const fallback = fallbackPool.slice(0, limit)
 
   const payload = {
-    total: matches.length,
+    total: rankedMatches.length,
     returned: fellBack ? fallback.length : returned.length,
-    truncated: fellBack ? fallbackPool.length > fallback.length : matches.length > returned.length,
+    truncated: fellBack
+      ? fallbackPool.length > fallback.length
+      : rankedMatches.length > returned.length,
     tools: fellBack ? fallback : returned.map(({ score: _score, ...tool }) => tool),
     ...(ignoredDomain ? { ignoredDomain: args.domain } : {}),
     ...(fellBack ? { howToFindARecord: recordLookupGuidance() } : {}),


### PR DESCRIPTION
The final GPT-5.6 Terra capability loop exposed two harness/discovery defects.

1. Every HTTP 429 was retried, including terminal `insufficient_quota`, and the outer catch erased partial calls, tokens, retry evidence, and provider classification.
2. Long natural-language searches admitted incidental matches from unrelated domains even when the supplied domain was recognized and had relevant matches.

This PR:
- stops retrying terminal quota/billing 429s while retaining retries for transient rate limits;
- preserves partial execution evidence and emits structured source/status/code/message fields in report schema v5;
- keeps relevant matches within a recognized domain, but retains cross-domain recovery when the domain hint is wrong;
- separates meaningful long-query and true zero-hit fallback contracts.

Verification:
- real quota integration: report v5 recorded `model_transport`, HTTP 429, `credit_balance_exhausted`, and zero retries in `.agent-runs/mcp-capability/2026-08-10T11-12-50.325Z/report.json`;
- operator focused tests: 14/14;
- MCP server/guide/budget tests: 55/55;
- operator typecheck;
- focused Biome checks.

Tracks #4378 and #3921.