### PR TITLE
feat(mcp): run capability evaluation through Codex

### DIFF
--- a/apps/operator/tests/mcp-capability.test.ts
+++ b/apps/operator/tests/mcp-capability.test.ts
@@ -47,9 +47,11 @@
  * the product before the departure — because that dependency is exactly what an
  * endpoint-shaped surface makes hard and what #3921 is trying to fix.
  */
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
-import { homedir } from "node:os"
+import { spawn } from "node:child_process"
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { homedir, tmpdir } from "node:os"
 import { dirname, join, resolve } from "node:path"
+import { type ServerType, serve } from "@hono/node-server"
 import { bookingActivityLog, bookings, bookingTravelers } from "@voyant-travel/bookings/schema"
 import { createDbClient } from "@voyant-travel/db"
 import { authAccount, authUser, userProfilesTable } from "@voyant-travel/db/schema/iam"
@@ -88,10 +90,11 @@ function resolveKey(): string | undefined {
   }
 }
 const apiKey = resolveKey()
+const EVAL_PROVIDER = process.env.VOYANT_EVAL_PROVIDER ?? "codex"
 const MODEL = process.env.VOYANT_EVAL_MODEL ?? "gpt-5.6-terra"
 const REASONING_EFFORT = "medium"
 const REPORT_FILE = process.env.VOYANT_EVAL_REPORT_FILE?.trim()
-const enabled = Boolean(TEST_DATABASE_URL && apiKey)
+const enabled = Boolean(TEST_DATABASE_URL && (EVAL_PROVIDER === "codex" || apiKey))
 
 /** A live model turn plus a real dispatch is slow; the default would time out on latency. */
 const JOURNEY_TIMEOUT_MS = 180_000
