### PR TITLE
Expose sellability policy tools

### DIFF
--- a/packages/bookings/src/voyant.ts
+++ b/packages/bookings/src/voyant.ts
@@ -558,6 +558,7 @@ export const bookingsVoyantModule = defineModule({
       requiredScopes: ["bookings:write"],
       context: ["bookings"],
       risk: "medium",
+      adminWrites: ["/v1/admin/bookings/{bookingId}/amendments/traveler-corrections/preview"],
     },
     {
       id: "@voyant-travel/bookings#tool.accept-booking-amendment",
@@ -580,6 +581,7 @@ export const bookingsVoyantModule = defineModule({
       requiredScopes: ["bookings:write"],
       context: ["bookings"],
       risk: "medium",
+      adminWrites: ["/v1/admin/bookings/{bookingId}/amendments/traveler-roster/preview"],
     },
     {
       id: "@voyant-travel/bookings#tool.apply-booking-amendment",

--- a/packages/commerce/src/created-target-policy.ts
+++ b/packages/commerce/src/created-target-policy.ts
@@ -20,6 +20,20 @@ interface CommerceCreatedTargetPolicy {
 }
 
 export const COMMERCE_CREATED_TARGET_POLICIES = {
+  sellabilityPolicy: {
+    actionName: "@voyant-travel/commerce#action.create-sellability-policy",
+    actionVersion: "v1",
+    toolName: "create_sellability_policy",
+    toolCapabilityId: "@voyant-travel/commerce#tool.create-sellability-policy",
+    capabilityId: "@voyant-travel/commerce#action.create-sellability-policy",
+    capabilityVersion: "v1",
+    commandTargetType: "sellability_policy_create_command",
+    canonicalTargetType: "sellability-policy",
+    resultReferenceType: "sellability-policy",
+    evaluatedRisk: "medium",
+    approvalPolicy: "none",
+    approvalReasonCode: null,
+  },
   cancellationPolicy: {
     actionName: "@voyant-travel/commerce#action.create-cancellation-policy",
     actionVersion: "v1",

--- a/packages/commerce/src/mcp-runtime.ts
+++ b/packages/commerce/src/mcp-runtime.ts
@@ -27,6 +27,36 @@ export const voyantToolContextContribution = defineToolContextContribution({
       async resolveSellability(input) {
         return json(await sellabilityService.resolve(db, input))
       },
+      async listSellabilityPolicies(input) {
+        return json(await sellabilityService.listPolicies(db, input))
+      },
+      async getSellabilityPolicy(id) {
+        return json(await sellabilityService.getPolicyById(db, id))
+      },
+      async createSellabilityPolicy(input, admitted) {
+        const { idempotencyKey: legacyIdempotencyKey, ...commandInput } = input
+        const result = await executeCommerceCreate(
+          db,
+          requestContext,
+          COMMERCE_CREATED_TARGET_POLICIES.sellabilityPolicy,
+          legacyIdempotencyKey,
+          commandInput,
+          admitted,
+          async (tx) => {
+            const row = await sellabilityService.createPolicy(tx, commandInput)
+            if (!row) throw new Error("Sellability policy creation returned no row")
+            return { id: row.id }
+          },
+        )
+        return json({
+          status: "created" as const,
+          sellabilityPolicy: result.value,
+          replayed: result.replayed,
+        })
+      },
+      async updateSellabilityPolicy(id, input) {
+        return json(await sellabilityService.updatePolicy(db, id, input))
+      },
       async listCancellationPolicies(input) {
         return json(await pricingService.listCancellationPolicies(db, input))
       },

--- a/packages/commerce/src/tools.test.ts
+++ b/packages/commerce/src/tools.test.ts
@@ -1,19 +1,30 @@
-import { createToolRegistry } from "@voyant-travel/tools"
+import { createToolRegistry, type ToolContext } from "@voyant-travel/tools"
 import { describe, expect, it } from "vitest"
 
 import { priceCatalogTypeEnum } from "./pricing/schema-shared.js"
 import {
   archivePromotionTool,
+  type CommerceToolServices,
   commerceTools,
   createCancellationPolicyTool,
   listPriceCatalogsTool,
+  listSellabilityPoliciesTool,
   resolveSellabilityTool,
+  updateSellabilityPolicyTool,
 } from "./tools.js"
 
 describe("commerce tools", () => {
   it("publishes complete guarded sellability, pricing-policy, and promotion surfaces", () => {
-    expect(commerceTools).toHaveLength(14)
-    expect(new Set(commerceTools.map((tool) => tool.capabilityId)).size).toBe(14)
+    expect(commerceTools.map((tool) => tool.name)).toEqual(
+      expect.arrayContaining([
+        "list_sellability_policies",
+        "get_sellability_policy",
+        "create_sellability_policy",
+        "update_sellability_policy",
+      ]),
+    )
+    expect(commerceTools).toHaveLength(18)
+    expect(new Set(commerceTools.map((tool) => tool.capabilityId)).size).toBe(18)
     expect(() => createToolRegistry().registerAll(commerceTools)).not.toThrow()
   })
 
@@ -58,6 +69,48 @@ describe("commerce tools", () => {
       resolveSellabilityTool.outputSchema.safeParse({ data: [], meta: { total: 0 } }).success,
     ).toBe(true)
     expect(resolveSellabilityTool.outputSchema.safeParse({ data: [] }).success).toBe(false)
+  })
+
+  it("lists and deactivates sellability policies through their domain contract", async () => {
+    const policy = {
+      id: "spol_1",
+      name: "Adults only",
+      scope: "product",
+      policyType: "occupancy",
+      productId: "prod_1",
+      optionId: null,
+      marketId: null,
+      channelId: null,
+      priority: 10,
+      active: true,
+      conditions: { minimumAge: 18 },
+      effects: { mode: "blocked" },
+      notes: null,
+      metadata: null,
+      createdAt: "2026-08-11T08:00:00.000Z",
+      updatedAt: "2026-08-11T08:00:00.000Z",
+    }
+    const services = {
+      async listSellabilityPolicies(input) {
+        return { data: [policy], total: 1, limit: input.limit, offset: input.offset }
+      },
+      async updateSellabilityPolicy(id, patch) {
+        expect({ id, patch }).toEqual({ id: policy.id, patch: { active: false } })
+        return { ...policy, active: false }
+      },
+    } satisfies Partial<CommerceToolServices>
+    const ctx = {
+      actor: "staff",
+      audience: "staff",
+      commerce: services as CommerceToolServices,
+    } as ToolContext & { commerce: CommerceToolServices }
+
+    await expect(
+      listSellabilityPoliciesTool.handler({ limit: 10, offset: 0 }, ctx),
+    ).resolves.toEqual({ data: [policy], total: 1, limit: 10, offset: 0 })
+    await expect(
+      updateSellabilityPolicyTool.handler({ id: policy.id, active: false }, ctx),
+    ).resolves.toMatchObject({ id: policy.id, active: false })
   })
 
   it("keeps writes staff-scoped and reports only concrete reversal support", () => {

--- a/packages/commerce/src/tools.ts
+++ b/packages/commerce/src/tools.ts
@@ -29,7 +29,14 @@ import {
   promotionalOfferSchema,
   updatePromotionalOfferSchema,
 } from "./promotions/validation.js"
-import { sellabilityResolveQuerySchema } from "./sellability/validation.js"
+import {
+  insertSellabilityPolicySchema,
+  sellabilityPolicyListQuerySchema,
+  sellabilityPolicyScopeSchema,
+  sellabilityPolicyTypeSchema,
+  sellabilityResolveQuerySchema,
+  updateSellabilityPolicySchema,
+} from "./sellability/validation.js"
 
 const OWNER = "@voyant-travel/commerce"
 const VERSION = "v1"
@@ -53,6 +60,7 @@ const idSchema = z.object({ id: z.string().min(1) })
 const updateCancellationPolicyToolSchema = z.intersection(idSchema, updateCancellationPolicySchema)
 const updatePriceCatalogToolSchema = z.intersection(idSchema, updatePriceCatalogSchema)
 const updatePromotionToolSchema = z.intersection(idSchema, updatePromotionalOfferSchema)
+const updateSellabilityPolicyToolSchema = z.intersection(idSchema, updateSellabilityPolicySchema)
 const createdCommandInput = {
   idempotencyKey: z
     .string()
@@ -66,6 +74,8 @@ const createCancellationPolicyToolInputSchema =
   insertCancellationPolicySchema.extend(createdCommandInput)
 const createPriceCatalogToolInputSchema = insertPriceCatalogSchema.extend(createdCommandInput)
 const createPromotionToolInputSchema = insertPromotionalOfferSchema.extend(createdCommandInput)
+const createSellabilityPolicyToolInputSchema =
+  insertSellabilityPolicySchema.extend(createdCommandInput)
 
 const cancellationPolicySchema = z.object({
   id: z.string(),
@@ -75,6 +85,25 @@ const cancellationPolicySchema = z.object({
   simpleCutoffHours: z.number().int().nullable(),
   isDefault: z.boolean(),
   active: z.boolean(),
+  notes: z.string().nullable(),
+  metadata: z.record(z.string(), z.unknown()).nullable(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+})
+
+const sellabilityPolicySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  scope: sellabilityPolicyScopeSchema,
+  policyType: sellabilityPolicyTypeSchema,
+  productId: z.string().nullable(),
+  optionId: z.string().nullable(),
+  marketId: z.string().nullable(),
+  channelId: z.string().nullable(),
+  priority: z.number().int(),
+  active: z.boolean(),
+  conditions: z.record(z.string(), z.unknown()),
+  effects: z.record(z.string(), z.unknown()),
   notes: z.string().nullable(),
   metadata: z.record(z.string(), z.unknown()).nullable(),
   createdAt: z.string().datetime(),
@@ -115,6 +144,11 @@ const createdPriceCatalogOutputSchema = z.object({
 const createdPromotionOutputSchema = z.object({
   status: z.literal("created"),
   promotion: z.object({ id: z.string() }),
+  replayed: z.boolean(),
+})
+const createdSellabilityPolicyOutputSchema = z.object({
+  status: z.literal("created"),
+  sellabilityPolicy: z.object({ id: z.string() }),
   replayed: z.boolean(),
 })
 
@@ -193,6 +227,13 @@ const resolveSellabilityOutputSchema = z.object({
 type AnyServiceInput = Record<string, unknown>
 export interface CommerceToolServices {
   resolveSellability(input: z.infer<typeof sellabilityResolveQuerySchema>): Promise<unknown>
+  listSellabilityPolicies(input: z.infer<typeof sellabilityPolicyListQuerySchema>): Promise<unknown>
+  getSellabilityPolicy(id: string): Promise<unknown>
+  createSellabilityPolicy(
+    input: z.infer<typeof createSellabilityPolicyToolInputSchema>,
+    admitted: ToolHandlerActionPolicyContext,
+  ): Promise<unknown>
+  updateSellabilityPolicy(id: string, input: AnyServiceInput): Promise<unknown>
   listCancellationPolicies(
     input: z.infer<typeof cancellationPolicyListQuerySchema>,
   ): Promise<unknown>
@@ -258,6 +299,71 @@ export const resolveSellabilityTool = defineTool({
   outputSchema: resolveSellabilityOutputSchema,
   async handler(input, ctx: CommerceToolContext) {
     return resolveSellabilityOutputSchema.parse(await commerce(ctx).resolveSellability(input))
+  },
+})
+
+export const listSellabilityPoliciesTool = defineTool({
+  ...readMetadata(["sellability:read"]),
+  capabilityId: `${OWNER}#tool.list-sellability-policies`,
+  name: "list_sellability_policies",
+  description:
+    "List the commercial policies that determine whether an offer can be sold. Read-only.",
+  inputSchema: sellabilityPolicyListQuerySchema,
+  outputSchema: listResponseSchema(sellabilityPolicySchema),
+  async handler(input, ctx: CommerceToolContext) {
+    return listResponseSchema(sellabilityPolicySchema).parse(
+      await commerce(ctx).listSellabilityPolicies(input),
+    )
+  },
+})
+
+export const getSellabilityPolicyTool = defineTool({
+  ...readMetadata(["sellability:read"]),
+  capabilityId: `${OWNER}#tool.get-sellability-policy`,
+  name: "get_sellability_policy",
+  description: "Read one commercial sellability policy by id. Read-only.",
+  inputSchema: idSchema,
+  outputSchema: sellabilityPolicySchema.nullable(),
+  async handler({ id }, ctx: CommerceToolContext) {
+    return sellabilityPolicySchema.nullable().parse(await commerce(ctx).getSellabilityPolicy(id))
+  },
+})
+
+export const createSellabilityPolicyTool = defineTool({
+  ...writeMetadata(["sellability:write"]),
+  riskPolicy: createdWriteRisk,
+  capabilityId: `${OWNER}#tool.create-sellability-policy`,
+  name: "create_sellability_policy",
+  description:
+    "Create a commercial sellability rule for a global, product, option, market, or channel scope. Exact retries return the original reference.",
+  inputSchema: createSellabilityPolicyToolInputSchema,
+  outputSchema: createdSellabilityPolicyOutputSchema,
+  annotations: { idempotentHint: true },
+  actionPolicyEnforcement: "handler",
+  async handler(input, ctx: CommerceToolContext) {
+    const admitted = admitHandlerActionPolicy(
+      ctx,
+      commerceHandlerActionPolicyExpectation(COMMERCE_CREATED_TARGET_POLICIES.sellabilityPolicy),
+    )
+    return createdSellabilityPolicyOutputSchema.parse(
+      await commerce(ctx).createSellabilityPolicy(input, admitted),
+    )
+  },
+})
+
+export const updateSellabilityPolicyTool = defineTool({
+  ...writeMetadata(["sellability:write"]),
+  capabilityId: `${OWNER}#tool.update-sellability-policy`,
+  name: "update_sellability_policy",
+  description:
+    "Update or deactivate an existing sellability policy while preserving its identity and evaluation history.",
+  inputSchema: updateSellabilityPolicyToolSchema,
+  outputSchema: sellabilityPolicySchema.nullable(),
+  annotations: { idempotentHint: true },
+  async handler({ id, ...patch }, ctx: CommerceToolContext) {
+    return sellabilityPolicySchema
+      .nullable()
+      .parse(await commerce(ctx).updateSellabilityPolicy(id, patch))
   },
 })
 
@@ -459,6 +565,10 @@ export const archivePromotionTool = defineTool({
 
 export const commerceTools = [
   resolveSellabilityTool,
+  listSellabilityPoliciesTool,
+  getSellabilityPolicyTool,
+  createSellabilityPolicyTool,
+  updateSellabilityPolicyTool,
   listCancellationPoliciesTool,
   getCancellationPolicyTool,
   createCancellationPolicyTool,

--- a/packages/commerce/src/voyant-tool-actions.ts
+++ b/packages/commerce/src/voyant-tool-actions.ts
@@ -1,0 +1,109 @@
+import type { VoyantGraphActionDeclaration } from "@voyant-travel/core/project"
+
+export const commerceToolActions = [
+  commerceToolAction("resolve-sellability", "sellability", "read"),
+  commerceToolAction("list-sellability-policies", "sellability", "read"),
+  commerceToolAction("get-sellability-policy", "sellability", "read"),
+  commerceToolAction("create-sellability-policy", "sellability", "write"),
+  commerceToolAction("update-sellability-policy", "sellability", "write"),
+  commerceToolAction("list-cancellation-policies", "pricing", "read"),
+  commerceToolAction("get-cancellation-policy", "pricing", "read"),
+  commerceToolAction("create-cancellation-policy", "pricing", "write"),
+  commerceToolAction("update-cancellation-policy", "pricing", "write"),
+  commerceToolAction("list-price-catalogs", "pricing", "read"),
+  commerceToolAction("get-price-catalog", "pricing", "read"),
+  commerceToolAction("create-price-catalog", "pricing", "write"),
+  commerceToolAction("update-price-catalog", "pricing", "write"),
+  commerceToolAction("list-promotions", "promotions", "read"),
+  commerceToolAction("get-promotion", "promotions", "read"),
+  commerceToolAction("create-promotion", "promotions", "write"),
+  commerceToolAction("update-promotion", "promotions", "write"),
+  commerceToolAction("archive-promotion", "promotions", "write"),
+] as const
+
+function commerceToolAction(
+  suffix: string,
+  resource: "sellability" | "pricing" | "promotions",
+  action: "read" | "write",
+): VoyantGraphActionDeclaration {
+  const write = action === "write"
+  const created = createdTarget(suffix)
+  return {
+    id: `@voyant-travel/commerce#action.${suffix}`,
+    version: "v1",
+    kind: write ? "execute" : "read",
+    targetType: created?.targetType ?? resource,
+    ...(isExistingTarget(suffix)
+      ? {
+          commandTargetField: "id",
+          availability: { status: "available" as const },
+          effectBoundary: "local" as const,
+          targetLifecycle: "existing" as const,
+        }
+      : {}),
+    ...(suffix === "create-promotion"
+      ? {
+          availability: { status: "available" as const },
+          effectBoundary: "multistage" as const,
+          durability: {
+            strategy: "outbox" as const,
+            testReference: "packages/commerce/tests/integration/promotion-created-command.test.ts",
+          },
+        }
+      : {}),
+    ...(created && suffix !== "create-promotion"
+      ? {
+          availability: { status: "available" as const },
+          effectBoundary: "local" as const,
+        }
+      : {}),
+    resource,
+    action,
+    requiredScopes: [`${resource}:${action}`],
+    risk: write ? "medium" : "low",
+    ledger: write ? "required" : "optional",
+    approval: "never",
+    reversible: write && !created,
+    allowedActorTypes: ["staff"],
+    ...(created
+      ? {
+          targetLifecycle: "created" as const,
+          createdTarget: {
+            commandTargetType: created.commandTargetType,
+            resultReferenceType: created.resultReferenceType,
+            durability: "handler-command-claim-v1" as const,
+          },
+        }
+      : {}),
+    from: { tools: [`@voyant-travel/commerce#tool.${suffix}`] },
+  }
+}
+
+function isExistingTarget(suffix: string): boolean {
+  return [
+    "update-cancellation-policy",
+    "update-sellability-policy",
+    "update-price-catalog",
+    "update-promotion",
+    "archive-promotion",
+  ].includes(suffix)
+}
+
+function createdTarget(suffix: string) {
+  switch (suffix) {
+    case "create-sellability-policy":
+      return target("sellability-policy", "sellability_policy_create_command")
+    case "create-cancellation-policy":
+      return target("cancellation-policy", "cancellation_policy_create_command")
+    case "create-price-catalog":
+      return target("price-catalog", "price_catalog_create_command")
+    case "create-promotion":
+      return target("promotion", "promotion_create_command")
+    default:
+      return null
+  }
+}
+
+function target(targetType: string, commandTargetType: string) {
+  return { targetType, commandTargetType, resultReferenceType: targetType }
+}

--- a/packages/commerce/src/voyant.ts
+++ b/packages/commerce/src/voyant.ts
@@ -9,7 +9,6 @@ import {
   defineModule,
   providePort,
   requirePort,
-  type VoyantGraphActionDeclaration,
 } from "@voyant-travel/core/project"
 import {
   financeAccommodationsPaymentPolicyRuntimePort,
@@ -41,111 +40,13 @@ import {
   pricingRuleChangedPayloadSchema,
   promotionChangedPayloadSchema,
 } from "./voyant-event-schemas.js"
+import { commerceToolActions } from "./voyant-tool-actions.js"
 
 const commerceAdminRouteId = "@voyant-travel/commerce#admin.route.promotions-index"
 const commerceAdminRuntime = {
   entry: "@voyant-travel/commerce-react/admin",
   export: "createCommerceAdminExtension",
 } as const
-
-const commerceToolActions = [
-  commerceToolAction("resolve-sellability", "sellability", "read"),
-  commerceToolAction("list-cancellation-policies", "pricing", "read"),
-  commerceToolAction("get-cancellation-policy", "pricing", "read"),
-  commerceToolAction("create-cancellation-policy", "pricing", "write"),
-  commerceToolAction("update-cancellation-policy", "pricing", "write"),
-  commerceToolAction("list-price-catalogs", "pricing", "read"),
-  commerceToolAction("get-price-catalog", "pricing", "read"),
-  commerceToolAction("create-price-catalog", "pricing", "write"),
-  commerceToolAction("update-price-catalog", "pricing", "write"),
-  commerceToolAction("list-promotions", "promotions", "read"),
-  commerceToolAction("get-promotion", "promotions", "read"),
-  commerceToolAction("create-promotion", "promotions", "write"),
-  commerceToolAction("update-promotion", "promotions", "write"),
-  commerceToolAction("archive-promotion", "promotions", "write"),
-] as const
-
-function commerceToolAction(
-  suffix: string,
-  resource: "sellability" | "pricing" | "promotions",
-  action: "read" | "write",
-): VoyantGraphActionDeclaration {
-  const write = action === "write"
-  const created =
-    suffix === "create-cancellation-policy"
-      ? {
-          targetType: "cancellation-policy",
-          commandTargetType: "cancellation_policy_create_command",
-          resultReferenceType: "cancellation-policy",
-        }
-      : suffix === "create-price-catalog"
-        ? {
-            targetType: "price-catalog",
-            commandTargetType: "price_catalog_create_command",
-            resultReferenceType: "price-catalog",
-          }
-        : suffix === "create-promotion"
-          ? {
-              targetType: "promotion",
-              commandTargetType: "promotion_create_command",
-              resultReferenceType: "promotion",
-            }
-          : null
-  return {
-    id: `@voyant-travel/commerce#action.${suffix}`,
-    version: "v1",
-    kind: write ? "execute" : "read",
-    targetType: created?.targetType ?? resource,
-    ...([
-      "update-cancellation-policy",
-      "update-price-catalog",
-      "update-promotion",
-      "archive-promotion",
-    ].includes(suffix)
-      ? {
-          commandTargetField: "id",
-          availability: { status: "available" as const },
-          effectBoundary: "local" as const,
-          targetLifecycle: "existing" as const,
-        }
-      : {}),
-    ...(suffix === "create-promotion"
-      ? {
-          availability: { status: "available" as const },
-          effectBoundary: "multistage" as const,
-          durability: {
-            strategy: "outbox" as const,
-            testReference: "packages/commerce/tests/integration/promotion-created-command.test.ts",
-          },
-        }
-      : {}),
-    ...(suffix === "create-cancellation-policy" || suffix === "create-price-catalog"
-      ? {
-          availability: { status: "available" as const },
-          effectBoundary: "local" as const,
-        }
-      : {}),
-    resource,
-    action,
-    requiredScopes: [`${resource}:${action}`],
-    risk: write ? "medium" : "low",
-    ledger: write ? "required" : "optional",
-    approval: "never",
-    reversible: write && !created,
-    allowedActorTypes: ["staff"],
-    ...(created
-      ? {
-          targetLifecycle: "created" as const,
-          createdTarget: {
-            commandTargetType: created.commandTargetType,
-            resultReferenceType: created.resultReferenceType,
-            durability: "handler-command-claim-v1" as const,
-          },
-        }
-      : {}),
-    from: { tools: [`@voyant-travel/commerce#tool.${suffix}`] },
-  }
-}
 
 /** Import-cheap deployment declaration owned by the commerce package. */
 export const commerceVoyantModule = defineModule({
@@ -265,6 +166,52 @@ export const commerceVoyantModule = defineModule({
       requiredScopes: ["sellability:read"],
       context: ["commerce"],
       risk: "low",
+    },
+    {
+      id: "@voyant-travel/commerce#tool.list-sellability-policies",
+      name: "list_sellability_policies",
+      runtime: {
+        entry: "@voyant-travel/commerce/tools",
+        export: "listSellabilityPoliciesTool",
+      },
+      requiredScopes: ["sellability:read"],
+      context: ["commerce"],
+      risk: "low",
+    },
+    {
+      id: "@voyant-travel/commerce#tool.get-sellability-policy",
+      name: "get_sellability_policy",
+      runtime: {
+        entry: "@voyant-travel/commerce/tools",
+        export: "getSellabilityPolicyTool",
+      },
+      requiredScopes: ["sellability:read"],
+      context: ["commerce"],
+      risk: "low",
+    },
+    {
+      id: "@voyant-travel/commerce#tool.create-sellability-policy",
+      name: "create_sellability_policy",
+      runtime: {
+        entry: "@voyant-travel/commerce/tools",
+        export: "createSellabilityPolicyTool",
+      },
+      requiredScopes: ["sellability:write"],
+      context: ["commerce"],
+      risk: "medium",
+      adminWrites: ["/v1/admin/sellability/policies"],
+    },
+    {
+      id: "@voyant-travel/commerce#tool.update-sellability-policy",
+      name: "update_sellability_policy",
+      runtime: {
+        entry: "@voyant-travel/commerce/tools",
+        export: "updateSellabilityPolicyTool",
+      },
+      requiredScopes: ["sellability:write"],
+      context: ["commerce"],
+      risk: "medium",
+      adminWrites: ["/v1/admin/sellability/policies/{id}"],
     },
     {
       id: "@voyant-travel/commerce#tool.list-cancellation-policies",

--- a/packages/commerce/tests/unit/created-target-policy.test.ts
+++ b/packages/commerce/tests/unit/created-target-policy.test.ts
@@ -12,12 +12,18 @@ import {
   createCancellationPolicyTool,
   createPriceCatalogTool,
   createPromotionTool,
+  createSellabilityPolicyTool,
 } from "../../src/tools.js"
 import { commerceVoyantModule } from "../../src/voyant.js"
 
 describe("commerce created-target commands", () => {
   it("declares handler-owned generated targets with immutable outputs", () => {
     for (const [policy, tool, outputKey] of [
+      [
+        COMMERCE_CREATED_TARGET_POLICIES.sellabilityPolicy,
+        createSellabilityPolicyTool,
+        "sellabilityPolicy",
+      ],
       [
         COMMERCE_CREATED_TARGET_POLICIES.cancellationPolicy,
         createCancellationPolicyTool,
@@ -52,6 +58,9 @@ describe("commerce created-target commands", () => {
       )
     }
     expect(createCancellationPolicyTool.inputSchema.safeParse({ name: "Policy" }).success).toBe(
+      true,
+    )
+    expect(createSellabilityPolicyTool.inputSchema.safeParse({ name: "Adults only" }).success).toBe(
       true,
     )
     expect(
@@ -148,6 +157,14 @@ describe("commerce created-target commands", () => {
 
   it("rejects missing, stale, and excluded-actor admission before service mutation", async () => {
     for (const [policy, tool, input] of [
+      [
+        COMMERCE_CREATED_TARGET_POLICIES.sellabilityPolicy,
+        createSellabilityPolicyTool,
+        createSellabilityPolicyTool.inputSchema.parse({
+          name: "Adults only",
+          idempotencyKey: "key",
+        }),
+      ],
       [
         COMMERCE_CREATED_TARGET_POLICIES.cancellationPolicy,
         createCancellationPolicyTool,

--- a/scripts/agent-write-coverage-baseline.json
+++ b/scripts/agent-write-coverage-baseline.json
@@ -3,7 +3,7 @@
   "@voyant-travel/action-ledger": 3,
   "@voyant-travel/apps": 17,
   "@voyant-travel/auth": 11,
-  "@voyant-travel/bookings": 14,
+  "@voyant-travel/bookings": 16,
   "@voyant-travel/catalog": 9,
   "@voyant-travel/charters": 6,
   "@voyant-travel/commerce": 28,


### PR DESCRIPTION
## What changed

- add typed list/get/create/update sellability-policy domain tools
- make policy creation an exact-idempotent created-target command
- expose the reads through `commerce_query` and retain explicit sellability scopes
- declare the actual booking amendment preview paths so traveler CRUD is no longer falsely counted as agent-covered
- record the two direct traveler CRUD resources as intentional gaps; agents continue to use preview/accept/apply amendments
- extract Commerce action declarations into a focused import-cheap module

## Why

The write-coverage heuristic confused cancellation policies with sellability policies and amendment previews with direct traveler mutation. That made the measured MCP surface look complete when it was not.

Sellability policies are operational commercial rules and need proper domain tools. Booking traveler changes already have the safer consequence-aware amendment workflow, so exposing direct CRUD would create a competing mutation path.

## Validation

- Commerce: 186 tests passed, 9 skipped
- focused post-rebase Commerce tests: 10 passed
- Bookings tool tests: 10 passed
- Commerce and Bookings typechecks
- `pnpm verify:agent-write-coverage`
- `pnpm verify:fast`

No changeset is included because Bookings and Commerce are private packages.

Closes #4240.