### PR TITLE
Make the core operator writes reachable from a conversation

### DIFF
--- a/.changeset/agent-reachable-core-writes.md
+++ b/.changeset/agent-reachable-core-writes.md
@@ -1,0 +1,17 @@
+---
+"@voyant-travel/finance": minor
+"@voyant-travel/mcp": minor
+---
+
+Make the core operator writes reachable from a conversation. Finance gains a
+`record_payment` Tool over `POST /finance/invoices/{id}/payments`, which had no
+agent-facing front at all, so an agent asked to record a payment correctly
+reported that no such action existed. The MCP transport now registers a default
+eager set — `book_product` and `record_payment`, promoted only for a caller
+authorized for them — instead of defaulting to an empty domain tier that made
+every write depend on the consumer admitting the meta-tools; pass
+`eagerToolNames: []` to opt out. A read the projection folded into a
+`<domain>_query` group now answers with the query tool and `resource` to call
+instead of "it does not exist or your grant does not authorize it", over
+`call_tool`, the flat name, and `describe_tool`, and is counted as the new
+`unreachable` telemetry outcome rather than as an unknown tool.

--- a/apps/operator/tests/selected-graph-mcp-tool-surface.test.ts
+++ b/apps/operator/tests/selected-graph-mcp-tool-surface.test.ts
@@ -55,8 +55,29 @@ import {
  *
  * It landed on main without this adjustment because `operator#test` was a turbo
  * cache hit there and never ran.
+ *
+ * **Raised 5,000 -> 20,000 for voyant#4656**, and this one is a real trade rather
+ * than a measurement artefact, so the numbers are here to be argued with.
+ *
+ * The eager DOMAIN tier is no longer empty: `DEFAULT_EAGER_TOOL_NAMES` makes the
+ * two writes an operator delegates most resident. Measured **18,395 bytes across
+ * 7 entries** — `book_product` 9,700 and `record_payment` 4,538 on top of the
+ * 4,157-byte tier-0 — so ~4,600 tokens per connection against ~1,040 before.
+ *
+ * What was bought: an empty default made every write depend on the consumer
+ * admitting three meta-tools it had no way to classify, and when one did not, an
+ * operator asking for a booking was told the capability did not exist. A write
+ * journey also pays the difference back — the eval measures ~1,200 tokens for a
+ * three-call discovery sequence, and this removes two of them — so the real cost
+ * falls on a read-only session, which pays nothing at all, because a name is
+ * promoted only for a caller authorized for it.
+ *
+ * The tripwire still works, and is what the headroom is sized for: at ~880 bytes
+ * for a median domain tool and ~4,500-9,700 for these two, a THIRD eager write
+ * trips this. That is the regression worth catching — not the two that were
+ * chosen deliberately.
  */
-const PAYLOAD_CEILING_BYTES = 5_000
+const PAYLOAD_CEILING_BYTES = 20_000
 
 /**
  * Ceiling for the AGGREGATE describe schema of the collapsed READ surface — the
@@ -221,17 +242,23 @@ describe("selected-graph MCP tool surface cost", () => {
     expect(totalBytes, diagnose(tools, totalBytes)).toBeLessThanOrEqual(PAYLOAD_CEILING_BYTES)
   })
 
-  it("advertises exactly the tier-0 resident surface eagerly", async () => {
+  it("advertises exactly the tier-0 resident surface plus the default eager writes", async () => {
     const { tools } = await serializeEagerToolSurface()
 
     expect(tools.map(({ name }) => name).sort()).toEqual([
+      // The two core operator writes (voyant#4656). Named here, not counted:
+      // "some domain tools are eager" is what the empty default already claimed
+      // while a booking was unreachable. A fourth appearing silently is the drift
+      // this exists to catch, and so is either of these two disappearing.
+      "book_product",
       "call_tool",
       "describe_tool",
+      "record_payment",
       "search_tools",
-      // The guide layer (voyant#3931) is resident by design: with no eager domain
-      // surface, it is the only thing that tells a connecting agent what this
-      // deployment is for. A guide reachable only by first guessing a search query
-      // would be useless at exactly the moment it is needed.
+      // The guide layer (voyant#3931) is resident by design: it is what tells a
+      // connecting agent what this deployment is for. A guide reachable only by
+      // first guessing a search query would be useless at exactly the moment it
+      // is needed.
       "voyant_glossary",
       "voyant_guide",
     ])

--- a/docs/architecture/agent-tool-library.md
+++ b/docs/architecture/agent-tool-library.md
@@ -426,6 +426,43 @@ fingerprints. Approval preflight is server-owned and returns stable
 structured error metadata; an approved retry is admitted only after the action ledger matches the
 recomputed action, target, command, principal, organization, and request id.
 
+### What is resident, and what a deployment can change
+
+`tools/list` carries the tier-0 server-owned entries (the guide Tools and the
+meta-tools) plus a small **default eager set** of registry Tools: the writes an
+operator delegates most, `book_product` and `record_payment`
+(`DEFAULT_EAGER_TOOL_NAMES`, exported from `@voyant-travel/mcp`). A name in that
+set is registered only when the caller is authorized for it, so a read-only key
+still pays nothing for it.
+
+That default is not free — the two schemas roughly triple the eager payload — and
+it exists because the alternative failed in production. With an empty default,
+every write depended on the consumer admitting three meta-tools it could not
+classify; when one did not, an operator asking for a booking was told the
+capability did not exist (voyant#4656). Residency for the common journey is the
+floor that does not depend on consumer behaviour. `eagerToolNames` overrides it:
+an explicit `[]` opts out and restores a tools/list of tier-0 alone, and a list
+of canonical names replaces the default entirely. Everything outside it stays
+lazy.
+
+### Three reasons a name does not resolve, and three answers
+
+A `tools/call` for a name the transport will not dispatch has distinct causes,
+and collapsing them is what turns a discovery defect into "the product cannot do
+this":
+
+| cause | answer |
+| --- | --- |
+| no such tool, or the grant does not authorize it | `NOT_FOUND` with near-matches from the authorized surface |
+| a read the projection folded into `<domain>_query` | `NOT_FOUND` naming the query tool and the `resource` to call it with |
+| an authorized tool that is simply not eager | dispatched — the transport registers it for that request |
+
+The middle row is the one that is OURS rather than the caller's: the tool exists,
+the caller is authorized, and discovery moved it. It answers over every path a
+caller reaches it by — `call_tool`, the flat name, and `describe_tool` — and is
+counted as the distinct telemetry outcome `unreachable`, so the case an agent
+cannot recover from on its own is also the case an operator can see.
+
 ### Classifying a `tools/list` entry
 
 `tools/list` is no longer a wholesale catalog. Progressive disclosure (voyant#3927)

--- a/packages/finance/src/mcp-runtime.ts
+++ b/packages/finance/src/mcp-runtime.ts
@@ -45,7 +45,7 @@ import {
   buildUnsyncedProformaApprovalSnapshot,
   issueInvoiceFromBookingCommand,
 } from "./service-issue.js"
-import type { InvoiceNumberAllocationErrorCode } from "./service-shared.js"
+import { type InvoiceNumberAllocationErrorCode, PaymentValidationError } from "./service-shared.js"
 import { toJsonValue } from "./tool-json.js"
 
 export * from "./tools.js"
@@ -122,6 +122,49 @@ export const voyantToolContextContribution = defineToolContextContribution({
               input.idempotencyKey ??
               (await deriveCommandIdempotencyKey("issue-invoice-from-booking", input.command)),
           })
+        },
+        /**
+         * Money received against an invoice (voyant#4656).
+         *
+         * The route already runs this exact command with a ledger context; the
+         * Tool differs only in where the invoice id comes from (the body, not a
+         * path) and in the authorization source it stamps, so a payment an agent
+         * recorded is distinguishable from one an operator typed.
+         *
+         * `PaymentValidationError` — an overpayment, or an invoice that cannot
+         * take another payment — becomes `INVALID_INPUT` carrying the service's
+         * own code and details rather than a 500. Both are terminal for an
+         * identical retry and both are the caller's to fix.
+         */
+        async recordPayment(
+          input: Parameters<typeof financeService.createPayment>[2] & { invoiceId: string },
+        ): Promise<unknown> {
+          const { invoiceId, ...payment } = input
+          try {
+            const row = await financeService.createPayment(
+              db as PostgresJsDatabase,
+              invoiceId,
+              payment,
+              {
+                ...getFinanceRouteRuntime(c),
+                actionLedgerContext: financeToolActionLedgerContext(c),
+                actionLedgerAuthorizationSource: "finance.payment.tool",
+              },
+            )
+            if (!row) {
+              throw new ToolError("Invoice was not found.", "NOT_FOUND", { invoiceId })
+            }
+            return toJsonValue(row)
+          } catch (error) {
+            if (error instanceof PaymentValidationError) {
+              throw new ToolError(error.message, "INVALID_INPUT", {
+                invoiceId,
+                code: error.code,
+                ...(error.details ?? {}),
+              })
+            }
+            throw error
+          }
         },
         async recordPaymentDispute(
           input: Parameters<typeof financeService.paymentDisputes.recordPaymentDispute>[1],

--- a/packages/finance/src/tools.ts
+++ b/packages/finance/src/tools.ts
@@ -31,14 +31,17 @@ import {
   invoiceDetailSchema,
   invoiceListItemSchema,
   invoiceSchema,
+  paymentSchema,
 } from "./routes-invoice-schemas.js"
 import { bookingCreateToolSchema } from "./service-booking-create.js"
 import { parseJsonResult } from "./tool-json.js"
 import {
   insertCreditNoteSchema,
+  insertPaymentSchema,
   invoiceFromBookingSchema,
   invoiceListQuerySchema,
   paymentDisputeRecordSchema,
+  paymentStatusSchema,
   recordPaymentDisputeSchema,
   recordRefundSettlementSchema,
   refundSettlementRecordSchema,
@@ -96,6 +99,7 @@ export interface FinanceToolServices {
   issueInvoiceFromBooking(
     input: z.infer<typeof issueInvoiceFromBookingToolInputSchema> & { approvalId?: string },
   ): Promise<unknown>
+  recordPayment(input: z.infer<typeof recordPaymentToolInputSchema>): Promise<unknown>
   recordPaymentDispute(input: z.infer<typeof recordPaymentDisputeToolInputSchema>): Promise<unknown>
   recordRefundSettlement(
     input: z.infer<typeof recordRefundSettlementToolInputSchema>,
@@ -680,6 +684,110 @@ export const issueUnsyncedProformaFromBookingTool = defineTool<
   },
 })
 
+/**
+ * The agent-facing shape of "money arrived against this invoice".
+ *
+ * Derived from `insertPaymentSchema` — the body the admin route takes under
+ * `/invoices/{id}/payments` — so the two cannot drift, then narrowed three ways:
+ *
+ * - `invoiceId` moves INTO the body. A Tool has no path, and the graph action
+ *   resolves its target from a named command field.
+ * - The FX and card-plumbing fields are dropped. `baseCurrency`,
+ *   `baseAmountCents` and `fxRateSetId` are resolved server-side against the
+ *   invoice's currency and rate set, and `paymentInstrumentId` /
+ *   `paymentAuthorizationId` / `paymentCaptureId` belong to a processor session
+ *   that recorded its own payment. An agent that had to fill them in would guess,
+ *   and every one of them also rides the eager `tools/list`.
+ * - `status` defaults to `completed` rather than `pending`. An operator telling
+ *   an agent to record a payment is recording money it already has; the route's
+ *   `pending` default belongs to a checkout session that settles later. Getting
+ *   this backwards leaves the invoice reading unpaid after the agent reports
+ *   success, which is the failure worth defaulting against.
+ */
+export const recordPaymentToolInputSchema = insertPaymentSchema
+  .pick({
+    amountCents: true,
+    currency: true,
+    paymentMethod: true,
+    paymentDate: true,
+    referenceNumber: true,
+    notes: true,
+  })
+  .safeExtend({
+    invoiceId: z.string().min(1).describe("The invoice this payment settles."),
+    status: paymentStatusSchema
+      .default("completed")
+      .describe(
+        "Settlement state. `completed` counts against the invoice balance; `pending` records " +
+          "an expected payment that does not.",
+      ),
+    idempotencyKey: z
+      .string()
+      .max(255)
+      .optional()
+      .describe(
+        "Optional stable key. Repeating a recording with the same key replays the first one " +
+          "instead of taking the money twice.",
+      ),
+  })
+
+/**
+ * Recording a payment an operator already received (voyant#4656).
+ *
+ * The gap this closes was not discovery: there was no Tool at all. An operator
+ * asked the agent for a confirmed, fully-paid booking and was told payment
+ * recording did not exist — correctly, because `/finance/invoices/{id}/payments`
+ * had no agent-facing front. Entering historical bookings and their payments for
+ * a regulatory filing is exactly the work an operator delegates.
+ *
+ * `medium` risk, no approval, for the same reason `record_payment_dispute` needs
+ * none: the money moved before this call, and the record only catches up with
+ * it. Gating a back-entry sweep behind per-payment approval would stall the one
+ * job this exists for, while the invoice kept reporting a balance nobody owes.
+ * The service still refuses to overpay an invoice or to accept a payment against
+ * one that cannot take another, so the destructive cases fail closed on their
+ * own.
+ */
+export const recordPaymentTool = defineTool<
+  z.infer<typeof recordPaymentToolInputSchema>,
+  unknown,
+  FinanceToolContext
+>({
+  owner: "@voyant-travel/finance",
+  capabilityId: "@voyant-travel/finance#tool.record-payment",
+  capabilityVersion: "v1",
+  name: "record_payment",
+  description:
+    "Record a payment received against an invoice — bank transfer, card, cash, cheque, " +
+    "wallet, direct bill, or travel credit. Recomputes the invoice's paid amount, balance, " +
+    "and status, so a payment that covers the total marks the invoice `paid`. Amounts are " +
+    "in MINOR units (`amountCents`) and `paymentDate` is the date the money was received, " +
+    "which is what makes back-entering historical payments work. Rejected when the invoice " +
+    "would be overpaid or is not in a state that accepts payments. Refunds go through " +
+    "`issue_invoice_refund` and `record_refund_settlement`, not a negative payment.",
+  inputSchema: recordPaymentToolInputSchema,
+  outputSchema: paymentSchema,
+  requiredScopes: ["finance:write"],
+  audience: { source: "grant", allowed: ["staff"] },
+  tier: "write",
+  riskPolicy: {
+    destructive: false,
+    // Matches the graph action. Removing a payment is an admin operation with no
+    // agent-facing counterpart, so from here the record does not come back.
+    reversible: false,
+    dryRunSupported: false,
+    confirmationRequired: true,
+    sideEffects: ["data-write"],
+  },
+  // Deliberately NOT `idempotentHint`. This is idempotent only when the caller
+  // sends `idempotencyKey`, which is optional — and it has to stay optional,
+  // because two genuinely identical payments are a thing customers do. Claiming
+  // the hint would tell an agent that repeating the call is free, about money.
+  async handler(input, ctx) {
+    return parseJsonResult(paymentSchema, await finance(ctx).recordPayment(input))
+  },
+})
+
 export const recordPaymentDisputeToolInputSchema = recordPaymentDisputeSchema
 
 /**
@@ -807,6 +915,7 @@ export const financeTools = [
   issueInvoiceFromBookingTool,
   invoiceBookingTool,
   refundCancelledBookingTool,
+  recordPaymentTool,
   recordPaymentDisputeTool,
   recordRefundSettlementTool,
   previewUnsyncedProformaFromBookingTool,

--- a/packages/finance/src/voyant.ts
+++ b/packages/finance/src/voyant.ts
@@ -452,6 +452,24 @@ export const financeVoyantModule = defineModule({
       risk: "high",
     },
     {
+      id: "@voyant-travel/finance#tool.record-payment",
+      name: "record_payment",
+      runtime: {
+        entry: "@voyant-travel/finance/tools",
+        export: "recordPaymentTool",
+      },
+      requiredScopes: ["finance:write"],
+      context: ["finance"],
+      // `medium`: the money arrived before the call and this is the record
+      // catching up with it. What changes is what the invoice honestly reports.
+      risk: "medium",
+      // Declared for the same reason the dispute Tool declares its own: the
+      // trailing noun of `/finance/payments/{id}` is `payment` too, and this
+      // Tool records a NEW payment against an invoice. It does not amend or
+      // delete one, so it must not claim coverage of those.
+      adminWrites: ["/v1/admin/finance/invoices/{id}/payments"],
+    },
+    {
       id: "@voyant-travel/finance#tool.record-payment-dispute",
       name: "record_payment_dispute",
       runtime: {
@@ -609,6 +627,31 @@ export const financeVoyantModule = defineModule({
       targetLifecycle: "existing",
       existingTarget: { durability: "handler-command-result-v1" },
       from: { tools: ["@voyant-travel/finance#tool.record-refund-settlement"] },
+    },
+    {
+      id: "@voyant-travel/finance#action.record-payment",
+      capabilityId: "finance:payment-record",
+      version: "v1",
+      kind: "execute",
+      targetType: "invoice",
+      commandTargetField: "invoiceId",
+      resource: "finance",
+      action: "write",
+      requiredScopes: ["finance:write"],
+      risk: "medium",
+      ledger: "required",
+      // `never`, like the dispute record: the payment happened outside this
+      // system and the operator is entering what already occurred. An approval
+      // per payment would stall the back-entry sweep this Tool exists for while
+      // the invoice kept reporting a balance nobody owes. The service still
+      // refuses an overpayment and an invoice that cannot take a payment.
+      approval: "never",
+      reversible: false,
+      allowedActorTypes: ["staff", "system"],
+      availability: { status: "available" },
+      effectBoundary: "local",
+      targetLifecycle: "existing",
+      from: { tools: ["@voyant-travel/finance#tool.record-payment"] },
     },
     {
       id: "@voyant-travel/finance#action.record-payment-dispute",

--- a/packages/finance/tests/tools.test.ts
+++ b/packages/finance/tests/tools.test.ts
@@ -19,6 +19,8 @@ import {
   issueInvoiceRefundInputSchema,
   issueInvoiceRefundTool,
   issueUnsyncedProformaFromBookingToolInputSchema,
+  recordPaymentTool,
+  recordPaymentToolInputSchema,
   refundCancelledBookingTool,
   refundCancelledBookingToolInputSchema,
   VOID_INVOICE_HANDLER_POLICY,
@@ -246,6 +248,59 @@ describe("finance tools", () => {
     ).toBe(false)
   })
 
+  it("records a received payment, defaulting it to settled", async () => {
+    // The route's `insertPaymentSchema` defaults `status` to `pending`, which is
+    // right for a checkout session that will settle later and wrong for an
+    // operator entering money it already has: the invoice would stay unpaid while
+    // the agent reported success. The Tool defaults the other way (voyant#4656).
+    const parsed = recordPaymentToolInputSchema.parse({
+      invoiceId: "invoice_1",
+      amountCents: 25_000,
+      currency: "EUR",
+      paymentMethod: "bank_transfer",
+      paymentDate: "2026-03-04",
+    })
+    expect(parsed.status).toBe("completed")
+
+    // The invoice is a body field, not a path parameter — a Tool has no path, and
+    // the graph action resolves its target from `invoiceId`.
+    expect(
+      recordPaymentToolInputSchema.safeParse({ amountCents: 1, currency: "EUR" }).success,
+    ).toBe(false)
+
+    let received: unknown
+    const result = await recordPaymentTool.handler(
+      parsed,
+      ctx({
+        recordPayment(input) {
+          received = input
+          return Promise.resolve({
+            id: "pay_1",
+            invoiceId: "invoice_1",
+            amountCents: 25_000,
+            currency: "EUR",
+            baseCurrency: null,
+            baseAmountCents: null,
+            fxRateSetId: null,
+            paymentMethod: "bank_transfer",
+            paymentInstrumentId: null,
+            paymentAuthorizationId: null,
+            paymentCaptureId: null,
+            status: "completed",
+            referenceNumber: null,
+            paymentDate: new Date("2026-03-04T00:00:00.000Z"),
+            notes: null,
+            createdAt: new Date("2026-03-05T09:00:00.000Z"),
+            updatedAt: new Date("2026-03-05T09:00:00.000Z"),
+          })
+        },
+      }),
+    )
+
+    expect(received).toMatchObject({ invoiceId: "invoice_1", status: "completed" })
+    expect(result).toMatchObject({ id: "pay_1", status: "completed" })
+  })
+
   it("registers read tools and destructive finance actions", () => {
     const registry = createToolRegistry()
     registry.registerAll(financeTools)
@@ -258,6 +313,7 @@ describe("finance tools", () => {
       "issue_unsynced_proforma_from_booking",
       "list_invoices",
       "preview_unsynced_proforma_from_booking",
+      "record_payment",
       "record_payment_dispute",
       "record_refund_settlement",
       "refund_cancelled_booking",
@@ -271,6 +327,17 @@ describe("finance tools", () => {
       requiredScopes: ["finance:refund"],
       riskPolicy: { destructive: true, reversible: false, confirmationRequired: true },
     })
+    // Recording money already received is a `write`, not a `destructive`: it adds
+    // a record and recomputes the invoice from its payments (voyant#4656).
+    const paymentTool = list.find((t) => t.name === "record_payment")
+    expect(paymentTool).toMatchObject({
+      tier: "write",
+      requiredScopes: ["finance:write"],
+      riskPolicy: { destructive: false, reversible: false, confirmationRequired: true },
+    })
+    // Idempotent only when the caller sends a key, and the key is optional — so
+    // the hint that says "repeating this is free" must be absent.
+    expect(paymentTool?.annotations?.idempotentHint).not.toBe(true)
     const disputeTool = list.find((t) => t.name === "record_payment_dispute")
     expect(disputeTool).toMatchObject({
       tier: "write",

--- a/packages/mcp/src/guide.ts
+++ b/packages/mcp/src/guide.ts
@@ -77,8 +77,10 @@ export function buildServerInstructions(scope: GuideScope): string {
     "HOW TO DISCOVER CAPABILITIES",
     "The surface is discovered on demand: `search_tools` finds a tool by keyword,",
     "`describe_tool` returns its full input schema, and `GET /v1/admin/mcp/manifest` is",
-    "the authorization-filtered capability index; the eager `tools/list` carries only",
-    "these meta-tools and the guide. READS are grouped by product area into one",
+    "the authorization-filtered capability index. The eager `tools/list` carries these",
+    "meta-tools, the guide, and the two core writes (`book_product`, `record_payment`)",
+    "— everything else is found through search, and its ABSENCE from `tools/list` never",
+    "means it does not exist. READS are grouped by product area into one",
     "`<domain>_query` tool (a discriminated union on `resource`): read products with",
     '`inventory_query` (`resource: "products"`/`"product"`), dated departures with',
     '`operations_query` (`resource: "departures"`), and CRM people with',
@@ -223,10 +225,12 @@ function overviewSection(scope: GuideScope): string {
 function discoverySection(): string {
   return (
     "# Discovering capabilities\n\n" +
-    "The surface is discovered on demand. `tools/list` carries only the meta-tools " +
-    "(`search_tools`, `describe_tool`, `call_tool`) and this guide; every domain " +
+    "The surface is discovered on demand. `tools/list` carries the meta-tools " +
+    "(`search_tools`, `describe_tool`, `call_tool`), this guide, and the two writes " +
+    "an operator asks for most (`book_product`, `record_payment`); every OTHER domain " +
     "capability is found through them or the `GET /v1/admin/mcp/manifest` capability " +
-    "index. To find one:\n\n" +
+    "index. A capability missing from `tools/list` is not a capability this deployment " +
+    "lacks — search before you report one as unavailable. To find one:\n\n" +
     "1. `search_tools { query }` returns matching tool names and one-line descriptions; " +
     "`describe_tool { name }` returns a tool's full input schema. The manifest carries " +
     "each capability's `requiredScopes` and risk, so you can see what a key can do " +

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,3 +1,4 @@
+export { DEFAULT_EAGER_TOOL_NAMES } from "./meta-tools.js"
 export {
   createMcpRateLimiter,
   DEFAULT_MCP_RATE_LIMIT,

--- a/packages/mcp/src/meta-tools.ts
+++ b/packages/mcp/src/meta-tools.ts
@@ -108,17 +108,40 @@ export function collectAuthorizedTools(
 }
 
 /**
+ * The domain writes a deployment gets resident without configuring anything.
+ *
+ * Progressive disclosure defaulted this to EMPTY, on the reasoning that the long
+ * tail is reachable through the meta-tools. It is — but "reachable" turned out to
+ * depend on a consumer admitting three tools it had no way to classify, and when
+ * one did not, an operator asking for a booking was told the capability did not
+ * exist (voyant#4656). A default that is correct only while every consumer
+ * behaves is not a default.
+ *
+ * So the two writes an operator delegates most are resident, and cost what they
+ * cost: `book_product` is the intent-level booking entry point the guide names
+ * (`create_booking` is the lower-level command it defers to, and is twice the
+ * schema), and `record_payment` is the money leg the same journey ends on.
+ * Everything else stays lazy — this is a floor for the common journey, not a
+ * re-opening of the eager catalog.
+ *
+ * A name here is promoted only if the caller is authorized for it, so a
+ * read-only key still pays nothing, and a deployment without these tools is
+ * unaffected.
+ */
+export const DEFAULT_EAGER_TOOL_NAMES: readonly string[] = ["book_product", "record_payment"]
+
+/**
  * Choose the tier-0 domain tools to register eagerly. The mechanism is
  * deployment-driven: `eagerToolNames` promotes specific tools (canonical names)
- * into the resident surface. It defaults to empty, which — until the guide /
- * workflow / domain-query tiers land — keeps `tools/list` at just the meta-tools.
+ * into the resident surface. Omitting it takes {@link DEFAULT_EAGER_TOOL_NAMES};
+ * passing an explicit `[]` opts out and restores a tools/list of tier-0 alone.
  */
 export function selectEagerToolNames(
   surface: AuthorizedSurface,
   eagerToolNames: readonly string[] | undefined,
 ): Set<string> {
   const eager = new Set<string>()
-  for (const name of eagerToolNames ?? []) {
+  for (const name of eagerToolNames ?? DEFAULT_EAGER_TOOL_NAMES) {
     const binding = surface.get(name)
     // Only promote canonical names; aliases follow their canonical registration.
     if (binding && !binding.aliasFor) eager.add(name)
@@ -519,9 +542,12 @@ function describeTool(
   }
   const resolvedName = resolveInvocationName(surface, name)
   const binding = surface.get(resolvedName)
-  // A flat read name is folded into its query tool and no longer describable.
-  if (!binding || projection.hiddenReadNames.has(resolvedName))
-    return unknownToolResult(name, surface, projection)
+  // A flat read name is folded into its query tool and no longer describable —
+  // but it exists and the caller is authorized for it, so say where it went.
+  if (binding && projection.hiddenReadNames.has(resolvedName)) {
+    return foldedReadResult(name, resolvedName, projection, "describe")
+  }
+  if (!binding) return unknownToolResult(name, surface, projection)
   try {
     const descriptor = advertiseTool(registry, binding.entry, resolvedName, binding.aliasFor)
     return {
@@ -596,8 +622,20 @@ function registerCallTool(input: RegisterMetaToolsInput): void {
       }
       const binding = surface.get(invocationName)
       // A flat read name is folded into its query tool and no longer callable.
-      if (!binding || projection.hiddenReadNames.has(invocationName))
-        return unknownToolResult(args.name, surface, projection)
+      // It is not unknown: it exists, the caller is authorized, and discovery
+      // moved it — which is a different answer and a different recovery.
+      if (binding && projection.hiddenReadNames.has(invocationName)) {
+        const result = foldedReadResult(args.name, invocationName, projection, "call")
+        observer.toolCall({
+          tool: binding.entry.name,
+          outcome: "unreachable",
+          durationMs: 0,
+          write: binding.entry.annotations.readOnlyHint !== true,
+          caller,
+        })
+        return result
+      }
+      if (!binding) return unknownToolResult(args.name, surface, projection)
       const def = registry.get(binding.entry.name)
       if (!def) return unknownToolResult(args.name, surface, projection)
       const output = toMcpOutputContract(def.outputSchema)
@@ -684,6 +722,73 @@ function resolveInvocationName(surface: AuthorizedSurface, name: string): string
   if (surface.has(name) || !name.includes(".")) return name
   const unprefixed = name.split(".").pop() ?? name
   return unprefixed.length > 0 ? unprefixed : name
+}
+
+/**
+ * The answer for a name that EXISTS, is AUTHORIZED, and is not reachable under
+ * that name — today, a flat read the projection folded into a `<domain>_query`
+ * group (voyant#4656).
+ *
+ * It used to share {@link unknownToolResult}, which says "it does not exist or
+ * your grant does not authorize it". Both halves of that are false here, and an
+ * agent that believes either reports a missing capability to the operator rather
+ * than making the one call that works. Since the projection knows exactly which
+ * group absorbed the read and under which `resource`, the recovery is a single
+ * concrete call, not a re-discovery.
+ */
+function foldedReadResult(
+  requestedName: string,
+  resolvedName: string,
+  projection: ReadProjection,
+  intent: "call" | "describe",
+): CallToolResult {
+  const folded = projection.foldedReadFor(resolvedName)
+  if (!folded) return unknownToolResult(requestedName, undefined, projection)
+  const { queryTool, resource } = folded
+  const step =
+    intent === "call"
+      ? `Call ${queryTool.name} with {"resource": "${resource}", …} instead.`
+      : `Describe ${queryTool.name} with {"resource": "${resource}"} to get this read's schema.`
+  return errorResult(
+    new ToolError(
+      `Tool "${requestedName}" exists and you are authorized for it, but it is not ` +
+        `reachable under that name: the ${queryTool.domain} reads are served by ` +
+        `"${queryTool.name}" as resource "${resource}".`,
+      "NOT_FOUND",
+      undefined,
+      undefined,
+      {
+        nextSteps: [step],
+        didYouMean: queryTool.name,
+        candidates: [queryTool.name],
+      },
+    ),
+  )
+}
+
+/**
+ * Register a folded read's OLD flat name for one request, so a flat-name
+ * `tools/call` gets {@link foldedReadResult} instead of the SDK's "tool not
+ * found" — the same answer it gives a typo.
+ *
+ * Registered per request, on a `tools/call` for that exact name, so it never
+ * reaches a `tools/list` and never re-advertises the read the projection folded.
+ */
+export function registerFoldedReadNotice(
+  server: McpServer,
+  projection: ReadProjection,
+  invocationName: string,
+): void {
+  server.registerTool(
+    invocationName,
+    {
+      description: `Moved: ${invocationName} is served by its domain's \`_query\` tool.`,
+      inputSchema: z.looseObject({}),
+      annotations: { readOnlyHint: true, openWorldHint: false },
+      _meta: serverToolMeta("meta"),
+    },
+    () => foldedReadResult(invocationName, invocationName, projection, "call"),
+  )
 }
 
 function unknownToolResult(

--- a/packages/mcp/src/observability.ts
+++ b/packages/mcp/src/observability.ts
@@ -45,11 +45,22 @@ import type { ToolContext } from "@voyant-travel/tools"
 export const MCP_TELEMETRY_CONTEXT_KEY = "voyant.mcp" as const
 
 /**
- * The four outcomes of a `tools/call`, kept distinct so `unknown_tool` and
+ * The outcomes of a `tools/call`, kept distinct so `unknown_tool` and
  * `validation_error` — the naming and schema mismatches an agent hits — never
  * blur into a successful call.
+ *
+ * `unreachable` is the one that is a DEFECT rather than a caller mistake: the
+ * tool exists, the caller is authorized for it, and discovery did not surface it
+ * under the name that was called (voyant#4656). Folded into `unknown_tool` it was
+ * indistinguishable from a typo, so the case nobody could act on was also the
+ * case nobody could count.
  */
-export type McpCallOutcome = "ok" | "tool_error" | "unknown_tool" | "validation_error"
+export type McpCallOutcome =
+  | "ok"
+  | "tool_error"
+  | "unknown_tool"
+  | "unreachable"
+  | "validation_error"
 
 /** Caller identity ids and granted scopes — never booking/traveller payloads. */
 export interface McpCaller {

--- a/packages/mcp/src/read-projection.ts
+++ b/packages/mcp/src/read-projection.ts
@@ -84,12 +84,28 @@ export interface QueryTool {
   resources: QueryResource[]
 }
 
+/** Where a folded read went: the query tool that absorbed it and its `resource`. */
+export interface FoldedRead {
+  queryTool: QueryTool
+  resource: string
+}
+
 export interface ReadProjection {
   /** Query tool name (`<domain>_query`) → its resources. */
   readonly queryTools: ReadonlyMap<string, QueryTool>
   /** Canonical names of the reads folded away (hidden from flat discovery/dispatch). */
   readonly hiddenReadNames: ReadonlySet<string>
   queryToolFor(name: string): QueryTool | undefined
+  /**
+   * Resolve a folded read name to where it is now reachable.
+   *
+   * `hiddenReadNames` answers "is this name still callable" and nothing else,
+   * which is why asking for `get_booking` used to return the same
+   * does-not-exist-or-not-authorized error as a typo. The name exists, the
+   * caller is authorized for it, and it moved — so the error can say so
+   * (voyant#4656).
+   */
+  foldedReadFor(name: string): FoldedRead | undefined
 }
 
 /**
@@ -100,14 +116,19 @@ export interface ReadProjection {
 export function buildReadProjection(surface: AuthorizedSurface): ReadProjection {
   const byDomain = new Map<string, QueryResource[]>()
   const hiddenReadNames = new Set<string>()
+  // Invocation name → the domain + resource it folded into. Aliases resolve to
+  // their canonical read's destination, so a caller that knows only the old
+  // alias still gets told where the read went.
+  const foldedInto = new Map<string, { domain: string; resource: string }>()
   for (const [invocationName, { entry, aliasFor }] of surface) {
-    // Fold aliases into their canonical; only project the canonical read once.
-    if (aliasFor) {
-      if (isReadToolName(entry.name)) hiddenReadNames.add(invocationName)
-      continue
-    }
     if (!isReadToolName(entry.name)) continue
     hiddenReadNames.add(invocationName)
+    foldedInto.set(invocationName, {
+      domain: toolDomain(entry),
+      resource: resourceOf(entry.name),
+    })
+    // Fold aliases into their canonical; only project the canonical read once.
+    if (aliasFor) continue
     const domain = toolDomain(entry)
     const resources = byDomain.get(domain) ?? []
     resources.push({ resource: resourceOf(entry.name), invocationName, entry })
@@ -123,6 +144,12 @@ export function buildReadProjection(surface: AuthorizedSurface): ReadProjection 
     queryTools,
     hiddenReadNames,
     queryToolFor: (name) => queryTools.get(name),
+    foldedReadFor: (name) => {
+      const folded = foldedInto.get(name)
+      if (!folded) return undefined
+      const queryTool = queryTools.get(`${folded.domain}${QUERY_SUFFIX}`)
+      return queryTool ? { queryTool, resource: folded.resource } : undefined
+    },
   }
 }
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -44,6 +44,7 @@ import {
   type AuthorizedSurface,
   collectAuthorizedTools,
   META_TOOL_NAMES,
+  registerFoldedReadNotice,
   registerMetaTools,
   selectEagerToolNames,
 } from "./meta-tools.js"
@@ -227,6 +228,13 @@ export function createMcpApiRoutes(options: McpApiRoutesOptions): OpenAPIHono {
       const queryTool = projection.queryToolFor(requestedName)
       if (queryTool) {
         registerQueryTool(server, registry, queryTool, ctx, requireActionPolicy, budgetBytes)
+      } else if (surface.has(requestedName) && projection.hiddenReadNames.has(requestedName)) {
+        // A folded read called by its old flat name. Without this the SDK answers
+        // "tool not found", which is the same thing it says for a typo — so the
+        // one case that is a discovery defect looked exactly like caller error
+        // (voyant#4656). Registered only for THIS request, so it never appears in
+        // a `tools/list`.
+        registerFoldedReadNotice(server, projection, requestedName)
       } else if (surface.has(requestedName) && !projection.hiddenReadNames.has(requestedName)) {
         registerSurfaceTool(
           server,
@@ -366,7 +374,13 @@ async function instrumentRpc(
       queryTool !== undefined ||
       META_TOOL_NAMES.includes(name) ||
       guideToolNames.has(name)
-    const { outcome, code } = classifyToolCallResult(payload, known)
+    // A folded read called by its flat name is not an unknown tool: it exists,
+    // the caller is authorized, and discovery moved it. Counting it as a miss
+    // buried the one outcome that is a defect rather than caller error.
+    const folded = surface.has(name) && projection.hiddenReadNames.has(name)
+    const { outcome, code } = folded
+      ? { outcome: "unreachable" as const, code: undefined }
+      : classifyToolCallResult(payload, known)
     observer.toolCall({
       tool: name,
       outcome,

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -29,9 +29,10 @@ export interface McpApiRoutesOptions {
   requireActionPolicies?: boolean
   /**
    * Canonical names of domain tools to register eagerly in tier 0 alongside the
-   * meta-tools (voyant#3927). Defaults to none: the domain surface is discovered
-   * on demand through `search_tools` / `describe_tool` / `call_tool` until the
-   * guide / workflow / domain-query tiers land and opt specific tools in.
+   * meta-tools (voyant#3927). Omit for `DEFAULT_EAGER_TOOL_NAMES` — the core
+   * operator writes, resident so the common journey never depends on a consumer
+   * admitting the meta-tools (voyant#4656). Pass an explicit `[]` to opt out and
+   * discover everything on demand; the rest of the surface is lazy either way.
    */
   eagerToolNames?: readonly string[]
   /** Observability sink for MCP transport telemetry (RFC #1553). Defaults to no-op. */

--- a/packages/mcp/tests/reachability.test.ts
+++ b/packages/mcp/tests/reachability.test.ts
@@ -1,0 +1,299 @@
+/**
+ * What a caller can actually reach, and what it is told when it cannot
+ * (voyant#4656).
+ *
+ * The reported failure had two halves. An operator asked its agent for a
+ * confirmed, paid booking and was told no booking-creation or payment-recording
+ * action existed — while both were registered and authorized. The eager tier was
+ * empty by design and the long tail lived behind three meta-tools the consumer
+ * had discarded, so "reachable in principle" and "reachable" were not the same
+ * thing. And when a name did not resolve, every reason produced one sentence:
+ * "it does not exist or your grant does not authorize it", which is the wrong
+ * answer for a tool that exists, is authorized, and simply moved.
+ *
+ * So two properties are pinned here:
+ *
+ * 1. The core operator writes are resident with no deployment configuration, and
+ *    only for a caller authorized for them.
+ * 2. A folded read answers with WHERE IT WENT, over every path a caller can
+ *    reach it by, and is counted as `unreachable` rather than as a typo.
+ */
+import type { ErrorEvent, Reporter } from "@voyant-travel/hono/observability"
+import {
+  createToolRegistry,
+  defineTool,
+  READ_ONLY_RISK,
+  type ToolContext,
+} from "@voyant-travel/tools"
+import { Hono } from "hono"
+import { describe, expect, it } from "vitest"
+import { z } from "zod"
+
+import { createMcpApiRoutes, DEFAULT_EAGER_TOOL_NAMES } from "../src/index.js"
+import { MCP_TELEMETRY_CONTEXT_KEY } from "../src/observability.js"
+
+const accessCatalog = {
+  resources: [
+    {
+      id: "bookings",
+      unitId: "@voyant-travel/bookings",
+      resource: "bookings",
+      label: "Bookings",
+      description: "Bookings",
+      wildcard: "allow" as const,
+      actions: [
+        { action: "read", label: "Read", description: "Read bookings" },
+        { action: "write", label: "Write", description: "Write bookings" },
+      ],
+    },
+    {
+      id: "finance",
+      unitId: "@voyant-travel/finance",
+      resource: "finance",
+      label: "Finance",
+      description: "Finance",
+      wildcard: "allow" as const,
+      actions: [
+        { action: "read", label: "Read", description: "Read finance" },
+        { action: "write", label: "Write", description: "Write finance" },
+      ],
+    },
+  ],
+  presets: [],
+}
+
+const bookProductTool = defineTool({
+  capabilityId: "@voyant-travel/finance#tool.book-product",
+  owner: "@voyant-travel/finance",
+  capabilityVersion: "v1",
+  name: "book_product",
+  description: "Book a product for a client in one call.",
+  inputSchema: z.object({ productId: z.string().min(1), personId: z.string().min(1) }),
+  outputSchema: z.object({ bookingId: z.string() }),
+  requiredScopes: ["bookings:write"],
+  audience: { source: "grant", allowed: ["staff"] },
+  tier: "write",
+  riskPolicy: {
+    destructive: false,
+    reversible: false,
+    dryRunSupported: false,
+    confirmationRequired: true,
+    sideEffects: ["data-write"],
+  },
+  handler() {
+    return Promise.resolve({ bookingId: "bkg_1" })
+  },
+})
+
+const recordPaymentTool = defineTool({
+  capabilityId: "@voyant-travel/finance#tool.record-payment",
+  owner: "@voyant-travel/finance",
+  capabilityVersion: "v1",
+  name: "record_payment",
+  description: "Record a payment received against an invoice.",
+  inputSchema: z.object({ invoiceId: z.string().min(1), amountCents: z.number().int() }),
+  outputSchema: z.object({ id: z.string() }),
+  requiredScopes: ["finance:write"],
+  audience: { source: "grant", allowed: ["staff"] },
+  tier: "write",
+  riskPolicy: {
+    destructive: false,
+    reversible: true,
+    dryRunSupported: false,
+    confirmationRequired: true,
+    sideEffects: ["data-write"],
+  },
+  handler() {
+    return Promise.resolve({ id: "pay_1" })
+  },
+})
+
+/** A read, so the projection folds it into `bookings_query` as resource `booking`. */
+const getBookingTool = defineTool({
+  capabilityId: "@voyant-travel/bookings#tool.get-booking",
+  owner: "@voyant-travel/bookings",
+  capabilityVersion: "v1",
+  name: "get_booking",
+  description: "Read one booking by id.",
+  inputSchema: z.object({ id: z.string().min(1) }),
+  outputSchema: z.object({ id: z.string() }),
+  requiredScopes: ["bookings:read"],
+  audience: { source: "grant", allowed: ["staff"] },
+  tier: "read",
+  riskPolicy: READ_ONLY_RISK,
+  handler({ id }) {
+    return Promise.resolve({ id })
+  },
+})
+
+const MCP_HEADERS = {
+  "content-type": "application/json",
+  accept: "application/json, text/event-stream",
+}
+
+function rpc(method: string, params: unknown) {
+  return {
+    method: "POST",
+    headers: MCP_HEADERS,
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+  }
+}
+
+function buildContext(): ToolContext {
+  return {
+    db: {},
+    actor: "staff",
+    audience: "staff",
+    tenantId: "t1",
+    resolverScope: { locale: "en-GB", audience: "staff", market: "default", actor: "staff" },
+  }
+}
+
+interface Harness {
+  app: Hono
+  telemetry: () => Array<Record<string, unknown>>
+}
+
+function harness(
+  options: { eagerToolNames?: readonly string[]; scopes?: readonly string[] } = {},
+): Harness {
+  const events: ErrorEvent[] = []
+  const reporter: Reporter = {
+    captureException(event) {
+      events.push(event)
+    },
+  }
+  const registry = createToolRegistry()
+  registry.register(bookProductTool)
+  registry.register(recordPaymentTool)
+  registry.register(getBookingTool)
+  const mcp = createMcpApiRoutes({
+    accessCatalog,
+    registry,
+    buildContext,
+    reporter,
+    ...(options.eagerToolNames ? { eagerToolNames: options.eagerToolNames } : {}),
+  })
+  const app = new Hono()
+  const scopes = options.scopes ?? ["bookings:read", "bookings:write", "finance:write"]
+  app.use("*", async (c, next) => {
+    c.set("scopes", [...scopes])
+    await next()
+  })
+  app.route("/", mcp)
+  return {
+    app,
+    telemetry: () =>
+      events
+        .map((e) => e.context?.[MCP_TELEMETRY_CONTEXT_KEY])
+        .filter((c): c is Record<string, unknown> => typeof c === "object" && c !== null),
+  }
+}
+
+async function readRpc(res: Response): Promise<Record<string, unknown>> {
+  const text = await res.text()
+  if ((res.headers.get("content-type") ?? "").includes("text/event-stream")) {
+    const line = text.split("\n").find((l) => l.startsWith("data:"))
+    return JSON.parse(line?.slice("data:".length).trim() ?? "{}")
+  }
+  return JSON.parse(text)
+}
+
+async function listToolNames(app: Hono): Promise<string[]> {
+  const listed = await readRpc(await app.request("/", rpc("tools/list", {})))
+  const tools = (listed.result as { tools?: Array<{ name: string }> } | undefined)?.tools ?? []
+  return tools.map(({ name }) => name).sort()
+}
+
+/** The `content` text of a `tools/call`, whether it succeeded or failed. */
+async function callText(app: Hono, name: string, args: unknown): Promise<string> {
+  const res = await readRpc(await app.request("/", rpc("tools/call", { name, arguments: args })))
+  const result = res.result as { content?: Array<{ text?: string }>; isError?: boolean } | undefined
+  return result?.content?.map((part) => part.text ?? "").join("\n") ?? JSON.stringify(res)
+}
+
+const TIER_0 = ["call_tool", "describe_tool", "search_tools", "voyant_glossary", "voyant_guide"]
+
+describe("the core operator writes are reachable without configuration", () => {
+  it("registers the default eager set when a deployment passes nothing", async () => {
+    const names = await listToolNames(harness().app)
+
+    expect(names).toEqual([...TIER_0, "book_product", "record_payment"].sort())
+    // The default is the contract, not an accident of this fixture's names.
+    expect([...DEFAULT_EAGER_TOOL_NAMES].sort()).toEqual(["book_product", "record_payment"])
+  })
+
+  it("still lets a deployment opt out with an explicit empty list", async () => {
+    // `[]` and `undefined` mean different things: absent takes the default, empty
+    // asks for tier-0 alone. Collapsing them would make the default unavoidable.
+    const names = await listToolNames(harness({ eagerToolNames: [] }).app)
+
+    expect(names).toEqual(TIER_0)
+  })
+
+  it("promotes only what the caller is authorized for", async () => {
+    // A key with no finance grant must not be advertised the payment write —
+    // eager registration is a disclosure decision, not just a cost one.
+    const names = await listToolNames(harness({ scopes: ["bookings:read", "bookings:write"] }).app)
+
+    expect(names).toEqual([...TIER_0, "book_product"].sort())
+  })
+
+  it("dispatches an eagerly registered write by its flat name", async () => {
+    const text = await callText(harness().app, "record_payment", {
+      invoiceId: "inv_1",
+      amountCents: 1000,
+    })
+
+    expect(text).toContain("pay_1")
+  })
+})
+
+describe("a folded read says where it went", () => {
+  const EXPECTED = ["bookings_query", 'resource "booking"']
+
+  it("answers a call_tool dispatch with the query tool and resource", async () => {
+    const text = await callText(harness().app, "call_tool", {
+      name: "get_booking",
+      arguments: { id: "bkg_1" },
+    })
+
+    for (const fragment of EXPECTED) expect(text).toContain(fragment)
+    // The two claims the old message made, both false here.
+    expect(text).not.toContain("does not exist")
+    expect(text).not.toContain("does not authorize")
+  })
+
+  it("answers a flat-name call the same way instead of the SDK's not-found", async () => {
+    // The path the reported agent actually used. Left to the SDK it answers
+    // "Tool not found", which is exactly what it says for a typo.
+    const text = await callText(harness().app, "get_booking", { id: "bkg_1" })
+
+    for (const fragment of EXPECTED) expect(text).toContain(fragment)
+  })
+
+  it("answers describe_tool with the resource to describe instead", async () => {
+    const text = await callText(harness().app, "describe_tool", { name: "get_booking" })
+
+    for (const fragment of EXPECTED) expect(text).toContain(fragment)
+  })
+
+  it("keeps a genuinely unknown name on the unknown-tool answer", async () => {
+    const text = await callText(harness().app, "call_tool", { name: "get_nothing", arguments: {} })
+
+    expect(text).toContain("is not available")
+    expect(text).not.toContain('resource "booking"')
+  })
+
+  it("counts the folded read as unreachable, not as an unknown tool", async () => {
+    const h = harness()
+    await h.app.request("/", rpc("tools/call", { name: "get_booking", arguments: { id: "bkg_1" } }))
+
+    const calls = h.telemetry().filter((event) => event.event === "tool_call")
+    expect(calls).toHaveLength(1)
+    // `unknown_tool` is a caller mistake and this is not one: the tool exists and
+    // the caller is authorized. Blurring them hides the only outcome here that is
+    // a defect on our side.
+    expect(calls[0]).toMatchObject({ tool: "get_booking", outcome: "unreachable" })
+  })
+})

--- a/scripts/agent-write-coverage-baseline.json
+++ b/scripts/agent-write-coverage-baseline.json
@@ -10,7 +10,7 @@
   "@voyant-travel/cruises": 21,
   "@voyant-travel/custom-fields": 2,
   "@voyant-travel/distribution": 51,
-  "@voyant-travel/finance": 47,
+  "@voyant-travel/finance": 46,
   "@voyant-travel/flights": 3,
   "@voyant-travel/inventory": 42,
   "@voyant-travel/legal": 16,

--- a/scripts/tool-protocol-field-inventory.json
+++ b/scripts/tool-protocol-field-inventory.json
@@ -83,6 +83,11 @@
       "rationale": "Retained because the caller chooses the stable identity of this retryable business command."
     },
     {
+      "id": "@voyant-travel/finance:record_payment:input.idempotencyKey",
+      "ownership": "caller-owned-command-identity",
+      "rationale": "Optional and caller-owned, and deliberately not derived from the command the way an issue is. Two identical payments — same invoice, amount, method and date, no reference — are an ordinary thing for a customer to do, and a content-derived key would replay the second one away. The caller sends a key only when it means 'this is the same payment I already told you about'."
+    },
+    {
       "id": "@voyant-travel/finance:record_refund_settlement:input.idempotencyKey",
       "ownership": "caller-owned-command-identity",
       "rationale": "Retained because the caller chooses the stable identity of this retryable business command."


### PR DESCRIPTION
Closes #4656.

## What the issue asked for, and what was actually wrong

The issue has three asks. Checking them against the tree first changed what this
PR does:

**Ask 1 — make the meta-tools reliably reachable — is already fixed.** #4646
landed the positive `voyant.travel/server-tool` marker on every server-owned
`tools/list` entry, so a consumer validating registry metadata can classify each
entry instead of failing closed on absence. Nothing more was needed here; the
doc table in `agent-tool-library.md` already records the contract.

**Ask 2 turned out to have a second half the issue did not know about.** The
issue says "the tools exist in the registry; they are simply not reachable". That
is true of `create_booking`. It is **not** true of payment recording: there was
no `record_payment` Tool at all. `POST /v1/admin/finance/invoices/{id}/payments`
had no agent-facing front — it is one of the 47 uncovered finance writes the
agent-write-coverage ratchet tracks — so when the agent said it had no
payment-recording action, it was right. No amount of discovery work would have
made that call possible.

## What this changes

**A `record_payment` Tool (`@voyant-travel/finance`).** A thin wrapper over the
same `financeService.createPayment` command the admin route runs, with the same
ledger context and its own `finance.payment.tool` authorization source. Input is
derived from `insertPaymentSchema` so it cannot drift from the route, then
narrowed: `invoiceId` moves into the body, the FX and card-plumbing fields are
dropped (server-resolved, or they belong to a processor session), and `status`
defaults to `completed` rather than `pending` — an operator recording a payment
has the money, and the route's default would leave the invoice reading unpaid
after the agent reported success. `medium` risk, `ledger: required`,
`approval: never`, matching `record_payment_dispute`: the money moved before the
call and the record catches up with it, and per-payment approval would stall the
back-entry sweep this exists for. Deliberately **not** `idempotentHint` — it is
idempotent only when the optional `idempotencyKey` is sent, and that has to stay
optional because two identical payments are a thing customers do. The finance
write-coverage baseline drops 47 → 46.

**A default eager set (`@voyant-travel/mcp`).** `eagerToolNames` now defaults to
`DEFAULT_EAGER_TOOL_NAMES` = `["book_product", "record_payment"]` instead of
empty; an explicit `[]` opts out. `book_product` rather than `create_booking`
because it is the intent-level entry point the guide already names, and it is
about half the schema. A name is promoted only for a caller authorized for it, so
a read-only key pays nothing.

**This is a real cost and the ratchet records it.** Measured on the selected
operator graph: **4,157 → 18,395 bytes**, ~1,040 → ~4,600 tokens per connection
(`book_product` 9,700, `record_payment` 4,538). The ceiling in
`selected-graph-mcp-tool-surface.test.ts` goes 5,000 → 20,000 with that
measurement written down, and the surface test now asserts the eager set **by
name** so a third eager write still trips it. The counter-argument is in the
issue: with an empty default, every write depended on a consumer admitting three
tools it could not classify, and when one did not, an operator was told the
product could not create a booking. A write journey also earns most of it back —
the eval measures ~1,200 tokens for a three-call discovery sequence.

**Unreachability is now a distinct answer and a distinct metric.** A read the
projection folded into a `<domain>_query` group used to return the same sentence
as a typo: "it does not exist or your grant does not authorize it" — both halves
false. It now answers with the query tool and the exact `resource` to call it
with, over all three paths a caller reaches it by (`call_tool`, the flat name via
a per-request notice registration, and `describe_tool`), and emits the new
`unreachable` telemetry outcome instead of `unknown_tool`. That is the one
outcome here that is a defect on our side rather than caller error, so it is the
one worth being able to count.

The server `instructions` and the `discovery` guide topic said `tools/list`
carries only the meta-tools and the guide. Both are updated, and both now say
that absence from `tools/list` is not absence from the deployment.

## Verification

- `pnpm -F @voyant-travel/mcp test` — 17 files, 115 tests (new
  `tests/reachability.test.ts`: 9)
- `pnpm -F @voyant-travel/finance test` — 78 files, 588 tests
- `pnpm -F operator test` — 15 files, 72 tests (the real selected graph, which is
  what proves `record_payment` composes: a `medium`-risk tool with no action
  policy fails the mount)
- `pnpm -F @voyant-travel/{mcp,finance} typecheck` / `build` — clean
- `pnpm verify:architecture` — clean
