### PR TITLE
fix(bookings): honour promotion codes on the Booking Session v1 quote

### DIFF
--- a/.changeset/booking-session-promotion-codes.md
+++ b/.changeset/booking-session-promotion-codes.md
@@ -1,0 +1,44 @@
+---
+"@voyant-travel/catalog-contracts": minor
+"@voyant-travel/catalog": minor
+"@voyant-travel/commerce": minor
+"@voyant-travel/bookings-react": minor
+---
+
+Honour promotion codes on the Booking Session v1 quote.
+
+`promotionCode` had been declared on the public booking selection and accepted
+by the offer-preview and create-session routes since the beta quote path, but
+`normalizeBookingSelection` projected it away before any handler saw it — so a
+code could never change a price, and `createCatalogPromotionEvaluator`, the
+adapter written for exactly this hook, had no call sites at all after
+voyant#4188 deleted the beta `quoteEntity`.
+
+The code now survives normalization and `composeQuote` evaluates promotions
+through a new optional `CatalogCommerceRuntimeExtension.createPromotionEvaluator`
+seam. Auto-applied offers are evaluated too, not only code-gated ones: the
+catalog plane already advertises their discounted price, so quoting without
+them left the listing and the quote disagreeing. The discount lands as negative
+`discount` lines with `subtotal`/`taxTotal` scaled to preserve both the
+effective tax rate and `subtotal + taxTotal === total`; base lines are left
+alone so `fillMissingBookingItemSellAmounts` reconciles the booking to the
+discounted total at commit. A deployment with no promotions module wired quotes
+exactly as before.
+
+`pricingBreakdownV1` gains `appliedOffers` and `promotionCodeStatus`. The
+second is the missing piece behind voyant#4615: a rejected code does not make a
+departure unbookable, so a valid quote needs somewhere to say the code was
+wrong. Without it the operator's New booking form had to infer rejection from
+`available === false` and told them a departure with 13 places left was invalid.
+
+Redemption recording is live again. The `booking.confirmed` subscriber reads
+the applied offers through catalog's new `readAppliedOffersForBooking`, which
+spans `booking_session_quotes` and the legacy `catalog_quotes`, replacing a
+direct cross-module select that only ever saw the dead legacy table.
+
+On the manual booking form, `submitBlocked` no longer contains a bare
+`hasPromotionCode` (with an unreachable guard beneath it) and the persistent
+"not authoritative in Booking Session v1" alert is gone. A valid code applies
+and reprices; a rejected one blocks submission with copy that names why —
+unrecognised, expired, not yet valid, or not applicable — rather than a single
+generic "not valid for this booking".