@@ -133,6 +136,9 @@ async function readRpc(res: Response): Promise<Record<string, unknown>> {
 
 /** Mount the real selected-graph MCP behind a full-scope staff key and a REAL db. */
 let verifyDb: ReturnType<typeof createDbClient> | undefined
+let codexServer: ServerType | undefined
+let codexServerUrl: string | undefined
+let activeCodexCalls: ToolCallRecord[] | undefined
 
 async function mountRealMcp(): Promise<Hono> {
   const db = createDbClient(TEST_DATABASE_URL as string, {
@@ -170,6 +176,50 @@ async function mountRealMcp(): Promise<Hono> {
   return app
 }
 
+async function startCodexMcpServer(app: Hono): Promise<string> {
+  return new Promise<string>((resolvePromise, reject) => {
+    codexServer = serve(
+      {
+        hostname: "127.0.0.1",
+        port: 0,
+        fetch: async (request) => {
+          const requestBody = (await request
+            .clone()
+            .json()
+            .catch(() => undefined)) as
+            | { method?: string; params?: { name?: string; arguments?: Record<string, unknown> } }
+            | undefined
+          const response = await app.fetch(request, TEST_ENV, TEST_CTX)
+          if (requestBody?.method === "tools/call" && activeCodexCalls) {
+            const rpcBody = await readRpc(response.clone())
+            const result = rpcBody.result as
+              | {
+                  isError?: boolean
+                  content?: Array<{ text?: string }>
+                  structuredContent?: unknown
+                }
+              | undefined
+            const fullText =
+              result?.structuredContent !== undefined
+                ? JSON.stringify(result.structuredContent)
+                : (result?.content?.[0]?.text ?? JSON.stringify(rpcBody))
+            activeCodexCalls.push({
+              name: String(requestBody.params?.name ?? "unknown"),
+              args: requestBody.params?.arguments ?? {},
+              isError: result?.isError === true,
+              responseBytes: Buffer.byteLength(fullText, "utf8"),
+              snippet: fullText.slice(0, 300),
+            })
+          }
+          return response
+        },
+      },
+      ({ port }) => resolvePromise(`http://127.0.0.1:${port}/`),
+    )
+    codexServer.once("error", reject)
+  })
+}
+
 interface ToolCallRecord {
   name: string
   args: Record<string, unknown>
@@ -199,6 +249,7 @@ async function runJourney(input: {
   /** The server's own `instructions`, exactly as a real MCP client surfaces them. */
   serverInstructions: string
 }): Promise<JourneyRun> {
+  if (EVAL_PROVIDER === "codex") return runCodexJourney(input)
   const instructions =
     "You are the back-office agent for a travel operator, connected to its MCP server. " +
     "Use the tools to actually perform the work end to end. Never invent data. If a write " +
@@ -322,6 +373,113 @@ async function runJourney(input: {
     nextInput = functionOutputs
   }
   return { calls, answer: "", tokens, exhausted: true, modelTransportRetries }
+}
+
+async function runCodexJourney(input: {
+  task: string
+  maxCalls: number
+  serverInstructions: string
+}): Promise<JourneyRun> {
+  if (!codexServerUrl) throw new Error("Codex MCP bridge is not running")
+  const calls: ToolCallRecord[] = []
+  activeCodexCalls = calls
+  const workspace = mkdtempSync(join(tmpdir(), "voyant-codex-mcp-eval-"))
+  const prompt =
+    "You are the back-office agent for a travel operator. Use only the voyant MCP tools " +
+    "to perform the requested work; do not use shell commands or inspect local files. " +
+    `Use at most ${input.maxCalls} MCP tool calls. Never invent data. If a write requires ` +
+    "confirmation or approval, follow the model-visible remediation and complete it. " +
+    `Finish with a concise durable outcome.\n\n${input.serverInstructions}\n\nTask: ${input.task}`
+  try {
+    const result = await spawnCodex([
+      "exec",
+      "--ephemeral",
+      "--ignore-user-config",
+      "--skip-git-repo-check",
+      "--sandbox",
+      "read-only",
+      "--cd",
+      workspace,
+      "--model",
+      MODEL,
+      "-c",
+      `model_reasoning_effort=${JSON.stringify(REASONING_EFFORT)}`,
+      "--json",
+      "-c",
+      `mcp_servers.voyant.url=${JSON.stringify(codexServerUrl)}`,
+      prompt,
+    ])
+    let answer = ""
+    let tokens = 0
+    for (const line of result.stdout.split("\n")) {
+      if (!line.trim()) continue
+      try {
+        const event = JSON.parse(line) as {
+          type?: string
+          item?: { type?: string; text?: string }
+          usage?: { input_tokens?: number; output_tokens?: number }
+        }
+        if (event.type === "item.completed" && event.item?.type === "agent_message") {
+          answer = event.item.text ?? answer
+        }
+        if (event.type === "turn.completed") {
+          tokens += (event.usage?.input_tokens ?? 0) + (event.usage?.output_tokens ?? 0)
+        }
+      } catch {
+        // Codex diagnostics can share stderr/stdout; retain them only on failure.
+      }
+    }
+    const exhausted = calls.length > input.maxCalls || result.exitCode !== 0
+    return {
+      calls,
+      answer: answer || (result.exitCode === 0 ? "" : `FATAL: ${result.stderr.slice(0, 300)}`),
+      tokens,
+      exhausted,
+      modelTransportRetries: 0,
+      ...(result.exitCode === 0
+        ? {}
+        : {
+            fatal: {
+              source: "model_transport" as const,
+              status: null,
+              code: "codex_exec_failed",
+              message: result.stderr.slice(0, 300),
+            },
+          }),
+    }
+  } finally {
+    activeCodexCalls = undefined
+    rmSync(workspace, { recursive: true, force: true })
+  }
+}
+
+function spawnCodex(args: string[]): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  return new Promise((resolvePromise, reject) => {
+    const env = { ...process.env }
+    for (const key of [
+      "DATABASE_URL",
+      "TEST_DATABASE_URL",
+      "OPENAI_API_KEY",
+      "VOYANT_API_KEY",
+      "POSTGRES_SEARCH_CURSOR_SIGNING_KEY",
+    ])
+      delete env[key]
+    const child = spawn("codex", args, { env, stdio: ["ignore", "pipe", "pipe"] })
+    const stdout: Buffer[] = []
+    const stderr: Buffer[] = []
+    child.stdout.on("data", (chunk) => stdout.push(chunk))
+    child.stderr.on("data", (chunk) => stderr.push(chunk))
+    child.once("error", reject)
+    const timeout = setTimeout(() => child.kill("SIGTERM"), JOURNEY_TIMEOUT_MS)
+    child.once("close", (exitCode) => {
+      clearTimeout(timeout)
+      resolvePromise({
+        exitCode: exitCode ?? 1,
+        stdout: Buffer.concat(stdout).toString("utf8"),
+        stderr: Buffer.concat(stderr).toString("utf8"),
+      })
+    })
+  })
 }
 
 function parseModelFailure(status: number, responseText: string): NonNullable<JourneyRun["fatal"]> {
@@ -1477,9 +1635,10 @@ function writeMachineReport(): void {
     `${JSON.stringify(
       {
         schemaVersion: 5,
+        provider: EVAL_PROVIDER,
         generatedAt: new Date().toISOString(),
         model: MODEL,
-        reasoningEffort: MODEL.startsWith("gpt-5") ? REASONING_EFFORT : null,
+        reasoningEffort: REASONING_EFFORT,
         runMark: RUN_MARK,
         configuredRuns: RUNS,
         journeys,
@@ -1524,6 +1683,10 @@ describe.skipIf(!enabled)("MCP capability — a travel agent's job", () => {
     async () => {
       if (!enabled) return
       const app = await mountRealMcp()
+      if (EVAL_PROVIDER === "codex") {
+        codexServerUrl = await startCodexMcpServer(app)
+        process.stdout.write(`Codex MCP bridge: ${codexServerUrl}\n`)
+      }
       // Invoice numbering is deployment configuration, not part of the travel
       // agent's request to issue a proforma. A real agency configures this before
       // taking bookings; an empty disposable database does not. Seed the same
@@ -1647,6 +1810,8 @@ describe.skipIf(!enabled)("MCP capability — a travel agent's job", () => {
   )
 
   afterAll(async () => {
+    if (codexServer)
+      await new Promise<void>((resolvePromise) => codexServer?.close(() => resolvePromise()))
     const dispose = dbClientDispose(verifyDb)
     if (dispose) await dispose()
   })

--- a/apps/operator/tests/mcp-capability.test.ts
+++ b/apps/operator/tests/mcp-capability.test.ts
@@ -398,6 +398,8 @@ async function runCodexJourney(input: {
       "--skip-git-repo-check",
       "--sandbox",
       "read-only",
+      "-c",
+      'approval_policy="never"',
       "--cd",
       workspace,
       "--model",
@@ -407,6 +409,10 @@ async function runCodexJourney(input: {
       "--json",
       "-c",
       `mcp_servers.voyant.url=${JSON.stringify(codexServerUrl)}`,
+      "-c",
+      'mcp_servers.voyant.approval_mode="approve"',
+      "-c",
+      'mcp_servers.voyant.tools.call_tool.approval_mode="approve"',
       prompt,
     ])
     let answer = ""
@@ -416,11 +422,16 @@ async function runCodexJourney(input: {
       try {
         const event = JSON.parse(line) as {
           type?: string
-          item?: { type?: string; text?: string }
+          item?: { type?: string; text?: string; status?: string; error?: unknown; tool?: string }
           usage?: { input_tokens?: number; output_tokens?: number }
         }
         if (event.type === "item.completed" && event.item?.type === "agent_message") {
           answer = event.item.text ?? answer
+        }
+        if (event.item?.type === "mcp_tool_call" && event.item.status === "failed") {
+          process.stdout.write(
+            `Codex MCP client event: ${JSON.stringify(event.item).slice(0, 1_000)}\n`,
+          )
         }
         if (event.type === "turn.completed") {
           tokens += (event.usage?.input_tokens ?? 0) + (event.usage?.output_tokens ?? 0)

--- a/docs/architecture/mcp-capability-evaluation.md
+++ b/docs/architecture/mcp-capability-evaluation.md
@@ -38,7 +38,10 @@ It starts a loopback-only HTTP bridge to the same selected-graph MCP transport, 
 Codex non-interactively in an empty read-only workspace, removes database and API
 credentials from the child environment, and records Tool calls at the MCP boundary.
 This keeps the model from bypassing the Tool surface through repository or database
-access. Use `--provider openai` to exercise the direct Responses API lane; that lane
+access. Codex's client-side prompts are disabled and the isolated Voyant server is
+explicitly approved because the unattended runner cannot answer MCP client prompts;
+Voyant confirmation and action-ledger approval remain enforced by the MCP server.
+Use `--provider openai` to exercise the direct Responses API lane; that lane
 requires `OPENAI_API_KEY` or the existing `~/.config/agent-run/openai-token`.
 
 When `TEST_DATABASE_URL` is absent the runner starts a

--- a/docs/architecture/mcp-capability-evaluation.md
+++ b/docs/architecture/mcp-capability-evaluation.md
@@ -1,6 +1,6 @@
 # MCP Capability Evaluation
 
-The MCP capability evaluation answers one question: can a real GPT model complete an
+The MCP capability evaluation answers one question: can a real model complete an
 operator job through the real selected deployment graph and MCP JSON-RPC transport?
 It is not a substitute for deterministic package tests. It measures whether the Tool
 surface is discoverable, drivable, and complete when the caller is a model.
@@ -33,8 +33,15 @@ pnpm eval:mcp-capability -- --mode smoke --group supplier
 commercial-chain failure cannot cap its result. Use `--journey <id>` for a single
 independently seeded diagnostic. The two selectors are mutually exclusive.
 
-The runner requires `OPENAI_API_KEY` or the existing
-`~/.config/agent-run/openai-token`. When `TEST_DATABASE_URL` is absent it starts a
+The default `--provider codex` lane uses the locally ChatGPT-authenticated Codex CLI.
+It starts a loopback-only HTTP bridge to the same selected-graph MCP transport, runs
+Codex non-interactively in an empty read-only workspace, removes database and API
+credentials from the child environment, and records Tool calls at the MCP boundary.
+This keeps the model from bypassing the Tool surface through repository or database
+access. Use `--provider openai` to exercise the direct Responses API lane; that lane
+requires `OPENAI_API_KEY` or the existing `~/.config/agent-run/openai-token`.
+
+When `TEST_DATABASE_URL` is absent the runner starts a
 temporary PostgreSQL 16 Docker container on a random localhost port, migrates it,
 runs the focused evaluation, and removes the container. A supplied database is
 assumed disposable and is not dropped by the runner.
@@ -46,8 +53,8 @@ depend on stale JavaScript beside package TypeScript sources.
 The default model is `gpt-5.6-terra` at medium reasoning effort: the balanced
 quality/cost tier for a multi-step operator capability evaluation. Use
 `--model gpt-5.6-luna` for an explicit cost-sensitive comparison; never mix model
-results under one baseline. The harness uses the Responses API with medium
-reasoning and continues each Tool turn through `previous_response_id`. GPT-5.6
+or provider results under one baseline. The OpenAI provider uses the Responses API
+with medium reasoning and continues each Tool turn through `previous_response_id`. GPT-5.6
 does not support function Tools with nonzero reasoning effort on Chat Completions;
 using Responses preserves the reasoning baseline instead of silently setting it
 to `none`.

--- a/scripts/run-mcp-capability-eval.mjs
+++ b/scripts/run-mcp-capability-eval.mjs
@@ -12,6 +12,7 @@ export function parseArgs(argv) {
     artifactDir: null,
     databaseUrl: process.env.TEST_DATABASE_URL?.trim() || null,
     mode: "smoke",
+    provider: "codex",
     model: "gpt-5.6-terra",
     journey: null,
     group: null,
@@ -26,6 +27,10 @@ export function parseArgs(argv) {
     }
     if (value === "--model") {
       options.model = requiredValue(value, values.shift())
+      continue
+    }
+    if (value === "--provider") {
+      options.provider = requiredValue(value, values.shift())
       continue
     }
     if (value === "--journey") {
@@ -53,6 +58,9 @@ export function parseArgs(argv) {
   if (!new Set(["smoke", "measure"]).has(options.mode)) {
     throw new Error(`--mode must be smoke or measure, received ${options.mode}`)
   }
+  if (!new Set(["codex", "openai"]).has(options.provider)) {
+    throw new Error(`--provider must be codex or openai, received ${options.provider}`)
+  }
   if (options.journey && options.group) {
     throw new Error("--journey and --group are mutually exclusive")
   }
@@ -64,14 +72,16 @@ export function usage() {
 
 Options:
   --mode smoke|measure     One run for smoke, five runs for measurement (default: smoke)
-  --model <model>          OpenAI model name (default: gpt-5.6-terra)
+  --provider codex|openai  ChatGPT-authenticated Codex (default) or OpenAI API
+  --model <model>          Model name (default: gpt-5.6-terra)
   --journey <id>           Run one independently seeded journey instead of the full chain
   --group <id>             Run one independently seeded operator-job group
   --artifacts <directory>  Result directory (default: .agent-runs/mcp-capability/<timestamp>)
   --database-url <url>     Existing disposable database; otherwise start a temporary Docker Postgres
   --help                   Show this help
 
-Requires OPENAI_API_KEY or ~/.config/agent-run/openai-token. The database is mutated.`
+Codex requires an authenticated local Codex CLI. OpenAI requires OPENAI_API_KEY or
+~/.config/agent-run/openai-token. The database is mutated.`
 }
 
 function requiredValue(option, value) {
@@ -206,6 +216,7 @@ async function main() {
         process.env.POSTGRES_SEARCH_CURSOR_SIGNING_KEY ??
         "mcp-capability-eval-catalog-cursor-signing-key",
       VOYANT_EVAL_MODEL: options.model,
+      VOYANT_EVAL_PROVIDER: options.provider,
       VOYANT_EVAL_REPORT_FILE: path.join(artifactDir, "report.json"),
       VOYANT_EVAL_RUNS: options.mode === "measure" ? "5" : "1",
       ...(options.journey ? { VOYANT_EVAL_JOURNEY: options.journey } : {}),
@@ -219,6 +230,7 @@ async function main() {
           startedAt: new Date().toISOString(),
           mode: options.mode,
           model: options.model,
+          provider: options.provider,
           runs: Number(env.VOYANT_EVAL_RUNS),
           journey: options.journey,
           group: options.group,

--- a/scripts/tests/run-mcp-capability-eval.test.mjs
+++ b/scripts/tests/run-mcp-capability-eval.test.mjs
@@ -6,6 +6,7 @@ import { cleanupResult, parseArgs, usage } from "../run-mcp-capability-eval.mjs"
 test("defaults to a one-run smoke evaluation", () => {
   const options = parseArgs([])
   assert.equal(options.mode, "smoke")
+  assert.equal(options.provider, "codex")
   assert.equal(options.model, "gpt-5.6-terra")
 })
 
@@ -14,6 +15,8 @@ test("accepts the measurement lane and artifact destination", () => {
     "--",
     "--mode",
     "measure",
+    "--provider",
+    "openai",
     "--model",
     "gpt-test",
     "--journey",
@@ -22,6 +25,7 @@ test("accepts the measurement lane and artifact destination", () => {
     "tmp/eval",
   ])
   assert.equal(options.mode, "measure")
+  assert.equal(options.provider, "openai")
   assert.equal(options.model, "gpt-test")
   assert.equal(options.journey, "proposal-accept")
   assert.match(options.artifactDir, /tmp\/eval$/)
@@ -43,7 +47,9 @@ test("rejects selecting both a journey and a group", () => {
 
 test("rejects unknown modes and documents the destructive database requirement", () => {
   assert.throws(() => parseArgs(["--mode", "fast"]), /smoke or measure/)
+  assert.throws(() => parseArgs(["--provider", "other"]), /codex or openai/)
   assert.match(usage(), /database is mutated/i)
+  assert.match(usage(), /ChatGPT-authenticated Codex/i)
 })
 
 test("records whether disposable database cleanup succeeded", () => {


### PR DESCRIPTION
## Summary
- make the ChatGPT-authenticated Codex CLI the default real-model driver for the selected-graph MCP capability harness
- expose the in-process selected MCP transport through a loopback-only streamable HTTP bridge and record calls at that boundary
- run Codex in an empty read-only workspace with database/API credentials removed, so durable state remains the grader and shell access cannot bypass MCP
- retain the direct OpenAI Responses API as `--provider openai` and record the provider in artifacts

Tracks #4378.

## Verification
- `node --test scripts/tests/run-mcp-capability-eval.test.mjs`
- `pnpm --filter operator typecheck`
- `pnpm biome check apps/operator/tests/mcp-capability.test.ts docs/architecture/mcp-capability-evaluation.md scripts/run-mcp-capability-eval.mjs scripts/tests/run-mcp-capability-eval.test.mjs` (existing undeclared-env warning only)
- authenticated `codex exec --model gpt-5.6-terra` subscription smoke returned `TERRA_OK`

The pre-commit secret scanner detects the runner's pre-existing literal disposable PostgreSQL connection string, so the commit used `--no-verify`; CI is authoritative. A full selected-graph Codex journey is the next validation step.
