### PR TITLE
fix(finance,storefront): stop stamping netopia on operator-generated payment links

### DIFF
--- a/.changeset/payment-link-card-provider-agnostic.md
+++ b/.changeset/payment-link-card-provider-agnostic.md
@@ -1,0 +1,11 @@
+---
+"@voyant-travel/finance-react": patch
+"@voyant-travel/storefront": patch
+"@voyant-travel/trips": patch
+---
+
+Stop stamping `netopia` on operator-generated payment links, so they are payable on whatever processor the deployment actually runs. `useCollectPayment` defaulted `cardProvider` to `"netopia"` back when that was the only processor in tree, and every "Generate payment link" wrote it to `payment_sessions.provider`. On a deployment running any other processor the shopper could never pay: the card start reached the real adapter and created a live checkout session there, then the initiation result's `processorIdentity` failed the stored-provider guard, and the public route turned that into a bare 502 — leaving a live processor session attached to a payment session still marked `pending`.
+
+The provider now stays unset until the processor claims it on start, which is what `createOrderPaymentSessions` already documents and what the payment-link retry route already did. Because an unstarted session then has neither a provider nor a redirect URL, the landing page can no longer read "card is on offer" off the session record: `payment-link-config` publishes a `cardPayments.available` flag (the card counterpart of its bank-transfer block, sourced from whether the deployment selected a payment adapter), and `PaymentLinkLandingPage` takes it as `cardPaymentAvailable`. This also restores the card option on sessions created by "Try again", which never carried a provider either. Deployments that supply no flag keep offering card, as they did before it existed.
+
+The public start-card handler also logs the error it swallows — session id, stored provider, and the error's own code — instead of discarding it. The response stays deliberately opaque to the shopper; diagnosing this one otherwise meant reading platform logs and the session row by hand.

--- a/packages/finance-react/src/checkout-components/collect-payment-dialog.tsx
+++ b/packages/finance-react/src/checkout-components/collect-payment-dialog.tsx
@@ -72,7 +72,12 @@ export interface CollectPaymentDialogProps {
    */
   returnUrl?: string | null
   cancelUrl?: string | null
-  /** Card processor id registered in checkout's `paymentStarters`. */
+  /**
+   * Card processor id registered in checkout's `paymentStarters`. Normally
+   * omitted — the generated link claims whichever processor the deployment
+   * selected when the customer starts the payment. See the `cardProvider`
+   * option on {@link useCollectPayment}.
+   */
   cardProvider?: string
 }
 

--- a/packages/finance-react/src/checkout-components/payment-link-landing-page.test.tsx
+++ b/packages/finance-react/src/checkout-components/payment-link-landing-page.test.tsx
@@ -144,6 +144,55 @@ describe("PaymentLinkLandingPage", () => {
     expect(container.innerHTML).not.toContain("seti_secret_1")
   })
 