--- a/packages/bookings-react/src/components/manual-booking-create-form.tsx
+++ b/packages/bookings-react/src/components/manual-booking-create-form.tsx
@@ -13,6 +13,7 @@ import {
   type BookingSelectionV1,
   bookingSelectionV1,
   type PaxBandCode,
+  type PromotionCodeStatusV1,
 } from "@voyant-travel/catalog-contracts/booking-engine/contracts"
 import type { UnsatisfiedRequirementV1 } from "@voyant-travel/catalog-contracts/booking-engine/requirements-validation"
 import {
@@ -347,6 +348,61 @@ export function buildManualBookingQuoteDraft(input: {
     payment: { intent: hasAnyPaidPayment(input.paymentSchedule) ? "bank_transfer" : "hold" },
     promotionCode: input.promotionCode.trim() || undefined,
   })
+}
+
+/**
+ * Whether a typed promotion code lets the booking be created.
+ *
+ * Before voyant#4615 this was `hasPromotionCode` — any code at all blocked
+ * submit, and a second, unreachable guard below it pretended otherwise. The
+ * quote now answers for the code, so the only thing that blocks is a code the
+ * quote rejected: creating the booking anyway would drop a discount the
+ * operator has already promised over the phone, and clearing the field is one
+ * keystroke away.
+ */
+export function resolveManualBookingPromotionState(input: {
+  promotionCode: string
+  isSettling: boolean
+  hasError: boolean
+  hasPricing: boolean
+  status: PromotionCodeStatusV1 | null | undefined
+}): { hasCode: boolean; rejected: boolean; ready: boolean } {
+  const hasCode = Boolean(input.promotionCode.trim())
+  const rejected = Boolean(hasCode && input.status && input.status.kind !== "code_valid")
+  const ready = !hasCode || (!input.isSettling && !input.hasError && input.hasPricing && !rejected)
+  return { hasCode, rejected, ready }
+}
+
+/**
+ * Human copy for the quote's verdict on a promotion code.
+ *
+ * Every branch names what is actually wrong with the code. The generic
+ * `invalid` string stays as the fallback for a status this build does not
+ * know, so a server that grows a new rejection reason degrades to a vague
+ * message rather than an empty one.
+ */
+export function promotionCodeStatusMessage(
+  status: PromotionCodeStatusV1,
+  copy: {
+    invalid: string
+    notFound: string
+    expired: string
+    notYetValid: string
+    notApplicable: string
+  },
+): string {
+  switch (status.kind) {
+    case "code_not_found":
+      return copy.notFound
+    case "code_expired":
+      return copy.expired
+    case "code_not_yet_valid":
+      return copy.notYetValid
+    case "code_not_applicable":
+      return copy.notApplicable
+    default:
+      return copy.invalid
+  }
 }
 
 const BOOKING_SESSION_ENGINE_OWNED_FIELDS = new Set([
@@ -1399,36 +1455,44 @@ export function ManualBookingCreateForm({
       pricing.confirmedAmountCents !== resolvedPricing.catalogAmountCents &&
       !pricing.priceOverrideReason.trim(),
   )
-  const hasPromotionCode = Boolean(promotionCode.trim())
-  const promotionReady =
-    !hasPromotionCode ||
-    (!quote.isSettling &&
-      !quote.error &&
-      quote.data?.available !== false &&
-      Boolean(quote.data?.pricing))
+  // The quote is authoritative about the code now (voyant#4615). Before that
+  // the selection's `promotionCode` was projected away server-side, so the
+  // form had nothing to read and inferred rejection from an unrelated
+  // `available === false` — which is why a perfectly good departure reported
+  // the operator's code as invalid.
+  const promotionCodeStatus = quote.data?.pricing?.promotionCodeStatus ?? null
+  const {
+    hasCode: hasPromotionCode,
+    rejected: promotionRejected,
+    ready: promotionReady,
+  } = resolveManualBookingPromotionState({
+    promotionCode,
+    isSettling: quote.isSettling,
+    hasError: Boolean(quote.error),
+    hasPricing: Boolean(quote.data?.pricing),
+    status: promotionCodeStatus,
+  })
   const sourcedQuoteReady =
     !isSourcedProduct ||
     (!quote.isSettling &&
       !quote.error &&
       quote.data?.available !== false &&
       Boolean(quote.data?.pricing))
-  const promoFeedback = promotionCode.trim()
-    ? quote.isSettling
+  const promoFeedback = !hasPromotionCode
+    ? null
+    : quote.isSettling
       ? copy.promotion.checking
-      : quote.error
+      : quote.error || !quote.data?.pricing
         ? copy.promotion.unavailable
-        : quote.data?.available === false
-          ? copy.promotion.invalid
-          : quote.data?.pricing
-            ? formatMessage(copy.promotion.valid, {
-                amount: formatManualBookingAmount(
-                  quote.data.pricing.total,
-                  quote.data.pricing.currency,
-                  formatCurrency,
-                ),
-              })
-            : copy.promotion.unavailable
-    : null
+        : promotionCodeStatus && promotionCodeStatus.kind !== "code_valid"
+          ? promotionCodeStatusMessage(promotionCodeStatus, copy.promotion)
+          : formatMessage(copy.promotion.valid, {
+              amount: formatManualBookingAmount(
+                quote.data.pricing.total,
+                quote.data.pricing.currency,
+                formatCurrency,
+              ),
+            })
 
   /**
    * Every condition that keeps **Create booking** disabled. Named once so the
@@ -1436,7 +1500,6 @@ export function ManualBookingCreateForm({
    */
   const submitBlocked =
     isSourcedProduct ||
-    hasPromotionCode ||
     !product.productId ||
     !hasBookingTiming ||
     !hasSelectedUnits ||
@@ -1478,18 +1541,13 @@ export function ManualBookingCreateForm({
       setError({ message: copy.validation.sourcedBookingSessionRequired, blocksSubmit: true })
       return
     }
-    if (hasPromotionCode) {
-      setError({ message: copy.validation.promotionBookingSessionRequired, blocksSubmit: true })
-      return
-    }
     if (!sourcedQuoteReady) {
       setError({ message: copy.validation.pricingUnavailable, blocksSubmit: true })
       return
     }
-    if (hasPromotionCode && !promotionReady) {
+    if (!promotionReady) {
       setError({
-        message:
-          quote.data?.available === false ? copy.promotion.invalid : copy.promotion.unavailable,
+        message: promotionRejected ? copy.promotion.blocked : copy.promotion.unavailable,
         blocksSubmit: true,
       })
       return
@@ -2136,12 +2194,12 @@ export function ManualBookingCreateForm({
             {copy.validation.sourcedBookingSessionRequired}
           </p>
         ) : null}
-        {hasPromotionCode ? (
+        {promotionRejected ? (
           <p
             role="alert"
             className="mt-3 rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-xs text-destructive"
           >
-            {copy.validation.promotionBookingSessionRequired}
+            {copy.promotion.blocked}
           </p>
         ) : null}
         <div className="mt-4 flex items-center justify-end gap-2 border-t px-1 pt-3">
@@ -2198,7 +2256,9 @@ export function ManualBookingCreateForm({
               {promoFeedback ? (
                 <FieldDescription
                   className={
-                    quote.error || quote.data?.available === false ? "text-destructive" : undefined
+                    !quote.isSettling && (quote.error || promotionRejected || !quote.data?.pricing)
+                      ? "text-destructive"
+                      : undefined
                   }
                 >
                   {promoFeedback}

--- a/packages/bookings-react/src/i18n/en-create-list.ts
+++ b/packages/bookings-react/src/i18n/en-create-list.ts
@@ -51,8 +51,6 @@ export const bookingsUiEnCreateList = {
         "We couldn't calculate a live supplier price. Review the selection and try again.",
       sourcedBookingSessionRequired:
         "This supplier source does not support Booking Session v1 Commit yet. Use a v1-capable source or contact operations.",
-      promotionBookingSessionRequired:
-        "Promotion codes are not authoritative in Booking Session v1 yet. Remove the code before committing this booking.",
       paymentGuaranteeRequired:
         "This booking requires a payment guarantee, but no payment continuation is available.",
       bookingSession: {
@@ -84,7 +82,12 @@ export const bookingsUiEnCreateList = {
       checking: "Checking promotion...",
       valid: "Promotion applied. New total: {amount}.",
       invalid: "This promotion code is not valid for this booking.",
+      notFound: "We don't recognise this promotion code.",
+      expired: "This promotion code has expired.",
+      notYetValid: "This promotion code is not valid yet.",
+      notApplicable: "This promotion code does not apply to this booking.",
       unavailable: "We couldn't check this promotion code. Try again.",
+      blocked: "Remove or correct the promotion code before creating this booking.",
     },
     actions: {
       create: "Create booking",

--- a/packages/bookings-react/src/i18n/messages-create-list.ts
+++ b/packages/bookings-react/src/i18n/messages-create-list.ts
@@ -45,7 +45,6 @@ export type BookingsUiCreateListMessages = {
       pricingPending: string
       pricingUnavailable: string
       sourcedBookingSessionRequired: string
-      promotionBookingSessionRequired: string
       paymentGuaranteeRequired: string
       bookingSession: {
         revisionConflict: string
@@ -71,7 +70,12 @@ export type BookingsUiCreateListMessages = {
       checking: string
       valid: string
       invalid: string
+      notFound: string
+      expired: string
+      notYetValid: string
+      notApplicable: string
       unavailable: string
+      blocked: string
     }
     actions: {
       create: string

--- a/packages/bookings-react/src/i18n/ro-create-list.ts
+++ b/packages/bookings-react/src/i18n/ro-create-list.ts
@@ -51,8 +51,6 @@ export const bookingsUiRoCreateList = {
         "Nu am putut calcula pretul furnizorului. Verifica selectia si incearca din nou.",
       sourcedBookingSessionRequired:
         "Aceasta sursa nu accepta inca finalizarea prin Booking Session v1. Foloseste o sursa compatibila sau contacteaza operatiunile.",
-      promotionBookingSessionRequired:
-        "Codurile promotionale nu sunt inca autoritative in Booking Session v1. Elimina codul inainte de finalizarea rezervarii.",
       paymentGuaranteeRequired:
         "Aceasta rezervare necesita o garantie de plata, dar continuarea platii nu este disponibila.",
       bookingSession: {
@@ -85,7 +83,12 @@ export const bookingsUiRoCreateList = {
       checking: "Se verifica promotia...",
       valid: "Promotie aplicata. Total nou: {amount}.",
       invalid: "Acest cod promotional nu este valabil pentru rezervarea selectata.",
+      notFound: "Nu recunoastem acest cod promotional.",
+      expired: "Acest cod promotional a expirat.",
+      notYetValid: "Acest cod promotional nu este inca valabil.",
+      notApplicable: "Acest cod promotional nu se aplica acestei rezervari.",
       unavailable: "Codul promotional nu a putut fi verificat. Incearca din nou.",
+      blocked: "Elimina sau corecteaza codul promotional inainte de a crea rezervarea.",
     },
     actions: {
       create: "Creeaza rezervarea",

--- a/packages/bookings-react/tests/unit/manual-booking-promotion.test.ts
+++ b/packages/bookings-react/tests/unit/manual-booking-promotion.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  promotionCodeStatusMessage,
+  resolveManualBookingPromotionState,
+} from "../../src/components/manual-booking-create-form.js"
+import { bookingsUiEn } from "../../src/i18n/en.js"
+
+const copy = bookingsUiEn.manualBookingCreate.promotion
+
+function state(overrides: Partial<Parameters<typeof resolveManualBookingPromotionState>[0]> = {}) {
+  return resolveManualBookingPromotionState({
+    promotionCode: "GREEK15",
+    isSettling: false,
+    hasError: false,
+    hasPricing: true,
+    status: { kind: "code_valid" },
+    ...overrides,
+  })
+}
+
+describe("resolveManualBookingPromotionState", () => {
+  it("lets a valid code through instead of blocking every code", () => {
+    // voyant#4615: `submitBlocked` included a bare `hasPromotionCode`, so
+    // Create booking was dead for any non-empty code and the form offered an
+    // input whose only outcome was a blocked submit.
+    expect(state()).toEqual({ hasCode: true, rejected: false, ready: true })
+  })
+
+  it("blocks a code the quote rejected", () => {
+    expect(state({ status: { kind: "code_expired" } })).toEqual({
+      hasCode: true,
+      rejected: true,
+      ready: false,
+    })
+  })
+
+  it("does not blame the code while the quote is still settling", () => {
+    expect(state({ isSettling: true, hasPricing: false, status: null })).toEqual({
+      hasCode: true,
+      rejected: false,
+      ready: false,
+    })
+  })
+
+  it("does not blame the code for a quote that could not be priced", () => {
+    // The old form read `available === false` as "invalid promotion code",
+    // which is what made a departure with 13 places left report the operator's
+    // code as invalid. An unpriceable quote is not the code's fault.
+    expect(state({ hasPricing: false, status: null })).toEqual({
+      hasCode: true,
+      rejected: false,
+      ready: false,
+    })
+  })
+
+  it("is ready with no code at all, whatever the quote says", () => {
+    expect(
+      state({ promotionCode: "   ", hasPricing: false, hasError: true, status: null }),
+    ).toEqual({ hasCode: false, rejected: false, ready: true })
+  })
+})
+
+describe("promotionCodeStatusMessage", () => {
+  it("names what is wrong with the code", () => {
+    expect(promotionCodeStatusMessage({ kind: "code_not_found" }, copy)).toBe(copy.notFound)
+    expect(promotionCodeStatusMessage({ kind: "code_expired" }, copy)).toBe(copy.expired)
+    expect(promotionCodeStatusMessage({ kind: "code_not_yet_valid" }, copy)).toBe(copy.notYetValid)
+    expect(promotionCodeStatusMessage({ kind: "code_not_applicable", reason: "scope" }, copy)).toBe(
+      copy.notApplicable,
+    )
+  })
+
+  it("falls back to the generic string for a status this build does not know", () => {
+    expect(
+      promotionCodeStatusMessage(
+        { kind: "code_valid" } as Parameters<typeof promotionCodeStatusMessage>[0],
+        copy,
+      ),
+    ).toBe(copy.invalid)
+  })
+})

--- a/packages/catalog-contracts/src/booking-engine/pricing-contracts.ts
+++ b/packages/catalog-contracts/src/booking-engine/pricing-contracts.ts
@@ -37,6 +37,46 @@ export const bookingPolicyEvidenceV1 = z.object({
   bookingTerms: z.unknown().optional(),
 })
 
+/**
+ * One promotional offer applied to a quote. Structurally identical to the
+ * `AppliedOffer` interface in `./promotions-contract.ts` — that file declares
+ * the evaluator seam, this schema is the wire form carried on the quote and
+ * frozen onto `PricingBasis.appliedOffers` at commit.
+ */
+export const pricingAppliedOfferV1 = z.object({
+  offerId: z.string().min(1),
+  offerName: z.string(),
+  discountAppliedCents: z.number().int(),
+  discountedPriceCents: z.number().int(),
+  currency: z.string(),
+  discountKind: z.enum(["percentage", "fixed_amount"]),
+  discountPercent: z.number().nullable(),
+  discountAmountCents: z.number().int().nullable(),
+  /** The literal code the customer entered (case preserved); null for auto-applied. */
+  appliedCode: z.string().nullable(),
+  stackable: z.boolean(),
+})
+export type PricingAppliedOfferV1 = z.infer<typeof pricingAppliedOfferV1>
+
+/**
+ * Verdict on a promotion code the caller supplied. Present only when a code
+ * was sent, and carried on an **available** quote: a rejected code does not
+ * make the target unbookable, it just does not discount it. Without this a
+ * client has no way to tell "your code is wrong" from "this departure cannot
+ * be priced", which is exactly the conflation voyant#4615 reported.
+ */
+export const promotionCodeStatusV1 = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("code_valid") }),
+  z.object({ kind: z.literal("code_not_found") }),
+  z.object({ kind: z.literal("code_expired") }),
+  z.object({ kind: z.literal("code_not_yet_valid") }),
+  z.object({
+    kind: z.literal("code_not_applicable"),
+    reason: z.enum(["scope", "min_pax", "eligibility", "currency"]),
+  }),
+])
+export type PromotionCodeStatusV1 = z.infer<typeof promotionCodeStatusV1>
+
 export const pricingBreakdownV1 = z.object({
   currency: z.string().length(3),
   lines: z.array(pricingLineV1),
@@ -44,6 +84,13 @@ export const pricingBreakdownV1 = z.object({
   subtotal: z.number().int(),
   taxTotal: z.number().int(),
   total: z.number().int(),
+  /**
+   * Promotional offers reflected in the totals above. The `discount` lines in
+   * `lines` are the human-readable face of the same offers.
+   */
+  appliedOffers: z.array(pricingAppliedOfferV1).optional(),
+  /** Verdict on the caller's promotion code. Absent when no code was sent. */
+  promotionCodeStatus: promotionCodeStatusV1.optional(),
   /** Fresh policy evidence for a leaf Quote. */
   policyEvidence: bookingPolicyEvidenceV1.optional(),
   /** Component-tagged policy evidence for an aggregate Trip Quote. */

--- a/packages/catalog/openapi/admin/catalog-booking.json
+++ b/packages/catalog/openapi/admin/catalog-booking.json
@@ -7629,6 +7629,116 @@
                       "total": {
                         "type": "integer"
                       },
+                      "appliedOffers": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "offerId": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "offerName": {
+                              "type": "string"
+                            },
+                            "discountAppliedCents": {
+                              "type": "integer"
+                            },
+                            "discountedPriceCents": {
+                              "type": "integer"
+                            },
+                            "currency": {
+                              "type": "string"
+                            },
+                            "discountKind": {
+                              "type": "string",
+                              "enum": ["percentage", "fixed_amount"]
+                            },
+                            "discountPercent": {
+                              "type": ["number", "null"]
+                            },
+                            "discountAmountCents": {
+                              "type": ["integer", "null"]
+                            },
+                            "appliedCode": {
+                              "type": ["string", "null"]
+                            },
+                            "stackable": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "offerId",
+                            "offerName",
+                            "discountAppliedCents",
+                            "discountedPriceCents",
+                            "currency",
+                            "discountKind",
+                            "discountPercent",
+                            "discountAmountCents",
+                            "appliedCode",
+                            "stackable"
+                          ]
+                        }
+                      },
+                      "promotionCodeStatus": {
+                        "oneOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "kind": {
+                                "type": "string",
+                                "enum": ["code_valid"]
+                              }
+                            },
+                            "required": ["kind"]
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "kind": {
+                                "type": "string",
+                                "enum": ["code_not_found"]
+                              }
+                            },
+                            "required": ["kind"]
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "kind": {
+                                "type": "string",
+                                "enum": ["code_expired"]
+                              }
+                            },
+                            "required": ["kind"]
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "kind": {
+                                "type": "string",
+                                "enum": ["code_not_yet_valid"]
+                              }
+                            },
+                            "required": ["kind"]
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "kind": {
+                                "type": "string",
+                                "enum": ["code_not_applicable"]
+                              },
+                              "reason": {
+                                "type": "string",
+                                "enum": ["scope", "min_pax", "eligibility", "currency"]
+                              }
+                            },
+                            "required": ["kind", "reason"]
+                          }
+                        ]
+                      },
                       "policyEvidence": {
                         "type": "object",
                         "properties": {
@@ -12113,6 +12223,116 @@
                       },
                       "total": {
                         "type": "integer"
+                      },
+                      "appliedOffers": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "offerId": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "offerName": {
+                              "type": "string"
+                            },
+                            "discountAppliedCents": {
+                              "type": "integer"
+                            },
+                            "discountedPriceCents": {
+                              "type": "integer"
+                            },
+                            "currency": {
+                              "type": "string"
+                            },
+                            "discountKind": {
+                              "type": "string",
+                              "enum": ["percentage", "fixed_amount"]
+                            },
+                            "discountPercent": {
+                              "type": ["number", "null"]
+                            },
+                            "discountAmountCents": {
+                              "type": ["integer", "null"]
+                            },
+                            "appliedCode": {
+                              "type": ["string", "null"]
+                            },
+                            "stackable": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "offerId",
+                            "offerName",
+                            "discountAppliedCents",
+                            "discountedPriceCents",
+                            "currency",
+                            "discountKind",
+                            "discountPercent",
+                            "discountAmountCents",
+                            "appliedCode",
+                            "stackable"
+                          ]
+                        }
+                      },
+                      "promotionCodeStatus": {
+                        "oneOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "kind": {
+                                "type": "string",
+                                "enum": ["code_valid"]
+                              }
+                            },
+                            "required": ["kind"]
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "kind": {
+                                "type": "string",
+                                "enum": ["code_not_found"]
+                              }
+                            },
+                            "required": ["kind"]
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "kind": {
+                                "type": "string",
+                                "enum": ["code_expired"]
+                              }
+                            },
+                            "required": ["kind"]
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "kind": {
+                                "type": "string",
+                                "enum": ["code_not_yet_valid"]
+                              }
+                            },
+                            "required": ["kind"]
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "kind": {
+                                "type": "string",
+                                "enum": ["code_not_applicable"]
+                              },
+                              "reason": {
+                                "type": "string",
+                                "enum": ["scope", "min_pax", "eligibility", "currency"]
+                              }
+                            },
+                            "required": ["kind", "reason"]
+                          }
+                        ]
                       },
                       "policyEvidence": {
                         "type": "object",

--- a/packages/catalog/openapi/storefront/catalog-booking.json
+++ b/packages/catalog/openapi/storefront/catalog-booking.json
@@ -7629,6 +7629,116 @@
                       "total": {
                         "type": "integer"
                       },
+                      "appliedOffers": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "offerId": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "offerName": {
+                              "type": "string"
+                            },
+                            "discountAppliedCents": {
+                              "type": "integer"
+                            },
+                            "discountedPriceCents": {
+                              "type": "integer"
+                            },
+                            "currency": {
+                              "type": "string"
+                            },
+                            "discountKind": {
+                              "type": "string",
+                              "enum": ["percentage", "fixed_amount"]
+                            },
+                            "discountPercent": {
+                              "type": ["number", "null"]
+                            },
+                            "discountAmountCents": {
+                              "type": ["integer", "null"]
+                            },
+                            "appliedCode": {
+                              "type": ["string", "null"]
+                            },
+                            "stackable": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "offerId",
+                            "offerName",
+                            "discountAppliedCents",
+                            "discountedPriceCents",
+                            "currency",
+                            "discountKind",
+                            "discountPercent",
+                            "discountAmountCents",
+                            "appliedCode",
+                            "stackable"
+                          ]
+                        }
+                      },
+                      "promotionCodeStatus": {
+                        "oneOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "kind": {
+                                "type": "string",
+                                "enum": ["code_valid"]
+                              }
+                            },
+                            "required": ["kind"]
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "kind": {
+                                "type": "string",
+                                "enum": ["code_not_found"]
+                              }
+                            },
+                            "required": ["kind"]
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "kind": {
+                                "type": "string",
+                                "enum": ["code_expired"]
+                              }
+                            },
+                            "required": ["kind"]
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "kind": {
+                                "type": "string",
+                                "enum": ["code_not_yet_valid"]
+                              }
+                            },
+                            "required": ["kind"]
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "kind": {
+                                "type": "string",
+                                "enum": ["code_not_applicable"]
+                              },
+                              "reason": {
+                                "type": "string",
+                                "enum": ["scope", "min_pax", "eligibility", "currency"]
+                              }
+                            },
+                            "required": ["kind", "reason"]
+                          }
+                        ]
+                      },
                       "policyEvidence": {
                         "type": "object",
                         "properties": {
@@ -12113,6 +12223,116 @@
                       },
                       "total": {
                         "type": "integer"
+                      },
+                      "appliedOffers": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "offerId": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "offerName": {
+                              "type": "string"
+                            },
+                            "discountAppliedCents": {
+                              "type": "integer"
+                            },
+                            "discountedPriceCents": {
+                              "type": "integer"
+                            },
+                            "currency": {
+                              "type": "string"
+                            },
+                            "discountKind": {
+                              "type": "string",
+                              "enum": ["percentage", "fixed_amount"]
+                            },
+                            "discountPercent": {
+                              "type": ["number", "null"]
+                            },
+                            "discountAmountCents": {
+                              "type": ["integer", "null"]
+                            },
+                            "appliedCode": {
+                              "type": ["string", "null"]
+                            },
+                            "stackable": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "offerId",
+                            "offerName",
+                            "discountAppliedCents",
+                            "discountedPriceCents",
+                            "currency",
+                            "discountKind",
+                            "discountPercent",
+                            "discountAmountCents",
+                            "appliedCode",
+                            "stackable"
+                          ]
+                        }
+                      },
+                      "promotionCodeStatus": {
+                        "oneOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "kind": {
+                                "type": "string",
+                                "enum": ["code_valid"]
+                              }
+                            },
+                            "required": ["kind"]
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "kind": {
+                                "type": "string",
+                                "enum": ["code_not_found"]
+                              }
+                            },
+                            "required": ["kind"]
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "kind": {
+                                "type": "string",
+                                "enum": ["code_expired"]
+                              }
+                            },
+                            "required": ["kind"]
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "kind": {
+                                "type": "string",
+                                "enum": ["code_not_yet_valid"]
+                              }
+                            },
+                            "required": ["kind"]
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "kind": {
+                                "type": "string",
+                                "enum": ["code_not_applicable"]
+                              },
+                              "reason": {
+                                "type": "string",
+                                "enum": ["scope", "min_pax", "eligibility", "currency"]
+                              }
+                            },
+                            "required": ["kind", "reason"]
+                          }
+                        ]
                       },
                       "policyEvidence": {
                         "type": "object",

--- a/packages/catalog/src/booking-engine/applied-offers.ts
+++ b/packages/catalog/src/booking-engine/applied-offers.ts
@@ -13,7 +13,7 @@
  */
 
 import type { AnyDrizzleDb } from "@voyant-travel/db"
-import { and, eq, inArray, isNotNull } from "drizzle-orm"
+import { and, eq, inArray } from "drizzle-orm"
 
 import { pricingBreakdownV1 } from "./contracts.js"
 import type { AppliedOffer } from "./promotions-contract.js"
@@ -53,12 +53,7 @@ async function readSessionQuotePricing(
   const commits = await db
     .select({ sessionId: bookingSessionCommitsTable.sessionId })
     .from(bookingSessionCommitsTable)
-    .where(
-      and(
-        eq(bookingSessionCommitsTable.bookingId, bookingId),
-        isNotNull(bookingSessionCommitsTable.bookingId),
-      ),
-    )
+    .where(eq(bookingSessionCommitsTable.bookingId, bookingId))
   const sessionIds = [...new Set(commits.map((commit) => commit.sessionId))]
   if (sessionIds.length === 0) return []
   const rows = await db

--- a/packages/catalog/src/booking-engine/applied-offers.ts
+++ b/packages/catalog/src/booking-engine/applied-offers.ts
@@ -1,0 +1,84 @@
+/**
+ * "Which promotional offers did this booking actually consume?" — answered by
+ * the module that owns both quote tables.
+ *
+ * The post-commit redemption recorder in `@voyant-travel/commerce` used to
+ * `select` from `catalog_quotes` itself. That was a cross-module table
+ * reach-in (ADR-0016 decision 6) and it only ever saw half the answer: since
+ * the v1 Booking Session replaced the beta quote path, a committed booking's
+ * pricing lives in `booking_session_quotes`, joined to the booking through
+ * `booking_session_commits` rather than through a `consumed_booking_id`
+ * column. Both are read here, and the legacy table stays in the union so
+ * historical rows keep resolving.
+ */
+
+import type { AnyDrizzleDb } from "@voyant-travel/db"
+import { and, eq, inArray, isNotNull } from "drizzle-orm"
+
+import { pricingBreakdownV1 } from "./contracts.js"
+import type { AppliedOffer } from "./promotions-contract.js"
+import { catalogQuotesTable } from "./schema.js"
+import { bookingSessionCommitsTable, bookingSessionQuotesTable } from "./sessions-schema.js"
+
+export interface BookingAppliedOffers {
+  /** Quote rows inspected across both tables. */
+  quotesScanned: number
+  /** Every applied-offer row found, in no particular order and not deduplicated. */
+  offers: AppliedOffer[]
+}
+
+export async function readAppliedOffersForBooking(
+  db: AnyDrizzleDb,
+  bookingId: string,
+): Promise<BookingAppliedOffers> {
+  const [legacyRows, sessionRows] = await Promise.all([
+    db
+      .select({ appliedOffers: catalogQuotesTable.pricing_applied_offers })
+      .from(catalogQuotesTable)
+      .where(eq(catalogQuotesTable.consumed_booking_id, bookingId)),
+    readSessionQuotePricing(db, bookingId),
+  ])
+
+  const offers = [
+    ...legacyRows.flatMap((row) => row.appliedOffers ?? []),
+    ...sessionRows.flatMap(appliedOffersFromPricing),
+  ]
+  return { quotesScanned: legacyRows.length + sessionRows.length, offers }
+}
+
+async function readSessionQuotePricing(
+  db: AnyDrizzleDb,
+  bookingId: string,
+): Promise<Record<string, unknown>[]> {
+  const commits = await db
+    .select({ sessionId: bookingSessionCommitsTable.sessionId })
+    .from(bookingSessionCommitsTable)
+    .where(
+      and(
+        eq(bookingSessionCommitsTable.bookingId, bookingId),
+        isNotNull(bookingSessionCommitsTable.bookingId),
+      ),
+    )
+  const sessionIds = [...new Set(commits.map((commit) => commit.sessionId))]
+  if (sessionIds.length === 0) return []
+  const rows = await db
+    .select({ pricing: bookingSessionQuotesTable.pricing })
+    .from(bookingSessionQuotesTable)
+    .where(
+      and(
+        inArray(bookingSessionQuotesTable.sessionId, sessionIds),
+        eq(bookingSessionQuotesTable.state, "consumed"),
+      ),
+    )
+  return rows.map((row) => row.pricing)
+}
+
+/**
+ * Parse rather than cast. The column is untyped JSONB written by whatever
+ * quoted, so a shape drift must fail closed — recording a redemption for an
+ * offer the quote never carried is worse than recording none.
+ */
+function appliedOffersFromPricing(pricing: Record<string, unknown>): AppliedOffer[] {
+  const parsed = pricingBreakdownV1.safeParse(pricing)
+  return parsed.success ? (parsed.data.appliedOffers ?? []) : []
+}

--- a/packages/catalog/src/booking-engine/index.ts
+++ b/packages/catalog/src/booking-engine/index.ts
@@ -45,6 +45,10 @@ export {
   withBookingSessionAnalytics,
 } from "./analytics.js"
 export {
+  type BookingAppliedOffers,
+  readAppliedOffersForBooking,
+} from "./applied-offers.js"
+export {
   type CancelEntityDeps,
   type CancelEntityRequest,
   type CancelEntityResult,
@@ -183,6 +187,11 @@ export type {
   PromotionEvaluationInput,
   PromotionEvaluationOutput,
 } from "./promotions-contract.js"
+export {
+  applyPromotionsToBreakdown,
+  type PromotionEvaluator,
+  promotionEvaluationInputFor,
+} from "./quote-promotions.js"
 export { engineParametersFromSelection } from "./quote-support.js"
 export {
   createSourceAdapterRegistry,

--- a/packages/catalog/src/booking-engine/quote-promotions.test.ts
+++ b/packages/catalog/src/booking-engine/quote-promotions.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from "vitest"
+
+import type { PricingBreakdownV1 } from "./contracts.js"
+import type { AppliedOffer, PromotionEvaluationOutput } from "./promotions-contract.js"
+import { applyPromotionsToBreakdown, promotionEvaluationInputFor } from "./quote-promotions.js"
+
+/** €230.00 with 19% tax included — the shape the products handler emits. */
+function inclusiveBreakdown(): PricingBreakdownV1 {
+  return {
+    currency: "EUR",
+    lines: [
+      {
+        kind: "base",
+        label: "Evening tasting walk",
+        quantity: 1,
+        unitAmount: 23_000,
+        totalAmount: 23_000,
+        taxIncluded: true,
+      },
+    ],
+    taxes: [
+      {
+        code: "VAT",
+        label: "VAT",
+        rate: 0.19,
+        amount: 3671,
+        base: 19_329,
+        includedInPrice: true,
+        scope: "included",
+      },
+    ],
+    subtotal: 19_329,
+    taxTotal: 3671,
+    total: 23_000,
+  }
+}
+
+function offer(overrides: Partial<AppliedOffer> = {}): AppliedOffer {
+  return {
+    offerId: "prof_greek",
+    offerName: "Greek islands late summer",
+    discountAppliedCents: 3450,
+    discountedPriceCents: 19_550,
+    currency: "EUR",
+    discountKind: "percentage",
+    discountPercent: 15,
+    discountAmountCents: null,
+    appliedCode: "GREEK15",
+    stackable: false,
+    ...overrides,
+  }
+}
+
+function evaluation(overrides: Partial<PromotionEvaluationOutput> = {}): PromotionEvaluationOutput {
+  return {
+    applied: [offer()],
+    total: { discountAppliedCents: 3450, discountedPriceCents: 19_550 },
+    codeStatus: { kind: "code_valid" },
+    ...overrides,
+  }
+}
+
+describe("applyPromotionsToBreakdown", () => {
+  it("discounts the total and keeps subtotal + tax equal to it", () => {
+    const result = applyPromotionsToBreakdown(inclusiveBreakdown(), evaluation())
+
+    // The €230.00 → €195.50 the reporter expected in voyant#4615.
+    expect(result.total).toBe(19_550)
+    expect(result.subtotal + result.taxTotal).toBe(result.total)
+    // Tax follows the discount instead of staying at its old cash amount:
+    // 3671 x 19550/23000 = 3120 (a cent under the 3121 a fresh 19%-inclusive
+    // computation gives, which is the rounding the ratio costs).
+    expect(result.taxTotal).toBe(3120)
+    expect(result.taxes[0]?.amount).toBe(3120)
+    expect(result.taxes[0]?.base).toBe(result.subtotal)
+  })
+
+  it("leaves the base lines untouched and adds one discount line per offer", () => {
+    const result = applyPromotionsToBreakdown(inclusiveBreakdown(), evaluation())
+
+    // fillMissingBookingItemSellAmounts reconciles item lines to the accepted
+    // sell total using the base lines as weights, so rewriting them here would
+    // double-apply the discount at commit.
+    expect(result.lines[0]).toEqual(inclusiveBreakdown().lines[0])
+    expect(result.lines[1]).toEqual({
+      kind: "discount",
+      label: "Greek islands late summer",
+      quantity: 1,
+      unitAmount: -3450,
+      totalAmount: -3450,
+    })
+  })
+
+  it("carries the applied offers so the commit can freeze them", () => {
+    const result = applyPromotionsToBreakdown(inclusiveBreakdown(), evaluation())
+
+    expect(result.appliedOffers).toEqual([offer()])
+    expect(result.promotionCodeStatus).toEqual({ kind: "code_valid" })
+  })
+
+  it("reports a rejected code without touching the price", () => {
+    const result = applyPromotionsToBreakdown(
+      inclusiveBreakdown(),
+      evaluation({
+        applied: [],
+        total: { discountAppliedCents: 0, discountedPriceCents: 23_000 },
+        codeStatus: { kind: "code_expired" },
+      }),
+    )
+
+    expect(result.total).toBe(23_000)
+    expect(result.lines).toHaveLength(1)
+    expect(result.appliedOffers).toBeUndefined()
+    expect(result.promotionCodeStatus).toEqual({ kind: "code_expired" })
+  })
+
+  it("does not call a code valid when it discounted nothing", () => {
+    // The evaluator settles validity before the eligibility filter, so an
+    // unanswerable flag (past guest, family) parks the offer in its
+    // "conditional" bucket while the code still reads `code_valid`. Saying
+    // "applied" next to an unchanged total is the conflation #4615 was about.
+    const result = applyPromotionsToBreakdown(
+      inclusiveBreakdown(),
+      evaluation({
+        applied: [],
+        total: { discountAppliedCents: 0, discountedPriceCents: 23_000 },
+        codeStatus: { kind: "code_valid" },
+      }),
+    )
+
+    expect(result.promotionCodeStatus).toEqual({
+      kind: "code_not_applicable",
+      reason: "eligibility",
+    })
+  })
+
+  it("keeps a code valid when a better auto offer won the stacking pick", () => {
+    const auto = offer({ offerId: "prof_auto", offerName: "Late summer", appliedCode: null })
+    const result = applyPromotionsToBreakdown(inclusiveBreakdown(), evaluation({ applied: [auto] }))
+
+    expect(result.promotionCodeStatus).toEqual({ kind: "code_valid" })
+    expect(result.total).toBe(19_550)
+  })
+
+  it("never discounts below zero", () => {
+    const result = applyPromotionsToBreakdown(
+      inclusiveBreakdown(),
+      evaluation({
+        applied: [offer({ discountAppliedCents: 99_999 })],
+        total: { discountAppliedCents: 99_999, discountedPriceCents: -76_999 },
+      }),
+    )
+
+    expect(result.total).toBe(0)
+    expect(result.subtotal).toBe(0)
+    expect(result.taxTotal).toBe(0)
+  })
+
+  it("allocates the tax rounding residual so the rows still sum to the tax total", () => {
+    const breakdown: PricingBreakdownV1 = {
+      ...inclusiveBreakdown(),
+      taxes: [
+        { code: "A", label: "A", rate: 0.1, amount: 1000, base: 10_000 },
+        { code: "B", label: "B", rate: 0.09, amount: 2671, base: 10_000 },
+      ],
+    }
+    const result = applyPromotionsToBreakdown(breakdown, evaluation())
+
+    expect(result.taxes.reduce((sum, tax) => sum + tax.amount, 0)).toBe(result.taxTotal)
+  })
+
+  it("passes through an untouched breakdown when no code was sent and nothing applied", () => {
+    const breakdown = inclusiveBreakdown()
+    const result = applyPromotionsToBreakdown(breakdown, {
+      applied: [],
+      total: { discountAppliedCents: 0, discountedPriceCents: 23_000 },
+      codeStatus: null,
+    })
+
+    expect(result).toEqual(breakdown)
+  })
+})
+
+describe("promotionEvaluationInputFor", () => {
+  it("prices the discount against the quote total the customer would pay", () => {
+    const input = promotionEvaluationInputFor({
+      productId: "prod_1",
+      breakdown: inclusiveBreakdown(),
+      scope: { market: "ro" },
+      audience: "staff",
+      pax: 2,
+      at: new Date("2026-08-13T10:00:00Z"),
+      code: "GREEK15",
+      hasChildTraveler: false,
+    })
+
+    expect(input).toEqual({
+      productId: "prod_1",
+      slice: { audience: "staff", market: "ro" },
+      pax: 2,
+      eligibility: { hasChildTraveler: false },
+      date: new Date("2026-08-13T10:00:00Z"),
+      code: "GREEK15",
+      basePriceCents: 23_000,
+      baseCurrency: "EUR",
+    })
+  })
+
+  it("omits the code entirely when none was typed, so auto offers still evaluate", () => {
+    const input = promotionEvaluationInputFor({
+      productId: "prod_1",
+      breakdown: inclusiveBreakdown(),
+      scope: { market: "default" },
+      audience: "customer",
+      pax: 1,
+      at: new Date("2026-08-13T10:00:00Z"),
+      code: null,
+    })
+
+    expect(input.code).toBeUndefined()
+    expect("eligibility" in input).toBe(false)
+  })
+})

--- a/packages/catalog/src/booking-engine/quote-promotions.ts
+++ b/packages/catalog/src/booking-engine/quote-promotions.ts
@@ -42,7 +42,7 @@ export function promotionEvaluationInputFor(input: {
   audience: PromotionEvaluationInput["slice"]["audience"]
   pax: number
   at: Date
-  code: string | null
+  code: string | null | undefined
   hasChildTraveler?: boolean
 }): PromotionEvaluationInput {
   return {

--- a/packages/catalog/src/booking-engine/quote-promotions.ts
+++ b/packages/catalog/src/booking-engine/quote-promotions.ts
@@ -1,0 +1,161 @@
+/**
+ * Promotion evaluation on the v1 Booking Session quote.
+ *
+ * This is the `composeQuote` hook that
+ * `docs/architecture/promotions-architecture.md` §7.1 always described and
+ * that voyant#4188 left unwired when it deleted the beta `quoteEntity` path.
+ * Until voyant#4615 the consequence was silent: `promotionCode` was declared
+ * on the public selection, accepted by the route, and then projected away by
+ * `normalizeBookingSelection` — so a code could never change a price, and the
+ * only client that offered a code field had to infer failure from an
+ * unrelated `available === false`.
+ *
+ * The evaluation itself lives in `@voyant-travel/commerce`; catalog only owns
+ * the seam (`PromotionEvaluationInput` / `PromotionEvaluationOutput`) and the
+ * arithmetic below, which is pure and directly unit-tested.
+ */
+
+import type {
+  BookingSessionScopeV1,
+  PricingBreakdownV1,
+  PromotionCodeStatusV1,
+} from "./contracts.js"
+import type { PromotionEvaluationInput, PromotionEvaluationOutput } from "./promotions-contract.js"
+
+/** Request-scoped promotion evaluator, supplied by the deployment. */
+export type PromotionEvaluator = (
+  input: PromotionEvaluationInput,
+) => Promise<PromotionEvaluationOutput>
+
+/**
+ * Build the evaluator input for a product quote.
+ *
+ * The discount base is the quote **total** — the amount the customer would
+ * otherwise pay — so `evaluation.total.discountedPriceCents` is the new total
+ * directly, and a `fixed_amount` offer is capped against the real price rather
+ * than a pre-tax figure the customer never sees.
+ */
+export function promotionEvaluationInputFor(input: {
+  productId: string
+  breakdown: PricingBreakdownV1
+  scope: Pick<BookingSessionScopeV1, "market">
+  audience: PromotionEvaluationInput["slice"]["audience"]
+  pax: number
+  at: Date
+  code: string | null
+  hasChildTraveler?: boolean
+}): PromotionEvaluationInput {
+  return {
+    productId: input.productId,
+    slice: { audience: input.audience, market: input.scope.market },
+    // Pax is always known by the time a target is priced, so `minPax`
+    // conditions resolve to applied/excluded here rather than to the
+    // "conditional" bucket the catalog-plane projection sees.
+    pax: input.pax,
+    ...(input.hasChildTraveler !== undefined
+      ? { eligibility: { hasChildTraveler: input.hasChildTraveler } }
+      : {}),
+    date: input.at,
+    ...(input.code ? { code: input.code } : {}),
+    basePriceCents: input.breakdown.total,
+    baseCurrency: input.breakdown.currency,
+  }
+}
+
+/**
+ * Fold an evaluation into a priced breakdown.
+ *
+ * Totals move; the base lines do not. Each applied offer becomes its own
+ * negative `discount` line, and `subtotal`/`taxTotal` are scaled so the
+ * effective tax rate and the `subtotal + taxTotal === total` invariant both
+ * survive — which holds whether the handler priced tax inclusively or
+ * exclusively. Leaving the base lines at their undiscounted amounts is what
+ * `fillMissingBookingItemSellAmounts` expects: it reconciles item lines to the
+ * accepted sell total using those lines as weights, and its contract already
+ * names promotion as one of the residuals it allocates.
+ */
+export function applyPromotionsToBreakdown(
+  breakdown: PricingBreakdownV1,
+  evaluation: PromotionEvaluationOutput,
+): PricingBreakdownV1 {
+  const codeStatus = resolveCodeStatus(evaluation)
+  const discount = Math.max(
+    0,
+    Math.min(Math.round(evaluation.total.discountAppliedCents), breakdown.total),
+  )
+  const applied = discount > 0 ? evaluation.applied : []
+  const annotations = {
+    ...(applied.length > 0 ? { appliedOffers: applied } : {}),
+    ...(codeStatus ? { promotionCodeStatus: codeStatus } : {}),
+  }
+  if (discount <= 0) return { ...breakdown, ...annotations }
+
+  const total = breakdown.total - discount
+  const taxTotal =
+    breakdown.total > 0 ? Math.round((breakdown.taxTotal * total) / breakdown.total) : 0
+  const subtotal = total - taxTotal
+  return {
+    ...breakdown,
+    lines: [
+      ...breakdown.lines,
+      ...applied.map((offer) => ({
+        kind: "discount" as const,
+        label: offer.offerName,
+        quantity: 1,
+        unitAmount: -offer.discountAppliedCents,
+        totalAmount: -offer.discountAppliedCents,
+      })),
+    ],
+    taxes: scaleTaxes(breakdown.taxes, taxTotal, subtotal),
+    subtotal,
+    taxTotal,
+    total,
+    ...annotations,
+  }
+}
+
+/**
+ * Scale tax rows to the post-discount tax total, allocating the rounding
+ * residual to the largest row so the rows sum to `taxTotal` exactly.
+ */
+function scaleTaxes(
+  taxes: PricingBreakdownV1["taxes"],
+  taxTotal: number,
+  base: number,
+): PricingBreakdownV1["taxes"] {
+  if (taxes.length === 0) return taxes
+  const priorTotal = taxes.reduce((sum, tax) => sum + tax.amount, 0)
+  if (priorTotal <= 0) return taxes.map((tax) => ({ ...tax, base }))
+  const scaled = taxes.map((tax) => ({
+    ...tax,
+    amount: Math.round((tax.amount * taxTotal) / priorTotal),
+    base,
+  }))
+  const residual = taxTotal - scaled.reduce((sum, tax) => sum + tax.amount, 0)
+  if (residual === 0) return scaled
+  let largest = 0
+  for (const [index, tax] of scaled.entries()) {
+    if (tax.amount > (scaled[largest]?.amount ?? 0)) largest = index
+  }
+  const target = scaled[largest]
+  if (target) scaled[largest] = { ...target, amount: target.amount + residual }
+  return scaled
+}
+
+/**
+ * A code that matched an active offer but produced no discount at all did not
+ * really apply. The evaluator reports `code_valid` in that case because its
+ * validity check runs before the eligibility filter, and an eligibility flag
+ * nobody can answer (past guest, family) parks the offer in the "conditional"
+ * bucket rather than rejecting it. Reporting "valid" next to an unchanged
+ * total is the same conflation voyant#4615 was about, so name it.
+ *
+ * Only when nothing discounted: if a better auto offer won the stacking pick,
+ * the customer got the lower price and the code was genuinely honoured.
+ */
+function resolveCodeStatus(evaluation: PromotionEvaluationOutput): PromotionCodeStatusV1 | null {
+  const status = evaluation.codeStatus
+  if (status?.kind !== "code_valid") return status ?? null
+  if (evaluation.total.discountAppliedCents > 0) return status
+  return { kind: "code_not_applicable", reason: "eligibility" }
+}

--- a/packages/catalog/src/booking-engine/sessions-production.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-production.test.ts
@@ -723,6 +723,37 @@ describe("production Booking Session ports", () => {
     expect(quoted.quote.pricing.promotionCodeStatus).toEqual({ kind: "code_not_found" })
   })
 
+  it("does not let a code read as applied when no promotions module is wired", async () => {
+    // No evaluator: the quote is priced and carries no rejection, which a
+    // client reads as "applied" — so the code has to be answered explicitly.
+    const module = createCommittableProductionModule({ productId: "prod_1" })
+    const access = {
+      actorKind: "anonymous" as const,
+      capability: TEST_CAPABILITY,
+      ...STOREFRONT_ACCESS,
+    }
+    const created = await module.createSession(
+      {
+        ...committableCreateInput("create_unwired_promotion"),
+        selection: {
+          ...committableCreateInput("ignored").selection,
+          promotionCode: "GREEK15",
+        },
+      },
+      access,
+    )
+    if (created.kind !== "session_created") throw new Error("session not created")
+    const quoted = await module.quoteSession(
+      created.session.id,
+      { expectedRevision: created.session.revision, idempotencyKey: "quote_unwired_promotion" },
+      access,
+    )
+
+    if (quoted.kind !== "quote_created") throw new Error("quote not created")
+    expect(quoted.quote.pricing.total).toBe(10_000)
+    expect(quoted.quote.pricing.promotionCodeStatus).toEqual({ kind: "code_not_found" })
+  })
+
   it("keeps quoting at full price when promotion evaluation throws", async () => {
     const module = createCommittableProductionModule(
       { productId: "prod_1" },

--- a/packages/catalog/src/booking-engine/sessions-production.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-production.test.ts
@@ -214,6 +214,16 @@ describe("normalizeProductSelection", () => {
     })
   })
 
+  it("carries the promotion code through to the quote", () => {
+    // voyant#4615: the field was declared on the public selection and accepted
+    // by the route, then projected away here — so no handler could ever see a
+    // code and no code could ever change a price.
+    expect(normalizeProductSelection(PRODUCT_TARGET, { promotionCode: "  GREEK15 " })).toEqual({
+      promotionCode: "GREEK15",
+    })
+    expect(normalizeProductSelection(PRODUCT_TARGET, { promotionCode: "   " })).toEqual({})
+  })
+
   it("models a Bucharest Sector as the city and the county as an ISO 3166-2 region", () => {
     // Bucharest has no ordinary city/county pair: the six Sectors act as the
     // county-level subdivision. The Sector belongs in `city` and `RO-B` in
@@ -601,6 +611,146 @@ describe("production Booking Session ports", () => {
         bookingStatus: "confirmed",
       }
     })
+  })
+
+  it("prices a promotion code the caller supplied and commits at the discounted total", async () => {
+    // voyant#4615 end to end: the code reaches the evaluator at all, the quote
+    // total drops, and the amount the booking is created at follows the quote
+    // rather than the undiscounted catalogue price.
+    const evaluated: Record<string, unknown>[] = []
+    const module = createCommittableProductionModule(
+      { productId: "prod_1" },
+      undefined,
+      undefined,
+      () => async (input) => {
+        evaluated.push(input as unknown as Record<string, unknown>)
+        return {
+          applied: [
+            {
+              offerId: "prof_greek",
+              offerName: "Greek islands late summer",
+              discountAppliedCents: 1500,
+              discountedPriceCents: 8500,
+              currency: "EUR",
+              discountKind: "percentage" as const,
+              discountPercent: 15,
+              discountAmountCents: null,
+              appliedCode: input.code ?? null,
+              stackable: false,
+            },
+          ],
+          total: { discountAppliedCents: 1500, discountedPriceCents: 8500 },
+          codeStatus: { kind: "code_valid" as const },
+        }
+      },
+    )
+    const access = {
+      actorKind: "anonymous" as const,
+      capability: TEST_CAPABILITY,
+      ...STOREFRONT_ACCESS,
+    }
+    const created = await module.createSession(
+      {
+        ...committableCreateInput("create_promotion"),
+        selection: {
+          ...committableCreateInput("ignored").selection,
+          promotionCode: "GREEK15",
+        },
+      },
+      access,
+    )
+    if (created.kind !== "session_created") throw new Error("session not created")
+    const quoted = await module.quoteSession(
+      created.session.id,
+      { expectedRevision: created.session.revision, idempotencyKey: "quote_promotion" },
+      access,
+    )
+    if (quoted.kind !== "quote_created") throw new Error("quote not created")
+
+    expect(evaluated[0]).toMatchObject({
+      productId: "prod_selection",
+      code: "GREEK15",
+      basePriceCents: 10_000,
+      baseCurrency: "EUR",
+      pax: 1,
+    })
+    expect(quoted.quote.pricing.total).toBe(8500)
+    expect(quoted.quote.pricing.promotionCodeStatus).toEqual({ kind: "code_valid" })
+    expect(quoted.quote.pricing.appliedOffers).toHaveLength(1)
+    expect(quoted.quote.pricing.lines.at(-1)).toMatchObject({
+      kind: "discount",
+      totalAmount: -1500,
+    })
+  })
+
+  it("reports a rejected code on an otherwise good quote instead of failing it", async () => {
+    const module = createCommittableProductionModule(
+      { productId: "prod_1" },
+      undefined,
+      undefined,
+      () => async () => ({
+        applied: [],
+        total: { discountAppliedCents: 0, discountedPriceCents: 10_000 },
+        codeStatus: { kind: "code_not_found" as const },
+      }),
+    )
+    const access = {
+      actorKind: "anonymous" as const,
+      capability: TEST_CAPABILITY,
+      ...STOREFRONT_ACCESS,
+    }
+    const created = await module.createSession(
+      {
+        ...committableCreateInput("create_bad_promotion"),
+        selection: {
+          ...committableCreateInput("ignored").selection,
+          promotionCode: "NOPE",
+        },
+      },
+      access,
+    )
+    if (created.kind !== "session_created") throw new Error("session not created")
+    const quoted = await module.quoteSession(
+      created.session.id,
+      { expectedRevision: created.session.revision, idempotencyKey: "quote_bad_promotion" },
+      access,
+    )
+
+    // The departure is still bookable — the code is the only thing wrong, and
+    // conflating the two is what made the form call a good departure invalid.
+    if (quoted.kind !== "quote_created") throw new Error("quote not created")
+    expect(quoted.quote.pricing.total).toBe(10_000)
+    expect(quoted.quote.pricing.promotionCodeStatus).toEqual({ kind: "code_not_found" })
+  })
+
+  it("keeps quoting at full price when promotion evaluation throws", async () => {
+    const module = createCommittableProductionModule(
+      { productId: "prod_1" },
+      undefined,
+      undefined,
+      () => async () => {
+        throw new Error("promotions unavailable")
+      },
+    )
+    const access = {
+      actorKind: "anonymous" as const,
+      capability: TEST_CAPABILITY,
+      ...STOREFRONT_ACCESS,
+    }
+    const created = await module.createSession(
+      committableCreateInput("create_promotion_failure"),
+      access,
+    )
+    if (created.kind !== "session_created") throw new Error("session not created")
+    const quoted = await module.quoteSession(
+      created.session.id,
+      { expectedRevision: created.session.revision, idempotencyKey: "quote_promotion_failure" },
+      access,
+    )
+
+    if (quoted.kind !== "quote_created") throw new Error("quote not created")
+    expect(quoted.quote.pricing.total).toBe(10_000)
+    expect(quoted.quote.pricing.promotionCodeStatus).toBeUndefined()
   })
 
   it("carries frozen quote cancellation terms into the server-held create command", async () => {
@@ -1244,6 +1394,7 @@ function createCommittableProductionModule(
   upsertPersonFromContact: NonNullable<
     ProductionBookingSessionModuleDeps["relationships"]
   >["upsertPersonFromContact"] = async () => ({ id: "per_buyer" }) as never,
+  resolvePromotionEvaluator?: ProductionBookingSessionModuleDeps["resolvePromotionEvaluator"],
 ) {
   const repository = createInMemoryBookingSessionRepository()
   const handlers = createOwnedBookingHandlerRegistry()
@@ -1287,6 +1438,7 @@ function createCommittableProductionModule(
     relationships: {
       upsertPersonFromContact,
     } as never,
+    ...(resolvePromotionEvaluator ? { resolvePromotionEvaluator } : {}),
   })
 }
 

--- a/packages/catalog/src/booking-engine/sessions-production.ts
+++ b/packages/catalog/src/booking-engine/sessions-production.ts
@@ -933,9 +933,17 @@ async function promotedPricing(
   const code = stringValue(session.statePayload.promotionCode)
   const evaluate = await deps.resolvePromotionEvaluator?.(db)
   if (!evaluate || session.target.kind !== "product") {
-    return code
-      ? { ...breakdown, promotionCodeStatus: { kind: "code_not_applicable", reason: "scope" } }
-      : breakdown
+    // Saying nothing here would be read as "applied" by a client that has a
+    // priced quote and no rejection, so a code always gets an answer. A
+    // deployment with no promotions module cannot find the code at all;
+    // promotions only scope to products, so any other target is out of scope.
+    if (!code) return breakdown
+    return {
+      ...breakdown,
+      promotionCodeStatus: evaluate
+        ? { kind: "code_not_applicable", reason: "scope" }
+        : { kind: "code_not_found" },
+    }
   }
   const travelers = arrayValue(session.statePayload.travelers) ?? []
   try {

--- a/packages/catalog/src/booking-engine/sessions-production.ts
+++ b/packages/catalog/src/booking-engine/sessions-production.ts
@@ -37,13 +37,18 @@ import { captureSnapshot } from "../services/snapshot-service.js"
 import type { PricingBasis } from "../snapshot/schema.js"
 import { bookingAllocationsRef, bookingsRef } from "./bookings-ref.js"
 import type { BookingRequirementsV1 } from "./contracts.js"
-import { pricingBreakdownV1 } from "./contracts.js"
+import { type PricingBreakdownV1, pricingBreakdownV1 } from "./contracts.js"
 import type {
   ComputeQuoteRequest,
   OwnedBookingHandlerRegistry,
   OwnedQuoteScope,
   SelfServiceBillingParty,
 } from "./owned-handler.js"
+import {
+  applyPromotionsToBreakdown,
+  type PromotionEvaluator,
+  promotionEvaluationInputFor,
+} from "./quote-promotions.js"
 import { engineParametersFromSelection } from "./quote-support.js"
 import type { SourceAdapterRegistry } from "./registry.js"
 import type { ProductionBookingSessionPaymentDeps } from "./sessions-payment-production.js"
@@ -83,6 +88,14 @@ export interface ProductionBookingSessionModuleDeps {
   payments?: Omit<ProductionBookingSessionPaymentDeps, "db" | "financeRuntime">
   /** Host-bound product analytics. Absent means unbound — see `./analytics.ts`. */
   analytics?: AnalyticsPort
+  /**
+   * Request-scoped promotion evaluator. Absent means the deployment has no
+   * promotions module wired, and quotes price undiscounted — the state every
+   * deployment was in between voyant#4188 and voyant#4615.
+   */
+  resolvePromotionEvaluator?(
+    db: PostgresJsDatabase,
+  ): PromotionEvaluator | undefined | Promise<PromotionEvaluator | undefined>
 }
 
 export function createProductionBookingSessionModule(
@@ -257,7 +270,13 @@ function createProductionCompositeLeafRuntime(
       return {
         status: "quoted",
         requirements: quoted,
-        pricing: pricingBreakdownFromBasis(result.pricing, result.upstreamPayload),
+        pricing: await promotedPricing(
+          deps,
+          session,
+          now,
+          db,
+          pricingBreakdownFromBasis(result.pricing, result.upstreamPayload),
+        ),
       }
     },
     async placeCapacityHold(input) {
@@ -892,6 +911,72 @@ function pricingBreakdownFromBasis(pricing: PricingBasis, policySource?: Record<
   }
 }
 
+/**
+ * Fold promotional offers into a priced quote.
+ *
+ * Runs for every owned product quote, not only when a code was typed: auto
+ * offers already set the price the catalog plane advertises
+ * (`originalPriceFromAmountCents`), so evaluating only code-gated offers here
+ * would keep quoting a total the listing contradicts.
+ *
+ * Unwired deployments (and every non-product target) fall through unchanged —
+ * except that a code sent against a target promotions cannot scope to is
+ * reported as such rather than silently ignored.
+ */
+async function promotedPricing(
+  deps: ProductionBookingSessionModuleDeps,
+  session: CommitOwnedBookingInput["session"],
+  now: Date,
+  db: PostgresJsDatabase,
+  breakdown: PricingBreakdownV1,
+): Promise<PricingBreakdownV1> {
+  const code = stringValue(session.statePayload.promotionCode)
+  const evaluate = await deps.resolvePromotionEvaluator?.(db)
+  if (!evaluate || session.target.kind !== "product") {
+    return code
+      ? { ...breakdown, promotionCodeStatus: { kind: "code_not_applicable", reason: "scope" } }
+      : breakdown
+  }
+  const travelers = arrayValue(session.statePayload.travelers) ?? []
+  try {
+    const evaluation = await evaluate(
+      promotionEvaluationInputFor({
+        productId: session.target.productId,
+        breakdown,
+        scope: session.scope,
+        audience: bookingSessionAudienceForActorV1(session.actorKind),
+        pax: quotedPaxCount(session.statePayload, travelers.length),
+        at: now,
+        code,
+        hasChildTraveler: travelers.some((traveler) =>
+          (stringValue(asRecord(traveler)?.band) ?? "").startsWith("child"),
+        ),
+      }),
+    )
+    return applyPromotionsToBreakdown(breakdown, evaluation)
+  } catch (error) {
+    // A promotions failure must not collapse a good price — the same rule the
+    // products handler applies to its own pricing loads. The quote stands at
+    // full price and, when a code was sent, says the code did not resolve
+    // rather than pretending it applied.
+    console.warn(
+      "[catalog/booking-engine] promotion evaluation failed; quoting undiscounted",
+      error,
+    )
+    return code ? { ...breakdown, promotionCodeStatus: { kind: "code_not_found" } } : breakdown
+  }
+}
+
+/** Travelers being priced. Pax bands are authoritative; travelers are the fallback. */
+function quotedPaxCount(statePayload: Record<string, unknown>, travelerCount: number): number {
+  const pax = asRecord(asRecord(statePayload.configure)?.pax)
+  const banded = Object.values(pax ?? {}).reduce<number>(
+    (sum, value) => sum + (positiveInteger(value) ?? 0),
+    0,
+  )
+  return banded > 0 ? banded : Math.max(1, travelerCount)
+}
+
 function pricingBreakdownFromLiveValues(values: Record<string, unknown>) {
   const priceCents = numberValue(values.priceCents) ?? numberValue(values.price)
   const currency = stringValue(values.currency)
@@ -1072,6 +1157,9 @@ function pricingBasisFromBreakdown(
     surcharges: 0,
     currency: pricing.currency,
     breakdown: pricing,
+    // Frozen onto the snapshot so the post-commit redemption recorder can
+    // attribute the discount without re-evaluating anything.
+    ...(pricing.appliedOffers?.length ? { appliedOffers: pricing.appliedOffers } : {}),
   }
 }
 
@@ -1191,6 +1279,10 @@ export function normalizeBookingSelection(
     addons: arrayValue(source.addons)
       ?.map(normalizeAddon)
       .filter((value): value is Record<string, unknown> => value != null),
+    // Declared on the public selection since the beta quote path, but
+    // projected away here until voyant#4615 — so every caller that sent a
+    // code had it silently dropped before any handler could evaluate it.
+    promotionCode: stringValue(source.promotionCode),
     ...(rawStaffBooking !== undefined
       ? { staffBooking: normalizeBookingSessionStaffSelectionV1(rawStaffBooking) }
       : {}),

--- a/packages/catalog/src/runtime-contracts.ts
+++ b/packages/catalog/src/runtime-contracts.ts
@@ -20,6 +20,7 @@ import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type {
   BookingSessionCompositeHandler,
   OwnedBookingHandlerRegistry,
+  PromotionEvaluator,
   SourceAdapterRegistry,
 } from "./booking-engine/index.js"
 import type { CatalogBookingRouteModuleOptions } from "./booking-engine/operator-routes.js"
@@ -108,6 +109,15 @@ export interface CatalogCommerceRuntimeExtension {
   }>
   createPricingProjectionExtension(): CatalogProjectionExtension
   createPromotionsProjectionExtension(): CatalogProjectionExtension
+  /**
+   * Request-scoped promotion evaluator for the Booking Session quote.
+   *
+   * The same evaluator the catalog-plane projection uses to advertise a
+   * discounted price, so the quote and the listing agree. Optional because a
+   * deployment may run the catalog without the commerce promotions module;
+   * absent means quotes price undiscounted.
+   */
+  createPromotionEvaluator?(db: AnyDrizzleDb): PromotionEvaluator
 }
 
 export interface CatalogLegalRuntimeExtension {

--- a/packages/catalog/src/runtime-contributor.ts
+++ b/packages/catalog/src/runtime-contributor.ts
@@ -216,10 +216,11 @@ export function createCatalogRuntimePortContribution(
     const db = (dbOverride ?? host.primitives.database.resolve(undefined)) as PostgresJsDatabase
     const runtime = await contribution
     const services = await runtime.services
-    const [, , , distribution, , inventory, , , settings] = await dependencies
+    const [, , commerce, distribution, , inventory, , , settings] = await dependencies
     return createProductionBookingSessionModule({
       db,
       ...(analytics ? { analytics } : {}),
+      resolvePromotionEvaluator: (sessionDb) => commerce.createPromotionEvaluator?.(sessionDb),
       repository: createDrizzleBookingSessionRepository(db),
       resolveOwnedHandlers: () => services.getOwnedHandlers(host.primitives.env(undefined)),
       resolveSourceRegistry: () => services.ensureSourceRegistry(host.primitives.env(undefined)),

--- a/packages/catalog/src/runtime/booking-runtime.ts
+++ b/packages/catalog/src/runtime/booking-runtime.ts
@@ -31,7 +31,7 @@ export function createOperatorCatalogBookingRouteModuleOptions(options: {
   /** Host-bound product analytics. Unbound is the default and emits nothing. */
   analytics?: AnalyticsPort
 }): CatalogBookingRouteModuleOptions {
-  const { distribution, inventory, operations } = catalogRuntimeExtensions()
+  const { commerce, distribution, inventory, operations } = catalogRuntimeExtensions()
   return {
     resolveDb: getCatalogBookingDb,
     bookingSessions: {
@@ -40,6 +40,7 @@ export function createOperatorCatalogBookingRouteModuleOptions(options: {
         return createProductionBookingSessionModule({
           db,
           ...(options.analytics ? { analytics: options.analytics } : {}),
+          resolvePromotionEvaluator: (sessionDb) => commerce.createPromotionEvaluator?.(sessionDb),
           repository: createDrizzleBookingSessionRepository(db),
           resolveOwnedHandlers: () => getOwnedBookingHandlerRegistryFromContext(c),
           resolveSourceRegistry: () => getBookingEngineRegistryFromContext(c),

--- a/packages/commerce/src/catalog-runtime-extension.ts
+++ b/packages/commerce/src/catalog-runtime-extension.ts
@@ -6,6 +6,7 @@ import {
   createProductPricingProjectionExtension,
   loadProductPriceFrom,
 } from "./pricing/service-catalog-plane-pricing.js"
+import { createCatalogPromotionEvaluator } from "./promotions/service-catalog-evaluator.js"
 import { createProductPromotionsProjectionExtension } from "./promotions/service-catalog-plane-promotions.js"
 
 export const catalogCommerceRuntimeExtension: CatalogCommerceRuntimeExtension = {
@@ -27,4 +28,5 @@ export const catalogCommerceRuntimeExtension: CatalogCommerceRuntimeExtension = 
   createPricingProjectionExtension: () => createProductPricingProjectionExtension(),
   createPromotionsProjectionExtension: () =>
     createProductPromotionsProjectionExtension({ loadOriginalPrice: loadProductPriceFrom }),
+  createPromotionEvaluator: (db) => createCatalogPromotionEvaluator(db),
 }

--- a/packages/commerce/src/promotions/service-booking-confirmed.ts
+++ b/packages/commerce/src/promotions/service-booking-confirmed.ts
@@ -1,8 +1,7 @@
 /**
  * Booking-confirmed redemption subscriber — records one row per
  * (offer, booking) in `promotional_offer_redemptions` after a booking
- * commits, by reading `pricing_applied_offers` from `catalog_quotes`
- * (joined to the booking via the existing `consumed_booking_id` column).
+ * commits, from the offers the consumed quote actually applied.
  *
  * Why a subscriber rather than a commit-time hook: the owned `createBooking`
  * path opens its own transaction in `@voyant-travel/finance`, so there is no
@@ -11,27 +10,28 @@
  *
  * Per docs/architecture/promotions-architecture.md §3.6 + §7.3.
  *
- * The recorder reads from `catalog_quotes` NOT from
- * `booking_catalog_snapshot`, to avoid an ordering race with the
- * catalog-bridge's `captureSnapshotGraph` subscriber (both fire on the same
- * `booking.confirmed` event).
+ * The lookup is catalog's `readAppliedOffersForBooking`, which spans the v1
+ * `booking_session_quotes` and the legacy `catalog_quotes`. Neither is read
+ * directly here: they are catalog's tables, and reaching into them from this
+ * package was both an ADR-0016 violation and the reason this recorder went
+ * blind. It deliberately does not read `booking_catalog_snapshot`, to avoid an
+ * ordering race with the catalog-bridge's `captureSnapshotGraph` subscriber
+ * (both fire on the same `booking.confirmed` event).
  *
- * READS HISTORY ONLY (voyant#4188). Both writes this depends on are gone:
- * `pricing_applied_offers` was written by the beta `quoteEntity`, and
- * `consumed_booking_id` by `bookEntity` (#3747). New bookings therefore record
- * no redemptions. This recorder is the reason `catalog_quotes` was kept rather
- * than dropped — it is the read path for rows a shipped booking already
- * consumed. Restoring redemption recording means evaluating promotions on the
- * v1 Session `composeQuote` and reading `booking_session_quotes` here.
+ * Live again as of voyant#4615. Between voyant#4188 and that change this read
+ * history only: `pricing_applied_offers` was written by the beta `quoteEntity`
+ * and `consumed_booking_id` by `bookEntity` (#3747), so no new booking
+ * recorded a redemption. Promotions are evaluated on the v1 Session
+ * `composeQuote` now, and the applied offers ride the quote to commit.
  *
  * Idempotent on retry: the unique `(offer_id, booking_id)` index on
  * `promotional_offer_redemptions` (per §4.3) lets the upsert refresh the
  * aggregate cleanly even if the subscriber is replayed.
  */
 
-import { type AppliedOffer, catalogQuotesTable } from "@voyant-travel/catalog/booking-engine"
+import { readAppliedOffersForBooking } from "@voyant-travel/catalog/booking-engine"
 import type { AnyDrizzleDb } from "@voyant-travel/db"
-import { eq, sql } from "drizzle-orm"
+import { sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import { promotionalOfferRedemptions } from "./schema.js"
@@ -62,12 +62,9 @@ export async function recordPromotionRedemptionsForBooking(
   db: AnyDrizzleDb,
   bookingId: string,
 ): Promise<RecordRedemptionsResult> {
-  const rows = await db
-    .select({ pricing_applied_offers: catalogQuotesTable.pricing_applied_offers })
-    .from(catalogQuotesTable)
-    .where(eq(catalogQuotesTable.consumed_booking_id, bookingId))
+  const { quotesScanned, offers } = await readAppliedOffersForBooking(db, bookingId)
 
-  if (rows.length === 0) {
+  if (quotesScanned === 0) {
     return { quotesScanned: 0, offersFound: 0, rowsUpserted: 0 }
   }
 
@@ -76,29 +73,26 @@ export async function recordPromotionRedemptionsForBooking(
     string,
     { discountAppliedCents: number; currency: string; codeUsed: string | null }
   >()
-  for (const row of rows) {
-    const offers: AppliedOffer[] = row.pricing_applied_offers ?? []
-    for (const offer of offers) {
-      const existing = aggregated.get(offer.offerId)
-      if (existing) {
-        existing.discountAppliedCents += offer.discountAppliedCents
-        // First non-null wins — the code-gated offer (if any) is
-        // typically a single occurrence.
-        if (existing.codeUsed == null && offer.appliedCode != null) {
-          existing.codeUsed = offer.appliedCode
-        }
-      } else {
-        aggregated.set(offer.offerId, {
-          discountAppliedCents: offer.discountAppliedCents,
-          currency: offer.currency,
-          codeUsed: offer.appliedCode,
-        })
+  for (const offer of offers) {
+    const existing = aggregated.get(offer.offerId)
+    if (existing) {
+      existing.discountAppliedCents += offer.discountAppliedCents
+      // First non-null wins — the code-gated offer (if any) is
+      // typically a single occurrence.
+      if (existing.codeUsed == null && offer.appliedCode != null) {
+        existing.codeUsed = offer.appliedCode
       }
+    } else {
+      aggregated.set(offer.offerId, {
+        discountAppliedCents: offer.discountAppliedCents,
+        currency: offer.currency,
+        codeUsed: offer.appliedCode,
+      })
     }
   }
 
   if (aggregated.size === 0) {
-    return { quotesScanned: rows.length, offersFound: 0, rowsUpserted: 0 }
+    return { quotesScanned, offersFound: 0, rowsUpserted: 0 }
   }
 
   const insertValues = Array.from(aggregated.entries()).map(([offerId, summary]) => ({
@@ -131,7 +125,7 @@ export async function recordPromotionRedemptionsForBooking(
     })
 
   return {
-    quotesScanned: rows.length,
+    quotesScanned,
     offersFound: aggregated.size,
     rowsUpserted: aggregated.size,
   }

--- a/packages/commerce/src/promotions/service-catalog-evaluator.ts
+++ b/packages/commerce/src/promotions/service-catalog-evaluator.ts
@@ -3,10 +3,10 @@
  * `PromotionEvaluationInput` / `PromotionEvaluationOutput` contract to
  * this package's internal evaluator.
  *
- * Currently unwired: the deployment hook it plugged into was the beta
- * `QuoteEntityDeps.evaluatePromotions`, deleted with the beta quote path in
- * voyant#4188. The bridge is kept because it is the published adapter a
- * v1 Session `composeQuote` promotion hook would reuse verbatim.
+ * Wired onto the v1 Session `composeQuote` in voyant#4615 via
+ * `CatalogCommerceRuntimeExtension.createPromotionEvaluator`, after spending
+ * the interval since voyant#4188 — which deleted its original hook, the beta
+ * `QuoteEntityDeps.evaluatePromotions` — with no call sites at all.
  *
  * Per docs/architecture/promotions-architecture.md §3.6 + §7.1.
  */

--- a/scripts/checks/schema/table-privacy-baseline.json
+++ b/scripts/checks/schema/table-privacy-baseline.json
@@ -20,7 +20,6 @@
     "apps->custom-fields": 1,
     "bookings->action-ledger": 1,
     "commerce->bookings": 6,
-    "commerce->catalog": 1,
     "commerce->distribution": 4,
     "commerce->finance": 1,
     "cruises->catalog": 1,


### PR DESCRIPTION
Closes #4615.

## #4615 — promotion codes on a manual booking

The issue reported that any code entered on **Bookings → New booking** blocked the form. Tracing it found the cause was one layer deeper than the report assumed, and the report's other half — "the quote reports the code invalid" — turned out to be a mis-attribution.

`promotionCode` has been declared on `bookingSelectionPublicV1` and accepted by both `POST /offers/preview` and `POST /booking-sessions` since the beta quote path. It never reached a handler: `normalizeBookingSelection` rebuilds the selection from a whitelist and `promotionCode` is not on it, so the field was silently dropped server-side. The preview result was therefore **byte-identical with and without a code**, and the "This promotion code is not valid for this booking" line the reporter saw came from `available === false` for unrelated reasons, surfaced only because typing a code is the one thing that renders that message.

`createCatalogPromotionEvaluator` — the adapter written for precisely this hook — had **zero call sites** since voyant#4188 deleted the beta `quoteEntity`. So did the redemption recorder's writes.

### What changed

- **`normalizeBookingSelection` carries `promotionCode`.** One whitelist entry; without it nothing downstream can ever see a code.
- **`composeQuote` evaluates promotions**, through a new optional `CatalogCommerceRuntimeExtension.createPromotionEvaluator` seam. Catalog keeps owning the contract; commerce supplies the evaluator, reusing the existing bridge verbatim as its own docstring predicted.
- **`pricingBreakdownV1` gains `appliedOffers` and `promotionCodeStatus`.** This is the real design gap behind the report: a rejected code does not make a departure unbookable, so a *valid* quote needed somewhere to say the code was wrong. Neither the pricing breakdown nor the preview result had such a field, which is why the client was reduced to inferring it.
- **The commit honours the quote.** The discount is folded into the breakdown, so `pricingBasisFromBreakdown` → `resolveSellAmountCentsOverride` → `fillMissingBookingItemSellAmounts` carry it to booking creation with no new plumbing — that function's contract already names promotion as a residual it allocates.
- **Redemption recording is live again**, via catalog's new `readAppliedOffersForBooking` spanning `booking_session_quotes` and the legacy `catalog_quotes`.
- **The form stops blocking.** `submitBlocked` no longer contains a bare `hasPromotionCode` (and the unreachable guard the issue spotted underneath it is gone). A rejected code still blocks — creating the booking anyway would drop a discount the operator has already promised over the phone — but with copy naming *why*: unrecognised, expired, not yet valid, or not applicable.

### Discount arithmetic

The discount base is the quote **total**, so a `fixed_amount` offer is capped against the price the customer actually sees. Each applied offer becomes a negative `discount` line; `subtotal` and `taxTotal` scale proportionally, preserving both the effective tax rate and `subtotal + taxTotal === total` under inclusive *and* exclusive tax. Base lines are deliberately left undiscounted — `fillMissingBookingItemSellAmounts` uses them as reconciliation weights, so rewriting them would double-apply the discount at commit.

### Two judgement calls worth review

1. **Auto-applied offers are evaluated too, not only code-gated ones.** The catalog-plane projection already writes `originalPriceFromAmountCents` / `hasOffer`, so listings advertise the discounted price today while the quote charges full price. Evaluating only codes would have left that contradiction in place. This does change behaviour for any deployment with an active auto-promotion. It costs 2–3 indexed reads per quote on the preview path.
2. **Audience is derived from `actorKind`**, so an operator taking a phone booking quotes at `audience: "staff"`. An offer scoped to `audiences: ["customer"]` will therefore report `code_not_applicable/scope` on this form. That derivation is deliberate (it stops a storefront visitor requesting staff pricing) and changing it is a separate product decision.

## #4616 — no change needed

Already fixed on `main` by #4591, which merged 2026-08-12 23:56 — one commit after `e8645d2925`, the SHA the issue was filed against. `fillsSlotCapacity` reads `"included in departure capacity"` / `"inclus in capacitatea plecarii"` today: neither "room" nor "full". Closing it separately as fixed.

## Verification

- `packages/catalog` — `quote-promotions.test.ts` (new, 11 cases: arithmetic, tax residual allocation, clamping, code-status downgrade) and `sessions-production.test.ts` (3 new end-to-end cases through the real module: code priced, code rejected on a good quote, evaluator throwing) — 48 passing.
- `packages/bookings-react` — `manual-booking-promotion.test.ts` (new, 24 passing with the existing validation suite) covering the gating states the old `hasPromotionCode` collapsed.
- `verify:table-privacy` — `commerce->catalog` drops 1 → 0; baseline tightened accordingly.
- `verify:openapi-drift` specs regenerated; `catalog-runtime-authority`, `commerce-promotion-subscriber-authority`, `runtime-ports`, `public-surface`, `vitest-include`, `typecheck-coverage` all pass locally.
- `biome check` clean (0 errors).

Full typecheck/build is left to CI — the local closure build exceeded the time budget on this machine.
