### PR TITLE
fix(finance): declare the operator-settings port the module requests

### DIFF
--- a/.changeset/finance-operator-settings-port.md
+++ b/.changeset/finance-operator-settings-port.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/finance": patch
+---
+
+Declare the operator-settings runtime port the Finance module's runtime factory
+requests, so the graph composes on packaged and image deployments.

--- a/packages/finance/src/voyant.ts
+++ b/packages/finance/src/voyant.ts
@@ -61,6 +61,7 @@ export const financeVoyantModule = defineModule({
     requirePort(financeHostRuntimePort),
     requirePort(customFieldsRuntimePort),
     requirePort(financeNotificationsRuntimePort),
+    requirePort(financeOperatorSettingsRuntimePort),
     requirePort(financeCheckoutPaymentStartersRuntimePort, { optional: true }),
     { ...paymentAdapterRuntimePortReference, optional: true },
     requirePort(financeInvoiceSettlementPollerRuntimePort, {

--- a/packages/finance/tests/unit/voyant-manifest.test.ts
+++ b/packages/finance/tests/unit/voyant-manifest.test.ts
@@ -17,6 +17,8 @@ import {
   financeVoyantModule,
 } from "../../src/voyant.js"
 
+const declaredRuntimePorts = new Set(financeVoyantModule.runtimePorts.map(({ id }) => id))
+
 describe("finance deployment manifest", () => {
   it("owns the module deployment surfaces", () => {
     expect(financeVoyantModule).toMatchObject({
@@ -39,6 +41,7 @@ describe("finance deployment manifest", () => {
         { id: "finance.host.runtime" },
         { id: "custom-fields.runtime" },
         { id: "finance.notifications.runtime" },
+        { id: "finance.operator-settings.runtime" },
         { id: "finance.checkout-payment-starters.runtime", optional: true },
         { id: "payments.adapter.runtime", optional: true },
         { id: "finance.invoice-settlement-poller", optional: true, cardinality: "many" },
@@ -451,8 +454,14 @@ describe("finance deployment manifest", () => {
       getUnitProjectConfig: () => undefined,
       hostOptions: {},
       api: [{ id: "finance.admin", surface: "admin" }],
-      hasPort: () => true,
+      hasPort: (port: { id: string }) => declaredRuntimePorts.has(port.id),
+      // The composer refuses a port the manifest does not declare, so a fake
+      // that answers every id would pass here and fail at boot. Refuse the
+      // same way it does.
       getPort: async <TProvider>(port: { id: string }) => {
+        if (!declaredRuntimePorts.has(port.id)) {
+          throw new Error(`requested undeclared port "${port.id}"`)
+        }
         const providers: Record<string, unknown> = {
           "finance.host.runtime": {
             primitives: {
@@ -478,6 +487,15 @@ describe("finance deployment manifest", () => {
           "finance.notifications.runtime": {
             resolveNotificationDispatcher: () => undefined,
             listBookingReminderRuns: async () => [],
+          },
+          "finance.operator-settings.runtime": {
+            resolveOperatorDefaultPaymentPolicy: async () => undefined,
+            resolveInvoicePayUrlTemplate: async () => null,
+            resolveBookingTaxSettings: async () => undefined,
+            updateBookingTaxSettings: async () => undefined,
+            resolveInvoicingMode: async () => undefined,
+            resolveInvoiceFxSettings: async () => undefined,
+            updateInvoiceFxSettings: async () => undefined,
           },
           "finance.checkout-payment-starters.runtime": { resolvePaymentStarters: () => ({}) },
           "payments.adapter.runtime": {


### PR DESCRIPTION
main is red. `packaged-acceptance`, `operator-image-smoke` and `build` fail on
`df9f45b7` and on every PR branched from it:

```
composeVoyantGraphRuntime: module "@voyant-travel/finance" requested undeclared
port "finance.operator-settings.runtime".
```

## Cause

#4572 added `await getPort(financeOperatorSettingsRuntimePort)` to
`createFinanceVoyantRuntime` (`finance/src/index.ts:233`) without adding the
matching `requirePort(...)` to `financeVoyantModule.runtimePorts`.
`assertDeclaredRuntimePort` (`framework/src/runtime-composition.ts:877`) refuses
a port the unit did not declare, so the Node host exits before it becomes ready
— the packaged starter never serves, and the operator image never goes healthy
(exit 7 after migrations apply cleanly).

One line: declare it, non-optional, the same way `catalog` and Finance's own
booking-tax extensions already declare it. `operator-settings` provides it.

## Why the unit tests were green

`voyant-manifest.test.ts` composes the real factory, but its fake
`hasPort` returned `true` unconditionally and its `getPort` answered any id from
a lookup table — so an undeclared port resolved fine in the test and only failed
where a real graph composes it. That is a green from a path no deployment takes.

Both now refuse anything `financeVoyantModule.runtimePorts` does not declare.
Reverting just the one-line manifest change reproduces the boot failure in the
unit suite:

```
Error: requested undeclared port "finance.operator-settings.runtime"
  Tests  1 failed | 7 skipped (8)
```

## Verification

`pnpm --filter @voyant-travel/finance test` 587 passed / 20 files skipped;
`verify:graph-conformance`, `verify:runtime-ports`, `verify:deployment-graph`
green; `pnpm -F @voyant-travel/finance... build` 0 errors.
