### PR TITLE
Mark server-owned MCP tools so a client can classify every tools/list entry

### DIFF
--- a/.changeset/mcp-server-owned-tool-marker.md
+++ b/.changeset/mcp-server-owned-tool-marker.md
@@ -1,0 +1,16 @@
+---
+"@voyant-travel/mcp": minor
+---
+
+Mark server-owned MCP tools with `_meta["voyant.travel/server-tool"]`
+
+The guide Tools, the tier-0 meta-tools, and the synthetic `<domain>_query` groups
+are owned by the server rather than the tenant registry, so they cannot carry
+`voyant.travel/tool` — and until now they carried nothing at all. A client reading
+`tools/list` could not tell one of them from a registry Tool whose metadata went
+missing, which is the opposite call: skip the first, fail closed on the second.
+
+Each now carries a positive marker with a `kind` of `guide`, `meta`, or
+`read-query`, so every advertised entry is classifiable. Purely additive to the
+wire format: nothing changes for registry Tools, and a client that ignores `_meta`
+on these entries is unaffected.

--- a/docs/architecture/agent-tool-library.md
+++ b/docs/architecture/agent-tool-library.md
@@ -401,8 +401,9 @@ bindings and outbound webhook plans. Separate `tools.json`, `actions.json`, and
 separate MCP service or Durable Object is required. `GET /v1/admin/mcp/manifest`
 serves a contract-versioned discovery manifest for remote agents.
 
-Standard `tools/list` is also a complete discovery surface. It includes input and
-structured-output schemas, derived standard MCP annotations, and exact framework
+A registry Tool advertised over MCP — eagerly in `tools/list`, or on demand through
+`describe_tool` — carries input and structured-output schemas, derived standard MCP
+annotations, and exact framework
 metadata under `_meta["voyant.travel/tool"]`. Aliases are registered as callable MCP
 names with `aliasFor` metadata, while the canonical manifest contains one entry per
 capability. Consumers resolve capabilities by `capabilityId` plus an exact supported
@@ -415,6 +416,41 @@ reason code. For those actions the MCP adapter never accepts client-authored tar
 fingerprints. Approval preflight is server-owned and returns stable
 structured error metadata; an approved retry is admitted only after the action ledger matches the
 recomputed action, target, command, principal, organization, and request id.
+
+### Classifying a `tools/list` entry
+
+`tools/list` is no longer a wholesale catalog. Progressive disclosure (voyant#3927)
+reduced it to a tier-0, and some of what remains is owned by the **server**, not by
+the tenant registry: the guide Tools (`voyant_guide`, `voyant_glossary`), the
+meta-tools (`search_tools`, `describe_tool`, `call_tool`), and the synthetic
+`<domain>_query` groups the flat reads were folded into. None of them are registry
+Tools, so none can carry `voyant.travel/tool`.
+
+A client therefore has to classify each entry, and it classifies on a **positive
+marker** — never on absence, which cannot distinguish a server-owned tool from a
+registry Tool whose metadata is missing or malformed:
+
+| `_meta` | meaning | client action |
+| --- | --- | --- |
+| `voyant.travel/tool` | registry Tool | parse strictly |
+| `voyant.travel/server-tool` | server-owned; `kind` is `guide`, `meta`, or `read-query` | classify by `kind` |
+| neither | contract break | fail closed |
+
+Both keys are exported from `@voyant-travel/mcp` as `VOYANT_TOOL_META_KEY` and
+`SERVER_TOOL_META_KEY`. Every advertised entry carries exactly one of them, and a
+test in that package holds the property for whatever gets registered next.
+
+A `read-query` group is deliberately **not** advertised as a registry Tool: it
+stands in for several capabilities and has none of its own, so a client parsing
+`voyant.travel/tool` strictly would reject it for incomplete metadata. It is
+callable, and `describe_tool` returns its discriminated-union schema along with the
+capability ids and scopes it absorbed — which is how a client knows which flat read
+names to stop offering.
+
+Reading absence as "not a registry Tool" is the failure this replaced: Max's
+discovery required `voyant.travel/tool` on every entry and threw on the first one
+without it, so a single unrecognized entry discarded the whole tenant catalog on
+every managed deployment from `@voyant-travel/mcp` 0.13 (voyant#4592).
 
 ## Migration status
 

--- a/packages/mcp/src/guide.ts
+++ b/packages/mcp/src/guide.ts
@@ -24,6 +24,8 @@
 import { z } from "@hono/zod-openapi"
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 
+import { serverToolMeta } from "./tool-meta.js"
+
 export interface GuideScope {
   /** Whether the caller can reach any state-mutating Tool with its granted key. */
   writeEnabled: boolean
@@ -121,6 +123,9 @@ export function registerGuideTools(server: McpServer, scope: GuideScope): readon
         readOnlyHint: true,
         openWorldHint: false,
       },
+      // Server-owned, never a registry Tool: without the marker a client cannot
+      // tell this entry from a tenant Tool that lost its metadata (voyant#4592).
+      _meta: serverToolMeta("guide"),
     },
     ({ topic }) => textResult(guideSection(topic ?? "overview", scope)),
   )
