### PR TITLE
fix(bookings): complete amendment Tool continuations

### DIFF
--- a/.changeset/booking-amendment-continuations.md
+++ b/.changeset/booking-amendment-continuations.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/bookings": patch
+---
+
+Return the server-issued proposed revision from Booking Amendment previews and derive Amendment Tool command identity server-side.

--- a/packages/bookings/src/tools.ts
+++ b/packages/bookings/src/tools.ts
@@ -96,19 +96,23 @@ export interface BookingsToolServices {
     admitted: ToolHandlerActionPolicyContext,
   ): Promise<unknown>
   previewTravelerCorrectionAmendment(
-    input: z.infer<typeof previewTravelerCorrectionAmendmentToolInputSchema>,
+    input: z.infer<typeof previewTravelerCorrectionAmendmentToolInputSchema> & {
+      idempotencyKey: string
+    },
   ): Promise<unknown>
   previewTravelerRosterChangeAmendment(
-    input: z.infer<typeof previewTravelerRosterChangeAmendmentToolInputSchema>,
+    input: z.infer<typeof previewTravelerRosterChangeAmendmentToolInputSchema> & {
+      idempotencyKey: string
+    },
   ): Promise<unknown>
   acceptBookingAmendment(
-    input: z.infer<typeof acceptBookingAmendmentToolInputSchema>,
+    input: z.infer<typeof acceptBookingAmendmentToolInputSchema> & { idempotencyKey: string },
   ): Promise<unknown>
   applyBookingAmendment(
-    input: z.infer<typeof applyBookingAmendmentToolInputSchema>,
+    input: z.infer<typeof applyBookingAmendmentToolInputSchema> & { idempotencyKey: string },
   ): Promise<unknown>
   reconcileBookingAmendment(
-    input: z.infer<typeof reconcileBookingAmendmentToolInputSchema>,
+    input: z.infer<typeof reconcileBookingAmendmentToolInputSchema> & { idempotencyKey: string },
   ): Promise<unknown>
 }
 
