### PR TITLE
fix(storefront): accept package destination queries

### DIFF
--- a/.changeset/fuzzy-cats-search.md
+++ b/.changeset/fuzzy-cats-search.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/voyant-connect-adapter": patch
+---
+
+Accept the Storefront shopping contract's free-text package destination and map it to Connect's city search while continuing to reject unsupported coordinate filters.

--- a/packages/voyant-connect-adapter/src/storefront-package-sources.test.ts
+++ b/packages/voyant-connect-adapter/src/storefront-package-sources.test.ts
@@ -144,6 +144,49 @@ describe("Voyant Connect Storefront package sources", () => {
     expect(searchAcrossProviders).not.toHaveBeenCalled()
   })
 
+  it("maps the public free-text destination query to Connect's city search", async () => {
+    searchAcrossProviders.mockResolvedValue({ offers: [] })
+    const provider = createVoyantConnectStorefrontPackageSourceProvider(
+      primitives({ VOYANT_API_KEY: "key", VOYANT_CONNECT_OPERATOR_ID: "op_1" }),
+    )
+    const queryInput = {
+      ...input,
+      destination: { query: "Paris" },
+      boards: undefined,
+      pagination: undefined,
+    }
+    const [source] = await provider.resolveSources({
+      context: { storefrontId: "sf_1", channelId: "ch_1" },
+      scope: input.scope,
+      destination: queryInput.destination,
+    })
+
+    await expect(source?.search(queryInput)).resolves.toMatchObject({ status: "empty" })
+    expect(searchAcrossProviders).toHaveBeenCalledWith(
+      expect.objectContaining({ destination: { city: "Paris" } }),
+      { operatorId: "op_1" },
+    )
+  })
+
+  it("continues to reject coordinates that Connect cannot enforce", async () => {
+    const provider = createVoyantConnectStorefrontPackageSourceProvider(
+      primitives({ VOYANT_API_KEY: "key", VOYANT_CONNECT_OPERATOR_ID: "op_1" }),
+    )
+    const [source] = await provider.resolveSources({
+      context: { storefrontId: "sf_1", channelId: "ch_1" },
+      scope: input.scope,
+      destination: { latitude: 48.8566, longitude: 2.3522 },
+    })
+
+    await expect(
+      source?.search({
+        ...input,
+        destination: { latitude: 48.8566, longitude: 2.3522 },
+      }),
+    ).rejects.toThrow("does not support coordinate destinations")
+    expect(searchAcrossProviders).not.toHaveBeenCalled()
+  })
+
   it("returns no source when server-owned Connect configuration is absent", async () => {
     const provider = createVoyantConnectStorefrontPackageSourceProvider(primitives({}))
     await expect(

--- a/packages/voyant-connect-adapter/src/storefront-package-sources.ts
+++ b/packages/voyant-connect-adapter/src/storefront-package-sources.ts
@@ -74,8 +74,12 @@ function packageQuery(input: PackageSourceInput): PackageSearchQuery {
   if (input.minStars !== undefined) {
     throw new Error("Connect package search does not support a minimum-stars constraint")
   }
-  if (input.destination.query || input.destination.latitude || input.destination.longitude) {
-    throw new Error("Connect package search requires a country or city destination")
+  if (input.destination.latitude !== undefined || input.destination.longitude !== undefined) {
+    throw new Error("Connect package search does not support coordinate destinations")
+  }
+  const city = input.destination.city ?? input.destination.query?.trim()
+  if (!input.destination.countryCode && !city) {
+    throw new Error("Connect package search requires a country, city, or query destination")
   }
   const boards = input.boards?.map((board) => board.toUpperCase())
   if (boards?.some((board) => !BOARD_CODES.has(board))) {
@@ -87,7 +91,7 @@ function packageQuery(input: PackageSourceInput): PackageSearchQuery {
       ...(input.destination.countryCode
         ? { countryCode: input.destination.countryCode.toUpperCase() }
         : {}),
-      ...(input.destination.city ? { city: input.destination.city } : {}),
+      ...(city ? { city } : {}),
     },
     departureDateFrom: input.departureDateFrom,
     departureDateTo: input.departureDateTo,


### PR DESCRIPTION
## Summary
- map the public shopping contract's free-text package destination to Connect's city search
- preserve fail-closed behavior for unsupported coordinate destinations
- add a patch changeset and focused regressions

## Validation
- `pnpm --filter @voyant-travel/voyant-connect-adapter exec vitest run src/storefront-package-sources.test.ts --maxWorkers=2` (5/5)
- `pnpm exec biome check packages/voyant-connect-adapter/src/storefront-package-sources.ts packages/voyant-connect-adapter/src/storefront-package-sources.test.ts`
- `git diff --check`

The package typecheck was started locally but stopped after five minutes with no diagnostics to relieve host pressure; GitHub Actions is the authoritative full-graph gate.