### PR TITLE
Fix managed Trip pricing handoff

### DIFF
--- a/.changeset/quiet-trips-price.md
+++ b/.changeset/quiet-trips-price.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/storefront": patch
+"@voyant-travel/trips": patch
+---
+
+Carry provider-native, non-binding shopping estimates through opaque offer references so managed Trip selections can freeze before Catalog revalidates every component for booking.

--- a/packages/storefront/src/shopping/managed-runtime.ts
+++ b/packages/storefront/src/shopping/managed-runtime.ts
@@ -262,7 +262,13 @@ async function searchInspiration(
             purpose: "catalog-item",
             context,
             scope,
-            payload: { entityModule: mapping.vertical, entityId: item.entityId },
+            payload: {
+              entityModule: mapping.vertical,
+              entityId: item.entityId,
+              ...(item.nativePrice
+                ? { estimatedPricing: tripPricingEstimate(item.nativePrice) }
+                : {}),
+            },
             replay: "multi-use",
           })
           return publicCatalogItem(item, issued.ref, priceFrom)
@@ -320,7 +326,11 @@ async function searchFlights(
         purpose: "flight-offer",
         context,
         scope,
-        payload: { selection: item.selection, providerData: item.providerData },
+        payload: {
+          selection: item.selection,
+          providerData: item.providerData,
+          estimatedPricing: tripPricingEstimate(item.nativePrice, item.expiresAt),
+        },
         replay: "single-use",
       })
       return {
@@ -371,7 +381,10 @@ async function searchStays(
           purpose: "stay-offer",
           context,
           scope,
-          payload: { selection: item.selection },
+          payload: {
+            selection: item.selection,
+            estimatedPricing: tripPricingEstimate(item.nativePrice, item.expiresAt),
+          },
           replay: "single-use",
         }),
         issueBoundedReference(options.references, now, {
@@ -435,7 +448,11 @@ async function searchPackages(
         purpose: "package-offer",
         context,
         scope,
-        payload: { selection: item.selection, providerData: item.providerData },
+        payload: {
+          selection: item.selection,
+          providerData: item.providerData,
+          estimatedPricing: tripPricingEstimate(item.nativePrice, item.expiresAt),
+        },
         replay: "single-use",
       })
       return {
@@ -622,7 +639,11 @@ async function searchCruises(
         purpose: "cruise-offer",
         context,
         scope,
-        payload: { selection: item.selection, providerData: item.providerData },
+        payload: {
+          selection: item.selection,
+          providerData: item.providerData,
+          estimatedPricing: tripPricingEstimate(item.nativePrice, item.expiresAt),
+        },
         replay: "single-use",
       })
       return {
@@ -667,6 +688,32 @@ async function normalizeLive<T extends { nativePrice: { amount: string; currency
     items.sort((left, right) => comparePresentationMoney(left.price, right.price))
   }
   return { items, dropped: page.items.length - items.length }
+}
+
+/**
+ * Preserve the provider-native, non-binding search estimate behind the opaque
+ * reference. Trips needs an accepted estimate to freeze an itinerary before
+ * Catalog immediately revalidates every component for the Booking Session.
+ * Presentation/FX money is deliberately never accepted here.
+ */
+function tripPricingEstimate(money: { amount: string; currency: string }, priceExpiresAt?: string) {
+  const fractionDigits =
+    new Intl.NumberFormat("en", {
+      style: "currency",
+      currency: money.currency,
+    }).resolvedOptions().maximumFractionDigits ?? 2
+  const [whole = "0", fraction = ""] = money.amount.split(".")
+  if (fraction.length > fractionDigits) throw new Error("native_price_precision_unsupported")
+  const amountMinor = Number(BigInt(`${whole}${fraction.padEnd(fractionDigits, "0") || "0"}`))
+  if (!Number.isSafeInteger(amountMinor)) throw new Error("native_price_amount_unsupported")
+  return {
+    currency: money.currency,
+    subtotalAmountCents: amountMinor,
+    taxAmountCents: 0,
+    totalAmountCents: amountMinor,
+    ...(priceExpiresAt ? { priceExpiresAt } : {}),
+    warnings: ["non_binding_storefront_estimate"],
+  }
 }
 
 function coverage(page: StorefrontLiveSearchPage<unknown>, dropped: number) {

--- a/packages/storefront/tests/unit/live-shopping-provider.test.ts
+++ b/packages/storefront/tests/unit/live-shopping-provider.test.ts
@@ -287,14 +287,14 @@ describe("storefront live shopping provider", () => {
       expect.arrayContaining([
         expect.objectContaining({
           purpose: "stay-offer",
-          payload: {
+          payload: expect.objectContaining({
             selection: expect.objectContaining({
               target: expect.objectContaining({ entityId: "accommodation_canonical" }),
               configure: expect.objectContaining({
                 dateRange: { checkIn: "2026-09-10", checkOut: "2026-09-15" },
               }),
             }),
-          },
+          }),
         }),
       ]),
     )

--- a/packages/storefront/tests/unit/managed-shopping-runtime.test.ts
+++ b/packages/storefront/tests/unit/managed-shopping-runtime.test.ts
@@ -5,6 +5,7 @@ import {
   createManagedStorefrontShoppingRuntime,
   inspirationCatalogSlice,
   type StorefrontInternalFlightOffer,
+  type StorefrontInternalPackageOffer,
   type StorefrontShoppingContext,
   StorefrontShoppingScopeError,
 } from "../../src/shopping/index.js"
@@ -466,5 +467,84 @@ describe("managed live shopping", () => {
       kind: "flight",
       offers: [{ offerRef: "opaque-reference-after-persistence" }],
     })
+  })
+
+  it("seals provider-native package pricing for Trip freeze without trusting presentation FX", async () => {
+    const packageOffer = {
+      nativePrice: { amount: "1000.00", currency: "RON" },
+      title: "Rome escape",
+      origin: "OTP",
+      destination: "Rome",
+      departureDate: "2026-09-10",
+      nights: 5,
+      accommodationName: "Hotel Roma",
+      expiresAt: "2026-08-08T10:08:00.000Z",
+      selection: {
+        target: {
+          entityModule: "products",
+          entityId: "product_package_1",
+          sourceKind: "voyant-connect",
+          sourceConnectionId: "connection_server_only",
+          sourceRef: "source_package_1",
+        },
+        configure: {
+          departureDate: "2026-09-10",
+          departureAirportCode: "OTP",
+          nights: 5,
+          pax: { adult: 2 },
+          ratePlanId: "rate_1",
+        },
+        offerExpiresAt: "2026-08-08T10:08:00.000Z",
+      },
+    } satisfies StorefrontInternalPackageOffer
+    const issue = vi.fn(async () => ({
+      ref: "opaque-package-reference-0001",
+      expiresAt: "2026-08-08T10:10:00.000Z",
+    }))
+    const runtime = createManagedStorefrontShoppingRuntime(
+      dependencies({
+        references: { redeem: vi.fn(async () => null), issue },
+        live: {
+          searchFlights: vi.fn(),
+          searchStays: vi.fn(),
+          searchPackages: vi.fn(async () => ({
+            items: [packageOffer],
+            sources: [{ status: "ok" }],
+          })),
+          searchCruises: vi.fn(),
+        },
+      }),
+    )
+    const scope = await runtime.resolveScope(context, {})
+
+    await runtime.search(context, {
+      scope,
+      intent: {
+        kind: "package",
+        origin: "OTP",
+        destination: { city: "Rome" },
+        departureDateFrom: "2026-09-01",
+        departureDateTo: "2026-09-30",
+        nights: { min: 5, max: 7 },
+        travelers: { adults: 2 },
+      },
+    })
+
+    expect(issue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        purpose: "package-offer",
+        payload: expect.objectContaining({
+          estimatedPricing: {
+            currency: "RON",
+            subtotalAmountCents: 100_000,
+            taxAmountCents: 0,
+            totalAmountCents: 100_000,
+            priceExpiresAt: "2026-08-08T10:08:00.000Z",
+            warnings: ["non_binding_storefront_estimate"],
+          },
+        }),
+      }),
+    )
+    expect(JSON.stringify(issue.mock.calls)).not.toContain("presentation")
   })
 })

