### PR TITLE
docs: refresh the README around the platform, not the framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,11 @@
 Voyant runs as a resident Node application. Run it yourself, or have it run for
 you.
 
-### Voyant Platform
+### Voyant
 
-[Voyant Platform](https://voyant.travel) is the managed offering: it provisions,
-upgrades, and operates your deployment — one Postgres database and one runtime
-per organization. A running deployment can be exported as a self-host bundle at
-any time, so you can move to Voyant OSS whenever you want
+Have the [Voyant team](https://voyant.travel) run it for you. Provisioning,
+upgrades, security, and maintenance are all handled — you get the platform
+without operating it. A deployment can be exported to Voyant OSS at any time
 ([details](./docs/exporting-from-voyant-cloud.md)).
 
 ### Voyant OSS
@@ -96,9 +95,9 @@ Visit the [documentation](https://voyant.travel/docs) to learn more.
 
 ## What is Voyant?
 
-Voyant is the back office an OTA, tour operator, or DMC runs on. It comes in two
-editions of the same software: **Voyant OSS**, the complete Apache-2.0 platform
-you self-host, and **Voyant Platform**, the managed offering.
+Voyant is the back office an OTA, tour operator, or DMC runs on. It comes two
+ways: **Voyant OSS**, the complete Apache-2.0 platform you self-host, and
+**Voyant**, the same platform run for you.
 
 What it covers:
 

--- a/README.md
+++ b/README.md
@@ -40,27 +40,27 @@
 
 <p align="center">
   Voyant is a complete travel commerce platform — catalog, pricing, inventory,
-  bookings, finance, CRM, proposals, and distribution in one deployable back
-  office called the <strong>Operator</strong>. Self-host it, or let Voyant Cloud
-  run it for you.
+  bookings, finance, CRM, proposals, and distribution in one back office for
+  OTAs, tour operators, and DMCs.
 </p>
 
 ## Getting started
 
-The Operator is a resident Node application distributed as a container image.
-Run it managed, or self-host it.
+Voyant runs as a resident Node application. Run it yourself, or have it run for
+you.
 
-### Managed
+### Voyant Platform
 
-[Voyant Cloud](https://voyant.travel) provisions and upgrades an Operator
-deployment for you: one Postgres database and one runtime per organization. A
-running deployment can be exported as a self-host bundle at any time — see
-[Exporting From Voyant Cloud](./docs/exporting-from-voyant-cloud.md).
+[Voyant Platform](https://voyant.travel) is the managed offering: it provisions,
+upgrades, and operates your deployment — one Postgres database and one runtime
+per organization. A running deployment can be exported as a self-host bundle at
+any time, so you can move to Voyant OSS whenever you want
+([details](./docs/exporting-from-voyant-cloud.md)).
 
-### Self-hosted
+### Voyant OSS
 
-The composed Operator image is published to GHCR and is the supported
-self-host artifact:
+Voyant OSS is this repository: the whole platform under Apache-2.0, published as
+a container image.
 
 ```bash
 docker pull ghcr.io/voyant-travel/operator:latest
@@ -96,12 +96,9 @@ Visit the [documentation](https://voyant.travel/docs) to learn more.
 
 ## What is Voyant?
 
-Voyant is the back office an OTA, tour operator, or DMC actually runs on. It is
-not a toolkit you assemble into a product — it is the product, and it is open
-source. The same platform runs both ways: the whole thing is Apache-2.0 and
-published as a container image you can self-host, and Voyant Cloud is the
-managed version of it. Nothing is held back from the open edition to make the
-managed one worth paying for.
+Voyant is the back office an OTA, tour operator, or DMC runs on. It comes in two
+editions of the same software: **Voyant OSS**, the complete Apache-2.0 platform
+you self-host, and **Voyant Platform**, the managed offering.
 
 What it covers:
 
@@ -119,40 +116,36 @@ What it covers:
 - **Distribution and storefronts** — channel distribution plus a public booking
   surface for customers.
 
-Underneath, it runs on Postgres with a normalized travel operations data model,
-serves a Hono API, and boots as a resident Node process. Domain modules
-contribute their own subscribers, jobs, and React surfaces, so the platform can
-be extended without forking it.
+It sits on a normalized travel operations data model, and each domain module
+contributes its own API surface, subscribers, jobs, and React components, so the
+platform can be extended in place.
 
-Voyant supports accommodation as catalog inventory for resale, packaging, and
-trip composition. It is not a hotel PMS or a hotel-operations system. See
+Accommodation is held as sellable catalog inventory, for resale, packaging, and
+trip composition — see
 [`docs/architecture/accommodation-resale-boundary.md`](./docs/architecture/accommodation-resale-boundary.md).
 
-## The Operator
+## How it runs
 
-The Operator is the product — there is one, and this is it. It runs as a
-resident Node process (TanStack Start + React 19, Hono, Better Auth, Drizzle on
-Postgres), assembled from the modules below through the resolved deployment
-graph and booted by [`@voyant-travel/runtime`](./packages/runtime).
-
-The unified composed application graph is **Node-only** — a fully composed
-operator cannot stay resident on Cloudflare Workers, though Workers still host
-separate edge-native storefront and federated surfaces. The measurements and
-the decision behind that are in
+Voyant runs as a resident Node process on Postgres — TanStack Start + React 19
+for the dashboard, Hono for the API, Better Auth for identity, Drizzle for data
+access. The modules below are assembled through the resolved deployment graph
+and booted by [`@voyant-travel/runtime`](./packages/runtime). Node is the target
+for the composed application; edge-native storefront and federated surfaces keep
+their own hosts. The reasoning and measurements are in
 [Deployment Targets](./docs/architecture/deployment-targets.md) and
 [Node Runtime Authority](./docs/architecture/node-runtime-authority.md).
 
-[`apps/operator`](./apps/operator/README.md) is the checked-in integration
-application that exercises the whole product in this workspace. It is not the
-consumer project — generated projects come from the CLI's
-`STANDARD_NODE_STARTER` contract, documented in
+The deployable is published as `ghcr.io/voyant-travel/operator`.
+[`apps/operator`](./apps/operator/README.md) is the checked-in application that
+exercises the whole platform in this workspace; generated projects come from the
+CLI's `STANDARD_NODE_STARTER` contract, documented in
 [Standard Node Starter Acceptance](./docs/architecture/standard-node-starter-acceptance.md).
 
 ## The module surface
 
-The platform is built from the modules below. They are internal components of
-one deployable rather than a menu of separately installable libraries — see
-[ADR-0016](./docs/adr/0016-modules-as-components-of-one-deployable.md).
+The platform is built from the modules below — components of one deployable,
+resolved together into the running application
+([ADR-0016](./docs/adr/0016-modules-as-components-of-one-deployable.md)).
 
 **Fourteen of them are published to npm**: the `*-contracts` tier plus
 `@voyant-travel/ui`, `@voyant-travel/payments`, `@voyant-travel/schema-kit`,
@@ -172,7 +165,7 @@ what may be published and why.
 | [`@voyant-travel/db`](./packages/db/README.md) | Drizzle schemas, TypeID, and database adapters |
 | [`@voyant-travel/hono`](./packages/hono/README.md) | `createApp`, middleware, auth, and actor guards |
 | [`@voyant-travel/react`](./packages/react) | Shared React provider and typed fetch client |
-| [`@voyant-travel/auth`](./packages/auth/README.md) | Better Auth wiring for the Operator application |
+| [`@voyant-travel/auth`](./packages/auth/README.md) | Better Auth wiring for the Voyant application |
 | [`@voyant-travel/auth-react`](./packages/auth-react/README.md) | Auth React hooks and components |
 | [`@voyant-travel/types`](./packages/types/README.md) | Shared workspace types |
 | [`@voyant-travel/utils`](./packages/utils/README.md) | Shared utility functions |
@@ -229,10 +222,10 @@ live under `@voyant-travel/bookings-react/requirements`; checkout UI lives under
 
 ## Extending the platform
 
-"Plugin" is retired as a classification ([RFC #3395](./docs/architecture/module-provider-plugin-taxonomy.md)),
-and no package in this repository declares that kind — `verify:deprecated-graph-kinds`
-denies it. Modules are components of the one deployable and are not selectable.
-Substitution happens at two seams instead.
+Voyant keeps a small extension vocabulary: **modules** are the components the
+platform is built from, and customization happens at two seams —
+**adapters and providers**, and **apps**. See
+[the taxonomy](./docs/architecture/module-provider-plugin-taxonomy.md).
 
 ### Adapters and providers
 
@@ -249,7 +242,7 @@ this way, as does [`@voyant-travel/storage`](./packages/storage/README.md).
 ### Apps
 
 An **app** is a separately deployed service activated for a deployment through
-OAuth. App code never executes inside the Operator process and never
+OAuth. App code runs entirely outside the Voyant process and never
 contributes migrations, routes, providers, or any other executable server code.
 Apps integrate through scoped APIs, events, durable webhook subscriptions,
 app-owned namespaced custom fields, and sandboxed admin extensions.
@@ -266,7 +259,7 @@ Voyant keeps a strict boundary between reusable business logic and deployment sh
 
 - `packages/*` hold reusable business logic, schemas, services, routes, adapters, and contracts
 - `apps/*` own UI, auth wiring, deployment shape, and runtime-specific configuration
-- Domain packages stay transport- and UI-agnostic even though the Operator uses React, TanStack Start, Hono, Better Auth, and Drizzle
+- Domain packages stay transport- and UI-agnostic even though the application layer uses React, TanStack Start, Hono, Better Auth, and Drizzle
 - Transport adapters stay thin and call shared domain services rather than owning business logic
 - Package manifests contribute required subscribers and jobs; deployment hosts provide their runtime infrastructure
 - Modules are components of one deployable, not independently shipped services ([ADR-0016](./docs/adr/0016-modules-as-components-of-one-deployable.md))
@@ -275,7 +268,7 @@ Architecture decisions live in [`docs/adr/`](./docs/adr/); domain conventions
 live in [`docs/architecture/`](./docs/architecture/); per-minor migration notes
 live in [`docs/migrations/`](./docs/migrations/README.md). Start with
 [the unified deployment graph](./docs/architecture/unified-deployment-graph.md),
-which is what resolves modules into the shipped Operator.
+which is what resolves modules into the shipped application.
 
 ### Security model
 
@@ -288,7 +281,7 @@ revisited.
 
 ## Contributing
 
-This repository is the whole platform: the domain modules, the Operator
+This repository is Voyant OSS: the domain modules, the deployable
 application, generated project packaging, runners, and examples.
 
 | Area | What it contains |

--- a/README.md
+++ b/README.md
@@ -227,18 +227,38 @@ live under `@voyant-travel/bookings-react/requirements`; checkout UI lives under
 [`@voyant-travel/admin`](./packages/admin/README.md); cross-cutting primitives in
 [`packages/ui`](./packages/ui/README.md).
 
-### Adapters and integrations
+## Extending the platform
 
-Vendor integrations are **adapters**, not plugins — "plugin" is retired as a
-classification. See
-[the taxonomy](./docs/architecture/module-provider-plugin-taxonomy.md).
+"Plugin" is retired as a classification ([RFC #3395](./docs/architecture/module-provider-plugin-taxonomy.md)),
+and no package in this repository declares that kind — `verify:deprecated-graph-kinds`
+denies it. Modules are components of the one deployable and are not selectable.
+Substitution happens at two seams instead.
+
+### Adapters and providers
+
+Adapters and providers swap a vendor or infrastructure implementation *inside*
+the deployment. They are ordinary graph units selected through the resolved
+deployment graph — object storage, KV, rate limiting, and search all resolve
+this way, as does [`@voyant-travel/storage`](./packages/storage/README.md).
 
 | Package | Description |
 | --- | --- |
-| [`@voyant-travel/payments`](./packages/payments) | The payment adapter contract: initiate/status/verify, provider catalog, and remote transport |
-| [`@voyant-travel/voyant-connect-adapter`](./packages/voyant-connect-adapter) | Voyant Connect supplier connectivity |
-| [`plugin-netopia`](https://github.com/voyant-travel/plugin-netopia) | Netopia payments (separate repository) |
-| [`plugin-payload`](https://github.com/voyant-travel/plugin-payload) | Payload CMS sync (separate repository) |
+| [`@voyant-travel/payments`](./packages/payments) | The payment adapter contract — initiate/status/verify, provider catalog, and remote transport. Netopia and Voyant Pay are catalog providers |
+| [`@voyant-travel/voyant-connect-adapter`](./packages/voyant-connect-adapter) | Voyant Connect supplier connectivity, on top of the external `@voyant-travel/connect-sdk` |
+
+### Apps
+
+An **app** is a separately deployed service activated for a deployment through
+OAuth. App code never executes inside the Operator process and never
+contributes migrations, routes, providers, or any other executable server code.
+Apps integrate through scoped APIs, events, durable webhook subscriptions,
+app-owned namespaced custom fields, and sandboxed admin extensions.
+
+The deployment-local runtime for this — registration, immutable declarative
+releases, consent, installation, grants, pause/revoke/uninstall — lives in
+[`@voyant-travel/apps`](./packages/apps). Accounting and CRM integrations such
+as SmartBill are apps. See
+[the Remote App Platform RFC](./docs/architecture/remote-app-platform-rfc.md).
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -12,15 +12,18 @@
 </h1>
 
 <p align="center">
-  The open-source travel commerce framework for OTAs, tour operators, and DMCs.
+  The open-source travel commerce platform for OTAs, tour operators, and DMCs.
 </p>
 
 <p align="center">
   <a href="https://github.com/voyant-travel/voyant/blob/main/LICENSE">
     <img src="https://img.shields.io/badge/license-Apache--2.0-blue.svg" alt="Voyant is released under the Apache 2.0 license." />
   </a>
-  <a href="https://www.npmjs.com/package/@voyant-travel/core">
-    <img src="https://img.shields.io/npm/v/@voyant-travel/core.svg?label=%40voyant-travel%2Fcore" alt="Current @voyant-travel/core npm version." />
+  <a href="https://www.npmjs.com/package/@voyant-travel/cli">
+    <img src="https://img.shields.io/npm/v/@voyant-travel/cli.svg?label=%40voyant-travel%2Fcli" alt="Current @voyant-travel/cli npm version." />
+  </a>
+  <a href="https://github.com/voyant-travel/voyant/pkgs/container/operator">
+    <img src="https://img.shields.io/badge/ghcr.io-voyant--travel%2Foperator-blue.svg" alt="The Operator container image on GHCR." />
   </a>
   <a href="https://github.com/voyant-travel/voyant/issues">
     <img src="https://img.shields.io/badge/issues-welcome-brightgreen.svg" alt="Issues welcome!" />
@@ -36,47 +39,72 @@
 </h4>
 
 <p align="center">
-  Voyant ships deployable starter apps, package-owned background execution, and
-  a wide set of headless domain modules (catalog, commerce, inventory, operations,
-  relationships, proposals, bookings, finance, distribution, legal, charters,
-  cruises, accommodation resale, and more) that you compose into your own
-  travel platform.
+  Voyant is delivered as the <strong>Operator</strong> — a complete, deployable
+  travel commerce back office — composed from a wide set of headless domain
+  modules (catalog, commerce, inventory, operations, relationships, proposals,
+  bookings, finance, distribution, legal, charters, cruises, accommodation
+  resale, and more) that live in this repository.
 </p>
 
 ## Getting started
 
-Install the CLI, scaffold an app from a first-party starter, and run it locally.
+The Operator is a resident Node application distributed as a container image.
+Run it managed, or self-host it.
+
+### Managed
+
+[Voyant Cloud](https://voyant.travel) provisions and upgrades an Operator
+deployment for you: one Postgres database and one runtime per organization. A
+running deployment can be exported as a self-host bundle at any time — see
+[Exporting From Voyant Cloud](./docs/exporting-from-voyant-cloud.md).
+
+### Self-hosted
+
+The composed Operator image is published to GHCR and is the supported
+self-host artifact:
 
 ```bash
-# 1. Install the CLI
-npm install -g @voyant-travel/cli
-
-# 2. Scaffold a project from the operator starter
-voyant new my-travel-app
-cd my-travel-app
-pnpm install
-
-# 3. Configure the app
-cp .env.example .env
-# set your secrets (DATABASE_URL, BETTER_AUTH_ADMIN_SECRET, …) in .env
-
-# 4. Run the app
-pnpm db:migrate
-pnpm dev
+docker pull ghcr.io/voyant-travel/operator:latest
+docker run --rm -p 8080:8080 --env-file ./operator.env \
+  ghcr.io/voyant-travel/operator:latest
 ```
 
-> `voyant new` scaffolds from the `operator` starter by default. Pass `--starter <name>` to pick another built-in starter (downloaded from GitHub Release assets for the matching CLI release), or point it at a custom local starter directory.
+The server listens on `PORT` (default `8080`) and exposes `/healthz` for
+container probes. It needs a Postgres URL and a set of auth, session, and
+integration secrets — [`apps/operator/.env.example`](./apps/operator/.env.example)
+is the authoritative key list.
+
+> Every push to `main` publishes an immutable `sha-<git-sha>` tag; deliberate
+> releases publish a bare semver tag, and `latest` is promoted from an
+> already-verified release digest. **Pin a semver tag or a digest in
+> production** — a `sha-` snapshot records which commit was built, not which
+> version was released. See
+> [Operator Image Distribution](./docs/architecture/operator-image-distribution.md).
+
+### From source
+
+To generate and own a project instead, use the CLI:
+
+```bash
+npm install -g @voyant-travel/cli
+voyant new my-travel-app
+cd my-travel-app && pnpm install
+cp .env.example .env   # set DATABASE_URL, auth secrets, …
+pnpm db:migrate && pnpm dev
+```
 
 Visit the [documentation](https://voyant.travel/docs) to learn more.
 
 ## What is Voyant?
 
-Voyant is a framework for building travel commerce platforms. Instead of a
-monolithic booking system, it gives you composable, headless domain modules
-and deployable application shells that you own and extend.
+Voyant is a travel commerce platform for OTAs, tour operators, and DMCs.
+Instead of a monolithic booking system, the product is assembled from
+composable, headless domain modules resolved into a single deployment graph —
+so the Operator you run is a real, complete application, and the modules behind
+it stay independently versioned and extensible.
 
-- **Deployable application shells, not just isolated packages.** First-party
-  starters ship as real, runnable apps.
+- **A deployable product, not a pile of packages.** The Operator is composed,
+  built, and shipped as one artifact.
 - **A normalized travel operations data model** on PostgreSQL + Drizzle.
 - **Headless domain modules** for catalog, commerce, inventory, operations,
   relationships, proposals, bookings, finance, distribution, legal, charters,
@@ -84,12 +112,11 @@ and deployable application shells that you own and extend.
 - **Hono-based API transport** with optional Next.js route helpers.
 - **Package-owned subscribers and jobs** selected with their domain modules and
   hosted by self-managed infrastructure or Voyant Cloud.
-- **Better Auth wiring** in first-party starters, with core packages staying
-  auth-provider agnostic.
+- **Better Auth wiring** in the generated application, with core packages
+  staying auth-provider agnostic.
 - **Versioned React packages per domain** (`relationships-react`,
-  `inventory-react`, `commerce-react`, `bookings-react`, …) consumed as
-  ordinary dependencies: hooks, clients, providers, query keys, and reusable
-  UI that wrap each module's HTTP contract.
+  `inventory-react`, `commerce-react`, `bookings-react`, …): hooks, clients,
+  providers, query keys, and reusable UI that wrap each module's HTTP contract.
 - **Optional integrations** for payments, e-invoicing, storage, CMS sync, and
   notifications.
 
@@ -98,21 +125,44 @@ trip composition. It is not positioned as a hotel PMS or first-party
 hotel-operations system. See
 [`docs/architecture/accommodation-resale-boundary.md`](./docs/architecture/accommodation-resale-boundary.md).
 
-## Starters
+## The Operator
 
-Voyant ships one first-party starter:
+The Operator is the first-party product: a tour operator and DMC back office
+running as a resident Node process (TanStack Start + React 19, Hono, Better
+Auth, Drizzle on Postgres). It is composed from the modules below through the
+resolved deployment graph and booted by
+[`@voyant-travel/runtime`](./packages/runtime).
 
-| Starter | Purpose | Stack |
-| --- | --- | --- |
-| Operator (generated by the CLI) | Tour operator platform | Node, TanStack Start, Hono, Better Auth, Drizzle |
+The unified composed application graph is **Node-only** — a fully composed
+operator cannot stay resident on Cloudflare Workers, though Workers still host
+separate edge-native storefront and federated surfaces. The measurements and
+the decision behind that are in
+[Deployment Targets](./docs/architecture/deployment-targets.md) and
+[Node Runtime Authority](./docs/architecture/node-runtime-authority.md).
 
-## The framework surface
+[`apps/operator`](./apps/operator/README.md) is the checked-in integration
+application that exercises the whole product in this workspace. It is not the
+consumer project — generated projects come from the CLI's
+`STANDARD_NODE_STARTER` contract, documented in
+[Standard Node Starter Acceptance](./docs/architecture/standard-node-starter-acceptance.md).
+
+## The module surface
+
+Voyant's packages are the composition surface for the product; most are
+internal to it rather than separately installable. **Fourteen packages are
+published to npm** — chiefly the `*-contracts` tier plus
+[`@voyant-travel/cli`](https://www.npmjs.com/package/@voyant-travel/cli),
+`@voyant-travel/ui`, `@voyant-travel/payments`, `@voyant-travel/schema-kit`,
+`@voyant-travel/app-manifest`, and `@voyant-travel/admin-extension-sdk`. The
+rest of the tables below map the repository, not the npm registry; see
+[`docs/frontend-package-strategy.md`](./docs/frontend-package-strategy.md) for
+what may be published and why.
 
 ### Core platform
 
 | Package | Description |
 | --- | --- |
-| [`@voyant-travel/core`](./packages/core/README.md) | Module system, container, event bus, and plugins |
+| [`@voyant-travel/core`](./packages/core/README.md) | Module system, container, event bus, and adapter registration |
 | [`@voyant-travel/db`](./packages/db/README.md) | Drizzle schemas, TypeID, and database adapters |
 | [`@voyant-travel/hono`](./packages/hono/README.md) | `createApp`, middleware, auth, and actor guards |
 | [`@voyant-travel/react`](./packages/react) | Shared React provider and typed fetch client |
@@ -171,14 +221,18 @@ live under `@voyant-travel/bookings-react/requirements`; checkout UI lives under
 [`@voyant-travel/admin`](./packages/admin/README.md); cross-cutting primitives in
 [`packages/ui`](./packages/ui/README.md).
 
-### Plugins
+### Adapters and integrations
+
+Vendor integrations are **adapters**, not plugins — "plugin" is retired as a
+classification. See
+[the taxonomy](./docs/architecture/module-provider-plugin-taxonomy.md).
 
 | Package | Description |
 | --- | --- |
-| [`@voyant-travel/plugin-netopia`](https://github.com/voyant-travel/plugin-netopia) | Netopia payments |
-| [`@voyant-travel/plugin-smartbill`](./packages/plugins/smartbill/README.md) | SmartBill e-invoicing (Romanian tax compliance) |
-| [`@voyant-travel/plugin-payload-cms`](https://github.com/voyant-travel/plugin-payload) | Payload CMS sync |
-| [`@voyant-travel/plugin-sanity-cms`](./packages/plugins/sanity-cms/README.md) | Sanity CMS sync |
+| [`@voyant-travel/payments`](./packages/payments) | The payment adapter contract: initiate/status/verify, provider catalog, and remote transport |
+| [`@voyant-travel/voyant-connect-adapter`](./packages/voyant-connect-adapter) | Voyant Connect supplier connectivity |
+| [`plugin-netopia`](https://github.com/voyant-travel/plugin-netopia) | Netopia payments (separate repository) |
+| [`plugin-payload`](https://github.com/voyant-travel/plugin-payload) | Payload CMS sync (separate repository) |
 
 ## Architecture
 
@@ -186,13 +240,16 @@ Voyant keeps a strict boundary between reusable business logic and deployment sh
 
 - `packages/*` hold reusable business logic, schemas, services, routes, adapters, and contracts
 - `apps/*` own UI, auth wiring, deployment shape, and runtime-specific configuration
-- Core packages stay framework-agnostic even when first-party starters use React, TanStack Start, Hono, Better Auth, and Cloudflare Workers
+- Core packages stay framework-agnostic even when the generated application uses React, TanStack Start, Hono, Better Auth, and Drizzle
 - Transport adapters stay thin and call shared domain services rather than owning business logic
 - Package manifests contribute required subscribers and jobs; deployment hosts provide their runtime infrastructure
+- Modules are components of one deployable, not independently shipped services ([ADR-0016](./docs/adr/0016-modules-as-components-of-one-deployable.md))
 
 Architecture decisions live in [`docs/adr/`](./docs/adr/); domain conventions
 live in [`docs/architecture/`](./docs/architecture/); per-minor migration notes
-live in [`docs/migrations/`](./docs/migrations/README.md).
+live in [`docs/migrations/`](./docs/migrations/README.md). Start with
+[the unified deployment graph](./docs/architecture/unified-deployment-graph.md),
+which is what resolves modules into the shipped Operator.
 
 ### Security model
 
@@ -206,12 +263,12 @@ revisited.
 ## Contributing
 
 This repository is the workspace that powers the framework, the Operator
-integration application, packaged starter generation, runners, and examples.
+integration application, generated project packaging, runners, and examples.
 
 | Area | What it contains |
 | --- | --- |
 | [`packages/*`](./packages) | Reusable business logic, schemas, services, transport adapters, and integrations |
-| [`packages/plugins/*`](./packages/plugins) | First-party plugin bundles (payments, invoicing, CMS sync) |
+| [`packages/*-contracts`](./packages) | Published contract packages consumed outside this repository |
 | [`apps/operator`](./apps/operator/README.md) | Checked-in Operator integration and deployable application |
 | [`apps/*`](./apps) | Applications, reference/demo APIs, and the shadcn registry host |
 | [`examples/operator-demo`](./examples/operator-demo/README.md) | Destructive and generated Operator demo fixtures |

--- a/README.md
+++ b/README.md
@@ -39,11 +39,10 @@
 </h4>
 
 <p align="center">
-  Voyant is delivered as the <strong>Operator</strong> — a complete, deployable
-  travel commerce back office — composed from a wide set of headless domain
-  modules (catalog, commerce, inventory, operations, relationships, proposals,
-  bookings, finance, distribution, legal, charters, cruises, accommodation
-  resale, and more) that live in this repository.
+  Voyant is a complete travel commerce platform — catalog, pricing, inventory,
+  bookings, finance, CRM, proposals, and distribution in one deployable back
+  office called the <strong>Operator</strong>. Self-host it, or let Voyant Cloud
+  run it for you.
 </p>
 
 ## Getting started
@@ -97,41 +96,44 @@ Visit the [documentation](https://voyant.travel/docs) to learn more.
 
 ## What is Voyant?
 
-Voyant is a travel commerce platform for OTAs, tour operators, and DMCs.
-Instead of a monolithic booking system, the product is assembled from
-composable, headless domain modules resolved into a single deployment graph —
-so the Operator you run is a real, complete application, and the modules behind
-it stay independently versioned and extensible.
+Voyant is the back office an OTA, tour operator, or DMC actually runs on. It is
+not a toolkit you assemble into a product — it is the product, and it is open
+source. The same platform runs both ways: the whole thing is Apache-2.0 and
+published as a container image you can self-host, and Voyant Cloud is the
+managed version of it. Nothing is held back from the open edition to make the
+managed one worth paying for.
 
-- **A deployable product, not a pile of packages.** The Operator is composed,
-  built, and shipped as one artifact.
-- **A normalized travel operations data model** on PostgreSQL + Drizzle.
-- **Headless domain modules** for catalog, commerce, inventory, operations,
-  relationships, proposals, bookings, finance, distribution, legal, charters,
-  cruises, accommodation resale, and more.
-- **Hono-based API transport** with optional Next.js route helpers.
-- **Package-owned subscribers and jobs** selected with their domain modules and
-  hosted by self-managed infrastructure or Voyant Cloud.
-- **Better Auth wiring** in the generated application, with core packages
-  staying auth-provider agnostic.
-- **Versioned React packages per domain** (`relationships-react`,
-  `inventory-react`, `commerce-react`, `bookings-react`, …): hooks, clients,
-  providers, query keys, and reusable UI that wrap each module's HTTP contract.
-- **Optional integrations** for payments, e-invoicing, storage, CMS sync, and
-  notifications.
+What it covers:
+
+- **Catalog and products** — tours, packages, charters, cruises, flights, and
+  accommodation held as resellable inventory.
+- **Pricing and sellability** — offers, occupancy pricing, promotions, travel
+  credits, and channel-aware rules.
+- **Inventory and availability** — allotments, departures, and the operational
+  logistics behind them.
+- **Bookings** — the full lifecycle, participants, requirements, and
+  itinerary composition.
+- **Finance** — invoicing, payments, supplier costs, tax, FX, and profitability.
+- **CRM and proposals** — people, organizations, pipelines, and versioned
+  proposals that carry a trip from sales pursuit to confirmed booking.
+- **Distribution and storefronts** — channel distribution plus a public booking
+  surface for customers.
+
+Underneath, it runs on Postgres with a normalized travel operations data model,
+serves a Hono API, and boots as a resident Node process. Domain modules
+contribute their own subscribers, jobs, and React surfaces, so the platform can
+be extended without forking it.
 
 Voyant supports accommodation as catalog inventory for resale, packaging, and
-trip composition. It is not positioned as a hotel PMS or first-party
-hotel-operations system. See
+trip composition. It is not a hotel PMS or a hotel-operations system. See
 [`docs/architecture/accommodation-resale-boundary.md`](./docs/architecture/accommodation-resale-boundary.md).
 
 ## The Operator
 
-The Operator is the first-party product: a tour operator and DMC back office
-running as a resident Node process (TanStack Start + React 19, Hono, Better
-Auth, Drizzle on Postgres). It is composed from the modules below through the
-resolved deployment graph and booted by
-[`@voyant-travel/runtime`](./packages/runtime).
+The Operator is the product — there is one, and this is it. It runs as a
+resident Node process (TanStack Start + React 19, Hono, Better Auth, Drizzle on
+Postgres), assembled from the modules below through the resolved deployment
+graph and booted by [`@voyant-travel/runtime`](./packages/runtime).
 
 The unified composed application graph is **Node-only** — a fully composed
 operator cannot stay resident on Cloudflare Workers, though Workers still host
@@ -148,13 +150,17 @@ consumer project — generated projects come from the CLI's
 
 ## The module surface
 
-Voyant's packages are the composition surface for the product; most are
-internal to it rather than separately installable. **Fourteen packages are
-published to npm** — chiefly the `*-contracts` tier plus
-[`@voyant-travel/cli`](https://www.npmjs.com/package/@voyant-travel/cli),
+The platform is built from the modules below. They are internal components of
+one deployable rather than a menu of separately installable libraries — see
+[ADR-0016](./docs/adr/0016-modules-as-components-of-one-deployable.md).
+
+**Fourteen of them are published to npm**: the `*-contracts` tier plus
 `@voyant-travel/ui`, `@voyant-travel/payments`, `@voyant-travel/schema-kit`,
-`@voyant-travel/app-manifest`, and `@voyant-travel/admin-extension-sdk`. The
-rest of the tables below map the repository, not the npm registry; see
+`@voyant-travel/app-manifest`, and `@voyant-travel/admin-extension-sdk`. Those
+are the integration points for code outside this repository.
+[`@voyant-travel/cli`](https://www.npmjs.com/package/@voyant-travel/cli) is
+published from its own repository. Everything else is private, so the tables
+below map this repository, not the npm registry; see
 [`docs/frontend-package-strategy.md`](./docs/frontend-package-strategy.md) for
 what may be published and why.
 
@@ -166,7 +172,7 @@ what may be published and why.
 | [`@voyant-travel/db`](./packages/db/README.md) | Drizzle schemas, TypeID, and database adapters |
 | [`@voyant-travel/hono`](./packages/hono/README.md) | `createApp`, middleware, auth, and actor guards |
 | [`@voyant-travel/react`](./packages/react) | Shared React provider and typed fetch client |
-| [`@voyant-travel/auth`](./packages/auth/README.md) | Better Auth wiring for first-party starters |
+| [`@voyant-travel/auth`](./packages/auth/README.md) | Better Auth wiring for the Operator application |
 | [`@voyant-travel/auth-react`](./packages/auth-react/README.md) | Auth React hooks and components |
 | [`@voyant-travel/types`](./packages/types/README.md) | Shared workspace types |
 | [`@voyant-travel/utils`](./packages/utils/README.md) | Shared utility functions |
@@ -240,7 +246,7 @@ Voyant keeps a strict boundary between reusable business logic and deployment sh
 
 - `packages/*` hold reusable business logic, schemas, services, routes, adapters, and contracts
 - `apps/*` own UI, auth wiring, deployment shape, and runtime-specific configuration
-- Core packages stay framework-agnostic even when the generated application uses React, TanStack Start, Hono, Better Auth, and Drizzle
+- Domain packages stay transport- and UI-agnostic even though the Operator uses React, TanStack Start, Hono, Better Auth, and Drizzle
 - Transport adapters stay thin and call shared domain services rather than owning business logic
 - Package manifests contribute required subscribers and jobs; deployment hosts provide their runtime infrastructure
 - Modules are components of one deployable, not independently shipped services ([ADR-0016](./docs/adr/0016-modules-as-components-of-one-deployable.md))
@@ -262,8 +268,8 @@ revisited.
 
 ## Contributing
 
-This repository is the workspace that powers the framework, the Operator
-integration application, generated project packaging, runners, and examples.
+This repository is the whole platform: the domain modules, the Operator
+application, generated project packaging, runners, and examples.
 
 | Area | What it contains |
 | --- | --- |


### PR DESCRIPTION
The README had drifted badly: it still documented a `starters/` directory and a
`packages/plugins/` tree that no longer exist, and it advertised ~30
npm-installable packages after #4098 contracted the published surface to
fourteen. Following it led to a 404.

## What changed

**Positioning.** Voyant is described as a complete travel commerce platform
rather than a framework you assemble into one, and stated in terms of what it
is rather than what it is not. The two editions are named: **Voyant OSS** (this
repository, Apache-2.0, published as a container image) and **Voyant** (the
same platform run by the Voyant team).

**Getting started** now covers the managed offering, the GHCR image, and
`voyant new` from source. The image invocation uses the real port (`8080`) and
points at `apps/operator/.env.example` for the key list rather than inventing a
minimal env set.

**Removed what no longer exists.** The Plugins table is gone: the CMS packages
were removed in #4074, voyant-connect was absorbed and renamed in #4070/#4171,
and Netopia is a provider in the `payments` catalog implemented outside this
repo — neither is an Operator dependency. It is replaced by the two real
extension seams, adapters/providers and apps. The Starters section is gone
(`starters/` moved to `apps/operator` in #4019).

**Corrected the npm claims.** The version badge tracks `@voyant-travel/cli`,
which is public and actively released, instead of `@voyant-travel/core`, which
is private and frozen on npm at 0.137.0 while this repo sits at 0.140.3. The
fourteen published packages are named; the tables are framed as a map of the
repository.

## Verification

Docs-only, one file. Every relative link resolves, and each factual claim was
checked against the tree: the fourteen public manifests, the Dockerfile port
and `/healthz`, the GHCR tag policy, the provider roles in `graph-contracts`,
and the payments provider catalog.

## Follow-ups, not in this PR

- "Voyant Cloud" still appears in 99 tracked files, including ADR-0001 and the
  auth/admin architecture docs; this README is the leading edge of the new
  naming.
- ~45 packages remain undocumented (the `*-contracts` tier, `mcp`, `media`,
  `framework`/`runtime`, the `admin-host`/`admin-app` split). Nothing in the
  file is false because of it.
- Bare-semver image releases are only at `0.1.1` while the README tells
  self-hosters to pin one.