### PR TITLE
Sign booking contracts after recorded payments

### DIFF
--- a/apps/operator/tests/api/selected-graph-runtime.test.ts
+++ b/apps/operator/tests/api/selected-graph-runtime.test.ts
@@ -325,7 +325,7 @@ describe("selected Operator graph runtime composition", () => {
     expect(subscribe.mock.calls.filter(([event]) => event === "payment.completed")).toHaveLength(1)
   })
 
-  it("activates both selected Commerce checkout subscribers exactly once", async () => {
+  it("activates all selected Commerce checkout subscribers exactly once", async () => {
     const runtime = createGeneratedGraphRuntime()
     const checkout = runtime.extensions.find(
       (unit) => unit.id === "@voyant-travel/commerce#catalog-checkout-extension",
@@ -349,16 +349,22 @@ describe("selected Operator graph runtime composition", () => {
         .map((reference) => reference.entityId),
     ).toEqual([
       "@voyant-travel/commerce#subscriber.catalog-checkout-contract-document-generated",
+      "@voyant-travel/commerce#subscriber.catalog-checkout-invoice-payment-recorded",
       "@voyant-travel/commerce#subscriber.catalog-checkout-payment-completed",
     ])
     expect(
       subscribe.mock.calls.filter(
         ([eventType]) =>
-          eventType === "contract.document.generated" || eventType === "payment.completed",
+          eventType === "contract.document.generated" ||
+          eventType === "payment.completed" ||
+          eventType === "invoice.payment.recorded",
       ),
-    ).toHaveLength(2)
+    ).toHaveLength(3)
     expect(
       subscribe.mock.calls.find(([eventType]) => eventType === "payment.completed")?.[2],
+    ).toEqual({ inline: true })
+    expect(
+      subscribe.mock.calls.find(([eventType]) => eventType === "invoice.payment.recorded")?.[2],
     ).toEqual({ inline: true })
   })
 

--- a/packages/commerce/src/checkout/subscriber-runtime.ts
+++ b/packages/commerce/src/checkout/subscriber-runtime.ts
@@ -37,6 +37,8 @@ export const COMMERCE_ACCEPTANCE_SIGNATURE_SUBSCRIBER_ID =
   "@voyant-travel/commerce#subscriber.catalog-checkout-contract-document-generated"
 export const COMMERCE_CHECKOUT_FINALIZE_SUBSCRIBER_ID =
   "@voyant-travel/commerce#subscriber.catalog-checkout-payment-completed"
+export const COMMERCE_INVOICE_PAYMENT_SIGNATURE_SUBSCRIBER_ID =
+  "@voyant-travel/commerce#subscriber.catalog-checkout-invoice-payment-recorded"
 
 export interface CatalogCheckoutRuntimeDatabase<TBindings = unknown>
   extends CatalogCheckoutDatabaseRuntime {
@@ -76,6 +78,12 @@ interface PaymentCompletedPayload {
   targetType?: string
   targetId?: string | null
   paymentIntent?: "card" | "bank_transfer" | "hold" | "ticket_on_credit"
+}
+
+interface InvoicePaymentRecordedPayload {
+  bookingId: string | null
+  paymentId: string
+  status: "pending" | "completed" | "failed" | "refunded"
 }
 
 /** Build the acceptance-signature descriptor without activating its manifest runtime. */
@@ -195,6 +203,45 @@ export function createCheckoutFinalizeSubscriberRuntime<TBindings = unknown>(
   }
 }
 
+/** Promote checkout acceptance after an operator confirms a booking invoice payment. */
+export function createInvoicePaymentSignatureSubscriberRuntime<TBindings = unknown>(
+  options: AcceptanceSignatureSubscriberRuntimeOptions<TBindings>,
+): SubscriberRuntimeDescriptor {
+  const persistSignature = options.persistSignature ?? persistAcceptanceSignature
+  const logger = options.logger ?? console
+
+  return {
+    id: COMMERCE_INVOICE_PAYMENT_SIGNATURE_SUBSCRIBER_ID,
+    eventType: "invoice.payment.recorded",
+    register: ({ bindings, eventBus }) => {
+      const runtimeBindings = bindings as TBindings
+      eventBus.subscribe<InvoicePaymentRecordedPayload>(
+        "invoice.payment.recorded",
+        async ({ data }, context) => {
+          if (data.status !== "completed" || !data.bookingId) return
+          const bookingId = data.bookingId
+          const nestedEventBus = (context?.eventBus ?? eventBus) as EventBus
+          try {
+            await options.withDb(runtimeBindings, async (db) => {
+              await options.legal.recordBookingPaymentConfirmation(db, bookingId, data.paymentId)
+              const contract = await options.legal.getBookingContract(db, bookingId)
+              if (!contract) return
+              await persistSignature(db, contract.id, nestedEventBus, options.legal)
+            })
+          } catch (error) {
+            logger.error(
+              `[catalog-checkout] invoice payment signature promotion failed for booking ${bookingId}`,
+              error,
+            )
+            throw error
+          }
+        },
+        { inline: true },
+      )
+    },
+  }
+}
+
 /** Selected-graph factory for acceptance-signature promotion. */
 export const createAcceptanceSignatureSubscriberGraphRuntime = defineGraphRuntimeFactory(
   async ({ getPort }) =>
@@ -228,4 +275,13 @@ export const createCheckoutFinalizeSubscriberGraphRuntime = defineGraphRuntimeFa
       },
     }
   },
+)
+
+/** Selected-graph factory for operator-recorded booking payment promotion. */
+export const createInvoicePaymentSignatureSubscriberGraphRuntime = defineGraphRuntimeFactory(
+  async ({ getPort }) =>
+    createInvoicePaymentSignatureSubscriberRuntime({
+      ...(await getPort(catalogCheckoutDatabaseRuntimePort)),
+      legal: await getPort(catalogCheckoutLegalRuntimePort),
+    }),
 )

