### PR TITLE
fix(trips): restore the composer pricing and reservation routes

### DIFF
--- a/.changeset/composer-trip-pricing-routes.md
+++ b/.changeset/composer-trip-pricing-routes.md
@@ -1,0 +1,22 @@
+---
+"@voyant-travel/trips": minor
+"@voyant-travel/framework": patch
+---
+
+Restore the composer pricing and reservation legs on the Trips HTTP surface.
+
+`POST /{envelopeId}/price` and `POST /{envelopeId}/reserve` are the
+staff/storefront composer lifecycle, dependency-injected exactly like checkout
+and cancellation. Removing them left the admin and storefront composers calling
+routes that did not exist — trip creation failed with a bare `404` after the
+envelope and its components had already been persisted — and the durable
+replacement cannot run at all on a deployment that selects no
+`trips.durable-action-runtime` provider.
+
+The agent-facing `price_trip` / `reserve_trip` tools are unchanged: they remain
+admitted, asynchronous durable operations behind that port.
+
+Also add `packages/trips/scripts/generate-openapi.ts` and register both Trips
+documents with `verify:openapi-drift`. They had no generator, so the checked-in
+specs had drifted from the routes — the storefront and admin documents still
+advertised `hold` and `inquiry` checkout intents that were removed in #4100.

