### PR TITLE
fix(legal): write booking contracts in the template's language

### DIFF
--- a/.changeset/contract-language-follows-template.md
+++ b/.changeset/contract-language-follows-template.md
@@ -1,0 +1,25 @@
+---
+"@voyant-travel/legal": patch
+---
+
+Generate booking contracts from the template the deployment actually owns, instead of
+requiring the booking to name its language.
+
+Nothing writes `bookings.communication_language` or `contact_preferred_language`, so the
+contract language resolved to `"en"` for essentially every booking. Template *selection*
+already handled that — `getDefaultTemplate` prefers the requested language and falls back
+to the operator's own active default — but the applicability re-check that followed
+demanded `template.language === language` and discarded the fallback, reporting
+`template.applicableCurrentVersion` as missing. On a single-language deployment that is
+the only template there is, so contract generation never once succeeded through the
+ordinary path: a Romanian operator with one active Romanian template had 311 confirmed
+bookings and no contract from any of them.
+
+A contract is now written, and labelled, in the language of the template it was rendered
+from; the booking's language is a preference that orders selection and nothing more. The
+same correction applies to the applicable-template listing, which filtered on that
+preference and so hid the operator's own template from its own bookings, and to the
+booking-contract draft tool, which rejected a template version the caller had named
+explicitly. Unfulfilled-generation ledger entries now carry the comparison that failed —
+the resolved preference, the selected template and its language, and both channels —
+rather than only the `template.applicableCurrentVersion` category.

--- a/packages/legal/src/booking-contract-confirmed.ts
+++ b/packages/legal/src/booking-contract-confirmed.ts
@@ -65,6 +65,13 @@ export type BookingContractConfirmationResult =
         | "contract_not_mutable"
         | "missing_prerequisites"
       missingPrerequisites?: string[]
+      /**
+       * What the selection actually compared, in words. The prerequisite token
+       * is `template.applicableCurrentVersion`, which does not say whether the
+       * template was inactive, superseded, or bound to another channel — that
+       * took a database comparison to establish (voyant#4650).
+       */
+      selectionDetail?: string
     }
 
 interface GenerateBookingContractOnConfirmationInput {
@@ -200,6 +207,7 @@ export async function generateBookingContractOnConfirmation(
         ...(prepared.missingPrerequisites
           ? { missingPrerequisites: prepared.missingPrerequisites }
           : {}),
+        ...(prepared.selectionDetail ? { selectionDetail: prepared.selectionDetail } : {}),
       })
     }
     return prepared