--- a/packages/commerce/src/voyant.ts
+++ b/packages/commerce/src/voyant.ts
@@ -564,6 +564,15 @@ export const commerceCatalogCheckoutVoyantPlugin = defineExtension({
         export: "createCheckoutFinalizeSubscriberGraphRuntime",
       },
     },
+    {
+      id: "@voyant-travel/commerce#subscriber.catalog-checkout-invoice-payment-recorded",
+      eventType: "invoice.payment.recorded",
+      source: "@voyant-travel/commerce/catalog-checkout-subscribers",
+      runtime: {
+        entry: "@voyant-travel/commerce/catalog-checkout-subscribers",
+        export: "createInvoicePaymentSignatureSubscriberGraphRuntime",
+      },
+    },
   ],
   meta: {
     ownership: "package",

--- a/packages/commerce/tests/unit/catalog-checkout-subscriber-runtime.test.ts
+++ b/packages/commerce/tests/unit/catalog-checkout-subscriber-runtime.test.ts
@@ -8,9 +8,11 @@ import { catalogCheckoutLegalRuntimePort } from "../../src/checkout/runtime-port
 import {
   COMMERCE_ACCEPTANCE_SIGNATURE_SUBSCRIBER_ID,
   COMMERCE_CHECKOUT_FINALIZE_SUBSCRIBER_ID,
+  COMMERCE_INVOICE_PAYMENT_SIGNATURE_SUBSCRIBER_ID,
   createAcceptanceSignatureSubscriberRuntime,
   createCheckoutFinalizeSubscriberGraphRuntime,
   createCheckoutFinalizeSubscriberRuntime,
+  createInvoicePaymentSignatureSubscriberRuntime,
 } from "../../src/checkout/subscriber-runtime.js"
 
 type Handler = (
@@ -150,6 +152,83 @@ describe("catalog-checkout subscriber runtimes", () => {
       "session_1",
     )
     expect(persistSignature).toHaveBeenCalledWith(db, "contract_1", scopedEventBus, paidLegalPort)
+  })
+
+  it("promotes an accepted booking contract after a completed invoice payment", async () => {
+    const db = {} as PostgresJsDatabase
+    const scopedEventBus = createEventBus()
+    const persistSignature = vi.fn(async () => undefined)
+    const paidLegalPort: AcceptanceSignatureLegalPort = {
+      ...legalPort,
+      getBookingContract: vi.fn(async () => ({
+        id: "contract_bank_1",
+        bookingId: "booking_bank_1",
+        metadata: null,
+        status: "draft",
+      })),
+      recordBookingPaymentConfirmation: vi.fn(async () => undefined),
+    }
+    const withDb = vi.fn(async (_bindings, operation) => operation(db))
+    const { eventBus, subscriptions } = recordingEventBus()
+    const descriptor = createInvoicePaymentSignatureSubscriberRuntime({
+      withDb,
+      legal: paidLegalPort,
+      persistSignature,
+    })
+    await descriptor.register({ bindings: {}, container: createContainer(), eventBus })
+
+    await subscriptions[0]?.handler(
+      event("invoice.payment.recorded", {
+        bookingId: "booking_bank_1",
+        paymentId: "payment_bank_1",
+        status: "completed",
+      }),
+      { eventBus: scopedEventBus },
+    )
+
+    expect(descriptor).toMatchObject({
+      id: COMMERCE_INVOICE_PAYMENT_SIGNATURE_SUBSCRIBER_ID,
+      eventType: "invoice.payment.recorded",
+    })
+    expect(subscriptions[0]?.inline).toBe(true)
+    expect(paidLegalPort.recordBookingPaymentConfirmation).toHaveBeenCalledWith(
+      db,
+      "booking_bank_1",
+      "payment_bank_1",
+    )
+    expect(persistSignature).toHaveBeenCalledWith(
+      db,
+      "contract_bank_1",
+      scopedEventBus,
+      paidLegalPort,
+    )
+  })
+
+  it("ignores invoice payments that are incomplete or unrelated to a booking", async () => {
+    const withDb = vi.fn(async (_bindings, operation) => operation({} as PostgresJsDatabase))
+    const { eventBus, subscriptions } = recordingEventBus()
+    const descriptor = createInvoicePaymentSignatureSubscriberRuntime({
+      withDb,
+      legal: legalPort,
+    })
+    await descriptor.register({ bindings: {}, container: createContainer(), eventBus })
+
+    await subscriptions[0]?.handler(
+      event("invoice.payment.recorded", {
+        bookingId: "booking_bank_1",
+        paymentId: "payment_bank_1",
+        status: "pending",
+      }),
+    )
+    await subscriptions[0]?.handler(
+      event("invoice.payment.recorded", {
+        bookingId: null,
+        paymentId: "payment_unrelated_1",
+        status: "completed",
+      }),
+    )
+
+    expect(withDb).not.toHaveBeenCalled()
   })
 
   it("commits paid Booking Sessions before finalizing their booking", async () => {

--- a/packages/commerce/tests/unit/voyant-manifest.test.ts
+++ b/packages/commerce/tests/unit/voyant-manifest.test.ts
@@ -286,9 +286,18 @@ describe("commerce deployment manifest", () => {
             export: "createCheckoutFinalizeSubscriberGraphRuntime",
           },
         },
+        {
+          id: "@voyant-travel/commerce#subscriber.catalog-checkout-invoice-payment-recorded",
+          eventType: "invoice.payment.recorded",
+          source: "@voyant-travel/commerce/catalog-checkout-subscribers",
+          runtime: {
+            entry: "@voyant-travel/commerce/catalog-checkout-subscribers",
+            export: "createInvoicePaymentSignatureSubscriberGraphRuntime",
+          },
+        },
       ],
     })
-    expect(commerceCatalogCheckoutVoyantPlugin.subscribers).toHaveLength(2)
+    expect(commerceCatalogCheckoutVoyantPlugin.subscribers).toHaveLength(3)
 
     expect(commerceBookingMaintenanceVoyantPlugin).toMatchObject({
       schemaVersion: "voyant.extension.v1",


### PR DESCRIPTION
## Summary
- listen for completed booking-linked invoice payments
- reuse the checkout Legal payment checkpoint and acceptance-signature promotion
- activate the subscriber in the selected Operator graph

## Validation
- `pnpm --filter @voyant-travel/commerce test -- --maxWorkers=4`
- `pnpm --filter @voyant-travel/commerce typecheck`
- `pnpm --filter @voyant-travel/commerce build`
- `pnpm --filter operator exec vitest run --config .voyant/vitest.config.ts tests/api/selected-graph-runtime.test.ts --maxWorkers=4`
- Biome on touched files

The full Operator typecheck was attempted locally but exhausted the Node heap; the focused generated-runtime test passes and CI will run the repository gates.