### PR TITLE
Make changing a live booking a first-class operation

### DIFF
--- a/.changeset/booking-amendments-operator-surface.md
+++ b/.changeset/booking-amendments-operator-surface.md
@@ -1,0 +1,14 @@
+---
+"@voyant-travel/bookings": minor
+"@voyant-travel/bookings-contracts": minor
+"@voyant-travel/bookings-react": minor
+"@voyant-travel/finance": minor
+"@voyant-travel/finance-react": minor
+---
+
+Make changing a live booking a first-class operation instead of free-text data entry.
+
+- **Deleting or resizing a Booking Item now returns the inventory it held.** `booking_allocations.booking_item_id` cascades, so deleting an item destroyed its allocation without giving the seats back — `availability_slots.remaining_pax` stayed decremented permanently with no row left to reconcile from. `deleteItem` now releases before the cascade, and `updateItem` keeps the allocation in step with a `quantity` change, refusing to oversell rather than silently desyncing.
+- **The Booking Amendment engine is reachable from the operator.** Adding or removing a traveller on a confirmed booking runs preview → accept → apply: the change is priced, the departure is capacity-checked, and the supplier consequence is shown before anything is written.
+- **A new `item_add` Amendment adds a catalog-linked service** — an extra excursion, a transfer — priced from the catalog and holding a real allocation. Supplier-sourced products are refused, since adding one needs a supplier reservation this system cannot make.
+- **The money follows.** Applying an Amendment that owes money now raises a payment schedule for the difference, so "Generate payment link" pre-fills the delta instead of the booking total, and the generated link can be emailed to the customer from the same dialog.

--- a/packages/bookings-contracts/src/amendments.ts
+++ b/packages/bookings-contracts/src/amendments.ts
@@ -78,6 +78,37 @@ export const previewTravelerRosterChangeSchema = z.object({
   change: travelerRosterChangeSchema,
 })
 
+/**
+ * Adding a catalog-linked service to a booking that already exists — an
+ * extra excursion, a transfer, another room.
+ *
+ * Only the identity of what is being added crosses the wire. Price, name,
+ * and timing are resolved from the catalog server-side, so an operator
+ * cannot quote themselves a number the catalog does not agree with, and
+ * the snapshot columns on the resulting Booking Item stay authoritative.
+ */
+export const bookingItemAdditionSchema = z.object({
+  type: z.literal("item_add"),
+  productId: z.string().min(1),
+  optionId: z.string().min(1).nullable().optional(),
+  optionUnitId: z.string().min(1).nullable().optional(),
+  /**
+   * Departure to consume capacity from. Required for a product that sells
+   * by departure; the preview refuses the addition when the product needs
+   * one and none is given.
+   */
+  availabilitySlotId: z.string().min(1).nullable().optional(),
+  quantity: z.number().int().positive().max(99).default(1),
+  /** Overrides the catalog name on the Booking Item only — never the price. */
+  title: z.string().trim().min(1).max(255).optional(),
+})
+
+export const previewBookingItemAdditionSchema = z.object({
+  expectedBookingRevision: z.number().int().positive(),
+  reason: z.string().trim().min(1).max(2_000),
+  addition: bookingItemAdditionSchema,
+})
+
 export const acceptBookingAmendmentSchema = z.object({
   proposedRevisionId: z.string().min(1),
 })
