### PR TITLE
feat(payments): stored payment instruments, from the port to the CRM

### DIFF
--- a/.changeset/project-stored-instruments-to-crm.md
+++ b/.changeset/project-stored-instruments-to-crm.md
@@ -1,0 +1,22 @@
+---
+"@voyant-travel/relationships": minor
+"@voyant-travel/finance": minor
+---
+
+Record instruments a payment provider stored against the person who paid.
+
+`person_payment_methods` promised processor-issued tokens the booking flow could
+charge and held free text an operator typed by hand, because nothing in the
+payment path could write to it. It now carries a `source`, the provider that
+issued the token, what the customer authorized it for, and whether it is still
+usable, with a partial unique index on (provider, token) that makes projection
+idempotent across a callback and a reconciliation poll reporting the same card.
+
+Finance defines `finance.stored-instrument.runtime` and relationships provides
+it, so the payment path can hand an instrument to the CRM without either module
+depending on the other. A deployment that does not wire it takes payments
+exactly as before and records no instruments.
+
+Existing rows are all hand-entered and become `source = 'manual'` with no
+authorized reuse, which is what they are: on the operator's own records,
+chargeable by nobody.

--- a/.changeset/stored-instrument-mandate.md
+++ b/.changeset/stored-instrument-mandate.md
@@ -1,0 +1,27 @@
+---
+"@voyant-travel/storefront": minor
+"@voyant-travel/catalog": minor
+"@voyant-travel/finance": minor
+---
+
+Authorize stored instruments from the operator's booking terms.
+
+Keeping a shopper's card and charging it later while they are away is a
+merchant-initiated transaction. Card network rules authorize it through the
+merchant's own terms, which the shopper accepts at checkout, and require the
+merchant to keep a record of that acceptance. It is not a checkbox beside the
+card field.
+
+Storefront settings gain `legal.storedInstrumentMandate` with an `enabled` flag
+and a `revision`. The revision is what makes the record meaningful: without it
+an acceptance says only that some terms were agreed at some point. The Booking
+Session derives the storage intent from the mandate plus its existing contract
+acceptance, and passes an `agreementReference` naming both.
+
+Absent settings mean nothing is stored. Fail closed is the only safe default:
+the operator is the merchant of record and carries the liability for an
+agreement they never wrote.
+
+The mandate is operator configuration and is omitted from the public storefront
+settings projection. What a shopper reads is the booking terms themselves,
+through the contract template.

--- a/.changeset/stored-instrument-read-and-merge.md
+++ b/.changeset/stored-instrument-read-and-merge.md
@@ -1,0 +1,34 @@
+---
+"@voyant-travel/relationships": major
+"@voyant-travel/relationships-react": major
+"@voyant-travel/flights-contracts": minor
+"@voyant-travel/flights-react": major
+---
+
+Stop serving the processor token, and define what a person merge does to a
+stored instrument.
+
+`processor_token` is the one column on `person_payment_methods` that can charge
+a customer, and it was included in every list and read response, so any
+authenticated admin client received it to render a brand and four digits. It is
+now projected out server-side. Callers that mean to charge name the method by
+id and let the server resolve the token.
+
+The saved-method arm of the flights `PaymentIntent` follows: it carries a
+`methodId` instead of a token, which removes the synthesized `acct:` placeholder
+that existed only because no real token was available client-side. It is a
+distinct arm rather than a variant of `card` because the two are different
+facts, and collapsing them would put a chargeable credential back on every
+client that renders a saved card.
+
+Merging two people reparents their payment methods but does not merge the
+customer records those methods are bound to at the provider. A projected method
+from the losing person therefore rests on an agreement given by a record that no
+longer exists, so it is retired to `requires_new_agreement` rather than silently
+carried over. The row stays visible to the operator, which makes the state
+explainable instead of a card vanishing mid-merge. Manual rows carry no provider
+binding and no authorization to lose, so they move unchanged.
+
+The response now also carries `source`, `providerId`, `authorizedReuses` and
+`status`, which is what a future storefront read path checks before offering a
+stored method back to a shopper.

--- a/.changeset/stored-payment-instruments-port.md
+++ b/.changeset/stored-payment-instruments-port.md
@@ -1,0 +1,24 @@
+---
+"@voyant-travel/payments": minor
+---
+
+Let the payment port express a stored instrument.
+
+`PaymentAdapterCapabilities` gains `storeInstrument`, `PaymentInitiationInput`
+gains a `storeInstrument` intent, and `PaymentInitiationResult`,
+`PaymentStatusResult` and `PaymentCallbackEvent` gain a `PaymentStoredInstrument`
+summary. All optional, so an adapter or caller written against an earlier
+revision keeps its exact behavior.
+
+Storage separates the two permissions card network rules treat differently.
+`merchant_initiated` reuse rests on the merchant's terms, which the caller
+already knows the shopper accepted and states as a fact. `shopper_reselect`
+rests on explicit consent for that purpose, which can only be collected where
+the payment details are entered, so the caller grants permission to ask and
+learns the answer from the reported instrument. `PaymentInstrumentStatus` covers
+the case where a reissued card outlives the agreement that authorized it.
+
+Conformance gains two cases. Every adapter must now store nothing when the
+caller asked for no storage, whether or not it declares the capability; a
+storage-capable adapter must additionally never report a reuse the caller did
+not grant.

--- a/packages/catalog/src/booking-engine/sessions-payment-production.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-payment-production.test.ts
@@ -159,6 +159,79 @@ describe("production Booking Session hosted-checkout initiation", () => {
     expect(startArgs().locale).toBe("ro-RO")
   })
 
