### PR TITLE
Fix post-payment document bundle delivery

### DIFF
--- a/.changeset/calm-post-payment-bundle.md
+++ b/.changeset/calm-post-payment-bundle.md
@@ -1,0 +1,8 @@
+---
+"@voyant-travel/commerce": patch
+"@voyant-travel/finance": patch
+"@voyant-travel/notifications": patch
+"@voyant-travel/storage": patch
+---
+
+Deliver post-payment booking document bundles only after every template-required attachment is ready, including final provider invoices, contracts, and product brochures. Emit a booking-keyed checkout-finalized event after Booking Session settlement, retry pending bundles on document and brochure readiness events, and encode storage metadata safely for Unicode values.

--- a/.changeset/calm-post-payment-bundle.md
+++ b/.changeset/calm-post-payment-bundle.md
@@ -1,8 +1,9 @@
 ---
 "@voyant-travel/commerce": patch
 "@voyant-travel/finance": patch
+"@voyant-travel/framework": patch
 "@voyant-travel/notifications": patch
 "@voyant-travel/storage": patch
 ---
 
-Deliver post-payment booking document bundles only after every template-required attachment is ready, including final provider invoices, contracts, and product brochures. Emit a booking-keyed checkout-finalized event after Booking Session settlement, retry pending bundles on document and brochure readiness events, and encode storage metadata safely for Unicode values.
+Deliver post-payment booking document bundles only after every template-required attachment is ready, including final provider invoices, contracts, and product brochures. Emit a booking-keyed checkout-finalized event after Booking Session settlement, retry pending bundles on document and brochure readiness events, encode storage metadata safely for Unicode values, and record the managed-runtime release identity for the new delivery contract.

