### PR TITLE
Enrich the CRM person when a booking is confirmed

### DIFF
--- a/.changeset/booking-crm-enrichment.md
+++ b/.changeset/booking-crm-enrichment.md
@@ -1,0 +1,15 @@
+---
+"@voyant-travel/relationships": minor
+"@voyant-travel/relationships-contracts": minor
+"@voyant-travel/relationships-react": minor
+"@voyant-travel/bookings": minor
+"@voyant-travel/notifications": minor
+---
+
+Fold a confirmed booking into the customer's CRM record. Until now a customer booking created a person row carrying a name, an email and a phone number, and nothing else — Activities, Addresses, Relationships and Communications all stayed empty unless an operator filled them in by hand.
+
+A `booking.confirmed` subscriber in relationships now writes a timeline activity linked to both the person and the booking, saves the billing address the checkout already collected (it was being parsed into the booking's contact columns and then dropped), and links co-travelers to the booker as travel companions. The pass is idempotent, so a redelivered event is a no-op, and it runs off the commit transaction so a CRM failure can never roll back a paid booking.
+
+The Communications tab now also lists messages the deployment actually delivered to the person, read from the notification delivery record rather than copied into `communication_log`, and each entry reports whether it was logged by staff or sent automatically.
+
+Bookings gains a `bookings.crm-snapshot.runtime` port so CRM can read a booking without importing its tables, and `entity_type` gains a `booking` member so an activity can name the booking it came from.

--- a/packages/accommodations/tsconfig.build.json
+++ b/packages/accommodations/tsconfig.build.json
@@ -1813,12 +1813,16 @@
       "@voyant-travel/relationships/action-ledger-capabilities": [
         "../relationships/dist/action-ledger-capabilities.d.ts"
       ],
+      "@voyant-travel/relationships/booking-enrichment-subscriber": [
+        "../relationships/dist/booking-enrichment/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/relationships/events": ["../relationships/dist/events.d.ts"],
       "@voyant-travel/relationships/linkables": ["../relationships/dist/linkables.d.ts"],
       "@voyant-travel/relationships/routes": ["../relationships/dist/routes/index.d.ts"],
       "@voyant-travel/relationships/runtime-contributor": [
         "../relationships/dist/runtime-contributor.d.ts"
       ],
+      "@voyant-travel/relationships/runtime-port": ["../relationships/dist/runtime-port.d.ts"],
       "@voyant-travel/relationships/schema": ["../relationships/dist/schema.d.ts"],
       "@voyant-travel/relationships/tools": ["../relationships/dist/mcp-runtime.d.ts"],
       "@voyant-travel/relationships/validation": ["../relationships/dist/validation.d.ts"],

--- a/packages/accommodations/tsconfig.typecheck.json
+++ b/packages/accommodations/tsconfig.typecheck.json
@@ -1814,12 +1814,16 @@
       "@voyant-travel/relationships/action-ledger-capabilities": [
         "../relationships/dist/action-ledger-capabilities.d.ts"
       ],
+      "@voyant-travel/relationships/booking-enrichment-subscriber": [
+        "../relationships/dist/booking-enrichment/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/relationships/events": ["../relationships/dist/events.d.ts"],
       "@voyant-travel/relationships/linkables": ["../relationships/dist/linkables.d.ts"],
       "@voyant-travel/relationships/routes": ["../relationships/dist/routes/index.d.ts"],
       "@voyant-travel/relationships/runtime-contributor": [
         "../relationships/dist/runtime-contributor.d.ts"
       ],
+      "@voyant-travel/relationships/runtime-port": ["../relationships/dist/runtime-port.d.ts"],
       "@voyant-travel/relationships/schema": ["../relationships/dist/schema.d.ts"],
       "@voyant-travel/relationships/tools": ["../relationships/dist/mcp-runtime.d.ts"],
       "@voyant-travel/relationships/validation": ["../relationships/dist/validation.d.ts"],

--- a/packages/bookings/src/crm-snapshot.ts
+++ b/packages/bookings/src/crm-snapshot.ts
@@ -1,0 +1,62 @@
+import { asc, eq } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import type { BookingCrmSnapshot, BookingCrmTravelerSnapshot } from "./runtime-port.js"
+import { bookings, bookingTravelers } from "./schema-core.js"
+
+/**
+ * Project a booking into the shape CRM enrichment needs.
+ *
+ * Deliberately reread from the tables rather than reconstructed from the
+ * `booking.confirmed` payload: by the time a subscriber runs, the booking is
+ * the authority on its own contact snapshot, and the event carries only the id.
+ *
+ * Returns `null` for an unknown booking so a subscriber handling a stale or
+ * rolled-back event does nothing rather than throwing.
+ */
+export async function loadBookingCrmSnapshot(
+  db: PostgresJsDatabase,
+  bookingId: string,
+): Promise<BookingCrmSnapshot | null> {
+  const [booking] = await db.select().from(bookings).where(eq(bookings.id, bookingId)).limit(1)
+  if (!booking) return null
+
+  const travelerRows = await db
+    .select({
+      personId: bookingTravelers.personId,
+      firstName: bookingTravelers.firstName,
+      lastName: bookingTravelers.lastName,
+      isPrimary: bookingTravelers.isPrimary,
+    })
+    .from(bookingTravelers)
+    .where(eq(bookingTravelers.bookingId, bookingId))
+    .orderBy(asc(bookingTravelers.createdAt))
+
+  const travelers: BookingCrmTravelerSnapshot[] = travelerRows.map((row) => ({
+    personId: row.personId ?? null,
+    firstName: row.firstName,
+    lastName: row.lastName,
+    isPrimary: row.isPrimary,
+  }))
+
+  return {
+    bookingId: booking.id,
+    bookingNumber: booking.bookingNumber,
+    status: booking.status,
+    personId: booking.personId ?? null,
+    organizationId: booking.organizationId ?? null,
+    sourceType: booking.sourceType,
+    startDate: booking.startDate ?? null,
+    sellCurrency: booking.sellCurrency,
+    sellAmountCents: booking.sellAmountCents ?? null,
+    billingAddress: {
+      line1: booking.contactAddressLine1 ?? null,
+      line2: booking.contactAddressLine2 ?? null,
+      city: booking.contactCity ?? null,
+      region: booking.contactRegion ?? null,
+      postalCode: booking.contactPostalCode ?? null,
+      country: booking.contactCountry ?? null,
+    },
+    travelers,
+  }
+}

--- a/packages/bookings/src/runtime-contributor.ts
+++ b/packages/bookings/src/runtime-contributor.ts
@@ -12,6 +12,8 @@ import {
 import { sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { checkBookingActionLedgerDrift } from "./action-ledger-drift.js"
+import { loadBookingCrmSnapshot } from "./crm-snapshot.js"
+import { type BookingsCrmSnapshotRuntime, bookingsCrmSnapshotRuntimePort } from "./runtime-port.js"
 
 export interface BookingsRuntimeContributorHost {
   primitives: VoyantRuntimeHostPrimitives
@@ -117,5 +119,8 @@ export function createBookingsRuntimePortContribution(
     } satisfies ActionLedgerBookingDriftRuntime,
     [customFieldValueLifecycleRuntimePort.id]: bookingCustomFieldValues,
     [customFieldValueOperationsRuntimePort.id]: bookingCustomFieldValueOperations,
+    [bookingsCrmSnapshotRuntimePort.id]: {
+      loadBookingCrmSnapshot,
+    } satisfies BookingsCrmSnapshotRuntime,
   }
 }

--- a/packages/bookings/src/runtime-port.ts
+++ b/packages/bookings/src/runtime-port.ts
@@ -118,6 +118,61 @@ export interface BookingsRelationshipsRuntime {
   getOrganizationById(db: PostgresJsDatabase, organizationId: string): Promise<unknown | null>
 }
 
+/**
+ * A traveler as CRM cares about them: who they are and, when the booking
+ * resolved one, which person row they belong to.
+ */
+export interface BookingCrmTravelerSnapshot {
+  personId: string | null
+  firstName: string
+  lastName: string
+  isPrimary: boolean
+}
+
+/**
+ * Everything a booking can tell CRM about the customer behind it.
+ *
+ * Read back from the booking rather than carried on `booking.confirmed`: the
+ * event is a wake-up signal, and stuffing an address plus a traveler list into
+ * an `additionalProperties: false` payload would make the two drift.
+ */
+export interface BookingCrmSnapshot {
+  bookingId: string
+  bookingNumber: string
+  status: string
+  personId: string | null
+  organizationId: string | null
+  sourceType: string
+  startDate: string | null
+  sellCurrency: string
+  sellAmountCents: number | null
+  billingAddress: {
+    line1: string | null
+    line2: string | null
+    city: string | null
+    region: string | null
+    postalCode: string | null
+    country: string | null
+  }
+  travelers: readonly BookingCrmTravelerSnapshot[]
+}
+
+/**
+ * Lets CRM read the booking behind a `booking.confirmed` event without
+ * importing Bookings' tables — ADR-0016 decision 6, and the reason the
+ * relationships->bookings pair is absent from the table-privacy baseline.
+ *
+ * Declared here rather than in Relationships because relationships already
+ * depends on bookings; defining the consumer's port in the consumer would
+ * make bookings import relationships and close a package cycle.
+ */
+export interface BookingsCrmSnapshotRuntime {
+  loadBookingCrmSnapshot(
+    db: PostgresJsDatabase,
+    bookingId: string,
+  ): Promise<BookingCrmSnapshot | null>
+}
+
 export interface BookingsCancellationPolicyRuntime {
   evaluateCancellationSnapshot: BookingCancellationPolicyEvaluator
   captureApplicableCancellationPolicySnapshot(
@@ -230,6 +285,10 @@ export const bookingsInventoryRuntimePort = objectPort<BookingsInventoryRuntime>
 export const bookingsRelationshipsRuntimePort = objectPort<BookingsRelationshipsRuntime>(
   "bookings.relationships.runtime",
   ["loadPersonTravelSnapshot", "upsertPersonFromContact", "getPersonById", "getOrganizationById"],
+)
+export const bookingsCrmSnapshotRuntimePort = objectPort<BookingsCrmSnapshotRuntime>(
+  "bookings.crm-snapshot.runtime",
+  ["loadBookingCrmSnapshot"],
 )
 export const bookingsCancellationPolicyRuntimePort = objectPort<BookingsCancellationPolicyRuntime>(
   "bookings.cancellation-policy.runtime",

--- a/packages/bookings/src/voyant.ts
+++ b/packages/bookings/src/voyant.ts
@@ -19,6 +19,7 @@ import {
   bookingActionProjectionRuntimePort,
   bookingsAccommodationRuntimePort,
   bookingsCancellationPolicyRuntimePort,
+  bookingsCrmSnapshotRuntimePort,
   bookingsFinanceRuntimePort,
   bookingsInventoryRuntimePort,
   bookingsRelationshipsRuntimePort,
@@ -361,6 +362,7 @@ export const bookingsVoyantModule = defineModule({
     capabilities: ["bookings.data-owner"],
     ports: [
       providePort(actionLedgerBookingDriftRuntimePort),
+      providePort(bookingsCrmSnapshotRuntimePort),
       providePort(customFieldValueLifecycleRuntimePort),
       providePort(customFieldValueOperationsRuntimePort),
     ],

--- a/packages/bookings/tests/unit/voyant-manifest.test.ts
+++ b/packages/bookings/tests/unit/voyant-manifest.test.ts
@@ -18,6 +18,8 @@ describe("bookings deployment manifest", () => {
         capabilities: ["bookings.data-owner"],
         ports: [
           { id: "action-ledger.booking-drift-runtime" },
+          // Lets CRM read a confirmed booking without importing these tables.
+          { id: "bookings.crm-snapshot.runtime" },
           { id: "custom-fields.value-lifecycle" },
           { id: "custom-fields.value-operations" },
         ],

--- a/packages/catalog/tsconfig.build.json
+++ b/packages/catalog/tsconfig.build.json
@@ -1762,12 +1762,16 @@
       "@voyant-travel/relationships/action-ledger-capabilities": [
         "../relationships/dist/action-ledger-capabilities.d.ts"
       ],
+      "@voyant-travel/relationships/booking-enrichment-subscriber": [
+        "../relationships/dist/booking-enrichment/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/relationships/events": ["../relationships/dist/events.d.ts"],
       "@voyant-travel/relationships/linkables": ["../relationships/dist/linkables.d.ts"],
       "@voyant-travel/relationships/routes": ["../relationships/dist/routes/index.d.ts"],
       "@voyant-travel/relationships/runtime-contributor": [
         "../relationships/dist/runtime-contributor.d.ts"
       ],
+      "@voyant-travel/relationships/runtime-port": ["../relationships/dist/runtime-port.d.ts"],
       "@voyant-travel/relationships/schema": ["../relationships/dist/schema.d.ts"],
       "@voyant-travel/relationships/tools": ["../relationships/dist/mcp-runtime.d.ts"],
       "@voyant-travel/relationships/validation": ["../relationships/dist/validation.d.ts"],

--- a/packages/catalog/tsconfig.typecheck.json
+++ b/packages/catalog/tsconfig.typecheck.json
@@ -1763,12 +1763,16 @@
       "@voyant-travel/relationships/action-ledger-capabilities": [
         "../relationships/dist/action-ledger-capabilities.d.ts"
       ],
+      "@voyant-travel/relationships/booking-enrichment-subscriber": [
+        "../relationships/dist/booking-enrichment/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/relationships/events": ["../relationships/dist/events.d.ts"],
       "@voyant-travel/relationships/linkables": ["../relationships/dist/linkables.d.ts"],
       "@voyant-travel/relationships/routes": ["../relationships/dist/routes/index.d.ts"],
       "@voyant-travel/relationships/runtime-contributor": [
         "../relationships/dist/runtime-contributor.d.ts"
       ],
+      "@voyant-travel/relationships/runtime-port": ["../relationships/dist/runtime-port.d.ts"],
       "@voyant-travel/relationships/schema": ["../relationships/dist/schema.d.ts"],
       "@voyant-travel/relationships/tools": ["../relationships/dist/mcp-runtime.d.ts"],
       "@voyant-travel/relationships/validation": ["../relationships/dist/validation.d.ts"],

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -1773,12 +1773,16 @@
       "@voyant-travel/relationships/action-ledger-capabilities": [
         "../relationships/dist/action-ledger-capabilities.d.ts"
       ],
+      "@voyant-travel/relationships/booking-enrichment-subscriber": [
+        "../relationships/dist/booking-enrichment/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/relationships/events": ["../relationships/dist/events.d.ts"],
       "@voyant-travel/relationships/linkables": ["../relationships/dist/linkables.d.ts"],
       "@voyant-travel/relationships/routes": ["../relationships/dist/routes/index.d.ts"],
       "@voyant-travel/relationships/runtime-contributor": [
         "../relationships/dist/runtime-contributor.d.ts"
       ],
+      "@voyant-travel/relationships/runtime-port": ["../relationships/dist/runtime-port.d.ts"],
       "@voyant-travel/relationships/schema": ["../relationships/dist/schema.d.ts"],
       "@voyant-travel/relationships/tools": ["../relationships/dist/mcp-runtime.d.ts"],
       "@voyant-travel/relationships/validation": ["../relationships/dist/validation.d.ts"],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -1767,12 +1767,16 @@
       "@voyant-travel/relationships/action-ledger-capabilities": [
         "../relationships/dist/action-ledger-capabilities.d.ts"
       ],
+      "@voyant-travel/relationships/booking-enrichment-subscriber": [
+        "../relationships/dist/booking-enrichment/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/relationships/events": ["../relationships/dist/events.d.ts"],
       "@voyant-travel/relationships/linkables": ["../relationships/dist/linkables.d.ts"],
       "@voyant-travel/relationships/routes": ["../relationships/dist/routes/index.d.ts"],
       "@voyant-travel/relationships/runtime-contributor": [
         "../relationships/dist/runtime-contributor.d.ts"
       ],
+      "@voyant-travel/relationships/runtime-port": ["../relationships/dist/runtime-port.d.ts"],
       "@voyant-travel/relationships/schema": ["../relationships/dist/schema.d.ts"],
       "@voyant-travel/relationships/tools": ["../relationships/dist/mcp-runtime.d.ts"],
       "@voyant-travel/relationships/validation": ["../relationships/dist/validation.d.ts"],

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -1818,12 +1818,16 @@
       "@voyant-travel/relationships/action-ledger-capabilities": [
         "../relationships/dist/action-ledger-capabilities.d.ts"
       ],
+      "@voyant-travel/relationships/booking-enrichment-subscriber": [
+        "../relationships/dist/booking-enrichment/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/relationships/events": ["../relationships/dist/events.d.ts"],
       "@voyant-travel/relationships/linkables": ["../relationships/dist/linkables.d.ts"],
       "@voyant-travel/relationships/routes": ["../relationships/dist/routes/index.d.ts"],
       "@voyant-travel/relationships/runtime-contributor": [
         "../relationships/dist/runtime-contributor.d.ts"
       ],
+      "@voyant-travel/relationships/runtime-port": ["../relationships/dist/runtime-port.d.ts"],
       "@voyant-travel/relationships/schema": ["../relationships/dist/schema.d.ts"],
       "@voyant-travel/relationships/tools": ["../relationships/dist/mcp-runtime.d.ts"],
       "@voyant-travel/relationships/validation": ["../relationships/dist/validation.d.ts"],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -1819,12 +1819,16 @@
       "@voyant-travel/relationships/action-ledger-capabilities": [
         "../relationships/dist/action-ledger-capabilities.d.ts"
       ],
+      "@voyant-travel/relationships/booking-enrichment-subscriber": [
+        "../relationships/dist/booking-enrichment/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/relationships/events": ["../relationships/dist/events.d.ts"],
       "@voyant-travel/relationships/linkables": ["../relationships/dist/linkables.d.ts"],
       "@voyant-travel/relationships/routes": ["../relationships/dist/routes/index.d.ts"],
       "@voyant-travel/relationships/runtime-contributor": [
         "../relationships/dist/runtime-contributor.d.ts"
       ],
+      "@voyant-travel/relationships/runtime-port": ["../relationships/dist/runtime-port.d.ts"],
       "@voyant-travel/relationships/schema": ["../relationships/dist/schema.d.ts"],
       "@voyant-travel/relationships/tools": ["../relationships/dist/mcp-runtime.d.ts"],
       "@voyant-travel/relationships/validation": ["../relationships/dist/validation.d.ts"],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -1822,12 +1822,16 @@
       "@voyant-travel/relationships/action-ledger-capabilities": [
         "../relationships/dist/action-ledger-capabilities.d.ts"
       ],
+      "@voyant-travel/relationships/booking-enrichment-subscriber": [
+        "../relationships/dist/booking-enrichment/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/relationships/events": ["../relationships/dist/events.d.ts"],
       "@voyant-travel/relationships/linkables": ["../relationships/dist/linkables.d.ts"],
       "@voyant-travel/relationships/routes": ["../relationships/dist/routes/index.d.ts"],
       "@voyant-travel/relationships/runtime-contributor": [
         "../relationships/dist/runtime-contributor.d.ts"
       ],
+      "@voyant-travel/relationships/runtime-port": ["../relationships/dist/runtime-port.d.ts"],
       "@voyant-travel/relationships/schema": ["../relationships/dist/schema.d.ts"],
       "@voyant-travel/relationships/tools": ["../relationships/dist/mcp-runtime.d.ts"],
       "@voyant-travel/relationships/validation": ["../relationships/dist/validation.d.ts"],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -1823,12 +1823,16 @@
       "@voyant-travel/relationships/action-ledger-capabilities": [
         "../relationships/dist/action-ledger-capabilities.d.ts"
       ],
+      "@voyant-travel/relationships/booking-enrichment-subscriber": [
+        "../relationships/dist/booking-enrichment/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/relationships/events": ["../relationships/dist/events.d.ts"],
       "@voyant-travel/relationships/linkables": ["../relationships/dist/linkables.d.ts"],
       "@voyant-travel/relationships/routes": ["../relationships/dist/routes/index.d.ts"],
       "@voyant-travel/relationships/runtime-contributor": [
         "../relationships/dist/runtime-contributor.d.ts"
       ],
+      "@voyant-travel/relationships/runtime-port": ["../relationships/dist/runtime-port.d.ts"],
       "@voyant-travel/relationships/schema": ["../relationships/dist/schema.d.ts"],
       "@voyant-travel/relationships/tools": ["../relationships/dist/mcp-runtime.d.ts"],
       "@voyant-travel/relationships/validation": ["../relationships/dist/validation.d.ts"],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -1854,12 +1854,16 @@
       "@voyant-travel/relationships/action-ledger-capabilities": [
         "../relationships/dist/action-ledger-capabilities.d.ts"
       ],
+      "@voyant-travel/relationships/booking-enrichment-subscriber": [
+        "../relationships/dist/booking-enrichment/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/relationships/events": ["../relationships/dist/events.d.ts"],
       "@voyant-travel/relationships/linkables": ["../relationships/dist/linkables.d.ts"],
       "@voyant-travel/relationships/routes": ["../relationships/dist/routes/index.d.ts"],
       "@voyant-travel/relationships/runtime-contributor": [
         "../relationships/dist/runtime-contributor.d.ts"
       ],
+      "@voyant-travel/relationships/runtime-port": ["../relationships/dist/runtime-port.d.ts"],
       "@voyant-travel/relationships/schema": ["../relationships/dist/schema.d.ts"],
       "@voyant-travel/relationships/tools": ["../relationships/dist/mcp-runtime.d.ts"],
       "@voyant-travel/relationships/validation": ["../relationships/dist/validation.d.ts"],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -1849,12 +1849,16 @@
       "@voyant-travel/relationships/action-ledger-capabilities": [
         "../relationships/dist/action-ledger-capabilities.d.ts"
       ],
+      "@voyant-travel/relationships/booking-enrichment-subscriber": [
+        "../relationships/dist/booking-enrichment/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/relationships/events": ["../relationships/dist/events.d.ts"],
       "@voyant-travel/relationships/linkables": ["../relationships/dist/linkables.d.ts"],
       "@voyant-travel/relationships/routes": ["../relationships/dist/routes/index.d.ts"],
       "@voyant-travel/relationships/runtime-contributor": [
         "../relationships/dist/runtime-contributor.d.ts"
       ],
+      "@voyant-travel/relationships/runtime-port": ["../relationships/dist/runtime-port.d.ts"],
       "@voyant-travel/relationships/schema": ["../relationships/dist/schema.d.ts"],
       "@voyant-travel/relationships/tools": ["../relationships/dist/mcp-runtime.d.ts"],
       "@voyant-travel/relationships/validation": ["../relationships/dist/validation.d.ts"],

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -1856,12 +1856,16 @@
       "@voyant-travel/relationships/action-ledger-capabilities": [
         "../relationships/dist/action-ledger-capabilities.d.ts"
       ],
+      "@voyant-travel/relationships/booking-enrichment-subscriber": [
+        "../relationships/dist/booking-enrichment/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/relationships/events": ["../relationships/dist/events.d.ts"],
       "@voyant-travel/relationships/linkables": ["../relationships/dist/linkables.d.ts"],
       "@voyant-travel/relationships/routes": ["../relationships/dist/routes/index.d.ts"],
       "@voyant-travel/relationships/runtime-contributor": [
         "../relationships/dist/runtime-contributor.d.ts"
       ],
+      "@voyant-travel/relationships/runtime-port": ["../relationships/dist/runtime-port.d.ts"],
       "@voyant-travel/relationships/schema": ["../relationships/dist/schema.d.ts"],
       "@voyant-travel/relationships/tools": ["../relationships/dist/mcp-runtime.d.ts"],
       "@voyant-travel/relationships/validation": ["../relationships/dist/validation.d.ts"],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -1857,12 +1857,16 @@
       "@voyant-travel/relationships/action-ledger-capabilities": [
         "../relationships/dist/action-ledger-capabilities.d.ts"
       ],
+      "@voyant-travel/relationships/booking-enrichment-subscriber": [
+        "../relationships/dist/booking-enrichment/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/relationships/events": ["../relationships/dist/events.d.ts"],
       "@voyant-travel/relationships/linkables": ["../relationships/dist/linkables.d.ts"],
       "@voyant-travel/relationships/routes": ["../relationships/dist/routes/index.d.ts"],
       "@voyant-travel/relationships/runtime-contributor": [
         "../relationships/dist/runtime-contributor.d.ts"
       ],
+      "@voyant-travel/relationships/runtime-port": ["../relationships/dist/runtime-port.d.ts"],
       "@voyant-travel/relationships/schema": ["../relationships/dist/schema.d.ts"],
       "@voyant-travel/relationships/tools": ["../relationships/dist/mcp-runtime.d.ts"],
       "@voyant-travel/relationships/validation": ["../relationships/dist/validation.d.ts"],

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -1854,12 +1854,16 @@
       "@voyant-travel/relationships/action-ledger-capabilities": [
         "../relationships/dist/action-ledger-capabilities.d.ts"
       ],
+      "@voyant-travel/relationships/booking-enrichment-subscriber": [
+        "../relationships/dist/booking-enrichment/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/relationships/events": ["../relationships/dist/events.d.ts"],
       "@voyant-travel/relationships/linkables": ["../relationships/dist/linkables.d.ts"],
       "@voyant-travel/relationships/routes": ["../relationships/dist/routes/index.d.ts"],
       "@voyant-travel/relationships/runtime-contributor": [
         "../relationships/dist/runtime-contributor.d.ts"
       ],
+      "@voyant-travel/relationships/runtime-port": ["../relationships/dist/runtime-port.d.ts"],
       "@voyant-travel/relationships/schema": ["../relationships/dist/schema.d.ts"],
       "@voyant-travel/relationships/tools": ["../relationships/dist/mcp-runtime.d.ts"],
       "@voyant-travel/relationships/validation": ["../relationships/dist/validation.d.ts"],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -1849,12 +1849,16 @@
       "@voyant-travel/relationships/action-ledger-capabilities": [
         "../relationships/dist/action-ledger-capabilities.d.ts"
       ],
+      "@voyant-travel/relationships/booking-enrichment-subscriber": [
+        "../relationships/dist/booking-enrichment/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/relationships/events": ["../relationships/dist/events.d.ts"],
       "@voyant-travel/relationships/linkables": ["../relationships/dist/linkables.d.ts"],
       "@voyant-travel/relationships/routes": ["../relationships/dist/routes/index.d.ts"],
       "@voyant-travel/relationships/runtime-contributor": [
         "../relationships/dist/runtime-contributor.d.ts"
       ],
+      "@voyant-travel/relationships/runtime-port": ["../relationships/dist/runtime-port.d.ts"],
       "@voyant-travel/relationships/schema": ["../relationships/dist/schema.d.ts"],
       "@voyant-travel/relationships/tools": ["../relationships/dist/mcp-runtime.d.ts"],
       "@voyant-travel/relationships/validation": ["../relationships/dist/validation.d.ts"],

--- a/packages/inventory/tsconfig.build.json
+++ b/packages/inventory/tsconfig.build.json
@@ -1786,12 +1786,16 @@
       "@voyant-travel/relationships/action-ledger-capabilities": [
         "../relationships/dist/action-ledger-capabilities.d.ts"
       ],
+      "@voyant-travel/relationships/booking-enrichment-subscriber": [
+        "../relationships/dist/booking-enrichment/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/relationships/events": ["../relationships/dist/events.d.ts"],
       "@voyant-travel/relationships/linkables": ["../relationships/dist/linkables.d.ts"],
       "@voyant-travel/relationships/routes": ["../relationships/dist/routes/index.d.ts"],
       "@voyant-travel/relationships/runtime-contributor": [
         "../relationships/dist/runtime-contributor.d.ts"
       ],
+      "@voyant-travel/relationships/runtime-port": ["../relationships/dist/runtime-port.d.ts"],
       "@voyant-travel/relationships/schema": ["../relationships/dist/schema.d.ts"],
       "@voyant-travel/relationships/tools": ["../relationships/dist/mcp-runtime.d.ts"],
       "@voyant-travel/relationships/validation": ["../relationships/dist/validation.d.ts"],

--- a/packages/inventory/tsconfig.typecheck.json
+++ b/packages/inventory/tsconfig.typecheck.json
@@ -1787,12 +1787,16 @@
       "@voyant-travel/relationships/action-ledger-capabilities": [
         "../relationships/dist/action-ledger-capabilities.d.ts"
       ],
+      "@voyant-travel/relationships/booking-enrichment-subscriber": [
+        "../relationships/dist/booking-enrichment/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/relationships/events": ["../relationships/dist/events.d.ts"],
       "@voyant-travel/relationships/linkables": ["../relationships/dist/linkables.d.ts"],
       "@voyant-travel/relationships/routes": ["../relationships/dist/routes/index.d.ts"],
       "@voyant-travel/relationships/runtime-contributor": [
         "../relationships/dist/runtime-contributor.d.ts"
       ],
+      "@voyant-travel/relationships/runtime-port": ["../relationships/dist/runtime-port.d.ts"],
       "@voyant-travel/relationships/schema": ["../relationships/dist/schema.d.ts"],
       "@voyant-travel/relationships/tools": ["../relationships/dist/mcp-runtime.d.ts"],
       "@voyant-travel/relationships/validation": ["../relationships/dist/validation.d.ts"],

--- a/packages/notifications/src/person-communications-runtime.ts
+++ b/packages/notifications/src/person-communications-runtime.ts
@@ -1,0 +1,64 @@
+import type {
+  PersonNotificationDelivery,
+  PersonNotificationDeliveryQuery,
+  RelationshipsPersonNotificationsRuntime,
+} from "@voyant-travel/relationships/runtime-port"
+import { and, desc, eq, gte, isNotNull, lte } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import { notificationDeliveries } from "./schema.js"
+
+/**
+ * Expose delivered customer messages to the CRM Communications tab.
+ *
+ * Only `sent` rows: a pending send has not reached the customer and a failed
+ * one never will, so neither is a communication that happened. Delivery status
+ * lives here and stays here — CRM reads this rather than holding a copy that
+ * could not follow a later bounce.
+ */
+export function createPersonCommunicationsRuntime(): RelationshipsPersonNotificationsRuntime {
+  return {
+    async listPersonDeliveries(
+      db: unknown,
+      personId: string,
+      query: PersonNotificationDeliveryQuery,
+    ): Promise<readonly PersonNotificationDelivery[]> {
+      const database = db as PostgresJsDatabase
+      const conditions = [
+        eq(notificationDeliveries.personId, personId),
+        eq(notificationDeliveries.status, "sent"),
+        isNotNull(notificationDeliveries.sentAt),
+      ]
+      if (query.dateFrom) {
+        conditions.push(gte(notificationDeliveries.createdAt, new Date(query.dateFrom)))
+      }
+      if (query.dateTo) {
+        conditions.push(lte(notificationDeliveries.createdAt, new Date(query.dateTo)))
+      }
+
+      const rows = await database
+        .select({
+          id: notificationDeliveries.id,
+          channel: notificationDeliveries.channel,
+          subject: notificationDeliveries.subject,
+          textBody: notificationDeliveries.textBody,
+          sentAt: notificationDeliveries.sentAt,
+          createdAt: notificationDeliveries.createdAt,
+        })
+        .from(notificationDeliveries)
+        .where(and(...conditions))
+        .orderBy(desc(notificationDeliveries.createdAt))
+        .limit(query.limit)
+        .offset(query.offset)
+
+      return rows.map((row) => ({
+        id: row.id,
+        channel: row.channel,
+        subject: row.subject ?? null,
+        body: row.textBody ?? null,
+        sentAt: row.sentAt?.toISOString() ?? null,
+        createdAt: row.createdAt.toISOString(),
+      }))
+    },
+  }
+}

--- a/packages/notifications/src/runtime-contributor.ts
+++ b/packages/notifications/src/runtime-contributor.ts
@@ -8,6 +8,7 @@ import {
   type ProposalsNotificationsRuntime,
   proposalsNotificationsRuntimePort,
 } from "@voyant-travel/proposals/runtime-port"
+import { relationshipsPersonNotificationsRuntimePort } from "@voyant-travel/relationships/runtime-port"
 import { storefrontVerificationRuntimePort } from "@voyant-travel/storefront"
 import type { StorefrontVerificationRoutesOptions } from "@voyant-travel/storefront/verification"
 import {
@@ -15,6 +16,7 @@ import {
   durableNotificationProviderPort,
 } from "./durable-provider-port.js"
 import { createFinanceNotificationsRuntime } from "./finance-runtime.js"
+import { createPersonCommunicationsRuntime } from "./person-communications-runtime.js"
 import { createProposalsNotificationsRuntime } from "./proposals-runtime.js"
 import { notificationsReminderJobRuntimePort } from "./reminder-job-runtime-port.js"
 import { createNotificationsRuntime } from "./runtime.js"
@@ -48,6 +50,7 @@ export function createNotificationsRuntimePortContribution(
     [financeNotificationsRuntimePort.id]: createFinanceNotificationsRuntime(
       host.primitives,
     ) satisfies FinanceNotificationsRuntime,
+    [relationshipsPersonNotificationsRuntimePort.id]: createPersonCommunicationsRuntime(),
   }
   if (host.hasRuntimePort?.(durableNotificationProviderPort)) {
     contribution[proposalsNotificationsRuntimePort.id] = Promise.resolve(

--- a/packages/notifications/src/voyant.ts
+++ b/packages/notifications/src/voyant.ts
@@ -10,6 +10,7 @@ import {
 } from "@voyant-travel/core/project"
 import { financeNotificationsRuntimePort } from "@voyant-travel/finance/runtime-port"
 import { proposalsNotificationsRuntimePort } from "@voyant-travel/proposals/runtime-port"
+import { relationshipsPersonNotificationsRuntimePort } from "@voyant-travel/relationships/runtime-port"
 import { storefrontVerificationRuntimePort } from "@voyant-travel/storefront/runtime-port"
 import { durableNotificationProviderPort } from "./durable-provider-port.js"
 import { bookingDocumentsSentEventPayloadSchema } from "./event-payload-schemas.js"
@@ -38,6 +39,7 @@ export const notificationsVoyantModule = defineModule({
       providePort(notificationsRuntimePort),
       providePort(notificationsReminderJobRuntimePort),
       providePort(proposalsNotificationsRuntimePort),
+      providePort(relationshipsPersonNotificationsRuntimePort),
     ],
   },
   api: [

--- a/packages/notifications/tests/unit/voyant-manifest.test.ts
+++ b/packages/notifications/tests/unit/voyant-manifest.test.ts
@@ -24,6 +24,9 @@ describe("notifications deployment manifest", () => {
           { id: "notifications.runtime" },
           { id: "notifications.reminder-job" },
           { id: proposalsNotificationsRuntimePort.id },
+          // Lets the CRM Communications tab read what was actually delivered
+          // without holding a second copy of it.
+          { id: "relationships.person-notifications" },
         ],
       },
       runtimePorts: [

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -1752,12 +1752,16 @@
       "@voyant-travel/relationships/action-ledger-capabilities": [
         "../relationships/dist/action-ledger-capabilities.d.ts"
       ],
+      "@voyant-travel/relationships/booking-enrichment-subscriber": [
+        "../relationships/dist/booking-enrichment/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/relationships/events": ["../relationships/dist/events.d.ts"],
       "@voyant-travel/relationships/linkables": ["../relationships/dist/linkables.d.ts"],
       "@voyant-travel/relationships/routes": ["../relationships/dist/routes/index.d.ts"],
       "@voyant-travel/relationships/runtime-contributor": [
         "../relationships/dist/runtime-contributor.d.ts"
       ],
+      "@voyant-travel/relationships/runtime-port": ["../relationships/dist/runtime-port.d.ts"],
       "@voyant-travel/relationships/schema": ["../relationships/dist/schema.d.ts"],
       "@voyant-travel/relationships/tools": ["../relationships/dist/mcp-runtime.d.ts"],
       "@voyant-travel/relationships/validation": ["../relationships/dist/validation.d.ts"],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -1747,12 +1747,16 @@
       "@voyant-travel/relationships/action-ledger-capabilities": [
         "../relationships/dist/action-ledger-capabilities.d.ts"
       ],
+      "@voyant-travel/relationships/booking-enrichment-subscriber": [
+        "../relationships/dist/booking-enrichment/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/relationships/events": ["../relationships/dist/events.d.ts"],
       "@voyant-travel/relationships/linkables": ["../relationships/dist/linkables.d.ts"],
       "@voyant-travel/relationships/routes": ["../relationships/dist/routes/index.d.ts"],
       "@voyant-travel/relationships/runtime-contributor": [
         "../relationships/dist/runtime-contributor.d.ts"
       ],
+      "@voyant-travel/relationships/runtime-port": ["../relationships/dist/runtime-port.d.ts"],
       "@voyant-travel/relationships/schema": ["../relationships/dist/schema.d.ts"],
       "@voyant-travel/relationships/tools": ["../relationships/dist/mcp-runtime.d.ts"],
       "@voyant-travel/relationships/validation": ["../relationships/dist/validation.d.ts"],

--- a/packages/relationships-contracts/src/validation/common.ts
+++ b/packages/relationships-contracts/src/validation/common.ts
@@ -5,7 +5,13 @@ export const paginationSchema = z.object({
   offset: z.coerce.number().int().min(0).default(0),
 })
 
-export const entityTypeSchema = z.enum(["organization", "person", "proposal", "activity"])
+export const entityTypeSchema = z.enum([
+  "organization",
+  "person",
+  "proposal",
+  "activity",
+  "booking",
+])
 export const customFieldTargetSchema = z.string().min(1)
 
 export const recordStatusSchema = z.enum(["active", "inactive", "archived"])

--- a/packages/relationships-react/src/components/person-detail-panels.tsx
+++ b/packages/relationships-react/src/components/person-detail-panels.tsx
@@ -690,6 +690,9 @@ export function PersonCommunicationsPanel({
               <div className="flex flex-col items-end gap-1">
                 <Badge variant="outline">{labels.channelLabels[communication.channel]}</Badge>
                 <Badge variant="secondary">{labels.directionLabels[communication.direction]}</Badge>
+                {communication.source === "notification" ? (
+                  <Badge variant="outline">{labels.automaticBadge}</Badge>
+                ) : null}
               </div>
             </li>
           ))}

--- a/packages/relationships-react/src/components/person-detail-types.ts
+++ b/packages/relationships-react/src/components/person-detail-types.ts
@@ -96,7 +96,15 @@ export type PersonPaymentMethod = Pick<
 
 export type PersonCommunication = Pick<
   CommunicationLogRecord,
-  "channel" | "content" | "createdAt" | "direction" | "id" | "personId" | "sentAt" | "subject"
+  | "channel"
+  | "content"
+  | "createdAt"
+  | "direction"
+  | "id"
+  | "personId"
+  | "sentAt"
+  | "source"
+  | "subject"
 >
 
 export type PersonTravelSnapshot = PersonTravelSnapshotRecord

--- a/packages/relationships-react/src/i18n/en/detail.ts
+++ b/packages/relationships-react/src/i18n/en/detail.ts
@@ -200,6 +200,7 @@ export const crmUiEnDetailMessages = {
         inbound: "Inbound",
         outbound: "Outbound",
       },
+      automaticBadge: "Automatic",
     },
     relationshipKindLabels: {
       spouse: "Spouse",

--- a/packages/relationships-react/src/i18n/messages.ts
+++ b/packages/relationships-react/src/i18n/messages.ts
@@ -503,6 +503,8 @@ export type CrmUiMessages = {
         inbound: string
         outbound: string
       }
+      /** Marks an entry the system sent, as opposed to one staff logged. */
+      automaticBadge: string
     }
     relationshipKindLabels: {
       spouse: string

--- a/packages/relationships-react/src/i18n/ro/detail.ts
+++ b/packages/relationships-react/src/i18n/ro/detail.ts
@@ -200,6 +200,7 @@ export const crmUiRoDetailMessages = {
         inbound: "Primita",
         outbound: "Trimisa",
       },
+      automaticBadge: "Automat",
     },
     relationshipKindLabels: {
       spouse: "Sot/sotie",

--- a/packages/relationships-react/src/schemas.ts
+++ b/packages/relationships-react/src/schemas.ts
@@ -231,6 +231,12 @@ export const communicationLogRecordSchema = z.object({
   content: z.string().nullable(),
   sentAt: z.string().nullable(),
   createdAt: z.string(),
+  /**
+   * `logged` entries were recorded by staff; `notification` entries are
+   * messages the deployment delivered and cannot be edited here. Defaulted so
+   * an older API that omits the field still parses.
+   */
+  source: z.enum(["logged", "notification"]).default("logged"),
 })
 
 export type CommunicationLogRecord = z.infer<typeof communicationLogRecordSchema>

--- a/packages/relationships/migrations/20260812000100_entity_type_booking.sql
+++ b/packages/relationships/migrations/20260812000100_entity_type_booking.sql
@@ -1,0 +1,13 @@
+-- Let a CRM activity link to the booking it came from.
+--
+-- `entity_type` backs `activity_links.entity_type`, and until now a booking
+-- could not be named there — so the activity a confirmed booking produces could
+-- reference the person but not the booking, and the operator had no way back to
+-- the record that caused it. `custom_field_target` already carries 'booking'
+-- (0003); this brings the link enum in line with it.
+--
+-- ADD VALUE IF NOT EXISTS is a no-op on re-run, and PostgreSQL 12+ permits it
+-- inside the migration transaction as long as the new label is not USED in the
+-- same transaction. Nothing here writes a row with it, so the first write is a
+-- later statement in a later transaction.
+ALTER TYPE "public"."entity_type" ADD VALUE IF NOT EXISTS 'booking';

--- a/packages/relationships/migrations/meta/_journal.json
+++ b/packages/relationships/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1785801660000,
       "tag": "20260804000100_proposal_entity_labels",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1786492800000,
+      "tag": "20260812000100_entity_type_booking",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/relationships/openapi/admin/relationships.json
+++ b/packages/relationships/openapi/admin/relationships.json
@@ -4965,6 +4965,10 @@
                           },
                           "createdAt": {
                             "type": "string"
+                          },
+                          "source": {
+                            "type": "string",
+                            "enum": ["logged", "notification"]
                           }
                         },
                         "required": [
@@ -4976,7 +4980,8 @@
                           "subject",
                           "content",
                           "sentAt",
-                          "createdAt"
+                          "createdAt",
+                          "source"
                         ]
                       }
                     }
@@ -5081,6 +5086,10 @@
                         },
                         "createdAt": {
                           "type": "string"
+                        },
+                        "source": {
+                          "type": "string",
+                          "enum": ["logged", "notification"]
                         }
                       },
                       "required": [
@@ -5092,7 +5101,8 @@
                         "subject",
                         "content",
                         "sentAt",
-                        "createdAt"
+                        "createdAt",
+                        "source"
                       ]
                     }
                   },

--- a/packages/relationships/package.json
+++ b/packages/relationships/package.json
@@ -13,6 +13,8 @@
     "./action-ledger-capabilities": "./src/action-ledger-capabilities.ts",
     "./tools": "./src/mcp-runtime.ts",
     "./runtime-contributor": "./src/runtime-contributor.ts",
+    "./runtime-port": "./src/runtime-port.ts",
+    "./booking-enrichment-subscriber": "./src/booking-enrichment/subscriber-runtime.ts",
     "./voyant": "./src/voyant.ts",
     "./openapi/admin": "./openapi/admin/relationships.json"
   },
@@ -100,6 +102,16 @@
         "types": "./dist/runtime-contributor.d.ts",
         "import": "./dist/runtime-contributor.js",
         "default": "./dist/runtime-contributor.js"
+      },
+      "./runtime-port": {
+        "types": "./dist/runtime-port.d.ts",
+        "import": "./dist/runtime-port.js",
+        "default": "./dist/runtime-port.js"
+      },
+      "./booking-enrichment-subscriber": {
+        "types": "./dist/booking-enrichment/subscriber-runtime.d.ts",
+        "import": "./dist/booking-enrichment/subscriber-runtime.js",
+        "default": "./dist/booking-enrichment/subscriber-runtime.js"
       },
       "./voyant": {
         "types": "./dist/voyant.d.ts",

--- a/packages/relationships/src/booking-enrichment/service.ts
+++ b/packages/relationships/src/booking-enrichment/service.ts
@@ -1,0 +1,265 @@
+import type { BookingCrmSnapshot } from "@voyant-travel/bookings/runtime-port"
+import { identityService } from "@voyant-travel/identity/service"
+import { and, eq, inArray, sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import {
+  activities,
+  activityLinks,
+  activityParticipants,
+  people,
+  personRelationships,
+} from "../schema.js"
+import { personEntityType } from "../service/accounts-shared.js"
+
+/** What a single enrichment pass wrote. Empty fields mean "nothing to write". */
+export interface BookingCrmEnrichmentResult {
+  activityId: string | null
+  addressId: string | null
+  companionPersonIds: readonly string[]
+  /** Set when the pass did nothing, so callers can log a cause rather than a silence. */
+  skipped: "no_person" | "already_enriched" | null
+}
+
+const EMPTY: BookingCrmEnrichmentResult = {
+  activityId: null,
+  addressId: null,
+  companionPersonIds: [],
+  skipped: null,
+}
+
+function trimmed(value: string | null | undefined): string | null {
+  const text = typeof value === "string" ? value.trim() : ""
+  return text ? text : null
+}
+
+/**
+ * The address fields the operator would recognise as "the same address".
+ *
+ * Line 2 and region are deliberately excluded: they are the fields a checkout
+ * most often leaves blank on a repeat booking, and including them would make
+ * the second booking add a near-duplicate row rather than recognise the first.
+ */
+function addressKey(address: {
+  line1: string | null
+  city: string | null
+  postalCode: string | null
+  country: string | null
+}): string | null {
+  const parts = [address.line1, address.city, address.postalCode, address.country].map((part) =>
+    trimmed(part)?.toLowerCase(),
+  )
+  return parts.some(Boolean) ? parts.join("|") : null
+}
+
+/**
+ * Project a confirmed booking onto the person who made it.
+ *
+ * Writes three things the operator otherwise has to enter by hand: a timeline
+ * activity, the billing address the checkout already collected, and a
+ * travel-companion edge per co-traveler who resolved to their own person.
+ *
+ * Idempotent by construction — `booking.confirmed` is redelivered on retry, and
+ * the booking's own activity link is the key that makes a replay a no-op. Every
+ * write is scoped to tables this module owns, except the address, which goes
+ * through Identity's service (the relationships->identity pair the baseline
+ * already carries).
+ */
+export async function enrichCrmFromBooking(
+  db: PostgresJsDatabase,
+  snapshot: BookingCrmSnapshot,
+): Promise<BookingCrmEnrichmentResult> {
+  const personId = snapshot.personId
+  // A booking with no CRM person is a booking there is nothing to enrich —
+  // a staff-entered organization booking, or one whose contact carried no
+  // dedupe key at all.
+  if (!personId) return { ...EMPTY, skipped: "no_person" }
+
+  // Serialize concurrent enrichment of the SAME booking. The guard below is a
+  // read followed by a write, so two simultaneous redeliveries would otherwise
+  // both find no link and both write an activity. Held to the end of the
+  // caller's transaction and scoped to this booking, so bookings never wait on
+  // each other.
+  await db.execute(
+    // agent-quality: raw-sql reviewed -- owner: crm; dynamic SQL interpolation uses Drizzle parameter binding or vetted SQL identifiers.
+    sql`select pg_advisory_xact_lock(hashtext(${`relationships.booking-enrichment:${snapshot.bookingId}`}))`,
+  )
+
+  const [existingLink] = await db
+    .select({ activityId: activityLinks.activityId })
+    .from(activityLinks)
+    .where(
+      and(
+        eq(activityLinks.entityType, "booking"),
+        eq(activityLinks.entityId, snapshot.bookingId),
+        eq(activityLinks.role, "primary"),
+      ),
+    )
+    .limit(1)
+  if (existingLink) {
+    return { ...EMPTY, activityId: existingLink.activityId, skipped: "already_enriched" }
+  }
+
+  // `booking_travelers.person_id` carries no foreign key, so it can name a
+  // person who has since been deleted. Both writes below do have one, and an
+  // unchecked stale id would roll back the whole enrichment over a traveler
+  // record nobody is looking at.
+  const travelerPersonIds = await livePersonIds(
+    db,
+    snapshot.travelers.flatMap((traveler) => (traveler.personId ? [traveler.personId] : [])),
+  )
+
+  const activityId = await writeBookingActivity(db, snapshot, personId, travelerPersonIds)
+  const addressId = await writeBillingAddress(db, snapshot, personId)
+  const companionPersonIds = await writeTravelCompanions(db, snapshot, personId, travelerPersonIds)
+
+  return { activityId, addressId, companionPersonIds, skipped: null }
+}
+
+async function livePersonIds(
+  db: PostgresJsDatabase,
+  candidates: readonly string[],
+): Promise<readonly string[]> {
+  const unique = [...new Set(candidates)]
+  if (unique.length === 0) return []
+  const rows = await db.select({ id: people.id }).from(people).where(inArray(people.id, unique))
+  return rows.map((row) => row.id)
+}
+
+async function writeBookingActivity(
+  db: PostgresJsDatabase,
+  snapshot: BookingCrmSnapshot,
+  personId: string,
+  travelerPersonIds: readonly string[],
+): Promise<string | null> {
+  const now = new Date()
+  const [activity] = await db
+    .insert(activities)
+    .values({
+      subject: `Booking ${snapshot.bookingNumber} confirmed`,
+      type: "note",
+      status: "done",
+      completedAt: now,
+      description: bookingActivityDescription(snapshot),
+    })
+    .returning({ id: activities.id })
+  if (!activity) return null
+
+  await db.insert(activityLinks).values([
+    {
+      activityId: activity.id,
+      entityType: "booking",
+      entityId: snapshot.bookingId,
+      role: "primary",
+    },
+    { activityId: activity.id, entityType: "person", entityId: personId, role: "related" },
+  ])
+
+  // The billing person plus every traveler who resolved to their own record, so
+  // the activity reads as "who this booking was for", not just who paid.
+  const participantIds = new Set<string>([personId, ...travelerPersonIds])
+  await db
+    .insert(activityParticipants)
+    .values(
+      [...participantIds].map((id) => ({
+        activityId: activity.id,
+        personId: id,
+        isPrimary: id === personId,
+      })),
+    )
+    .onConflictDoNothing({
+      target: [activityParticipants.activityId, activityParticipants.personId],
+    })
+
+  return activity.id
+}
+
+function bookingActivityDescription(snapshot: BookingCrmSnapshot): string {
+  const parts = [`Booking ${snapshot.bookingNumber} (${snapshot.sourceType})`]
+  if (snapshot.startDate) parts.push(`departing ${snapshot.startDate}`)
+  if (snapshot.sellAmountCents != null) {
+    parts.push(`${(snapshot.sellAmountCents / 100).toFixed(2)} ${snapshot.sellCurrency}`)
+  }
+  const travelerCount = snapshot.travelers.length
+  if (travelerCount > 0) {
+    parts.push(`${travelerCount} traveler${travelerCount === 1 ? "" : "s"}`)
+  }
+  return parts.join(" · ")
+}
+
+async function writeBillingAddress(
+  db: PostgresJsDatabase,
+  snapshot: BookingCrmSnapshot,
+  personId: string,
+): Promise<string | null> {
+  const address = {
+    line1: trimmed(snapshot.billingAddress.line1),
+    line2: trimmed(snapshot.billingAddress.line2),
+    city: trimmed(snapshot.billingAddress.city),
+    region: trimmed(snapshot.billingAddress.region),
+    postalCode: trimmed(snapshot.billingAddress.postalCode),
+    country: trimmed(snapshot.billingAddress.country),
+  }
+  const key = addressKey(address)
+  // Checkout did not collect one. Nothing to save, and an empty row would be
+  // worse than no row.
+  if (!key) return null
+
+  const existing = await identityService.listAddressesForEntity(db, personEntityType, personId)
+  if (existing.some((row) => addressKey(row) === key)) return null
+
+  const created = await identityService.createAddress(db, {
+    entityType: personEntityType,
+    entityId: personId,
+    label: "billing",
+    ...address,
+    // Only claim primary when the person has nothing on file. A checkout
+    // address must not silently displace one an operator curated.
+    isPrimary: existing.length === 0,
+    notes: `Captured from booking ${snapshot.bookingNumber}`,
+  })
+  return created?.id ?? null
+}
+
+async function writeTravelCompanions(
+  db: PostgresJsDatabase,
+  snapshot: BookingCrmSnapshot,
+  personId: string,
+  travelerPersonIds: readonly string[],
+): Promise<readonly string[]> {
+  const companionIds = new Set(travelerPersonIds.filter((id) => id !== personId))
+  if (companionIds.size === 0) return []
+
+  // Symmetric, so either person's Relationships tab shows the other. Written
+  // here rather than through `createPersonRelationship` because that one throws
+  // on a duplicate edge, and a redelivered event must be a no-op.
+  const edges = [...companionIds].flatMap((companionId) => [
+    {
+      fromPersonId: personId,
+      toPersonId: companionId,
+      kind: "travel_companion" as const,
+      inverseKind: "travel_companion" as const,
+      notes: `Traveled together on booking ${snapshot.bookingNumber}`,
+    },
+    {
+      fromPersonId: companionId,
+      toPersonId: personId,
+      kind: "travel_companion" as const,
+      inverseKind: "travel_companion" as const,
+      notes: `Traveled together on booking ${snapshot.bookingNumber}`,
+    },
+  ])
+
+  await db
+    .insert(personRelationships)
+    .values(edges)
+    .onConflictDoNothing({
+      target: [
+        personRelationships.fromPersonId,
+        personRelationships.toPersonId,
+        personRelationships.kind,
+      ],
+    })
+
+  return [...companionIds]
+}

--- a/packages/relationships/src/booking-enrichment/subscriber-runtime.ts
+++ b/packages/relationships/src/booking-enrichment/subscriber-runtime.ts
@@ -1,0 +1,88 @@
+import {
+  type BookingsCrmSnapshotRuntime,
+  bookingsCrmSnapshotRuntimePort,
+} from "@voyant-travel/bookings/runtime-port"
+import type { SubscriberRuntimeDescriptor } from "@voyant-travel/core"
+import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
+import type { AnyDrizzleDb } from "@voyant-travel/db"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import { relationshipsBookingEnrichmentDatabaseRuntimePort } from "../runtime-port.js"
+import { enrichCrmFromBooking } from "./service.js"
+
+export const RELATIONSHIPS_BOOKING_ENRICHMENT_SUBSCRIBER_ID =
+  "@voyant-travel/relationships#subscriber.crm-enrichment-booking-confirmed"
+
+export interface BookingCrmEnrichmentSubscriberRuntimeOptions<TBindings = unknown> {
+  /** Resolve the deployment database and retain ownership of its lifecycle. */
+  withDb<T>(bindings: TBindings, operation: (db: AnyDrizzleDb) => Promise<T>): Promise<T>
+  snapshots: BookingsCrmSnapshotRuntime
+  enrich?: typeof enrichCrmFromBooking
+  logger?: Pick<Console, "warn">
+}
+
+interface BookingConfirmedPayload {
+  bookingId: string
+}
+
+/**
+ * Fold a confirmed booking into the customer's CRM record.
+ *
+ * A subscriber rather than a step inside the commit: enrichment is derived
+ * bookkeeping, and a CRM write that failed must never be able to roll back a
+ * booking the customer has already paid for. Failures are logged and dropped
+ * for the same reason.
+ */
+export function createBookingCrmEnrichmentSubscriberRuntime<TBindings = unknown>(
+  options: BookingCrmEnrichmentSubscriberRuntimeOptions<TBindings>,
+): SubscriberRuntimeDescriptor {
+  const enrich = options.enrich ?? enrichCrmFromBooking
+  const logger = options.logger ?? console
+
+  return {
+    id: RELATIONSHIPS_BOOKING_ENRICHMENT_SUBSCRIBER_ID,
+    eventType: "booking.confirmed",
+    register: ({ bindings, eventBus }) => {
+      const runtimeBindings = bindings as TBindings
+      eventBus.subscribe<BookingConfirmedPayload>("booking.confirmed", async ({ data }) => {
+        await options.withDb(runtimeBindings, async (db) => {
+          try {
+            const database = db as PostgresJsDatabase
+            const snapshot = await options.snapshots.loadBookingCrmSnapshot(
+              database,
+              data.bookingId,
+            )
+            if (!snapshot) return
+            await enrich(database, snapshot)
+          } catch (error) {
+            logger.warn("[relationships] booking CRM enrichment failed", {
+              bookingId: data.bookingId,
+              error: error instanceof Error ? error.message : String(error),
+            })
+          }
+        })
+      })
+    },
+  }
+}
+
+/** Selected-graph factory binding the enrichment subscriber to its two ports. */
+export const createBookingCrmEnrichmentSubscriberGraphRuntime = defineGraphRuntimeFactory(
+  async ({ getPort, hasPort }) => {
+    // A deployment can select CRM without Bookings. Then nothing emits
+    // `booking.confirmed` and there is no snapshot reader, so the subscriber
+    // registers as an inert descriptor rather than failing the boot.
+    if (!hasPort(bookingsCrmSnapshotRuntimePort)) {
+      return {
+        id: RELATIONSHIPS_BOOKING_ENRICHMENT_SUBSCRIBER_ID,
+        eventType: "booking.confirmed",
+        register: () => {},
+      } satisfies SubscriberRuntimeDescriptor
+    }
+    const [database, snapshots] = await Promise.all([
+      getPort(relationshipsBookingEnrichmentDatabaseRuntimePort),
+      getPort(bookingsCrmSnapshotRuntimePort),
+    ])
+    return createBookingCrmEnrichmentSubscriberRuntime({ ...database, snapshots })
+  },
+)

--- a/packages/relationships/src/route-runtime.ts
+++ b/packages/relationships/src/route-runtime.ts
@@ -1,6 +1,8 @@
 import type { CustomFieldRegistryResolver } from "@voyant-travel/core/custom-fields"
 import { createKmsProviderFromEnv, type KmsProvider } from "@voyant-travel/utils"
 
+import type { RelationshipsPersonNotificationsRuntime } from "./runtime-port.js"
+
 export const RELATIONSHIPS_ROUTE_RUNTIME_CONTAINER_KEY = "runtime.relationships.routes"
 
 /**
@@ -23,12 +25,20 @@ export interface RelationshipsRouteRuntime {
   customFields?: CustomFieldRegistryResolver
   /** Resolves and locks persisted definitions for an entity write transaction. */
   customFieldsForWrite?: (db: unknown, entity: string) => ReturnType<CustomFieldRegistryResolver>
+  /**
+   * Reads messages a deployment actually delivered to a person, so the
+   * Communications tab shows them alongside hand-logged entries. Absent when
+   * the deployment selects no notifications module — the tab then lists only
+   * what staff recorded, which is what it did before.
+   */
+  personNotifications?: RelationshipsPersonNotificationsRuntime
 }
 
 export interface RelationshipsRouteRuntimeOptions {
   resolveKmsProvider?: ResolveRelationshipsKmsProvider
   customFields?: CustomFieldRegistryResolver
   customFieldsForWrite?: (db: unknown, entity: string) => ReturnType<CustomFieldRegistryResolver>
+  personNotifications?: RelationshipsPersonNotificationsRuntime
 }
 
 function buildRuntimeEnv(bindings: Record<string, unknown>): Record<string, string | undefined> {
@@ -67,5 +77,6 @@ export function buildRelationshipsRouteRuntime(
     },
     customFields: options.customFields,
     customFieldsForWrite: options.customFieldsForWrite,
+    personNotifications: options.personNotifications,
   }
 }

--- a/packages/relationships/src/routes/accounts-openapi-schemas.ts
+++ b/packages/relationships/src/routes/accounts-openapi-schemas.ts
@@ -143,6 +143,12 @@ export const communicationLogEntrySchema = z.object({
   content: z.string().nullable(),
   sentAt: isoTimestamp.nullable(),
   createdAt: isoTimestamp,
+  /**
+   * Where the entry came from. `logged` is a row staff wrote and can edit;
+   * `notification` is a message the deployment delivered, and is read-only —
+   * its authority is the delivery record, not CRM.
+   */
+  source: z.enum(["logged", "notification"]).default("logged"),
 })
 
 // --- segments ---------------------------------------------------------------

--- a/packages/relationships/src/routes/accounts.ts
+++ b/packages/relationships/src/routes/accounts.ts
@@ -52,6 +52,7 @@ import {
 } from "../route-runtime.js"
 import { RelationshipsMergeError } from "../service/accounts-merge.js"
 import { relationshipsService } from "../service/index.js"
+import { mergePersonCommunications } from "../service/person-communications.js"
 import {
   communicationListQuerySchema,
   insertCommunicationLogSchema,
@@ -964,25 +965,31 @@ peopleRoutes
       ? c.json({ success: true } as const, 200)
       : c.json({ error: "Payment method not found" }, 404)
   })
-  .openapi(listCommunicationsRoute, async (c) =>
-    c.json(
-      {
-        data: await relationshipsService.listCommunications(
-          c.get("db"),
-          c.req.valid("param").id,
-          c.req.valid("query"),
-        ),
-      },
-      200,
-    ),
-  )
+  .openapi(listCommunicationsRoute, async (c) => {
+    const personId = c.req.valid("param").id
+    const query = c.req.valid("query")
+    const runtime = c.get("container")?.resolve(RELATIONSHIPS_ROUTE_RUNTIME_CONTAINER_KEY) as
+      | RelationshipsRouteRuntime
+      | undefined
+    const [logged, delivered] = await Promise.all([
+      relationshipsService.listCommunications(c.get("db"), personId, query),
+      // Deliveries are outbound by definition, so a caller filtering for
+      // inbound is asking for hand-logged entries only.
+      query.direction === "inbound" || !runtime?.personNotifications
+        ? Promise.resolve([])
+        : runtime.personNotifications.listPersonDeliveries(c.get("db"), personId, query),
+    ])
+    return c.json({ data: mergePersonCommunications(personId, logged, delivered, query) }, 200)
+  })
   .openapi(createCommunicationRoute, async (c) => {
     const row = await relationshipsService.createCommunication(
       c.get("db"),
       c.req.valid("param").id,
       c.req.valid("json"),
     )
-    return row ? c.json({ data: row }, 201) : c.json({ error: "Person not found" }, 404)
+    return row
+      ? c.json({ data: { ...row, source: "logged" as const } }, 201)
+      : c.json({ error: "Person not found" }, 404)
   })
 
 // ===========================================================================

--- a/packages/relationships/src/runtime-contributor.ts
+++ b/packages/relationships/src/runtime-contributor.ts
@@ -2,6 +2,7 @@ import {
   type BookingsRelationshipsRuntime,
   bookingsRelationshipsRuntimePort,
 } from "@voyant-travel/bookings/runtime-port"
+import type { VoyantRuntimeHostPrimitives } from "@voyant-travel/core"
 import {
   type CustomFieldsRuntime,
   type CustomFieldValueLifecycleRuntime,
@@ -16,12 +17,17 @@ import {
   type CustomFieldValueOperationsRuntime,
   customFieldValueOperationsRuntimePort,
 } from "@voyant-travel/core/runtime-port"
+import type { AnyDrizzleDb } from "@voyant-travel/db"
 import { sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { RelationshipsRouteRuntimeOptions } from "./route-runtime.js"
 import {
+  type RelationshipsBookingEnrichmentDatabaseRuntime,
   type RelationshipsMiceRuntime,
+  type RelationshipsPersonNotificationsRuntime,
+  relationshipsBookingEnrichmentDatabaseRuntimePort,
   relationshipsMiceRuntimePort,
+  relationshipsPersonNotificationsRuntimePort,
   relationshipsRouteRuntimePort,
 } from "./runtime-port.js"
 import { relationshipsService } from "./service/index.js"
@@ -146,7 +152,27 @@ const relationshipCustomFieldValueOperations: CustomFieldValueOperationsRuntime 
 }
 
 interface RelationshipsRuntimeContributorHost {
+  primitives: VoyantRuntimeHostPrimitives
+  hasRuntimePort?(port: Pick<VoyantPort<unknown>, "id">): boolean
   getRuntimePort<T>(port: Pick<VoyantPort<T>, "id">): T | Promise<T>
+}
+
+/**
+ * Notifications is optional. A deployment that selects CRM without it keeps a
+ * Communications tab listing only hand-logged entries, which is what it showed
+ * before this seam existed.
+ */
+async function resolvePersonNotifications(
+  host: RelationshipsRuntimeContributorHost,
+): Promise<RelationshipsPersonNotificationsRuntime | undefined> {
+  if (host.hasRuntimePort?.(relationshipsPersonNotificationsRuntimePort) === false) return undefined
+  try {
+    return await host.getRuntimePort<RelationshipsPersonNotificationsRuntime>(
+      relationshipsPersonNotificationsRuntimePort,
+    )
+  } catch {
+    return undefined
+  }
 }
 
 /** Package-owned registration map for Relationships deployment adapters. */
@@ -156,6 +182,7 @@ export function createRelationshipsRuntimePortContribution(
   const customFieldsRuntime = Promise.resolve(
     host.getRuntimePort<CustomFieldsRuntime>(customFieldsRuntimePort),
   )
+  const personNotifications = resolvePersonNotifications(host)
   const customFields: CustomFieldValueReaderRuntime = {
     async resolveVisibleValues(db, entity, entityId, channel) {
       const database = db as PostgresJsDatabase
@@ -195,11 +222,25 @@ export function createRelationshipsRuntimePortContribution(
         (await customFieldsRuntime).resolveRegistry(db as PostgresJsDatabase),
       customFieldsForWrite: async (db, entity) =>
         (await customFieldsRuntime).resolveRegistryForWrite(db as PostgresJsDatabase, entity),
+      // Resolved per call, not folded into this object: routes read the route
+      // runtime synchronously, so awaiting an optional port to build it would
+      // hand them a promise where they expect the options. Answers with an
+      // empty list when no notifications module is selected.
+      personNotifications: {
+        listPersonDeliveries: async (db, personId, query) =>
+          (await personNotifications)?.listPersonDeliveries(db, personId, query) ?? [],
+      },
     } satisfies RelationshipsRouteRuntimeOptions,
     [relationshipsMiceRuntimePort.id]: {
       personExists: async (db, personId) =>
         (await relationshipsService.getPersonById(db as never, personId)) != null,
     } satisfies RelationshipsMiceRuntime,
+    [relationshipsBookingEnrichmentDatabaseRuntimePort.id]: {
+      withDb: <T>(bindings: unknown, operation: (db: AnyDrizzleDb) => Promise<T>) =>
+        host.primitives.database.transaction(bindings, (database) =>
+          operation(database as AnyDrizzleDb),
+        ),
+    } satisfies RelationshipsBookingEnrichmentDatabaseRuntime,
     [bookingsRelationshipsRuntimePort.id]: {
       loadPersonTravelSnapshot: (...args) => relationshipsService.loadPersonTravelSnapshot(...args),
       upsertPersonFromContact: (...args) => relationshipsService.upsertPersonFromContact(...args),

--- a/packages/relationships/src/runtime-port.ts
+++ b/packages/relationships/src/runtime-port.ts
@@ -1,9 +1,48 @@
 import { definePort } from "@voyant-travel/core/project"
+import type { AnyDrizzleDb } from "@voyant-travel/db"
 
 import type { RelationshipsRouteRuntimeOptions } from "./route-runtime.js"
 
 export interface RelationshipsMiceRuntime {
   personExists(db: unknown, personId: string): Promise<boolean>
+}
+
+/** Database access for the CRM enrichment subscriber, which runs off-request. */
+export interface RelationshipsBookingEnrichmentDatabaseRuntime {
+  withDb<T>(bindings: unknown, operation: (db: AnyDrizzleDb) => Promise<T>): Promise<T>
+}
+
+/** One message a deployment actually delivered to a person. */
+export interface PersonNotificationDelivery {
+  id: string
+  channel: "email" | "sms"
+  subject: string | null
+  body: string | null
+  sentAt: string | null
+  createdAt: string
+}
+
+export interface PersonNotificationDeliveryQuery {
+  limit: number
+  offset: number
+  dateFrom?: string
+  dateTo?: string
+}
+
+/**
+ * Lets the Communications tab show what was actually sent.
+ *
+ * The delivery record is the authority on a sent message, so CRM reads it
+ * rather than keeping a second copy in `communication_log` that would go stale
+ * the moment a delivery bounced. Declared here because notifications already
+ * depends on relationships; the reverse import would close a package cycle.
+ */
+export interface RelationshipsPersonNotificationsRuntime {
+  listPersonDeliveries(
+    db: unknown,
+    personId: string,
+    query: PersonNotificationDeliveryQuery,
+  ): Promise<readonly PersonNotificationDelivery[]>
 }
 
 /** Deployment contract consumed by the package-owned Relationships graph runtime. */
@@ -26,6 +65,38 @@ export const relationshipsRouteRuntimePort = definePort<RelationshipsRouteRuntim
     }
   },
 })
+
+export const relationshipsBookingEnrichmentDatabaseRuntimePort =
+  definePort<RelationshipsBookingEnrichmentDatabaseRuntime>({
+    id: "relationships.booking-enrichment-database",
+    test(provider) {
+      if (
+        provider === null ||
+        typeof provider !== "object" ||
+        typeof provider.withDb !== "function"
+      ) {
+        throw new Error(
+          "relationships.booking-enrichment-database provider must implement withDb().",
+        )
+      }
+    },
+  })
+
+export const relationshipsPersonNotificationsRuntimePort =
+  definePort<RelationshipsPersonNotificationsRuntime>({
+    id: "relationships.person-notifications",
+    test(provider) {
+      if (
+        provider === null ||
+        typeof provider !== "object" ||
+        typeof provider.listPersonDeliveries !== "function"
+      ) {
+        throw new Error(
+          "relationships.person-notifications provider must implement listPersonDeliveries().",
+        )
+      }
+    },
+  })
 
 /** Narrow Relationships behavior consumed by MICE without deployment wiring. */
 export const relationshipsMiceRuntimePort = definePort<RelationshipsMiceRuntime>({

--- a/packages/relationships/src/schema-shared.ts
+++ b/packages/relationships/src/schema-shared.ts
@@ -5,6 +5,7 @@ export const entityTypeEnum = pgEnum("entity_type", [
   "person",
   "proposal",
   "activity",
+  "booking",
 ])
 
 export const relationTypeEnum = pgEnum("relation_type", ["client", "partner", "supplier", "other"])

--- a/packages/relationships/src/service/activities.ts
+++ b/packages/relationships/src/service/activities.ts
@@ -33,19 +33,26 @@ function firstExecuteRow<T>(result: unknown): T | undefined {
   return undefined
 }
 
-async function proposalExists(db: PostgresJsDatabase, proposalId: string) {
+/**
+ * Existence probe for a table this module does not own.
+ *
+ * Raw SQL behind a `to_regclass` guard rather than an imported Drizzle table:
+ * the linked module may not be in the selected graph at all, and importing its
+ * schema here would be the ADR-0016 reach-in the table-privacy ratchet exists
+ * to stop. A deployment without the table simply cannot link to it.
+ */
+async function foreignRowExists(db: PostgresJsDatabase, table: string, id: string) {
   const tableResult = await db.execute(
-    sql<{ exists: boolean }[]>`select (to_regclass('public.proposals') is not null) as exists`,
+    sql<{ exists: boolean }[]>`select (to_regclass(${`public.${table}`}) is not null) as exists`,
   )
-  const tableRow = firstExecuteRow<{ exists: boolean }>(tableResult)
-  if (!tableRow?.exists) return false
+  if (!firstExecuteRow<{ exists: boolean }>(tableResult)?.exists) return false
 
-  const proposalResult = await db.execute(
-    sql<{ exists: boolean }[]>`
-      select exists(select 1 from public.proposals where id = ${proposalId}) as exists
-    `,
+  const rowResult = await db.execute(
+    sql<
+      { exists: boolean }[]
+    >`select exists(select 1 from ${sql.identifier(table)} where id = ${id}) as exists`,
   )
-  return !!firstExecuteRow<{ exists: boolean }>(proposalResult)?.exists
+  return !!firstExecuteRow<{ exists: boolean }>(rowResult)?.exists
 }
 
 async function linkedEntityExists(db: PostgresJsDatabase, data: CreateActivityLinkInput) {
@@ -75,7 +82,9 @@ async function linkedEntityExists(db: PostgresJsDatabase, data: CreateActivityLi
       return !!row
     }
     case "proposal":
-      return proposalExists(db, data.entityId)
+      return foreignRowExists(db, "proposals", data.entityId)
+    case "booking":
+      return foreignRowExists(db, "bookings", data.entityId)
   }
 }
 

--- a/packages/relationships/src/service/person-communications.ts
+++ b/packages/relationships/src/service/person-communications.ts
@@ -1,0 +1,83 @@
+import type { PersonNotificationDelivery } from "../runtime-port.js"
+import type { CommunicationLogEntry } from "../schema.js"
+
+/**
+ * A communication as the Communications tab sees it.
+ *
+ * `source` is the field the UI needs: a `logged` entry is a row staff wrote and
+ * may edit, a `notification` entry is a message the deployment sent and is
+ * read-only. Without it the tab would offer to edit a delivery record that has
+ * no edit route behind it.
+ */
+export interface PersonCommunicationEntry {
+  id: string
+  personId: string
+  organizationId: string | null
+  channel: CommunicationLogEntry["channel"]
+  direction: CommunicationLogEntry["direction"]
+  subject: string | null
+  content: string | null
+  sentAt: Date | null
+  createdAt: Date
+  source: "logged" | "notification"
+}
+
+interface MergeQuery {
+  limit: number
+  offset: number
+  channel?: CommunicationLogEntry["channel"]
+  direction?: CommunicationLogEntry["direction"]
+}
+
+function orderedAt(entry: PersonCommunicationEntry): number {
+  return (entry.sentAt ?? entry.createdAt).getTime()
+}
+
+/**
+ * Interleave hand-logged entries with delivered notifications, newest first.
+ *
+ * Both inputs arrive already paged by their own source, so the merge is exact
+ * for the first page and approximate beyond it — a deep page can miss an entry
+ * that sorted into the other source's earlier page. The tab reads one page of
+ * 50, and the alternative is a cross-module SQL union that would put Bookings'
+ * and Notifications' tables inside a CRM query.
+ */
+export function mergePersonCommunications(
+  personId: string,
+  logged: readonly CommunicationLogEntry[],
+  delivered: readonly PersonNotificationDelivery[],
+  query: MergeQuery,
+): PersonCommunicationEntry[] {
+  const entries: PersonCommunicationEntry[] = logged.map((row) => ({
+    id: row.id,
+    personId: row.personId,
+    organizationId: row.organizationId,
+    channel: row.channel,
+    direction: row.direction,
+    subject: row.subject,
+    content: row.content,
+    sentAt: row.sentAt,
+    createdAt: row.createdAt,
+    source: "logged",
+  }))
+
+  for (const delivery of delivered) {
+    // The delivery channel enum is a subset of the communication one, but a
+    // caller filtering on `phone` or `meeting` must not see email deliveries.
+    if (query.channel && query.channel !== delivery.channel) continue
+    entries.push({
+      id: delivery.id,
+      personId,
+      organizationId: null,
+      channel: delivery.channel,
+      direction: "outbound",
+      subject: delivery.subject,
+      content: delivery.body,
+      sentAt: delivery.sentAt ? new Date(delivery.sentAt) : null,
+      createdAt: new Date(delivery.createdAt),
+      source: "notification",
+    })
+  }
+
+  return entries.sort((left, right) => orderedAt(right) - orderedAt(left)).slice(0, query.limit)
+}

--- a/packages/relationships/src/voyant.ts
+++ b/packages/relationships/src/voyant.ts
@@ -1,5 +1,8 @@
 // agent-quality: file-size exception -- owner: relationships; the import-cheap package manifest remains centralized until #3398 moves custom-field API and Settings facets to their generic owner.
-import { bookingsRelationshipsRuntimePort } from "@voyant-travel/bookings/runtime-port"
+import {
+  bookingsCrmSnapshotRuntimePort,
+  bookingsRelationshipsRuntimePort,
+} from "@voyant-travel/bookings/runtime-port"
 import { defineModule, providePort, requirePort } from "@voyant-travel/core/project"
 import {
   customFieldsRuntimePort,
@@ -7,7 +10,11 @@ import {
   customFieldValueOperationsRuntimePort,
   customFieldValueReaderRuntimePort,
 } from "@voyant-travel/core/runtime-port"
-import { relationshipsMiceRuntimePort, relationshipsRouteRuntimePort } from "./runtime-port.js"
+import {
+  relationshipsBookingEnrichmentDatabaseRuntimePort,
+  relationshipsMiceRuntimePort,
+  relationshipsRouteRuntimePort,
+} from "./runtime-port.js"
 
 export {
   type RelationshipsMiceRuntime,
@@ -85,9 +92,17 @@ export const relationshipsVoyantModule = defineModule({
       providePort(customFieldValueReaderRuntimePort),
       providePort(customFieldValueLifecycleRuntimePort),
       providePort(customFieldValueOperationsRuntimePort),
+      providePort(relationshipsBookingEnrichmentDatabaseRuntimePort),
     ],
   },
-  runtimePorts: [requirePort(customFieldsRuntimePort), requirePort(relationshipsRouteRuntimePort)],
+  runtimePorts: [
+    requirePort(customFieldsRuntimePort),
+    requirePort(relationshipsRouteRuntimePort),
+    requirePort(relationshipsBookingEnrichmentDatabaseRuntimePort),
+    // Optional so a deployment that selects CRM without Bookings still boots;
+    // the enrichment subscriber simply has nothing to read.
+    requirePort(bookingsCrmSnapshotRuntimePort, { optional: true }),
+  ],
   api: [
     {
       id: "@voyant-travel/relationships#api.admin",
@@ -150,6 +165,17 @@ export const relationshipsVoyantModule = defineModule({
       payloadSchema: relationshipChangedPayloadSchema,
       visibility: "internal",
       audit: { sourceModule: "relationships", category: "domain" },
+    },
+  ],
+  subscribers: [
+    {
+      id: "@voyant-travel/relationships#subscriber.crm-enrichment-booking-confirmed",
+      eventType: "booking.confirmed",
+      source: "@voyant-travel/relationships/booking-enrichment-subscriber",
+      runtime: {
+        entry: "@voyant-travel/relationships/booking-enrichment-subscriber",
+        export: "createBookingCrmEnrichmentSubscriberGraphRuntime",
+      },
     },
   ],
   access: {

--- a/packages/relationships/tests/integration/booking-enrichment.test.ts
+++ b/packages/relationships/tests/integration/booking-enrichment.test.ts
@@ -1,0 +1,218 @@
+import type { BookingCrmSnapshot } from "@voyant-travel/bookings/runtime-port"
+import { identityService } from "@voyant-travel/identity/service"
+import { eq } from "drizzle-orm"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { enrichCrmFromBooking } from "../../src/booking-enrichment/service.js"
+import {
+  activities,
+  activityLinks,
+  activityParticipants,
+  people,
+  personRelationships,
+} from "../../src/schema.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+function snapshot(overrides: Partial<BookingCrmSnapshot> = {}): BookingCrmSnapshot {
+  return {
+    bookingId: "bookings_01",
+    bookingNumber: "BK-2608-399637",
+    status: "confirmed",
+    personId: null,
+    organizationId: null,
+    sourceType: "storefront",
+    startDate: "2026-08-22",
+    sellCurrency: "RON",
+    sellAmountCents: 16000,
+    billingAddress: {
+      line1: "Str. Republicii 12",
+      line2: null,
+      city: "Cluj-Napoca",
+      region: "RO-CJ",
+      postalCode: "400015",
+      country: "RO",
+    },
+    travelers: [],
+    ...overrides,
+  }
+}
+
+describe.skipIf(!DB_AVAILABLE)("enrichCrmFromBooking", () => {
+  // biome-ignore lint/suspicious/noExplicitAny: test db typing -- owner: crm; existing suppression is intentional pending typed cleanup.
+  let db: any
+
+  beforeAll(async () => {
+    const { createTestDb, cleanupTestDb } = await import("@voyant-travel/db/test-utils")
+    db = createTestDb()
+    await cleanupTestDb(db)
+  })
+
+  beforeEach(async () => {
+    const { cleanupTestDb } = await import("@voyant-travel/db/test-utils")
+    await cleanupTestDb(db)
+  })
+
+  afterAll(async () => {
+    const { closeTestDb } = await import("@voyant-travel/db/test-utils")
+    await closeTestDb()
+  })
+
+  async function seedPerson(firstName = "Myra") {
+    const [row] = await db
+      .insert(people)
+      .values({ firstName, lastName: "Edelstein", tags: [], status: "active" })
+      .returning()
+    return row
+  }
+
+  it("records the booking on the person's timeline", async () => {
+    const person = await seedPerson()
+
+    const result = await enrichCrmFromBooking(db, snapshot({ personId: person.id }))
+
+    expect(result.skipped).toBeNull()
+    expect(result.activityId).toBeTruthy()
+
+    const [activity] = await db
+      .select()
+      .from(activities)
+      .where(eq(activities.id, result.activityId as string))
+    expect(activity.subject).toBe("Booking BK-2608-399637 confirmed")
+    expect(activity.status).toBe("done")
+
+    const links = await db
+      .select()
+      .from(activityLinks)
+      .where(eq(activityLinks.activityId, result.activityId as string))
+    expect(links.map((link: { entityType: string; entityId: string }) => link)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ entityType: "booking", entityId: "bookings_01" }),
+        expect.objectContaining({ entityType: "person", entityId: person.id }),
+      ]),
+    )
+  })
+
+  it("saves the checkout billing address as the person's billing address", async () => {
+    const person = await seedPerson()
+
+    const result = await enrichCrmFromBooking(db, snapshot({ personId: person.id }))
+
+    expect(result.addressId).toBeTruthy()
+    const addresses = await identityService.listAddressesForEntity(db, "person", person.id)
+    expect(addresses).toHaveLength(1)
+    expect(addresses[0]).toMatchObject({
+      label: "billing",
+      line1: "Str. Republicii 12",
+      city: "Cluj-Napoca",
+      region: "RO-CJ",
+      postalCode: "400015",
+      country: "RO",
+      // First address on file, so it becomes primary.
+      isPrimary: true,
+    })
+  })
+
+  it("does not add a second address for the same place on a repeat booking", async () => {
+    const person = await seedPerson()
+    await enrichCrmFromBooking(db, snapshot({ personId: person.id }))
+
+    const second = await enrichCrmFromBooking(
+      db,
+      snapshot({ personId: person.id, bookingId: "bookings_02", bookingNumber: "BK-2606-339104" }),
+    )
+
+    expect(second.addressId).toBeNull()
+    const addresses = await identityService.listAddressesForEntity(db, "person", person.id)
+    expect(addresses).toHaveLength(1)
+  })
+
+  it("writes nothing when the checkout collected no address", async () => {
+    const person = await seedPerson()
+
+    const result = await enrichCrmFromBooking(
+      db,
+      snapshot({
+        personId: person.id,
+        billingAddress: {
+          line1: null,
+          line2: null,
+          city: null,
+          region: null,
+          postalCode: null,
+          country: null,
+        },
+      }),
+    )
+
+    expect(result.addressId).toBeNull()
+    expect(await identityService.listAddressesForEntity(db, "person", person.id)).toHaveLength(0)
+  })
+
+  it("links co-travelers to the booker in both directions", async () => {
+    const booker = await seedPerson("Myra")
+    const companion = await seedPerson("Dana")
+
+    const result = await enrichCrmFromBooking(
+      db,
+      snapshot({
+        personId: booker.id,
+        travelers: [
+          { personId: booker.id, firstName: "Myra", lastName: "Edelstein", isPrimary: true },
+          { personId: companion.id, firstName: "Dana", lastName: "Edelstein", isPrimary: false },
+        ],
+      }),
+    )
+
+    expect(result.companionPersonIds).toEqual([companion.id])
+    const edges = await db.select().from(personRelationships)
+    expect(edges).toHaveLength(2)
+    expect(edges.every((edge: { kind: string }) => edge.kind === "travel_companion")).toBe(true)
+
+    const participants = await db
+      .select()
+      .from(activityParticipants)
+      .where(eq(activityParticipants.activityId, result.activityId as string))
+    expect(participants).toHaveLength(2)
+  })
+
+  it("ignores a traveler pointing at a person that no longer exists", async () => {
+    const booker = await seedPerson("Myra")
+
+    const result = await enrichCrmFromBooking(
+      db,
+      snapshot({
+        personId: booker.id,
+        travelers: [
+          { personId: booker.id, firstName: "Myra", lastName: "Edelstein", isPrimary: true },
+          // `booking_travelers.person_id` has no foreign key, so a deleted
+          // person leaves a danging id behind.
+          { personId: "person_deleted", firstName: "Gone", lastName: "Away", isPrimary: false },
+        ],
+      }),
+    )
+
+    expect(result.companionPersonIds).toEqual([])
+    expect(result.activityId).toBeTruthy()
+    expect(await db.select().from(personRelationships)).toHaveLength(0)
+  })
+
+  it("is a no-op when the same booking is delivered twice", async () => {
+    const person = await seedPerson()
+    const first = await enrichCrmFromBooking(db, snapshot({ personId: person.id }))
+
+    const replay = await enrichCrmFromBooking(db, snapshot({ personId: person.id }))
+
+    expect(replay.skipped).toBe("already_enriched")
+    expect(replay.activityId).toBe(first.activityId)
+    expect(await db.select().from(activities)).toHaveLength(1)
+    expect(await identityService.listAddressesForEntity(db, "person", person.id)).toHaveLength(1)
+  })
+
+  it("skips a booking that resolved no CRM person", async () => {
+    const result = await enrichCrmFromBooking(db, snapshot({ personId: null }))
+
+    expect(result.skipped).toBe("no_person")
+    expect(await db.select().from(activities)).toHaveLength(0)
+  })
+})

--- a/packages/relationships/tests/unit/person-communications.test.ts
+++ b/packages/relationships/tests/unit/person-communications.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest"
+
+import type { PersonNotificationDelivery } from "../../src/runtime-port.js"
+import type { CommunicationLogEntry } from "../../src/schema.js"
+import { mergePersonCommunications } from "../../src/service/person-communications.js"
+
+const PERSON_ID = "person_01"
+
+function logged(overrides: Partial<CommunicationLogEntry> = {}): CommunicationLogEntry {
+  return {
+    id: "communication_log_01",
+    personId: PERSON_ID,
+    organizationId: null,
+    channel: "phone",
+    direction: "inbound",
+    subject: "Called about the itinerary",
+    content: null,
+    sentAt: new Date("2026-08-02T10:00:00Z"),
+    createdAt: new Date("2026-08-02T10:00:00Z"),
+    ...overrides,
+  }
+}
+
+function delivery(overrides: Partial<PersonNotificationDelivery> = {}): PersonNotificationDelivery {
+  return {
+    id: "notification_deliveries_01",
+    channel: "email",
+    subject: "Your booking is confirmed",
+    body: "Thanks for booking with us.",
+    sentAt: "2026-08-03T09:00:00.000Z",
+    createdAt: "2026-08-03T08:59:00.000Z",
+    ...overrides,
+  }
+}
+
+const QUERY = { limit: 50, offset: 0 }
+
+describe("mergePersonCommunications", () => {
+  it("interleaves both sources newest first", () => {
+    const merged = mergePersonCommunications(PERSON_ID, [logged()], [delivery()], QUERY)
+
+    expect(merged.map((entry) => entry.id)).toEqual([
+      "notification_deliveries_01",
+      "communication_log_01",
+    ])
+  })
+
+  it("tags each entry with where it came from", () => {
+    const merged = mergePersonCommunications(PERSON_ID, [logged()], [delivery()], QUERY)
+
+    expect(merged.map((entry) => entry.source)).toEqual(["notification", "logged"])
+  })
+
+  it("presents a delivery as an outbound message attributed to the person", () => {
+    const [entry] = mergePersonCommunications(PERSON_ID, [], [delivery()], QUERY)
+
+    expect(entry).toMatchObject({
+      personId: PERSON_ID,
+      direction: "outbound",
+      channel: "email",
+      subject: "Your booking is confirmed",
+      content: "Thanks for booking with us.",
+      source: "notification",
+    })
+    expect(entry?.sentAt).toEqual(new Date("2026-08-03T09:00:00.000Z"))
+  })
+
+  it("drops deliveries whose channel the caller filtered out", () => {
+    const merged = mergePersonCommunications(PERSON_ID, [logged()], [delivery()], {
+      ...QUERY,
+      channel: "phone",
+    })
+
+    expect(merged.map((entry) => entry.id)).toEqual(["communication_log_01"])
+  })
+
+  it("orders by createdAt when a delivery has no sent timestamp", () => {
+    const merged = mergePersonCommunications(
+      PERSON_ID,
+      [logged({ sentAt: null, createdAt: new Date("2026-08-05T00:00:00Z") })],
+      [delivery({ sentAt: null })],
+      QUERY,
+    )
+
+    expect(merged.map((entry) => entry.id)).toEqual([
+      "communication_log_01",
+      "notification_deliveries_01",
+    ])
+  })
+
+  it("never returns more than the requested page", () => {
+    const merged = mergePersonCommunications(
+      PERSON_ID,
+      [logged(), logged({ id: "communication_log_02" })],
+      [delivery(), delivery({ id: "notification_deliveries_02" })],
+      { ...QUERY, limit: 3 },
+    )
+
+    expect(merged).toHaveLength(3)
+  })
+})

--- a/packages/relationships/tests/unit/voyant-manifest.test.ts
+++ b/packages/relationships/tests/unit/voyant-manifest.test.ts
@@ -29,9 +29,17 @@ describe("relationships deployment manifest", () => {
           { id: customFieldValueReaderRuntimePort.id },
           { id: customFieldValueLifecycleRuntimePort.id },
           { id: customFieldValueOperationsRuntimePort.id },
+          { id: "relationships.booking-enrichment-database" },
         ],
       },
-      runtimePorts: [{ id: customFieldsRuntimePort.id }, { id: "relationships.route-runtime" }],
+      runtimePorts: [
+        { id: customFieldsRuntimePort.id },
+        { id: "relationships.route-runtime" },
+        { id: "relationships.booking-enrichment-database" },
+        // Optional: a deployment can select CRM without Bookings, and then
+        // nothing emits `booking.confirmed` for the enrichment subscriber.
+        { id: "bookings.crm-snapshot.runtime", optional: true },
+      ],
       api: [
         {
           id: "@voyant-travel/relationships#api.admin",

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -1865,12 +1865,16 @@
       "@voyant-travel/relationships/action-ledger-capabilities": [
         "../relationships/dist/action-ledger-capabilities.d.ts"
       ],
+      "@voyant-travel/relationships/booking-enrichment-subscriber": [
+        "../relationships/dist/booking-enrichment/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/relationships/events": ["../relationships/dist/events.d.ts"],
       "@voyant-travel/relationships/linkables": ["../relationships/dist/linkables.d.ts"],
       "@voyant-travel/relationships/routes": ["../relationships/dist/routes/index.d.ts"],
       "@voyant-travel/relationships/runtime-contributor": [
         "../relationships/dist/runtime-contributor.d.ts"
       ],
+      "@voyant-travel/relationships/runtime-port": ["../relationships/dist/runtime-port.d.ts"],
       "@voyant-travel/relationships/schema": ["../relationships/dist/schema.d.ts"],
       "@voyant-travel/relationships/tools": ["../relationships/dist/mcp-runtime.d.ts"],
       "@voyant-travel/relationships/validation": ["../relationships/dist/validation.d.ts"],

--- a/scripts/checks/graph/graph-conformance.json
+++ b/scripts/checks/graph/graph-conformance.json
@@ -31,7 +31,8 @@
       "portIds": [
         "relationships.route-runtime",
         "relationships.mice.runtime",
-        "custom-fields.runtime"
+        "custom-fields.runtime",
+        "relationships.booking-enrichment-database"
       ],
       "runtimeExport": "createRelationshipsRuntimePortContribution"
     }


### PR DESCRIPTION
When a customer books, the CRM person we create carries a name, an email and a phone number — and nothing else. Activities, Relationships, Communications and Addresses all sit at `(0)`, so a customer with two confirmed bookings looks identical to one who has never booked.



## What was actually broken

`upsertPersonFromContact` (`packages/relationships/src/service/accounts-resolve.ts:126`) writes name + email + phone. Everything else on that page was only ever written by a human clicking **Add …**.

The **billing address** is the sharpest case, because the data was already collected and then dropped:

- the Booking Session contract accepts `line1/line2/city/region/postal/country`
- `billingContact()` (`packages/catalog/src/booking-engine/sessions-production.ts:817`) parses all six
- `resolveBilling()` directly above it passes only `firstName/lastName/email/phone` into the person upsert

So the address landed on the booking's `contact_*` columns and stopped there, and the operator re-typed an address the customer had already given them.

## Approach

A `booking.confirmed` subscriber in relationships — the same seam `commerce` already uses for promotion redemption. It writes a timeline activity linked to both the person and the booking, saves the billing address, and links co-travelers to the booker as `travel_companion`.

It runs **off** the commit transaction on purpose: enrichment is derived bookkeeping, and a CRM write that failed must never be able to roll back a booking the customer has already paid for. Failures are logged and dropped.

**Idempotency is real, not best-effort.** `booking.confirmed` is redelivered on retry. The booking's own activity link is the replay key, and a `pg_advisory_xact_lock` scoped to the booking id serializes concurrent redeliveries — without it, two simultaneous deliveries both pass the read-then-write guard and both write an activity.

**Stale traveler ids can't take the pass down.** `booking_travelers.person_id` has no foreign key, but `person_relationships` and `activity_participants` both do. An id left behind by a deleted person would have rolled back the entire enrichment over a traveler record nobody is looking at; traveler ids are now filtered against `people` first.

## Communications reads, it does not copy

The Communications tab now also shows messages the deployment actually delivered — read from `notification_deliveries`, not copied into `communication_log`. A copy goes stale the moment a delivery bounces, and the delivery row is the authority on whether a message was sent. Only `sent` rows appear: a pending send hasn't reached the customer and a failed one never will.

Each entry carries `source` (`logged` | `notification`) so the operator can tell what staff recorded from what the system sent. Paging is exact for the first page and approximate beyond it — both sources arrive pre-paged, and the alternative was a cross-module SQL union putting another module's tables inside a CRM query. The tab reads one page of 50.

## Module boundaries

Two new runtime ports, both declared where the dependency direction already points — defining a consumer's port in the consumer would close a package cycle (relationships already depends on bookings; notifications already depends on relationships):

| Port | Declared in | Provided by |
|---|---|---|
| `bookings.crm-snapshot.runtime` | bookings | bookings |
| `relationships.person-notifications` | relationships | notifications |

`verify:table-privacy` still reports **184 reach-ins across 35 pairs, none new** — no module reaches into another's tables here.

`entity_type` gains a `booking` member so an activity can name the booking it came from. `custom_field_target` already carried one (migration `0003`).

## Verification

- **Migration executed against real Postgres**, not reviewed: applies inside a transaction, idempotent on re-run (`NOTICE: enum label "booking" already exists, skipping`), leaves `organization,person,proposal,activity,booking`.
- **8 integration tests** against a migrated database — timeline write, address save, repeat-booking dedupe, no-address case, both-direction companion links, stale traveler id, replay no-op, and no-person skip.
- **6 unit tests** for the communications merge. They live in `tests/unit/` — this package's vitest `include` is `tests/**/*.test.ts`, so a test under `src/` would silently never run.
- Full suites: relationships **297 passed**, bookings **353 passed**, notifications unit **160 passed**, relationships-react **14 passed**, contracts **3 passed**.
- All five changed packages build with **0 type errors**; `biome check` clean.
- Architecture checks run: `table-privacy`, `graph-conformance`, `deployment-graph`, `runtime-ports`, `migration-identity`, `migration-boundaries`, `migration-cutline`, `openapi-drift`, `public-surface`, `symbol-policy`, `dep-paths`, `dist-configs`, `relationships-runtime-authority`, `custom-fields-settings-authority`.

### Pre-existing failures, not from this branch

`relationships/tests/integration/accounts.test.ts` (6) and `notifications` integration (10) fail on `invalid input value for enum booking_status`. Their fixtures insert `'draft'` and `'awaiting_payment'`, which the enum no longer has. Those fixture files and `bookingStatusEnum` are **byte-identical to `origin/main`** on this branch — confirmed with `git diff --stat origin/main`.

## Deliberately not here

**Backfill.** Forward-only. Existing bookings keep bare person records; a backfill writes to production data and deserves its own reviewed change.

**Passport write-back to `person_documents`** — [#4589](https://github.com/voyant-travel/voyant/issues/4589). It needs KMS re-encryption between the booking PII envelope and the CRM one, and a product decision about turning a document supplied for one trip into a permanent record. The schema comment currently declares the intended direction as person → traveler pre-fill only, and that would have to change with it. Products that never collect a passport will correctly keep showing `(0)`.

**Activity subjects are English.** Persisted server-side, matching the existing `proposals` precedent (`"Customer requested proposal edits"`). Localizing stored records needs a mechanism this PR does not invent. UI strings added here have en + ro parity.