### PR TITLE
Stop three admin screens reporting what is not true

### DIFF
--- a/.changeset/report-money-and-supplier-display.md
+++ b/.changeset/report-money-and-supplier-display.md
@@ -1,0 +1,20 @@
+---
+"@voyant-travel/reporting-contracts": minor
+"@voyant-travel/reporting": minor
+"@voyant-travel/reporting-react": minor
+"@voyant-travel/finance": minor
+"@voyant-travel/finance-react": minor
+"@voyant-travel/bookings": minor
+---
+
+Stop three admin screens from reporting something that is not true.
+
+A custom report widget summing a money column rendered `$351,533.00` on a row whose own grouping column said `EUR`. Two separate inventions: the renderer defaulted an absent currency to `USD`, and it attached a symbol and two decimals to an integer it had not scaled — the real balance was €3,515.33. Every money field these datasets expose is a `*Cents` measure with no major-unit alternative to select, so an unscaled currency format was wrong on all of them, and the symbol is what made it believable.
+
+A report column now carries the two presentation facts only the dataset that produced it can know — `minorUnit`, and the output column holding the row's ISO currency code — and Finance declares both. Where they are absent the amount is written as a plain number rather than borrowing a symbol from a default. This applies to the widget renderer and to PDF export, which had the same `|| "USD"` fallback.
+
+The same widget's header showed `Outstanding balance` for a column the query named `as owed`. Finance and Bookings now honour a selection's alias as its header. An alias that merely restates the field id is the query language's mandatory output name rather than a name the author chose, so those keep the dataset's own label and the preset widgets read as before.
+
+In the supplier invoice **Add allocation** dialog, the Departure picker returned an empty list until something was typed: its resolver closes over the chosen product, but the combobox only re-ran on the query, so it kept results resolved before a product existed. `AsyncCombobox` takes a `searchKey` for whatever else its resolver depends on, and drops stale options the moment it changes.
+
+Supplier invoices showed `supp_01kz…` where the supplier's name belongs, in the list column and the detail header. The name is resolved on read and the id stays available on hover.

--- a/packages/bookings/src/reporting.ts
+++ b/packages/bookings/src/reporting.ts
@@ -205,6 +205,17 @@ function compileQuery(
   }
 }
 
+/**
+ * The header a selection should carry. The query language requires an alias on
+ * every aggregate, so an alias that merely restates the field id is the DSL's
+ * mandatory output name and the dataset's own label still reads better; an alias
+ * that says something else is the author naming the column, and replacing it
+ * with a canned field label loses what they asked for.
+ */
+function outputLabel(alias: string | undefined, fallback: string, fieldId: string): string {
+  return alias && alias !== fieldId ? alias : fallback
+}
+
 function compileSelection(
   selection: ReportSelection,
   groups: ReadonlyMap<string, ReportQuery["groupBy"][number]>,
@@ -220,7 +231,7 @@ function compileSelection(
     }
     return {
       expression: compileGroupExpression(field, group?.timeGrain),
-      label: field.definition.label,
+      label: outputLabel(selection.as, field.definition.label, field.definition.id),
       valueType: group?.timeGrain ? "date" : field.definition.valueType,
     }
   }
