### PR TITLE
fix(auth): make invitation revocation durable

### DIFF
--- a/packages/auth/src/mcp-runtime.ts
+++ b/packages/auth/src/mcp-runtime.ts
@@ -9,6 +9,7 @@ import type { Context } from "hono"
 
 import { teamManagementRuntimePort } from "./team-management-runtime-port.js"
 import {
+  executeRevokeTeamInvitationCommand,
   executeSetTeamMemberAccessCommand,
   executeUpdateTeamMemberRoleCommand,
 } from "./team-member-role-command.js"
@@ -61,7 +62,15 @@ export const voyantToolContextContribution = defineToolContextContribution({
       listRoles: () => runtime.listRoles(runtimeContext),
       listInvitations: () => runtime.listInvitations(runtimeContext),
       inviteMember: (input) => runtime.inviteMember(runtimeContext, input),
-      revokeInvitation: (invitationId) => runtime.revokeInvitation(runtimeContext, invitationId),
+      revokeInvitation: (invitationId, admitted) =>
+        executeRevokeTeamInvitationCommand({
+          db: runtimeContext.db,
+          context: actionLedgerContext(c),
+          admitted,
+          invitationId,
+          list: () => runtime.listInvitations(runtimeContext),
+          revoke: () => runtime.revokeInvitation(runtimeContext, invitationId),
+        }),
       async updateMemberRole(
         memberId: string,
         roleId: string,

--- a/packages/auth/src/team-member-role-command.ts
+++ b/packages/auth/src/team-member-role-command.ts
@@ -8,8 +8,7 @@ import {
   type ToolHandlerActionPolicyContext,
   withServerResolvedIdempotencyKey,
 } from "@voyant-travel/tools"
-
-import type { TeamMemberDto } from "./team-management-runtime-port.js"
+import type { TeamInvitationDto, TeamMemberDto } from "./team-management-runtime-port.js"
 
 /**
  * Admit one exact desired-role command before crossing the local/cloud adapter boundary.
@@ -75,4 +74,37 @@ export async function executeSetTeamMemberAccessCommand(input: {
     },
   )
   return result.value
+}
+
+/** Revoke an invitation, reconciling an ambiguous DELETE before redispatch. */
+export async function executeRevokeTeamInvitationCommand(input: {
+  db: AnyDrizzleDb
+  context: ActionLedgerRequestContextValues
+  admitted: ToolHandlerActionPolicyContext
+  invitationId: string
+  list(): Promise<TeamInvitationDto[]>
+  revoke(): Promise<void>
+}) {
+  const commandInput = { invitationId: input.invitationId }
+  const resolvedAdmitted = withServerResolvedIdempotencyKey(
+    input.admitted,
+    await deriveCommandIdempotencyKey("revoke-team-invitation", commandInput),
+  )
+  await executeAdmittedExistingTargetCommand(
+    {
+      db: input.db,
+      context: input.context,
+      admitted: resolvedAdmitted,
+      commandInput,
+      evaluatedRisk: "high",
+    },
+    {
+      prepare: () => Promise.resolve(),
+      execute: input.revoke,
+      async replay() {
+        const stillPresent = (await input.list()).some(({ id }) => id === input.invitationId)
+        if (stillPresent) await input.revoke()
+      },
+    },
+  )
 }

--- a/packages/auth/src/tools.ts
+++ b/packages/auth/src/tools.ts
@@ -145,13 +145,35 @@ export const DEACTIVATE_TEAM_MEMBER_HANDLER_POLICY = memberAccessHandlerPolicy({
   reversible: false,
 })
 
+export const REVOKE_TEAM_INVITATION_HANDLER_POLICY = {
+  capabilityId: "@voyant-travel/auth#team.tool.revoke-invitation",
+  capabilityVersion: "v1",
+  canonicalName: "revoke_team_invitation",
+  actionPolicy: {
+    id: "@voyant-travel/auth#team.action.revoke-invitation",
+    capabilityId: "@voyant-travel/auth#team.action.revoke-invitation",
+    version: "v1",
+    kind: "execute",
+    targetType: "team-invitation",
+    commandTargetField: "invitationId",
+    targetLifecycle: "existing",
+    existingTarget: { durability: "handler-command-result-v1" },
+    risk: "high",
+    ledger: "required",
+    approval: "required",
+    policy: "@voyant-travel/auth#team.action.revoke-invitation",
+    reversible: false,
+    allowedActorTypes: ["staff"],
+  },
+} as const satisfies HandlerActionPolicyExpectation
+
 export interface TeamManagementToolServices {
   getCapabilities(): Promise<TeamManagementCapabilitiesDto>
   listMembers(): Promise<TeamMemberDto[]>
   listRoles(): Promise<TeamRoleDto[]>
   listInvitations(): Promise<TeamInvitationDto[]>
   inviteMember(input: InviteTeamMemberInput): Promise<CreatedTeamInvitationDto>
-  revokeInvitation(invitationId: string): Promise<void>
+  revokeInvitation(invitationId: string, admitted: ToolHandlerActionPolicyContext): Promise<void>
   updateMemberRole(
     memberId: string,
     roleId: string,
@@ -289,6 +311,8 @@ export const revokeTeamInvitationTool = defineTool<
   { invitationId: string; revoked: true },
   TeamManagementToolContext
 >({
+  capabilityId: REVOKE_TEAM_INVITATION_HANDLER_POLICY.capabilityId,
+  capabilityVersion: REVOKE_TEAM_INVITATION_HANDLER_POLICY.capabilityVersion,
   name: "revoke_team_invitation",
   description:
     "Revoke a pending team invitation. Invalidates its acceptance path and requires confirmation." +
@@ -297,6 +321,9 @@ export const revokeTeamInvitationTool = defineTool<
   outputSchema: z.object({ invitationId: z.string(), revoked: z.literal(true) }),
   requiredScopes: ["team:delete"],
   tier: "destructive",
+  resolvesIdempotencyKeyServerSide: true,
+  actionPolicyEnforcement: "handler",
+  annotations: { idempotentHint: true },
   riskPolicy: {
     destructive: true,
     reversible: false,
@@ -305,7 +332,8 @@ export const revokeTeamInvitationTool = defineTool<
     sideEffects: ["data-delete"],
   },
   async handler({ invitationId }, ctx) {
-    await teamManagement(ctx).revokeInvitation(invitationId)
+    const admitted = admitHandlerActionPolicy(ctx, REVOKE_TEAM_INVITATION_HANDLER_POLICY)
+    await teamManagement(ctx).revokeInvitation(invitationId, admitted)
     return { invitationId, revoked: true }
   },
 })

--- a/packages/auth/src/voyant.ts
+++ b/packages/auth/src/voyant.ts
@@ -361,11 +361,13 @@ export const authTeamVoyantModule = defineModule({
       kind: "execute",
       targetType: "team-invitation",
       commandTargetField: "invitationId",
-      availability: {
-        status: "unavailable",
-        reasonCode: "unsafe-nontransactional-effect",
-      },
+      targetLifecycle: "existing",
+      existingTarget: { durability: "handler-command-result-v1" },
       effectBoundary: "multistage",
+      durability: {
+        strategy: "saga",
+        testReference: "packages/auth/tests/integration/team-member-role-command.test.ts",
+      },
       resource: "team",
       action: "delete",
       requiredScopes: ["team:delete"],

--- a/packages/auth/tests/integration/team-member-role-command.test.ts
+++ b/packages/auth/tests/integration/team-member-role-command.test.ts
@@ -8,6 +8,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest"
 import { z } from "zod"
 
 import {
+  executeRevokeTeamInvitationCommand,
   executeSetTeamMemberAccessCommand,
   executeUpdateTeamMemberRoleCommand,
 } from "../../src/team-member-role-command.js"
@@ -15,6 +16,7 @@ import {
   ACTIVATE_TEAM_MEMBER_HANDLER_POLICY,
   DEACTIVATE_TEAM_MEMBER_HANDLER_POLICY,
   UPDATE_TEAM_MEMBER_ROLE_HANDLER_POLICY as POLICY,
+  REVOKE_TEAM_INVITATION_HANDLER_POLICY,
 } from "../../src/tools.js"
 
 const DB_AVAILABLE = Boolean(process.env.TEST_DATABASE_URL)
@@ -162,14 +164,82 @@ describe.skipIf(!DB_AVAILABLE)("durable team member role command", () => {
     ).resolves.toMatchObject({ id: "member_2", status: access })
     expect(dispatches).toBe(2)
   })
+
+  it("reconciles an ambiguous invitation revoke without dispatching DELETE twice", async () => {
+    const command = {
+      db,
+      context: requestContext,
+      invitationId: "invitation_ambiguous",
+    }
+    const initial = await mintAdmission({ confirmed: true }, REVOKE_TEAM_INVITATION_HANDLER_POLICY)
+    const approvalError = await executeRevokeTeamInvitationCommand({
+      ...command,
+      admitted: initial,
+      list: async () => [],
+      revoke: async () => undefined,
+    }).catch((error) => error as { code?: string; meta?: Record<string, unknown> })
+    expect(approvalError).toMatchObject({ code: "APPROVAL_REQUIRED" })
+    const approvalId = String(approvalError.meta?.approvalId ?? "")
+    const idempotencyFingerprint = String(approvalError.meta?.idempotencyFingerprint ?? "")
+    await approve(db, approvalId, REVOKE_TEAM_INVITATION_HANDLER_POLICY.actionPolicy.id)
+    const admitted = await mintAdmission(
+      { confirmed: true, approvalId, idempotencyFingerprint },
+      REVOKE_TEAM_INVITATION_HANDLER_POLICY,
+    )
+
+    let present = true
+    let dispatches = 0
+    const revoke = async () => {
+      dispatches += 1
+      present = false
+      throw new Error("response lost after invitation was revoked")
+    }
+    await expect(
+      executeRevokeTeamInvitationCommand({
+        ...command,
+        admitted,
+        list: async () => (present ? [invitation(command.invitationId)] : []),
+        revoke,
+      }),
+    ).rejects.toThrow(/response lost/)
+    await expect(
+      executeRevokeTeamInvitationCommand({
+        ...command,
+        admitted,
+        list: async () => (present ? [invitation(command.invitationId)] : []),
+        revoke,
+      }),
+    ).resolves.toBeUndefined()
+    expect(dispatches).toBe(1)
+  })
 })
+
+async function approve(
+  db: ReturnType<typeof import("@voyant-travel/db/test-utils").createTestDb>,
+  approvalId: string,
+  actionName: string,
+) {
+  await actionLedgerService.decideApproval(db, {
+    id: approvalId,
+    status: "approved",
+    decidedByPrincipalId: "user_team_role_approver",
+    decisionAction: {
+      actionName: `${actionName}.approve-test`,
+      actionVersion: "v1",
+      principalType: "user",
+      principalId: "user_team_role_approver",
+      organizationId: requestContext.organizationId,
+    },
+  })
+}
 
 async function mintAdmission(
   invocation: Record<string, string | boolean>,
   policy:
     | typeof POLICY
     | typeof ACTIVATE_TEAM_MEMBER_HANDLER_POLICY
-    | typeof DEACTIVATE_TEAM_MEMBER_HANDLER_POLICY = POLICY,
+    | typeof DEACTIVATE_TEAM_MEMBER_HANDLER_POLICY
+    | typeof REVOKE_TEAM_INVITATION_HANDLER_POLICY = POLICY,
 ): Promise<ToolHandlerActionPolicyContext> {
   let admitted: ToolHandlerActionPolicyContext | undefined
   const registry = createToolRegistry()
@@ -234,5 +304,17 @@ function member(roleId: string) {
     status: "active" as const,
     joinedAt: null,
     lastActivityAt: null,
+  }
+}
+
+function invitation(id: string) {
+  return {
+    id,
+    email: "invitee@example.com",
+    roleId: "editor",
+    roleName: "Editor",
+    status: "pending" as const,
+    createdAt: "2026-08-10T00:00:00.000Z",
+    expiresAt: "2026-08-13T00:00:00.000Z",
   }
 }

--- a/packages/auth/tests/tools.test.ts
+++ b/packages/auth/tests/tools.test.ts
@@ -8,6 +8,8 @@ import {
   activateTeamMemberTool,
   DEACTIVATE_TEAM_MEMBER_HANDLER_POLICY,
   deactivateTeamMemberTool,
+  REVOKE_TEAM_INVITATION_HANDLER_POLICY,
+  revokeTeamInvitationTool,
   type TeamManagementToolContext,
   type TeamManagementToolServices,
   teamManagementTools,
@@ -81,7 +83,9 @@ function teamRegistry() {
           ? { actionPolicy: ACTIVATE_TEAM_MEMBER_HANDLER_POLICY.actionPolicy }
           : tool.name === "deactivate_team_member"
             ? { actionPolicy: DEACTIVATE_TEAM_MEMBER_HANDLER_POLICY.actionPolicy }
-            : undefined,
+            : tool.name === "revoke_team_invitation"
+              ? { actionPolicy: REVOKE_TEAM_INVITATION_HANDLER_POLICY.actionPolicy }
+              : undefined,
     )
   }
   return registry
@@ -151,6 +155,11 @@ describe("auth team-management tools", () => {
         annotations: { idempotentHint: true },
       })
     }
+    expect(revokeTeamInvitationTool).toMatchObject({
+      actionPolicyEnforcement: "handler",
+      resolvesIdempotencyKeyServerSide: true,
+      annotations: { idempotentHint: true },
+    })
     expect(
       registry
         .list()
@@ -172,7 +181,14 @@ describe("auth team-management tools", () => {
       ),
     ).resolves.toEqual(invitation)
     await expect(
-      registry.dispatch("revoke_team_invitation", { invitationId: "invitation_1" }, ctx),
+      registry.dispatch(
+        "revoke_team_invitation",
+        { invitationId: "invitation_1" },
+        {
+          ...ctx,
+          handlerActionPolicy: admission(registry, "revoke_team_invitation"),
+        },
+      ),
     ).resolves.toEqual({ invitationId: "invitation_1", revoked: true })
     await registry.dispatch(
       "update_team_member_role",
@@ -201,7 +217,7 @@ describe("auth team-management tools", () => {
       roleId: "editor",
       expiresInDays: 5,
     })
-    expect(runtime.revokeInvitation).toHaveBeenCalledWith("invitation_1")
+    expect(runtime.revokeInvitation).toHaveBeenCalledWith("invitation_1", expect.any(Object))
     expect(runtime.updateMemberRole).toHaveBeenCalledWith("member_1", "admin", expect.any(Object))
     expect(runtime.activateMember).toHaveBeenCalledWith("member_1", expect.any(Object))
     expect(runtime.deactivateMember).toHaveBeenCalledWith("member_1", expect.any(Object))

--- a/packages/auth/tests/unit/voyant-manifest.test.ts
+++ b/packages/auth/tests/unit/voyant-manifest.test.ts
@@ -174,6 +174,7 @@ describe("auth identity/access deployment manifests", () => {
       ),
     ).not.toHaveProperty("availability")
     for (const actionId of [
+      "@voyant-travel/auth#team.action.revoke-invitation",
       "@voyant-travel/auth#team.action.activate-member",
       "@voyant-travel/auth#team.action.deactivate-member",
     ]) {


### PR DESCRIPTION
## Summary
- expose `revoke_team_invitation` as an Auth-owned, handler-enforced existing-target command with server-derived identity and required approval
- reconcile an ambiguous DELETE by reading invitation state before replay: absence completes the desired revoked state without redispatch; presence permits a controlled retry
- reject payload/approval drift through the shared action-ledger command protocol and keep `invite_team_member` unavailable
- advertise durability only for the revoke action and cover its Tool/selected-manifest projection

Tracks #4542 and #4378.

## Verification
- RED first: Tool/manifest tests failed while revoke lacked handler policy and remained unavailable
- `pnpm --filter @voyant-travel/auth typecheck`
- `pnpm --filter @voyant-travel/auth exec vitest run tests/tools.test.ts tests/unit/voyant-manifest.test.ts --maxWorkers=1` (10 passed)
- added real-PostgreSQL integration coverage for provider-accepted/response-lost replay, asserting one DELETE dispatch after reconciliation; CI DB lane is authoritative

## Semantics
This claims at-most-once DELETE dispatch for the covered accepted-but-response-lost case when the provider's authoritative invitation list observes absence. If the provider still reports the invitation, replay deliberately retries the desired-state transition. `invite_team_member` remains fail-closed until invitation creation and delivery share a durable state machine.
