### PR TITLE
fix(legal): make the admin record pickers show their options

### DIFF
--- a/.changeset/legal-admin-pickers-render-options.md
+++ b/.changeset/legal-admin-pickers-render-options.md
@@ -1,0 +1,19 @@
+---
+"@voyant-travel/legal-react": patch
+---
+
+Fix the legal admin record pickers so they render the records their list
+queries return.
+
+- The combobox told base-ui how to stringify an item for form submission but
+  not for display, so the typed query was matched against the raw record id
+  and every option was filtered out. Contract templates, people, suppliers,
+  channels and the policy-assignment product picker all reported "No results."
+  for records the API had just returned.
+- The `loading` guards ORed the list query's `isPending` with a detail query
+  that is disabled until a record is selected. A disabled query stays pending,
+  so a settled empty list read "Loading…" forever. Both terms now use
+  `isLoading`, which a disabled query never reports.
+- The channel pickers asked for `limit: 250` against an endpoint that caps the
+  page at 200, so every dialog open answered 400 and the picker had nothing to
+  show. Both call sites now use a shared `CHANNEL_PAGE_LIMIT` at the cap.

--- a/packages/legal-react/src/admin/contract-dialog.tsx
+++ b/packages/legal-react/src/admin/contract-dialog.tsx
@@ -63,7 +63,7 @@ import {
   VariableValueField,
 } from "./contract-dialog-fields.js"
 import { ContractUploadField } from "./contract-upload-field.js"
-import { mergeUniqueOptions, SearchableSelect } from "./legal-admin-shared.js"
+import { CHANNEL_PAGE_LIMIT, mergeUniqueOptions, SearchableSelect } from "./legal-admin-shared.js"
 
 export type { ContractDialogProps } from "./contract-dialog-fields.js"
 
