### PR TITLE
fix(auth): rebuild the API tokens page around a scope picker

### DIFF
--- a/.changeset/api-token-scope-picker.md
+++ b/.changeset/api-token-scope-picker.md
@@ -1,0 +1,14 @@
+---
+"@voyant-travel/auth-react": minor
+"@voyant-travel/operator-settings-react": patch
+---
+
+Rebuild the API tokens page around a scope picker, and make a missing permission catalog fail loudly.
+
+Settings → API tokens rendered its permission catalog inline, so a deployment that mounted the page without an `accessCatalog` silently produced a create form with no checkboxes whose only possible outcome was "Select at least one permission." The page now says so — a destructive alert plus a disabled create action — instead of offering a form that cannot succeed.
+
+Creating a token moved into a sheet: name, expiration, then scopes as preset chips, a search box, and one collapsed accordion section per resource. Ticking a resource grants it whole and locks its actions, and the grant names any `wildcard: "explicit"` action alongside the `*` so it covers exactly what it displays. Presets published as `api-token-grant` (the audience-scoped agent presets) are offered too — previously only `api-token` presets were, so deployments that publish only the former showed none.
+
+Existing tokens moved from stacked cards to a table with a per-row action menu, and deleting a token now asks for confirmation the way rotating one already did.
+
+Webhooks: the create-subscription dialog scrolls its body instead of pushing Cancel and Create subscription past the viewport, and both webhook pages use the design-system `Checkbox` rather than a raw `<input type="checkbox">`.