--- a/packages/framework/src/runtime-composition.ts
+++ b/packages/framework/src/runtime-composition.ts
@@ -180,6 +180,7 @@ function runtimePortStub(id: string): unknown {
     resolveDocumentGenerator: () => undefined,
     guessMimeType: () => "application/octet-stream",
     resolvePublicProposalBaseUrl: () => "http://localhost:8080",
+    priceTripDeps: () => runtimeServiceStub(id),
     reserveTripDeps: () => runtimeServiceStub(id),
     startCheckoutDeps: () => runtimeServiceStub(id),
     cancelTripComponentsDeps: () => runtimeServiceStub(id),

--- a/packages/trips/README.md
+++ b/packages/trips/README.md
@@ -10,13 +10,26 @@ catalog component adapter, checkout handoff, component-level cancellation
 preview/cancel operations, Cruise Extension representation helpers, Hono
 routes, and MCP tools.
 
-Agent-triggered pricing and reservation are asynchronous durable operations.
-The package records an admitted command and immutable accepted result before
-provider dispatch. They remain unavailable unless the selected deployment
-provides `trips.durable-action-runtime` and passes behavioral replay, restart
-reconciliation, payload-drift, and exact backend-identity conformance. The
-framework ships no fallback provider. Use `get_trip_action_operation` to read
-the terminal outcome.
+Pricing and reservation have two distinct entry points, and they are not
+interchangeable:
+
+- **Staff and storefront composers** call `POST /{envelopeId}/price` and
+  `POST /{envelopeId}/reserve` synchronously, dependency-injected exactly like
+  checkout and cancellation. A composer price is a *read*: it resolves a
+  non-binding v1 Offer Preview per component and aggregates it onto the
+  envelope. Both legs answer `501` until the deployment configures their deps.
+- **Agents** call the `price_trip` / `reserve_trip` tools, which are
+  asynchronous durable operations. The package records an admitted command and
+  immutable accepted result before provider dispatch. They remain unavailable
+  unless the selected deployment provides `trips.durable-action-runtime` and
+  passes behavioral replay, restart reconciliation, payload-drift, and exact
+  backend-identity conformance. The framework ships no fallback provider. Use
+  `get_trip_action_operation` to read the terminal outcome.
+
+Collapsing the first into the second is what broke trip creation in
+[voyant#4601](https://github.com/voyant-travel/voyant/issues/4601): the composer
+UIs kept calling routes that no longer existed, and the durable replacement
+cannot run on a deployment that selects no provider.
 
 Checkout and cancellation are dependency-injected so app/runtime packages keep
 owning payment-provider, bank-transfer, storefront URL, supplier, and

--- a/packages/trips/openapi/admin/trips.json
+++ b/packages/trips/openapi/admin/trips.json
@@ -18,6 +18,7 @@
   "paths": {
     "/v1/admin/trips/health": {
       "get": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.admin",
         "responses": {
           "200": {
             "description": "Trips module health status",
@@ -56,6 +57,7 @@
     },
     "/v1/admin/trips": {
       "get": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.admin",
         "parameters": [
           {
             "schema": {
@@ -518,6 +520,7 @@
         "x-voyant-surface": "admin"
       },
       "post": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.admin",
         "requestBody": {
           "required": true,
           "content": {
@@ -908,6 +911,7 @@
     },
     "/v1/admin/trips/{envelopeId}": {
       "get": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.admin",
         "parameters": [
           {
             "schema": {
@@ -1238,6 +1242,7 @@
         "x-voyant-surface": "admin"
       },
       "patch": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.admin",
         "parameters": [
           {
             "schema": {
@@ -1497,6 +1502,7 @@
     },
     "/v1/admin/trips/{envelopeId}/snapshots": {
       "get": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.admin",
         "parameters": [
           {
             "schema": {
@@ -1625,6 +1631,7 @@
         "x-voyant-surface": "admin"
       },
       "post": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.admin",
         "parameters": [
           {
             "schema": {
@@ -1819,6 +1826,7 @@
     },
     "/v1/admin/trips/snapshots/{snapshotId}": {
       "get": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.admin",
         "parameters": [
           {
             "schema": {
@@ -1963,6 +1971,7 @@
     },
     "/v1/admin/trips/{envelopeId}/components": {
       "post": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.admin",
         "parameters": [
           {
             "schema": {
@@ -2306,6 +2315,7 @@
     },
     "/v1/admin/trips/{envelopeId}/components/reorder": {
       "post": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.admin",
         "parameters": [
           {
             "schema": {
@@ -2592,6 +2602,7 @@
     },
     "/v1/admin/trips/components/{componentId}": {
       "patch": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.admin",
         "parameters": [
           {
             "schema": {
@@ -2922,6 +2933,7 @@
         "x-voyant-surface": "admin"
       },
       "delete": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.admin",
         "parameters": [
           {
             "schema": {
@@ -3184,6 +3196,7 @@
     },
     "/v1/admin/trips/components/{componentId}/refs": {
       "post": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.admin",
         "parameters": [
           {
             "schema": {
@@ -3495,6 +3508,7 @@
     },
     "/v1/admin/trips/{envelopeId}/requirements": {
       "post": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.admin",
         "parameters": [
           {
             "schema": {
@@ -3714,6 +3728,7 @@
         "x-voyant-surface": "admin"
       },
       "get": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.admin",
         "parameters": [
           {
             "schema": {
@@ -3892,6 +3907,7 @@
     },
     "/v1/admin/trips/requirements/{requirementId}/sourcing-operations/{operationId}": {
       "get": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.admin",
         "parameters": [
           {
             "schema": {
@@ -4082,6 +4098,7 @@
     },
     "/v1/admin/trips/requirements/{requirementId}/select": {
       "post": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.admin",
         "parameters": [
           {
             "schema": {
@@ -4517,6 +4534,7 @@
     },
     "/v1/admin/trips/{envelopeId}/price": {
       "post": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.admin",
         "parameters": [
           {
             "schema": {
@@ -4941,6 +4959,7 @@
     },
     "/v1/admin/trips/{envelopeId}/reserve": {
       "post": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.admin",
         "parameters": [
           {
             "schema": {
@@ -5365,6 +5384,7 @@
     },
     "/v1/admin/trips/{envelopeId}/checkout": {
       "post": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.admin",
         "parameters": [
           {
             "schema": {
@@ -5776,6 +5796,7 @@
     },
     "/v1/admin/trips/{envelopeId}/cancellation-preview": {
       "post": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.admin",
         "parameters": [
           {
             "schema": {
@@ -6194,6 +6215,7 @@
     },
     "/v1/admin/trips/{envelopeId}/cancel-components": {
       "post": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.admin",
         "parameters": [
           {
             "schema": {

--- a/packages/trips/openapi/admin/trips.json
+++ b/packages/trips/openapi/admin/trips.json
@@ -12,118 +12,7 @@
     }
   ],
   "components": {
-    "schemas": {
-      "CatalogSearchFilter": {
-        "anyOf": [
-          {
-            "type": "object",
-            "properties": {
-              "kind": {
-                "type": "string",
-                "enum": ["eq"]
-              },
-              "field": {
-                "type": "string",
-                "minLength": 1
-              },
-              "value": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "boolean"
-                  }
-                ]
-              }
-            },
-            "required": ["kind", "field", "value"]
-          },
-          {
-            "type": "object",
-            "properties": {
-              "kind": {
-                "type": "string",
-                "enum": ["in"]
-              },
-              "field": {
-                "type": "string",
-                "minLength": 1
-              },
-              "values": {
-                "type": "array",
-                "items": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "number"
-                    }
-                  ]
-                }
-              }
-            },
-            "required": ["kind", "field", "values"]
-          },
-          {
-            "type": "object",
-            "properties": {
-              "kind": {
-                "type": "string",
-                "enum": ["range"]
-              },
-              "field": {
-                "type": "string",
-                "minLength": 1
-              },
-              "gte": {
-                "type": "number"
-              },
-              "lte": {
-                "type": "number"
-              }
-            },
-            "required": ["kind", "field"]
-          },
-          {
-            "type": "object",
-            "properties": {
-              "kind": {
-                "type": "string",
-                "enum": ["and"]
-              },
-              "clauses": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/CatalogSearchFilter"
-                }
-              }
-            },
-            "required": ["kind", "clauses"]
-          },
-          {
-            "type": "object",
-            "properties": {
-              "kind": {
-                "type": "string",
-                "enum": ["or"]
-              },
-              "clauses": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/CatalogSearchFilter"
-                }
-              }
-            },
-            "required": ["kind", "clauses"]
-          }
-        ]
-      }
-    },
+    "schemas": {},
     "parameters": {}
   },
   "paths": {
@@ -4100,13 +3989,12 @@
                               "required": ["status", "error"]
                             },
                             {
-                              "nullable": true
+                              "type": "null"
                             }
                           ]
                         },
                         "error": {
-                          "type": "string",
-                          "nullable": true
+                          "type": ["string", "null"]
                         },
                         "attempts": {
                           "type": "integer",
@@ -4114,15 +4002,13 @@
                         },
                         "maxAttempts": {
                           "type": "integer",
-                          "minimum": 0,
-                          "exclusiveMinimum": true
+                          "exclusiveMinimum": 0
                         },
                         "nextAttemptAt": {
                           "type": "string"
                         },
                         "completedAt": {
-                          "type": "string",
-                          "nullable": true
+                          "type": ["string", "null"]
                         },
                         "createdAt": {
                           "type": "string"
@@ -4164,9 +4050,7 @@
                     }
                   },
                   "required": ["error"],
-                  "additionalProperties": {
-                    "nullable": true
-                  }
+                  "additionalProperties": {}
                 }
               }
             }
@@ -4183,9 +4067,7 @@
                     }
                   },
                   "required": ["error"],
-                  "additionalProperties": {
-                    "nullable": true
-                  }
+                  "additionalProperties": {}
                 }
               }
             }
@@ -4633,6 +4515,854 @@
         "x-voyant-surface": "admin"
       }
     },
+    "/v1/admin/trips/{envelopeId}/price": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "envelopeId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "scope": {
+                    "type": "object",
+                    "properties": {
+                      "locale": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "audience": {
+                        "type": "string",
+                        "enum": ["staff", "customer", "partner", "supplier"]
+                      },
+                      "market": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "currency": {
+                        "type": "string",
+                        "minLength": 3,
+                        "maxLength": 3
+                      }
+                    },
+                    "required": ["locale", "audience", "market"]
+                  },
+                  "ttlMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0
+                  }
+                },
+                "required": ["scope"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The priced envelope with components and a composed pricing result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "envelope": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string"
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "draft",
+                                "priced",
+                                "reserve_in_progress",
+                                "reserved",
+                                "checkout_started",
+                                "booked",
+                                "failed",
+                                "cancelled"
+                              ]
+                            },
+                            "title": {
+                              "type": ["string", "null"]
+                            },
+                            "description": {
+                              "type": ["string", "null"]
+                            },
+                            "travelerParty": {
+                              "type": "object",
+                              "additionalProperties": {}
+                            },
+                            "constraints": {
+                              "type": "object",
+                              "additionalProperties": {}
+                            },
+                            "aggregateCurrency": {
+                              "type": ["string", "null"]
+                            },
+                            "aggregateSubtotalAmountCents": {
+                              "type": ["integer", "null"]
+                            },
+                            "aggregateTaxAmountCents": {
+                              "type": ["integer", "null"]
+                            },
+                            "aggregateTotalAmountCents": {
+                              "type": ["integer", "null"]
+                            },
+                            "aggregatePricingSnapshot": {},
+                            "currentPriceExpiresAt": {
+                              "type": ["string", "null"]
+                            },
+                            "bookingGroupId": {
+                              "type": ["string", "null"]
+                            },
+                            "orderId": {
+                              "type": ["string", "null"]
+                            },
+                            "paymentSessionId": {
+                              "type": ["string", "null"]
+                            },
+                            "reserveIdempotencyKey": {
+                              "type": ["string", "null"]
+                            },
+                            "reserveStartedAt": {
+                              "type": ["string", "null"]
+                            },
+                            "reservedAt": {
+                              "type": ["string", "null"]
+                            },
+                            "checkoutIdempotencyKey": {
+                              "type": ["string", "null"]
+                            },
+                            "checkoutStartedAt": {
+                              "type": ["string", "null"]
+                            },
+                            "createdBy": {
+                              "type": ["string", "null"]
+                            },
+                            "updatedBy": {
+                              "type": ["string", "null"]
+                            },
+                            "createdAt": {
+                              "type": "string"
+                            },
+                            "updatedAt": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "status",
+                            "title",
+                            "description",
+                            "travelerParty",
+                            "constraints",
+                            "aggregateCurrency",
+                            "aggregateSubtotalAmountCents",
+                            "aggregateTaxAmountCents",
+                            "aggregateTotalAmountCents",
+                            "currentPriceExpiresAt",
+                            "bookingGroupId",
+                            "orderId",
+                            "paymentSessionId",
+                            "reserveIdempotencyKey",
+                            "reserveStartedAt",
+                            "reservedAt",
+                            "checkoutIdempotencyKey",
+                            "checkoutStartedAt",
+                            "createdBy",
+                            "updatedBy",
+                            "createdAt",
+                            "updatedAt"
+                          ]
+                        },
+                        "components": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "envelopeId": {
+                                "type": "string"
+                              },
+                              "sequence": {
+                                "type": "integer"
+                              },
+                              "kind": {
+                                "type": "string",
+                                "enum": [
+                                  "catalog_booking",
+                                  "manual_placeholder",
+                                  "flight_placeholder",
+                                  "flight_order",
+                                  "external_order"
+                                ]
+                              },
+                              "status": {
+                                "type": "string",
+                                "enum": [
+                                  "draft",
+                                  "priced",
+                                  "unavailable",
+                                  "held",
+                                  "booked",
+                                  "checkout_started",
+                                  "failed",
+                                  "cancelled",
+                                  "removed"
+                                ]
+                              },
+                              "title": {
+                                "type": ["string", "null"]
+                              },
+                              "description": {
+                                "type": ["string", "null"]
+                              },
+                              "entityModule": {
+                                "type": ["string", "null"]
+                              },
+                              "entityId": {
+                                "type": ["string", "null"]
+                              },
+                              "sourceKind": {
+                                "type": ["string", "null"]
+                              },
+                              "sourceConnectionId": {
+                                "type": ["string", "null"]
+                              },
+                              "sourceRef": {
+                                "type": ["string", "null"]
+                              },
+                              "bookingDraftId": {
+                                "type": ["string", "null"]
+                              },
+                              "catalogQuoteId": {
+                                "type": ["string", "null"]
+                              },
+                              "bookingId": {
+                                "type": ["string", "null"]
+                              },
+                              "bookingGroupId": {
+                                "type": ["string", "null"]
+                              },
+                              "orderId": {
+                                "type": ["string", "null"]
+                              },
+                              "paymentSessionId": {
+                                "type": ["string", "null"]
+                              },
+                              "providerRef": {
+                                "type": ["string", "null"]
+                              },
+                              "supplierRef": {
+                                "type": ["string", "null"]
+                              },
+                              "componentCurrency": {
+                                "type": ["string", "null"]
+                              },
+                              "componentSubtotalAmountCents": {
+                                "type": ["integer", "null"]
+                              },
+                              "componentTaxAmountCents": {
+                                "type": ["integer", "null"]
+                              },
+                              "componentTotalAmountCents": {
+                                "type": ["integer", "null"]
+                              },
+                              "pricingSnapshot": {},
+                              "taxLines": {
+                                "type": ["array", "null"],
+                                "items": {}
+                              },
+                              "cancellationSnapshot": {},
+                              "holdToken": {
+                                "type": ["string", "null"]
+                              },
+                              "holdExpiresAt": {
+                                "type": ["string", "null"]
+                              },
+                              "priceExpiresAt": {
+                                "type": ["string", "null"]
+                              },
+                              "warningCodes": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "metadata": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              },
+                              "createdAt": {
+                                "type": "string"
+                              },
+                              "updatedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "envelopeId",
+                              "sequence",
+                              "kind",
+                              "status",
+                              "title",
+                              "description",
+                              "entityModule",
+                              "entityId",
+                              "sourceKind",
+                              "sourceConnectionId",
+                              "sourceRef",
+                              "bookingDraftId",
+                              "catalogQuoteId",
+                              "bookingId",
+                              "bookingGroupId",
+                              "orderId",
+                              "paymentSessionId",
+                              "providerRef",
+                              "supplierRef",
+                              "componentCurrency",
+                              "componentSubtotalAmountCents",
+                              "componentTaxAmountCents",
+                              "componentTotalAmountCents",
+                              "taxLines",
+                              "holdToken",
+                              "holdExpiresAt",
+                              "priceExpiresAt",
+                              "warningCodes",
+                              "metadata",
+                              "createdAt",
+                              "updatedAt"
+                            ]
+                          }
+                        }
+                      },
+                      "required": ["envelope", "components"],
+                      "additionalProperties": {}
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid_request — body failed validation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Trip envelope not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Envelope cannot be priced in its current state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Trips price dependencies are not configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postAdminTripsByEnvelopeIdPrice",
+        "summary": "POST /v1/admin/trips/{envelopeId}/price",
+        "tags": ["trips"],
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
+      }
+    },
+    "/v1/admin/trips/{envelopeId}/reserve": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "envelopeId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "idempotencyKey": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 255
+                  },
+                  "refreshScope": {
+                    "type": "object",
+                    "properties": {
+                      "locale": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "audience": {
+                        "type": "string",
+                        "enum": ["staff", "customer", "partner", "supplier"]
+                      },
+                      "market": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "currency": {
+                        "type": "string",
+                        "minLength": 3,
+                        "maxLength": 3
+                      }
+                    },
+                    "required": ["locale", "audience", "market"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The reserved envelope with components and a composed reservation result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "envelope": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string"
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "draft",
+                                "priced",
+                                "reserve_in_progress",
+                                "reserved",
+                                "checkout_started",
+                                "booked",
+                                "failed",
+                                "cancelled"
+                              ]
+                            },
+                            "title": {
+                              "type": ["string", "null"]
+                            },
+                            "description": {
+                              "type": ["string", "null"]
+                            },
+                            "travelerParty": {
+                              "type": "object",
+                              "additionalProperties": {}
+                            },
+                            "constraints": {
+                              "type": "object",
+                              "additionalProperties": {}
+                            },
+                            "aggregateCurrency": {
+                              "type": ["string", "null"]
+                            },
+                            "aggregateSubtotalAmountCents": {
+                              "type": ["integer", "null"]
+                            },
+                            "aggregateTaxAmountCents": {
+                              "type": ["integer", "null"]
+                            },
+                            "aggregateTotalAmountCents": {
+                              "type": ["integer", "null"]
+                            },
+                            "aggregatePricingSnapshot": {},
+                            "currentPriceExpiresAt": {
+                              "type": ["string", "null"]
+                            },
+                            "bookingGroupId": {
+                              "type": ["string", "null"]
+                            },
+                            "orderId": {
+                              "type": ["string", "null"]
+                            },
+                            "paymentSessionId": {
+                              "type": ["string", "null"]
+                            },
+                            "reserveIdempotencyKey": {
+                              "type": ["string", "null"]
+                            },
+                            "reserveStartedAt": {
+                              "type": ["string", "null"]
+                            },
+                            "reservedAt": {
+                              "type": ["string", "null"]
+                            },
+                            "checkoutIdempotencyKey": {
+                              "type": ["string", "null"]
+                            },
+                            "checkoutStartedAt": {
+                              "type": ["string", "null"]
+                            },
+                            "createdBy": {
+                              "type": ["string", "null"]
+                            },
+                            "updatedBy": {
+                              "type": ["string", "null"]
+                            },
+                            "createdAt": {
+                              "type": "string"
+                            },
+                            "updatedAt": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "status",
+                            "title",
+                            "description",
+                            "travelerParty",
+                            "constraints",
+                            "aggregateCurrency",
+                            "aggregateSubtotalAmountCents",
+                            "aggregateTaxAmountCents",
+                            "aggregateTotalAmountCents",
+                            "currentPriceExpiresAt",
+                            "bookingGroupId",
+                            "orderId",
+                            "paymentSessionId",
+                            "reserveIdempotencyKey",
+                            "reserveStartedAt",
+                            "reservedAt",
+                            "checkoutIdempotencyKey",
+                            "checkoutStartedAt",
+                            "createdBy",
+                            "updatedBy",
+                            "createdAt",
+                            "updatedAt"
+                          ]
+                        },
+                        "components": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "envelopeId": {
+                                "type": "string"
+                              },
+                              "sequence": {
+                                "type": "integer"
+                              },
+                              "kind": {
+                                "type": "string",
+                                "enum": [
+                                  "catalog_booking",
+                                  "manual_placeholder",
+                                  "flight_placeholder",
+                                  "flight_order",
+                                  "external_order"
+                                ]
+                              },
+                              "status": {
+                                "type": "string",
+                                "enum": [
+                                  "draft",
+                                  "priced",
+                                  "unavailable",
+                                  "held",
+                                  "booked",
+                                  "checkout_started",
+                                  "failed",
+                                  "cancelled",
+                                  "removed"
+                                ]
+                              },
+                              "title": {
+                                "type": ["string", "null"]
+                              },
+                              "description": {
+                                "type": ["string", "null"]
+                              },
+                              "entityModule": {
+                                "type": ["string", "null"]
+                              },
+                              "entityId": {
+                                "type": ["string", "null"]
+                              },
+                              "sourceKind": {
+                                "type": ["string", "null"]
+                              },
+                              "sourceConnectionId": {
+                                "type": ["string", "null"]
+                              },
+                              "sourceRef": {
+                                "type": ["string", "null"]
+                              },
+                              "bookingDraftId": {
+                                "type": ["string", "null"]
+                              },
+                              "catalogQuoteId": {
+                                "type": ["string", "null"]
+                              },
+                              "bookingId": {
+                                "type": ["string", "null"]
+                              },
+                              "bookingGroupId": {
+                                "type": ["string", "null"]
+                              },
+                              "orderId": {
+                                "type": ["string", "null"]
+                              },
+                              "paymentSessionId": {
+                                "type": ["string", "null"]
+                              },
+                              "providerRef": {
+                                "type": ["string", "null"]
+                              },
+                              "supplierRef": {
+                                "type": ["string", "null"]
+                              },
+                              "componentCurrency": {
+                                "type": ["string", "null"]
+                              },
+                              "componentSubtotalAmountCents": {
+                                "type": ["integer", "null"]
+                              },
+                              "componentTaxAmountCents": {
+                                "type": ["integer", "null"]
+                              },
+                              "componentTotalAmountCents": {
+                                "type": ["integer", "null"]
+                              },
+                              "pricingSnapshot": {},
+                              "taxLines": {
+                                "type": ["array", "null"],
+                                "items": {}
+                              },
+                              "cancellationSnapshot": {},
+                              "holdToken": {
+                                "type": ["string", "null"]
+                              },
+                              "holdExpiresAt": {
+                                "type": ["string", "null"]
+                              },
+                              "priceExpiresAt": {
+                                "type": ["string", "null"]
+                              },
+                              "warningCodes": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "metadata": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              },
+                              "createdAt": {
+                                "type": "string"
+                              },
+                              "updatedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "envelopeId",
+                              "sequence",
+                              "kind",
+                              "status",
+                              "title",
+                              "description",
+                              "entityModule",
+                              "entityId",
+                              "sourceKind",
+                              "sourceConnectionId",
+                              "sourceRef",
+                              "bookingDraftId",
+                              "catalogQuoteId",
+                              "bookingId",
+                              "bookingGroupId",
+                              "orderId",
+                              "paymentSessionId",
+                              "providerRef",
+                              "supplierRef",
+                              "componentCurrency",
+                              "componentSubtotalAmountCents",
+                              "componentTaxAmountCents",
+                              "componentTotalAmountCents",
+                              "taxLines",
+                              "holdToken",
+                              "holdExpiresAt",
+                              "priceExpiresAt",
+                              "warningCodes",
+                              "metadata",
+                              "createdAt",
+                              "updatedAt"
+                            ]
+                          }
+                        }
+                      },
+                      "required": ["envelope", "components"],
+                      "additionalProperties": {}
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid_request — body failed validation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Trip envelope not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Envelope cannot be reserved in its current state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Trips reserve dependencies are not configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postAdminTripsByEnvelopeIdReserve",
+        "summary": "POST /v1/admin/trips/{envelopeId}/reserve",
+        "tags": ["trips"],
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
+      }
+    },
     "/v1/admin/trips/{envelopeId}/checkout": {
       "post": {
         "parameters": [
@@ -4659,7 +5389,7 @@
                   },
                   "intent": {
                     "type": "string",
-                    "enum": ["card", "bank_transfer", "hold", "inquiry"],
+                    "enum": ["card", "bank_transfer"],
                     "default": "card"
                   },
                   "request": {

--- a/packages/trips/openapi/storefront/trips.json
+++ b/packages/trips/openapi/storefront/trips.json
@@ -12,124 +12,12 @@
     }
   ],
   "components": {
-    "schemas": {
-      "CatalogSearchFilter": {
-        "anyOf": [
-          {
-            "type": "object",
-            "properties": {
-              "kind": {
-                "type": "string",
-                "enum": ["eq"]
-              },
-              "field": {
-                "type": "string",
-                "minLength": 1
-              },
-              "value": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "boolean"
-                  }
-                ]
-              }
-            },
-            "required": ["kind", "field", "value"]
-          },
-          {
-            "type": "object",
-            "properties": {
-              "kind": {
-                "type": "string",
-                "enum": ["in"]
-              },
-              "field": {
-                "type": "string",
-                "minLength": 1
-              },
-              "values": {
-                "type": "array",
-                "items": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "number"
-                    }
-                  ]
-                }
-              }
-            },
-            "required": ["kind", "field", "values"]
-          },
-          {
-            "type": "object",
-            "properties": {
-              "kind": {
-                "type": "string",
-                "enum": ["range"]
-              },
-              "field": {
-                "type": "string",
-                "minLength": 1
-              },
-              "gte": {
-                "type": "number"
-              },
-              "lte": {
-                "type": "number"
-              }
-            },
-            "required": ["kind", "field"]
-          },
-          {
-            "type": "object",
-            "properties": {
-              "kind": {
-                "type": "string",
-                "enum": ["and"]
-              },
-              "clauses": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/CatalogSearchFilter"
-                }
-              }
-            },
-            "required": ["kind", "clauses"]
-          },
-          {
-            "type": "object",
-            "properties": {
-              "kind": {
-                "type": "string",
-                "enum": ["or"]
-              },
-              "clauses": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/CatalogSearchFilter"
-                }
-              }
-            },
-            "required": ["kind", "clauses"]
-          }
-        ]
-      }
-    },
+    "schemas": {},
     "parameters": {}
   },
   "paths": {
     "/v1/public/trips/health": {
       "get": {
-        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "responses": {
           "200": {
             "description": "Trips module health status",
@@ -168,7 +56,6 @@
     },
     "/v1/public/trips": {
       "get": {
-        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {
@@ -631,7 +518,6 @@
         "x-voyant-surface": "storefront"
       },
       "post": {
-        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "requestBody": {
           "required": true,
           "content": {
@@ -1022,7 +908,6 @@
     },
     "/v1/public/trips/{envelopeId}": {
       "get": {
-        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {
@@ -1353,7 +1238,6 @@
         "x-voyant-surface": "storefront"
       },
       "patch": {
-        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {
@@ -1613,7 +1497,6 @@
     },
     "/v1/public/trips/{envelopeId}/snapshots": {
       "get": {
-        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {
@@ -1742,7 +1625,6 @@
         "x-voyant-surface": "storefront"
       },
       "post": {
-        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {
@@ -1937,7 +1819,6 @@
     },
     "/v1/public/trips/snapshots/{snapshotId}": {
       "get": {
-        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {
@@ -2082,7 +1963,6 @@
     },
     "/v1/public/trips/{envelopeId}/components": {
       "post": {
-        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {
@@ -2426,7 +2306,6 @@
     },
     "/v1/public/trips/{envelopeId}/components/reorder": {
       "post": {
-        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {
@@ -2713,7 +2592,6 @@
     },
     "/v1/public/trips/components/{componentId}": {
       "patch": {
-        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {
@@ -3044,7 +2922,6 @@
         "x-voyant-surface": "storefront"
       },
       "delete": {
-        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {
@@ -3307,7 +3184,6 @@
     },
     "/v1/public/trips/components/{componentId}/refs": {
       "post": {
-        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {
@@ -3619,7 +3495,6 @@
     },
     "/v1/public/trips/{envelopeId}/requirements": {
       "post": {
-        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {
@@ -3839,7 +3714,6 @@
         "x-voyant-surface": "storefront"
       },
       "get": {
-        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {
@@ -4018,7 +3892,6 @@
     },
     "/v1/public/trips/requirements/{requirementId}/sourcing-operations/{operationId}": {
       "get": {
-        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {
@@ -4116,13 +3989,12 @@
                               "required": ["status", "error"]
                             },
                             {
-                              "nullable": true
+                              "type": "null"
                             }
                           ]
                         },
                         "error": {
-                          "type": "string",
-                          "nullable": true
+                          "type": ["string", "null"]
                         },
                         "attempts": {
                           "type": "integer",
@@ -4130,15 +4002,13 @@
                         },
                         "maxAttempts": {
                           "type": "integer",
-                          "minimum": 0,
-                          "exclusiveMinimum": true
+                          "exclusiveMinimum": 0
                         },
                         "nextAttemptAt": {
                           "type": "string"
                         },
                         "completedAt": {
-                          "type": "string",
-                          "nullable": true
+                          "type": ["string", "null"]
                         },
                         "createdAt": {
                           "type": "string"
@@ -4180,9 +4050,7 @@
                     }
                   },
                   "required": ["error"],
-                  "additionalProperties": {
-                    "nullable": true
-                  }
+                  "additionalProperties": {}
                 }
               }
             }
@@ -4199,9 +4067,7 @@
                     }
                   },
                   "required": ["error"],
-                  "additionalProperties": {
-                    "nullable": true
-                  }
+                  "additionalProperties": {}
                 }
               }
             }
@@ -4216,7 +4082,6 @@
     },
     "/v1/public/trips/requirements/{requirementId}/select": {
       "post": {
-        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {
@@ -4650,9 +4515,856 @@
         "x-voyant-surface": "storefront"
       }
     },
+    "/v1/public/trips/{envelopeId}/price": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "envelopeId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "scope": {
+                    "type": "object",
+                    "properties": {
+                      "locale": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "audience": {
+                        "type": "string",
+                        "enum": ["staff", "customer", "partner", "supplier"]
+                      },
+                      "market": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "currency": {
+                        "type": "string",
+                        "minLength": 3,
+                        "maxLength": 3
+                      }
+                    },
+                    "required": ["locale", "audience", "market"]
+                  },
+                  "ttlMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0
+                  }
+                },
+                "required": ["scope"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The priced envelope with components and a composed pricing result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "envelope": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string"
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "draft",
+                                "priced",
+                                "reserve_in_progress",
+                                "reserved",
+                                "checkout_started",
+                                "booked",
+                                "failed",
+                                "cancelled"
+                              ]
+                            },
+                            "title": {
+                              "type": ["string", "null"]
+                            },
+                            "description": {
+                              "type": ["string", "null"]
+                            },
+                            "travelerParty": {
+                              "type": "object",
+                              "additionalProperties": {}
+                            },
+                            "constraints": {
+                              "type": "object",
+                              "additionalProperties": {}
+                            },
+                            "aggregateCurrency": {
+                              "type": ["string", "null"]
+                            },
+                            "aggregateSubtotalAmountCents": {
+                              "type": ["integer", "null"]
+                            },
+                            "aggregateTaxAmountCents": {
+                              "type": ["integer", "null"]
+                            },
+                            "aggregateTotalAmountCents": {
+                              "type": ["integer", "null"]
+                            },
+                            "aggregatePricingSnapshot": {},
+                            "currentPriceExpiresAt": {
+                              "type": ["string", "null"]
+                            },
+                            "bookingGroupId": {
+                              "type": ["string", "null"]
+                            },
+                            "orderId": {
+                              "type": ["string", "null"]
+                            },
+                            "paymentSessionId": {
+                              "type": ["string", "null"]
+                            },
+                            "reserveIdempotencyKey": {
+                              "type": ["string", "null"]
+                            },
+                            "reserveStartedAt": {
+                              "type": ["string", "null"]
+                            },
+                            "reservedAt": {
+                              "type": ["string", "null"]
+                            },
+                            "checkoutIdempotencyKey": {
+                              "type": ["string", "null"]
+                            },
+                            "checkoutStartedAt": {
+                              "type": ["string", "null"]
+                            },
+                            "createdBy": {
+                              "type": ["string", "null"]
+                            },
+                            "updatedBy": {
+                              "type": ["string", "null"]
+                            },
+                            "createdAt": {
+                              "type": "string"
+                            },
+                            "updatedAt": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "status",
+                            "title",
+                            "description",
+                            "travelerParty",
+                            "constraints",
+                            "aggregateCurrency",
+                            "aggregateSubtotalAmountCents",
+                            "aggregateTaxAmountCents",
+                            "aggregateTotalAmountCents",
+                            "currentPriceExpiresAt",
+                            "bookingGroupId",
+                            "orderId",
+                            "paymentSessionId",
+                            "reserveIdempotencyKey",
+                            "reserveStartedAt",
+                            "reservedAt",
+                            "checkoutIdempotencyKey",
+                            "checkoutStartedAt",
+                            "createdBy",
+                            "updatedBy",
+                            "createdAt",
+                            "updatedAt"
+                          ]
+                        },
+                        "components": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "envelopeId": {
+                                "type": "string"
+                              },
+                              "sequence": {
+                                "type": "integer"
+                              },
+                              "kind": {
+                                "type": "string",
+                                "enum": [
+                                  "catalog_booking",
+                                  "manual_placeholder",
+                                  "flight_placeholder",
+                                  "flight_order",
+                                  "external_order"
+                                ]
+                              },
+                              "status": {
+                                "type": "string",
+                                "enum": [
+                                  "draft",
+                                  "priced",
+                                  "unavailable",
+                                  "held",
+                                  "booked",
+                                  "checkout_started",
+                                  "failed",
+                                  "cancelled",
+                                  "removed"
+                                ]
+                              },
+                              "title": {
+                                "type": ["string", "null"]
+                              },
+                              "description": {
+                                "type": ["string", "null"]
+                              },
+                              "entityModule": {
+                                "type": ["string", "null"]
+                              },
+                              "entityId": {
+                                "type": ["string", "null"]
+                              },
+                              "sourceKind": {
+                                "type": ["string", "null"]
+                              },
+                              "sourceConnectionId": {
+                                "type": ["string", "null"]
+                              },
+                              "sourceRef": {
+                                "type": ["string", "null"]
+                              },
+                              "bookingDraftId": {
+                                "type": ["string", "null"]
+                              },
+                              "catalogQuoteId": {
+                                "type": ["string", "null"]
+                              },
+                              "bookingId": {
+                                "type": ["string", "null"]
+                              },
+                              "bookingGroupId": {
+                                "type": ["string", "null"]
+                              },
+                              "orderId": {
+                                "type": ["string", "null"]
+                              },
+                              "paymentSessionId": {
+                                "type": ["string", "null"]
+                              },
+                              "providerRef": {
+                                "type": ["string", "null"]
+                              },
+                              "supplierRef": {
+                                "type": ["string", "null"]
+                              },
+                              "componentCurrency": {
+                                "type": ["string", "null"]
+                              },
+                              "componentSubtotalAmountCents": {
+                                "type": ["integer", "null"]
+                              },
+                              "componentTaxAmountCents": {
+                                "type": ["integer", "null"]
+                              },
+                              "componentTotalAmountCents": {
+                                "type": ["integer", "null"]
+                              },
+                              "pricingSnapshot": {},
+                              "taxLines": {
+                                "type": ["array", "null"],
+                                "items": {}
+                              },
+                              "cancellationSnapshot": {},
+                              "holdToken": {
+                                "type": ["string", "null"]
+                              },
+                              "holdExpiresAt": {
+                                "type": ["string", "null"]
+                              },
+                              "priceExpiresAt": {
+                                "type": ["string", "null"]
+                              },
+                              "warningCodes": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "metadata": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              },
+                              "createdAt": {
+                                "type": "string"
+                              },
+                              "updatedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "envelopeId",
+                              "sequence",
+                              "kind",
+                              "status",
+                              "title",
+                              "description",
+                              "entityModule",
+                              "entityId",
+                              "sourceKind",
+                              "sourceConnectionId",
+                              "sourceRef",
+                              "bookingDraftId",
+                              "catalogQuoteId",
+                              "bookingId",
+                              "bookingGroupId",
+                              "orderId",
+                              "paymentSessionId",
+                              "providerRef",
+                              "supplierRef",
+                              "componentCurrency",
+                              "componentSubtotalAmountCents",
+                              "componentTaxAmountCents",
+                              "componentTotalAmountCents",
+                              "taxLines",
+                              "holdToken",
+                              "holdExpiresAt",
+                              "priceExpiresAt",
+                              "warningCodes",
+                              "metadata",
+                              "createdAt",
+                              "updatedAt"
+                            ]
+                          }
+                        }
+                      },
+                      "required": ["envelope", "components"],
+                      "additionalProperties": {}
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid_request — body failed validation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Trip envelope not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Envelope cannot be priced in its current state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Trips price dependencies are not configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postPublicTripsByEnvelopeIdPrice",
+        "summary": "POST /v1/public/trips/{envelopeId}/price",
+        "tags": ["trips"],
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
+      }
+    },
+    "/v1/public/trips/{envelopeId}/reserve": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "envelopeId",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "idempotencyKey": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 255
+                  },
+                  "refreshScope": {
+                    "type": "object",
+                    "properties": {
+                      "locale": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "audience": {
+                        "type": "string",
+                        "enum": ["staff", "customer", "partner", "supplier"]
+                      },
+                      "market": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "currency": {
+                        "type": "string",
+                        "minLength": 3,
+                        "maxLength": 3
+                      }
+                    },
+                    "required": ["locale", "audience", "market"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The reserved envelope with components and a composed reservation result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "envelope": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string"
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "draft",
+                                "priced",
+                                "reserve_in_progress",
+                                "reserved",
+                                "checkout_started",
+                                "booked",
+                                "failed",
+                                "cancelled"
+                              ]
+                            },
+                            "title": {
+                              "type": ["string", "null"]
+                            },
+                            "description": {
+                              "type": ["string", "null"]
+                            },
+                            "travelerParty": {
+                              "type": "object",
+                              "additionalProperties": {}
+                            },
+                            "constraints": {
+                              "type": "object",
+                              "additionalProperties": {}
+                            },
+                            "aggregateCurrency": {
+                              "type": ["string", "null"]
+                            },
+                            "aggregateSubtotalAmountCents": {
+                              "type": ["integer", "null"]
+                            },
+                            "aggregateTaxAmountCents": {
+                              "type": ["integer", "null"]
+                            },
+                            "aggregateTotalAmountCents": {
+                              "type": ["integer", "null"]
+                            },
+                            "aggregatePricingSnapshot": {},
+                            "currentPriceExpiresAt": {
+                              "type": ["string", "null"]
+                            },
+                            "bookingGroupId": {
+                              "type": ["string", "null"]
+                            },
+                            "orderId": {
+                              "type": ["string", "null"]
+                            },
+                            "paymentSessionId": {
+                              "type": ["string", "null"]
+                            },
+                            "reserveIdempotencyKey": {
+                              "type": ["string", "null"]
+                            },
+                            "reserveStartedAt": {
+                              "type": ["string", "null"]
+                            },
+                            "reservedAt": {
+                              "type": ["string", "null"]
+                            },
+                            "checkoutIdempotencyKey": {
+                              "type": ["string", "null"]
+                            },
+                            "checkoutStartedAt": {
+                              "type": ["string", "null"]
+                            },
+                            "createdBy": {
+                              "type": ["string", "null"]
+                            },
+                            "updatedBy": {
+                              "type": ["string", "null"]
+                            },
+                            "createdAt": {
+                              "type": "string"
+                            },
+                            "updatedAt": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "status",
+                            "title",
+                            "description",
+                            "travelerParty",
+                            "constraints",
+                            "aggregateCurrency",
+                            "aggregateSubtotalAmountCents",
+                            "aggregateTaxAmountCents",
+                            "aggregateTotalAmountCents",
+                            "currentPriceExpiresAt",
+                            "bookingGroupId",
+                            "orderId",
+                            "paymentSessionId",
+                            "reserveIdempotencyKey",
+                            "reserveStartedAt",
+                            "reservedAt",
+                            "checkoutIdempotencyKey",
+                            "checkoutStartedAt",
+                            "createdBy",
+                            "updatedBy",
+                            "createdAt",
+                            "updatedAt"
+                          ]
+                        },
+                        "components": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "envelopeId": {
+                                "type": "string"
+                              },
+                              "sequence": {
+                                "type": "integer"
+                              },
+                              "kind": {
+                                "type": "string",
+                                "enum": [
+                                  "catalog_booking",
+                                  "manual_placeholder",
+                                  "flight_placeholder",
+                                  "flight_order",
+                                  "external_order"
+                                ]
+                              },
+                              "status": {
+                                "type": "string",
+                                "enum": [
+                                  "draft",
+                                  "priced",
+                                  "unavailable",
+                                  "held",
+                                  "booked",
+                                  "checkout_started",
+                                  "failed",
+                                  "cancelled",
+                                  "removed"
+                                ]
+                              },
+                              "title": {
+                                "type": ["string", "null"]
+                              },
+                              "description": {
+                                "type": ["string", "null"]
+                              },
+                              "entityModule": {
+                                "type": ["string", "null"]
+                              },
+                              "entityId": {
+                                "type": ["string", "null"]
+                              },
+                              "sourceKind": {
+                                "type": ["string", "null"]
+                              },
+                              "sourceConnectionId": {
+                                "type": ["string", "null"]
+                              },
+                              "sourceRef": {
+                                "type": ["string", "null"]
+                              },
+                              "bookingDraftId": {
+                                "type": ["string", "null"]
+                              },
+                              "catalogQuoteId": {
+                                "type": ["string", "null"]
+                              },
+                              "bookingId": {
+                                "type": ["string", "null"]
+                              },
+                              "bookingGroupId": {
+                                "type": ["string", "null"]
+                              },
+                              "orderId": {
+                                "type": ["string", "null"]
+                              },
+                              "paymentSessionId": {
+                                "type": ["string", "null"]
+                              },
+                              "providerRef": {
+                                "type": ["string", "null"]
+                              },
+                              "supplierRef": {
+                                "type": ["string", "null"]
+                              },
+                              "componentCurrency": {
+                                "type": ["string", "null"]
+                              },
+                              "componentSubtotalAmountCents": {
+                                "type": ["integer", "null"]
+                              },
+                              "componentTaxAmountCents": {
+                                "type": ["integer", "null"]
+                              },
+                              "componentTotalAmountCents": {
+                                "type": ["integer", "null"]
+                              },
+                              "pricingSnapshot": {},
+                              "taxLines": {
+                                "type": ["array", "null"],
+                                "items": {}
+                              },
+                              "cancellationSnapshot": {},
+                              "holdToken": {
+                                "type": ["string", "null"]
+                              },
+                              "holdExpiresAt": {
+                                "type": ["string", "null"]
+                              },
+                              "priceExpiresAt": {
+                                "type": ["string", "null"]
+                              },
+                              "warningCodes": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "metadata": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              },
+                              "createdAt": {
+                                "type": "string"
+                              },
+                              "updatedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "envelopeId",
+                              "sequence",
+                              "kind",
+                              "status",
+                              "title",
+                              "description",
+                              "entityModule",
+                              "entityId",
+                              "sourceKind",
+                              "sourceConnectionId",
+                              "sourceRef",
+                              "bookingDraftId",
+                              "catalogQuoteId",
+                              "bookingId",
+                              "bookingGroupId",
+                              "orderId",
+                              "paymentSessionId",
+                              "providerRef",
+                              "supplierRef",
+                              "componentCurrency",
+                              "componentSubtotalAmountCents",
+                              "componentTaxAmountCents",
+                              "componentTotalAmountCents",
+                              "taxLines",
+                              "holdToken",
+                              "holdExpiresAt",
+                              "priceExpiresAt",
+                              "warningCodes",
+                              "metadata",
+                              "createdAt",
+                              "updatedAt"
+                            ]
+                          }
+                        }
+                      },
+                      "required": ["envelope", "components"],
+                      "additionalProperties": {}
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid_request — body failed validation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Trip envelope not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Envelope cannot be reserved in its current state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Trips reserve dependencies are not configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postPublicTripsByEnvelopeIdReserve",
+        "summary": "POST /v1/public/trips/{envelopeId}/reserve",
+        "tags": ["trips"],
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
+      }
+    },
     "/v1/public/trips/{envelopeId}/checkout": {
       "post": {
-        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {
@@ -4677,7 +5389,7 @@
                   },
                   "intent": {
                     "type": "string",
-                    "enum": ["card", "bank_transfer", "hold", "inquiry"],
+                    "enum": ["card", "bank_transfer"],
                     "default": "card"
                   },
                   "request": {
@@ -5064,7 +5776,6 @@
     },
     "/v1/public/trips/{envelopeId}/cancellation-preview": {
       "post": {
-        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {
@@ -5483,7 +6194,6 @@
     },
     "/v1/public/trips/{envelopeId}/cancel-components": {
       "post": {
-        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {

--- a/packages/trips/openapi/storefront/trips.json
+++ b/packages/trips/openapi/storefront/trips.json
@@ -18,6 +18,7 @@
   "paths": {
     "/v1/public/trips/health": {
       "get": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "responses": {
           "200": {
             "description": "Trips module health status",
@@ -56,6 +57,7 @@
     },
     "/v1/public/trips": {
       "get": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {
@@ -518,6 +520,7 @@
         "x-voyant-surface": "storefront"
       },
       "post": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "requestBody": {
           "required": true,
           "content": {
@@ -908,6 +911,7 @@
     },
     "/v1/public/trips/{envelopeId}": {
       "get": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {
@@ -1238,6 +1242,7 @@
         "x-voyant-surface": "storefront"
       },
       "patch": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {
@@ -1497,6 +1502,7 @@
     },
     "/v1/public/trips/{envelopeId}/snapshots": {
       "get": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {
@@ -1625,6 +1631,7 @@
         "x-voyant-surface": "storefront"
       },
       "post": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {
@@ -1819,6 +1826,7 @@
     },
     "/v1/public/trips/snapshots/{snapshotId}": {
       "get": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {
@@ -1963,6 +1971,7 @@
     },
     "/v1/public/trips/{envelopeId}/components": {
       "post": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {
@@ -2306,6 +2315,7 @@
     },
     "/v1/public/trips/{envelopeId}/components/reorder": {
       "post": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {
@@ -2592,6 +2602,7 @@
     },
     "/v1/public/trips/components/{componentId}": {
       "patch": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {
@@ -2922,6 +2933,7 @@
         "x-voyant-surface": "storefront"
       },
       "delete": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {
@@ -3184,6 +3196,7 @@
     },
     "/v1/public/trips/components/{componentId}/refs": {
       "post": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {
@@ -3495,6 +3508,7 @@
     },
     "/v1/public/trips/{envelopeId}/requirements": {
       "post": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {
@@ -3714,6 +3728,7 @@
         "x-voyant-surface": "storefront"
       },
       "get": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {
@@ -3892,6 +3907,7 @@
     },
     "/v1/public/trips/requirements/{requirementId}/sourcing-operations/{operationId}": {
       "get": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {
@@ -4082,6 +4098,7 @@
     },
     "/v1/public/trips/requirements/{requirementId}/select": {
       "post": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {
@@ -4517,6 +4534,7 @@
     },
     "/v1/public/trips/{envelopeId}/price": {
       "post": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {
@@ -4941,6 +4959,7 @@
     },
     "/v1/public/trips/{envelopeId}/reserve": {
       "post": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {
@@ -5365,6 +5384,7 @@
     },
     "/v1/public/trips/{envelopeId}/checkout": {
       "post": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {
@@ -5776,6 +5796,7 @@
     },
     "/v1/public/trips/{envelopeId}/cancellation-preview": {
       "post": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {
@@ -6194,6 +6215,7 @@
     },
     "/v1/public/trips/{envelopeId}/cancel-components": {
       "post": {
+        "x-voyant-api-id": "@voyant-travel/trips#api.public",
         "parameters": [
           {
             "schema": {

--- a/packages/trips/package.json
+++ b/packages/trips/package.json
@@ -58,7 +58,8 @@
     "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
-    "db:generate": "drizzle-kit generate --config=drizzle.migrations.config.ts --name=trips_baseline && node ../../scripts/migrations/guard-create-type.mjs ./migrations && node ../../scripts/migrations/ensure-extensions.mjs ./migrations"
+    "db:generate": "drizzle-kit generate --config=drizzle.migrations.config.ts --name=trips_baseline && node ../../scripts/migrations/guard-create-type.mjs ./migrations && node ../../scripts/migrations/ensure-extensions.mjs ./migrations",
+    "generate:openapi": "tsx scripts/generate-openapi.ts && biome format --write openapi/admin/trips.json openapi/storefront/trips.json"
   },
   "dependencies": {
     "@voyant-travel/action-ledger": "workspace:^",

--- a/packages/trips/scripts/generate-openapi.ts
+++ b/packages/trips/scripts/generate-openapi.ts
@@ -17,6 +17,7 @@
 
 import { writeFile } from "node:fs/promises"
 
+import { stampOpenApiRegistryApiId } from "@voyant-travel/hono"
 import type { OpenApiDocument } from "@voyant-travel/hono/openapi"
 import { generateOpenApiDocument, stampModuleMetadata } from "@voyant-travel/hono/openapi"
 
@@ -34,11 +35,25 @@ const options = {
 /**
  * The same factory produces both documents — admin-only legs are documented on
  * the public surface too and answer 403 there at runtime, which is the existing
- * contract `createTripsApiModule` mounts. Surface is therefore not passed here.
+ * contract `createTripsApiModule` mounts. Surface is therefore not passed to
+ * the factory.
+ *
+ * `apiId` is not decoration: `createTripsApiModule` stamps each mounted route
+ * tree with its graph API bundle, and `voyant-manifest.test.ts` asserts every
+ * operation in the storefront document carries it. Generating without the same
+ * stamp silently drops `x-voyant-api-id` from every operation.
  */
 const targets = [
-  { file: "../openapi/admin/trips.json", prefix: "/v1/admin/trips" },
-  { file: "../openapi/storefront/trips.json", prefix: "/v1/public/trips" },
+  {
+    file: "../openapi/admin/trips.json",
+    prefix: "/v1/admin/trips",
+    apiId: "@voyant-travel/trips#api.admin",
+  },
+  {
+    file: "../openapi/storefront/trips.json",
+    prefix: "/v1/public/trips",
+    apiId: "@voyant-travel/trips#api.public",
+  },
 ] as const
 
 function withPrefix(document: OpenApiDocument, prefix: string): OpenApiDocument {
@@ -68,10 +83,15 @@ function serialize(document: OpenApiDocument) {
  * reshaped without regenerating.
  */
 await Promise.all(
-  targets.map(({ file, prefix }) =>
+  targets.map(({ file, prefix, apiId }) =>
     writeFile(
       new URL(file, import.meta.url),
-      serialize(withPrefix(generateOpenApiDocument(createTripsRoutes(), options), prefix)),
+      serialize(
+        withPrefix(
+          generateOpenApiDocument(stampOpenApiRegistryApiId(createTripsRoutes(), apiId), options),
+          prefix,
+        ),
+      ),
     ),
   ),
 )

--- a/packages/trips/scripts/generate-openapi.ts
+++ b/packages/trips/scripts/generate-openapi.ts
@@ -1,0 +1,77 @@
+/**
+ * Regenerate the package-owned operator API documents for Trips.
+ *
+ * `openapi/admin/trips.json` and `openapi/storefront/trips.json` had no
+ * generator, so they were only ever as current as the last person who
+ * remembered to hand-edit a document whose own header says "Do not edit by
+ * hand". Nothing compared them to the routes: the deployment-graph coverage
+ * check validates that a document exists for a surface/module pair, not that
+ * it describes the legs that are actually mounted.
+ *
+ * Mirrors `packages/operations/scripts/generate-openapi.ts`, including the
+ * `stampModuleMetadata` call: these package-owned documents are generated
+ * outside the application manifest composer, so the same metadata stamping has
+ * to be run explicitly for operation ids, summaries, owner and surface to match
+ * what the composer would have produced.
+ */
+
+import { writeFile } from "node:fs/promises"
+
+import type { OpenApiDocument } from "@voyant-travel/hono/openapi"
+import { generateOpenApiDocument, stampModuleMetadata } from "@voyant-travel/hono/openapi"
+
+import { createTripsRoutes } from "../src/routes.js"
+
+const options = {
+  info: {
+    title: "Voyant Operator API",
+    version: "0.0.0",
+    description: "Generated from the composed operator app. Do not edit by hand.",
+  },
+  servers: [{ url: "/", description: "This deployment (same origin)" }],
+}
+
+/**
+ * The same factory produces both documents — admin-only legs are documented on
+ * the public surface too and answer 403 there at runtime, which is the existing
+ * contract `createTripsApiModule` mounts. Surface is therefore not passed here.
+ */
+const targets = [
+  { file: "../openapi/admin/trips.json", prefix: "/v1/admin/trips" },
+  { file: "../openapi/storefront/trips.json", prefix: "/v1/public/trips" },
+] as const
+
+function withPrefix(document: OpenApiDocument, prefix: string): OpenApiDocument {
+  const prefixed = {
+    ...document,
+    paths: Object.fromEntries(
+      Object.entries(document.paths ?? {}).map(([path, item]) => [
+        `${prefix}${path === "/" ? "" : path}`,
+        item,
+      ]),
+    ),
+  } as OpenApiDocument
+
+  return stampModuleMetadata(prefixed, new Map())
+}
+
+function serialize(document: OpenApiDocument) {
+  return `${JSON.stringify(document, null, 2)}\n`
+}
+
+/**
+ * The `generate:openapi` script pipes this through `biome format --write`, the
+ * way `@voyant-travel/catalog` does, so the checked-in bytes are the ones
+ * `verify:openapi-drift` regenerates and compares. That check is registered in
+ * `scripts/checks/openapi/generated-specs.json` and is what stops these
+ * drifting again: it fails the moment a Trips route is added, removed or
+ * reshaped without regenerating.
+ */
+await Promise.all(
+  targets.map(({ file, prefix }) =>
+    writeFile(
+      new URL(file, import.meta.url),
+      serialize(withPrefix(generateOpenApiDocument(createTripsRoutes(), options), prefix)),
+    ),
+  ),
+)

--- a/packages/trips/src/route-runtime.ts
+++ b/packages/trips/src/route-runtime.ts
@@ -1,3 +1,4 @@
+import { submitBookingReservationPlan } from "@voyant-travel/bookings/reservation-plans"
 import type { Context } from "hono"
 
 import type { CatalogComponentAdapter } from "./catalog-component.js"
@@ -7,7 +8,12 @@ import type { TripCheckoutDeps } from "./checkout/types.js"
 import type { FlightComponentAdapterApi } from "./flight-component.js"
 import { previewFlightCancellation } from "./flight-component.js"
 import type { TripsRoutesOptions, TripsRoutesOptionsProvider } from "./routes.js"
-import type { CancelTripComponentsDeps, StartCheckoutDeps } from "./service.js"
+import type {
+  CancelTripComponentsDeps,
+  PriceTripDeps,
+  ReserveTripDeps,
+  StartCheckoutDeps,
+} from "./service.js"
 import type { ComponentCheckoutResult } from "./service-types.js"
 
 export interface TripsRouteRuntimeHost {
@@ -18,12 +24,74 @@ export interface TripsRouteRuntimeHost {
 
 export interface TripsRouteRuntime {
   createRoutesOptions: TripsRoutesOptionsProvider
+  createPriceDeps(c: Context): PriceTripDeps
+  createReserveDeps(c: Context): ReserveTripDeps
   createStartCheckoutDeps(c: Context): StartCheckoutDeps
   createCancelDeps(c: Context): CancelTripComponentsDeps
 }
 
 /** Trips-owned lifecycle composition with only request-scoped host adapters injected. */
 export function createTripsRouteRuntime(host: TripsRouteRuntimeHost): TripsRouteRuntime {
+  const createPriceDeps = (c: Context): PriceTripDeps => ({
+    quoteCatalogComponent: (input) => host.createCatalogAdapter(c).quote(input),
+  })
+
+  const createReserveDeps = (c: Context): ReserveTripDeps => ({
+    quoteCatalogComponentBeforeReserve: (input) => host.createCatalogAdapter(c).quote(input),
+    validateNonCatalogComponentBeforeReserve: (input) =>
+      host.createFlightAdapter(c).validateBeforeReserve(input),
+    submitReservationPlan: async (input) => {
+      const submitted = await submitBookingReservationPlan(
+        {
+          reservationPlanId: input.reservationPlan.id,
+          idempotencyKey: input.idempotencyKey,
+          origin: { source: "trips", tripEnvelopeId: input.envelope.id },
+          envelope: input.envelope,
+          lines: input.components.map((component) => ({
+            planLineId: component.componentId,
+            componentId: component.componentId,
+            kind: component.reservationKind,
+            line: component.component,
+          })),
+        },
+        {
+          reserveCatalogBackedLine: ({ plan, line }) =>
+            host.createCatalogAdapter(c).reserve({
+              envelope: plan.envelope,
+              component: line.line,
+              reservationPlanId: plan.reservationPlanId,
+            }),
+          reserveNonCatalogLine: ({ plan, line }) =>
+            host.createFlightAdapter(c).reserve({
+              envelope: plan.envelope,
+              component: line.line,
+              reservationPlanId: plan.reservationPlanId,
+            }),
+          releaseReservedLine: ({ line, result }) =>
+            line.kind === "catalog_backed"
+              ? host.createCatalogAdapter(c).release({
+                  component: line.line,
+                  reserveResult: result,
+                })
+              : Promise.resolve({ released: false, reason: "release_not_configured" }),
+        },
+      )
+
+      return {
+        reservationPlanId: submitted.reservationPlanId,
+        status: submitted.status,
+        reserved: submitted.reserved.map((item) => ({
+          componentId: item.componentId,
+          status: item.status,
+          result: item.result,
+        })),
+        failures: submitted.failures,
+        compensations: submitted.compensations,
+        warnings: submitted.warnings,
+      }
+    },
+  })
+
   const createStartCheckoutDeps = (c: Context): StartCheckoutDeps => ({
     startTripCheckout: (input) => startTripCheckout(host.createCheckoutDeps(c), input),
     startComponentCheckout: (input) => host.createCatalogAdapter(c).startCheckout(input),
@@ -41,11 +109,19 @@ export function createTripsRouteRuntime(host: TripsRouteRuntimeHost): TripsRoute
   })
 
   const createRoutesOptions = (): TripsRoutesOptions => ({
+    priceTripDeps: (c) => createPriceDeps(c),
+    reserveTripDeps: (c) => createReserveDeps(c),
     startCheckoutDeps: (c) => createStartCheckoutDeps(c),
     cancelTripComponentsDeps: (c) => createCancelDeps(c),
   })
 
-  return { createRoutesOptions, createStartCheckoutDeps, createCancelDeps }
+  return {
+    createRoutesOptions,
+    createPriceDeps,
+    createReserveDeps,
+    createStartCheckoutDeps,
+    createCancelDeps,
+  }
 }
 
 export type CatalogCheckoutResult =

--- a/packages/trips/src/routes.ts
+++ b/packages/trips/src/routes.ts
@@ -15,7 +15,7 @@
  * deeply-nested composed/opaque sub-objects (pricing/candidate payloads,
  * frozen snapshot blobs) are documented pass-throughs typed as `z.unknown()`.
  *
- * The 20 legs are split across per-resource `OpenAPIHono` sub-chains
+ * The 22 legs are split across per-resource `OpenAPIHono` sub-chains
  * (envelopes / snapshots / components / requirements / lifecycle / health),
  * each composed onto the parent `OpenAPIHono` via `.route("/", subApp)`.
  * Mounting an `OpenAPIHono` child with `.route("/")` DOES propagate the child's
@@ -26,11 +26,16 @@
  * bounded — one flat multi-leg `.openapi()` chain has O(n²) inference cost and
  * OOMed CI's typecheck at its 8 GB heap. See voyant#2114 / voyant#2208.
  *
- * agent-quality: file-size exception — intentional: 20 Travel Composer legs
- * (envelope/snapshot/component/requirement CRUD + checkout/cancel lifecycle)
- * authored as `createRoute` objects co-located with their
+ * agent-quality: file-size exception — intentional: 22 Travel Composer legs
+ * (envelope/snapshot/component/requirement CRUD + the price/reserve/checkout/
+ * cancel lifecycle) authored as `createRoute` objects co-located with their
  * handlers, grouped into per-resource `OpenAPIHono` sub-chains composed onto a
  * single parent. See voyant#2114 / voyant#2208.
+ *
+ * The price and reserve legs are the staff/storefront composer lifecycle,
+ * dependency-injected exactly like checkout and cancel. They are NOT the
+ * agent-facing pricing path: `price_trip` / `reserve_trip` remain admitted
+ * durable operations behind `trips.durable-action-runtime`. See voyant#4601.
  */
 
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
@@ -40,6 +45,8 @@ import { listResponseSchema } from "@voyant-travel/types"
 import type { Context } from "hono"
 import {
   type CancelTripComponentsDeps,
+  type PriceTripDeps,
+  type ReserveTripDeps,
   type StartCheckoutDeps,
   TripsInvariantError,
   tripsService,
@@ -53,7 +60,9 @@ import {
   createTripSnapshotSchema,
   listTripsQuerySchema,
   previewTripCancellationSchema,
+  priceTripSchema,
   reorderTripComponentsSchema,
+  reserveTripSchema,
   selectCandidateSchema,
   startTripCheckoutSchema,
   tripComponentKindSchema,
@@ -74,6 +83,8 @@ type Env = {
 
 export interface TripsRoutesOptions {
   surface?: "admin" | "public"
+  priceTripDeps?: TripsRouteDeps<PriceTripDeps>
+  reserveTripDeps?: TripsRouteDeps<ReserveTripDeps>
   startCheckoutDeps?: TripsRouteDeps<StartCheckoutDeps>
   cancelTripComponentsDeps?: TripsRouteDeps<CancelTripComponentsDeps>
 }
@@ -83,7 +94,9 @@ export type TripsRoutesOptionsProvider = () => TripsRoutesOptions | Promise<Trip
 export type TripsRoutesOptionsInput = TripsRoutesOptions | TripsRoutesOptionsProvider
 type ResolveTripsRoutesOptions = () => Promise<TripsRoutesOptions>
 
+const priceTripBodySchema = priceTripSchema.omit({ envelopeId: true })
 const createTripSnapshotBodySchema = createTripSnapshotSchema.omit({ envelopeId: true })
+const reserveTripBodySchema = reserveTripSchema.omit({ envelopeId: true })
 const startCheckoutBodySchema = startTripCheckoutSchema.omit({ envelopeId: true })
 const previewCancellationBodySchema = previewTripCancellationSchema.omit({ envelopeId: true })
 const cancelTripComponentsBodySchema = cancelTripComponentsSchema.omit({ envelopeId: true })
@@ -245,9 +258,9 @@ const envelopeDataSchema = z.object({ data: tripEnvelopeRowSchema })
 const componentDataSchema = z.object({ data: tripComponentRowSchema })
 
 /**
- * Lifecycle result envelopes (checkout/cancellation). The
+ * Lifecycle result envelopes (price/reserve/checkout/cancellation). The
  * envelope + components rows are modeled faithfully; the per-operation
- * composed result fields (checkout/cancellation payloads)
+ * composed result fields (pricing/reservation/checkout/cancellation payloads)
  * pass through as `z.unknown()` — bounded effort per voyant#2208.
  */
 const lifecycleResultSchema = z.object({
@@ -276,6 +289,19 @@ function routeError(error: unknown): { message: string; status: 400 | 404 | 409 
   return {
     message: isInternalErrorMessage(message) ? "Trips route failed" : message,
     status: 400,
+  }
+}
+
+function reserveFailureResponse(result: Awaited<ReturnType<typeof tripsService.reserveTrip>>) {
+  return {
+    error: "Trip reservation failed",
+    data: result,
+    failures: result.failures.map(({ componentId, reason, code }) => ({
+      componentId,
+      reason,
+      ...(code ? { code } : {}),
+    })),
+    reservationPlanId: result.reservationPlanId ?? null,
   }
 }
 
@@ -828,6 +854,74 @@ const selectCandidateRoute = createRoute({
 
 // lifecycle ──────────────────────────────────────────────────────────────────
 
+const priceTripRoute = createRoute({
+  method: "post",
+  path: "/{envelopeId}/price",
+  request: {
+    params: envelopeIdParamSchema,
+    body: {
+      required: true,
+      content: { "application/json": { schema: priceTripBodySchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "The priced envelope with components and a composed pricing result",
+      content: { "application/json": { schema: lifecycleResultSchema } },
+    },
+    400: {
+      description: "invalid_request — body failed validation",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    404: {
+      description: "Trip envelope not found",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    409: {
+      description: "Envelope cannot be priced in its current state",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    501: {
+      description: "Trips price dependencies are not configured",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+const reserveTripRoute = createRoute({
+  method: "post",
+  path: "/{envelopeId}/reserve",
+  request: {
+    params: envelopeIdParamSchema,
+    body: {
+      required: true,
+      content: { "application/json": { schema: reserveTripBodySchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "The reserved envelope with components and a composed reservation result",
+      content: { "application/json": { schema: lifecycleResultSchema } },
+    },
+    400: {
+      description: "invalid_request — body failed validation",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    404: {
+      description: "Trip envelope not found",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    409: {
+      description: "Envelope cannot be reserved in its current state",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    501: {
+      description: "Trips reserve dependencies are not configured",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
 const checkoutTripRoute = createRoute({
   method: "post",
   path: "/{envelopeId}/checkout",
@@ -1141,6 +1235,51 @@ function createRequirementRoutes(readOptions: ResolveTripsRoutesOptions): OpenAP
 
 function createLifecycleRoutes(readOptions: ResolveTripsRoutesOptions): OpenAPIHono<Env> {
   return new OpenAPIHono<Env>({ defaultHook: openApiValidationHook })
+    .openapi(priceTripRoute, async (c) => {
+      const deps = await resolveConfiguredRouteDeps(
+        c,
+        readOptions,
+        (options) => options.priceTripDeps,
+      )
+      if (!deps) {
+        return c.json({ error: "Trips price dependencies are not configured" }, 501)
+      }
+      try {
+        const result = await tripsService.priceTrip(
+          c.get("db"),
+          { ...c.req.valid("json"), envelopeId: c.req.valid("param").envelopeId },
+          deps,
+        )
+        return c.json({ data: result }, 200)
+      } catch (error) {
+        const { message, status } = routeError(error)
+        return c.json({ error: message }, status)
+      }
+    })
+    .openapi(reserveTripRoute, async (c) => {
+      const deps = await resolveConfiguredRouteDeps(
+        c,
+        readOptions,
+        (options) => options.reserveTripDeps,
+      )
+      if (!deps) {
+        return c.json({ error: "Trips reserve dependencies are not configured" }, 501)
+      }
+      try {
+        const result = await tripsService.reserveTrip(
+          c.get("db"),
+          { ...c.req.valid("json"), envelopeId: c.req.valid("param").envelopeId },
+          deps,
+        )
+        if (result.failures.length > 0) {
+          return c.json(reserveFailureResponse(result), 409)
+        }
+        return c.json({ data: result }, 200)
+      } catch (error) {
+        const { message, status } = routeError(error)
+        return c.json({ error: message }, status)
+      }
+    })
     .openapi(checkoutTripRoute, async (c) => {
       const deps = await resolveConfiguredRouteDeps(
         c,

--- a/packages/trips/tests/routes.test.ts
+++ b/packages/trips/tests/routes.test.ts
@@ -163,7 +163,10 @@ describe("trips routes", () => {
     })
   })
 
-  it("does not expose direct price or reserve mutation routes", async () => {
+  it("exposes the composer price and reserve legs, gated on their runtime deps", async () => {
+    // voyant#4601: these legs are the staff/storefront composer lifecycle and
+    // must stay reachable. The agent-facing `price_trip` / `reserve_trip` tools
+    // are a separate, durable path and are unaffected by this route surface.
     const routeOptions = vi.fn(async () => ({}))
     const app = appWithDb(createTripsRoutes(routeOptions))
 
@@ -171,17 +174,90 @@ describe("trips routes", () => {
 
     const health = await app.request("/health")
     expect(health.status).toBe(200)
+    // Route options stay lazy: health must not resolve deployment deps.
     expect(routeOptions).not.toHaveBeenCalled()
 
-    for (const path of ["/trip_123/price", "/trip_123/reserve"]) {
+    const cases = [
+      {
+        path: "/trip_123/price",
+        body: { scope: { locale: "en-US", audience: "staff", market: "default", currency: "EUR" } },
+        error: "Trips price dependencies are not configured",
+      },
+      {
+        path: "/trip_123/reserve",
+        body: { idempotencyKey: "admin-reserve-trip_123" },
+        error: "Trips reserve dependencies are not configured",
+      },
+    ]
+    for (const { path, body, error } of cases) {
       const response = await app.request(path, {
         method: "POST",
-        body: JSON.stringify({}),
+        body: JSON.stringify(body),
         headers: { "content-type": "application/json" },
       })
-      expect(response.status, path).toBe(404)
+      expect(response.status, path).toBe(501)
+      await expect(response.json()).resolves.toEqual({ error })
     }
-    expect(routeOptions).not.toHaveBeenCalled()
+    expect(routeOptions).toHaveBeenCalled()
+  })
+
+  it("prices a composer trip through the configured deps", async () => {
+    const priced = {
+      envelope: { id: "trip_123", status: "priced" },
+      components: [],
+      pricing: { currency: "EUR", totalAmountCents: 9500 },
+      failures: [],
+      warnings: [],
+    }
+    const price = vi
+      .spyOn(tripsService, "priceTrip")
+      .mockResolvedValue(priced as unknown as Awaited<ReturnType<typeof tripsService.priceTrip>>)
+    const quoteCatalogComponent = vi.fn()
+    const app = appWithDb(createTripsRoutes({ priceTripDeps: { quoteCatalogComponent } }))
+
+    const scope = { locale: "en-US", audience: "staff", market: "default", currency: "EUR" }
+    const response = await app.request("/trip_123/price", {
+      method: "POST",
+      body: JSON.stringify({ scope }),
+      headers: { "content-type": "application/json" },
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ data: priced })
+    expect(price).toHaveBeenCalledWith(
+      expect.anything(),
+      { envelopeId: "trip_123", scope },
+      { quoteCatalogComponent },
+    )
+  })
+
+  it("reports reserve failures as 409 with the composed reservation result", async () => {
+    const result = {
+      envelope: { id: "trip_123", status: "failed" },
+      components: [],
+      failures: [{ componentId: "trcp_1", reason: "sold_out", code: "supplier_rejected" }],
+      reservationPlanId: "trrp_1",
+      warnings: [],
+    }
+    vi.spyOn(tripsService, "reserveTrip").mockResolvedValue(
+      result as unknown as Awaited<ReturnType<typeof tripsService.reserveTrip>>,
+    )
+    const app = appWithDb(
+      createTripsRoutes({ reserveTripDeps: { submitReservationPlan: vi.fn() } as never }),
+    )
+
+    const response = await app.request("/trip_123/reserve", {
+      method: "POST",
+      body: JSON.stringify({ idempotencyKey: "admin-reserve-trip_123" }),
+      headers: { "content-type": "application/json" },
+    })
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Trip reservation failed",
+      failures: [{ componentId: "trcp_1", reason: "sold_out", code: "supplier_rejected" }],
+      reservationPlanId: "trrp_1",
+    })
   })
 })
 

--- a/scripts/checks/openapi/generated-specs.json
+++ b/scripts/checks/openapi/generated-specs.json
@@ -15,6 +15,13 @@
         "packages/catalog/openapi/admin/catalog-booking.json",
         "packages/catalog/openapi/storefront/catalog-booking.json"
       ]
+    },
+    {
+      "command": "pnpm --filter @voyant-travel/trips generate:openapi",
+      "files": [
+        "packages/trips/openapi/admin/trips.json",
+        "packages/trips/openapi/storefront/trips.json"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Closes #4601.

## The bug

Creating a trip from the admin fails at the pricing step. The envelope and its components are persisted, then the composer posts to `POST /v1/admin/trips/{envelopeId}/price` and gets a bare `text/plain` 404 — an unregistered route, not a missing envelope. Every attempt leaves an orphaned draft behind.

```
POST /api/v1/admin/trips                          201
POST /api/v1/admin/trips/{envelopeId}/components  201
POST /api/v1/admin/trips/{envelopeId}/price       404
```

## The cause runs deeper than a missing route

#3746 (`feat(trips, quotes)!: enforce durable provider actions`, 2026-07-25) deleted the `price` and `reserve` HTTP legs plus their `route-runtime` deps, and replaced them with handler-admitted durable operations behind `trips.durable-action-runtime`.

Three facts make that replacement inert:

- **No provider exists.** Nothing in this repo selects the port, and the framework deliberately ships no fallback — so `price_trip` / `reserve_trip` are unavailable on every deployment.
- **The durable path would not run this code anyway.** When a provider *is* present, `drainTripActionOperations` dispatches to the provider's own `price` capability, not to `tripsService.priceTrip`. The deterministic composer pricing — manual placeholder pricing, per-component tax preservation, envelope aggregation — has had no execution path at all.
- **Both services have been dead since.** `tripsService.priceTrip` and `reserveTrip` have zero production callers on `main`; only tests reference them.

So the Travel Composer's price→reserve lifecycle has been broken since July, and both the admin *and* storefront composers have been calling deleted routes.

## The fix

Restore both legs and their `route-runtime` deps. They are the staff/storefront composer lifecycle, dependency-injected exactly like `checkout` and `cancel-components` — which #3746 left in place despite being strictly more consequential than a price read. `PriceTripDeps.quoteCatalogComponent` is documented in-tree as a non-binding v1 Offer Preview: *"a composer price is a read, and the binding price is minted later by the accepted-Proposal Booking Session."*

The deps reuse the same catalog and flight adapters the operator already provides for checkout and cancel, so no new deployment wiring is needed. Both legs answer `501` when unconfigured.

**The agent path is untouched.** `price_trip` / `reserve_trip` remain admitted, asynchronous durable operations behind `trips.durable-action-runtime`, with their ledger, approval and conformance requirements intact. The two entry points are now documented as distinct in the package README.

### Scope note

The issue names only pricing. I restored `reserve` as well, because fixing only `price` moves the same 404 one click later to the Reserve button — both were removed by the same commit with the same inert replacement.

The orphaned drafts are a consequence of the 404, not a separate defect: the composer creates the envelope lazily, immediately before the component it is committing. With pricing working the orphan generator is gone. I did not add rollback-on-failure — discarding an operator's in-progress trip because one component failed to price would lose their work.

## OpenAPI drift, found on the way

`packages/trips/openapi/{admin,storefront}/trips.json` had **no generator**, despite their own header reading "Generated from the composed operator app. Do not edit by hand." Regenerating them showed they had drifted well beyond this change:

- both still advertised `hold` and `inquiry` checkout intents, removed from `startTripCheckoutSchema` in #4100
- both were still in OpenAPI 3.0 `nullable: true` form; every other generated document in the repo (operations, inventory, catalog) has moved to 3.1 `type: ["string", "null"]`

Added `packages/trips/scripts/generate-openapi.ts` (mirroring the operations/inventory generators, `biome format`ed the way catalog's is) and registered both documents in `scripts/checks/openapi/generated-specs.json`. `verify:openapi-drift` now covers 4 documents instead of 2.

Per AGENTS.md, this is an **imperative** addition rather than a declarative rule because it has to build an `OpenAPIHono` document from the route module — it cannot be expressed as data.

## Verification

**End-to-end against real Postgres**, driving the issue's exact three-call sequence through the mounted routes with a 95.00 EUR manual service:

```
POST /trips                  -> 201
POST /trips/{id}/components  -> 201
POST /trips/{id}/price       -> 200
  envelope status : priced
  aggregate total : 9500
  failures        : []
```

- `packages/trips` suite: 218 passed / 12 skipped. Three new route tests, confirmed by name: dep-gating (`501` + lazy option resolution), a priced 200 asserting the deps reach `tripsService.priceTrip`, and a reserve `409` carrying the composed failure envelope.
- `packages/trips-react`: green (one 5s-timeout flake under parallel-build load; passes clean on re-run).
- `verify:openapi-drift`, `verify:route-conformance`, `verify:trips-runtime-authority`, `verify:public-surface`, `verify:package-descriptions`, `verify:dep-paths`: pass. `biome check`: clean.
- **Typecheck is not locally complete.** The dependency build was repeatedly SIGTERM'd by memory pressure from another worktree building in parallel; it reached zero `error TS` through `bookings`/`finance` and the downstream packages before I stopped chasing it. Relying on CI for the full typecheck here.

## Follow-up worth filing

Nothing checks that a client's called paths exist on the server — that disagreement is what this issue *is*. A conformance rule would need to resolve cross-module mounts (`/v1/admin/trips/{id}/proposal-versions/{id}/snapshot` is served by `packages/proposals`, not `packages/trips`), so I left it out rather than ship a checker I could not fully verify.