### PR TITLE
Keep runtime port startup preflight side-effect free

### DIFF
--- a/.changeset/calm-runtime-port-preflight.md
+++ b/.changeset/calm-runtime-port-preflight.md
@@ -1,0 +1,9 @@
+---
+"@voyant-travel/graph-contracts": patch
+"@voyant-travel/trips": patch
+"@voyant-travel/flights": patch
+"@voyant-travel/legal": patch
+"@voyant-travel/notifications": patch
+---
+
+Keep production runtime-port startup preflight side-effect free while retaining exhaustive behavioral provider verification for CI and release gates.

--- a/docs/architecture/graph-host-options.md
+++ b/docs/architecture/graph-host-options.md
@@ -45,7 +45,7 @@ spread it unconditionally.
 | | runtime port | host options |
 |---|---|---|
 | declared by | the consuming package, in its manifest | nobody — the host supplies it |
-| validated | `definePort({ test })` conformance | not validated |
+| validated | side-effect-free `test`; optional behavioral `verify` in provider CI/release verification | not validated |
 | visible to | `verify:graph-conformance`, graph resolution | composition only |
 | for | behaviour one graph unit needs from another | knowledge only the host has |
 

--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -280,8 +280,13 @@ passed to job handlers; the host never creates per-run bindings or input.
 Packages own product runtime composition. A selected package declares the ports
 its runtime factory requires and publishes a package-owned runtime contributor.
 Generated composition loads contributors from selected packages, runs port
-conformance checks, and passes only the declared providers to each package
-factory.
+startup preflight, and passes only the declared providers to each package
+factory. Startup preflight is deliberately structural and side-effect free:
+runtime composition may resolve the same port for multiple units, so it must
+never turn a cold start into repeated network calls, durable writes, renderer
+jobs, or storage mutations. Ports that need executable behavioral proof expose
+an additional `verify` hook. Provider CI and release verification run it through
+`assertPortConforms`; production composition runs only `test`.
 
 Ports carry behaviour one graph unit needs from another. A host may also
 contribute per-unit runtime options that the graph cannot supply, because they