@@ -185,7 +185,7 @@ export function ContractDialog({ open, onOpenChange, contract, onSuccess }: Cont
   const selectedSupplierQuery = useSupplier(selectedSupplierId ?? "", {
     enabled: open && !!selectedSupplierId,
   })
-  const channelsQuery = useChannels({ limit: 250, enabled: open })
+  const channelsQuery = useChannels({ limit: CHANNEL_PAGE_LIMIT, enabled: open })
   const selectedChannelQuery = useChannel(selectedChannelId, {
     enabled: open && !!selectedChannelId,
   })
@@ -665,7 +665,7 @@ export function ContractDialog({ open, onOpenChange, contract, onSuccess }: Cont
                     placeholder={t.templatePlaceholder}
                     searchPlaceholder={t.templateSearchPlaceholder}
                     emptyLabel={t.templateEmpty}
-                    loading={templateListQuery.isPending || selectedTemplateQuery.isPending}
+                    loading={templateListQuery.isLoading || selectedTemplateQuery.isLoading}
                     onSearchChange={setTemplateSearch}
                     loadingLabel={t.loading}
                   />
@@ -689,7 +689,7 @@ export function ContractDialog({ open, onOpenChange, contract, onSuccess }: Cont
                       templateId ? t.templateVersionEmpty : t.templateVersionPickTemplateFirst
                     }
                     loading={
-                      templateVersionsQuery.isPending || selectedTemplateVersionQuery.isPending
+                      templateVersionsQuery.isLoading || selectedTemplateVersionQuery.isLoading
                     }
                     disabled={!templateId}
                     loadingLabel={t.loading}
@@ -712,7 +712,7 @@ export function ContractDialog({ open, onOpenChange, contract, onSuccess }: Cont
                     placeholder={t.numberSeriesPlaceholder}
                     searchPlaceholder={t.numberSeriesSearchPlaceholder}
                     emptyLabel={t.numberSeriesEmpty}
-                    loading={numberSeriesQuery.isPending}
+                    loading={numberSeriesQuery.isLoading}
                     loadingLabel={t.loading}
                   />
                 </div>
@@ -750,7 +750,7 @@ export function ContractDialog({ open, onOpenChange, contract, onSuccess }: Cont
                     placeholder={t.personPlaceholder}
                     searchPlaceholder={t.personSearchPlaceholder}
                     emptyLabel={t.personEmpty}
-                    loading={peopleQuery.isPending || selectedPersonQuery.isPending}
+                    loading={peopleQuery.isLoading || selectedPersonQuery.isLoading}
                     onSearchChange={setPersonSearch}
                     loadingLabel={t.loading}
                   />
@@ -770,7 +770,7 @@ export function ContractDialog({ open, onOpenChange, contract, onSuccess }: Cont
                     placeholder={t.organizationPlaceholder}
                     searchPlaceholder={t.organizationSearchPlaceholder}
                     emptyLabel={t.organizationEmpty}
-                    loading={organizationsQuery.isPending}
+                    loading={organizationsQuery.isLoading}
                     onSearchChange={setOrganizationSearch}
                     loadingLabel={t.loading}
                   />
@@ -792,7 +792,7 @@ export function ContractDialog({ open, onOpenChange, contract, onSuccess }: Cont
                     placeholder={t.supplierPlaceholder}
                     searchPlaceholder={t.supplierSearchPlaceholder}
                     emptyLabel={t.supplierEmpty}
-                    loading={suppliersQuery.isPending || selectedSupplierQuery.isPending}
+                    loading={suppliersQuery.isLoading || selectedSupplierQuery.isLoading}
                     onSearchChange={setSupplierSearch}
                     loadingLabel={t.loading}
                   />
@@ -812,7 +812,7 @@ export function ContractDialog({ open, onOpenChange, contract, onSuccess }: Cont
                     placeholder={t.channelPlaceholder}
                     searchPlaceholder={t.channelSearchPlaceholder}
                     emptyLabel={t.channelEmpty}
-                    loading={channelsQuery.isPending || selectedChannelQuery.isPending}
+                    loading={channelsQuery.isLoading || selectedChannelQuery.isLoading}
                     loadingLabel={t.loading}
                   />
                 </div>

--- a/packages/legal-react/src/admin/legal-admin-shared.test.tsx
+++ b/packages/legal-react/src/admin/legal-admin-shared.test.tsx
@@ -1,0 +1,168 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query"
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { SearchableSelect } from "./legal-admin-shared.js"
+
+;(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true
+
+const OPTIONS = [
+  {
+    value: "prod_01kz996xesegnv4vd6aescjnhf",
+    label: "Santorini Caldera Sunset Sail",
+    description: "active / date",
+  },
+  { value: "prod_01kz996xesegnv4vd6aescjnhg", label: "Amalfi Coast Day Tour" },
+]
+
+function setNativeInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set
+  setter?.call(input, value)
+  input.dispatchEvent(new Event("input", { bubbles: true }))
+}
+
+describe("SearchableSelect", () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  async function openPopup() {
+    const trigger = document.querySelector<HTMLElement>('[aria-label="Open options"]')
+    if (!trigger) throw new Error("Expected the combobox trigger to render")
+    await act(async () => {
+      trigger.dispatchEvent(new MouseEvent("click", { bubbles: true }))
+    })
+
+    const input = container.querySelector<HTMLInputElement>("input")
+    if (!input) throw new Error("Expected the combobox input to render")
+    return input
+  }
+
+  async function renderSelect(props?: { loading?: boolean }) {
+    await act(async () => {
+      root.render(
+        <SearchableSelect
+          value={null}
+          onChange={vi.fn()}
+          options={OPTIONS}
+          placeholder="Product"
+          emptyLabel="No results."
+          loadingLabel="Loading…"
+          loading={props?.loading}
+        />,
+      )
+    })
+
+    return openPopup()
+  }
+
+  /**
+   * Regression: item values are record ids, so base-ui matched the typed query
+   * against `prod_01k…` and reported "No results." for a record the list query
+   * had just returned. Filtering reads `itemToStringLabel`, not
+   * `itemToStringValue`.
+   */
+  it("keeps an option whose label matches the typed query", async () => {
+    const input = await renderSelect()
+
+    await act(async () => {
+      setNativeInputValue(input, "Santorini")
+    })
+
+    expect(document.body.textContent).toContain("Santorini Caldera Sunset Sail")
+    expect(document.body.textContent).not.toContain("No results.")
+    expect(document.body.textContent).not.toContain("Amalfi Coast Day Tour")
+  })
+
+  it("drops options whose label does not match the typed query", async () => {
+    const input = await renderSelect()
+
+    await act(async () => {
+      setNativeInputValue(input, "Reykjavik")
+    })
+
+    expect(document.body.textContent).not.toContain("Santorini Caldera Sunset Sail")
+    expect(document.body.textContent).toContain("No results.")
+  })
+
+  it("shows the loading label instead of the empty label while loading", async () => {
+    const input = await renderSelect({ loading: true })
+
+    await act(async () => {
+      setNativeInputValue(input, "Reykjavik")
+    })
+
+    expect(document.body.textContent).toContain("Loading…")
+    expect(document.body.textContent).not.toContain("No results.")
+  })
+
+  /**
+   * Regression: the pickers pair a list query with a detail query for the
+   * selected record, and the detail query is disabled until something is
+   * selected. A disabled query stays `status: "pending"` for as long as it
+   * stays disabled, so `list.isPending || selected.isPending` was true on
+   * every fresh picker and a settled empty list read "Loading…" forever.
+   * `isLoading` is `isPending && isFetching`, which a disabled query is not.
+   */
+  it("reports an empty settled list as empty, not as loading", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+
+    function Picker() {
+      const listQuery = useQuery({
+        queryKey: ["products", "list"],
+        queryFn: async () => [] as typeof OPTIONS,
+      })
+      const selectedQuery = useQuery({
+        queryKey: ["products", "detail", null],
+        queryFn: async () => OPTIONS[0],
+        enabled: false,
+      })
+
+      return (
+        <SearchableSelect
+          value={null}
+          onChange={vi.fn()}
+          options={listQuery.data ?? []}
+          placeholder="Product"
+          emptyLabel="No results."
+          loadingLabel="Loading…"
+          loading={listQuery.isLoading || selectedQuery.isLoading}
+        />
+      )
+    }
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <Picker />
+        </QueryClientProvider>,
+      )
+    })
+    await act(async () => {
+      await queryClient.getQueryCache().find({ queryKey: ["products", "list"] })?.promise
+    })
+    await openPopup()
+
+    expect(document.body.textContent).toContain("No results.")
+    expect(document.body.textContent).not.toContain("Loading…")
+
+    queryClient.clear()
+  })
+})

--- a/packages/legal-react/src/admin/legal-admin-shared.tsx
+++ b/packages/legal-react/src/admin/legal-admin-shared.tsx
@@ -11,6 +11,13 @@ import {
 } from "@voyant-travel/ui/components/combobox"
 import { useEffect, useMemo, useState } from "react"
 
+/**
+ * Widest page `/v1/admin/distribution/channels` accepts. The channel pickers
+ * filter client-side because the endpoint exposes no `search`, so they ask for
+ * the cap; anything above it is rejected as `too_big` and the picker is empty.
+ */
+export const CHANNEL_PAGE_LIMIT = 200
+
 /** A searchable-select option: stable id + label, optional secondary line. */
 export interface ComboboxOption {
   value: string
@@ -83,6 +90,9 @@ export function SearchableSelect({
       inputValue={inputValue}
       autoHighlight
       disabled={disabled}
+      // base-ui matches the typed query against the item's *label* string, and
+      // filters everything out when it is left to stringify the raw id.
+      itemToStringLabel={(id) => optionMap.get(id as string)?.label ?? ""}
       itemToStringValue={(id) => optionMap.get(id as string)?.label ?? ""}
       onInputValueChange={(next) => {
         setInputValue(next)

--- a/packages/legal-react/src/admin/policy-assignment-dialog.tsx
+++ b/packages/legal-react/src/admin/policy-assignment-dialog.tsx
@@ -29,7 +29,7 @@ import { useForm } from "react-hook-form"
 import { z } from "zod/v4"
 import { type LegalPolicyAssignmentRecord, useLegalPolicyAssignmentMutation } from "../index.js"
 
-import { mergeUniqueOptions, SearchableSelect } from "./legal-admin-shared.js"
+import { CHANNEL_PAGE_LIMIT, mergeUniqueOptions, SearchableSelect } from "./legal-admin-shared.js"
 
 // Parity with the previous operator-local entity combobox, which showed a
 // hardcoded "No results." empty state; the loading label is localized via
@@ -339,7 +339,7 @@ function ProductPicker({ value, onChange, placeholder }: ScopedPickerProps) {
       searchPlaceholder={placeholder}
       emptyLabel={PICKER_EMPTY_LABEL}
       loadingLabel={loadingLabel}
-      loading={listQuery.isPending || (Boolean(value) && selectedQuery.isPending)}
+      loading={listQuery.isLoading || selectedQuery.isLoading}
       onSearchChange={setSearch}
     />
   )
@@ -347,9 +347,11 @@ function ProductPicker({ value, onChange, placeholder }: ScopedPickerProps) {
 
 function ChannelPicker({ value, onChange, placeholder }: ScopedPickerProps) {
   const loadingLabel = usePickerLoadingLabel()
-  // Channels expose no server-side search filter; load a wide page and let
-  // the combobox narrow client-side (same approach as the contract dialog).
-  const listQuery = useChannels({ limit: 250 })
+  // Channels expose no server-side search filter; load the widest page the
+  // endpoint allows and let the combobox narrow client-side (same approach as
+  // the contract dialog). 200 is the distribution list cap — asking for more
+  // is a 400 and an empty picker.
+  const listQuery = useChannels({ limit: CHANNEL_PAGE_LIMIT })
   const selectedQuery = useChannel(value, { enabled: Boolean(value) })
 
   const options = useMemo(() => {
@@ -382,7 +384,7 @@ function ChannelPicker({ value, onChange, placeholder }: ScopedPickerProps) {
       searchPlaceholder={placeholder}
       emptyLabel={PICKER_EMPTY_LABEL}
       loadingLabel={loadingLabel}
-      loading={listQuery.isPending || (Boolean(value) && selectedQuery.isPending)}
+      loading={listQuery.isLoading || selectedQuery.isLoading}
     />
   )
 }
@@ -423,7 +425,7 @@ function SupplierPicker({ value, onChange, placeholder }: ScopedPickerProps) {
       searchPlaceholder={placeholder}
       emptyLabel={PICKER_EMPTY_LABEL}
       loadingLabel={loadingLabel}
-      loading={listQuery.isPending || (Boolean(value) && selectedQuery.isPending)}
+      loading={listQuery.isLoading || selectedQuery.isLoading}
       onSearchChange={setSearch}
     />
   )
@@ -465,7 +467,7 @@ function MarketPicker({ value, onChange, placeholder }: ScopedPickerProps) {
       searchPlaceholder={placeholder}
       emptyLabel={PICKER_EMPTY_LABEL}
       loadingLabel={loadingLabel}
-      loading={listQuery.isPending || (Boolean(value) && selectedQuery.isPending)}
+      loading={listQuery.isLoading || selectedQuery.isLoading}
       onSearchChange={setSearch}
     />
   )
@@ -507,7 +509,7 @@ function OrganizationPicker({ value, onChange, placeholder }: ScopedPickerProps)
       searchPlaceholder={placeholder}
       emptyLabel={PICKER_EMPTY_LABEL}
       loadingLabel={loadingLabel}
-      loading={listQuery.isPending || (Boolean(value) && selectedQuery.isPending)}
+      loading={listQuery.isLoading || selectedQuery.isLoading}
       onSearchChange={setSearch}
     />
   )

--- a/packages/legal-react/src/components/contract-dialog-fields.tsx
+++ b/packages/legal-react/src/components/contract-dialog-fields.tsx
@@ -261,6 +261,9 @@ export function SearchableSelect({
       inputValue={inputValue}
       autoHighlight
       disabled={disabled}
+      // base-ui matches the typed query against the item's *label* string, and
+      // filters everything out when it is left to stringify the raw id.
+      itemToStringLabel={(id) => optionMap.get(id as string)?.label ?? ""}
       itemToStringValue={(id) => optionMap.get(id as string)?.label ?? ""}
       onInputValueChange={(next) => {
         setInputValue(next)

--- a/packages/legal-react/src/components/contract-dialog.tsx
+++ b/packages/legal-react/src/components/contract-dialog.tsx
@@ -551,7 +551,7 @@ export function ContractDialog({
                     placeholder={t.templatePlaceholder}
                     searchPlaceholder={t.templateSearchPlaceholder}
                     emptyLabel={t.templateEmpty}
-                    loading={templateListQuery.isPending || selectedTemplateQuery.isPending}
+                    loading={templateListQuery.isLoading || selectedTemplateQuery.isLoading}
                     onSearchChange={setTemplateSearch}
                     loadingLabel={t.loading}
                   />
@@ -575,7 +575,7 @@ export function ContractDialog({
                       templateId ? t.templateVersionEmpty : t.templateVersionPickTemplateFirst
                     }
                     loading={
-                      templateVersionsQuery.isPending || selectedTemplateVersionQuery.isPending
+                      templateVersionsQuery.isLoading || selectedTemplateVersionQuery.isLoading
                     }
                     disabled={!templateId}
                     loadingLabel={t.loading}
@@ -597,7 +597,7 @@ export function ContractDialog({
                   placeholder={t.numberSeriesPlaceholder}
                   searchPlaceholder={t.numberSeriesSearchPlaceholder}
                   emptyLabel={t.numberSeriesEmpty}
-                  loading={numberSeriesQuery.isPending}
+                  loading={numberSeriesQuery.isLoading}
                   loadingLabel={t.loading}
                 />
               </div>


### PR DESCRIPTION
Three filed bugs, all in the legal admin record pickers, all of which had to be
fixed together before a contract or a scoped policy assignment could be created.

Closes #4608, closes #4609, closes #4610.

## What was wrong

**The typed query was matched against the record id (#4610).** The comboboxes
pass `itemToStringValue` but not `itemToStringLabel`. base-ui uses the *label*
function for filtering and falls back to stringifying the item itself, and the
items are ids — so typing `Santorini` filtered `prod_01kz996x…` and every option
was dropped. `packages/ui/src/components/async-combobox.tsx` already documents
this and passes both.

**A disabled query is pending forever (#4608).** Every picker OR'd its list
query's `isPending` with a detail query that is disabled until a record is
selected. In TanStack Query v5 a disabled query sits at `status: "pending"` /
`fetchStatus: "idle"`, so on a fresh dialog the flag was permanently true.

**The channel page exceeded the endpoint's cap (#4609).** `useChannels({ limit:
250 })` against a list that caps `limit` at 200 — a 400 on every dialog open, so
the Channel picker had nothing to show whatever the other two did.

## One correction to #4608's write-up

`loading` only selects between the empty-state's two labels; it does not gate
the option list. So the permanent `isPending` did not hide the templates — the
id-filtering did — and what `isPending` contributed was labelling that empty
list `Loading…` instead of `No results.`, which is why the dialog read as stuck
rather than as empty. Both are real defects and both are fixed here; the
`itemToStringLabel` one is what actually unblocks contract creation.

## Changes

- `itemToStringLabel` on both `SearchableSelect` copies (`admin/`, `components/`).
- Every `loading` guard in the two dialogs uses `isLoading` — `isPending &&
  isFetching`, which a disabled query never is. This replaces the
  `Boolean(value) && selectedQuery.isPending` guard too: it worked, but it
  restated the `enabled` condition at a second site, which is the drift the
  issue asks to prevent.
- Both channel call sites share `CHANNEL_PAGE_LIMIT = 200`, commented with why
  the number is what it is.

## Verification

`packages/legal-react/src/admin/legal-admin-shared.test.tsx` drives the real
base-ui combobox in jsdom. Both regressions were confirmed red before the fix:
reverting `itemToStringLabel` makes the popup print `No results.` for a matching
label — the reported symptom exactly — and restoring `isPending` makes a settled
empty list print `Loading…`.

`vitest` (9 files / 29 tests), `biome check`, and `tsc` for the package are green.

## Follow-up, not fixed here

The same missing `itemToStringLabel` is in **29 other comboboxes** that map
items to ids — 15 in `commerce-react`, 8 in `inventory-react`, plus
`bookings-react`, `operations-react`, `finance-react`, `proposals-react` and
`ui`. Every one of them should report `No results.` for a record the server
returned as soon as the operator types. That is a mechanical sweep over other
packages' surfaces and wants its own issue rather than riding along here.
