### PR TITLE
Record runtime preflight framework release identity

### DIFF
--- a/.changeset/calm-runtime-preflight-identity.md
+++ b/.changeset/calm-runtime-preflight-identity.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": patch
+---
+
+Record the side-effect-free runtime port startup contract in the framework release identity.


### PR DESCRIPTION
## Summary
- add the missing framework patch changeset for the side-effect-free port preflight contract
- ensure the operator image can publish as 0.81.2 instead of colliding with the immutable 0.81.1 release tag

## Validation
- `git diff --check`
- changeset is a single framework patch entry

This is release metadata only; runtime behavior was merged in #4564.