### PR TITLE
Make Direct the channel a public surface resolves to

### DIFF
--- a/.changeset/direct-channel-is-implicit.md
+++ b/.changeset/direct-channel-is-implicit.md
@@ -1,0 +1,20 @@
+---
+"@voyant-travel/distribution": minor
+"@voyant-travel/distribution-react": minor
+"@voyant-travel/auth": minor
+"@voyant-travel/auth-react": minor
+---
+
+Provision the Direct channel, and let the public surface resolve to it without being configured.
+
+Publication is default-deny per channel and every public catalog read resolves a channel before it answers, so serving your own website meant hand-creating a row in `channels` — a table of commercial counterparties, sitting next to `suppliers`, carrying contracts, rate limits and contact projections — that represents yourself, then binding a storefront to it. Nothing provisioned that row on an ongoing basis: a one-shot setup cutover backfilled the storefronts that existed when it ran, and every storefront created afterwards got a 403 on `/settings`, `/departures/*`, `/products/*`, `/offers/*`, `/leads`, `/newsletter/*`, on the anonymous booking-session routes, and on checkout start.
+
+`channels` now carries a `system_key`, and a migration provisions exactly one row marked `direct`. It adopts before it inserts — the cutover's own `chan_storefront_direct` row first, then the oldest active `direct` channel — because publication rules and storefront bindings are keyed by channel id, and a fresh row beside an existing one would silently unpublish everything already published.
+
+A storefront with no explicit binding now resolves to that channel instead of to nothing, and so does one whose explicitly bound channel has gone inactive. `StorefrontChannelBindingDto` gains `implicit`, so an admin surface can show the default as a default; clearing a binding means "back to Direct" rather than "off the air". A binding that names another channel still wins, so `affiliate` / `reseller` / `api_partner` keep working.
+
+The system channel cannot be deleted or moved off `active` through the API (409, not a 404 that reads like the row is gone), and its `kind` is fixed; its name and contact details stay the operator's to edit. `GET /v1/admin/distribution/channels` takes `system=include|exclude|only`, defaulting to `include` — publication and product-mapping pickers read that endpoint and must still be able to target Direct. Only the Distribution counterparty list passes `exclude`.
+
+Batch update and batch delete now isolate failures per id rather than rejecting the whole batch when one id is refused.
+
+The storefront admin's channel section stops warning about something that is no longer true. It said "Default-deny is enforced: customer requests are rejected until this storefront is bound to an active channel", in an amber alert, and offered "Clear binding" with a confirmation warning that customer API access would be denied. It now states the default plainly, shows "Publishing to Direct (default)" for an implicit binding, and the clear action reads "Use Direct" and is disabled when Direct is already what you have.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,6 +365,12 @@ jobs:
                 tests/integration/linked-payment-contract-confirmation.test.ts
               pnpm --filter @voyant-travel/cruises exec vitest run \
                 tests/integration/created-target-tools.test.ts
+              pnpm --filter @voyant-travel/auth exec vitest run \
+                tests/integration/storefront-channel-binding.test.ts
+              pnpm --filter @voyant-travel/distribution exec vitest run \
+                tests/integration/direct-channel-migration.test.ts
+              pnpm --filter @voyant-travel/distribution exec vitest run \
+                tests/integration/routes.direct-channel.test.ts
               pnpm --filter @voyant-travel/inventory exec vitest run \
                 tests/integration/conservative-family-backfill.test.ts
               pnpm --filter @voyant-travel/inventory exec vitest run \

--- a/docs/architecture/marketplace-channel-distribution.md
+++ b/docs/architecture/marketplace-channel-distribution.md
@@ -507,18 +507,23 @@ Direct Storefronts and external marketplace Channels use the same Channel
 assortment authority.
 
 The marketplace is the customer-facing surface for channel bookings. Voyant may
-also run one or more direct Storefronts in parallel. Each active Storefront binds
-to exactly one active Channel through deployment-composed link data; a Channel
-may serve many Storefronts. Public Storefront requests derive Channel from the
-resolved Storefront API key or approved origin, not from caller-submitted
-Channel input.
+also run one or more direct Storefronts in parallel. Each active Storefront
+resolves to exactly one active Channel; a Channel may serve many Storefronts.
+Public Storefront requests derive Channel from the resolved Storefront API key or
+approved origin, not from caller-submitted Channel input.
+
+**Direct is the default and needs no binding.** Distribution provisions one
+system Channel per deployment (`system_key = 'direct'`) and a Storefront resolves
+to it unless deployment-composed link data binds it elsewhere. Binding is how you
+sell a Storefront through a *counterparty*; it is not a prerequisite for selling
+through yourself. See `docs/architecture/storefront-architecture.md` §6.
 
 The DB package migration owns only the link-table DDL and Storefront-local
-origin-overlap validation. Channel creation, binding backfill, and the
-fail-closed active-binding check run as a Distribution-owned setup migration
-after the DB, Storefront, and Distribution schema migration facets. This keeps
-fresh installs independent of package migration ordering while preserving one
-transactional, idempotent cutover.
+origin-overlap validation. The original binding backfill ran as a
+Distribution-owned setup migration after the DB, Storefront, and Distribution
+schema migration facets; the Direct Channel itself is provisioned by an ordinary
+Distribution schema migration, which is what makes it present on a fresh install
+with no storefronts yet.
 
 The prior-visible publication snapshot is also a Distribution-owned setup
 migration, never a hard `requiresSchemas` edge to operated Inventory. It runs

--- a/docs/architecture/storefront-architecture.md
+++ b/docs/architecture/storefront-architecture.md
@@ -107,21 +107,35 @@ A Storefront is the authenticated identity of one customer-facing frontend or
 application. A Channel is the sales and distribution context that controls
 assortment and commercial behavior. Those are separate identities:
 
-- every active Storefront binds to exactly one active Channel after migration
+- every active Storefront resolves to exactly one active Channel
 - a Channel may have zero or many Storefronts
-- the Storefront-to-Channel association is deployment-composed link data
+- an explicit Storefront-to-Channel association is deployment-composed link data
 - neither Storefront nor Channel owns a cross-package foreign key to the other
 - frontend route composition is never publication authority
 
 Public runtime resolves Storefront identity from the admitted Storefront API key
-or approved origin and then resolves the bound Channel. Public callers cannot
-select, override, or probe Channel context by request parameter, header, body, or
-URL shape. Admin callers may select a Channel only on authorized preview and
+or approved origin and then resolves its Channel. Public callers cannot select,
+override, or probe Channel context by request parameter, header, body, or URL
+shape. Admin callers may select a Channel only on authorized preview and
 management surfaces.
 