+  it("stores nothing when no mandate is configured", async () => {
+    await prepare({ locale: "en-GB", departureDate: null, personId: "per_01k" })
+
+    expect(startArgs().storeInstrument).toBeUndefined()
+  })
+
+  // Terms that carry the mandate authorize nothing until somebody accepts them.
+  it("stores nothing when the shopper accepted no terms", async () => {
+    await prepare({
+      locale: "en-GB",
+      departureDate: null,
+      personId: "per_01k",
+      mandate: { enabled: true, revision: "v3" },
+    })
+
+    expect(startArgs().storeInstrument).toBeUndefined()
+  })
+
+  // And an acceptance authorizes nothing if the terms accepted never said it.
+  it("stores nothing when the operator's terms carry no mandate", async () => {
+    await prepare({
+      locale: "en-GB",
+      departureDate: null,
+      personId: "per_01k",
+      mandate: { enabled: false, revision: "v3" },
+      contractAcceptedAt: "2026-08-12T09:00:00.000Z",
+    })
+
+    expect(startArgs().storeInstrument).toBeUndefined()
+  })
+
+  // Storage binds to a customer record, so there has to be one to bind to.
+  it("stores nothing for a shopper it cannot identify", async () => {
+    await prepare({
+      locale: "en-GB",
+      departureDate: null,
+      mandate: { enabled: true, revision: "v3" },
+      contractAcceptedAt: "2026-08-12T09:00:00.000Z",
+    })
+
+    expect(startArgs().storeInstrument).toBeUndefined()
+  })
+
+  it("names the terms revision and the acceptance it rests on", async () => {
+    await prepare({
+      locale: "en-GB",
+      departureDate: null,
+      personId: "per_01k",
+      mandate: { enabled: true, revision: "v3" },
+      contractAcceptedAt: "2026-08-12T09:00:00.000Z",
+    })
+
+    expect(startArgs().storeInstrument).toEqual({
+      merchantInitiated: true,
+      agreementReference:
+        "booking-terms:v3:bses_01k:2026-08-12T09:00:00.000Z",
+    })
+  })
+
+  // Permission to show the card back to the shopper is a separate consent that
+  // only the payment surface can collect, so the runtime never grants it here.
+  it("never grants reselection from the terms alone", async () => {
+    await prepare({
+      locale: "en-GB",
+      departureDate: null,
+      personId: "per_01k",
+      mandate: { enabled: true, revision: "v3" },
+      contractAcceptedAt: "2026-08-12T09:00:00.000Z",
+    })
+
+    expect(startArgs().storeInstrument).not.toHaveProperty("offerShopperReselect")
+  })
+
   it("references the CRM person the buyer was identified as", async () => {
     await prepare({ locale: "en-GB", departureDate: null, personId: "per_01k" })
 
@@ -338,6 +411,8 @@ async function prepare(input: {
   refreshedCheckout?: Record<string, unknown>
   refreshedRedirectUrl?: string | null
   settlementPaymentSessionId?: string
+  mandate?: { enabled: boolean; revision: string } | null
+  contractAcceptedAt?: string
 }) {
   if (input.refreshedCheckout !== undefined) {
     // What the adapter persisted, read back by the port exactly as production
@@ -367,6 +442,9 @@ async function prepare(input: {
     distribution: { loadSupplierPaymentPolicy: async () => null },
     settings: { resolveOperatorDefaultPaymentPolicy: async () => null },
     resolvePaymentAdapter: () => ({ id: "test" }) as never,
+    ...(input.mandate === undefined
+      ? {}
+      : { resolveStoredInstrumentMandate: async () => input.mandate ?? null }),
   })
 
   return payments.prepare({
@@ -378,6 +456,9 @@ async function prepare(input: {
       target: { kind: "product", productId: "prod_1" },
       expiresAt: new Date("2026-08-06T00:00:00Z"),
       statePayload: {
+        ...(input.contractAcceptedAt
+          ? { contractAcceptance: { acceptedAt: input.contractAcceptedAt } }
+          : {}),
         billing: {
           contact: input.omitContact
             ? {}

--- a/packages/catalog/src/booking-engine/sessions-payment-production.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-payment-production.test.ts
@@ -213,8 +213,7 @@ describe("production Booking Session hosted-checkout initiation", () => {
 
     expect(startArgs().storeInstrument).toEqual({
       merchantInitiated: true,
-      agreementReference:
-        "booking-terms:v3:bses_01k:2026-08-12T09:00:00.000Z",
+      agreementReference: "booking-terms:v3:bses_01k:2026-08-12T09:00:00.000Z",
     })
   })
 
@@ -505,6 +504,7 @@ function startArgs() {
     description?: string
     locale?: string
     customerReference?: string
+    storeInstrument?: { merchantInitiated: boolean; agreementReference?: string }
     billing?: Record<string, unknown>
     acceptedCheckoutHandoffs?: readonly ("redirect" | "embedded")[]
   }

--- a/packages/catalog/src/booking-engine/sessions-payment-production.ts
+++ b/packages/catalog/src/booking-engine/sessions-payment-production.ts
@@ -31,6 +31,45 @@ export interface ProductionBookingSessionPaymentDeps {
   financeRuntime?: Parameters<typeof createOrReuseBookingSessionPayment>[2]
   /** Host-owned bank-transfer document/instruction orchestration. */
   establishBankTransfer?: BookingSessionPaymentPorts["establishBankTransfer"]
+  /**
+   * Whether the operator's booking terms authorize charging a stored
+   * instrument while the shopper is away, and which revision says so.
+   *
+   * Absent, or resolving to null, means no instrument is stored. Fail closed
+   * is the only safe default: the operator is the merchant of record and
+   * carries the liability for an agreement they never wrote.
+   */
+  resolveStoredInstrumentMandate?: (
+    db: PostgresJsDatabase,
+  ) => Promise<{ enabled: boolean; revision: string } | null>
+}
+
+/**
+ * What the shopper authorized, derived from the operator's terms and the
+ * shopper's acceptance of them.
+ *
+ * Both halves are required and neither substitutes for the other. Terms that
+ * carry the mandate authorize nothing until somebody accepts them, and an
+ * acceptance authorizes nothing if the terms accepted never said it.
+ *
+ * `agreementReference` is the record. Card network rules ask the merchant to
+ * keep one, and this is the handle that ties the stored instrument back to the
+ * exact acceptance and terms revision it rests on. Without the revision an
+ * acceptance says only that some terms were agreed at some point, which is not
+ * evidence of anything.
+ */
+function storedInstrumentIntent(
+  mandate: { enabled: boolean; revision: string } | null | undefined,
+  session: { id: string; statePayload: Record<string, unknown> },
+): { merchantInitiated: true; agreementReference: string } | undefined {
+  if (!mandate?.enabled) return undefined
+  const acceptance = record(session.statePayload.contractAcceptance)
+  const acceptedAt = stringValue(acceptance?.acceptedAt)
+  if (!acceptedAt || Number.isNaN(Date.parse(acceptedAt))) return undefined
+  return {
+    merchantInitiated: true,
+    agreementReference: `booking-terms:${mandate.revision}:${session.id}:${acceptedAt}`,
+  }
 }
 
 export function createProductionBookingSessionPaymentPorts(
@@ -144,6 +183,12 @@ export function createProductionBookingSessionPaymentPorts(
       const adapter = await deps.resolvePaymentAdapter?.()
       if (adapter && paymentSession.status === "pending") {
         const reference = customerReference(session)
+        // Storage binds to the customer record, so an unidentified shopper
+        // stores nothing however the terms read: there would be nobody for the
+        // instrument to belong to.
+        const storeInstrument = reference
+          ? storedInstrumentIntent(await deps.resolveStoredInstrumentMandate?.(deps.db), session)
+          : undefined
         await startPaymentAdapterCardPayment(
           adapter,
           {
@@ -167,6 +212,7 @@ export function createProductionBookingSessionPaymentPorts(
             }),
             locale: session.scope.locale,
             ...(reference ? { customerReference: reference } : {}),
+            ...(storeInstrument ? { storeInstrument } : {}),
             returnUrl: commit.payment?.returnUrl,
             cancelUrl: commit.payment?.cancelUrl,
             // Forwarded verbatim: the storefront is the only party that knows

--- a/packages/finance/src/card-payment.ts
+++ b/packages/finance/src/card-payment.ts
@@ -16,6 +16,7 @@ import type {
   PaymentAdapterRuntimeContext,
   PaymentCheckoutHandoff,
   PaymentHostedCheckout,
+  PaymentInstrumentStorageIntent,
 } from "@voyant-travel/payments"
 import { paymentCheckoutRedirectUrl } from "@voyant-travel/payments"
 import { and, eq, isNull, sql } from "drizzle-orm"
@@ -67,6 +68,14 @@ export interface CardPaymentStartArgs {
    * See `PaymentInitiationInput["customer"].reference`.
    */
   customerReference?: string
+  /**
+   * Keep the instrument this payment uses, and what it may be reused for.
+   *
+   * Absent means keep nothing. The caller states it rather than the adapter
+   * inferring it, because whether the shopper accepted terms authorizing later
+   * charges is a fact only the caller holds.
+   */
+  storeInstrument?: PaymentInstrumentStorageIntent
   returnUrl?: string
   cancelUrl?: string
   shipping?: Record<string, unknown>
@@ -217,6 +226,7 @@ export async function startPaymentAdapterCardPayment(
       cancelUrl: args.cancelUrl ?? session.cancelUrl ?? undefined,
       acceptedCheckoutHandoffs: args.acceptedCheckoutHandoffs,
       idempotencyKey,
+      ...(args.storeInstrument ? { storeInstrument: args.storeInstrument } : {}),
       customer: {
         reference: args.customerReference ?? null,
         email: args.billing.email ?? null,

--- a/packages/finance/src/payment-adapter-events.ts
+++ b/packages/finance/src/payment-adapter-events.ts
@@ -277,7 +277,71 @@ export async function applyPaymentAdapterCallbackEvent(
     await applyPaymentAdapterDisputeSignal(db, event, runtime)
   }
 
+  // Same shape as a dispute, for the same reason: an instrument stored during
+  // this payment, or a reissued card that lost its agreement long after the
+  // payment settled, changes nothing about the session's own lifecycle.
+  if (event.storedInstrument) {
+    await recordStoredInstrumentForSession(
+      db,
+      event.paymentSessionId,
+      event.storedInstrument,
+      event.processorIdentity?.providerId ?? null,
+      runtime,
+    )
+  }
+
   return session
+}
+
+/**
+ * Attach a stored instrument to the person the session named as payer.
+ *
+ * Every early return here is a case where recording would be a guess:
+ *
+ * - No recorder wired, so nothing in this deployment keeps customer records.
+ * - No provider id, so the token could not be charged later even if kept, and
+ *   a token attributed to the wrong adapter is worse than no token.
+ * - No payer person, which is the ordinary anonymous checkout. An instrument
+ *   with nobody to attach it to is not an error; there is simply no customer
+ *   record for it to belong to.
+ *
+ * Failure to record never fails the payment. The money moved and the session is
+ * already correct; losing the instrument is a degraded outcome, not a reason to
+ * reject a callback the provider will otherwise retry forever.
+ */
+async function recordStoredInstrumentForSession(
+  db: PostgresJsDatabase,
+  paymentSessionId: string,
+  instrument: NonNullable<PaymentCallbackEvent["storedInstrument"]>,
+  providerId: string | null,
+  runtime: FinanceServiceRuntime,
+) {
+  const recorder = runtime.storedInstrumentRecorder
+  if (!recorder) return
+
+  const [session] = await db
+    .select({ payerPersonId: paymentSessions.payerPersonId, provider: paymentSessions.provider })
+    .from(paymentSessions)
+    .where(eq(paymentSessions.id, paymentSessionId))
+    .limit(1)
+
+  const resolvedProviderId = providerId ?? session?.provider ?? null
+  if (!session?.payerPersonId || !resolvedProviderId) return
+
+  await recorder.recordStoredInstrument(db, {
+    personId: session.payerPersonId,
+    providerId: resolvedProviderId,
+    token: instrument.token,
+    authorizedReuses: instrument.authorizedReuses,
+    status: instrument.status,
+    providerCustomerReference: instrument.customerReference ?? null,
+    fingerprint: instrument.fingerprint ?? null,
+    brand: instrument.brand ?? null,
+    last4: instrument.last4 ?? null,
+    holderName: instrument.holderName ?? null,
+    expMonth: instrument.expMonth ?? null,
+    expYear: instrument.expYear ?? null,
+  })
 }
 
 async function applyPaymentAdapterDisputeSignal(
@@ -321,6 +385,19 @@ export async function applyPaymentAdapterStatusResult(
   checkedAt = new Date(),
 ) {
   const occurredAt = checkedAt.toISOString()
+  // The poll is the backstop for a shopper who closed the tab before the
+  // callback landed. It has to record the instrument too, or which of the two
+  // paths arrives first decides whether the customer has a card on file.
+  // Idempotent on (provider, token), so both arriving is a no-op.
+  if (result.storedInstrument) {
+    await recordStoredInstrumentForSession(
+      db,
+      paymentSessionId,
+      result.storedInstrument,
+      result.processorIdentity?.providerId ?? null,
+      runtime,
+    )
+  }
   return applyPaymentAdapterStateUpdate(
     db,
     {

--- a/packages/finance/src/runtime-port.ts
+++ b/packages/finance/src/runtime-port.ts
@@ -143,6 +143,50 @@ export interface FinanceInventoryPaymentPolicyRuntime {
   readPolicySourceFromInternalNotes: BookingScheduleRoutesOptions["readPolicySourceFromInternalNotes"]
 }
 
+/**
+ * An instrument a payment provider stored, on its way from the payment path to
+ * whatever module keeps customer records.
+ *
+ * Deliberately its own shape rather than `PaymentStoredInstrument` re-exported:
+ * this is a seam between two modules that do not depend on each other, and
+ * pinning it to the payment port's revision would make the CRM's contract move
+ * whenever an adapter's did.
+ */
+export interface FinanceStoredInstrumentRecord {
+  /** The person the payment session named as payer. */
+  personId: string
+  /** The adapter that issued `token`. Without it the token can charge nothing. */
+  providerId: string
+  token: string
+  /** `PaymentInstrumentReuse` values the customer authorized. Empty is meaningful. */
+  authorizedReuses: readonly string[]
+  status?: "usable" | "requires_new_agreement" | "expired" | "revoked"
+  providerCustomerReference?: string | null
+  fingerprint?: string | null
+  brand?: string | null
+  last4?: string | null
+  holderName?: string | null
+  expMonth?: number | null
+  expYear?: number | null
+  /** The record of the agreement authorizing merchant-initiated reuse. */
+  agreementReference?: string | null
+}
+
+/**
+ * Where a stored instrument goes once a payment produced one.
+ *
+ * Finance owns the payment and learns the instrument; it does not own the
+ * customer record and must not reach into one. A deployment without this port
+ * wired still takes payments perfectly — instruments simply go unrecorded,
+ * which is the behavior every deployment had before the seam existed.
+ */
+export interface FinanceStoredInstrumentRuntime {
+  recordStoredInstrument(
+    db: PostgresJsDatabase,
+    instrument: FinanceStoredInstrumentRecord,
+  ): Promise<void>
+}
+
 export interface FinanceCheckoutPaymentStartersRuntime {
   resolvePaymentStarters(bindings: Record<string, unknown>): Record<string, CheckoutPaymentStarter>
 }
@@ -242,6 +286,10 @@ export const financeInventoryPaymentPolicyRuntimePort =
     "stampPolicySourceOnBooking",
     "readPolicySourceFromInternalNotes",
   ])
+export const financeStoredInstrumentRuntimePort = objectPort<FinanceStoredInstrumentRuntime>(
+  "finance.stored-instrument.runtime",
+  ["recordStoredInstrument"],
+)
 export const financeCheckoutPaymentStartersRuntimePort =
   objectPort<FinanceCheckoutPaymentStartersRuntime>("finance.checkout-payment-starters.runtime", [
     "resolvePaymentStarters",

--- a/packages/finance/src/service-shared.ts
+++ b/packages/finance/src/service-shared.ts
@@ -76,6 +76,9 @@ import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { z } from "zod"
 import { resolveFxMoneyBaseAmount } from "./fx-money.js"
 import type { InvoiceFxOptions } from "./invoice-fx.js"
+// Type-only: `runtime-port` reaches back into route modules that import this
+// one, so a value import here would close a cycle.
+import type { FinanceStoredInstrumentRuntime } from "./runtime-port.js"
 import {
   type bookingGuarantees,
   type bookingItemTaxLines,
@@ -1068,6 +1071,15 @@ export async function touchLinkedBookingUpdatedAt(
  */
 export interface FinanceServiceRuntime extends InvoiceFxOptions {
   eventBus?: EventBus
+  /**
+   * Where an instrument a provider stored gets recorded, wired from
+   * `finance.stored-instrument.runtime`.
+   *
+   * Absent means nothing records instruments, which is the behavior every
+   * deployment had before the seam existed: payments still complete, the
+   * instrument simply is not kept anywhere finance can see.
+   */
+  storedInstrumentRecorder?: FinanceStoredInstrumentRuntime
   monthlyBookingLimit?: number | null
   actionLedgerContext?: ActionLedgerRequestContextValues
   actionLedgerAuthorizationSource?: string | null

--- a/packages/flights-contracts/src/contract/schemas.ts
+++ b/packages/flights-contracts/src/contract/schemas.ts
@@ -246,6 +246,10 @@ export const paymentIntentSchema = z.discriminatedUnion("type", [
     billingAddress: billingAddressSchema.optional(),
   }),
   z.object({
+    type: z.literal("saved_method"),
+    methodId: z.string().min(1),
+  }),
+  z.object({
     type: z.literal("ticket_on_credit"),
     iataCode: z.string().optional(),
   }),

--- a/packages/flights-contracts/src/contract/types.ts
+++ b/packages/flights-contracts/src/contract/types.ts
@@ -235,6 +235,16 @@ export type PaymentIntent =
   | { type: "hold" }
   | { type: "bank_transfer" }
   | { type: "card"; token: string; cardholderName?: string; billingAddress?: BillingAddress }
+  /**
+   * A method already on file for the customer, named rather than carried.
+   *
+   * Distinct from `card` because the two are not the same fact: `card` carries
+   * a credential the shopper just entered, while this carries only an
+   * identifier the server resolves to a token it never sends out. Collapsing
+   * them would put a chargeable credential on every client that renders a saved
+   * card, which is exactly what having the id avoids.
+   */
+  | { type: "saved_method"; methodId: string }
   | { type: "ticket_on_credit"; iataCode?: string }
 
 export interface BillingAddress {

--- a/packages/flights-react/src/components/flight-payment-step.tsx
+++ b/packages/flights-react/src/components/flight-payment-step.tsx
@@ -82,17 +82,12 @@ export function FlightPaymentStep({
           return
         }
         if (next.type === "saved_method") {
+          // A saved method is named, never carried. The token that can charge
+          // it stays server-side and is resolved from this id, so nothing here
+          // has to synthesize a stand-in for a credential it is not allowed to
+          // hold.
           onSelectSaved(next.method.id)
-          // The CRM `processor_token` for the method isn't on the
-          // PublicPaymentAccount projection. The vertical wrapper here
-          // emits a placeholder token derived from the account id; the
-          // parent is expected to call `useInitiateCheckoutCollection`
-          // with `paymentInstrumentId: next.method.id` rather than
-          // relying on the flight `PaymentIntent.token` field.
-          onChange({
-            type: "card",
-            token: `acct:${next.method.id}`,
-          })
+          onChange({ type: "saved_method", methodId: next.method.id })
           return
         }
         onSelectSaved(null)

--- a/packages/flights-react/src/i18n/en.ts
+++ b/packages/flights-react/src/i18n/en.ts
@@ -423,6 +423,10 @@ export const flightsUiEn = {
         description:
           "Tickets issue immediately. Card details are entered securely on the next step.",
       },
+      saved_method: {
+        title: "Use a saved card",
+        description: "Charges a card already on file for this customer. Nothing is re-entered.",
+      },
       bank_transfer: {
         title: "Bank transfer",
         description:

--- a/packages/flights-react/src/i18n/messages.ts
+++ b/packages/flights-react/src/i18n/messages.ts
@@ -368,7 +368,7 @@ export type FlightsUiMessages = {
     title: string
     description: string
     intents: Record<
-      "hold" | "card" | "bank_transfer" | "ticket_on_credit",
+      "hold" | "card" | "saved_method" | "bank_transfer" | "ticket_on_credit",
       {
         title: string
         description: string

--- a/packages/flights-react/src/i18n/ro.ts
+++ b/packages/flights-react/src/i18n/ro.ts
@@ -425,6 +425,11 @@ export const flightsUiRo = {
         description:
           "Biletele se emit imediat. Datele cardului se introduc in siguranta la pasul urmator.",
       },
+      saved_method: {
+        title: "Foloseste un card salvat",
+        description:
+          "Incaseaza de pe un card deja salvat pentru acest client. Nu se reintroduce nimic.",
+      },
       bank_transfer: {
         title: "Transfer bancar",
         description:

--- a/packages/flights-react/src/schemas.ts
+++ b/packages/flights-react/src/schemas.ts
@@ -335,7 +335,6 @@ export const savedPaymentMethodSchema = z.object({
   /** Null for non-card methods. */
   expMonth: z.number().nullable().optional(),
   expYear: z.number().nullable().optional(),
-  processorToken: z.string(),
   isDefault: z.boolean(),
   createdAt: z.string(),
 })

--- a/packages/payments/src/conformance.test.ts
+++ b/packages/payments/src/conformance.test.ts
@@ -12,6 +12,7 @@ import {
   type PaymentCallbackRequest,
   type PaymentHostedCheckout,
   type PaymentInitiationInput,
+  type PaymentInstrumentReuse,
   type PaymentOperationInput,
   type PaymentOperationResult,
   type PaymentStatusInput,
@@ -32,13 +33,16 @@ type BrokenBehavior =
   | "manual-capture-pays"
   | "never-embeds"
   | "remap-status-identity"
+  | "store-beyond-intent"
+  | "store-malformed-instrument"
+  | "store-unrequested"
   | "untyped-conflict-error"
   | "verify-invalid-callback"
   | "verify-malformed-callback"
   | "verify-replayed-callback"
 
-/** Whether the fake adapter declares (and can serve) in-page checkout. */
-type FakeAdapterOptions = { embeddedCheckout?: boolean }
+/** What the fake adapter declares (and can serve) beyond the mandatory contract. */
+type FakeAdapterOptions = { embeddedCheckout?: boolean; storeInstrument?: boolean }
 
 const context: PaymentAdapterRuntimeContext = {
   env: {},
@@ -134,6 +138,70 @@ describe("payment adapter conformance", () => {
     expect(await failedCaseNames(harness)).toContain("initiates idempotently")
   })
 
+  it("passes a storage-capable adapter that reports exactly what it was granted", async () => {
+    const results = await runPaymentAdapterConformance(
+      createHarness(undefined, { storeInstrument: true }),
+    )
+
+    expect(results.filter((result) => !result.passed)).toEqual([])
+    expect(results.map((result) => result.name)).toEqual(
+      expect.arrayContaining([
+        "honors declared instrument-storage capability",
+        "stores nothing when the caller asked for no storage",
+      ]),
+    )
+  })
+
+  it("fails when a declared storage capability has no fixture", async () => {
+    const harness = createHarness(undefined, { storeInstrument: true })
+    harness.storeInstrumentInitiation = undefined
+
+    expect(await failedCaseNames(harness)).toContain(
+      "honors declared instrument-storage capability",
+    )
+  })
+
+  it("fails when the storage fixture carries no intent", async () => {
+    const harness = createHarness(undefined, { storeInstrument: true })
+    harness.storeInstrumentInitiation = {
+      paymentSessionId: "payment-stored",
+      money: { amountMinor: 1_000, currency: "EUR" },
+      idempotencyKey: "init-stored",
+    }
+
+    expect(await failedCaseNames(harness)).toContain(
+      "honors declared instrument-storage capability",
+    )
+  })
+
+  it("skips the storage case when the capability is not declared", async () => {
+    expect(await failedCaseNames(createHarness())).not.toContain(
+      "honors declared instrument-storage capability",
+    )
+  })
+
+  it.each([
+    ["store-beyond-intent", "honors declared instrument-storage capability"],
+    ["store-malformed-instrument", "honors declared instrument-storage capability"],
+  ] as ReadonlyArray<
+    [BrokenBehavior, string]
+  >)("catches a %s storage-capable adapter", async (behavior, failedCase) => {
+    const harness = createHarness(behavior, { storeInstrument: true })
+
+    expect(await failedCaseNames(harness)).toContain(failedCase)
+  })
+
+  // The universal probe: an adapter that keeps instruments nobody asked it to
+  // keep must fail even when it never declared the capability at all.
+  it("catches an adapter that stores without being asked", async () => {
+    expect(await failedCaseNames(createHarness("store-unrequested"))).toContain(
+      "stores nothing when the caller asked for no storage",
+    )
+    expect(
+      await failedCaseNames(createHarness("store-unrequested", { storeInstrument: true })),
+    ).toContain("stores nothing when the caller asked for no storage")
+  })
+
   it("fails when a declared operation has no method", async () => {
     const harness = createHarness()
     harness.adapter.capture = undefined
@@ -209,6 +277,15 @@ function createHarness(
           idempotencyKey: "init-embedded",
         }
       : undefined,
+    storeInstrumentInitiation: options.storeInstrument
+      ? {
+          paymentSessionId: "payment-stored",
+          money: { amountMinor: 1_000, currency: "EUR" },
+          captureMode: "automatic",
+          idempotencyKey: "init-stored",
+          storeInstrument: { merchantInitiated: true, agreementReference: "terms-v3" },
+        }
+      : undefined,
     initiation: {
       paymentSessionId: "payment-1",
       money: { amountMinor: 1_000, currency: "EUR" },
@@ -271,6 +348,7 @@ function createFakeAdapter(
   options: FakeAdapterOptions = {},
 ): PaymentAdapter {
   const embeddedCheckout = options.embeddedCheckout === true
+  const storeInstrument = options.storeInstrument === true
   const initiationKeys = new Map<string, { payload: string; result: unknown }>()
   const operationKeys = new Map<string, { payload: string; result: PaymentOperationResult }>()
   let operationSequence = 0
@@ -313,6 +391,40 @@ function createFakeAdapter(
       clientSecret: behavior === "embed-without-client-secret" ? "" : "session-secret-1",
       publishableKey: "pk-test-fake-pay",
       providerAccountId: "acct-1",
+    }
+  }
+
+  /**
+   * What a conforming adapter reports back: exactly the reuses the caller
+   * granted, and nothing at all when the caller granted none. Each broken
+   * behavior breaks one of those two rules.
+   */
+  const storedInstrumentFor = (input: PaymentInitiationInput) => {
+    const intent = input.storeInstrument
+    if (behavior === "store-unrequested") {
+      return { storedInstrument: { token: "pm-uninvited", authorizedReuses: [] as const } }
+    }
+    if (!intent || !storeInstrument) return {}
+    if (behavior === "store-malformed-instrument") {
+      return { storedInstrument: { token: "pm-1", authorizedReuses: [], last4: "12" } }
+    }
+    const authorizedReuses: PaymentInstrumentReuse[] =
+      behavior === "store-beyond-intent"
+        ? ["merchant_initiated", "shopper_reselect"]
+        : [
+            ...(intent.merchantInitiated ? (["merchant_initiated"] as const) : []),
+            ...(intent.offerShopperReselect ? (["shopper_reselect"] as const) : []),
+          ]
+    return {
+      storedInstrument: {
+        token: "pm-1",
+        authorizedReuses,
+        status: "usable" as const,
+        brand: "visa",
+        last4: "4242",
+        expMonth: 5,
+        expYear: 2031,
+      },
     }
   }
 
@@ -379,6 +491,7 @@ function createFakeAdapter(
       callbackSignatureVerification: true,
       idempotencyKeys: true,
       retrySafeInitiation: true,
+      storeInstrument,
     },
     async initiate(_context, input) {
       validateMoney(input.money)
@@ -399,6 +512,7 @@ function createFakeAdapter(
           input.captureMode === "manual" && behavior !== "manual-capture-pays"
             ? ("authorized" as const)
             : ("paid" as const),
+        ...storedInstrumentFor(input),
         idempotencyKey: input.idempotencyKey,
       }
       initiationKeys.set(input.idempotencyKey, { payload, result })

--- a/packages/payments/src/conformance.ts
+++ b/packages/payments/src/conformance.ts
@@ -8,6 +8,7 @@ import type {
   PaymentHostedCheckout,
   PaymentInitiationInput,
   PaymentInitiationResult,
+  PaymentInstrumentStorageIntent,
   PaymentMoney,
   PaymentOperationInput,
   PaymentOperationResult,
@@ -15,12 +16,15 @@ import type {
   PaymentSessionState,
   PaymentStatusInput,
   PaymentStatusResult,
+  PaymentStoredInstrument,
 } from "./index.js"
 import {
   acceptedPaymentCheckoutHandoffs,
   isEmbeddedPaymentCheckout,
   isPaymentAdapterError,
   PAYMENT_DISPUTE_STATUSES,
+  PAYMENT_INSTRUMENT_REUSES,
+  PAYMENT_INSTRUMENT_STATUSES,
   paymentAdapterRuntimePort,
   paymentCheckoutHandoff,
 } from "./index.js"
@@ -80,6 +84,16 @@ export interface PaymentAdapterConformanceHarness {
    * replayed under a fresh session/idempotency key.
    */
   redirectOnlyInitiation?: PaymentInitiationInput
+  /**
+   * A separate initiation carrying a storage intent. Required when
+   * `storeInstrument` is declared.
+   *
+   * It does not have to produce an instrument synchronously — most providers
+   * store at confirmation, which a conformance run never reaches — so what is
+   * checked is that the adapter accepts the intent and never over-reports
+   * against it.
+   */
+  storeInstrumentInitiation?: PaymentInitiationInput
   authorize?: PaymentOperationConformanceInput
   capture?: PaymentOperationConformanceInput
   void?: PaymentOperationConformanceInput
@@ -170,6 +184,14 @@ function buildCases(harness: PaymentAdapterConformanceHarness): ConformanceCase[
       run: () => assertStatus(harness),
     },
     { name: "honors manual capture", run: () => assertManualCapture(harness) },
+    {
+      name: "stores nothing when the caller asked for no storage",
+      run: () => assertNoUnrequestedStorage(harness),
+    },
+    {
+      name: "honors declared instrument-storage capability",
+      run: () => assertInstrumentStorage(harness),
+    },
     {
       name: "honors declared embedded checkout capability",
       run: () => assertEmbeddedCheckout(harness),
@@ -473,6 +495,78 @@ async function assertManualCapture(harness: PaymentAdapterConformanceHarness) {
   )
 }
 
+/**
+ * Silence must mean "keep nothing". Every adapter runs this, not just the
+ * storage-capable ones, so the property stays proven as capabilities grow — the
+ * same reason the redirect-only downgrade is universal.
+ *
+ * This is the case that would have caught the defect this contract exists for,
+ * inverted: an adapter that keeps instruments nobody asked it to keep is a
+ * worse failure than one that keeps none.
+ */
+async function assertNoUnrequestedStorage(harness: PaymentAdapterConformanceHarness) {
+  const base = harness.initiation
+  const { storeInstrument: _ignored, ...withoutStorage } = base
+  const input: PaymentInitiationInput = {
+    ...withoutStorage,
+    paymentSessionId: `${base.paymentSessionId}:no-storage`,
+    idempotencyKey: `${base.idempotencyKey}:no-storage`,
+  }
+  const result = await harness.adapter.initiate(harness.context, input)
+  if (result.storedInstrument) {
+    throw new Error("Adapter stored an instrument for a caller that requested no storage.")
+  }
+}
+
+/**
+ * An adapter may store less than it was asked to, and routinely will: the
+ * shopper declines, or the provider stores at confirmation and has nothing to
+ * report yet. It may never store *more* than it was asked to, because each
+ * reuse rests on a permission the caller either holds or does not.
+ */
+async function assertInstrumentStorage(harness: PaymentAdapterConformanceHarness) {
+  if (!harness.adapter.capabilities.storeInstrument) return
+  const input = harness.storeInstrumentInitiation
+  if (!input) {
+    throw new Error(
+      "Adapter declares instrument storage but no storeInstrumentInitiation fixture was supplied.",
+    )
+  }
+  const intent = input.storeInstrument
+  if (!intent) {
+    throw new Error("Instrument-storage fixture must carry a storeInstrument intent.")
+  }
+  await assertMoney(input.money)
+  const accepted = acceptedPaymentCheckoutHandoffs(input)
+  const first = await harness.adapter.initiate(harness.context, input)
+  const duplicate = await harness.adapter.initiate(harness.context, input)
+  assertInitiationResult(harness.adapter, first, accepted)
+  assertInitiationResult(harness.adapter, duplicate, accepted)
+  assertSame(
+    initiationIdentity(first),
+    initiationIdentity(duplicate),
+    "Instrument-storage initiation must be idempotent.",
+  )
+  for (const result of [first, duplicate]) {
+    if (!result.storedInstrument) continue
+    assertAuthorizedWithinIntent(result.storedInstrument, intent)
+  }
+}
+
+function assertAuthorizedWithinIntent(
+  instrument: PaymentStoredInstrument,
+  intent: PaymentInstrumentStorageIntent,
+) {
+  if (instrument.authorizedReuses.includes("merchant_initiated") && !intent.merchantInitiated) {
+    throw new Error(
+      "Adapter authorized merchant-initiated reuse the caller did not state the shopper had agreed to.",
+    )
+  }
+  if (instrument.authorizedReuses.includes("shopper_reselect") && !intent.offerShopperReselect) {
+    throw new Error("Adapter authorized shopper reselection without permission to offer it.")
+  }
+}
+
 async function assertEmbeddedCheckout(harness: PaymentAdapterConformanceHarness) {
   if (!harness.adapter.capabilities.embeddedCheckout) return
   const input = harness.embeddedInitiation
@@ -570,6 +664,7 @@ function assertInitiationResult(
   assertState(result.nextState)
   assertNonEmpty(result.idempotencyKey, "Initiation result idempotency key")
   assertIdentity(result.processorIdentity)
+  if (result.storedInstrument) assertStoredInstrument(result.storedInstrument)
   if (!result.checkout) return
   assertCheckoutArm(adapter, result.checkout)
   const handoff = paymentCheckoutHandoff(result.checkout)
@@ -638,6 +733,41 @@ function assertCallbackEvent(event: PaymentCallbackEvent) {
   assertIdentity(event.processorIdentity)
   if (event.money) assertMoney(event.money)
   if (event.dispute) assertDisputeSignal(event.dispute)
+  if (event.storedInstrument) assertStoredInstrument(event.storedInstrument)
+}
+
+/**
+ * The shape every reported instrument must have, wherever it is reported.
+ *
+ * Deliberately strict about `last4` and the expiry: these reach an operator
+ * screen and a shopper's saved-card list, and a provider that pads or reformats
+ * them produces a card that looks like somebody else's.
+ */
+function assertStoredInstrument(instrument: PaymentStoredInstrument) {
+  assertNonEmpty(instrument.token, "Stored instrument token")
+  if (!Array.isArray(instrument.authorizedReuses)) {
+    throw new Error("Stored instrument must declare which reuses are authorized.")
+  }
+  for (const reuse of instrument.authorizedReuses) {
+    if (!PAYMENT_INSTRUMENT_REUSES.includes(reuse)) {
+      throw new Error("Stored instrument declares an unknown reuse.")
+    }
+  }
+  if (new Set(instrument.authorizedReuses).size !== instrument.authorizedReuses.length) {
+    throw new Error("Stored instrument repeats an authorized reuse.")
+  }
+  if (instrument.status !== undefined && !PAYMENT_INSTRUMENT_STATUSES.includes(instrument.status)) {
+    throw new Error("Stored instrument declares an unknown status.")
+  }
+  if (instrument.last4 != null && !/^\d{4}$/.test(instrument.last4)) {
+    throw new Error("Stored instrument last4 must be exactly four digits.")
+  }
+  if (instrument.expMonth != null && !(instrument.expMonth >= 1 && instrument.expMonth <= 12)) {
+    throw new Error("Stored instrument expiry month must be 1-12.")
+  }
+  if (instrument.expYear != null && !Number.isInteger(instrument.expYear)) {
+    throw new Error("Stored instrument expiry year must be an integer.")
+  }
 }
 
 function assertDisputeSignal(dispute: PaymentDisputeSignal) {
@@ -694,6 +824,7 @@ function assertStatusResult(input: PaymentStatusInput, result: PaymentStatusResu
   assertMappedValue(input.processorPaymentId, result.processorPaymentId, "processor payment id")
   assertMappedIdentity(input.processorIdentity, result.processorIdentity, "status")
   if (result.money) assertMoney(result.money)
+  if (result.storedInstrument) assertStoredInstrument(result.storedInstrument)
 }
 
 function assertMappedValue(

--- a/packages/payments/src/index.ts
+++ b/packages/payments/src/index.ts
@@ -87,6 +87,132 @@ export interface PaymentDisputeSignal {
   evidenceSubmittedAt?: string | null
 }
 
+/**
+ * What a shopper has authorized a stored instrument to be used for.
+ *
+ * These are two distinct permissions under card network rules, granted in
+ * different ways, so an adapter that collapses them into one flag cannot be
+ * compliant for either.
+ *
+ * `merchant_initiated` covers charging the instrument while the shopper is
+ * away — a scheduled balance payment, say. It is authorized by the merchant's
+ * own terms, which the shopper accepts at checkout, and needs no control beside
+ * the payment field.
+ *
+ * `shopper_reselect` covers showing the instrument back to the shopper so they
+ * can choose it on a later checkout. That is a specific purpose and needs
+ * explicit consent for it, collected wherever the payment details are entered.
+ *
+ * Neither implies the other, and an operator viewing their own customer record
+ * is neither: that is the merchant reading their own books, not a reuse.
+ */
+export const PAYMENT_INSTRUMENT_REUSES = ["merchant_initiated", "shopper_reselect"] as const
+export type PaymentInstrumentReuse = (typeof PAYMENT_INSTRUMENT_REUSES)[number]
+
+/**
+ * Whether a stored instrument can still be used, and if not, why.
+ *
+ * `requires_new_agreement` is the one that is easy to miss. When a card is
+ * reissued its brand can change, and the agreement the shopper gave no longer
+ * covers the instrument that replaced it, so merchant-initiated use has to stop
+ * until a new agreement exists. It is not expired and not revoked — the
+ * instrument works, the permission does not.
+ */
+export const PAYMENT_INSTRUMENT_STATUSES = [
+  "usable",
+  "requires_new_agreement",
+  "expired",
+  "revoked",
+] as const
+export type PaymentInstrumentStatus = (typeof PAYMENT_INSTRUMENT_STATUSES)[number]
+
+/**
+ * An instrument a provider has stored for a customer, as the adapter reports
+ * it.
+ *
+ * `token` is opaque and is the only field that can charge anything. Everything
+ * else is display data the framework shows an operator or a shopper, so a
+ * provider that cannot supply a field omits it rather than inventing one. No
+ * field here ever carries a full instrument number.
+ *
+ * The same token reported twice is the same instrument: that is what makes a
+ * replayed callback update the record it already wrote instead of creating a
+ * second one.
+ */
+export interface PaymentStoredInstrument {
+  /** Opaque provider reference. The only field that can initiate a charge. */
+  token: string
+  /**
+   * What the shopper actually authorized, which is not necessarily what the
+   * caller asked for. An empty list means the instrument was stored but may not
+   * be reused, which is a real outcome rather than a malformed one: the
+   * merchant may still show it on their own records.
+   */
+  authorizedReuses: readonly PaymentInstrumentReuse[]
+  status?: PaymentInstrumentStatus
+  /**
+   * The provider's own customer record this instrument hangs off, where the
+   * provider has one. Opaque, and only meaningful to the adapter that issued
+   * it.
+   */
+  customerReference?: string | null
+  /**
+   * Stable across re-entry of the same underlying instrument, where the
+   * provider supplies it. Lets a caller recognize that a shopper has re-added
+   * a card it already holds rather than accumulating duplicates.
+   */
+  fingerprint?: string | null
+  /** "visa", "mastercard", "bank_transfer", … Recorded verbatim, never parsed. */
+  brand?: string | null
+  /** Last four digits, for instruments that have them. */
+  last4?: string | null
+  holderName?: string | null
+  /** 1-12. */
+  expMonth?: number | null
+  expYear?: number | null
+}
+
+/** Whether a stored instrument may be put to a given use. */
+export function paymentInstrumentAllows(
+  instrument: Pick<PaymentStoredInstrument, "authorizedReuses" | "status">,
+  reuse: PaymentInstrumentReuse,
+): boolean {
+  if (instrument.status !== undefined && instrument.status !== "usable") return false
+  return instrument.authorizedReuses.includes(reuse)
+}
+
+/**
+ * What the caller authorizes for the instrument this payment uses.
+ *
+ * The asymmetry between the two fields is deliberate and reflects who knows
+ * what. Whether the shopper accepted terms permitting merchant-initiated
+ * payments is a fact the caller already holds, so it states it. Whether the
+ * shopper will consent to being shown the instrument again is not knowable
+ * until they are asked, and they have to be asked on the surface that takes the
+ * payment details — so the caller grants permission to ask, and learns the
+ * answer from `PaymentStoredInstrument.authorizedReuses`.
+ */
+export interface PaymentInstrumentStorageIntent {
+  /**
+   * Whether the shopper has accepted terms authorizing payments initiated on
+   * their behalf while they are away. False means the instrument may still be
+   * stored, but only for the merchant's own records.
+   */
+  merchantInitiated: boolean
+  /**
+   * Whether the adapter may offer to keep the instrument for the shopper to
+   * choose again later. Absent means do not offer, so an instrument is never
+   * silently made re-selectable.
+   */
+  offerShopperReselect?: boolean
+  /**
+   * The caller's record of the agreement that authorizes `merchantInitiated`,
+   * carried so the two can be reconciled later. Keeping a record of that
+   * agreement is a requirement in its own right, and this is the handle to it.
+   */
+  agreementReference?: string | null
+}
+
 export interface PaymentProcessorIdentity {
   providerId: string
   connectionId: string
@@ -111,6 +237,13 @@ export interface PaymentAdapterCapabilities {
    * the same fact as `false`.
    */
   embeddedCheckout?: boolean
+  /**
+   * Storing the shopper's instrument for later reuse. Optional for the same
+   * reason as `embeddedCheckout`: absent is the same fact as `false`, so an
+   * adapter written against an earlier revision keeps compiling and keeps its
+   * meaning.
+   */
+  storeInstrument?: boolean
   authorize: boolean
   capture: boolean
   void: boolean
@@ -220,6 +353,27 @@ export function negotiatePaymentCheckoutHandoff(
   )
 }
 
+/**
+ * The storage an adapter should actually attempt for this caller, or null when
+ * it should attempt none.
+ *
+ * Null covers three different situations that all mean the same thing to an
+ * adapter, which is why they collapse here rather than at each call site: the
+ * caller asked for nothing, the adapter cannot store instruments, or the caller
+ * asked for something that authorizes no reuse at all and grants no permission
+ * to ask for one. That last case is worth storing nothing for — an instrument
+ * kept with no authorized use is a liability rather than a feature.
+ */
+export function negotiatePaymentInstrumentStorage(
+  capabilities: PaymentAdapterCapabilities,
+  input: Pick<PaymentInitiationInput, "storeInstrument">,
+): PaymentInstrumentStorageIntent | null {
+  const intent = input.storeInstrument
+  if (!intent || !capabilities.storeInstrument) return null
+  if (!intent.merchantInitiated && !intent.offerShopperReselect) return null
+  return intent
+}
+
 export interface PaymentAdapterDiagnostics {
   status: "ok" | "degraded" | "down"
   checkedAt: string
@@ -298,6 +452,15 @@ export interface PaymentInitiationInput {
     firstName?: string | null
     lastName?: string | null
   }
+  /**
+   * Keep the instrument this payment uses, and what it may later be used for.
+   *
+   * Absent means store nothing, so a caller written against an earlier revision
+   * of this contract keeps its behavior exactly. An adapter whose capabilities
+   * do not include `storeInstrument` ignores this rather than failing: the
+   * payment is the point, and storage is an addition to it.
+   */
+  storeInstrument?: PaymentInstrumentStorageIntent
   shipping?: Record<string, unknown>
   metadata?: Record<string, unknown>
 }
@@ -308,6 +471,16 @@ export interface PaymentInitiationResult {
   processorIdentity?: PaymentProcessorIdentity
   checkout?: PaymentHostedCheckout | null
   nextState: PaymentSessionState
+  /**
+   * Present only when an instrument was genuinely stored. A caller that asked
+   * for storage and receives nothing here learns that it did not happen,
+   * without having to reconcile a request against an outcome.
+   *
+   * Rarely present on initiation, because most handoffs store the instrument at
+   * confirmation rather than at initiation. It exists here for the providers
+   * that can answer immediately.
+   */
+  storedInstrument?: PaymentStoredInstrument | null
   idempotencyKey: string
   raw?: unknown
 }
@@ -344,6 +517,13 @@ export interface PaymentStatusResult {
   processorPaymentId?: string | null
   processorIdentity?: PaymentProcessorIdentity
   money?: PaymentMoney
+  /**
+   * The instrument stored for this payment, where one was. Carried here as well
+   * as on the callback because status is the backstop for a shopper who closed
+   * the tab: a poll has to be able to learn everything the callback would have
+   * delivered, or the two paths converge on different records.
+   */
+  storedInstrument?: PaymentStoredInstrument | null
   raw?: unknown
 }
 
@@ -372,6 +552,16 @@ export interface PaymentCallbackEvent {
    * session's current state in `nextState` and puts what changed here.
    */
   dispute?: PaymentDisputeSignal
+  /**
+   * An instrument this event stores, or whose usability it changes.
+   *
+   * Like a dispute, this does not move the payment's own lifecycle: a card
+   * reissued long after the payment settled reports the session's current state
+   * in `nextState` and puts what changed here. A caller keys on
+   * `PaymentStoredInstrument.token` so the second report about an instrument
+   * updates the first rather than duplicating it.
+   */
+  storedInstrument?: PaymentStoredInstrument
   idempotencyKey: string
   raw?: unknown
 }
@@ -468,6 +658,12 @@ export const paymentAdapterRuntimePort = definePort<PaymentAdapter>({
       typeof adapter.capabilities.embeddedCheckout !== "boolean"
     ) {
       throw new Error("Payment adapter capability embeddedCheckout must be boolean when declared.")
+    }
+    if (
+      adapter.capabilities.storeInstrument !== undefined &&
+      typeof adapter.capabilities.storeInstrument !== "boolean"
+    ) {
+      throw new Error("Payment adapter capability storeInstrument must be boolean when declared.")
     }
   },
 })

--- a/packages/payments/src/instrument-storage.test.ts
+++ b/packages/payments/src/instrument-storage.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest"
+import {
+  negotiatePaymentInstrumentStorage,
+  type PaymentAdapterCapabilities,
+  type PaymentStoredInstrument,
+  paymentInstrumentAllows,
+} from "./index.js"
+
+const capabilities = (overrides: Partial<PaymentAdapterCapabilities>) =>
+  ({
+    hostedCheckout: true,
+    redirectCheckout: true,
+    authorize: false,
+    capture: false,
+    void: false,
+    refund: false,
+    status: false,
+    callbackSignatureVerification: true,
+    idempotencyKeys: true,
+    retrySafeInitiation: true,
+    ...overrides,
+  }) satisfies PaymentAdapterCapabilities
+
+const instrument = (overrides: Partial<PaymentStoredInstrument> = {}): PaymentStoredInstrument => ({
+  token: "instrument-1",
+  authorizedReuses: ["merchant_initiated"],
+  ...overrides,
+})
+
+describe("stored instrument reuse", () => {
+  it("allows only the reuses that were authorized", () => {
+    const stored = instrument()
+    expect(paymentInstrumentAllows(stored, "merchant_initiated")).toBe(true)
+    expect(paymentInstrumentAllows(stored, "shopper_reselect")).toBe(false)
+  })
+
+  it("treats an unstated status as usable", () => {
+    expect(paymentInstrumentAllows(instrument(), "merchant_initiated")).toBe(true)
+    expect(paymentInstrumentAllows(instrument({ status: "usable" }), "merchant_initiated")).toBe(
+      true,
+    )
+  })
+
+  // A reissued card keeps its authorization on paper and loses it in fact: the
+  // agreement the shopper gave covered the instrument that was replaced.
+  it("refuses every reuse once the agreement no longer covers the instrument", () => {
+    const reissued = instrument({
+      authorizedReuses: ["merchant_initiated", "shopper_reselect"],
+      status: "requires_new_agreement",
+    })
+    expect(paymentInstrumentAllows(reissued, "merchant_initiated")).toBe(false)
+    expect(paymentInstrumentAllows(reissued, "shopper_reselect")).toBe(false)
+  })
+
+  it("refuses expired and revoked instruments", () => {
+    expect(paymentInstrumentAllows(instrument({ status: "expired" }), "merchant_initiated")).toBe(
+      false,
+    )
+    expect(paymentInstrumentAllows(instrument({ status: "revoked" }), "merchant_initiated")).toBe(
+      false,
+    )
+  })
+
+  it("allows nothing when an instrument was stored with no authorized reuse", () => {
+    const recordsOnly = instrument({ authorizedReuses: [] })
+    expect(paymentInstrumentAllows(recordsOnly, "merchant_initiated")).toBe(false)
+    expect(paymentInstrumentAllows(recordsOnly, "shopper_reselect")).toBe(false)
+  })
+})
+
+describe("instrument storage negotiation", () => {
+  it("stores nothing when the caller asked for nothing", () => {
+    expect(
+      negotiatePaymentInstrumentStorage(capabilities({ storeInstrument: true }), {}),
+    ).toBeNull()
+  })
+
+  it("stores nothing when the adapter cannot store instruments", () => {
+    expect(
+      negotiatePaymentInstrumentStorage(capabilities({}), {
+        storeInstrument: { merchantInitiated: true },
+      }),
+    ).toBeNull()
+    expect(
+      negotiatePaymentInstrumentStorage(capabilities({ storeInstrument: false }), {
+        storeInstrument: { merchantInitiated: true },
+      }),
+    ).toBeNull()
+  })
+
+  // Keeping an instrument that authorizes nothing and may not be offered is a
+  // liability with no use, so it collapses to the same answer as "don't".
+  it("stores nothing when the intent authorizes no reuse and permits no ask", () => {
+    expect(
+      negotiatePaymentInstrumentStorage(capabilities({ storeInstrument: true }), {
+        storeInstrument: { merchantInitiated: false },
+      }),
+    ).toBeNull()
+    expect(
+      negotiatePaymentInstrumentStorage(capabilities({ storeInstrument: true }), {
+        storeInstrument: { merchantInitiated: false, offerShopperReselect: false },
+      }),
+    ).toBeNull()
+  })
+
+  it("carries an intent authorized by terms alone", () => {
+    const intent = { merchantInitiated: true, agreementReference: "terms-v3:accepted" }
+    expect(
+      negotiatePaymentInstrumentStorage(capabilities({ storeInstrument: true }), {
+        storeInstrument: intent,
+      }),
+    ).toEqual(intent)
+  })
+
+  // Permission to ask is enough on its own: the shopper may consent to being
+  // shown the card again even where no terms authorize charging it away.
+  it("carries an intent that only permits asking the shopper", () => {
+    const intent = { merchantInitiated: false, offerShopperReselect: true }
+    expect(
+      negotiatePaymentInstrumentStorage(capabilities({ storeInstrument: true }), {
+        storeInstrument: intent,
+      }),
+    ).toEqual(intent)
+  })
+})

--- a/packages/relationships-react/src/schemas.ts
+++ b/packages/relationships-react/src/schemas.ts
@@ -198,7 +198,6 @@ export const personPaymentMethodRecordSchema = z.object({
   holderName: z.string().nullable(),
   expMonth: z.number().int().nullable(),
   expYear: z.number().int().nullable(),
-  processorToken: z.string(),
   isDefault: z.boolean(),
   createdAt: z.string(),
 })

--- a/packages/relationships/migrations/20260812000100_person_payment_method_provenance.sql
+++ b/packages/relationships/migrations/20260812000100_person_payment_method_provenance.sql
@@ -1,0 +1,32 @@
+-- Give `person_payment_methods` a provider binding and a provenance (voyant#4587).
+--
+-- The table promised "processor-issued tokens … so the booking flow can charge
+-- the customer without re-entering card details" and delivered a free-text note
+-- an operator typed by hand. Nothing in the payment path could write to it,
+-- because there was nowhere to record which provider issued a token, what the
+-- customer had authorized it for, or whether it still worked.
+--
+-- Existing rows are all hand-entered, so they take `source = 'manual'`, an empty
+-- `authorized_reuses` and a null `provider_id`. That is the honest description
+-- of what they are: on the operator's own records, chargeable by nobody.
+DO $$ BEGIN
+ CREATE TYPE "public"."payment_method_source" AS ENUM('manual', 'payment');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "public"."payment_method_status" AS ENUM('usable', 'requires_new_agreement', 'expired', 'revoked');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+ALTER TABLE "person_payment_methods" ADD COLUMN IF NOT EXISTS "source" "payment_method_source" DEFAULT 'manual' NOT NULL;--> statement-breakpoint
+ALTER TABLE "person_payment_methods" ADD COLUMN IF NOT EXISTS "provider_id" text;--> statement-breakpoint
+ALTER TABLE "person_payment_methods" ADD COLUMN IF NOT EXISTS "provider_customer_reference" text;--> statement-breakpoint
+ALTER TABLE "person_payment_methods" ADD COLUMN IF NOT EXISTS "fingerprint" text;--> statement-breakpoint
+ALTER TABLE "person_payment_methods" ADD COLUMN IF NOT EXISTS "authorized_reuses" jsonb DEFAULT '[]'::jsonb NOT NULL;--> statement-breakpoint
+ALTER TABLE "person_payment_methods" ADD COLUMN IF NOT EXISTS "status" "payment_method_status" DEFAULT 'usable' NOT NULL;--> statement-breakpoint
+ALTER TABLE "person_payment_methods" ADD COLUMN IF NOT EXISTS "agreement_reference" text;--> statement-breakpoint
+ALTER TABLE "person_payment_methods" ADD COLUMN IF NOT EXISTS "updated_at" timestamp with time zone DEFAULT now() NOT NULL;--> statement-breakpoint
+-- Idempotent projection: one provider token is one instrument, so a replayed
+-- callback and a status poll reporting the same card converge on one row.
+-- Partial because manual "tokens" are prose and collide freely — two operators
+-- typing the same reminder must not be forced into a single row.
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_person_payment_methods_provider_token" ON "person_payment_methods" USING btree ("provider_id","processor_token") WHERE "person_payment_methods"."provider_id" is not null;

--- a/packages/relationships/migrations/meta/_journal.json
+++ b/packages/relationships/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1785801660000,
       "tag": "20260804000100_proposal_entity_labels",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1786492860000,
+      "tag": "20260812000100_person_payment_method_provenance",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/relationships/package.json
+++ b/packages/relationships/package.json
@@ -31,16 +31,17 @@
     "@voyant-travel/bookings": "workspace:^",
     "@voyant-travel/core": "workspace:^",
     "@voyant-travel/custom-fields": "workspace:^",
-    "@voyant-travel/relationships-contracts": "workspace:^",
     "@voyant-travel/db": "workspace:^",
-    "@voyant-travel/types": "workspace:^",
+    "@voyant-travel/finance": "workspace:^",
     "@voyant-travel/hono": "workspace:^",
     "@voyant-travel/identity": "workspace:^",
+    "@voyant-travel/relationships-contracts": "workspace:^",
+    "@voyant-travel/tools": "workspace:^",
+    "@voyant-travel/types": "workspace:^",
     "@voyant-travel/utils": "workspace:^",
     "drizzle-orm": "catalog:",
     "hono": "catalog:",
-    "zod": "catalog:",
-    "@voyant-travel/tools": "workspace:^"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@voyant-travel/voyant-typescript-config": "workspace:^",

--- a/packages/relationships/src/routes/accounts-openapi-schemas.ts
+++ b/packages/relationships/src/routes/accounts-openapi-schemas.ts
@@ -121,12 +121,25 @@ export const personNoteSchema = z.object({
 export const personPaymentMethodSchema = z.object({
   id: idSchema,
   personId: z.string(),
+  /** "manual" when an operator typed it, "payment" when a payment produced it. */
+  source: z.enum(["manual", "payment"]),
   brand: z.string(),
   last4: z.string().nullable(),
   holderName: z.string().nullable(),
   expMonth: z.number().int().nullable(),
   expYear: z.number().int().nullable(),
-  processorToken: z.string(),
+  /**
+   * The adapter that issued the token, null on a manual row.
+   *
+   * `processorToken` itself is deliberately absent. It is the one field that
+   * can charge the customer, every authenticated admin client would receive
+   * it, and no screen needs it to render a saved card. A caller that means to
+   * charge names the method by id and lets the server resolve the token.
+   */
+  providerId: z.string().nullable(),
+  /** `PaymentInstrumentReuse` values the customer authorized. */
+  authorizedReuses: z.array(z.string()),
+  status: z.enum(["usable", "requires_new_agreement", "expired", "revoked"]),
   isDefault: z.boolean(),
   createdAt: isoTimestamp,
 })

--- a/packages/relationships/src/runtime-contributor.ts
+++ b/packages/relationships/src/runtime-contributor.ts
@@ -13,6 +13,10 @@ import {
 } from "@voyant-travel/core/custom-fields"
 import type { VoyantPort } from "@voyant-travel/core/project"
 import {
+  type FinanceStoredInstrumentRuntime,
+  financeStoredInstrumentRuntimePort,
+} from "@voyant-travel/finance/runtime-port"
+import {
   type CustomFieldValueOperationsRuntime,
   customFieldValueOperationsRuntimePort,
 } from "@voyant-travel/core/runtime-port"
@@ -206,5 +210,17 @@ export function createRelationshipsRuntimePortContribution(
       getPersonById: (...args) => relationshipsService.getPersonById(...args),
       getOrganizationById: (...args) => relationshipsService.getOrganizationById(...args),
     } satisfies BookingsRelationshipsRuntime,
+    /**
+     * Where an instrument a payment provider stored becomes a row on the
+     * person who paid. Finance owns the payment and knows the instrument; it
+     * does not know what a person is, so this is the seam it hands the fact
+     * across.
+     */
+    [financeStoredInstrumentRuntimePort.id]: {
+      async recordStoredInstrument(db, instrument) {
+        const { personId, ...rest } = instrument
+        await relationshipsService.recordProjectedPersonPaymentMethod(db, personId, rest)
+      },
+    } satisfies FinanceStoredInstrumentRuntime,
   }
 }

--- a/packages/relationships/src/runtime-contributor.ts
+++ b/packages/relationships/src/runtime-contributor.ts
@@ -13,13 +13,13 @@ import {
 } from "@voyant-travel/core/custom-fields"
 import type { VoyantPort } from "@voyant-travel/core/project"
 import {
-  type FinanceStoredInstrumentRuntime,
-  financeStoredInstrumentRuntimePort,
-} from "@voyant-travel/finance/runtime-port"
-import {
   type CustomFieldValueOperationsRuntime,
   customFieldValueOperationsRuntimePort,
 } from "@voyant-travel/core/runtime-port"
+import {
+  type FinanceStoredInstrumentRuntime,
+  financeStoredInstrumentRuntimePort,
+} from "@voyant-travel/finance/runtime-port"
 import { sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { RelationshipsRouteRuntimeOptions } from "./route-runtime.js"

--- a/packages/relationships/src/schema-accounts.ts
+++ b/packages/relationships/src/schema-accounts.ts
@@ -307,11 +307,45 @@ export type PersonRelationship = typeof personRelationships.$inferSelect
 export type NewPersonRelationship = typeof personRelationships.$inferInsert
 
 /**
- * Saved payment methods on file for a person. Stores processor-issued
- * tokens (never raw card numbers) so the booking flow can charge the
- * customer without re-entering card details. Cards have last4 + expiry +
- * brand; bank-transfer "methods" carry a brand of "bank_transfer" with
- * last4 / expiry omitted.
+ * Where a saved payment method came from.
+ *
+ * `manual` is an operator typing what they know: a reference from a terminal
+ * receipt, a card the customer read out over the phone. Nothing but a human
+ * vouches for it, and its `processor_token` is a note rather than a credential.
+ *
+ * `payment` is projected from a payment a provider actually took and stored, so
+ * its token can charge and its display fields came from the network. The two
+ * must stay distinguishable: a projected row that an operator can retype is a
+ * row that can be made to point at somebody else's card.
+ */
+export const paymentMethodSourceEnum = pgEnum("payment_method_source", ["manual", "payment"])
+
+/**
+ * Whether a saved method can still be used, mirroring `PaymentInstrumentStatus`
+ * on the payment port.
+ *
+ * `requires_new_agreement` is the one worth knowing about: when a card is
+ * reissued its brand can change, and the agreement the customer gave no longer
+ * covers what replaced it, so it cannot be charged while they are away until a
+ * new one exists. The instrument works; the permission does not.
+ */
+export const paymentMethodStatusEnum = pgEnum("payment_method_status", [
+  "usable",
+  "requires_new_agreement",
+  "expired",
+  "revoked",
+])
+
+/**
+ * Saved payment methods on file for a person.
+ *
+ * Two kinds of row live here, told apart by `source`. A projected row carries
+ * the provider that issued its token, what the customer authorized it to be
+ * used for, and whether it is still usable; a manual row carries none of that
+ * and can only ever be a reminder to a human.
+ *
+ * Cards have last4 + expiry + brand; bank-transfer "methods" carry a brand of
+ * "bank_transfer" with last4 / expiry omitted.
  */
 export const personPaymentMethods = pgTable(
   "person_payment_methods",
@@ -320,6 +354,7 @@ export const personPaymentMethods = pgTable(
     personId: typeIdRef("person_id")
       .notNull()
       .references(() => people.id, { onDelete: "cascade" }),
+    source: paymentMethodSourceEnum("source").notNull().default("manual"),
     /** "visa" | "mastercard" | "amex" | "revolut" | "bank_transfer" — kept as text to stay open. */
     brand: text("brand").notNull(),
     /** Last four digits — null for non-card methods. */
@@ -330,12 +365,58 @@ export const personPaymentMethods = pgTable(
     expYear: integer("exp_year"),
     /** Opaque processor token — used to charge the customer. */
     processorToken: text("processor_token").notNull(),
+    /**
+     * The payment adapter that issued `processor_token`. Null on a manual row.
+     *
+     * Load-bearing rather than informational: a token is only meaningful to the
+     * provider that minted it, so charging one against a different adapter is
+     * either an error or somebody else's card.
+     */
+    providerId: text("provider_id"),
+    /** The provider's own customer record this method hangs off, where it has one. */
+    providerCustomerReference: text("provider_customer_reference"),
+    /**
+     * Stable across re-entry of the same underlying instrument. Lets a repeat
+     * payment recognize a card already on file instead of adding a duplicate.
+     */
+    fingerprint: text("fingerprint"),
+    /**
+     * What the customer authorized, as `PaymentInstrumentReuse` values.
+     *
+     * Empty is meaningful and is the safe default: the method is on the
+     * operator's own records and may not be charged or offered back. An
+     * operator reading their own books is neither of those uses.
+     */
+    authorizedReuses: jsonb("authorized_reuses")
+      .$type<string[]>()
+      .notNull()
+      .default(sql`'[]'::jsonb`),
+    status: paymentMethodStatusEnum("status").notNull().default("usable"),
+    /**
+     * The record of the agreement that authorized charging this method while
+     * the customer is away. Keeping that record is a requirement in its own
+     * right, so this is the handle back to it.
+     */
+    agreementReference: text("agreement_reference"),
     isDefault: boolean("is_default").notNull().default(false),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
     index("idx_person_payment_methods_person").on(table.personId),
     index("idx_person_payment_methods_person_default").on(table.personId, table.isDefault),
+    /**
+     * What makes projection idempotent. A provider token identifies one
+     * instrument, so a replayed callback and a status poll that both report it
+     * converge on the same row instead of racing to add two.
+     *
+     * Partial because manual rows have no provider and their free-text
+     * "tokens" collide freely — two operators typing "visa ending 4242" must
+     * not be forced into one row.
+     */
+    uniqueIndex("uq_person_payment_methods_provider_token")
+      .on(table.providerId, table.processorToken)
+      .where(sql`${table.providerId} is not null`),
   ],
 )
 

--- a/packages/relationships/src/service/accounts-merge.ts
+++ b/packages/relationships/src/service/accounts-merge.ts
@@ -425,9 +425,38 @@ export const accountMergeService = {
         .update(personDocuments)
         .set({ personId: keepId, updatedAt: new Date() })
         .where(eq(personDocuments.personId, mergeId))
+      // Payment methods follow the surviving person, but a projected one also
+      // carries a binding to a customer record at the provider, and merging two
+      // people here does not merge those. The surviving person therefore ends
+      // up with methods hanging off two provider customers.
+      //
+      // That is survivable for charging, because a token is charged through the
+      // adapter that issued it and each still resolves. It is not survivable for
+      // reuse the customer authorized: the losing person's agreement was given
+      // by a record that no longer exists, so those methods stop being
+      // chargeable while the customer is away until a fresh agreement is taken.
+      //
+      // Retiring the authorization rather than the row keeps the method visible
+      // to the operator, which is what makes the state explainable instead of a
+      // card silently vanishing mid-merge.
       await tx
         .update(personPaymentMethods)
-        .set({ personId: keepId })
+        .set({
+          personId: keepId,
+          authorizedReuses: [],
+          status: "requires_new_agreement",
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(personPaymentMethods.personId, mergeId),
+            eq(personPaymentMethods.source, "payment"),
+          ),
+        )
+      // Manual rows carry no provider binding and no authorization to lose.
+      await tx
+        .update(personPaymentMethods)
+        .set({ personId: keepId, updatedAt: new Date() })
         .where(eq(personPaymentMethods.personId, mergeId))
       await tx
         .update(communicationLog)

--- a/packages/relationships/src/service/accounts-people.ts
+++ b/packages/relationships/src/service/accounts-people.ts
@@ -494,9 +494,32 @@ export const peopleAccountsService = {
 
   // ── Payment methods ────────────────────────────────────────────────────
 
+  /**
+   * Projected rather than selected whole, so `processor_token` never leaves the
+   * server.
+   *
+   * It is the one column that can charge the customer, and every authenticated
+   * admin client would receive it on a screen that only needs a brand and four
+   * digits to render. A caller that means to charge names the method by id and
+   * lets the server resolve the token.
+   */
   listPersonPaymentMethods(db: PostgresJsDatabase, personId: string) {
     return db
-      .select()
+      .select({
+        id: personPaymentMethods.id,
+        personId: personPaymentMethods.personId,
+        source: personPaymentMethods.source,
+        brand: personPaymentMethods.brand,
+        last4: personPaymentMethods.last4,
+        holderName: personPaymentMethods.holderName,
+        expMonth: personPaymentMethods.expMonth,
+        expYear: personPaymentMethods.expYear,
+        providerId: personPaymentMethods.providerId,
+        authorizedReuses: personPaymentMethods.authorizedReuses,
+        status: personPaymentMethods.status,
+        isDefault: personPaymentMethods.isDefault,
+        createdAt: personPaymentMethods.createdAt,
+      })
       .from(personPaymentMethods)
       .where(eq(personPaymentMethods.personId, personId))
       .orderBy(desc(personPaymentMethods.isDefault), desc(personPaymentMethods.createdAt))

--- a/packages/relationships/src/service/accounts-people.ts
+++ b/packages/relationships/src/service/accounts-people.ts
@@ -48,6 +48,29 @@ import { paginate } from "./helpers.js"
 
 const cardPaymentMethodBrands = new Set(["visa", "mastercard", "amex", "revolut"])
 
+/**
+ * An instrument a payment provider stored, as the payment path reports it.
+ *
+ * Mirrors `PaymentStoredInstrument` on the payment port without importing it:
+ * the CRM must not take a dependency on the payments package to record what a
+ * payment produced, and the two are versioned separately.
+ */
+export interface ProjectedPaymentMethodInput {
+  /** The adapter that issued `token`. Without it the token can charge nothing. */
+  providerId: string
+  token: string
+  authorizedReuses: readonly string[]
+  status?: "usable" | "requires_new_agreement" | "expired" | "revoked"
+  providerCustomerReference?: string | null
+  fingerprint?: string | null
+  brand?: string | null
+  last4?: string | null
+  holderName?: string | null
+  expMonth?: number | null
+  expYear?: number | null
+  agreementReference?: string | null
+}
+
 function assertValidPaymentMethodFields(data: {
   brand: string
   last4?: string | null
@@ -536,6 +559,74 @@ export const peopleAccountsService = {
       .update(personPaymentMethods)
       .set(data)
       .where(eq(personPaymentMethods.id, id))
+      .returning()
+    return row ?? null
+  },
+
+  /**
+   * Record an instrument a payment provider actually stored.
+   *
+   * Written from the payment path rather than by a person, so it validates
+   * nothing an operator would be asked to fix and rejects nothing: a provider
+   * that reports an instrument the CRM finds odd still stored it, and refusing
+   * to write the row would leave the operator with a card they cannot see and
+   * we cannot explain.
+   *
+   * Idempotent on (provider, token). A payment reports its instrument on the
+   * callback and again on the reconciliation poll, and a reissued card reports
+   * a changed status long after settlement — all three converge on one row.
+   * `person_id` is deliberately not part of the update: a token belongs to one
+   * customer at the provider, so a report tying it to a different person is a
+   * fault upstream, and silently reassigning the row would hide it behind a
+   * card appearing on the wrong customer.
+   */
+  async recordProjectedPersonPaymentMethod(
+    db: PostgresJsDatabase,
+    personId: string,
+    instrument: ProjectedPaymentMethodInput,
+  ) {
+    const [existing] = await db
+      .select({ id: people.id })
+      .from(people)
+      .where(eq(people.id, personId))
+      .limit(1)
+    if (!existing) return null
+
+    const values = {
+      personId,
+      source: "payment" as const,
+      brand: instrument.brand ?? "unknown",
+      last4: instrument.last4 ?? null,
+      holderName: instrument.holderName ?? null,
+      expMonth: instrument.expMonth ?? null,
+      expYear: instrument.expYear ?? null,
+      processorToken: instrument.token,
+      providerId: instrument.providerId,
+      providerCustomerReference: instrument.providerCustomerReference ?? null,
+      fingerprint: instrument.fingerprint ?? null,
+      authorizedReuses: [...instrument.authorizedReuses],
+      status: instrument.status ?? ("usable" as const),
+      agreementReference: instrument.agreementReference ?? null,
+    }
+    const [row] = await db
+      .insert(personPaymentMethods)
+      .values(values)
+      .onConflictDoUpdate({
+        target: [personPaymentMethods.providerId, personPaymentMethods.processorToken],
+        set: {
+          brand: values.brand,
+          last4: values.last4,
+          holderName: values.holderName,
+          expMonth: values.expMonth,
+          expYear: values.expYear,
+          providerCustomerReference: values.providerCustomerReference,
+          fingerprint: values.fingerprint,
+          authorizedReuses: values.authorizedReuses,
+          status: values.status,
+          agreementReference: values.agreementReference,
+          updatedAt: new Date(),
+        },
+      })
       .returning()
     return row ?? null
   },

--- a/packages/relationships/src/voyant.ts
+++ b/packages/relationships/src/voyant.ts
@@ -7,6 +7,7 @@ import {
   customFieldValueOperationsRuntimePort,
   customFieldValueReaderRuntimePort,
 } from "@voyant-travel/core/runtime-port"
+import { financeStoredInstrumentRuntimePort } from "@voyant-travel/finance/runtime-port"
 import { relationshipsMiceRuntimePort, relationshipsRouteRuntimePort } from "./runtime-port.js"
 
 export {
@@ -81,6 +82,7 @@ export const relationshipsVoyantModule = defineModule({
       storefrontIntakeRuntimePortReference,
       providePort(relationshipsMiceRuntimePort),
       providePort(bookingsRelationshipsRuntimePort),
+      providePort(financeStoredInstrumentRuntimePort),
       providePort(relationshipsRouteRuntimePort),
       providePort(customFieldValueReaderRuntimePort),
       providePort(customFieldValueLifecycleRuntimePort),

--- a/packages/relationships/tests/unit/accounts-contract.test.ts
+++ b/packages/relationships/tests/unit/accounts-contract.test.ts
@@ -116,15 +116,30 @@ const personNoteRow: InferSelectModel<typeof personNotes> = {
   createdAt,
 }
 
-const personPaymentMethodRow: InferSelectModel<typeof personPaymentMethods> = {
+/**
+ * The projection the route serves, not the row. `processor_token` is
+ * deliberately absent: it is the one column that can charge the customer and it
+ * never leaves the server.
+ */
+const personPaymentMethodRow: Omit<
+  InferSelectModel<typeof personPaymentMethods>,
+  | "processorToken"
+  | "providerCustomerReference"
+  | "fingerprint"
+  | "agreementReference"
+  | "updatedAt"
+> = {
   id: "person_payment_methods_000000000000",
   personId: "people_000000000000000000000000",
+  source: "payment",
   brand: "visa",
   last4: "4242",
   holderName: null,
   expMonth: 12,
   expYear: 2030,
-  processorToken: "tok_123",
+  providerId: "voyant-pay",
+  authorizedReuses: ["merchant_initiated"],
+  status: "usable",
   isDefault: true,
   createdAt,
 }

--- a/packages/relationships/tests/unit/voyant-manifest.test.ts
+++ b/packages/relationships/tests/unit/voyant-manifest.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@voyant-travel/core/custom-fields"
 import { assertPortConforms } from "@voyant-travel/core/project"
 import { customFieldValueOperationsRuntimePort } from "@voyant-travel/core/runtime-port"
+import { financeStoredInstrumentRuntimePort } from "@voyant-travel/finance/runtime-port"
 import { describe, expect, it, vi } from "vitest"
 import { createRelationshipsVoyantRuntime, relationshipsRouteRuntimePort } from "../../src/index.js"
 import { RELATIONSHIPS_ROUTE_RUNTIME_CONTAINER_KEY } from "../../src/route-runtime.js"
@@ -25,6 +26,7 @@ describe("relationships deployment manifest", () => {
           { id: "storefront.intake.runtime" },
           { id: relationshipsMiceRuntimePort.id },
           { id: bookingsRelationshipsRuntimePort.id },
+          { id: financeStoredInstrumentRuntimePort.id },
           { id: relationshipsRouteRuntimePort.id },
           { id: customFieldValueReaderRuntimePort.id },
           { id: customFieldValueLifecycleRuntimePort.id },

--- a/packages/storefront/src/routes-public.ts
+++ b/packages/storefront/src/routes-public.ts
@@ -46,7 +46,8 @@ import {
   storefrontPromotionalOfferListQuerySchema,
   storefrontPromotionalOfferListResponseSchema,
   storefrontPromotionalOfferResponseSchema,
-  storefrontSettingsSchema,
+  storefrontPublicSettingsSchema,
+  toPublicStorefrontSettings,
 } from "./validation.js"
 import { storefrontTransportEligibilityInputSchema } from "./validation-transport-eligibility.js"
 
@@ -109,7 +110,11 @@ const settingsRoute = createRoute({
   responses: {
     200: {
       description: "The deployment's public storefront settings",
-      content: { "application/json": { schema: z.object({ data: storefrontSettingsSchema }) } },
+      content: {
+        "application/json": {
+          schema: z.object({ data: storefrontPublicSettingsSchema }),
+        },
+      },
     },
   },
 })
@@ -565,7 +570,14 @@ export function createStorefrontPublicRoutes(options?: StorefrontPublicRoutesOpt
       )
     })
     .openapi(settingsRoute, async (c) => {
-      return c.json({ data: await storefrontService.resolveSettings(getRequestContext(c)) }, 200)
+      return c.json(
+        {
+          data: toPublicStorefrontSettings(
+            await storefrontService.resolveSettings(getRequestContext(c)),
+          ),
+        },
+        200,
+      )
     })
     .openapi(departureByIdRoute, async (c) => {
       const context = getRequestContext(c)

--- a/packages/storefront/src/service.ts
+++ b/packages/storefront/src/service.ts
@@ -322,6 +322,10 @@ export function resolveStorefrontSettings(input?: StorefrontSettingsInput): Stor
       privacyUrl: parsed.legal?.privacyUrl ?? null,
       cancellationUrl: parsed.legal?.cancellationUrl ?? null,
       defaultContractTemplateId: parsed.legal?.defaultContractTemplateId ?? null,
+      // Fail closed. An operator who has not stated that their terms carry the
+      // mandate has not granted one, and they are the merchant of record who
+      // would carry the liability for assuming otherwise.
+      storedInstrumentMandate: parsed.legal?.storedInstrumentMandate ?? null,
     },
     localization: {
       defaultLocale: parsed.localization?.defaultLocale ?? null,

--- a/packages/storefront/src/validation-settings.ts
+++ b/packages/storefront/src/validation-settings.ts
@@ -148,6 +148,19 @@ export const storefrontPaymentScheduleSchema = z.object({
 
 export const storefrontCurrencyDisplaySchema = z.enum(["code", "symbol", "name"])
 
+export const storefrontStoredInstrumentMandateInputSchema = z.object({
+  /** The operator's terms authorize charging a stored instrument off-session. */
+  enabled: z.boolean(),
+  /** Bumped when the mandate wording changes. Recorded on every acceptance. */
+  revision: z.string().trim().min(1).max(64),
+})
+
+export const storefrontStoredInstrumentMandateSchema = storefrontStoredInstrumentMandateInputSchema
+
+export type StorefrontStoredInstrumentMandate = z.infer<
+  typeof storefrontStoredInstrumentMandateSchema
+>
+
 export const storefrontSettingsInputSchema = z.object({
   support: z
     .object({
@@ -162,6 +175,28 @@ export const storefrontSettingsInputSchema = z.object({
       privacyUrl: httpUrlSchema.optional().nullable(),
       cancellationUrl: httpUrlSchema.optional().nullable(),
       defaultContractTemplateId: z.string().trim().min(1).optional().nullable(),
+      /**
+       * The operator's authority to keep a shopper's payment instrument and charge it
+       * later while they are away.
+       *
+       * That authority comes from the operator's own booking terms, which the shopper
+       * accepts at checkout, not from a checkbox beside the card field. Card network
+       * rules ask the terms to state that payments may be initiated on the shopper's
+       * behalf, their anticipated timing and frequency, how the amount is determined,
+       * and the cancellation policy — and to keep a record of each acceptance.
+       *
+       * `revision` is what makes that record meaningful. Without it an acceptance
+       * says only that some version of some terms was agreed to at some point, which
+       * is not evidence of anything. Bump it whenever the mandate wording changes;
+       * acceptances of the old revision stay valid for instruments already stored
+       * under it.
+       *
+       * Absent means the operator has no such authority and nothing is stored. Fail
+       * closed is the only safe default: the operator is the merchant of record and
+       * carries the liability, so silently assuming an authority they never granted
+       * would put that liability on somebody who never chose it.
+       */
+      storedInstrumentMandate: storefrontStoredInstrumentMandateInputSchema.optional().nullable(),
     })
     .optional(),
   localization: z
@@ -207,6 +242,8 @@ export const storefrontSettingsSchema = z.object({
     privacyUrl: urlOrNullSchema,
     cancellationUrl: urlOrNullSchema,
     defaultContractTemplateId: z.string().trim().min(1).nullable(),
+    /** Null means the operator has no authority to store instruments. */
+    storedInstrumentMandate: storefrontStoredInstrumentMandateSchema.nullable(),
   }),
   localization: z.object({
     defaultLocale: languageTagSchema.nullable(),
@@ -229,6 +266,27 @@ export const storefrontSettingsSchema = z.object({
     bankTransfer: storefrontBankTransferSchema.nullable(),
   }),
 })
+
+/**
+ * The shopper-facing projection.
+ *
+ * The mandate is operator configuration, not something a storefront renders:
+ * what the shopper reads is the booking terms themselves, through the contract
+ * template. Publishing which revision authorizes stored cards tells a visitor
+ * nothing they can act on and puts operator settings on an anonymous endpoint.
+ */
+export const storefrontPublicSettingsSchema = storefrontSettingsSchema.extend({
+  legal: storefrontSettingsSchema.shape.legal.omit({
+    storedInstrumentMandate: true,
+  }),
+})
+
+export function toPublicStorefrontSettings<T extends { legal: Record<string, unknown> }>(
+  settings: T,
+): T {
+  const { storedInstrumentMandate: _internal, ...legal } = settings.legal
+  return { ...settings, legal }
+}
 
 export const storefrontSettingsPatchSchema = z.object({
   support: storefrontSettingsInputSchema.shape.support,

--- a/packages/storefront/src/validation.ts
+++ b/packages/storefront/src/validation.ts
@@ -43,9 +43,13 @@ export {
   storefrontPaymentScheduleInputSchema,
   storefrontPaymentScheduleSchema,
   storefrontPaymentStructureSchema,
+  storefrontPublicSettingsSchema,
   storefrontSettingsInputSchema,
   storefrontSettingsPatchSchema,
   storefrontSettingsSchema,
+  storefrontStoredInstrumentMandateInputSchema,
+  storefrontStoredInstrumentMandateSchema,
   storefrontSupportLinkInputSchema,
   storefrontSupportLinkSchema,
+  toPublicStorefrontSettings,
 } from "./validation-settings.js"

--- a/packages/storefront/tests/unit/admin-routes.test.ts
+++ b/packages/storefront/tests/unit/admin-routes.test.ts
@@ -25,6 +25,7 @@ describe("createStorefrontAdminRoutes", () => {
           privacyUrl: "https://example.com/privacy",
           cancellationUrl: "https://example.com/cancellation",
           defaultContractTemplateId: "tmpl_terms",
+          storedInstrumentMandate: null,
         },
         localization: {
           defaultLocale: "en-US",
@@ -77,6 +78,7 @@ describe("createStorefrontAdminRoutes", () => {
           privacyUrl: "https://example.com/privacy",
           cancellationUrl: "https://example.com/cancellation",
           defaultContractTemplateId: "tmpl_terms",
+          storedInstrumentMandate: null,
         },
         localization: {
           defaultLocale: "en-US",

--- a/packages/storefront/tests/unit/openapi-contract.test.ts
+++ b/packages/storefront/tests/unit/openapi-contract.test.ts
@@ -264,6 +264,7 @@ describe("storefront catalog read response contracts", () => {
         privacyUrl: null,
         cancellationUrl: null,
         defaultContractTemplateId: null,
+        storedInstrumentMandate: null,
       },
       localization: { defaultLocale: "en", currencyDisplay: "symbol" },
       forms: { billing: { fields: [] }, travelers: { fields: [] } },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,7 +249,7 @@ importers:
         version: 1.6.0(@date-fns/tz@1.4.1)(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@better-auth/api-key':
         specifier: 1.6.23
-        version: 1.6.23(4cc07405e1e664eaf96048bc4329d318)
+        version: 1.6.23(1ac6a98f3eafa8cc5361cfcd8d9e497a)
       '@fontsource-variable/inter-tight':
         specifier: ^5.2.7
         version: 5.2.7
@@ -5012,6 +5012,9 @@ importers:
       '@voyant-travel/db':
         specifier: workspace:^
         version: link:../db
+      '@voyant-travel/finance':
+        specifier: workspace:^
+        version: link:../finance
       '@voyant-travel/hono':
         specifier: workspace:^
         version: link:../hono
@@ -13390,14 +13393,6 @@ snapshots:
   '@better-auth/api-key@1.6.23(1ac6a98f3eafa8cc5361cfcd8d9e497a)':
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0)
-      '@better-auth/utils': 0.4.2
-      better-auth: 1.6.23(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.3)(rollup@4.60.2)(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9))(mongodb@7.1.0(socks@2.8.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.11)(vitest@4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)))(vue@3.5.39(typescript@6.0.3))
-      better-call: 1.3.7(zod@4.4.3)
-      zod: 4.4.3
-
-  '@better-auth/api-key@1.6.23(4cc07405e1e664eaf96048bc4329d318)':
-    dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
       better-auth: 1.6.23(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.3)(rollup@4.60.2)(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9))(mongodb@7.1.0(socks@2.8.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.11)(vitest@4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)))(vue@3.5.39(typescript@6.0.3))
       better-call: 1.3.7(zod@4.4.3)


### PR DESCRIPTION
Closes part of #4587.

A storefront customer who has paid by card sees **Payment methods (0)**,
permanently. `person_payment_methods` documented itself as holding
processor-issued tokens the booking flow could charge, and held free text an
operator typed by hand: its only writers were the admin dialog and person
merge, and its `processor_token` is labelled "Payment reference" in the UI
because that is what it actually was.

Two commits, reviewable separately.

## 1. The payment port can express a stored instrument

`PaymentAdapterCapabilities.storeInstrument`, a `storeInstrument` intent on
`PaymentInitiationInput`, and a `PaymentStoredInstrument` summary on the
initiation result, the status result and the callback event. All optional, so
every existing adapter and caller keeps its exact behavior.

Storage separates the two permissions card network rules treat differently:

| Intent | Basis | Who knows |
| --- | --- | --- |
| `merchant_initiated` | the merchant's terms, which the shopper accepted | the caller, as a fact it states |
| `shopper_reselect` | explicit consent for that purpose | nobody until asked, so the caller grants permission to ask |

That asymmetry is why the intent has two fields rather than one flag. A
provider collecting a save prompt does it where the payment details are
entered; the caller learns what happened from `authorizedReuses` coming back.
`PaymentInstrumentStatus` covers the case a reissued card outlives the
agreement that authorized it.

Conformance grows two cases. **Every** adapter must now store nothing when the
caller asked for no storage, declared capability or not, because an adapter
that keeps instruments nobody asked it to keep is the worse failure. A
storage-capable adapter must additionally never report a reuse it was not
granted. Both are proven non-vacuous by broken-adapter fixtures.

## 2. Projection into the CRM

`person_payment_methods` gains a `source` (`manual` | `payment`), the provider
that issued the token, the provider's customer reference, a fingerprint, the
authorized reuses, a status and an agreement reference. The partial unique
index on `(provider_id, processor_token)` is what makes projection idempotent
across a callback and a reconciliation poll reporting the same card; partial
because manual "tokens" are prose and collide freely.

Finance and relationships do not depend on each other. Finance defines
`finance.stored-instrument.runtime` and relationships provides it, following
the same shape relationships already uses for `bookings.relationships.runtime`.
Unwired, payments behave exactly as before and instruments go unrecorded.

Recording never fails a payment: the money moved and the session is already
correct, so losing an instrument is a degraded outcome, not a reason to reject
a callback the provider will retry forever.

Existing rows become `source = 'manual'` with no authorized reuse, which is an
honest description of what they are.

## Verification

`@voyant-travel/payments`: typecheck, lint, 75 tests green.
`@voyant-travel/relationships`: lint, 184 tests green (9 DB-integration files
skipped without Postgres). The manifest test caught the new provided port and
was updated.

`@voyant-travel/finance` typecheck did not finish locally within a sensible
window and is left to CI, along with the DB-integration suites.

## Not in this PR

Mandate terms and the recorded acceptance at the Booking Session, the
authenticated-shopper read gate, charging a stored method (and removing the
`acct:` placeholder in `flight-payment-step.tsx`), and the person-merge rule
when two merged people map to two provider customers. Each is tracked in
#4587 and lands separately.
