### PR TITLE
Hold capacity for the whole party

### DIFF
--- a/.changeset/held-for-the-whole-party.md
+++ b/.changeset/held-for-the-whole-party.md
@@ -1,0 +1,26 @@
+---
+"@voyant-travel/catalog-contracts": minor
+"@voyant-travel/catalog-react": minor
+"@voyant-travel/catalog": minor
+"@voyant-travel/trips": patch
+---
+
+Hold capacity for the party the Booking Session is already for. An unstated
+Hold quantity is now derived from the Session's own selection instead of
+becoming a literal `1`, which no multi-traveler checkout could ever satisfy: the
+capacity port expects the real traveler count, so every Hold for two or more
+people was rejected as a quantity mismatch, and the rejection asked the client
+to retry — with the same invented `1`, forever.
+
+`placeBookingHoldV1.quantity` loses its `.default(1)`. A default there was not a
+fallback at all — parsing filled the field in before any code could consult the
+Session — and the same invented `1` was applied again in `useBookingHold` and
+required by the shared journey. All three now leave it absent and let the server
+derive it. `partySizeFromSelection` is that one derivation, replacing the two
+private copies in the capacity port and the Trips composite handler.
+
+A genuine mismatch — a caller that names a quantity other than the Session's
+party size — no longer answers `request_new_hold`. Repeating a request whose
+quantity is derived cannot succeed, so that next action described a livelock;
+`hold_quantity_mismatch` now answers `request_hold_for_expected_quantity` and
+`expectedQuantity` is the value to hold instead.

--- a/packages/catalog-contracts/src/booking-engine/session-contracts.test.ts
+++ b/packages/catalog-contracts/src/booking-engine/session-contracts.test.ts
@@ -64,6 +64,27 @@ describe("Booking Session v1 contracts", () => {
     ).toBe(true)
   })
 