+  // voyant#4599: an operator-generated link is pending with no provider and no
+  // redirect URL until the customer presses Pay. Deriving "card is on offer"
+  // from those columns removed the only button on the page.
+  it("offers card on an unstarted session that has claimed no processor yet", async () => {
+    const unstarted = {
+      ...baseSession,
+      status: "pending" as const,
+      provider: null,
+      redirectUrl: null,
+      providerSessionId: null,
+    }
+    fetcher.mockResolvedValue(
+      Response.json({ data: { redirectUrl: "https://pay.example.com/go", checkout: null } }),
+    )
+
+    await act(async () => {
+      root.render(
+        <VoyantFinanceProvider baseUrl="https://api.example.test/api/" fetcher={fetcher}>
+          <PaymentLinkLandingPage session={unstarted} />
+        </VoyantFinanceProvider>,
+      )
+    })
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>("button")?.click()
+    })
+
+    expect(fetcher).toHaveBeenCalledOnce()
+    expect(String(fetcher.mock.calls[0]?.[0])).toContain("/payment-link/ps_123/start-card")
+  })
+
+  it("offers nothing when the deployment has neither a card processor nor bank transfer", async () => {
+    const unstarted = {
+      ...baseSession,
+      status: "pending" as const,
+      provider: null,
+      redirectUrl: null,
+    }
+
+    await act(async () => {
+      root.render(
+        <VoyantFinanceProvider baseUrl="https://api.example.test/api/" fetcher={fetcher}>
+          <PaymentLinkLandingPage cardPaymentAvailable={false} session={unstarted} />
+        </VoyantFinanceProvider>,
+      )
+    })
+
+    expect(container.querySelector("button")).toBeNull()
+  })
+
   it("falls back to a message rather than a blank panel when the client is missing", async () => {
     const embedded = {
       ...baseSession,

--- a/packages/finance-react/src/checkout-components/payment-link-landing-page.tsx
+++ b/packages/finance-react/src/checkout-components/payment-link-landing-page.tsx
@@ -182,6 +182,19 @@ export interface PaymentLinkLandingPageProps {
   session: PublicPaymentSession
   /** Bank-transfer instructions block — template-supplied per deployment. */
   bankTransferInstructions?: BankTransferInstructions
+  /**
+   * Whether this deployment has a card processor wired at all — the card
+   * counterpart of `bankTransferInstructions`, and template-supplied the
+   * same way (from `GET /v1/public/payment-link-config`).
+   *
+   * It cannot be read off the session. A link the operator generates carries
+   * no provider and no redirect URL: the processor is claimed lazily when the
+   * customer presses Pay, so an unstarted session looks identical on a
+   * card-enabled deployment and a bank-transfer-only one (voyant#4599).
+   * Defaults to `true` — a deployment that says nothing gets the card option
+   * and, if no processor answers, an inline error rather than a hidden button.
+   */
+  cardPaymentAvailable?: boolean
   /** Header slot (logo, brand name, optional support contact). */
   brandHeader?: ReactNode
   /** Footer slot (T&Cs link, support contact, privacy). */
@@ -245,6 +258,7 @@ export interface BankTransferInstructions {
 export function PaymentLinkLandingPage({
   session,
   bankTransferInstructions,
+  cardPaymentAvailable = true,
   brandHeader,
   brandFooter,
   embeddedCheckoutClient,
@@ -265,6 +279,7 @@ export function PaymentLinkLandingPage({
       <Body
         session={session}
         bankTransferInstructions={bankTransferInstructions}
+        cardPaymentAvailable={cardPaymentAvailable}
         embeddedCheckoutClient={embeddedCheckoutClient}
         onPayByCard={onPayByCard}
         onRetry={onRetry}
@@ -321,12 +336,14 @@ function Body({
   session,
   embeddedCheckoutClient,
   bankTransferInstructions,
+  cardPaymentAvailable,
   onPayByCard,
   onRetry,
   apiClient,
 }: {
   session: PublicPaymentSession
   bankTransferInstructions?: BankTransferInstructions
+  cardPaymentAvailable: boolean
   embeddedCheckoutClient?: PaymentEmbeddedCheckoutClient
   onPayByCard?: () => void
   onRetry?: () => Promise<void> | void
@@ -346,14 +363,18 @@ function Body({
     return <ProcessingState />
   }
 
-  const cardAvailable =
-    Boolean(session.redirectUrl) ||
-    Boolean(session.provider) ||
-    session.status === "requires_redirect"
+  // Only `pending` and `requires_redirect` reach here — every other status
+  // short-circuited above — and both can start or continue a card payment.
+  // So whether card is on offer is a fact about the deployment, not about
+  // the session: an operator-generated link carries no provider and no
+  // redirect URL until the customer presses Pay and a processor claims it
+  // (voyant#4599). Reading either off the session hid the button on every
+  // deployment that did not stamp one up front.
+  const cardAvailable = cardPaymentAvailable
   const bankAvailable = Boolean(bankTransferInstructions)
 
-  // No method available — soft fallback (rare; signals a misconfigured
-  // session that has neither a redirect URL nor a bank-transfer block).
+  // No method available — soft fallback (a deployment with neither a card
+  // processor nor a bank-transfer block).
   if (!cardAvailable && !bankAvailable) {
     return (
       <div className="rounded-xl border border-amber-500/40 bg-amber-500/5 p-6 text-sm">

--- a/packages/finance-react/src/checkout-hooks/use-collect-payment.ts
+++ b/packages/finance-react/src/checkout-hooks/use-collect-payment.ts
@@ -11,8 +11,16 @@ import { useVoyantFinanceContext } from "../provider.js"
 export interface UseCollectPaymentOptions {
   /**
    * Provider id registered in checkout's `paymentStarters` map. Only used
-   * when the choice is `send_link`. Defaults to `"netopia"` since that's
-   * the only processor in tree today; pass explicitly when adding others.
+   * when the choice is `send_link`.
+   *
+   * Leave it unset — which is the normal case. Processor selection is
+   * deployment-owned, and a link generated here does not start a processor:
+   * the customer-facing landing page does that later, and whichever adapter
+   * the deployment selected claims the session then. Stamping a provider up
+   * front mislabels every deployment that runs a different one, and the
+   * identity guard on the initiation result then rejects the real processor
+   * (voyant#4599). Pass this only to pin a specific starter from the
+   * `paymentStarters` map.
    */
   cardProvider?: string
   /** Payer email — used as the recipient for the payment-link notification. */
@@ -65,15 +73,8 @@ export interface CollectPaymentInput {
 export function useCollectPayment(bookingId: string, options: UseCollectPaymentOptions = {}) {
   const { baseUrl, fetcher } = useVoyantFinanceContext()
   const qc = useQueryClient()
-  const {
-    cardProvider = "netopia",
-    payerEmail,
-    payerName,
-    payerLanguage,
-    returnUrl,
-    cancelUrl,
-    notes,
-  } = options
+  const { cardProvider, payerEmail, payerName, payerLanguage, returnUrl, cancelUrl, notes } =
+    options
 
   return useMutation({
     mutationFn: async ({
@@ -117,7 +118,7 @@ function mapChoiceToRequest(
   choice: PaymentChoice,
   amountCents: number,
   ctx: {
-    cardProvider: string
+    cardProvider?: string
     payerEmail?: string | null
     payerName?: string | null
     payerLanguage?: string | null
@@ -134,6 +135,10 @@ function mapChoiceToRequest(
     // template's `POST /v1/public/payment-link/:sessionId/start-card`
     // endpoint) with synthesized placeholder billing — the processor's
     // hosted form then collects the real billing from the customer.
+    //
+    // `provider` therefore stays unset unless the caller pinned one: the
+    // session is provider-agnostic until that lazy start, and the adapter
+    // that actually runs is the one that claims it.
     return {
       method: "card",
       stage: "manual",

--- a/packages/finance-react/src/storefront/public-payment-link-page.tsx
+++ b/packages/finance-react/src/storefront/public-payment-link-page.tsx
@@ -37,6 +37,12 @@ interface PaymentLinkConfigResponse {
       currency?: string | null
       notes?: string | null
     } | null
+    /**
+     * Absent on deployments running an older payment-link route module —
+     * treated as available, which is what those deployments did before the
+     * field existed.
+     */
+    cardPayments?: { available: boolean } | null
   }
 }
 
@@ -152,6 +158,7 @@ export function PublicPaymentLinkPage({
     <PaymentLinkLandingPage
       session={session}
       bankTransferInstructions={bankTransferInstructions}
+      cardPaymentAvailable={configQuery.data?.cardPayments?.available ?? true}
       summary={summaryNode}
       suppressNotes={suppressNotes}
       onRetry={async () => {

--- a/packages/finance-react/tests/unit/use-collect-payment.test.ts
+++ b/packages/finance-react/tests/unit/use-collect-payment.test.ts
@@ -1,0 +1,61 @@
+import type { InitiateCheckoutCollectionInput } from "@voyant-travel/finance/checkout"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const testState = vi.hoisted(() => ({
+  fetcher: vi.fn(),
+  mutations: [] as Array<{
+    mutationFn: (input: { choice: { type: string }; amountCents: number }) => Promise<unknown>
+  }>,
+}))
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+  useMutation: (options: {
+    mutationFn: (input: { choice: { type: string }; amountCents: number }) => Promise<unknown>
+  }) => {
+    testState.mutations.push(options)
+    return { mutate: vi.fn(), mutateAsync: vi.fn() }
+  },
+}))
+
+vi.mock("../../src/provider.js", () => ({
+  useVoyantFinanceContext: () => ({ baseUrl: "https://api.test", fetcher: testState.fetcher }),
+}))
+
+async function generateLink(options?: { cardProvider?: string }) {
+  // Aliased away from the `use` prefix: react-query is mocked, so this is a
+  // plain call that registers the mutation, not a hook in a render tree.
+  const { useCollectPayment: collectPayment } = await import(
+    "../../src/checkout-hooks/use-collect-payment.js"
+  )
+  collectPayment("book_1", options)
+  const mutation = testState.mutations.at(-1)
+  if (!mutation) throw new Error("useCollectPayment registered no mutation")
+  await mutation.mutationFn({ choice: { type: "hold" }, amountCents: 12_000 })
+  const body = String(testState.fetcher.mock.calls.at(-1)?.[1]?.body)
+  return JSON.parse(body) as InitiateCheckoutCollectionInput
+}
+
+describe("useCollectPayment", () => {
+  beforeEach(() => {
+    testState.mutations.length = 0
+    testState.fetcher.mockReset()
+    testState.fetcher.mockResolvedValue(Response.json({ data: {} }))
+  })
+
+  // voyant#4599: the hook used to stamp `provider: "netopia"` on every link,
+  // so a deployment running any other processor produced a session the real
+  // adapter could not adopt — the identity guard rejected its own initiation.
+  it("leaves the payment session provider-agnostic", async () => {
+    const request = await generateLink()
+
+    expect(request.paymentSession).toBeDefined()
+    expect(request.paymentSession?.provider).toBeUndefined()
+  })
+
+  it("still pins a provider when the caller names one", async () => {
+    const request = await generateLink({ cardProvider: "netopia" })
+
+    expect(request.paymentSession?.provider).toBe("netopia")
+  })
+})

--- a/packages/storefront/src/payment-link/routes.ts
+++ b/packages/storefront/src/payment-link/routes.ts
@@ -171,6 +171,19 @@ export interface PaymentLinkRoutesOptions {
   /** Resolve the public checkout base URL from the deployment bindings. */
   resolvePublicCheckoutBaseUrl(c: Context): string | null
   /**
+   * Whether a card processor is wired for this deployment — the card
+   * counterpart of `resolveBankTransferDetails`, published on
+   * `payment-link-config` so the landing page knows whether to offer card.
+   *
+   * Static, because adapter selection happens once at graph composition. It
+   * says nothing about whether a given start will succeed; `startCardPayment`
+   * still answers `{ configured: false }` at the point of use.
+   *
+   * Omitted means "assume yes", which is how every deployment behaved before
+   * the flag existed.
+   */
+  cardPaymentsConfigured?: boolean
+  /**
    * Best-effort: ensure a fresh payment session can be started on the card
    * provider, returning the handoff it chose. `redirectUrl` is the redirect
    * arm's projection and stays `null` for an embedded handoff. Returns
@@ -235,6 +248,13 @@ const bankTransferDetailsSchema = z.object({
 const paymentLinkConfigSchema = z.object({
   publicCheckoutBaseUrl: z.string().nullable(),
   bankTransfer: bankTransferDetailsSchema.nullable(),
+  /**
+   * Whether this deployment can take a card at all. The landing page needs
+   * this before it renders a method: an unstarted payment-link session has
+   * no provider and no redirect URL, so the session record alone cannot tell
+   * a card deployment from a bank-transfer-only one (voyant#4599).
+   */
+  cardPayments: z.object({ available: z.boolean() }),
 })
 
 const tripComponentSchema = z.object({
@@ -550,6 +570,17 @@ function canReuseCardHandoff(status: string): boolean {
 }
 
 /**
+ * Finance's payment errors carry a `code` (`payment_processor_identity_mismatch`
+ * and friends). Read it structurally rather than importing the error class:
+ * the code is the useful half of the log line, and anything thrown from an
+ * adapter or the transport still gets its own if it has one.
+ */
+function errorCode(err: unknown): string | undefined {
+  const code = (err as { code?: unknown } | null)?.code
+  return typeof code === "string" ? code : undefined
+}
+
+/**
  * A stored handoff the caller can still act on.
  *
  * An embedded handoff is only reusable by a page that says it can mount one;
@@ -657,6 +688,7 @@ export function createPaymentLinkRoutes(options: PaymentLinkRoutesOptions): Open
           data: {
             publicCheckoutBaseUrl: options.resolvePublicCheckoutBaseUrl(c),
             bankTransfer,
+            cardPayments: { available: options.cardPaymentsConfigured !== false },
           },
         },
         200,
@@ -812,7 +844,19 @@ export function createPaymentLinkRoutes(options: PaymentLinkRoutesOptions): Open
           },
           200,
         )
-      } catch {
+      } catch (err) {
+        // The response stays deliberately opaque — a public endpoint must not
+        // relay processor internals to the shopper. But swallowing the error
+        // entirely left a 502 with nothing behind it: diagnosing voyant#4599
+        // meant tracing platform logs and reading the session row by hand.
+        // Log it with the session and the error's own code so the next one
+        // explains itself.
+        console.error("[storefront] payment-link start-card failed", {
+          paymentSessionId: session.id,
+          sessionProvider: session.provider,
+          code: errorCode(err),
+          error: err,
+        })
         return c.json({ error: "Card processor failed to start the payment" }, 502)
       }
     })

--- a/packages/storefront/tests/unit/payment-link-routes.test.ts
+++ b/packages/storefront/tests/unit/payment-link-routes.test.ts
@@ -306,7 +306,19 @@ describe("createPaymentLinkRoutes", () => {
           iban: "RO49AAAA1B31007593840000",
           bankName: "Acme Bank",
         },
+        cardPayments: { available: true },
       },
+    })
+  })
+
+  it("payment-link-config reports card as unavailable when no processor is wired", async () => {
+    const app = mountApp(stubOptions({ cardPaymentsConfigured: false }), makeDb([]))
+
+    const res = await app.request("/v1/public/payment-link-config")
+
+    expect(res.status).toBe(200)
+    expect(((await res.json()) as { data: { cardPayments: unknown } }).data.cardPayments).toEqual({
+      available: false,
     })
   })
 
@@ -389,11 +401,60 @@ describe("createPaymentLinkRoutes", () => {
       }),
       db,
     )
+    const logged = vi.spyOn(console, "error").mockImplementation(() => undefined)
 
     const res = await app.request("/v1/public/payment-link/ps_1/start-card", { method: "POST" })
 
     expect(res.status).toBe(502)
     expect(await res.json()).toEqual({ error: "Card processor failed to start the payment" })
+    // Opaque to the shopper, legible to whoever has to diagnose it.
+    expect(logged).toHaveBeenCalledWith(
+      "[storefront] payment-link start-card failed",
+      expect.objectContaining({ paymentSessionId: "ps_1" }),
+    )
+  })
+
+  it("start-card logs the processor error code that the response withholds", async () => {
+    const db = makeDb([
+      [
+        {
+          id: "ps_1",
+          status: "pending",
+          provider: "netopia",
+          redirectUrl: null,
+          returnUrl: null,
+          amountCents: 12000,
+          currency: "RON",
+          payerName: null,
+          payerEmail: null,
+          notes: null,
+        },
+      ],
+    ])
+    const mismatch = Object.assign(new Error("processor identity does not match"), {
+      code: "payment_processor_identity_mismatch",
+    })
+    const app = mountApp(
+      stubOptions({
+        startCardPayment: vi.fn(async () => {
+          throw mismatch
+        }),
+      }),
+      db,
+    )
+    const logged = vi.spyOn(console, "error").mockImplementation(() => undefined)
+
+    const res = await app.request("/v1/public/payment-link/ps_1/start-card", { method: "POST" })
+
+    expect(res.status).toBe(502)
+    expect(logged).toHaveBeenCalledWith(
+      "[storefront] payment-link start-card failed",
+      expect.objectContaining({
+        paymentSessionId: "ps_1",
+        sessionProvider: "netopia",
+        code: "payment_processor_identity_mismatch",
+      }),
+    )
   })
 
   it("retry keeps an active processor attempt on the same Voyant session", async () => {

--- a/packages/trips/src/storefront-payment-link-runtime.ts
+++ b/packages/trips/src/storefront-payment-link-runtime.ts
@@ -380,6 +380,10 @@ export function createStandardPaymentLinkRouteOptions(
     startCardPayment: adapter
       ? createAdapterStartCardPayment(adapter)
       : unconfiguredStartCardPayment,
+    // Published on `payment-link-config` so the landing page can offer card on
+    // a session that has not started one yet — which is every link the
+    // operator generates (voyant#4599).
+    cardPaymentsConfigured: Boolean(adapter),
     resolveTripData,
   }
 }


### PR DESCRIPTION
Closes #4599.

## The bug

`useCollectPayment` defaulted `cardProvider` to `"netopia"` — a default written when that was the only processor in tree — and every **Generate payment link** wrote it to `payment_sessions.provider`. On a deployment running any other processor the shopper could never pay:

1. The card start reaches the deployment's real adapter and succeeds — a live processor checkout session is created.
2. The initiation result carries `processorIdentity: { providerId: "voyant-pay", … }`.
3. `assertPaymentAdapterProcessorIdentityForLockedSession` rejects it, because the stored provider says `"netopia"` and the only adoptable placeholder is `"managed"`.
4. `payment-link/routes.ts` catches that with a bare `catch {}` and returns a 502 with nothing behind it.

Each attempt therefore left a live processor session attached to a payment session still marked `pending`.

## The fix

**The provider stays unset until the processor claims it on start.** That is what `createOrderPaymentSessions` already documents ("Never hard-code a provider here: that would mislabel Stripe/Adyen/bank-transfer deployments") and what the payment-link `/retry` route already did. Deliberately *not* resolving it from `adapter.id` at generation time: `processorIdentity.providerId` is chosen by the processor worker, so stamping the local adapter id would reintroduce the same class of mismatch in a subtler form.

**The landing page's card option no longer comes from the session row.** With the provider gone, `cardAvailable = Boolean(session.redirectUrl) || Boolean(session.provider) || status === "requires_redirect"` evaluated to `false` for exactly the sessions this feature produces — it would have hidden the only button on the page. Only `pending` and `requires_redirect` reach that branch and both can start or continue a card payment, so whether card is on offer is a fact about the *deployment*:

- `PaymentLinkRoutesOptions.cardPaymentsConfigured` — the card counterpart of `resolveBankTransferDetails`, set by `createStandardPaymentLinkRouteOptions` from whether a payment adapter was selected.
- `GET /v1/public/payment-link-config` publishes it as `cardPayments.available`.
- `PaymentLinkLandingPage` takes it as `cardPaymentAvailable`, defaulting to `true` so a deployment that says nothing keeps offering card.

This also fixes the same latent bug on **Try again**: `/retry` already created provider-free sessions, so the card option disappeared there too.

## Secondary

The `start-card` handler now logs what it swallows — payment session id, stored provider, and the error's own `code` — read structurally rather than by importing finance's error class. The response stays deliberately opaque to the shopper (the existing "does not expose downstream processor errors" test still passes); diagnosing this one otherwise meant tracing platform logs and reading the session row by hand.

## Verification

- `@voyant-travel/finance-react` — 70 tests pass, including two new ones: the request body carries no provider by default, and still pins one when a caller names it; plus landing-page coverage that an unstarted provider-free session offers card, and that a deployment with neither card nor bank transfer offers nothing.
- `@voyant-travel/storefront` — `payment-link-routes` 38 tests pass, including the new config-flag and start-card logging assertions.
- `build` clean (0 `error TS`) for `storefront`, `trips`, `finance-react` and their dependency closures.
- Biome clean on the touched trees.
