### PR TITLE
fix: keep active MCP eval journeys alive

### DIFF
--- a/apps/operator/tests/mcp-capability.test.ts
+++ b/apps/operator/tests/mcp-capability.test.ts
@@ -73,6 +73,7 @@ import {
 } from "./api/generated-project-runtime.js"
 import { measureResponseFormats } from "./support/mcp-response-format-metrics.js"
 import { fetchWithTransientRetry } from "./support/openai-response-retry.js"
+import { createProcessInactivityTimeout } from "./support/process-inactivity-timeout.js"
 
 const TEST_DATABASE_URL = process.env.TEST_DATABASE_URL
 
@@ -93,8 +94,8 @@ const REASONING_EFFORT = "medium"
 const REPORT_FILE = process.env.VOYANT_EVAL_REPORT_FILE?.trim()
 const enabled = Boolean(TEST_DATABASE_URL && (EVAL_PROVIDER === "codex" || apiKey))
 
-/** A live model turn plus a real dispatch is slow; the default would time out on latency. */
-const JOURNEY_TIMEOUT_MS = 180_000
+/** Kill a genuinely wedged model process, not a healthy multi-turn journey. */
+const JOURNEY_INACTIVITY_TIMEOUT_MS = 180_000
 
 const TEST_ENV = {
   DATABASE_URL: TEST_DATABASE_URL ?? "",
@@ -450,8 +451,10 @@ async function runCodexJourney(input: {
             fatal: {
               source: "model_transport" as const,
               status: null,
-              code: "codex_exec_failed",
-              message: result.stderr.slice(0, 300),
+              code: result.timedOut ? "codex_exec_inactivity_timeout" : "codex_exec_failed",
+              message: result.timedOut
+                ? `Codex produced no output for ${JOURNEY_INACTIVITY_TIMEOUT_MS}ms. ${result.stderr.slice(0, 220)}`
+                : result.stderr.slice(0, 300),
             },
           }),
     }
@@ -461,7 +464,9 @@ async function runCodexJourney(input: {
   }
 }
 
-function spawnCodex(args: string[]): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+function spawnCodex(
+  args: string[],
+): Promise<{ exitCode: number; stdout: string; stderr: string; timedOut: boolean }> {
   return new Promise((resolvePromise, reject) => {
     const env = { ...process.env }
     for (const key of [
@@ -475,16 +480,30 @@ function spawnCodex(args: string[]): Promise<{ exitCode: number; stdout: string;
     const child = spawn("codex", args, { env, stdio: ["ignore", "pipe", "pipe"] })
     const stdout: Buffer[] = []
     const stderr: Buffer[] = []
-    child.stdout.on("data", (chunk) => stdout.push(chunk))
-    child.stderr.on("data", (chunk) => stderr.push(chunk))
-    child.once("error", reject)
-    const timeout = setTimeout(() => child.kill("SIGTERM"), JOURNEY_TIMEOUT_MS)
+    let timedOut = false
+    const inactivity = createProcessInactivityTimeout(JOURNEY_INACTIVITY_TIMEOUT_MS, () => {
+      timedOut = true
+      child.kill("SIGTERM")
+    })
+    child.stdout.on("data", (chunk) => {
+      stdout.push(chunk)
+      inactivity.touch()
+    })
+    child.stderr.on("data", (chunk) => {
+      stderr.push(chunk)
+      inactivity.touch()
+    })
+    child.once("error", (error) => {
+      inactivity.clear()
+      reject(error)
+    })
     child.once("close", (exitCode) => {
-      clearTimeout(timeout)
+      inactivity.clear()
       resolvePromise({
         exitCode: exitCode ?? 1,
         stdout: Buffer.concat(stdout).toString("utf8"),
         stderr: Buffer.concat(stderr).toString("utf8"),
+        timedOut,
       })
     })
   })
@@ -1689,7 +1708,7 @@ describe.skipIf(!enabled)("MCP capability — a travel agent's job", () => {
       process.stdout.write(`\n${report()}\n\n`)
       writeMachineReport()
     },
-    JOURNEY_TIMEOUT_MS * JOURNEYS.length * RUNS,
+    JOURNEY_INACTIVITY_TIMEOUT_MS * JOURNEYS.length * RUNS,
   )
 
   afterAll(async () => {

--- a/apps/operator/tests/support/process-inactivity-timeout.test.ts
+++ b/apps/operator/tests/support/process-inactivity-timeout.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { createProcessInactivityTimeout } from "./process-inactivity-timeout.js"
+
+describe("createProcessInactivityTimeout", () => {
+  it("resets the deadline while a long-running process remains active", () => {
+    vi.useFakeTimers()
+    const onTimeout = vi.fn()
+    const timeout = createProcessInactivityTimeout(180_000, onTimeout)
+
+    vi.advanceTimersByTime(170_000)
+    timeout.touch()
+    vi.advanceTimersByTime(170_000)
+
+    expect(onTimeout).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(10_000)
+    expect(onTimeout).toHaveBeenCalledOnce()
+
+    timeout.clear()
+    vi.useRealTimers()
+  })
+
+  it("can be cleared after the process exits", () => {
+    vi.useFakeTimers()
+    const onTimeout = vi.fn()
+    const timeout = createProcessInactivityTimeout(180_000, onTimeout)
+
+    timeout.clear()
+    vi.advanceTimersByTime(180_000)
+
+    expect(onTimeout).not.toHaveBeenCalled()
+    vi.useRealTimers()
+  })
+})

--- a/apps/operator/tests/support/process-inactivity-timeout.ts
+++ b/apps/operator/tests/support/process-inactivity-timeout.ts
@@ -1,0 +1,17 @@
+export function createProcessInactivityTimeout(
+  timeoutMs: number,
+  onTimeout: () => void,
+): {
+  touch: () => void
+  clear: () => void
+} {
+  let timer: ReturnType<typeof setTimeout>
+
+  const arm = () => {
+    clearTimeout(timer)
+    timer = setTimeout(onTimeout, timeoutMs)
+  }
+
+  arm()
+  return { touch: arm, clear: () => clearTimeout(timer) }
+}


### PR DESCRIPTION
## Summary
- replace the fixed three-minute wall-clock kill with a three-minute inactivity deadline
- reset the deadline whenever the model process emits stdout or stderr
- report true inactivity timeouts separately from generic CLI exits
- cover deadline reset and cleanup with deterministic tests

## Evidence
- reproduced commercial certification at 14/15 journeys 5/5; paid-refund was 4/5 because the healthy process was killed after approving the refund
- post-fix commercial certification: all 15 journeys 5/5 (75/75), paid-refund 5/5, zero exhausted attempts, zero fatalities, zero model transport retries
- `pnpm verify:fast`
- `pnpm --filter operator typecheck`
- focused inactivity timer tests

Artifacts: `.agent-runs/mcp-capability/2026-08-10T19-09-46.144Z/` (local, disposable database cleanup succeeded).

Tracks #4378 and #3921.