### PR TITLE
fix: wait for stable MCP eval database readiness

### DIFF
--- a/scripts/run-mcp-capability-eval.mjs
+++ b/scripts/run-mcp-capability-eval.mjs
@@ -1,7 +1,6 @@
 import { spawn, spawnSync } from "node:child_process"
 import { randomBytes } from "node:crypto"
 import { mkdirSync, writeFileSync } from "node:fs"
-import net from "node:net"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
 
@@ -115,23 +114,38 @@ function capture(command, args) {
   return result.stdout.trim()
 }
 
-function canConnect(port) {
-  return new Promise((resolvePromise) => {
-    const socket = net.createConnection({ host: "127.0.0.1", port })
-    socket.once("connect", () => {
-      socket.end()
-      resolvePromise(true)
-    })
-    socket.once("error", () => resolvePromise(false))
-  })
+function postgresIsReady(name) {
+  const result = spawnSync(
+    "docker",
+    [
+      "exec",
+      name,
+      "pg_isready",
+      "--host=127.0.0.1",
+      "--username=voyant_eval",
+      "--dbname=voyant_eval",
+      "--quiet",
+    ],
+    { cwd: repoRoot, encoding: "utf8" },
+  )
+  return result.status === 0
 }
 
-async function waitForPostgres(port) {
-  for (let attempt = 0; attempt < 60; attempt += 1) {
-    if (await canConnect(port)) return
-    await new Promise((resolvePromise) => setTimeout(resolvePromise, 500))
+export async function waitForPostgres(
+  name,
+  {
+    attempts = 60,
+    delay = () => new Promise((resolvePromise) => setTimeout(resolvePromise, 500)),
+    probe = postgresIsReady,
+  } = {},
+) {
+  let consecutiveReady = 0
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    consecutiveReady = (await probe(name)) ? consecutiveReady + 1 : 0
+    if (consecutiveReady >= 2) return
+    await delay()
   }
-  throw new Error(`timed out waiting for temporary Postgres on port ${port}`)
+  throw new Error(`timed out waiting for temporary Postgres container ${name}`)
 }
 
 function startTemporaryPostgres() {
@@ -204,7 +218,7 @@ async function main() {
   try {
     if (!databaseUrl) {
       temporaryDatabase = startTemporaryPostgres()
-      await waitForPostgres(temporaryDatabase.port)
+      await waitForPostgres(temporaryDatabase.name)
       databaseUrl = temporaryDatabase.url
     }
 

--- a/scripts/tests/run-mcp-capability-eval.test.mjs
+++ b/scripts/tests/run-mcp-capability-eval.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict"
 import test from "node:test"
 
-import { cleanupResult, parseArgs, usage } from "../run-mcp-capability-eval.mjs"
+import { cleanupResult, parseArgs, usage, waitForPostgres } from "../run-mcp-capability-eval.mjs"
 
 test("defaults to a one-run smoke evaluation", () => {
   const options = parseArgs([])
@@ -69,4 +69,20 @@ test("records whether disposable database cleanup succeeded", () => {
     exitCode: 1,
     error: "daemon failed",
   })
+})
+
+test("waits for PostgreSQL itself to remain ready before returning", async () => {
+  const readiness = [true, false, true, true]
+  let probes = 0
+
+  await waitForPostgres("voyant-eval-1", {
+    attempts: readiness.length,
+    delay: async () => {},
+    probe: async () => {
+      probes += 1
+      return readiness.shift()
+    },
+  })
+
+  assert.equal(probes, 4)
 })


### PR DESCRIPTION
## Summary

- replace the temporary eval database's raw TCP-open check with PostgreSQL's own `pg_isready` probe against the final TCP server
- require two consecutive ready probes before migrations can begin
- keep readiness bounded and preserve disposable-container cleanup

## Failure evidence

After the independent operational groups completed, the commercial smoke failed twice before any model call with `voyant migrate: Connection terminated unexpectedly`. The prior runner returned as soon as the published port accepted TCP, which can happen while the PostgreSQL image is still completing initialization/restarting its final server.

## TDD and real-path verification

- red: the runner had no PostgreSQL-readiness interface and could not prove that a single transient ready signal was insufficient
- green: `node --test scripts/tests/run-mcp-capability-eval.test.mjs` (7/7)
- real path: `pnpm eval:mcp-capability -- --mode smoke --journey supplier-find --model gpt-5.6-terra` applied all 33 migrations, completed through the real selected graph/MCP transport in six calls with zero Tool errors, and cleaned up the disposable container

Tracks #4378.