@@ -241,7 +252,11 @@ function compileSelection(
   const expression = aggregateExpression(selection.operation, field.expression)
   return {
     expression,
-    label: `${aggregationLabel(selection.operation)} ${field.definition.label}`,
+    label: outputLabel(
+      selection.as,
+      `${aggregationLabel(selection.operation)} ${field.definition.label}`,
+      field.definition.id,
+    ),
     valueType:
       selection.operation === "count" || selection.operation === "countDistinct"
         ? "integer"

--- a/packages/finance-react/src/components/async-combobox.test.tsx
+++ b/packages/finance-react/src/components/async-combobox.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+
+import type * as ReactTypes from "react"
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+;(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true
+
+/**
+ * The primitive is reduced to the one thing under test: the option list the
+ * combobox is currently offering, by label.
+ */
+vi.mock("@voyant-travel/ui/components/combobox", () => ({
+  Combobox: ({
+    items,
+    itemToStringValue,
+    children,
+  }: {
+    items: readonly unknown[]
+    itemToStringValue: (value: unknown) => string
+    children?: ReactTypes.ReactNode
+  }) => (
+    <div>
+      <ul data-testid="options">
+        {items.map((value) => (
+          <li key={String(value)}>{itemToStringValue(value)}</li>
+        ))}
+      </ul>
+      {children}
+    </div>
+  ),
+  ComboboxCollection: () => null,
+  ComboboxContent: () => null,
+  ComboboxEmpty: () => null,
+  ComboboxInput: () => null,
+  ComboboxItem: () => null,
+  ComboboxList: () => null,
+}))
+
+import { AsyncCombobox, type AsyncComboboxOption } from "./async-combobox.js"
+
+/** Longer than the resolver debounce, so a settled list is what gets asserted. */
+const settle = () => act(async () => void (await new Promise((r) => setTimeout(r, 260))))
+
+function offeredLabels(container: HTMLElement): string[] {
+  return [...container.querySelectorAll("[data-testid='options'] li")].map((li) =>
+    li.textContent!.trim(),
+  )
+}
+
+const DEPARTURES: Record<string, AsyncComboboxOption[]> = {
+  prod_alpine: [
+    { value: "slot_1", label: "2026-08-09" },
+    { value: "slot_2", label: "2026-08-16" },
+  ],
+  prod_danube: [{ value: "slot_9", label: "2026-09-06" }],
+}
+
+describe("AsyncCombobox", () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  it("offers the unfiltered first page without anything being typed", async () => {
+    await act(async () => {
+      root.render(
+        <AsyncCombobox
+          value={null}
+          onChange={() => {}}
+          searchKey="prod_alpine"
+          search={(query) =>
+            Promise.resolve(
+              DEPARTURES.prod_alpine!.filter((o) => !query || o.label.includes(query)),
+            )
+          }
+        />,
+      )
+    })
+    await settle()
+
+    expect(offeredLabels(container)).toEqual(["2026-08-09", "2026-08-16"])
+  })
+
+  it("re-resolves when searchKey changes, without waiting for the user to type", async () => {
+    // A dependent picker: `search` closes over the parent selection, and its
+    // identity changes every render, so the query alone cannot say when the
+    // resolved list went stale.
+    const render = (productId: string) =>
+      root.render(
+        <AsyncCombobox
+          value={null}
+          onChange={() => {}}
+          searchKey={productId}
+          search={() => Promise.resolve(DEPARTURES[productId] ?? [])}
+        />,
+      )
+
+    await act(async () => render("prod_alpine"))
+    await settle()
+    expect(offeredLabels(container)).toEqual(["2026-08-09", "2026-08-16"])
+
+    await act(async () => render("prod_danube"))
+    // The previous product's departures are dropped immediately rather than
+    // being offered until the next resolve lands.
+    expect(offeredLabels(container)).toEqual([])
+
+    await settle()
+    expect(offeredLabels(container)).toEqual(["2026-09-06"])
+  })
+})

--- a/packages/finance-react/src/components/async-combobox.tsx
+++ b/packages/finance-react/src/components/async-combobox.tsx
@@ -31,6 +31,13 @@ export interface AsyncComboboxProps {
   /** Resolve options for a query (debounced). */
   search: (query: string) => Promise<AsyncComboboxOption[]>
   /**
+   * Opaque key for whatever else {@link search} depends on — a dependent
+   * picker's parent selection, say. `search` is re-run whenever it changes, so
+   * the list is not left holding results resolved against the previous value.
+   * Callers who pass a plain `search` do not need it.
+   */
+  searchKey?: string
+  /**
    * When set, an inline "create" row appears for the current query (unless it
    * exactly matches an existing option). Returns the new option to select, or
    * null to cancel.
@@ -56,6 +63,7 @@ export function AsyncCombobox({
   value,
   onChange,
   search,
+  searchKey,
   onCreate,
   createLabel,
   placeholder = "Search…", // i18n-literal-ok (generic fallback; callers pass localized copy)
@@ -69,13 +77,24 @@ export function AsyncCombobox({
   const [inputValue, setInputValue] = useState("")
   const [creating, setCreating] = useState(false)
 
+  // Options on screen were resolved against the previous `searchKey`; drop them
+  // as soon as it changes rather than offering them until the next resolve lands.
+  const [resolvedFor, setResolvedFor] = useState(searchKey)
+  if (resolvedFor !== searchKey) {
+    setResolvedFor(searchKey)
+    setOptions([])
+  }
+
   const onCreateRef = useRef(onCreate)
   onCreateRef.current = onCreate
 
-  // Latest search fn via ref so the debounce effect only re-runs on query.
+  // Latest search fn via ref so the debounce effect re-runs on the query and on
+  // `searchKey` only — callers pass an inline arrow, whose identity changes every
+  // render.
   const searchRef = useRef(search)
   searchRef.current = search
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: searchKey is the meaningful-change signal; the resolver it keys is read off searchRef so the effect doesn't re-fire on every render -- owner: finance-react
   useEffect(() => {
     let active = true
     const handle = setTimeout(() => {
@@ -98,7 +117,7 @@ export function AsyncCombobox({
       active = false
       clearTimeout(handle)
     }
-  }, [query])
+  }, [query, searchKey])
 
   // Reflect the selected value's label (or raw id) in the input.
   useEffect(() => {

--- a/packages/finance-react/src/components/supplier-invoice-detail-page.tsx
+++ b/packages/finance-react/src/components/supplier-invoice-detail-page.tsx
@@ -163,7 +163,9 @@ export function SupplierInvoiceDetailPage({
         <CardHeader className="flex flex-row items-start justify-between gap-2">
           <div>
             <CardTitle className="text-lg">{invoice.supplierInvoiceNo}</CardTitle>
-            <p className="text-sm text-muted-foreground">{invoice.supplierId}</p>
+            <p className="text-sm text-muted-foreground" title={invoice.supplierId}>
+              {invoice.supplierName ?? invoice.supplierId}
+            </p>
           </div>
           <div className="flex items-center gap-2">
             <Badge variant={STATUS_VARIANT[invoice.status]}>{statusLabels[invoice.status]}</Badge>

--- a/packages/finance-react/src/components/supplier-invoice-detail-page/dialogs.tsx
+++ b/packages/finance-react/src/components/supplier-invoice-detail-page/dialogs.tsx
@@ -297,6 +297,7 @@ export function AllocationDialog({
                   value={targetId || null}
                   onChange={(v) => setTargetId(v ?? "")}
                   disabled={!productId}
+                  searchKey={productId}
                   search={(query) =>
                     productId
                       ? (listDeparturesForProduct?.(productId, query) ?? Promise.resolve([]))

--- a/packages/finance-react/src/components/supplier-invoice-form-dialog.tsx
+++ b/packages/finance-react/src/components/supplier-invoice-form-dialog.tsx
@@ -354,9 +354,9 @@ export function SupplierInvoiceFormDialog({
               {listDeparturesForProduct ? (
                 <Field label={t.departure} className="col-span-2">
                   <AsyncCombobox
-                    // Remount when the product changes so stale departures from
-                    // the previous product can't be offered/selected.
-                    key={form.productId || "no-product"}
+                    // Re-resolve when the product changes so stale departures
+                    // from the previous product can't be offered/selected.
+                    searchKey={form.productId}
                     value={form.departureId || null}
                     onChange={(v) => set({ departureId: v ?? "" })}
                     disabled={!form.productId}

--- a/packages/finance-react/src/components/supplier-invoices-page.tsx
+++ b/packages/finance-react/src/components/supplier-invoices-page.tsx
@@ -243,7 +243,9 @@ export function SupplierInvoicesPage({
                   }
                 >
                   <TableCell className="font-medium">{invoice.supplierInvoiceNo}</TableCell>
-                  <TableCell className="text-muted-foreground">{invoice.supplierId}</TableCell>
+                  <TableCell className="text-muted-foreground" title={invoice.supplierId}>
+                    {invoice.supplierName ?? invoice.supplierId}
+                  </TableCell>
                   <TableCell>
                     <Badge variant={STATUS_VARIANT[invoice.status]}>
                       {t.statusLabels[invoice.status]}

--- a/packages/finance-react/src/schemas/supplier.ts
+++ b/packages/finance-react/src/schemas/supplier.ts
@@ -73,6 +73,8 @@ export type SupplierCostAllocationRecord = z.infer<typeof supplierCostAllocation
 export const supplierInvoiceRecordSchema = z.object({
   id: z.string(),
   supplierId: z.string(),
+  /** Resolved supplier display name; `null` when the id resolves to nothing. */
+  supplierName: z.string().nullable().optional(),
   supplierInvoiceNo: z.string(),
   internalRef: z.string().nullable(),
   status: supplierInvoiceStatusSchema,

--- a/packages/finance/openapi/admin/finance.json
+++ b/packages/finance/openapi/admin/finance.json
@@ -31672,6 +31672,12 @@
                           "supplierId": {
                             "type": "string"
                           },
+                          "supplierName": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
                           "supplierInvoiceNo": {
                             "type": "string"
                           },
@@ -31820,6 +31826,7 @@
                         "required": [
                           "id",
                           "supplierId",
+                          "supplierName",
                           "supplierInvoiceNo",
                           "internalRef",
                           "status",
@@ -32158,6 +32165,12 @@
                         "supplierId": {
                           "type": "string"
                         },
+                        "supplierName": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
                         "supplierInvoiceNo": {
                           "type": "string"
                         },
@@ -32498,6 +32511,7 @@
                       "required": [
                         "id",
                         "supplierId",
+                        "supplierName",
                         "supplierInvoiceNo",
                         "internalRef",
                         "status",
@@ -32637,6 +32651,12 @@
                         "supplierId": {
                           "type": "string"
                         },
+                        "supplierName": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
                         "supplierInvoiceNo": {
                           "type": "string"
                         },
@@ -32977,6 +32997,7 @@
                       "required": [
                         "id",
                         "supplierId",
+                        "supplierName",
                         "supplierInvoiceNo",
                         "internalRef",
                         "status",
@@ -33199,6 +33220,12 @@
                         "supplierId": {
                           "type": "string"
                         },
+                        "supplierName": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
                         "supplierInvoiceNo": {
                           "type": "string"
                         },
@@ -33539,6 +33566,7 @@
                       "required": [
                         "id",
                         "supplierId",
+                        "supplierName",
                         "supplierInvoiceNo",
                         "internalRef",
                         "status",
@@ -33826,6 +33854,12 @@
                         "supplierId": {
                           "type": "string"
                         },
+                        "supplierName": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
                         "supplierInvoiceNo": {
                           "type": "string"
                         },
@@ -34166,6 +34200,7 @@
                       "required": [
                         "id",
                         "supplierId",
+                        "supplierName",
                         "supplierInvoiceNo",
                         "internalRef",
                         "status",
@@ -34397,6 +34432,12 @@
                         "supplierId": {
                           "type": "string"
                         },
+                        "supplierName": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
                         "supplierInvoiceNo": {
                           "type": "string"
                         },
@@ -34737,6 +34778,7 @@
                       "required": [
                         "id",
                         "supplierId",
+                        "supplierName",
                         "supplierInvoiceNo",
                         "internalRef",
                         "status",

--- a/packages/finance/src/reporting.ts
+++ b/packages/finance/src/reporting.ts
@@ -216,6 +216,15 @@ export function compileFinanceReceivablesQuery(input: ReportDatasetExecutionInpu
     groups.set(group.field, group)
   }
 
+  // The output column that carries each row's ISO currency code, when the query
+  // selects one. Money measures are denominated by it; without it in the result
+  // there is no currency to render with.
+  const currencySelection = query.select.find(
+    (selection) => selection.kind === "field" && selection.field === "currency",
+  )
+  const currencyField =
+    currencySelection?.kind === "field" ? (currencySelection.as ?? "currency") : undefined
+
   const aggregateQuery = query.select.some((selection) => selection.kind === "aggregate")
   const selections = query.select.map((selection): CompiledSelection => {
     if (selection.kind === "field") {
@@ -230,7 +239,12 @@ export function compileFinanceReceivablesQuery(input: ReportDatasetExecutionInpu
         id,
         field,
         expression: groupExpression(field.id, groups.get(field.id)?.timeGrain),
-        column: { id, label: field.label, valueType: field.valueType },
+        column: {
+          id,
+          label: outputLabel(selection.as, field),
+          valueType: field.valueType,
+          ...moneyPresentation(field.valueType, currencyField),
+        },
       }
     }
 
@@ -263,17 +277,19 @@ export function compileFinanceReceivablesQuery(input: ReportDatasetExecutionInpu
         : selection.operation === "countDistinct"
           ? sql`count(DISTINCT ${fieldExpression(field?.id ?? "")})::bigint`
           : sql`coalesce(sum(${fieldExpression(field?.id ?? "")}), 0)::bigint`
+    const valueType =
+      selection.operation === "count" || selection.operation === "countDistinct"
+        ? "integer"
+        : (field?.valueType ?? "number")
     return {
       id: selection.as,
       field,
       expression,
       column: {
         id: selection.as,
-        label: field?.label ?? "Count",
-        valueType:
-          selection.operation === "count" || selection.operation === "countDistinct"
-            ? "integer"
-            : (field?.valueType ?? "number"),
+        label: field ? outputLabel(selection.as, field) : "Count",
+        valueType,
+        ...moneyPresentation(valueType, currencyField),
       },
     }
   })
@@ -363,6 +379,31 @@ export const financeReceivablesDataset: ReportDatasetContribution = {
       warnings: [],
     }
   },
+}
+
+/**
+ * The header a selection should carry. The query language requires an alias on
+ * every aggregate, so an alias that merely restates the field id is the DSL's
+ * mandatory output name and the dataset's own label still reads better; an alias
+ * that says something else is the author naming the column, and replacing it
+ * with a canned field label loses what they asked for.
+ */
+function outputLabel(alias: string | undefined, field: ReportDatasetField): string {
+  return alias && alias !== field.id ? alias : field.label
+}
+
+/**
+ * Every money field in this dataset is a `*Cents` measure in the document
+ * currency — there is no major-unit alternative to select — so a currency column
+ * is always minor-unit, and is denominated by the currency dimension whenever
+ * the query selects it.
+ */
+function moneyPresentation(
+  valueType: ReportDatasetField["valueType"],
+  currencyField: string | undefined,
+): { minorUnit?: true; currencyField?: string } {
+  if (valueType !== "currency") return {}
+  return { minorUnit: true, ...(currencyField ? { currencyField } : {}) }
 }
 
 function requireField(

--- a/packages/finance/src/routes-supplier-invoices.ts
+++ b/packages/finance/src/routes-supplier-invoices.ts
@@ -118,6 +118,13 @@ const paymentStatusValues = ["pending", "completed", "failed", "refunded"] as co
 const supplierInvoiceSchema = z.object({
   id: z.string(),
   supplierId: z.string(),
+  /**
+   * Joined in on read from the suppliers module. `null` when the id resolves to
+   * nothing — a supplier deleted since, or a deployment without the suppliers
+   * module — so the caller can fall back to the id rather than render an empty
+   * cell.
+   */
+  supplierName: z.string().nullable(),
   supplierInvoiceNo: z.string(),
   internalRef: z.string().nullable(),
   status: z.enum(supplierInvoiceStatusValues),

--- a/packages/finance/src/service-supplier-invoices.ts
+++ b/packages/finance/src/service-supplier-invoices.ts
@@ -519,13 +519,60 @@ async function loadSupplierInvoice(db: PostgresJsDatabase, id: string) {
       .where(eq(supplierCostAllocations.supplierInvoiceId, id))
       .orderBy(asc(supplierCostAllocations.createdAt)),
   ])
-  const targetLabels = await resolveAllocationTargetLabels(db, allocations)
+  const [targetLabels, supplierNames] = await Promise.all([
+    resolveAllocationTargetLabels(db, allocations),
+    resolveSupplierNames(db, [invoice.supplierId]),
+  ])
   const allocationsWithLabels = allocations.map((a) => ({
     ...a,
     targetLabel:
       targetLabels.get(a.departureId ?? a.productId ?? a.bookingId ?? a.travelerId ?? "") ?? null,
   }))
-  return { ...invoice, lines, allocations: allocationsWithLabels }
+  return {
+    ...invoice,
+    supplierName: supplierNames.get(invoice.supplierId) ?? null,
+    lines,
+    allocations: allocationsWithLabels,
+  }
+}
+
+/**
+ * Resolve supplier display names for AP reads. The invoice stores only the
+ * supplier's id (a loose text reference, no cross-package FK — see
+ * `useSupplierPicker`), so every read that shows an invoice has to join the name
+ * back or the screen shows a ULID. Read-only, ids parameter-bound, and tolerant
+ * of a deployment whose graph does not include the suppliers module at all — the
+ * same shape as {@link resolveAllocationTargetLabels}.
+ */
+export async function resolveSupplierNames(
+  db: PostgresJsDatabase,
+  supplierIds: ReadonlyArray<string | null>,
+): Promise<Map<string, string>> {
+  const names = new Map<string, string>()
+  const ids = [...new Set(supplierIds.filter((id): id is string => Boolean(id)))]
+  if (ids.length === 0) return names
+
+  const tableResult = await db.execute(sql`
+    SELECT EXISTS (
+      SELECT 1
+      FROM information_schema.tables
+      WHERE table_schema = 'public'
+        AND table_name = 'suppliers'
+    ) AS table_exists
+  `)
+  if (!toRows<{ table_exists: boolean }>(tableResult)[0]?.table_exists) return names
+
+  const rows = await executeBoundaryRows<{ id: string; name: string | null }>(
+    db,
+    // agent-quality: raw-sql reviewed -- owner: finance; Supplier is a read-only display-name source and ids are parameter-bound.
+    sql`
+      SELECT id, name
+      FROM suppliers
+      WHERE id IN (${sqlList(ids)})
+    `,
+  )
+  for (const row of rows) if (row.name) names.set(row.id, row.name)
+  return names
 }
 
 /** Resolve friendly labels for allocation targets (departure date+product, product, booking no). */
@@ -652,8 +699,16 @@ export const supplierInvoicesService = {
       db.select({ count: sql<number>`count(*)::int` }).from(supplierInvoices).where(where),
     ])
 
+    const supplierNames = await resolveSupplierNames(
+      db,
+      rows.map((row) => row.supplierId),
+    )
+
     return {
-      data: rows,
+      data: rows.map((row) => ({
+        ...row,
+        supplierName: supplierNames.get(row.supplierId) ?? null,
+      })),
       total: countResult[0]?.count ?? 0,
       limit: query.limit,
       offset: query.offset,

--- a/packages/finance/tests/unit/reporting.test.ts
+++ b/packages/finance/tests/unit/reporting.test.ts
@@ -153,6 +153,82 @@ describe("Finance receivables query compiler", () => {
     ).toThrow(FinanceReportingQueryError)
   })
 
+  it("names an output column after the author's alias, keeping the field label for a restated one", () => {
+    const compiled = compileFinanceReceivablesQuery({
+      query: {
+        ...groupedOutstandingQuery,
+        select: [
+          { kind: "field", field: "currency" },
+          {
+            kind: "aggregate",
+            operation: "sum",
+            field: "outstandingBalanceCents",
+            as: "owed",
+          },
+        ],
+        orderBy: [],
+      },
+      parameters: {},
+      maximumRows: 100,
+    })
+
+    expect(compiled.columns).toEqual([
+      { id: "currency", label: "Document currency", valueType: "string" },
+      {
+        id: "owed",
+        label: "owed",
+        valueType: "currency",
+        minorUnit: true,
+        currencyField: "currency",
+      },
+    ])
+
+    // The query language requires an alias on every aggregate, so one that
+    // restates the field id is not a name the author chose.
+    expect(
+      compileFinanceReceivablesQuery({
+        query: groupedOutstandingQuery,
+        parameters: {},
+        maximumRows: 100,
+      }).columns.at(-1),
+    ).toMatchObject({ id: "outstandingBalanceCents", label: "Outstanding balance" })
+  })
+
+  it("declares money columns as minor-unit, and names their currency column only when selected", () => {
+    const withoutCurrency = compileFinanceReceivablesQuery({
+      query: {
+        ...groupedOutstandingQuery,
+        select: [
+          {
+            kind: "aggregate",
+            operation: "sum",
+            field: "outstandingBalanceCents",
+            as: "outstandingBalanceCents",
+          },
+        ],
+        filters: [
+          { field: "currency", operator: "equal", value: { kind: "literal", value: "EUR" } },
+        ],
+        groupBy: [],
+        orderBy: [],
+      },
+      parameters: {},
+      maximumRows: 100,
+    })
+
+    // Filtered to one currency, so no currency column comes back in the result:
+    // the scale is still known, the denomination is not, and it is left absent
+    // rather than guessed.
+    expect(withoutCurrency.columns).toEqual([
+      {
+        id: "outstandingBalanceCents",
+        label: "Outstanding balance",
+        valueType: "currency",
+        minorUnit: true,
+      },
+    ])
+  })
+
   it("rejects filters with missing parameter values", () => {
     expect(() =>
       compileFinanceReceivablesQuery({

--- a/packages/finance/tests/unit/service-supplier-invoices.test.ts
+++ b/packages/finance/tests/unit/service-supplier-invoices.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import {
   nextStatusForBalance,
   recomputeTotalsFromLines,
+  resolveSupplierNames,
   SupplierInvoiceServiceError,
   supplierInvoicesService,
   validateAllocations,
@@ -287,5 +288,59 @@ describe("nextStatusForBalance (§5.4 settlement flow)", () => {
 
   it("leaves a zero-total invoice with no payments unchanged", () => {
     expect(nextStatusForBalance("received", 0, 0)).toBe("received")
+  })
+})
+
+describe("resolveSupplierNames (AP read-side display)", () => {
+  it("maps ids to names, and reports the unresolvable ones as absent", async () => {
+    const statements: string[] = []
+    const db = {
+      execute: async (query: { queryChunks?: unknown[] }) => {
+        statements.push(JSON.stringify(query.queryChunks ?? query))
+        return statements.length === 1
+          ? [{ table_exists: true }]
+          : [
+              { id: "supp_alpen", name: "Alpenroute Chauffeur GmbH" },
+              // A supplier row that exists but was never named.
+              { id: "supp_blank", name: null },
+            ]
+      },
+    }
+
+    const names = await resolveSupplierNames(db as never, [
+      "supp_alpen",
+      "supp_blank",
+      "supp_gone",
+      "supp_alpen",
+      null,
+    ])
+
+    expect(names.get("supp_alpen")).toBe("Alpenroute Chauffeur GmbH")
+    expect(names.has("supp_blank")).toBe(false)
+    expect(names.has("supp_gone")).toBe(false)
+  })
+
+  it("degrades to no names on a deployment without the suppliers module", async () => {
+    let calls = 0
+    const db = {
+      execute: async () => {
+        calls += 1
+        return [{ table_exists: false }]
+      },
+    }
+
+    await expect(resolveSupplierNames(db as never, ["supp_alpen"])).resolves.toEqual(new Map())
+    // The existence probe is the only statement: no query is run against a
+    // table that is not there.
+    expect(calls).toBe(1)
+  })
+
+  it("does not touch the database when there is nothing to resolve", async () => {
+    const db = {
+      execute: async () => {
+        throw new Error("should not query")
+      },
+    }
+    await expect(resolveSupplierNames(db as never, [null, null])).resolves.toEqual(new Map())
   })
 })

--- a/packages/reporting-contracts/src/contracts.ts
+++ b/packages/reporting-contracts/src/contracts.ts
@@ -171,6 +171,20 @@ export const reportColumnSchema = z
     id: reportingIdentifierSchema,
     label: z.string().trim().min(1).max(160),
     valueType: reportFieldValueTypeSchema,
+    // Presentation facts about a `currency` column that only the dataset that
+    // produced it can know. A renderer has the value and the value type; it has
+    // no way to tell whether 351533 is a balance of 351,533 or of 3,515.33, and
+    // no way to tell which currency the row is denominated in. Without both, the
+    // honest rendering is a plain number — a symbol picked from a default is a
+    // number that reads as an amount it is not.
+    /** The column's values are in minor units and must be scaled to display. */
+    minorUnit: z.boolean().optional(),
+    /**
+     * Output column of the same result carrying this column's ISO currency code.
+     * Only set when the query actually selects it, so it is absent rather than
+     * guessed.
+     */
+    currencyField: reportingIdentifierSchema.optional(),
   })
   .strict()
 export const reportResultSchema = z

--- a/packages/reporting-react/src/admin/renderers/format.test.ts
+++ b/packages/reporting-react/src/admin/renderers/format.test.ts
@@ -29,6 +29,15 @@ describe("formatReportValue", () => {
     ).toContain("123.45")
   })
 
+  it("never invents a currency symbol when none was declared", () => {
+    // 351533 minor units is a balance of 3,515.33 — rendering "$351,533.00" is
+    // wrong twice over, and the symbol is what makes it believable.
+    expect(formatReportValue(351_533, "currency", { locale: "en-US" })).toBe("351,533")
+    expect(formatReportValue(351_533, "currency", { locale: "en-US", minorUnit: true })).toBe(
+      "3,515.33",
+    )
+  })
+
   it("formats booleans, dates, and json", () => {
     expect(formatReportValue(true, "boolean")).toBe("Yes")
     expect(formatReportValue(false, "boolean")).toBe("No")

--- a/packages/reporting-react/src/admin/renderers/format.ts
+++ b/packages/reporting-react/src/admin/renderers/format.ts
@@ -16,8 +16,11 @@ export interface FormatOptions {
 
 /**
  * Format a raw report cell value for display, keyed by its declared field value
- * type. Deliberately dataset-semantics-neutral: it never rescales values (e.g.
- * it does not assume currency is stored in minor units), it only presents them.
+ * type. Deliberately dataset-semantics-neutral: it never decides on its own that
+ * a value is in minor units or what currency it is in — the caller passes what
+ * the dataset declared. A currency value with no declared currency is formatted
+ * as a plain number rather than borrowing a symbol from a default, because a
+ * symbol makes an amount believable and this one would not be true.
  */
 export function formatReportValue(
   value: unknown,
@@ -25,7 +28,7 @@ export function formatReportValue(
   options: FormatOptions = {},
 ): string {
   if (value === null || value === undefined) return "—"
-  const { locale, currency = "USD", minorUnit = false, timeZone } = options
+  const { locale, currency, minorUnit = false, timeZone } = options
 
   switch (valueType) {
     case "integer":
@@ -36,9 +39,14 @@ export function formatReportValue(
     case "currency": {
       const numeric = toNumber(value)
       if (numeric === undefined) return String(value)
-      return new Intl.NumberFormat(locale, { style: "currency", currency }).format(
-        minorUnit ? numeric / 100 : numeric,
-      )
+      const amount = minorUnit ? numeric / 100 : numeric
+      if (!currency) {
+        return new Intl.NumberFormat(
+          locale,
+          minorUnit ? { minimumFractionDigits: 2, maximumFractionDigits: 2 } : {},
+        ).format(amount)
+      }
+      return new Intl.NumberFormat(locale, { style: "currency", currency }).format(amount)
     }
     case "boolean":
       return value ? "Yes" : "No"

--- a/packages/reporting-react/src/admin/renderers/report-renderer.tsx
+++ b/packages/reporting-react/src/admin/renderers/report-renderer.tsx
@@ -115,11 +115,7 @@ function KpiView({
   if (!valueColumn) return <p className="text-muted-foreground text-sm">No value to display.</p>
   const row = result.rows[0] ?? {}
   const raw = row[valueColumn.id]
-  const currencyField = readFirstString(options, "currencyField")
-  const rowFormat = {
-    ...format,
-    currency: readString(currencyField ? row[currencyField] : undefined) ?? format.currency,
-  }
+  const rowFormat = cellFormat(valueColumn, row, format, readFirstString(options, "currencyField"))
   return (
     <Card size="sm" className="h-full">
       <CardHeader>
@@ -159,11 +155,11 @@ function TableView({
           <TableRow key={rowIndex}>
             {result.columns.map((column) => (
               <TableCell key={column.id}>
-                {formatReportValue(row[column.id], column.valueType, {
-                  ...format,
-                  currency:
-                    readString(currencyField ? row[currencyField] : undefined) ?? format.currency,
-                })}
+                {formatReportValue(
+                  row[column.id],
+                  column.valueType,
+                  cellFormat(column, row, format, currencyField),
+                )}
               </TableCell>
             ))}
           </TableRow>
@@ -226,7 +222,7 @@ function SeriesChart({
         keysByLabel.set(seriesLabel, seriesKey)
       }
       const point = pointsByCategory.get(category) ?? { [categoryColumn.id]: category }
-      point[seriesKey] = chartNumber(row[valueColumn.id], valueColumn.valueType, format)
+      point[seriesKey] = chartNumber(row[valueColumn.id], valueColumn, format)
       pointsByCategory.set(category, point)
     }
     chartSeriesColumns = [...keysByLabel].map(([label, id]) => ({
@@ -245,7 +241,7 @@ function SeriesChart({
         ),
       }
       for (const column of chartSeriesColumns) {
-        point[column.id] = chartNumber(row[column.id], column.valueType, format)
+        point[column.id] = chartNumber(row[column.id], column, format)
       }
       return point
     })
@@ -320,7 +316,7 @@ function PieView({
 
   const data = result.rows.map((row, index) => ({
     name: formatReportValue(row[categoryColumn.id], categoryColumn.valueType, format),
-    value: chartNumber(row[valueColumn.id], valueColumn.valueType, format),
+    value: chartNumber(row[valueColumn.id], valueColumn, format),
     fill: CHART_COLORS[index % CHART_COLORS.length],
   }))
 
@@ -340,6 +336,26 @@ function PieView({
       </PieChart>
     </ChartContainer>
   )
+}
+
+/**
+ * Presentation options for one cell. The widget's own options win where the
+ * author set them; otherwise the column's declaration from its dataset is used,
+ * so a custom widget that never opened the inspector still renders money at the
+ * right scale and in the currency its own result reports.
+ */
+function cellFormat(
+  column: ReportColumn,
+  row: Record<string, unknown>,
+  format: FormatOptions,
+  optionCurrencyField: string | undefined,
+): FormatOptions {
+  const currencyField = optionCurrencyField ?? column.currencyField
+  return {
+    ...format,
+    minorUnit: format.minorUnit ?? column.minorUnit,
+    currency: readString(currencyField ? row[currencyField] : undefined) ?? format.currency,
+  }
 }
 
 function findColumn(result: ReportResult, id: string | undefined): ReportColumn | undefined {
@@ -390,11 +406,8 @@ function optionalArray(value: string | undefined): string[] | undefined {
   return value ? [value] : undefined
 }
 
-function chartNumber(
-  value: unknown,
-  valueType: ReportFieldValueType,
-  format: FormatOptions,
-): number {
+function chartNumber(value: unknown, column: ReportColumn, format: FormatOptions): number {
   const numeric = toNumber(value) ?? 0
-  return valueType === "currency" && format.minorUnit ? numeric / 100 : numeric
+  const minorUnit = format.minorUnit ?? column.minorUnit
+  return column.valueType === "currency" && minorUnit ? numeric / 100 : numeric
 }

--- a/packages/reporting/src/export.ts
+++ b/packages/reporting/src/export.ts
@@ -29,10 +29,16 @@ function cellText(value: unknown): string {
 type ExportColumn = ReportExportSection["columns"][number]
 type ExportFormat = ReportExportSection["format"]
 
-function toMajorUnits(value: unknown, format: ExportFormat): number | null {
+/**
+ * Scale a money cell to major units. The widget's own option wins where the
+ * author set it; otherwise the column's declaration from its dataset is used, so
+ * a custom widget that never opened the inspector still exports at the right
+ * scale.
+ */
+function toMajorUnits(value: unknown, column: ExportColumn, format: ExportFormat): number | null {
   const numeric = typeof value === "number" ? value : Number(value)
   if (!Number.isFinite(numeric)) return null
-  return format?.minorUnit ? numeric / 100 : numeric
+  return (format?.minorUnit ?? column.minorUnit) ? numeric / 100 : numeric
 }
 
 /**
@@ -46,14 +52,19 @@ function numericCell(
   format: ExportFormat,
 ): number | boolean | string {
   if (column.valueType === "currency") {
-    const major = toMajorUnits(value, format)
+    const major = toMajorUnits(value, column, format)
     return major ?? cellText(value)
   }
   if (typeof value === "number" || typeof value === "boolean") return value
   return cellText(value)
 }
 
-/** Presentation cell (PDF): currency formatted with the row's own currency symbol. */
+/**
+ * Presentation cell (PDF): currency formatted with the row's own currency
+ * symbol. When neither the widget nor the column says which currency the row is
+ * in, the amount is written as a plain number — a symbol borrowed from a default
+ * would make it read as an amount it is not.
+ */
 function displayCell(
   value: unknown,
   column: ExportColumn,
@@ -62,10 +73,12 @@ function displayCell(
 ): string {
   if (value === null || value === undefined) return ""
   if (column.valueType === "currency") {
-    const major = toMajorUnits(value, format)
+    const major = toMajorUnits(value, column, format)
     if (major === null) return cellText(value)
-    const perRow = format?.currencyField ? row[format.currencyField] : undefined
-    const currency = (typeof perRow === "string" && perRow) || format?.currency || "USD"
+    const currencyField = format?.currencyField ?? column.currencyField
+    const perRow = currencyField ? row[currencyField] : undefined
+    const currency = (typeof perRow === "string" && perRow) || format?.currency
+    if (!currency) return major.toLocaleString("en-US")
     try {
       return new Intl.NumberFormat("en-US", { style: "currency", currency }).format(major)
     } catch {

--- a/packages/reporting/src/service.ts
+++ b/packages/reporting/src/service.ts
@@ -156,7 +156,7 @@ export function createReportingService(registry: ReportingRegistry) {
             columns: result.columns,
             rows: result.rows,
             format: {
-              minorUnit: options.minorUnit === true,
+              minorUnit: typeof options.minorUnit === "boolean" ? options.minorUnit : undefined,
               currencyField:
                 typeof options.currencyField === "string" ? options.currencyField : undefined,
               currency: typeof options.currency === "string" ? options.currency : undefined,
@@ -178,8 +178,12 @@ export function createReportingService(registry: ReportingRegistry) {
 
 /** Presentation hints carried from a widget's visualization options into export. */
 export interface ReportExportSectionFormat {
-  /** Currency values are stored in minor units (cents) and must be divided by 100. */
-  readonly minorUnit: boolean
+  /**
+   * Currency values are stored in minor units (cents) and must be divided by
+   * 100. Absent when the widget does not say, in which case each column's own
+   * dataset-declared scale applies.
+   */
+  readonly minorUnit?: boolean
   /** Column whose value holds the ISO currency code for each row. */
   readonly currencyField?: string
   /** Fallback ISO currency when a row has no {@link currencyField}. */
@@ -189,7 +193,15 @@ export interface ReportExportSectionFormat {
 /** A single widget's tabular data within an exported report. */
 export interface ReportExportSection {
   readonly title: string
-  readonly columns: ReadonlyArray<{ id: string; label: string; valueType: string }>
+  readonly columns: ReadonlyArray<{
+    id: string
+    label: string
+    valueType: string
+    /** Dataset-declared: the column's values are in minor units. */
+    minorUnit?: boolean
+    /** Dataset-declared: the output column carrying this column's ISO currency. */
+    currencyField?: string
+  }>
   readonly rows: ReadonlyArray<Record<string, unknown>>
   readonly format?: ReportExportSectionFormat
   readonly error?: string


### PR DESCRIPTION
Fixes three reported display defects. Each is a screen stating something the data does not say.

Closes #4611, closes #4612, closes #4613.

## #4611 — the widget invented a currency, and dropped the alias

`from finance.receivables where status = 'issued' group by currency select currency, sum(outstandingBalanceCents) as owed` rendered:

```
Document currency    Outstanding balance
EUR                  $351,533.00
```

Two inventions, and they compound. The renderer defaulted an absent currency to `USD`, and it attached a symbol and two decimals to an integer it had never scaled — the balance is €3,515.33. As the issue notes, every money field these datasets expose ends in `Cents` with no major-unit alternative to select, so *currency formatting without scaling was wrong on all of them*, and the symbol is exactly what makes the wrong number believable.

A renderer has the value and its value type. It has no way to tell whether `351533` is a balance of 351,533 or of 3,515.33, and no way to tell which currency the row is in. So `reportColumnSchema` gains the two facts only the producing dataset knows:

- `minorUnit` — the column's values need scaling
- `currencyField` — the output column carrying this row's ISO currency code, set **only when the query actually selects it**

Finance declares both. Where either is absent the amount is written as a plain number rather than borrowing a symbol from a default. The same `|| "USD"` fallback in PDF export is fixed with it.

The header is the second half: the query said `as owed` and got back `Outstanding balance`, the canned field label. Finance and Bookings now honour a selection's alias. The query language *requires* an alias on every aggregate, so an alias that merely restates the field id is its mandatory output name rather than a name anybody chose — those keep the dataset's label, which is what keeps the four preset widgets (`Outstanding by currency`, `Collections by currency`, …) reading as they do today.

The magnitude was never the bug, and nothing here changes it.

## #4612 — Departure picker empty until you type

The picker's resolver closes over the chosen product, but `AsyncCombobox` re-ran its debounced search on the query alone. Callers pass an inline arrow whose identity changes every render, so nothing could tell the effect the product had arrived: the list stayed as resolved *before a product existed* — empty — until a keystroke moved the query.

`AsyncCombobox` takes a `searchKey` for whatever else its resolver depends on, and drops stale options the moment it changes rather than offering the previous product's departures for another 200ms. The record dialog's copy of the same two-step picker was working around this with a `key` remount; it uses `searchKey` now too, so there is one mechanism instead of two.

The Product picker in the same dialog was never affected, which is why the inconsistency was visible within one dialog.

## #4613 — supplier invoices showed the raw id

The list column and detail header printed `supp_01kz996qkqe7a9ar07rectxm9b`. The invoice stores only the id — a loose cross-module text reference, no FK — so the name has to be joined back on read, and nothing did.

`list` and the detail loader resolve it through the same guarded boundary read the allocation labels already use: read-only, ids parameter-bound, and returning no names at all on a deployment whose graph has no suppliers module. `supplierName` is nullable so a deleted supplier falls back to the id, which also stays on hover for support.

## Verification

- `format.test.ts` — a currency value with no declared currency formats as `351,533`/`3,515.33`, never `$…`
- `finance/reporting.test.ts` — `as owed` becomes the header; a restated alias keeps `Outstanding balance`; money columns declare `minorUnit`, and name their currency column only when the query selects it
- `async-combobox.test.tsx` — offers the unfiltered first page with nothing typed, and re-resolves on a `searchKey` change. **Reverting the one-line dependency fix turns the second red** (`expected [] to deeply equal [ '2026-09-06' ]`), which is the reported symptom exactly
- `service-supplier-invoices.test.ts` — names map back, unresolvable ids stay absent, and a deployment without the suppliers table runs the existence probe and nothing else
- `packages/finance/openapi/admin/finance.json` updated for the six supplier-invoice **response** schemas; the two request bodies are deliberately untouched
- Repo-wide `biome check`: 0 errors