### PR TITLE
fix(bookings): unblock booking create for person-priced options

### DIFF
--- a/.changeset/booking-create-person-priced-options.md
+++ b/.changeset/booking-create-person-priced-options.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/bookings-react": patch
+---
+
+Stop labelling person-priced booking options as sold out. The manual booking create form showed "room is full" on an option whose per-unit capacity is uncapped but whose departure has finite capacity, so operators never touched the stepper and Create booking stayed disabled behind an unclearable "Select at least one option.". The label now states that the row draws on the departure's capacity, the Options section is marked required and carries the validation message and focus on a failed submit, blocking messages clear as soon as submit is possible again, and unit quantities are reset on the selected departure/option rather than on every refetch of the slots query.

--- a/packages/bookings-react/src/components/manual-booking-create-form.tsx
+++ b/packages/bookings-react/src/components/manual-booking-create-form.tsx
@@ -515,6 +515,61 @@ export function validateManualBookingDraft(input: {
   return null
 }
 
+/**
+ * A validation message plus enough context to keep it honest.
+ *
+ * Before #4588 this was a bare string cleared only at the top of
+ * `handleSubmit`. Every condition that raises a `blocksSubmit` message also
+ * disables **Create booking**, so the operator could not resubmit to clear it
+ * — and a disabled submit button means Enter does not fire implicit form
+ * submission either. The banner outlived its cause until a page reload.
+ */
+export interface ManualBookingFormError {
+  message: string
+  /**
+   * The control the message refers to, when there is one. `units` renders the
+   * message against the Options section and sends focus there on failure —
+   * "option" is overloaded in this form and operators read the unanchored
+   * sentence as the Document generation checkboxes.
+   */
+  field?: "units"
+  /**
+   * Set when the raising condition also disables **Create booking**. Those
+   * messages are cleared as soon as submit becomes possible again, because
+   * nothing else can clear them.
+   */
+  blocksSubmit?: boolean
+}
+
+/**
+ * Wraps a draft validation message with the context above. The units check is
+ * the only draft validation that also disables **Create booking**, so it is
+ * the only one that gets an anchor and an automatic clear.
+ */
+export function toManualBookingFormError(
+  message: string,
+  unitsMessage: string,
+): ManualBookingFormError {
+  const isUnitsError = message === unitsMessage
+  return {
+    message,
+    field: isUnitsError ? "units" : undefined,
+    blocksSubmit: isUnitsError || undefined,
+  }
+}
+
+/**
+ * Drops a message raised by a submit-gating condition once submit is possible
+ * again. Messages the operator can act on and resubmit are left alone.
+ */
+export function clearUnblockedManualBookingError(
+  previous: ManualBookingFormError | null,
+  submitBlocked: boolean,
+): ManualBookingFormError | null {
+  if (submitBlocked) return previous
+  return previous?.blocksSubmit ? null : previous
+}
+
 export function ManualBookingCreateForm({
   defaultProductId,
   defaultSlotId,
@@ -579,7 +634,7 @@ export function ManualBookingCreateForm({
   })
   const [contactTouched, setContactTouched] = React.useState(false)
   const [notes, setNotes] = React.useState("")
-  const [error, setError] = React.useState<string | null>(null)
+  const [error, setError] = React.useState<ManualBookingFormError | null>(null)
   /**
    * The requirements the Booking Session said this selection does not satisfy.
    *
@@ -592,6 +647,7 @@ export function ManualBookingCreateForm({
    */
   const [unsatisfied, setUnsatisfied] = React.useState<UnsatisfiedRequirementV1[]>([])
   const errorRef = React.useRef<HTMLParagraphElement>(null)
+  const unitsSectionRef = React.useRef<HTMLDivElement>(null)
   const [submitting, setSubmitting] = React.useState(false)
   const [payloadMismatchUnitIds, setPayloadMismatchUnitIds] = React.useState<string[]>([])
   const attemptRef = React.useRef<ManualBookingAttempt | null>(null)
@@ -600,8 +656,11 @@ export function ManualBookingCreateForm({
 
   React.useEffect(() => {
     if (!error) return
-    errorRef.current?.focus()
-    errorRef.current?.scrollIntoView({ block: "nearest" })
+    // Anchored messages take the operator to the control that blocked the
+    // submit; everything else falls back to the banner.
+    const target = error.field === "units" ? unitsSectionRef.current : errorRef.current
+    target?.focus()
+    target?.scrollIntoView({ block: "nearest" })
   }, [error])
 
   const defaultSlotQuery = useQuery({
@@ -772,21 +831,32 @@ export function ManualBookingCreateForm({
     setPayloadMismatchUnitIds([])
   }, [product.productId, defaultSlotId])
 
+  // Unit quantities belong to a (departure, option) pair, so they are dropped
+  // when the operator changes either. Keyed on the ids and NOT on the slots
+  // array identity: `allOpenSlots` and `defaultSlot` get a new identity on
+  // every refetch — including one triggered by an unrelated booking mutating
+  // a slot row the query returns — which used to wipe a filled-in stepper
+  // under the operator mid-form (#4588).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: the ids are the reset key, not values the effect reads.
   React.useEffect(() => {
     setRooms(emptyOptionUnitsStepperValue)
     setRoomUnits([])
     setPayloadMismatchUnitIds([])
+  }, [slotId, product.optionId])
+
+  // Reconcile a departure that is bound to a different option than the one
+  // selected. Setting either id re-runs the reset above.
+  React.useEffect(() => {
     if (!slotId || !product.optionId) return
     const departure =
       allOpenSlots.find((slot) => slot.id === slotId) ??
       (defaultSlot?.id === slotId ? defaultSlot : null)
-    if (departure?.optionId && departure.optionId !== product.optionId) {
-      if (defaultSlotId && departure.id === defaultSlotId) {
-        setProduct((prev) => ({ ...prev, optionId: departure.optionId }))
-        return
-      }
-      setSlotId(null)
+    if (!departure?.optionId || departure.optionId === product.optionId) return
+    if (defaultSlotId && departure.id === defaultSlotId) {
+      setProduct((prev) => ({ ...prev, optionId: departure.optionId }))
+      return
     }
+    setSlotId(null)
   }, [allOpenSlots, product.optionId, slotId, defaultSlotId, defaultSlot])
 
   React.useEffect(() => {
@@ -1360,6 +1430,28 @@ export function ManualBookingCreateForm({
             : copy.promotion.unavailable
     : null
 
+  /**
+   * Every condition that keeps **Create booking** disabled. Named once so the
+   * button and the error-clearing effect below cannot drift apart.
+   */
+  const submitBlocked =
+    isSourcedProduct ||
+    hasPromotionCode ||
+    !product.productId ||
+    !hasBookingTiming ||
+    !hasSelectedUnits ||
+    quote.isSettling ||
+    !sourcedQuoteReady ||
+    !promotionReady
+
+  // #4588: a message raised by a submit-gating condition has no other way out
+  // — the button is dead, and Enter does not fire implicit submission through
+  // a disabled submit button either. Drop it the moment submit is possible
+  // again, so it can never outlive the condition that produced it.
+  React.useEffect(() => {
+    setError((prev) => clearUnblockedManualBookingError(prev, submitBlocked))
+  }, [submitBlocked])
+
   // Human copy for the server's findings. The descriptor is only consulted for
   // labels, and an owned product's form never loaded one — the messages then
   // name the requirement by its own key, which is what an operator would look
@@ -1379,25 +1471,27 @@ export function ManualBookingCreateForm({
     setUnsatisfied([])
     setPayloadMismatchUnitIds([])
     if (quote.isSettling) {
-      setError(copy.validation.pricingPending)
+      setError({ message: copy.validation.pricingPending, blocksSubmit: true })
       return
     }
     if (isSourcedProduct) {
-      setError(copy.validation.sourcedBookingSessionRequired)
+      setError({ message: copy.validation.sourcedBookingSessionRequired, blocksSubmit: true })
       return
     }
     if (hasPromotionCode) {
-      setError(copy.validation.promotionBookingSessionRequired)
+      setError({ message: copy.validation.promotionBookingSessionRequired, blocksSubmit: true })
       return
     }
     if (!sourcedQuoteReady) {
-      setError(copy.validation.pricingUnavailable)
+      setError({ message: copy.validation.pricingUnavailable, blocksSubmit: true })
       return
     }
     if (hasPromotionCode && !promotionReady) {
-      setError(
-        quote.data?.available === false ? copy.promotion.invalid : copy.promotion.unavailable,
-      )
+      setError({
+        message:
+          quote.data?.available === false ? copy.promotion.invalid : copy.promotion.unavailable,
+        blocksSubmit: true,
+      })
       return
     }
     const validationError = validateManualBookingDraft({
@@ -1418,11 +1512,11 @@ export function ManualBookingCreateForm({
       messages: copy,
     })
     if (validationError) {
-      setError(validationError)
+      setError(toManualBookingFormError(validationError, copy.validation.units))
       return
     }
     if (sharedRoom.enabled && sharedRoom.mode === "join" && !sharedRoom.groupId) {
-      setError(copy.validation.sharedRoomGroup)
+      setError({ message: copy.validation.sharedRoomGroup })
       return
     }
     const overCapacity = getOverCapacityInventoryAssignments(
@@ -1431,13 +1525,13 @@ export function ManualBookingCreateForm({
       displayDraft.travelers,
     )[0]
     if (overCapacity) {
-      setError(
-        formatMessage(messages.bookingCreateDialog.validation.roomCapacityExceeded, {
+      setError({
+        message: formatMessage(messages.bookingCreateDialog.validation.roomCapacityExceeded, {
           room: overCapacity.unitName,
           assigned: overCapacity.assignedTravelers,
           capacity: overCapacity.capacity,
         }),
-      )
+      })
       return
     }
     if (!resolvedPricing) return
@@ -1580,7 +1674,7 @@ export function ManualBookingCreateForm({
     } satisfies Record<string, unknown>
     if (!quoteDraft) {
       submissionRef.current = false
-      setError(copy.validation.pricingUnavailable)
+      setError({ message: copy.validation.pricingUnavailable, blocksSubmit: true })
       return
     }
     const fingerprint = JSON.stringify({
@@ -1650,13 +1744,14 @@ export function ManualBookingCreateForm({
       attemptRef.current = null
       onCreated(result.bookingId)
     } catch (cause) {
-      setError(
-        cause instanceof BookingSessionJourneyError
-          ? copy.validation.bookingSession[cause.recovery]
-          : cause instanceof Error
-            ? cause.message
-            : copy.validation.create,
-      )
+      setError({
+        message:
+          cause instanceof BookingSessionJourneyError
+            ? copy.validation.bookingSession[cause.recovery]
+            : cause instanceof Error
+              ? cause.message
+              : copy.validation.create,
+      })
       // The typed outcome carried the list; keep it. Collapsing it back into
       // the sentence above is what made the server's enforcement invisible.
       setUnsatisfied(cause instanceof BookingSessionJourneyError ? (cause.unsatisfied ?? []) : [])
@@ -1778,6 +1873,9 @@ export function ManualBookingCreateForm({
               invalidOptionUnitIds={payloadMismatchUnitIds}
               providedOptions={isSourcedProduct ? sourcedProductOptions : undefined}
               providedUnits={isSourcedProduct ? sourcedOptionUnits : undefined}
+              sectionRef={unitsSectionRef}
+              required={requiresUnitSelection}
+              error={error?.field === "units" ? error.message : null}
               labels={{
                 heading: messages.bookingCreateDialog.labels.roomsHeading,
                 noOption: messages.bookingCreateDialog.labels.roomsNoOption,
@@ -2014,7 +2112,7 @@ export function ManualBookingCreateForm({
             tabIndex={-1}
             className="mt-3 rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-xs text-destructive"
           >
-            {error}
+            {error.message}
           </p>
         ) : null}
         {unsatisfiedMessages.length > 0 ? (
@@ -2050,21 +2148,7 @@ export function ManualBookingCreateForm({
           <Button type="button" variant="ghost" size="sm" onClick={onCancel} disabled={submitting}>
             {messages.common.cancel}
           </Button>
-          <Button
-            type="submit"
-            size="sm"
-            disabled={
-              submitting ||
-              isSourcedProduct ||
-              hasPromotionCode ||
-              !product.productId ||
-              !hasBookingTiming ||
-              !hasSelectedUnits ||
-              quote.isSettling ||
-              !sourcedQuoteReady ||
-              !promotionReady
-            }
-          >
+          <Button type="submit" size="sm" disabled={submitting || submitBlocked}>
             {submitting ? (
               <Loader2 data-icon="inline-start" className="animate-spin" aria-hidden="true" />
             ) : null}

--- a/packages/bookings-react/src/components/option-units-stepper-section.tsx
+++ b/packages/bookings-react/src/components/option-units-stepper-section.tsx
@@ -73,9 +73,28 @@ export interface OptionUnitsStepperSectionProps {
     unlimited?: string
     fillsSlotCapacity?: string
     reviewLine?: string
+    required?: string
   }
   slotHasFiniteCapacity?: boolean
   invalidOptionUnitIds?: readonly string[]
+  /**
+   * Marks the section as a required control so an operator can tell, before
+   * submitting, that a quantity has to be picked here. See #4588.
+   */
+  required?: boolean
+  /**
+   * Field-level validation message, rendered against this section rather than
+   * only in the form's error banner. Anchors "Select at least one option." to
+   * the control it actually refers to.
+   */
+  error?: string | null
+  /**
+   * Focus/scroll anchor for the section container, so a failed submit can
+   * bring the operator to the control that blocked it.
+   */
+  sectionRef?: React.Ref<HTMLDivElement>
+  /** DOM id for the section container, for `aria-describedby` from outside. */
+  id?: string
   /** Catalog-sourced products provide option/unit shape through the live quote. */
   providedOptions?: ReadonlyArray<{ id: string; name: string }>
   /** When present (including an empty array), skip owned product/availability lookups. */
@@ -124,10 +143,17 @@ export function OptionUnitsStepperSection({
   invalidOptionUnitIds = [],
   providedOptions,
   providedUnits,
+  required = false,
+  error = null,
+  sectionRef,
+  id,
 }: OptionUnitsStepperSectionProps) {
   const productsClient = useVoyantProductsContext()
   const messages = useBookingsUiMessagesOrDefault()
   const merged = { ...messages.roomsStepperSection.labels, ...labels }
+  const generatedId = React.useId()
+  const sectionId = id ?? generatedId
+  const errorId = `${sectionId}-error`
   const usesProvidedUnits = providedUnits !== undefined
   const availability = useSlotUnitAvailability({
     slotId,
@@ -254,10 +280,44 @@ export function OptionUnitsStepperSection({
     [units, productOptions],
   )
 
+  // The section is a group of steppers rather than a single control, so the
+  // required marker and the validation message live on the container. Both
+  // are rendered in every branch — an operator who has to pick a quantity
+  // here should be told so before they press a disabled button (#4588).
+  const containerProps = {
+    id: sectionId,
+    ref: sectionRef,
+    tabIndex: -1,
+    "aria-invalid": error ? true : undefined,
+    "aria-describedby": error ? errorId : undefined,
+    className: `flex flex-col gap-2 rounded-md border p-3 outline-none ${
+      error ? "border-destructive/70 bg-destructive/5 ring-1 ring-destructive/20" : ""
+    }`,
+  } as const
+  const heading = (
+    <Label>
+      {merged.heading}
+      {required ? (
+        <>
+          <span aria-hidden="true" className="text-destructive">
+            {" *"}
+          </span>
+          <span className="sr-only">{` (${merged.required})`}</span>
+        </>
+      ) : null}
+    </Label>
+  )
+  const errorNode = error ? (
+    <p id={errorId} role="alert" className="text-xs font-medium text-destructive">
+      {error}
+    </p>
+  ) : null
+
   if (!slotId && !productId && !optionId) {
     return (
-      <div className="flex flex-col gap-2 rounded-md border p-3">
-        <Label>{merged.heading}</Label>
+      <div {...containerProps}>
+        {heading}
+        {errorNode}
         <p className="text-xs text-muted-foreground">{merged.noOption}</p>
       </div>
     )
@@ -277,8 +337,9 @@ export function OptionUnitsStepperSection({
       : optionsLoaded
   if (loaded && units.length === 0) {
     return (
-      <div className="flex flex-col gap-2 rounded-md border p-3">
-        <Label>{merged.heading}</Label>
+      <div {...containerProps}>
+        {heading}
+        {errorNode}
         <p className="text-xs text-muted-foreground">{merged.noUnits}</p>
       </div>
     )
@@ -295,8 +356,9 @@ export function OptionUnitsStepperSection({
   }
 
   return (
-    <div className="flex flex-col gap-2 rounded-md border p-3">
-      <Label>{merged.heading}</Label>
+    <div {...containerProps}>
+      {heading}
+      {errorNode}
       <div className="flex flex-col gap-2">
         {optionRows.map(({ optionKey, optionName, primary, allUnits, totalRemaining }) => {
           const qty = value.quantities[primary.optionUnitId] ?? 0

--- a/packages/bookings-react/src/i18n/en-sections.ts
+++ b/packages/bookings-react/src/i18n/en-sections.ts
@@ -275,10 +275,11 @@ export const bookingsUiEnSections = {
       noUnits: "This departure has no per-unit availability configured.",
       remaining: "left",
       unlimited: "unlimited",
-      fillsSlotCapacity: "room is full",
+      fillsSlotCapacity: "included in departure capacity",
       decreaseUnitPrefix: "Decrease",
       increaseUnitPrefix: "Increase",
       reviewLine: "Review this line",
+      required: "Required",
     },
   },
   sharedRoomSection: {

--- a/packages/bookings-react/src/i18n/messages-sections.ts
+++ b/packages/bookings-react/src/i18n/messages-sections.ts
@@ -268,10 +268,17 @@ export type BookingsUiSectionsMessages = {
       noUnits: string
       remaining: string
       unlimited: string
+      /**
+       * Shown when per-unit capacity is uncapped but the departure's own
+       * capacity is finite: the row draws on the departure's shared pool.
+       * It is NOT a sold-out state — see #4588.
+       */
       fillsSlotCapacity: string
       decreaseUnitPrefix: string
       increaseUnitPrefix: string
       reviewLine: string
+      /** Screen-reader text for the required marker on the section heading. */
+      required: string
     }
   }
   sharedRoomSection: {

--- a/packages/bookings-react/src/i18n/ro-sections.ts
+++ b/packages/bookings-react/src/i18n/ro-sections.ts
@@ -275,10 +275,11 @@ export const bookingsUiRoSections = {
       noUnits: "Aceasta plecare nu are disponibilitate configurata pe unitati.",
       remaining: "ramase",
       unlimited: "nelimitat",
-      fillsSlotCapacity: "camera este plina",
+      fillsSlotCapacity: "inclus in capacitatea plecarii",
       decreaseUnitPrefix: "Scade",
       increaseUnitPrefix: "Creste",
       reviewLine: "Verifica aceasta linie",
+      required: "Obligatoriu",
     },
   },
   sharedRoomSection: {

--- a/packages/bookings-react/tests/unit/manual-booking-validation.test.ts
+++ b/packages/bookings-react/tests/unit/manual-booking-validation.test.ts
@@ -3,12 +3,14 @@ import { describe, expect, it, vi } from "vitest"
 import {
   buildManualBookingQuoteDraft,
   buildManualBookingSessionSelection,
+  clearUnblockedManualBookingError,
   formatManualBookingAmount,
   manualBookingTravelersToRows,
   normalizeCatalogBookingSlot,
   resolveManualBookingPricing,
   resolveSourcedOptionUnits,
   resolveSourcedProductOptions,
+  toManualBookingFormError,
   validateManualBookingDraft,
 } from "../../src/components/manual-booking-create-form.js"
 import { bookingsUiEn } from "../../src/i18n/en.js"
@@ -470,5 +472,44 @@ describe("manual booking validation", () => {
       travelerCategory: "senior",
       roomUnitId: "unit_adult",
     })
+  })
+})
+
+describe("manual booking error banner lifecycle (#4588)", () => {
+  const unitsMessage = bookingsUiEn.manualBookingCreate.validation.units
+
+  it("anchors the units message to the Options section and marks it blocking", () => {
+    expect(toManualBookingFormError(unitsMessage, unitsMessage)).toEqual({
+      message: unitsMessage,
+      field: "units",
+      blocksSubmit: true,
+    })
+  })
+
+  it("leaves messages the operator can resubmit past unanchored", () => {
+    const contactMessage = bookingsUiEn.manualBookingCreate.validation.contact
+
+    expect(toManualBookingFormError(contactMessage, unitsMessage)).toEqual({
+      message: contactMessage,
+      field: undefined,
+      blocksSubmit: undefined,
+    })
+  })
+
+  it("drops a blocking message once submit is possible again", () => {
+    const blocking = toManualBookingFormError(unitsMessage, unitsMessage)
+
+    expect(clearUnblockedManualBookingError(blocking, true)).toBe(blocking)
+    expect(clearUnblockedManualBookingError(blocking, false)).toBeNull()
+  })
+
+  it("keeps a non-blocking message so the operator can read it while fixing it", () => {
+    const recoverable = toManualBookingFormError(
+      bookingsUiEn.manualBookingCreate.validation.contact,
+      unitsMessage,
+    )
+
+    expect(clearUnblockedManualBookingError(recoverable, false)).toBe(recoverable)
+    expect(clearUnblockedManualBookingError(null, false)).toBeNull()
   })
 })

--- a/packages/bookings-react/tests/unit/option-units-stepper-merge.test.ts
+++ b/packages/bookings-react/tests/unit/option-units-stepper-merge.test.ts
@@ -8,6 +8,8 @@ import {
   resolveOptionRemainingLabel,
   resolveSlotOptionId,
 } from "../../src/components/option-units-stepper-section.js"
+import { bookingsUiEn } from "../../src/i18n/en.js"
+import { bookingsUiRo } from "../../src/i18n/ro.js"
 
 function makeRow(
   optionId: string | null,
@@ -140,6 +142,26 @@ describe("resolveOptionRemainingLabel", () => {
         fillsSlotCapacity: "fills slot capacity",
       }),
     ).toBe("unlimited")
+  })
+
+  it("does not describe an uncapped person row as sold out in either locale", () => {
+    // #4588: the shipped copy read "room is full" / "camera este plina" next
+    // to a departure showing "45 left", so operators never touched the
+    // stepper and Create booking stayed disabled. The label states that the
+    // row draws on the departure's capacity — it is not a sold-out state.
+    for (const messages of [bookingsUiEn, bookingsUiRo]) {
+      const label = resolveOptionRemainingLabel({
+        totalRemaining: null,
+        units: [{ unitType: "person" }],
+        slotHasFiniteCapacity: true,
+        remaining: messages.roomsStepperSection.labels.remaining,
+        unlimited: messages.roomsStepperSection.labels.unlimited,
+        fillsSlotCapacity: messages.roomsStepperSection.labels.fillsSlotCapacity,
+      })
+
+      expect(label).toBe(messages.roomsStepperSection.labels.fillsSlotCapacity)
+      expect(label).not.toMatch(/full|plin/i)
+    }
   })
 
   it("shows explicit remaining counts when option units are capped", () => {

--- a/packages/bookings-react/tests/unit/option-units-stepper-required-error.test.tsx
+++ b/packages/bookings-react/tests/unit/option-units-stepper-required-error.test.tsx
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+
+import type * as ReactTypes from "react"
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+;(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock("@voyant-travel/ui/components", () => ({
+  Button: ({ children, ...props }: ReactTypes.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+  Label: ({ children }: { children?: ReactTypes.ReactNode }) => <span>{children}</span>,
+}))
+
+vi.mock("@tanstack/react-query", () => ({ useQueries: () => [] }))
+
+vi.mock("@voyant-travel/inventory-react", () => ({
+  getOptionUnitsQueryOptions: () => ({ queryKey: ["option-units"] }),
+  useProductOptions: () => ({ data: { data: [] }, isSuccess: true }),
+  useVoyantProductsContext: () => ({}),
+}))
+
+vi.mock("@voyant-travel/operations-react/availability", () => ({
+  useSlotUnitAvailability: () => ({ data: { data: [] }, isSuccess: true }),
+}))
+
+import {
+  OptionUnitsStepperSection,
+  type OptionUnitsStepperUnit,
+} from "../../src/components/option-units-stepper-section.js"
+import { bookingsUiEn } from "../../src/i18n/en.js"
+
+const personUnits: OptionUnitsStepperUnit[] = [
+  {
+    optionId: "opt_excursion",
+    optionUnitId: "unit_adult",
+    unitName: "Adult",
+    unitType: "person",
+    occupancyMax: null,
+    initial: null,
+    reserved: 0,
+    remaining: null,
+  },
+]
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement("div")
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+function render(node: ReactTypes.ReactNode) {
+  act(() => root.render(node))
+}
+
+describe("OptionUnitsStepperSection required/error anchoring", () => {
+  it("renders a person option's uncapped row as drawing on departure capacity", () => {
+    render(
+      <OptionUnitsStepperSection
+        value={{ quantities: {} }}
+        onChange={() => {}}
+        productId="prod_1"
+        slotId="slot_1"
+        optionId="opt_excursion"
+        slotHasFiniteCapacity
+        providedOptions={[{ id: "opt_excursion", name: "One-day excursion" }]}
+        providedUnits={personUnits}
+      />,
+    )
+
+    const text = container.textContent ?? ""
+    expect(text).toContain(bookingsUiEn.roomsStepperSection.labels.fillsSlotCapacity)
+    expect(text).not.toMatch(/full/i)
+  })
+
+  it("anchors the validation message to the section and marks it required", () => {
+    render(
+      <OptionUnitsStepperSection
+        value={{ quantities: {} }}
+        onChange={() => {}}
+        productId="prod_1"
+        slotId="slot_1"
+        optionId="opt_excursion"
+        required
+        error="Select at least one option."
+        slotHasFiniteCapacity
+        providedOptions={[{ id: "opt_excursion", name: "One-day excursion" }]}
+        providedUnits={personUnits}
+      />,
+    )
+
+    const alert = container.querySelector('[role="alert"]')
+    expect(alert?.textContent).toBe("Select at least one option.")
+
+    const section = container.querySelector("[aria-invalid]")
+    expect(section).not.toBeNull()
+    expect(section?.getAttribute("aria-describedby")).toBe(alert?.id)
+    expect(container.textContent).toContain(bookingsUiEn.roomsStepperSection.labels.required)
+  })
+
+  it("leaves the section unmarked when no message is anchored to it", () => {
+    render(
+      <OptionUnitsStepperSection
+        value={{ quantities: {} }}
+        onChange={() => {}}
+        productId="prod_1"
+        slotId="slot_1"
+        optionId="opt_excursion"
+        providedOptions={[{ id: "opt_excursion", name: "One-day excursion" }]}
+        providedUnits={personUnits}
+      />,
+    )
+
+    expect(container.querySelector('[role="alert"]')).toBeNull()
+    expect(container.querySelector("[aria-invalid]")).toBeNull()
+  })
+
+  it("exposes a focus anchor so a failed submit can reach the control", () => {
+    const sectionRef: { current: HTMLDivElement | null } = { current: null }
+    render(
+      <OptionUnitsStepperSection
+        value={{ quantities: {} }}
+        onChange={() => {}}
+        productId="prod_1"
+        slotId="slot_1"
+        optionId="opt_excursion"
+        sectionRef={sectionRef}
+        providedOptions={[{ id: "opt_excursion", name: "One-day excursion" }]}
+        providedUnits={personUnits}
+      />,
+    )
+
+    expect(sectionRef.current).not.toBeNull()
+    act(() => sectionRef.current?.focus())
+    expect(document.activeElement).toBe(sectionRef.current)
+  })
+})


### PR DESCRIPTION
Closes #4588.

An operator could not create a booking for a person-priced product: the one control that unblocks the form was labelled **"room is full"**, so nobody touched it, and the resulting `Select at least one option.` could never be cleared without a page reload.

## What was wrong

`resolveOptionRemainingLabel` returns the `fillsSlotCapacity` string when per-unit capacity is *unlimited* and the departure's capacity is finite. The string said `room is full` / `camera este plina` — rendered directly next to a departure showing `45 left`. The intent was "this option draws on the departure's shared capacity"; what it said was "sold out".

Two things then compounded it. Nothing connected `Select at least one option.` to the Options row — no required marker, no field-level error, no `aria-describedby`, no scroll — and "option" is overloaded in this form, so operators reasonably read the sentence as the Document generation checkboxes. And `error` was only cleared at the top of `handleSubmit`, while the same condition that raised it kept the submit button disabled — a disabled submit button does not fire implicit submission via Enter either, so there was no way back.

## Changes

**1. The label says what it means.** `included in departure capacity` / `inclus in capacitatea plecarii`, with a doc comment on the message interface recording that it is not a sold-out state.

**2. The validation is anchored to the control.** `OptionUnitsStepperSection` gained `required`, `error`, `sectionRef` and `id` props. It renders a required marker on the heading (visible `*` plus screen-reader text), a field-level `role="alert"` message wired to the container through `aria-describedby`, and a destructive border. The form passes the message only when `error.field === "units"`, and sends focus to the section instead of the banner on a failed submit.

**3. The message cannot outlive its cause.** `error` is now `{ message, field?, blocksSubmit? }`. Every condition that also disables **Create booking** tags `blocksSubmit`, and an effect drops those messages as soon as submit becomes possible. The button's disabled expression is extracted into a named `submitBlocked` const used by both, so the gate and the clear cannot drift apart.

**4. The related wipe.** The issue flagged, unconfirmed, that the effect resetting `rooms`/`roomUnits` was keyed on `allOpenSlots`/`defaultSlot` *array identity* — which changes on any refetch, including one caused by an unrelated booking mutating a slot row. Split into a reset keyed on `[slotId, product.optionId]` and a separate option/departure reconciliation keyed on the rest. Setting either id from the reconciliation still re-runs the reset, so the intended behaviour is unchanged; a refetch no longer wipes a filled-in stepper under the operator.

## Verification

- `pnpm -F @voyant-travel/bookings-react test` — **34 files / 217 tests pass** (was 33 / 208; the 9 new tests ran).
- `pnpm -F @voyant-travel/bookings-react... build` — 0 `error TS`.
- `pnpm -F @voyant-travel/bookings-react typecheck` — exit 0, 0 `error TS`; `--listFiles` confirms all 26 test files are in the program, including the new `.tsx` one.
- `npx biome check packages/bookings-react/` — clean.
- `pnpm i18n:check` — all three lanes pass (49 definition sets / 38 entrypoints; hardcoded-string scan over 23 roots).

New tests: the locale copy for an uncapped person row on a finite departure asserts it does not read as sold out in **either** locale; four render tests cover the required marker, the anchored `role="alert"` + `aria-describedby` pairing, the unmarked default, and the focus anchor; four cover the error lifecycle — that the units message is anchored and blocking, that recoverable messages are not, and that only blocking ones are dropped when submit unblocks.

## Not done

Browser verification against a live operator tenant. The defects are covered by the unit and render tests above, but the end-to-end operator flow described in the issue was not re-driven.