@@ -285,6 +293,7 @@ export async function recordUnfulfilledBookingContract(
     event: LegalBookingConfirmedEvent
     reason: UnfulfilledBookingContractReason
     missingPrerequisites?: readonly string[]
+    selectionDetail?: string
   },
 ): Promise<{ recorded: boolean }> {
   const bookingId = input.event.data.bookingId
@@ -317,6 +326,8 @@ export async function recordUnfulfilledBookingContract(
   const missing = input.missingPrerequisites?.length
     ? ` Missing: ${input.missingPrerequisites.join(", ")}.`
     : ""
+  // The reason and the token both name a category; this names the comparison.
+  const selection = input.selectionDetail ? ` Selection: ${input.selectionDetail}.` : ""
 
   await actionLedgerService.appendEntry(
     db,
@@ -344,7 +355,7 @@ export async function recordUnfulfilledBookingContract(
       idempotencyKey,
       idempotencyFingerprint,
       mutationDetail: {
-        summary: `${UNFULFILLED_BOOKING_CONTRACT_SUMMARIES[input.reason]}${missing}`,
+        summary: `${UNFULFILLED_BOOKING_CONTRACT_SUMMARIES[input.reason]}${missing}${selection}`,
         reversalKind: "none",
       },
     }),
@@ -396,7 +407,8 @@ async function prepareBookingContractTarget(
     bookingsService.listItems(db, bookingId),
     bookingsService.listTravelers(db, bookingId),
   ])
-  const language = resolveBookingContractLanguage(booking)
+  const preferredLanguage = resolveBookingContractLanguage(booking)
+  const channelId = origin?.channelId ?? null
   const reusable = existingContracts.find((contract) => {
     const metadata = record(contract.metadata)
     return (
@@ -409,11 +421,25 @@ async function prepareBookingContractTarget(
 
   const selected = await resolveTemplateSelection(db, {
     reusable,
-    language,
-    channelId: origin?.channelId ?? null,
+    language: preferredLanguage,
+    channelId,
   })
-  if (selected.status !== "selected") return selected
+  if (selected.status !== "selected") {
+    return {
+      ...selected,
+      selectionDetail: `preferred language "${preferredLanguage}", booking channel ${channelId ?? "none"}`,
+    }
+  }
 
+  // A contract is written in the language of the template it is rendered from.
+  // `preferredLanguage` only ordered the selection above, where
+  // `getDefaultTemplate` already applies the deployment's language policy —
+  // prefer the requested language, then English, then whatever active template
+  // the operator marked default. Re-asserting the preference here as an
+  // equality contradicted that policy: it discarded every template the selector
+  // had deliberately fallen back to, which on a single-language deployment is
+  // the only template there is (voyant#4650).
+  const language = selected.template.language
   const variables = bookingContractVariables(booking, items, travelers)
   const missingPrerequisites = bookingContractPrerequisites({
     templateApplicable:
@@ -421,11 +447,7 @@ async function prepareBookingContractTarget(
       (selected.template.active &&
         selected.template.scope === "customer" &&
         selected.template.currentVersionId === selected.version.id &&
-        selected.template.language === language &&
-        bookingContractTemplateMatchesChannel(
-          selected.template.channelId,
-          origin?.channelId ?? null,
-        )),
+        bookingContractTemplateMatchesChannel(selected.template.channelId, channelId)),
     totalAmountCents: booking.sellAmountCents,
     itemCount: items.length,
     missingRequiredVariables: validateTemplateVariables(
@@ -434,7 +456,18 @@ async function prepareBookingContractTarget(
     ),
   })
   if (missingPrerequisites.length > 0) {
-    return { status: "skipped", reason: "missing_prerequisites", missingPrerequisites }
+    return {
+      status: "skipped",
+      reason: "missing_prerequisites",
+      missingPrerequisites,
+      selectionDetail:
+        `preferred language "${preferredLanguage}", ` +
+        `selected template "${selected.template.name}" in "${selected.template.language}" ` +
+        `(active ${selected.template.active}, scope ${selected.template.scope}, ` +
+        `current version ${selected.template.currentVersionId === selected.version.id}, ` +
+        `template channel ${selected.template.channelId ?? "none"}), ` +
+        `booking channel ${channelId ?? "none"}`,
+    }
   }
 
   const reviewSnapshot = bookingContractReviewSnapshot({
@@ -501,7 +534,7 @@ async function prepareBookingContractTarget(
         seriesId,
         personId: reusable.personId ?? booking.personId,
         organizationId: reusable.organizationId ?? booking.organizationId,
-        channelId: reusable.channelId ?? origin?.channelId ?? null,
+        channelId: reusable.channelId ?? channelId,
         language,
         variables,
         renderedBody,
@@ -524,7 +557,7 @@ async function prepareBookingContractTarget(
         bookingId,
         personId: booking.personId,
         organizationId: booking.organizationId,
-        channelId: origin?.channelId ?? null,
+        channelId,
         language,
         variables,
         metadata,

--- a/packages/legal/src/booking-contract-review.ts
+++ b/packages/legal/src/booking-contract-review.ts
@@ -86,6 +86,20 @@ export function missingBookingContractRequiredVariables(
   })
 }
 
+/**
+ * The language this booking would *prefer* its contract in.
+ *
+ * It is a preference and nothing more: it orders template selection, where
+ * `contractsService.getDefaultTemplate` tries it first and falls back to the
+ * deployment's own templates. It is never the language a generated contract is
+ * labelled with — that is the language of the template the document was
+ * rendered from, which is the only claim the body can support.
+ *
+ * voyant#4650: no booking creation path writes either field, so this resolves
+ * to `"en"` for essentially every booking. Treating that as a hard match is
+ * what stopped a Romanian deployment with one Romanian template from ever
+ * generating a contract through the ordinary path.
+ */
 export function resolveBookingContractLanguage(booking: {
   communicationLanguage: string | null
   contactPreferredLanguage: string | null
@@ -170,7 +184,13 @@ export async function listApplicableBookingContractTemplates(
     .where(eq(bookingItems.bookingId, booking.id))
   const primaryProduct = bookingProductRows[0]
 
-  const language = input.language ?? resolveBookingContractLanguage(booking)
+  // Only a caller that names a language gets a language-filtered list. Filtering
+  // on the booking's *preferred* language hid every template a single-language
+  // deployment owns, because that preference resolves to "en" on a booking
+  // nothing ever wrote a language to (voyant#4650) — so the operator's own
+  // Romanian template was absent from the list of templates that apply to a
+  // Romanian booking. Each row carries its `language`, so the caller can still
+  // tell them apart.
   const templates = await db
     .select()
     .from(contractTemplates)
@@ -178,7 +198,7 @@ export async function listApplicableBookingContractTemplates(
       and(
         eq(contractTemplates.scope, "customer"),
         eq(contractTemplates.active, true),
-        eq(contractTemplates.language, language),
+        ...(input.language ? [eq(contractTemplates.language, input.language)] : []),
       ),
     )
 

--- a/packages/legal/src/mcp-runtime.ts
+++ b/packages/legal/src/mcp-runtime.ts
@@ -27,7 +27,6 @@ import {
   bookingContractTemplateMatchesChannel,
   getBookingContractReview,
   listApplicableBookingContractTemplates,
-  resolveBookingContractLanguage,
 } from "./booking-contract-review.js"
 import { executeLegalContractDocumentCommand } from "./contract-document-command.js"
 import type { ContractDocumentRoutesOptions } from "./contract-document-routes.js"
@@ -770,14 +769,17 @@ export async function executeLegalContractDraftCreate(
           }
           const items = bookingRows.flatMap(({ item }) => (item ? [item] : []))
           await testHooks?.afterBookingReviewSourceRead?.()
-          language =
-            requestedInput.language ?? previous?.language ?? resolveBookingContractLanguage(booking)
+          // The caller named this template version, so the draft is written in
+          // that template's language. Requiring it to equal the *booking's*
+          // preferred language rejected every deployment whose templates are
+          // not in English, because nothing populates the fields that
+          // preference reads (voyant#4650).
+          language = requestedInput.language ?? previous?.language ?? template.language
           const expectedChannelId = requestedInput.channelId ?? previous?.channelId ?? null
           const templateApplicable =
             template?.active === true &&
             template.scope === "customer" &&
             template.currentVersionId === templateVersion.id &&
-            template.language === language &&
             bookingContractTemplateMatchesChannel(template.channelId, expectedChannelId)
           const missingPrerequisites = bookingContractPrerequisites({
             templateApplicable,
@@ -807,7 +809,6 @@ export async function executeLegalContractDraftCreate(
               template.active === true &&
               template.scope === "customer" &&
               template.currentVersionId === templateVersion.id &&
-              template.language === language &&
               bookingContractTemplateMatchesChannel(template.channelId, expectedChannelId)
             )
           ) {

--- a/packages/legal/tests/integration/booking-contract-confirmed.test.ts
+++ b/packages/legal/tests/integration/booking-contract-confirmed.test.ts
@@ -380,4 +380,189 @@ describe.skipIf(!DB_AVAILABLE)("booking-confirmed contract generation", () => {
       await db.select().from(contracts).where(eq(contracts.bookingId, booking!.id)),
     ).toHaveLength(0)
   })
+
+  // voyant#4650: this is the shape of a real Romanian deployment — one market,
+  // one active Romanian customer template, an active series, and 311 bookings
+  // whose `communication_language` is null because no creation path writes it.
+  // Template *selection* already falls back to the deployment's own template;
+  // the applicability re-check then discarded it for not being English, so
+  // contract generation had never once succeeded through the ordinary path.
+  it("generates from the deployment's own template when the booking carries no language", async () => {
+    const [booking] = await db
+      .insert(bookings)
+      .values({
+        bookingNumber: "BK-AUTO-CONTRACT-RO",
+        status: "confirmed",
+        contactFirstName: "Ana",
+        contactLastName: "Pop",
+        contactEmail: "ana@example.test",
+        communicationLanguage: null,
+        contactPreferredLanguage: null,
+        sellCurrency: "RON",
+        sellAmountCents: 500_00,
+        startDate: "2026-09-01",
+        endDate: "2026-09-07",
+        pax: 2,
+      })
+      .returning()
+    await db.insert(bookingItems).values({
+      bookingId: booking!.id,
+      title: "Excursie de toamnă",
+      status: "confirmed",
+      productNameSnapshot: "Excursie de toamnă",
+      quantity: 2,
+      sellCurrency: "RON",
+      totalSellAmountCents: 500_00,
+    })
+    const body = "Contract {{ contract.number }} pentru rezervarea {{ booking.number }}"
+    const [template] = await db
+      .insert(contractTemplates)
+      .values({
+        name: "Contract de comercializare",
+        slug: "contract-comercializare",
+        scope: "customer",
+        language: "ro",
+        body,
+        active: true,
+        isDefault: true,
+      })
+      .returning()
+    const [version] = await db
+      .insert(contractTemplateVersions)
+      .values({ templateId: template!.id, version: 1, body, variableSchema: {} })
+      .returning()
+    await db
+      .update(contractTemplates)
+      .set({ currentVersionId: version!.id })
+      .where(eq(contractTemplates.id, template!.id))
+    await db.insert(contractNumberSeries).values({
+      name: "Contracte clienți",
+      prefix: "CTR",
+      scope: "customer",
+      isDefault: true,
+      active: true,
+      currentSequence: 0,
+      padLength: 5,
+      separator: "-",
+      resetStrategy: "never",
+    })
+
+    const eventBus = createEventBus({ handlerTimeoutMs: false })
+    await createLegalBookingContractConfirmedSubscriber({
+      resolveDb: async () => db,
+      provider: provider(),
+    }).register({ bindings: {}, container: {} as never, eventBus })
+    await eventBus.emit(
+      "booking.confirmed",
+      {
+        bookingId: booking!.id,
+        bookingNumber: booking!.bookingNumber,
+        actorId: null,
+      } satisfies LegalBookingConfirmedPayload,
+      {
+        eventId: `evt_finance_booking_confirmed_${booking!.id}`,
+        category: "domain",
+        source: "service",
+      },
+    )
+
+    const contractRows = await db
+      .select()
+      .from(contracts)
+      .where(eq(contracts.bookingId, booking!.id))
+    expect(contractRows).toHaveLength(1)
+    // The document is labelled with the language it is actually written in —
+    // the template's — never the "en" the booking's absent fields resolve to.
+    expect(contractRows[0]).toMatchObject({
+      templateVersionId: version!.id,
+      language: "ro",
+      contractNumber: "CTR-00001",
+      renderedBody: "Contract CTR-00001 pentru rezervarea BK-AUTO-CONTRACT-RO",
+    })
+    expect(await db.select().from(contractAttachments)).toMatchObject([
+      { contractId: contractRows[0]!.id, kind: "document" },
+    ])
+    const ledgerRows = await db
+      .select()
+      .from(actionLedgerEntries)
+      .where(eq(actionLedgerEntries.targetId, booking!.id))
+    expect(ledgerRows).toMatchObject([{ status: "requested" }])
+  })
+
+  // voyant#4650: `template.applicableCurrentVersion` names a category, not a
+  // comparison. Establishing which comparison failed took a database query
+  // against the deployment; the entry now carries it.
+  it("records what the template selection compared when prerequisites are missing", async () => {
+    const [booking] = await db
+      .insert(bookings)
+      .values({
+        bookingNumber: "BK-AUTO-CONTRACT-DETAIL",
+        status: "confirmed",
+        contactFirstName: "Ana",
+        contactLastName: "Pop",
+        contactEmail: "ana@example.test",
+        sellCurrency: "RON",
+        sellAmountCents: 500_00,
+        startDate: "2026-09-01",
+        endDate: "2026-09-07",
+      })
+      .returning()
+    const body = "Contract {{ contract.number }}"
+    const [template] = await db
+      .insert(contractTemplates)
+      .values({
+        name: "Contract de comercializare",
+        slug: "contract-comercializare-detail",
+        scope: "customer",
+        language: "ro",
+        body,
+        active: true,
+        isDefault: true,
+      })
+      .returning()
+    const [version] = await db
+      .insert(contractTemplateVersions)
+      .values({ templateId: template!.id, version: 1, body, variableSchema: {} })
+      .returning()
+    await db
+      .update(contractTemplates)
+      .set({ currentVersionId: version!.id })
+      .where(eq(contractTemplates.id, template!.id))
+
+    const eventBus = createEventBus({ handlerTimeoutMs: false })
+    await createLegalBookingContractConfirmedSubscriber({
+      resolveDb: async () => db,
+      provider: provider(),
+    }).register({ bindings: {}, container: {} as never, eventBus })
+    await eventBus.emit(
+      "booking.confirmed",
+      {
+        bookingId: booking!.id,
+        bookingNumber: booking!.bookingNumber,
+        actorId: null,
+      } satisfies LegalBookingConfirmedPayload,
+      {
+        eventId: `evt_finance_booking_confirmed_${booking!.id}`,
+        category: "domain",
+        source: "service",
+      },
+    )
+
+    const [ledgerRow] = await db
+      .select()
+      .from(actionLedgerEntries)
+      .where(eq(actionLedgerEntries.targetId, booking!.id))
+    expect(ledgerRow).toMatchObject({
+      status: "failed",
+      idempotencyKey: `booking-confirmed-unfulfilled:${booking!.id}:missing_prerequisites`,
+    })
+    const [detail] = await db
+      .select()
+      .from(actionMutationDetails)
+      .where(eq(actionMutationDetails.actionId, ledgerRow!.id))
+    expect(detail!.summary).toContain("Missing: booking.items")
+    expect(detail!.summary).toContain('preferred language "en"')
+    expect(detail!.summary).toContain('selected template "Contract de comercializare" in "ro"')
+    expect(detail!.summary).toContain("booking channel none")
+  })
 })

--- a/packages/legal/tests/integration/booking-contract-workflow.test.ts
+++ b/packages/legal/tests/integration/booking-contract-workflow.test.ts
@@ -268,6 +268,79 @@ describe.skipIf(!DB_AVAILABLE)("managed booking contract workflow", () => {
     })
   })
 
+  // voyant#4650: the listing filtered templates on the booking's *preferred*
+  // language, which resolves to "en" on a booking nothing ever wrote a language
+  // to. A single-language deployment's only customer template was therefore
+  // absent from the list of templates that apply to its own bookings.
+  it("lists the deployment's own templates for a booking that carries no language", async () => {
+    const [booking] = await db
+      .insert(bookings)
+      .values({
+        bookingNumber: "BK-NO-LANGUAGE-1",
+        status: "confirmed",
+        contactFirstName: "Ana",
+        contactLastName: "Pop",
+        contactEmail: "ana@example.test",
+        communicationLanguage: null,
+        contactPreferredLanguage: null,
+        sellCurrency: "RON",
+        sellAmountCents: 500_00,
+        startDate: "2026-09-01",
+        endDate: "2026-09-07",
+      })
+      .returning()
+    await db.insert(bookingItems).values({
+      bookingId: booking.id,
+      title: "Excursie de toamnă",
+      status: "confirmed",
+      productNameSnapshot: "Excursie de toamnă",
+      quantity: 2,
+      sellCurrency: "RON",
+      totalSellAmountCents: 500_00,
+    })
+    const [template] = await db
+      .insert(contractTemplates)
+      .values({
+        name: "Contract de comercializare",
+        slug: "contract-comercializare-listing",
+        scope: "customer",
+        language: "ro",
+        body: "Contract pentru {{ customer.name }}",
+        active: true,
+        isDefault: true,
+      })
+      .returning()
+    const [version] = await db
+      .insert(contractTemplateVersions)
+      .values({
+        templateId: template.id,
+        version: 1,
+        body: "Contract pentru {{ customer.name }}",
+        variableSchema: { required: ["customer.name"] },
+      })
+      .returning()
+    await db
+      .update(contractTemplates)
+      .set({ currentVersionId: version.id })
+      .where(eq(contractTemplates.id, template.id))
+
+    const service = createLegalToolServices(db, undefined, {
+      userId: "usr_listing",
+      callerType: "session",
+      actor: "staff",
+    })
+    await expect(
+      service.listApplicableBookingTemplates({ bookingId: booking.id }),
+    ).resolves.toMatchObject({
+      bookingFound: true,
+      data: [{ id: template.id, language: "ro", applicable: true, missingPrerequisites: [] }],
+    })
+    // A caller that names a language still gets exactly that language.
+    await expect(
+      service.listApplicableBookingTemplates({ bookingId: booking.id, language: "en" }),
+    ).resolves.toMatchObject({ bookingFound: true, data: [] })
+  })
+
   it("gates booking draft snapshots with trusted PII context and preserves generic drafts", async () => {
     const { booking, version } = await seedBookingTemplate("BK-DRAFT-PII-GATE")
     let snapshotSourceRead = false
@@ -894,6 +967,7 @@ describe.skipIf(!DB_AVAILABLE)("managed booking contract workflow", () => {
       .insert(bookings)
       .values({
         bookingNumber,
+        status: "confirmed",
         contactFirstName: "Ana",
         contactLastName: "Pop",
         contactEmail: "ana@example.test",
@@ -910,6 +984,7 @@ describe.skipIf(!DB_AVAILABLE)("managed booking contract workflow", () => {
       .values({
         bookingId: booking.id,
         title: "Fallback title",
+        status: "confirmed",
         productNameSnapshot: "Original tour",
         quantity: 2,
         sellCurrency: "EUR",


### PR DESCRIPTION
Fixes #4650.

## What was actually wrong

The issue frames this as "nothing ever sets the language", and that is true —
no booking creation path writes `communication_language` or
`contact_preferred_language`, so `resolveBookingContractLanguage` returns `"en"`
for essentially every booking. But that alone would not have blocked anything,
because template *selection* already copes with it: `getDefaultTemplate` tries
the requested language, then English, then falls back to whichever active
customer template the operator marked default.

The block was one clause further on. After selecting a template, the
prerequisite check re-asserted the preference as an equality:

```ts
selected.template.language === language && …
```

which discards exactly the template the selector had deliberately fallen back
to. On a single-language deployment that is the only template there is, so the
check reported `template.applicableCurrentVersion` missing and generation
stopped — matching the reported ledger entry, and matching the evidence that
selection found the Romanian template and something downstream rejected it.

## The rule this settles on

**A contract is written in the language of the template it was rendered from.**
The booking's language is a preference that orders selection and nothing more.
That is the only claim the body can support, and it is what makes the fallback
safe: the issue's objection to falling back was that it would mean "issuing a
contract whose body is Romanian while its metadata claims English", and
labelling the contract from the template removes that.

Three call sites re-asserted the preference and all three now defer to the
selection:

- **`prepareBookingContractTarget`** — the confirmed-booking generation path.
  The contract row's `language` is now `selected.template.language`.
- **`listApplicableBookingContractTemplates`** — filtered its SQL by the
  inferred language, so the operator's own template was absent from the list of
  templates that apply to the operator's own bookings. It now filters only when
  the caller names a language; each row already carries its own `language`.
- **`executeLegalContractDraftCreate`** — rejected a template version the caller
  had explicitly named, for not matching a language the booking never had.

## On the issue's other suggested directions

Suggestions 1 and 2 (consult the market/deployment default language, or write
`communication_language` at booking creation) are not needed for the reported
failure and are not taken here. The operator already has a lever for "which
template when the booking says nothing" — `isDefault`, which
`pickBestDefaultTemplate` consults precisely in the no-language-match case, and
which has UI today. Reading `markets.default_language_tag` from Legal would
also be a new cross-module table pair, which the `verify:table-privacy` ratchet
holds closed; routing it through a new port would add a third source of truth
for a decision the templates already express. Worth revisiting if a bilingual
deployment turns out to need preference ordering beyond `isDefault`.

Suggestion 4 is taken: unfulfilled-generation ledger entries now append the
comparison that failed — the resolved preference, the selected template and its
language, whether it is active and current, and both channels — instead of only
the `template.applicableCurrentVersion` category, which took a database query
against the deployment to interpret. The detail is not part of the idempotency
fingerprint, which stays keyed on booking-and-reason.

## Verification

- `packages/legal` build and typecheck: clean, 0 `error TS`.
- `biome check .` from the repo root: 0 errors; no diagnostics in `packages/legal`.
- `tests/integration/booking-contract-confirmed.test.ts` (the file CI's database
  lane runs): **4/4 green**, including two new cases — a Romanian deployment with
  one Romanian template and a booking carrying no language now generates a
  contract labelled `ro`, and a failing selection records its comparison.
- Full `packages/legal` suite against a freshly migrated database: 288 passed,
  10 failed. **All 10 fail identically on `main`** with this branch's `src`
  changes reverted (`document-operation.test.ts` ×8, `public-routes.test.ts` ×1,
  and one same-parent-successor concurrency case). None are touched by this
  change.

`booking-contract-workflow.test.ts` seeded bookings and booking items without
`status`, which is NOT NULL with no default, so all 14 tests died in the fixture.
That file is not in CI's database lane ([#4251](https://github.com/voyant-travel/voyant/issues/4251)),
which is why it went unnoticed. The seeds are repaired here so the new listing
coverage can actually run; the file goes from 14 red to 13 green, with the one
remaining failure being the pre-existing concurrency case above, left alone as
out of scope.
