### PR TITLE
Fix sellability tool command identity and live eval gating

### DIFF
--- a/packages/commerce/src/mcp-runtime.ts
+++ b/packages/commerce/src/mcp-runtime.ts
@@ -34,16 +34,15 @@ export const voyantToolContextContribution = defineToolContextContribution({
         return json(await sellabilityService.getPolicyById(db, id))
       },
       async createSellabilityPolicy(input, admitted) {
-        const { idempotencyKey: legacyIdempotencyKey, ...commandInput } = input
         const result = await executeCommerceCreate(
           db,
           requestContext,
           COMMERCE_CREATED_TARGET_POLICIES.sellabilityPolicy,
-          legacyIdempotencyKey,
-          commandInput,
+          undefined,
+          input,
           admitted,
           async (tx) => {
-            const row = await sellabilityService.createPolicy(tx, commandInput)
+            const row = await sellabilityService.createPolicy(tx, input)
             if (!row) throw new Error("Sellability policy creation returned no row")
             return { id: row.id }
           },

--- a/packages/commerce/src/tools.ts
+++ b/packages/commerce/src/tools.ts
@@ -3,10 +3,12 @@
 import {
   admitHandlerActionPolicy,
   defineTool,
+  deriveCommandIdempotencyKey,
   READ_ONLY_RISK,
   requireService,
   type ToolContext,
   type ToolHandlerActionPolicyContext,
+  withServerResolvedIdempotencyKey,
 } from "@voyant-travel/tools"
 import { listResponseSchema } from "@voyant-travel/types"
 import { z } from "zod"
@@ -74,8 +76,7 @@ const createCancellationPolicyToolInputSchema =
   insertCancellationPolicySchema.extend(createdCommandInput)
 const createPriceCatalogToolInputSchema = insertPriceCatalogSchema.extend(createdCommandInput)
 const createPromotionToolInputSchema = insertPromotionalOfferSchema.extend(createdCommandInput)
-const createSellabilityPolicyToolInputSchema =
-  insertSellabilityPolicySchema.extend(createdCommandInput)
+const createSellabilityPolicyToolInputSchema = insertSellabilityPolicySchema
 
 const cancellationPolicySchema = z.object({
   id: z.string(),
@@ -340,10 +341,14 @@ export const createSellabilityPolicyTool = defineTool({
   outputSchema: createdSellabilityPolicyOutputSchema,
   annotations: { idempotentHint: true },
   actionPolicyEnforcement: "handler",
+  resolvesIdempotencyKeyServerSide: true,
   async handler(input, ctx: CommerceToolContext) {
-    const admitted = admitHandlerActionPolicy(
-      ctx,
-      commerceHandlerActionPolicyExpectation(COMMERCE_CREATED_TARGET_POLICIES.sellabilityPolicy),
+    const admitted = withServerResolvedIdempotencyKey(
+      admitHandlerActionPolicy(
+        ctx,
+        commerceHandlerActionPolicyExpectation(COMMERCE_CREATED_TARGET_POLICIES.sellabilityPolicy),
+      ),
+      await deriveCommandIdempotencyKey("create-sellability-policy", input),
     )
     return createdSellabilityPolicyOutputSchema.parse(
       await commerce(ctx).createSellabilityPolicy(input, admitted),

--- a/packages/commerce/tests/unit/created-target-policy.test.ts
+++ b/packages/commerce/tests/unit/created-target-policy.test.ts
@@ -162,7 +162,6 @@ describe("commerce created-target commands", () => {
         createSellabilityPolicyTool,
         createSellabilityPolicyTool.inputSchema.parse({
           name: "Adults only",
-          idempotencyKey: "key",
         }),
       ],
       [

--- a/packages/mcp/tests/agent-journey-live.test.ts
+++ b/packages/mcp/tests/agent-journey-live.test.ts
@@ -1,9 +1,10 @@
 /**
  * Live-client agent journey eval (voyant#3936, RFC voyant#3921).
  *
- * OPT-IN. Skipped with no `OPENAI_API_KEY` (or `~/.config/agent-run/openai-token`),
- * so CI stays deterministic and a rotated key can never redden the build. Run it
- * deliberately, when changing the prose an agent depends on.
+ * OPT-IN. Skipped unless `VOYANT_RUN_LIVE_EVALS=1` and an `OPENAI_API_KEY` (or
+ * `~/.config/agent-run/openai-token`) is available, so CI stays deterministic
+ * and a rotated key can never redden the build. Run it deliberately when
+ * changing the prose an agent depends on.
  *
  * Why it exists alongside the scripted lane rather than replacing it: the
  * scripted driver is handed the tool name, the resource, and the argument shape,

--- a/packages/mcp/tests/live-client.test.ts
+++ b/packages/mcp/tests/live-client.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from "vitest"
+
+import { resolveOpenAiKey } from "./support/live-client.js"
+
+const originalLiveEvalFlag = process.env.VOYANT_RUN_LIVE_EVALS
+const originalApiKey = process.env.OPENAI_API_KEY
+
+afterEach(() => {
+  restoreEnv("VOYANT_RUN_LIVE_EVALS", originalLiveEvalFlag)
+  restoreEnv("OPENAI_API_KEY", originalApiKey)
+})
+
+describe("live client credential resolution", () => {
+  it("does not resolve a credential unless live evals are explicitly enabled", () => {
+    delete process.env.VOYANT_RUN_LIVE_EVALS
+    process.env.OPENAI_API_KEY = "available-but-not-opted-in"
+
+    expect(resolveOpenAiKey()).toBeUndefined()
+  })
+
+  it("resolves the environment credential for an explicitly enabled run", () => {
+    process.env.VOYANT_RUN_LIVE_EVALS = "1"
+    process.env.OPENAI_API_KEY = "explicit-live-key"
+
+    expect(resolveOpenAiKey()).toBe("explicit-live-key")
+  })
+})
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name]
+  else process.env[name] = value
+}

--- a/packages/mcp/tests/support/live-client.ts
+++ b/packages/mcp/tests/support/live-client.ts
@@ -13,9 +13,10 @@
  * does it pull the whole union? Is a `nextSteps` string followable? Those are
  * claims about PROSE, and prose cannot be unit-tested.
  *
- * So this lane is opt-in and never blocks: no key, no run. It talks to the
- * OpenAI HTTP API with `fetch` rather than adding an SDK dependency to a
- * published package for a test-only path.
+ * So this lane is opt-in and never blocks: `VOYANT_RUN_LIVE_EVALS=1` plus a key
+ * enables it; otherwise it does not run. It talks to the OpenAI HTTP API with
+ * `fetch` rather than adding an SDK dependency to a published package for a
+ * test-only path.
  */
 import { readFileSync } from "node:fs"
 import { homedir } from "node:os"
@@ -25,10 +26,13 @@ import { join } from "node:path"
 const OPENAI_URL = "https://api.openai.com/v1/chat/completions"
 
 /**
- * Resolve the key from the environment, else from the 0600 file the operator
- * convention puts it in. Returns undefined when absent — the caller skips.
+ * Resolve the key only for an explicitly enabled live-eval run, first from the
+ * environment and then from the 0600 file the operator convention puts it in.
+ * A developer having that shared token must not silently turn normal tests into
+ * paid network calls.
  */
 export function resolveOpenAiKey(): string | undefined {
+  if (process.env.VOYANT_RUN_LIVE_EVALS !== "1") return undefined
   const fromEnv = process.env.OPENAI_API_KEY?.trim()
   if (fromEnv) return fromEnv
   try {


### PR DESCRIPTION
Fix-forward for #4567.

## What changed
- remove the newly exposed top-level `idempotencyKey` from `create_sellability_policy`
- derive stable command identity server-side and bind it to the authenticated handler admission
- require `VOYANT_RUN_LIVE_EVALS=1` before resolving any API credential or running paid live-model MCP journeys
- add regression coverage for the live-eval opt-in boundary

## Why
The architecture lane correctly rejected a new caller-owned protocol field. During local verification, the MCP package also proved its nominally opt-in live suite was automatically enabled by the shared token file and could fail normal tests when API credits were exhausted.

## Verification
- `pnpm verify:tool-refinement-visibility`
- `pnpm --filter @voyant-travel/commerce test`
- `pnpm --filter @voyant-travel/commerce typecheck`
- `pnpm --filter @voyant-travel/mcp test`
- `pnpm --filter @voyant-travel/mcp typecheck`
- `pnpm verify:fast`