--- a/packages/trips/src/shopping-opaque-references.ts
+++ b/packages/trips/src/shopping-opaque-references.ts
@@ -13,6 +13,7 @@ import type {
   StorefrontTripOfferComponent,
   StorefrontTripOfferResolver,
 } from "./storefront-trip-offer-resolver-port.js"
+import { tripComponentPricingSnapshotSchema } from "./validation.js"
 
 const MAX_REFERENCE_TTL_SECONDS = 24 * 60 * 60
 const referenceSchema = z.string().regex(/^sref_[a-f0-9]{64}$/)
@@ -483,7 +484,11 @@ function componentFromReference(
   const payload = payloadSchema.parse(reference.payload)
   if (reference.purpose === "catalog-item") {
     const catalog = z
-      .object({ entityModule: z.string().min(1), entityId: z.string().min(1) })
+      .object({
+        entityModule: z.string().min(1),
+        entityId: z.string().min(1),
+        estimatedPricing: tripComponentPricingSnapshotSchema.optional(),
+      })
       .passthrough()
       .parse(payload)
     return {
@@ -493,13 +498,18 @@ function componentFromReference(
         entityId: catalog.entityId,
         sourceKind: "owned",
       },
+      ...(catalog.estimatedPricing ? { estimatedPricing: catalog.estimatedPricing } : {}),
       metadata: {},
     }
   }
 
   if (reference.purpose === "package-offer") {
     const payload = z
-      .object({ selection: packageSelectionSchema, providerData: z.never().optional() })
+      .object({
+        selection: packageSelectionSchema,
+        providerData: z.never().optional(),
+        estimatedPricing: tripComponentPricingSnapshotSchema.optional(),
+      })
       .strict()
       .parse(reference.payload)
     if (Date.parse(payload.selection.offerExpiresAt) <= now.getTime()) {
@@ -509,6 +519,7 @@ function componentFromReference(
     return {
       kind: "catalog_booking",
       catalogRef: target,
+      ...(payload.estimatedPricing ? { estimatedPricing: payload.estimatedPricing } : {}),
       metadata: {
         bookingDraftV1: {
           entity: {
@@ -526,13 +537,18 @@ function componentFromReference(
 
   if (reference.purpose === "stay-offer") {
     const payload = z
-      .object({ selection: staySelectionSchema, providerData: z.never().optional() })
+      .object({
+        selection: staySelectionSchema,
+        providerData: z.never().optional(),
+        estimatedPricing: tripComponentPricingSnapshotSchema.optional(),
+      })
       .strict()
       .parse(reference.payload)
     const { target, configure, rooms } = payload.selection
     return {
       kind: "catalog_booking",
       catalogRef: target,
+      ...(payload.estimatedPricing ? { estimatedPricing: payload.estimatedPricing } : {}),
       metadata: {
         bookingDraftV1: {
           entity: {
@@ -559,13 +575,18 @@ function componentFromReference(
 
   if (reference.purpose === "cruise-offer") {
     const payload = z
-      .object({ selection: cruiseSelectionSchema, providerData: z.never().optional() })
+      .object({
+        selection: cruiseSelectionSchema,
+        providerData: z.never().optional(),
+        estimatedPricing: tripComponentPricingSnapshotSchema.optional(),
+      })
       .strict()
       .parse(reference.payload)
     const { target, configure } = payload.selection
     return {
       kind: "catalog_booking",
       catalogRef: target,
+      ...(payload.estimatedPricing ? { estimatedPricing: payload.estimatedPricing } : {}),
       metadata: {
         bookingDraftV1: {
           entity: {
@@ -590,6 +611,7 @@ function componentFromReference(
     .object({
       selection: z.record(z.string(), z.unknown()),
       providerData: z.record(z.string(), z.unknown()).optional(),
+      estimatedPricing: tripComponentPricingSnapshotSchema.optional(),
     })
     .strict()
     .parse(payload)
@@ -602,6 +624,7 @@ function componentFromReference(
   return reference.purpose === "flight-offer"
     ? {
         kind: "flight_placeholder",
+        ...(offer.estimatedPricing ? { estimatedPricing: offer.estimatedPricing } : {}),
         metadata: {
           flightDraft: { selectedOffer: offer.selection },
           storefrontShopping: durableSelection,
@@ -609,6 +632,7 @@ function componentFromReference(
       }
     : {
         kind: "catalog_booking",
+        ...(offer.estimatedPricing ? { estimatedPricing: offer.estimatedPricing } : {}),
         metadata: { storefrontShopping: durableSelection },
       }
 }

--- a/packages/trips/tests/shopping-opaque-references.test.ts
+++ b/packages/trips/tests/shopping-opaque-references.test.ts
@@ -199,6 +199,14 @@ describe("durable shopping opaque references", () => {
     await expect(runtime.offerResolver.resolve(CONTEXT, input)).resolves.toEqual({
       component: {
         kind: "catalog_booking",
+        estimatedPricing: {
+          currency: "EUR",
+          subtotalAmountCents: 100_000,
+          taxAmountCents: 0,
+          totalAmountCents: 100_000,
+          priceExpiresAt: "2026-08-08T12:10:00.000Z",
+          warnings: ["non_binding_storefront_estimate"],
+        },
         catalogRef: {
           entityModule: "products",
           entityId: "product_1",
@@ -452,6 +460,14 @@ function packageInput(
     owner: { userId: CONTEXT.userId, buyerAccountId: CONTEXT.buyerAccountId },
     scope: SCOPE,
     payload: {
+      estimatedPricing: {
+        currency: "EUR",
+        subtotalAmountCents: 100_000,
+        taxAmountCents: 0,
+        totalAmountCents: 100_000,
+        priceExpiresAt: offerExpiresAt,
+        warnings: ["non_binding_storefront_estimate"],
+      },
       selection: {
         target: {
           entityModule: "products",


### PR DESCRIPTION
## Summary

- preserve provider-native, non-binding shopping estimates behind opaque references
- hydrate Trip components with those estimates before itinerary freeze
- keep shopper presentation FX out of booking state; Catalog still revalidates the exact supplier selection
- cover indexed products and live flights, stays, packages, and cruises

## Root cause

Managed shopping returned a valid native package price, but the opaque offer payload dropped it. The resulting Trip component had no pricing snapshot, so `trip-selections/book` failed before Catalog could create and revalidate the composite Booking Session.

## Validation

- Storefront managed shopping: 15 tests passed
- Trips opaque references + selection/booking runtime: 36 tests passed
- targeted Biome and diff checks passed
- package typecheck was started locally but stopped after prolonged compilation to preserve host responsiveness; GitHub CI is the authoritative full typecheck