@@ -147,6 +152,7 @@ export function registerGuideTools(server: McpServer, scope: GuideScope): readon
         readOnlyHint: true,
         openWorldHint: false,
       },
+      _meta: serverToolMeta("guide"),
     },
     ({ term }) => textResult(glossary(term)),
   )

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -21,3 +21,9 @@ export {
   type McpApiRoutesOptions,
   type McpServerInfo,
 } from "./server.js"
+export {
+  SERVER_TOOL_META_KEY,
+  type ServerToolKind,
+  serverToolMeta,
+  VOYANT_TOOL_META_KEY,
+} from "./tool-meta.js"

--- a/packages/mcp/src/meta-tools.ts
+++ b/packages/mcp/src/meta-tools.ts
@@ -43,6 +43,7 @@ import {
 import { toMcpMeta } from "./register.js"
 import { DEFAULT_RESPONSE_BUDGET_BYTES, isListShapedOutput } from "./response-budget.js"
 import { toMcpInputSchema, toMcpOutputContract } from "./schema-projection.js"
+import { serverToolMeta } from "./tool-meta.js"
 import { expandSearchTerm } from "./vocabulary.js"
 
 export { toolDomain } from "./read-projection.js"
@@ -200,6 +201,10 @@ function registerSearchTools({ server, surface, projection }: RegisterMetaToolsI
         limit: z.number().int().min(1).max(MAX_SEARCH_LIMIT).optional(),
       }),
       annotations: { readOnlyHint: true, openWorldHint: false },
+      // The tier-0 surface is the server's own, not the tenant registry's
+      // (voyant#4592): mark it positively so a client skips it knowingly rather
+      // than inferring "no metadata" and having to guess what that means.
+      _meta: serverToolMeta("meta"),
     },
     (args) => searchTools(surface, projection, args),
   )
@@ -441,6 +446,7 @@ function registerDescribeTool({
         ),
       }),
       annotations: { readOnlyHint: true, openWorldHint: false },
+      _meta: serverToolMeta("meta"),
     },
     (args) => describeTool(registry, surface, projection, args.name, args.resource),
   )
@@ -462,6 +468,9 @@ function describeTool(
         unrepresentable: "any",
       }),
       annotations: { openWorldHint: true },