@@ -266,41 +270,31 @@ export const cancelBookingTool = defineTool<
 const amendmentCommandFields = {
   bookingId: z.string().min(1).describe("The stable Booking id."),
   amendmentId: z.string().min(1).describe("The Booking Amendment id."),
-  idempotencyKey: z
-    .string()
-    .trim()
-    .min(1)
-    .describe("Stable key for safely replaying this exact Amendment command."),
 }
 
 export const previewTravelerCorrectionAmendmentToolInputSchema =
   previewTravelerCorrectionSchema.extend({
     bookingId: amendmentCommandFields.bookingId,
-    idempotencyKey: amendmentCommandFields.idempotencyKey,
   })
 
 export const previewTravelerRosterChangeAmendmentToolInputSchema =
   previewTravelerRosterChangeSchema.extend({
     bookingId: amendmentCommandFields.bookingId,
-    idempotencyKey: amendmentCommandFields.idempotencyKey,
   })
 
 export const acceptBookingAmendmentToolInputSchema = acceptBookingAmendmentSchema.extend({
   bookingId: amendmentCommandFields.bookingId,
   amendmentId: amendmentCommandFields.amendmentId,
-  idempotencyKey: amendmentCommandFields.idempotencyKey,
 })
 
 export const applyBookingAmendmentToolInputSchema = applyBookingAmendmentSchema.extend({
   bookingId: amendmentCommandFields.bookingId,
   amendmentId: amendmentCommandFields.amendmentId,
-  idempotencyKey: amendmentCommandFields.idempotencyKey,
 })
 
 export const reconcileBookingAmendmentToolInputSchema = z.object({
   bookingId: amendmentCommandFields.bookingId,
   amendmentId: amendmentCommandFields.amendmentId,
-  idempotencyKey: amendmentCommandFields.idempotencyKey,
 })
 
 const amendmentOutcomeReferenceSchema = z.object({
@@ -326,7 +320,14 @@ const amendmentOutcomeReferenceSchema = z.object({
   }),
 })
 const amendmentPreviewToolOutputSchema = z.union([
-  z.object({ status: z.literal("ok"), amendment: amendmentOutcomeReferenceSchema }),
+  z.object({
+    status: z.literal("ok"),
+    amendment: amendmentOutcomeReferenceSchema.extend({
+      proposedRevisionId: z
+        .string()
+        .describe("Pass this exact server-issued id to the next accept/apply command."),
+    }),
+  }),
   ...bookingAmendmentPreviewResultSchema.options.slice(1),
 ])
 const acceptBookingAmendmentServiceResultSchema = z.discriminatedUnion("status", [
@@ -395,9 +396,28 @@ function toAcceptAmendmentToolOutcome(value: unknown) {
 function toAmendmentPreviewToolOutcome(value: unknown) {
   const result = bookingAmendmentPreviewResultSchema.parse(value)
   if (!("amendment" in result)) return result
+  const proposedRevision = result.amendment.revisions?.find(
+    (revision) => revision.role === "proposed_after",
+  )
+  if (!proposedRevision) {
+    throw new ToolError(
+      "The Amendment preview did not produce its required proposed Booking revision.",
+      "PROVIDER_ERROR",
+    )
+  }
   return {
     status: result.status,
-    amendment: amendmentOutcomeReferenceSchema.parse(result.amendment),
+    amendment: {
+      ...amendmentOutcomeReferenceSchema.parse(result.amendment),
+      proposedRevisionId: proposedRevision.id,
+    },
+  }
+}
+
+async function withAmendmentCommandIdentity<T extends object>(command: string, input: T) {
+  return {
+    ...input,
+    idempotencyKey: await deriveCommandIdempotencyKey(`booking-amendment-${command}`, input),
   }
 }
 
@@ -423,10 +443,15 @@ export const previewTravelerCorrectionAmendmentTool = defineTool({
   tier: "write",
   riskPolicy: bookingAmendmentWriteRisk,
   annotations: { idempotentHint: true },
+  resolvesIdempotencyKeyServerSide: true,
   async handler(input, ctx: BookingsToolContext) {
     return parseJsonResult(
       amendmentPreviewToolOutputSchema,
-      toAmendmentPreviewToolOutcome(await bookings(ctx).previewTravelerCorrectionAmendment(input)),
+      toAmendmentPreviewToolOutcome(
+        await bookings(ctx).previewTravelerCorrectionAmendment(
+          await withAmendmentCommandIdentity("preview-traveler-correction", input),
+        ),
+      ),
     )
   },
 })
@@ -445,11 +470,14 @@ export const previewTravelerRosterChangeAmendmentTool = defineTool({
   tier: "write",
   riskPolicy: bookingAmendmentWriteRisk,
   annotations: { idempotentHint: true },
+  resolvesIdempotencyKeyServerSide: true,
   async handler(input, ctx: BookingsToolContext) {
     return parseJsonResult(
       amendmentPreviewToolOutputSchema,
       toAmendmentPreviewToolOutcome(
-        await bookings(ctx).previewTravelerRosterChangeAmendment(input),
+        await bookings(ctx).previewTravelerRosterChangeAmendment(
+          await withAmendmentCommandIdentity("preview-traveler-roster", input),
+        ),
       ),
     )
   },
@@ -469,10 +497,15 @@ export const acceptBookingAmendmentTool = defineTool({
   tier: "write",
   riskPolicy: bookingAmendmentWriteRisk,
   annotations: { idempotentHint: true },
+  resolvesIdempotencyKeyServerSide: true,
   async handler(input, ctx: BookingsToolContext) {
     return parseJsonResult(
       acceptBookingAmendmentToolOutputSchema,
-      toAcceptAmendmentToolOutcome(await bookings(ctx).acceptBookingAmendment(input)),
+      toAcceptAmendmentToolOutcome(
+        await bookings(ctx).acceptBookingAmendment(
+          await withAmendmentCommandIdentity("accept", input),
+        ),
+      ),
     )
   },
 })
@@ -491,10 +524,15 @@ export const applyBookingAmendmentTool = defineTool({
   tier: "write",
   riskPolicy: bookingAmendmentWriteRisk,
   annotations: { idempotentHint: true },
+  resolvesIdempotencyKeyServerSide: true,
   async handler(input, ctx: BookingsToolContext) {
     return parseJsonResult(
       applyBookingAmendmentToolOutputSchema,
-      toAmendmentToolOutcome(await bookings(ctx).applyBookingAmendment(input)),
+      toAmendmentToolOutcome(
+        await bookings(ctx).applyBookingAmendment(
+          await withAmendmentCommandIdentity("apply", input),
+        ),
+      ),
     )
   },
 })
@@ -513,10 +551,15 @@ export const reconcileBookingAmendmentTool = defineTool({
   tier: "write",
   riskPolicy: bookingAmendmentWriteRisk,
   annotations: { idempotentHint: true },
+  resolvesIdempotencyKeyServerSide: true,
   async handler(input, ctx: BookingsToolContext) {
     return parseJsonResult(
       applyBookingAmendmentToolOutputSchema,
-      toAmendmentToolOutcome(await bookings(ctx).reconcileBookingAmendment(input)),
+      toAmendmentToolOutcome(
+        await bookings(ctx).reconcileBookingAmendment(
+          await withAmendmentCommandIdentity("reconcile", input),
+        ),
+      ),
     )
   },
 })

--- a/packages/bookings/tests/tools.test.ts
+++ b/packages/bookings/tests/tools.test.ts
@@ -150,6 +150,19 @@ describe("bookings tools", () => {
     expect(bookingsTools.find((tool) => tool.name === "cancel_booking")).toMatchObject({
       resolvesIdempotencyKeyServerSide: true,
     })
+    for (const name of [
+      "accept_booking_amendment",
+      "apply_booking_amendment",
+      "preview_traveler_correction_amendment",
+      "preview_traveler_roster_change_amendment",
+      "reconcile_booking_amendment",
+    ]) {
+      const tool = bookingsTools.find((entry) => entry.name === name)
+      expect(tool).toMatchObject({ resolvesIdempotencyKeyServerSide: true })
+      expect(tool?.inputSchema.safeParse({}).error?.issues).not.toContainEqual(
+        expect.objectContaining({ path: ["idempotencyKey"] }),
+      )
+    }
     expect(
       bookingsTools
         .find((tool) => tool.name === "cancel_booking")
@@ -305,11 +318,10 @@ describe("bookings tools", () => {
         expectedBookingRevision: 1,
         reason: "Correct the travel document spelling",
         patch: { firstName: "Ada" },
-        idempotencyKey: "amendment-preview-bk-1",
       },
       ctx({
         async previewTravelerCorrectionAmendment(input) {
-          expect(input.idempotencyKey).toBe("amendment-preview-bk-1")
+          expect(input.idempotencyKey).toMatch(/^booking-amendment-preview-traveler-correction:v1:/)
           return {
             status: "no_op",
             bookingId: input.bookingId,
@@ -341,16 +353,15 @@ describe("bookings tools", () => {
           bookingItemIds: ["bitm_1"],
           traveler: { firstName: "Ada", lastName: "Lovelace" },
         },
-        idempotencyKey: "roster-preview-bk-1",
       },
       ctx({
         async previewTravelerRosterChangeAmendment(input) {
           expect(input).toMatchObject({
             bookingId: "bk_1",
             expectedBookingRevision: 3,
-            idempotencyKey: "roster-preview-bk-1",
             change: { type: "traveler_add", bookingItemIds: ["bitm_1"] },
           })
+          expect(input.idempotencyKey).toMatch(/^booking-amendment-preview-traveler-roster:v1:/)
           return { status: "availability_changed", bookingItemId: "bitm_1" }
         },
       }),
@@ -359,14 +370,14 @@ describe("bookings tools", () => {
 
     const reconciled = await registry.dispatch(
       "reconcile_booking_amendment",
-      { bookingId: "bk_1", amendmentId: "bamd_1", idempotencyKey: "test-key-1" },
+      { bookingId: "bk_1", amendmentId: "bamd_1" },
       ctx({
         async reconcileBookingAmendment(input) {
-          expect(input).toEqual({
+          expect(input).toMatchObject({
             bookingId: "bk_1",
             amendmentId: "bamd_1",
-            idempotencyKey: "test-key-1",
           })
+          expect(input.idempotencyKey).toMatch(/^booking-amendment-reconcile:v1:/)
           return { status: "not_found" }
         },
       }),

--- a/scripts/tool-protocol-field-inventory.json
+++ b/scripts/tool-protocol-field-inventory.json
@@ -18,32 +18,7 @@
       "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
     },
     {
-      "id": "@voyant-travel/bookings:accept_booking_amendment:input.idempotencyKey",
-      "ownership": "caller-owned-command-identity",
-      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
-    },
-    {
-      "id": "@voyant-travel/bookings:apply_booking_amendment:input.idempotencyKey",
-      "ownership": "caller-owned-command-identity",
-      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
-    },
-    {
       "id": "@voyant-travel/bookings:create_booking_extra:input.idempotencyKey",
-      "ownership": "caller-owned-command-identity",
-      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
-    },
-    {
-      "id": "@voyant-travel/bookings:preview_traveler_correction_amendment:input.idempotencyKey",
-      "ownership": "caller-owned-command-identity",
-      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
-    },
-    {
-      "id": "@voyant-travel/bookings:preview_traveler_roster_change_amendment:input.idempotencyKey",
-      "ownership": "caller-owned-command-identity",
-      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
-    },
-    {
-      "id": "@voyant-travel/bookings:reconcile_booking_amendment:input.idempotencyKey",
       "ownership": "caller-owned-command-identity",
       "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
     },


### PR DESCRIPTION
## Summary

- hide server-owned idempotency keys from all Booking Amendment Tools and derive stable command identities in the handler
- return the exact server-issued `proposedRevisionId` from Amendment previews so accept/apply can continue without inventing internal identifiers
- fail explicitly if the domain preview ever omits its proposed revision

## Real-model evidence

GPT-5.6 Terra against the real selected graph, MCP JSON-RPC transport, and disposable PostgreSQL initially created the preview but could not apply it: the model-visible result omitted `proposedRevisionId`, while preview also rejected the first attempt for a missing caller-facing `idempotencyKey`.

After this change, the same independently seeded `booking-amend-traveler` job passed in 13 MCP calls with zero Tool errors. Durable grading confirmed the stable Booking reached revision 2, the traveler changed from Mihai to Michael, and the Amendment row was applied.

Artifact: `.agent-runs/mcp-capability/2026-08-10T16-11-21.601Z/report.json` (local, intentionally untracked).

## Verification

- `pnpm --filter @voyant-travel/bookings exec vitest run tests/tools.test.ts --reporter=dot`
- `pnpm --filter @voyant-travel/bookings typecheck`
- `pnpm --filter operator typecheck`
- `pnpm verify:agent-tool-coverage`
- `pnpm eval:mcp-capability -- --mode smoke --group amendment --model gpt-5.6-terra`

Tracks #4378.
