### PR TITLE
test(mcp): add team role capability journey

### DIFF
--- a/apps/operator/tests/mcp-capability.test.ts
+++ b/apps/operator/tests/mcp-capability.test.ts
@@ -62,6 +62,7 @@ import { contractsService, policiesService } from "@voyant-travel/legal"
 import { operatorProfile } from "@voyant-travel/operator-settings/schema"
 import { proposalsService, tripSnapshotToProposalVersionApply } from "@voyant-travel/proposals"
 import { tripsService } from "@voyant-travel/trips"
+import { scopesForRole } from "@voyant-travel/types/member-roles"
 import { sql as sqlRaw } from "drizzle-orm"
 import { Hono } from "hono"
 import { afterAll, beforeAll, describe, expect, it } from "vitest"
@@ -818,6 +819,18 @@ function buildJourneys(RUN_MARK: string): CapabilityJourney[] {
       maxCalls: 10,
       requiresDispatch: true,
     },
+    {
+      id: "team-role-update",
+      group: "team-admin",
+      domain: "team",
+      task: `Change the active team member Role Candidate ${RUN_MARK} (role.candidate.${RUN_MARK}@capability.example) from Editor to Viewer. Complete any required approval and confirm the saved role.`,
+      expect: "viewer",
+      maxCalls: 16,
+      verify: `select 1 from user_profiles
+             where id = 'user_team_role_${RUN_MARK}'
+               and is_super_admin = false
+               and permissions = '["*:read", "*:search"]'::jsonb`,
+    },
   ]
 }
 
@@ -1011,7 +1024,7 @@ async function seedContractJourney(journeyId: string, mark: string): Promise<voi
 }
 
 /** Staff authority and ordinary operator configuration for isolated admin jobs. */
-async function seedTeamAdminJourney(journeyId: string): Promise<void> {
+async function seedTeamAdminJourney(journeyId: string, mark: string): Promise<void> {
   if (!verifyDb) throw new Error("Capability eval database is not mounted")
   const now = new Date()
   await verifyDb
@@ -1053,6 +1066,41 @@ async function seedTeamAdminJourney(journeyId: string): Promise<void> {
       supportedLocales: ["en"],
       defaultLocale: "en",
     })
+  }
+  if (journeyId === "team-role-update") {
+    const targetUserId = `user_team_role_${mark}`
+    await verifyDb
+      .insert(authUser)
+      .values({
+        id: targetUserId,
+        name: `Role Candidate ${mark}`,
+        email: `role.candidate.${mark}@capability.example`,
+        emailVerified: true,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoNothing()
+    await verifyDb
+      .insert(userProfilesTable)
+      .values({
+        id: targetUserId,
+        firstName: "Role",
+        lastName: `Candidate ${mark}`,
+        isSuperAdmin: false,
+        permissions: scopesForRole("editor"),
+      })
+      .onConflictDoNothing()
+    await verifyDb
+      .insert(authAccount)
+      .values({
+        id: `account_team_role_${mark}`,
+        accountId: targetUserId,
+        providerId: "credential",
+        userId: targetUserId,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoNothing()
   }
 }
 
@@ -1538,7 +1586,7 @@ describe.skipIf(!enabled)("MCP capability — a travel agent's job", () => {
           if (journey.group === "amendment") await seedBookingAmendment(mark)
           if (journey.group === "supplier") await seedSupplierJourney(journey.id, mark)
           if (journey.group === "contract") await seedContractJourney(journey.id, mark)
-          if (journey.group === "team-admin") await seedTeamAdminJourney(journey.id)
+          if (journey.group === "team-admin") await seedTeamAdminJourney(journey.id, mark)
           if (journey.id === "proposal-accept") await seedProposalAcceptance(mark)
           if (journey.id === "paid-refund") await seedPaidCancellationRefund(mark)
           let run: JourneyRun


### PR DESCRIPTION
## What changed

- add an independently seeded `team-role-update` journey to the real-model `team-admin` group
- seed a distinct active Editor target while retaining the full-access evaluator actor
- ask GPT-5.6 Terra to complete approval and change that member to Viewer
- grade the result from the exact persisted Viewer permission set, not model prose

## Why

#4544 made `update_team_member_role` honestly discoverable through the selected graph. The capability harness now needs to exercise that Tool as an operator job and verify durable state.

## Validation

- `pnpm --filter operator typecheck`
- targeted Biome check
- `pnpm --filter operator exec vitest run --config .voyant/vitest.config.ts --passWithNoTests --maxWorkers=4` (14 files passed, 1 skipped; 70 tests passed, 15 skipped)
- live selected-graph Terra smoke reached graph generation, 33 migrations, fixture seeding, JSON-RPC initialization, and Tool discovery; the model transport then returned the account-level 429 `credit_balance_exhausted` before any Tool call
- artifact: `.agent-runs/mcp-capability/2026-08-10T13-18-10.550Z/report.json`

Refs #4542
Refs #4378