--- a/packages/flights/src/durable-action-runtime-port.test.ts
+++ b/packages/flights/src/durable-action-runtime-port.test.ts
@@ -1,5 +1,5 @@
 import { assertPortConforms } from "@voyant-travel/core/project"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
 import {
   DURABLE_FLIGHT_ACTION_PROTOCOL,
@@ -24,6 +24,15 @@ describe("durableFlightActionRuntimePort", () => {
     await expect(
       assertPortConforms(durableFlightActionRuntimePort, conformingRuntime()),
     ).resolves.toBeUndefined()
+  })
+
+  it("does not execute the isolated behavioral probe during runtime startup", async () => {
+    const runtime = conformingRuntime()
+    runtime.createIsolatedProbe = vi.fn(runtime.createIsolatedProbe)
+
+    await durableFlightActionRuntimePort.test(runtime)
+
+    expect(runtime.createIsolatedProbe).not.toHaveBeenCalled()
   })
 
   it("rejects an incomplete selected runtime", async () => {

--- a/packages/flights/src/durable-action-runtime-port.ts
+++ b/packages/flights/src/durable-action-runtime-port.ts
@@ -55,18 +55,24 @@ export const durableFlightActionRuntimePort = definePort<DurableFlightActionRunt
     entry: "@voyant-travel/flights/durable-action-runtime-port",
     export: "durableFlightActionRuntimePort",
   },
-  async test(runtime) {
-    if (
-      !runtime ||
-      typeof runtime !== "object" ||
-      typeof runtime.createIsolatedProbe !== "function"
-    ) {
-      throw new Error("flights.durable-action-runtime provider is incomplete")
-    }
+  test: assertRuntimeShape,
+  async verify(runtime) {
     await assertActionConforms(runtime, "ticket-order")
     await assertActionConforms(runtime, "cancel-order")
   },
 })
+
+function assertRuntimeShape(runtime: DurableFlightActionRuntime): void {
+  if (
+    !runtime ||
+    typeof runtime !== "object" ||
+    typeof runtime.createIsolatedProbe !== "function"
+  ) {
+    throw new Error("flights.durable-action-runtime provider is incomplete")
+  }
+  assertCapability(runtime.ticket)
+  assertCapability(runtime.cancel)
+}
 
 async function assertActionConforms(
   runtime: DurableFlightActionRuntime,

--- a/packages/framework/src/runtime-composition.test.ts
+++ b/packages/framework/src/runtime-composition.test.ts
@@ -1,6 +1,10 @@
 // agent-quality: file-size exception -- owner: framework; graph unit, facet, port, route posture, and plugin output contracts share one composition harness.
 import { createEventBus } from "@voyant-travel/core"
-import { defineGraphRuntimeFactory, definePort } from "@voyant-travel/core/project"
+import {
+  assertPortConforms,
+  defineGraphRuntimeFactory,
+  definePort,
+} from "@voyant-travel/core/project"
 import { mountApp } from "@voyant-travel/hono"
 import { Hono } from "hono"
 import { describe, expect, it, vi } from "vitest"
@@ -774,11 +778,13 @@ describe("graph runtime composition", () => {
   })
 
   it("runs a port's conformance kit before exposing a deployment binding", async () => {
+    const exhaustiveVerification = vi.fn()
     const runtimePort = definePort<{ ready: boolean }>({
       id: "loyalty.runtime",
       test(provider) {
         if (!provider.ready) throw new Error("loyalty.runtime provider is not ready")
       },
+      verify: exhaustiveVerification,
     })
     const runtime = createVoyantGraphRuntime({
       graphHash: "sha256:non-conforming-runtime-port",
@@ -829,6 +835,10 @@ describe("graph runtime composition", () => {
         ports: { [runtimePort.id]: { ready: false } },
       }),
     ).rejects.toThrow("loyalty.runtime provider is not ready")
+    expect(exhaustiveVerification).not.toHaveBeenCalled()
+
+    await assertPortConforms(runtimePort, { ready: true })
+    expect(exhaustiveVerification).toHaveBeenCalledOnce()
   })
 
   it("uses selected ID bindings for option-bearing factories and local units", async () => {

--- a/packages/graph-contracts/src/index.ts
+++ b/packages/graph-contracts/src/index.ts
@@ -93,7 +93,20 @@ export interface VoyantGraphPortDeclaration {
 
 export interface VoyantPort<TProvider> {
   readonly id: string
+  /**
+   * Side-effect-free startup preflight. Runtime composition may call this more
+   * than once while separate graph units resolve the same selected provider,
+   * so it must not perform network requests, durable writes, or other live
+   * behavioral probes.
+   */
   readonly test: (provider: TProvider) => void | Promise<void>
+  /**
+   * Exhaustive behavioral conformance for provider CI/release verification.
+   * `assertPortConforms` runs this after the structural hook; production
+   * runtime composition deliberately uses only the side-effect-free `test`
+   * hook above.
+   */
+  readonly verify?: (provider: TProvider) => void | Promise<void>
   /** Import-cheap reference back to this typed port for generic startup preflight. */
   readonly conformance?: VoyantGraphRuntimeReference
 }
@@ -108,6 +121,7 @@ export function definePort<TProvider>(input: VoyantPort<TProvider>): VoyantPort<
   return Object.freeze({
     id: input.id,
     test: input.test,
+    ...(input.verify ? { verify: input.verify } : {}),
     ...(input.conformance ? { conformance: input.conformance } : {}),
   })
 }
@@ -133,6 +147,7 @@ export async function assertPortConforms<TProvider>(
   provider: TProvider,
 ): Promise<void> {
   await port.test(provider)
+  await port.verify?.(provider)
 }
 
 export interface VoyantGraphRuntimeFactoryGraph {

--- a/packages/legal/src/contracts/document-artifact-provider.ts
+++ b/packages/legal/src/contracts/document-artifact-provider.ts
@@ -86,7 +86,8 @@ export const legalDocumentArtifactProviderPort = definePort<LegalDocumentArtifac
     entry: "@voyant-travel/legal",
     export: "legalDocumentArtifactProviderPort",
   },
-  async test(provider) {
+  test: assertLegalDocumentArtifactProvider,
+  async verify(provider) {
     await assertLegalDocumentArtifactProviderConformance({
       provider,
       namespace: "legal/contract-documents/provider-conformance",

--- a/packages/legal/tests/unit/document-artifact-provider.test.ts
+++ b/packages/legal/tests/unit/document-artifact-provider.test.ts
@@ -1,3 +1,4 @@
+import { assertPortConforms } from "@voyant-travel/core/project"
 import { describe, expect, it } from "vitest"
 import {
   assertLegalDocumentArtifactProviderConformance,
@@ -105,11 +106,20 @@ describe("legal document artifact provider conformance", () => {
     const provider = memoryProvider()
     const alternate = memoryProvider()
 
-    await legalDocumentArtifactProviderPort.test(provider)
+    await assertPortConforms(legalDocumentArtifactProviderPort, provider)
 
     expect(provider.puts).toBe(4)
     expect(provider.deletes).toBe(4)
     expect(alternate.puts).toBe(0)
     expect(alternate.deletes).toBe(0)
+  })
+
+  it("keeps runtime startup preflight side-effect free", async () => {
+    const provider = memoryProvider()
+
+    await legalDocumentArtifactProviderPort.test(provider)
+
+    expect(provider.puts).toBe(0)
+    expect(provider.deletes).toBe(0)
   })
 })

--- a/packages/notifications/src/durable-provider-port.ts
+++ b/packages/notifications/src/durable-provider-port.ts
@@ -22,19 +22,9 @@ export const durableNotificationProviderPort = definePort<DurableNotificationPro
     entry: "@voyant-travel/notifications/durable-provider-port",
     export: "durableNotificationProviderPort",
   },
-  async test(runtime) {
-    if (
-      !runtime ||
-      typeof runtime !== "object" ||
-      !Array.isArray(runtime.providers) ||
-      runtime.providers.length === 0 ||
-      typeof runtime.createIsolatedProbe !== "function"
-    ) {
-      throw new Error("notifications.durable-provider must expose providers and an isolated probe")
-    }
+  test: assertRuntimeShape,
+  async verify(runtime) {
     const selectedProviders = [...runtime.providers]
-    for (const provider of selectedProviders) assertDurableProvider(provider)
-    assertUniqueProviderNames(selectedProviders, "selected runtime")
 
     const probe = await runtime.createIsolatedProbe()
     if (
@@ -98,6 +88,20 @@ export const durableNotificationProviderPort = definePort<DurableNotificationPro
     }
   },
 })
+
+function assertRuntimeShape(runtime: DurableNotificationProviderRuntime): void {
+  if (
+    !runtime ||
+    typeof runtime !== "object" ||
+    !Array.isArray(runtime.providers) ||
+    runtime.providers.length === 0 ||
+    typeof runtime.createIsolatedProbe !== "function"
+  ) {
+    throw new Error("notifications.durable-provider must expose providers and an isolated probe")
+  }
+  for (const provider of runtime.providers) assertDurableProvider(provider)
+  assertUniqueProviderNames(runtime.providers, "selected runtime")
+}
 
 function assertDurableProvider(provider: NotificationProvider): void {
   const capability = provider?.durableDelivery

--- a/packages/notifications/tests/unit/runtime-port.test.ts
+++ b/packages/notifications/tests/unit/runtime-port.test.ts
@@ -73,16 +73,20 @@ describe("Notifications runtime port", () => {
       },
     })
     const selected = providerForProcess()
+    const createIsolatedProbe = vi.fn(async () => ({
+      providers: [providerForProcess()],
+      restart: async () => [providerForProcess()],
+      acceptedCount: (_providerName: string, key: string) => (accepted.has(key) ? 1 : 0),
+    }))
+    const runtime = { providers: [selected], createIsolatedProbe }
+
+    await durableNotificationProviderPort.test(runtime)
+    expect(createIsolatedProbe).not.toHaveBeenCalled()
+
     await expect(
-      assertPortConforms(durableNotificationProviderPort, {
-        providers: [selected],
-        createIsolatedProbe: async () => ({
-          providers: [providerForProcess()],
-          restart: async () => [providerForProcess()],
-          acceptedCount: (_providerName: string, key: string) => (accepted.has(key) ? 1 : 0),
-        }),
-      }),
+      assertPortConforms(durableNotificationProviderPort, runtime),
     ).resolves.toBeUndefined()
+    expect(createIsolatedProbe).toHaveBeenCalledOnce()
 
     let lieCount = 0
     const liar = () => ({

--- a/packages/trips/src/durable-action-runtime-port.ts
+++ b/packages/trips/src/durable-action-runtime-port.ts
@@ -49,18 +49,24 @@ export const durableTripActionRuntimePort = definePort<DurableTripActionRuntime>
     entry: "@voyant-travel/trips/durable-action-runtime-port",
     export: "durableTripActionRuntimePort",
   },
-  async test(runtime) {
-    if (
-      !runtime ||
-      typeof runtime !== "object" ||
-      typeof runtime.createIsolatedProbe !== "function"
-    ) {
-      throw new Error("trips.durable-action-runtime provider is incomplete")
-    }
+  test: assertRuntimeShape,
+  async verify(runtime) {
     await assertActionConforms(runtime, "price-trip")
     await assertActionConforms(runtime, "reserve-trip")
   },
 })
+
+function assertRuntimeShape(runtime: DurableTripActionRuntime): void {
+  if (
+    !runtime ||
+    typeof runtime !== "object" ||
+    typeof runtime.createIsolatedProbe !== "function"
+  ) {
+    throw new Error("trips.durable-action-runtime provider is incomplete")
+  }
+  assertCapability(runtime.price)
+  assertCapability(runtime.reserve)
+}
 
 async function assertActionConforms(
   runtime: DurableTripActionRuntime,

--- a/packages/trips/tests/durable-action-runtime-port.test.ts
+++ b/packages/trips/tests/durable-action-runtime-port.test.ts
@@ -1,5 +1,5 @@
 import { assertPortConforms } from "@voyant-travel/core/project"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
 import {
   type DurableTripActionCapability,
@@ -12,6 +12,15 @@ describe("durable Trip action provider conformance", () => {
     await expect(
       assertPortConforms(durableTripActionRuntimePort, conformingRuntime()),
     ).resolves.toBeUndefined()
+  })
+
+  it("does not execute the isolated behavioral probe during runtime startup", async () => {
+    const runtime = conformingRuntime()
+    runtime.createIsolatedProbe = vi.fn(runtime.createIsolatedProbe)
+
+    await durableTripActionRuntimePort.test(runtime)
+
+    expect(runtime.createIsolatedProbe).not.toHaveBeenCalled()
   })
 
   it("rejects an identity change after restart", async () => {


### PR DESCRIPTION
## Summary
- define `VoyantPort.test` as side-effect-free structural startup preflight
- add optional exhaustive `VoyantPort.verify` for live behavioral conformance
- move Trips, Flights, Notifications, and Legal network/storage probes out of production graph composition
- document the startup contract and add package changesets

## Incident evidence
The managed Cloud Run runtime bound its listener immediately, but cold graph composition repeatedly executed provider conformance against remote Voyant Cloud services, renderer/storage, and notification providers. With eager readiness and Cloud Run's startup probe, those multiplied live probes could exceed the 240-second startup window. Runtime composition still validates required port shape, but no longer performs externally observable conformance work during startup.

## Validation
- focused Vitest: 5 files / 36 tests passed
- focused Biome passed
- `git diff --check` passed
- changeset status passed
- graph-contracts, framework, and Flights typechecks passed
- precommit secretlint and agent-quality passed

## Rollout
After merge and release, promote only to the managed canary first. Verify Cloud Run readiness/traffic, migration ledger, and the signed-in YC Demo UI before changing stable.