-During migration, a deployment may carry an explicit temporary default Channel
-for compatibility. After cutover, an active unbound Storefront fails closed, and
-an inactive bound Channel denies public access.
+**Direct is the default, and it is implicit.** `@voyant-travel/distribution`
+provisions exactly one system Channel per deployment — `system_key = 'direct'`,
+non-deletable, kind fixed, and left out of the counterparty list. A Storefront
+with no explicit binding resolves to it, and so does one whose bound Channel has
+gone inactive: losing the Channel an operator chose is a reason to serve the
+default, not a reason to take the public surface down. An explicit binding still
+wins, which is what keeps `affiliate` / `reseller` / `api_partner` working.
+
+This replaces the earlier fail-closed rule. Requiring an explicit binding meant
+an operator had to hand-create a commercial counterparty representing
+themselves, in a table carrying contracts and rate limits, before their own
+website could read a departure — and nothing provisioned it, so every Storefront
+created after the one-shot backfill 403ed
+([#4624](https://github.com/voyant-travel/voyant/issues/4624)). Public access is
+still denied when no Storefront resolves at all, and when the deployment has no
+active Direct Channel — which now means a migration has not run, not that
+someone forgot to configure something.
 
 Rule:
 

--- a/packages/auth-react/src/components/storefront-detail.tsx
+++ b/packages/auth-react/src/components/storefront-detail.tsx
@@ -18,7 +18,7 @@ import {
   Label,
   Separator,
 } from "@voyant-travel/ui/components"
-import { AlertTriangle, Check, Copy, KeyRound, Plus, RefreshCw, Trash2, X } from "lucide-react"
+import { Check, Copy, KeyRound, Plus, RefreshCw, Trash2, X } from "lucide-react"
 import { useState } from "react"
 
 import { useAuthUiI18nOrDefault } from "../i18n/provider.js"
@@ -172,8 +172,10 @@ function ChannelBindingSection({
 }) {
   const queryClient = useQueryClient()
   const copy = useAuthUiI18nOrDefault().messages.storefrontsPage
+  // An implicit binding is the absence of a choice, so the picker shows its
+  // "Direct (default)" placeholder rather than preselecting the Direct row.
   const [selectedChannelId, setSelectedChannelId] = useState(
-    storefront.channelBinding?.channelId ?? "",
+    storefront.channelBinding?.implicit ? "" : (storefront.channelBinding?.channelId ?? ""),
   )
   const channelsQuery = useQuery({
     ...storefrontChannelsQueryOptions(api),
@@ -233,12 +235,15 @@ function ChannelBindingSection({
         <h3 className="text-sm font-medium">{copy.channel.title}</h3>
         <p className="text-xs text-muted-foreground">{copy.channel.description}</p>
       </div>
-      <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900">
-        <div className="flex gap-2">
-          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
-          <span>{copy.channel.defaultDeny}</span>
-        </div>
-      </div>
+      {binding?.implicit ? (
+        // Publishing to Direct is the resting state, not a warning. It read as
+        // an amber alert while an unbound storefront actually 403ed; now that
+        // Direct is the default, saying so in the same tone would be telling an
+        // operator something is wrong when nothing is. Shown only when the
+        // binding really is the default — with no channel at all, the badge
+        // says so, and claiming Direct here would be a lie.
+        <p className="text-xs text-muted-foreground">{copy.channel.directDefault}</p>
+      ) : null}
       <div className="grid gap-2">
         <Label htmlFor={`storefront-channel-${storefront.id}`}>{copy.channel.selectLabel}</Label>
         <select
@@ -263,14 +268,16 @@ function ChannelBindingSection({
       ) : null}
       <div className="flex flex-wrap items-center gap-2 text-sm">
         <Badge variant={binding?.channelStatus === "active" ? "default" : "secondary"}>
-          {binding
-            ? copy.channel.boundStatus
-                .replace(
-                  "{channel}",
-                  binding.channelName ?? boundChannel?.name ?? binding.channelId,
-                )
-                .replace("{status}", binding.channelStatus)
-            : copy.channel.unboundStatus}
+          {!binding
+            ? copy.channel.unboundStatus
+            : binding.implicit
+              ? copy.channel.implicitStatus
+              : copy.channel.boundStatus
+                  .replace(
+                    "{channel}",
+                    binding.channelName ?? boundChannel?.name ?? binding.channelId,
+                  )
+                  .replace("{status}", binding.channelStatus)}
         </Badge>
         {boundChannel && boundChannel.status !== "active" ? (
           <span className="text-xs text-destructive">{copy.channel.inactiveWarning}</span>
@@ -291,7 +298,7 @@ function ChannelBindingSection({
           type="button"
           size="sm"
           variant="outline"
-          disabled={!binding || clear.isPending}
+          disabled={!binding || binding.implicit === true || clear.isPending}
           onClick={async () => {
             if (
               await confirmDialog({

--- a/packages/auth-react/src/i18n/en.ts
+++ b/packages/auth-react/src/i18n/en.ts
@@ -508,24 +508,25 @@ export const authUiEn: AuthUiMessages = {
       localhostHint: "HTTP is allowed only for localhost; every other origin must use HTTPS.",
     },
     channel: {
-      title: "Active channel",
-      description: "Bind this storefront to exactly one active distribution channel.",
+      title: "Sales channel",
+      description:
+        "Everything you sell through your own surfaces publishes to Direct. Choose another channel only to sell this storefront through a partner.",
       unavailable:
         "Channel binding is not configured for this deployment, so storefront access fails closed.",
-      defaultDeny:
-        "Default-deny is enforced: customer requests are rejected until this storefront is bound to an active channel.",
+      directDefault:
+        "This storefront publishes to Direct. You do not need to configure anything for your own website, checkout or customer portal.",
       selectLabel: "Channel",
-      selectPlaceholder: "Select an active channel",
+      selectPlaceholder: "Direct (default)",
       loading: "Loading channel status",
-      noActiveChannels: "No active channels are available. Activate a channel in Settings first.",
-      boundStatus: "Bound to {channel} ({status})",
-      unboundStatus: "No channel bound",
-      inactiveWarning: "The bound channel is not active; storefront access is denied.",
+      noActiveChannels: "No other active channels are available.",
+      boundStatus: "Publishing to {channel} ({status})",
+      implicitStatus: "Publishing to Direct (default)",
+      unboundStatus: "No channel available",
+      inactiveWarning: "The bound channel is not active; this storefront falls back to Direct.",
       save: "Save channel",
       saving: "Saving…",
-      clear: "Clear binding",
-      clearConfirm:
-        "Clear this storefront channel binding? Customer API access will be denied until another active channel is saved.",
+      clear: "Use Direct",
+      clearConfirm: "Publish this storefront to Direct again?",
     },
     keys: {
       title: "Access keys",

--- a/packages/auth-react/src/i18n/messages.ts
+++ b/packages/auth-react/src/i18n/messages.ts
@@ -459,12 +459,13 @@ export interface StorefrontsPageMessages {
     title: string
     description: string
     unavailable: string
-    defaultDeny: string
+    directDefault: string
     selectLabel: string
     selectPlaceholder: string
     loading: string
     noActiveChannels: string
     boundStatus: string
+    implicitStatus: string
     unboundStatus: string
     inactiveWarning: string
     save: string

--- a/packages/auth-react/src/i18n/ro.ts
+++ b/packages/auth-react/src/i18n/ro.ts
@@ -515,25 +515,25 @@ export const authUiRo: AuthUiMessages = {
         "HTTP este permis doar pentru localhost; orice alta origine trebuie sa foloseasca HTTPS.",
     },
     channel: {
-      title: "Canal activ",
-      description: "Leaga acest magazin de exact un canal de distributie activ.",
+      title: "Canal de vanzare",
+      description:
+        "Tot ce vinzi prin propriile suprafete se publica pe Direct. Alege alt canal doar daca vinzi acest magazin printr-un partener.",
       unavailable:
         "Legarea canalelor nu este configurata pentru acest deployment, deci accesul magazinului esueaza inchis.",
-      defaultDeny:
-        "Default-deny este aplicat: cererile clientilor sunt respinse pana cand magazinul este legat de un canal activ.",
+      directDefault:
+        "Acest magazin publica pe Direct. Nu trebuie sa configurezi nimic pentru propriul site, checkout sau portalul de clienti.",
       selectLabel: "Canal",
-      selectPlaceholder: "Selecteaza un canal activ",
+      selectPlaceholder: "Direct (implicit)",
       loading: "Se incarca starea canalului",
-      noActiveChannels:
-        "Nu exista canale active disponibile. Activeaza mai intai un canal in Setari.",
-      boundStatus: "Legat de {channel} ({status})",
-      unboundStatus: "Niciun canal legat",
-      inactiveWarning: "Canalul legat nu este activ; accesul magazinului este respins.",
+      noActiveChannels: "Nu exista alte canale active disponibile.",
+      boundStatus: "Publica pe {channel} ({status})",
+      implicitStatus: "Publica pe Direct (implicit)",
+      unboundStatus: "Niciun canal disponibil",
+      inactiveWarning: "Canalul legat nu este activ; acest magazin revine la Direct.",
       save: "Salveaza canalul",
       saving: "Se salveaza…",
-      clear: "Sterge legarea",
-      clearConfirm:
-        "Stergi legarea canalului pentru acest magazin? Accesul prin API al clientilor va fi respins pana cand salvezi alt canal activ.",
+      clear: "Foloseste Direct",
+      clearConfirm: "Publici din nou acest magazin pe Direct?",
     },
     keys: {
       title: "Chei de acces",

--- a/packages/auth-react/src/storefronts-page.test.tsx
+++ b/packages/auth-react/src/storefronts-page.test.tsx
@@ -51,10 +51,22 @@ const API_KEY: StorefrontApiKeyDto = {
 const CHANNEL_BINDING = {
   storefrontId: "storefront_1",
   channelId: "channel_1",
-  channelName: "Website",
+  channelName: "Partner OTA",
   channelStatus: "active",
   createdAt: "2026-07-15T00:00:00.000Z",
   updatedAt: "2026-07-15T00:00:00.000Z",
+  implicit: false,
+}
+
+/** What an unconfigured storefront resolves to: the deployment's Direct channel. */
+const IMPLICIT_DIRECT_BINDING = {
+  storefrontId: "storefront_1",
+  channelId: "chan_system_direct",
+  channelName: "Direct",
+  channelStatus: "active",
+  createdAt: null,
+  updatedAt: null,
+  implicit: true,
 }
 
 describe("storefront admin surface", () => {
@@ -215,21 +227,22 @@ describe("storefront admin surface", () => {
     await act(async () => root.unmount())
   })
 
-  it("sets a storefront channel binding with default-deny copy", async () => {
+  it("overrides the implicit Direct default with an explicit channel", async () => {
     const queryClient = seededQueryClient({
       businessAccounts: true,
       manageProviders: true,
       channelBinding: true,
     })
     const api = pageApi()
-    let currentBinding: typeof CHANNEL_BINDING | null = null
+    let currentBinding: typeof CHANNEL_BINDING | typeof IMPLICIT_DIRECT_BINDING =
+      IMPLICIT_DIRECT_BINDING
     api.getChannelBinding = vi.fn(async () => currentBinding)
     api.setChannelBinding = vi.fn(async () => {
       currentBinding = CHANNEL_BINDING
       return CHANNEL_BINDING
     })
     api.clearChannelBinding = vi.fn(async () => {
-      currentBinding = null
+      currentBinding = IMPLICIT_DIRECT_BINDING
     })
     const container = document.createElement("div")
     const root = createRoot(container)
@@ -243,7 +256,10 @@ describe("storefront admin surface", () => {
     })
     await clickButton(container, "Web store")
 
-    expect(container.textContent).toContain("Default-deny is enforced")
+    expect(container.textContent).toContain("publishes to Direct")
+    await vi.waitFor(() =>
+      expect(container.textContent).toContain("Publishing to Direct (default)"),
+    )
     const select = container.querySelector<HTMLSelectElement>("#storefront-channel-storefront_1")
     expect(select).not.toBeNull()
     await vi.waitFor(() => expect(select!.options.length).toBeGreaterThan(1))
@@ -257,12 +273,12 @@ describe("storefront admin surface", () => {
         channelId: "channel_1",
       }),
     )
-    await vi.waitFor(() => expect(container.textContent).toContain("Bound to Website"))
+    await vi.waitFor(() => expect(container.textContent).toContain("Publishing to Partner OTA"))
 
     await act(async () => root.unmount())
   })
 
-  it("clears a storefront channel binding after confirmation", async () => {
+  it("returns an explicitly bound storefront to Direct after confirmation", async () => {
     const queryClient = seededQueryClient({
       businessAccounts: true,
       manageProviders: true,
@@ -281,21 +297,21 @@ describe("storefront admin surface", () => {
       )
     })
     await clickButton(container, "Web store")
-    await vi.waitFor(() => expect(container.textContent).toContain("Bound to Website"))
+    await vi.waitFor(() => expect(container.textContent).toContain("Publishing to Partner OTA"))
 
     const clearButton = Array.from(container.querySelectorAll("button")).find(
-      (button) => button.textContent?.includes("Clear binding") && !button.disabled,
+      (button) => button.textContent?.includes("Use Direct") && !button.disabled,
     )
     expect(clearButton).toBeDefined()
     await act(async () => {
       clearButton?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }))
     })
     await vi.waitFor(() =>
-      expect(document.body.textContent).toContain("Customer API access will be denied"),
+      expect(document.body.textContent).toContain("Publish this storefront to Direct again?"),
     )
     const clearDialogButton = Array.from(document.body.querySelectorAll("button"))
       .reverse()
-      .find((button) => button.textContent?.includes("Clear binding"))
+      .find((button) => button.textContent?.includes("Use Direct"))
     await act(async () => {
       clearDialogButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }))
     })
@@ -379,7 +395,7 @@ function pageApi(): StorefrontsAdminApi {
     deleteStorefront: vi.fn(async () => undefined),
     setAllowedOrigins: vi.fn(async () => STOREFRONT),
     listChannels: vi.fn(async () => [
-      { id: "channel_1", name: "Website", status: "active" as const },
+      { id: "channel_1", name: "Partner OTA", status: "active" as const },
     ]),
     getChannelBinding: vi.fn(async () => CHANNEL_BINDING),
     setChannelBinding: vi.fn(async () => CHANNEL_BINDING),

--- a/packages/auth/src/storefront-admin-contracts.ts
+++ b/packages/auth/src/storefront-admin-contracts.ts
@@ -95,6 +95,12 @@ export const storefrontSchema = z.object({
       channelStatus: z.string(),
       createdAt: z.string().nullable(),
       updatedAt: z.string().nullable(),
+      /**
+       * True when nothing binds this storefront explicitly and it resolved to
+       * the deployment's Direct channel. Optional so a client keeps parsing
+       * responses from a runtime that predates the field.
+       */
+      implicit: z.boolean().optional(),
     })
     .nullable()
     .optional(),

--- a/packages/auth/src/storefront-channel-binding-provider.ts
+++ b/packages/auth/src/storefront-channel-binding-provider.ts
@@ -66,6 +66,43 @@ function channelFromRow(row: Record<string, unknown>): ChannelRow | null {
   }
 }
 
+/**
+ * The deployment's Direct channel — the one everything sold through the
+ * operator's own surfaces publishes to. `@voyant-travel/distribution` marks it
+ * with `system_key = 'direct'` and provisions exactly one by migration.
+ *
+ * The fallback to `kind = 'direct'` is not belt-and-braces: it is what a
+ * deployment whose operator hand-created a self-representing channel before
+ * the system row existed already binds to, and it is the same tie-break the
+ * storefront-channel-binding cutover used. Preferring the system row and
+ * falling back to the oldest active `direct` keeps both resolving to the row
+ * their publication rules are keyed by.
+ *
+ * Returns null rather than throwing when the lookup faults — a deployment that
+ * has not run the distribution migration has no `system_key` column, and the
+ * honest answer there is "no Direct channel", which leaves behaviour exactly as
+ * it was before this existed.
+ */
+async function loadDirectChannel(context: BindingContext): Promise<ChannelRow | null> {
+  try {
+    const rows = await executeRows(
+      context,
+      sql`
+        SELECT id, name, status
+        FROM channels
+        WHERE status = 'active'
+          AND (system_key = 'direct' OR kind = 'direct')
+        ORDER BY (system_key IS NOT DISTINCT FROM 'direct') DESC, created_at, id
+        LIMIT 1
+      `,
+    )
+    const row = rows[0]
+    return row ? channelFromRow(row) : null
+  } catch {
+    return null
+  }
+}
+
 async function loadChannels(
   context: BindingContext,
   channelIds: readonly string[],
@@ -112,6 +149,27 @@ function toBinding(
     channelStatus: channel.status,
     createdAt: iso(linkRow.createdAt),
     updatedAt: iso(linkRow.updatedAt),
+    implicit: false,
+  }
+}
+
+/**
+ * The binding a storefront has by default. There is no link row behind it, so
+ * the timestamps are null — nothing was ever configured, which is the point.
+ */
+function toImplicitDirectBinding(
+  storefrontId: string,
+  channel: ChannelRow | null,
+): StorefrontChannelBindingDto | null {
+  if (!channel || channel.status !== ACTIVE_CHANNEL_STATUS) return null
+  return {
+    storefrontId,
+    channelId: channel.id,
+    channelName: channel.name,
+    channelStatus: channel.status,
+    createdAt: null,
+    updatedAt: null,
+    implicit: true,
   }
 }
 
@@ -145,6 +203,9 @@ export function createLinkServiceStorefrontChannelBindingProvider(): StorefrontC
         return channelId ? [channelId] : []
       })
       const channels = await loadChannels(context, channelIds)
+      // Resolved once for the whole batch, and lazily: a deployment where every
+      // storefront is explicitly bound never issues the query.
+      let directChannel: ChannelRow | null | undefined
 
       for (const storefrontId of ids) {
         const bindingRows = rowsByStorefront.get(storefrontId) ?? []
@@ -153,8 +214,19 @@ export function createLinkServiceStorefrontChannelBindingProvider(): StorefrontC
           bindingRows.map((row) => row.rightId),
         )
         const linkRow = bindingRows.find((row) => row.rightId === channelId)
-        result[storefrontId] =
+        const explicit =
           channelId && linkRow ? toBinding(storefrontId, channels.get(channelId), linkRow) : null
+        if (explicit) {
+          result[storefrontId] = explicit
+          continue
+        }
+        // No explicit binding — or one pointing at a channel that is gone or no
+        // longer active. Either way the storefront falls back to Direct rather
+        // than to nothing: publishing to yourself is the default, and the 403
+        // that used to follow from an absent binding was asking the operator to
+        // hand-create a counterparty representing themselves (#4624).
+        if (directChannel === undefined) directChannel = await loadDirectChannel(context)
+        result[storefrontId] = toImplicitDirectBinding(storefrontId, directChannel)
       }
 
       return result
@@ -189,6 +261,11 @@ export function createLinkServiceStorefrontChannelBindingProvider(): StorefrontC
       return binding
     },
 
+    /**
+     * Drop the explicit binding. The storefront does not become channel-less —
+     * it falls back to the deployment's Direct channel, which is what it had
+     * before anyone chose otherwise.
+     */
     async clearStorefrontChannelBinding(context, storefrontId) {
       const link = resolveLinkService(context)
       const rows = await link.list(linkKey, { leftId: storefrontId })

--- a/packages/auth/src/storefront-customer-auth-resolver.ts
+++ b/packages/auth/src/storefront-customer-auth-resolver.ts
@@ -176,17 +176,21 @@ export function createLocalStorefrontCustomerAuthResolver<Env>(
         storefront.id,
         enabledProviders,
       )
+      // A storefront resolves to the deployment's Direct channel unless
+      // something binds it elsewhere, so reaching either branch below means the
+      // deployment has no active Direct channel at all — a migration that has
+      // not run, not an operator who forgot to configure something.
       if (!config.resolveStorefrontChannelBinding) {
         throw new StorefrontCustomerAuthResolutionError(
           "missing_channel_binding",
-          "The storefront is not bound to an active sales channel.",
+          "This runtime resolves no sales channel for the public surface.",
         )
       }
       const channelBinding = await config.resolveStorefrontChannelBinding(context, storefront.id)
       if (!channelBinding || channelBinding.channelStatus !== "active") {
         throw new StorefrontCustomerAuthResolutionError(
           "missing_channel_binding",
-          "The storefront is not bound to an active sales channel.",
+          "The deployment has no active Direct channel to serve the public surface from.",
         )
       }
 

--- a/packages/auth/src/storefront-runtime-port.ts
+++ b/packages/auth/src/storefront-runtime-port.ts
@@ -30,6 +30,18 @@ export interface StorefrontChannelBindingDto {
   channelStatus: string
   createdAt: string | null
   updatedAt: string | null
+  /**
+   * True when nothing binds this storefront to a channel explicitly and it
+   * resolved to the deployment's Direct channel — the default every public
+   * surface gets without an operator configuring anything. False when an
+   * explicit binding row selected the channel.
+   *
+   * The distinction is for display and diagnostics only; both are equally
+   * valid to serve on. An admin surface should show an implicit binding as the
+   * default rather than as a configured choice, so clearing it reads as
+   * "back to Direct" and not as "breaks the public API".
+   */
+  implicit: boolean
 }
 
 export interface SetStorefrontChannelBindingInput {

--- a/packages/auth/tests/integration/storefront-channel-binding.test.ts
+++ b/packages/auth/tests/integration/storefront-channel-binding.test.ts
@@ -1,0 +1,156 @@
+import { createDbClient } from "@voyant-travel/db"
+import { authOrganization, storefronts } from "@voyant-travel/db/schema/iam"
+import { sql } from "drizzle-orm"
+import { afterAll, beforeEach, describe, expect, it } from "vitest"
+
+import { createLinkServiceStorefrontChannelBindingProvider } from "../../src/storefront-channel-binding-provider.js"
+import { createLocalStorefrontAdapter } from "../../src/storefront-local-adapter.js"
+import type { StorefrontRequestContext } from "../../src/storefront-runtime-port.js"
+
+const TEST_DATABASE_URL = process.env.TEST_DATABASE_URL
+
+/**
+ * The Direct-channel lookup is raw SQL — `packages/auth` reads `channels`
+ * without importing Distribution's tables — so a fake `db` that records
+ * statements can only tell you what the query *says*. It cannot tell you the
+ * query is wrong.
+ *
+ * It was: `ORDER BY (system_key = 'direct') DESC` reads NULL for every
+ * operator-created channel, and a DESC sort puts NULLs first, so the row the
+ * clause exists to prefer came last. Only Postgres says so, which is why this
+ * lives here and not next to the unit tests.
+ */
+describe.skipIf(!TEST_DATABASE_URL)("storefront channel binding against Postgres", () => {
+  const db = createDbClient(TEST_DATABASE_URL!, {
+    adapter: "node",
+    nodeMaxConnections: 4,
+    timeouts: { connectMs: false, queryMs: false, statementMs: false },
+  })
+  const adapter = createLocalStorefrontAdapter({ resolveCipher: () => ({}) as never })
+  const provider = createLinkServiceStorefrontChannelBindingProvider()
+  const context: StorefrontRequestContext = { bindings: {}, db }
+
+  beforeEach(async () => {
+    await db.execute(sql`DELETE FROM "auth_storefront_distribution_channel"`)
+    await db.execute(sql`DELETE FROM "channels"`)
+    await db.delete(storefronts)
+    await db.delete(authOrganization)
+  })
+
+  afterAll(async () => {
+    await db.execute(sql`DELETE FROM "auth_storefront_distribution_channel"`)
+    await db.execute(sql`DELETE FROM "channels"`)
+    await db.delete(storefronts)
+  })
+
+  async function createShop() {
+    return adapter.createStorefront(context, {
+      name: "Shop",
+      slug: "shop",
+      hostingKind: "external",
+      allowedOrigins: ["https://shop.example.com"],
+      methods: {
+        emailCode: true,
+        emailPassword: false,
+        google: false,
+        facebook: false,
+        apple: false,
+      },
+    })
+  }
+
+  async function insertChannel(input: {
+    id: string
+    name: string
+    kind?: string
+    status?: string
+    systemKey?: string | null
+  }) {
+    await db.execute(sql`
+      INSERT INTO "channels" ("id", "name", "kind", "status", "system_key")
+      VALUES (
+        ${input.id},
+        ${input.name},
+        ${input.kind ?? "direct"}::channel_kind,
+        ${input.status ?? "active"}::channel_status,
+        ${input.systemKey ?? null}
+      )
+    `)
+    return input.id
+  }
+
+  it("reports no binding when the deployment has no Direct channel", async () => {
+    const shop = await createShop()
+
+    await expect(provider.getStorefrontChannelBinding(context, shop.id)).resolves.toBeNull()
+  })
+
+  it("resolves an unbound storefront to the system Direct channel", async () => {
+    const shop = await createShop()
+    await insertChannel({ id: "chan_system_direct", name: "Direct", systemKey: "direct" })
+
+    await expect(provider.getStorefrontChannelBinding(context, shop.id)).resolves.toMatchObject({
+      storefrontId: shop.id,
+      channelId: "chan_system_direct",
+      channelName: "Direct",
+      implicit: true,
+    })
+  })
+
+  it("prefers the system row over an operator's own, older, direct channel", async () => {
+    const shop = await createShop()
+    await insertChannel({ id: "chan_operator_own", name: "Our website" })
+    await db.execute(
+      sql`UPDATE "channels" SET "created_at" = now() - interval '1 year' WHERE "id" = 'chan_operator_own'`,
+    )
+    await insertChannel({ id: "chan_system_direct", name: "Direct", systemKey: "direct" })
+
+    const binding = await provider.getStorefrontChannelBinding(context, shop.id)
+
+    expect(binding?.channelId).toBe("chan_system_direct")
+  })
+
+  it("falls back to an operator's own direct channel when no system row exists", async () => {
+    const shop = await createShop()
+    await insertChannel({ id: "chan_operator_own", name: "Our website" })
+
+    const binding = await provider.getStorefrontChannelBinding(context, shop.id)
+
+    expect(binding?.channelId).toBe("chan_operator_own")
+    expect(binding?.implicit).toBe(true)
+  })
+
+  it("lets an explicit binding win, and returns to Direct when it is cleared", async () => {
+    const shop = await createShop()
+    await insertChannel({ id: "chan_system_direct", name: "Direct", systemKey: "direct" })
+    await insertChannel({ id: "chan_partner", name: "Partner OTA", kind: "ota" })
+
+    await provider.setStorefrontChannelBinding(context, shop.id, { channelId: "chan_partner" })
+    await expect(provider.getStorefrontChannelBinding(context, shop.id)).resolves.toMatchObject({
+      channelId: "chan_partner",
+      implicit: false,
+    })
+
+    await provider.clearStorefrontChannelBinding(context, shop.id)
+    await expect(provider.getStorefrontChannelBinding(context, shop.id)).resolves.toMatchObject({
+      channelId: "chan_system_direct",
+      implicit: true,
+    })
+  })
+
+  it("falls back to Direct when the explicitly bound channel is archived", async () => {
+    const shop = await createShop()
+    await insertChannel({ id: "chan_system_direct", name: "Direct", systemKey: "direct" })
+    await insertChannel({ id: "chan_partner", name: "Partner OTA", kind: "ota" })
+    await provider.setStorefrontChannelBinding(context, shop.id, { channelId: "chan_partner" })
+
+    await db.execute(sql`UPDATE "channels" SET "status" = 'archived' WHERE "id" = 'chan_partner'`)
+
+    // Losing the channel an operator chose is a reason to serve the default,
+    // not a reason to take the public surface down.
+    await expect(provider.getStorefrontChannelBinding(context, shop.id)).resolves.toMatchObject({
+      channelId: "chan_system_direct",
+      implicit: true,
+    })
+  })
+})

--- a/packages/auth/tests/unit/storefront-channel-binding-provider.test.ts
+++ b/packages/auth/tests/unit/storefront-channel-binding-provider.test.ts
@@ -48,11 +48,18 @@ function activeChannelRow(overrides: Record<string, unknown> = {}) {
   return { id: "chan_1", name: "Direct", status: "active", ...overrides }
 }
 
+/**
+ * The Direct-channel lookup is the only read that mentions `system_key`, which
+ * is what separates it from the by-id channel read both go through `channels`.
+ */
+const isDirectChannelRead = (sql: string) => sql.includes("system_key")
+
 describe("storefront channel binding without a deployment LinkService", () => {
   it("lists bindings by reading the pivot table from the request database", async () => {
     const provider = createLinkServiceStorefrontChannelBindingProvider()
     const { context, statements } = managedContext(({ sql }) => {
       if (sql.includes(BINDING_TABLE)) return [linkRow()]
+      if (isDirectChannelRead(sql)) return []
       if (sql.includes("channels")) return [activeChannelRow()]
       return []
     })
@@ -67,7 +74,9 @@ describe("storefront channel binding without a deployment LinkService", () => {
         channelStatus: "active",
         createdAt: "2026-08-01T00:00:00.000Z",
         updatedAt: "2026-08-02T00:00:00.000Z",
+        implicit: false,
       },
+      // No pivot row and no Direct channel in this deployment: still null.
       sf_2: null,
     })
     const pivotRead = statements.find((statement) => statement.sql.includes(BINDING_TABLE))
@@ -79,6 +88,7 @@ describe("storefront channel binding without a deployment LinkService", () => {
     const provider = createLinkServiceStorefrontChannelBindingProvider()
     const { context } = managedContext(({ sql }) => {
       if (sql.includes(BINDING_TABLE)) return [linkRow()]
+      if (isDirectChannelRead(sql)) return []
       if (sql.includes("channels")) return [activeChannelRow()]
       return []
     })
@@ -136,11 +146,113 @@ describe("storefront channel binding without a deployment LinkService", () => {
   })
 })
 
+describe("implicit Direct channel", () => {
+  const directRow = { id: "chan_system_direct", name: "Direct", status: "active" }
+
+  function deploymentWithDirectChannel(pivotRows: unknown[]) {
+    return managedContext(({ sql }) => {
+      if (sql.includes(BINDING_TABLE)) return pivotRows as Record<string, unknown>[]
+      if (isDirectChannelRead(sql)) return [directRow]
+      if (sql.includes("channels")) return [activeChannelRow()]
+      return []
+    })
+  }
+
+  it("binds an unbound storefront to the deployment's Direct channel", async () => {
+    const provider = createLinkServiceStorefrontChannelBindingProvider()
+    const { context } = deploymentWithDirectChannel([])
+
+    const binding = await provider.getStorefrontChannelBinding(context, "sf_1")
+
+    expect(binding).toEqual({
+      storefrontId: "sf_1",
+      channelId: "chan_system_direct",
+      channelName: "Direct",
+      channelStatus: "active",
+      // Nothing was configured, so there is no link row to date.
+      createdAt: null,
+      updatedAt: null,
+      implicit: true,
+    })
+  })
+
+  it("prefers an explicit binding over Direct", async () => {
+    const provider = createLinkServiceStorefrontChannelBindingProvider()
+    const { context } = deploymentWithDirectChannel([linkRow()])
+
+    await expect(provider.getStorefrontChannelBinding(context, "sf_1")).resolves.toMatchObject({
+      channelId: "chan_1",
+      implicit: false,
+    })
+  })
+
+  it("falls back to Direct when the explicitly bound channel is no longer active", async () => {
+    const provider = createLinkServiceStorefrontChannelBindingProvider()
+    const { context } = managedContext(({ sql }) => {
+      if (sql.includes(BINDING_TABLE)) return [linkRow()]
+      if (isDirectChannelRead(sql)) return [directRow]
+      if (sql.includes("channels")) return [activeChannelRow({ status: "archived" })]
+      return []
+    })
+
+    // Losing the channel an operator chose is a reason to serve the default,
+    // not a reason to take the public surface down.
+    await expect(provider.getStorefrontChannelBinding(context, "sf_1")).resolves.toMatchObject({
+      channelId: "chan_system_direct",
+      implicit: true,
+    })
+  })
+
+  it("reads the Direct channel once for a batch, and not at all when every storefront is bound", async () => {
+    const provider = createLinkServiceStorefrontChannelBindingProvider()
+    const { context, statements } = deploymentWithDirectChannel([
+      linkRow({ storefront_id: "sf_1" }),
+      linkRow({ id: "lnk_2", storefront_id: "sf_2" }),
+    ])
+
+    await provider.listStorefrontChannelBindings(context, ["sf_1", "sf_2"])
+
+    expect(statements.filter((statement) => isDirectChannelRead(statement.sql))).toHaveLength(0)
+  })
+
+  it("prefers the system row over an operator's own direct channel", async () => {
+    const provider = createLinkServiceStorefrontChannelBindingProvider()
+    const { context, statements } = deploymentWithDirectChannel([])
+
+    await provider.getStorefrontChannelBinding(context, "sf_1")
+
+    const read = statements.find((statement) => isDirectChannelRead(statement.sql))
+    expect(read?.sql).toContain("system_key = 'direct'")
+    expect(read?.sql).toContain("kind = 'direct'")
+    // `IS NOT DISTINCT FROM`, not `=`. `system_key` is null on every
+    // operator-created channel, `NULL = 'direct'` is NULL, and a DESC sort puts
+    // NULLs first — so the `=` form ranked the operator's own direct channel
+    // above the system row. What this fake db cannot tell you is that the query
+    // is wrong; `routes.direct-channel.test.ts` runs it against Postgres, which
+    // is what caught it.
+    expect(read?.sql).toContain("(system_key IS NOT DISTINCT FROM 'direct') DESC")
+  })
+
+  it("reports no binding, rather than failing, when the channel read faults", async () => {
+    const provider = createLinkServiceStorefrontChannelBindingProvider()
+    // A deployment that has not run the distribution migration has no
+    // `system_key` column. "No Direct channel" is the honest answer there; a
+    // throw would turn a 403 into a 500.
+    const { context } = managedContext(({ sql }) => {
+      if (sql.includes(BINDING_TABLE)) return []
+      if (isDirectChannelRead(sql)) throw new Error('column "system_key" does not exist')
+      return []
+    })
+
+    await expect(provider.getStorefrontChannelBinding(context, "sf_1")).resolves.toBeNull()
+  })
+})
+
 describe("storefront channel binding with a deployment LinkService", () => {
   it("prefers the wired service over the database fallback", async () => {
     const provider = createLinkServiceStorefrontChannelBindingProvider()
     const { context, statements } = managedContext(({ sql }) =>
-      sql.includes("channels") ? [activeChannelRow()] : [],
+      sql.includes("channels") && !isDirectChannelRead(sql) ? [activeChannelRow()] : [],
     )
     const list = vi.fn(async () => [
       {

--- a/packages/distribution-react/src/components/channels-page.tsx
+++ b/packages/distribution-react/src/components/channels-page.tsx
@@ -72,6 +72,13 @@ export function ChannelsPage({ className, pageSize = PAGE_SIZE }: ChannelsPagePr
   const { data, isPending, refetch } = useChannels({
     limit: pageSize,
     offset: pageIndex * pageSize,
+    // This page is the list of parties the operator distributes through. Direct
+    // is the deployment selling through its own surfaces, not a counterparty —
+    // it has no contract, no commission and no contact, and it cannot be
+    // deleted, so every row action here is inapplicable to it. Publication and
+    // product-mapping pickers read the same endpoint without this filter and do
+    // still target Direct.
+    system: "exclude",
   })
   const { remove } = useChannelMutation()
 

--- a/packages/distribution-react/src/query-keys.ts
+++ b/packages/distribution-react/src/query-keys.ts
@@ -6,7 +6,14 @@ export interface PaginationFilters {
 export interface SuppliersListFilters extends PaginationFilters {}
 export interface ProductsListFilters extends PaginationFilters {}
 export interface BookingsListFilters extends PaginationFilters {}
-export interface ChannelsListFilters extends PaginationFilters {}
+export interface ChannelsListFilters extends PaginationFilters {
+  /**
+   * How to treat system-provisioned channels (today: Direct). Defaults to
+   * including them, because publication and product-mapping pickers must be
+   * able to target Direct. Only the counterparty list asks to drop it.
+   */
+  system?: "include" | "exclude" | "only" | undefined
+}
 export interface ContractsListFilters extends PaginationFilters {
   channelId?: string | undefined
 }

--- a/packages/distribution-react/src/query-options.ts
+++ b/packages/distribution-react/src/query-options.ts
@@ -159,6 +159,7 @@ export function getChannelsQueryOptions(
     queryFn: () => {
       const params = new URLSearchParams()
       appendPagination(params, filters)
+      if (filters.system) params.set("system", filters.system)
       const qs = params.toString()
       return fetchWithValidation(
         `/v1/admin/distribution/channels${qs ? `?${qs}` : ""}`,

--- a/packages/distribution-react/src/schemas.ts
+++ b/packages/distribution-react/src/schemas.ts
@@ -64,6 +64,12 @@ export const channelRecordSchema = z.object({
   contactName: z.string().nullable(),
   contactEmail: z.string().nullable(),
   metadata: z.record(z.string(), z.unknown()).nullable(),
+  /**
+   * Non-null on a channel the deployment provisions for itself — `"direct"` is
+   * the only one. Optional here so a client built against this schema keeps
+   * parsing responses from a server that predates the column.
+   */
+  systemKey: z.string().nullable().optional(),
 })
 
 export type ChannelRow = z.infer<typeof channelRecordSchema>

--- a/packages/distribution/README.md
+++ b/packages/distribution/README.md
@@ -8,6 +8,35 @@ tour-operator, and DMC deployments.
 Distribution is cross-cutting channel support. It is not a separate
 implementation scenario or user base.
 
+## The Direct channel is not a counterparty
+
+`channels` is a table of parties an operator distributes through — it carries
+contracts, commissions, rate limits and contact projections, and it sits next to
+`suppliers`. Exactly one row is not like that: the one the deployment publishes
+its own surfaces to.
+
+A migration provisions it and marks it `system_key = 'direct'`. It is the
+channel a public request resolves to when nothing names another one, which is
+why it cannot be deleted or moved off `active` (both answer `409`) and why its
+`kind` is fixed. Its name and contact details remain the operator's to edit.
+
+The marker is a column rather than a `metadata` key because it has to be
+unforgeable: `metadata` is editable through the ordinary channel `PATCH`, so a
+flag there could be cleared and the row the public API depends on then deleted.
+
+`GET /channels` takes `system=include|exclude|only` and **defaults to
+`include`**. Publication and product-mapping surfaces read the same endpoint and
+must be able to target Direct — default-hiding it would make the channel
+everything publishes to the one channel nothing can be published to. Only the
+counterparty list passes `exclude`.
+
+Resolution lives with the consumer, not here: `@voyant-travel/auth` reads the
+row directly in `storefront-channel-binding-provider.ts` (raw SQL, so
+Distribution's tables are not imported into Auth). It prefers the system row and
+falls back to the oldest active `direct` channel, so a deployment whose operator
+hand-created a self-representing channel before this existed keeps resolving to
+the row its publication rules are already keyed by.
+
 ## Install
 
 ```bash

--- a/packages/distribution/migrations/20260814120000_direct_channel_system_key.sql
+++ b/packages/distribution/migrations/20260814120000_direct_channel_system_key.sql
@@ -1,0 +1,86 @@
+-- The Direct channel becomes a thing the deployment owns rather than a
+-- counterparty the operator has to invent.
+--
+-- Publication is default-deny per channel, and every public catalog read
+-- resolves a channel before it answers, so serving your own website used to
+-- require hand-creating a row in `channels` — a table of commercial
+-- counterparties, sitting next to `suppliers`, with contracts and rate limits —
+-- that represents yourself. Nothing provisioned it, so the surface 403ed until
+-- someone did (voyant#4624, voyant#4323).
+--
+-- `system_key` marks the rows the deployment provisions for itself. It is a
+-- column and not a `metadata` key because the marker has to be unforgeable:
+-- `deleteChannel` and the status guard refuse on it, and `metadata` is editable
+-- through the ordinary channel PATCH.
+ALTER TABLE "channels" ADD COLUMN IF NOT EXISTS "system_key" text;
+--> statement-breakpoint
+-- Partial: null on every operator-created channel, so only the one system row
+-- per key is constrained.
+CREATE UNIQUE INDEX IF NOT EXISTS "uniq_channels_system_key"
+	ON "channels" ("system_key")
+	WHERE "system_key" IS NOT NULL;
+--> statement-breakpoint
+DO $$
+DECLARE
+	adopted_id text;
+BEGIN
+	-- Already provisioned (re-run, or a deployment that arrived here twice).
+	IF EXISTS (SELECT 1 FROM "channels" WHERE "system_key" = 'direct') THEN
+		RETURN;
+	END IF;
+
+	-- Adopt before inserting. `channel_product_mappings` and the publication
+	-- rules are keyed by channel id, and storefront->channel bindings point at
+	-- one specific row, so minting a fresh channel next to an existing `direct`
+	-- one would silently unpublish everything already published and leave every
+	-- binding pointing at a channel the public surface no longer resolves to.
+	--
+	-- Preference order:
+	--   1. the row the storefront-channel-binding setup cutover created — ours,
+	--      so it is safe to rename from "Storefront Direct" to "Direct"
+	--   2. the oldest active `direct` channel — the operator's own
+	--      self-representing counterparty, exactly the row this work retires.
+	--      Keep its name; it is theirs, and the id is what everything points at.
+	SELECT "id" INTO adopted_id
+	FROM "channels"
+	WHERE "id" = 'chan_storefront_direct'
+		AND "kind" = 'direct'
+	LIMIT 1;
+
+	IF adopted_id IS NOT NULL THEN
+		UPDATE "channels"
+		SET "system_key" = 'direct',
+			"name" = 'Direct',
+			"description" = 'Everything you sell through yourself — your website, the booking engine, the customer portal, and anything built on the Public API.',
+			"status" = 'active',
+			"updated_at" = now()
+		WHERE "id" = adopted_id;
+		RETURN;
+	END IF;
+
+	SELECT "id" INTO adopted_id
+	FROM "channels"
+	WHERE "kind" = 'direct'
+		AND "status" = 'active'
+	ORDER BY "created_at", "id"
+	LIMIT 1;
+
+	IF adopted_id IS NOT NULL THEN
+		UPDATE "channels"
+		SET "system_key" = 'direct',
+			"updated_at" = now()
+		WHERE "id" = adopted_id;
+		RETURN;
+	END IF;
+
+	INSERT INTO "channels" ("id", "name", "description", "kind", "status", "system_key")
+	VALUES (
+		'chan_system_direct',
+		'Direct',
+		'Everything you sell through yourself — your website, the booking engine, the customer portal, and anything built on the Public API.',
+		'direct',
+		'active',
+		'direct'
+	)
+	ON CONFLICT ("id") DO NOTHING;
+END $$;

--- a/packages/distribution/migrations/meta/_journal.json
+++ b/packages/distribution/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1785715800000,
       "tag": "20260803121000_channel_source_publications",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1786708800000,
+      "tag": "20260814120000_direct_channel_system_key",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/distribution/openapi/admin/distribution.json
+++ b/packages/distribution/openapi/admin/distribution.json
@@ -66,6 +66,16 @@
             "required": false,
             "name": "status",
             "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": ["include", "exclude", "only"]
+            },
+            "required": false,
+            "name": "system",
+            "in": "query",
+            "description": "How to treat system-provisioned channels (today: Direct). Defaults to `include` \u2014 publication and product-mapping pickers must be able to target Direct. The counterparty list passes `exclude`."
           }
         ],
         "responses": {
@@ -110,6 +120,10 @@
                             "type": ["object", "null"],
                             "additionalProperties": {}
                           },
+                          "systemKey": {
+                            "type": ["string", "null"],
+                            "description": "Non-null on a channel the deployment provisions for itself. `direct` is the only one today: it cannot be deleted or deactivated, and the counterparty list leaves it out."
+                          },
                           "rateLimitRps": {
                             "type": ["integer", "null"]
                           },
@@ -145,6 +159,7 @@
                           "kind",
                           "status",
                           "metadata",
+                          "systemKey",
                           "rateLimitRps",
                           "rateLimitBurst",
                           "rateLimitPriorityGates",
@@ -278,6 +293,10 @@
                           "type": ["object", "null"],
                           "additionalProperties": {}
                         },
+                        "systemKey": {
+                          "type": ["string", "null"],
+                          "description": "Non-null on a channel the deployment provisions for itself. `direct` is the only one today: it cannot be deleted or deactivated, and the counterparty list leaves it out."
+                        },
                         "rateLimitRps": {
                           "type": ["integer", "null"]
                         },
@@ -313,6 +332,7 @@
                         "kind",
                         "status",
                         "metadata",
+                        "systemKey",
                         "rateLimitRps",
                         "rateLimitBurst",
                         "rateLimitPriorityGates",
@@ -469,6 +489,10 @@
                             "type": ["object", "null"],
                             "additionalProperties": {}
                           },
+                          "systemKey": {
+                            "type": ["string", "null"],
+                            "description": "Non-null on a channel the deployment provisions for itself. `direct` is the only one today: it cannot be deleted or deactivated, and the counterparty list leaves it out."
+                          },
                           "rateLimitRps": {
                             "type": ["integer", "null"]
                           },
@@ -504,6 +528,7 @@
                           "kind",
                           "status",
                           "metadata",
+                          "systemKey",
                           "rateLimitRps",
                           "rateLimitBurst",
                           "rateLimitPriorityGates",
@@ -698,6 +723,10 @@
                           "type": ["object", "null"],
                           "additionalProperties": {}
                         },
+                        "systemKey": {
+                          "type": ["string", "null"],
+                          "description": "Non-null on a channel the deployment provisions for itself. `direct` is the only one today: it cannot be deleted or deactivated, and the counterparty list leaves it out."
+                        },
                         "rateLimitRps": {
                           "type": ["integer", "null"]
                         },
@@ -733,6 +762,7 @@
                         "kind",
                         "status",
                         "metadata",
+                        "systemKey",
                         "rateLimitRps",
                         "rateLimitBurst",
                         "rateLimitPriorityGates",
@@ -881,6 +911,10 @@
                           "type": ["object", "null"],
                           "additionalProperties": {}
                         },
+                        "systemKey": {
+                          "type": ["string", "null"],
+                          "description": "Non-null on a channel the deployment provisions for itself. `direct` is the only one today: it cannot be deleted or deactivated, and the counterparty list leaves it out."
+                        },
                         "rateLimitRps": {
                           "type": ["integer", "null"]
                         },
@@ -916,6 +950,7 @@
                         "kind",
                         "status",
                         "metadata",
+                        "systemKey",
                         "rateLimitRps",
                         "rateLimitBurst",
                         "rateLimitPriorityGates",
@@ -950,6 +985,22 @@
           },
           "404": {
             "description": "Channel not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Patch is not permitted on a system-provisioned channel",
             "content": {
               "application/json": {
                 "schema": {
@@ -998,6 +1049,22 @@
           },
           "404": {
             "description": "Channel not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Channel is system-provisioned and cannot be deleted",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/distribution/src/index.ts
+++ b/packages/distribution/src/index.ts
@@ -169,6 +169,11 @@ export {
   channels,
   channelWebhookEvents,
 } from "./schema.js"
+export {
+  CHANNEL_SYSTEM_KEYS,
+  type ChannelSystemKey,
+  DIRECT_CHANNEL_SYSTEM_KEY,
+} from "./schema-core.js"
 export type {
   ChannelAvailabilityPushIntent,
   ChannelContentPushIntent,
@@ -179,6 +184,7 @@ export {
   channelAvailabilityPushIntents,
   channelContentPushIntents,
 } from "./schema-push-intents.js"
+export { SystemChannelProtectedError } from "./service/channels.js"
 export * from "./suppliers/index.js"
 export {
   channelBookingLinkListQuerySchema,

--- a/packages/distribution/src/routes.ts
+++ b/packages/distribution/src/routes.ts
@@ -77,6 +77,7 @@ import {
   supplierPublicationPreviewResponseSchema,
 } from "./routes/openapi-schemas.js"
 import { settlementRoutes } from "./routes/settlements.js"
+import { SystemChannelProtectedError } from "./service/channels.js"
 import { distributionService } from "./service.js"
 import {
   channelBookingLinkListQuerySchema,
@@ -182,6 +183,10 @@ const updateChannelRoute = createRoute({
     200: { description: "The updated channel", ...jsonContent(z.object({ data: channelSchema })) },
     400: { description: "invalid_request", ...jsonContent(errorResponseSchema) },
     404: { description: "Channel not found", ...jsonContent(errorResponseSchema) },
+    409: {
+      description: "Patch is not permitted on a system-provisioned channel",
+      ...jsonContent(errorResponseSchema),
+    },
   },
 })
 
@@ -192,6 +197,10 @@ const deleteChannelRoute = createRoute({
   responses: {
     200: { description: "Channel deleted", ...jsonContent(successResponseSchema) },
     404: { description: "Channel not found", ...jsonContent(errorResponseSchema) },
+    409: {
+      description: "Channel is system-provisioned and cannot be deleted",
+      ...jsonContent(errorResponseSchema),
+    },
   },
 })
 
@@ -234,23 +243,37 @@ const channelRoutes = new OpenAPIHono<DistributionRouteEnv>({ defaultHook: openA
     return row ? c.json({ data: row }, 200) : c.json({ error: "Channel not found" }, 404)
   })
   .openapi(updateChannelRoute, async (c) => {
-    const row = await distributionService.updateChannel(
-      c.get("db"),
-      c.req.valid("param").id,
-      c.req.valid("json"),
-      c.get("eventBus"),
-    )
-    return row ? c.json({ data: row }, 200) : c.json({ error: "Channel not found" }, 404)
+    try {
+      const row = await distributionService.updateChannel(
+        c.get("db"),
+        c.req.valid("param").id,
+        c.req.valid("json"),
+        c.get("eventBus"),
+      )
+      return row ? c.json({ data: row }, 200) : c.json({ error: "Channel not found" }, 404)
+    } catch (error) {
+      if (error instanceof SystemChannelProtectedError) {
+        return c.json({ error: error.message }, 409)
+      }
+      throw error
+    }
   })
   .openapi(deleteChannelRoute, async (c) => {
-    const row = await distributionService.deleteChannel(
-      c.get("db"),
-      c.req.valid("param").id,
-      c.get("eventBus"),
-    )
-    return row
-      ? c.json({ success: true } as const, 200)
-      : c.json({ error: "Channel not found" }, 404)
+    try {
+      const row = await distributionService.deleteChannel(
+        c.get("db"),
+        c.req.valid("param").id,
+        c.get("eventBus"),
+      )
+      return row
+        ? c.json({ success: true } as const, 200)
+        : c.json({ error: "Channel not found" }, 404)
+    } catch (error) {
+      if (error instanceof SystemChannelProtectedError) {
+        return c.json({ error: error.message }, 409)
+      }
+      throw error
+    }
   })
 
 // --- channel contact points / named contacts --------------------------------

--- a/packages/distribution/src/routes/batch.ts
+++ b/packages/distribution/src/routes/batch.ts
@@ -1,6 +1,7 @@
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { z } from "zod"
 
+import { isDistributionServiceRefusal } from "../service/errors.js"
 import {
   updateChannelBookingLinkSchema,
   updateChannelCommissionRuleSchema,
@@ -49,6 +50,16 @@ export const batchUpdateChannelInventoryReleaseRuleSchema = createBatchUpdateSch
   updateChannelInventoryReleaseRuleSchema,
 )
 
+/**
+ * A per-id failure message. A service refusal carries wording written to be
+ * read (the single-row route surfaces the same text as a 409 body); anything
+ * else collapses to a generic string rather than leaking an internal error
+ * through a 200 batch response.
+ */
+function toBatchError(error: unknown) {
+  return isDistributionServiceRefusal(error) ? error.message : "Operation failed"
+}
+
 export async function handleBatchUpdate<TPatch, TRow>({
   db,
   ids,
@@ -60,17 +71,29 @@ export async function handleBatchUpdate<TPatch, TRow>({
   patch: TPatch
   update: (db: PostgresJsDatabase, id: string, patch: TPatch) => Promise<TRow | null>
 }) {
+  // Every outcome carries `error`, null on success. Narrowing has to happen on
+  // that and not on `row`: `TRow` is generic, so TypeScript cannot use it as a
+  // discriminant, and the route declares `failed: { id, error: string }[]` —
+  // narrowing that leaves `error` as `string | undefined` fails the response
+  // type on all nine `/batch-update` legs.
   const results = await Promise.all(
     ids.map(async (id) => {
-      const row = await update(db, id, patch)
-      return row ? { id, row } : { id, row: null }
+      try {
+        const row = await update(db, id, patch)
+        return row ? { id, row, error: null } : { id, row: null, error: "Not found" }
+      } catch (error) {
+        // Per-id isolation. A refusal on one id (e.g. patching a
+        // system-provisioned channel) belongs in that id's `failed` entry — it
+        // must not reject the batch and discard the results of every other id.
+        return { id, row: null, error: toBatchError(error) }
+      }
     }),
   )
 
   const data = results.flatMap((result) => (result.row ? [result.row] : []))
-  const failed = results
-    .filter((result) => result.row === null)
-    .map((result) => ({ id: result.id, error: "Not found" }))
+  const failed = results.flatMap((result) =>
+    result.error === null ? [] : [{ id: result.id, error: result.error }],
+  )
 
   return {
     data,
@@ -91,8 +114,15 @@ export async function handleBatchDelete({
 }) {
   const results = await Promise.all(
     ids.map(async (id) => {
-      const row = await remove(db, id)
-      return row ? { id } : { id, error: "Not found" }
+      try {
+        const row = await remove(db, id)
+        return row ? { id } : { id, error: "Not found" }
+      } catch (error) {
+        // Per-id isolation, as in `handleBatchUpdate`: one refused id (e.g. the
+        // system-provisioned Direct channel) reports itself in `failed` instead
+        // of rejecting the batch and discarding every other id's outcome.
+        return { id, error: toBatchError(error) }
+      }
     }),
   )
 

--- a/packages/distribution/src/routes/openapi-schemas.ts
+++ b/packages/distribution/src/routes/openapi-schemas.ts
@@ -86,6 +86,12 @@ const channelBaseSchema = z.object({
   kind: channelKindSchema,
   status: channelStatusSchema,
   metadata: jsonRecord.nullable(),
+  /**
+   * Non-null on a channel the deployment provisions for itself — `direct` is
+   * the only one today. Such a channel cannot be deleted or deactivated, and
+   * the counterparty list leaves it out.
+   */
+  systemKey: z.string().nullable(),
   rateLimitRps: z.number().int().nullable(),
   rateLimitBurst: z.number().int().nullable(),
   rateLimitPriorityGates: numberRecord.nullable(),

--- a/packages/distribution/src/schema-core.ts
+++ b/packages/distribution/src/schema-core.ts
@@ -23,6 +23,19 @@ import {
 } from "./schema-shared.js"
 import { suppliers } from "./suppliers/schema.js"
 
+/**
+ * The Direct channel: everything the operator sells through itself — its
+ * website, the booking engine, the customer portal, a custom frontend on the
+ * Public API — publishes to this one channel. Exactly one row per deployment
+ * carries it, provisioned by migration, and it is the channel a public request
+ * resolves to when nothing names another one.
+ */
+export const DIRECT_CHANNEL_SYSTEM_KEY = "direct"
+
+/** Every system-provisioned channel marker. Only Direct exists today. */
+export const CHANNEL_SYSTEM_KEYS = [DIRECT_CHANNEL_SYSTEM_KEY] as const
+export type ChannelSystemKey = (typeof CHANNEL_SYSTEM_KEYS)[number]
+
 export const channels = pgTable(
   "channels",
   {
@@ -32,6 +45,20 @@ export const channels = pgTable(
     kind: channelKindEnum("kind").notNull(),
     status: channelStatusEnum("status").notNull().default("active"),
     metadata: jsonb("metadata").$type<Record<string, unknown>>(),
+    /**
+     * Non-null on a channel the deployment provisions for itself rather than
+     * one the operator created for a counterparty. Today the only value is
+     * `direct` (see {@link DIRECT_CHANNEL_SYSTEM_KEY}): the channel everything
+     * we sell through ourselves publishes to.
+     *
+     * It is a column rather than a `metadata` key because three things depend
+     * on it being unforgeable and indexable — the public surface resolves its
+     * channel through it, `deleteChannel` refuses on it, and the counterparty
+     * list filters on it. A `metadata` flag is editable through the ordinary
+     * channel PATCH, which would let an operator delete the row the public API
+     * depends on by first clearing the marker.
+     */
+    systemKey: text("system_key").$type<ChannelSystemKey>(),
 
     // ── Channel push: per-channel rate-limit defaults ───────────────
     // Per channel-push-architecture §14.1. Contract-level rules in
@@ -56,6 +83,11 @@ export const channels = pgTable(
     index("idx_channels_created").on(table.createdAt),
     index("idx_channels_kind_created").on(table.kind, table.createdAt),
     index("idx_channels_status_created").on(table.status, table.createdAt),
+    // Partial, so the column stays null on every operator-created channel and
+    // only the one system row per key is constrained.
+    uniqueIndex("uniq_channels_system_key")
+      .on(table.systemKey)
+      .where(sql`${table.systemKey} IS NOT NULL`),
   ],
 )
 

--- a/packages/distribution/src/service/channels.ts
+++ b/packages/distribution/src/service/channels.ts
@@ -6,12 +6,29 @@ import type {
   UpdateContactPoint as UpdateIdentityContactPoint,
   UpdateNamedContact as UpdateIdentityNamedContact,
 } from "@voyant-travel/identity/validation"
-import { and, eq, inArray, sql } from "drizzle-orm"
+import { and, eq, inArray, isNotNull, isNull, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
-
 import { channelContactProjections, channels } from "../schema.js"
+import { DistributionServiceRefusalError } from "./errors.js"
 import { publicationServiceOperations } from "./publications.js"
 import type { ChannelListQuery, CreateChannelInput, UpdateChannelInput } from "./types.js"
+
+/**
+ * Refusal to mutate a system-provisioned channel in a way that would break the
+ * surface depending on it. Distinct from "not found" so the route answers 409
+ * rather than a 404 that reads like the row is gone.
+ */
+export class SystemChannelProtectedError extends DistributionServiceRefusalError {
+  readonly channelId: string
+  readonly systemKey: string
+
+  constructor(channelId: string, systemKey: string, message: string) {
+    super(message)
+    this.name = "SystemChannelProtectedError"
+    this.channelId = channelId
+    this.systemKey = systemKey
+  }
+}
 
 const channelEntityType = "channel"
 const channelBaseIdentitySource = "distribution.base"
@@ -238,6 +255,11 @@ export const channelServiceOperations = {
     const conditions = []
     if (query.kind) conditions.push(eq(channels.kind, query.kind))
     if (query.status) conditions.push(eq(channels.status, query.status))
+    // Defaults to `include`: publication pickers and product-mapping surfaces
+    // read this same endpoint and must keep seeing Direct, or nothing could be
+    // published to it. Only the counterparty list asks to drop it.
+    if (query.system === "exclude") conditions.push(isNull(channels.systemKey))
+    if (query.system === "only") conditions.push(isNotNull(channels.systemKey))
     const where = conditions.length ? and(...conditions) : undefined
     const [rows, countResult] = await Promise.all([
       db
@@ -287,6 +309,25 @@ export const channelServiceOperations = {
     if (!existing) {
       return null
     }
+    // A system channel stays editable — its name and contact details are the
+    // operator's to set — but not in the two ways that would take the public
+    // surface down: re-kinding it, or moving it off `active`.
+    if (existing.systemKey) {
+      if (data.kind !== undefined && data.kind !== existing.kind) {
+        throw new SystemChannelProtectedError(
+          id,
+          existing.systemKey,
+          "The Direct channel's kind cannot be changed.",
+        )
+      }
+      if (data.status !== undefined && data.status !== "active") {
+        throw new SystemChannelProtectedError(
+          id,
+          existing.systemKey,
+          "The Direct channel cannot be deactivated — every public surface resolves to it.",
+        )
+      }
+    }
     await db
       .update(channels)
       .set({ ...toUpdateChannelBaseValues(data), updatedAt: new Date() })
@@ -304,6 +345,18 @@ export const channelServiceOperations = {
   },
 
   async deleteChannel(db: PostgresJsDatabase, id: string, eventBus?: EventBus) {
+    const [existing] = await db
+      .select({ systemKey: channels.systemKey })
+      .from(channels)
+      .where(eq(channels.id, id))
+      .limit(1)
+    if (existing?.systemKey) {
+      throw new SystemChannelProtectedError(
+        id,
+        existing.systemKey,
+        "The Direct channel cannot be deleted — every public surface resolves to it.",
+      )
+    }
     const row = await db.transaction(async (tx) => {
       const affectedProductIds = await publicationServiceOperations.captureChannelDeletionReindex(
         tx,

--- a/packages/distribution/src/service/errors.ts
+++ b/packages/distribution/src/service/errors.ts
@@ -1,0 +1,18 @@
+/**
+ * Service-level refusals: the operation was understood, addressed a row that
+ * exists, and was declined on a domain rule. They are deliberately separate
+ * from "not found" and from faults — a route maps them to 409 and a batch
+ * endpoint may echo their message, which no internal error is safe to do.
+ */
+export class DistributionServiceRefusalError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "DistributionServiceRefusalError"
+  }
+}
+
+export function isDistributionServiceRefusal(
+  error: unknown,
+): error is DistributionServiceRefusalError {
+  return error instanceof DistributionServiceRefusalError
+}

--- a/packages/distribution/src/validation.ts
+++ b/packages/distribution/src/validation.ts
@@ -114,6 +114,13 @@ export const updateChannelSchema = channelCoreSchema.partial()
 export const channelListQuerySchema = paginationSchema.extend({
   kind: channelKindSchema.optional(),
   status: channelStatusSchema.optional(),
+  /**
+   * How to treat system-provisioned channels (today: Direct). Defaults to
+   * `include` — publication and product-mapping pickers read this endpoint and
+   * must be able to target Direct. The counterparty list passes `exclude`,
+   * because Direct is the deployment itself and not a party it trades with.
+   */
+  system: z.enum(["include", "exclude", "only"]).optional(),
 })
 
 export const channelContractCoreSchema = z.object({

--- a/packages/distribution/tests/integration/direct-channel-migration.test.ts
+++ b/packages/distribution/tests/integration/direct-channel-migration.test.ts
@@ -1,0 +1,143 @@
+import { readFileSync } from "node:fs"
+
+import { sql } from "drizzle-orm"
+import { describe, expect, it } from "vitest"
+
+import { DB_AVAILABLE, setupDistributionRoutes } from "./routes.setup.js"
+
+/**
+ * Drives the Direct-channel provisioning migration against a real Postgres,
+ * from each starting state a deployment can actually be in.
+ *
+ * Asserting the file's text would prove nothing about what it does — the
+ * adoption logic is a `DO` block whose whole job is choosing between rows that
+ * exist. So the migration is executed, and the row it leaves behind is read
+ * back.
+ */
+const MIGRATION = readFileSync(
+  new URL("../../migrations/20260814120000_direct_channel_system_key.sql", import.meta.url),
+  "utf8",
+)
+
+describe.skipIf(!DB_AVAILABLE)("Direct channel provisioning migration", () => {
+  const ctx = setupDistributionRoutes()
+
+  async function runMigration() {
+    // postgres.js rejects a multi-statement query, so replay the file the way
+    // the migration runner does: one statement per breakpoint.
+    for (const statement of MIGRATION.split("--> statement-breakpoint")) {
+      const trimmed = statement.trim()
+      if (trimmed) await ctx.db.execute(sql.raw(trimmed))
+    }
+  }
+
+  async function directChannels() {
+    const rows = await ctx.db.execute<{
+      id: string
+      name: string
+      status: string
+      system_key: string | null
+    }>(sql`SELECT id, name, status, system_key FROM channels WHERE kind = 'direct' ORDER BY id`)
+    return [...rows] as { id: string; name: string; status: string; system_key: string | null }[]
+  }
+
+  async function insertChannel(values: {
+    id: string
+    name: string
+    kind?: string
+    status?: string
+    metadata?: string | null
+  }) {
+    await ctx.db.execute(sql`
+      INSERT INTO "channels" ("id", "name", "kind", "status", "metadata")
+      VALUES (
+        ${values.id},
+        ${values.name},
+        ${values.kind ?? "direct"},
+        ${values.status ?? "active"},
+        ${values.metadata ?? null}::jsonb
+      )
+    `)
+  }
+
+  it("provisions Direct on a deployment that has no channels at all", async () => {
+    await runMigration()
+
+    expect(await directChannels()).toEqual([
+      expect.objectContaining({ id: "chan_system_direct", name: "Direct", system_key: "direct" }),
+    ])
+  })
+
+  it("adopts the row the storefront-channel cutover created, rather than adding a second", async () => {
+    await insertChannel({ id: "chan_storefront_direct", name: "Storefront Direct" })
+
+    await runMigration()
+
+    // Adoption, not insertion: publication rules and storefront bindings are
+    // keyed by this id, and a fresh row beside it would silently unpublish
+    // everything already published.
+    expect(await directChannels()).toEqual([
+      expect.objectContaining({
+        id: "chan_storefront_direct",
+        name: "Direct",
+        system_key: "direct",
+      }),
+    ])
+  })
+
+  it("adopts an operator's own direct channel and leaves its name alone", async () => {
+    await insertChannel({ id: "chan_operator_own", name: "Our website" })
+
+    await runMigration()
+
+    expect(await directChannels()).toEqual([
+      expect.objectContaining({
+        id: "chan_operator_own",
+        name: "Our website",
+        system_key: "direct",
+      }),
+    ])
+  })
+
+  it("adopts the oldest active direct channel when there is more than one", async () => {
+    await insertChannel({ id: "chan_aaa_newer", name: "Newer" })
+    await ctx.db.execute(sql`
+      UPDATE "channels" SET "created_at" = now() + interval '1 day' WHERE "id" = 'chan_aaa_newer'
+    `)
+    await insertChannel({ id: "chan_zzz_older", name: "Older" })
+
+    await runMigration()
+
+    const marked = (await directChannels()).filter((row) => row.system_key === "direct")
+    expect(marked).toHaveLength(1)
+    expect(marked[0]?.id).toBe("chan_zzz_older")
+  })
+
+  it("skips an inactive direct channel rather than reviving it", async () => {
+    await insertChannel({ id: "chan_archived", name: "Retired", status: "archived" })
+
+    await runMigration()
+
+    const rows = await directChannels()
+    expect(rows.find((row) => row.id === "chan_archived")?.system_key).toBeNull()
+    expect(rows.find((row) => row.system_key === "direct")?.id).toBe("chan_system_direct")
+  })
+
+  it("is idempotent", async () => {
+    await runMigration()
+    await runMigration()
+
+    expect((await directChannels()).filter((row) => row.system_key === "direct")).toHaveLength(1)
+  })
+
+  it("leaves the marker unique across every channel", async () => {
+    await runMigration()
+    await insertChannel({ id: "chan_other", name: "Someone else", kind: "ota" })
+
+    await expect(
+      ctx.db.execute(sql`
+        UPDATE "channels" SET "system_key" = 'direct' WHERE "id" = 'chan_other'
+      `),
+    ).rejects.toThrow()
+  })
+})

--- a/packages/distribution/tests/integration/routes.direct-channel.test.ts
+++ b/packages/distribution/tests/integration/routes.direct-channel.test.ts
@@ -1,0 +1,106 @@
+import { sql } from "drizzle-orm"
+import { describe, expect, it } from "vitest"
+
+import { DB_AVAILABLE, json, setupDistributionRoutes } from "./routes.setup.js"
+
+/**
+ * The system Direct channel is provisioned by migration, and the integration
+ * harness truncates every table between tests — so each case that needs it
+ * plants it the way the migration does: through SQL, because `system_key` is
+ * deliberately not settable through the API.
+ */
+describe.skipIf(!DB_AVAILABLE)("System-provisioned Direct channel", () => {
+  const ctx = setupDistributionRoutes()
+
+  async function seedDirectChannel(id = "chan_system_direct") {
+    await ctx.db.execute(sql`
+      INSERT INTO "channels" ("id", "name", "kind", "status", "system_key")
+      VALUES (${id}, 'Direct', 'direct', 'active', 'direct')
+    `)
+    return id
+  }
+
+  it("refuses to delete it", async () => {
+    const id = await seedDirectChannel()
+
+    const res = await ctx.app.request(`/channels/${id}`, { method: "DELETE" })
+
+    expect(res.status).toBe(409)
+    expect((await res.json()).error).toMatch(/cannot be deleted/i)
+
+    const stillThere = await ctx.app.request(`/channels/${id}`, { method: "GET" })
+    expect(stillThere.status).toBe(200)
+  })
+
+  it("refuses to deactivate it", async () => {
+    const id = await seedDirectChannel()
+
+    const res = await ctx.app.request(`/channels/${id}`, {
+      method: "PATCH",
+      ...json({ status: "archived" }),
+    })
+
+    expect(res.status).toBe(409)
+    expect((await res.json()).error).toMatch(/cannot be deactivated/i)
+  })
+
+  it("refuses to re-kind it", async () => {
+    const id = await seedDirectChannel()
+
+    const res = await ctx.app.request(`/channels/${id}`, {
+      method: "PATCH",
+      ...json({ kind: "ota" }),
+    })
+
+    expect(res.status).toBe(409)
+  })
+
+  it("still accepts the edits that are the operator's to make", async () => {
+    const id = await seedDirectChannel()
+
+    const res = await ctx.app.request(`/channels/${id}`, {
+      method: "PATCH",
+      ...json({ description: "Our own website and checkout", contactEmail: "hello@example.com" }),
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data.description).toBe("Our own website and checkout")
+    expect(body.data.systemKey).toBe("direct")
+  })
+
+  it("is left out of the counterparty list but kept in the default one", async () => {
+    const directId = await seedDirectChannel()
+    const counterparty = await ctx.seedChannel({ kind: "ota" })
+
+    const listed = async (query: string) => {
+      const res = await ctx.app.request(`/channels${query}`, { method: "GET" })
+      expect(res.status).toBe(200)
+      return ((await res.json()).data as { id: string }[]).map((row) => row.id)
+    }
+
+    // Publication and product-mapping pickers read the unfiltered endpoint and
+    // must be able to target Direct — default-hiding it would make the channel
+    // everything publishes to the one channel nothing can be published to.
+    expect(await listed("")).toEqual(expect.arrayContaining([directId, counterparty.id]))
+    expect(await listed("?system=exclude")).toEqual([counterparty.id])
+    expect(await listed("?system=only")).toEqual([directId])
+  })
+
+  it("reports the refusal per id in a batch delete instead of failing the batch", async () => {
+    const directId = await seedDirectChannel()
+    const counterparty = await ctx.seedChannel({ kind: "ota" })
+
+    const res = await ctx.app.request("/channels/batch-delete", {
+      method: "POST",
+      ...json({ ids: [directId, counterparty.id] }),
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.deletedIds).toEqual([counterparty.id])
+    expect(body.failed).toEqual([
+      { id: directId, error: expect.stringMatching(/cannot be deleted/i) },
+    ])
+  })
+})

--- a/packages/distribution/tests/unit/routes-contract.test.ts
+++ b/packages/distribution/tests/unit/routes-contract.test.ts
@@ -101,6 +101,7 @@ const channelRow: InferSelectModel<typeof channels> = {
   kind: "ota",
   status: "active",
   metadata: null,
+  systemKey: null,
   rateLimitRps: null,
   rateLimitBurst: null,
   rateLimitPriorityGates: null,

--- a/packages/storefront/tests/unit/public-routes.test.ts
+++ b/packages/storefront/tests/unit/public-routes.test.ts
@@ -54,6 +54,34 @@ describe("createStorefrontPublicRoutes", () => {
     expect(await res.json()).toEqual({ data: [], total: 0, limit: 100, offset: 0 })
   })
 
+  it("serves a storefront whose channel context came from the implicit Direct default", async () => {
+    // The guard asks whether the request has an active channel, not whether an
+    // operator configured one. Nothing binds this storefront explicitly; the
+    // binding provider resolved it to the deployment's system Direct channel,
+    // and from here that is indistinguishable from a chosen one (#4624).
+    const isProductPublished = vi.fn(async () => false)
+    const app = new Hono().use("*", async (c, next) => {
+      c.set(
+        "storefrontChannel" as never,
+        {
+          storefrontId: "sf_unbound",
+          channelId: "chan_system_direct",
+          channelStatus: "active",
+        } as never,
+      )
+      await next()
+    })
+    app.route("/", createStorefrontPublicRoutes({ publication: { isProductPublished } }))
+
+    const res = await app.request("/products/prod_1/departures")
+
+    expect(res.status).toBe(200)
+    expect(isProductPublished).toHaveBeenCalledWith({
+      productId: "prod_1",
+      context: expect.objectContaining({ channelId: "chan_system_direct" }),
+    })
+  })
+
   it("rejects public requests without an active storefront channel context", async () => {
     const app = new Hono().route("/", createStorefrontPublicRoutes())
 


### PR DESCRIPTION
Closes part of #4624 — workstream **5 (Direct channel)**, the `routes-public.ts`
bullet of workstream 3, and the verification asked for in workstream 6.

## The defect

Publication is default-deny per channel, and every public read resolves a
channel before it answers. So serving your own website meant hand-creating a row
in `channels` — a table of commercial counterparties, sitting next to
`suppliers`, carrying contracts, rate limits and contact projections — that
represents yourself, then binding a storefront to it.

The issue says nothing auto-provisions that row. Nearly: a one-shot setup cutover
(`@voyant-travel/distribution#setup.storefront-channel-bindings.v1`) creates a
`Storefront Direct` channel and backfills the storefronts that exist when it
runs. What it does not do is bind anything afterwards, and `createStorefront`
never creates a binding. So **every storefront created after that cutover 403s**
— on `/settings`, `/departures/*`, `/products/*`, `/offers/*`, `/leads`,
`/newsletter/*`, on the anonymous booking-session routes
(`sessions-routes.ts:415`), and on checkout start. That is the shape #4323 took.

The backfill bullet in the issue is therefore already done. What was missing is
the default.

## What this does

**`channels` gains `system_key`.** A migration provisions exactly one row marked
`direct`. It *adopts before it inserts* — the cutover's own
`chan_storefront_direct` first, then the oldest active `direct` channel — because
publication rules and storefront bindings are keyed by channel id, and minting a
fresh row beside an existing one would silently unpublish everything already
published.

A column and not a `metadata` key, because the marker has to be unforgeable:
`metadata` is editable through the ordinary channel `PATCH`, so a flag there
could be cleared and the row the public API depends on then deleted.

**Direct is implicit.** A storefront with no explicit binding resolves to it, and
so does one whose bound channel has gone inactive — losing the channel an
operator chose is a reason to serve the default, not a reason to take the public
surface down. An explicit binding still wins, so `affiliate` / `reseller` /
`api_partner` keep working. `StorefrontChannelBindingDto` gains `implicit`, so
the admin surface can show a default as a default; clearing a binding now reads
as "back to Direct" rather than "off the air".

**The system row is protected.** Delete and deactivate answer `409` (not a `404`
that reads like the row is gone); `kind` is fixed; name and contact details stay
the operator's to edit.

**`GET /channels` takes `system=include|exclude|only`, defaulting to `include`.**
Publication and product-mapping pickers read that same endpoint — default-hiding
Direct would make the channel everything publishes to the one channel nothing can
be published to. Only the Distribution counterparty list passes `exclude`.

Batch update and batch delete now isolate failures per id instead of rejecting
the whole batch when one id is refused.

## Workstream 6: checkout handoff for any consumer

Verified, and the gap was this same one. `commitBookingSessionV1.payment
.acceptedCheckoutHandoffs` is forwarded verbatim to
`PaymentInitiationInput.acceptedCheckoutHandoffs` and interpreted nowhere
(`sessions-payment-production.ts:227`); the adapter's own capabilities decide
through `negotiatePaymentCheckoutHandoff`. There is no first-party branch in the
contract. The only thing standing between a custom frontend holding a
publishable key and an identical checkout was the channel gate, which this
removes.

## A bug the tests caught

The first cut ordered by `(system_key = 'direct') DESC`. `system_key` is null on
every operator-created channel, `NULL = 'direct'` is NULL, and a `DESC` sort puts
NULLs **first** — so the operator's own direct channel outranked the system row
the clause exists to prefer. The unit test asserting the SQL text passed. Postgres
did not. Both queries now use `IS NOT DISTINCT FROM`, and the real-DB tests are
what hold it.

## Verification

- `verify:migration-replay-parity` against Postgres 16 — the migration replays in
  every source order and the resulting schema matches the Drizzle declaration
  exactly (5827 columns / 1490 enums / 2258 indexes / 988 constraints)
- `direct-channel-migration.test.ts` — drives the migration end to end from each
  starting state a deployment can be in (no channels, the cutover's row, an
  operator's own, several, an archived one, re-run, uniqueness). Asserting the
  file's text would prove nothing about a `DO` block whose job is choosing
  between rows that exist.
- `storefront-channel-binding.test.ts` (auth, Postgres) — implicit resolution,
  system-row preference, explicit override, clear, archived fallback
- `routes.direct-channel.test.ts` (distribution, Postgres) — the guards, the list
  filter, per-id batch refusal
- unit: auth binding provider (12), distribution (142), auth-react storefronts
  page (10), storefront public routes (15)
- `verify:openapi-drift`, `verify:table-privacy` (none new),
  `verify:route-conformance`, `verify:chain-reachability`,
  `verify:migration-identity`, `verify:migration-boundaries`,
  `verify:migration-cutline`, `verify:vitest-include`,
  `verify:ci-typecheck-selection` — all pass
- `biome check .` — 0 errors, no new warnings
- the three new integration files are registered in `ci.yml`'s integration lane;
  that lane is a hand-written path list, so a test not added to it never runs

No new architecture checker: the rules here ("the system row cannot be deleted",
"Direct is the fallback") are runtime invariants over data, not statements about
the source tree, so there is nothing for a declarative rule file to match.

## Not in this PR

The rest of #4624, which the issue itself lays out as separate workstreams:
dropping the `storefronts` table and re-scoping keys (1), the `packages/auth`
reshape and header rename (2), the `storefront` → `public-api` renames (3, and
#4626 asks for that to land once, with #4256), the admin surface split (4), and
the docs sweep (7). Those are a schema cutover, an auth reshape, a UI redesign
and three package renames across ~840 files; landing them with this would make
one unreviewable change out of five separable ones.

Two notes for whoever picks up workstream 3: `packages/commerce` already exists,
so the earlier "rename to commerce" framing could not have worked — the issue has
since moved to `public-api`, which is clear. And `@voyant-travel/storefront`,
`-sdk` and `-react` are all confirmed `private: true` with in-repo consumers
only, so the issue's "no compatibility window needed" premise holds.
