### PR TITLE
fix(mcp): clarify eager Tool routing

### DIFF
--- a/.changeset/mcp-meta-tool-guidance.md
+++ b/.changeset/mcp-meta-tool-guidance.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/mcp": patch
+---
+
+Describe the eager `call_tool` meta-tool on demand and return direct-invocation guidance when eager MCP tools are incorrectly nested through it.

--- a/packages/mcp/src/meta-tools.ts
+++ b/packages/mcp/src/meta-tools.ts
@@ -57,6 +57,18 @@ export const META_TOOL_NAMES: readonly string[] = [
   CALL_TOOL_NAME,
 ]
 
+const EAGER_TOOL_NAMES: readonly string[] = [...META_TOOL_NAMES, "voyant_guide", "voyant_glossary"]
+
+const CALL_TOOL_DESCRIPTION =
+  "Dispatch a tool discovered through search_tools / describe_tool. Pass the " +
+  "tool name and its arguments object; the result is the underlying tool's " +
+  "result. For a `<domain>_query` tool, include `resource` in the arguments."
+
+const callToolInputSchema = z.object({
+  name: z.string().trim().min(1),
+  arguments: z.record(z.string(), z.unknown()).optional(),
+})
+
 /** Default and maximum number of hits `search_tools` returns in one call. */
 const DEFAULT_SEARCH_LIMIT = 20
 const MAX_SEARCH_LIMIT = 50
@@ -441,6 +453,21 @@ function describeTool(
   name: string,
   resource?: string,
 ): CallToolResult {
+  if (name === CALL_TOOL_NAME) {
+    const descriptor = {
+      name: CALL_TOOL_NAME,
+      description: CALL_TOOL_DESCRIPTION,
+      inputSchema: z.toJSONSchema(callToolInputSchema, {
+        io: "input",
+        unrepresentable: "any",
+      }),
+      annotations: { openWorldHint: true },
+    }
+    return {
+      content: [{ type: "text", text: JSON.stringify(descriptor, null, 2) }],
+      structuredContent: descriptor,
+    }
+  }
   const queryTool = projection.queryToolFor(name)
   if (queryTool) {
     // Fail closed on an unknown resource rather than advertising an empty union,
@@ -504,20 +531,29 @@ function registerCallTool(input: RegisterMetaToolsInput): void {
   server.registerTool(
     CALL_TOOL_NAME,
     {
-      description:
-        "Dispatch a tool discovered through search_tools / describe_tool. Pass the " +
-        "tool name and its arguments object; the result is the underlying tool's " +
-        "result. For a `<domain>_query` tool, include `resource` in the arguments.",
-      inputSchema: z.object({
-        name: z.string().trim().min(1),
-        arguments: z.record(z.string(), z.unknown()).optional(),
-      }),
+      description: CALL_TOOL_DESCRIPTION,
+      inputSchema: callToolInputSchema,
       annotations: { openWorldHint: true },
     },
     async (args) => {
       // Tolerate a client namespace prefix before anything else, so both the
       // query-tool route and the flat route see the same resolved name.
       const invocationName = resolveInvocationName(surface, args.name)
+      if (EAGER_TOOL_NAMES.includes(invocationName)) {
+        return errorResult(
+          new ToolError(
+            `${invocationName} is an eager MCP tool and cannot be nested inside call_tool.`,
+            "INVALID_INPUT",
+            undefined,
+            undefined,
+            {
+              nextSteps: [
+                `Invoke ${invocationName} directly as an MCP tool with the same arguments.`,
+              ],
+            },
+          ),
+        )
+      }
       const queryToolName = projection.queryToolFor(args.name)
         ? args.name
         : projection.queryToolFor(invocationName)

--- a/packages/mcp/tests/server.test.ts
+++ b/packages/mcp/tests/server.test.ts
@@ -1423,6 +1423,37 @@ describe("createMcpApiRoutes", () => {
     })
   })
 
+  it("describes the eager call_tool meta-tool without reporting it missing", async () => {
+    const app = appWithScopes(["catalog:read"])
+    const described = await describeTool(app, "call_tool")
+
+    expect(described.result?.isError).not.toBe(true)
+    expect(described.structuredContent).toMatchObject({
+      name: "call_tool",
+      inputSchema: {
+        type: "object",
+        required: ["name"],
+      },
+    })
+  })
+
+  it("tells callers to invoke eager guide tools directly instead of nesting them", async () => {
+    const app = appWithScopes(["catalog:read"])
+    const response = await readRpc(
+      await app.request(
+        "/",
+        rpc("tools/call", {
+          name: "call_tool",
+          arguments: { name: "voyant_guide", arguments: { topic: "overview" } },
+        }),
+      ),
+    )
+    const serialized = JSON.stringify(response.result)
+
+    expect(serialized).toContain("Invoke voyant_guide directly")
+    expect(serialized).not.toContain("does not exist")
+  })
+
   it("ranks useful partial matches for verbose operator searches", async () => {
     const app = appWithScopes(["records:write"])
 


### PR DESCRIPTION
## Summary

- let `describe_tool` return the real eager `call_tool` descriptor instead of claiming it is unavailable
- reject nested eager meta/guide Tool calls with precise direct-invocation remediation
- keep `call_tool` non-recursive and preserve the lazy domain dispatch boundary

## Real-model evidence

The current-main GPT-5.6 Terra commercial smoke passed all 15 durable/read journeys within their call budgets, including publish, booking, invoice, contractual cancellation, paid refund, and proposal acceptance. Across that trace Terra repeatedly attempted `describe_tool(call_tool)` and once nested `voyant_guide` through `call_tool`; the server returned misleading `NOT_FOUND` responses saying eager Tools did not exist. Proposal certification independently showed the same detour.

This PR corrects the protocol contract without changing any domain Tool or administrative scope.

Commercial artifact: `.agent-runs/mcp-capability/2026-08-10T17-15-14.056Z/report.json` (local, untracked).

## TDD / verification

- red: both eager Tool interactions returned misleading `NOT_FOUND`
- green: `pnpm --filter @voyant-travel/mcp exec vitest run tests/server.test.ts --reporter=dot` (40/40)
- `pnpm --filter @voyant-travel/mcp typecheck`

Tracks #4378.