+      // Same marker `tools/list` carries, so a client classifying a descriptor
+      // and one classifying a listing reach the same answer.
+      _meta: serverToolMeta("meta"),
     }
     return {
       content: [{ type: "text", text: JSON.stringify(descriptor, null, 2) }],
@@ -534,6 +543,7 @@ function registerCallTool(input: RegisterMetaToolsInput): void {
       description: CALL_TOOL_DESCRIPTION,
       inputSchema: callToolInputSchema,
       annotations: { openWorldHint: true },
+      _meta: serverToolMeta("meta"),
     },
     async (args) => {
       // Tolerate a client namespace prefix before anything else, so both the

--- a/packages/mcp/src/read-projection.ts
+++ b/packages/mcp/src/read-projection.ts
@@ -43,6 +43,7 @@ import { isRecord } from "./guards.js"
 import type { AuthorizedSurface } from "./meta-tools.js"
 import { DEFAULT_RESPONSE_BUDGET_BYTES, isListShapedOutput } from "./response-budget.js"
 import { toMcpInputSchema, toMcpOutputContract } from "./schema-projection.js"
+import { serverToolMeta, VOYANT_TOOL_META_KEY } from "./tool-meta.js"
 
 /** Read verbs that collapse into a per-domain query tool. Matches the 133 reads. */
 const READ_VERB = /^(?:get|list|search)_/
@@ -282,7 +283,11 @@ export function advertiseQueryTool(
     outputSchema: QUERY_OUTPUT_SCHEMA,
     annotations: { readOnlyHint: true, openWorldHint: false },
     _meta: {
-      "voyant.travel/tool": {
+      // The server-owned marker a client classifies BY; the block below stays for
+      // the descriptor's existing consumers, which read the absorbed capabilities
+      // out of `voyant.travel/tool` (voyant#4592).
+      ...queryToolServerMeta(queryTool),
+      [VOYANT_TOOL_META_KEY]: {
         contractVersion: TOOL_CONTRACT_VERSION,
         kind: "read-query",
         domain: queryTool.domain,
@@ -300,6 +305,21 @@ export function advertiseQueryTool(
       },
     },
   }
+}
+
+/**
+ * The server-owned marker for a `<domain>_query` group.
+ *
+ * A group is not a registry Tool — it stands in for several, and has no
+ * capability identity of its own — so it takes the `server-tool` marker rather
+ * than pretending to metadata it cannot fill in. It carries identity and
+ * classification only: the resources it serves are named in its description and
+ * described in full by `describe_tool`, and repeating every resource's
+ * capability id and scopes here would put the eager-serialization cost
+ * voyant#3927 removed straight back onto every `tools/list`.
+ */
+export function queryToolServerMeta(queryTool: QueryTool): Record<string, unknown> {
+  return serverToolMeta("read-query", { domain: queryTool.domain, tier: "read" })
 }
 
 export interface DispatchQueryToolInput {
@@ -371,6 +391,7 @@ export function registerQueryTool(
       description: `Query ${queryTool.domain} read data by \`resource\`.`,
       inputSchema: z.looseObject({ resource: z.string() }),
       annotations: { readOnlyHint: true, openWorldHint: false },
+      _meta: queryToolServerMeta(queryTool),
     },
     async (args): Promise<CallToolResult> => {
       const { result } = await dispatchQueryTool({

--- a/packages/mcp/src/register.ts
+++ b/packages/mcp/src/register.ts
@@ -14,6 +14,7 @@ import {
 import { dispatchToResult } from "./dispatch.js"
 import { DEFAULT_RESPONSE_BUDGET_BYTES, isListShapedOutput } from "./response-budget.js"
 import { toMcpInputSchema, toMcpOutputContract } from "./schema-projection.js"
+import { VOYANT_TOOL_META_KEY } from "./tool-meta.js"
 
 export function registerMcpTool(
   server: McpServer,
@@ -52,7 +53,7 @@ export function registerMcpTool(
 
 export function toMcpMeta(entry: ToolManifestEntry, aliasFor?: string): Record<string, unknown> {
   return {
-    "voyant.travel/tool": {
+    [VOYANT_TOOL_META_KEY]: {
       contractVersion: TOOL_CONTRACT_VERSION,
       capabilityId: entry.capabilityId,
       owner: entry.owner,

--- a/packages/mcp/src/tool-meta.ts
+++ b/packages/mcp/src/tool-meta.ts
@@ -1,0 +1,66 @@
+/**
+ * The two `_meta` blocks a client reads off `tools/list` to classify an entry.
+ *
+ * Progressive disclosure (voyant#3927) and the folded read groups (voyant#3932)
+ * put tools on the wire that the *server* owns rather than the tenant registry —
+ * the guide layer, the tier-0 meta-tools, and the synthetic `<domain>_query`
+ * groups. None of them are registry Tools, so none can carry
+ * `voyant.travel/tool`, and until voyant#4592 they carried nothing at all.
+ *
+ * Absence is not a signal: a client seeing an entry with no metadata cannot tell
+ * a server-owned tool (skip it) from a registry Tool whose metadata is missing or
+ * malformed (a contract break, fail closed). Both read as "no `_meta`", and Max
+ * failing closed on the first one discarded the whole tenant catalog on every
+ * managed deployment from `@voyant-travel/mcp` 0.13 on.
+ *
+ * So server-owned entries carry a POSITIVE marker instead, and the classification
+ * rule becomes total:
+ *
+ * | `_meta` | meaning | client action |
+ * | --- | --- | --- |
+ * | {@link VOYANT_TOOL_META_KEY} | registry Tool | parse strictly |
+ * | {@link SERVER_TOOL_META_KEY} | server-owned | classify by `kind` |
+ * | neither | contract break | fail closed |
+ *
+ * A `read-query` group is deliberately NOT advertised as a registry Tool. It has
+ * no capability identity of its own — it is a projection over several — so a
+ * client parsing `voyant.travel/tool` strictly would reject it for incomplete
+ * metadata, which is the same outage in a different costume. It is server-owned,
+ * it is callable, and `describe_tool` returns the capabilities it absorbed.
+ */
+import { TOOL_CONTRACT_VERSION } from "@voyant-travel/tools"
+
+/** `_meta` key carrying a registry Tool's capability identity and policy. */
+export const VOYANT_TOOL_META_KEY = "voyant.travel/tool"
+
+/** `_meta` key marking an entry the server owns rather than the tenant registry. */
+export const SERVER_TOOL_META_KEY = "voyant.travel/server-tool"
+
+/**
+ * What a server-owned entry is, so a client can act on it rather than only skip
+ * it:
+ * - `guide` — `voyant_guide` / `voyant_glossary`, read-only prose.
+ * - `meta` — `search_tools` / `describe_tool` / `call_tool`, the tier-0 surface
+ *   through which the long tail is discovered and dispatched.
+ * - `read-query` — a `<domain>_query` group standing in for the flat reads it
+ *   absorbed; the tenant read surface, expanded through `describe_tool`.
+ */
+export type ServerToolKind = "guide" | "meta" | "read-query"
+
+/**
+ * Build the server-owned marker. `details` stays small on purpose: this rides on
+ * every `tools/list`, which is the payload progressive disclosure exists to keep
+ * short, so identity and classification belong here and schemas do not.
+ */
+export function serverToolMeta(
+  kind: ServerToolKind,
+  details: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    [SERVER_TOOL_META_KEY]: {
+      contractVersion: TOOL_CONTRACT_VERSION,
+      kind,
+      ...details,
+    },
+  }
+}

--- a/packages/mcp/tests/tool-list-metadata.test.ts
+++ b/packages/mcp/tests/tool-list-metadata.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Every `tools/list` entry says what it is (voyant#4592).
+ *
+ * A client cannot read absence: an entry with no `_meta` is either a tool the
+ * SERVER owns — never a registry Tool, safe to skip — or a registry Tool whose
+ * metadata went missing, which is a contract break it must fail closed on. Max
+ * chose the second reading and one unmarked entry discarded the whole tenant
+ * catalog on every managed deployment from 0.13 on.
+ *
+ * So the property under test is totality, not the presence of any one block:
+ * every advertised entry carries exactly one marker, whatever gets registered
+ * later. A new server-owned tool that forgets its marker fails here rather than
+ * in a client.
+ */
+import {
+  createToolRegistry,
+  defineTool,
+  READ_ONLY_RISK,
+  TOOL_CONTRACT_VERSION,
+  type ToolContext,
+} from "@voyant-travel/tools"
+import { Hono } from "hono"
+import { describe, expect, it } from "vitest"
+import { z } from "zod"
+
+import { createMcpApiRoutes, SERVER_TOOL_META_KEY, VOYANT_TOOL_META_KEY } from "../src/index.js"
+
+const accessCatalog = {
+  resources: [
+    {
+      id: "catalog",
+      unitId: "@voyant-travel/catalog",
+      resource: "catalog",
+      label: "Catalog",
+      description: "Catalog",
+      wildcard: "allow" as const,
+      actions: [{ action: "read", label: "Read", description: "Read" }],
+    },
+    {
+      id: "records",
+      unitId: "@voyant-travel/test",
+      resource: "records",
+      label: "Records",
+      description: "Test records",
+      wildcard: "allow" as const,
+      actions: [
+        { action: "read", label: "Read", description: "Read records" },
+        { action: "write", label: "Write", description: "Write records" },
+      ],
+    },
+  ],
+  presets: [],
+}
+
+const listRecordsTool = defineTool({
+  capabilityId: "@voyant-travel/test#tool.list-records",
+  owner: "@voyant-travel/test",
+  capabilityVersion: "v1",
+  name: "list_records",
+  description: "List records.",
+  inputSchema: z.object({ limit: z.number().int().optional() }),
+  outputSchema: z.object({ data: z.array(z.string()), total: z.number() }),
+  requiredScopes: ["records:read"],
+  audience: { source: "grant", allowed: ["staff"] },
+  tier: "read",
+  riskPolicy: READ_ONLY_RISK,
+  annotations: { idempotentHint: true },
+  async handler() {
+    return { data: ["a"], total: 1 }
+  },
+})
+
+const updateRecordTool = defineTool({
+  capabilityId: "@voyant-travel/test#tool.update-record",
+  owner: "@voyant-travel/test",
+  capabilityVersion: "v1",
+  name: "update_record",
+  description: "Update a record.",
+  inputSchema: z.object({ id: z.string().min(1), name: z.string().min(1) }),
+  outputSchema: z.object({ id: z.string(), name: z.string() }),
+  requiredScopes: ["records:write"],
+  audience: { source: "grant", allowed: ["staff"] },
+  tier: "write",
+  riskPolicy: {
+    destructive: false,
+    reversible: true,
+    dryRunSupported: false,
+    confirmationRequired: false,
+    sideEffects: [],
+  },
+  async handler(input) {
+    return input
+  },
+})
+
+const MCP_HEADERS = {
+  "content-type": "application/json",
+  accept: "application/json, text/event-stream",
+}
+
+function rpc(method: string, params: unknown) {
+  return {
+    method: "POST",
+    headers: MCP_HEADERS,
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+  }
+}
+
+function buildContext(): ToolContext {
+  return {
+    db: {},
+    actor: "staff",
+    audience: "staff",
+    tenantId: "t1",
+    resolverScope: { locale: "en-GB", audience: "staff", market: "default", actor: "staff" },
+  }
+}
+
+function mcpApp(eagerToolNames?: readonly string[]): Hono {
+  const registry = createToolRegistry()
+  registry.register(listRecordsTool)
+  registry.register(updateRecordTool)
+  const mcp = createMcpApiRoutes({
+    accessCatalog,
+    registry,
+    buildContext,
+    ...(eagerToolNames ? { eagerToolNames } : {}),
+  })
+  const outer = new Hono()
+  outer.use("*", async (c, next) => {
+    c.set("scopes", ["records:read", "records:write"])
+    await next()
+  })
+  outer.route("/", mcp)
+  return outer
+}
+
+async function readRpc(res: Response): Promise<Record<string, unknown>> {
+  const text = await res.text()
+  if ((res.headers.get("content-type") ?? "").includes("text/event-stream")) {
+    const line = text.split("\n").find((l) => l.startsWith("data:"))
+    return JSON.parse(line?.slice("data:".length).trim() ?? "{}")
+  }
+  return JSON.parse(text)
+}
+
+interface ListedTool {
+  name: string
+  _meta?: Record<string, unknown>
+}
+
+async function listTools(app: Hono): Promise<ListedTool[]> {
+  const listed = await readRpc(await app.request("/", rpc("tools/list", {})))
+  return (listed.result as { tools?: ListedTool[] } | undefined)?.tools ?? []
+}
+
+async function callTool(
+  app: Hono,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<Record<string, unknown> | undefined> {
+  const res = await readRpc(await app.request("/", rpc("tools/call", { name, arguments: args })))
+  return (res.result as { structuredContent?: Record<string, unknown> } | undefined)
+    ?.structuredContent
+}
+
+/** The marker block, or undefined when the entry does not claim to be server-owned. */
+function serverMarker(tool: ListedTool): Record<string, unknown> | undefined {
+  const marker = tool._meta?.[SERVER_TOOL_META_KEY]
+  return typeof marker === "object" && marker !== null
+    ? (marker as Record<string, unknown>)
+    : undefined
+}
+
+describe("tools/list metadata", () => {
+  it("marks every advertised entry as either a registry Tool or server-owned", async () => {
+    const tools = await listTools(mcpApp(["update_record"]))
+    expect(tools.length).toBeGreaterThan(0)
+
+    // Totality is the point: not "the tools we happen to name below carry a
+    // marker" but "nothing on the wire is unclassifiable". The two claims are
+    // also mutually exclusive — an entry asserting both would leave a client
+    // with the same ambiguity in a different form.
+    const unclassifiable = tools
+      .map((tool) => ({
+        name: tool.name,
+        registryTool: tool._meta?.[VOYANT_TOOL_META_KEY] !== undefined,
+        serverTool: tool._meta?.[SERVER_TOOL_META_KEY] !== undefined,
+      }))
+      .filter((claim) => claim.registryTool === claim.serverTool)
+    expect(unclassifiable).toEqual([])
+  })
+
+  it("classifies the guide and meta tiers by kind", async () => {
+    const tools = await listTools(mcpApp())
+    const kinds = Object.fromEntries(
+      tools.map((tool) => [tool.name, serverMarker(tool)?.kind]),
+    ) as Record<string, string | undefined>
+
+    expect(kinds).toEqual({
+      voyant_guide: "guide",
+      voyant_glossary: "guide",
+      search_tools: "meta",
+      describe_tool: "meta",
+      call_tool: "meta",
+    })
+    // The marker is versioned by the same Tool contract a registry Tool is, so a
+    // client checks one version across the whole surface.
+    expect(serverMarker(tools[0] as ListedTool)?.contractVersion).toBe(TOOL_CONTRACT_VERSION)
+  })
+
+  it("keeps an eagerly registered registry Tool on the registry-Tool block", async () => {
+    const eager = (await listTools(mcpApp(["update_record"]))).find(
+      (tool) => tool.name === "update_record",
+    )
+    expect(eager?._meta?.[VOYANT_TOOL_META_KEY]).toMatchObject({
+      capabilityId: "@voyant-travel/test#tool.update-record",
+      owner: "@voyant-travel/test",
+      tier: "write",
+    })
+    expect(eager?._meta?.[SERVER_TOOL_META_KEY]).toBeUndefined()
+  })
+
+  it("describes a folded read group as server-owned without dropping its capabilities", async () => {
+    const app = mcpApp()
+    const found = await callTool(app, "search_tools", { query: "query" })
+    const queryName = ((found?.tools ?? []) as Array<{ name: string }>)
+      .map(({ name }) => name)
+      .find((name) => name.endsWith("_query"))
+    expect(queryName).toBeDefined()
+
+    const descriptor = await callTool(app, "describe_tool", { name: queryName })
+    const meta = descriptor?._meta as Record<string, Record<string, unknown>> | undefined
+
+    // A group has no capability identity of its own — it stands in for several —
+    // so it is marked server-owned rather than advertised as a registry Tool a
+    // strict client would then reject for incomplete metadata.
+    expect(meta?.[SERVER_TOOL_META_KEY]).toMatchObject({ kind: "read-query" })
+    // The capabilities it absorbed still travel on the block clients already
+    // read, which is how they know which flat reads to stop offering.
+    expect(meta?.[VOYANT_TOOL_META_KEY]).toMatchObject({
+      kind: "read-query",
+      resources: [{ resource: "records", capabilityId: "@voyant-travel/test#tool.list-records" }],
+    })
+  })
+
+  it("describes call_tool with the same marker it advertises", async () => {
+    const descriptor = await callTool(mcpApp(), "describe_tool", { name: "call_tool" })
+    expect(
+      (descriptor?._meta as Record<string, unknown> | undefined)?.[SERVER_TOOL_META_KEY],
+    ).toMatchObject({ kind: "meta" })
+  })
+})


### PR DESCRIPTION
Closes #4592.

`tools/list` carries entries the **server** owns rather than the tenant registry — `voyant_guide`, `voyant_glossary`, `search_tools`, `describe_tool`, `call_tool` — and none of them carried any `_meta`. A client could not tell one of those from a registry Tool whose metadata went missing, which deserves the opposite handling: skip the first, fail closed on the second. Max read absence as the second, and one unmarked entry discarded the whole tenant catalog on every managed deployment from 0.13 on.

## What this does

Every server-owned entry now carries a positive marker:

```jsonc
"_meta": { "voyant.travel/server-tool": { "contractVersion": "…", "kind": "guide" } }
```

`kind` is `guide`, `meta`, or `read-query`, so the classification rule is total:

| `_meta` | meaning | client action |
| --- | --- | --- |
| `voyant.travel/tool` | registry Tool | parse strictly |
| `voyant.travel/server-tool` | server-owned | classify by `kind` |
| neither | contract break | fail closed |

Both keys are exported from the package (`VOYANT_TOOL_META_KEY`, `SERVER_TOOL_META_KEY`) so a client stops hardcoding the strings.

## Two deviations from the proposal, both deliberate

**1. A `<domain>_query` group is marked server-owned, not `voyant.travel/tool`.** The issue proposed passing `advertiseQueryTool(...)._meta` straight through. That block has `kind`/`domain`/`tier`/`resources` and no `capabilityId`, `owner`, `capabilityVersion`, `canonicalName` or `riskPolicy`, because a group stands in for several capabilities and has none of its own. Max's `parseMetadata` requires all of those and throws `invalid_tool` without them (platform `operator-mcp.ts:573-588`) — so advertising a group as a registry Tool re-runs the same failure one layer down, and the issue's own table (`voyant.travel/tool` → "parse strictly") says any conforming client should do the same. It takes the `server-tool` marker with `kind: "read-query"` instead. Its `describe_tool` descriptor **keeps** the existing `voyant.travel/tool` block unchanged — that is where the current client reads the absorbed `capabilityId`s and scopes (`operator-mcp-progressive.ts:208-226`), and nothing about it changes.

**2. The marker carries no `resources` array on `tools/list`.** Identity and classification only. Repeating every resource's capability id and scopes across ~24 groups would put a large chunk of the eager-serialization cost #3927 removed straight back onto every list; the resource names are already in each group's description, and `describe_tool` remains authoritative.

## One correction to the repro

The `<domain>_query no _meta` row does not reproduce on current `main`. Query tools are registered lazily — only for the name a `tools/call` actually asks for (`server.ts:220-240`) — and `selectEagerToolNames` only promotes names from the registry surface, so a group can never reach `tools/list`. The five tier-0 rows are exactly as described. The marker is still attached at the registration site, so the property holds if a group is ever advertised eagerly.

## Verification

- New `packages/mcp/tests/tool-list-metadata.test.ts` (5 tests). The load-bearing one asserts **totality** — every advertised entry claims exactly one of the two blocks — so a future server-owned tool that forgets its marker fails here rather than in a client. Confirmed red before the fix: removing the guide marker fails 2 of 5.
- `@voyant-travel/mcp` suite: 16 files / 106 passed, 1 file / 5 skipped.
- `pnpm --filter @voyant-travel/mcp typecheck`: exit 0, 0 `error TS`.
- `pnpm verify:architecture`: exit 0.
- `biome check packages/mcp docs .changeset`: clean (one pre-existing unrelated warning in `response-budget.test.ts`).

Changeset: `@voyant-travel/mcp` minor. Purely additive to the wire format — nothing changes for registry Tools, and a client that ignores `_meta` on these entries is unaffected.