@@ -194,8 +225,9 @@ export const bookingRevisionSchema = z.object({
 export const bookingAmendmentSchema = z.object({
   id: z.string(),
   bookingId: z.string(),
-  travelerId: z.string(),
-  kind: z.enum(["traveler_correction", "traveler_add", "traveler_drop"]),
+  /** Null for `item_add`, which concerns a service rather than a person. */
+  travelerId: z.string().nullable(),
+  kind: z.enum(["traveler_correction", "traveler_add", "traveler_drop", "item_add"]),
   status: bookingAmendmentStatusSchema,
   baseBookingRevision: z.number().int().positive(),
   resultBookingRevision: z.number().int().positive(),
@@ -239,7 +271,7 @@ export const bookingAmendmentPreviewResultSchema = z.discriminatedUnion("status"
   z.object({
     status: z.literal("no_op"),
     bookingId: z.string(),
-    travelerId: z.string(),
+    travelerId: z.string().nullable(),
     bookingRevision: z.number().int().positive(),
   }),
   z.object({ status: z.literal("not_found") }),
@@ -280,6 +312,8 @@ export type BookingAmendmentPrice = z.infer<typeof bookingAmendmentPriceSchema>
 export type BookingRevisionSnapshot = z.infer<typeof bookingRevisionSnapshotSchema>
 export type PreviewTravelerCorrectionInput = z.infer<typeof previewTravelerCorrectionSchema>
 export type PreviewTravelerRosterChangeInput = z.infer<typeof previewTravelerRosterChangeSchema>
+export type BookingItemAddition = z.infer<typeof bookingItemAdditionSchema>
+export type PreviewBookingItemAdditionInput = z.infer<typeof previewBookingItemAdditionSchema>
 export type TravelerRosterChange = z.infer<typeof travelerRosterChangeSchema>
 export type TravelerCorrectionPatch = z.infer<typeof travelerCorrectionPatchSchema>
 export type AcceptBookingAmendmentInput = z.infer<typeof acceptBookingAmendmentSchema>

--- a/packages/bookings-react/src/amendment-schemas.ts
+++ b/packages/bookings-react/src/amendment-schemas.ts
@@ -1,0 +1,126 @@
+import { z } from "zod"
+
+/**
+ * Client-side shapes for the Booking Amendment admin surface.
+ *
+ * Declared here rather than imported from `@voyant-travel/bookings-contracts`
+ * for the same reason the rest of this package declares its own: the server
+ * package pulls Drizzle and Hono through value imports, which browser bundles
+ * must not reach (`verify:boundary`). Only the fields the operator UI renders
+ * are modelled; unknown keys are ignored by zod, so the server may add more.
+ */
+
+export const bookingAmendmentStatusSchema = z.enum([
+  "proposed",
+  "accepted",
+  "applying",
+  "applied",
+  "rejected",
+  "failed",
+  "in_doubt",
+  "manual_review",
+])
+
+export type BookingAmendmentStatus = z.infer<typeof bookingAmendmentStatusSchema>
+
+export const bookingAmendmentKindSchema = z.enum([
+  "traveler_correction",
+  "traveler_add",
+  "traveler_drop",
+])
+
+export type BookingAmendmentKind = z.infer<typeof bookingAmendmentKindSchema>
+
+export const bookingAmendmentNextActionSchema = z.enum([
+  "accept",
+  "apply",
+  "wait_supplier",
+  "reconcile_supplier",
+  "manual_review",
+  "collect_payment",
+  "issue_refund",
+  "reissue_documents",
+])
+
+export type BookingAmendmentNextAction = z.infer<typeof bookingAmendmentNextActionSchema>
+
+export const bookingAmendmentPriceSchema = z.object({
+  currency: z.string(),
+  subtotalDeltaCents: z.number().int(),
+  feeDeltaCents: z.number().int(),
+  taxDeltaCents: z.number().int(),
+  amountCents: z.number().int(),
+  collectionAmountCents: z.number().int(),
+  refundAmountCents: z.number().int(),
+})
+
+export const bookingAmendmentEffectsSchema = z.object({
+  finance: z.string(),
+  legal: z.string(),
+  documents: z.string(),
+  fulfillment: z.string(),
+  supplier: z.string(),
+  allocation: z.string(),
+})
+
+export type BookingAmendmentEffects = z.infer<typeof bookingAmendmentEffectsSchema>
+
+export const bookingAmendmentRevisionSchema = z.object({
+  id: z.string(),
+  role: z.enum(["before", "proposed_after"]),
+  bookingRevision: z.number().int(),
+})
+
+export const bookingAmendmentRecordSchema = z.object({
+  id: z.string(),
+  bookingId: z.string(),
+  travelerId: z.string(),
+  kind: bookingAmendmentKindSchema,
+  status: bookingAmendmentStatusSchema,
+  baseBookingRevision: z.number().int(),
+  resultBookingRevision: z.number().int(),
+  acceptanceRequired: z.boolean(),
+  priceDelta: bookingAmendmentPriceSchema,
+  effects: bookingAmendmentEffectsSchema,
+  nextActions: z.array(bookingAmendmentNextActionSchema),
+  quotedAt: z.string(),
+  quoteExpiresAt: z.string().nullable(),
+  failureCode: z.string().nullable(),
+  reason: z.string(),
+  appliedAt: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  revisions: z.array(bookingAmendmentRevisionSchema).optional(),
+})
+
+export type BookingAmendmentRecord = z.infer<typeof bookingAmendmentRecordSchema>
+
+/**
+ * A preview can come back as a real amendment, or as one of several
+ * "nothing to quote" outcomes. The server distinguishes them by HTTP
+ * status (201 vs 200) and by the presence of `data.amendment`.
+ */
+export const bookingAmendmentPreviewResponse = z.union([
+  z.object({ data: z.object({ amendment: bookingAmendmentRecordSchema }) }),
+  z.object({
+    data: z.object({
+      status: z.string(),
+      bookingId: z.string().optional(),
+      bookingRevision: z.number().int().optional(),
+    }),
+  }),
+])
+
+export const bookingAmendmentResponse = z.object({ data: bookingAmendmentRecordSchema })
+export const bookingAmendmentListResponse = z.object({
+  data: z.array(bookingAmendmentRecordSchema),
+})
+
+/** True when the amendment still needs an operator to do something. */
+export function amendmentIsOpen(amendment: BookingAmendmentRecord): boolean {
+  return (
+    amendment.status !== "applied" &&
+    amendment.status !== "rejected" &&
+    amendment.status !== "failed"
+  )
+}

--- a/packages/bookings-react/src/amendment-schemas.ts
+++ b/packages/bookings-react/src/amendment-schemas.ts
@@ -27,6 +27,7 @@ export const bookingAmendmentKindSchema = z.enum([
   "traveler_correction",
   "traveler_add",
   "traveler_drop",
+  "item_add",
 ])
 
 export type BookingAmendmentKind = z.infer<typeof bookingAmendmentKindSchema>
@@ -74,7 +75,8 @@ export const bookingAmendmentRevisionSchema = z.object({
 export const bookingAmendmentRecordSchema = z.object({
   id: z.string(),
   bookingId: z.string(),
-  travelerId: z.string(),
+  /** Null for `item_add`, which concerns a service rather than a person. */
+  travelerId: z.string().nullable(),
   kind: bookingAmendmentKindSchema,
   status: bookingAmendmentStatusSchema,
   baseBookingRevision: z.number().int(),
@@ -112,6 +114,19 @@ export const bookingAmendmentPreviewResponse = z.union([
 ])
 
 export const bookingAmendmentResponse = z.object({ data: bookingAmendmentRecordSchema })
+
+/**
+ * Apply answers with an outcome wrapper, not a bare record: a successful
+ * apply is `{ data: { status: "ok", amendment } }`, and the supplier-pending
+ * and refused outcomes reuse the same shape with a different `status`.
+ * Accept, by contrast, returns the record directly.
+ */
+export const bookingAmendmentApplyResponse = z.object({
+  data: z.object({
+    status: z.string(),
+    amendment: bookingAmendmentRecordSchema,
+  }),
+})
 export const bookingAmendmentListResponse = z.object({
   data: z.array(bookingAmendmentRecordSchema),
 })

--- a/packages/bookings-react/src/components/booking-item-addition-dialog.tsx
+++ b/packages/bookings-react/src/components/booking-item-addition-dialog.tsx
@@ -1,0 +1,328 @@
+"use client"
+
+import { useOptionUnits, useProductOptions } from "@voyant-travel/inventory-react"
+import { type AvailabilitySlotRecord, useSlots } from "@voyant-travel/operations-react/availability"
+import {
+  Button,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Sheet,
+  SheetBody,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  Textarea,
+} from "@voyant-travel/ui/components"
+import { AsyncCombobox } from "@voyant-travel/ui/components/async-combobox"
+import { AlertTriangle, Loader2 } from "lucide-react"
+import { useEffect, useMemo, useState } from "react"
+
+import type { BookingAmendmentRecord } from "../amendment-schemas.js"
+import {
+  type RosterPreviewResult,
+  useBookingAmendmentFlow,
+} from "../hooks/use-booking-amendments.js"
+import { useBookingsUiI18nOrDefault, useBookingsUiMessagesOrDefault } from "../i18n/provider.js"
+import { getBookableDepartureSlots } from "./booking-create-utils.js"
+import { ProductPickerSection, type ProductPickerValue } from "./product-picker-section.js"
+
+export interface BookingItemAdditionDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  bookingId: string
+  bookingRevision: number
+  onApplied?: (amendment: BookingAmendmentRecord) => void
+}
+
+const UNIT_NONE = "__none__"
+
+/**
+ * Add a catalog service to a booking that already exists — the extra
+ * excursion or transfer a customer asks for mid-trip.
+ *
+ * The operator picks *what*, never *how much*: price, name and timing come
+ * back from the catalog in the quote, which is also what makes the added
+ * line hold real inventory instead of being free text.
+ *
+ * Supplier-sourced products are not offered here. Adding a service the
+ * supplier has never been told about needs a reservation this system cannot
+ * make, so the picker stays on owned inventory.
+ */
+export function BookingItemAdditionDialog({
+  open,
+  onOpenChange,
+  bookingId,
+  bookingRevision,
+  onApplied,
+}: BookingItemAdditionDialogProps) {
+  const messages = useBookingsUiMessagesOrDefault().itemAdditionDialog
+  const { formatCurrency } = useBookingsUiI18nOrDefault()
+  const { previewItemAddition, accept, apply } = useBookingAmendmentFlow(bookingId)
+
+  const [product, setProduct] = useState<ProductPickerValue>({ productId: "", optionId: null })
+  const [unitId, setUnitId] = useState<string>(UNIT_NONE)
+  const [slotId, setSlotId] = useState<string | null>(null)
+  const [quantity, setQuantity] = useState(1)
+  const [reason, setReason] = useState("")
+  const [quoted, setQuoted] = useState<BookingAmendmentRecord | null>(null)
+  const [blocked, setBlocked] = useState<RosterPreviewResult | null>(null)
+  const [attempt, setAttempt] = useState(0)
+
+  const isSourced = Boolean(product.sourceKind) && product.sourceKind !== "owned"
+
+  const optionsQuery = useProductOptions({
+    productId: product.productId || undefined,
+    status: "active",
+    limit: 100,
+    enabled: open && Boolean(product.productId) && !isSourced,
+  })
+  const resolvedOptionId =
+    product.optionId ??
+    (optionsQuery.data?.data ?? []).find((option) => option.isDefault)?.id ??
+    (optionsQuery.data?.data ?? [])[0]?.id ??
+    null
+  const unitsQuery = useOptionUnits({
+    optionId: resolvedOptionId || undefined,
+    limit: 100,
+    enabled: open && Boolean(resolvedOptionId) && !isSourced,
+  })
+  const slotsQuery = useSlots({
+    productId: product.productId || undefined,
+    status: "open",
+    limit: 100,
+    enabled: open && Boolean(product.productId) && !isSourced,
+  })
+
+  const slots = useMemo(
+    () =>
+      getBookableDepartureSlots(slotsQuery.data?.data ?? [], {
+        nowIso: new Date().toISOString(),
+        optionId: product.optionId,
+      }),
+    [slotsQuery.data?.data, product.optionId],
+  )
+  const selectedSlot = slots.find((slot) => slot.id === slotId) ?? null
+
+  const units = useMemo(() => unitsQuery.data?.data ?? [], [unitsQuery.data?.data])
+
+  useEffect(() => {
+    if (!open) return
+    setProduct({ productId: "", optionId: null })
+    setUnitId(UNIT_NONE)
+    setSlotId(null)
+    setQuantity(1)
+    setReason("")
+    setQuoted(null)
+    setBlocked(null)
+    setAttempt((value) => value + 1)
+  }, [open])
+
+  const canQuote =
+    Boolean(product.productId) && !isSourced && quantity > 0 && reason.trim().length > 0
+
+  async function onQuote() {
+    setBlocked(null)
+    const result = await previewItemAddition.mutateAsync({
+      input: {
+        expectedBookingRevision: bookingRevision,
+        reason: reason.trim(),
+        addition: {
+          type: "item_add",
+          productId: product.productId,
+          optionId: resolvedOptionId,
+          optionUnitId: unitId === UNIT_NONE ? null : unitId,
+          availabilitySlotId: slotId,
+          quantity,
+        },
+      },
+      idempotencyKey: `item-add-${bookingId}-${attempt}`,
+    })
+    if (result.status === "ok") {
+      setQuoted(result.amendment)
+      return
+    }
+    setBlocked(result)
+  }
+
+  async function onApply() {
+    if (!quoted) return
+    const proposed = quoted.revisions?.find((revision) => revision.role === "proposed_after")
+    if (!proposed) return
+    const key = `item-add-apply-${quoted.id}`
+    if (quoted.acceptanceRequired && quoted.status === "proposed") {
+      await accept.mutateAsync({
+        amendmentId: quoted.id,
+        proposedRevisionId: proposed.id,
+        idempotencyKey: `${key}-accept`,
+      })
+    }
+    const applied = await apply.mutateAsync({
+      amendmentId: quoted.id,
+      proposedRevisionId: proposed.id,
+      expectedBookingRevision: quoted.baseBookingRevision,
+      idempotencyKey: key,
+    })
+    onApplied?.(applied)
+    onOpenChange(false)
+  }
+
+  const busy = previewItemAddition.isPending || accept.isPending || apply.isPending
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" size="lg">
+        <SheetHeader>
+          <SheetTitle>{messages.title}</SheetTitle>
+        </SheetHeader>
+
+        <SheetBody className="grid gap-5">
+          <ProductPickerSection
+            value={product}
+            onChange={(next) => {
+              setProduct(next)
+              setUnitId(UNIT_NONE)
+              setSlotId(null)
+              setQuoted(null)
+            }}
+            enabled={open}
+          />
+
+          {isSourced ? (
+            <Notice text={messages.sourcedUnsupported} />
+          ) : (
+            <>
+              {slots.length > 0 ? (
+                <div className="flex flex-col gap-2">
+                  <Label>{messages.fields.departure}</Label>
+                  <AsyncCombobox<AvailabilitySlotRecord>
+                    value={slotId}
+                    onChange={(next) => setSlotId(next)}
+                    items={slots}
+                    selectedItem={selectedSlot}
+                    getKey={(slot) => slot.id}
+                    getLabel={(slot) => slot.startsAt ?? slot.id}
+                    placeholder={messages.fields.departurePlaceholder}
+                    emptyText={messages.fields.departureEmpty}
+                    triggerClassName="w-full"
+                    clearable
+                  />
+                </div>
+              ) : null}
+
+              {units.length > 0 ? (
+                <div className="flex flex-col gap-2">
+                  <Label>{messages.fields.unit}</Label>
+                  <Select value={unitId} onValueChange={(next) => setUnitId(next ?? UNIT_NONE)}>
+                    <SelectTrigger className="w-full">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value={UNIT_NONE}>{messages.fields.unitNone}</SelectItem>
+                      {units.map((unit) => (
+                        <SelectItem key={unit.id} value={unit.id}>
+                          {unit.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              ) : null}
+
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="item-add-quantity">{messages.fields.quantity}</Label>
+                <Input
+                  id="item-add-quantity"
+                  type="number"
+                  min={1}
+                  value={quantity}
+                  onChange={(event) => setQuantity(Number(event.target.value) || 1)}
+                />
+              </div>
+            </>
+          )}
+
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="item-add-reason">{messages.fields.reason}</Label>
+            <Textarea
+              id="item-add-reason"
+              value={reason}
+              onChange={(event) => setReason(event.target.value)}
+              placeholder={messages.fields.reasonPlaceholder}
+            />
+          </div>
+
+          {blocked ? <Notice text={blockedText(blocked, messages.blocked)} /> : null}
+
+          {quoted ? (
+            <div className="flex flex-col gap-2 rounded-md border bg-muted/30 p-4">
+              <div className="flex items-baseline justify-between">
+                <span className="font-medium text-sm">{messages.quote.title}</span>
+                <span className="font-semibold text-lg">
+                  {formatCurrency(quoted.priceDelta.amountCents, quoted.priceDelta.currency)}
+                </span>
+              </div>
+              {quoted.priceDelta.collectionAmountCents > 0 ? (
+                <p className="text-muted-foreground text-xs">
+                  {messages.quote.collect.replace(
+                    "{amount}",
+                    formatCurrency(
+                      quoted.priceDelta.collectionAmountCents,
+                      quoted.priceDelta.currency,
+                    ),
+                  )}
+                </p>
+              ) : null}
+            </div>
+          ) : null}
+        </SheetBody>
+
+        <SheetFooter>
+          <Button type="button" variant="ghost" size="sm" onClick={() => onOpenChange(false)}>
+            {messages.actions.cancel}
+          </Button>
+          {quoted ? (
+            <Button type="button" size="sm" disabled={busy} onClick={onApply}>
+              {busy && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {messages.actions.apply}
+            </Button>
+          ) : (
+            <Button type="button" size="sm" disabled={!canQuote || busy} onClick={onQuote}>
+              {busy && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {messages.actions.quote}
+            </Button>
+          )}
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+function blockedText(
+  result: RosterPreviewResult,
+  messages: {
+    availabilityChanged: string
+    unsupported: string
+    staleRevision: string
+    generic: string
+  },
+): string {
+  if (result.status === "availability_changed") return messages.availabilityChanged
+  if (result.status === "unsupported_configuration") return result.reason ?? messages.unsupported
+  if (result.status === "stale_revision") return messages.staleRevision
+  return messages.generic
+}
+
+function Notice({ text }: { text: string }) {
+  return (
+    <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/5 p-3 text-sm">
+      <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+      <span>{text}</span>
+    </div>
+  )
+}

--- a/packages/bookings-react/src/components/booking-item-list.tsx
+++ b/packages/bookings-react/src/components/booking-item-list.tsx
@@ -23,7 +23,13 @@ import {
 import { Eye, Package, Pencil, Plus, Trash2 } from "lucide-react"
 import * as React from "react"
 import { useBookingsUiI18nOrDefault, useBookingsUiMessagesOrDefault } from "../i18n/provider.js"
-import { type BookingItemRecord, useBookingItemMutation, useBookingItems } from "../index.js"
+import {
+  type BookingItemRecord,
+  useBooking,
+  useBookingItemMutation,
+  useBookingItems,
+} from "../index.js"
+import { BookingItemAdditionDialog } from "./booking-item-addition-dialog.js"
 import { BookingItemDialog } from "./booking-item-dialog.js"
 import { IconActionButton } from "./icon-action-button.js"
 import { StatusBadge } from "./status-badge.js"
@@ -50,7 +56,20 @@ export function BookingItemList({
   const [editing, setEditing] = React.useState<BookingItemRecord | undefined>(undefined)
   const [deleteTarget, setDeleteTarget] = React.useState<BookingItemRecord | null>(null)
   const [viewing, setViewing] = React.useState<BookingItemRecord | null>(null)
+  const [additionOpen, setAdditionOpen] = React.useState(false)
   const { data } = useBookingItems(bookingId)
+  const bookingQuery = useBooking(bookingId)
+  const booking = bookingQuery.data?.data
+
+  /**
+   * On a live booking, adding a line is not data entry — it buys something.
+   * Route it through the Amendment flow so the catalog prices it and the
+   * departure actually gives up a seat, and keep the free-text dialog for
+   * bookings that have not been committed yet.
+   */
+  const requiresAmendment =
+    (booking?.status === "confirmed" || booking?.status === "in_progress") &&
+    typeof booking.revision === "number"
   const { remove } = useBookingItemMutation(bookingId)
   const { formatCurrency, formatDateTime } = useBookingsUiI18nOrDefault()
   const messages = useBookingsUiMessagesOrDefault()
@@ -194,6 +213,10 @@ export function BookingItemList({
             variant="outline"
             size="sm"
             onClick={() => {
+              if (requiresAmendment) {
+                setAdditionOpen(true)
+                return
+              }
               setEditing(undefined)
               setDialogOpen(true)
             }}
@@ -210,6 +233,15 @@ export function BookingItemList({
         emptyMessage={messages.bookingItemList.empty}
         showPagination={false}
       />
+
+      {booking?.revision !== undefined ? (
+        <BookingItemAdditionDialog
+          open={additionOpen}
+          onOpenChange={setAdditionOpen}
+          bookingId={bookingId}
+          bookingRevision={booking.revision}
+        />
+      ) : null}
 
       <BookingItemDialog
         open={dialogOpen}

--- a/packages/bookings-react/src/components/booking-roster-amendment-dialog.tsx
+++ b/packages/bookings-react/src/components/booking-roster-amendment-dialog.tsx
@@ -1,0 +1,361 @@
+"use client"
+
+import { useQueries } from "@tanstack/react-query"
+import {
+  Button,
+  Checkbox,
+  Input,
+  Label,
+  Sheet,
+  SheetBody,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  Textarea,
+} from "@voyant-travel/ui/components"
+import { AlertTriangle, Loader2 } from "lucide-react"
+import { useEffect, useMemo, useState } from "react"
+
+import type { BookingAmendmentRecord } from "../amendment-schemas.js"
+import {
+  type RosterPreviewResult,
+  type TravelerRosterChangeInput,
+  useBookingAmendmentFlow,
+} from "../hooks/use-booking-amendments.js"
+import { useBookingItems } from "../hooks/use-booking-items.js"
+import { useTravelers } from "../hooks/use-travelers.js"
+import { useBookingsUiMessagesOrDefault } from "../i18n/provider.js"
+import { useVoyantBookingsContext } from "../provider.js"
+import { getBookingItemTravelersQueryOptions } from "../query-options.js"
+
+export interface BookingRosterAmendmentDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  bookingId: string
+  bookingRevision: number
+  /** `add` collects a new traveller; `drop` removes an existing one. */
+  mode: "add" | "drop"
+  /** Pre-selected traveller for `drop`. */
+  travelerId?: string
+  onApplied?: (amendment: BookingAmendmentRecord) => void
+}
+
+/**
+ * Quote-then-commit flow for adding or removing a traveller on a confirmed
+ * booking.
+ *
+ * The engine behind it prices the change, checks the departure still has
+ * room, and asks the supplier when the inventory is sourced — so the
+ * operator's job is to describe the change, read the consequences, and
+ * decide. Nothing is written until Apply.
+ */
+export function BookingRosterAmendmentDialog({
+  open,
+  onOpenChange,
+  bookingId,
+  bookingRevision,
+  mode,
+  travelerId,
+  onApplied,
+}: BookingRosterAmendmentDialogProps) {
+  const messages = useBookingsUiMessagesOrDefault().rosterAmendmentDialog
+  const { baseUrl, fetcher } = useVoyantBookingsContext()
+  const { previewRosterChange: preview, accept, apply } = useBookingAmendmentFlow(bookingId)
+  const itemsQuery = useBookingItems(bookingId, { enabled: open })
+  const travelersQuery = useTravelers(bookingId, { enabled: open })
+
+  const [selectedItemIds, setSelectedItemIds] = useState<string[]>([])
+  const [firstName, setFirstName] = useState("")
+  const [lastName, setLastName] = useState("")
+  const [email, setEmail] = useState("")
+  const [reason, setReason] = useState("")
+  const [quoted, setQuoted] = useState<BookingAmendmentRecord | null>(null)
+  const [blocked, setBlocked] = useState<RosterPreviewResult | null>(null)
+  const [attempt, setAttempt] = useState(0)
+
+  const items = useMemo(
+    () => (itemsQuery.data?.data ?? []).filter((item) => item.status === "confirmed"),
+    [itemsQuery.data],
+  )
+
+  /**
+   * Which travellers sit on each item. Needed because dropping someone
+   * must cover *exactly* the items they are assigned to — the engine
+   * rejects a partial set — so that selection is derived, never chosen.
+   *
+   * The assignment lives on a per-item endpoint, hence the fan-out.
+   */
+  const itemTravelerQueries = useQueries({
+    queries: items.map((item) => ({
+      ...getBookingItemTravelersQueryOptions({ baseUrl, fetcher }, bookingId, item.id),
+      enabled: open && mode === "drop",
+    })),
+    combine: (results) => results.map((result) => result.data?.data ?? []),
+  })
+
+  const travelerItemIds = useMemo(() => {
+    if (mode !== "drop" || !travelerId) return []
+    return items
+      .filter((_item, index) =>
+        (itemTravelerQueries[index] ?? []).some((link) => link.travelerId === travelerId),
+      )
+      .map((item) => item.id)
+  }, [mode, travelerId, items, itemTravelerQueries])
+
+  useEffect(() => {
+    if (!open) return
+    setSelectedItemIds(mode === "drop" ? travelerItemIds : items.map((item) => item.id))
+    setFirstName("")
+    setLastName("")
+    setEmail("")
+    setReason("")
+    setQuoted(null)
+    setBlocked(null)
+    setAttempt((value) => value + 1)
+  }, [open, mode, items, travelerItemIds])
+
+  const droppedTraveler = travelersQuery.data?.data.find((traveler) => traveler.id === travelerId)
+
+  const change: TravelerRosterChangeInput | null =
+    mode === "add"
+      ? firstName.trim() && lastName.trim()
+        ? {
+            type: "traveler_add",
+            bookingItemIds: selectedItemIds,
+            traveler: {
+              participantType: "traveler",
+              firstName: firstName.trim(),
+              lastName: lastName.trim(),
+              email: email.trim() || null,
+            },
+          }
+        : null
+      : travelerId
+        ? { type: "traveler_drop", bookingItemIds: selectedItemIds, travelerId }
+        : null
+
+  const canQuote = Boolean(change) && selectedItemIds.length > 0 && reason.trim().length > 0
+
+  async function onQuote() {
+    if (!change) return
+    setBlocked(null)
+    const result = await preview.mutateAsync({
+      input: {
+        expectedBookingRevision: bookingRevision,
+        reason: reason.trim(),
+        change,
+      },
+      idempotencyKey: `roster-${bookingId}-${mode}-${attempt}`,
+    })
+    if (result.status === "ok") {
+      setQuoted(result.amendment)
+      return
+    }
+    setBlocked(result)
+  }
+
+  async function onApply() {
+    if (!quoted) return
+    const proposed = quoted.revisions?.find((revision) => revision.role === "proposed_after")
+    if (!proposed) return
+    const key = `roster-apply-${quoted.id}`
+    if (quoted.acceptanceRequired && quoted.status === "proposed") {
+      await accept.mutateAsync({
+        amendmentId: quoted.id,
+        proposedRevisionId: proposed.id,
+        idempotencyKey: `${key}-accept`,
+      })
+    }
+    const applied = await apply.mutateAsync({
+      amendmentId: quoted.id,
+      proposedRevisionId: proposed.id,
+      expectedBookingRevision: quoted.baseBookingRevision,
+      idempotencyKey: key,
+    })
+    onApplied?.(applied)
+    onOpenChange(false)
+  }
+
+  const busy = preview.isPending || accept.isPending || apply.isPending
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" size="lg">
+        <SheetHeader>
+          <SheetTitle>{mode === "add" ? messages.titles.add : messages.titles.drop}</SheetTitle>
+        </SheetHeader>
+
+        <SheetBody className="grid gap-5">
+          {mode === "add" ? (
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="roster-first-name">{messages.fields.firstName}</Label>
+                <Input
+                  id="roster-first-name"
+                  value={firstName}
+                  onChange={(event) => setFirstName(event.target.value)}
+                />
+              </div>
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="roster-last-name">{messages.fields.lastName}</Label>
+                <Input
+                  id="roster-last-name"
+                  value={lastName}
+                  onChange={(event) => setLastName(event.target.value)}
+                />
+              </div>
+              <div className="flex flex-col gap-2 sm:col-span-2">
+                <Label htmlFor="roster-email">{messages.fields.email}</Label>
+                <Input
+                  id="roster-email"
+                  type="email"
+                  value={email}
+                  onChange={(event) => setEmail(event.target.value)}
+                />
+              </div>
+            </div>
+          ) : (
+            <p className="text-sm">
+              {droppedTraveler
+                ? `${droppedTraveler.firstName} ${droppedTraveler.lastName}`
+                : messages.fields.unknownTraveler}
+            </p>
+          )}
+
+          <div className="flex flex-col gap-2">
+            <Label>{messages.fields.items}</Label>
+            <p className="text-muted-foreground text-xs">{messages.fields.itemsHint}</p>
+            <div className="flex flex-col gap-2 rounded-md border p-3">
+              {items.map((item) => (
+                <div key={item.id} className="flex items-center gap-2 text-sm">
+                  <Checkbox
+                    id={`roster-item-${item.id}`}
+                    checked={selectedItemIds.includes(item.id)}
+                    disabled={mode === "drop"}
+                    onCheckedChange={(checked) =>
+                      setSelectedItemIds((current) =>
+                        checked
+                          ? [...current, item.id]
+                          : current.filter((value) => value !== item.id),
+                      )
+                    }
+                  />
+                  <Label htmlFor={`roster-item-${item.id}`} className="font-normal">
+                    {item.productNameSnapshot ?? item.title}
+                  </Label>
+                </div>
+              ))}
+              {items.length === 0 ? (
+                <span className="text-muted-foreground text-sm">{messages.fields.noItems}</span>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="roster-reason">{messages.fields.reason}</Label>
+            <Textarea
+              id="roster-reason"
+              value={reason}
+              onChange={(event) => setReason(event.target.value)}
+              placeholder={messages.fields.reasonPlaceholder}
+            />
+          </div>
+
+          {blocked ? <BlockedNotice result={blocked} /> : null}
+          {quoted ? <QuotePanel amendment={quoted} /> : null}
+        </SheetBody>
+
+        <SheetFooter>
+          <Button type="button" variant="ghost" size="sm" onClick={() => onOpenChange(false)}>
+            {messages.actions.cancel}
+          </Button>
+          {quoted ? (
+            <Button type="button" size="sm" disabled={busy} onClick={onApply}>
+              {busy && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {messages.actions.apply}
+            </Button>
+          ) : (
+            <Button type="button" size="sm" disabled={!canQuote || busy} onClick={onQuote}>
+              {busy && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {messages.actions.quote}
+            </Button>
+          )}
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+/**
+ * A preview that produced no amendment. Each of these is a real answer
+ * about the booking, so each gets its own sentence rather than a generic
+ * failure.
+ */
+function BlockedNotice({ result }: { result: RosterPreviewResult }) {
+  const messages = useBookingsUiMessagesOrDefault().rosterAmendmentDialog
+  const text =
+    result.status === "no_op"
+      ? messages.blocked.noOp
+      : result.status === "availability_changed"
+        ? messages.blocked.availabilityChanged
+        : result.status === "unsupported_configuration"
+          ? (result.reason ?? messages.blocked.unsupported)
+          : result.status === "stale_revision"
+            ? messages.blocked.staleRevision
+            : messages.blocked.generic
+
+  return (
+    <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/5 p-3 text-sm">
+      <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+      <span>{text}</span>
+    </div>
+  )
+}
+
+/** What the change costs and what it will set in motion. */
+function QuotePanel({ amendment }: { amendment: BookingAmendmentRecord }) {
+  const messages = useBookingsUiMessagesOrDefault().rosterAmendmentDialog
+  const price = amendment.priceDelta
+  const money = (cents: number) => `${(cents / 100).toFixed(2)} ${price.currency}`
+
+  const consequences: string[] = []
+  if (price.collectionAmountCents > 0) {
+    consequences.push(
+      messages.consequences.collect.replace("{amount}", money(price.collectionAmountCents)),
+    )
+  }
+  if (price.refundAmountCents > 0) {
+    consequences.push(
+      messages.consequences.refund.replace("{amount}", money(price.refundAmountCents)),
+    )
+  }
+  if (amendment.effects.supplier === "modify_required") {
+    consequences.push(messages.consequences.supplier)
+  }
+  if (amendment.effects.documents === "reissue_required") {
+    consequences.push(messages.consequences.documents)
+  }
+
+  return (
+    <div className="flex flex-col gap-3 rounded-md border bg-muted/30 p-4">
+      <div className="flex items-baseline justify-between">
+        <span className="font-medium text-sm">{messages.quote.title}</span>
+        <span className="font-semibold text-lg">{money(price.amountCents)}</span>
+      </div>
+      <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+        <dt className="text-muted-foreground">{messages.quote.subtotal}</dt>
+        <dd className="text-right">{money(price.subtotalDeltaCents)}</dd>
+        <dt className="text-muted-foreground">{messages.quote.tax}</dt>
+        <dd className="text-right">{money(price.taxDeltaCents)}</dd>
+      </dl>
+      {consequences.length > 0 ? (
+        <ul className="list-inside list-disc text-muted-foreground text-xs">
+          {consequences.map((line) => (
+            <li key={line}>{line}</li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  )
+}

--- a/packages/bookings-react/src/components/traveler-list.tsx
+++ b/packages/bookings-react/src/components/traveler-list.tsx
@@ -33,11 +33,13 @@ import {
   type BookingTravelerDocumentRecord,
   type BookingTravelerRecord,
   type BookingTravelerRevealRecord,
+  useBooking,
   useBookingTravelerDocuments,
   useRevealTraveler,
   useTravelerMutation,
   useTravelers,
 } from "../index.js"
+import { BookingRosterAmendmentDialog } from "./booking-roster-amendment-dialog.js"
 import { IconActionButton } from "./icon-action-button.js"
 import { TravelerDialog } from "./traveler-dialog.js"
 
@@ -52,7 +54,22 @@ export function TravelerList({ bookingId, autoReveal = false }: TravelerListProp
   const [viewingId, setViewingId] = React.useState<string | null>(null)
   const [deleteTarget, setDeleteTarget] = React.useState<BookingTravelerRecord | null>(null)
   const [revealedIds, setRevealedIds] = React.useState<Set<string>>(new Set())
+  const [amendment, setAmendment] = React.useState<{
+    mode: "add" | "drop"
+    travelerId?: string
+  } | null>(null)
   const { data } = useTravelers(bookingId)
+  const bookingQuery = useBooking(bookingId)
+  const booking = bookingQuery.data?.data
+
+  /**
+   * On a confirmed booking a roster change is not data entry — it moves
+   * inventory, money, and possibly a supplier reservation. Route those
+   * through the Amendment flow so the operator sees the price and the
+   * departure is actually checked, and keep the plain add/delete dialogs
+   * for bookings that have not been committed yet.
+   */
+  const requiresAmendment = booking?.status === "confirmed" && typeof booking.revision === "number"
   const documentsQuery = useBookingTravelerDocuments(bookingId)
   const { remove } = useTravelerMutation(bookingId)
   const messages = useBookingsUiMessagesOrDefault()
@@ -212,6 +229,10 @@ export function TravelerList({ bookingId, autoReveal = false }: TravelerListProp
                 className="text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
                 onClick={(e) => {
                   e.stopPropagation()
+                  if (requiresAmendment) {
+                    setAmendment({ mode: "drop", travelerId: traveler.id })
+                    return
+                  }
                   setDeleteTarget(traveler)
                 }}
               />
@@ -228,6 +249,10 @@ export function TravelerList({ bookingId, autoReveal = false }: TravelerListProp
       isRevealed,
       messages,
       toggleReveal,
+      // The booking loads after the first render, so without this the row
+      // actions would keep the initial `false` and hard-delete a traveller
+      // off a confirmed booking instead of quoting the change.
+      requiresAmendment,
     ],
   )
 
@@ -244,6 +269,10 @@ export function TravelerList({ bookingId, autoReveal = false }: TravelerListProp
           variant="outline"
           size="sm"
           onClick={() => {
+            if (requiresAmendment) {
+              setAmendment({ mode: "add" })
+              return
+            }
             setEditing(undefined)
             setDialogOpen(true)
           }}
@@ -270,6 +299,19 @@ export function TravelerList({ bookingId, autoReveal = false }: TravelerListProp
         traveler={editing}
         onSuccess={() => setEditing(undefined)}
       />
+
+      {amendment && booking?.revision !== undefined ? (
+        <BookingRosterAmendmentDialog
+          open
+          onOpenChange={(next) => {
+            if (!next) setAmendment(null)
+          }}
+          bookingId={bookingId}
+          bookingRevision={booking.revision}
+          mode={amendment.mode}
+          travelerId={amendment.travelerId}
+        />
+      ) : null}
 
       <Sheet
         open={Boolean(viewingTraveler)}

--- a/packages/bookings-react/src/hooks/index.ts
+++ b/packages/bookings-react/src/hooks/index.ts
@@ -12,6 +12,15 @@ export {
 } from "./use-booking-action-ledger.js"
 export { type UseBookingActivityOptions, useBookingActivity } from "./use-booking-activity.js"
 export {
+  type BookingItemAdditionInput,
+  type PreviewItemAdditionInput,
+  type PreviewRosterChangeInput,
+  type RosterPreviewResult,
+  type TravelerRosterChangeInput,
+  useBookingAmendmentFlow,
+  useBookingAmendments,
+} from "./use-booking-amendments.js"
+export {
   type CancelBookingInput,
   useBookingCancelMutation,
 } from "./use-booking-cancel-mutation.js"

--- a/packages/bookings-react/src/hooks/use-booking-amendments.ts
+++ b/packages/bookings-react/src/hooks/use-booking-amendments.ts
@@ -1,0 +1,241 @@
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import type { z } from "zod"
+
+import {
+  type BookingAmendmentRecord,
+  bookingAmendmentListResponse,
+  bookingAmendmentPreviewResponse,
+  bookingAmendmentResponse,
+} from "../amendment-schemas.js"
+import { fetchWithValidation } from "../client.js"
+import { useVoyantBookingsContext } from "../provider.js"
+import { bookingsQueryKeys } from "../query-keys.js"
+
+export interface TravelerRosterAddInput {
+  type: "traveler_add"
+  bookingItemIds: string[]
+  traveler: {
+    personId?: string | null
+    participantType?: "traveler" | "occupant" | "other"
+    travelerCategory?: string | null
+    firstName: string
+    lastName: string
+    email?: string | null
+    phone?: string | null
+    preferredLanguage?: string | null
+  }
+}
+
+export interface TravelerRosterDropInput {
+  type: "traveler_drop"
+  bookingItemIds: string[]
+  travelerId: string
+}
+
+export type TravelerRosterChangeInput = TravelerRosterAddInput | TravelerRosterDropInput
+
+export interface PreviewRosterChangeInput {
+  expectedBookingRevision: number
+  reason: string
+  change: TravelerRosterChangeInput
+}
+
+export interface BookingItemAdditionInput {
+  type: "item_add"
+  productId: string
+  optionId?: string | null
+  optionUnitId?: string | null
+  availabilitySlotId?: string | null
+  quantity: number
+  title?: string
+}
+
+export interface PreviewItemAdditionInput {
+  expectedBookingRevision: number
+  reason: string
+  addition: BookingItemAdditionInput
+}
+
+/**
+ * Outcome of a roster preview.
+ *
+ * `no_op`, `availability_changed` and the rest are not errors — they are
+ * answers, and the dialog shows each one differently. Collapsing them into
+ * a thrown error would tell an operator "something went wrong" when the
+ * real answer is "that departure just sold out".
+ */
+export type RosterPreviewResult =
+  | { status: "ok"; amendment: BookingAmendmentRecord }
+  | { status: "no_op" }
+  | { status: "availability_changed"; bookingItemId?: string }
+  | { status: "unsupported_configuration"; reason?: string }
+  | { status: "stale_revision"; currentBookingRevision?: number }
+  | { status: "other"; code: string }
+
+function invalidateAmendmentQueries(
+  queryClient: ReturnType<typeof useQueryClient>,
+  bookingId: string,
+) {
+  void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.amendments(bookingId) })
+  void queryClient.invalidateQueries({
+    queryKey: bookingsQueryKeys.booking(bookingId),
+    exact: true,
+  })
+  void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.items(bookingId) })
+  void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.travelers(bookingId) })
+  void queryClient.invalidateQueries({ queryKey: bookingsQueryKeys.activity(bookingId) })
+}
+
+/**
+ * Amendment mutations are idempotent by contract — the server rejects a
+ * request without an `Idempotency-Key`. One key per attempt: retrying the
+ * same attempt must replay, while a fresh attempt must quote afresh.
+ */
+function idempotencyHeaders(key: string): HeadersInit {
+  return { "Idempotency-Key": key }
+}
+
+export function useBookingAmendments(bookingId: string, options: { enabled?: boolean } = {}) {
+  const { baseUrl, fetcher } = useVoyantBookingsContext()
+
+  return useQuery({
+    queryKey: bookingsQueryKeys.amendments(bookingId),
+    enabled: options.enabled ?? true,
+    queryFn: async () => {
+      const { data } = await fetchWithValidation(
+        `/v1/admin/bookings/${bookingId}/amendments`,
+        bookingAmendmentListResponse,
+        { baseUrl, fetcher },
+      )
+      return data
+    },
+  })
+}
+
+/**
+ * Normalise a preview response into the discriminated result the dialog
+ * renders. Shared by both preview endpoints — they answer with the same
+ * envelope and the same set of "nothing to quote" outcomes.
+ */
+function toPreviewResult(
+  body: z.infer<typeof bookingAmendmentPreviewResponse>,
+): RosterPreviewResult {
+  if ("amendment" in body.data) {
+    return { status: "ok", amendment: body.data.amendment }
+  }
+  const status = body.data.status
+  if (
+    status === "no_op" ||
+    status === "availability_changed" ||
+    status === "unsupported_configuration" ||
+    status === "stale_revision"
+  ) {
+    return { ...body.data, status } as RosterPreviewResult
+  }
+  return { status: "other", code: status }
+}
+
+export function useBookingAmendmentFlow(bookingId: string) {
+  const { baseUrl, fetcher } = useVoyantBookingsContext()
+  const queryClient = useQueryClient()
+
+  const previewRosterChange = useMutation({
+    mutationFn: async ({
+      input,
+      idempotencyKey,
+    }: {
+      input: PreviewRosterChangeInput
+      idempotencyKey: string
+    }): Promise<RosterPreviewResult> =>
+      toPreviewResult(
+        await fetchWithValidation(
+          `/v1/admin/bookings/${bookingId}/amendments/traveler-roster/preview`,
+          bookingAmendmentPreviewResponse,
+          { baseUrl, fetcher },
+          {
+            method: "POST",
+            body: JSON.stringify(input),
+            headers: idempotencyHeaders(idempotencyKey),
+          },
+        ),
+      ),
+  })
+
+  const previewItemAddition = useMutation({
+    mutationFn: async ({
+      input,
+      idempotencyKey,
+    }: {
+      input: PreviewItemAdditionInput
+      idempotencyKey: string
+    }): Promise<RosterPreviewResult> =>
+      toPreviewResult(
+        await fetchWithValidation(
+          `/v1/admin/bookings/${bookingId}/amendments/items/preview`,
+          bookingAmendmentPreviewResponse,
+          { baseUrl, fetcher },
+          {
+            method: "POST",
+            body: JSON.stringify(input),
+            headers: idempotencyHeaders(idempotencyKey),
+          },
+        ),
+      ),
+  })
+
+  const accept = useMutation({
+    mutationFn: async ({
+      amendmentId,
+      proposedRevisionId,
+      idempotencyKey,
+    }: {
+      amendmentId: string
+      proposedRevisionId: string
+      idempotencyKey: string
+    }) => {
+      const { data } = await fetchWithValidation(
+        `/v1/admin/bookings/${bookingId}/amendments/${amendmentId}/accept`,
+        bookingAmendmentResponse,
+        { baseUrl, fetcher },
+        {
+          method: "POST",
+          body: JSON.stringify({ proposedRevisionId }),
+          headers: idempotencyHeaders(idempotencyKey),
+        },
+      )
+      return data
+    },
+    onSuccess: () => invalidateAmendmentQueries(queryClient, bookingId),
+  })
+
+  const apply = useMutation({
+    mutationFn: async ({
+      amendmentId,
+      proposedRevisionId,
+      expectedBookingRevision,
+      idempotencyKey,
+    }: {
+      amendmentId: string
+      proposedRevisionId: string
+      expectedBookingRevision: number
+      idempotencyKey: string
+    }) => {
+      const { data } = await fetchWithValidation(
+        `/v1/admin/bookings/${bookingId}/amendments/${amendmentId}/apply`,
+        bookingAmendmentResponse,
+        { baseUrl, fetcher },
+        {
+          method: "POST",
+          body: JSON.stringify({ proposedRevisionId, expectedBookingRevision }),
+          headers: idempotencyHeaders(idempotencyKey),
+        },
+      )
+      return data
+    },
+    onSuccess: () => invalidateAmendmentQueries(queryClient, bookingId),
+  })
+
+  return { previewRosterChange, previewItemAddition, accept, apply }
+}

--- a/packages/bookings-react/src/hooks/use-booking-amendments.ts
+++ b/packages/bookings-react/src/hooks/use-booking-amendments.ts
@@ -5,6 +5,7 @@ import type { z } from "zod"
 
 import {
   type BookingAmendmentRecord,
+  bookingAmendmentApplyResponse,
   bookingAmendmentListResponse,
   bookingAmendmentPreviewResponse,
   bookingAmendmentResponse,
@@ -224,7 +225,7 @@ export function useBookingAmendmentFlow(bookingId: string) {
     }) => {
       const { data } = await fetchWithValidation(
         `/v1/admin/bookings/${bookingId}/amendments/${amendmentId}/apply`,
-        bookingAmendmentResponse,
+        bookingAmendmentApplyResponse,
         { baseUrl, fetcher },
         {
           method: "POST",
@@ -232,7 +233,7 @@ export function useBookingAmendmentFlow(bookingId: string) {
           headers: idempotencyHeaders(idempotencyKey),
         },
       )
-      return data
+      return data.amendment
     },
     onSuccess: () => invalidateAmendmentQueries(queryClient, bookingId),
   })

--- a/packages/bookings-react/src/i18n/en-sections.ts
+++ b/packages/bookings-react/src/i18n/en-sections.ts
@@ -367,4 +367,75 @@ export const bookingsUiEnSections = {
       deleteConfirm: "Delete this document?",
     },
   },
+  rosterAmendmentDialog: {
+    titles: {
+      add: "Add a traveller",
+      drop: "Remove a traveller",
+    },
+    fields: {
+      firstName: "First name",
+      lastName: "Last name",
+      email: "Email",
+      unknownTraveler: "This traveller is no longer on the booking.",
+      items: "Applies to",
+      itemsHint: "Pick the services this traveller joins. Pricing is quoted per service.",
+      noItems: "This booking has no confirmed services to change.",
+      reason: "Reason",
+      reasonPlaceholder:
+        "Why is the booking changing? The customer sees this on the change record.",
+    },
+    actions: {
+      cancel: "Cancel",
+      quote: "Get a price",
+      apply: "Apply change",
+    },
+    quote: {
+      title: "Price of this change",
+      subtotal: "Subtotal",
+      tax: "Tax",
+    },
+    consequences: {
+      collect: "Collect {amount} from the customer.",
+      refund: "Refund {amount} to the customer.",
+      supplier: "The supplier must confirm this change before it takes effect.",
+      documents: "Travel documents will need reissuing.",
+    },
+    blocked: {
+      noOp: "Nothing would change on this booking.",
+      availabilityChanged: "That departure no longer has room for another traveller.",
+      unsupported: "This booking is not set up for traveller changes.",
+      staleRevision: "Someone else changed this booking. Close and reopen to try again.",
+      generic: "This change could not be quoted.",
+    },
+  },
+  itemAdditionDialog: {
+    title: "Add a service",
+    sourcedUnsupported:
+      "This is a supplier product. Adding it to an existing booking has to be arranged with the supplier first.",
+    fields: {
+      departure: "Departure",
+      departurePlaceholder: "Pick a departure",
+      departureEmpty: "No open departures",
+      unit: "Unit",
+      unitNone: "No specific unit",
+      quantity: "Quantity",
+      reason: "Reason",
+      reasonPlaceholder: "Why is this being added? The customer sees this on the change record.",
+    },
+    actions: {
+      cancel: "Cancel",
+      quote: "Get a price",
+      apply: "Add to booking",
+    },
+    quote: {
+      title: "Price of this addition",
+      collect: "Collect {amount} from the customer.",
+    },
+    blocked: {
+      availabilityChanged: "That departure no longer has room for this.",
+      unsupported: "This service cannot be added to this booking.",
+      staleRevision: "Someone else changed this booking. Close and reopen to try again.",
+      generic: "This addition could not be quoted.",
+    },
+  },
 } satisfies BookingsUiSectionsMessages

--- a/packages/bookings-react/src/i18n/messages-sections.ts
+++ b/packages/bookings-react/src/i18n/messages-sections.ts
@@ -360,4 +360,76 @@ export type BookingsUiSectionsMessages = {
       deleteConfirm: string
     }
   }
+  rosterAmendmentDialog: {
+    titles: {
+      add: string
+      drop: string
+    }
+    fields: {
+      firstName: string
+      lastName: string
+      email: string
+      unknownTraveler: string
+      items: string
+      itemsHint: string
+      noItems: string
+      reason: string
+      reasonPlaceholder: string
+    }
+    actions: {
+      cancel: string
+      quote: string
+      apply: string
+    }
+    quote: {
+      title: string
+      subtotal: string
+      tax: string
+    }
+    consequences: {
+      /** `{amount}` is replaced with the money to collect. */
+      collect: string
+      /** `{amount}` is replaced with the money to refund. */
+      refund: string
+      supplier: string
+      documents: string
+    }
+    blocked: {
+      noOp: string
+      availabilityChanged: string
+      unsupported: string
+      staleRevision: string
+      generic: string
+    }
+  }
+  itemAdditionDialog: {
+    title: string
+    sourcedUnsupported: string
+    fields: {
+      departure: string
+      departurePlaceholder: string
+      departureEmpty: string
+      unit: string
+      unitNone: string
+      quantity: string
+      reason: string
+      reasonPlaceholder: string
+    }
+    actions: {
+      cancel: string
+      quote: string
+      apply: string
+    }
+    quote: {
+      title: string
+      /** `{amount}` is replaced with the money to collect. */
+      collect: string
+    }
+    blocked: {
+      availabilityChanged: string
+      unsupported: string
+      staleRevision: string
+      generic: string
+    }
+  }
 }

--- a/packages/bookings-react/src/i18n/ro-sections.ts
+++ b/packages/bookings-react/src/i18n/ro-sections.ts
@@ -367,4 +367,78 @@ export const bookingsUiRoSections = {
       deleteConfirm: "Stergi acest document?",
     },
   },
+  rosterAmendmentDialog: {
+    titles: {
+      add: "Adauga un calator",
+      drop: "Elimina un calator",
+    },
+    fields: {
+      firstName: "Prenume",
+      lastName: "Nume",
+      email: "Email",
+      unknownTraveler: "Acest calator nu mai este pe rezervare.",
+      items: "Se aplica la",
+      itemsHint:
+        "Alege serviciile la care participa acest calator. Pretul este calculat per serviciu.",
+      noItems: "Aceasta rezervare nu are servicii confirmate de modificat.",
+      reason: "Motiv",
+      reasonPlaceholder:
+        "De ce se modifica rezervarea? Clientul vede acest text pe fisa modificarii.",
+    },
+    actions: {
+      cancel: "Anuleaza",
+      quote: "Calculeaza pretul",
+      apply: "Aplica modificarea",
+    },
+    quote: {
+      title: "Pretul acestei modificari",
+      subtotal: "Subtotal",
+      tax: "Taxa",
+    },
+    consequences: {
+      collect: "Incaseaza {amount} de la client.",
+      refund: "Restituie {amount} clientului.",
+      supplier: "Furnizorul trebuie sa confirme modificarea inainte sa intre in vigoare.",
+      documents: "Documentele de calatorie vor trebui reemise.",
+    },
+    blocked: {
+      noOp: "Nu s-ar modifica nimic pe aceasta rezervare.",
+      availabilityChanged: "Aceasta plecare nu mai are loc pentru inca un calator.",
+      unsupported: "Aceasta rezervare nu permite modificari de calatori.",
+      staleRevision:
+        "Altcineva a modificat rezervarea. Inchide si redeschide pentru a incerca din nou.",
+      generic: "Aceasta modificare nu a putut fi cotata.",
+    },
+  },
+  itemAdditionDialog: {
+    title: "Adauga un serviciu",
+    sourcedUnsupported:
+      "Acesta este un produs de furnizor. Adaugarea lui pe o rezervare existenta trebuie stabilita intai cu furnizorul.",
+    fields: {
+      departure: "Plecare",
+      departurePlaceholder: "Alege o plecare",
+      departureEmpty: "Nicio plecare disponibila",
+      unit: "Unitate",
+      unitNone: "Fara unitate anume",
+      quantity: "Cantitate",
+      reason: "Motiv",
+      reasonPlaceholder: "De ce se adauga? Clientul vede acest text pe fisa modificarii.",
+    },
+    actions: {
+      cancel: "Anuleaza",
+      quote: "Calculeaza pretul",
+      apply: "Adauga pe rezervare",
+    },
+    quote: {
+      title: "Pretul acestei adaugari",
+      collect: "Incaseaza {amount} de la client.",
+    },
+    blocked: {
+      availabilityChanged: "Aceasta plecare nu mai are loc pentru asa ceva.",
+      unsupported: "Acest serviciu nu poate fi adaugat pe aceasta rezervare.",
+      staleRevision:
+        "Altcineva a modificat rezervarea. Inchide si redeschide pentru a incerca din nou.",
+      generic: "Aceasta adaugare nu a putut fi cotata.",
+    },
+  },
 } satisfies BookingsUiSectionsMessages

--- a/packages/bookings-react/src/index.ts
+++ b/packages/bookings-react/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./amendment-schemas.js"
 export {
   defaultFetcher,
   fetchWithValidation,

--- a/packages/bookings-react/src/query-keys.ts
+++ b/packages/bookings-react/src/query-keys.ts
@@ -77,6 +77,8 @@ export const bookingsQueryKeys = {
   supplierStatuses: (bookingId: string) =>
     [...bookingsQueryKeys.booking(bookingId), "supplier-statuses"] as const,
   activity: (bookingId: string) => [...bookingsQueryKeys.booking(bookingId), "activity"] as const,
+  amendments: (bookingId: string) =>
+    [...bookingsQueryKeys.booking(bookingId), "amendments"] as const,
   actionLedger: (bookingId: string) =>
     [...bookingsQueryKeys.booking(bookingId), "action-ledger"] as const,
   notes: (bookingId: string) => [...bookingsQueryKeys.booking(bookingId), "notes"] as const,

--- a/packages/bookings-react/src/schemas.ts
+++ b/packages/bookings-react/src/schemas.ts
@@ -61,6 +61,12 @@ export type BookingRecordItemSummary = z.infer<typeof bookingRecordItemSummarySc
 export const bookingRecordSchema = z.object({
   id: z.string(),
   bookingNumber: z.string(),
+  /**
+   * Optimistic-concurrency token. Amendment previews and applies quote
+   * against it, so a change raced by another operator is refused rather
+   * than silently applied to a booking that has moved on.
+   */
+  revision: z.number().int().positive().optional(),
   status: bookingStatusSchema,
   personId: z.string().nullable(),
   organizationId: z.string().nullable(),

--- a/packages/bookings-react/src/ui.ts
+++ b/packages/bookings-react/src/ui.ts
@@ -51,6 +51,10 @@ export {
   BookingGuaranteeList,
   type BookingGuaranteeListProps,
 } from "./components/booking-guarantee-list.js"
+export {
+  BookingItemAdditionDialog,
+  type BookingItemAdditionDialogProps,
+} from "./components/booking-item-addition-dialog.js"
 export { BookingItemDialog, type BookingItemDialogProps } from "./components/booking-item-dialog.js"
 export { BookingItemList, type BookingItemListProps } from "./components/booking-item-list.js"
 export {
@@ -88,6 +92,10 @@ export {
   BookingRefundBanner,
   type BookingRefundBannerProps,
 } from "./components/booking-refund-banner.js"
+export {
+  BookingRosterAmendmentDialog,
+  type BookingRosterAmendmentDialogProps,
+} from "./components/booking-roster-amendment-dialog.js"
 export { BookingsPage, type BookingsPageProps } from "./components/bookings-page.js"
 export {
   FileDropzone,

--- a/packages/bookings-react/tests/unit/booking-payment-reconciliation-banner.test.tsx
+++ b/packages/bookings-react/tests/unit/booking-payment-reconciliation-banner.test.tsx
@@ -92,6 +92,7 @@ function schedule(data: Partial<BookingPaymentScheduleRecord> = {}): BookingPaym
     id: "bps_123",
     bookingId: "book_123",
     bookingItemId: null,
+    amendmentId: null,
     scheduleType: "deposit",
     status: "paid",
     dueDate: "2026-05-30",

--- a/packages/bookings/migrations/20260815103000_booking_item_addition_amendments.sql
+++ b/packages/bookings/migrations/20260815103000_booking_item_addition_amendments.sql
@@ -1,0 +1,17 @@
+-- An `item_add` Amendment adds a service to a booking, so it has no
+-- traveler of its own. `traveler_id` stops being mandatory and the kind
+-- constraint widens to admit the new kind.
+ALTER TABLE "booking_amendments"
+ALTER COLUMN "traveler_id" DROP NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "booking_amendments"
+DROP CONSTRAINT "ck_booking_amendments_kind";
+--> statement-breakpoint
+ALTER TABLE "booking_amendments"
+ADD CONSTRAINT "ck_booking_amendments_kind"
+CHECK ("kind" IN ('traveler_correction', 'traveler_add', 'traveler_drop', 'item_add'));
+--> statement-breakpoint
+-- Every kind except `item_add` still names the traveler it concerns.
+ALTER TABLE "booking_amendments"
+ADD CONSTRAINT "ck_booking_amendments_traveler_required"
+CHECK ("kind" = 'item_add' OR "traveler_id" IS NOT NULL);

--- a/packages/bookings/migrations/meta/_journal.json
+++ b/packages/bookings/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1786102200000,
       "tag": "20260807143000_booking_item_cancellation_terms_snapshot",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1786869000000,
+      "tag": "20260815103000_booking_item_addition_amendments",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/bookings/src/routes-admin.ts
+++ b/packages/bookings/src/routes-admin.ts
@@ -3068,7 +3068,9 @@ const itemsRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidationHook })
     const body = c.req.valid("json") ?? {}
     const ledgerContext = getActionLedgerRequestContext(c)
     const row = await c.get("db").transaction(async (tx) => {
-      const row = await bookingsService.updateItem(tx as PostgresJsDatabase, itemId, body)
+      const row = await bookingsService.updateItem(tx as PostgresJsDatabase, itemId, body, {
+        eventBus: c.get("eventBus"),
+      })
       if (!row) return null
       await appendBookingMutationLedgerEntryToDb(tx as AnyDrizzleDb, ledgerContext, {
         action: "update",
@@ -3106,6 +3108,7 @@ const itemsRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidationHook })
         tx as PostgresJsDatabase,
         itemId,
         c.get("userId"),
+        { eventBus: c.get("eventBus") },
       )
       if (!row) return null
       await appendBookingMutationLedgerEntryToDb(tx as AnyDrizzleDb, ledgerContext, {

--- a/packages/bookings/src/routes-amendments.ts
+++ b/packages/bookings/src/routes-amendments.ts
@@ -4,6 +4,7 @@ import {
   acceptBookingAmendmentSchema,
   applyBookingAmendmentSchema,
   bookingAmendmentSchema,
+  previewBookingItemAdditionSchema,
   previewTravelerCorrectionSchema,
   previewTravelerRosterChangeSchema,
 } from "@voyant-travel/bookings-contracts"
@@ -225,7 +226,13 @@ async function visibleAdminAmendment(
   metadata: Record<string, unknown>,
 ) {
   const reveal = shouldRevealAdminHistory(c)
-  await logAmendmentHistoryRead(c, amendment.bookingId, reveal, metadata, amendment.travelerId)
+  await logAmendmentHistoryRead(
+    c,
+    amendment.bookingId,
+    reveal,
+    metadata,
+    amendment.travelerId ?? undefined,
+  )
   return reveal ? amendment : redactAmendmentHistory(amendment)
 }
 
@@ -234,7 +241,13 @@ async function auditedPublicAmendment(
   amendment: z.infer<typeof bookingAmendmentSchema>,
   metadata: Record<string, unknown>,
 ) {
-  await logAmendmentHistoryRead(c, amendment.bookingId, true, metadata, amendment.travelerId)
+  await logAmendmentHistoryRead(
+    c,
+    amendment.bookingId,
+    true,
+    metadata,
+    amendment.travelerId ?? undefined,
+  )
   return publicAmendmentHistory(amendment)
 }
 
@@ -277,6 +290,19 @@ const adminRosterPreviewRoute = createBookingsAdminRoute({
     body: {
       required: true,
       content: { "application/json": { schema: previewTravelerRosterChangeSchema } },
+    },
+  },
+  responses: adminPreviewRoute.responses,
+})
+
+const adminItemAdditionPreviewRoute = createBookingsAdminRoute({
+  method: "post",
+  path: "/{bookingId}/amendments/items/preview",
+  request: {
+    params: bookingParamsSchema,
+    body: {
+      required: true,
+      content: { "application/json": { schema: previewBookingItemAdditionSchema } },
     },
   },
   responses: adminPreviewRoute.responses,
@@ -447,6 +473,30 @@ export const bookingAmendmentAdminRoutes = adminApp
     }
     return amendmentError(c, result)
   })
+  .openapi(adminItemAdditionPreviewRoute, async (c) => {
+    const result = await bookingAmendmentService.previewItemAddition(
+      c.get("db"),
+      c.req.valid("param").bookingId,
+      c.req.valid("json"),
+      mutationContext(c, "staff"),
+      amendmentDependencies(c),
+    )
+    if (result.status === "ok") {
+      return c.json(
+        {
+          data: {
+            ...result,
+            amendment: await visibleAdminAmendment(c, result.amendment, {
+              amendmentId: result.amendment.id,
+              operation: "preview_item_addition",
+            }),
+          },
+        },
+        201,
+      )
+    }
+    return amendmentError(c, result)
+  })
   .openapi(adminListRoute, async (c) => {
     const bookingId = c.req.valid("param").bookingId
     const rows = await bookingAmendmentService.list(c.get("db"), bookingId)
@@ -459,7 +509,13 @@ export const bookingAmendmentAdminRoutes = adminApp
     const row = await bookingAmendmentService.get(c.get("db"), bookingId, amendmentId)
     if (!row) return c.json({ error: "amendment_not_found" }, 404)
     const reveal = shouldRevealAdminHistory(c)
-    await logAmendmentHistoryRead(c, bookingId, reveal, { amendmentId }, row.travelerId)
+    await logAmendmentHistoryRead(
+      c,
+      bookingId,
+      reveal,
+      { amendmentId },
+      row.travelerId ?? undefined,
+    )
     return c.json({ data: reveal ? row : redactAmendmentHistory(row) }, 200)
   })
   .openapi(adminAcceptRoute, async (c) => {
@@ -716,7 +772,7 @@ export const bookingAmendmentPublicRoutes = publicApp
     if (denied) return denied
     const row = await bookingAmendmentService.get(c.get("db"), bookingId, amendmentId)
     if (!row) return c.json({ error: "amendment_not_found" }, 404)
-    await logAmendmentHistoryRead(c, bookingId, true, { amendmentId }, row.travelerId)
+    await logAmendmentHistoryRead(c, bookingId, true, { amendmentId }, row.travelerId ?? undefined)
     return c.json({ data: publicAmendmentHistory(row) }, 200)
   })
   .openapi(publicAcceptRoute, async (c) => {

--- a/packages/bookings/src/runtime-port.ts
+++ b/packages/bookings/src/runtime-port.ts
@@ -56,6 +56,12 @@ export interface BookingsFinanceRuntime {
       price: BookingAmendmentPrice
       consequences: BookingAmendmentFinancialConsequences
       reason: string
+      /**
+       * Application instant, supplied so finance dates the obligation it
+       * raises from the same clock the amendment was applied on rather
+       * than from its own `new Date()`. Tests inject a fixed value.
+       */
+      now?: Date
     },
   ): Promise<{ adjustmentId: string; status: "recorded" | "replay" }>
 }

--- a/packages/bookings/src/schema-amendments.ts
+++ b/packages/bookings/src/schema-amendments.ts
@@ -1,5 +1,6 @@
 import type {
   BookingAmendmentFinancialConsequences,
+  BookingItemAddition,
   BookingRevisionSnapshot,
   TravelerCorrectionPatch,
   TravelerRosterChange,
@@ -31,11 +32,16 @@ export type BookingAmendmentStatus =
   | "manual_review"
 export type BookingAmendmentActor = "customer" | "staff" | "partner" | "system"
 export type BookingRevisionRole = "before" | "proposed_after"
-export type BookingAmendmentKind = "traveler_correction" | "traveler_add" | "traveler_drop"
+export type BookingAmendmentKind =
+  | "traveler_correction"
+  | "traveler_add"
+  | "traveler_drop"
+  | "item_add"
 
 export type BookingAmendmentRequestedChange =
   | { type: "traveler_correction"; travelerId: string; patch: TravelerCorrectionPatch }
   | (TravelerRosterChange & { travelerId: string })
+  | BookingItemAddition
 
 export interface BookingAmendmentPolicyDecision {
   code: string
@@ -91,6 +97,49 @@ export interface BookingAmendmentRosterItemPlan {
   } | null
 }
 
+/**
+ * Plan for adding one catalog-linked service to an existing booking.
+ *
+ * Unlike a roster plan — which moves an allocation that already exists —
+ * this one creates both the Booking Item and its allocation, so it carries
+ * everything needed to write them without re-reading the catalog at apply
+ * time. The quote the operator accepted is the quote that gets applied.
+ */
+export interface BookingAmendmentItemAddPlan {
+  kind: "item_add"
+  productId: string
+  optionId: string | null
+  optionUnitId: string | null
+  availabilitySlotId: string | null
+  quantity: number
+  title: string
+  sellCurrency: string
+  unitSellAmountCents: number
+  totalSellAmountCents: number
+  costCurrency: string | null
+  unitCostAmountCents: number | null
+  totalCostAmountCents: number | null
+  serviceDate: string | null
+  productNameSnapshot: string | null
+  optionNameSnapshot: string | null
+  unitNameSnapshot: string | null
+  departureLabelSnapshot: string | null
+}
+
+/**
+ * What an Amendment will do at apply time. Roster plans move an existing
+ * allocation; an item-add plan creates one.
+ */
+export type BookingAmendmentOperationPlan =
+  | BookingAmendmentRosterItemPlan
+  | BookingAmendmentItemAddPlan
+
+export function isItemAddPlan(
+  plan: BookingAmendmentOperationPlan,
+): plan is BookingAmendmentItemAddPlan {
+  return "kind" in plan && plan.kind === "item_add"
+}
+
 export const bookingAmendments = pgTable(
   "booking_amendments",
   {
@@ -98,7 +147,10 @@ export const bookingAmendments = pgTable(
     bookingId: typeIdRef("booking_id")
       .notNull()
       .references(() => bookings.id, { onDelete: "cascade" }),
-    travelerId: text("traveler_id").notNull(),
+    // Null for `item_add`, which concerns a service rather than a person.
+    // The `ck_booking_amendments_traveler_required` constraint holds the
+    // rule that every other kind still names its traveler.
+    travelerId: text("traveler_id"),
     kind: text("kind").$type<BookingAmendmentKind>().notNull().default("traveler_correction"),
     status: text("status").$type<BookingAmendmentStatus>().notNull().default("proposed"),
     baseBookingRevision: integer("base_booking_revision").notNull(),
@@ -125,7 +177,7 @@ export const bookingAmendments = pgTable(
     quoteExpiresAt: timestamp("quote_expires_at", { withTimezone: true }),
     supplierOperationIds: jsonb("supplier_operation_ids").$type<string[]>().notNull().default([]),
     operationPlan: jsonb("operation_plan")
-      .$type<BookingAmendmentRosterItemPlan[]>()
+      .$type<BookingAmendmentOperationPlan[]>()
       .notNull()
       .default([]),
     failureCode: text("failure_code"),
@@ -156,7 +208,7 @@ export const bookingAmendments = pgTable(
     check(
       "ck_booking_amendments_kind",
       // agent-quality: raw-sql reviewed -- owner: bookings; static enum membership constraint over Drizzle identifiers.
-      sql`${table.kind} IN ('traveler_correction', 'traveler_add', 'traveler_drop')`,
+      sql`${table.kind} IN ('traveler_correction', 'traveler_add', 'traveler_drop', 'item_add')`,
     ),
     check(
       "ck_booking_amendments_status",

--- a/packages/bookings/src/service-amendments.ts
+++ b/packages/bookings/src/service-amendments.ts
@@ -3,7 +3,9 @@ import type {
   BookingAmendment,
   BookingAmendmentFinancialConsequences,
   BookingAmendmentPrice,
+  BookingItemAddition,
   BookingRevisionSnapshot,
+  PreviewBookingItemAdditionInput,
   PreviewTravelerCorrectionInput,
   PreviewTravelerRosterChangeInput,
   TravelerCorrectionPatch,
@@ -13,6 +15,7 @@ import { and, asc, eq, inArray, or, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import { availabilitySlotsRef } from "./availability-ref.js"
+import { productsRef } from "./products-ref.js"
 import type { BookingsFinanceRuntime, BookingsSupplierAmendmentRuntime } from "./runtime-port.js"
 import {
   bookingActivityLog,
@@ -27,11 +30,15 @@ import {
 import type {
   BookingAmendmentActor,
   BookingAmendmentEffects,
+  BookingAmendmentItemAddPlan,
   BookingAmendmentPolicyDecision,
   BookingAmendmentRosterItemPlan,
   BookingAmendmentRow,
   BookingRevisionRow,
 } from "./schema-amendments.js"
+import { isItemAddPlan } from "./schema-amendments.js"
+import { resolveBookingItemSnapshot } from "./service-core.js"
+import { resolveSessionPricingSnapshot } from "./service-public-core.js"
 
 const TRAVELER_IDENTITY_FIELDS = new Set<keyof TravelerCorrectionPatch>(["firstName", "lastName"])
 export const DEFAULT_BOOKING_AMENDMENT_QUOTE_TTL_MS = 30 * 60 * 1_000
@@ -285,6 +292,13 @@ function snapshotBooking(
     allocationQuantityDelta?: Map<string, number>
     sellAmountDeltaCents?: number
     paxDelta?: number
+    /**
+     * Items the Amendment will create. They have no row yet, so they
+     * cannot come from `state` — the proposed snapshot has to be told
+     * about them or it would show the booking without the very service
+     * being added.
+     */
+    addedItems?: BookingRevisionSnapshot["items"]
   } = {},
 ): BookingRevisionSnapshot {
   const itemQuantityDelta = overrides.itemQuantityDelta ?? new Map()
@@ -300,23 +314,26 @@ function snapshotBooking(
         : booking.sellAmountCents + (overrides.sellAmountDeltaCents ?? 0),
     pax: booking.pax == null ? null : Math.max(0, booking.pax + (overrides.paxDelta ?? 0)),
     travelers: overrides.travelers ?? state.travelers.map(snapshotTraveler),
-    items: state.items.map((item) => ({
-      id: item.id,
-      quantity: item.quantity + (itemQuantityDelta.get(item.id) ?? 0),
-      totalSellAmountCents:
-        item.totalSellAmountCents == null
-          ? null
-          : item.totalSellAmountCents +
-            (itemQuantityDelta.get(item.id) ?? 0) * (item.unitSellAmountCents ?? 0),
-      travelerIds: [...(itemTravelerIds.get(item.id) ?? [])].sort(),
-      allocations: state.allocations
-        .filter((allocation) => allocation.bookingItemId === item.id)
-        .map((allocation) => ({
-          id: allocation.id,
-          quantity: allocation.quantity + (allocationQuantityDelta.get(allocation.id) ?? 0),
-          status: allocation.status,
-        })),
-    })),
+    items: [
+      ...state.items.map((item) => ({
+        id: item.id,
+        quantity: item.quantity + (itemQuantityDelta.get(item.id) ?? 0),
+        totalSellAmountCents:
+          item.totalSellAmountCents == null
+            ? null
+            : item.totalSellAmountCents +
+              (itemQuantityDelta.get(item.id) ?? 0) * (item.unitSellAmountCents ?? 0),
+        travelerIds: [...(itemTravelerIds.get(item.id) ?? [])].sort(),
+        allocations: state.allocations
+          .filter((allocation) => allocation.bookingItemId === item.id)
+          .map((allocation) => ({
+            id: allocation.id,
+            quantity: allocation.quantity + (allocationQuantityDelta.get(allocation.id) ?? 0),
+            status: allocation.status,
+          })),
+      })),
+      ...(overrides.addedItems ?? []),
+    ],
   }
 }
 
@@ -609,6 +626,157 @@ function mapPlanError(error: RosterPlanError): PreviewTravelerRosterChangeResult
   return { status: "unsupported_configuration", reason: error.message }
 }
 
+/**
+ * Resolve what a requested addition actually costs and whether it can be
+ * held, from the catalog rather than from the caller.
+ *
+ * The price comes from `resolveSessionPricingSnapshot` — the same authority
+ * the storefront prices against — so an operator adding a service mid-trip
+ * quotes the number the catalog says, not one they typed. Anything the
+ * catalog cannot answer is refused rather than guessed.
+ *
+ * Sourced (supplier) products are refused outright: adding a service the
+ * supplier has never heard of needs a supplier *create* call, and the
+ * supplier amendment port only knows how to modify an operation that
+ * already has an `upstreamRef`. Quoting one would promise capacity nobody
+ * reserved.
+ */
+async function buildItemAddPlan(
+  db: PostgresJsDatabase,
+  booking: BookingRow,
+  addition: BookingItemAddition,
+): Promise<BookingAmendmentItemAddPlan> {
+  const [product] = await db
+    .select({
+      id: productsRef.id,
+      name: productsRef.name,
+      status: productsRef.status,
+      sellCurrency: productsRef.sellCurrency,
+      sellAmountCents: productsRef.sellAmountCents,
+      costAmountCents: productsRef.costAmountCents,
+      supplierId: productsRef.supplierId,
+    })
+    .from(productsRef)
+    .where(eq(productsRef.id, addition.productId))
+    .limit(1)
+  if (!product) throw new RosterPlanError("not_found", "Product does not exist")
+  if (product.status !== "active") {
+    throw new RosterPlanError("unsupported_configuration", "Product is not active")
+  }
+  if (product.sellCurrency !== booking.sellCurrency) {
+    throw new RosterPlanError(
+      "unsupported_configuration",
+      "Product is priced in a different currency from the Booking",
+    )
+  }
+
+  const pricing = await resolveSessionPricingSnapshot(db, addition.productId, {
+    optionId: addition.optionId ?? undefined,
+    requirePublicProduct: false,
+  })
+  if (!pricing) {
+    throw new RosterPlanError("unsupported_configuration", "Product has no resolvable pricing")
+  }
+  if (pricing.catalog.currencyCode && pricing.catalog.currencyCode !== booking.sellCurrency) {
+    throw new RosterPlanError(
+      "unsupported_configuration",
+      "Price catalog is in a different currency from the Booking",
+    )
+  }
+
+  const option = addition.optionId
+    ? (pricing.options.find((entry) => entry.id === addition.optionId) ?? null)
+    : (pricing.options[0] ?? null)
+
+  let unitSellAmountCents: number | null = null
+  let unitName: string | null = null
+  if (addition.optionUnitId) {
+    const unitPrice = pricing.unitPrices.find((entry) => entry.unitId === addition.optionUnitId)
+    if (!unitPrice) {
+      throw new RosterPlanError("unsupported_configuration", "Unit has no price in this catalog")
+    }
+    unitSellAmountCents = unitPrice.sellAmountCents ?? null
+    unitName = unitPrice.unitName
+  } else {
+    const rule =
+      pricing.rules.find((entry) => entry.optionId === option?.id) ?? pricing.rules[0] ?? null
+    unitSellAmountCents = rule?.baseSellAmountCents ?? product.sellAmountCents ?? null
+  }
+  if (unitSellAmountCents == null) {
+    throw new RosterPlanError(
+      "unsupported_configuration",
+      "Selection has no authoritative sell price",
+    )
+  }
+
+  if (addition.availabilitySlotId) {
+    const [slot] = await db
+      .select({
+        status: availabilitySlotsRef.status,
+        unlimited: availabilitySlotsRef.unlimited,
+        remainingPax: availabilitySlotsRef.remainingPax,
+        pastCutoff: availabilitySlotsRef.pastCutoff,
+        tooEarly: availabilitySlotsRef.tooEarly,
+      })
+      .from(availabilitySlotsRef)
+      .where(eq(availabilitySlotsRef.id, addition.availabilitySlotId))
+      .limit(1)
+    if (!slot) throw new RosterPlanError("not_found", "Departure does not exist")
+    const room = slot.unlimited || (slot.remainingPax ?? 0) >= addition.quantity
+    if (slot.status !== "open" || slot.pastCutoff || slot.tooEarly || !room) {
+      throw new RosterPlanError("availability_changed", "Departure cannot take this addition")
+    }
+  }
+
+  const snapshot = await resolveBookingItemSnapshot(db, {
+    productId: addition.productId,
+    optionId: addition.optionId ?? null,
+    optionUnitId: addition.optionUnitId ?? null,
+    availabilitySlotId: addition.availabilitySlotId ?? null,
+  })
+
+  const quantity = addition.quantity
+  const unitCostAmountCents =
+    product.costAmountCents != null ? Math.floor(product.costAmountCents) : null
+
+  return {
+    kind: "item_add",
+    productId: addition.productId,
+    optionId: addition.optionId ?? option?.id ?? null,
+    optionUnitId: addition.optionUnitId ?? null,
+    availabilitySlotId: addition.availabilitySlotId ?? null,
+    quantity,
+    title: addition.title ?? unitName ?? option?.name ?? product.name,
+    sellCurrency: booking.sellCurrency,
+    unitSellAmountCents,
+    totalSellAmountCents: unitSellAmountCents * quantity,
+    costCurrency: unitCostAmountCents == null ? null : product.sellCurrency,
+    unitCostAmountCents,
+    totalCostAmountCents: unitCostAmountCents == null ? null : unitCostAmountCents * quantity,
+    serviceDate: snapshot.serviceDate,
+    productNameSnapshot: snapshot.productName ?? product.name,
+    optionNameSnapshot: snapshot.optionName ?? option?.name ?? null,
+    unitNameSnapshot: snapshot.unitName ?? unitName,
+    departureLabelSnapshot: snapshot.departureLabel,
+  }
+}
+
+function itemAddEffects(price: BookingAmendmentPrice): BookingAmendmentEffects {
+  return {
+    finance:
+      price.collectionAmountCents > 0
+        ? "collection_required"
+        : price.refundAmountCents > 0
+          ? "refund_required"
+          : "not_required",
+    legal: "not_required",
+    documents: "reissue_required",
+    fulfillment: "reissue_required",
+    supplier: "not_required",
+    allocation: "increase_required",
+  }
+}
+
 export const bookingAmendmentService = {
   async previewTravelerCorrection(
     db: PostgresJsDatabase,
@@ -869,6 +1037,152 @@ export const bookingAmendmentService = {
     })
   },
 
+  /**
+   * Quote adding a catalog-linked service to a booking that already exists.
+   *
+   * Same protocol as a roster change — preview, accept, apply — so the
+   * price, the departure check, and the money that follows all behave the
+   * way an operator has already learned they do. Nothing is written to the
+   * booking here; the plan is stored on the Amendment and replayed at apply.
+   */
+  async previewItemAddition(
+    db: PostgresJsDatabase,
+    bookingId: string,
+    input: PreviewBookingItemAdditionInput,
+    context: BookingAmendmentCommandContext,
+    dependencies: BookingAmendmentServiceDependencies = {},
+  ): Promise<PreviewTravelerRosterChangeResult> {
+    if (!dependencies.finance) {
+      return {
+        status: "unsupported_configuration",
+        reason: "Finance runtime is required for priced Booking Amendments",
+      }
+    }
+    const finance = dependencies.finance
+    return db.transaction(async (rawTx) => {
+      const tx = rawTx as PostgresJsDatabase
+      const [booking] = await tx
+        .select()
+        .from(bookings)
+        .where(eq(bookings.id, bookingId))
+        .for("update")
+        .limit(1)
+      if (!booking) return { status: "not_found" as const }
+
+      const [existing] = await tx
+        .select()
+        .from(bookingAmendments)
+        .where(
+          and(
+            eq(bookingAmendments.bookingId, booking.id),
+            eq(bookingAmendments.previewIdempotencyKey, context.idempotencyKey),
+          ),
+        )
+        .limit(1)
+      if (existing) {
+        if (!sameItemAdditionRequest(existing, input)) {
+          return { status: "idempotency_conflict" as const }
+        }
+        return { status: "ok" as const, amendment: await hydrateAmendment(tx, existing) }
+      }
+      if (booking.revision !== input.expectedBookingRevision) {
+        return { status: "stale_revision" as const, currentBookingRevision: booking.revision }
+      }
+      if (booking.status !== "confirmed" && booking.status !== "in_progress") {
+        return {
+          status: "unsupported_configuration" as const,
+          reason: "Only a live Booking can take an added service",
+        }
+      }
+
+      let plan: BookingAmendmentItemAddPlan
+      try {
+        plan = await buildItemAddPlan(tx, booking, input.addition)
+      } catch (error) {
+        if (error instanceof RosterPlanError) return mapPlanError(error)
+        throw error
+      }
+
+      const state = await loadSnapshotState(tx, booking.id)
+      const financeQuote = await finance.quoteBookingAmendment(tx, {
+        bookingId: booking.id,
+        currency: booking.sellCurrency,
+        lines: [
+          {
+            // The Booking Item does not exist yet, so there is no id to
+            // quote against. Finance only uses it to attribute tax lines;
+            // the placeholder is replaced at apply time.
+            bookingItemId: PENDING_ITEM_ID,
+            productId: plan.productId,
+            subtotalDeltaCents: plan.totalSellAmountCents,
+          },
+        ],
+      })
+
+      const now = dependencies.now?.() ?? new Date()
+      const quoteExpiresAt = new Date(
+        now.getTime() + (dependencies.quoteTtlMs ?? DEFAULT_BOOKING_AMENDMENT_QUOTE_TTL_MS),
+      )
+      const before = snapshotBooking(booking, booking.revision, state)
+      const proposed = snapshotBooking(booking, booking.revision + 1, state, {
+        sellAmountDeltaCents: financeQuote.price.amountCents,
+        addedItems: [
+          {
+            id: PENDING_ITEM_ID,
+            quantity: plan.quantity,
+            totalSellAmountCents: plan.totalSellAmountCents,
+            travelerIds: [],
+            allocations: [],
+          },
+        ],
+      })
+
+      const amendmentId = newId("booking_amendments")
+      const [amendment] = await tx
+        .insert(bookingAmendments)
+        .values({
+          id: amendmentId,
+          bookingId: booking.id,
+          travelerId: null,
+          kind: "item_add",
+          baseBookingRevision: booking.revision,
+          resultBookingRevision: booking.revision + 1,
+          requestedChange: input.addition,
+          acceptanceRequired: true,
+          policyDecisions: rosterPolicy(financeQuote.policyVersion),
+          subtotalDeltaCents: financeQuote.price.subtotalDeltaCents,
+          feeDeltaCents: financeQuote.price.feeDeltaCents,
+          taxDeltaCents: financeQuote.price.taxDeltaCents,
+          priceDeltaCents: financeQuote.price.amountCents,
+          priceCurrency: financeQuote.price.currency,
+          collectionAmountCents: financeQuote.price.collectionAmountCents,
+          refundAmountCents: financeQuote.price.refundAmountCents,
+          taxLines: financeQuote.price.taxLines,
+          financialConsequences: financeQuote.consequences,
+          effects: itemAddEffects(financeQuote.price),
+          quotedAt: now,
+          quoteExpiresAt,
+          operationPlan: [plan],
+          previewIdempotencyKey: context.idempotencyKey,
+          requestedBy: context.actorId ?? null,
+          requestedActor: context.actor,
+          reason: input.reason,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .returning()
+      if (!amendment) throw new Error("Booking Amendment insert did not return a row")
+
+      const revisions = await insertRevisions(tx, amendmentId, booking.id, [before, proposed], {
+        changedFields: ["items", "sellAmountCents"],
+        authorizedBy: context.actorId ?? null,
+        reason: input.reason,
+        now,
+      })
+      return { status: "ok" as const, amendment: serializeAmendment(amendment, revisions) }
+    })
+  },
+
   async accept(
     db: PostgresJsDatabase,
     amendmentId: string,
@@ -938,10 +1252,15 @@ export const bookingAmendmentService = {
     if (staged.amendment.kind === "traveler_correction") {
       return applyCorrection(db, staged.amendment.id, context, dependencies)
     }
+    if (staged.amendment.kind === "item_add") {
+      return finalizeItemAddApply(db, staged.amendment.id, context, dependencies)
+    }
     const supplierPlans = staged.amendment.operationPlan.flatMap((plan) =>
-      plan.supplierOperation
-        ? [{ ...plan.supplierOperation, bookingItemId: plan.bookingItemId }]
-        : [],
+      // Item-add plans carry no supplier operation — only owned inventory
+      // can be added this way, which `buildItemAddPlan` enforces.
+      isItemAddPlan(plan) || !plan.supplierOperation
+        ? []
+        : [{ ...plan.supplierOperation, bookingItemId: plan.bookingItemId }],
     )
     if (supplierPlans.length === 0) {
       return finalizeRosterApply(db, staged.amendment.id, context, dependencies)
@@ -1073,6 +1392,53 @@ async function insertRevisions(
       })),
     )
     .returning()
+}
+
+/**
+ * Stands in for the Booking Item an `item_add` will create, in the quote
+ * and in the proposed revision snapshot. The row does not exist until
+ * apply, but the snapshot has to show the service being bought.
+ */
+const PENDING_ITEM_ID = "pending"
+
+/**
+ * Whether a replayed preview describes the same addition as the stored one.
+ *
+ * Compared field by field rather than by serialising both sides: the stored
+ * copy has been through `jsonb`, which normalises key order, so two
+ * identical requests would not produce identical JSON strings and every
+ * replay would look like a conflict.
+ */
+function sameItemAdditionRequest(row: BookingAmendmentRow, input: PreviewBookingItemAdditionInput) {
+  const requested = row.requestedChange
+  if (requested.type !== "item_add") return false
+  if (row.baseBookingRevision !== input.expectedBookingRevision || row.reason !== input.reason) {
+    return false
+  }
+  const addition = input.addition
+  return (
+    requested.productId === addition.productId &&
+    (requested.optionId ?? null) === (addition.optionId ?? null) &&
+    (requested.optionUnitId ?? null) === (addition.optionUnitId ?? null) &&
+    (requested.availabilitySlotId ?? null) === (addition.availabilitySlotId ?? null) &&
+    requested.quantity === addition.quantity &&
+    (requested.title ?? null) === (addition.title ?? null)
+  )
+}
+
+/**
+ * The traveler a non-`item_add` Amendment concerns.
+ *
+ * `traveler_id` is nullable only so `item_add` can leave it unset; the
+ * `ck_booking_amendments_traveler_required` constraint guarantees every
+ * other kind has one. Throwing here reports a violated invariant instead
+ * of silently querying `id = NULL` and finding nothing.
+ */
+function requireAmendmentTravelerId(amendment: BookingAmendmentRow): string {
+  if (!amendment.travelerId) {
+    throw new Error(`Booking Amendment ${amendment.id} of kind ${amendment.kind} has no traveler`)
+  }
+  return amendment.travelerId
 }
 
 function sameRosterRequest(row: BookingAmendmentRow, input: PreviewTravelerRosterChangeInput) {
@@ -1222,12 +1588,13 @@ async function applyCorrection(
     }
     const requested = amendment.requestedChange
     if (requested.type !== "traveler_correction") return { status: "invalid_state" as const }
+    const amendmentTravelerId = requireAmendmentTravelerId(amendment)
     const [traveler] = await tx
       .update(bookingTravelers)
       .set({ ...requested.patch, updatedAt: dependencies.now?.() ?? new Date() })
       .where(
         and(
-          eq(bookingTravelers.id, amendment.travelerId),
+          eq(bookingTravelers.id, amendmentTravelerId),
           eq(bookingTravelers.bookingId, booking.id),
         ),
       )
@@ -1277,11 +1644,17 @@ async function finalizeRosterApply(
         return { status: "invalid_state" as const }
       }
       const now = dependencies.now?.() ?? new Date()
-      await applyCapacityAndAllocationPlan(tx, amendment.operationPlan, now)
+      // A roster Amendment only ever carries roster plans; `item_add` is
+      // dispatched to its own finalizer well before this point.
+      const rosterPlans = amendment.operationPlan.filter(
+        (plan): plan is BookingAmendmentRosterItemPlan => !isItemAddPlan(plan),
+      )
+      await applyCapacityAndAllocationPlan(tx, rosterPlans, now)
+      const amendmentTravelerId = requireAmendmentTravelerId(amendment)
       const requested = amendment.requestedChange
       if (requested.type === "traveler_add") {
         await tx.insert(bookingTravelers).values({
-          id: amendment.travelerId,
+          id: amendmentTravelerId,
           bookingId: booking.id,
           personId: requested.traveler.personId ?? null,
           participantType: requested.traveler.participantType,
@@ -1299,7 +1672,7 @@ async function finalizeRosterApply(
           requested.bookingItemIds.map((bookingItemId) => ({
             id: newId("booking_item_travelers"),
             bookingItemId,
-            travelerId: amendment.travelerId,
+            travelerId: amendmentTravelerId,
             role: "traveler" as const,
             isPrimary: false,
             createdAt: now,
@@ -1310,21 +1683,21 @@ async function finalizeRosterApply(
           .delete(bookingItemTravelers)
           .where(
             and(
-              eq(bookingItemTravelers.travelerId, amendment.travelerId),
+              eq(bookingItemTravelers.travelerId, amendmentTravelerId),
               inArray(bookingItemTravelers.bookingItemId, requested.bookingItemIds),
             ),
           )
         const [remainingAssignment] = await tx
           .select({ id: bookingItemTravelers.id })
           .from(bookingItemTravelers)
-          .where(eq(bookingItemTravelers.travelerId, amendment.travelerId))
+          .where(eq(bookingItemTravelers.travelerId, amendmentTravelerId))
           .limit(1)
         if (!remainingAssignment) {
           await tx
             .delete(bookingTravelers)
             .where(
               and(
-                eq(bookingTravelers.id, amendment.travelerId),
+                eq(bookingTravelers.id, amendmentTravelerId),
                 eq(bookingTravelers.bookingId, booking.id),
               ),
             )
@@ -1332,7 +1705,7 @@ async function finalizeRosterApply(
       } else {
         return { status: "invalid_state" as const }
       }
-      for (const plan of amendment.operationPlan) {
+      for (const plan of rosterPlans) {
         await tx
           .update(bookingItems)
           // agent-quality: raw-sql reviewed -- owner: bookings; integer deltas are server-derived from the immutable Amendment plan and Drizzle binds them.
@@ -1353,6 +1726,7 @@ async function finalizeRosterApply(
         price,
         consequences: amendment.financialConsequences,
         reason: amendment.reason,
+        now,
       })
       await advanceBookingRevision(tx, booking.id, amendment.baseBookingRevision, {
         revision: amendment.resultBookingRevision,
@@ -1399,6 +1773,153 @@ async function finalizeRosterApply(
         const amendment = await hydrateAmendment(db, failed)
         return { status: "manual_review", amendment }
       }
+      return { status: "availability_changed", bookingItemId: error.bookingItemId ?? "unknown" }
+    }
+    throw error
+  }
+}
+
+/**
+ * Write the service the Amendment quoted: the Booking Item, its capacity
+ * allocation, and the departure decrement — then advance the revision and
+ * hand finance the delta to collect.
+ *
+ * The slot decrement is a conditional UPDATE guarded on the departure still
+ * being open, in-window, and having room, exactly as the roster path does.
+ * A departure that filled up between the quote and the apply fails the
+ * guard and the whole transaction rolls back rather than overselling.
+ */
+async function finalizeItemAddApply(
+  db: PostgresJsDatabase,
+  amendmentId: string,
+  context: BookingAmendmentCommandContext,
+  dependencies: BookingAmendmentServiceDependencies,
+): Promise<ApplyBookingAmendmentResult> {
+  if (!dependencies.finance) return { status: "unsupported_capability" }
+  const finance = dependencies.finance
+  try {
+    return await db.transaction(async (rawTx) => {
+      const tx = rawTx as PostgresJsDatabase
+      const locked = await lockAmendment(tx, amendmentId)
+      if (!locked) return { status: "not_found" as const }
+      const { booking, amendment } = locked
+      if (amendment.status === "applied") {
+        return { status: "ok" as const, amendment: await hydrateAmendment(tx, amendment) }
+      }
+      if (booking.revision !== amendment.baseBookingRevision) {
+        return { status: "stale_revision" as const, currentBookingRevision: booking.revision }
+      }
+      const plan = amendment.operationPlan.find(isItemAddPlan)
+      if (!plan) return { status: "invalid_state" as const }
+
+      const now = dependencies.now?.() ?? new Date()
+
+      if (plan.availabilitySlotId) {
+        const [updated] = await tx
+          .update(availabilitySlotsRef)
+          // agent-quality: raw-sql reviewed -- owner: bookings; conditional capacity decrement uses locked, server-owned plan data and Drizzle identifiers.
+          .set({
+            remainingPax: sql`CASE WHEN ${availabilitySlotsRef.unlimited} THEN ${availabilitySlotsRef.remainingPax} ELSE ${availabilitySlotsRef.remainingPax} - ${plan.quantity} END`,
+            updatedAt: now,
+          })
+          .where(
+            and(
+              eq(availabilitySlotsRef.id, plan.availabilitySlotId),
+              eq(availabilitySlotsRef.status, "open"),
+              eq(availabilitySlotsRef.pastCutoff, false),
+              eq(availabilitySlotsRef.tooEarly, false),
+              // agent-quality: raw-sql reviewed -- owner: bookings; atomic positive-capacity guard over a Drizzle identifier.
+              or(
+                eq(availabilitySlotsRef.unlimited, true),
+                sql`${availabilitySlotsRef.remainingPax} >= ${plan.quantity}`,
+              ),
+            ),
+          )
+          .returning({ id: availabilitySlotsRef.id })
+        if (!updated) {
+          throw new RosterPlanError("availability_changed", "Departure filled up", PENDING_ITEM_ID)
+        }
+      }
+
+      const [item] = await tx
+        .insert(bookingItems)
+        .values({
+          bookingId: booking.id,
+          title: plan.title,
+          itemType: "unit",
+          status: "confirmed",
+          quantity: plan.quantity,
+          sellCurrency: plan.sellCurrency,
+          unitSellAmountCents: plan.unitSellAmountCents,
+          totalSellAmountCents: plan.totalSellAmountCents,
+          costCurrency: plan.costCurrency,
+          unitCostAmountCents: plan.unitCostAmountCents,
+          totalCostAmountCents: plan.totalCostAmountCents,
+          serviceDate: plan.serviceDate,
+          productId: plan.productId,
+          optionId: plan.optionId,
+          optionUnitId: plan.optionUnitId,
+          availabilitySlotId: plan.availabilitySlotId,
+          productNameSnapshot: plan.productNameSnapshot,
+          optionNameSnapshot: plan.optionNameSnapshot,
+          unitNameSnapshot: plan.unitNameSnapshot,
+          departureLabelSnapshot: plan.departureLabelSnapshot,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .returning()
+      if (!item) throw new Error("Booking Item insert did not return a row")
+
+      await tx.insert(bookingAllocations).values({
+        bookingId: booking.id,
+        bookingItemId: item.id,
+        productId: plan.productId,
+        optionId: plan.optionId,
+        optionUnitId: plan.optionUnitId,
+        availabilitySlotId: plan.availabilitySlotId,
+        quantity: plan.quantity,
+        allocationType: "unit",
+        status: "confirmed",
+        confirmedAt: now,
+        createdAt: now,
+        updatedAt: now,
+      })
+
+      const price = priceFromRow(amendment)
+      await finance.recordBookingAmendment(tx, {
+        amendmentId: amendment.id,
+        bookingId: booking.id,
+        idempotencyKey: context.idempotencyKey,
+        price,
+        consequences: amendment.financialConsequences,
+        reason: amendment.reason,
+        now,
+      })
+      await advanceBookingRevision(tx, booking.id, amendment.baseBookingRevision, {
+        revision: amendment.resultBookingRevision,
+        sellAmountCents:
+          booking.sellAmountCents == null
+            ? amendment.priceDeltaCents
+            : booking.sellAmountCents + amendment.priceDeltaCents,
+        updatedAt: now,
+      })
+      const applied = await markApplied(tx, amendment, context, now, {
+        ...amendment.effects,
+        finance: "recorded",
+        allocation: "applied",
+      })
+      await writeActivity(tx, amendment, context, `Service "${plan.title}" added`, now)
+      return { status: "ok" as const, amendment: await hydrateAmendment(tx, applied) }
+    })
+  } catch (error) {
+    if (error instanceof RosterPlanError && error.code === "availability_changed") {
+      await setAmendmentFailure(
+        db,
+        amendmentId,
+        "failed",
+        "availability_changed",
+        dependencies.now?.() ?? new Date(),
+      )
       return { status: "availability_changed", bookingItemId: error.bookingItemId ?? "unknown" }
     }
     throw error

--- a/packages/bookings/src/service-amendments.ts
+++ b/packages/bookings/src/service-amendments.ts
@@ -641,6 +641,63 @@ function mapPlanError(error: RosterPlanError): PreviewTravelerRosterChangeResult
  * already has an `upstreamRef`. Quoting one would promise capacity nobody
  * reserved.
  */
+/**
+ * Load the departure an addition targets, scoped to the product that
+ * claims it.
+ *
+ * Scoping is the point. Looking a slot up by id alone lets a caller pair
+ * product A with a departure belonging to product B: apply would then
+ * decrement B's capacity while writing an item and allocation that say A,
+ * corrupting both inventory views at once. Not found and wrong-product are
+ * deliberately the same answer.
+ */
+async function loadAdditionSlot(db: PostgresJsDatabase, slotId: string, productId: string) {
+  const [slot] = await db
+    .select({
+      id: availabilitySlotsRef.id,
+      status: availabilitySlotsRef.status,
+      unlimited: availabilitySlotsRef.unlimited,
+      remainingPax: availabilitySlotsRef.remainingPax,
+      pastCutoff: availabilitySlotsRef.pastCutoff,
+      tooEarly: availabilitySlotsRef.tooEarly,
+    })
+    .from(availabilitySlotsRef)
+    .where(and(eq(availabilitySlotsRef.id, slotId), eq(availabilitySlotsRef.productId, productId)))
+    .limit(1)
+  if (!slot) {
+    throw new RosterPlanError("not_found", "Departure does not exist for this product")
+  }
+  return slot
+}
+
+/**
+ * The catalog price for `quantity` of a unit, honouring quantity tiers.
+ *
+ * Tiers are ordered by the pricing snapshot; the matching one is the tier
+ * whose `[minQuantity, maxQuantity]` window contains the requested
+ * quantity. With no tiers — or none that match — the rule's own price
+ * stands.
+ */
+function resolveTieredUnitPrice(
+  unitPrice: {
+    sellAmountCents: number | null
+    tiers?: Array<{
+      minQuantity: number
+      maxQuantity: number | null
+      sellAmountCents: number | null
+    }>
+  },
+  quantity: number,
+): number | null {
+  const tier = (unitPrice.tiers ?? []).find(
+    (entry) =>
+      quantity >= entry.minQuantity &&
+      (entry.maxQuantity == null || quantity <= entry.maxQuantity) &&
+      entry.sellAmountCents != null,
+  )
+  return tier?.sellAmountCents ?? unitPrice.sellAmountCents ?? null
+}
+
 async function buildItemAddPlan(
   db: PostgresJsDatabase,
   booking: BookingRow,
@@ -670,8 +727,40 @@ async function buildItemAddPlan(
     )
   }
 
+  // The departure has to be resolved BEFORE pricing: a slot can carry
+  // `departure_price_overrides`, and quoting without it charges the base
+  // catalog rate for a date the operator has deliberately repriced.
+  const slot = addition.availabilitySlotId
+    ? await loadAdditionSlot(db, addition.availabilitySlotId, addition.productId)
+    : null
+
+  if (!slot) {
+    // A product that sells by departure has no meaning without one:
+    // writing an item with a null slot would consume no capacity while
+    // looking confirmed. Treat "this product has bookable departures" as
+    // the signal, since that is the same thing the booking-create flow
+    // requires the operator to pick from.
+    const [anySlot] = await db
+      .select({ id: availabilitySlotsRef.id })
+      .from(availabilitySlotsRef)
+      .where(
+        and(
+          eq(availabilitySlotsRef.productId, addition.productId),
+          eq(availabilitySlotsRef.status, "open"),
+        ),
+      )
+      .limit(1)
+    if (anySlot) {
+      throw new RosterPlanError(
+        "unsupported_configuration",
+        "This product sells by departure — pick one for the added service",
+      )
+    }
+  }
+
   const pricing = await resolveSessionPricingSnapshot(db, addition.productId, {
     optionId: addition.optionId ?? undefined,
+    departureId: addition.availabilitySlotId ?? undefined,
     requirePublicProduct: false,
   })
   if (!pricing) {
@@ -695,7 +784,23 @@ async function buildItemAddPlan(
     if (!unitPrice) {
       throw new RosterPlanError("unsupported_configuration", "Unit has no price in this catalog")
     }
-    unitSellAmountCents = unitPrice.sellAmountCents ?? null
+    // A unit may only be sold in the quantities the catalog permits.
+    if (unitPrice.minQuantity != null && addition.quantity < unitPrice.minQuantity) {
+      throw new RosterPlanError(
+        "unsupported_configuration",
+        `This unit sells in quantities of at least ${unitPrice.minQuantity}`,
+      )
+    }
+    if (unitPrice.maxQuantity != null && addition.quantity > unitPrice.maxQuantity) {
+      throw new RosterPlanError(
+        "unsupported_configuration",
+        `This unit sells in quantities of at most ${unitPrice.maxQuantity}`,
+      )
+    }
+    // Quantity tiers are the authoritative price when one matches — the
+    // rule's own `sellAmountCents` is the untiered fallback, and quoting
+    // it for a group-sized addition would charge the wrong rate.
+    unitSellAmountCents = resolveTieredUnitPrice(unitPrice, addition.quantity)
     unitName = unitPrice.unitName
   } else {
     const rule =
@@ -709,19 +814,7 @@ async function buildItemAddPlan(
     )
   }
 
-  if (addition.availabilitySlotId) {
-    const [slot] = await db
-      .select({
-        status: availabilitySlotsRef.status,
-        unlimited: availabilitySlotsRef.unlimited,
-        remainingPax: availabilitySlotsRef.remainingPax,
-        pastCutoff: availabilitySlotsRef.pastCutoff,
-        tooEarly: availabilitySlotsRef.tooEarly,
-      })
-      .from(availabilitySlotsRef)
-      .where(eq(availabilitySlotsRef.id, addition.availabilitySlotId))
-      .limit(1)
-    if (!slot) throw new RosterPlanError("not_found", "Departure does not exist")
+  if (slot) {
     const room = slot.unlimited || (slot.remainingPax ?? 0) >= addition.quantity
     if (slot.status !== "open" || slot.pastCutoff || slot.tooEarly || !room) {
       throw new RosterPlanError("availability_changed", "Departure cannot take this addition")
@@ -1825,6 +1918,10 @@ async function finalizeItemAddApply(
           .where(
             and(
               eq(availabilitySlotsRef.id, plan.availabilitySlotId),
+              // Re-asserted at apply, not just at preview: the decrement
+              // must land on the product the item claims, or capacity
+              // moves on one product while the booking records another.
+              eq(availabilitySlotsRef.productId, plan.productId),
               eq(availabilitySlotsRef.status, "open"),
               eq(availabilitySlotsRef.pastCutoff, false),
               eq(availabilitySlotsRef.tooEarly, false),

--- a/packages/bookings/src/service-core.ts
+++ b/packages/bookings/src/service-core.ts
@@ -1794,6 +1794,29 @@ async function releaseAllocationCapacity(
 }
 
 /**
+ * Take a row lock on a Booking Item before its capacity is recomputed.
+ *
+ * Every mutation that moves capacity — resize, delete — has to read the
+ * item's current quantity, decide a delta, and then adjust the slot. Two
+ * of those running concurrently would read the same starting value and
+ * both apply their delta to availability, while only one of them survives
+ * on the row. Serialising on the item makes the read-decide-write one
+ * atomic step.
+ *
+ * Returns `null` when the item is gone, which a concurrent delete makes
+ * an ordinary outcome rather than an error.
+ */
+async function lockBookingItemForCapacityChange(db: PostgresJsDatabase, itemId: string) {
+  const [row] = await db
+    .select({ id: bookingItems.id })
+    .from(bookingItems)
+    .where(eq(bookingItems.id, itemId))
+    .for("update")
+    .limit(1)
+  return row ?? null
+}
+
+/**
  * Move an item's capacity allocation by `delta` seats and adjust the
  * availability slot to match.
  *
@@ -1818,6 +1841,7 @@ async function syncAllocationQuantity(
     .select()
     .from(bookingAllocations)
     .where(eq(bookingAllocations.bookingItemId, bookingItemId))
+    .for("update")
 
   const active = allocations.filter((allocation) =>
     allocationStatusConsumesSlotCapacity(allocation.status),
@@ -4471,6 +4495,13 @@ const bookingsServiceInternal = {
   ) {
     const slotChanges: AvailabilitySlotChangedEventPayload[] = []
     const result = await db.transaction(async (tx) => {
+      // Lock the item before reading the quantity the delta is computed
+      // from. Two concurrent updates that both read the same old value
+      // would each adjust the slot while only one survives on the row,
+      // leaving allocation and capacity permanently out of step.
+      const locked = await lockBookingItemForCapacityChange(tx as PostgresJsDatabase, itemId)
+      if (!locked) return null
+
       const [parent] = await tx
         .select({ status: bookings.status, quantity: bookingItems.quantity })
         .from(bookingItems)
@@ -4617,6 +4648,11 @@ const bookingsServiceInternal = {
     const result = await db.transaction(async (tx) => {
       // Look up the parent booking BEFORE the delete so we can roll up
       // afterwards.
+      // Same lock as `updateItem`: two concurrent deletes would otherwise
+      // both read the live allocation and release its capacity twice.
+      const locked = await lockBookingItemForCapacityChange(tx as PostgresJsDatabase, itemId)
+      if (!locked) return null
+
       const [item] = await tx
         .select({
           bookingId: bookingItems.bookingId,
@@ -4637,6 +4673,7 @@ const bookingsServiceInternal = {
         .select()
         .from(bookingAllocations)
         .where(eq(bookingAllocations.bookingItemId, itemId))
+        .for("update")
 
       const releasedAllocationIds: string[] = []
       for (const allocation of allocations) {

--- a/packages/bookings/src/service-core.ts
+++ b/packages/bookings/src/service-core.ts
@@ -1048,7 +1048,15 @@ function isUndefinedTableError(error: unknown) {
  * OTA deployment) just yields `null` for that piece — the caller's
  * explicit values still win.
  */
-async function resolveBookingItemSnapshot(
+/**
+ * Catalog names and departure timing for a Booking Item's foreign ids.
+ *
+ * Exported so the Amendment engine snapshots an item it is about to create
+ * exactly the way `createItem` snapshots one — the same columns, resolved
+ * the same way, so "what did the customer buy?" reads identically whether
+ * the line arrived at booking time or through a later change.
+ */
+export async function resolveBookingItemSnapshot(
   db: PostgresJsDatabase,
   input: {
     productId: string | null
@@ -1738,6 +1746,7 @@ async function releaseAllocationCapacity(
     "availabilitySlotId" | "bookingId" | "quantity" | "status" | "id"
   >,
   source: SlotChangeSource = "cancel",
+  options: { allowTerminalCapacityRelease?: boolean } = {},
 ): Promise<AvailabilitySlotChangedEventPayload | undefined> {
   if (!allocation.availabilitySlotId) {
     return undefined
@@ -1752,7 +1761,15 @@ async function releaseAllocationCapacity(
     allocation.availabilitySlotId,
     allocation.quantity,
     source,
-    { allowTerminalCapacityRelease: source === "cancel" || source === "expire" },
+    {
+      // Giving capacity back is always safe on a closed or cancelled
+      // departure — the seat stops being consumed either way. Callers
+      // that release (cancel, expire, or dropping the line item that
+      // held it) must not be blocked by the slot's terminal status,
+      // or the capacity leaks with no row left to reconcile from.
+      allowTerminalCapacityRelease:
+        options.allowTerminalCapacityRelease ?? (source === "cancel" || source === "expire"),
+    },
   )
   if (result.status === "slot_not_found") {
     await db.insert(bookingActivityLog).values({
@@ -1774,6 +1791,86 @@ async function releaseAllocationCapacity(
     throw new BookingServiceError(result.status)
   }
   return result.slotChange
+}
+
+/**
+ * Move an item's capacity allocation by `delta` seats and adjust the
+ * availability slot to match.
+ *
+ * Only meaningful when the item has exactly one allocation that still
+ * consumes capacity — that is the shape every allocation-creating path
+ * produces, and the same precondition `bookingAmendmentService` enforces
+ * for roster changes. Items with no such allocation (manually authored
+ * lines, sourced inventory with no slot) are left alone: there is no
+ * local capacity to move.
+ *
+ * Throws `BookingServiceError("insufficient_capacity")` rather than
+ * overselling the slot.
+ */
+async function syncAllocationQuantity(
+  db: PostgresJsDatabase,
+  bookingItemId: string,
+  delta: number,
+): Promise<AvailabilitySlotChangedEventPayload | undefined> {
+  if (delta === 0) return undefined
+
+  const allocations = await db
+    .select()
+    .from(bookingAllocations)
+    .where(eq(bookingAllocations.bookingItemId, bookingItemId))
+
+  const active = allocations.filter((allocation) =>
+    allocationStatusConsumesSlotCapacity(allocation.status),
+  )
+  if (active.length !== 1) return undefined
+
+  const allocation = active[0]!
+  const nextQuantity = allocation.quantity + delta
+  if (nextQuantity < 0) {
+    throw new BookingServiceError("insufficient_capacity")
+  }
+
+  let slotChange: AvailabilitySlotChangedEventPayload | undefined
+  if (allocation.availabilitySlotId) {
+    // Slot capacity moves opposite the allocation: consuming one more
+    // seat leaves one fewer remaining.
+    const result = await adjustSlotCapacity(
+      db,
+      allocation.availabilitySlotId,
+      -delta,
+      "modify",
+      // Releasing back into a closed departure is fine; taking more
+      // from one is not, and `adjustSlotCapacity` still refuses that.
+      { allowTerminalCapacityRelease: delta < 0 },
+    )
+    if (result.status === "slot_not_found") {
+      await db.insert(bookingActivityLog).values({
+        bookingId: allocation.bookingId,
+        actorId: "system",
+        activityType: "system_action",
+        description:
+          "Allocation quantity change requires reconciliation: availability slot missing",
+        metadata: {
+          kind: "allocation_capacity_sync_reconciliation",
+          allocationId: allocation.id,
+          availabilitySlotId: allocation.availabilitySlotId,
+          delta,
+          problem: "slot_not_found",
+        },
+      })
+    } else if (result.status !== "ok") {
+      throw new BookingServiceError(result.status)
+    } else {
+      slotChange = result.slotChange
+    }
+  }
+
+  await db
+    .update(bookingAllocations)
+    .set({ quantity: nextQuantity, updatedAt: new Date() })
+    .where(eq(bookingAllocations.id, allocation.id))
+
+  return slotChange
 }
 
 async function autoIssueFulfillmentsForBooking(
@@ -4353,10 +4450,29 @@ const bookingsServiceInternal = {
     })
   },
 
-  async updateItem(db: PostgresJsDatabase, itemId: string, data: UpdateBookingItemInput) {
-    return db.transaction(async (tx) => {
+  /**
+   * Update a Booking Item, keeping any capacity allocation it holds in
+   * step with its `quantity`.
+   *
+   * A quantity change on an allocation-backed item is a capacity change:
+   * leaving `booking_allocations.quantity` behind desynchronises the
+   * ledger from what the booking actually consumes. Increases are
+   * checked against the slot and fail with `insufficient_capacity`
+   * rather than overselling.
+   *
+   * This is the ad-hoc correction path. Priced, consented, supplier-aware
+   * quantity changes belong in `bookingAmendmentService`.
+   */
+  async updateItem(
+    db: PostgresJsDatabase,
+    itemId: string,
+    data: UpdateBookingItemInput,
+    runtime: BookingServiceRuntime = {},
+  ) {
+    const slotChanges: AvailabilitySlotChangedEventPayload[] = []
+    const result = await db.transaction(async (tx) => {
       const [parent] = await tx
-        .select({ status: bookings.status })
+        .select({ status: bookings.status, quantity: bookingItems.quantity })
         .from(bookingItems)
         .innerJoin(bookings, eq(bookings.id, bookingItems.bookingId))
         .where(eq(bookingItems.id, itemId))
@@ -4364,6 +4480,15 @@ const bookingsServiceInternal = {
 
       if (!parent || !bookingAllowsItemMutation(parent.status)) {
         return null
+      }
+
+      if (data.quantity !== undefined && data.quantity !== parent.quantity) {
+        const change = await syncAllocationQuantity(
+          tx as PostgresJsDatabase,
+          itemId,
+          data.quantity - parent.quantity,
+        )
+        if (change) slotChanges.push(change)
       }
 
       // Refresh snapshots only when the foreign IDs change. Existing
@@ -4467,10 +4592,29 @@ const bookingsServiceInternal = {
       await bookingsService.recomputeBookingTotal(tx as PostgresJsDatabase, row.bookingId)
       return row
     })
+
+    await emitSlotChanges(runtime, slotChanges)
+    return result
   },
 
-  async deleteItem(db: PostgresJsDatabase, itemId: string, userId?: string) {
-    return db.transaction(async (tx) => {
+  /**
+   * Delete a Booking Item, returning any capacity its allocations still
+   * consume.
+   *
+   * `booking_allocations.booking_item_id` is `ON DELETE CASCADE`, so the
+   * allocation rows disappear with the item. Releasing BEFORE the delete
+   * is therefore not an optimisation — it is the only chance to give the
+   * seats back. Skipping it leaks `availability_slots.remaining_pax`
+   * permanently, with no allocation row left to reconcile from.
+   */
+  async deleteItem(
+    db: PostgresJsDatabase,
+    itemId: string,
+    userId?: string,
+    runtime: BookingServiceRuntime = {},
+  ) {
+    const slotChanges: AvailabilitySlotChangedEventPayload[] = []
+    const result = await db.transaction(async (tx) => {
       // Look up the parent booking BEFORE the delete so we can roll up
       // afterwards.
       const [item] = await tx
@@ -4489,6 +4633,25 @@ const bookingsServiceInternal = {
         return null
       }
 
+      const allocations = await tx
+        .select()
+        .from(bookingAllocations)
+        .where(eq(bookingAllocations.bookingItemId, itemId))
+
+      const releasedAllocationIds: string[] = []
+      for (const allocation of allocations) {
+        const change = await releaseAllocationCapacity(
+          tx as PostgresJsDatabase,
+          allocation,
+          "modify",
+          { allowTerminalCapacityRelease: true },
+        )
+        if (allocationStatusConsumesSlotCapacity(allocation.status)) {
+          releasedAllocationIds.push(allocation.id)
+        }
+        if (change) slotChanges.push(change)
+      }
+
       const [row] = await tx
         .delete(bookingItems)
         .where(eq(bookingItems.id, itemId))
@@ -4501,12 +4664,19 @@ const bookingsServiceInternal = {
           actorId: userId ?? "system",
           activityType: "item_update",
           description: `Booking item "${item.title}" deleted`,
-          metadata: { bookingItemId: itemId, itemType: item.itemType },
+          metadata: {
+            bookingItemId: itemId,
+            itemType: item.itemType,
+            releasedAllocationIds,
+          },
         })
       }
 
       return row ?? null
     })
+
+    await emitSlotChanges(runtime, slotChanges)
+    return result
   },
 
   listItemParticipants(db: PostgresJsDatabase, itemId: string) {

--- a/packages/bookings/tests/integration/booking-item-addition.test.ts
+++ b/packages/bookings/tests/integration/booking-item-addition.test.ts
@@ -339,6 +339,84 @@ describe.skipIf(!DB_AVAILABLE)("Booking item addition Amendments", () => {
     expect(conflicting.status).toBe("idempotency_conflict")
   })
 
+  it("refuses a departure that belongs to a different product", async () => {
+    // Pairing product A with product B's departure would decrement B's
+    // capacity while writing an item that claims A.
+    const seeded = await seed()
+    const other = await seed()
+
+    const preview = await bookingAmendmentService.previewItemAddition(
+      db,
+      seeded.booking.id,
+      {
+        expectedBookingRevision: 1,
+        reason: "Cross-product departure",
+        addition: {
+          type: "item_add",
+          productId: seeded.product.id,
+          optionId: seeded.option.id,
+          availabilitySlotId: other.slot!.id,
+          quantity: 1,
+        },
+      },
+      context("cross-product"),
+      { finance: financeRuntime() },
+    )
+
+    expect(preview.status).toBe("not_found")
+    const [slot] = await db
+      .select()
+      .from(availabilitySlotsRef)
+      .where(eq(availabilitySlotsRef.id, other.slot!.id))
+    expect(slot?.remainingPax).toBe(10)
+  })
+
+  it("refuses to add a departure-sold product without picking a departure", async () => {
+    const seeded = await seed()
+    const preview = await bookingAmendmentService.previewItemAddition(
+      db,
+      seeded.booking.id,
+      {
+        expectedBookingRevision: 1,
+        reason: "No departure picked",
+        addition: {
+          type: "item_add",
+          productId: seeded.product.id,
+          optionId: seeded.option.id,
+          availabilitySlotId: null,
+          quantity: 1,
+        },
+      },
+      context("no-departure"),
+      { finance: financeRuntime() },
+    )
+
+    expect(preview.status).toBe("unsupported_configuration")
+  })
+
+  it("adds a product that has no departures at all without one", async () => {
+    const seeded = await seed({ withSlot: false })
+    const preview = await bookingAmendmentService.previewItemAddition(
+      db,
+      seeded.booking.id,
+      {
+        expectedBookingRevision: 1,
+        reason: "Unscheduled service",
+        addition: {
+          type: "item_add",
+          productId: seeded.product.id,
+          optionId: seeded.option.id,
+          availabilitySlotId: null,
+          quantity: 1,
+        },
+      },
+      context("unscheduled"),
+      { finance: financeRuntime() },
+    )
+
+    expect(preview.status).toBe("ok")
+  })
+
   it("refuses a stale booking revision", async () => {
     const seeded = await seed()
     await db.update(bookings).set({ revision: 7 }).where(eq(bookings.id, seeded.booking.id))

--- a/packages/bookings/tests/integration/booking-item-addition.test.ts
+++ b/packages/bookings/tests/integration/booking-item-addition.test.ts
@@ -1,0 +1,348 @@
+/**
+ * `item_add` Amendments: adding a catalog service to a booking that already
+ * exists, priced by the catalog and holding real capacity.
+ *
+ * The invariant worth protecting is that the quote and the write agree.
+ * These drive preview → accept → apply against a live database and assert
+ * on the Booking Item, the allocation, and the departure's remaining pax —
+ * not on the return value, because a plan that quotes correctly and writes
+ * nothing would still look fine from the caller's side.
+ */
+
+import { eq } from "drizzle-orm"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { availabilitySlotsRef } from "../../src/availability-ref.js"
+import { optionPriceRulesRef, priceCatalogsRef } from "../../src/pricing-ref.js"
+import { productOptionsRef, productsRef } from "../../src/products-ref.js"
+import type { BookingsFinanceRuntime } from "../../src/runtime-port.js"
+import { bookingAllocations, bookingItems, bookings } from "../../src/schema.js"
+import { bookingAmendmentService } from "../../src/service-amendments.js"
+
+const DB_AVAILABLE = Boolean(process.env.TEST_DATABASE_URL)
+
+describe.skipIf(!DB_AVAILABLE)("Booking item addition Amendments", () => {
+  let db: ReturnType<typeof import("@voyant-travel/db/test-utils").createTestDb>
+  let sequence = 0
+
+  beforeAll(async () => {
+    const { cleanupTestDb, createTestDb } = await import("@voyant-travel/db/test-utils")
+    db = createTestDb()
+    await cleanupTestDb(db)
+  })
+
+  beforeEach(async () => {
+    const { cleanupTestDb } = await import("@voyant-travel/db/test-utils")
+    await cleanupTestDb(db)
+  })
+
+  afterAll(async () => {
+    const { closeTestDb } = await import("@voyant-travel/db/test-utils")
+    await closeTestDb()
+  })
+
+  /**
+   * Passes the subtotal straight through. The real finance runtime adds
+   * tax; these tests are about the plan and the write, so the arithmetic
+   * stays legible.
+   */
+  function financeRuntime(): BookingsFinanceRuntime {
+    return {
+      async quoteBookingAmendment(_db, input) {
+        const amountCents = input.lines.reduce((sum, line) => sum + line.subtotalDeltaCents, 0)
+        return {
+          price: {
+            currency: input.currency,
+            subtotalDeltaCents: amountCents,
+            feeDeltaCents: 0,
+            taxDeltaCents: 0,
+            amountCents,
+            collectionAmountCents: Math.max(amountCents, 0),
+            refundAmountCents: Math.max(-amountCents, 0),
+            taxLines: [],
+          },
+          consequences: {
+            collection: amountCents > 0 ? "required" : "not_required",
+            refund: "not_required",
+            invoice: amountCents > 0 ? "reissue_required" : "not_required",
+            creditNote: "not_required",
+            paymentSchedule: amountCents === 0 ? "not_required" : "recalculate_required",
+          },
+          policyVersion: "test-finance-v1",
+        }
+      },
+      async recordBookingAmendment() {
+        return { adjustmentId: "faad_test", status: "recorded" }
+      },
+    }
+  }
+
+  async function seed(options: { remainingPax?: number; withSlot?: boolean } = {}) {
+    sequence += 1
+    const remainingPax = options.remainingPax ?? 10
+    const withSlot = options.withSlot ?? true
+
+    const [booking] = await db
+      .insert(bookings)
+      .values({
+        bookingNumber: `BK-ITEMADD-${String(sequence).padStart(6, "0")}`,
+        sellCurrency: "EUR",
+        status: "confirmed",
+        sellAmountCents: 50_000,
+      })
+      .returning()
+
+    const [catalog] = await db
+      .insert(priceCatalogsRef)
+      .values({
+        code: `PUB-${sequence}`,
+        name: "Public",
+        currencyCode: "EUR",
+        catalogType: "public",
+        isDefault: true,
+        active: true,
+      })
+      .returning()
+
+    const [product] = await db
+      .insert(productsRef)
+      .values({
+        name: "Bosphorus cruise",
+        status: "active",
+        visibility: "public",
+        activated: true,
+        sellCurrency: "EUR",
+        sellAmountCents: 6_400,
+        costAmountCents: 3_500,
+      })
+      .returning()
+
+    const [option] = await db
+      .insert(productOptionsRef)
+      .values({
+        productId: product!.id,
+        name: "Standard",
+        status: "active",
+        isDefault: true,
+      })
+      .returning()
+
+    await db.insert(optionPriceRulesRef).values({
+      productId: product!.id,
+      optionId: option!.id,
+      priceCatalogId: catalog!.id,
+      name: "Default",
+      pricingMode: "per_person",
+      baseSellAmountCents: 6_400,
+      isDefault: true,
+      active: true,
+    })
+
+    const [slot] = withSlot
+      ? await db
+          .insert(availabilitySlotsRef)
+          .values({
+            productId: product!.id,
+            dateLocal: "2026-09-10",
+            startsAt: new Date("2026-09-10T08:00:00.000Z"),
+            timezone: "Europe/Bucharest",
+            status: "open",
+            unlimited: false,
+            initialPax: remainingPax,
+            remainingPax,
+          })
+          .returning()
+      : [null]
+
+    return { booking: booking!, product: product!, option: option!, slot }
+  }
+
+  function context(key: string) {
+    return { actor: "staff" as const, actorId: "usr_staff", idempotencyKey: key }
+  }
+
+  async function previewAddition(
+    seeded: Awaited<ReturnType<typeof seed>>,
+    overrides: { quantity?: number; key?: string } = {},
+  ) {
+    return bookingAmendmentService.previewItemAddition(
+      db,
+      seeded.booking.id,
+      {
+        expectedBookingRevision: 1,
+        reason: "Customer asked for an extra excursion",
+        addition: {
+          type: "item_add",
+          productId: seeded.product.id,
+          optionId: seeded.option.id,
+          availabilitySlotId: seeded.slot?.id ?? null,
+          quantity: overrides.quantity ?? 1,
+        },
+      },
+      context(overrides.key ?? "preview-item-1"),
+      { finance: financeRuntime() },
+    )
+  }
+
+  it("prices the addition from the catalog, not from the caller", async () => {
+    const seeded = await seed()
+    const preview = await previewAddition(seeded, { quantity: 2 })
+
+    expect(preview.status).toBe("ok")
+    if (preview.status !== "ok") throw new Error("Expected a quote")
+    expect(preview.amendment).toMatchObject({
+      kind: "item_add",
+      travelerId: null,
+      priceDelta: { amountCents: 12_800, collectionAmountCents: 12_800, currency: "EUR" },
+      effects: { allocation: "increase_required", supplier: "not_required" },
+    })
+    // Collecting is not offered on a quote — only once the change is
+    // actually applied is there anything to collect for.
+    expect(preview.amendment.nextActions).toEqual(["accept"])
+  })
+
+  it("writes nothing to the booking until the Amendment is applied", async () => {
+    const seeded = await seed()
+    await previewAddition(seeded)
+
+    const items = await db
+      .select()
+      .from(bookingItems)
+      .where(eq(bookingItems.bookingId, seeded.booking.id))
+    expect(items).toHaveLength(0)
+    const [slot] = await db
+      .select()
+      .from(availabilitySlotsRef)
+      .where(eq(availabilitySlotsRef.id, seeded.slot!.id))
+    expect(slot?.remainingPax).toBe(10)
+  })
+
+  it("creates the item, its allocation, and takes the seats on apply", async () => {
+    const seeded = await seed()
+    const preview = await previewAddition(seeded, { quantity: 2 })
+    if (preview.status !== "ok") throw new Error("Expected a quote")
+    const proposed = preview.amendment.revisions?.find((r) => r.role === "proposed_after")
+    if (!proposed) throw new Error("Expected a proposed revision")
+
+    await bookingAmendmentService.accept(
+      db,
+      preview.amendment.id,
+      proposed.id,
+      context("accept-item-1"),
+      { finance: financeRuntime() },
+    )
+    const applied = await bookingAmendmentService.apply(
+      db,
+      preview.amendment.id,
+      { expectedBookingRevision: 1, proposedRevisionId: proposed.id },
+      context("apply-item-1"),
+      { finance: financeRuntime() },
+    )
+
+    expect(applied.status).toBe("ok")
+
+    const [item] = await db
+      .select()
+      .from(bookingItems)
+      .where(eq(bookingItems.bookingId, seeded.booking.id))
+    expect(item).toMatchObject({
+      productId: seeded.product.id,
+      optionId: seeded.option.id,
+      availabilitySlotId: seeded.slot!.id,
+      quantity: 2,
+      unitSellAmountCents: 6_400,
+      totalSellAmountCents: 12_800,
+      status: "confirmed",
+      productNameSnapshot: "Bosphorus cruise",
+    })
+
+    const [allocation] = await db
+      .select()
+      .from(bookingAllocations)
+      .where(eq(bookingAllocations.bookingId, seeded.booking.id))
+    expect(allocation).toMatchObject({
+      bookingItemId: item!.id,
+      availabilitySlotId: seeded.slot!.id,
+      quantity: 2,
+      status: "confirmed",
+    })
+
+    const [slot] = await db
+      .select()
+      .from(availabilitySlotsRef)
+      .where(eq(availabilitySlotsRef.id, seeded.slot!.id))
+    expect(slot?.remainingPax).toBe(8)
+
+    const [booking] = await db.select().from(bookings).where(eq(bookings.id, seeded.booking.id))
+    expect(booking).toMatchObject({ revision: 2, sellAmountCents: 62_800 })
+
+    // Now that it is applied, the money to collect is the operator's
+    // next move.
+    if (applied.status !== "ok") throw new Error("Expected an applied amendment")
+    expect(applied.amendment.nextActions).toContain("collect_payment")
+  })
+
+  it("refuses a departure that cannot seat the addition", async () => {
+    const seeded = await seed({ remainingPax: 1 })
+    const preview = await previewAddition(seeded, { quantity: 4 })
+    expect(preview.status).toBe("availability_changed")
+  })
+
+  it("refuses to apply a quote whose departure filled up in the meantime", async () => {
+    const seeded = await seed({ remainingPax: 2 })
+    const preview = await previewAddition(seeded, { quantity: 2 })
+    if (preview.status !== "ok") throw new Error("Expected a quote")
+    const proposed = preview.amendment.revisions?.find((r) => r.role === "proposed_after")
+    if (!proposed) throw new Error("Expected a proposed revision")
+
+    // Somebody else took the seats between quote and commit.
+    await db
+      .update(availabilitySlotsRef)
+      .set({ remainingPax: 0, status: "sold_out" })
+      .where(eq(availabilitySlotsRef.id, seeded.slot!.id))
+
+    await bookingAmendmentService.accept(
+      db,
+      preview.amendment.id,
+      proposed.id,
+      context("accept-item-2"),
+      { finance: financeRuntime() },
+    )
+    const applied = await bookingAmendmentService.apply(
+      db,
+      preview.amendment.id,
+      { expectedBookingRevision: 1, proposedRevisionId: proposed.id },
+      context("apply-item-2"),
+      { finance: financeRuntime() },
+    )
+
+    expect(applied.status).toBe("availability_changed")
+    const items = await db
+      .select()
+      .from(bookingItems)
+      .where(eq(bookingItems.bookingId, seeded.booking.id))
+    expect(items).toHaveLength(0)
+  })
+
+  it("replays an identical preview instead of quoting twice", async () => {
+    const seeded = await seed()
+    const first = await previewAddition(seeded, { key: "same-key" })
+    const second = await previewAddition(seeded, { key: "same-key" })
+    if (first.status !== "ok" || second.status !== "ok") throw new Error("Expected quotes")
+    expect(second.amendment.id).toBe(first.amendment.id)
+  })
+
+  it("rejects a reused idempotency key that describes a different addition", async () => {
+    const seeded = await seed()
+    await previewAddition(seeded, { key: "shared-key", quantity: 1 })
+    const conflicting = await previewAddition(seeded, { key: "shared-key", quantity: 3 })
+    expect(conflicting.status).toBe("idempotency_conflict")
+  })
+
+  it("refuses a stale booking revision", async () => {
+    const seeded = await seed()
+    await db.update(bookings).set({ revision: 7 }).where(eq(bookings.id, seeded.booking.id))
+    const preview = await previewAddition(seeded)
+    expect(preview.status).toBe("stale_revision")
+  })
+})

--- a/packages/bookings/tests/integration/item-allocation-capacity.test.ts
+++ b/packages/bookings/tests/integration/item-allocation-capacity.test.ts
@@ -1,0 +1,272 @@
+/**
+ * `booking_allocations.booking_item_id` is `ON DELETE CASCADE`, so deleting a
+ * Booking Item takes its allocation rows with it. Before this suite, nothing
+ * gave the seats back first: `availability_slots.remaining_pax` stayed
+ * decremented forever with no allocation row left to reconcile from.
+ *
+ * The same gap applied to `quantity` edits — the item moved, the allocation
+ * did not.
+ *
+ * These tests drive the real service methods against a live database and
+ * assert on the slot row, not on a return value, because the leak is
+ * invisible from the caller's side.
+ */
+
+import { eq } from "drizzle-orm"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { availabilitySlotsRef } from "../../src/availability-ref.js"
+import { bookingAllocations, bookingItems, bookings } from "../../src/schema.js"
+import { bookingsService } from "../../src/service.js"
+
+const DB_AVAILABLE = Boolean(process.env.TEST_DATABASE_URL)
+
+describe.skipIf(!DB_AVAILABLE)("booking item allocation capacity", () => {
+  let db: ReturnType<typeof import("@voyant-travel/db/test-utils").createTestDb>
+  let sequence = 0
+
+  beforeAll(async () => {
+    const { cleanupTestDb, createTestDb } = await import("@voyant-travel/db/test-utils")
+    db = createTestDb()
+    await cleanupTestDb(db)
+  })
+
+  beforeEach(async () => {
+    const { cleanupTestDb } = await import("@voyant-travel/db/test-utils")
+    await cleanupTestDb(db)
+  })
+
+  afterAll(async () => {
+    const { closeTestDb } = await import("@voyant-travel/db/test-utils")
+    await closeTestDb()
+  })
+
+  /**
+   * A confirmed booking holding `quantity` seats on an open slot that
+   * started with `initialPax` and has `initialPax - quantity` left.
+   */
+  async function seedAllocatedItem(
+    options: {
+      quantity?: number
+      initialPax?: number
+      slotStatus?: "open" | "closed" | "sold_out"
+      allocationStatus?: "held" | "confirmed" | "cancelled"
+      withSlot?: boolean
+    } = {},
+  ) {
+    const quantity = options.quantity ?? 1
+    const initialPax = options.initialPax ?? 5
+    const withSlot = options.withSlot ?? true
+    sequence += 1
+
+    const [booking] = await db
+      .insert(bookings)
+      .values({
+        bookingNumber: `BK-CAP-${String(sequence).padStart(6, "0")}`,
+        sellCurrency: "EUR",
+        status: "confirmed",
+      })
+      .returning()
+
+    const [slot] = withSlot
+      ? await db
+          .insert(availabilitySlotsRef)
+          .values({
+            productId: "prod_capacity",
+            dateLocal: "2026-09-10",
+            startsAt: new Date("2026-09-10T08:00:00.000Z"),
+            timezone: "Europe/Bucharest",
+            status: options.slotStatus ?? "open",
+            unlimited: false,
+            initialPax,
+            remainingPax: initialPax - quantity,
+          })
+          .returning()
+      : [null]
+
+    const [item] = await db
+      .insert(bookingItems)
+      .values({
+        bookingId: booking!.id,
+        title: "Istanbul 7 days",
+        status: "confirmed",
+        quantity,
+        sellCurrency: "EUR",
+        unitSellAmountCents: 10_000,
+        totalSellAmountCents: 10_000 * quantity,
+        productId: "prod_capacity",
+        availabilitySlotId: slot?.id ?? null,
+      })
+      .returning()
+
+    const [allocation] = await db
+      .insert(bookingAllocations)
+      .values({
+        bookingId: booking!.id,
+        bookingItemId: item!.id,
+        productId: "prod_capacity",
+        availabilitySlotId: slot?.id ?? null,
+        quantity,
+        status: options.allocationStatus ?? "confirmed",
+      })
+      .returning()
+
+    return { booking: booking!, slot, item: item!, allocation: allocation! }
+  }
+
+  async function readSlot(slotId: string) {
+    const [row] = await db
+      .select({
+        remainingPax: availabilitySlotsRef.remainingPax,
+        status: availabilitySlotsRef.status,
+      })
+      .from(availabilitySlotsRef)
+      .where(eq(availabilitySlotsRef.id, slotId))
+    return row
+  }
+
+  async function readAllocations(bookingId: string) {
+    return db.select().from(bookingAllocations).where(eq(bookingAllocations.bookingId, bookingId))
+  }
+
+  describe("deleteItem", () => {
+    it("returns the seats its allocation held before cascading it away", async () => {
+      const { slot, item, booking } = await seedAllocatedItem({ quantity: 2, initialPax: 5 })
+      expect((await readSlot(slot!.id))?.remainingPax).toBe(3)
+
+      await bookingsService.deleteItem(db, item.id)
+
+      expect((await readSlot(slot!.id))?.remainingPax).toBe(5)
+      expect(await readAllocations(booking.id)).toHaveLength(0)
+    })
+
+    it("reopens a slot that the booking had sold out", async () => {
+      const { slot, item } = await seedAllocatedItem({
+        quantity: 2,
+        initialPax: 2,
+        slotStatus: "sold_out",
+      })
+      expect(await readSlot(slot!.id)).toMatchObject({ remainingPax: 0, status: "sold_out" })
+
+      await bookingsService.deleteItem(db, item.id)
+
+      expect(await readSlot(slot!.id)).toMatchObject({ remainingPax: 2, status: "open" })
+    })
+
+    it("still releases when the departure has since closed", async () => {
+      // A closed departure refuses ordinary capacity mutations. Releasing
+      // into one has to keep working or the seats leak precisely when an
+      // operator is cleaning up a booking on a closed date.
+      const { slot, item } = await seedAllocatedItem({
+        quantity: 1,
+        initialPax: 4,
+        slotStatus: "closed",
+      })
+
+      await bookingsService.deleteItem(db, item.id)
+
+      expect(await readSlot(slot!.id)).toMatchObject({ remainingPax: 4, status: "closed" })
+    })
+
+    it("leaves capacity alone for an allocation that already gave its seat back", async () => {
+      const { slot, item } = await seedAllocatedItem({
+        quantity: 1,
+        initialPax: 5,
+        allocationStatus: "cancelled",
+      })
+      // Seeded as if the release already happened.
+      await db
+        .update(availabilitySlotsRef)
+        .set({ remainingPax: 5 })
+        .where(eq(availabilitySlotsRef.id, slot!.id))
+
+      await bookingsService.deleteItem(db, item.id)
+
+      expect((await readSlot(slot!.id))?.remainingPax).toBe(5)
+    })
+
+    it("deletes a manually authored item that holds no allocation", async () => {
+      const { booking } = await seedAllocatedItem()
+      const manual = await bookingsService.createItem(db, booking.id, {
+        title: "Airport transfer",
+        itemType: "service",
+        quantity: 1,
+        sellCurrency: "EUR",
+        totalSellAmountCents: 4_000,
+      })
+      if (!manual) throw new Error("createItem returned null")
+
+      await expect(bookingsService.deleteItem(db, manual.id)).resolves.toMatchObject({
+        id: manual.id,
+      })
+    })
+
+    it("records the released allocation ids on the activity log entry", async () => {
+      const { item, allocation, booking } = await seedAllocatedItem()
+      await bookingsService.deleteItem(db, item.id)
+
+      const { bookingActivityLog } = await import("../../src/schema.js")
+      const entries = await db
+        .select()
+        .from(bookingActivityLog)
+        .where(eq(bookingActivityLog.bookingId, booking.id))
+      const deletion = entries.find((entry) =>
+        String(entry.description).includes("Istanbul 7 days"),
+      )
+      expect(deletion?.metadata).toMatchObject({ releasedAllocationIds: [allocation.id] })
+    })
+  })
+
+  describe("updateItem", () => {
+    it("takes another seat when the quantity goes up", async () => {
+      const { slot, item, booking } = await seedAllocatedItem({ quantity: 1, initialPax: 5 })
+
+      await bookingsService.updateItem(db, item.id, { quantity: 3 })
+
+      expect((await readSlot(slot!.id))?.remainingPax).toBe(2)
+      expect((await readAllocations(booking.id))[0]?.quantity).toBe(3)
+    })
+
+    it("gives seats back when the quantity goes down", async () => {
+      const { slot, item, booking } = await seedAllocatedItem({ quantity: 3, initialPax: 5 })
+
+      await bookingsService.updateItem(db, item.id, { quantity: 1 })
+
+      expect((await readSlot(slot!.id))?.remainingPax).toBe(4)
+      expect((await readAllocations(booking.id))[0]?.quantity).toBe(1)
+    })
+
+    it("refuses to oversell the departure", async () => {
+      const { slot, item, booking } = await seedAllocatedItem({ quantity: 1, initialPax: 2 })
+
+      await expect(bookingsService.updateItem(db, item.id, { quantity: 4 })).rejects.toThrow(
+        "insufficient_capacity",
+      )
+
+      // The whole update is one transaction: nothing moved.
+      expect((await readSlot(slot!.id))?.remainingPax).toBe(1)
+      expect((await readAllocations(booking.id))[0]?.quantity).toBe(1)
+      const [row] = await db.select().from(bookingItems).where(eq(bookingItems.id, item.id))
+      expect(row?.quantity).toBe(1)
+      expect(booking.id).toBeTruthy()
+    })
+
+    it("leaves capacity alone when the quantity is unchanged", async () => {
+      const { slot, item } = await seedAllocatedItem({ quantity: 2, initialPax: 5 })
+
+      await bookingsService.updateItem(db, item.id, { quantity: 2, title: "Renamed" })
+
+      expect((await readSlot(slot!.id))?.remainingPax).toBe(3)
+    })
+
+    it("moves an allocation that has no slot without touching availability", async () => {
+      // Sourced inventory: the allocation is real but the authoritative
+      // capacity lives at the supplier, not in a local slot.
+      const { item, booking } = await seedAllocatedItem({ quantity: 1, withSlot: false })
+
+      await bookingsService.updateItem(db, item.id, { quantity: 2 })
+
+      expect((await readAllocations(booking.id))[0]?.quantity).toBe(2)
+    })
+  })
+})

--- a/packages/finance-react/src/checkout-components/collect-payment-dialog.tsx
+++ b/packages/finance-react/src/checkout-components/collect-payment-dialog.tsx
@@ -24,7 +24,12 @@ import {
 import { CheckCircle2, Copy, ExternalLink, Loader2, X } from "lucide-react"
 import { useEffect, useMemo, useRef, useState } from "react"
 import { toast } from "sonner"
-import { useCheckoutPaymentLinkConfig, useCollectPayment } from "../checkout-hooks/index.js"
+import {
+  useCheckoutPaymentLinkConfig,
+  useCollectPayment,
+  usePaymentLinkEmailTemplates,
+  useSendPaymentLink,
+} from "../checkout-hooks/index.js"
 import {
   useCheckoutUiI18nOrDefault,
   useCheckoutUiMessagesOrDefault,
@@ -125,17 +130,45 @@ export function CollectPaymentDialog({
     cancelUrl,
   })
 
+  /**
+   * The obligation a Booking Amendment just raised, if any.
+   *
+   * When an operator adds a traveller and then reaches for "collect
+   * payment", the difference is what they want — not the booking total.
+   * Finance writes exactly one open schedule per amendment, so the most
+   * recent one is the amount the customer now owes for the change.
+   */
+  const amendmentSchedule = useMemo(
+    () =>
+      schedules
+        .filter((schedule) => schedule.amendmentId)
+        .sort((left, right) => right.createdAt.localeCompare(left.createdAt))[0] ?? null,
+    [schedules],
+  )
+
   // Re-seed the amount from the latest props only on the closed→open
   // transition. Watching state mid-flight would clobber manual edits.
   const wasOpenRef = useRef(false)
+  const seededRef = useRef(false)
   useEffect(() => {
     if (open && !wasOpenRef.current) {
+      // Schedules arrive asynchronously; `seededRef` lets the amendment
+      // pre-fill land once they do, without re-seeding afterwards.
+      seededRef.current = false
       setAmountCents(defaultAmountCents ?? 0)
       setScheduleId(FULL_AMOUNT_VALUE)
       setCurrency(defaultCurrency)
     }
     wasOpenRef.current = open
   }, [open, defaultAmountCents, defaultCurrency])
+
+  useEffect(() => {
+    if (!open || seededRef.current || !amendmentSchedule) return
+    seededRef.current = true
+    setScheduleId(amendmentSchedule.id)
+    setAmountCents(amendmentSchedule.amountCents)
+    setCurrency(amendmentSchedule.currency)
+  }, [open, amendmentSchedule])
 
   function reset() {
     setAmountCents(defaultAmountCents ?? 0)
@@ -190,7 +223,7 @@ export function CollectPaymentDialog({
 
         {result ? (
           <div className="px-6 py-5">
-            <ResultPanel result={result} />
+            <ResultPanel result={result} bookingId={bookingId} />
           </div>
         ) : (
           <div className="flex flex-col gap-4 px-6 py-5">
@@ -209,7 +242,12 @@ export function CollectPaymentDialog({
                       <SelectItem value={FULL_AMOUNT_VALUE}>{fullAmountLabel}</SelectItem>
                       {schedules.map((schedule) => (
                         <SelectItem key={schedule.id} value={schedule.id}>
-                          {formatScheduleOption(schedule, messages.scheduleTypeLabels, locale)}
+                          {formatScheduleOption(
+                            schedule,
+                            messages.scheduleTypeLabels,
+                            locale,
+                            messages.scheduleAmendmentLabel,
+                          )}
                         </SelectItem>
                       ))}
                     </SelectContent>
@@ -292,13 +330,24 @@ function formatScheduleOption(
   schedule: BookingPaymentScheduleRecord,
   typeLabels: Record<string, string>,
   locale: string,
+  amendmentLabel: string,
 ): string {
-  const typeLabel = typeLabels[schedule.scheduleType] ?? schedule.scheduleType
+  // An amendment obligation is stored as `other`; showing "Other" would
+  // hide the one thing that makes it recognisable.
+  const typeLabel = schedule.amendmentId
+    ? amendmentLabel
+    : (typeLabels[schedule.scheduleType] ?? schedule.scheduleType)
   const amount = formatAmount(schedule.amountCents, schedule.currency, locale)
   return `${typeLabel} • ${amount} • ${schedule.dueDate}`
 }
 
-function ResultPanel({ result }: { result: InitiatedCheckoutCollectionRecord }) {
+function ResultPanel({
+  result,
+  bookingId,
+}: {
+  result: InitiatedCheckoutCollectionRecord
+  bookingId: string
+}) {
   const messages = useCheckoutUiMessagesOrDefault().collectPaymentDialog
   const configQuery = useCheckoutPaymentLinkConfig()
   const sessionId = result.paymentSession?.id ?? null
@@ -350,6 +399,71 @@ function ResultPanel({ result }: { result: InitiatedCheckoutCollectionRecord }) 
           <ExternalLink className="h-3.5 w-3.5" />
         </a>
       </div>
+      {sessionId ? <SendPanel bookingId={bookingId} sessionId={sessionId} /> : null}
+    </div>
+  )
+}
+
+/**
+ * Emails the generated link instead of leaving the operator to paste it
+ * somewhere themselves.
+ *
+ * The template list is deployment-authored, so this renders a hint rather
+ * than a broken button when nothing is published.
+ */
+function SendPanel({ bookingId, sessionId }: { bookingId: string; sessionId: string }) {
+  const messages = useCheckoutUiMessagesOrDefault().collectPaymentDialog
+  const templatesQuery = usePaymentLinkEmailTemplates()
+  const send = useSendPaymentLink(bookingId)
+  const [templateId, setTemplateId] = useState<string | null>(null)
+  const [sent, setSent] = useState(false)
+
+  const templates = templatesQuery.data ?? []
+
+  if (templatesQuery.isPending) return null
+
+  if (templates.length === 0) {
+    return (
+      <p className="border-t pt-4 text-muted-foreground text-xs">{messages.send.noTemplates}</p>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-3 border-t pt-4">
+      <span className="font-medium text-sm">{messages.send.title}</span>
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="send-template">{messages.send.templateLabel}</Label>
+        <Select value={templateId ?? ""} onValueChange={(next) => setTemplateId(next ?? null)}>
+          <SelectTrigger id="send-template" className="w-full">
+            <SelectValue placeholder={messages.send.templatePlaceholder} />
+          </SelectTrigger>
+          <SelectContent>
+            {templates.map((template) => (
+              <SelectItem key={template.id} value={template.id}>
+                {template.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <Button
+        className="self-start"
+        disabled={!templateId || send.isPending || sent}
+        onClick={async () => {
+          if (!templateId) return
+          try {
+            await send.mutateAsync({ paymentSessionId: sessionId, templateId })
+            setSent(true)
+            toast.success(messages.send.sent)
+          } catch (err) {
+            toast.error((err as Error).message)
+          }
+        }}
+      >
+        {send.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+        {sent && <CheckCircle2 className="mr-2 h-4 w-4" />}
+        {messages.send.action}
+      </Button>
     </div>
   )
 }

--- a/packages/finance-react/src/checkout-components/collect-payment-dialog.tsx
+++ b/packages/finance-react/src/checkout-components/collect-payment-dialog.tsx
@@ -199,7 +199,13 @@ export function CollectPaymentDialog({
       return
     }
     try {
-      const data = await collect.mutateAsync({ choice: { type: "hold" }, amountCents })
+      const data = await collect.mutateAsync({
+        choice: { type: "hold" },
+        amountCents,
+        // Bind the payment to the schedule the operator actually picked.
+        // Left unset, checkout settles the earliest open one instead.
+        scheduleId: scheduleId === FULL_AMOUNT_VALUE ? null : scheduleId,
+      })
       setResult(data)
       toast.success(messages.validation.linkReady)
     } catch (err) {

--- a/packages/finance-react/src/checkout-hooks/index.ts
+++ b/packages/finance-react/src/checkout-hooks/index.ts
@@ -9,3 +9,9 @@ export {
 } from "./use-collect-payment.js"
 export { useInitiateCheckoutCollection } from "./use-initiate-checkout-collection.js"
 export { usePreviewCheckoutCollection } from "./use-preview-checkout-collection.js"
+export {
+  type PaymentLinkEmailTemplate,
+  type SendPaymentLinkInput,
+  usePaymentLinkEmailTemplates,
+  useSendPaymentLink,
+} from "./use-send-payment-link.js"

--- a/packages/finance-react/src/checkout-hooks/use-collect-payment.ts
+++ b/packages/finance-react/src/checkout-hooks/use-collect-payment.ts
@@ -53,6 +53,16 @@ export interface UseCollectPaymentOptions {
 export interface CollectPaymentInput {
   choice: PaymentChoice
   amountCents: number
+  /**
+   * Payment schedule this collection settles.
+   *
+   * Without it checkout picks the *earliest* open schedule on the booking,
+   * which is the wrong one whenever an operator is collecting the delta
+   * from a Booking Amendment while an older instalment is still due: the
+   * payment lands on the instalment and the amendment's obligation stays
+   * open, collectable a second time.
+   */
+  scheduleId?: string | null
 }
 
 /**
@@ -80,8 +90,10 @@ export function useCollectPayment(bookingId: string, options: UseCollectPaymentO
     mutationFn: async ({
       choice,
       amountCents,
+      scheduleId,
     }: CollectPaymentInput): Promise<InitiatedCheckoutCollectionRecord> => {
       const body = mapChoiceToRequest(choice, amountCents, {
+        scheduleId,
         cardProvider,
         payerEmail,
         payerName,
@@ -118,6 +130,7 @@ function mapChoiceToRequest(
   choice: PaymentChoice,
   amountCents: number,
   ctx: {
+    scheduleId?: string | null
     cardProvider?: string
     payerEmail?: string | null
     payerName?: string | null
@@ -143,6 +156,7 @@ function mapChoiceToRequest(
       method: "card",
       stage: "manual",
       amountCents,
+      scheduleId: ctx.scheduleId ?? undefined,
       ensureDefaultPaymentPlan: true,
       paymentSession: {
         provider: ctx.cardProvider,

--- a/packages/finance-react/src/checkout-hooks/use-send-payment-link.ts
+++ b/packages/finance-react/src/checkout-hooks/use-send-payment-link.ts
@@ -1,0 +1,102 @@
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+
+import { useVoyantFinanceContext } from "../provider.js"
+
+/**
+ * A published email template the deployment can send a payment link with.
+ *
+ * Reached over HTTP rather than through `@voyant-travel/notifications-react`
+ * on purpose: the send surface is an admin endpoint, and going through it
+ * keeps finance from taking a package dependency on notifications for what
+ * is one POST.
+ */
+export interface PaymentLinkEmailTemplate {
+  id: string
+  slug: string
+  name: string
+}
+
+interface TemplateListResponse {
+  data: Array<{
+    id: string
+    slug: string
+    name: string
+    channel: string
+    status: string
+  }>
+}
+
+/**
+ * Published email templates, offered as the "send with" choice after a
+ * payment link is generated.
+ *
+ * Templates are deployment-authored rows — there is no slug this repo can
+ * assume exists — so the caller must handle the empty list by falling back
+ * to copying the link by hand.
+ */
+export function usePaymentLinkEmailTemplates(options: { enabled?: boolean } = {}) {
+  const { baseUrl, fetcher } = useVoyantFinanceContext()
+
+  return useQuery({
+    queryKey: ["payment-link-email-templates"],
+    enabled: options.enabled ?? true,
+    queryFn: async (): Promise<PaymentLinkEmailTemplate[]> => {
+      const response = await fetcher(
+        `${baseUrl}/v1/admin/notifications/templates?channel=email&status=active&limit=100`,
+        { headers: { Accept: "application/json" } },
+      )
+      if (!response.ok) throw new Error(`template fetch failed: ${response.status}`)
+      const body = (await response.json()) as TemplateListResponse
+      return (body.data ?? []).map((template) => ({
+        id: template.id,
+        slug: template.slug,
+        name: template.name,
+      }))
+    },
+    staleTime: 5 * 60 * 1000,
+  })
+}
+
+export interface SendPaymentLinkInput {
+  paymentSessionId: string
+  templateId: string
+}
+
+/**
+ * Email a generated payment link to the payer through the notifications
+ * dispatch route.
+ *
+ * `idempotencyKey` is derived from the session and template rather than
+ * randomised, so a double-click cannot send the customer two copies of the
+ * same request for money.
+ */
+export function useSendPaymentLink(bookingId: string) {
+  const { baseUrl, fetcher } = useVoyantFinanceContext()
+  const qc = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ paymentSessionId, templateId }: SendPaymentLinkInput) => {
+      const response = await fetcher(
+        `${baseUrl}/v1/admin/notifications/payment-sessions/${paymentSessionId}/send`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            idempotencyKey: `payment-link-${paymentSessionId}-${templateId}`,
+            templateId,
+          }),
+        },
+      )
+      const json = (await response.json()) as { data?: unknown; error?: string }
+      if (!response.ok) {
+        throw new Error(json.error ?? `Send failed: ${response.status}`)
+      }
+      return json.data
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["bookings", bookingId] })
+    },
+  })
+}

--- a/packages/finance-react/src/checkout-i18n/en.ts
+++ b/packages/finance-react/src/checkout-i18n/en.ts
@@ -114,6 +114,7 @@ export const checkoutUiEn: CheckoutUiMessages = {
       hold: "Hold",
       other: "Other",
     },
+    scheduleAmendmentLabel: "Change difference",
     amountLabel: "Amount ({currency})",
     amountLabelShort: "Amount",
     currencyLabel: "Currency",
@@ -132,6 +133,15 @@ export const checkoutUiEn: CheckoutUiMessages = {
       body: "Share this link with the customer. They'll choose card or bank transfer on the page.",
       copyLink: "Copy link",
       openLink: "Open link",
+    },
+    send: {
+      title: "Send it to the customer",
+      templateLabel: "Email template",
+      templatePlaceholder: "Pick a template",
+      action: "Send email",
+      sent: "Payment link sent.",
+      noTemplates:
+        "No published email templates yet. Copy the link above, or add a template under Notifications.",
     },
   },
 }

--- a/packages/finance-react/src/checkout-i18n/messages.ts
+++ b/packages/finance-react/src/checkout-i18n/messages.ts
@@ -104,6 +104,12 @@ export type CheckoutUiMessages = {
     scheduleFullAmount: string
     /** Localized labels for each `payment_schedule_type` enum value. */
     scheduleTypeLabels: Record<"deposit" | "installment" | "balance" | "hold" | "other", string>
+    /**
+     * Label used instead of `scheduleTypeLabels` when the obligation was
+     * raised by a Booking Amendment — "Change difference" reads better to
+     * an operator than "Other".
+     */
+    scheduleAmendmentLabel: string
     amountLabel: string
     amountLabelShort: string
     currencyLabel: string
@@ -122,6 +128,22 @@ export type CheckoutUiMessages = {
       body: string
       copyLink: string
       openLink: string
+    }
+    send: {
+      /** Heading for the "email this link" block under a ready link. */
+      title: string
+      /** Label for the template picker. */
+      templateLabel: string
+      templatePlaceholder: string
+      /** Primary action. */
+      action: string
+      /** Toast on a successful dispatch. */
+      sent: string
+      /**
+       * Shown instead of the picker when the deployment has published no
+       * email templates — the link is still copyable.
+       */
+      noTemplates: string
     }
   }
 }

--- a/packages/finance-react/src/checkout-i18n/ro.ts
+++ b/packages/finance-react/src/checkout-i18n/ro.ts
@@ -114,6 +114,7 @@ export const checkoutUiRo: CheckoutUiMessages = {
       hold: "Retinere",
       other: "Alta",
     },
+    scheduleAmendmentLabel: "Diferenta din modificare",
     amountLabel: "Suma ({currency})",
     amountLabelShort: "Suma",
     currencyLabel: "Moneda",
@@ -133,6 +134,15 @@ export const checkoutUiRo: CheckoutUiMessages = {
       body: "Trimite acest link clientului. Va alege cardul sau transferul bancar pe pagina.",
       copyLink: "Copiaza linkul",
       openLink: "Deschide linkul",
+    },
+    send: {
+      title: "Trimite-l clientului",
+      templateLabel: "Sablon de email",
+      templatePlaceholder: "Alege un sablon",
+      action: "Trimite emailul",
+      sent: "Linkul de plata a fost trimis.",
+      noTemplates:
+        "Nu exista sabloane de email publicate. Copiaza linkul de mai sus sau adauga un sablon in Notificari.",
     },
   },
 }

--- a/packages/finance-react/src/schemas/invoice.ts
+++ b/packages/finance-react/src/schemas/invoice.ts
@@ -240,6 +240,8 @@ export const bookingPaymentScheduleRecordSchema = z.object({
   id: z.string(),
   bookingId: z.string(),
   bookingItemId: z.string().nullable(),
+  /** Present when a Booking Amendment raised this obligation. */
+  amendmentId: z.string().nullable().default(null),
   scheduleType: paymentScheduleTypeSchema,
   status: paymentScheduleStatusSchema,
   dueDate: z.string(),

--- a/packages/finance/migrations/20260815100000_booking_payment_schedule_amendment.sql
+++ b/packages/finance/migrations/20260815100000_booking_payment_schedule_amendment.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "booking_payment_schedules"
+ADD COLUMN "amendment_id" text;
+--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_booking_payment_schedules_amendment"
+ON "booking_payment_schedules" USING btree ("amendment_id")
+WHERE "amendment_id" IS NOT NULL;

--- a/packages/finance/migrations/meta/_journal.json
+++ b/packages/finance/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1786125600000,
       "tag": "20260806120000_refund_settlements",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1786867200000,
+      "tag": "20260815100000_booking_payment_schedule_amendment",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/finance/src/booking-amendment-runtime.ts
+++ b/packages/finance/src/booking-amendment-runtime.ts
@@ -3,7 +3,8 @@ import { and, eq } from "drizzle-orm"
 
 import type { ResolveBookingTaxSettings } from "./booking-tax.js"
 import { computeBookingItemTaxLine, resolveBookingSellTaxRate } from "./booking-tax.js"
-import { financeAmendmentAdjustments } from "./schema.js"
+import { bookingPaymentSchedules, financeAmendmentAdjustments } from "./schema.js"
+import { toDateString } from "./service-shared.js"
 
 export const BOOKING_AMENDMENT_FINANCE_POLICY_VERSION = "booking-amendment-finance-v1"
 
@@ -110,7 +111,33 @@ export function createBookingAmendmentFinanceRuntime(
         })
         .onConflictDoNothing({ target: financeAmendmentAdjustments.amendmentId })
         .returning({ id: financeAmendmentAdjustments.id })
-      if (created) return { adjustmentId: created.id, status: "recorded" }
+      if (created) {
+        // The adjustment is a ledger fact; on its own nobody can act on
+        // it. Raising the matching obligation is what puts the delta in
+        // front of an operator — `CollectPaymentDialog` offers open
+        // schedules as pre-fills, so the amount to collect stops being
+        // something read off one screen and retyped into another.
+        //
+        // Only on the freshly-created branch: a replay must not bill twice.
+        // The partial unique index on `amendment_id` is the backstop.
+        if (input.price.collectionAmountCents > 0) {
+          const dueDate = toDateString(input.now ?? new Date())
+          await tx.insert(bookingPaymentSchedules).values({
+            bookingId: input.bookingId,
+            amendmentId: input.amendmentId,
+            scheduleType: "other",
+            // The amendment is being applied now, so the money is owed
+            // now — not at some future planned instalment date.
+            status: "due",
+            dueDate,
+            dueTimeZone: "UTC",
+            currency: input.price.currency,
+            amountCents: input.price.collectionAmountCents,
+            notes: input.reason,
+          })
+        }
+        return { adjustmentId: created.id, status: "recorded" }
+      }
 
       const [existing] = await tx
         .select()

--- a/packages/finance/src/routes-booking-billing.ts
+++ b/packages/finance/src/routes-booking-billing.ts
@@ -91,6 +91,7 @@ const bookingPaymentScheduleSchema = z.object({
   id: z.string(),
   bookingId: z.string(),
   bookingItemId: z.string().nullable(),
+  amendmentId: z.string().nullable(),
   scheduleType: z.enum(["deposit", "installment", "balance", "hold", "other"]),
   status: z.enum(["pending", "due", "paid", "waived", "cancelled", "expired"]),
   dueDate: isoString,

--- a/packages/finance/src/schema/booking-billing.ts
+++ b/packages/finance/src/schema/booking-billing.ts
@@ -1,6 +1,16 @@
 import { typeId, typeIdRef } from "@voyant-travel/db/lib/typeid-column"
 import { sql } from "drizzle-orm"
-import { boolean, check, date, index, integer, pgTable, text, timestamp } from "drizzle-orm/pg-core"
+import {
+  boolean,
+  check,
+  date,
+  index,
+  integer,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+} from "drizzle-orm/pg-core"
 
 import {
   commissionModelEnum,
@@ -23,6 +33,13 @@ export const bookingPaymentSchedules = pgTable(
     id: typeId("booking_payment_schedules"),
     bookingId: text("booking_id").notNull(),
     bookingItemId: text("booking_item_id"),
+    /**
+     * Set when this obligation was raised by a Booking Amendment rather
+     * than by the original payment plan. Plain id, not an FK — amendments
+     * are owned by `@voyant-travel/bookings`. Unique where present, so
+     * replaying `recordBookingAmendment` cannot bill the customer twice.
+     */
+    amendmentId: text("amendment_id"),
     scheduleType: paymentScheduleTypeEnum("schedule_type").notNull().default("balance"),
     status: paymentScheduleStatusEnum("status").notNull().default("pending"),
     dueDate: date("due_date").notNull(),
@@ -42,6 +59,9 @@ export const bookingPaymentSchedules = pgTable(
       table.createdAt,
     ),
     index("idx_booking_payment_schedules_item").on(table.bookingItemId),
+    uniqueIndex("uq_booking_payment_schedules_amendment")
+      .on(table.amendmentId)
+      .where(sql`${table.amendmentId} IS NOT NULL`),
     index("idx_booking_payment_schedules_status").on(table.status),
     index("idx_booking_payment_schedules_due_date").on(table.dueDate),
   ],

--- a/packages/finance/tests/integration/booking-amendment-collection.test.ts
+++ b/packages/finance/tests/integration/booking-amendment-collection.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Applying an Amendment that owes money has to leave something an operator
+ * can act on. The adjustment ledger row on its own is inert — nothing reads
+ * it — so `recordBookingAmendment` also raises the payment schedule that
+ * `CollectPaymentDialog` offers as a pre-fill.
+ *
+ * These run against the real table rather than a fake `db`, because the
+ * thing being protected is the row that gets written and the partial unique
+ * index that stops a replay writing it twice.
+ */
+
+import { eq } from "drizzle-orm"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { createBookingAmendmentFinanceRuntime } from "../../src/booking-amendment-runtime.js"
+import { bookingPaymentSchedules, financeAmendmentAdjustments } from "../../src/schema.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+describe.skipIf(!DB_AVAILABLE)("Booking Amendment collection", () => {
+  let db: ReturnType<typeof import("@voyant-travel/db/test-utils").createTestDb>
+  let sequence = 0
+
+  beforeAll(async () => {
+    const { createTestDb, cleanupTestDb } = await import("@voyant-travel/db/test-utils")
+    db = createTestDb()
+    await cleanupTestDb(db)
+  })
+
+  afterAll(async () => {
+    const { closeTestDb } = await import("@voyant-travel/db/test-utils")
+    await closeTestDb()
+  })
+
+  beforeEach(async () => {
+    const { cleanupTestDb } = await import("@voyant-travel/db/test-utils")
+    await cleanupTestDb(db)
+  })
+
+  const runtime = createBookingAmendmentFinanceRuntime()
+  const now = new Date("2026-08-15T09:00:00.000Z")
+
+  function price(amountCents: number) {
+    return {
+      currency: "EUR",
+      subtotalDeltaCents: amountCents,
+      feeDeltaCents: 0,
+      taxDeltaCents: 0,
+      amountCents,
+      collectionAmountCents: Math.max(amountCents, 0),
+      refundAmountCents: Math.max(-amountCents, 0),
+      taxLines: [],
+    }
+  }
+
+  const consequences = {
+    collection: "required",
+    refund: "not_required",
+    invoice: "reissue_required",
+    creditNote: "not_required",
+    paymentSchedule: "recalculate_required",
+  } as const
+
+  function record(amountCents: number, overrides: { amendmentId?: string; key?: string } = {}) {
+    sequence += 1
+    const amendmentId = overrides.amendmentId ?? `bkam_test_${sequence}`
+    return runtime.recordBookingAmendment(db, {
+      amendmentId,
+      // Derived from the amendment, not the call counter: a replay is the
+      // same apply of the same amendment, so both sides must agree on the
+      // booking or the runtime reads it as a different request entirely.
+      bookingId: `bkng_for_${amendmentId}`,
+      idempotencyKey: overrides.key ?? `apply-${sequence}`,
+      price: price(amountCents),
+      consequences:
+        amountCents > 0
+          ? consequences
+          : { ...consequences, collection: "not_required", invoice: "not_required" },
+      reason: "Added a traveller",
+      now,
+    })
+  }
+
+  async function schedulesFor(amendmentId: string) {
+    return db
+      .select()
+      .from(bookingPaymentSchedules)
+      .where(eq(bookingPaymentSchedules.amendmentId, amendmentId))
+  }
+
+  it("raises a due obligation for the amount to collect", async () => {
+    const result = await record(12_800, { amendmentId: "bkam_collect" })
+    expect(result.status).toBe("recorded")
+
+    const schedules = await schedulesFor("bkam_collect")
+    expect(schedules).toHaveLength(1)
+    expect(schedules[0]).toMatchObject({
+      amountCents: 12_800,
+      currency: "EUR",
+      status: "due",
+      scheduleType: "other",
+      // Dated from the clock the Amendment was applied on, not the
+      // runtime's own `new Date()`.
+      dueDate: "2026-08-15",
+      notes: "Added a traveller",
+    })
+  })
+
+  it("still writes the adjustment ledger row", async () => {
+    await record(5_000, { amendmentId: "bkam_ledger" })
+    const [adjustment] = await db
+      .select()
+      .from(financeAmendmentAdjustments)
+      .where(eq(financeAmendmentAdjustments.amendmentId, "bkam_ledger"))
+    expect(adjustment).toMatchObject({
+      status: "collection_required",
+      collectionAmountCents: 5_000,
+    })
+  })
+
+  it("raises nothing when the change costs nothing", async () => {
+    await record(0, { amendmentId: "bkam_free" })
+    expect(await schedulesFor("bkam_free")).toHaveLength(0)
+  })
+
+  it("raises nothing when the change is a refund", async () => {
+    await record(-4_000, { amendmentId: "bkam_refund" })
+    expect(await schedulesFor("bkam_refund")).toHaveLength(0)
+  })
+
+  it("does not bill the customer twice when the apply replays", async () => {
+    const first = await record(9_900, { amendmentId: "bkam_replay", key: "same-apply" })
+    const second = await record(9_900, { amendmentId: "bkam_replay", key: "same-apply" })
+
+    expect(first.status).toBe("recorded")
+    expect(second.status).toBe("replay")
+    expect(await schedulesFor("bkam_replay")).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
Adding a traveller or a service to a confirmed booking was free-text data entry. The **Add item** dialog wrote eleven text fields and no catalog reference — so a line added mid-trip held no inventory and had no price the system agreed with. The operator still had to go drop a seat by hand, call the supplier, and retype the difference into a payment link.

The data model already supported all of it (`booking_items` carries `productId`/`optionId`/`optionUnitId`/`availabilitySlotId`, `booking_allocations` is a real inventory ledger), and the item list already *reads* it. Only the write side was missing.

## Four changes, each usable on its own

### 1. Deleting or resizing an item returns the inventory it held

`booking_allocations.booking_item_id` is `ON DELETE CASCADE`, so deleting a Booking Item destroyed its allocation without giving the seats back — `availability_slots.remaining_pax` stayed decremented **permanently**, with no allocation row left to reconcile from. Silent, and unrecoverable without SQL.

`deleteItem` now releases before the cascade (`service-core.ts`), and `updateItem` keeps the allocation in step with a `quantity` change, failing with `insufficient_capacity` rather than overselling.

### 2. The Amendment engine is reachable from the operator

`service-amendments.ts` already implemented preview → accept → apply with capacity checks, supplier dispatch and priced deltas. `bookings-react` contained **zero** references to it. On a confirmed booking, adding or removing a traveller now quotes the change, reports whether the departure still has room, and shows the supplier and document consequences before anything is written. Non-confirmed bookings keep the plain dialogs.

### 3. A new `item_add` Amendment kind adds catalog-linked services

The extra excursion or transfer a customer asks for mid-trip. Price, name and timing resolve server-side through `resolveSessionPricingSnapshot` — the same authority the storefront prices against — so the operator picks *what*, never *how much*, and the added line holds a real allocation.

**Scope limit:** supplier-sourced products are refused with `unsupported_configuration`. Adding a service the supplier has never been told about needs a supplier *create* call, and the supplier amendment port only knows how to modify an operation that already has an `upstreamRef`. Quoting one would promise capacity nobody reserved.

### 4. The money follows

`recordBookingAmendment` wrote a `collection_required` ledger row that **nothing read**. It now also raises the payment schedule for the delta, so **Generate payment link** pre-fills the difference instead of the booking total, and the link can be emailed to the customer from the same dialog (through the notifications dispatch route that already existed).

## Verification

Driven against a live Postgres, asserting on the slot row and the written entities rather than on return values — the leak is invisible from the caller's side:

- **11** capacity tests (`item-allocation-capacity.test.ts`) — release on delete, reopening a sold-out slot, releasing into a *closed* departure, refusing to oversell on resize, leaving sourced allocations alone
- **8** item-addition tests (`booking-item-addition.test.ts`) — catalog pricing, nothing written until apply, item + allocation + slot decrement on apply, apply racing a departure that fills up, idempotent replay
- **5** collection tests (`booking-amendment-collection.test.ts`) — obligation raised, none for a free or refunding change, no double-billing on replay

All five packages compile clean; `biome check` clean; `verify:migration-boundaries`, `verify:migration-identity`, `verify:table-privacy` and `verify:cross-package-fk` all pass.

Two bugs surfaced during verification and were fixed: the `item_add` idempotency comparator serialised a `jsonb` round-trip (which normalises key order, so every replay would have read as a conflict), and the traveller row-actions memo captured `requiresAmendment` without depending on it (so before the booking query resolved, delete would hard-delete off a confirmed booking).

### Pre-existing failures, not from this branch

`auto-rollup-total.test.ts`, `fx-rollup.test.ts` and several others fail on `main` too: their `seedBooking` omits `bookings.status`, which is `NOT NULL` with no default. Related to #4251.

## Migrations

- `finance`: `booking_payment_schedules.amendment_id` + partial unique index (a replay cannot bill twice)
- `bookings`: `traveler_id` nullable (an `item_add` has no traveller), `kind` check widened, and a new check that every other kind still names its traveller
