### PR TITLE
fix(storefront): decouple presentation currency

### DIFF
--- a/.changeset/brave-shopping-currency.md
+++ b/.changeset/brave-shopping-currency.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/storefront": patch
+---
+
+Allow visitors to choose any operator-configured presentation currency independently of their resolved shopping market and locale, while keeping market, locale, and currency validation server-owned.

--- a/packages/storefront/src/shopping/closed-live-provider.ts
+++ b/packages/storefront/src/shopping/closed-live-provider.ts
@@ -361,9 +361,12 @@ async function assertActiveScope(
     channelId: context.channelId,
   })
   const market = active.find(({ id }) => id === scope.marketId)
+  const currency = scope.currency.trim().toUpperCase()
   if (
     !market?.locales.includes(scope.locale) ||
-    !market.currencies.map((currency) => currency.toUpperCase()).includes(scope.currency)
+    !active.some(({ currencies }) =>
+      currencies.map((candidate) => candidate.trim().toUpperCase()).includes(currency),
+    )
   ) {
     throw new StorefrontShoppingUnavailableError("active market scope")
   }

--- a/packages/storefront/src/shopping/closed-provider-adapters.ts
+++ b/packages/storefront/src/shopping/closed-provider-adapters.ts
@@ -121,9 +121,12 @@ async function assertActiveScope(
 ): Promise<void> {
   const active = await provider.listActiveMarkets(context)
   const market = active.find(({ id }) => id === scope.marketId)
+  const currency = scope.currency.trim().toUpperCase()
   if (
     !market?.locales.includes(scope.locale) ||
-    !market.currencies.includes(scope.currency.trim().toUpperCase())
+    !active.some(({ currencies }) =>
+      currencies.map((candidate) => candidate.trim().toUpperCase()).includes(currency),
+    )
   ) {
     throw new StorefrontShoppingUnavailableError("active market scope")
   }

--- a/packages/storefront/src/shopping/managed-runtime.ts
+++ b/packages/storefront/src/shopping/managed-runtime.ts
@@ -105,9 +105,7 @@ async function resolveActiveScope(
   )
   const requestedCurrency = requested.currency ? upperCurrency(requested.currency) : undefined
   const eligible = markets.filter(
-    (candidate) =>
-      (!requested.locale || resolveSupportedLocale(candidate, requested.locale)) &&
-      (!requestedCurrency || marketCurrencies(candidate).includes(requestedCurrency)),
+    (candidate) => !requested.locale || resolveSupportedLocale(candidate, requested.locale),
   )
   const market = requested.marketId
     ? markets.find((candidate) => candidate.id === requested.marketId)
@@ -128,10 +126,9 @@ async function resolveActiveScope(
   const locale = requested.locale
     ? resolveSupportedLocale(market, requested.locale)
     : market.defaultLocale
-  const currencies = marketCurrencies(market)
   const currency = requestedCurrency ?? upperCurrency(market.defaultCurrency)
   if (!locale) throw new StorefrontShoppingScopeError("locale", requested.locale)
-  if (!currencies.includes(currency)) {
+  if (!availableCurrencies.includes(currency)) {
     throw new StorefrontShoppingScopeError("currency", currency)
   }
 
@@ -149,10 +146,6 @@ async function resolveActiveScope(
 
 function marketLocales(market: StorefrontActiveMarket): string[] {
   return unique([market.defaultLocale, ...market.locales])
-}
-
-function marketCurrencies(market: StorefrontActiveMarket): string[] {
-  return unique([market.defaultCurrency, ...market.currencies].map(upperCurrency))
 }
 
 function baseLanguageRange(locale: string): string | null {

--- a/packages/storefront/tests/unit/closed-shopping-provider-adapters.test.ts
+++ b/packages/storefront/tests/unit/closed-shopping-provider-adapters.test.ts
@@ -68,6 +68,7 @@ function adapters(
   input: {
     active?: (context: typeof storefront) => boolean
     indexer?: IndexerAdapter
+    markets?: Array<typeof activeMarket>
     policies?: FieldPolicy[]
   } = {},
 ) {
@@ -102,7 +103,7 @@ function adapters(
           ],
         ]),
     },
-    listMarkets: vi.fn(async () => [activeMarket]),
+    listMarkets: vi.fn(async () => input.markets ?? [activeMarket]),
     isActiveStorefrontChannel: vi.fn(async (_db, context) =>
       input.active ? input.active(context as typeof storefront) : true,
     ),
@@ -163,6 +164,46 @@ describe("closed storefront shopping market adapter", () => {
 })
 
 describe("closed storefront shopping catalog adapter", () => {
+  it("admits a presentation currency configured on another active market", async () => {
+    const indexer = createIndexer()
+    const provider = adapters({
+      indexer,
+      markets: [
+        activeMarket,
+        {
+          ...activeMarket,
+          id: "market_uk",
+          code: "UK",
+          countryCode: "GB",
+          defaultLocale: "en-GB",
+          defaultCurrency: "GBP",
+          locales: [{ languageTag: "en-GB", isDefault: true }],
+          currencies: [{ currencyCode: "GBP", isDefault: true }],
+        },
+      ],
+    }).catalog
+
+    await expect(
+      provider.searchSlice({
+        context: storefront,
+        scope: {
+          marketId: "market_ro",
+          locale: "ro-RO",
+          currency: "GBP",
+          available: {
+            marketIds: ["market_ro", "market_uk"],
+            locales: ["ro-RO", "en-GB"],
+            currencies: ["RON", "EUR", "GBP"],
+          },
+        },
+        vertical: "products",
+        query: "",
+        filters: [],
+      }),
+    ).resolves.toMatchObject({ items: [], total: 0 })
+    expect(indexer.search).toHaveBeenCalledOnce()
+  })
+
   it.each([
     ["disabled locale", { marketId: "market_ro", locale: "de-DE", currency: "RON" }],
     ["disabled currency", { marketId: "market_ro", locale: "ro-RO", currency: "USD" }],

--- a/packages/storefront/tests/unit/managed-shopping-runtime.test.ts
+++ b/packages/storefront/tests/unit/managed-shopping-runtime.test.ts
@@ -122,13 +122,24 @@ describe("managed storefront shopping scope", () => {
       currency: "RON",
     })
     await expect(runtime.resolveScope(context, { currency: "GBP" })).resolves.toMatchObject({
-      marketId: "market_uk",
+      marketId: "market_eu",
       locale: "en-GB",
       currency: "GBP",
     })
     await expect(
+      runtime.resolveScope(context, { locale: "ro", currency: "GBP" }),
+    ).resolves.toMatchObject({
+      marketId: "market_ro",
+      locale: "ro-RO",
+      currency: "GBP",
+    })
+    await expect(
       runtime.resolveScope(context, { locale: "fr-FR", currency: "RON" }),
-    ).rejects.toMatchObject({ code: "storefront_shopping_scope_unsupported" })
+    ).resolves.toMatchObject({
+      marketId: "market_eu",
+      locale: "fr-FR",
+      currency: "RON",
+    })
     await expect(runtime.resolveScope(context, { locale: "en-US" })).rejects.toMatchObject({
       code: "storefront_shopping_scope_unsupported",
       selector: "locale",


### PR DESCRIPTION
## Summary
- keep market and locale resolution server-owned while allowing any operator-configured presentation currency
- preserve the resolved content market when a visitor changes currency
- validate the selected currency against active operator market configuration across the storefront

## Why
The managed theme currency picker currently offers the union of enabled currencies, but the runtime requires the selected currency to belong to the same market as the selected locale. Valid combinations such as `ro-RO` + `GBP` therefore fail even though managed Voyant Data FX is responsible for presenting all results in the visitor-selected currency.

## Validation
- Storefront focused Vitest: 3 files, 32 tests passed
- targeted Biome check passed
- `git diff --check` passed
- package-wide local TypeScript was stopped before the known 4 GB Node heap ceiling; GitHub CI is the authoritative full-package check
