### PR TITLE
Fix provider-owned invoice number allocation

### DIFF
--- a/.changeset/quiet-invoices-allocate.md
+++ b/.changeset/quiet-invoices-allocate.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/finance": patch
+---
+
+Preserve provider-owned invoice numbering for booking-created and already-paid invoices.

--- a/packages/finance/src/app-api-runtime.ts
+++ b/packages/finance/src/app-api-runtime.ts
@@ -186,16 +186,29 @@ export function createFinanceAppApiRuntime(
       )[0]
       if (!locked) return { status: "not_found" }
 
+      let existingReference: typeof invoiceExternalRefs.$inferSelect | undefined
+      let existingReferenceLoaded = false
+      const loadExistingReference = async () => {
+        if (!existingReferenceLoaded) {
+          const rows = await db
+            .select()
+            .from(invoiceExternalRefs)
+            .where(
+              and(
+                eq(invoiceExternalRefs.invoiceId, documentId),
+                eq(invoiceExternalRefs.provider, provider),
+              ),
+            )
+            .limit(1)
+          existingReference = rows[0]
+          existingReferenceLoaded = true
+        }
+        return existingReference
+      }
+
       let allocationOutcome: "not_requested" | "applied" | "already_applied" = "not_requested"
       if (input.allocation) {
-        if (locked.status !== "pending_external_allocation") {
-          if (locked.invoice_number !== input.allocation.invoiceNumber) {
-            return {
-              status: "allocation_conflict",
-              currentNumber: locked.invoice_number,
-              currentStatus: locked.status,
-            }
-          }
+        if (locked.invoice_number === input.allocation.invoiceNumber) {
           allocationOutcome = "already_applied"
         } else {
           const series = toRows<{ external_provider: string | null }>(
@@ -204,7 +217,13 @@ export function createFinanceAppApiRuntime(
               sql`SELECT external_provider FROM invoice_number_series WHERE id = ${locked.series_id} FOR UPDATE`,
             ),
           )[0]
-          if (!series || series.external_provider !== provider) {
+          const existing =
+            series?.external_provider === provider ? await loadExistingReference() : null
+          if (
+            !series ||
+            series.external_provider !== provider ||
+            (existing && !referenceIdentityMatches(existing, input.reference))
+          ) {
             return {
               status: "allocation_conflict",
               currentNumber: locked.invoice_number,
@@ -215,6 +234,7 @@ export function createFinanceAppApiRuntime(
           try {
             const allocation = await financeService.applyExternalInvoiceAllocation(db, documentId, {
               invoiceNumber: input.allocation.invoiceNumber,
+              preserveProgressedStatus: true,
             })
             if (allocation.status === "not_found") return { status: "not_found" }
             if (allocation.status === "not_pending_external_allocation") {
@@ -234,16 +254,7 @@ export function createFinanceAppApiRuntime(
         }
       }
 
-      const [existing] = await db
-        .select()
-        .from(invoiceExternalRefs)
-        .where(
-          and(
-            eq(invoiceExternalRefs.invoiceId, documentId),
-            eq(invoiceExternalRefs.provider, provider),
-          ),
-        )
-        .limit(1)
+      const existing = await loadExistingReference()
       const referenceOutcome = existing
         ? referenceMatches(existing, input.reference)
           ? "unchanged"
@@ -960,6 +971,16 @@ function referenceMatches(
     canonicalJson(existing.metadata) === canonicalJson(input.metadata ?? null) &&
     (existing.syncedAt?.toISOString() ?? null) === (input.syncedAt ?? null) &&
     existing.syncError === (input.syncError ?? null)
+  )
+}
+
+function referenceIdentityMatches(
+  existing: typeof invoiceExternalRefs.$inferSelect,
+  input: FinanceAppApiExternalReferenceUpsertInput["reference"],
+) {
+  return (
+    existing.externalId === (input.externalId ?? null) &&
+    existing.externalNumber === (input.externalNumber ?? null)
   )
 }
 

--- a/packages/finance/src/service-booking-create.ts
+++ b/packages/finance/src/service-booking-create.ts
@@ -2889,12 +2889,18 @@ export async function createBookingMutation(
       issueDate
     const dueDatePaymentSchedule =
       result.paymentSchedules.find((schedule) => schedule.dueDate === dueDate) ?? null
+    const defaultSeries = await financeService.resolveDefaultInvoiceNumberSeries(
+      tx,
+      documentGeneration.invoiceType,
+    )
 
     const invoice = await financeService.createInvoiceFromBooking(
       tx,
       {
         bookingId: result.booking.id,
-        invoiceNumber: generateInvoiceNumber(result.booking.bookingNumber),
+        ...(defaultSeries
+          ? { seriesId: defaultSeries.id }
+          : { invoiceNumber: generateInvoiceNumber(result.booking.bookingNumber) }),
         issueDate,
         dueDate,
         invoiceType: documentGeneration.invoiceType,

--- a/packages/finance/src/service-invoice-numbering.ts
+++ b/packages/finance/src/service-invoice-numbering.ts
@@ -326,13 +326,28 @@ export const financeInvoiceNumberingService = {
   async applyExternalInvoiceAllocation(
     db: PostgresJsDatabase,
     invoiceId: string,
-    data: { invoiceNumber: string; status?: "issued" | "draft" },
+    data: {
+      invoiceNumber: string
+      status?: "issued" | "draft"
+      preserveProgressedStatus?: boolean
+    },
   ) {
     const [existing] = await db.select().from(invoices).where(eq(invoices.id, invoiceId)).limit(1)
     if (!existing) return { status: "not_found" as const }
-    if (existing.status !== "pending_external_allocation") {
+    const progressedStatus = ["issued", "partially_paid", "paid", "overdue"].includes(
+      existing.status,
+    )
+    if (
+      existing.status !== "pending_external_allocation" &&
+      !(data.preserveProgressedStatus && progressedStatus)
+    ) {
       return { status: "not_pending_external_allocation" as const, invoice: existing }
     }
+
+    const nextStatus =
+      existing.status === "pending_external_allocation"
+        ? (data.status ?? "issued")
+        : existing.status
 
     let invoice: typeof invoices.$inferSelect | undefined
     try {
@@ -340,7 +355,7 @@ export const financeInvoiceNumberingService = {
         .update(invoices)
         .set({
           invoiceNumber: data.invoiceNumber,
-          status: data.status ?? "issued",
+          status: nextStatus,
           updatedAt: new Date(),
         })
         .where(eq(invoices.id, invoiceId))

--- a/packages/finance/tests/integration/booking-create.test.ts
+++ b/packages/finance/tests/integration/booking-create.test.ts
@@ -45,6 +45,7 @@ import { financeBookingLifecycle } from "../../src/booking-lifecycle.js"
 import {
   bookingItemTaxLines,
   bookingPaymentSchedules,
+  invoiceNumberSeries,
   invoiceRenditions,
   invoices,
   paymentInstruments,
@@ -1312,6 +1313,54 @@ describe.skipIf(!DB_AVAILABLE)("createBooking", () => {
       .from(payments)
       .where(eq(payments.invoiceId, invoiceRows[0]!.id))
     expect(paymentRows).toHaveLength(1)
+  })
+
+  it("keeps the default external series on invoices created with paid bookings", async () => {
+    const { productId } = await seedProduct()
+    const [series] = await db
+      .insert(invoiceNumberSeries)
+      .values({
+        code: "SMARTBILL_B_INV",
+        name: "SmartBill B",
+        scope: "invoice",
+        prefix: "",
+        separator: "",
+        padLength: 0,
+        externalProvider: "mapp_smartbill",
+        externalConfigKey: "B",
+        isDefault: true,
+        active: true,
+      })
+      .returning()
+
+    const outcome = await createBooking(db, {
+      productId,
+      bookingNumber: nextBookingNumber(),
+      ...bookingParty(),
+      paymentSchedules: [
+        {
+          scheduleType: "balance",
+          status: "paid",
+          dueDate: "2026-06-15",
+          currency: "EUR",
+          amountCents: 50_000,
+          notes: JSON.stringify({
+            alreadyPaid: true,
+            paymentDate: "2026-06-10",
+            paymentMethod: "credit_card",
+            paymentReference: "pi_paid_before_allocation",
+          }),
+        },
+      ],
+    })
+
+    expect(outcome.status).toBe("ok")
+    if (outcome.status !== "ok") return
+    expect(outcome.result.invoice).toMatchObject({
+      seriesId: series?.id,
+      status: "paid",
+    })
+    expect(outcome.result.invoice?.invoiceNumber).toMatch(/^PENDING-INVOICE-/)
   })
 
   it("previews exact paid invoice settlement consequences before cancellation", async () => {

--- a/packages/finance/tests/unit/app-api-runtime.test.ts
+++ b/packages/finance/tests/unit/app-api-runtime.test.ts
@@ -176,6 +176,90 @@ describe("finance App API runtime", () => {
     })
   })
 
+  it("repairs a paid placeholder when the owning provider reports its fiscal number", async () => {
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          invoice_number: "INV-BK-2608-399637",
+          series_id: "series_1",
+          status: "paid",
+        },
+      ])
+      .mockResolvedValueOnce([{ external_provider: "smartbill" }])
+    const db = postgresStub({
+      execute,
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            limit: async () => [
+              {
+                id: "ref_1",
+                invoiceId: "inv_1",
+                provider: "smartbill",
+                externalId: "0174",
+                externalNumber: "0174",
+                externalUrl: null,
+                status: "retrying",
+                metadata: { series: "B", number: "0174" },
+                syncedAt: null,
+                syncError: "allocation was delayed",
+                createdAt: new Date(),
+                updatedAt: new Date(),
+              },
+            ],
+          }),
+        }),
+      }),
+    })
+    vi.spyOn(financeService, "applyExternalInvoiceAllocation").mockResolvedValue({
+      status: "applied",
+      invoice: { invoiceNumber: "B0174", status: "paid" },
+    } as never)
+    vi.spyOn(financeService, "registerInvoiceExternalRef").mockResolvedValue({
+      id: "ref_1",
+      invoiceId: "inv_1",
+      provider: "smartbill",
+      externalId: "0174",
+      externalNumber: "0174",
+      externalUrl: null,
+      status: "issued",
+      metadata: { series: "B", number: "0174" },
+      syncedAt: null,
+      syncError: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as never)
+
+    const result = await createFinanceAppApiRuntime().upsertExternalReference(
+      db,
+      "inv_1",
+      "smartbill",
+      {
+        reference: {
+          externalId: "0174",
+          externalNumber: "0174",
+          externalUrl: null,
+          status: "issued",
+          metadata: { series: "B", number: "0174" },
+          syncedAt: null,
+          syncError: null,
+        },
+        allocation: { invoiceNumber: "B0174" },
+      },
+    )
+
+    expect(result).toMatchObject({
+      status: "ok",
+      allocationOutcome: "applied",
+      referenceOutcome: "updated",
+    })
+    expect(financeService.applyExternalInvoiceAllocation).toHaveBeenCalledWith(db, "inv_1", {
+      invoiceNumber: "B0174",
+      preserveProgressedStatus: true,
+    })
+  })
+
   it("rejects allocation when the caller does not own the external series", async () => {
     const execute = vi
       .fn()

--- a/packages/finance/tests/unit/service-invoice-number-allocation.test.ts
+++ b/packages/finance/tests/unit/service-invoice-number-allocation.test.ts
@@ -1546,6 +1546,28 @@ describe("financeService.applyExternalInvoiceAllocation", () => {
     })
   })
 
+  it("preserves paid status when a provider number arrives after settlement", async () => {
+    const paidInvoice = {
+      ...pendingInvoice,
+      invoiceNumber: "INV-BK-2608-399637",
+      status: "paid",
+      paidCents: 12_000,
+      balanceDueCents: 0,
+    }
+    const { db, updates } = makeExternalAllocationDb({ existing: paidInvoice })
+
+    const result = await financeService.applyExternalInvoiceAllocation(db, "inv_new", {
+      invoiceNumber: "B0174",
+      preserveProgressedStatus: true,
+    })
+
+    expect(result.status).toBe("applied")
+    expect(updates[0]).toMatchObject({
+      invoiceNumber: "B0174",
+      status: "paid",
+    })
+  })
+
   it("normalizes duplicate external allocation numbers into a typed conflict", async () => {
     const { db } = makeExternalAllocationDb({
       existing: pendingInvoice,


### PR DESCRIPTION
## What changed
- use the configured default invoice series for booking-created invoices instead of forcing an `INV-{booking}` placeholder
- allow an owning external provider to apply its fiscal number after an invoice has progressed to issued/paid/overdue without changing that status
- preserve idempotency and reject provider or external-identity conflicts
- add regression coverage for the Pro Travel paid-before-allocation case

## Root cause
Booking creation explicitly supplied an internal invoice number, bypassing Pro Travel’s default SmartBill series. Separately, late external allocations were rejected after payment moved the invoice out of `pending_external_allocation`.

## Validation
- 55 focused Finance unit tests passed
- Finance typecheck passed
- formatting and diff checks passed
- booking-create integration regression added (runs with `TEST_DATABASE_URL`)
