### PR TITLE
fix(auth): make team role updates durable

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -316,6 +316,7 @@
     "@better-auth/api-key": "1.6.23",
     "@better-auth/oauth-provider": "1.6.23",
     "@hono/zod-openapi": "catalog:",
+    "@voyant-travel/action-ledger": "workspace:^",
     "@voyant-travel/core": "workspace:^",
     "@voyant-travel/db": "workspace:^",
     "@voyant-travel/distribution": "workspace:^",

--- a/packages/auth/src/mcp-runtime.ts
+++ b/packages/auth/src/mcp-runtime.ts
@@ -1,7 +1,14 @@
-import { defineToolContextContribution, requireService, ToolError } from "@voyant-travel/tools"
+import type { ActionLedgerRequestContextValues } from "@voyant-travel/action-ledger"
+import {
+  defineToolContextContribution,
+  requireService,
+  ToolError,
+  type ToolHandlerActionPolicyContext,
+} from "@voyant-travel/tools"
 import type { Context } from "hono"
 
 import { teamManagementRuntimePort } from "./team-management-runtime-port.js"
+import { executeUpdateTeamMemberRoleCommand } from "./team-member-role-command.js"
 import type { TeamManagementToolServices } from "./tools.js"
 
 export * from "./tools.js"
@@ -52,14 +59,45 @@ export const voyantToolContextContribution = defineToolContextContribution({
       listInvitations: () => runtime.listInvitations(runtimeContext),
       inviteMember: (input) => runtime.inviteMember(runtimeContext, input),
       revokeInvitation: (invitationId) => runtime.revokeInvitation(runtimeContext, invitationId),
-      updateMemberRole: (memberId, roleId) =>
-        runtime.updateMemberRole(runtimeContext, memberId, roleId),
+      async updateMemberRole(
+        memberId: string,
+        roleId: string,
+        admitted: ToolHandlerActionPolicyContext,
+      ) {
+        return executeUpdateTeamMemberRoleCommand({
+          db: runtimeContext.db,
+          context: actionLedgerContext(c),
+          admitted,
+          memberId,
+          roleId,
+          update: () => runtime.updateMemberRole(runtimeContext, memberId, roleId),
+        })
+      },
       activateMember: (memberId) => runtime.activateMember(runtimeContext, memberId),
       deactivateMember: (memberId) => runtime.deactivateMember(runtimeContext, memberId),
     }
     return { teamManagement }
   },
 })
