### PR TITLE
fix: admit approved created-target commands

### DIFF
--- a/packages/action-ledger/src/created-command-internal.ts
+++ b/packages/action-ledger/src/created-command-internal.ts
@@ -445,7 +445,7 @@ export async function executeAdmittedCreatedTargetCommand<TValue, TReferenceType
     selected.targetType !== input.canonicalTargetType ||
     createdTarget.resultReferenceType !== input.resultReferenceType ||
     selected.risk !== input.evaluatedRisk ||
-    selected.approval !== "never" ||
+    (selected.approval !== "never" && selected.approval !== "required") ||
     !idempotencyKey ||
     !commandTargetId?.trim() ||
     !routeOrToolName.trim() ||
@@ -454,6 +454,14 @@ export async function executeAdmittedCreatedTargetCommand<TValue, TReferenceType
     throw new ActionLedgerCreatedCommandProtocolError("admitted_policy_mismatch")
   }
   assertCreatedTargetParentAnchor(createdTarget.parentAnchor, input.commandInput)
+  const approvalPolicy: ActionLedgerCapabilityApprovalPolicy =
+    selected.approval === "required" ? "required" : "none"
+  const approvalId = input.admitted.invocation.approvalId?.trim()
+  const approvalReasonCode =
+    input.admitted.invocation.reasonCode ??
+    (approvalId && !input.admitted.invocation.idempotencyFingerprint
+      ? ((await actionLedgerService.getApproval(input.db, approvalId))?.approval.reasonCode ?? null)
+      : null)
   const command = {
     actionName: selected.id,
     actionVersion: selected.version,
@@ -465,8 +473,9 @@ export async function executeAdmittedCreatedTargetCommand<TValue, TReferenceType
     capabilityId: selected.capabilityId,
     capabilityVersion: selected.version,
     evaluatedRisk: selected.risk,
-    approvalPolicy: "none" as const,
-    approvalReasonCode: null,
+    approvalPolicy,
+    approvalPolicyName: selected.policy ?? null,
+    approvalReasonCode,
   }
   const fingerprint = await buildCreatedTargetCommandFingerprint(command)
   const scope = await buildCreatedTargetIdempotencyScope({
@@ -476,6 +485,40 @@ export async function executeAdmittedCreatedTargetCommand<TValue, TReferenceType
     principalId: principal.principalId,
     organizationId: principal.organizationId,
   })
+  if (
+    selected.approval === "never" &&
+    (input.admitted.invocation.approvalId || input.admitted.invocation.idempotencyFingerprint)
+  ) {
+    throw new ActionLedgerCreatedCommandProtocolError("forged_approval_linkage")
+  }
+  if (selected.approval === "required" && !approvalId) {
+    await throwHandlerApprovalRequired({
+      db: input.db,
+      context: input.context,
+      principal,
+      actionName: selected.id,
+      actionVersion: selected.version,
+      evaluatedRisk: selected.risk,
+      policyName: selected.policy,
+      targetType: createdTarget.commandTargetType,
+      targetId: commandTargetId,
+      capabilityId: selected.capabilityId,
+      routeOrToolName,
+      idempotencyKey,
+      fingerprint,
+      reasonCode: approvalReasonCode,
+    })
+  }
+  const approvalControls =
+    selected.approval === "required"
+      ? {
+          approvalId: approvalId ?? "",
+          idempotencyKey,
+          idempotencyFingerprint:
+            input.admitted.invocation.idempotencyFingerprint?.trim() || fingerprint,
+          reasonCode: approvalReasonCode,
+        }
+      : undefined
   return executeCreatedTargetCommand(
     input.db,
     {
@@ -485,6 +528,7 @@ export async function executeAdmittedCreatedTargetCommand<TValue, TReferenceType
       routeOrToolName,
       authorizationSource: createdTargetAuthorizationSource(input.admitted),
       idempotency: { scope, key: idempotencyKey, fingerprint },
+      ...(approvalControls ? { approvalControls } : {}),
     },
     handlers,
   )

--- a/packages/action-ledger/tests/unit/created-command.test.ts
+++ b/packages/action-ledger/tests/unit/created-command.test.ts
@@ -778,6 +778,19 @@ describe("created-target command protocol", () => {
       organizationId: "org_1",
     })
 
+    const requestApproval = vi.spyOn(actionLedgerService, "requestApproval").mockResolvedValue({
+      requestedAction: { id: "requested_created" },
+      approval: { id: "approval_created", status: "pending" },
+      replayed: false,
+    } as never)
+    const approvalRequiredAdmission = await mintAdmission({
+      ...admitted,
+      actionPolicy: {
+        ...admitted.actionPolicy,
+        approval: "required" as const,
+        policy: "inventory-create-extra-policy",
+      },
+    })
     await expect(
       executeAdmittedCreatedTargetCommand(
         {
@@ -788,10 +801,7 @@ describe("created-target command protocol", () => {
             actor: "staff",
             callerType: "session",
           },
-          admitted: {
-            ...admitted,
-            actionPolicy: { ...admitted.actionPolicy, approval: "required" as const },
-          },
+          admitted: approvalRequiredAdmission,
           idempotencyKey: "key_1",
           commandTargetType: "product-extra-create-command",
           canonicalTargetType: "product_extra",
@@ -806,7 +816,20 @@ describe("created-target command protocol", () => {
           },
         },
       ),
-    ).rejects.toMatchObject({ code: "ACTION_POLICY_REQUIRED" })
+    ).rejects.toMatchObject({
+      code: "APPROVAL_REQUIRED",
+      meta: { approvalId: "approval_created", requestedActionId: "requested_created" },
+    })
+    expect(requestApproval).toHaveBeenCalledWith(
+      harness.db,
+      expect.objectContaining({
+        requestedAction: expect.objectContaining({
+          targetType: "product-extra-create-command",
+          targetId: "key_1",
+          capabilityId: actionName,
+        }),
+      }),
+    )
     expect(create).toHaveBeenCalledTimes(1)
   })
 


### PR DESCRIPTION
## Summary
- allow handler-owned created-target commands to use selected approval-required policies
- bind approval requests and execution controls to the synthetic command target and canonical fingerprint
- keep forged approval linkage fail-closed

## Verification
- pnpm --filter @voyant-travel/action-ledger test -- --run tests/unit/created-command.test.ts
- pnpm --filter @voyant-travel/action-ledger typecheck
- git diff --check

Prerequisite for #4542.