### PR TITLE
fix(crm): align person and organization detail pages with the app shell

### DIFF
--- a/packages/relationships-react/src/admin/organization-detail-skeleton.tsx
+++ b/packages/relationships-react/src/admin/organization-detail-skeleton.tsx
@@ -4,43 +4,64 @@ import { Card, CardContent, CardHeader } from "@voyant-travel/ui/components/card
 import { Skeleton } from "@voyant-travel/ui/components/skeleton"
 
 /**
- * Layout-matched placeholder for OrganizationDetailPage.
- *   - Top bar: back + org name + delete
- *   - 12-col grid:
- *       - lg:col-span-3  sidebar: identity + org details card
- *       - lg:col-span-6  main: tabs (People / Proposals / Activities) + list rows
- *       - lg:col-span-3  aside: metrics summary
+ * Layout-matched placeholder for OrganizationDetailPage. Mirrors the real page
+ * class-for-class so nothing shifts when the data lands:
+ *   - header: avatar + name/badges + actions (no breadcrumb — the chrome owns it)
+ *   - grid-cols-[minmax(0,1fr)_320px]:
+ *       - main: tab strip + panel card
+ *       - sidebar: About field list + Tags
  */
 export function OrganizationDetailSkeleton() {
   return (
-    <div className="flex min-h-screen flex-col">
-      {/* Top bar */}
-      <div className="flex items-center justify-between border-b px-4 py-3 lg:px-6">
-        <div className="flex items-center gap-3">
-          <Skeleton className="h-9 w-9 rounded-md" />
-          <Skeleton className="h-6 w-56" />
+    <div className="flex flex-col gap-6">
+      {/* Header */}
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-3">
+          <Skeleton className="size-10 shrink-0 rounded-full" />
+          <div className="flex flex-col gap-1">
+            <Skeleton className="h-7 w-56" />
+            <Skeleton className="h-4 w-40" />
+          </div>
         </div>
         <div className="flex items-center gap-2">
-          <Skeleton className="h-9 w-24" />
+          <Skeleton className="h-8 w-24" />
+          <Skeleton className="h-8 w-20" />
         </div>
       </div>
 
-      <div className="grid flex-1 grid-cols-12 gap-4 p-4 lg:p-6">
-        {/* Sidebar */}
-        <aside className="col-span-12 flex flex-col gap-4 lg:col-span-3">
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
+        {/* Main */}
+        <main className="flex min-w-0 flex-col gap-6">
+          <div className="flex flex-wrap items-center gap-1">
+            <Skeleton className="h-8 w-24" />
+            <Skeleton className="h-8 w-28" />
+            <Skeleton className="h-8 w-36" />
+            <Skeleton className="h-8 w-28" />
+          </div>
           <Card>
-            <CardContent className="flex flex-col items-center gap-3">
-              <Skeleton className="h-16 w-16 rounded-lg" />
-              <Skeleton className="h-5 w-40" />
-              <Skeleton className="h-3 w-28" />
+            <CardContent className="flex flex-col gap-3">
+              {Array.from({ length: 4 }).map((_, i) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: stable placeholder -- owner: relationships-react; existing suppression is intentional pending typed cleanup.
+                <div key={i} className="flex items-center gap-3 py-1.5">
+                  <Skeleton className="size-9 shrink-0 rounded-full" />
+                  <div className="flex-1 space-y-1.5">
+                    <Skeleton className="h-4 w-40" />
+                    <Skeleton className="h-3 w-56" />
+                  </div>
+                </div>
+              ))}
             </CardContent>
           </Card>
+        </main>
+
+        {/* Sidebar */}
+        <aside className="flex flex-col gap-6">
           <Card>
-            <CardHeader>
+            <CardHeader className="pb-3">
               <Skeleton className="h-4 w-20" />
             </CardHeader>
             <CardContent className="space-y-4">
-              {Array.from({ length: 5 }).map((_, i) => (
+              {Array.from({ length: 6 }).map((_, i) => (
                 // biome-ignore lint/suspicious/noArrayIndexKey: stable placeholder -- owner: relationships-react; existing suppression is intentional pending typed cleanup.
                 <div key={i} className="flex items-start gap-3">
                   <Skeleton className="mt-0.5 h-4 w-4" />
@@ -52,52 +73,13 @@ export function OrganizationDetailSkeleton() {
               ))}
             </CardContent>
           </Card>
-        </aside>
-
-        {/* Main */}
-        <main className="col-span-12 flex flex-col gap-4 lg:col-span-6">
-          <div className="flex items-center gap-1 border-b">
-            <Skeleton className="h-9 w-20" />
-            <Skeleton className="h-9 w-32" />
-            <Skeleton className="h-9 w-24" />
-          </div>
-
-          <div className="flex flex-col gap-3">
-            {Array.from({ length: 5 }).map((_, i) => (
-              // biome-ignore lint/suspicious/noArrayIndexKey: stable placeholder -- owner: relationships-react; existing suppression is intentional pending typed cleanup.
-              <Card key={i}>
-                <CardContent className="flex items-center gap-3 py-3">
-                  <Skeleton className="h-9 w-9 rounded-full" />
-                  <div className="flex-1 space-y-1.5">
-                    <Skeleton className="h-4 w-40" />
-                    <Skeleton className="h-3 w-56" />
-                  </div>
-                  <Skeleton className="h-5 w-16 rounded-full" />
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        </main>
-
-        {/* Aside */}
-        <aside className="col-span-12 flex flex-col gap-4 lg:col-span-3">
           <Card>
-            <CardHeader>
-              <Skeleton className="h-4 w-32" />
+            <CardHeader className="pb-3">
+              <Skeleton className="h-4 w-16" />
             </CardHeader>
-            <CardContent className="space-y-3">
-              <div className="rounded-md border p-3 space-y-2">
-                <Skeleton className="h-3 w-20" />
-                <Skeleton className="h-5 w-28" />
-              </div>
-              <div className="rounded-md border p-3 space-y-2">
-                <Skeleton className="h-3 w-16" />
-                <Skeleton className="h-5 w-16" />
-              </div>
-              <div className="rounded-md border p-3 space-y-2">
-                <Skeleton className="h-3 w-24" />
-                <Skeleton className="h-5 w-16" />
-              </div>
+            <CardContent className="flex flex-wrap gap-2">
+              <Skeleton className="h-6 w-16 rounded-full" />
+              <Skeleton className="h-6 w-20 rounded-full" />
             </CardContent>
           </Card>
         </aside>

--- a/packages/relationships-react/src/admin/person-detail-host.tsx
+++ b/packages/relationships-react/src/admin/person-detail-host.tsx
@@ -3,11 +3,15 @@
 import {
   AdminWidgetSlotRenderer,
   resolveAdminWidgets,
+  useAdminBreadcrumbs,
   useAdminExtensions,
+  useAdminHref,
   useAdminNavigate,
+  useOperatorAdminMessages,
 } from "@voyant-travel/admin"
 
 import { PersonDetailPage } from "../components/person-detail-page.js"
+import { usePerson } from "../index.js"
 import { type PersonDetailBookingsTabContext, personDetailBookingsTabSlot } from "./slots.js"
 
 export interface PersonDetailHostProps {
@@ -27,11 +31,27 @@ export interface PersonDetailHostProps {
  *     card travels the widget seam, not an import).
  */
 export function PersonDetailHost({ id }: PersonDetailHostProps) {
+  const messages = useOperatorAdminMessages().crm.personDetail
   const navigateTo = useAdminNavigate()
+  const resolveHref = useAdminHref()
   const adminExtensions = useAdminExtensions()
   const hasBookingsTabWidgets =
     resolveAdminWidgets({ slot: personDetailBookingsTabSlot, extensions: adminExtensions }).length >
     0
+
+  // Mirrors the organization host: the chrome owns the breadcrumb trail, so the
+  // page renders none of its own. TanStack Query dedupes this against the
+  // page's own fetch, so it costs no extra request.
+  const person = usePerson(id).data
+  const personLabel = person
+    ? [person.firstName, person.lastName].filter(Boolean).join(" ").trim() || messages.unnamedPerson
+    : null
+  const peopleHref = resolveHref("person.list", {})
+  useAdminBreadcrumbs(
+    personLabel
+      ? [{ label: messages.breadcrumbRoot, href: peopleHref }, { label: personLabel }]
+      : [{ label: messages.breadcrumbRoot, href: peopleHref }],
+  )
 
   return (
     <PersonDetailPage

--- a/packages/relationships-react/src/admin/person-detail-skeleton.tsx
+++ b/packages/relationships-react/src/admin/person-detail-skeleton.tsx
@@ -4,128 +4,82 @@ import { Card, CardContent, CardHeader } from "@voyant-travel/ui/components/card
 import { Skeleton } from "@voyant-travel/ui/components/skeleton"
 
 /**
- * Layout-matched placeholder for PersonDetailPage.
- *   - Top bar (back button + name + edit/delete actions)
- *   - 12-col body grid:
- *       - lg:col-span-3  sidebar: avatar + identity card + details card
- *       - lg:col-span-6  main: tabs (Notes / Activities / Proposals) + editor + list
- *       - lg:col-span-3  aside: organization card + proposals summary
+ * Layout-matched placeholder for PersonDetailPage. Mirrors the real page
+ * class-for-class so nothing shifts when the data lands:
+ *   - header: avatar + name/badges + actions (no breadcrumb — the chrome owns it)
+ *   - grid-cols-[minmax(0,1fr)_320px]:
+ *       - main: tab strip + panel card
+ *       - sidebar: About field list + Tags
  */
 export function PersonDetailSkeleton() {
   return (
-    <div className="flex min-h-screen flex-col">
-      {/* Top bar */}
-      <div className="flex items-center justify-between border-b px-4 py-3 lg:px-6">
-        <div className="flex items-center gap-3">
-          <Skeleton className="h-9 w-9 rounded-md" />
-          <Skeleton className="h-6 w-48" />
+    <div className="flex flex-col gap-6">
+      {/* Header */}
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-3">
+          <Skeleton className="size-10 shrink-0 rounded-full" />
+          <div className="flex flex-col gap-1">
+            <Skeleton className="h-7 w-48" />
+            <Skeleton className="h-4 w-56" />
+          </div>
         </div>
         <div className="flex items-center gap-2">
-          <Skeleton className="h-9 w-20" />
-          <Skeleton className="h-9 w-24" />
+          <Skeleton className="h-8 w-20" />
+          <Skeleton className="h-8 w-24" />
+          <Skeleton className="h-8 w-20" />
         </div>
       </div>
 
-      {/* Body */}
-      <div className="grid flex-1 grid-cols-12 gap-4 p-4 lg:p-6">
-        {/* Sidebar */}
-        <aside className="col-span-12 flex flex-col gap-4 lg:col-span-3">
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
+        {/* Main */}
+        <main className="flex min-w-0 flex-col gap-6">
+          <div className="flex flex-wrap items-center gap-1">
+            <Skeleton className="h-8 w-24" />
+            <Skeleton className="h-8 w-28" />
+            <Skeleton className="h-8 w-32" />
+            <Skeleton className="h-8 w-28" />
+          </div>
           <Card>
-            <CardContent className="flex flex-col items-center gap-3">
-              <Skeleton className="h-20 w-20 rounded-full" />
-              <Skeleton className="h-5 w-40" />
-              <Skeleton className="h-3 w-32" />
+            <CardContent className="flex flex-col gap-4">
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                {Array.from({ length: 4 }).map((_, i) => (
+                  // biome-ignore lint/suspicious/noArrayIndexKey: stable placeholder -- owner: relationships-react; existing suppression is intentional pending typed cleanup.
+                  <div key={i} className="space-y-1.5">
+                    <Skeleton className="h-3 w-20" />
+                    <Skeleton className="h-4 w-32" />
+                  </div>
+                ))}
+              </div>
             </CardContent>
           </Card>
+        </main>
+
+        {/* Sidebar */}
+        <aside className="flex flex-col gap-6">
           <Card>
-            <CardHeader>
+            <CardHeader className="pb-3">
               <Skeleton className="h-4 w-20" />
             </CardHeader>
             <CardContent className="space-y-4">
-              {Array.from({ length: 5 }).map((_, i) => (
+              {Array.from({ length: 7 }).map((_, i) => (
                 // biome-ignore lint/suspicious/noArrayIndexKey: stable placeholder -- owner: relationships-react; existing suppression is intentional pending typed cleanup.
                 <div key={i} className="flex items-start gap-3">
                   <Skeleton className="mt-0.5 h-4 w-4" />
                   <div className="flex-1 space-y-1.5">
-                    <Skeleton className="h-3 w-20" />
+                    <Skeleton className="h-3 w-24" />
                     <Skeleton className="h-4 w-4/5" />
                   </div>
                 </div>
               ))}
             </CardContent>
           </Card>
-        </aside>
-
-        {/* Main */}
-        <main className="col-span-12 flex flex-col gap-4 lg:col-span-6">
-          {/* Tab row */}
-          <div className="flex items-center gap-1 border-b">
-            <Skeleton className="h-9 w-20" />
-            <Skeleton className="h-9 w-24" />
-            <Skeleton className="h-9 w-28" />
-          </div>
-
-          {/* Composer */}
           <Card>
-            <CardContent className="space-y-3 py-4">
-              <Skeleton className="h-20 w-full" />
-              <div className="flex justify-end">
-                <Skeleton className="h-9 w-24" />
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* Feed */}
-          <div className="flex flex-col gap-3">
-            {Array.from({ length: 4 }).map((_, i) => (
-              // biome-ignore lint/suspicious/noArrayIndexKey: stable placeholder -- owner: relationships-react; existing suppression is intentional pending typed cleanup.
-              <Card key={i}>
-                <CardContent className="flex items-start gap-3 py-4">
-                  <Skeleton className="h-8 w-8 rounded-full" />
-                  <div className="flex-1 space-y-2">
-                    <div className="flex items-center gap-2">
-                      <Skeleton className="h-4 w-28" />
-                      <Skeleton className="h-3 w-16" />
-                    </div>
-                    <Skeleton className="h-4 w-full" />
-                    <Skeleton className="h-4 w-2/3" />
-                  </div>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        </main>
-
-        {/* Aside */}
-        <aside className="col-span-12 flex flex-col gap-4 lg:col-span-3">
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between">
-              <Skeleton className="h-4 w-28" />
-              <Skeleton className="h-7 w-7 rounded" />
+            <CardHeader className="pb-3">
+              <Skeleton className="h-4 w-16" />
             </CardHeader>
-            <CardContent className="space-y-3">
-              <Skeleton className="h-4 w-40" />
-              <Skeleton className="h-3 w-48" />
-              <Skeleton className="h-3 w-32" />
-            </CardContent>
-          </Card>
-          <Card>
-            <CardHeader>
-              <Skeleton className="h-4 w-32" />
-            </CardHeader>
-            <CardContent className="space-y-3">
-              <div className="rounded-md border p-3">
-                <Skeleton className="h-3 w-16" />
-                <Skeleton className="mt-2 h-5 w-24" />
-              </div>
-              <div className="rounded-md border p-3">
-                <Skeleton className="h-3 w-20" />
-                <Skeleton className="mt-2 h-5 w-16" />
-              </div>
-              <div className="rounded-md border p-3">
-                <Skeleton className="h-3 w-24" />
-                <Skeleton className="mt-2 h-5 w-16" />
-              </div>
+            <CardContent className="flex flex-wrap gap-2">
+              <Skeleton className="h-6 w-16 rounded-full" />
+              <Skeleton className="h-6 w-20 rounded-full" />
             </CardContent>
           </Card>
         </aside>

--- a/packages/relationships-react/src/components/inline-field.tsx
+++ b/packages/relationships-react/src/components/inline-field.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { formatMessage } from "@voyant-travel/i18n"
 import { Button, cn, Input, Textarea } from "@voyant-travel/ui/components"
 import { Check, Loader2, Pencil, X } from "lucide-react"
 import { type ComponentType, type KeyboardEvent, useState } from "react"
@@ -124,19 +125,24 @@ export function InlineField({
             </div>
           </div>
         ) : (
-          <div className="flex items-center gap-2">
-            <div className={cn("flex-1 text-sm", kind !== "textarea" && "truncate")}>
+          <div className="flex items-start gap-2">
+            {/* `break-words` rather than `truncate`: in a 320px rail these are
+                long values (legal names, URLs, industries) and silently cutting
+                them off hid data that had no other place on the page. */}
+            <div
+              className={cn("min-w-0 flex-1 text-sm", kind === "textarea" && "whitespace-pre-wrap")}
+            >
               {href && value ? (
                 <a
                   href={href}
-                  className="text-primary hover:underline"
+                  className="break-words text-primary hover:underline"
                   target={href.startsWith("http") ? "_blank" : undefined}
                   rel={href.startsWith("http") ? "noreferrer" : undefined}
                 >
                   {value}
                 </a>
               ) : (
-                display
+                <span className="break-words">{display}</span>
               )}
             </div>
             {!disabled ? (
@@ -144,7 +150,8 @@ export function InlineField({
                 size="sm"
                 variant="ghost"
                 onClick={() => setEditing(true)}
-                className="h-6 w-6 p-0 opacity-0 group-hover:opacity-100"
+                aria-label={formatMessage(messages.editTemplate, { label: label.toLowerCase() })}
+                className="h-6 w-6 shrink-0 p-0 opacity-0 transition-opacity focus-visible:opacity-100 group-hover:opacity-100"
               >
                 <Pencil className="h-3 w-3" aria-hidden="true" />
               </Button>

--- a/packages/relationships-react/src/components/organization-detail-main.tsx
+++ b/packages/relationships-react/src/components/organization-detail-main.tsx
@@ -12,11 +12,10 @@ import {
   Button,
   Card,
   CardContent,
-  CardHeader,
 } from "@voyant-travel/ui/components"
 import { Separator } from "@voyant-travel/ui/components/separator"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@voyant-travel/ui/components/tabs"
-import { Loader2, Pencil, Plus } from "lucide-react"
+import { Loader2, Plus } from "lucide-react"
 
 import { useCrmUiI18nOrDefault, useCrmUiMessagesOrDefault } from "../i18n/index.js"
 import type { UpdateOrganizationInput } from "../index.js"
@@ -67,221 +66,209 @@ export function OrganizationMain({
     slots?.proposalsContent !== undefined || slots?.proposalsEnd !== undefined
 
   return (
-    <main className="col-span-12 flex flex-col gap-4 lg:col-span-9">
-      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-        <Card>
-          <CardContent>
-            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-              {messages.organizationDetail.metrics.people}
-            </p>
-            <p className="mt-1 text-2xl font-semibold">{people.length}</p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent>
-            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-              {messages.organizationDetail.tabs.activities}
-            </p>
-            <p className="mt-1 text-2xl font-semibold">{activities.length}</p>
-          </CardContent>
-        </Card>
-      </div>
+    <main className="flex min-w-0 flex-col gap-6">
+      <Tabs
+        value={activeTab}
+        onValueChange={(value) => setActiveTab(value as OrganizationDetailTab)}
+      >
+        <TabsList className="h-auto w-full flex-wrap justify-start [&_[data-slot=tabs-trigger]]:flex-none">
+          <TabsTrigger value="overview">{messages.organizationDetail.tabs.overview}</TabsTrigger>
+          <TabsTrigger value="people">
+            {messages.organizationDetail.tabs.people} ({people.length})
+          </TabsTrigger>
+          <TabsTrigger value="contactMethods">
+            {messages.organizationDetail.tabs.contactMethods}
+          </TabsTrigger>
+          <TabsTrigger value="addresses">{messages.organizationDetail.tabs.addresses}</TabsTrigger>
+          <TabsTrigger value="namedContacts">
+            {messages.organizationDetail.tabs.namedContacts}
+          </TabsTrigger>
+          {hasProposalsSlot ? (
+            <TabsTrigger value="proposals">
+              {messages.organizationDetail.tabs.proposals}
+            </TabsTrigger>
+          ) : null}
+          <TabsTrigger value="activities">
+            {messages.organizationDetail.tabs.activities} ({activities.length})
+          </TabsTrigger>
+          {slots?.bookingsTab ? (
+            <TabsTrigger value="bookings">
+              {formatTabLabel(messages.organizationDetail.tabs.bookings, slots.bookingsTab)}
+            </TabsTrigger>
+          ) : null}
+          {slots?.invoicesTab ? (
+            <TabsTrigger value="invoices">
+              {formatTabLabel(messages.organizationDetail.tabs.invoices, slots.invoicesTab)}
+            </TabsTrigger>
+          ) : null}
+          {slots?.paymentsTab ? (
+            <TabsTrigger value="payments">
+              {formatTabLabel(messages.organizationDetail.tabs.payments, slots.paymentsTab)}
+            </TabsTrigger>
+          ) : null}
+          {slots?.contractsTab ? (
+            <TabsTrigger value="contracts">
+              {formatTabLabel(messages.organizationDetail.tabs.contracts, slots.contractsTab)}
+            </TabsTrigger>
+          ) : null}
+        </TabsList>
+        <TabsContent value="overview" className="mt-4 flex flex-col gap-6">
+          {slots?.overviewContent !== undefined ? (
+            slots.overviewContent
+          ) : (
+            <Card>
+              <CardContent className="flex flex-col gap-4">
+                <dl className="grid grid-cols-1 gap-4 text-sm sm:grid-cols-2">
+                  <div>
+                    <dt className="text-xs font-medium text-muted-foreground">
+                      {messages.organizationDetail.sections.created}
+                    </dt>
+                    <dd className="mt-0.5">{formatCrmDate(i18n, org.createdAt)}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs font-medium text-muted-foreground">
+                      {messages.organizationDetail.sections.updated}
+                    </dt>
+                    <dd className="mt-0.5">{formatCrmRelative(i18n, org.updatedAt)}</dd>
+                  </div>
+                </dl>
+                <Separator />
+                <InlineField
+                  label={messages.organizationDetail.sections.notes}
+                  kind="textarea"
+                  value={org.notes}
+                  onSave={(next) => onUpdateField({ notes: next })}
+                />
+              </CardContent>
+            </Card>
+          )}
+          {slots?.overviewEnd}
+        </TabsContent>
 
-      <Card>
-        <Tabs
-          value={activeTab}
-          onValueChange={(value) => setActiveTab(value as OrganizationDetailTab)}
-        >
-          <CardHeader className="pb-0">
-            <TabsList className="h-auto flex-wrap justify-start [&_[data-slot=tabs-trigger]]:flex-none">
-              <TabsTrigger value="overview">
-                {messages.organizationDetail.tabs.overview}
-              </TabsTrigger>
-              <TabsTrigger value="people">
-                {messages.organizationDetail.tabs.people} ({people.length})
-              </TabsTrigger>
-              <TabsTrigger value="contactMethods">
-                {messages.organizationDetail.tabs.contactMethods}
-              </TabsTrigger>
-              <TabsTrigger value="addresses">
-                {messages.organizationDetail.tabs.addresses}
-              </TabsTrigger>
-              <TabsTrigger value="namedContacts">
-                {messages.organizationDetail.tabs.namedContacts}
-              </TabsTrigger>
-              {hasProposalsSlot ? (
-                <TabsTrigger value="proposals">
-                  {messages.organizationDetail.tabs.proposals}
-                </TabsTrigger>
-              ) : null}
-              <TabsTrigger value="activities">
-                {messages.organizationDetail.tabs.activities} ({activities.length})
-              </TabsTrigger>
-              {slots?.bookingsTab ? (
-                <TabsTrigger value="bookings">
-                  {formatTabLabel(messages.organizationDetail.tabs.bookings, slots.bookingsTab)}
-                </TabsTrigger>
-              ) : null}
-              {slots?.invoicesTab ? (
-                <TabsTrigger value="invoices">
-                  {formatTabLabel(messages.organizationDetail.tabs.invoices, slots.invoicesTab)}
-                </TabsTrigger>
-              ) : null}
-              {slots?.paymentsTab ? (
-                <TabsTrigger value="payments">
-                  {formatTabLabel(messages.organizationDetail.tabs.payments, slots.paymentsTab)}
-                </TabsTrigger>
-              ) : null}
-              {slots?.contractsTab ? (
-                <TabsTrigger value="contracts">
-                  {formatTabLabel(messages.organizationDetail.tabs.contracts, slots.contractsTab)}
-                </TabsTrigger>
-              ) : null}
-            </TabsList>
-          </CardHeader>
-          <CardContent className="pt-4">
-            <TabsContent value="overview" className="m-0">
-              {slots?.overviewContent !== undefined ? (
-                slots.overviewContent
-              ) : (
-                <>
-                  <dl className="grid grid-cols-1 gap-4 text-sm sm:grid-cols-2">
-                    <div>
-                      <dt className="text-xs font-medium uppercase text-muted-foreground">
-                        {messages.organizationDetail.sections.created}
-                      </dt>
-                      <dd className="mt-0.5">{formatCrmDate(i18n, org.createdAt)}</dd>
-                    </div>
-                    <div>
-                      <dt className="text-xs font-medium uppercase text-muted-foreground">
-                        {messages.organizationDetail.sections.updated}
-                      </dt>
-                      <dd className="mt-0.5">{formatCrmRelative(i18n, org.updatedAt)}</dd>
-                    </div>
-                    {org.notes && (
-                      <div className="sm:col-span-2">
-                        <dt className="text-xs font-medium uppercase text-muted-foreground">
-                          {messages.organizationDetail.sections.notes}
-                        </dt>
-                        <dd className="mt-0.5 whitespace-pre-wrap">{org.notes}</dd>
-                      </div>
-                    )}
-                  </dl>
-                  <Separator className="my-4" />
-                  <InlineField
-                    label={messages.organizationDetail.sections.notes}
-                    kind="textarea"
-                    value={org.notes}
-                    onSave={(next) => onUpdateField({ notes: next })}
+        <TabsContent value="people" className="mt-4 flex flex-col gap-6">
+          {slots?.peopleContent !== undefined ? (
+            slots.peopleContent
+          ) : (
+            <Card>
+              <CardContent>
+                {peoplePending ? (
+                  <div className="flex justify-center py-6">
+                    <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+                  </div>
+                ) : people.length === 0 ? (
+                  <EmptyManagedSection
+                    actionLabel={messages.organizationDetail.actions.addPerson}
+                    emptyLabel={messages.organizationDetail.empty.noPeople}
+                    onAction={onAddPerson}
                   />
-                </>
-              )}
-              {slots?.overviewEnd}
-            </TabsContent>
+                ) : (
+                  <PeopleList
+                    people={people}
+                    onOpenPerson={onOpenPerson}
+                    onAddPerson={onAddPerson}
+                  />
+                )}
+              </CardContent>
+            </Card>
+          )}
+          {slots?.peopleEnd}
+        </TabsContent>
 
-            <TabsContent value="people" className="m-0">
-              {slots?.peopleContent !== undefined ? (
-                slots.peopleContent
-              ) : peoplePending ? (
-                <div className="flex justify-center py-6">
-                  <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
-                </div>
-              ) : people.length === 0 ? (
-                <EmptyManagedSection
-                  actionLabel={messages.organizationDetail.actions.addPerson}
-                  emptyLabel={messages.organizationDetail.empty.noPeople}
-                  onAction={onAddPerson}
-                />
-              ) : (
-                <PeopleList people={people} onOpenPerson={onOpenPerson} onAddPerson={onAddPerson} />
-              )}
-              {slots?.peopleEnd}
-            </TabsContent>
-
-            <TabsContent value="contactMethods" className="m-0">
-              {slots?.contactMethodsContent !== undefined ? (
-                slots.contactMethodsContent
-              ) : (
+        <TabsContent value="contactMethods" className="mt-4 flex flex-col gap-6">
+          {slots?.contactMethodsContent !== undefined ? (
+            slots.contactMethodsContent
+          ) : (
+            <Card>
+              <CardContent>
                 <ContactPointsTab entityType="organization" entityId={org.id} />
-              )}
-              {slots?.contactMethodsEnd}
-            </TabsContent>
+              </CardContent>
+            </Card>
+          )}
+          {slots?.contactMethodsEnd}
+        </TabsContent>
 
-            <TabsContent value="addresses" className="m-0">
-              {slots?.addressesContent !== undefined ? (
-                slots.addressesContent
-              ) : (
+        <TabsContent value="addresses" className="mt-4 flex flex-col gap-6">
+          {slots?.addressesContent !== undefined ? (
+            slots.addressesContent
+          ) : (
+            <Card>
+              <CardContent>
                 <AddressesTab entityType="organization" entityId={org.id} />
-              )}
-              {slots?.addressesEnd}
-            </TabsContent>
+              </CardContent>
+            </Card>
+          )}
+          {slots?.addressesEnd}
+        </TabsContent>
 
-            <TabsContent value="namedContacts" className="m-0">
-              {slots?.namedContactsContent !== undefined ? (
-                slots.namedContactsContent
-              ) : (
+        <TabsContent value="namedContacts" className="mt-4 flex flex-col gap-6">
+          {slots?.namedContactsContent !== undefined ? (
+            slots.namedContactsContent
+          ) : (
+            <Card>
+              <CardContent>
                 <NamedContactsTab entityType="organization" entityId={org.id} />
-              )}
-              {slots?.namedContactsEnd}
-            </TabsContent>
+              </CardContent>
+            </Card>
+          )}
+          {slots?.namedContactsEnd}
+        </TabsContent>
 
-            {hasProposalsSlot ? (
-              <TabsContent value="proposals" className="m-0">
-                {slots?.proposalsContent}
-                {slots?.proposalsEnd}
-              </TabsContent>
-            ) : null}
+        {hasProposalsSlot ? (
+          <TabsContent value="proposals" className="mt-4 flex flex-col gap-6">
+            {slots?.proposalsContent}
+            {slots?.proposalsEnd}
+          </TabsContent>
+        ) : null}
 
-            <TabsContent value="activities" className="m-0">
-              {slots?.activitiesContent !== undefined ? (
-                slots.activitiesContent
-              ) : activitiesPending ? (
-                <div className="flex justify-center py-6">
-                  <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
-                </div>
-              ) : activities.length === 0 ? (
-                <EmptyManagedSection
-                  actionLabel={messages.organizationDetail.actions.addActivity}
-                  emptyLabel={messages.organizationDetail.empty.noActivities}
-                  onAction={onAddActivity}
-                />
-              ) : (
-                <ActivitiesList
-                  activities={activities}
-                  onAddActivity={onAddActivity}
-                  formatRelative={(value) => formatCrmRelative(i18n, value)}
-                />
-              )}
-              {slots?.activitiesEnd}
-            </TabsContent>
-            {slots?.bookingsTab ? (
-              <TabsContent value="bookings" className="m-0">
-                {slots.bookingsTab.content}
-              </TabsContent>
-            ) : null}
-            {slots?.invoicesTab ? (
-              <TabsContent value="invoices" className="m-0">
-                {slots.invoicesTab.content}
-              </TabsContent>
-            ) : null}
-            {slots?.paymentsTab ? (
-              <TabsContent value="payments" className="m-0">
-                {slots.paymentsTab.content}
-              </TabsContent>
-            ) : null}
-            {slots?.contractsTab ? (
-              <TabsContent value="contracts" className="m-0">
-                {slots.contractsTab.content}
-              </TabsContent>
-            ) : null}
-          </CardContent>
-        </Tabs>
-      </Card>
-
-      <div className="flex items-center gap-2">
-        <Pencil className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
-        <span className="text-xs text-muted-foreground">{messages.organizationDetail.hint}</span>
-      </div>
+        <TabsContent value="activities" className="mt-4 flex flex-col gap-6">
+          {slots?.activitiesContent !== undefined ? (
+            slots.activitiesContent
+          ) : (
+            <Card>
+              <CardContent>
+                {activitiesPending ? (
+                  <div className="flex justify-center py-6">
+                    <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+                  </div>
+                ) : activities.length === 0 ? (
+                  <EmptyManagedSection
+                    actionLabel={messages.organizationDetail.actions.addActivity}
+                    emptyLabel={messages.organizationDetail.empty.noActivities}
+                    onAction={onAddActivity}
+                  />
+                ) : (
+                  <ActivitiesList
+                    activities={activities}
+                    onAddActivity={onAddActivity}
+                    formatRelative={(value) => formatCrmRelative(i18n, value)}
+                  />
+                )}
+              </CardContent>
+            </Card>
+          )}
+          {slots?.activitiesEnd}
+        </TabsContent>
+        {slots?.bookingsTab ? (
+          <TabsContent value="bookings" className="mt-4 flex flex-col gap-6">
+            {slots.bookingsTab.content}
+          </TabsContent>
+        ) : null}
+        {slots?.invoicesTab ? (
+          <TabsContent value="invoices" className="mt-4 flex flex-col gap-6">
+            {slots.invoicesTab.content}
+          </TabsContent>
+        ) : null}
+        {slots?.paymentsTab ? (
+          <TabsContent value="payments" className="mt-4 flex flex-col gap-6">
+            {slots.paymentsTab.content}
+          </TabsContent>
+        ) : null}
+        {slots?.contractsTab ? (
+          <TabsContent value="contracts" className="mt-4 flex flex-col gap-6">
+            {slots.contractsTab.content}
+          </TabsContent>
+        ) : null}
+      </Tabs>
     </main>
   )
 }

--- a/packages/relationships-react/src/components/organization-detail-page.tsx
+++ b/packages/relationships-react/src/components/organization-detail-page.tsx
@@ -11,9 +11,9 @@ import { OrganizationMergeDialog } from "./merge-dialogs.js"
 import {
   type OrganizationDetailPageSlots,
   type OrganizationDetailTab,
+  OrganizationHeader,
   OrganizationMain,
   OrganizationSidebar,
-  OrganizationTopBar,
 } from "./organization-detail-sections.js"
 import { PersonDialog } from "./person-dialog.js"
 
@@ -109,13 +109,10 @@ export function OrganizationDetailPage({
     : undefined
 
   return (
-    <div
-      data-slot="organization-detail-page"
-      className={cn("flex min-h-screen flex-col", className)}
-    >
-      <OrganizationTopBar
-        orgName={org.name}
-        onBack={() => onBack?.()}
+    <div data-slot="organization-detail-page" className={cn("flex flex-col gap-6", className)}>
+      <OrganizationHeader
+        org={org}
+        websiteHref={websiteHref}
         onMerge={() => setMergeOpen(true)}
         deletePending={remove.isPending}
         onDelete={async () => {
@@ -126,10 +123,7 @@ export function OrganizationDetailPage({
       />
       {slots?.afterTopBar}
 
-      <div className="grid flex-1 grid-cols-12 gap-4 p-4 lg:p-6">
-        <OrganizationSidebar org={org} websiteHref={websiteHref} onUpdateField={updateField}>
-          {slots?.sidebarEnd}
-        </OrganizationSidebar>
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
         <OrganizationMain
           activeTab={activeTab}
           setActiveTab={setActiveTab}
@@ -144,6 +138,9 @@ export function OrganizationDetailPage({
           onUpdateField={updateField}
           slots={slots}
         />
+        <OrganizationSidebar org={org} websiteHref={websiteHref} onUpdateField={updateField}>
+          {slots?.sidebarEnd}
+        </OrganizationSidebar>
       </div>
       <PersonDialog
         open={personDialogOpen}

--- a/packages/relationships-react/src/components/organization-detail-sections.tsx
+++ b/packages/relationships-react/src/components/organization-detail-sections.tsx
@@ -12,7 +12,6 @@ import {
   ConfirmActionButton,
 } from "@voyant-travel/ui/components"
 import {
-  ArrowLeft,
   Building,
   Calendar,
   CircleDot,
@@ -45,36 +44,73 @@ export type {
   OrganizationPerson,
 } from "./organization-detail-types.js"
 
-export interface OrganizationTopBarProps {
-  orgName: string
-  onBack: () => void
+export interface OrganizationHeaderProps {
+  org: OrganizationData
+  websiteHref?: string
   onMerge?: () => void
   onDelete: () => Promise<void>
   deletePending: boolean
 }
 
-export function OrganizationTopBar({
-  orgName,
-  onBack,
+/**
+ * Page header for the organization detail route.
+ *
+ * Deliberately renders no breadcrumb and no back affordance: the admin chrome
+ * already owns both (`useAdminBreadcrumbs` in the host). Identity — avatar,
+ * name, legal name, website and the relation/status badges — lives here rather
+ * than in the sidebar, matching the product detail header.
+ */
+export function OrganizationHeader({
+  org,
+  websiteHref,
   onMerge,
   onDelete,
   deletePending,
-}: OrganizationTopBarProps) {
+}: OrganizationHeaderProps) {
   const messages = useCrmUiMessagesOrDefault()
+  const relationLabel = org.relation
+    ? (messages.common.relationTypeLabels[
+        org.relation as keyof typeof messages.common.relationTypeLabels
+      ] ?? org.relation)
+    : null
+  const statusLabel =
+    messages.common.recordStatusLabels[
+      org.status as keyof typeof messages.common.recordStatusLabels
+    ] ?? org.status
 
   return (
-    <div className="sticky top-0 z-10 flex items-center gap-3 border-b bg-background px-6 py-3">
-      <Button variant="ghost" size="icon" onClick={onBack} className="h-8 w-8">
-        <ArrowLeft className="h-4 w-4" aria-hidden="true" />
-      </Button>
-      <div className="flex items-center gap-2 text-sm text-muted-foreground">
-        <button type="button" onClick={onBack} className="hover:text-foreground">
-          {messages.organizationDetail.topBar.organizations}
-        </button>
-        <span>/</span>
-        <span className="text-foreground">{orgName}</span>
+    <div className="flex flex-wrap items-start justify-between gap-3">
+      <div className="flex min-w-0 items-center gap-3">
+        <Avatar className="size-10 shrink-0">
+          <AvatarFallback>{initialsFrom(org.name)}</AvatarFallback>
+        </Avatar>
+        <div className="flex min-w-0 flex-col gap-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h1 className="text-xl font-bold tracking-tight sm:text-2xl">{org.name}</h1>
+            {relationLabel ? <Badge variant="secondary">{relationLabel}</Badge> : null}
+            <Badge variant="outline">{statusLabel}</Badge>
+          </div>
+          {org.legalName || websiteHref ? (
+            <div className="flex min-w-0 flex-wrap items-center gap-1.5 text-sm text-muted-foreground">
+              {org.legalName ? <span className="truncate">{org.legalName}</span> : null}
+              {org.legalName && websiteHref ? (
+                <span className="text-muted-foreground/60">/</span>
+              ) : null}
+              {websiteHref ? (
+                <a
+                  href={websiteHref}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="truncate transition-colors hover:text-foreground hover:underline"
+                >
+                  {org.website}
+                </a>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
       </div>
-      <div className="ml-auto flex items-center gap-2">
+      <div className="flex flex-wrap items-center gap-2">
         {onMerge ? (
           <Button variant="outline" size="sm" onClick={onMerge}>
             <GitMerge className="size-4" aria-hidden="true" />
@@ -103,6 +139,11 @@ export interface OrganizationSidebarProps {
   children?: ReactNode
 }
 
+/**
+ * About + Tags rail. The standalone profile card is gone — its avatar, badges
+ * and website now live in {@link OrganizationHeader} — leaving this rail as the
+ * single place every organization field is read and inline-edited.
+ */
 export function OrganizationSidebar({
   org,
   websiteHref,
@@ -123,43 +164,7 @@ export function OrganizationSidebar({
   ]
 
   return (
-    <aside className="col-span-12 flex flex-col gap-4 lg:col-span-3">
-      <Card>
-        <CardContent className="flex flex-col items-center gap-3 text-center">
-          <Avatar className="h-20 w-20">
-            <AvatarFallback className="text-xl">{initialsFrom(org.name)}</AvatarFallback>
-          </Avatar>
-          <div className="space-y-1">
-            <h2 className="text-lg font-semibold leading-tight">{org.name}</h2>
-            {org.legalName && <p className="text-sm text-muted-foreground">{org.legalName}</p>}
-            {websiteHref && (
-              <a
-                href={websiteHref}
-                target="_blank"
-                rel="noreferrer"
-                className="text-sm text-primary hover:underline"
-              >
-                {org.website}
-              </a>
-            )}
-          </div>
-          <div className="flex flex-wrap justify-center gap-1">
-            {org.relation && (
-              <Badge variant="secondary">
-                {messages.common.relationTypeLabels[
-                  org.relation as keyof typeof messages.common.relationTypeLabels
-                ] ?? org.relation}
-              </Badge>
-            )}
-            <Badge variant="outline">
-              {messages.common.recordStatusLabels[
-                org.status as keyof typeof messages.common.recordStatusLabels
-              ] ?? org.status}
-            </Badge>
-          </div>
-        </CardContent>
-      </Card>
-
+    <aside className="flex flex-col gap-6">
       <Card>
         <CardHeader className="pb-3">
           <CardTitle className="text-sm font-semibold">
@@ -167,6 +172,9 @@ export function OrganizationSidebar({
           </CardTitle>
         </CardHeader>
         <CardContent className="divide-y text-sm">
+          {/* Name and legal name stay here even though the header displays them:
+              the header is read-only, and this list is the only inline editor
+              for them — the organization page has no edit dialog. */}
           <InlineField
             icon={Building}
             label={messages.organizationDetail.sidebar.fields.name}
@@ -189,6 +197,7 @@ export function OrganizationSidebar({
             icon={Globe}
             label={messages.organizationDetail.sidebar.fields.website}
             kind="url"
+            href={websiteHref}
             value={org.website}
             onSave={(next) => onUpdateField({ website: next })}
           />

--- a/packages/relationships-react/src/components/person-detail-page.tsx
+++ b/packages/relationships-react/src/components/person-detail-page.tsx
@@ -1,15 +1,17 @@
 "use client"
 
 import {
+  Avatar,
+  AvatarFallback,
+  Badge,
   Button,
   Card,
   CardContent,
-  CardHeader,
   ConfirmActionButton,
   cn,
 } from "@voyant-travel/ui/components"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@voyant-travel/ui/components/tabs"
-import { ArrowLeft, GitMerge, Loader2, Pencil } from "lucide-react"
+import { GitMerge, Loader2, Pencil } from "lucide-react"
 import { type ReactNode, useEffect, useState } from "react"
 import { useCrmUiMessagesOrDefault } from "../i18n/index.js"
 import type { UpdatePersonInput } from "../index.js"
@@ -26,6 +28,7 @@ import {
 import { PersonMergeDialog } from "./merge-dialogs.js"
 import { PersonAddressesSection } from "./person-addresses-section.js"
 import {
+  initialsFrom,
   PersonActivitiesPanel,
   PersonCommunicationsPanel,
   PersonDocumentsPanel,
@@ -163,13 +166,13 @@ export function PersonDetailPage({
   const paymentMethods = paymentMethodsQuery.data?.data ?? []
   const communications = communicationsQuery.data?.data ?? []
   const organization = organizationQuery.data ?? null
-  const displayName = personDisplayName(person, messages.personCard.unnamed)
 
   return (
-    <div data-slot="person-detail-page" className={cn("flex min-h-screen flex-col", className)}>
-      <PersonTopBar
-        personName={displayName}
-        onBack={() => onBack?.()}
+    <div data-slot="person-detail-page" className={cn("flex flex-col gap-6", className)}>
+      <PersonHeader
+        person={person}
+        organization={organization}
+        onOrganizationOpen={onOrganizationOpen}
         onEdit={() => setEditOpen(true)}
         onMerge={() => setMergeOpen(true)}
         deletePending={remove.isPending}
@@ -181,15 +184,7 @@ export function PersonDetailPage({
       />
       {slots?.afterTopBar}
 
-      <div className="grid flex-1 grid-cols-12 gap-4 p-4 lg:p-6">
-        <PersonSidebar
-          person={person}
-          organization={organization}
-          onOrganizationOpen={onOrganizationOpen}
-          onUpdateField={updateField}
-        >
-          {slots?.sidebarEnd}
-        </PersonSidebar>
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
         <PersonMain
           activeTab={activeTab}
           setActiveTab={setActiveTab}
@@ -209,6 +204,9 @@ export function PersonDetailPage({
           onPersonOpen={onPersonOpen}
           slots={slots}
         />
+        <PersonSidebar person={person} onUpdateField={updateField}>
+          {slots?.sidebarEnd}
+        </PersonSidebar>
       </div>
 
       <PersonDialog open={editOpen} onOpenChange={setEditOpen} person={person} />
@@ -217,38 +215,76 @@ export function PersonDetailPage({
   )
 }
 
-export interface PersonTopBarProps {
-  personName: string
-  onBack: () => void
+export interface PersonHeaderProps {
+  person: PersonData
+  organization: PersonOrganization | null
+  onOrganizationOpen?: (organizationId: string) => void
   onEdit: () => void
   onMerge: () => void
   onDelete: () => Promise<void>
   deletePending: boolean
 }
 
-export function PersonTopBar({
-  personName,
-  onBack,
+/**
+ * Page header for the person detail route.
+ *
+ * Renders no breadcrumb and no back affordance — the admin chrome owns both
+ * (`useAdminBreadcrumbs` in the host). Identity moved here out of the sidebar
+ * profile card so the rail is purely the field list.
+ */
+export function PersonHeader({
+  person,
+  organization,
+  onOrganizationOpen,
   onEdit,
   onMerge,
   onDelete,
   deletePending,
-}: PersonTopBarProps) {
+}: PersonHeaderProps) {
   const messages = useCrmUiMessagesOrDefault()
+  const displayName = personDisplayName(person, messages.personCard.unnamed)
+  const relationLabel = person.relation
+    ? (messages.common.relationTypeLabels[
+        person.relation as keyof typeof messages.common.relationTypeLabels
+      ] ?? person.relation)
+    : null
+  const statusLabel =
+    messages.common.recordStatusLabels[
+      person.status as keyof typeof messages.common.recordStatusLabels
+    ] ?? person.status
 
   return (
-    <div className="sticky top-0 z-10 flex items-center gap-3 border-b bg-background px-6 py-3">
-      <Button variant="ghost" size="icon" onClick={onBack} className="size-8">
-        <ArrowLeft className="size-4" aria-hidden="true" />
-      </Button>
-      <div className="flex min-w-0 items-center gap-2 text-sm text-muted-foreground">
-        <button type="button" onClick={onBack} className="hover:text-foreground">
-          {messages.personDetail.topBar.people}
-        </button>
-        <span>/</span>
-        <span className="truncate text-foreground">{personName}</span>
+    <div className="flex flex-wrap items-start justify-between gap-3">
+      <div className="flex min-w-0 items-center gap-3">
+        <Avatar className="size-10 shrink-0">
+          <AvatarFallback>{initialsFrom(displayName)}</AvatarFallback>
+        </Avatar>
+        <div className="flex min-w-0 flex-col gap-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h1 className="text-xl font-bold tracking-tight sm:text-2xl">{displayName}</h1>
+            {relationLabel ? <Badge variant="secondary">{relationLabel}</Badge> : null}
+            <Badge variant="outline">{statusLabel}</Badge>
+          </div>
+          {person.jobTitle || organization ? (
+            <div className="flex min-w-0 flex-wrap items-center gap-1.5 text-sm text-muted-foreground">
+              {person.jobTitle ? <span className="truncate">{person.jobTitle}</span> : null}
+              {person.jobTitle && organization ? (
+                <span className="text-muted-foreground/60">/</span>
+              ) : null}
+              {organization ? (
+                <button
+                  type="button"
+                  onClick={() => onOrganizationOpen?.(organization.id)}
+                  className="truncate transition-colors hover:text-foreground hover:underline"
+                >
+                  {organization.name}
+                </button>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
       </div>
-      <div className="ml-auto flex items-center gap-2">
+      <div className="flex flex-wrap items-center gap-2">
         <Button variant="outline" size="sm" onClick={onEdit}>
           <Pencil className="size-4" aria-hidden="true" />
           {messages.personDetail.topBar.edit}
@@ -320,149 +356,171 @@ export function PersonMain({
     slots?.proposalsContent !== undefined || slots?.proposalsEnd !== undefined
 
   return (
-    <main className="col-span-12 flex flex-col gap-4 lg:col-span-9">
-      <Card>
-        <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as PersonDetailTab)}>
-          <CardHeader className="pb-0">
-            <TabsList className="h-auto flex-wrap justify-start [&_[data-slot=tabs-trigger]]:flex-none">
-              <TabsTrigger value="overview">{messages.personDetail.tabs.overview}</TabsTrigger>
-              {hasProposalsSlot ? (
-                <TabsTrigger value="proposals">{messages.personDetail.tabs.proposals}</TabsTrigger>
-              ) : null}
-              <TabsTrigger value="activities">
-                {messages.personDetail.tabs.activities} ({activities.length})
-              </TabsTrigger>
-              <TabsTrigger value="relationships">
-                {messages.personDetail.tabs.relationships} ({relationships.length})
-              </TabsTrigger>
-              <TabsTrigger value="documents">
-                {messages.personDetail.tabs.documents} ({documents.length})
-              </TabsTrigger>
-              <TabsTrigger value="paymentMethods">
-                {messages.personDetail.tabs.paymentMethods} ({paymentMethods.length})
-              </TabsTrigger>
-              <TabsTrigger value="communications">
-                {messages.personDetail.tabs.communications} ({communications.length})
-              </TabsTrigger>
-              <TabsTrigger value="addresses">{messages.personDetail.tabs.addresses}</TabsTrigger>
-              {slots?.bookingsTab ? (
-                <TabsTrigger value="bookings">
-                  {formatTabLabel(messages.personDetail.tabs.bookings, slots.bookingsTab)}
-                </TabsTrigger>
-              ) : null}
-              {slots?.invoicesTab ? (
-                <TabsTrigger value="invoices">
-                  {formatTabLabel(messages.personDetail.tabs.invoices, slots.invoicesTab)}
-                </TabsTrigger>
-              ) : null}
-              {slots?.paymentsTab ? (
-                <TabsTrigger value="payments">
-                  {formatTabLabel(messages.personDetail.tabs.payments, slots.paymentsTab)}
-                </TabsTrigger>
-              ) : null}
-              {slots?.contractsTab ? (
-                <TabsTrigger value="contracts">
-                  {formatTabLabel(messages.personDetail.tabs.contracts, slots.contractsTab)}
-                </TabsTrigger>
-              ) : null}
-            </TabsList>
-          </CardHeader>
-          <CardContent className="pt-4">
-            <TabsContent value="overview" className="m-0">
-              {slots?.overviewContent !== undefined ? (
-                slots.overviewContent
-              ) : (
+    <main className="flex min-w-0 flex-col gap-6">
+      <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as PersonDetailTab)}>
+        <TabsList className="h-auto w-full flex-wrap justify-start [&_[data-slot=tabs-trigger]]:flex-none">
+          <TabsTrigger value="overview">{messages.personDetail.tabs.overview}</TabsTrigger>
+          {hasProposalsSlot ? (
+            <TabsTrigger value="proposals">{messages.personDetail.tabs.proposals}</TabsTrigger>
+          ) : null}
+          <TabsTrigger value="activities">
+            {messages.personDetail.tabs.activities} ({activities.length})
+          </TabsTrigger>
+          <TabsTrigger value="relationships">
+            {messages.personDetail.tabs.relationships} ({relationships.length})
+          </TabsTrigger>
+          <TabsTrigger value="documents">
+            {messages.personDetail.tabs.documents} ({documents.length})
+          </TabsTrigger>
+          <TabsTrigger value="paymentMethods">
+            {messages.personDetail.tabs.paymentMethods} ({paymentMethods.length})
+          </TabsTrigger>
+          <TabsTrigger value="communications">
+            {messages.personDetail.tabs.communications} ({communications.length})
+          </TabsTrigger>
+          <TabsTrigger value="addresses">{messages.personDetail.tabs.addresses}</TabsTrigger>
+          {slots?.bookingsTab ? (
+            <TabsTrigger value="bookings">
+              {formatTabLabel(messages.personDetail.tabs.bookings, slots.bookingsTab)}
+            </TabsTrigger>
+          ) : null}
+          {slots?.invoicesTab ? (
+            <TabsTrigger value="invoices">
+              {formatTabLabel(messages.personDetail.tabs.invoices, slots.invoicesTab)}
+            </TabsTrigger>
+          ) : null}
+          {slots?.paymentsTab ? (
+            <TabsTrigger value="payments">
+              {formatTabLabel(messages.personDetail.tabs.payments, slots.paymentsTab)}
+            </TabsTrigger>
+          ) : null}
+          {slots?.contractsTab ? (
+            <TabsTrigger value="contracts">
+              {formatTabLabel(messages.personDetail.tabs.contracts, slots.contractsTab)}
+            </TabsTrigger>
+          ) : null}
+        </TabsList>
+        <TabsContent value="overview" className="mt-4 flex flex-col gap-6">
+          {slots?.overviewContent !== undefined ? (
+            slots.overviewContent
+          ) : (
+            <Card>
+              <CardContent>
                 <PersonOverviewPanel
                   person={person}
                   organization={organization}
                   onUpdateField={onUpdateField}
                 />
-              )}
-              {slots?.overviewEnd}
-            </TabsContent>
-            {hasProposalsSlot ? (
-              <TabsContent value="proposals" className="m-0">
-                {slots?.proposalsContent}
-                {slots?.proposalsEnd}
-              </TabsContent>
-            ) : null}
-            <TabsContent value="activities" className="m-0">
-              {slots?.activitiesContent !== undefined ? (
-                slots.activitiesContent
-              ) : (
+              </CardContent>
+            </Card>
+          )}
+          {slots?.overviewEnd}
+        </TabsContent>
+        {hasProposalsSlot ? (
+          <TabsContent value="proposals" className="mt-4 flex flex-col gap-6">
+            {slots?.proposalsContent}
+            {slots?.proposalsEnd}
+          </TabsContent>
+        ) : null}
+        <TabsContent value="activities" className="mt-4 flex flex-col gap-6">
+          {slots?.activitiesContent !== undefined ? (
+            slots.activitiesContent
+          ) : (
+            <Card>
+              <CardContent>
                 <PersonActivitiesPanel
                   activities={activities}
                   activitiesPending={activitiesPending}
                 />
-              )}
-              {slots?.activitiesEnd}
-            </TabsContent>
-            <TabsContent value="relationships" className="m-0">
-              {slots?.relationshipsContent !== undefined ? (
-                slots.relationshipsContent
-              ) : (
+              </CardContent>
+            </Card>
+          )}
+          {slots?.activitiesEnd}
+        </TabsContent>
+        <TabsContent value="relationships" className="mt-4 flex flex-col gap-6">
+          {slots?.relationshipsContent !== undefined ? (
+            slots.relationshipsContent
+          ) : (
+            <Card>
+              <CardContent>
                 <PersonRelationshipsPanel
                   personId={person.id}
                   relationships={relationships}
                   relationshipsPending={relationshipsPending}
                   onPersonOpen={onPersonOpen}
                 />
-              )}
-              {slots?.relationshipsEnd}
-            </TabsContent>
-            <TabsContent value="documents" className="m-0">
-              {slots?.documentsContent !== undefined ? (
-                slots.documentsContent
-              ) : (
+              </CardContent>
+            </Card>
+          )}
+          {slots?.relationshipsEnd}
+        </TabsContent>
+        <TabsContent value="documents" className="mt-4 flex flex-col gap-6">
+          {slots?.documentsContent !== undefined ? (
+            slots.documentsContent
+          ) : (
+            <Card>
+              <CardContent>
                 <PersonDocumentsPanel
                   documents={documents}
                   documentsPending={documentsPending}
                   primaryCount={primaryDocuments.length}
                   personId={person.id}
                 />
-              )}
-              {slots?.documentsEnd}
-            </TabsContent>
-            <TabsContent value="paymentMethods" className="m-0">
+              </CardContent>
+            </Card>
+          )}
+          {slots?.documentsEnd}
+        </TabsContent>
+        <TabsContent value="paymentMethods" className="mt-4 flex flex-col gap-6">
+          <Card>
+            <CardContent>
               <PersonPaymentMethodsPanel
                 personId={person.id}
                 paymentMethods={paymentMethods}
                 paymentMethodsPending={paymentMethodsPending}
               />
-            </TabsContent>
-            <TabsContent value="communications" className="m-0">
+            </CardContent>
+          </Card>
+        </TabsContent>
+        <TabsContent value="communications" className="mt-4 flex flex-col gap-6">
+          <Card>
+            <CardContent>
               <PersonCommunicationsPanel
                 personId={person.id}
                 communications={communications}
                 communicationsPending={communicationsPending}
               />
-            </TabsContent>
-            <TabsContent value="addresses" className="m-0">
+            </CardContent>
+          </Card>
+        </TabsContent>
+        <TabsContent value="addresses" className="mt-4 flex flex-col gap-6">
+          <Card>
+            <CardContent>
               <PersonAddressesSection personId={person.id} />
-            </TabsContent>
-            {slots?.bookingsTab ? (
-              <TabsContent value="bookings" className="m-0">
-                {slots.bookingsTab.content}
-              </TabsContent>
-            ) : null}
-            {slots?.invoicesTab ? (
-              <TabsContent value="invoices" className="m-0">
-                {slots.invoicesTab.content}
-              </TabsContent>
-            ) : null}
-            {slots?.paymentsTab ? (
-              <TabsContent value="payments" className="m-0">
-                {slots.paymentsTab.content}
-              </TabsContent>
-            ) : null}
-            {slots?.contractsTab ? (
-              <TabsContent value="contracts" className="m-0">
-                {slots.contractsTab.content}
-              </TabsContent>
-            ) : null}
-          </CardContent>
-        </Tabs>
-      </Card>
+            </CardContent>
+          </Card>
+        </TabsContent>
+        {slots?.bookingsTab ? (
+          <TabsContent value="bookings" className="mt-4 flex flex-col gap-6">
+            {slots.bookingsTab.content}
+          </TabsContent>
+        ) : null}
+        {slots?.invoicesTab ? (
+          <TabsContent value="invoices" className="mt-4 flex flex-col gap-6">
+            {slots.invoicesTab.content}
+          </TabsContent>
+        ) : null}
+        {slots?.paymentsTab ? (
+          <TabsContent value="payments" className="mt-4 flex flex-col gap-6">
+            {slots.paymentsTab.content}
+          </TabsContent>
+        ) : null}
+        {slots?.contractsTab ? (
+          <TabsContent value="contracts" className="mt-4 flex flex-col gap-6">
+            {slots.contractsTab.content}
+          </TabsContent>
+        ) : null}
+      </Tabs>
     </main>
   )
 }

--- a/packages/relationships-react/src/components/person-detail-sidebar.tsx
+++ b/packages/relationships-react/src/components/person-detail-sidebar.tsx
@@ -1,16 +1,6 @@
 "use client"
 
-import {
-  Avatar,
-  AvatarFallback,
-  Badge,
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-  cn,
-} from "@voyant-travel/ui/components"
-import { buttonVariants } from "@voyant-travel/ui/components/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@voyant-travel/ui/components"
 import {
   BriefcaseBusiness,
   Calendar,
@@ -31,27 +21,22 @@ import { InlineCurrencyField } from "./inline-currency-field.js"
 import { InlineField } from "./inline-field.js"
 import { InlineLanguageField } from "./inline-language-field.js"
 import { InlineSelectField } from "./inline-select-field.js"
-import { initialsFrom, personDisplayName } from "./person-detail-panels.js"
-import type { PersonData, PersonOrganization } from "./person-detail-types.js"
+import type { PersonData } from "./person-detail-types.js"
 import { TagsEditor } from "./tags-editor.js"
 
 export interface PersonSidebarProps {
   person: PersonData
-  organization: PersonOrganization | null
-  onOrganizationOpen?: (organizationId: string) => void
   onUpdateField: (patch: UpdatePersonInput) => Promise<void>
   children?: ReactNode
 }
 
-export function PersonSidebar({
-  person,
-  organization,
-  onOrganizationOpen,
-  onUpdateField,
-  children,
-}: PersonSidebarProps) {
+/**
+ * About + Tags rail. The standalone profile card is gone — its avatar, badges,
+ * job title and organization link now live in `PersonHeader` — leaving this
+ * rail as the single place every person field is read and inline-edited.
+ */
+export function PersonSidebar({ person, onUpdateField, children }: PersonSidebarProps) {
   const messages = useCrmUiMessagesOrDefault()
-  const displayName = personDisplayName(person, messages.personCard.unnamed)
   const websiteHref = person.website
     ? person.website.startsWith("http")
       ? person.website
@@ -70,44 +55,7 @@ export function PersonSidebar({
   ]
 
   return (
-    <aside className="col-span-12 flex flex-col gap-4 lg:col-span-3">
-      <Card>
-        <CardContent className="flex flex-col items-center gap-3 text-center">
-          <Avatar className="size-20">
-            <AvatarFallback className="text-xl">{initialsFrom(displayName)}</AvatarFallback>
-          </Avatar>
-          <div className="flex max-w-full flex-col gap-1">
-            <h2 className="truncate text-lg font-semibold leading-tight">{displayName}</h2>
-            {person.jobTitle ? (
-              <p className="truncate text-sm text-muted-foreground">{person.jobTitle}</p>
-            ) : null}
-            {organization ? (
-              <button
-                type="button"
-                onClick={() => onOrganizationOpen?.(organization.id)}
-                className="truncate text-sm text-primary hover:underline"
-              >
-                {organization.name}
-              </button>
-            ) : null}
-          </div>
-          <div className="flex flex-wrap justify-center gap-1">
-            {person.relation ? (
-              <Badge variant="secondary">
-                {messages.common.relationTypeLabels[
-                  person.relation as keyof typeof messages.common.relationTypeLabels
-                ] ?? person.relation}
-              </Badge>
-            ) : null}
-            <Badge variant="outline">
-              {messages.common.recordStatusLabels[
-                person.status as keyof typeof messages.common.recordStatusLabels
-              ] ?? person.status}
-            </Badge>
-          </div>
-        </CardContent>
-      </Card>
-
+    <aside className="flex flex-col gap-6">
       <Card>
         <CardHeader className="pb-3">
           <CardTitle className="text-sm font-semibold">
@@ -150,6 +98,7 @@ export function PersonSidebar({
             icon={Globe}
             label={messages.personDetail.sidebar.fields.website}
             kind="url"
+            href={websiteHref}
             value={person.website}
             onSave={(next) => onUpdateField({ website: next })}
           />
@@ -193,18 +142,6 @@ export function PersonSidebar({
           />
         </CardContent>
       </Card>
-
-      {websiteHref ? (
-        <a
-          href={websiteHref}
-          target="_blank"
-          rel="noreferrer"
-          className={cn(buttonVariants({ variant: "outline" }))}
-        >
-          <Globe className="size-4" aria-hidden="true" />
-          {messages.personDetail.sidebar.openWebsite}
-        </a>
-      ) : null}
 
       <Card>
         <CardHeader className="pb-3">

--- a/packages/relationships-react/src/i18n/en/commerce.ts
+++ b/packages/relationships-react/src/i18n/en/commerce.ts
@@ -55,6 +55,7 @@ export const crmUiEnCommerceMessages = {
     searchLanguagePlaceholder: "Search language...",
     noLanguagesFound: "No languages found.",
     addTemplate: "Add {label}",
+    editTemplate: "Edit {label}",
     addTagPlaceholder: "Add tag...",
     tagAlreadyAdded: "Tag already added.",
     addTagFailed: "Failed to add tag.",

--- a/packages/relationships-react/src/i18n/en/detail.ts
+++ b/packages/relationships-react/src/i18n/en/detail.ts
@@ -5,7 +5,6 @@ export const crmUiEnDetailMessages = {
   },
   organizationDetail: {
     topBar: {
-      organizations: "Organizations",
       merge: "Merge",
       delete: "Delete",
       deleteTitle: "Delete this organization?",
@@ -73,7 +72,6 @@ export const crmUiEnDetailMessages = {
       addPerson: "Add person",
       addActivity: "Add activity",
     },
-    hint: "Hover a field to edit it.",
   },
   personDetailPage: {
     notFound: "Person not found",
@@ -81,7 +79,6 @@ export const crmUiEnDetailMessages = {
   },
   personDetail: {
     topBar: {
-      people: "People",
       edit: "Edit",
       merge: "Merge",
       delete: "Delete",
@@ -102,7 +99,6 @@ export const crmUiEnDetailMessages = {
     sidebar: {
       about: "About",
       tags: "Tags",
-      openWebsite: "Open website",
       fields: {
         firstName: "First name",
         lastName: "Last name",
@@ -231,7 +227,6 @@ export const crmUiEnDetailMessages = {
       noCommunications: "No communications.",
       noTravelProfile: "No travel profile data.",
     },
-    hint: "Hover a field to edit it.",
   },
   personDocument: {
     row: {

--- a/packages/relationships-react/src/i18n/messages.ts
+++ b/packages/relationships-react/src/i18n/messages.ts
@@ -299,6 +299,7 @@ export type CrmUiMessages = {
     searchLanguagePlaceholder: string
     noLanguagesFound: string
     addTemplate: string
+    editTemplate: string
     addTagPlaceholder: string
     tagAlreadyAdded: string
     addTagFailed: string
@@ -310,7 +311,6 @@ export type CrmUiMessages = {
   }
   organizationDetail: {
     topBar: {
-      organizations: string
       merge: string
       delete: string
       deleteTitle: string
@@ -377,7 +377,6 @@ export type CrmUiMessages = {
       addPerson: string
       addActivity: string
     }
-    hint: string
   }
   personDetailPage: {
     notFound: string
@@ -385,7 +384,6 @@ export type CrmUiMessages = {
   }
   personDetail: {
     topBar: {
-      people: string
       edit: string
       merge: string
       delete: string
@@ -405,7 +403,6 @@ export type CrmUiMessages = {
     sidebar: {
       about: string
       tags: string
-      openWebsite: string
       fields: {
         firstName: string
         lastName: string
@@ -535,7 +532,6 @@ export type CrmUiMessages = {
       noCommunications: string
       noTravelProfile: string
     }
-    hint: string
   }
   personDocument: {
     /** Row-level inline reveal panel + per-row action icons. */

--- a/packages/relationships-react/src/i18n/ro/commerce.ts
+++ b/packages/relationships-react/src/i18n/ro/commerce.ts
@@ -55,6 +55,7 @@ export const crmUiRoCommerceMessages = {
     searchLanguagePlaceholder: "Cauta limba...",
     noLanguagesFound: "Nu au fost gasite limbi.",
     addTemplate: "Adauga {label}",
+    editTemplate: "Editeaza {label}",
     addTagPlaceholder: "Adauga eticheta...",
     tagAlreadyAdded: "Eticheta este deja adaugata.",
     addTagFailed: "Adaugarea etichetei a esuat.",

--- a/packages/relationships-react/src/i18n/ro/detail.ts
+++ b/packages/relationships-react/src/i18n/ro/detail.ts
@@ -5,7 +5,6 @@ export const crmUiRoDetailMessages = {
   },
   organizationDetail: {
     topBar: {
-      organizations: "Organizatii",
       merge: "Uneste",
       delete: "Sterge",
       deleteTitle: "Stergi aceasta organizatie?",
@@ -73,7 +72,6 @@ export const crmUiRoDetailMessages = {
       addPerson: "Adauga persoana",
       addActivity: "Adauga activitate",
     },
-    hint: "Treci cu mouse-ul peste un camp pentru a-l edita.",
   },
   personDetailPage: {
     notFound: "Persoana nu a fost gasita",
@@ -81,7 +79,6 @@ export const crmUiRoDetailMessages = {
   },
   personDetail: {
     topBar: {
-      people: "Persoane",
       edit: "Editeaza",
       merge: "Uneste",
       delete: "Sterge",
@@ -102,7 +99,6 @@ export const crmUiRoDetailMessages = {
     sidebar: {
       about: "Despre",
       tags: "Etichete",
-      openWebsite: "Deschide website",
       fields: {
         firstName: "Prenume",
         lastName: "Nume",
@@ -231,7 +227,6 @@ export const crmUiRoDetailMessages = {
       noCommunications: "Nu exista comunicari.",
       noTravelProfile: "Nu exista date de profil de calatorie.",
     },
-    hint: "Treci cu mouse-ul peste un camp pentru a-l edita.",
   },
   personDocument: {
     row: {

--- a/packages/relationships-react/src/ui.ts
+++ b/packages/relationships-react/src/ui.ts
@@ -25,13 +25,13 @@ export {
   type OrganizationData,
   type OrganizationDetailPageSlots,
   type OrganizationDetailTab,
+  OrganizationHeader,
+  type OrganizationHeaderProps,
   OrganizationMain,
   type OrganizationMainProps,
   type OrganizationPerson,
   OrganizationSidebar,
   type OrganizationSidebarProps,
-  OrganizationTopBar,
-  type OrganizationTopBarProps,
 } from "./components/organization-detail-sections.js"
 export {
   OrganizationDialog,
@@ -84,6 +84,8 @@ export {
   type PersonDocument,
   PersonDocumentsPanel,
   type PersonDocumentsPanelProps,
+  PersonHeader,
+  type PersonHeaderProps,
   PersonMain,
   type PersonMainProps,
   type PersonOrganization,
@@ -94,8 +96,6 @@ export {
   type PersonRelationshipsPanelProps,
   PersonSidebar,
   type PersonSidebarProps,
-  PersonTopBar,
-  type PersonTopBarProps,
   type PersonTravelSnapshot,
   personDisplayName,
 } from "./components/person-detail-page.js"


### PR DESCRIPTION
The People and Organizations detail pages were built before the bookings/products page conventions settled, and had drifted from them in ways that read as layout bugs — duplicated headers, an overflowing website link, truncated field values, and inconsistent spacing.

This aligns both pages with the pattern used by the booking and product detail pages. Everything is in `packages/relationships-react` (the operator app owns no CRM page files — the routes are contributed as a packaged admin extension).

### What was wrong, and what changed

| Defect | Fix |
|---|---|
| Both pages rendered their own sticky top bar with a back arrow *and* an `Organizations / Name` breadcrumb, directly beneath the admin chrome's breadcrumb for the same record | `OrganizationTopBar`/`PersonTopBar` replaced by `OrganizationHeader`/`PersonHeader`, which render identity and actions only. `PersonDetailHost` never pushed breadcrumbs at all — it now does what the organization host already did |
| Page root was `flex min-h-screen flex-col` with `p-4 lg:p-6` on the body grid — viewport height plus a second layer of padding inside a shell that already supplies `px-4 py-6 md:px-6` | Root is `flex flex-col gap-6`; the shell owns page padding |
| Sidebar was `lg:col-span-3` of a 12-col grid, too narrow for its contents; `inline-field` hard-coded `truncate` on every value, so long names and URLs were silently cut. The website link had no width constraint and overflowed its card | Fixed 320px rail (`lg:grid-cols-[minmax(0,1fr)_320px]`) with `break-words` values; website moved into the header subtitle with `truncate` |
| A full-width row of two stat cards whose numbers already appear in the tab labels (`People (3)`, `Activities (1)`), in an uppercase label style used nowhere else | Removed |
| Tabs nested inside a `Card` via `CardHeader`/`CardContent` | Bare `Tabs`, `TabsList w-full justify-start`, per-panel `Card`s, `TabsContent` at `mt-4 flex flex-col gap-6` — matching booking detail |
| Overview rendered `notes` twice — read-only, then again as an inline editor | Editor only |
| "Hover a field to edit it." floated unattached below the card, and existed because the edit pencil is invisible until hover | Replaced with an `aria-label` and `focus-visible:opacity-100`, so the control is reachable by keyboard rather than merely explained |
| Both pending skeletons described a three-column layout the pages never had | Rewritten to mirror the real grid class-for-class |

### Deliberate non-changes

Name, legal name and job title stay in the About list even though the header now displays them. The header is read-only, and that list is the **only** inline editor for those fields — the organization page has no edit dialog, so removing them would make an organization unrenameable.

The website rows now receive `href`, which is what the person sidebar's separate "Open website" button was compensating for (the row rendered `kind="url"` as plain text without it).

The pre-existing unused `metrics` message block is left alone — it predates this change and is part of the exported message type.

### Verification

- `tsc -p tsconfig.build.json` — exit 0, 0 `error TS`
- `vitest run` — 14 passed / 2 files
- `biome check .` (repo-wide) — 0 errors, 22 warnings, 8 infos (baseline)
- `pnpm i18n:check` — exit 0, en+ro parity across 23 roots
- Operator booted locally against a seeded DB; `/organizations` and `/people` both serve 200

`@voyant-travel/relationships-react` is `private: true`, so no changeset.