### PR TITLE
Sign contracts after transferred checkout payments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,6 +361,8 @@ jobs:
                 tests/integration/postgres-pgtrgm-indexer.test.ts
               pnpm --filter @voyant-travel/commerce exec vitest run \
                 tests/integration/promotion-created-command.test.ts
+              pnpm --filter @voyant-travel/commerce exec vitest run \
+                tests/integration/linked-payment-contract-confirmation.test.ts
               pnpm --filter @voyant-travel/cruises exec vitest run \
                 tests/integration/created-target-tools.test.ts
               pnpm --filter @voyant-travel/inventory exec vitest run \

--- a/packages/commerce/src/checkout/subscriber-runtime.ts
+++ b/packages/commerce/src/checkout/subscriber-runtime.ts
@@ -9,6 +9,7 @@ import {
 } from "@voyant-travel/catalog/ports"
 import type { BootstrapContext, EventBus, SubscriberRuntimeDescriptor } from "@voyant-travel/core"
 import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
+import { and, desc, eq, inArray } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import {
@@ -48,6 +49,7 @@ export interface CatalogCheckoutRuntimeDatabase<TBindings = unknown>
 export interface AcceptanceSignatureSubscriberRuntimeOptions<TBindings = unknown>
   extends CatalogCheckoutRuntimeDatabase<TBindings> {
   legal: AcceptanceSignatureLegalPort
+  promoteLinkedPayment?: typeof recordLinkedBookingPaymentConfirmation
   persistSignature?: typeof persistAcceptanceSignature
   logger?: Pick<Console, "error">
 }
@@ -86,10 +88,47 @@ interface InvoicePaymentRecordedPayload {
   status: "pending" | "completed" | "failed" | "refunded"
 }
 
+/**
+ * Recover the card path when the shopper's paid Commit wins the settlement
+ * subscriber race.
+ *
+ * The Booking Session payment is transferred onto the Booking in the same
+ * transaction that creates it. The earlier `payment.completed` event may have
+ * already been delivered while that payment still targeted the Booking
+ * Session, so document generation is the first durable post-commit checkpoint
+ * guaranteed to see both the Contract and the transferred payment.
+ */
+export async function recordLinkedBookingPaymentConfirmation(
+  db: PostgresJsDatabase,
+  contractId: string,
+  legal: AcceptanceSignatureLegalPort,
+): Promise<void> {
+  const contract = await legal.getContract(db, contractId)
+  if (!contract?.bookingId) return
+
+  const { paymentSessions } = await import("@voyant-travel/finance/schema")
+  const [paymentSession] = await db
+    .select({ id: paymentSessions.id })
+    .from(paymentSessions)
+    .where(
+      and(
+        eq(paymentSessions.bookingId, contract.bookingId),
+        inArray(paymentSessions.status, ["authorized", "paid"]),
+      ),
+    )
+    .orderBy(desc(paymentSessions.updatedAt), desc(paymentSessions.id))
+    .limit(1)
+  if (!paymentSession) return
+
+  await legal.recordBookingPaymentConfirmation(db, contract.bookingId, paymentSession.id)
+}
+
 /** Build the acceptance-signature descriptor without activating its manifest runtime. */
 export function createAcceptanceSignatureSubscriberRuntime<TBindings = unknown>(
   options: AcceptanceSignatureSubscriberRuntimeOptions<TBindings>,
 ): SubscriberRuntimeDescriptor {
+  const promoteLinkedPayment =
+    options.promoteLinkedPayment ?? recordLinkedBookingPaymentConfirmation
   const persistSignature = options.persistSignature ?? persistAcceptanceSignature
   const logger = options.logger ?? console
 
@@ -102,9 +141,10 @@ export function createAcceptanceSignatureSubscriberRuntime<TBindings = unknown>(
         "contract.document.generated",
         async ({ data }) => {
           try {
-            await options.withDb(runtimeBindings, (db) =>
-              persistSignature(db, data.contractId, eventBus, options.legal),
-            )
+            await options.withDb(runtimeBindings, async (db) => {
+              await promoteLinkedPayment(db, data.contractId, options.legal)
+              await persistSignature(db, data.contractId, eventBus, options.legal)
+            })
           } catch (error) {
             logger.error("[catalog-checkout] persistAcceptanceSignature failed", error)
             throw error

--- a/packages/commerce/tests/integration/linked-payment-contract-confirmation.test.ts
+++ b/packages/commerce/tests/integration/linked-payment-contract-confirmation.test.ts
@@ -1,0 +1,73 @@
+import { newId } from "@voyant-travel/db/lib/typeid"
+import { paymentSessions } from "@voyant-travel/finance/schema"
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { AcceptanceSignatureLegalPort } from "../../src/checkout/acceptance-signature.js"
+import { recordLinkedBookingPaymentConfirmation } from "../../src/checkout/subscriber-runtime.js"
+
+const DB_AVAILABLE = Boolean(process.env.TEST_DATABASE_URL)
+
+describe.skipIf(!DB_AVAILABLE)("linked checkout payment contract confirmation", () => {
+  let db: ReturnType<typeof import("@voyant-travel/db/test-utils").createTestDb>
+
+  beforeAll(async () => {
+    const { createTestDb } = await import("@voyant-travel/db/test-utils")
+    db = createTestDb()
+  })
+
+  beforeEach(async () => {
+    const { cleanupTestDb } = await import("@voyant-travel/db/test-utils")
+    await cleanupTestDb(db)
+  })
+
+  afterAll(async () => {
+    const { closeTestDb } = await import("@voyant-travel/db/test-utils")
+    await closeTestDb()
+  })
+
+  it("finds a transferred paid session with the real Postgres query", async () => {
+    const bookingId = newId("bookings")
+    const pendingId = newId("payment_sessions")
+    const paidId = newId("payment_sessions")
+    await db.insert(paymentSessions).values([
+      {
+        id: pendingId,
+        targetType: "booking",
+        targetId: bookingId,
+        bookingId,
+        status: "pending",
+        currency: "EUR",
+        amountCents: 6_400,
+        paymentMethod: "credit_card",
+      },
+      {
+        id: paidId,
+        targetType: "booking",
+        targetId: bookingId,
+        bookingId,
+        status: "paid",
+        currency: "EUR",
+        amountCents: 6_400,
+        paymentMethod: "credit_card",
+      },
+    ])
+    const legal: AcceptanceSignatureLegalPort = {
+      getContract: vi.fn(async () => ({
+        id: "contract_card_1",
+        bookingId,
+        metadata: null,
+        status: "draft",
+      })),
+      getBookingContract: vi.fn(),
+      recordBookingPaymentConfirmation: vi.fn(async () => undefined),
+      listSignatures: vi.fn(),
+      issueContract: vi.fn(),
+      sendContract: vi.fn(),
+      signContract: vi.fn(),
+    }
+
+    await recordLinkedBookingPaymentConfirmation(db, "contract_card_1", legal)
+
+    expect(legal.recordBookingPaymentConfirmation).toHaveBeenCalledWith(db, bookingId, paidId)
+  })
+})

--- a/packages/commerce/tests/unit/catalog-checkout-subscriber-runtime.test.ts
+++ b/packages/commerce/tests/unit/catalog-checkout-subscriber-runtime.test.ts
@@ -13,6 +13,7 @@ import {
   createCheckoutFinalizeSubscriberGraphRuntime,
   createCheckoutFinalizeSubscriberRuntime,
   createInvoicePaymentSignatureSubscriberRuntime,
+  recordLinkedBookingPaymentConfirmation,
 } from "../../src/checkout/subscriber-runtime.js"
 
 type Handler = (
@@ -72,6 +73,63 @@ describe("catalog-checkout subscriber runtimes", () => {
     })
     expect(withDb).toHaveBeenCalledWith(bindings, expect.any(Function))
     expect(persistSignature).toHaveBeenCalledWith(db, "contract_1", eventBus, legalPort)
+  })
+
+  it("recovers a linked paid checkout before promoting the generated contract", async () => {
+    const db = {} as PostgresJsDatabase
+    const calls: string[] = []
+    const promoteLinkedPayment = vi.fn(async () => {
+      calls.push("payment")
+    })
+    const persistSignature = vi.fn(async () => {
+      calls.push("signature")
+    })
+    const { eventBus, subscriptions } = recordingEventBus()
+    const descriptor = createAcceptanceSignatureSubscriberRuntime({
+      legal: legalPort,
+      withDb: async (_bindings, operation) => operation(db),
+      promoteLinkedPayment,
+      persistSignature,
+    })
+
+    await descriptor.register({ bindings: {}, container: createContainer(), eventBus })
+    await subscriptions[0]?.handler(
+      event("contract.document.generated", { contractId: "contract_card_1" }),
+    )
+
+    expect(promoteLinkedPayment).toHaveBeenCalledWith(db, "contract_card_1", legalPort)
+    expect(calls).toEqual(["payment", "signature"])
+  })
+
+  it("records a transferred paid Booking Session as contract payment confirmation", async () => {
+    const limit = vi.fn(async () => [{ id: "session_card_1" }])
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            orderBy: () => ({ limit }),
+          }),
+        }),
+      }),
+    } as PostgresJsDatabase
+    const paidLegalPort: AcceptanceSignatureLegalPort = {
+      ...legalPort,
+      getContract: vi.fn(async () => ({
+        id: "contract_card_1",
+        bookingId: "booking_card_1",
+        metadata: null,
+        status: "draft",
+      })),
+      recordBookingPaymentConfirmation: vi.fn(async () => undefined),
+    }
+
+    await recordLinkedBookingPaymentConfirmation(db, "contract_card_1", paidLegalPort)
+
+    expect(paidLegalPort.recordBookingPaymentConfirmation).toHaveBeenCalledWith(
+      db,
+      "booking_card_1",
+      "session_card_1",
+    )
   })
 
   it("logs and rethrows acceptance-signature failures for outbox retry", async () => {


### PR DESCRIPTION
## Summary
- recover a paid or authorized booking-linked payment session when the contract document is generated
- record Legal payment confirmation before persisting the acceptance signature, closing the race where browser commit wins before `payment.completed` observes the transferred booking
- preserve bank-transfer semantics: unpaid bookings remain draft and the existing recorded-payment subscriber signs only after payment confirmation
- add the real PostgreSQL integration test to the explicit CI database lane

## Verification
- Commerce unit suite: 186 passed, 9 skipped
- Commerce typecheck and build
- changed-file agent quality gate
- PostgreSQL 16 integration test after all 33 operator migrations

## Live failure reproduced
A fresh embedded-card sandbox booking completed successfully and received the next contract number, but the contract remained Draft because `payment.completed` had already targeted the pre-commit Booking Session. This change makes document generation the durable post-commit reconciliation point.