### PR TITLE
fix(catalog-react): classify a failed Commit by its own outcome

### DIFF
--- a/packages/bookings-react/src/components/manual-booking-create-form.tsx
+++ b/packages/bookings-react/src/components/manual-booking-create-form.tsx
@@ -25,6 +25,7 @@ import {
 import {
   type BookingSessionJourneyContinuation,
   BookingSessionJourneyError,
+  bookingSessionContinuationIsStale,
   commitBookingSessionJourneyV1,
   createBookingJourneyApi,
   useOfferPreview,
@@ -1853,6 +1854,18 @@ export function ManualBookingCreateForm({
       // The typed outcome carried the list; keep it. Collapsing it back into
       // the sentence above is what made the server's enforcement invisible.
       setUnsatisfied(cause instanceof BookingSessionJourneyError ? (cause.unsatisfied ?? []) : [])
+      if (
+        cause instanceof BookingSessionJourneyError &&
+        bookingSessionContinuationIsStale(cause.outcome)
+      ) {
+        // The server said the Quote, Hold or revision we are holding is dead.
+        // Keeping the attempt would replay the same dead continuation on every
+        // resubmit, which is how one operator hit the same failure three times
+        // in a row (voyant#4662). Dropping it makes the next submit run a fresh
+        // Create → Quote → Hold → Commit under a new idempotency key — safe
+        // precisely because these outcomes mean no booking was created.
+        attemptRef.current = null
+      }
     } finally {
       submissionRef.current = false
       setSubmitting(false)

--- a/packages/bookings-react/src/i18n/en-create-list.ts
+++ b/packages/bookings-react/src/i18n/en-create-list.ts
@@ -68,6 +68,8 @@ export const bookingsUiEnCreateList = {
         commitRejected: "The booking could not be committed from the current selection.",
         commitInFlight:
           "This booking is still being confirmed. Do not submit it again — refresh in a moment to see the result.",
+        alreadyCommitted:
+          "This booking session was already completed by another attempt. Find the booking it created instead of submitting again.",
         supplierUnavailable:
           "The supplier could not confirm this booking. Choose different inventory or send it for manual review.",
         proposalAcceptanceRequired:

--- a/packages/bookings-react/src/i18n/en-create-list.ts
+++ b/packages/bookings-react/src/i18n/en-create-list.ts
@@ -66,6 +66,12 @@ export const bookingsUiEnCreateList = {
         requirementsChanged:
           "The booking details this product requires changed. Review the refreshed form and try again.",
         commitRejected: "The booking could not be committed from the current selection.",
+        commitInFlight:
+          "This booking is still being confirmed. Do not submit it again — refresh in a moment to see the result.",
+        supplierUnavailable:
+          "The supplier could not confirm this booking. Choose different inventory or send it for manual review.",
+        proposalAcceptanceRequired:
+          "The proposal changed since it was accepted. Have the traveller accept the current version and try again.",
         notAuthorized: "You do not have permission to commit this booking.",
         unknown: "The Booking Session rejected this request. Review the booking and try again.",
       },

--- a/packages/bookings-react/src/i18n/messages-create-list.ts
+++ b/packages/bookings-react/src/i18n/messages-create-list.ts
@@ -54,6 +54,9 @@ export type BookingsUiCreateListMessages = {
         selectionIncomplete: string
         requirementsChanged: string
         commitRejected: string
+        commitInFlight: string
+        supplierUnavailable: string
+        proposalAcceptanceRequired: string
         notAuthorized: string
         unknown: string
       }

--- a/packages/bookings-react/src/i18n/messages-create-list.ts
+++ b/packages/bookings-react/src/i18n/messages-create-list.ts
@@ -55,6 +55,7 @@ export type BookingsUiCreateListMessages = {
         requirementsChanged: string
         commitRejected: string
         commitInFlight: string
+        alreadyCommitted: string
         supplierUnavailable: string
         proposalAcceptanceRequired: string
         notAuthorized: string

--- a/packages/bookings-react/src/i18n/ro-create-list.ts
+++ b/packages/bookings-react/src/i18n/ro-create-list.ts
@@ -69,6 +69,8 @@ export const bookingsUiRoCreateList = {
         commitRejected: "Rezervarea nu a putut fi finalizata din selectia curenta.",
         commitInFlight:
           "Rezervarea este inca in curs de confirmare. Nu o trimite din nou - reincarca peste un moment pentru a vedea rezultatul.",
+        alreadyCommitted:
+          "Aceasta sesiune a fost deja finalizata printr-o alta incercare. Cauta rezervarea creata in loc sa trimiti din nou.",
         supplierUnavailable:
           "Furnizorul nu a putut confirma rezervarea. Alege alta disponibilitate sau trimite cazul spre verificare manuala.",
         proposalAcceptanceRequired:

--- a/packages/bookings-react/src/i18n/ro-create-list.ts
+++ b/packages/bookings-react/src/i18n/ro-create-list.ts
@@ -67,6 +67,12 @@ export const bookingsUiRoCreateList = {
         requirementsChanged:
           "Datele solicitate de acest produs s-au schimbat. Verifica formularul actualizat si incearca din nou.",
         commitRejected: "Rezervarea nu a putut fi finalizata din selectia curenta.",
+        commitInFlight:
+          "Rezervarea este inca in curs de confirmare. Nu o trimite din nou - reincarca peste un moment pentru a vedea rezultatul.",
+        supplierUnavailable:
+          "Furnizorul nu a putut confirma rezervarea. Alege alta disponibilitate sau trimite cazul spre verificare manuala.",
+        proposalAcceptanceRequired:
+          "Propunerea s-a schimbat de la acceptare. Cere calatorului sa accepte versiunea curenta si incearca din nou.",
         notAuthorized: "Nu ai permisiunea de a finaliza aceasta rezervare.",
         unknown: "Booking Session a respins cererea. Verifica rezervarea si incearca din nou.",
       },

--- a/packages/catalog-react/src/booking-engine/index.ts
+++ b/packages/catalog-react/src/booking-engine/index.ts
@@ -60,9 +60,13 @@ export {
 } from "./session-journey.js"
 export {
   BookingSessionJourneyError,
+  type BookingSessionNextActionV1,
   type BookingSessionOutcomeKind,
   type BookingSessionOutcomeOf,
   type BookingSessionRecoveryV1,
+  bookingSessionCommitOutcome,
+  bookingSessionContinuationIsStale,
+  bookingSessionNextActionV1,
   bookingSessionOf,
   bookingSessionOutcomeOf,
   bookingSessionRecoveryV1,

--- a/packages/catalog-react/src/booking-engine/session-journey.test.ts
+++ b/packages/catalog-react/src/booking-engine/session-journey.test.ts
@@ -4,7 +4,11 @@ import {
   type BookingSessionJourneyContinuation,
   commitBookingSessionJourneyV1,
 } from "./session-journey.js"
-import { BookingSessionJourneyError, unsatisfiedBookingRequirements } from "./session-outcomes.js"
+import {
+  BookingSessionJourneyError,
+  bookingSessionContinuationIsStale,
+  unsatisfiedBookingRequirements,
+} from "./session-outcomes.js"
 import { createBookingJourneyApi } from "./use-booking-journey-api.js"
 
 const REQUIREMENTS = {
@@ -299,6 +303,48 @@ describe("Booking Session v1 journey", () => {
       "/v1/admin/catalog/booking-sessions/bses_1/commit",
       expect.objectContaining({ credentials: "include", method: "POST" }),
     )
+  })
+
+  it("classifies a failed Commit by its outcome rather than as unknown", async () => {
+    // The Commit envelope is `commit_result`, not `rejected`, so a mapper that
+    // only reads rejections hands the operator the generic fallback for a
+    // fully-structured failure (voyant#4662).
+    const fetcher = vi.fn(async (url: string) => {
+      if (url.endsWith("/booking-sessions")) {
+        return json({ kind: "session_created", session: session() })
+      }
+      if (url.endsWith("/quote")) return json(quote())
+      if (url.endsWith("/hold")) return json(hold())
+      return json({
+        kind: "commit_result",
+        outcome: {
+          kind: "quote_failure",
+          nextAction: "request_fresh_quote",
+          reason: "superseded",
+        },
+      })
+    })
+
+    const failure = await commitBookingSessionJourneyV1(
+      createBookingJourneyApi({ baseUrl: "", fetcher }),
+      {
+        target: { kind: "product", productId: "prod_1" },
+        selection: {},
+        quantity: 1,
+        idempotencyKey: "manual-booking:commit-quote-failure",
+      },
+    ).catch((error: unknown) => error)
+
+    expect(failure).toBeInstanceOf(BookingSessionJourneyError)
+    const error = failure as BookingSessionJourneyError
+    expect(error.recovery).toBe("quoteChanged")
+    expect(error.message).toBe("booking_session_quoteChanged")
+    // `rejected` is the only envelope carrying a lifecycle error, so this stays
+    // null — the Commit outcome is where the cause lives.
+    expect(error.error).toBeNull()
+    expect(error.commitOutcome).toMatchObject({ kind: "quote_failure", reason: "superseded" })
+    expect(error.nextAction).toBe("request_fresh_quote")
+    expect(bookingSessionContinuationIsStale(error.outcome)).toBe(true)
   })
 
   it("exposes typed recovery without embedding UI copy", async () => {

--- a/packages/catalog-react/src/booking-engine/session-outcomes.test.ts
+++ b/packages/catalog-react/src/booking-engine/session-outcomes.test.ts
@@ -1,0 +1,221 @@
+import {
+  type BookingLifecycleCommitOutcomeV1,
+  bookingLifecycleCommitOutcomeKindV1,
+} from "@voyant-travel/catalog-contracts/booking-engine/lifecycle-conformance"
+import type { BookingSessionOutcomeV1 } from "@voyant-travel/catalog-contracts/booking-engine/session-contracts"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import {
+  type BookingSessionRecoveryV1,
+  bookingSessionCommitOutcome,
+  bookingSessionContinuationIsStale,
+  bookingSessionNextActionV1,
+  bookingSessionRecoveryV1,
+} from "./session-outcomes.js"
+
+function commitResult(outcome: BookingLifecycleCommitOutcomeV1): BookingSessionOutcomeV1 {
+  return { kind: "commit_result", outcome }
+}
+
+/** One representative value per Commit outcome kind, straight from the contract. */
+const COMMIT_OUTCOMES = {
+  committed: {
+    kind: "committed",
+    nextAction: "none",
+    booking: { id: "book_1", status: "confirmed" },
+    allocationIds: ["bkac_1"],
+    consumedSessionId: "bses_1",
+    consumedQuoteId: "bsqu_1",
+  },
+  component_bookings_committed: {
+    kind: "component_bookings_committed",
+    nextAction: "none",
+    bookings: [
+      { componentId: "cmp_1", bookingId: "book_1", status: "confirmed", allocationIds: ["bkac_1"] },
+    ],
+    consumedSessionId: "bses_1",
+    consumedQuoteId: "bsqu_1",
+  },
+  component_commit_pending: {
+    kind: "component_commit_pending",
+    nextAction: "continue_component_commit",
+    components: [{ componentId: "cmp_1", state: "supplier_pending" }],
+  },
+  payment_required: {
+    kind: "payment_required",
+    nextAction: "establish_payment_guarantee",
+    paymentTarget: "booking_session",
+    allowedGuarantees: ["deposit"],
+    paymentSession: {
+      id: "pays_1",
+      status: "requires_redirect",
+      amountCents: 1000,
+      currency: "EUR",
+      redirectUrl: "https://pay.test/1",
+      checkout: null,
+      expiresAt: null,
+    },
+  },
+  supplier_pending: {
+    kind: "supplier_pending",
+    nextAction: "await_supplier_operation",
+    supplierOperationId: "supop_1",
+    operatorBackedRiskAccepted: false,
+  },
+  supplier_in_doubt: {
+    kind: "supplier_in_doubt",
+    nextAction: "reconcile_supplier_operation",
+    supplierOperationId: "supop_1",
+    operatorBackedRiskAccepted: false,
+  },
+  supplier_failed: {
+    kind: "supplier_failed",
+    nextAction: "select_alternative_inventory",
+    supplierOperationId: "supop_1",
+    operatorBackedRiskAccepted: false,
+  },
+  revision_mismatch: {
+    kind: "revision_mismatch",
+    nextAction: "refresh_session_state",
+    expectedRevision: 1,
+    actualRevision: 2,
+  },
+  quote_failure: {
+    kind: "quote_failure",
+    nextAction: "request_fresh_quote",
+    reason: "superseded",
+  },
+  hold_failure: { kind: "hold_failure", nextAction: "request_new_hold", reason: "expired" },
+  proposal_acceptance_required: {
+    kind: "proposal_acceptance_required",
+    nextAction: "renew_proposal_version_acceptance",
+    proposalVersionId: "prpv_1",
+  },
+  idempotent_replay: {
+    kind: "idempotent_replay",
+    nextAction: "return_idempotent_result",
+    originalCommitId: "bscm_1",
+    originalOutcome: {
+      kind: "quote_failure",
+      nextAction: "request_fresh_quote",
+      reason: "expired",
+    },
+  },
+} satisfies Record<string, BookingLifecycleCommitOutcomeV1>
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("bookingSessionRecoveryV1 over the commit_result envelope", () => {
+  // The defect: `commit_result` is not `rejected`, so every failed Commit fell
+  // straight through to the generic fallback (voyant#4662).
+  it.each([
+    ["quote_failure", "quoteChanged"],
+    ["hold_failure", "availabilityChanged"],
+    ["revision_mismatch", "revisionConflict"],
+    ["supplier_pending", "commitInFlight"],
+    ["supplier_in_doubt", "commitInFlight"],
+    ["component_commit_pending", "commitInFlight"],
+    ["supplier_failed", "supplierUnavailable"],
+    ["proposal_acceptance_required", "proposalAcceptanceRequired"],
+  ] as Array<
+    [keyof typeof COMMIT_OUTCOMES, BookingSessionRecoveryV1]
+  >)("classifies a %s Commit as %s", (kind, recovery) => {
+    expect(bookingSessionRecoveryV1(commitResult(COMMIT_OUTCOMES[kind]))).toBe(recovery)
+  })
+
+  it("classifies a replayed failure by the outcome it replays, not by the wrapper", () => {
+    const outcome = commitResult(COMMIT_OUTCOMES.idempotent_replay)
+    expect(bookingSessionRecoveryV1(outcome)).toBe("quoteChanged")
+    // The reader hands back the original so a host can read `reason` too.
+    expect(bookingSessionCommitOutcome(outcome)).toMatchObject({
+      kind: "quote_failure",
+      reason: "expired",
+    })
+  })
+
+  it("keeps the server's instruction reachable instead of only reporting it", () => {
+    expect(bookingSessionNextActionV1(commitResult(COMMIT_OUTCOMES.quote_failure))).toBe(
+      "request_fresh_quote",
+    )
+    expect(bookingSessionNextActionV1(commitResult(COMMIT_OUTCOMES.hold_failure))).toBe(
+      "request_new_hold",
+    )
+    expect(
+      bookingSessionNextActionV1({
+        kind: "rejected",
+        error: { kind: "selection_incomplete", unsatisfied: [], nextAction: "update_selection" },
+      } as BookingSessionOutcomeV1),
+    ).toBe("update_selection")
+  })
+
+  it("classifies every Commit outcome the contract declares without warning", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+    for (const kind of bookingLifecycleCommitOutcomeKindV1.options) {
+      const outcome = COMMIT_OUTCOMES[kind as keyof typeof COMMIT_OUTCOMES]
+      // A kind added to the contract with no fixture here is the point of the
+      // assertion: it would otherwise reach the mapper as `undefined`.
+      expect(outcome, `no fixture for commit outcome "${kind}"`).toBeDefined()
+      bookingSessionRecoveryV1(commitResult(outcome))
+    }
+    expect(warn).not.toHaveBeenCalled()
+  })
+})
+
+describe("the unknown fallback", () => {
+  it("is loud outside production for a shape this build does not know", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+    const recovery = bookingSessionRecoveryV1(
+      commitResult({
+        kind: "invented_by_a_newer_server",
+      } as unknown as BookingLifecycleCommitOutcomeV1),
+    )
+    expect(recovery).toBe("unknown")
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("invented_by_a_newer_server"))
+  })
+
+  it("stays quiet for a declared kind that deliberately has no remedy to name", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+    expect(
+      bookingSessionRecoveryV1({
+        kind: "rejected",
+        error: { kind: "session_expired" },
+      } as BookingSessionOutcomeV1),
+    ).toBe("unknown")
+    expect(warn).not.toHaveBeenCalled()
+  })
+})
+
+describe("bookingSessionContinuationIsStale", () => {
+  it("condemns the continuation when the Quote, Hold or revision it pins is gone", () => {
+    expect(bookingSessionContinuationIsStale(commitResult(COMMIT_OUTCOMES.quote_failure))).toBe(
+      true,
+    )
+    expect(bookingSessionContinuationIsStale(commitResult(COMMIT_OUTCOMES.hold_failure))).toBe(true)
+    expect(bookingSessionContinuationIsStale(commitResult(COMMIT_OUTCOMES.revision_mismatch))).toBe(
+      true,
+    )
+    // A replay of a dead Quote is still a dead Quote.
+    expect(bookingSessionContinuationIsStale(commitResult(COMMIT_OUTCOMES.idempotent_replay))).toBe(
+      true,
+    )
+  })
+
+  it("keeps it whenever the Commit may have landed", () => {
+    // Discarding here would lose the only key that can retrieve the original
+    // result, and the next submit would mint a second booking.
+    expect(bookingSessionContinuationIsStale(commitResult(COMMIT_OUTCOMES.supplier_pending))).toBe(
+      false,
+    )
+    expect(bookingSessionContinuationIsStale(commitResult(COMMIT_OUTCOMES.supplier_in_doubt))).toBe(
+      false,
+    )
+    expect(
+      bookingSessionContinuationIsStale({
+        kind: "rejected",
+        error: { kind: "payment_in_flight", nextAction: "await_payment_outcome" },
+      } as BookingSessionOutcomeV1),
+    ).toBe(false)
+  })
+})

--- a/packages/catalog-react/src/booking-engine/session-outcomes.test.ts
+++ b/packages/catalog-react/src/booking-engine/session-outcomes.test.ts
@@ -163,6 +163,26 @@ describe("bookingSessionRecoveryV1 over the commit_result envelope", () => {
   })
 })
 
+describe("bookingSessionRecoveryV1 over the rejected envelope", () => {
+  it("separates an already-consumed Session from work still in flight", () => {
+    // The server only answers `commit_already_consumed` after looking for a
+    // commit under *this* caller's key and finding none, so nothing is coming
+    // and waiting is not the remedy — the booking exists under another attempt.
+    expect(
+      bookingSessionRecoveryV1({
+        kind: "rejected",
+        error: { kind: "commit_already_consumed", nextAction: "return_idempotent_result" },
+      } as BookingSessionOutcomeV1),
+    ).toBe("alreadyCommitted")
+    expect(
+      bookingSessionRecoveryV1({
+        kind: "rejected",
+        error: { kind: "payment_in_flight", nextAction: "await_payment_outcome" },
+      } as BookingSessionOutcomeV1),
+    ).toBe("commitInFlight")
+  })
+})
+
 describe("the unknown fallback", () => {
   it("is loud outside production for a shape this build does not know", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {})

--- a/packages/catalog-react/src/booking-engine/session-outcomes.ts
+++ b/packages/catalog-react/src/booking-engine/session-outcomes.ts
@@ -15,6 +15,10 @@
  * branches on.
  */
 
+import type {
+  BookingLifecycleCommitOutcomeV1,
+  BookingLifecycleNextActionV1,
+} from "@voyant-travel/catalog-contracts/booking-engine/lifecycle-conformance"
 import type { UnsatisfiedRequirementV1 } from "@voyant-travel/catalog-contracts/booking-engine/requirements-validation"
 import type {
   BookingSessionLifecycleErrorV1,
@@ -60,6 +64,86 @@ export function unsatisfiedBookingRequirements(
   return error?.kind === "selection_incomplete" ? error.unsatisfied : null
 }
 
+/**
+ * The commit outcome a `commit_result` carries, with `idempotent_replay`
+ * already unwrapped to the outcome it replays.
+ *
+ * A replay is the *same* answer the first Commit gave, so every reader that
+ * branches on the outcome wants the original — a caller that branched on
+ * `idempotent_replay` itself would have to unwrap it again to learn anything.
+ */
+export function bookingSessionCommitOutcome(
+  outcome: BookingSessionOutcomeV1 | null | undefined,
+): BookingLifecycleCommitOutcomeV1 | null {
+  if (outcome?.kind !== "commit_result") return null
+  return outcome.outcome.kind === "idempotent_replay"
+    ? outcome.outcome.originalOutcome
+    : outcome.outcome
+}
+
+/**
+ * Every instruction either envelope can carry. Derived from both contracts
+ * rather than restated, because the two sets only overlap — `contact_operator`
+ * exists only on a rejection and `continue_component_commit` only on a Commit.
+ */
+export type BookingSessionNextActionV1 =
+  | BookingLifecycleNextActionV1
+  | Extract<BookingSessionLifecycleErrorV1, { nextAction: string }>["nextAction"]
+
+/**
+ * The machine-readable instruction the server attached to this outcome, or
+ * `null` when it attached none.
+ *
+ * Reporting a failure and discarding its `nextAction` is what made a failed
+ * Commit unactionable (voyant#4662): the server said `request_fresh_quote`,
+ * and the only thing that reached the operator was a sentence with no cause
+ * and no remedy. Hosts that can follow the instruction should read it here;
+ * `bookingSessionRecoveryV1` below is the coarse classification for hosts that
+ * only render one message per remedy.
+ */
+export function bookingSessionNextActionV1(
+  outcome: BookingSessionOutcomeV1 | null | undefined,
+): BookingSessionNextActionV1 | null {
+  const commit = bookingSessionCommitOutcome(outcome)
+  if (commit) return commit.nextAction
+  const error = bookingSessionRejection(outcome)
+  return error && "nextAction" in error ? error.nextAction : null
+}
+
+/**
+ * The next actions that condemn a stored `BookingSessionJourneyContinuation`:
+ * the Quote, the Hold or the revision it pins is gone, so committing it again
+ * can only fail the same way.
+ *
+ * Everything else is excluded on purpose. `return_idempotent_result`,
+ * `await_payment_outcome` and the supplier actions all mean the Commit may
+ * have landed, and the continuation is the only thing that can retrieve its
+ * result under the original idempotency key — discarding it there would mint a
+ * second booking.
+ */
+const CONTINUATION_KILLING_NEXT_ACTIONS = new Set<BookingSessionNextActionV1>([
+  "request_fresh_quote",
+  "request_new_hold",
+  "request_hold_for_expected_quantity",
+  "refresh_session_state",
+])
+
+/**
+ * Whether a host holding a continuation for this outcome must throw it away
+ * and re-run Create → Quote → Hold before committing again.
+ *
+ * This is the actionable half of a failed Commit. A host that reports
+ * `quote_failure` but keeps its continuation resubmits the same superseded
+ * Quote on every retry, so the operator sees the same failure however many
+ * times they press the button (voyant#4662).
+ */
+export function bookingSessionContinuationIsStale(
+  outcome: BookingSessionOutcomeV1 | null | undefined,
+): boolean {
+  const nextAction = bookingSessionNextActionV1(outcome)
+  return nextAction !== null && CONTINUATION_KILLING_NEXT_ACTIONS.has(nextAction)
+}
+
 /** The Session record or redacted view an outcome carries, when it carries one. */
 export function bookingSessionOf(
   outcome: BookingSessionOutcomeV1 | null | undefined,
@@ -83,12 +167,43 @@ export type BookingSessionRecoveryV1 =
   | "selectionIncomplete"
   | "requirementsChanged"
   | "commitRejected"
+  | "commitInFlight"
+  | "supplierUnavailable"
+  | "proposalAcceptanceRequired"
   | "notAuthorized"
   | "unknown"
+
+/**
+ * `unknown` is for a shape this build does not know — a newer server, nothing
+ * else. Every kind either contract declares is answered explicitly below, even
+ * when the honest answer is that there is no remedy to name, so the switches
+ * are exhaustive and a kind added to a contract fails the build here rather
+ * than falling silently into the fallback. That silence is how voyant#4662
+ * survived: a fully-structured `quote_failure` rendered as "the Booking
+ * Session rejected this request".
+ */
+function unrecognisedOutcome(kind: unknown, discriminator: string): BookingSessionRecoveryV1 {
+  // Read through `globalThis` because this package runs in a browser, where a
+  // bare `process` is a ReferenceError unless the bundler defined it.
+  const nodeEnv = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process
+    ?.env?.NODE_ENV
+  if (nodeEnv !== "production") {
+    console.warn(
+      `[booking-session] no recovery class for ${discriminator} "${String(kind)}"; falling back to "unknown". ` +
+        "Map it in bookingSessionRecoveryV1 rather than letting the host render the generic message.",
+    )
+  }
+  return "unknown"
+}
 
 export function bookingSessionRecoveryV1(
   outcome: BookingSessionOutcomeV1,
 ): BookingSessionRecoveryV1 {
+  const commit = bookingSessionCommitOutcome(outcome)
+  if (commit) return commitOutcomeRecovery(commit)
+  // Any other kind is a *successful* outcome of a kind the caller did not
+  // expect — `expectBookingSessionOutcome` asking for `quote_created` and
+  // getting `session_updated`. Nothing failed, so there is no remedy to name.
   if (outcome.kind !== "rejected") return "unknown"
   switch (outcome.error.kind) {
     case "revision_conflict":
@@ -109,25 +224,103 @@ export function bookingSessionRecoveryV1(
       return "requirementsChanged"
     case "commit_rejected":
       return "commitRejected"
+    /**
+     * Money or a supplier operation is already moving. These must not read as
+     * "try again": a storefront that re-quoted a Session with a payment in
+     * flight released the Hold seconds before the money landed (voyant#4636).
+     */
+    case "payment_in_flight":
+    case "supplier_operation_active":
+    case "commit_already_consumed":
+      return "commitInFlight"
     case "not_authorized":
     case "capability_required":
     case "capability_scope_required":
       return "notAuthorized"
-    default:
+    /**
+     * Declared, and deliberately unclassified: the remedy is to start over or
+     * to change the request itself, which is not one of the recovery classes a
+     * host branches on. Listed so the exhaustiveness check below stays honest.
+     */
+    case "session_expired":
+    case "session_consumed":
+    case "renewal_not_allowed":
+    case "idempotency_conflict":
+    case "invalid_selection":
+    case "checkout_intent_not_offered":
+    case "hold_quantity_mismatch":
       return "unknown"
+    default: {
+      const unhandled: never = outcome.error
+      return unrecognisedOutcome((unhandled as { kind?: unknown }).kind, "lifecycle error")
+    }
+  }
+}
+
+/**
+ * The Commit envelope, which is not a rejection and never reached the switch
+ * above (voyant#4662). A failed Commit answers `commit_result` carrying a
+ * `quote_failure` or `hold_failure` — the same conditions the `rejected`
+ * envelope already classified, arriving by a different door.
+ */
+function commitOutcomeRecovery(outcome: BookingLifecycleCommitOutcomeV1): BookingSessionRecoveryV1 {
+  switch (outcome.kind) {
+    case "revision_mismatch":
+      return "revisionConflict"
+    case "quote_failure":
+      return "quoteChanged"
+    case "hold_failure":
+      return "availabilityChanged"
+    /**
+     * The commit is underway at a supplier. Telling an operator it was
+     * rejected invites the resubmit that books twice; the remedy is to wait
+     * for or reconcile the operation.
+     */
+    case "supplier_pending":
+    case "supplier_in_doubt":
+    case "component_commit_pending":
+      return "commitInFlight"
+    case "supplier_failed":
+      return "supplierUnavailable"
+    case "proposal_acceptance_required":
+      return "proposalAcceptanceRequired"
+    /**
+     * Successes. A caller only classifies these if it could not read the
+     * result it was handed — the journey helper cannot express a multi-booking
+     * commit — and there is nothing to recover from, so there is no class.
+     */
+    case "committed":
+    case "component_bookings_committed":
+    case "payment_required":
+      return "unknown"
+    /**
+     * Unwrapped before the switch by `bookingSessionCommitOutcome`; the case
+     * exists so the exhaustiveness check covers the whole union.
+     */
+    case "idempotent_replay":
+      return commitOutcomeRecovery(outcome.originalOutcome)
+    default: {
+      const unhandled: never = outcome
+      return unrecognisedOutcome((unhandled as { kind?: unknown }).kind, "commit outcome")
+    }
   }
 }
 
 /**
  * Thrown only by the choreographed journey helper, which cannot return a
  * partial result mid-sequence. It carries the whole outcome, the lifecycle
- * error, the coarse recovery class, and — when the rejection was
- * `selection_incomplete` — the `unsatisfied[]` list, so nothing the server
- * said is lost on the way to the catch block.
+ * error, the failed Commit's outcome, the instruction the server attached, the
+ * coarse recovery class, and — when the rejection was `selection_incomplete` —
+ * the `unsatisfied[]` list, so nothing the server said is lost on the way to
+ * the catch block.
  */
 export class BookingSessionJourneyError extends Error {
   readonly recovery: BookingSessionRecoveryV1
   readonly error: BookingSessionLifecycleErrorV1 | null
+  /** The Commit outcome, when Commit is what failed. `idempotent_replay` unwrapped. */
+  readonly commitOutcome: BookingLifecycleCommitOutcomeV1 | null
+  /** What the server said to do next, whichever envelope carried the failure. */
+  readonly nextAction: BookingSessionNextActionV1 | null
   readonly unsatisfied: UnsatisfiedRequirementV1[] | null
 
   constructor(readonly outcome: BookingSessionOutcomeV1) {
@@ -136,6 +329,8 @@ export class BookingSessionJourneyError extends Error {
     this.name = "BookingSessionJourneyError"
     this.recovery = recovery
     this.error = bookingSessionRejection(outcome)
+    this.commitOutcome = bookingSessionCommitOutcome(outcome)
+    this.nextAction = bookingSessionNextActionV1(outcome)
     this.unsatisfied = unsatisfiedBookingRequirements(outcome)
   }
 }

--- a/packages/catalog-react/src/booking-engine/session-outcomes.ts
+++ b/packages/catalog-react/src/booking-engine/session-outcomes.ts
@@ -168,6 +168,7 @@ export type BookingSessionRecoveryV1 =
   | "requirementsChanged"
   | "commitRejected"
   | "commitInFlight"
+  | "alreadyCommitted"
   | "supplierUnavailable"
   | "proposalAcceptanceRequired"
   | "notAuthorized"
@@ -231,8 +232,16 @@ export function bookingSessionRecoveryV1(
      */
     case "payment_in_flight":
     case "supplier_operation_active":
-    case "commit_already_consumed":
       return "commitInFlight"
+    /**
+     * Terminal, not in flight. The server reaches this only after looking for
+     * a commit under *this* caller's idempotency key and finding none, so the
+     * Session was consumed by some other attempt: there is no result to wait
+     * for and no result this continuation can retrieve. The remedy is to go
+     * find the booking that already exists.
+     */
+    case "commit_already_consumed":
+      return "alreadyCommitted"
     case "not_authorized":
     case "capability_required":
     case "capability_scope_required":


### PR DESCRIPTION
Closes #4662.

## The defect

`bookingSessionRecoveryV1` opened with `if (outcome.kind !== "rejected") return "unknown"`. A failed Commit does not use that envelope — it answers

```json
{"kind":"commit_result","outcome":{"kind":"quote_failure","nextAction":"request_fresh_quote","reason":"superseded"}}
```

so the guard returned before the switch and the operator got the `unknown` fallback for a fully-structured outcome whose precise message (`quoteChanged` — "The price changed or expired…") was already authored and translated.

## Ask 1 — map the `commit_result` envelope

`commitOutcomeRecovery` classifies the Commit union, with `idempotent_replay` unwrapped to the outcome it replays:

| Commit outcome | recovery |
|---|---|
| `quote_failure` | `quoteChanged` |
| `hold_failure` | `availabilityChanged` |
| `revision_mismatch` | `revisionConflict` |
| `supplier_pending`, `supplier_in_doubt`, `component_commit_pending` | `commitInFlight` *(new)* |
| `supplier_failed` | `supplierUnavailable` *(new)* |
| `proposal_acceptance_required` | `proposalAcceptanceRequired` *(new)* |
| `committed`, `component_bookings_committed`, `payment_required` | `unknown` — successes, nothing to recover from |

The three new classes exist because no existing one was true. `commitInFlight` is the one that matters beyond wording: telling an operator a supplier-pending Commit was *rejected* invites the resubmit that books twice. On the rejection side the same reasoning moves `payment_in_flight`, `supplier_operation_active` and `commit_already_consumed` off `unknown` — re-quoting a Session with a payment in flight is voyant#4636.

en + ro strings added for all three.

## Ask 3 — make `unknown` loud

Both switches are now exhaustive over their contract unions, so **a kind added to either contract fails the build here** rather than silently joining the fallback. The remaining `default` is reachable only for a shape this build does not know (a newer server) and `console.warn`s outside production.

Kinds that genuinely have no remedy to name — `session_expired`, `invalid_selection`, `renewal_not_allowed`, … — are listed explicitly and return `unknown` silently, so the warning stays worth reading.

## Ask 2 — act on `nextAction`, without gambling with the commit key

`nextAction` and the unwrapped `commitOutcome` are now on `BookingSessionJourneyError`, and `bookingSessionContinuationIsStale()` says whether a stored continuation is dead.

I did **not** auto re-quote and retry. Two reasons: the message the operator would skip says "review the refreshed total", and committing at a price they never saw is a money decision that is not ours to make; and a silent retry under a live continuation is how you mint a second booking.

What the form does instead explains the report's "three times in a row". `attemptRef` was cleared only on success, so after a `quote_failure` an unchanged resubmit replayed the *same superseded* `quoteId` and failed identically, forever. It is now dropped when — and only when — the outcome says the Quote, Hold or revision it pins is gone (`request_fresh_quote`, `request_new_hold`, `request_hold_for_expected_quantity`, `refresh_session_state`). The next submit runs a fresh Create → Quote → Hold → Commit under a new idempotency key, which is safe precisely because those outcomes mean no booking was created. It is kept for `return_idempotent_result`, `await_payment_outcome` and the supplier actions, where it is the only key that can retrieve the original result.

## Tests

New `session-outcomes.test.ts` (15 tests) plus a journey-level test driving Create → Quote → Hold → a `quote_failure` Commit through the real helper and asserting `quoteChanged` at the catch block. One test iterates `bookingLifecycleCommitOutcomeKindV1.options` and asserts every declared Commit kind classifies without warning — so the contract, not a hand-written list, is what this is checked against.

`bookingSessionContinuationIsStale` is unit-tested in `catalog-react`; the form's one-line use of it is not, as `manual-booking-create-form.tsx` has no test harness today.

## Noted, not fixed

`commitBookingSessionJourneyV1` throws on `component_bookings_committed` — a success it cannot express through a single-`bookingId` result. Pre-existing, out of scope here, and now at least classified rather than reported as a rejection.

## Verification

- `catalog-react` booking-engine suite: 36 passed
- `tsc --noEmit` on `catalog-react` and `bookings-react` typecheck projects: 0 errors
- `biome check` on both packages: clean
- `i18n:check:packages`: passed, 49 definition sets

Both packages are private, so no changeset.