### PR TITLE
fix(trips): preserve composite supplier selection

### DIFF
--- a/.changeset/steady-composite-supplier.md
+++ b/.changeset/steady-composite-supplier.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/catalog": patch
+"@voyant-travel/catalog-contracts": patch
+"@voyant-travel/trips": patch
+---
+
+Preserve the exact server-selected supplier kind, connection, and source reference when a Trip composite session quotes and books sourced inventory.

--- a/packages/catalog-contracts/src/adapter/availability-search.ts
+++ b/packages/catalog-contracts/src/adapter/availability-search.ts
@@ -77,7 +77,18 @@ export interface AvailabilityCandidate {
    * origin; otherwise the fan-out stamps it from the dispatching connection /
    * owned module. Optional only so adapters need not construct it themselves.
    */
-  source?: { kind: "sourced"; connectionId: string } | { kind: "owned"; module: string }
+  source?:
+    | {
+        kind: "sourced"
+        connectionId: string
+        /** Concrete server-owned adapter kind; the fan-out always stamps it. */
+        sourceKind?: string
+        /** Concrete supplier/provider label when the adapter can prove it. */
+        sourceProvider?: string
+        /** Stable upstream entity reference used only for server-side re-resolution. */
+        sourceRef?: string
+      }
+    | { kind: "owned"; module: string }
   /** Public-safe price for ranking and display. */
   price: { amount: string; currency: string }
   /**

--- a/packages/catalog/src/booking-engine/sessions-production.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-production.test.ts
@@ -42,6 +42,9 @@ vi.mock("@voyant-travel/finance", async (importOriginal) => ({
 
 import type { BookingRequirementsV1 } from "@voyant-travel/catalog-contracts/booking-engine/requirements-contracts"
 import { defaultRequirementsFlags } from "@voyant-travel/catalog-contracts/booking-engine/requirements-defaults"
+import type { SQL } from "drizzle-orm"
+import { PgDialect } from "drizzle-orm/pg-core"
+import type { SourceAdapter } from "../adapter/contract.js"
 import type { OwnedBookingHandler } from "./owned-handler.js"
 import { createOwnedBookingHandlerRegistry } from "./owned-handler.js"
 import { createSourceAdapterRegistry } from "./registry.js"
@@ -307,6 +310,274 @@ describe("normalizeProductSelection", () => {
         },
       ),
     ).toThrow(/booking_session_selection_forbidden_field:selection\.staffBooking/)
+  })
+})
+
+describe("composite sourced target authority", () => {
+  it("resolves a legacy generic sourced kind from the exact connection and reference", async () => {
+    const repository = createInMemoryBookingSessionRepository()
+    const registry = createSourceAdapterRegistry()
+    const liveResolve = vi.fn<NonNullable<SourceAdapter["liveResolve"]>>(
+      async (_context, request) => ({
+        values: { [request.ids[0] ?? "missing"]: { priceCents: 104_400, currency: "EUR" } },
+      }),
+    )
+    registry.register("connection_selected", {
+      kind: "voyant-connect",
+      capabilities: {
+        verticals: ["products"],
+        supportsLiveResolution: true,
+        supportsDriftDetection: false,
+        supportsBookingForwarding: false,
+        postBookOperations: [],
+      },
+      liveResolve,
+    } as never)
+    const predicates: Array<{ sql: string; params: unknown[] }> = []
+    const dialect = new PgDialect()
+    const selectedRow = {
+      entity_module: "products",
+      entity_id: "prod_shared",
+      source_kind: "voyant-connect",
+      source_provider: "tui",
+      source_connection_id: "connection_selected",
+      source_ref: "selected-package-ref",
+      projection: { name: "Selected package" },
+      status: "active",
+    }
+    const module = createProductionBookingSessionModule({
+      db: {
+        select: () => ({
+          from: () => ({
+            where: (condition: SQL) => ({
+              limit: async () => {
+                predicates.push(dialect.sqlToQuery(condition))
+                return [selectedRow]
+              },
+            }),
+          }),
+        }),
+        transaction: async (operation: (tx: unknown) => Promise<unknown>) => operation({}),
+      } as never,
+      repository,
+      resolveOwnedHandlers: () => createOwnedBookingHandlerRegistry(),
+      resolveSourceRegistry: () => registry,
+      resolveCompositeHandler: () => ({
+        composeRequirements: ({ session, leaf }) =>
+          leaf.composeRequirements({
+            session: {
+              ...session,
+              target: { kind: "catalog_item", catalogItemId: "prod_shared" },
+              sourcedTargetPin: {
+                entityModule: "products",
+                entityId: "prod_shared",
+                sourceKind: "sourced",
+                sourceProvider: null,
+                sourceConnectionId: "connection_selected",
+                sourceRef: "selected-package-ref",
+                projection: { title: "Selected package" },
+                title: "Selected package",
+              },
+            },
+            now: new Date("2026-08-11T12:00:00.000Z"),
+            tx: undefined,
+          }),
+        composeQuote: ({ session, leaf }) =>
+          leaf.composeQuote({
+            session: {
+              ...session,
+              target: { kind: "catalog_item", catalogItemId: "prod_shared" },
+              sourcedTargetPin: {
+                entityModule: "products",
+                entityId: "prod_shared",
+                sourceKind: "sourced",
+                sourceProvider: null,
+                sourceConnectionId: "connection_selected",
+                sourceRef: "selected-package-ref",
+                projection: { title: "Selected package" },
+                title: "Selected package",
+              },
+            },
+            now: new Date("2026-08-11T12:00:00.000Z"),
+            tx: undefined,
+          }),
+        placeCapacityHold: async () => "held",
+        releaseCapacityHold: async () => undefined,
+        commit: async () => ({ kind: "committed", bookings: [] }),
+      }),
+    })
+
+    const outcome = await module.createCompositeSession(
+      {
+        idempotencyKey: "legacy_generic_source_kind",
+        target: {
+          kind: "trip_snapshot",
+          tripSnapshotId: "trsn_legacy",
+          tripEnvelopeId: "trip_legacy",
+        },
+        selection: { configure: { pax: { adult: 2 } } },
+      },
+      {
+        actorKind: "anonymous",
+        capability: TEST_CAPABILITY,
+        ...STOREFRONT_ACCESS,
+      },
+    )
+
+    expect(outcome.kind).toBe("session_created")
+    expect(liveResolve).toHaveBeenCalledWith(
+      { connection_id: "connection_selected" },
+      expect.objectContaining({
+        ids: ["prod_shared"],
+        source_refs: { prod_shared: "selected-package-ref" },
+      }),
+    )
+    expect(predicates).toHaveLength(2)
+    for (const predicate of predicates) {
+      expect(predicate.params).not.toContain("sourced")
+      expect(predicate.params).toContain("connection_selected")
+      expect(predicate.params).toContain("selected-package-ref")
+    }
+  })
+
+  it("quotes the exact internal supplier pin without re-resolving a conflicting Catalog row", async () => {
+    const repository = createInMemoryBookingSessionRepository()
+    const registry = createSourceAdapterRegistry()
+    const liveResolve = vi.fn<NonNullable<SourceAdapter["liveResolve"]>>(
+      async (_context, request) => {
+        const id = request.ids[0] ?? "missing"
+        return { values: { [id]: { priceCents: 104_400, currency: "EUR" } } }
+      },
+    )
+    registry.register("connection_selected", {
+      kind: "voyant-connect",
+      capabilities: {
+        verticals: ["products"],
+        supportsLiveResolution: true,
+        supportsDriftDetection: false,
+        supportsBookingForwarding: false,
+        postBookOperations: [],
+      },
+      liveResolve,
+    } as never)
+    const access = {
+      actorKind: "anonymous" as const,
+      capability: TEST_CAPABILITY,
+      ...STOREFRONT_ACCESS,
+    }
+    let sourcedEntryReads = 0
+    const sourcedEntryPredicates: Array<{ sql: string; params: unknown[] }> = []
+    const dialect = new PgDialect()
+    const module = createProductionBookingSessionModule({
+      db: {
+        select: () => ({
+          from: () => ({
+            where: (condition: SQL) => ({
+              limit: async () => {
+                sourcedEntryPredicates.push(dialect.sqlToQuery(condition))
+                sourcedEntryReads += 1
+                if (sourcedEntryReads % 2 === 1) return []
+                return [
+                  {
+                    entity_module: "products",
+                    entity_id: "prod_shared",
+                    source_kind: "other-source",
+                    source_provider: "other-provider",
+                    source_connection_id: "connection_other",
+                    source_ref: "other-package-ref",
+                    projection: { name: "Canonical package title" },
+                    status: "active",
+                  },
+                ]
+              },
+            }),
+          }),
+        }),
+        transaction: async (operation: (tx: unknown) => Promise<unknown>) => operation({}),
+      } as never,
+      repository,
+      resolveOwnedHandlers: () => createOwnedBookingHandlerRegistry(),
+      resolveSourceRegistry: () => registry,
+      resolveCompositeHandler: () => ({
+        composeRequirements: ({ session, leaf }) =>
+          leaf.composeRequirements({
+            session: {
+              ...session,
+              target: { kind: "catalog_item", catalogItemId: "prod_shared" },
+              sourcedTargetPin: {
+                entityModule: "products",
+                entityId: "prod_shared",
+                sourceKind: "voyant-connect",
+                sourceProvider: "voyant-connect",
+                sourceConnectionId: "connection_selected",
+                sourceRef: "selected-package-ref",
+                projection: { title: "Selected package" },
+                title: "Selected package",
+              },
+            },
+            now: new Date("2026-08-11T12:00:00.000Z"),
+            tx: undefined,
+          }),
+        composeQuote: ({ session, leaf }) =>
+          leaf.composeQuote({
+            session: {
+              ...session,
+              target: { kind: "catalog_item", catalogItemId: "prod_shared" },
+              sourcedTargetPin: {
+                entityModule: "products",
+                entityId: "prod_shared",
+                sourceKind: "voyant-connect",
+                sourceProvider: "voyant-connect",
+                sourceConnectionId: "connection_selected",
+                sourceRef: "selected-package-ref",
+                projection: { title: "Selected package" },
+                title: "Selected package",
+              },
+            },
+            now: new Date("2026-08-11T12:00:00.000Z"),
+            tx: undefined,
+          }),
+        placeCapacityHold: async () => "held",
+        releaseCapacityHold: async () => undefined,
+        commit: async () => ({ kind: "committed", bookings: [] }),
+      }),
+    })
+
+    const outcome = await module.createCompositeSession(
+      {
+        idempotencyKey: "selected_package_composite",
+        target: {
+          kind: "trip_snapshot",
+          tripSnapshotId: "trsn_selected",
+          tripEnvelopeId: "trip_selected",
+        },
+        selection: {
+          configure: {
+            departureDate: "2026-10-15",
+            departureAirportCode: "OTP",
+            nights: 3,
+            pax: { adult: 2 },
+          },
+        },
+      },
+      access,
+    )
+
+    expect(outcome.kind).toBe("session_created")
+    expect(liveResolve).toHaveBeenCalledWith(
+      { connection_id: "connection_selected" },
+      expect.objectContaining({
+        ids: ["prod_shared"],
+        source_refs: { prod_shared: "selected-package-ref" },
+      }),
+    )
+    expect(repository.sessions.size).toBe(1)
+    expect(sourcedEntryReads).toBe(4)
+    expect(sourcedEntryPredicates).toHaveLength(4)
+    for (const predicate of sourcedEntryPredicates) {
+      expect(predicate.sql).toContain('"catalog_sourced_entries"."entity_module"')
+      expect(predicate.params).toContain("products")
+    }
   })
 })
 

--- a/packages/catalog/src/booking-engine/sessions-production.ts
+++ b/packages/catalog/src/booking-engine/sessions-production.ts
@@ -568,6 +568,75 @@ async function resolveSourcedTarget(
   session: CommitSourcedBookingInput["session"],
 ) {
   if (session.target.kind !== "catalog_item") return null
+  const pin = session.sourcedTargetPin
+  if (pin) {
+    if (
+      pin.entityId !== session.target.catalogItemId ||
+      pin.sourceKind === "owned" ||
+      !pin.sourceConnectionId ||
+      !pin.sourceRef
+    ) {
+      return null
+    }
+    const hasConcreteSourceKind = pin.sourceKind !== "sourced"
+    const exactRows = await db
+      .select()
+      .from(catalogSourcedEntriesTable)
+      .where(
+        and(
+          eq(catalogSourcedEntriesTable.entity_module, pin.entityModule),
+          eq(catalogSourcedEntriesTable.entity_id, pin.entityId),
+          eq(catalogSourcedEntriesTable.status, "active"),
+          hasConcreteSourceKind
+            ? eq(catalogSourcedEntriesTable.source_kind, pin.sourceKind)
+            : undefined,
+          eq(catalogSourcedEntriesTable.source_connection_id, pin.sourceConnectionId),
+          eq(catalogSourcedEntriesTable.source_ref, pin.sourceRef),
+        ),
+      )
+      .limit(hasConcreteSourceKind ? 1 : 2)
+    const exact = exactRows.length === 1 ? exactRows[0] : undefined
+    if (exact && exact.source_kind !== "owned") {
+      const title =
+        stringValue(exact.projection.name) ?? stringValue(exact.projection.title) ?? pin.title
+      return {
+        ...pin,
+        sourceKind: exact.source_kind,
+        sourceProvider: exact.source_provider ?? pin.sourceProvider ?? null,
+        projection: exact.projection,
+        title,
+      }
+    }
+    // Legacy/manual Trip components can carry the classification literal
+    // `sourced` instead of a concrete adapter kind. The connection/ref pair is
+    // still sufficient to recover that provenance while its exact Catalog row
+    // is active, but it is not safe to commit the generic classifier after the
+    // row disappears (or when that identity is ambiguous).
+    if (!hasConcreteSourceKind) return null
+    // Older/source-specific offers can outlive the exact projection row while
+    // the canonical Catalog entity remains active. Preserve that entity's
+    // display snapshot only; supplier authority still comes exclusively from
+    // the frozen pin.
+    const displayRows = await db
+      .select()
+      .from(catalogSourcedEntriesTable)
+      .where(
+        and(
+          eq(catalogSourcedEntriesTable.entity_module, pin.entityModule),
+          eq(catalogSourcedEntriesTable.entity_id, pin.entityId),
+          eq(catalogSourcedEntriesTable.status, "active"),
+        ),
+      )
+      .limit(2)
+    const display = displayRows.length === 1 ? displayRows[0] : undefined
+    const projection = display?.projection ?? pin.projection
+    return {
+      ...pin,
+      sourceProvider: pin.sourceProvider ?? null,
+      projection,
+      title: stringValue(projection.name) ?? stringValue(projection.title) ?? pin.title,
+    }
+  }
   const rows = await db
     .select()
     .from(catalogSourcedEntriesTable)

--- a/packages/catalog/src/booking-engine/sessions-service.ts
+++ b/packages/catalog/src/booking-engine/sessions-service.ts
@@ -1,3 +1,4 @@
+// agent-quality: file-size exception -- owner: catalog; the Session state machine, internal records, authorization, and atomic lifecycle intentionally remain one protocol.
 import type { BookingPaymentCheckoutV1 } from "@voyant-travel/catalog-contracts/booking-engine/lifecycle-conformance"
 import type {
   OfferPreviewOutcomeV1,
@@ -71,6 +72,22 @@ export interface BookingSessionInternalRecord {
   ownerOrganizationId?: string
   /** Immutable server-derived public storefront provenance. Never serialized. */
   storefrontOrigin?: { storefrontId: string; channelId: string }
+  /**
+   * Exact server-selected sourced inventory identity for an internal composite
+   * leaf. This is never accepted from public input, persisted, or serialized.
+   * It prevents a Trip leaf from being re-resolved to a different supplier row
+   * that happens to share the same Catalog entity id.
+   */
+  sourcedTargetPin?: {
+    entityModule: string
+    entityId: string
+    sourceKind: string
+    sourceProvider?: string | null
+    sourceConnectionId: string
+    sourceRef: string
+    projection: Record<string, unknown>
+    title: string
+  }
   /**
    * Immutable commercial scope. Fixed at create so a Quote, the Hold taken
    * against it, and the Commit that consumes both all mean one price in one

--- a/packages/catalog/src/search/availability-fan-out.test.ts
+++ b/packages/catalog/src/search/availability-fan-out.test.ts
@@ -159,14 +159,23 @@ describe("fanOutAvailabilitySearch", () => {
     })
 
     const byId = Object.fromEntries(result.candidates.map((c) => [c.entity_id, c.source]))
-    expect(byId.a1).toEqual({ kind: "sourced", connectionId: "conn_a" })
+    expect(byId.a1).toEqual({
+      kind: "sourced",
+      connectionId: "conn_a",
+      sourceKind: "a",
+    })
     expect(byId.owned1).toEqual({ kind: "owned", module: "accommodations" })
   })
 
   it("does not clobber an origin the adapter already set (cross-provider case)", async () => {
     const pre = {
       ...candidate("x", "200"),
-      source: { kind: "sourced" as const, connectionId: "upstream_real" },
+      source: {
+        kind: "sourced" as const,
+        connectionId: "upstream_real",
+        sourceProvider: "supplier-a",
+        sourceRef: "hotel-42",
+      },
     }
     const result = await fanOutAvailabilitySearch({
       adapters: [
@@ -178,7 +187,13 @@ describe("fanOutAvailabilitySearch", () => {
       request: REQUEST,
     })
 
-    expect(result.candidates[0]?.source).toEqual({ kind: "sourced", connectionId: "upstream_real" })
+    expect(result.candidates[0]?.source).toEqual({
+      kind: "sourced",
+      connectionId: "upstream_real",
+      sourceKind: "agg",
+      sourceProvider: "supplier-a",
+      sourceRef: "hotel-42",
+    })
   })
 
   it("skips sources that don't feed the requested vertical, without querying them", async () => {

--- a/packages/catalog/src/search/availability-fan-out.ts
+++ b/packages/catalog/src/search/availability-fan-out.ts
@@ -145,9 +145,21 @@ export async function fanOutAvailabilitySearch(
       )
       // Stamp the dispatching connection as origin, unless the adapter already
       // set a more specific one (e.g. a cross-provider search per candidate).
-      const candidates = result.candidates.map((c) =>
-        c.source ? c : { ...c, source: { kind: "sourced" as const, connectionId } },
-      )
+      const candidates = result.candidates.map((candidate) => {
+        if (candidate.source?.kind === "owned") return candidate
+        return {
+          ...candidate,
+          source: {
+            kind: "sourced" as const,
+            connectionId: candidate.source?.connectionId ?? connectionId,
+            sourceKind: candidate.source?.sourceKind ?? adapter.kind,
+            ...(candidate.source?.sourceProvider
+              ? { sourceProvider: candidate.source.sourceProvider }
+              : {}),
+            ...(candidate.source?.sourceRef ? { sourceRef: candidate.source.sourceRef } : {}),
+          },
+        }
+      })
       return { status: result.status, candidates, nextCursor: result.next_cursor }
     }),
   )

--- a/packages/trips/src/booking-session-composite-handler.ts
+++ b/packages/trips/src/booking-session-composite-handler.ts
@@ -1,3 +1,4 @@
+// agent-quality: file-size exception -- owner: trips; aggregate quote, hold, commit, compensation, and component projection intentionally remain one composite protocol.
 import { bookingsService, setAcceptedProposalBookingOrigin } from "@voyant-travel/bookings"
 import type {
   BookingHoldInternalRecord,
@@ -462,7 +463,8 @@ async function loadTargetSnapshot(
 function frozenComponents(snapshot: TripSnapshot): Map<string, TripComponent> {
   return new Map(
     snapshot.frozenComponents.map((value) => {
-      const component = value as unknown as TripComponent
+      // agent-quality: unsafe-cast reviewed -- owner: trips; immutable snapshots store the validated TripComponent projection as JSON records.
+      const component = { ...value } as TripComponent
       return [component.id, component]
     }),
   )
@@ -480,6 +482,24 @@ function childSession(
   return {
     ...parent,
     target: componentTarget(component),
+    sourcedTargetPin:
+      component.sourceKind !== "owned" && component.sourceConnectionId && component.sourceRef
+        ? {
+            entityModule: required(component.entityModule, "component.entityModule"),
+            entityId: required(component.entityId, "component.entityId"),
+            sourceKind: required(component.sourceKind, "component.sourceKind"),
+            sourceProvider: componentSourceProvider(component),
+            sourceConnectionId: component.sourceConnectionId,
+            sourceRef: component.sourceRef,
+            projection: compact({
+              title: component.title,
+              description: component.description,
+            }),
+            title:
+              component.title ??
+              `Sourced ${required(component.entityModule, "component.entityModule")}`,
+          }
+        : undefined,
     statePayload: compact({
       configure: draft.configure,
       billing: parentBilling ?? draft.billing,
@@ -807,4 +827,9 @@ function compact(value: Record<string, unknown>): Record<string, unknown> {
 function required(value: string | null | undefined, label: string): string {
   if (!value) throw new Error(`${label} is required`)
   return value
+}
+
+function componentSourceProvider(component: TripComponent): string | null {
+  const value = component.metadata.sourceProvider
+  return typeof value === "string" && value.length > 0 ? value : null
 }

--- a/packages/trips/src/schema.ts
+++ b/packages/trips/src/schema.ts
@@ -565,7 +565,7 @@ export const tripCandidates = pgTable(
     entityId: text("entity_id").notNull(),
 
     // Origin, so a selection routes back to the right source at reserve time.
-    sourceKind: text("source_kind").notNull(), // "sourced" | "owned"
+    sourceKind: text("source_kind").notNull(), // concrete sourced adapter kind | "owned"
     sourceConnectionId: text("source_connection_id"), // when sourced
     sourceModule: text("source_module"), // when owned
 

--- a/packages/trips/src/service-requirements.ts
+++ b/packages/trips/src/service-requirements.ts
@@ -31,6 +31,9 @@ import { assertTripEnvelopeCanMutateComponents } from "./service-edit-safeguards
 import { createComponentEvent } from "./service-internals.js"
 import { TripsInvariantError } from "./service-types.js"
 
+const SOURCE_PROVIDER_DATA_KEY = "_voyantSourceProvider"
+const SOURCE_REF_DATA_KEY = "_voyantSourceRef"
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Pure helpers (invariants + mapping) — no db
 // ─────────────────────────────────────────────────────────────────────────────
@@ -88,14 +91,17 @@ export function availabilityCandidateToRow(args: {
     candidateRef: candidate.candidateRef,
     entityModule: candidate.entity_module,
     entityId: candidate.entity_id,
-    sourceKind: candidate.source?.kind ?? "sourced",
+    sourceKind:
+      candidate.source?.kind === "owned"
+        ? "owned"
+        : (candidate.source?.sourceKind ?? candidate.source?.kind ?? "sourced"),
     sourceConnectionId: candidate.source?.kind === "sourced" ? candidate.source.connectionId : null,
     sourceModule: candidate.source?.kind === "owned" ? candidate.source.module : null,
     selection: candidate.selection,
     priceCurrency: candidate.price.currency,
     priceAmount: candidate.price.amount,
     expiresAt: candidate.expiresAt ?? null,
-    providerData: candidate.providerData ?? null,
+    providerData: candidateProviderData(candidate),
   }
 }
 
@@ -110,7 +116,8 @@ export function availabilityCandidateToRow(args: {
  * to placeholder pricing → `unavailable`), and the catalog booking engine
  * routes on it — `"owned"` (`OWNED_SOURCE_KIND`) to an owned handler keyed by
  * entityModule, anything else to a sourced adapter keyed by `sourceConnectionId`.
- * The candidate's `sourceKind` is already `"owned"`/`"sourced"`, which aligns.
+ * The candidate's `sourceKind` is already `"owned"` or the concrete sourced
+ * adapter kind stamped by Catalog fan-out, which preserves booking authority.
  */
 export function pinnedComponentValuesFromCandidate(
   candidate: TripCandidate,
@@ -125,6 +132,7 @@ export function pinnedComponentValuesFromCandidate(
     entityId: candidate.entityId,
     sourceKind: candidate.sourceKind,
     sourceConnectionId: candidate.sourceConnectionId,
+    sourceRef: candidateSourceRef(candidate),
     componentCurrency: candidate.priceCurrency,
     metadata: {
       resolvedFromCandidateId: candidate.id,
@@ -134,9 +142,33 @@ export function pinnedComponentValuesFromCandidate(
         candidate.sourceKind === "owned"
           ? { kind: "owned", module: candidate.sourceModule }
           : { kind: "sourced", connectionId: candidate.sourceConnectionId },
+      sourceProvider: candidateSourceProvider(candidate),
       selection: candidate.selection,
     },
   }
+}
+
+function candidateSourceProvider(candidate: TripCandidate): string | undefined {
+  const value = candidate.providerData?.[SOURCE_PROVIDER_DATA_KEY]
+  return typeof value === "string" && value.length > 0 ? value : undefined
+}
+
+function candidateSourceRef(candidate: TripCandidate): string | undefined {
+  const value = candidate.providerData?.[SOURCE_REF_DATA_KEY]
+  return typeof value === "string" && value.length > 0 ? value : undefined
+}
+
+function candidateProviderData(candidate: AvailabilityCandidate): Record<string, unknown> | null {
+  const sourceProvider =
+    candidate.source?.kind === "sourced" ? candidate.source.sourceProvider : undefined
+  const sourceRef = candidate.source?.kind === "sourced" ? candidate.source.sourceRef : undefined
+  return sourceProvider || sourceRef
+    ? {
+        ...candidate.providerData,
+        ...(sourceProvider ? { [SOURCE_PROVIDER_DATA_KEY]: sourceProvider } : {}),
+        ...(sourceRef ? { [SOURCE_REF_DATA_KEY]: sourceRef } : {}),
+      }
+    : (candidate.providerData ?? null)
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/trips/tests/booking-session-composite-handler.test.ts
+++ b/packages/trips/tests/booking-session-composite-handler.test.ts
@@ -1,3 +1,4 @@
+// agent-quality: file-size exception -- owner: trips; this suite exercises the aggregate composite lifecycle through one shared snapshot harness.
 import type {
   BookingHoldInternalRecord,
   BookingQuoteInternalRecord,
@@ -132,6 +133,7 @@ describe("accepted Proposal Version Booking Session composite", () => {
       sourceConnectionId: "connection_server",
       sourceRef: "product_1",
       metadata: {
+        sourceProvider: "tui",
         bookingDraftV1: {
           entity: {
             module: "products",
@@ -155,6 +157,16 @@ describe("accepted Proposal Version Booking Session composite", () => {
     const state = harness([selectedPackage])
     const commitSourced = vi.fn(async (input) => {
       expect(input.session.target).toEqual({ kind: "catalog_item", catalogItemId: "prod_1" })
+      expect(input.session.sourcedTargetPin).toEqual({
+        entityModule: "products",
+        entityId: "prod_1",
+        sourceKind: "voyant-connect",
+        sourceProvider: "tui",
+        sourceConnectionId: "connection_server",
+        sourceRef: "product_1",
+        projection: { title: "Live component", description: "Live component" },
+        title: "Live component",
+      })
       expect(input.session.statePayload).toMatchObject({
         configure: {
           departureDate: "2026-09-10",
@@ -473,7 +485,8 @@ function harness(components: TripComponent[]) {
   const allocations = new Map<string, string[]>()
   const db = {
     transaction: async <T>(operation: (tx: unknown) => Promise<T>) => operation({}),
-  } as unknown as PostgresJsDatabase
+    // agent-quality: unsafe-cast reviewed -- owner: trips; this transaction-only test double deliberately implements the persistence surface used by the handler.
+  } as PostgresJsDatabase
   const persistence: TripBookingSessionCompositePersistence = {
     loadSnapshot: async () => snapshot,
     loadCurrentComponents: async () => components,
@@ -688,7 +701,7 @@ function tripSnapshot(components: TripComponent[]): TripSnapshot {
     componentCount: lines.length,
     pricedComponentCount: lines.length,
     frozenEnvelope: {},
-    frozenComponents: components as unknown as Record<string, unknown>[],
+    frozenComponents: components.map((component) => ({ ...component })),
     proposal: {
       envelopeId: "trip_1",
       title: "Bespoke trip",

--- a/packages/trips/tests/requirements.test.ts
+++ b/packages/trips/tests/requirements.test.ts
@@ -44,14 +44,17 @@ function candidate(overrides: Partial<TripCandidate> = {}): TripCandidate {
     candidateRef: "ref_1",
     entityModule: "accommodations",
     entityId: "acc_1",
-    sourceKind: "sourced",
+    sourceKind: "direct:tui",
     sourceConnectionId: "conn_a",
     sourceModule: null,
     selection: { ratePlanId: "rate_1" },
     priceCurrency: "USD",
     priceAmount: "200.00",
     expiresAt: null,
-    providerData: null,
+    providerData: {
+      _voyantSourceProvider: "direct:tui",
+      _voyantSourceRef: "hotel_1",
+    },
     createdAt: new Date("2026-06-22T00:00:00Z"),
     updatedAt: new Date("2026-06-22T00:00:00Z"),
     ...overrides,
@@ -126,7 +129,13 @@ describe("availabilityCandidateToRow", () => {
       envelopeId: "trip_9",
       candidate: {
         ...base,
-        source: { kind: "sourced", connectionId: "conn_x" },
+        source: {
+          kind: "sourced",
+          connectionId: "conn_x",
+          sourceKind: "voyant-connect",
+          sourceProvider: "tui",
+          sourceRef: "hotel_42",
+        },
         expiresAt: new Date("2026-06-22T13:00:00Z"),
       },
       rank: 3,
@@ -139,11 +148,15 @@ describe("availabilityCandidateToRow", () => {
       candidateRef: "ref_42",
       entityModule: "accommodations",
       entityId: "acc_42",
-      sourceKind: "sourced",
+      sourceKind: "voyant-connect",
       sourceConnectionId: "conn_x",
       sourceModule: null,
       priceCurrency: "EUR",
       priceAmount: "349.95",
+      providerData: {
+        _voyantSourceProvider: "tui",
+        _voyantSourceRef: "hotel_42",
+      },
     })
   })
 
@@ -170,14 +183,16 @@ describe("pinnedComponentValuesFromCandidate", () => {
       status: "draft",
       entityModule: "accommodations",
       entityId: "acc_1",
-      sourceKind: "sourced",
+      sourceKind: "direct:tui",
       sourceConnectionId: "conn_a",
+      sourceRef: "hotel_1",
       componentCurrency: "USD",
     })
     expect(values.metadata).toMatchObject({
       resolvedFromCandidateId: "trcd_1",
       candidateRef: "ref_1",
       selection: { ratePlanId: "rate_1" },
+      sourceProvider: "direct:tui",
     })
   })
 


### PR DESCRIPTION
## Summary
- preserve the exact server-selected supplier connection and source reference on sourced Trip composite leaves
- resolve internal sourced pins directly instead of querying an unrelated active Catalog row sharing the same entity id
- keep public targets, persisted Session state, and browser inputs unchanged

## Security boundary
The pin is constructed only from the server-owned frozen Trip component. It is never accepted from public input, persisted, or serialized. Entity identity must still match the internal `catalog_item` target and owned/empty pins fail closed.

## Validation
- Trips composite handler: 10/10
- Catalog production sessions: 32/32
- Catalog typecheck: pass
- changed-file Biome: pass
- changed-file agent-quality: pass
- git diff --check: pass

The standalone Trips typecheck exceeded the default 4 GB Node heap locally; GitHub changed-graph CI is the remaining authoritative full typecheck gate.
