### PR TITLE
test: repair OSS release gates

### DIFF
--- a/packages/runtime/src/runtime-composition.test.ts
+++ b/packages/runtime/src/runtime-composition.test.ts
@@ -251,7 +251,9 @@ describe("Voyant project runtime composition", () => {
         protocol: "legal-document-artifact.v1",
       },
     })
-    await expect(legalDocumentArtifactProviderPort.test(provider as never)).resolves.toBeUndefined()
+    await expect(
+      Promise.resolve(legalDocumentArtifactProviderPort.test(provider as never)),
+    ).resolves.toBeUndefined()
     expect(mocks.loadVoyantNodeRuntime.mock.calls[0]?.[0]).toMatchObject({
       graphRuntime: mocks.activatedGraphRuntime,
     })

--- a/packages/trips/tests/integration/durable-sourcing.test.ts
+++ b/packages/trips/tests/integration/durable-sourcing.test.ts
@@ -705,7 +705,7 @@ describe.skipIf(!DB_AVAILABLE)("Trips durable requirement sourcing", () => {
 
   function availabilityAdapter(candidates: AvailabilityCandidate[]): SourceAdapter {
     return {
-      kind: "test",
+      kind: "sourced",
       capabilities: {
         verticals: ["accommodations"],
         supportsLiveResolution: true,


### PR DESCRIPTION
## Summary
- make the runtime composition assertion accept the port contract’s supported `void | Promise<void>` return shape
- align the Trips integration fixture adapter kind with the sourced result asserted by the test
- unblock the pending OSS package release without changing production behavior

## Validation
- `pnpm --filter @voyant-travel/runtime exec vitest run src/runtime-composition.test.ts --maxWorkers=2` (27/27)
- targeted Biome checks
- `git diff --check`
- first CI head passed tests, quality/typecheck, build, architecture, artifacts, packaged acceptance, security, and all database lanes except the stale Trips fixture corrected in the second commit

The repository-wide pre-push hook was also attempted; it hit an unrelated flaky webhook test before the first push, so exact GitHub CI remains authoritative.