### PR TITLE
Certify CRM organization MCP workflows

### DIFF
--- a/apps/operator/tests/mcp-capability.test.ts
+++ b/apps/operator/tests/mcp-capability.test.ts
@@ -61,6 +61,7 @@ import { invoices } from "@voyant-travel/finance/schema"
 import { composeVoyantGraphRuntime } from "@voyant-travel/framework"
 import { contractsService, policiesService } from "@voyant-travel/legal"
 import { proposalsService, tripSnapshotToProposalVersionApply } from "@voyant-travel/proposals"
+import { organizations } from "@voyant-travel/relationships/schema"
 import { tripsService } from "@voyant-travel/trips"
 import { sql as sqlRaw } from "drizzle-orm"
 import { Hono } from "hono"
@@ -556,7 +557,7 @@ const RUN_MARK = process.env.VOYANT_EVAL_MARK ?? String(Date.now()).slice(-6)
 
 interface CapabilityJourney {
   id: string
-  group: "commercial" | "proposal" | "amendment" | "supplier" | "contract"
+  group: "commercial" | "proposal" | "amendment" | "supplier" | "contract" | "organization"
   domain: string
   task: string
   expect: string
@@ -934,6 +935,49 @@ function buildJourneys(RUN_MARK: string): CapabilityJourney[] {
              where name = 'Dormant Experiences ${RUN_MARK}' and status = 'inactive'`,
     },
     {
+      id: "organization-create",
+      group: "organization",
+      domain: "organizations",
+      task: `Create an active client organization named 'Northstar Corporate Travel ${RUN_MARK}' with legal name 'Northstar Corporate Travel SRL', website 'https://northstar-${RUN_MARK}.example.com', tax id 'RO${RUN_MARK}42', default currency EUR, preferred language en, and 30-day payment terms. Confirm its organization id and recorded commercial details.`,
+      expect: "northstar",
+      maxCalls: 16,
+      verify: `select 1 from organizations
+             where name = 'Northstar Corporate Travel ${RUN_MARK}'
+               and legal_name = 'Northstar Corporate Travel SRL'
+               and website = 'https://northstar-${RUN_MARK}.example.com'
+               and tax_id = 'RO${RUN_MARK}42'
+               and relation = 'client'
+               and default_currency = 'EUR'
+               and preferred_language = 'en'
+               and payment_terms = 30
+               and status = 'active'`,
+    },
+    {
+      id: "organization-find",
+      group: "organization",
+      domain: "organizations",
+      task: `Find the CRM organization 'Danube Corporate Events ${RUN_MARK}' and report its legal name, relationship, tax id, default currency, and payment terms.`,
+      expect: `RODANUBE${RUN_MARK}`,
+      maxCalls: 12,
+      requiresDispatch: true,
+    },
+    {
+      id: "organization-deactivate",
+      group: "organization",
+      domain: "organizations",
+      task: `Mark the CRM organization 'Former Alpine Client ${RUN_MARK}' inactive without changing its name, client relationship, tax id, currency, language, or 45-day payment terms. Confirm its final status.`,
+      expect: "inactive",
+      maxCalls: 16,
+      verify: `select 1 from organizations
+             where name = 'Former Alpine Client ${RUN_MARK}'
+               and relation = 'client'
+               and tax_id = 'ROALPINE${RUN_MARK}'
+               and default_currency = 'EUR'
+               and preferred_language = 'de'
+               and payment_terms = 45
+               and status = 'inactive'`,
+    },
+    {
       id: "contract-template-create",
       group: "contract",
       domain: "contracts",
@@ -1086,6 +1130,37 @@ async function seedSupplierJourney(journeyId: string, mark: string): Promise<voi
     supplierId: supplier.id,
     email: fixture.email,
   })
+}
+
+async function seedOrganizationJourney(journeyId: string, mark: string): Promise<void> {
+  if (!verifyDb) throw new Error("Capability eval database is not mounted")
+  if (journeyId === "organization-create") return
+  const values =
+    journeyId === "organization-find"
+      ? {
+          name: `Danube Corporate Events ${mark}`,
+          legalName: "Danube Corporate Events SRL",
+          relation: "client" as const,
+          taxId: `RODANUBE${mark}`,
+          defaultCurrency: "EUR",
+          preferredLanguage: "ro",
+          paymentTerms: 30,
+          status: "active" as const,
+        }
+      : journeyId === "organization-deactivate"
+        ? {
+            name: `Former Alpine Client ${mark}`,
+            legalName: "Former Alpine Client GmbH",
+            relation: "client" as const,
+            taxId: `ROALPINE${mark}`,
+            defaultCurrency: "EUR",
+            preferredLanguage: "de",
+            paymentTerms: 45,
+            status: "active" as const,
+          }
+        : null
+  if (!values) throw new Error(`Unknown organization journey ${journeyId}`)
+  await verifyDb.insert(organizations).values(values)
 }
 
 async function seedProposalAuthoring(mark: string): Promise<void> {
@@ -1652,6 +1727,9 @@ describe.skipIf(!enabled)("MCP capability — a travel agent's job", () => {
           if (journey.group === "amendment") await seedBookingAmendment(mark)
           if (journey.group === "supplier") await seedSupplierJourney(journey.id, mark)
           if (journey.group === "contract") await seedContractJourney(journey.id, mark)
+          if (journey.group === "organization") {
+            await seedOrganizationJourney(journey.id, mark)
+          }
           if (journey.id === "proposal-accept") await seedProposalAcceptance(mark)
           if (journey.id === "paid-refund") await seedPaidCancellationRefund(mark)
           let run: JourneyRun

--- a/docs/architecture/mcp-capability-evaluation.md
+++ b/docs/architecture/mcp-capability-evaluation.md
@@ -29,6 +29,9 @@ Run one independently seeded operator-job group:
 pnpm eval:mcp-capability -- --mode smoke --group supplier
 ```
 
+Supported independent groups include `organization`, `supplier`, `contract`,
+`proposal`, and `amendment`.
+
 `--group` keeps each journey's fixture boundary local to that group, so an unrelated
 commercial-chain failure cannot cap its result. Use `--journey <id>` for a single
 independently seeded diagnostic. The two selectors are mutually exclusive.

--- a/packages/relationships/src/mcp-runtime.ts
+++ b/packages/relationships/src/mcp-runtime.ts
@@ -105,26 +105,30 @@ export const voyantToolContextContribution = defineToolContextContribution({
             taxId?: string | null
             vatNumber?: string
             billingAddress?: Record<string, unknown>
-            idempotencyKey?: string
             [key: string]: unknown
           },
           admitted: ToolHandlerActionPolicyContext,
         ) {
-          const { idempotencyKey, vatNumber, billingAddress, ...rawOrganization } = input
+          const { vatNumber, billingAddress, ...rawOrganization } = input
           const organizationData = {
             ...rawOrganization,
             taxId: rawOrganization.taxId ?? vatNumber,
           } as Parameters<typeof relationshipsService.createOrganization>[1]
+          const commandInput = {
+            organization: organizationData,
+            billingAddress: billingAddress
+              ? (billingAddress as Parameters<typeof relationshipsService.createAddress>[3])
+              : null,
+          }
+          const idempotencyKey = await deriveCommandIdempotencyKey(
+            "create-organization",
+            commandInput,
+          )
           const result = await executeOrganizationCreateCommand({
             db,
             context: requestContext,
-            commandInput: {
-              organization: organizationData,
-              billingAddress: billingAddress
-                ? (billingAddress as Parameters<typeof relationshipsService.createAddress>[3])
-                : null,
-            },
-            admitted,
+            commandInput,
+            admitted: withServerResolvedIdempotencyKey(admitted, idempotencyKey),
             legacyIdempotencyKey: idempotencyKey,
           })
           return {

--- a/packages/relationships/src/tools.ts
+++ b/packages/relationships/src/tools.ts
@@ -138,13 +138,6 @@ const billingAddressSchema = insertAddressForEntitySchema.omit({ metadata: true 
 export const createOrganizationToolInputSchema = insertOrganizationSchema
   .omit({ ownerId: true, source: true, sourceRef: true, customFields: true })
   .extend({
-    idempotencyKey: z
-      .string()
-      .trim()
-      .min(1)
-      .max(255)
-      .optional()
-      .describe("Compatibility copy of the admitted created-command idempotency key."),
     vatNumber: z.string().optional().describe("Compatibility alias for taxId."),
     billingAddress: billingAddressSchema,
   })
@@ -416,6 +409,7 @@ export const createOrganizationTool = defineTool<
   riskPolicy: CREATED_WRITE_RISK,
   capabilityId: `${OWNER}#tool.create-organization`,
   name: "create_organization",
+  resolvesIdempotencyKeyServerSide: true,
   description:
     "Create a CRM organization and optional billing address atomically. Exact retries return the original immutable organization reference.",
   inputSchema: createOrganizationToolInputSchema,

--- a/scripts/tool-protocol-field-inventory.json
+++ b/scripts/tool-protocol-field-inventory.json
@@ -128,11 +128,6 @@
       "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
     },
     {
-      "id": "@voyant-travel/relationships:create_organization:input.idempotencyKey",
-      "ownership": "caller-owned-command-identity",
-      "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
-    },
-    {
       "id": "@voyant-travel/storefront:create_invoice_payment_link:input.idempotencyKey",
       "ownership": "caller-owned-command-identity",
       "rationale": "Retained because the caller chooses the stable identity of this retryable business command."


### PR DESCRIPTION
## Summary
- make `create_organization` use server-derived idempotency and remove the caller-owned protocol field
- add independent real-model MCP journeys for organization create, find, and deactivate
- document CRM Organizations as a supported capability group while leaving tenant settings and membership dashboard-only

## Verification
- `pnpm verify:tool-refinement-visibility`
- relationships tests: 184 passed, 105 skipped
- relationships and operator typechecks
- `node --test scripts/tests/run-mcp-capability-eval.test.mjs` (7/7)
- `pnpm lint:changed`
- `pnpm verify:fast`
- GPT-5.6 Terra smoke: 3/3 journeys, zero tool errors
- GPT-5.6 Terra measurement: 15/15 journeys, zero tool errors

## Scope
Advanced CRM workflows remain deferred. Tenant organization settings, members, and other administration remain dashboard-only. Flights durability continues separately in #4569.