### PR TITLE
fix: deliver staff invitations durably

### DIFF
--- a/packages/auth/src/runtime-contributor.test.ts
+++ b/packages/auth/src/runtime-contributor.test.ts
@@ -36,11 +36,51 @@ describe("auth runtime contributor", () => {
 
     expect(() => runtime.resolveDeployment({})).toThrow(/deployment\.providers\.adminAuth/)
   })
+
+  it("delivers invitation email through the provider's durable capability", async () => {
+    const sends: Array<{ payload: unknown; idempotencyKey: string }> = []
+    const host = hostWithAuthProvider("better-auth", undefined, () => [
+      {
+        name: "test-email",
+        channels: ["email"],
+        durableDelivery: {
+          protocol: "notification-provider-idempotency-v1",
+          async send(payload: unknown, context: { idempotencyKey: string }) {
+            sends.push({ payload, idempotencyKey: context.idempotencyKey })
+            return { id: "msg_1", provider: "test-email" }
+          },
+        },
+      },
+    ])
+    const contribution = createAuthRuntimePortContribution(host)
+    const runtime = contribution[identityAccessRuntimePort.id] as IdentityAccessRuntimeProvider
+    const message = {
+      acceptUrl: "https://operator.example/accept-invite?token=secret",
+      expiresInHours: 72,
+      to: "new.member@example.com",
+    }
+
+    await expect(runtime.sendInvitationEmail({}, message)).resolves.toBe(true)
+    await expect(runtime.sendInvitationEmail({}, message)).resolves.toBe(true)
+
+    expect(sends).toHaveLength(2)
+    expect(sends[0]).toMatchObject({
+      payload: {
+        channel: "email",
+        to: "new.member@example.com",
+        template: "auth.invitation",
+        subject: "You've been invited to Voyant",
+      },
+      idempotencyKey: expect.stringMatching(/^auth-invitation:/),
+    })
+    expect(sends[1]?.idempotencyKey).toBe(sends[0]?.idempotencyKey)
+  })
 })
 
 function hostWithAuthProvider(
   provider: "better-auth" | "voyant-cloud" | undefined,
   removedSharedProvider?: "better-auth" | "voyant-cloud",
+  notificationProviders?: (env: Readonly<Record<string, unknown>>) => ReadonlyArray<unknown>,
 ): {
   primitives: VoyantRuntimeHostPrimitives
 } {
@@ -55,6 +95,7 @@ function hostWithAuthProvider(
         read: (_bindings, key) => {
           if (key === "deployment.providers.adminAuth") return provider
           if (key === "deployment.providers.auth") return removedSharedProvider
+          if (key === "notificationProviders") return notificationProviders
           return undefined
         },
       },

--- a/packages/auth/src/runtime-contributor.ts
+++ b/packages/auth/src/runtime-contributor.ts
@@ -13,14 +13,34 @@ import { createGuardedTeamManagementProvider } from "./team-management-policy.js
 import { teamManagementRuntimePort } from "./team-management-runtime-port.js"
 
 interface InvitationNotificationProvider {
+  readonly name: string
   readonly channels: ReadonlyArray<string>
-  send(payload: {
-    channel: "email"
-    to: string
-    template: string
-    subject: string
-    html: string
-  }): Promise<unknown>
+  readonly durableDelivery: {
+    readonly protocol: "notification-provider-idempotency-v1"
+    send(
+      payload: {
+        channel: "email"
+        to: string
+        template: string
+        subject: string
+        html: string
+      },
+      context: { idempotencyKey: string },
+    ): Promise<unknown>
+  }
+}
+
+async function invitationDeliveryIdempotencyKey(input: {
+  acceptUrl: string
+  expiresInHours: number
+  to: string
+}): Promise<string> {
+  const canonical = JSON.stringify([input.to, input.acceptUrl, input.expiresInHours])
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(canonical))
+  const hex = Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join(
+    "",
+  )
+  return `auth-invitation:${hex}`
 }
 
 export interface AuthRuntimeContributorHost {
@@ -70,13 +90,25 @@ export function createAuthRuntimePortContribution(
       const provider = providers.find((candidate) => candidate.channels.includes("email"))
       if (!provider) return false
       try {
-        await provider.send({
-          channel: "email",
-          to: message.to,
-          template: "auth.invitation",
-          subject: "You've been invited to Voyant",
-          html: `<p>You've been invited to join a Voyant workspace.</p><p><a href="${message.acceptUrl}">Accept invitation</a></p><p>The link expires in ${message.expiresInHours} hours.</p>`,
-        })
+        const capability = provider.durableDelivery
+        if (
+          capability?.protocol !== "notification-provider-idempotency-v1" ||
+          typeof capability.send !== "function"
+        ) {
+          throw new Error(
+            `Notification provider "${provider.name}" does not expose durable delivery for Auth invitations.`,
+          )
+        }
+        await capability.send(
+          {
+            channel: "email",
+            to: message.to,
+            template: "auth.invitation",
+            subject: "You've been invited to Voyant",
+            html: `<p>You've been invited to join a Voyant workspace.</p><p><a href="${message.acceptUrl}">Accept invitation</a></p><p>The link expires in ${message.expiresInHours} hours.</p>`,
+          },
+          { idempotencyKey: await invitationDeliveryIdempotencyKey(message) },
+        )
         return true
       } catch (error) {
         console.error("[invitations] email send failed:", error)


### PR DESCRIPTION
## Summary
- adapt Auth invitation delivery to the configured provider durable-delivery contract
- derive a stable hashed idempotency key from the exact invitation payload
- add a regression proving exact replays reuse the key and never call a nonexistent bare provider method

## Verification
- `pnpm --filter @voyant-travel/auth exec vitest run src/runtime-contributor.test.ts`
- `pnpm --filter @voyant-travel/auth typecheck`
- `pnpm --filter @voyant-travel/auth test` (286 passed, 20 skipped)
- Biome and diff checks

Closes #3958. Supports #4542 and #4378.