### PR TITLE
fix(trips): commit customer-built itineraries

### DIFF
--- a/.changeset/fresh-customer-trip-commit.md
+++ b/.changeset/fresh-customer-trip-commit.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/trips": patch
+---
+
+Commit customer-built Trip snapshots without requiring accepted Proposal provenance, while preserving Proposal booking-origin evidence and renewed-acceptance handling for Proposal-backed journeys.

--- a/packages/trips/src/booking-session-composite-handler.ts
+++ b/packages/trips/src/booking-session-composite-handler.ts
@@ -273,10 +273,13 @@ export function createTripBookingSessionCompositeHandler(
       const database = input.db as PostgresJsDatabase
       const snapshot = await loadTargetSnapshot(database, input.session, persistence.loadSnapshot)
       if (materialTermsChanged(snapshot, input.quote.pricing)) {
-        return {
-          kind: "proposal_acceptance_required",
-          nextAction: "renew_proposal_version_acceptance",
-          proposalVersionId: requiredProposalOrigin(input.session).proposalVersionId,
+        const proposalOrigin = acceptedProposalOrigin(input.session)
+        if (proposalOrigin) {
+          return {
+            kind: "proposal_acceptance_required",
+            nextAction: "renew_proposal_version_acceptance",
+            proposalVersionId: proposalOrigin.proposalVersionId,
+          }
         }
       }
 
@@ -755,25 +758,24 @@ async function recordComponentCommit(input: {
       bookingSessionQuoteId: quote.id,
     },
   })
-  const origin = requiredProposalOrigin(session)
-  await setAcceptedProposalBookingOrigin(db, {
-    bookingId: commitment.bookingId,
-    proposalId: origin.proposalId,
-    proposalVersionId: origin.proposalVersionId,
-    tripEnvelopeId: snapshot.envelopeId,
-    tripSnapshotId: snapshot.id,
-    tripComponentId: component.id,
-    bookingSessionId: session.id,
-    bookingSessionQuoteId: quote.id,
-    supplierOperationId: commitment.supplierOperationId,
-  })
+  const origin = acceptedProposalOrigin(session)
+  if (origin) {
+    await setAcceptedProposalBookingOrigin(db, {
+      bookingId: commitment.bookingId,
+      proposalId: origin.proposalId,
+      proposalVersionId: origin.proposalVersionId,
+      tripEnvelopeId: snapshot.envelopeId,
+      tripSnapshotId: snapshot.id,
+      tripComponentId: component.id,
+      bookingSessionId: session.id,
+      bookingSessionQuoteId: quote.id,
+      supplierOperationId: commitment.supplierOperationId,
+    })
+  }
 }
 
-function requiredProposalOrigin(session: BookingSessionInternalRecord) {
-  if (session.origin?.kind !== "accepted_proposal_version") {
-    throw new Error("accepted_proposal_version_origin_required")
-  }
-  return session.origin
+function acceptedProposalOrigin(session: BookingSessionInternalRecord) {
+  return session.origin?.kind === "accepted_proposal_version" ? session.origin : undefined
 }
 
 function componentQuantity(payload: Record<string, unknown>): number {

--- a/packages/trips/tests/booking-session-composite-handler.test.ts
+++ b/packages/trips/tests/booking-session-composite-handler.test.ts
@@ -234,6 +234,64 @@ describe("accepted Proposal Version Booking Session composite", () => {
     )
   })
 
+  it("commits a customer-built Trip without an accepted Proposal origin", async () => {
+    const selectedPackage = component({
+      sourceKind: "voyant-connect",
+      sourceConnectionId: "connection_server",
+      sourceRef: "product_1",
+    })
+    const state = harness([selectedPackage])
+    state.session.origin = undefined
+    state.session.actorKind = "customer"
+    state.session.ownerPrincipalId = undefined
+    const handler = createTripBookingSessionCompositeHandler(state.persistence)
+    const leaf = leafRuntime()
+    const quote = await createQuote(handler, state.session, leaf, state.db)
+
+    await expect(
+      handler.commit({
+        session: state.session,
+        quote,
+        idempotencyKey: "commit_customer_trip",
+        requestFingerprint: "fp_customer_trip",
+        access: ACCESS,
+        now: NOW,
+        consumeSources: async () => {},
+        leaf,
+        db: state.db,
+      }),
+    ).resolves.toMatchObject({ kind: "committed" })
+  })
+
+  it("commits an originless customer Trip against its accepted fresh quote", async () => {
+    const state = harness([component()])
+    state.session.origin = undefined
+    state.session.actorKind = "customer"
+    state.session.ownerPrincipalId = undefined
+    const handler = createTripBookingSessionCompositeHandler(state.persistence)
+    const quote = await createQuote(
+      handler,
+      state.session,
+      leafRuntime({ quoteTotal: 12_000 }),
+      state.db,
+    )
+
+    await expect(
+      handler.commit({
+        session: state.session,
+        quote,
+        hold: aggregateHold(state.session, quote),
+        idempotencyKey: "commit_customer_changed_price",
+        requestFingerprint: "fp_customer_changed_price",
+        access: ACCESS,
+        now: NOW,
+        consumeSources: async () => {},
+        leaf: leafRuntime({ quoteTotal: 12_000 }),
+        db: state.db,
+      }),
+    ).resolves.toMatchObject({ kind: "committed" })
+  })
+
   it("keeps an ambiguous package confirmation in doubt without materializing a booking", async () => {
     const selectedPackage = component({
       sourceKind: "voyant-connect",


### PR DESCRIPTION
## What changed

- allow customer-built Trip snapshots to commit without accepted Proposal provenance
- preserve accepted Proposal booking-origin evidence when that provenance exists
- return a fresh-quote outcome, instead of an impossible Proposal re-acceptance action, when customer-built Trip terms change

## Root cause

The composite Trip commit path unconditionally called `requiredProposalOrigin` after a supplier-backed component committed. Managed storefront Trips intentionally have no accepted Proposal origin, so the live sandbox journey reached quote and hold but failed at commit with `accepted_proposal_version_origin_required`.

## Validation

- `pnpm --filter @voyant-travel/trips exec vitest run tests/booking-session-composite-handler.test.ts --maxWorkers=2` (12/12)
- `pnpm --filter @voyant-travel/trips typecheck`
- targeted Biome check
- `git diff --check`

Live sandbox correlation: managed package search, opaque Trip creation, Booking Session creation, binding quote, and hold all succeeded; commit reproduced the exact origin guard failure this patch removes.