--- a/packages/auth-react/src/components/api-token-scope-picker.tsx
+++ b/packages/auth-react/src/components/api-token-scope-picker.tsx
@@ -1,0 +1,255 @@
+"use client"
+
+import { formatMessage } from "@voyant-travel/i18n"
+import {
+  type AccessCatalog,
+  type AccessCatalogResource,
+  type ApiKeyPermissions,
+  hasApiKeyPermission,
+  permissionsToStrings,
+} from "@voyant-travel/types/api-keys"
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+  Badge,
+  Button,
+  Checkbox,
+  Input,
+  Label,
+} from "@voyant-travel/ui/components"
+import { Lock, Search, ShieldAlert } from "lucide-react"
+import { useMemo, useState } from "react"
+import { useAuthUiMessagesOrDefault } from "../i18n/provider.js"
+import {
+  apiTokenPresets,
+  grantedActionCount,
+  isFullAccess,
+  isResourceGranted,
+  matchesScopeSearch,
+  setActionGrant,
+  setFullAccess,
+  setResourceGrant,
+} from "./api-token-scopes.js"
+
+export interface ApiTokenScopePickerProps {
+  catalog: AccessCatalog
+  value: ApiKeyPermissions
+  onChange: (next: ApiKeyPermissions) => void
+}
+
+/**
+ * Scope selection for an API token. At deployment scale the catalog is a long
+ * flat list (~60 resources / ~140 actions), so it is presented as presets, a
+ * search box, and one collapsed accordion section per resource rather than a
+ * wall of checkboxes.
+ */
+export function ApiTokenScopePicker({ catalog, value, onChange }: ApiTokenScopePickerProps) {
+  const messages = useAuthUiMessagesOrDefault().serviceApiKeysPage.scopes
+  const [search, setSearch] = useState("")
+
+  const presets = useMemo(() => apiTokenPresets(catalog), [catalog])
+  const visibleResources = useMemo(
+    () => catalog.resources.filter((resource) => matchesScopeSearch(resource, search)),
+    [catalog.resources, search],
+  )
+  const fullAccess = isFullAccess(value)
+  const selectedCount = permissionsToStrings(value).length
+
+  return (
+    <section className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <h2 className="text-sm font-medium">{messages.title}</h2>
+          <p className="text-xs text-muted-foreground">{messages.description}</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Badge variant={selectedCount > 0 ? "default" : "outline"}>
+            {formatMessage(messages.selectedCount, { count: String(selectedCount) })}
+          </Badge>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={selectedCount === 0}
+            onClick={() => onChange({})}
+          >
+            {messages.clear}
+          </Button>
+        </div>
+      </div>
+
+      {presets.length > 0 && (
+        <div className="flex flex-col gap-2">
+          <span className="text-xs font-medium text-muted-foreground uppercase">
+            {messages.presets}
+          </span>
+          <div className="flex flex-wrap gap-2">
+            {presets.map((preset) => (
+              <Button
+                key={preset.id}
+                type="button"
+                variant="outline"
+                size="sm"
+                title={preset.description}
+                onClick={() => onChange({ ...preset.permissions })}
+              >
+                {preset.label}
+              </Button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <Label
+        htmlFor="api-token-full-access"
+        className="flex items-start gap-3 rounded-md border border-destructive/30 bg-destructive/5 p-3 font-normal"
+      >
+        <Checkbox
+          id="api-token-full-access"
+          checked={fullAccess}
+          onCheckedChange={(checked) => onChange(setFullAccess(checked === true))}
+          className="mt-0.5"
+        />
+        <span className="min-w-0">
+          <span className="flex items-center gap-1.5 text-sm font-medium">
+            <ShieldAlert className="size-3.5 text-destructive" />
+            {messages.fullAccess}
+          </span>
+          <span className="block text-xs text-muted-foreground">{messages.fullAccessHint}</span>
+        </span>
+      </Label>
+
+      <div className="relative">
+        <Search className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder={messages.search}
+          className="pl-9"
+          aria-label={messages.search}
+        />
+      </div>
+
+      {visibleResources.length === 0 ? (
+        <p className="py-6 text-center text-sm text-muted-foreground">{messages.noResults}</p>
+      ) : (
+        <Accordion className="rounded-md border px-3">
+          {visibleResources.map((resource) => (
+            <ScopeGroup
+              key={resource.id}
+              resource={resource}
+              catalog={catalog}
+              value={value}
+              onChange={onChange}
+              locked={fullAccess}
+            />
+          ))}
+        </Accordion>
+      )}
+    </section>
+  )
+}
+
+function ScopeGroup({
+  resource,
+  catalog,
+  value,
+  onChange,
+  locked,
+}: {
+  resource: AccessCatalogResource
+  catalog: AccessCatalog
+  value: ApiKeyPermissions
+  onChange: (next: ApiKeyPermissions) => void
+  locked: boolean
+}) {
+  const messages = useAuthUiMessagesOrDefault().serviceApiKeysPage.scopes
+  const granted = isResourceGranted(value, resource)
+  const selected = grantedActionCount(value, resource, catalog)
+  // Full access and a resource grant both make every action a foregone
+  // conclusion, so the action checkboxes go read-only rather than pretending an
+  // individual toggle would still change the outcome.
+  const actionsLocked = locked || granted
+  const groupId = `api-token-scope-${resource.resource}`
+
+  return (
+    <AccordionItem value={resource.resource}>
+      <div className="flex items-center gap-3">
+        <Checkbox
+          id={groupId}
+          checked={locked || granted}
+          disabled={locked}
+          onCheckedChange={(checked) =>
+            onChange(setResourceGrant(value, resource, checked === true))
+          }
+          aria-label={formatMessage(messages.groupAllLabel, { resource: resource.label })}
+        />
+        <AccordionTrigger className="py-3">
+          <span className="flex min-w-0 flex-col">
+            <span className="flex items-center gap-2">
+              {resource.label}
+              <Badge variant={selected > 0 ? "default" : "outline"} className="font-normal">
+                {formatMessage(messages.countOf, {
+                  selected: String(selected),
+                  total: String(resource.actions.length),
+                })}
+              </Badge>
+            </span>
+            <span className="truncate text-xs font-normal text-muted-foreground">
+              {resource.description}
+            </span>
+          </span>
+        </AccordionTrigger>
+      </div>
+      <AccordionContent className="pl-7">
+        <div className="flex flex-col gap-1">
+          <p className="pb-1 text-xs text-muted-foreground">
+            {actionsLocked ? (
+              <span className="flex items-center gap-1.5">
+                <Lock className="size-3" />
+                {messages.lockedHint}
+              </span>
+            ) : (
+              messages.groupAllHint
+            )}
+          </p>
+          {resource.actions.map((action) => {
+            const actionId = `${groupId}-${action.action}`
+            return (
+              <Label
+                key={action.action}
+                htmlFor={actionId}
+                className="flex items-start gap-3 rounded-md p-2 font-normal hover:bg-muted/60 has-disabled:hover:bg-transparent"
+              >
+                <Checkbox
+                  id={actionId}
+                  disabled={actionsLocked}
+                  checked={hasApiKeyPermission(value, resource.resource, action.action, catalog)}
+                  onCheckedChange={(checked) =>
+                    onChange(
+                      setActionGrant(value, resource.resource, action.action, checked === true),
+                    )
+                  }
+                  className="mt-0.5"
+                />
+                <span className="min-w-0">
+                  <span className="flex items-center gap-2 text-sm font-medium">
+                    {action.label}
+                    {action.sensitive && (
+                      <Badge variant="outline" className="text-[10px] font-normal">
+                        {messages.sensitive}
+                      </Badge>
+                    )}
+                  </span>
+                  <span className="block text-xs text-muted-foreground">{action.description}</span>
+                </span>
+              </Label>
+            )
+          })}
+        </div>
+      </AccordionContent>
+    </AccordionItem>
+  )
+}

--- a/packages/auth-react/src/components/api-token-scopes.ts
+++ b/packages/auth-react/src/components/api-token-scopes.ts
@@ -1,0 +1,153 @@
+import {
+  type AccessCatalog,
+  type AccessCatalogResource,
+  type ApiKeyPermissions,
+  hasApiKeyPermission,
+  permissionStringsToPermissions,
+} from "@voyant-travel/types/api-keys"
+
+/**
+ * Scope-selection helpers for the API token editor.
+ *
+ * The editor works in two tiers, mirroring how the catalog resolves a grant:
+ *
+ * - a RESOURCE grant (`bookings:*`) covers every current and future action on
+ *   that resource, so its actions are shown checked and locked; and
+ * - individual ACTION grants (`bookings:read`) are the granular fallback.
+ *
+ * `wildcard: "explicit"` actions are deliberately NOT covered by `resource:*`
+ * (see `hasApiKeyPermission`), so a resource grant has to name them alongside
+ * the wildcard or the "select the whole group" affordance would silently grant
+ * less than it displays.
+ */
+
+/** A preset the token editor may apply — both catalog preset kinds qualify. */
+export interface ApiTokenPreset {
+  id: string
+  label: string
+  description: string
+  audience?: string
+  permissions: ApiKeyPermissions
+}
+
+/**
+ * Presets offered by the token editor. `api-token` presets are authored for
+ * tokens directly; `api-token-grant` presets are audience-scoped grants the
+ * deployment publishes (agent, public catalog reader) and are equally valid
+ * starting points. `staff` presets are member roles and are excluded.
+ */
+export function apiTokenPresets(catalog: AccessCatalog): ApiTokenPreset[] {
+  return catalog.presets
+    .filter((preset) => preset.kind === "api-token" || preset.kind === "api-token-grant")
+    .map((preset) => ({
+      id: preset.id,
+      label: preset.label,
+      description: preset.description,
+      ...(preset.audience ? { audience: preset.audience } : {}),
+      permissions: permissionStringsToPermissions(preset.grants),
+    }))
+}
+
+/** Actions a whole-resource grant must name so it covers what the UI shows. */
+export function resourceGrantActions(resource: AccessCatalogResource): string[] {
+  const explicit = resource.actions
+    .filter((action) => action.wildcard === "explicit")
+    .map((action) => action.action)
+  return Array.from(new Set(["*", ...explicit])).sort()
+}
+
+/** Whether the whole resource is granted (and its actions therefore locked). */
+export function isResourceGranted(
+  permissions: ApiKeyPermissions,
+  resource: AccessCatalogResource,
+): boolean {
+  return permissions[resource.resource]?.includes("*") === true
+}
+
+/** Grant or revoke a whole resource. */
+export function setResourceGrant(
+  permissions: ApiKeyPermissions,
+  resource: AccessCatalogResource,
+  granted: boolean,
+): ApiKeyPermissions {
+  const next = { ...permissions }
+  if (granted) {
+    next[resource.resource] = resourceGrantActions(resource)
+  } else {
+    delete next[resource.resource]
+  }
+  return next
+}
+
+/** Grant or revoke a single action on a resource. */
+export function setActionGrant(
+  permissions: ApiKeyPermissions,
+  resource: string,
+  action: string,
+  granted: boolean,
+): ApiKeyPermissions {
+  const current = new Set(permissions[resource] ?? [])
+  if (granted) {
+    current.add(action)
+  } else {
+    current.delete(action)
+  }
+
+  const next = { ...permissions }
+  if (current.size === 0) {
+    delete next[resource]
+  } else {
+    next[resource] = Array.from(current).sort()
+  }
+  return next
+}
+
+/** Whether the token carries the unrestricted `*` grant. */
+export function isFullAccess(permissions: ApiKeyPermissions): boolean {
+  return permissions["*"]?.includes("*") === true
+}
+
+/**
+ * Apply or drop full access. Turning it on replaces the selection outright —
+ * `*` already implies everything, and keeping stale per-resource entries around
+ * would resurface them the moment it is turned back off.
+ */
+export function setFullAccess(on: boolean): ApiKeyPermissions {
+  return on ? { "*": ["*"] } : {}
+}
+
+/** Number of a resource's actions the current selection satisfies. */
+export function grantedActionCount(
+  permissions: ApiKeyPermissions,
+  resource: AccessCatalogResource,
+  catalog: AccessCatalog,
+): number {
+  return resource.actions.filter((action) =>
+    hasApiKeyPermission(permissions, resource.resource, action.action, catalog),
+  ).length
+}
+
+/** Case-insensitive match over the labels a reader actually scans. */
+export function matchesScopeSearch(resource: AccessCatalogResource, query: string): boolean {
+  const term = query.trim().toLowerCase()
+  if (!term) return true
+  const haystack = [
+    resource.resource,
+    resource.label,
+    resource.description,
+    ...resource.actions.flatMap((action) => [action.action, action.label, action.description]),
+  ]
+  return haystack.some((value) => value.toLowerCase().includes(term))
+}
+
+/**
+ * The selection a fresh token starts from: the deployment's read-oriented
+ * catalog preset when it publishes one, else the first token preset, else
+ * nothing (which the editor surfaces as "no scopes selected" rather than
+ * letting the form submit an empty grant).
+ */
+export function defaultTokenPermissions(catalog: AccessCatalog): ApiKeyPermissions {
+  const presets = apiTokenPresets(catalog)
+  const preferred = presets.find((preset) => preset.id === "catalog-read") ?? presets[0]
+  return { ...(preferred?.permissions ?? {}) }
+}

--- a/packages/auth-react/src/components/service-api-keys-page.tsx
+++ b/packages/auth-react/src/components/service-api-keys-page.tsx
@@ -4,36 +4,55 @@ import { formatMessage } from "@voyant-travel/i18n"
 import {
   type AccessCatalog,
   type ApiKeyPermissions,
-  accessCatalogPermissionGroups,
-  describePermissions,
-  hasApiKeyPermission,
-  permissionStringsToPermissions,
   permissionsToStrings,
 } from "@voyant-travel/types/api-keys"
 import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
   Badge,
   Button,
   Card,
   CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-  Checkbox,
   cn,
   confirmDialog,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
   Input,
   Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Sheet,
+  SheetBody,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
 } from "@voyant-travel/ui/components"
 import {
   Check,
   Copy,
   KeyRound,
   Loader2,
+  MoreHorizontal,
   Plus,
   Power,
   PowerOff,
   RefreshCw,
   Trash2,
+  TriangleAlert,
 } from "lucide-react"
 import { type FormEvent, useMemo, useState } from "react"
 import { useAuthUiI18nOrDefault, useAuthUiMessagesOrDefault } from "../i18n/provider.js"
@@ -43,6 +62,8 @@ import {
   useApiTokenMutation,
   useApiTokens,
 } from "../index.js"
+import { ApiTokenScopePicker } from "./api-token-scope-picker.js"
+import { defaultTokenPermissions } from "./api-token-scopes.js"
 
 export interface ServiceApiKeysPageProps {
   className?: string
@@ -53,6 +74,8 @@ export interface ServiceApiKeysPageProps {
 }
 
 export type ApiTokensPageProps = ServiceApiKeysPageProps
+
+const EMPTY_CATALOG: AccessCatalog = { resources: [], presets: [] }
 
 function expiresInSeconds(days: number | null): number | null {
   return days === null ? null : days * 24 * 60 * 60
@@ -71,28 +94,6 @@ function permissionLabel(permission: string, fullAccessLabel: string): string {
   if (permission === "*") return fullAccessLabel
   const [resource, action] = permission.split(":")
   return `${resource ?? permission}:${action ?? ""}`
-}
-
-function togglePermission(
-  permissions: ApiKeyPermissions,
-  resource: string,
-  action: string,
-  checked: boolean,
-): ApiKeyPermissions {
-  const current = new Set(permissions[resource] ?? [])
-  if (checked) {
-    current.add(action)
-  } else {
-    current.delete(action)
-  }
-
-  const next = { ...permissions }
-  if (current.size === 0) {
-    delete next[resource]
-  } else {
-    next[resource] = Array.from(current).sort()
-  }
-  return next
 }
 
 function useClipboard() {
@@ -115,139 +116,202 @@ export function ServiceApiKeysPage({
   description,
   accessCatalog,
 }: ServiceApiKeysPageProps) {
-  const catalog = useMemo(() => accessCatalog ?? { resources: [], presets: [] }, [accessCatalog])
-  const permissionGroups = useMemo(() => accessCatalogPermissionGroups(catalog), [catalog])
-  const permissionPresets = useMemo(
-    () =>
-      Object.fromEntries(
-        catalog.presets
-          .filter((preset) => preset.kind === "api-token")
-          .map((preset) => [
-            preset.id,
-            {
-              label: preset.label,
-              description: preset.description,
-              permissions: permissionStringsToPermissions(preset.grants),
-            },
-          ]),
-      ) as Record<string, { label: string; description: string; permissions: ApiKeyPermissions }>,
-    [catalog],
-  )
+  const catalog = accessCatalog ?? EMPTY_CATALOG
+  // A deployment whose catalog never arrived can only render a create form that
+  // is guaranteed to fail validation, so the page says so instead (#4618).
+  const catalogUnavailable = catalog.resources.length === 0
   const messages = useAuthUiMessagesOrDefault().serviceApiKeysPage
   const pageTitle = title ?? messages.title
   const pageDescription = description ?? messages.description
-  const expirationOptions = [
-    { label: messages.create.expirationOptions.never, days: null },
-    { label: messages.create.expirationOptions.sevenDays, days: 7 },
-    { label: messages.create.expirationOptions.thirtyDays, days: 30 },
-    { label: messages.create.expirationOptions.ninetyDays, days: 90 },
-    { label: messages.create.expirationOptions.oneYear, days: 365 },
-  ] as const
   const keys = useApiTokens({ limit: pageSize, sortBy: "createdAt", sortDirection: "desc" })
-  const mutations = useApiTokenMutation()
   const clipboard = useClipboard()
 
-  const [name, setName] = useState("")
-  const [expirationDays, setExpirationDays] = useState<number | null>(90)
-  const [selectedPermissions, setSelectedPermissions] = useState<ApiKeyPermissions>(() => ({
-    ...(permissionPresets["catalog-read"]?.permissions ??
-      Object.values(permissionPresets)[0]?.permissions ??
-      {}),
-  }))
+  const [createOpen, setCreateOpen] = useState(false)
   const [issuedKey, setIssuedKey] = useState<ApiTokenWithSecret | null>(null)
   const [error, setError] = useState<string | null>(null)
 
-  const selectedDescription = useMemo(
-    () => describePermissions(selectedPermissions),
-    [selectedPermissions],
+  return (
+    <div data-slot="api-tokens-page" className={cn("flex flex-col gap-6", className)}>
+      <header className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">{pageTitle}</h1>
+          <p className="text-sm text-muted-foreground">{pageDescription}</p>
+        </div>
+        <div className="flex gap-2">
+          <Button type="button" variant="outline" onClick={() => void keys.refetch()}>
+            <RefreshCw className="mr-2 size-4" />
+            {messages.list.refresh}
+          </Button>
+          <Button type="button" disabled={catalogUnavailable} onClick={() => setCreateOpen(true)}>
+            <Plus className="mr-2 size-4" />
+            {messages.create.open}
+          </Button>
+        </div>
+      </header>
+
+      {catalogUnavailable && (
+        <Alert variant="destructive">
+          <TriangleAlert />
+          <AlertTitle>{messages.catalogUnavailable.title}</AlertTitle>
+          <AlertDescription>{messages.catalogUnavailable.description}</AlertDescription>
+        </Alert>
+      )}
+
+      {error && (
+        <Alert variant="destructive">
+          <TriangleAlert />
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {issuedKey && (
+        <Alert>
+          <KeyRound />
+          <AlertTitle>{messages.createdToken.title}</AlertTitle>
+          <AlertDescription className="flex flex-col gap-3">
+            <span>{messages.createdToken.description}</span>
+            <span className="flex w-full flex-col gap-2 sm:flex-row">
+              <Input value={issuedKey.key} readOnly className="font-mono text-xs" />
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => void clipboard.copy(issuedKey.id, issuedKey.key)}
+              >
+                {clipboard.copied === issuedKey.id ? (
+                  <Check className="mr-2 size-4" />
+                ) : (
+                  <Copy className="mr-2 size-4" />
+                )}
+                {messages.createdToken.copy}
+              </Button>
+            </span>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {keys.isLoading ? (
+        <Card>
+          <CardContent className="flex items-center gap-2 py-6 text-sm text-muted-foreground">
+            <Loader2 className="size-4 animate-spin" />
+            {messages.list.loading}
+          </CardContent>
+        </Card>
+      ) : keys.data?.apiKeys.length ? (
+        <section className="flex flex-col gap-3">
+          <h2 className="text-lg font-semibold">{messages.list.title}</h2>
+          <ServiceApiKeyTable
+            apiKeys={keys.data.apiKeys}
+            onError={setError}
+            onSecretIssued={setIssuedKey}
+          />
+        </section>
+      ) : (
+        <Card>
+          <CardContent className="py-10 text-center text-sm text-muted-foreground">
+            {messages.list.empty}
+          </CardContent>
+        </Card>
+      )}
+
+      <CreateApiTokenSheet
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        catalog={catalog}
+        onCreated={(created) => {
+          setError(null)
+          setIssuedKey(created)
+          setCreateOpen(false)
+        }}
+      />
+    </div>
   )
+}
 
-  const onTogglePermission = (resource: string, action: string, checked: boolean) => {
-    setSelectedPermissions((current) => togglePermission(current, resource, action, checked))
-  }
+export const ApiTokensPage = ServiceApiKeysPage
 
-  const applyPreset = (preset: string) => {
-    const selected = permissionPresets[preset]
-    if (selected) setSelectedPermissions({ ...selected.permissions })
+function CreateApiTokenSheet({
+  open,
+  onOpenChange,
+  catalog,
+  onCreated,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  catalog: AccessCatalog
+  onCreated: (created: ApiTokenWithSecret) => void
+}) {
+  const messages = useAuthUiMessagesOrDefault().serviceApiKeysPage
+  const mutations = useApiTokenMutation()
+  const expirationOptions = [
+    { value: "never", label: messages.create.expirationOptions.never, days: null },
+    { value: "7", label: messages.create.expirationOptions.sevenDays, days: 7 },
+    { value: "30", label: messages.create.expirationOptions.thirtyDays, days: 30 },
+    { value: "90", label: messages.create.expirationOptions.ninetyDays, days: 90 },
+    { value: "365", label: messages.create.expirationOptions.oneYear, days: 365 },
+  ] as const
+
+  const [name, setName] = useState("")
+  const [expiration, setExpiration] = useState<string>("90")
+  const [permissions, setPermissions] = useState<ApiKeyPermissions>(() =>
+    defaultTokenPermissions(catalog),
+  )
+  const [error, setError] = useState<string | null>(null)
+
+  const scopeStrings = useMemo(() => permissionsToStrings(permissions), [permissions])
+
+  const reset = () => {
+    setName("")
+    setExpiration("90")
+    setPermissions(defaultTokenPermissions(catalog))
+    setError(null)
   }
 
   const handleCreate = async (event: FormEvent) => {
     event.preventDefault()
     setError(null)
-    setIssuedKey(null)
 
     if (!name.trim()) {
       setError(messages.create.errors.nameRequired)
       return
     }
-
-    if (permissionsToStrings(selectedPermissions).length === 0) {
+    if (scopeStrings.length === 0) {
       setError(messages.create.errors.permissionRequired)
       return
     }
 
     try {
+      const days = expirationOptions.find((option) => option.value === expiration)?.days ?? null
       const result = await mutations.create.mutateAsync({
         name: name.trim(),
-        permissions: selectedPermissions,
-        expiresIn: expiresInSeconds(expirationDays),
+        permissions,
+        expiresIn: expiresInSeconds(days),
       })
-      setIssuedKey(result)
-      setName("")
+      reset()
+      onCreated(result)
     } catch (err) {
       setError(err instanceof Error ? err.message : messages.create.errors.createFailed)
     }
   }
 
   return (
-    <div data-slot="api-tokens-page" className={cn("flex flex-col gap-6", className)}>
-      <div>
-        <h1 className="text-2xl font-bold tracking-tight">{pageTitle}</h1>
-        <p className="text-sm text-muted-foreground">{pageDescription}</p>
-      </div>
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent size="xl" className="gap-0">
+        <SheetHeader className="border-b">
+          <SheetTitle>{messages.create.title}</SheetTitle>
+          <SheetDescription>{messages.create.description}</SheetDescription>
+        </SheetHeader>
 
-      {issuedKey && (
-        <Card className="border-primary/30 bg-primary/5">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-base">
-              <KeyRound className="h-4 w-4" />
-              {messages.createdToken.title}
-            </CardTitle>
-            <CardDescription>{messages.createdToken.description}</CardDescription>
-          </CardHeader>
-          <CardContent className="flex flex-col gap-3 sm:flex-row">
-            <Input value={issuedKey.key} readOnly className="font-mono text-xs" />
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => void clipboard.copy(issuedKey.id, issuedKey.key)}
-            >
-              {clipboard.copied === issuedKey.id ? (
-                <Check className="mr-2 h-4 w-4" />
-              ) : (
-                <Copy className="mr-2 h-4 w-4" />
-              )}
-              {messages.createdToken.copy}
-            </Button>
-          </CardContent>
-        </Card>
-      )}
-
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">{messages.create.title}</CardTitle>
-          <CardDescription>{selectedDescription}</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <form onSubmit={handleCreate} className="flex flex-col gap-4">
+        <form onSubmit={handleCreate} className="flex min-h-0 flex-1 flex-col overflow-hidden">
+          <SheetBody className="flex flex-col gap-4">
             {error && (
-              <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
-                {error}
-              </div>
+              <Alert variant="destructive">
+                <TriangleAlert />
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
             )}
 
-            <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_180px]">
-              <div className="space-y-2">
+            <div className="grid gap-4 sm:grid-cols-[minmax(0,1fr)_180px]">
+              <div className="flex flex-col gap-2">
                 <Label htmlFor="api-token-name">{messages.create.name}</Label>
                 <Input
                   id="api-token-name"
@@ -256,135 +320,82 @@ export function ServiceApiKeysPage({
                   placeholder={messages.create.namePlaceholder}
                 />
               </div>
-              <div className="space-y-2">
+              <div className="flex flex-col gap-2">
                 <Label htmlFor="api-token-expiration">{messages.create.expiration}</Label>
-                <select
-                  id="api-token-expiration"
-                  value={expirationDays ?? "never"}
-                  onChange={(event) =>
-                    setExpirationDays(
-                      event.target.value === "never" ? null : Number(event.target.value),
-                    )
-                  }
-                  className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
-                >
-                  {expirationOptions.map((option) => (
-                    <option key={option.label} value={option.days ?? "never"}>
-                      {option.label}
-                    </option>
-                  ))}
-                </select>
+                <Select value={expiration} onValueChange={(value) => setExpiration(String(value))}>
+                  <SelectTrigger id="api-token-expiration" className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {expirationOptions.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
             </div>
 
-            <div className="flex flex-wrap gap-2">
-              {Object.entries(permissionPresets).map(([key, preset]) => (
-                <Button key={key} type="button" variant="outline" onClick={() => applyPreset(key)}>
-                  {preset.label}
-                </Button>
-              ))}
-            </div>
+            <ApiTokenScopePicker catalog={catalog} value={permissions} onChange={setPermissions} />
+          </SheetBody>
 
-            <div className="grid gap-4 lg:grid-cols-2">
-              {permissionGroups.map((group) => (
-                <div key={group.resource} className="rounded-md border p-4">
-                  <div className="mb-3">
-                    <h2 className="text-sm font-medium">{group.label}</h2>
-                    <p className="text-xs text-muted-foreground">{group.description}</p>
-                  </div>
-                  <div className="space-y-3">
-                    {group.permissions.map((descriptor) => {
-                      const checked = hasApiKeyPermission(
-                        selectedPermissions,
-                        descriptor.resource,
-                        descriptor.action,
-                        catalog,
-                      )
-                      const permissionId = `permission-${descriptor.resource}-${descriptor.action}`
-                      return (
-                        <label
-                          key={`${descriptor.resource}:${descriptor.action}`}
-                          htmlFor={permissionId}
-                          className="flex cursor-pointer items-start gap-3 rounded-md p-2 hover:bg-muted/60"
-                        >
-                          <Checkbox
-                            id={permissionId}
-                            checked={checked}
-                            onCheckedChange={(value) =>
-                              onTogglePermission(
-                                descriptor.resource,
-                                descriptor.action,
-                                value === true,
-                              )
-                            }
-                            className="mt-0.5"
-                          />
-                          <span className="min-w-0">
-                            <span className="block text-sm font-medium">{descriptor.label}</span>
-                            <span className="block text-xs text-muted-foreground">
-                              {descriptor.description}
-                            </span>
-                          </span>
-                        </label>
-                      )
-                    })}
-                  </div>
-                </div>
-              ))}
-            </div>
-
-            <div>
-              <Button type="submit" disabled={mutations.create.isPending}>
-                {mutations.create.isPending ? (
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                ) : (
-                  <Plus className="mr-2 h-4 w-4" />
-                )}
-                {messages.create.submit}
-              </Button>
-            </div>
-          </form>
-        </CardContent>
-      </Card>
-
-      <div className="flex items-center justify-between">
-        <h2 className="text-lg font-semibold">{messages.list.title}</h2>
-        <Button type="button" variant="outline" size="sm" onClick={() => void keys.refetch()}>
-          <RefreshCw className="mr-2 h-4 w-4" />
-          {messages.list.refresh}
-        </Button>
-      </div>
-
-      {keys.isLoading ? (
-        <Card>
-          <CardContent className="flex items-center gap-2 py-6 text-sm text-muted-foreground">
-            <Loader2 className="h-4 w-4 animate-spin" />
-            {messages.list.loading}
-          </CardContent>
-        </Card>
-      ) : keys.data?.apiKeys.length ? (
-        <div className="space-y-3">
-          {keys.data.apiKeys.map((key) => (
-            <ServiceApiKeyRow
-              key={key.id}
-              apiKey={key}
-              onError={setError}
-              onSecretIssued={setIssuedKey}
-            />
-          ))}
-        </div>
-      ) : (
-        <Card>
-          <CardContent className="py-6 text-sm text-muted-foreground">
-            {messages.list.empty}
-          </CardContent>
-        </Card>
-      )}
-    </div>
+          <SheetFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              {messages.create.cancel}
+            </Button>
+            <Button type="submit" disabled={mutations.create.isPending}>
+              {mutations.create.isPending ? (
+                <Loader2 className="mr-2 size-4 animate-spin" />
+              ) : (
+                <Plus className="mr-2 size-4" />
+              )}
+              {messages.create.submit}
+            </Button>
+          </SheetFooter>
+        </form>
+      </SheetContent>
+    </Sheet>
   )
 }
 
-export const ApiTokensPage = ServiceApiKeysPage
+function ServiceApiKeyTable({
+  apiKeys,
+  onError,
+  onSecretIssued,
+}: {
+  apiKeys: readonly ApiToken[]
+  onError: (error: string | null) => void
+  onSecretIssued: (apiKey: ApiTokenWithSecret) => void
+}) {
+  const messages = useAuthUiMessagesOrDefault().serviceApiKeysPage
+
+  return (
+    <Card className="gap-0 py-0">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>{messages.list.columns.name}</TableHead>
+            <TableHead>{messages.list.columns.scopes}</TableHead>
+            <TableHead>{messages.list.columns.expires}</TableHead>
+            <TableHead>{messages.list.columns.lastUsed}</TableHead>
+            <TableHead className="w-10" />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {apiKeys.map((apiKey) => (
+            <ServiceApiKeyRow
+              key={apiKey.id}
+              apiKey={apiKey}
+              onError={onError}
+              onSecretIssued={onSecretIssued}
+            />
+          ))}
+        </TableBody>
+      </Table>
+    </Card>
+  )
+}
 
 function ServiceApiKeyRow({
   apiKey,
@@ -399,6 +410,17 @@ function ServiceApiKeyRow({
   const messages = i18n.messages.serviceApiKeysPage
   const mutations = useApiTokenMutation()
   const enabled = apiKey.enabled !== false
+  const removeToken = async () => {
+    // A dropdown item is a single click away from destroying a live
+    // credential, so it asks first — the same guard rotation already has.
+    if (!(await confirmDialog(messages.list.deleteConfirm))) return
+    onError(null)
+    try {
+      await mutations.remove.mutateAsync({ keyId: apiKey.id })
+    } catch (err) {
+      onError(err instanceof Error ? err.message : messages.list.rotateFailed)
+    }
+  }
   const rotateToken = async () => {
     if (!(await confirmDialog(messages.list.rotateConfirm))) return
     onError(null)
@@ -415,74 +437,89 @@ function ServiceApiKeyRow({
   }
 
   return (
-    <Card>
-      <CardContent className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-        <div className="min-w-0 space-y-2">
-          <div className="flex flex-wrap items-center gap-2">
-            <h3 className="font-medium">{apiKey.name || messages.list.untitled}</h3>
+    <TableRow>
+      <TableCell className="align-top">
+        <div className="flex flex-col gap-1">
+          <span className="flex flex-wrap items-center gap-2 font-medium">
+            {apiKey.name || messages.list.untitled}
             <Badge variant={enabled ? "default" : "secondary"}>
               {enabled ? messages.list.enabled : messages.list.disabled}
             </Badge>
-            {apiKey.start && <Badge variant="outline">{apiKey.start}</Badge>}
-          </div>
-          <div className="flex flex-wrap gap-1">
-            {apiKey.permissionList.length ? (
-              apiKey.permissionList.map((permission) => (
-                <Badge key={permission} variant="outline" className="font-mono text-[11px]">
-                  {permissionLabel(permission, messages.permissions.fullAccess)}
-                </Badge>
-              ))
-            ) : (
-              <span className="text-xs text-muted-foreground">{messages.list.noPermissions}</span>
+            {apiKey.start && (
+              <Badge variant="outline" className="font-mono text-[11px]">
+                {apiKey.start}
+              </Badge>
             )}
-          </div>
-          <p className="text-xs text-muted-foreground">
-            {formatMessage(messages.list.metadata, {
+          </span>
+          <span className="text-xs text-muted-foreground">
+            {formatMessage(messages.list.created, {
               created: formatDate(apiKey.createdAt, messages.date.never, i18n.formatDateTime),
-              expires: formatDate(apiKey.expiresAt, messages.date.never, i18n.formatDateTime),
-              lastUsed: formatDate(apiKey.lastRequest, messages.date.never, i18n.formatDateTime),
             })}
-          </p>
+          </span>
         </div>
-        <div className="flex flex-wrap gap-2">
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            disabled={mutations.update.isPending}
-            onClick={() =>
-              void mutations.update.mutateAsync({ keyId: apiKey.id, enabled: !enabled })
-            }
-          >
-            {enabled ? <PowerOff className="mr-2 h-4 w-4" /> : <Power className="mr-2 h-4 w-4" />}
-            {enabled ? messages.list.disable : messages.list.enable}
-          </Button>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            disabled={mutations.rotate.isPending}
-            onClick={() => void rotateToken()}
-          >
-            {mutations.rotate.isPending ? (
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-            ) : (
-              <RefreshCw className="mr-2 h-4 w-4" />
+      </TableCell>
+      <TableCell className="max-w-xs align-top">
+        {apiKey.permissionList.length ? (
+          <div className="flex flex-wrap gap-1">
+            {apiKey.permissionList.slice(0, 6).map((permission) => (
+              <Badge key={permission} variant="outline" className="font-mono text-[11px]">
+                {permissionLabel(permission, messages.permissions.fullAccess)}
+              </Badge>
+            ))}
+            {apiKey.permissionList.length > 6 && (
+              <Badge variant="secondary" className="text-[11px]">
+                {formatMessage(messages.list.moreScopes, {
+                  count: String(apiKey.permissionList.length - 6),
+                })}
+              </Badge>
             )}
-            {messages.list.rotate}
-          </Button>
-          <Button
-            type="button"
-            variant="destructive"
-            size="sm"
-            disabled={mutations.remove.isPending}
-            onClick={() => void mutations.remove.mutateAsync({ keyId: apiKey.id })}
+          </div>
+        ) : (
+          <span className="text-xs text-muted-foreground">{messages.list.noPermissions}</span>
+        )}
+      </TableCell>
+      <TableCell className="align-top text-sm text-muted-foreground">
+        {formatDate(apiKey.expiresAt, messages.date.never, i18n.formatDateTime)}
+      </TableCell>
+      <TableCell className="align-top text-sm text-muted-foreground">
+        {formatDate(apiKey.lastRequest, messages.date.never, i18n.formatDateTime)}
+      </TableCell>
+      <TableCell className="align-top">
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={<Button type="button" variant="ghost" size="icon-sm" />}
+            aria-label={messages.list.actions}
           >
-            <Trash2 className="mr-2 h-4 w-4" />
-            {messages.list.delete}
-          </Button>
-        </div>
-      </CardContent>
-    </Card>
+            <MoreHorizontal className="size-4" />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem
+              disabled={mutations.update.isPending}
+              onClick={() =>
+                void mutations.update.mutateAsync({ keyId: apiKey.id, enabled: !enabled })
+              }
+            >
+              {enabled ? <PowerOff className="mr-2 size-4" /> : <Power className="mr-2 size-4" />}
+              {enabled ? messages.list.disable : messages.list.enable}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              disabled={mutations.rotate.isPending}
+              onClick={() => void rotateToken()}
+            >
+              <RefreshCw className="mr-2 size-4" />
+              {messages.list.rotate}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              variant="destructive"
+              disabled={mutations.remove.isPending}
+              onClick={() => void removeToken()}
+            >
+              <Trash2 className="mr-2 size-4" />
+              {messages.list.delete}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </TableCell>
+    </TableRow>
   )
 }

--- a/packages/auth-react/src/i18n/en.ts
+++ b/packages/auth-react/src/i18n/en.ts
@@ -370,6 +370,11 @@ export const authUiEn: AuthUiMessages = {
     title: "API tokens",
     description:
       "Create permissioned API tokens for automation, integrations, and third-party systems.",
+    catalogUnavailable: {
+      title: "Permissions are unavailable",
+      description:
+        "This deployment did not supply its permission catalog, so no scopes can be selected and no token can be created. Reload the page; if it persists, the operator app is mounting the API tokens page without its access catalog.",
+    },
     createdToken: {
       title: "Token secret",
       description: "This token secret is shown once. Store it before leaving.",
@@ -377,6 +382,9 @@ export const authUiEn: AuthUiMessages = {
     },
     create: {
       title: "Create token",
+      description: "Name the token, choose how long it lives, and pick the scopes it may use.",
+      open: "New token",
+      cancel: "Cancel",
       name: "Name",
       namePlaceholder: "CMS sync, webhook relay, nightly automation",
       expiration: "Expiration",
@@ -394,6 +402,24 @@ export const authUiEn: AuthUiMessages = {
         oneYear: "1 year",
       },
     },
+    scopes: {
+      title: "Select scopes",
+      description:
+        "A scope is one action on one resource. Grant a whole resource to cover every action it has today and every action added later.",
+      presets: "Start from a preset",
+      fullAccess: "Full access",
+      fullAccessHint:
+        "Every resource and every action, including ones added in future releases. Replaces any other selection.",
+      search: "Search resources and actions",
+      noResults: "No resources match your search.",
+      selectedCount: "{count} selected",
+      groupAllLabel: "Grant all of {resource}",
+      groupAllHint: "Tick the resource to grant every action below and lock them together.",
+      lockedHint: "Included by the resource grant above.",
+      sensitive: "Sensitive",
+      countOf: "{selected}/{total}",
+      clear: "Clear all",
+    },
     list: {
       title: "Existing tokens",
       refresh: "Refresh",
@@ -403,7 +429,16 @@ export const authUiEn: AuthUiMessages = {
       enabled: "Enabled",
       disabled: "Disabled",
       noPermissions: "No permissions",
-      metadata: "Created {created} · Expires {expires} · Last used {lastUsed}",
+      created: "Created {created}",
+      actions: "Token actions",
+      moreScopes: "+{count} more",
+      deleteConfirm: "Delete this token? Anything using it stops working immediately.",
+      columns: {
+        name: "Token",
+        scopes: "Scopes",
+        expires: "Expires",
+        lastUsed: "Last used",
+      },
       disable: "Disable",
       enable: "Enable",
       rotate: "Rotate",

--- a/packages/auth-react/src/i18n/messages.ts
+++ b/packages/auth-react/src/i18n/messages.ts
@@ -555,6 +555,10 @@ export type AuthUiMessages = {
   serviceApiKeysPage: {
     title: string
     description: string
+    catalogUnavailable: {
+      title: string
+      description: string
+    }
     createdToken: {
       title: string
       description: string
@@ -562,6 +566,9 @@ export type AuthUiMessages = {
     }
     create: {
       title: string
+      description: string
+      open: string
+      cancel: string
       name: string
       namePlaceholder: string
       expiration: string
@@ -579,6 +586,22 @@ export type AuthUiMessages = {
         oneYear: string
       }
     }
+    scopes: {
+      title: string
+      description: string
+      presets: string
+      fullAccess: string
+      fullAccessHint: string
+      search: string
+      noResults: string
+      selectedCount: string
+      groupAllLabel: string
+      groupAllHint: string
+      lockedHint: string
+      sensitive: string
+      countOf: string
+      clear: string
+    }
     list: {
       title: string
       refresh: string
@@ -588,7 +611,16 @@ export type AuthUiMessages = {
       enabled: string
       disabled: string
       noPermissions: string
-      metadata: string
+      created: string
+      actions: string
+      moreScopes: string
+      deleteConfirm: string
+      columns: {
+        name: string
+        scopes: string
+        expires: string
+        lastUsed: string
+      }
       disable: string
       enable: string
       rotate: string

--- a/packages/auth-react/src/i18n/ro.ts
+++ b/packages/auth-react/src/i18n/ro.ts
@@ -374,6 +374,11 @@ export const authUiRo: AuthUiMessages = {
     title: "Tokenuri API",
     description:
       "Creeaza tokenuri API cu permisiuni pentru automatizari, integrari si sisteme terte.",
+    catalogUnavailable: {
+      title: "Permisiunile nu sunt disponibile",
+      description:
+        "Acest deployment nu a furnizat catalogul de permisiuni, deci nu poate fi selectat niciun scope si nu poate fi creat niciun token. Reincarca pagina; daca problema persista, aplicatia de operare monteaza pagina de tokenuri API fara catalogul de acces.",
+    },
     createdToken: {
       title: "Secret token",
       description: "Acest secret de token este afisat o singura data. Salveaza-l inainte sa pleci.",
@@ -381,6 +386,10 @@ export const authUiRo: AuthUiMessages = {
     },
     create: {
       title: "Creeaza token",
+      description:
+        "Denumeste tokenul, alege cat timp este valabil si selecteaza scope-urile pe care le poate folosi.",
+      open: "Token nou",
+      cancel: "Anuleaza",
       name: "Nume",
       namePlaceholder: "Sincronizare CMS, webhook relay, automatizare nocturna",
       expiration: "Expirare",
@@ -398,6 +407,25 @@ export const authUiRo: AuthUiMessages = {
         oneYear: "1 an",
       },
     },
+    scopes: {
+      title: "Selecteaza scope-uri",
+      description:
+        "Un scope este o actiune pe o resursa. Acorda o resursa intreaga pentru a acoperi toate actiunile ei de azi si pe cele adaugate ulterior.",
+      presets: "Porneste de la un preset",
+      fullAccess: "Acces complet",
+      fullAccessHint:
+        "Toate resursele si toate actiunile, inclusiv cele adaugate in versiuni viitoare. Inlocuieste orice alta selectie.",
+      search: "Cauta resurse si actiuni",
+      noResults: "Nicio resursa nu corespunde cautarii.",
+      selectedCount: "{count} selectate",
+      groupAllLabel: "Acorda tot pentru {resource}",
+      groupAllHint:
+        "Bifeaza resursa pentru a acorda toate actiunile de mai jos si a le bloca impreuna.",
+      lockedHint: "Incluse de acordarea resursei de mai sus.",
+      sensitive: "Sensibil",
+      countOf: "{selected}/{total}",
+      clear: "Sterge tot",
+    },
     list: {
       title: "Tokenuri existente",
       refresh: "Reincarca",
@@ -407,7 +435,16 @@ export const authUiRo: AuthUiMessages = {
       enabled: "Activ",
       disabled: "Inactiv",
       noPermissions: "Fara permisiuni",
-      metadata: "Creat {created} · Expira {expires} · Ultima utilizare {lastUsed}",
+      created: "Creat {created}",
+      actions: "Actiuni token",
+      moreScopes: "+{count} in plus",
+      deleteConfirm: "Stergi acest token? Tot ce il foloseste nu va mai functiona imediat.",
+      columns: {
+        name: "Token",
+        scopes: "Scope-uri",
+        expires: "Expira",
+        lastUsed: "Ultima utilizare",
+      },
       disable: "Dezactiveaza",
       enable: "Activeaza",
       rotate: "Roteste",

--- a/packages/auth-react/src/service-api-keys-page.test.tsx
+++ b/packages/auth-react/src/service-api-keys-page.test.tsx
@@ -1,8 +1,20 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { AccessCatalog } from "@voyant-travel/types/api-keys"
+import type { ReactNode } from "react"
 import { renderToStaticMarkup } from "react-dom/server"
 import { describe, expect, it } from "vitest"
 
+import {
+  apiTokenPresets,
+  defaultTokenPermissions,
+  grantedActionCount,
+  isFullAccess,
+  isResourceGranted,
+  matchesScopeSearch,
+  setActionGrant,
+  setFullAccess,
+  setResourceGrant,
+} from "./components/api-token-scopes.js"
 import { ServiceApiKeysPage } from "./components/service-api-keys-page.js"
 import { VoyantAuthProvider, type VoyantFetcher } from "./index.js"
 
@@ -15,25 +27,128 @@ const selectedCatalog: AccessCatalog = {
       label: "Selected Bookings",
       description: "Selected booking permissions.",
       wildcard: "allow",
-      actions: [{ action: "read", label: "Selected read", description: "Read bookings." }],
+      actions: [
+        { action: "read", label: "Selected read", description: "Read bookings." },
+        {
+          action: "export",
+          label: "Export bookings",
+          description: "Export bookings.",
+          sensitive: true,
+          wildcard: "explicit",
+        },
+      ],
     },
   ],
-  presets: [],
+  presets: [
+    {
+      id: "catalog-read",
+      kind: "api-token",
+      label: "Catalog read",
+      description: "Read the catalog.",
+      grants: ["bookings:read"],
+    },
+    {
+      id: "agent-staff",
+      kind: "api-token-grant",
+      label: "Agent (staff)",
+      description: "Staff agent grant.",
+      audience: "staff",
+      grants: ["bookings:read"],
+    },
+    {
+      id: "editor",
+      kind: "staff",
+      label: "Editor",
+      description: "A member role, not a token preset.",
+      grants: ["bookings:read"],
+    },
+  ],
+}
+
+const bookings = selectedCatalog.resources[0]!
+
+function render(node: ReactNode): string {
+  const fetcher: VoyantFetcher = async () => new Response(null, { status: 204 })
+  return renderToStaticMarkup(
+    <QueryClientProvider client={new QueryClient()}>
+      <VoyantAuthProvider baseUrl="https://operator.example/api" fetcher={fetcher}>
+        {node}
+      </VoyantAuthProvider>
+    </QueryClientProvider>,
+  )
 }
 
 describe("ServiceApiKeysPage access catalog", () => {
-  it("renders selected descriptors instead of the legacy resource descriptor", () => {
-    const fetcher: VoyantFetcher = async () => new Response(null, { status: 204 })
-    const html = renderToStaticMarkup(
-      <QueryClientProvider client={new QueryClient()}>
-        <VoyantAuthProvider baseUrl="https://operator.example/api" fetcher={fetcher}>
-          <ServiceApiKeysPage accessCatalog={selectedCatalog} />
-        </VoyantAuthProvider>
-      </QueryClientProvider>,
-    )
+  it("fails loudly when the deployment supplies no catalog", () => {
+    const html = render(<ServiceApiKeysPage />)
 
-    expect(html).toContain("Selected Bookings")
-    expect(html).toContain("Selected read")
-    expect(html).not.toContain("Cancel bookings")
+    // Without a catalog the create form's only possible outcome is "Select at
+    // least one permission.", so the page refuses instead of offering it (#4618).
+    expect(html).toContain("Permissions are unavailable")
+    expect(html).toContain("New token")
+    expect(html).toContain('disabled=""')
+  })
+
+  it("keeps the create affordance usable when the catalog arrived", () => {
+    const html = render(<ServiceApiKeysPage accessCatalog={selectedCatalog} />)
+
+    expect(html).not.toContain("Permissions are unavailable")
+    expect(html).not.toContain('disabled=""')
+  })
+})
+
+describe("api token scope selection", () => {
+  it("offers both token preset kinds and never a member role", () => {
+    expect(apiTokenPresets(selectedCatalog).map((preset) => preset.id)).toEqual([
+      "catalog-read",
+      "agent-staff",
+    ])
+  })
+
+  it("drives its labels from the deployment catalog, not a built-in list", () => {
+    expect(matchesScopeSearch(bookings, "Selected Bookings")).toBe(true)
+    expect(matchesScopeSearch(bookings, "Selected read")).toBe(true)
+    expect(matchesScopeSearch(bookings, "cancel bookings")).toBe(false)
+  })
+
+  it("names explicit-wildcard actions alongside the resource wildcard", () => {
+    // `bookings:*` alone does not satisfy an `explicit` action, so a group grant
+    // that stored only `*` would lock boxes it had not actually granted.
+    const granted = setResourceGrant({}, bookings, true)
+
+    expect(granted.bookings).toEqual(["*", "export"])
+    expect(isResourceGranted(granted, bookings)).toBe(true)
+    expect(grantedActionCount(granted, bookings, selectedCatalog)).toBe(2)
+  })
+
+  it("revokes the whole group without stranding leftover actions", () => {
+    const granted = setResourceGrant({}, bookings, true)
+
+    expect(setResourceGrant(granted, bookings, false)).toEqual({})
+  })
+
+  it("toggles a single action", () => {
+    const withRead = setActionGrant({}, "bookings", "read", true)
+
+    expect(withRead).toEqual({ bookings: ["read"] })
+    expect(isResourceGranted(withRead, bookings)).toBe(false)
+    expect(grantedActionCount(withRead, bookings, selectedCatalog)).toBe(1)
+    expect(setActionGrant(withRead, "bookings", "read", false)).toEqual({})
+  })
+
+  it("replaces the selection when full access is applied and clears it when removed", () => {
+    expect(setFullAccess(true)).toEqual({ "*": ["*"] })
+    expect(isFullAccess(setFullAccess(true))).toBe(true)
+    expect(setFullAccess(false)).toEqual({})
+  })
+
+  it("matches an empty search and misses an unrelated term", () => {
+    expect(matchesScopeSearch(bookings, "")).toBe(true)
+    expect(matchesScopeSearch(bookings, "invoices")).toBe(false)
+  })
+
+  it("seeds a new token from the catalog-read preset", () => {
+    expect(defaultTokenPermissions(selectedCatalog)).toEqual({ bookings: ["read"] })
+    expect(defaultTokenPermissions({ resources: [], presets: [] })).toEqual({})
   })
 })

--- a/packages/operator-settings-react/src/webhook-subscription-detail-page.tsx
+++ b/packages/operator-settings-react/src/webhook-subscription-detail-page.tsx
@@ -10,6 +10,7 @@ import {
   CardContent,
   CardHeader,
   CardTitle,
+  Checkbox,
   Input,
   Label,
 } from "@voyant-travel/ui/components"
@@ -198,23 +199,24 @@ export function WebhookSubscriptionDetailPage({ params }: AdminRoutePageProps) {
             <legend className="text-sm font-medium">{t.events}</legend>
             <div className="grid gap-2 sm:grid-cols-2">
               {catalog.data?.map((event) => (
-                <label
+                <Label
                   key={event.id}
-                  className="flex items-center gap-2 rounded-md border p-2 text-sm"
+                  htmlFor={`detail-webhook-event-${event.id}`}
+                  className="flex items-center gap-2 rounded-md border p-2 font-normal"
                 >
-                  <input
-                    type="checkbox"
+                  <Checkbox
+                    id={`detail-webhook-event-${event.id}`}
                     checked={selectedEvents.includes(event.eventType)}
-                    onChange={(input) =>
+                    onCheckedChange={(checked) =>
                       setSelectedEvents((current) =>
-                        input.target.checked
+                        checked === true
                           ? [...current, event.eventType]
                           : current.filter((value) => value !== event.eventType),
                       )
                     }
                   />
                   <span className="font-mono text-xs">{event.eventType}</span>
-                </label>
+                </Label>
               ))}
             </div>
           </fieldset>

--- a/packages/operator-settings-react/src/webhooks-settings-page.tsx
+++ b/packages/operator-settings-react/src/webhooks-settings-page.tsx
@@ -10,7 +10,9 @@ import {
   CardDescription,
   CardHeader,
   CardTitle,
+  Checkbox,
   Dialog,
+  DialogBody,
   DialogContent,
   DialogDescription,
   DialogFooter,
@@ -147,12 +149,15 @@ export function WebhooksSettingsPage() {
       )}
 
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="max-w-xl">
+        <DialogContent size="lg">
           <DialogHeader>
             <DialogTitle>{t.create}</DialogTitle>
             <DialogDescription>{t.description}</DialogDescription>
           </DialogHeader>
-          <div className="space-y-4">
+          {/* DialogBody, not a plain div: DialogContent is a flex column with a
+              capped height, so the scroll region has to be the shrinkable child
+              or the footer's buttons get pushed past the viewport. */}
+          <DialogBody className="space-y-4">
             <div className="space-y-2">
               <Label htmlFor="webhook-url">{t.endpoint}</Label>
               <Input
@@ -173,15 +178,19 @@ export function WebhooksSettingsPage() {
             </div>
             <fieldset className="space-y-2">
               <legend className="text-sm font-medium">{t.events}</legend>
-              <div className="max-h-52 space-y-2 overflow-auto rounded-md border p-3">
+              <div className="max-h-64 space-y-1 overflow-y-auto rounded-md border p-2">
                 {catalog.data?.map((event) => (
-                  <label key={event.id} className="flex items-center gap-2 text-sm">
-                    <input
-                      type="checkbox"
+                  <Label
+                    key={event.id}
+                    htmlFor={`webhook-event-${event.id}`}
+                    className="flex items-center gap-2 rounded-md p-1.5 font-normal hover:bg-muted/60"
+                  >
+                    <Checkbox
+                      id={`webhook-event-${event.id}`}
                       checked={events.includes(event.eventType)}
-                      onChange={(input) =>
+                      onCheckedChange={(checked) =>
                         setEvents((current) =>
-                          input.target.checked
+                          checked === true
                             ? [...current, event.eventType]
                             : current.filter((value) => value !== event.eventType),
                         )
@@ -189,11 +198,11 @@ export function WebhooksSettingsPage() {
                     />
                     <span className="font-mono text-xs">{event.eventType}</span>
                     <span className="text-muted-foreground">v{event.version}</span>
-                  </label>
+                  </Label>
                 ))}
               </div>
             </fieldset>
-          </div>
+          </DialogBody>
           <DialogFooter>
             <Button variant="outline" onClick={() => setOpen(false)}>
               {t.cancel}


### PR DESCRIPTION
Closes #4618.

## The bug

`ServiceApiKeysPage` took the whole permission catalog as an `accessCatalog` prop and fell back to `{ resources: [], presets: [] }` when it was absent. Both renders then produced nothing — no preset buttons, no permission groups — while validation still rejected the submission because `selectedPermissions` could only ever be empty. The result was a create form whose single possible outcome was "Select at least one permission."

The mount in `packages/admin-app/src/core-extension/index.tsx` does pass a catalog (`loadAccessCatalog`, wired through `createAdminHostPresentation` → the generated operator frontend), and the catalog this repo resolves is healthy — 59 resources / 141 actions / 9 presets. So the silent-empty fallback is the part that turns any host-side gap into an unactionable page, and that is what this PR removes.

**Now:** an empty catalog renders a destructive alert and disables the create action, instead of a form that cannot succeed.

## A second, always-live bug

The preset row filtered on `preset.kind === "api-token"` only. The catalog also publishes `api-token-grant` presets — the audience-scoped agent grants (`agent-staff`, `agent-customer`, `public-catalog-reader`). A deployment publishing only those showed no presets at all. Both kinds are offered now; `staff` (member-role) presets stay excluded.

## The redesign

Creating a token moved into a **sheet** — name, expiration (design-system `Select`, not a bare `<select>`), then scopes:

- **preset chips** to start from
- a **full access** toggle, called out as destructive, which locks everything below it
- a **search box** over resource and action labels
- one **collapsed accordion section per resource**, each with a group checkbox and an `n/m` badge

Ticking a resource grants it whole and **locks its actions** — they render checked and disabled, because at that point an individual toggle cannot change the outcome. The stored grant is `["*", ...explicit]`, not bare `["*"]`: `hasApiKeyPermission` deliberately does not let a resource wildcard satisfy a `wildcard: "explicit"` action, so a group grant that stored only `*` would lock boxes it had not actually granted. There is a test for exactly that.

Existing tokens moved from stacked cards to a **table** with a per-row action menu, and **deleting** a token now confirms — it was one click from destroying a live credential, while rotating already asked.

## Webhooks (same settings area)

- The create-subscription dialog body is a `DialogBody` (`flex-1 min-h-0 overflow-y-auto`) rather than a plain `div`. `DialogContent` is a height-capped flex column, so a non-shrinkable child pushed **Cancel** and **Create subscription** past the viewport — visible in the report, unreachable in practice.
- Both webhook pages use the design-system `Checkbox` instead of a raw `<input type="checkbox">`.

## Files

- `packages/auth-react/src/components/api-token-scopes.ts` — new, pure selection logic (grant/revoke, explicit-wildcard handling, presets, search, default seed)
- `packages/auth-react/src/components/api-token-scope-picker.tsx` — new, the presets + search + accordion picker
- `packages/auth-react/src/components/service-api-keys-page.tsx` — page, create sheet, token table
- `packages/auth-react/src/i18n/{messages,en,ro}.ts` — new keys, en/ro parity
- `packages/operator-settings-react/src/webhooks-settings-page.tsx`, `.../webhook-subscription-detail-page.tsx`

## Verification

- `pnpm -F @voyant-travel/auth-react typecheck` — clean
- `pnpm -F @voyant-travel/auth-react test` — 22 files / 79 tests pass, including new coverage for the empty-catalog refusal, the preset-kind filter, and the explicit-wildcard group grant
- `pnpm -F @voyant-travel/operator-settings-react test` — 4 files / 34 tests pass
- `biome check` — clean

**Not verified in a browser.** A local operator dev server in this worktree never became usable (vite's client dep optimizer kept re-bundling and re-triggering SSR reloads, and the route eventually stopped answering), so there are no screenshots. Every component and layout idiom here is taken from existing pages in the repo, but the visual result has not been seen. Worth a look before merge.