--- a/apps/operator/tests/api/selected-graph-runtime.test.ts
+++ b/apps/operator/tests/api/selected-graph-runtime.test.ts
@@ -267,7 +267,11 @@ describe("selected Operator graph runtime composition", () => {
     expect(subscribe.mock.calls.map(([eventType]) => eventType)).toEqual([
       "booking.cancelled",
       "booking.confirmed",
+      "checkout.finalized",
+      "contract.document.generated",
+      "invoice.rendered",
       "payment.completed",
+      "product.content.changed",
       "booking.cancelled",
       "booking.confirmed",
       "booking.inquiry.created",
@@ -284,7 +288,7 @@ describe("selected Operator graph runtime composition", () => {
         .map(([eventType], index) => ({ eventType, index }))
         .filter(({ eventType }) => eventType === "booking.confirmed")
         .map(({ index }) => index),
-    ).toEqual([1, 4])
+    ).toEqual([1, 8])
   })
 
   it("activates the Trips payment subscriber and its runtime service", async () => {

--- a/packages/commerce/src/checkout/subscriber-runtime.ts
+++ b/packages/commerce/src/checkout/subscriber-runtime.ts
@@ -229,6 +229,14 @@ export function createCheckoutFinalizeSubscriberRuntime<TBindings = unknown>(
                 options.legal,
               )
             })
+            await nestedEventBus.emit(
+              "checkout.finalized",
+              {
+                bookingId: finalizedBookingId,
+                paymentSessionId: data.paymentSessionId,
+              },
+              { category: "internal", source: "service" },
+            )
           } catch (error) {
             logger.error(
               `[catalog-checkout] checkout finalization failed for booking ${bookingId ?? data.targetId ?? "unknown"}`,

--- a/packages/commerce/src/voyant-event-schemas.ts
+++ b/packages/commerce/src/voyant-event-schemas.ts
@@ -51,3 +51,13 @@ export const inquiryCreatedPayloadSchema = {
   },
   additionalProperties: false,
 } as const
+
+export const checkoutFinalizedPayloadSchema = {
+  type: "object",
+  required: ["bookingId", "paymentSessionId"],
+  properties: {
+    bookingId: { type: "string" },
+    paymentSessionId: { type: "string" },
+  },
+  additionalProperties: false,
+} as const

--- a/packages/commerce/src/voyant.ts
+++ b/packages/commerce/src/voyant.ts
@@ -36,6 +36,7 @@ import {
 } from "./runtime-port.js"
 import { commerceAccess } from "./voyant-access.js"
 import {
+  checkoutFinalizedPayloadSchema,
   inquiryCreatedPayloadSchema,
   pricingRuleChangedPayloadSchema,
   promotionChangedPayloadSchema,
@@ -332,6 +333,14 @@ export const commerceVoyantModule = defineModule({
   ],
   actions: commerceToolActions,
   events: [
+    {
+      id: "@voyant-travel/commerce#event.checkout.finalized",
+      eventType: "checkout.finalized",
+      version: "1.0.0",
+      payloadSchema: checkoutFinalizedPayloadSchema,
+      visibility: "internal",
+      audit: { sourceModule: "commerce", category: "domain" },
+    },
     {
       id: "@voyant-travel/commerce#event.promotion.changed",
       eventType: "promotion.changed",

--- a/packages/commerce/tests/unit/voyant-manifest.test.ts
+++ b/packages/commerce/tests/unit/voyant-manifest.test.ts
@@ -133,6 +133,10 @@ describe("commerce deployment manifest", () => {
       migrations: [{ id: "@voyant-travel/commerce#migrations" }],
       events: [
         {
+          id: "@voyant-travel/commerce#event.checkout.finalized",
+          eventType: "checkout.finalized",
+        },
+        {
           id: "@voyant-travel/commerce#event.promotion.changed",
           eventType: "promotion.changed",
         },

--- a/packages/finance/src/app-api-runtime.ts
+++ b/packages/finance/src/app-api-runtime.ts
@@ -1,5 +1,5 @@
 import { bookings } from "@voyant-travel/bookings/schema"
-import type { VoyantRuntimeHostPrimitives } from "@voyant-travel/core"
+import type { EventBus, VoyantRuntimeHostPrimitives } from "@voyant-travel/core"
 import type {
   FinanceAppApiExternalLifecycleMutationResult,
   FinanceAppApiExternalLifecycleObservation,
@@ -40,8 +40,26 @@ import { InvoiceNumberConflictError, toRows } from "./service-shared.js"
 
 type ArtifactRuntimePrimitives = Pick<VoyantRuntimeHostPrimitives, "storage">
 
+function artifactEventBus(
+  primitives: Pick<VoyantRuntimeHostPrimitives, "events"> | undefined,
+  bindings: unknown,
+): EventBus | undefined {
+  if (!primitives) return undefined
+  return {
+    emit: async (name, data, metadata) => {
+      await primitives.events.deliver(
+        { name, data, metadata, emittedAt: new Date().toISOString() },
+        bindings,
+      )
+    },
+    subscribe() {
+      throw new Error("Finance app artifact event adapter does not support subscriptions")
+    },
+  }
+}
+
 export function createFinanceAppApiRuntime(
-  primitives?: ArtifactRuntimePrimitives,
+  primitives?: ArtifactRuntimePrimitives & Pick<VoyantRuntimeHostPrimitives, "events">,
 ): FinanceAppApiRuntime<PostgresJsDatabase> {
   return {
     async getIssuanceDocument(db, documentId) {
@@ -283,18 +301,23 @@ export function createFinanceAppApiRuntime(
       const storageKey = uploaded.key
 
       try {
-        const result = await financeService.bindInvoiceRendition(db, documentId, {
-          format: "pdf",
-          contentType: input.contentType,
-          storageKey,
-          fileSize: input.bytes.byteLength,
-          checksum,
-          generatedAt: new Date().toISOString(),
-          appProvider: provider,
-          appIdempotencyDigest: idempotencyDigest,
-          appFileName: input.fileName,
-          metadata: { source: "remote_app" },
-        })
+        const result = await financeService.bindInvoiceRendition(
+          db,
+          documentId,
+          {
+            format: "pdf",
+            contentType: input.contentType,
+            storageKey,
+            fileSize: input.bytes.byteLength,
+            checksum,
+            generatedAt: new Date().toISOString(),
+            appProvider: provider,
+            appIdempotencyDigest: idempotencyDigest,
+            appFileName: input.fileName,
+            metadata: { source: "remote_app" },
+          },
+          { eventBus: artifactEventBus(primitives, environment) },
+        )
         if (result.status === "not_found") {
           await bestEffortDelete(storage, storageKey)
           return { status: "not_found" }

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -43,6 +43,7 @@
     "@voyant-travel/finance": "workspace:^",
     "@voyant-travel/hono": "workspace:^",
     "@voyant-travel/legal": "workspace:^",
+    "@voyant-travel/inventory": "workspace:^",
     "@voyant-travel/operator-settings": "workspace:^",
     "@voyant-travel/proposals": "workspace:^",
     "@voyant-travel/relationships": "workspace:^",
@@ -187,7 +188,8 @@
     },
     "schema": "./schema",
     "requiresSchemas": [
-      "@voyant-travel/db"
+      "@voyant-travel/db",
+      "@voyant-travel/inventory"
     ]
   },
   "private": true

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -43,7 +43,6 @@
     "@voyant-travel/finance": "workspace:^",
     "@voyant-travel/hono": "workspace:^",
     "@voyant-travel/legal": "workspace:^",
-    "@voyant-travel/inventory": "workspace:^",
     "@voyant-travel/operator-settings": "workspace:^",
     "@voyant-travel/proposals": "workspace:^",
     "@voyant-travel/relationships": "workspace:^",
@@ -188,8 +187,7 @@
     },
     "schema": "./schema",
     "requiresSchemas": [
-      "@voyant-travel/db",
-      "@voyant-travel/inventory"
+      "@voyant-travel/db"
     ]
   },
   "private": true

--- a/packages/notifications/src/payment-bundle-refs.ts
+++ b/packages/notifications/src/payment-bundle-refs.ts
@@ -1,0 +1,42 @@
+import { boolean, integer, pgTable, text, timestamp } from "drizzle-orm/pg-core"
+
+/**
+ * Minimal read-only references used to assemble and retry the post-payment
+ * document bundle. These deliberately carry no foreign keys: Notifications
+ * observes document readiness without taking ownership of the source tables.
+ */
+export const bookingItemsRef = pgTable("booking_items", {
+  bookingId: text("booking_id").notNull(),
+  productId: text("product_id"),
+})
+
+export const paymentSessionsRef = pgTable("payment_sessions", {
+  id: text("id").primaryKey(),
+  bookingId: text("booking_id"),
+  status: text("status").notNull(),
+  completedAt: timestamp("completed_at", { withTimezone: true }),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull(),
+})
+
+export const invoicesRef = pgTable("invoices", {
+  id: text("id").primaryKey(),
+  bookingId: text("booking_id").notNull(),
+})
+
+export const contractsRef = pgTable("contracts", {
+  id: text("id").primaryKey(),
+  bookingId: text("booking_id"),
+})
+
+export const productMediaRef = pgTable("product_media", {
+  id: text("id").primaryKey(),
+  productId: text("product_id").notNull(),
+  name: text("name").notNull(),
+  url: text("url").notNull(),
+  storageKey: text("storage_key"),
+  mimeType: text("mime_type"),
+  isBrochure: boolean("is_brochure").notNull(),
+  isBrochureCurrent: boolean("is_brochure_current").notNull(),
+  brochureVersion: integer("brochure_version"),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
+})

--- a/packages/notifications/src/service-booking-documents.ts
+++ b/packages/notifications/src/service-booking-documents.ts
@@ -1,5 +1,6 @@
-import { bookings } from "@voyant-travel/bookings/schema"
+import { bookingItems, bookings } from "@voyant-travel/bookings/schema"
 import { invoiceRenditions, invoices } from "@voyant-travel/finance/schema"
+import { productMedia } from "@voyant-travel/inventory/schema"
 import { contractAttachments, contracts } from "@voyant-travel/legal/schema"
 import { and, desc, eq, ne, or } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
@@ -242,6 +243,65 @@ async function listFinanceBookingDocuments(
   })
 }
 
+async function listProductBookingDocuments(
+  db: PostgresJsDatabase,
+  bookingId: string,
+): Promise<BookingDocumentBundleItem[]> {
+  const itemRows = await db
+    .select({ productId: bookingItems.productId })
+    .from(bookingItems)
+    .where(eq(bookingItems.bookingId, bookingId))
+  const productIds = [
+    ...new Set(
+      itemRows
+        .map(({ productId }) => productId)
+        .filter((productId): productId is string => Boolean(productId)),
+    ),
+  ]
+  if (productIds.length === 0) return []
+
+  const brochureRows = await db
+    .select()
+    .from(productMedia)
+    .where(
+      and(
+        eq(productMedia.isBrochure, true),
+        eq(productMedia.isBrochureCurrent, true),
+        or(...productIds.map((productId) => eq(productMedia.productId, productId))),
+      ),
+    )
+    .orderBy(desc(productMedia.brochureVersion), desc(productMedia.createdAt))
+
+  const bestByProductId = new Map<string, typeof productMedia.$inferSelect>()
+  for (const brochure of brochureRows) {
+    if (!bestByProductId.has(brochure.productId)) bestByProductId.set(brochure.productId, brochure)
+  }
+
+  return [...bestByProductId.values()].map((brochure) => ({
+    key: `products:${brochure.id}`,
+    source: "products" as const,
+    documentType: "brochure" as const,
+    bookingId,
+    contractId: null,
+    invoiceId: null,
+    attachmentId: null,
+    renditionId: null,
+    contractStatus: null,
+    invoiceStatus: null,
+    name: brochure.name,
+    format: brochure.mimeType === "application/pdf" ? "pdf" : null,
+    mimeType: brochure.mimeType,
+    storageKey: brochure.storageKey,
+    downloadUrl: brochure.url,
+    language: null,
+    metadata: {
+      productId: brochure.productId,
+      brochureVersion: brochure.brochureVersion,
+    },
+    createdAt: brochure.createdAt.toISOString(),
+  }))
+}
+
 export const bookingDocumentNotificationsService = {
   async listBookingDocumentBundle(db: PostgresJsDatabase, bookingId: string) {
     const [booking] = await db.select().from(bookings).where(eq(bookings.id, bookingId)).limit(1)
@@ -249,14 +309,15 @@ export const bookingDocumentNotificationsService = {
       return null
     }
 
-    const [legalDocuments, financeDocuments] = await Promise.all([
+    const [legalDocuments, financeDocuments, productDocuments] = await Promise.all([
       listLegalBookingDocuments(db, bookingId),
       listFinanceBookingDocuments(db, bookingId),
+      listProductBookingDocuments(db, bookingId),
     ])
 
     return {
       bookingId,
-      documents: [...legalDocuments, ...financeDocuments],
+      documents: [...legalDocuments, ...financeDocuments, ...productDocuments],
     }
   },
 

--- a/packages/notifications/src/service-booking-documents.ts
+++ b/packages/notifications/src/service-booking-documents.ts
@@ -1,10 +1,10 @@
-import { bookingItems, bookings } from "@voyant-travel/bookings/schema"
+import { bookings } from "@voyant-travel/bookings/schema"
 import { invoiceRenditions, invoices } from "@voyant-travel/finance/schema"
-import { productMedia } from "@voyant-travel/inventory/schema"
 import { contractAttachments, contracts } from "@voyant-travel/legal/schema"
 import { and, desc, eq, ne, or } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
+import { bookingItemsRef, productMediaRef } from "./payment-bundle-refs.js"
 import { enqueueNotification } from "./service-durable-send.js"
 import { buildNotificationPortalContext } from "./service-portal-context.js"
 import type {
@@ -248,9 +248,9 @@ async function listProductBookingDocuments(
   bookingId: string,
 ): Promise<BookingDocumentBundleItem[]> {
   const itemRows = await db
-    .select({ productId: bookingItems.productId })
-    .from(bookingItems)
-    .where(eq(bookingItems.bookingId, bookingId))
+    .select({ productId: bookingItemsRef.productId })
+    .from(bookingItemsRef)
+    .where(eq(bookingItemsRef.bookingId, bookingId))
   const productIds = [
     ...new Set(
       itemRows
@@ -262,17 +262,17 @@ async function listProductBookingDocuments(
 
   const brochureRows = await db
     .select()
-    .from(productMedia)
+    .from(productMediaRef)
     .where(
       and(
-        eq(productMedia.isBrochure, true),
-        eq(productMedia.isBrochureCurrent, true),
-        or(...productIds.map((productId) => eq(productMedia.productId, productId))),
+        eq(productMediaRef.isBrochure, true),
+        eq(productMediaRef.isBrochureCurrent, true),
+        or(...productIds.map((productId) => eq(productMediaRef.productId, productId))),
       ),
     )
-    .orderBy(desc(productMedia.brochureVersion), desc(productMedia.createdAt))
+    .orderBy(desc(productMediaRef.brochureVersion), desc(productMediaRef.createdAt))
 
-  const bestByProductId = new Map<string, typeof productMedia.$inferSelect>()
+  const bestByProductId = new Map<string, typeof productMediaRef.$inferSelect>()
   for (const brochure of brochureRows) {
     if (!bestByProductId.has(brochure.productId)) bestByProductId.set(brochure.productId, brochure)
   }

--- a/packages/notifications/src/service-reminder-booking-context.ts
+++ b/packages/notifications/src/service-reminder-booking-context.ts
@@ -169,12 +169,16 @@ export async function getBookingEventDocumentContext(
   db: PostgresJsDatabase,
   bookingId: string,
   attachmentResolver?: BookingDocumentAttachmentResolver,
+  requestedDocumentTypes?: ReadonlyArray<BookingDocumentBundleItem["documentType"]>,
 ): Promise<{
   documents: BookingDocumentBundleItem[]
   attachments: NotificationAttachment[]
 }> {
   const bundle = await bookingDocumentNotificationsService.listBookingDocumentBundle(db, bookingId)
-  const documents = bundle?.documents ?? []
+  const requested = requestedDocumentTypes ? new Set(requestedDocumentTypes) : null
+  const documents = (bundle?.documents ?? []).filter(
+    (document) => !requested || requested.has(document.documentType),
+  )
   if (documents.length === 0) {
     return { documents, attachments: [] }
   }

--- a/packages/notifications/src/service-reminder-events.ts
+++ b/packages/notifications/src/service-reminder-events.ts
@@ -16,7 +16,11 @@ import {
   serializeBookingPaymentContext,
 } from "./service-reminder-booking-context.js"
 import { markReminderRunFailed, markReminderRunSkipped } from "./service-reminder-run-state.js"
-import type { NotificationReminderRuleRow, NotificationService } from "./service-shared.js"
+import type {
+  BookingDocumentBundleItem,
+  NotificationReminderRuleRow,
+  NotificationService,
+} from "./service-shared.js"
 import {
   buildReminderDedupeKey,
   listBookingNotificationItems,
@@ -58,6 +62,44 @@ export async function requiredAttachmentTypes(
           .limit(1)
       : []
   return configuredAttachmentTypes(template?.metadata ?? null)
+}
+
+export function shouldResolveBookingEventDocuments(
+  targetType: BookingEventReminderTargetType,
+  channel: NotificationReminderRuleRow["channel"],
+  requiredDocumentTypes: ReadonlyArray<BookingDocumentBundleItem["documentType"]>,
+) {
+  return (
+    channel === "email" &&
+    (targetType === "booking_confirmed" ||
+      (targetType === "payment_complete" && requiredDocumentTypes.length > 0))
+  )
+}
+
+export function missingRequiredAttachmentTypes(
+  requiredDocumentTypes: ReadonlyArray<BookingDocumentBundleItem["documentType"]>,
+  documents: ReadonlyArray<BookingDocumentBundleItem>,
+  bookedProductIds: ReadonlyArray<string>,
+) {
+  const readyTypes = new Set(documents.map(({ documentType }) => documentType))
+  const missingTypes = requiredDocumentTypes.filter((type) => !readyTypes.has(type))
+
+  if (requiredDocumentTypes.includes("brochure")) {
+    const brochureProductIds = new Set(
+      documents
+        .filter(({ documentType }) => documentType === "brochure")
+        .map(({ metadata }) => metadata?.productId)
+        .filter((productId): productId is string => typeof productId === "string"),
+    )
+    if (
+      bookedProductIds.some((productId) => !brochureProductIds.has(productId)) &&
+      !missingTypes.includes("brochure")
+    ) {
+      missingTypes.push("brochure")
+    }
+  }
+
+  return missingTypes
 }
 
 async function sendBookingEventReminder(
@@ -122,9 +164,11 @@ async function sendBookingEventReminder(
 
   const requiredDocumentTypes =
     rule.channel === "email" ? await requiredAttachmentTypes(db, rule) : []
-  const shouldResolveDocuments =
-    rule.channel === "email" &&
-    (input.targetType === "booking_confirmed" || input.targetType === "payment_complete")
+  const shouldResolveDocuments = shouldResolveBookingEventDocuments(
+    input.targetType,
+    rule.channel,
+    requiredDocumentTypes,
+  )
   const [participants, items, paymentContext, unfilteredDocumentContext] = await Promise.all([
     db
       .select({
@@ -145,15 +189,25 @@ async function sendBookingEventReminder(
           db,
           booking.id,
           runtime.documentAttachmentResolver,
-          requiredDocumentTypes.length > 0 ? requiredDocumentTypes : undefined,
+          input.targetType === "payment_complete" ? requiredDocumentTypes : undefined,
         )
       : Promise.resolve({ documents: [], attachments: [] }),
   ])
   const documentContext = unfilteredDocumentContext
 
   if (input.targetType === "payment_complete" && requiredDocumentTypes.length > 0) {
-    const readyTypes = new Set(documentContext.documents.map(({ documentType }) => documentType))
-    const missingTypes = requiredDocumentTypes.filter((type) => !readyTypes.has(type))
+    const bookedProductIds = [
+      ...new Set(
+        items
+          .map((item) => item.productId)
+          .filter((productId): productId is string => typeof productId === "string"),
+      ),
+    ]
+    const missingTypes = missingRequiredAttachmentTypes(
+      requiredDocumentTypes,
+      documentContext.documents,
+      bookedProductIds,
+    )
     if (
       missingTypes.length > 0 ||
       documentContext.attachments.length !== documentContext.documents.length

--- a/packages/notifications/src/service-reminder-events.ts
+++ b/packages/notifications/src/service-reminder-events.ts
@@ -2,7 +2,11 @@ import { bookings, bookingTravelers } from "@voyant-travel/bookings/schema"
 import { and, desc, eq } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
-import { notificationReminderRules, notificationReminderRuns } from "./schema.js"
+import {
+  notificationReminderRules,
+  notificationReminderRuns,
+  notificationTemplates,
+} from "./schema.js"
 import { enqueueNotification } from "./service-durable-send.js"
 import {
   type BookingEventReminderRuntimeOptions,
@@ -25,6 +29,37 @@ type BookingEventReminderTargetType = Extract<
   "booking_confirmed" | "payment_complete" | "booking_cancelled_non_payment"
 >
 
+const BOOKING_DOCUMENT_TYPES = new Set(["contract", "invoice", "proforma", "brochure"])
+
+function configuredAttachmentTypes(metadata: Record<string, unknown> | null) {
+  const configured = metadata?.attachments
+  if (!Array.isArray(configured)) return []
+  return configured.filter(
+    (value): value is "contract" | "invoice" | "proforma" | "brochure" =>
+      typeof value === "string" && BOOKING_DOCUMENT_TYPES.has(value),
+  )
+}
+
+export async function requiredAttachmentTypes(
+  db: PostgresJsDatabase,
+  rule: NotificationReminderRuleRow,
+) {
+  const [template] = rule.templateId
+    ? await db
+        .select({ metadata: notificationTemplates.metadata })
+        .from(notificationTemplates)
+        .where(eq(notificationTemplates.id, rule.templateId))
+        .limit(1)
+    : rule.templateSlug
+      ? await db
+          .select({ metadata: notificationTemplates.metadata })
+          .from(notificationTemplates)
+          .where(eq(notificationTemplates.slug, rule.templateSlug))
+          .limit(1)
+      : []
+  return configuredAttachmentTypes(template?.metadata ?? null)
+}
+
 async function sendBookingEventReminder(
   db: PostgresJsDatabase,
   dispatcher: NotificationService,
@@ -41,11 +76,15 @@ async function sendBookingEventReminder(
   const dedupeKey = buildReminderDedupeKey(rule.id, input.bookingId, input.targetType)
 
   const [existingRun] = await db
-    .select({ id: notificationReminderRuns.id })
+    .select()
     .from(notificationReminderRuns)
     .where(eq(notificationReminderRuns.dedupeKey, dedupeKey))
     .limit(1)
-  if (existingRun) {
+  const retryingPendingBundle =
+    existingRun?.status === "failed" &&
+    existingRun.notificationDeliveryId === null &&
+    existingRun.errorMessage?.startsWith("payment_document_bundle_not_ready:")
+  if (existingRun && !retryingPendingBundle) {
     return null
   }
 
@@ -81,7 +120,12 @@ async function sendBookingEventReminder(
     return run ?? null
   }
 
-  const [participants, items, paymentContext, documentContext] = await Promise.all([
+  const requiredDocumentTypes =
+    rule.channel === "email" ? await requiredAttachmentTypes(db, rule) : []
+  const shouldResolveDocuments =
+    rule.channel === "email" &&
+    (input.targetType === "booking_confirmed" || input.targetType === "payment_complete")
+  const [participants, items, paymentContext, unfilteredDocumentContext] = await Promise.all([
     db
       .select({
         id: bookingTravelers.id,
@@ -96,37 +140,127 @@ async function sendBookingEventReminder(
       .orderBy(desc(bookingTravelers.isPrimary), bookingTravelers.createdAt),
     listBookingNotificationItems(db, booking.id),
     getBookingPaymentNotificationContext(db, booking.id),
-    input.targetType === "booking_confirmed" && rule.channel === "email"
-      ? getBookingEventDocumentContext(db, booking.id, runtime.documentAttachmentResolver)
+    shouldResolveDocuments
+      ? getBookingEventDocumentContext(
+          db,
+          booking.id,
+          runtime.documentAttachmentResolver,
+          requiredDocumentTypes.length > 0 ? requiredDocumentTypes : undefined,
+        )
       : Promise.resolve({ documents: [], attachments: [] }),
   ])
+  const documentContext = unfilteredDocumentContext
+
+  if (input.targetType === "payment_complete" && requiredDocumentTypes.length > 0) {
+    const readyTypes = new Set(documentContext.documents.map(({ documentType }) => documentType))
+    const missingTypes = requiredDocumentTypes.filter((type) => !readyTypes.has(type))
+    if (
+      missingTypes.length > 0 ||
+      documentContext.attachments.length !== documentContext.documents.length
+    ) {
+      const unresolved =
+        documentContext.attachments.length !== documentContext.documents.length
+          ? ["unresolvable_attachment"]
+          : []
+      const errorMessage = `payment_document_bundle_not_ready:${[
+        ...missingTypes,
+        ...unresolved,
+      ].join(",")}`
+      if (existingRun) {
+        const [pendingRun] = await db
+          .update(notificationReminderRuns)
+          .set({
+            paymentSessionId: input.paymentSessionId ?? existingRun.paymentSessionId,
+            processedAt: now,
+            errorMessage,
+            metadata: {
+              ...(existingRun.metadata ?? {}),
+              eventTargetType: input.targetType,
+              bookingNumber: booking.bookingNumber,
+              requiredDocumentTypes,
+              ...(input.eventData ?? {}),
+            },
+            updatedAt: now,
+          })
+          .where(eq(notificationReminderRuns.id, existingRun.id))
+          .returning()
+        return pendingRun ?? null
+      }
+      const [pendingRun] = await db
+        .insert(notificationReminderRuns)
+        .values({
+          reminderRuleId: rule.id,
+          targetType: input.targetType,
+          targetId: booking.id,
+          dedupeKey,
+          bookingId: booking.id,
+          personId: booking.personId ?? null,
+          organizationId: booking.organizationId ?? null,
+          paymentSessionId: input.paymentSessionId ?? null,
+          notificationDeliveryId: null,
+          status: "failed",
+          recipient: null,
+          scheduledFor: now,
+          processedAt: now,
+          errorMessage,
+          metadata: {
+            eventTargetType: input.targetType,
+            bookingNumber: booking.bookingNumber,
+            requiredDocumentTypes,
+            ...(input.eventData ?? {}),
+          },
+        })
+        .onConflictDoNothing({ target: notificationReminderRuns.dedupeKey })
+        .returning()
+      return pendingRun ?? null
+    }
+  }
 
   const recipient = resolveReminderRecipient(booking, participants)
-  const [processingRun] = await db
-    .insert(notificationReminderRuns)
-    .values({
-      reminderRuleId: rule.id,
-      targetType: input.targetType,
-      targetId: booking.id,
-      dedupeKey,
-      bookingId: booking.id,
-      personId: booking.personId ?? null,
-      organizationId: booking.organizationId ?? null,
-      paymentSessionId: input.paymentSessionId ?? null,
-      notificationDeliveryId: null,
-      status: "queued",
-      recipient: recipient?.email ?? null,
-      scheduledFor: now,
-      processedAt: now,
-      errorMessage: null,
-      metadata: {
-        eventTargetType: input.targetType,
-        bookingNumber: booking.bookingNumber,
-        ...(input.eventData ?? {}),
-      },
-    })
-    .onConflictDoNothing({ target: notificationReminderRuns.dedupeKey })
-    .returning()
+  const [processingRun] = existingRun
+    ? await db
+        .update(notificationReminderRuns)
+        .set({
+          paymentSessionId: input.paymentSessionId ?? existingRun.paymentSessionId,
+          status: "queued",
+          recipient: recipient?.email ?? null,
+          processedAt: now,
+          errorMessage: null,
+          metadata: {
+            ...(existingRun.metadata ?? {}),
+            eventTargetType: input.targetType,
+            bookingNumber: booking.bookingNumber,
+            ...(input.eventData ?? {}),
+          },
+          updatedAt: now,
+        })
+        .where(eq(notificationReminderRuns.id, existingRun.id))
+        .returning()
+    : await db
+        .insert(notificationReminderRuns)
+        .values({
+          reminderRuleId: rule.id,
+          targetType: input.targetType,
+          targetId: booking.id,
+          dedupeKey,
+          bookingId: booking.id,
+          personId: booking.personId ?? null,
+          organizationId: booking.organizationId ?? null,
+          paymentSessionId: input.paymentSessionId ?? null,
+          notificationDeliveryId: null,
+          status: "queued",
+          recipient: recipient?.email ?? null,
+          scheduledFor: now,
+          processedAt: now,
+          errorMessage: null,
+          metadata: {
+            eventTargetType: input.targetType,
+            bookingNumber: booking.bookingNumber,
+            ...(input.eventData ?? {}),
+          },
+        })
+        .onConflictDoNothing({ target: notificationReminderRuns.dedupeKey })
+        .returning()
 
   if (!processingRun) {
     return null

--- a/packages/notifications/src/service-shared.ts
+++ b/packages/notifications/src/service-shared.ts
@@ -285,7 +285,10 @@ export async function listBookingNotificationItems(db: PostgresJsDatabase, booki
     .where(eq(bookingItems.bookingId, bookingId))
     .orderBy(bookingItems.createdAt)
 
-  return rows.map((row) => enrichBookingItem(row))
+  return rows.map((row) => ({
+    ...(enrichBookingItem(row) as Record<string, unknown>),
+    productId: row.productId,
+  }))
 }
 
 export async function paginate<T>(

--- a/packages/notifications/src/service-shared.ts
+++ b/packages/notifications/src/service-shared.ts
@@ -279,6 +279,7 @@ export async function listBookingNotificationItems(db: PostgresJsDatabase, booki
       sellCurrency: bookingItems.sellCurrency,
       unitSellAmountCents: bookingItems.unitSellAmountCents,
       totalSellAmountCents: bookingItems.totalSellAmountCents,
+      productId: bookingItems.productId,
     })
     .from(bookingItems)
     .where(eq(bookingItems.bookingId, bookingId))

--- a/packages/notifications/src/subscriber-runtime.ts
+++ b/packages/notifications/src/subscriber-runtime.ts
@@ -1,5 +1,8 @@
+import { bookingItems } from "@voyant-travel/bookings/schema"
 import type { ModuleContainer, SubscriberRuntimeDescriptor } from "@voyant-travel/core"
-import { and, eq } from "drizzle-orm"
+import { invoices, paymentSessions } from "@voyant-travel/finance/schema"
+import { contracts } from "@voyant-travel/legal/schema"
+import { and, desc, eq } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { notificationReminderRuns } from "./schema.js"
 import type { NotificationService } from "./service.js"
@@ -16,6 +19,14 @@ export const NOTIFICATIONS_BOOKING_CONFIRMED_REMINDER_SUBSCRIBER_ID =
   "@voyant-travel/notifications#subscriber.reminder-booking-confirmed"
 export const NOTIFICATIONS_PAYMENT_COMPLETED_REMINDER_SUBSCRIBER_ID =
   "@voyant-travel/notifications#subscriber.reminder-payment-completed"
+export const NOTIFICATIONS_CHECKOUT_FINALIZED_REMINDER_SUBSCRIBER_ID =
+  "@voyant-travel/notifications#subscriber.reminder-checkout-finalized"
+export const NOTIFICATIONS_INVOICE_RENDERED_REMINDER_SUBSCRIBER_ID =
+  "@voyant-travel/notifications#subscriber.reminder-invoice-rendered"
+export const NOTIFICATIONS_CONTRACT_DOCUMENT_REMINDER_SUBSCRIBER_ID =
+  "@voyant-travel/notifications#subscriber.reminder-contract-document-generated"
+export const NOTIFICATIONS_PRODUCT_CONTENT_REMINDER_SUBSCRIBER_ID =
+  "@voyant-travel/notifications#subscriber.reminder-product-content-changed"
 export const NOTIFICATIONS_BOOKING_CANCELLED_REMINDER_SUBSCRIBER_ID =
   "@voyant-travel/notifications#subscriber.reminder-booking-cancelled"
 /** Deployment-owned services required by package-owned Notifications subscribers. */
@@ -49,6 +60,24 @@ interface PaymentCompletedPayload extends Record<string, unknown> {
   provider: string
 }
 
+interface CheckoutFinalizedPayload extends Record<string, unknown> {
+  bookingId: string
+  paymentSessionId: string
+}
+
+interface InvoiceRenderedPayload extends Record<string, unknown> {
+  invoiceId: string
+}
+
+interface ContractDocumentGeneratedPayload extends Record<string, unknown> {
+  contractId: string
+}
+
+interface ProductContentChangedPayload extends Record<string, unknown> {
+  id: string
+  axis?: string
+}
+
 interface BookingCancelledPayload extends Record<string, unknown> {
   bookingId: string
   bookingNumber: string
@@ -68,6 +97,27 @@ function resolveRuntime(container: ModuleContainer): NotificationsSubscriberRunt
 
 function errorMessage(error: unknown) {
   return error instanceof Error ? error.message : String(error)
+}
+
+async function dispatchPaymentCompleteForBooking(
+  db: PostgresJsDatabase,
+  runtime: NotificationsSubscriberRuntime,
+  dependencies: NotificationsSubscriberDependencies,
+  bookingId: string,
+  paymentSessionId: string | null,
+  eventData: Record<string, unknown>,
+) {
+  const isPaidInFull = dependencies.isPaidInFull ?? bookingIsPaidInFullForNotification
+  const isNotificationsSuppressed =
+    dependencies.isNotificationsSuppressed ?? bookingNotificationsSuppressedForNotification
+  if (await isNotificationsSuppressed(db, bookingId)) return
+  if (!(await isPaidInFull(db, bookingId))) return
+  await (dependencies.dispatchReminderRules ?? dispatchReminderEventRules)(
+    db,
+    runtime.dispatcher,
+    { targetType: "payment_complete", bookingId, paymentSessionId, eventData },
+    { documentAttachmentResolver: runtime.documentAttachmentResolver },
+  )
 }
 
 export function createBookingConfirmedReminderSubscriberRuntime(
@@ -123,19 +173,13 @@ export function createPaymentCompletedReminderSubscriberRuntime(
         try {
           const runtime = resolveRuntime(container)
           const db = runtime.resolveDb(bindings)
-          if (await isNotificationsSuppressed(db, data.bookingId)) return
-          if (!(await isPaidInFull(db, data.bookingId))) return
-
-          await dispatchReminderRules(
+          await dispatchPaymentCompleteForBooking(
             db,
-            runtime.dispatcher,
-            {
-              targetType: "payment_complete",
-              bookingId: data.bookingId,
-              paymentSessionId: data.paymentSessionId,
-              eventData: data,
-            },
-            { documentAttachmentResolver: runtime.documentAttachmentResolver },
+            runtime,
+            { dispatchReminderRules, isPaidInFull, isNotificationsSuppressed },
+            data.bookingId,
+            data.paymentSessionId,
+            data,
           )
         } catch (error) {
           logger.error(
@@ -143,6 +187,154 @@ export function createPaymentCompletedReminderSubscriberRuntime(
           )
         }
       })
+    },
+  }
+}
+
+export function createCheckoutFinalizedReminderSubscriberRuntime(
+  dependencies: NotificationsSubscriberDependencies = {},
+): SubscriberRuntimeDescriptor {
+  const logger = dependencies.logger ?? console
+  return {
+    id: NOTIFICATIONS_CHECKOUT_FINALIZED_REMINDER_SUBSCRIBER_ID,
+    eventType: "checkout.finalized",
+    register: ({ bindings, container, eventBus }) => {
+      eventBus.subscribe<CheckoutFinalizedPayload>("checkout.finalized", async ({ data }) => {
+        try {
+          const runtime = resolveRuntime(container)
+          await dispatchPaymentCompleteForBooking(
+            runtime.resolveDb(bindings),
+            runtime,
+            dependencies,
+            data.bookingId,
+            data.paymentSessionId,
+            data,
+          )
+        } catch (error) {
+          logger.error(
+            `[notifications] checkout_finalized bundle delivery failed for booking ${data.bookingId}: ${errorMessage(error)}`,
+          )
+        }
+      })
+    },
+  }
+}
+
+async function retryPaymentBundleForBooking(
+  db: PostgresJsDatabase,
+  runtime: NotificationsSubscriberRuntime,
+  dependencies: NotificationsSubscriberDependencies,
+  bookingId: string,
+  eventData: Record<string, unknown>,
+) {
+  const [session] = await db
+    .select({ id: paymentSessions.id })
+    .from(paymentSessions)
+    .where(and(eq(paymentSessions.bookingId, bookingId), eq(paymentSessions.status, "paid")))
+    .orderBy(desc(paymentSessions.completedAt), desc(paymentSessions.updatedAt))
+    .limit(1)
+  if (!session) return
+  await dispatchPaymentCompleteForBooking(
+    db,
+    runtime,
+    dependencies,
+    bookingId,
+    session.id,
+    eventData,
+  )
+}
+
+export function createInvoiceRenderedReminderSubscriberRuntime(
+  dependencies: NotificationsSubscriberDependencies = {},
+): SubscriberRuntimeDescriptor {
+  const logger = dependencies.logger ?? console
+  return {
+    id: NOTIFICATIONS_INVOICE_RENDERED_REMINDER_SUBSCRIBER_ID,
+    eventType: "invoice.rendered",
+    register: ({ bindings, container, eventBus }) => {
+      eventBus.subscribe<InvoiceRenderedPayload>("invoice.rendered", async ({ data }) => {
+        try {
+          const runtime = resolveRuntime(container)
+          const db = runtime.resolveDb(bindings)
+          const [invoice] = await db
+            .select({ bookingId: invoices.bookingId })
+            .from(invoices)
+            .where(eq(invoices.id, data.invoiceId))
+            .limit(1)
+          if (!invoice) return
+          await retryPaymentBundleForBooking(db, runtime, dependencies, invoice.bookingId, data)
+        } catch (error) {
+          logger.error(
+            `[notifications] invoice_rendered bundle retry failed for invoice ${data.invoiceId}: ${errorMessage(error)}`,
+          )
+        }
+      })
+    },
+  }
+}
+
+export function createContractDocumentReminderSubscriberRuntime(
+  dependencies: NotificationsSubscriberDependencies = {},
+): SubscriberRuntimeDescriptor {
+  const logger = dependencies.logger ?? console
+  return {
+    id: NOTIFICATIONS_CONTRACT_DOCUMENT_REMINDER_SUBSCRIBER_ID,
+    eventType: "contract.document.generated",
+    register: ({ bindings, container, eventBus }) => {
+      eventBus.subscribe<ContractDocumentGeneratedPayload>(
+        "contract.document.generated",
+        async ({ data }) => {
+          try {
+            const runtime = resolveRuntime(container)
+            const db = runtime.resolveDb(bindings)
+            const [contract] = await db
+              .select({ bookingId: contracts.bookingId })
+              .from(contracts)
+              .where(eq(contracts.id, data.contractId))
+              .limit(1)
+            if (!contract?.bookingId) return
+            await retryPaymentBundleForBooking(db, runtime, dependencies, contract.bookingId, data)
+          } catch (error) {
+            logger.error(
+              `[notifications] contract_document_generated bundle retry failed for contract ${data.contractId}: ${errorMessage(error)}`,
+            )
+          }
+        },
+      )
+    },
+  }
+}
+
+export function createProductContentReminderSubscriberRuntime(
+  dependencies: NotificationsSubscriberDependencies = {},
+): SubscriberRuntimeDescriptor {
+  const logger = dependencies.logger ?? console
+  return {
+    id: NOTIFICATIONS_PRODUCT_CONTENT_REMINDER_SUBSCRIBER_ID,
+    eventType: "product.content.changed",
+    register: ({ bindings, container, eventBus }) => {
+      eventBus.subscribe<ProductContentChangedPayload>(
+        "product.content.changed",
+        async ({ data }) => {
+          if (data.axis && data.axis !== "media") return
+          try {
+            const runtime = resolveRuntime(container)
+            const db = runtime.resolveDb(bindings)
+            const paidBookings = await db
+              .selectDistinct({ bookingId: bookingItems.bookingId })
+              .from(bookingItems)
+              .innerJoin(paymentSessions, eq(paymentSessions.bookingId, bookingItems.bookingId))
+              .where(and(eq(bookingItems.productId, data.id), eq(paymentSessions.status, "paid")))
+            for (const { bookingId } of paidBookings) {
+              await retryPaymentBundleForBooking(db, runtime, dependencies, bookingId, data)
+            }
+          } catch (error) {
+            logger.error(
+              `[notifications] product_content_changed bundle retry failed for product ${data.id}: ${errorMessage(error)}`,
+            )
+          }
+        },
+      )
     },
   }
 }
@@ -213,10 +405,22 @@ export const notificationsBookingConfirmedReminderSubscriber =
   createBookingConfirmedReminderSubscriberRuntime()
 export const notificationsPaymentCompletedReminderSubscriber =
   createPaymentCompletedReminderSubscriberRuntime()
+export const notificationsCheckoutFinalizedReminderSubscriber =
+  createCheckoutFinalizedReminderSubscriberRuntime()
+export const notificationsInvoiceRenderedReminderSubscriber =
+  createInvoiceRenderedReminderSubscriberRuntime()
+export const notificationsContractDocumentReminderSubscriber =
+  createContractDocumentReminderSubscriberRuntime()
+export const notificationsProductContentReminderSubscriber =
+  createProductContentReminderSubscriberRuntime()
 export const notificationsBookingCancelledReminderSubscriber =
   createBookingCancelledReminderSubscriberRuntime()
 export const notificationsReminderSubscriberRuntimeDescriptors = [
   notificationsBookingConfirmedReminderSubscriber,
   notificationsPaymentCompletedReminderSubscriber,
+  notificationsCheckoutFinalizedReminderSubscriber,
+  notificationsInvoiceRenderedReminderSubscriber,
+  notificationsContractDocumentReminderSubscriber,
+  notificationsProductContentReminderSubscriber,
   notificationsBookingCancelledReminderSubscriber,
 ] as const

--- a/packages/notifications/src/subscriber-runtime.ts
+++ b/packages/notifications/src/subscriber-runtime.ts
@@ -1,9 +1,12 @@
-import { bookingItems } from "@voyant-travel/bookings/schema"
 import type { ModuleContainer, SubscriberRuntimeDescriptor } from "@voyant-travel/core"
-import { invoices, paymentSessions } from "@voyant-travel/finance/schema"
-import { contracts } from "@voyant-travel/legal/schema"
 import { and, desc, eq } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import {
+  bookingItemsRef,
+  contractsRef,
+  invoicesRef,
+  paymentSessionsRef,
+} from "./payment-bundle-refs.js"
 import { notificationReminderRuns } from "./schema.js"
 import type { NotificationService } from "./service.js"
 import type { BookingDocumentAttachmentResolver } from "./service-booking-documents.js"
@@ -228,10 +231,10 @@ async function retryPaymentBundleForBooking(
   eventData: Record<string, unknown>,
 ) {
   const [session] = await db
-    .select({ id: paymentSessions.id })
-    .from(paymentSessions)
-    .where(and(eq(paymentSessions.bookingId, bookingId), eq(paymentSessions.status, "paid")))
-    .orderBy(desc(paymentSessions.completedAt), desc(paymentSessions.updatedAt))
+    .select({ id: paymentSessionsRef.id })
+    .from(paymentSessionsRef)
+    .where(and(eq(paymentSessionsRef.bookingId, bookingId), eq(paymentSessionsRef.status, "paid")))
+    .orderBy(desc(paymentSessionsRef.completedAt), desc(paymentSessionsRef.updatedAt))
     .limit(1)
   if (!session) return
   await dispatchPaymentCompleteForBooking(
@@ -257,9 +260,9 @@ export function createInvoiceRenderedReminderSubscriberRuntime(
           const runtime = resolveRuntime(container)
           const db = runtime.resolveDb(bindings)
           const [invoice] = await db
-            .select({ bookingId: invoices.bookingId })
-            .from(invoices)
-            .where(eq(invoices.id, data.invoiceId))
+            .select({ bookingId: invoicesRef.bookingId })
+            .from(invoicesRef)
+            .where(eq(invoicesRef.id, data.invoiceId))
             .limit(1)
           if (!invoice) return
           await retryPaymentBundleForBooking(db, runtime, dependencies, invoice.bookingId, data)
@@ -288,9 +291,9 @@ export function createContractDocumentReminderSubscriberRuntime(
             const runtime = resolveRuntime(container)
             const db = runtime.resolveDb(bindings)
             const [contract] = await db
-              .select({ bookingId: contracts.bookingId })
-              .from(contracts)
-              .where(eq(contracts.id, data.contractId))
+              .select({ bookingId: contractsRef.bookingId })
+              .from(contractsRef)
+              .where(eq(contractsRef.id, data.contractId))
               .limit(1)
             if (!contract?.bookingId) return
             await retryPaymentBundleForBooking(db, runtime, dependencies, contract.bookingId, data)
@@ -321,10 +324,15 @@ export function createProductContentReminderSubscriberRuntime(
             const runtime = resolveRuntime(container)
             const db = runtime.resolveDb(bindings)
             const paidBookings = await db
-              .selectDistinct({ bookingId: bookingItems.bookingId })
-              .from(bookingItems)
-              .innerJoin(paymentSessions, eq(paymentSessions.bookingId, bookingItems.bookingId))
-              .where(and(eq(bookingItems.productId, data.id), eq(paymentSessions.status, "paid")))
+              .selectDistinct({ bookingId: bookingItemsRef.bookingId })
+              .from(bookingItemsRef)
+              .innerJoin(
+                paymentSessionsRef,
+                eq(paymentSessionsRef.bookingId, bookingItemsRef.bookingId),
+              )
+              .where(
+                and(eq(bookingItemsRef.productId, data.id), eq(paymentSessionsRef.status, "paid")),
+              )
             for (const { bookingId } of paidBookings) {
               await retryPaymentBundleForBooking(db, runtime, dependencies, bookingId, data)
             }

--- a/packages/notifications/src/voyant.ts
+++ b/packages/notifications/src/voyant.ts
@@ -426,6 +426,42 @@ export const notificationsReminderSubscribersVoyantPlugin = defineExtension({
       },
     },
     {
+      id: "@voyant-travel/notifications#subscriber.reminder-checkout-finalized",
+      eventType: "checkout.finalized",
+      source: "@voyant-travel/notifications/subscriber-runtime",
+      runtime: {
+        entry: "@voyant-travel/notifications/subscriber-runtime",
+        export: "notificationsCheckoutFinalizedReminderSubscriber",
+      },
+    },
+    {
+      id: "@voyant-travel/notifications#subscriber.reminder-invoice-rendered",
+      eventType: "invoice.rendered",
+      source: "@voyant-travel/notifications/subscriber-runtime",
+      runtime: {
+        entry: "@voyant-travel/notifications/subscriber-runtime",
+        export: "notificationsInvoiceRenderedReminderSubscriber",
+      },
+    },
+    {
+      id: "@voyant-travel/notifications#subscriber.reminder-contract-document-generated",
+      eventType: "contract.document.generated",
+      source: "@voyant-travel/notifications/subscriber-runtime",
+      runtime: {
+        entry: "@voyant-travel/notifications/subscriber-runtime",
+        export: "notificationsContractDocumentReminderSubscriber",
+      },
+    },
+    {
+      id: "@voyant-travel/notifications#subscriber.reminder-product-content-changed",
+      eventType: "product.content.changed",
+      source: "@voyant-travel/notifications/subscriber-runtime",
+      runtime: {
+        entry: "@voyant-travel/notifications/subscriber-runtime",
+        export: "notificationsProductContentReminderSubscriber",
+      },
+    },
+    {
       id: "@voyant-travel/notifications#subscriber.reminder-booking-cancelled",
       eventType: "booking.cancelled",
       source: "@voyant-travel/notifications/subscriber-runtime",

--- a/packages/notifications/tests/unit/service-reminder-events.test.ts
+++ b/packages/notifications/tests/unit/service-reminder-events.test.ts
@@ -1,8 +1,15 @@
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { describe, expect, it, vi } from "vitest"
 
-import { requiredAttachmentTypes } from "../../src/service-reminder-events.js"
-import type { NotificationReminderRuleRow } from "../../src/service-shared.js"
+import {
+  missingRequiredAttachmentTypes,
+  requiredAttachmentTypes,
+  shouldResolveBookingEventDocuments,
+} from "../../src/service-reminder-events.js"
+import type {
+  BookingDocumentBundleItem,
+  NotificationReminderRuleRow,
+} from "../../src/service-shared.js"
 
 function rule(overrides: Partial<NotificationReminderRuleRow> = {}): NotificationReminderRuleRow {
   return {
@@ -48,5 +55,24 @@ describe("requiredAttachmentTypes", () => {
   it("ignores legacy and unknown attachment labels", async () => {
     const { db } = dbWithMetadata({ attachments: ["contract", "product", "receipt"] })
     await expect(requiredAttachmentTypes(db, rule())).resolves.toEqual(["contract"])
+  })
+})
+
+describe("post-payment document readiness", () => {
+  it("does not resolve documents when a payment template selects no attachments", () => {
+    expect(shouldResolveBookingEventDocuments("payment_complete", "email", [])).toBe(false)
+    expect(shouldResolveBookingEventDocuments("booking_confirmed", "email", [])).toBe(true)
+  })
+
+  it("waits until every booked product has a current brochure", () => {
+    const brochure = {
+      documentType: "brochure",
+      metadata: { productId: "product_1" },
+    } as BookingDocumentBundleItem
+
+    expect(
+      missingRequiredAttachmentTypes(["brochure"], [brochure], ["product_1", "product_2"]),
+    ).toEqual(["brochure"])
+    expect(missingRequiredAttachmentTypes(["brochure"], [brochure], ["product_1"])).toEqual([])
   })
 })

--- a/packages/notifications/tests/unit/service-reminder-events.test.ts
+++ b/packages/notifications/tests/unit/service-reminder-events.test.ts
@@ -1,0 +1,52 @@
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { describe, expect, it, vi } from "vitest"
+
+import { requiredAttachmentTypes } from "../../src/service-reminder-events.js"
+import type { NotificationReminderRuleRow } from "../../src/service-shared.js"
+
+function rule(overrides: Partial<NotificationReminderRuleRow> = {}): NotificationReminderRuleRow {
+  return {
+    id: "rule_1",
+    slug: "payment-complete",
+    name: "Payment complete",
+    targetType: "payment_complete",
+    channel: "email",
+    provider: null,
+    templateId: "template_1",
+    templateSlug: null,
+    status: "active",
+    priority: 0,
+    suppressionGroup: null,
+    isSystem: false,
+    metadata: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as NotificationReminderRuleRow
+}
+
+function dbWithMetadata(metadata: Record<string, unknown>) {
+  const limit = vi.fn(async () => [{ metadata }])
+  const where = vi.fn(() => ({ limit }))
+  const from = vi.fn(() => ({ where }))
+  const select = vi.fn(() => ({ from }))
+  return { db: { select } as unknown as PostgresJsDatabase, select }
+}
+
+describe("requiredAttachmentTypes", () => {
+  it("uses the template attachment contract for the post-payment bundle", async () => {
+    const { db } = dbWithMetadata({
+      attachments: ["contract", "invoice", "brochure"],
+    })
+    await expect(requiredAttachmentTypes(db, rule())).resolves.toEqual([
+      "contract",
+      "invoice",
+      "brochure",
+    ])
+  })
+
+  it("ignores legacy and unknown attachment labels", async () => {
+    const { db } = dbWithMetadata({ attachments: ["contract", "product", "receipt"] })
+    await expect(requiredAttachmentTypes(db, rule())).resolves.toEqual(["contract"])
+  })
+})

--- a/packages/notifications/tests/unit/subscriber-runtime.test.ts
+++ b/packages/notifications/tests/unit/subscriber-runtime.test.ts
@@ -6,6 +6,7 @@ import type { NotificationService } from "../../src/service.js"
 import {
   createBookingCancelledReminderSubscriberRuntime,
   createBookingConfirmedReminderSubscriberRuntime,
+  createCheckoutFinalizedReminderSubscriberRuntime,
   createPaymentCompletedReminderSubscriberRuntime,
   NOTIFICATIONS_SUBSCRIBER_RUNTIME_KEY,
   type NotificationsSubscriberRuntime,
@@ -48,6 +49,22 @@ describe("Notifications subscriber runtime descriptors", () => {
       {
         id: "@voyant-travel/notifications#subscriber.reminder-payment-completed",
         eventType: "payment.completed",
+      },
+      {
+        id: "@voyant-travel/notifications#subscriber.reminder-checkout-finalized",
+        eventType: "checkout.finalized",
+      },
+      {
+        id: "@voyant-travel/notifications#subscriber.reminder-invoice-rendered",
+        eventType: "invoice.rendered",
+      },
+      {
+        id: "@voyant-travel/notifications#subscriber.reminder-contract-document-generated",
+        eventType: "contract.document.generated",
+      },
+      {
+        id: "@voyant-travel/notifications#subscriber.reminder-product-content-changed",
+        eventType: "product.content.changed",
       },
       {
         id: "@voyant-travel/notifications#subscriber.reminder-booking-cancelled",
@@ -168,6 +185,31 @@ describe("Notifications subscriber runtime descriptors", () => {
     expect(isNotificationsSuppressed).toHaveBeenCalledWith(db, "book_silent")
     expect(isPaidInFull).not.toHaveBeenCalled()
     expect(dispatchReminderRules).not.toHaveBeenCalled()
+  })
+
+  it("dispatches a booking-keyed payment reminder after checkout finalization", async () => {
+    const dispatchReminderRules = vi.fn().mockResolvedValue(undefined)
+    const harness = createHarness()
+    createCheckoutFinalizedReminderSubscriberRuntime({
+      dispatchReminderRules,
+      isPaidInFull: vi.fn().mockResolvedValue(true),
+      isNotificationsSuppressed: vi.fn().mockResolvedValue(false),
+    }).register(harness)
+
+    const payload = { bookingId: "book_1", paymentSessionId: "pay_1" }
+    await harness.eventBus.emit("checkout.finalized", payload)
+
+    expect(dispatchReminderRules).toHaveBeenCalledWith(
+      db,
+      dispatcher,
+      {
+        targetType: "payment_complete",
+        bookingId: "book_1",
+        paymentSessionId: "pay_1",
+        eventData: payload,
+      },
+      { documentAttachmentResolver: attachmentResolver },
+    )
   })
 
   it("dispatches cancellation rules for committed Bookings", async () => {

--- a/packages/notifications/tests/unit/voyant-manifest.test.ts
+++ b/packages/notifications/tests/unit/voyant-manifest.test.ts
@@ -216,6 +216,10 @@ describe("notifications deployment manifest", () => {
     expect(declarations.map((subscriber) => subscriber.runtime?.export)).toEqual([
       "notificationsBookingConfirmedReminderSubscriber",
       "notificationsPaymentCompletedReminderSubscriber",
+      "notificationsCheckoutFinalizedReminderSubscriber",
+      "notificationsInvoiceRenderedReminderSubscriber",
+      "notificationsContractDocumentReminderSubscriber",
+      "notificationsProductContentReminderSubscriber",
       "notificationsBookingCancelledReminderSubscriber",
       "notificationsStaffBookingConfirmedAlertSubscriber",
       "notificationsStaffBookingCancelledAlertSubscriber",

--- a/packages/storage/src/providers/gateway.test.ts
+++ b/packages/storage/src/providers/gateway.test.ts
@@ -52,7 +52,18 @@ function createFakeGateway(options: { token?: string } = {}) {
         bytes: body,
         contentType: headers.get("content-type") ?? "application/octet-stream",
       }
-      if (rawMetadata) record.metadata = JSON.parse(rawMetadata)
+      if (rawMetadata) {
+        const decoded =
+          headers.get("x-voyant-metadata-encoding") === "base64url"
+            ? new TextDecoder().decode(
+                Uint8Array.from(
+                  atob(rawMetadata.replace(/-/g, "+").replace(/_/g, "/")),
+                  (character) => character.charCodeAt(0),
+                ),
+              )
+            : rawMetadata
+        record.metadata = JSON.parse(decoded)
+      }
       store.set(key, record)
       return Response.json({ key, url: `${url.origin}/objects/${encodeURIComponent(key)}` })
     }
@@ -121,6 +132,25 @@ describe("createGatewayStorageProvider", () => {
     expect(stored?.bytes).toEqual(new Uint8Array([1, 2, 3]))
     expect(stored?.contentType).toBe("application/pdf")
     expect(stored?.metadata).toEqual({ owner: "workspace" })
+  })
+
+  it("uploads Unicode metadata through an ASCII-safe header", async () => {
+    const gateway = createFakeGateway()
+    const provider = createGatewayStorageProvider({
+      endpoint: "https://gw.test",
+      token: "t",
+      fetch: gateway.fetch,
+    })
+
+    await expect(
+      provider.upload(new Uint8Array([1]), {
+        key: "docs/contract.pdf",
+        metadata: { title: "Contract — Călătorie în România" },
+      }),
+    ).resolves.toBeDefined()
+    expect(gateway.store.get("docs/contract.pdf")?.metadata).toEqual({
+      title: "Contract — Călătorie în România",
+    })
   })
 
   it("derives public urls from the configured base and returns null without one", () => {

--- a/packages/storage/src/providers/gateway.ts
+++ b/packages/storage/src/providers/gateway.ts
@@ -45,6 +45,13 @@ async function opaqueBackendIdentity(value: string): Promise<string> {
   return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("")
 }
 
+function base64UrlUtf8(value: string): string {
+  const bytes = new TextEncoder().encode(value)
+  let binary = ""
+  for (const byte of bytes) binary += String.fromCharCode(byte)
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
+}
+
 /**
  * Build a storage provider that talks to an HTTP storage gateway.
  *
@@ -92,7 +99,8 @@ export function createGatewayStorageProvider(
         "content-type": uploadOptions.contentType ?? "application/octet-stream",
       })
       if (uploadOptions.metadata !== undefined) {
-        headers["x-voyant-metadata"] = JSON.stringify(uploadOptions.metadata)
+        headers["x-voyant-metadata"] = base64UrlUtf8(JSON.stringify(uploadOptions.metadata))
+        headers["x-voyant-metadata-encoding"] = "base64url"
       }
       const response = await doFetch(objectUrl(key), {
         method: "PUT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,7 +249,7 @@ importers:
         version: 1.6.0(@date-fns/tz@1.4.1)(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@better-auth/api-key':
         specifier: 1.6.23
-        version: 1.6.23(1ac6a98f3eafa8cc5361cfcd8d9e497a)
+        version: 1.6.23(4cc07405e1e664eaf96048bc4329d318)
       '@fontsource-variable/inter-tight':
         specifier: ^5.2.7
         version: 5.2.7
@@ -3998,6 +3998,9 @@ importers:
       '@voyant-travel/hono':
         specifier: workspace:^
         version: link:../hono
+      '@voyant-travel/inventory':
+        specifier: workspace:^
+        version: link:../inventory
       '@voyant-travel/legal':
         specifier: workspace:^
         version: link:../legal
@@ -13390,6 +13393,14 @@ snapshots:
   '@better-auth/api-key@1.6.23(1ac6a98f3eafa8cc5361cfcd8d9e497a)':
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0)
+      '@better-auth/utils': 0.4.2
+      better-auth: 1.6.23(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.3)(rollup@4.60.2)(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9))(mongodb@7.1.0(socks@2.8.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.11)(vitest@4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)))(vue@3.5.39(typescript@6.0.3))
+      better-call: 1.3.7(zod@4.4.3)
+      zod: 4.4.3
+
+  '@better-auth/api-key@1.6.23(4cc07405e1e664eaf96048bc4329d318)':
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
       better-auth: 1.6.23(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.3)(rollup@4.60.2)(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9))(mongodb@7.1.0(socks@2.8.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.11)(vitest@4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)))(vue@3.5.39(typescript@6.0.3))
       better-call: 1.3.7(zod@4.4.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3998,9 +3998,6 @@ importers:
       '@voyant-travel/hono':
         specifier: workspace:^
         version: link:../hono
-      '@voyant-travel/inventory':
-        specifier: workspace:^
-        version: link:../inventory
       '@voyant-travel/legal':
         specifier: workspace:^
         version: link:../legal


### PR DESCRIPTION
## Summary
- emit a booking-keyed checkout finalization milestone after Booking Session settlement
- require every template-configured attachment before sending post-payment mail
- include current product brochures and retry when contract, SmartBill PDF, or brochure becomes ready
- emit final invoice rendition events from managed app uploads
- encode Unicode storage metadata safely

## Validation
- 44 focused tests passed across notifications, finance, and storage
- affected files pass Biome
- storage and finance typechecks passed
- notifications/commerce full package typechecks exceeded the local validation window and were stopped; CI remains authoritative