+  it("leaves an unstated Hold quantity absent for the server to derive", () => {
+    // A `.default(1)` here filled the field in during parsing, so the server's
+    // own fallback to the Session's party size was unreachable and every
+    // multi-traveler Hold was rejected against an invented `1` (voyant#4655).
+    const parsed = placeBookingHoldV1.parse({
+      quoteId: "bsqu_1",
+      expectedRevision: 1,
+      idempotencyKey: "stable_hold_key",
+    })
+    expect(parsed.quantity).toBeUndefined()
+    expect("quantity" in parsed).toBe(false)
+    expect(
+      placeBookingHoldV1.parse({
+        quoteId: "bsqu_1",
+        expectedRevision: 1,
+        quantity: 3,
+        idempotencyKey: "stable_hold_key",
+      }).quantity,
+    ).toBe(3)
+  })
+
   it("does not accept client-authoritative Booking status, source, or price fields on Commit", () => {
     const parsed = commitBookingSessionV1.parse({
       expectedRevision: 1,
@@ -225,7 +246,7 @@ describe("Booking Session v1 contracts", () => {
       kind: "hold_quantity_mismatch",
       requestedQuantity: 1,
       expectedQuantity: 2,
-      nextAction: "request_new_hold",
+      nextAction: "request_hold_for_expected_quantity",
     },
   ])("accepts the actionable $kind lifecycle rejection", (error) => {
     expect(bookingSessionOutcomeV1.safeParse({ kind: "rejected", error }).success).toBe(true)

--- a/packages/catalog-contracts/src/booking-engine/session-contracts.ts
+++ b/packages/catalog-contracts/src/booking-engine/session-contracts.ts
@@ -276,7 +276,20 @@ export type BookingQuoteRecordV1 = z.infer<typeof bookingQuoteRecordV1>
 export const placeBookingHoldV1 = z.object({
   expectedRevision: z.number().int().positive(),
   quoteId: z.string().min(1),
-  quantity: z.number().int().positive().default(1),
+  /**
+   * How much capacity to hold. **Omit it** unless the caller is deliberately
+   * holding for a party other than the one the Session states: absent means
+   * the Session's own party size, which is what the capacity port checks
+   * against.
+   *
+   * This carried `.default(1)` until voyant#4655. A default here is not a
+   * default at all — it is a value the server invents and then rejects itself
+   * for, because parsing filled the field in before any code could fall back
+   * to the Session. Every storefront checkout for two or more travelers was
+   * unholdable, and the rejection asked the client to retry, so it retried the
+   * same invented `1` forever.
+   */
+  quantity: z.number().int().positive().optional(),
   idempotencyKey: z.string().min(8).max(128),
 })
 export type PlaceBookingHoldV1 = z.input<typeof placeBookingHoldV1>
@@ -491,10 +504,19 @@ export const bookingSessionLifecycleErrorV1 = z.discriminatedUnion("kind", [
     nextAction: z.literal("request_new_hold"),
   }),
   z.object({
+    /**
+     * The caller named a quantity, and it is not the party this Session is
+     * for. The server derives the expected quantity from the Session's own
+     * selection, so repeating the same request is rejected the same way:
+     * `request_new_hold` here was a livelock, not a recovery (voyant#4655).
+     *
+     * `expectedQuantity` is the value to hold instead. A caller that meant a
+     * different party size changes the Session's pax and re-quotes.
+     */
     kind: z.literal("hold_quantity_mismatch"),
     requestedQuantity: z.number().int().positive(),
     expectedQuantity: z.number().int().positive(),
-    nextAction: z.literal("request_new_hold"),
+    nextAction: z.literal("request_hold_for_expected_quantity"),
   }),
   z.object({
     kind: z.literal("commit_already_consumed"),

--- a/packages/catalog-react/src/booking-engine/session-journey.test.ts
+++ b/packages/catalog-react/src/booking-engine/session-journey.test.ts
@@ -77,6 +77,46 @@ describe("Booking Session v1 journey", () => {
     expect(calls[2]?.body.quantity).toBe(2)
   })
 
+  it("sends no Hold quantity when the host states none", async () => {
+    // The server derives the party size from the selection it was just sent.
+    // Inventing a `1` here is what made a two-traveler checkout unholdable —
+    // the server rejected its own invented quantity and asked for a retry that
+    // sent the same `1` again (voyant#4655).
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = []
+    const fetcher = vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({ url, body: JSON.parse(String(init?.body)) as Record<string, unknown> })
+      if (url.endsWith("/booking-sessions")) {
+        return json({ kind: "session_created", session: session() })
+      }
+      if (url.endsWith("/quote")) return json(quote())
+      if (url.endsWith("/hold")) return json(hold())
+      return json({
+        kind: "commit_result",
+        outcome: {
+          kind: "committed",
+          nextAction: "none",
+          booking: { id: "book_1", status: "confirmed" },
+          allocationIds: ["bkac_1"],
+          consumedSessionId: "bses_1",
+          consumedQuoteId: "bsqu_1",
+          convertedHoldId: "bshd_1",
+        },
+      })
+    })
+
+    await expect(
+      commitBookingSessionJourneyV1(createBookingJourneyApi({ baseUrl: "", fetcher }), {
+        target: { kind: "product", productId: "prod_1" },
+        selection: { configure: { pax: { adult: 3 } } },
+        idempotencyKey: "storefront:stable",
+      }),
+    ).resolves.toEqual({ kind: "committed", bookingId: "book_1" })
+
+    const holdBody = calls.find((call) => call.url.endsWith("/hold"))?.body
+    expect(holdBody).toBeDefined()
+    expect("quantity" in (holdBody ?? {})).toBe(false)
+  })
+
   it("returns the same Commit continuation when payment is required", async () => {
     const fetcher = vi.fn(async (url: string) => {
       if (url.endsWith("/booking-sessions")) {

--- a/packages/catalog-react/src/booking-engine/session-journey.ts
+++ b/packages/catalog-react/src/booking-engine/session-journey.ts
@@ -47,7 +47,13 @@ export interface BookingSessionJourneyInput {
   target: CreateBookingSessionTargetV1
   selection?: Record<string, unknown>
   scope?: BookingSessionScopeV1
-  quantity: number
+  /**
+   * How much capacity to hold. Omit it and the server holds for the party the
+   * `selection` already states — the only number that can be right, and the
+   * one the capacity port checks against (voyant#4655). Pass one only when the
+   * host genuinely knows better than the selection it just sent.
+   */
+  quantity?: number
   /**
    * Stable root for every key this journey derives. Must be the same string
    * across retries of the same user action — that is what makes the sequence
@@ -107,7 +113,7 @@ export async function commitBookingSessionJourneyV1(
     await holdBookingSession(api, session.id, {
       expectedRevision: session.revision,
       quoteId: quoted.quote.id,
-      quantity: input.quantity,
+      ...(input.quantity === undefined ? {} : { quantity: input.quantity }),
       idempotencyKey: bookingSessionIdempotencyKey(input.idempotencyKey, "hold"),
     }),
     "hold_created",

--- a/packages/catalog-react/src/booking-engine/use-booking-hold.ts
+++ b/packages/catalog-react/src/booking-engine/use-booking-hold.ts
@@ -26,6 +26,10 @@ export interface UseBookingHoldOptions extends BookingJourneyApiOptions {
 export interface PlaceBookingHoldInput {
   /** The Quote the Hold is taken against. A Hold without one holds no price. */
   quoteId: string
+  /**
+   * Omit to hold for the party the Session already states. Naming a different
+   * number is rejected — see `hold_quantity_mismatch`.
+   */
   quantity?: number
 }
 
@@ -79,18 +83,21 @@ export function useBookingHold(options: UseBookingHoldOptions): UseBookingHold {
   const place = useCallback(
     (input: PlaceBookingHoldInput) => {
       const current = requireSession()
-      const quantity = input.quantity ?? 1
+      // No local default. Sending an invented `1` is what made a
+      // multi-traveler Hold impossible (voyant#4655); an absent quantity means
+      // "the party this Session is for", which only the server can derive.
+      const quantity = input.quantity
       return run(() =>
         holdBookingSession(api, current.sessionId, {
           expectedRevision: current.revision,
           quoteId: input.quoteId,
-          quantity,
+          ...(quantity === undefined ? {} : { quantity }),
           idempotencyKey: bookingSessionIdempotencyKey(
             idempotencyRoot,
             "hold",
             current.revision,
             input.quoteId,
-            quantity,
+            quantity ?? "session",
           ),
         }),
       )

--- a/packages/catalog/openapi/admin/catalog-booking.json
+++ b/packages/catalog/openapi/admin/catalog-booking.json
@@ -11323,7 +11323,7 @@
                       },
                       "nextAction": {
                         "type": "string",
-                        "enum": ["request_new_hold"]
+                        "enum": ["request_hold_for_expected_quantity"]
                       }
                     },
                     "required": ["kind", "requestedQuantity", "expectedQuantity", "nextAction"]
@@ -13553,7 +13553,7 @@
                       },
                       "nextAction": {
                         "type": "string",
-                        "enum": ["request_new_hold"]
+                        "enum": ["request_hold_for_expected_quantity"]
                       }
                     },
                     "required": ["kind", "requestedQuantity", "expectedQuantity", "nextAction"]
@@ -14320,8 +14320,7 @@
                   },
                   "quantity": {
                     "type": "integer",
-                    "exclusiveMinimum": 0,
-                    "default": 1
+                    "exclusiveMinimum": 0
                   },
                   "idempotencyKey": {
                     "type": "string",

--- a/packages/catalog/openapi/storefront/catalog-booking.json
+++ b/packages/catalog/openapi/storefront/catalog-booking.json
@@ -11323,7 +11323,7 @@
                       },
                       "nextAction": {
                         "type": "string",
-                        "enum": ["request_new_hold"]
+                        "enum": ["request_hold_for_expected_quantity"]
                       }
                     },
                     "required": ["kind", "requestedQuantity", "expectedQuantity", "nextAction"]
@@ -13553,7 +13553,7 @@
                       },
                       "nextAction": {
                         "type": "string",
-                        "enum": ["request_new_hold"]
+                        "enum": ["request_hold_for_expected_quantity"]
                       }
                     },
                     "required": ["kind", "requestedQuantity", "expectedQuantity", "nextAction"]
@@ -14320,8 +14320,7 @@
                   },
                   "quantity": {
                     "type": "integer",
-                    "exclusiveMinimum": 0,
-                    "default": 1
+                    "exclusiveMinimum": 0
                   },
                   "idempotencyKey": {
                     "type": "string",

--- a/packages/catalog/src/booking-engine/index.ts
+++ b/packages/catalog/src/booking-engine/index.ts
@@ -192,7 +192,7 @@ export {
   type PromotionEvaluator,
   promotionEvaluationInputFor,
 } from "./quote-promotions.js"
-export { engineParametersFromSelection } from "./quote-support.js"
+export { engineParametersFromSelection, partySizeFromSelection } from "./quote-support.js"
 export {
   createSourceAdapterRegistry,
   type SourceAdapterRegistry,

--- a/packages/catalog/src/booking-engine/quote-support.ts
+++ b/packages/catalog/src/booking-engine/quote-support.ts
@@ -61,6 +61,27 @@ export function engineParametersFromSelection(
   return next
 }
 
+/**
+ * How many people this Session is for, read from its canonical selection.
+ *
+ * This is the single derivation of party size in the Session lifecycle.
+ * `engineParametersFromSelection` publishes it to adapters as `paxCount`, the
+ * capacity port checks a requested Hold quantity against it, and `placeHold`
+ * holds this much when the caller names no quantity of its own.
+ *
+ * Deriving it in only one of those places is what made a checkout for more
+ * than one traveler impossible: the Hold defaulted to a literal `1` while the
+ * port expected the real party size, every Hold was rejected, and the
+ * rejection told the client to retry — identically, forever (voyant#4655).
+ *
+ * A selection that names no pax is one person.
+ */
+export function partySizeFromSelection(selectionPayload: unknown): number {
+  const configure = asRecord(asRecord(selectionPayload)?.configure)
+  const total = sumPax(configure?.pax)
+  return total > 0 ? total : 1
+}
+
 function applyConnectStayParameters(
   parameters: Record<string, unknown>,
   selection: Record<string, unknown> | undefined,

--- a/packages/catalog/src/booking-engine/sessions-production.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-production.test.ts
@@ -1346,10 +1346,62 @@ describe("production Booking Session ports", () => {
         kind: "hold_quantity_mismatch",
         requestedQuantity: 1,
         expectedQuantity: 2,
-        nextAction: "request_new_hold",
+        nextAction: "request_hold_for_expected_quantity",
       },
     })
     expect(placeHoldCalls).toBe(0)
+  })
+
+  it("holds the session's own party size when the caller names no quantity", async () => {
+    // voyant#4655: this is the storefront's request shape. It named no
+    // quantity, the server invented `1`, the capacity port expected the two
+    // travelers the selection states, and the rejection asked for a retry that
+    // could only be rejected the same way — forever.
+    const placeHoldRequests: Array<Record<string, unknown>> = []
+    const { module } = createProductionHarness({
+      entityModule: "products",
+      computeRequirements: HANDLER_REQUIREMENTS_PORT,
+      async computeQuote() {
+        return {
+          available: true,
+          pricing: {
+            base_amount: 10000,
+            taxes: 0,
+            fees: 0,
+            surcharges: 0,
+            currency: "EUR",
+          },
+        }
+      },
+      async placeHold(_ctx, request) {
+        placeHoldRequests.push(request.parameters as Record<string, unknown>)
+        return { status: "held", holdToken: request.draftId ?? "hold", expiresAt: new Date() }
+      },
+    })
+    const { created, access } = await createAnonymousSession(module, {
+      configure: { pax: { adult: 2 }, departureSlotId: "slot_1" },
+    })
+    const quoted = await module.quoteSession(
+      created.session.id,
+      { expectedRevision: created.session.revision, idempotencyKey: "quote_default_quantity" },
+      access,
+    )
+    if (quoted.kind !== "quote_created") throw new Error("quote not created")
+
+    const held = await module.placeHold(
+      created.session.id,
+      {
+        expectedRevision: created.session.revision,
+        quoteId: quoted.quote.id,
+        idempotencyKey: "hold_default_quantity",
+      },
+      access,
+    )
+
+    if (held.kind !== "hold_created") throw new Error(`hold rejected: ${JSON.stringify(held)}`)
+    expect(held.hold.quantity).toBe(2)
+    expect(placeHoldRequests).toHaveLength(1)
+    expect(placeHoldRequests[0]?.paxCount).toBe(2)
   })
 
   it("returns a typed actionable rejection for an incomplete commit", async () => {

--- a/packages/catalog/src/booking-engine/sessions-production.ts
+++ b/packages/catalog/src/booking-engine/sessions-production.ts
@@ -49,7 +49,7 @@ import {
   type PromotionEvaluator,
   promotionEvaluationInputFor,
 } from "./quote-promotions.js"
-import { engineParametersFromSelection } from "./quote-support.js"
+import { engineParametersFromSelection, partySizeFromSelection } from "./quote-support.js"
 import type { SourceAdapterRegistry } from "./registry.js"
 import type { ProductionBookingSessionPaymentDeps } from "./sessions-payment-production.js"
 import { createProductionBookingSessionPaymentPorts } from "./sessions-payment-production.js"
@@ -290,7 +290,9 @@ function createProductionCompositeLeafRuntime(
         entityModule: handler.entityModule,
         sourceKind: "owned",
       })
-      const expectedQuantity = positiveInteger(parameters.paxCount) ?? 1
+      // The same derivation `placeHold` defaults to, so the two can only
+      // disagree when a caller named a quantity of its own (voyant#4655).
+      const expectedQuantity = partySizeFromSelection(session.statePayload)
       if (expectedQuantity !== quantity) {
         return { status: "quantity_mismatch", expectedQuantity }
       }

--- a/packages/catalog/src/booking-engine/sessions-service.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-service.test.ts
@@ -1906,6 +1906,10 @@ const SATISFYING_SELECTION = {
 describe("Booking Session v1 requirements enforcement", () => {
   async function prepare(selection: Record<string, unknown>) {
     const harness = createHarness({}, undefined, undefined, perPersonProductRequirements())
+    // These selections are for two adults, and a Hold now asks for the seats
+    // the party actually needs. The shared default of one seat used to be
+    // enough only because the Hold was quietly for one person (voyant#4655).
+    harness.inventory.setCapacity("product:prod_owned_1", 2)
     const created = await harness.module.createSession(
       {
         idempotencyKey: nextCreateKey("create_requirements"),

--- a/packages/catalog/src/booking-engine/sessions-service.ts
+++ b/packages/catalog/src/booking-engine/sessions-service.ts
@@ -42,6 +42,7 @@ import type {
 import { validateSelectionAgainstRequirements } from "./contracts.js"
 import { InvalidBookingSessionSelectionError } from "./errors.js"
 import { previewOffer } from "./offer-preview.js"
+import { partySizeFromSelection } from "./quote-support.js"
 
 const DEFAULT_SESSION_TTL_MS = 24 * 60 * 60 * 1000
 const DEFAULT_QUOTE_TTL_MS = 10 * 60 * 1000
@@ -1248,7 +1249,10 @@ export function createBookingSessionModule(
           sessionId,
           quoteId: quote.id,
           target: session.target,
-          quantity: input.quantity ?? 1,
+          // A caller that names no quantity is holding for the party the
+          // Session is already for. Defaulting to a literal `1` here made
+          // every multi-traveler checkout unholdable (voyant#4655).
+          quantity: input.quantity ?? partySizeFromSelection(session.statePayload),
           state: "active",
           capacityKey: capacityKeyForTarget(session.target),
           expiresAt: new Date(at.getTime() + holdTtlMs),
@@ -1272,7 +1276,11 @@ export function createBookingSessionModule(
               kind: "hold_quantity_mismatch",
               requestedQuantity: hold.quantity,
               expectedQuantity: held.expectedQuantity,
-              nextAction: "request_new_hold",
+              // Not `request_new_hold`: the quantity is derived, so an
+              // identical retry is rejected identically and the client spins.
+              // `expectedQuantity` is the value to hold instead — or the
+              // caller changes the Session's pax and takes a fresh Quote.
+              nextAction: "request_hold_for_expected_quantity",
             },
           })
         }

--- a/packages/trips/src/booking-session-composite-handler.ts
+++ b/packages/trips/src/booking-session-composite-handler.ts
@@ -9,6 +9,7 @@ import type {
   CompositeBookingCommitment,
   PricingBreakdownV1,
 } from "@voyant-travel/catalog/booking-engine"
+import { partySizeFromSelection } from "@voyant-travel/catalog/booking-engine"
 import {
   DEFAULT_PAX_BANDS,
   DEFAULT_PAYMENT_INTENTS,
@@ -229,7 +230,7 @@ export function createTripBookingSessionCompositeHandler(
           quote: childQuote(input.quote, pricing),
           holdId: hold.id,
           capacityKey: hold.capacityKey,
-          quantity: componentQuantity(child.statePayload),
+          quantity: partySizeFromSelection(child.statePayload),
           expiresAt: hold.expiresAt,
           access: input.access,
           now: input.now,
@@ -566,7 +567,7 @@ function childHold(
     sessionId: session.id,
     quoteId: "hold" in input ? input.hold.quoteId : input.quote.id,
     target: session.target,
-    quantity: componentQuantity(session.statePayload),
+    quantity: partySizeFromSelection(session.statePayload),
     state: "active",
     capacityKey: componentCapacityKey(session.target, componentId),
     expiresAt: "hold" in input ? input.hold.expiresAt : input.expiresAt,
@@ -776,16 +777,6 @@ async function recordComponentCommit(input: {
 
 function acceptedProposalOrigin(session: BookingSessionInternalRecord) {
   return session.origin?.kind === "accepted_proposal_version" ? session.origin : undefined
-}
-
-function componentQuantity(payload: Record<string, unknown>): number {
-  const configure = record(payload.configure)
-  const pax = record(configure?.pax)
-  const total = Object.values(pax ?? {}).reduce(
-    (sum: number, value) => sum + (typeof value === "number" && value > 0 ? value : 0),
-    0,
-  )
-  return total > 0 ? total : 1
 }
 
 function componentCapacityKey(target: BookingSessionTargetV1, componentId: string) {


### PR DESCRIPTION
Fixes #4655.

A storefront checkout for more than one traveler could not complete. The Hold took `input.quantity ?? 1`, the capacity port derived the expected quantity from the Session's selection — the real traveler count — and rejected the mismatch. The rejection's `request_new_hold` then sent the client back to make the identical request again. One production session recorded 30 hold attempts over eleven minutes and no commit. A one-traveler booking passed only because `1 === 1`.

## The literal was not the only invented `1`

The issue asks for the service's `?? 1` to fall back to the quote's quantity. That alone would have changed nothing, because two other places had already decided the answer was 1:

| | |
|---|---|
| `placeBookingHoldV1.quantity` | carried `.default(1)`, so **parsing filled the field in** before the server could fall back to anything — `input.quantity` was never `undefined` on the route |
| `useBookingHold` | applied its own `?? 1` and sent it explicitly |
| `commitBookingSessionJourneyV1` | required `quantity` outright |

All three now leave an unstated quantity absent and let the server derive it. `placeBookingHoldV1.quantity` is optional; a client that means "the party this Session is for" says nothing, which is the only number that can be right.

## One derivation instead of three

`partySizeFromSelection` replaces the capacity port's `positiveInteger(parameters.paxCount) ?? 1` and the Trips composite handler's private `componentQuantity`. All three read `configure.pax` and summed it the same way, which is exactly what let the Hold and the check that validates it disagree. They cannot now — a mismatch means a caller deliberately named a different number.

## `request_new_hold` was a livelock, not a recovery

For that caller, the expected quantity is derived, so an identical retry is rejected identically. `hold_quantity_mismatch` now answers `request_hold_for_expected_quantity`, and `expectedQuantity` is the value to hold instead.

This is a contract change: the literal in the published storefront and admin OpenAPI documents moves with it (regenerated here), and `catalog-contracts` / `catalog` / `catalog-react` take a minor.

## Coverage

- `sessions-production.test.ts` — a Hold with no quantity against a two-adult session succeeds, records `quantity: 2`, and passes `paxCount: 2` to the handler. Reverting the service default to `?? 1` reproduces the production rejection verbatim: `{"kind":"hold_quantity_mismatch","requestedQuantity":1,"expectedQuantity":2}`.
- `session-contracts.test.ts` — an unstated quantity survives parsing as absent, pinning the `.default(1)` trap.
- `session-journey.test.ts` — a journey with no stated quantity sends no `quantity` field.

Four requirements-enforcement tests in `sessions-service.test.ts` held two adults against a product with one seat and passed only because the Hold was quietly for one person — a one-seat overselling that the fix now correctly refuses. The fixture provides the seats the party needs.

## Not in scope

Ask 3 — surfacing a repeatedly-failing checkout to an operator. Filed separately as #4659: the rejections are already persisted durably in `booking_session_operations.outcome` (that column is where #4655's own evidence table came from), so the gap is a read surface, not instrumentation — and it covers every deterministic rejection loop in the lifecycle, not just this one.

## Verification

- `pnpm --filter @voyant-travel/{catalog,catalog-contracts,catalog-react,trips,bookings-react,storefront-sdk,core} test` — green
- `build` (tsc) across the affected graph — 0 `error TS`
- `pnpm verify:architecture` — full chain green, including `verify:openapi-drift`
- `npx biome check .` from the root — 0 errors

