### PR TITLE
Coalesce cloud team management reads

### DIFF
--- a/packages/auth/src/team-management-cloud-adapter.ts
+++ b/packages/auth/src/team-management-cloud-adapter.ts
@@ -107,10 +107,38 @@ async function resolveCloudRequest(
 export function createCloudTeamManagementAdapter(
   identityAccess: IdentityAccessRuntimeProvider,
 ): TeamManagementAdapter {
+  const requests = new WeakMap<
+    TeamManagementRequestContext,
+    Promise<CloudAdminMembersRequest & { actingExternalUserId: string }>
+  >()
+  const members = new WeakMap<TeamManagementRequestContext, Promise<CloudAdminMember[]>>()
+
+  function requestFor(context: TeamManagementRequestContext) {
+    const existing = requests.get(context)
+    if (existing) return existing
+    const pending = resolveCloudRequest(identityAccess, context)
+    requests.set(context, pending)
+    void pending.catch(() => {
+      if (requests.get(context) === pending) requests.delete(context)
+    })
+    return pending
+  }
+
+  function membersFor(context: TeamManagementRequestContext) {
+    const existing = members.get(context)
+    if (existing) return existing
+    const pending = requestFor(context).then(listCloudAdminMembers)
+    members.set(context, pending)
+    void pending.catch(() => {
+      if (members.get(context) === pending) members.delete(context)
+    })
+    return pending
+  }
+
   return {
     async getActor(context) {
-      const request = await resolveCloudRequest(identityAccess, context)
-      const actor = (await listCloudAdminMembers(request)).find(
+      const request = await requestFor(context)
+      const actor = (await membersFor(context)).find(
         (member) => member.externalUserId === request.actingExternalUserId,
       )
       if (!actor?.hasDeploymentAccess) {
@@ -130,24 +158,24 @@ export function createCloudTeamManagementAdapter(
       }
     },
     async listMembers(context) {
-      return (await listCloudAdminMembers(await resolveCloudRequest(identityAccess, context))).map(
-        cloudTeamMemberDto,
-      )
+      return (await membersFor(context)).map(cloudTeamMemberDto)
     },
     async listRoles(context) {
-      return (
-        await listCloudAdminMemberRoles(await resolveCloudRequest(identityAccess, context))
-      ).map((role) => ({ id: role.slug, name: role.name, description: role.description }))
+      return (await listCloudAdminMemberRoles(await requestFor(context))).map((role) => ({
+        id: role.slug,
+        name: role.name,
+        description: role.description,
+      }))
     },
     async listInvitations(context) {
-      return (
-        await listCloudAdminInvitations(await resolveCloudRequest(identityAccess, context))
-      ).map(cloudTeamInvitationDto)
+      return (await listCloudAdminInvitations(await requestFor(context))).map(
+        cloudTeamInvitationDto,
+      )
     },
     async inviteMember(context, input) {
       return createdInvitationDto(
         await inviteCloudAdminMember({
-          ...(await resolveCloudRequest(identityAccess, context)),
+          ...(await requestFor(context)),
           input: {
             email: input.email,
             roleSlug: input.roleId,
@@ -158,14 +186,14 @@ export function createCloudTeamManagementAdapter(
     },
     async revokeInvitation(context, invitationId) {
       await revokeCloudAdminInvitation({
-        ...(await resolveCloudRequest(identityAccess, context)),
+        ...(await requestFor(context)),
         invitationId,
       })
     },
     async updateMemberRole(context, memberId, roleId) {
       return cloudTeamMemberDto(
         await setCloudAdminMemberRole({
-          ...(await resolveCloudRequest(identityAccess, context)),
+          ...(await requestFor(context)),
           membershipId: memberId,
           roleSlug: roleId,
         }),
@@ -174,7 +202,7 @@ export function createCloudTeamManagementAdapter(
     async deactivateMember(context, memberId) {
       return cloudTeamMemberDto(
         await setCloudAdminMemberAccess({
-          ...(await resolveCloudRequest(identityAccess, context)),
+          ...(await requestFor(context)),
           membershipId: memberId,
           hasAccess: false,
         }),
@@ -183,7 +211,7 @@ export function createCloudTeamManagementAdapter(
     async activateMember(context, memberId) {
       return cloudTeamMemberDto(
         await setCloudAdminMemberAccess({
-          ...(await resolveCloudRequest(identityAccess, context)),
+          ...(await requestFor(context)),
           membershipId: memberId,
           hasAccess: true,
         }),

--- a/packages/auth/tests/unit/team-management-cloud-adapter.test.ts
+++ b/packages/auth/tests/unit/team-management-cloud-adapter.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { createCloudTeamManagementAdapter } from "../../src/team-management-cloud-adapter.js"
+import { createGuardedTeamManagementProvider } from "../../src/team-management-policy.js"
+import type { TeamManagementRequestContext } from "../../src/team-management-runtime-port.js"
+
+const broker = vi.hoisted(() => ({
+  listInvitations: vi.fn(),
+  listMembers: vi.fn(),
+}))
+
+vi.mock("../../src/cloud-broker.js", () => ({
+  inviteCloudAdminMember: vi.fn(),
+  listCloudAdminInvitations: broker.listInvitations,
+  listCloudAdminMemberRoles: vi.fn(),
+  listCloudAdminMembers: broker.listMembers,
+  revokeCloudAdminInvitation: vi.fn(),
+  setCloudAdminMemberAccess: vi.fn(),
+  setCloudAdminMemberRole: vi.fn(),
+}))
+
+const actor = {
+  membershipId: "member_actor",
+  externalUserId: "workos_actor",
+  email: "actor@example.test",
+  name: "Actor",
+  roleSlug: "owner",
+  roleName: "Owner",
+  status: "active",
+  hasDeploymentAccess: true,
+  createdAt: null,
+  lastActivityAt: null,
+}
+
+function harness() {
+  const linkLookup = vi.fn(async () => [{ providerAccountId: "workos_actor" }])
+  const db = {
+    select: vi.fn(() => ({
+      from: () => ({
+        where: () => ({ limit: linkLookup }),
+      }),
+    })),
+  }
+  const identityAccess = {
+    resolveDeployment: vi.fn(() => ({ cloudAdminMembers: { endpoint: "https://cloud.test" } })),
+  }
+  const adapter = createCloudTeamManagementAdapter(identityAccess as never)
+  const provider = createGuardedTeamManagementProvider(() => adapter)
+  const context = {
+    bindings: {},
+    db,
+    userId: "user_actor",
+  } as unknown as TeamManagementRequestContext
+  return { context, linkLookup, provider }
+}
+
+describe("cloud team-management request single-flight", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("shares identity and member reads across authorization and member listing", async () => {
+    broker.listMembers.mockResolvedValue([actor])
+    const { context, linkLookup, provider } = harness()
+
+    await expect(provider.listMembers(context)).resolves.toHaveLength(1)
+
+    expect(linkLookup).toHaveBeenCalledTimes(1)
+    expect(broker.listMembers).toHaveBeenCalledTimes(1)
+  })
+
+  it("shares identity resolution with invitation listing", async () => {
+    broker.listMembers.mockResolvedValue([actor])
+    broker.listInvitations.mockResolvedValue([])
+    const { context, linkLookup, provider } = harness()
+
+    await expect(provider.listInvitations(context)).resolves.toEqual([])
+
+    expect(linkLookup).toHaveBeenCalledTimes(1)
+    expect(broker.listMembers).toHaveBeenCalledTimes(1)
+    expect(broker.listInvitations).toHaveBeenCalledTimes(1)
+  })
+
+  it("coalesces concurrent consumers of the same request context", async () => {
+    broker.listMembers.mockResolvedValue([actor])
+    const { context, linkLookup, provider } = harness()
+
+    await Promise.all([provider.listMembers(context), provider.listMembers(context)])
+
+    expect(linkLookup).toHaveBeenCalledTimes(1)
+    expect(broker.listMembers).toHaveBeenCalledTimes(1)
+  })
+
+  it("never shares authorization work across request contexts", async () => {
+    broker.listMembers.mockResolvedValue([actor])
+    const first = harness()
+    const secondContext = { ...first.context }
+
+    await providerList(first.provider, first.context, secondContext)
+
+    expect(first.linkLookup).toHaveBeenCalledTimes(2)
+    expect(broker.listMembers).toHaveBeenCalledTimes(2)
+  })
+
+  it("does not let a rejected request poison a later context", async () => {
+    broker.listMembers
+      .mockRejectedValueOnce(new Error("broker unavailable"))
+      .mockResolvedValueOnce([actor])
+    const first = harness()
+
+    await expect(first.provider.listMembers(first.context)).rejects.toThrow("broker unavailable")
+    await expect(first.provider.listMembers({ ...first.context })).resolves.toHaveLength(1)
+  })
+})
+
+async function providerList(
+  provider: ReturnType<typeof createGuardedTeamManagementProvider>,
+  first: TeamManagementRequestContext,
+  second: TeamManagementRequestContext,
+) {
+  await provider.listMembers(first)
+  await provider.listMembers(second)
+}


### PR DESCRIPTION
## Summary

- single-flight cloud identity resolution within one team-management request context
- reuse the member broker response for actor authorization and roster listing
- keep all caches request-object scoped with rejected entries evicted
- preserve authorization, role, mutation, and provider-neutral contracts

## Why

The generation-4 cell benchmark left `/team/members` at 2.65s and `/team/invitations` at 2.20s. Each endpoint repeated the same cloud-link lookup, and members also repeated the same platform member-list request after authorization.

## Verification

- focused adapter and route tests: 10 passed
- auth package typecheck passed
- Biome and `git diff --check` passed

Closes #4576
Related: voyant-travel/platform#1908, voyant-travel/platform#1916