+
+function actionLedgerContext(c: Context): ActionLedgerRequestContextValues {
+  const vars = c.var as Record<string, unknown>
+  return {
+    userId: (vars.userId as string | undefined) ?? null,
+    agentId: (vars.agentId as string | undefined) ?? null,
+    workflowPrincipalId: (vars.workflowPrincipalId as string | undefined) ?? null,
+    principalSubtype: (vars.principalSubtype as string | undefined) ?? null,
+    sessionId: (vars.sessionId as string | undefined) ?? null,
+    apiTokenId: ((vars.apiTokenId ?? vars.apiKeyId) as string | undefined) ?? null,
+    callerType: (vars.callerType as ActionLedgerRequestContextValues["callerType"]) ?? null,
+    actor: (vars.actor as ActionLedgerRequestContextValues["actor"]) ?? null,
+    isInternalRequest: (vars.isInternalRequest as boolean | undefined) ?? false,
+    organizationId: (vars.organizationId as string | undefined) ?? null,
+    workflowRunId: (vars.workflowRunId as string | undefined) ?? null,
+    workflowStepId: (vars.workflowStepId as string | undefined) ?? null,
+    correlationId: c.req.header("x-correlation-id") ?? c.req.header("x-request-id") ?? null,
+  }
+}
 
 function actingUserRequiredTeamManagement(): TeamManagementToolServices {
   const deny = async (): Promise<never> => {

--- a/packages/auth/src/team-member-role-command.ts
+++ b/packages/auth/src/team-member-role-command.ts
@@ -1,0 +1,47 @@
+import {
+  type ActionLedgerRequestContextValues,
+  executeAdmittedExistingTargetCommand,
+} from "@voyant-travel/action-ledger"
+import type { AnyDrizzleDb } from "@voyant-travel/db"
+import {
+  deriveCommandIdempotencyKey,
+  type ToolHandlerActionPolicyContext,
+  withServerResolvedIdempotencyKey,
+} from "@voyant-travel/tools"
+
+import type { TeamMemberDto } from "./team-management-runtime-port.js"
+
+/**
+ * Admit one exact desired-role command before crossing the local/cloud adapter boundary.
+ * Both adapters implement role assignment as an idempotent setter, so a replay after an
+ * ambiguous timeout safely converges on the same role instead of inventing another effect.
+ */
+export async function executeUpdateTeamMemberRoleCommand(input: {
+  db: AnyDrizzleDb
+  context: ActionLedgerRequestContextValues
+  admitted: ToolHandlerActionPolicyContext
+  memberId: string
+  roleId: string
+  update(): Promise<TeamMemberDto>
+}) {
+  const commandInput = { memberId: input.memberId, roleId: input.roleId }
+  const resolvedAdmitted = withServerResolvedIdempotencyKey(
+    input.admitted,
+    await deriveCommandIdempotencyKey("update-team-member-role", commandInput),
+  )
+  const result = await executeAdmittedExistingTargetCommand(
+    {
+      db: input.db,
+      context: input.context,
+      admitted: resolvedAdmitted,
+      commandInput,
+      evaluatedRisk: "high",
+    },
+    {
+      prepare: () => Promise.resolve(),
+      execute: input.update,
+      replay: input.update,
+    },
+  )
+  return result.value
+}

--- a/packages/auth/src/tools.ts
+++ b/packages/auth/src/tools.ts
@@ -1,9 +1,12 @@
 import {
+  admitHandlerActionPolicy,
   defineTool,
+  type HandlerActionPolicyExpectation,
   READ_ONLY_RISK,
   requireService,
   type ToolContext,
   ToolError,
+  type ToolHandlerActionPolicyContext,
 } from "@voyant-travel/tools"
 import { z } from "zod"
 
@@ -77,6 +80,28 @@ const updateMemberRoleInputSchema = memberIdInputSchema.extend({
 const actingUserRequirement =
   " Requires an authenticated acting staff user; organization-only grants are rejected."
 
+export const UPDATE_TEAM_MEMBER_ROLE_HANDLER_POLICY = {
+  capabilityId: "@voyant-travel/auth#team.tool.update-member-role",
+  capabilityVersion: "v1",
+  canonicalName: "update_team_member_role",
+  actionPolicy: {
+    id: "@voyant-travel/auth#team.action.update-member-role",
+    capabilityId: "@voyant-travel/auth#team.action.update-member-role",
+    version: "v1",
+    kind: "execute",
+    targetType: "team-member",
+    commandTargetField: "memberId",
+    targetLifecycle: "existing",
+    existingTarget: { durability: "handler-command-result-v1" },
+    risk: "high",
+    ledger: "required",
+    approval: "required",
+    policy: "@voyant-travel/auth#team.action.update-member-role",
+    reversible: true,
+    allowedActorTypes: ["staff"],
+  },
+} as const satisfies HandlerActionPolicyExpectation
+
 export interface TeamManagementToolServices {
   getCapabilities(): Promise<TeamManagementCapabilitiesDto>
   listMembers(): Promise<TeamMemberDto[]>
@@ -84,7 +109,11 @@ export interface TeamManagementToolServices {
   listInvitations(): Promise<TeamInvitationDto[]>
   inviteMember(input: InviteTeamMemberInput): Promise<CreatedTeamInvitationDto>
   revokeInvitation(invitationId: string): Promise<void>
-  updateMemberRole(memberId: string, roleId: string): Promise<TeamMemberDto>
+  updateMemberRole(
+    memberId: string,
+    roleId: string,
+    admitted: ToolHandlerActionPolicyContext,
+  ): Promise<TeamMemberDto>
   activateMember(memberId: string): Promise<TeamMemberDto>
   deactivateMember(memberId: string): Promise<TeamMemberDto>
 }
@@ -240,6 +269,8 @@ export const updateTeamMemberRoleTool = defineTool<
   TeamMemberDto,
   TeamManagementToolContext
 >({
+  capabilityId: UPDATE_TEAM_MEMBER_ROLE_HANDLER_POLICY.capabilityId,
+  capabilityVersion: UPDATE_TEAM_MEMBER_ROLE_HANDLER_POLICY.capabilityVersion,
   name: "update_team_member_role",
   description:
     "Change a team member's role and effective access. Requires explicit confirmation." +
@@ -248,6 +279,8 @@ export const updateTeamMemberRoleTool = defineTool<
   outputSchema: teamMemberSchema,
   requiredScopes: ["team:write"],
   tier: "sensitive",
+  resolvesIdempotencyKeyServerSide: true,
+  actionPolicyEnforcement: "handler",
   riskPolicy: {
     destructive: false,
     reversible: true,
@@ -255,8 +288,10 @@ export const updateTeamMemberRoleTool = defineTool<
     confirmationRequired: true,
     sideEffects: ["data-write"],
   },
+  annotations: { idempotentHint: true },
   async handler({ memberId, roleId }, ctx) {
-    return teamManagement(ctx).updateMemberRole(memberId, roleId)
+    const admitted = admitHandlerActionPolicy(ctx, UPDATE_TEAM_MEMBER_ROLE_HANDLER_POLICY)
+    return teamManagement(ctx).updateMemberRole(memberId, roleId, admitted)
   },
 })
 

--- a/packages/auth/src/voyant.ts
+++ b/packages/auth/src/voyant.ts
@@ -382,11 +382,13 @@ export const authTeamVoyantModule = defineModule({
       kind: "execute",
       targetType: "team-member",
       commandTargetField: "memberId",
-      availability: {
-        status: "unavailable",
-        reasonCode: "unsafe-nontransactional-effect",
-      },
+      targetLifecycle: "existing",
+      existingTarget: { durability: "handler-command-result-v1" },
       effectBoundary: "multistage",
+      durability: {
+        strategy: "saga",
+        testReference: "packages/auth/tests/integration/team-member-role-command.test.ts",
+      },
       resource: "team",
       action: "write",
       requiredScopes: ["team:write"],

--- a/packages/auth/tests/integration/team-member-role-command.test.ts
+++ b/packages/auth/tests/integration/team-member-role-command.test.ts
@@ -1,0 +1,181 @@
+import { actionLedgerService } from "@voyant-travel/action-ledger"
+import {
+  createToolRegistry,
+  defineTool,
+  type ToolHandlerActionPolicyContext,
+} from "@voyant-travel/tools"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+import { z } from "zod"
+
+import { executeUpdateTeamMemberRoleCommand } from "../../src/team-member-role-command.js"
+import { UPDATE_TEAM_MEMBER_ROLE_HANDLER_POLICY as POLICY } from "../../src/tools.js"
+
+const DB_AVAILABLE = Boolean(process.env.TEST_DATABASE_URL)
+const requestContext = {
+  userId: "user_team_role_actor",
+  agentId: null,
+  workflowPrincipalId: null,
+  principalSubtype: null,
+  sessionId: "session_team_role",
+  apiTokenId: null,
+  callerType: "human" as const,
+  actor: "staff" as const,
+  isInternalRequest: false,
+  organizationId: "organization_team_role",
+  workflowRunId: null,
+  workflowStepId: null,
+  correlationId: "correlation_team_role",
+}
+
+describe.skipIf(!DB_AVAILABLE)("durable team member role command", () => {
+  let db: ReturnType<typeof import("@voyant-travel/db/test-utils").createTestDb>
+
+  beforeAll(async () => {
+    const { createTestDb } = await import("@voyant-travel/db/test-utils")
+    db = createTestDb()
+  })
+
+  beforeEach(async () => {
+    const { cleanupTestDb } = await import("@voyant-travel/db/test-utils")
+    await cleanupTestDb(db)
+  })
+
+  afterAll(async () => {
+    const { closeTestDb } = await import("@voyant-travel/db/test-utils")
+    await closeTestDb()
+  })
+
+  it("recovers an ambiguous desired-role setter without accepting command drift", async () => {
+    const initial = await mintAdmission({ confirmed: true })
+    const command = {
+      db,
+      context: requestContext,
+      admitted: initial,
+      memberId: "member_2",
+      roleId: "admin",
+    }
+    const approvalError = await executeUpdateTeamMemberRoleCommand({
+      ...command,
+      update: async () => member("editor"),
+    }).catch((error) => error as { code?: string; meta?: Record<string, unknown> })
+    expect(approvalError).toMatchObject({ code: "APPROVAL_REQUIRED" })
+    const approvalId = String(approvalError.meta?.approvalId ?? "")
+    const idempotencyFingerprint = String(approvalError.meta?.idempotencyFingerprint ?? "")
+    expect(approvalId).not.toBe("")
+    expect(idempotencyFingerprint).not.toBe("")
+
+    await actionLedgerService.decideApproval(db, {
+      id: approvalId,
+      status: "approved",
+      decidedByPrincipalId: "user_team_role_approver",
+      decisionAction: {
+        actionName: "@voyant-travel/auth#team.action.approve-role-test",
+        actionVersion: "v1",
+        principalType: "user",
+        principalId: "user_team_role_approver",
+        organizationId: requestContext.organizationId,
+      },
+    })
+    const approved = await mintAdmission({
+      confirmed: true,
+      approvalId,
+      idempotencyFingerprint,
+    })
+
+    let roleId = "editor"
+    let dispatches = 0
+    const update = async () => {
+      dispatches += 1
+      roleId = "admin"
+      if (dispatches === 1) throw new Error("response lost after provider accepted role")
+      return member(roleId)
+    }
+    await expect(
+      executeUpdateTeamMemberRoleCommand({ ...command, admitted: approved, update }),
+    ).rejects.toThrow(/response lost/)
+    await expect(
+      executeUpdateTeamMemberRoleCommand({ ...command, admitted: approved, update }),
+    ).resolves.toMatchObject({ id: "member_2", roleId: "admin" })
+
+    expect(roleId).toBe("admin")
+    expect(dispatches).toBe(2)
+    await expect(
+      executeUpdateTeamMemberRoleCommand({
+        ...command,
+        admitted: approved,
+        roleId: "viewer",
+        update: async () => member("viewer"),
+      }),
+    ).rejects.toThrow()
+    expect(roleId).toBe("admin")
+  })
+})
+
+async function mintAdmission(
+  invocation: Record<string, string | boolean>,
+): Promise<ToolHandlerActionPolicyContext> {
+  let admitted: ToolHandlerActionPolicyContext | undefined
+  const registry = createToolRegistry()
+  registry.register(
+    defineTool({
+      capabilityId: POLICY.capabilityId,
+      capabilityVersion: POLICY.capabilityVersion,
+      name: POLICY.canonicalName,
+      description: "Mint an authentic team role command admission for integration coverage.",
+      inputSchema: z.object({}),
+      outputSchema: z.object({ ok: z.literal(true) }),
+      requiredScopes: [],
+      audience: { source: "grant", allowed: ["staff"] },
+      tier: "sensitive",
+      riskPolicy: {
+        destructive: false,
+        reversible: true,
+        dryRunSupported: false,
+        confirmationRequired: true,
+        sideEffects: ["data-write"],
+      },
+      actionPolicyEnforcement: "handler",
+      async handler(_args, context) {
+        admitted = context.handlerActionPolicy
+        return { ok: true as const }
+      },
+    }),
+    { actionPolicy: POLICY.actionPolicy },
+  )
+  const manifest = registry.list()[0]
+  if (!manifest?.actionPolicy) throw new Error("team role action policy missing")
+  await registry.dispatch(
+    POLICY.canonicalName,
+    {},
+    {
+      db: {},
+      actor: "staff",
+      audience: "staff",
+      tenantId: requestContext.organizationId,
+      organizationId: requestContext.organizationId,
+      resolverScope: { locale: "en-GB", audience: "staff", market: "default", actor: "staff" },
+      handlerActionPolicy: {
+        capabilityId: manifest.capabilityId,
+        capabilityVersion: manifest.capabilityVersion,
+        canonicalName: manifest.name,
+        actionPolicy: manifest.actionPolicy,
+        invocation,
+      },
+    },
+  )
+  if (!admitted) throw new Error("Tool registry did not mint team role admission")
+  return admitted
+}
+
+function member(roleId: string) {
+  return {
+    id: "member_2",
+    email: "member@example.com",
+    name: "Member",
+    roleId,
+    roleName: roleId,
+    status: "active" as const,
+    joinedAt: null,
+    lastActivityAt: null,
+  }
+}

--- a/packages/auth/tests/tools.test.ts
+++ b/packages/auth/tests/tools.test.ts
@@ -7,6 +7,8 @@ import {
   type TeamManagementToolContext,
   type TeamManagementToolServices,
   teamManagementTools,
+  UPDATE_TEAM_MEMBER_ROLE_HANDLER_POLICY,
+  updateTeamMemberRoleTool,
 } from "../src/tools.js"
 
 const member = {
@@ -64,10 +66,36 @@ function services(): TeamManagementToolServices {
   }
 }
 
+function teamRegistry() {
+  const registry = createToolRegistry()
+  for (const tool of teamManagementTools) {
+    registry.register(
+      tool,
+      tool.name === "update_team_member_role"
+        ? { actionPolicy: UPDATE_TEAM_MEMBER_ROLE_HANDLER_POLICY.actionPolicy }
+        : undefined,
+    )
+  }
+  return registry
+}
+
+function updateRoleAdmission(
+  registry: ReturnType<typeof createToolRegistry>,
+): ToolContext["handlerActionPolicy"] {
+  const manifest = registry.list().find(({ name }) => name === "update_team_member_role")
+  if (!manifest?.actionPolicy) throw new Error("update role action policy was not registered")
+  return {
+    capabilityId: manifest.capabilityId,
+    capabilityVersion: manifest.capabilityVersion,
+    canonicalName: manifest.name,
+    actionPolicy: manifest.actionPolicy,
+    invocation: { approvalId: "approval_1", idempotencyFingerprint: "fingerprint_1" },
+  }
+}
+
 describe("auth team-management tools", () => {
   it("registers provider-neutral reads and confirmation-gated access writes", () => {
-    const registry = createToolRegistry()
-    registry.registerAll(teamManagementTools)
+    const registry = teamRegistry()
 
     expect(
       registry
@@ -102,6 +130,11 @@ describe("auth team-management tools", () => {
       tier: "destructive",
       riskPolicy: { destructive: true, reversible: false, confirmationRequired: true },
     })
+    expect(updateTeamMemberRoleTool).toMatchObject({
+      actionPolicyEnforcement: "handler",
+      resolvesIdempotencyKeyServerSide: true,
+      annotations: { idempotentHint: true },
+    })
     expect(
       registry
         .list()
@@ -111,9 +144,8 @@ describe("auth team-management tools", () => {
 
   it("delegates every operation to the injected guarded runtime service", async () => {
     const runtime = services()
-    const registry = createToolRegistry()
-    registry.registerAll(teamManagementTools)
-    const ctx = toolContext(runtime)
+    const registry = teamRegistry()
+    const ctx = { ...toolContext(runtime), handlerActionPolicy: updateRoleAdmission(registry) }
 
     await expect(registry.dispatch("list_team_members", {}, ctx)).resolves.toEqual([member])
     await expect(
@@ -140,14 +172,13 @@ describe("auth team-management tools", () => {
       expiresInDays: 5,
     })
     expect(runtime.revokeInvitation).toHaveBeenCalledWith("invitation_1")
-    expect(runtime.updateMemberRole).toHaveBeenCalledWith("member_1", "admin")
+    expect(runtime.updateMemberRole).toHaveBeenCalledWith("member_1", "admin", expect.any(Object))
     expect(runtime.activateMember).toHaveBeenCalledWith("member_1")
     expect(runtime.deactivateMember).toHaveBeenCalledWith("member_1")
   })
 
   it("denies non-staff callers and missing service wiring", async () => {
-    const registry = createToolRegistry()
-    registry.registerAll(teamManagementTools)
+    const registry = teamRegistry()
 
     await expect(
       registry.dispatch("list_team_members", {}, toolContext(services(), "customer")),
@@ -201,8 +232,7 @@ describe("auth team-management tools", () => {
       context: toolContext(),
       resources: { [teamManagementRuntimePort.id]: services() },
     })
-    const registry = createToolRegistry()
-    registry.registerAll(teamManagementTools)
+    const registry = teamRegistry()
 
     await expect(
       registry.dispatch(

--- a/packages/auth/tests/unit/mcp-runtime-durable-role.test.ts
+++ b/packages/auth/tests/unit/mcp-runtime-durable-role.test.ts
@@ -1,0 +1,120 @@
+import { createToolRegistry, type ToolContext } from "@voyant-travel/tools"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const executeAdmittedExistingTargetCommand = vi.hoisted(() => vi.fn())
+
+vi.mock("@voyant-travel/action-ledger", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@voyant-travel/action-ledger")>()),
+  executeAdmittedExistingTargetCommand,
+}))
+
+import { voyantToolContextContribution } from "../../src/mcp-runtime.js"
+import { teamManagementRuntimePort } from "../../src/team-management-runtime-port.js"
+import {
+  type TeamManagementToolContext,
+  UPDATE_TEAM_MEMBER_ROLE_HANDLER_POLICY,
+  updateTeamMemberRoleTool,
+} from "../../src/tools.js"
+
+const member = {
+  id: "member_2",
+  email: "member@example.com",
+  name: "Member",
+  roleId: "admin",
+  roleName: "Admin",
+  status: "active" as const,
+  joinedAt: null,
+  lastActivityAt: null,
+}
+
+describe("Auth MCP durable team role command", () => {
+  beforeEach(() => {
+    executeAdmittedExistingTargetCommand.mockReset()
+    executeAdmittedExistingTargetCommand.mockImplementation(async (_input, handlers) => ({
+      replayed: false,
+      command: { claimActionId: "claim_1" },
+      value: await handlers.execute(),
+    }))
+  })
+
+  it("derives command identity and enters the ledger before changing provider state", async () => {
+    const updateMemberRole = vi.fn(async () => member)
+    const db = { kind: "transactional-db" }
+    const request = {
+      env: { DEPLOYMENT: "local" },
+      var: { userId: "user_1", actor: "staff" },
+      get(key: string) {
+        return key === "userId" ? "user_1" : key === "db" ? db : undefined
+      },
+      req: { header: () => undefined },
+    }
+    const contribution = await voyantToolContextContribution.contribute({
+      request,
+      context: context(),
+      resources: {
+        [teamManagementRuntimePort.id]: {
+          updateMemberRole,
+        },
+      },
+    })
+    const registry = createToolRegistry()
+    registry.register(updateTeamMemberRoleTool, {
+      actionPolicy: UPDATE_TEAM_MEMBER_ROLE_HANDLER_POLICY.actionPolicy,
+    })
+    const manifest = registry.list()[0]
+    if (!manifest?.actionPolicy) throw new Error("role command policy missing")
+
+    await expect(
+      registry.dispatch(
+        "update_team_member_role",
+        { memberId: "member_2", roleId: "admin" },
+        {
+          ...context(),
+          teamManagement: contribution.teamManagement,
+          handlerActionPolicy: {
+            capabilityId: manifest.capabilityId,
+            capabilityVersion: manifest.capabilityVersion,
+            canonicalName: manifest.name,
+            actionPolicy: manifest.actionPolicy,
+            invocation: {
+              approvalId: "approval_1",
+              idempotencyFingerprint: "fingerprint_1",
+            },
+          },
+        },
+      ),
+    ).resolves.toEqual(member)
+
+    expect(executeAdmittedExistingTargetCommand).toHaveBeenCalledOnce()
+    const [command] = executeAdmittedExistingTargetCommand.mock.calls[0] ?? []
+    expect(command).toMatchObject({
+      db,
+      commandInput: { memberId: "member_2", roleId: "admin" },
+      evaluatedRisk: "high",
+      admitted: {
+        capabilityId: UPDATE_TEAM_MEMBER_ROLE_HANDLER_POLICY.capabilityId,
+        invocation: { idempotencyKey: expect.stringMatching(/^update-team-member-role:v1:/) },
+      },
+    })
+    expect(updateMemberRole).toHaveBeenCalledWith(
+      { bindings: request.env, db, userId: "user_1" },
+      "member_2",
+      "admin",
+    )
+  })
+})
+
+function context(): TeamManagementToolContext {
+  return {
+    db: {},
+    actor: "staff",
+    audience: "staff",
+    tenantId: "operator_1",
+    resolverScope: {
+      locale: "en-GB",
+      audience: "staff",
+      market: "default",
+      actor: "staff",
+    },
+  } satisfies ToolContext
+}

--- a/packages/auth/tests/unit/voyant-manifest.test.ts
+++ b/packages/auth/tests/unit/voyant-manifest.test.ts
@@ -160,6 +160,19 @@ describe("auth identity/access deployment manifests", () => {
       },
       effectBoundary: "multistage",
     })
+    expect(
+      authTeamVoyantModule.actions?.find(
+        ({ id }) => id === "@voyant-travel/auth#team.action.update-member-role",
+      ),
+    ).toMatchObject({
+      targetLifecycle: "existing",
+      existingTarget: { durability: "handler-command-result-v1" },
+    })
+    expect(
+      authTeamVoyantModule.actions?.find(
+        ({ id }) => id === "@voyant-travel/auth#team.action.update-member-role",
+      ),
+    ).not.toHaveProperty("availability")
     expect(authTeamVoyantModule.access?.resources[0]).toMatchObject({
       wildcard: "explicit-resource",
       actions: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1376,6 +1376,9 @@ importers:
       '@hono/zod-openapi':
         specifier: 'catalog:'
         version: 1.4.0(hono@4.12.25)(zod@4.4.3)
+      '@voyant-travel/action-ledger':
+        specifier: workspace:^
+        version: link:../action-ledger
       '@voyant-travel/core':
         specifier: workspace:^
         version: link:../core


### PR DESCRIPTION
## What changed

- expose `update_team_member_role` as a handler-owned existing-target command
- derive command identity server-side and require the selected-graph approval policy
- converge exact retries through the local/cloud desired-role setter while rejecting command drift
- keep invite, revoke, activate, and deactivate unavailable under #4542

## Why

The role mutation was hidden from MCP because it crossed a non-transactional adapter boundary without a durable command protocol. The role APIs are desired-state setters (including cloud PUT), so an exact retry can safely converge on the approved role after an ambiguous response.

This does not claim provider dispatch at-most-once: an ambiguous exact replay may send the same idempotent setter again. #4542 remains open for the other team mutations and stricter external-effect semantics.

## Validation

- real Postgres integration test: approval, response loss after accepted role, exact replay, and drift rejection
- `pnpm --filter @voyant-travel/auth typecheck`
- `pnpm --filter @voyant-travel/auth test`
- targeted Biome check
- `pnpm --filter operator prepare:verify`
- `pnpm verify:architecture`

Refs #4542
Refs #4378