### PR TITLE
Charge a nested write to the write bucket, and stop over-promising the eager tier

### DIFF
--- a/.changeset/eager-write-rate-limit-and-recordable-status.md
+++ b/.changeset/eager-write-rate-limit-and-recordable-status.md
@@ -1,0 +1,17 @@
+---
+"@voyant-travel/finance": patch
+"@voyant-travel/mcp": patch
+---
+
+Follow-ups from the review of the core-operator-writes change. The MCP rate
+limiter now picks its bucket from the tool a request will DISPATCH rather than
+the name on the envelope, so a write reached through `call_tool` — the ordinary
+way to reach anything non-eager — is charged to the tight write bucket instead
+of the loose read one, and a client namespace prefix (`functions.x`) can no
+longer downgrade it either. `record_payment` accepts only the two recordable
+payment states: `failed` and `refunded` were inserted and then ignored by the
+balance recomputation, so the agent reported success against an invoice that
+never moved. The server instructions and the `discovery` guide topic now name
+the eager writes this caller actually received rather than the configured
+default, so a read-only key, an opted-out deployment, or a graph without those
+tools is no longer told a resident tool it cannot see.

--- a/packages/finance/src/tools.ts
+++ b/packages/finance/src/tools.ts
@@ -685,6 +685,14 @@ export const issueUnsyncedProformaFromBookingTool = defineTool<
 })
 
 /**
+ * The payment states an agent may RECORD, out of the four the lifecycle has.
+ *
+ * Derived by subsetting `paymentStatusSchema` rather than re-listing it, so a new
+ * lifecycle state has to be considered here rather than silently admitted.
+ */
+export const recordablePaymentStatusSchema = paymentStatusSchema.extract(["pending", "completed"])
+
+/**
  * The agent-facing shape of "money arrived against this invoice".
  *
  * Derived from `insertPaymentSchema` — the body the admin route takes under
@@ -698,11 +706,16 @@ export const issueUnsyncedProformaFromBookingTool = defineTool<
  *   `paymentAuthorizationId` / `paymentCaptureId` belong to a processor session
  *   that recorded its own payment. An agent that had to fill them in would guess,
  *   and every one of them also rides the eager `tools/list`.
- * - `status` defaults to `completed` rather than `pending`. An operator telling
- *   an agent to record a payment is recording money it already has; the route's
- *   `pending` default belongs to a checkout session that settles later. Getting
- *   this backwards leaves the invoice reading unpaid after the agent reports
- *   success, which is the failure worth defaulting against.
+ * - `status` is narrowed to the two RECORDABLE states and defaults to
+ *   `completed` rather than `pending`. An operator telling an agent to record a
+ *   payment is recording money it already has; the route's `pending` default
+ *   belongs to a checkout session that settles later, and getting that backwards
+ *   leaves the invoice reading unpaid after the agent reports success. The other
+ *   two lifecycle states are not things this call means: `failed` is not money
+ *   received, and `refunded` is reached by refunding a payment
+ *   (`issue_invoice_refund` then `record_refund_settlement`), never by recording
+ *   one. Both were accepted, inserted, and then silently ignored by the balance
+ *   recomputation, which counts only `completed` (voyant#4661 review).
  */
 export const recordPaymentToolInputSchema = insertPaymentSchema
   .pick({
@@ -715,11 +728,12 @@ export const recordPaymentToolInputSchema = insertPaymentSchema
   })
   .safeExtend({
     invoiceId: z.string().min(1).describe("The invoice this payment settles."),
-    status: paymentStatusSchema
+    status: recordablePaymentStatusSchema
       .default("completed")
       .describe(
         "Settlement state. `completed` counts against the invoice balance; `pending` records " +
-          "an expected payment that does not.",
+          "an expected payment that does not. A failed attempt is not recorded here, and a " +
+          "refund goes through `issue_invoice_refund`.",
       ),
     idempotencyKey: z
       .string()

--- a/packages/finance/tests/tools.test.ts
+++ b/packages/finance/tests/tools.test.ts
@@ -268,6 +268,24 @@ describe("finance tools", () => {
       recordPaymentToolInputSchema.safeParse({ amountCents: 1, currency: "EUR" }).success,
     ).toBe(false)
 
+    // Only the two RECORDABLE states. `failed` is not money received and
+    // `refunded` is reached by refunding a payment, never by recording one —
+    // both used to insert a row the balance recomputation then ignored, so the
+    // agent reported success against an invoice that never moved.
+    const withStatus = (status: string) =>
+      recordPaymentToolInputSchema.safeParse({
+        invoiceId: "invoice_1",
+        amountCents: 25_000,
+        currency: "EUR",
+        paymentMethod: "bank_transfer",
+        paymentDate: "2026-03-04",
+        status,
+      }).success
+    expect(withStatus("completed")).toBe(true)
+    expect(withStatus("pending")).toBe(true)
+    expect(withStatus("failed")).toBe(false)
+    expect(withStatus("refunded")).toBe(false)
+
     let received: unknown
     const result = await recordPaymentTool.handler(
       parsed,

--- a/packages/mcp/src/guide.ts
+++ b/packages/mcp/src/guide.ts
@@ -37,6 +37,34 @@ export interface GuideScope {
    * silence: the agent trusts the orientation and blames its own queries.
    */
   anyToolReachable: boolean
+  /**
+   * The domain tools actually registered eagerly for THIS caller, in `tools/list`
+   * order.
+   *
+   * The guide named the default eager set as a fixed pair, which is wrong for
+   * three real cases: a read-only key (neither is authorized), a deployment that
+   * passes `eagerToolNames: []` or its own list, and a graph that ships neither
+   * tool. In each, the text promised a resident tool the caller could not see —
+   * and telling an agent a tool is resident when it is not is exactly the failure
+   * this guide exists to prevent (voyant#4661 review). Say what is there.
+   */
+  eagerToolNames?: readonly string[]
+}
+
+/** The sentence describing what the eager `tools/list` carries for this caller. */
+function eagerSurfaceSentence(scope: GuideScope): string {
+  const eager = scope.eagerToolNames ?? []
+  const resident =
+    eager.length > 0
+      ? `, and ${eager.length === 1 ? "one core write" : `${eager.length} core writes`} (${eager
+          .map((name) => `\`${name}\``)
+          .join(", ")})`
+      : ""
+  return (
+    `The eager \`tools/list\` carries these meta-tools, the guide${resident} — ` +
+    "everything else is found through search, and its ABSENCE from `tools/list` " +
+    "never means it does not exist."
+  )
 }
 
 /** Names of the guide Tools registered on every MCP server, for instrumentation. */
@@ -77,10 +105,8 @@ export function buildServerInstructions(scope: GuideScope): string {
     "HOW TO DISCOVER CAPABILITIES",
     "The surface is discovered on demand: `search_tools` finds a tool by keyword,",
     "`describe_tool` returns its full input schema, and `GET /v1/admin/mcp/manifest` is",
-    "the authorization-filtered capability index. The eager `tools/list` carries these",
-    "meta-tools, the guide, and the two core writes (`book_product`, `record_payment`)",
-    "— everything else is found through search, and its ABSENCE from `tools/list` never",
-    "means it does not exist. READS are grouped by product area into one",
+    `the authorization-filtered capability index. ${eagerSurfaceSentence(scope)}`,
+    "READS are grouped by product area into one",
     "`<domain>_query` tool (a discriminated union on `resource`): read products with",
     '`inventory_query` (`resource: "products"`/`"product"`), dated departures with',
     '`operations_query` (`resource: "departures"`), and CRM people with',
@@ -171,7 +197,7 @@ function guideSection(topic: GuideTopic, scope: GuideScope): string {
     case "overview":
       return overviewSection(scope)
     case "discovery":
-      return discoverySection()
+      return discoverySection(scope)
     case "booking-journey":
       return bookingJourneySection(scope)
     case "proposals":
@@ -222,15 +248,20 @@ function overviewSection(scope: GuideScope): string {
   )
 }
 
-function discoverySection(): string {
+function discoverySection(scope: GuideScope): string {
+  const eager = scope.eagerToolNames ?? []
+  const resident =
+    eager.length > 0
+      ? `, and the ${eager.length === 1 ? "write" : "writes"} an operator asks for most ` +
+        `(${eager.map((name) => `\`${name}\``).join(", ")})`
+      : ""
   return (
     "# Discovering capabilities\n\n" +
     "The surface is discovered on demand. `tools/list` carries the meta-tools " +
-    "(`search_tools`, `describe_tool`, `call_tool`), this guide, and the two writes " +
-    "an operator asks for most (`book_product`, `record_payment`); every OTHER domain " +
-    "capability is found through them or the `GET /v1/admin/mcp/manifest` capability " +
-    "index. A capability missing from `tools/list` is not a capability this deployment " +
-    "lacks — search before you report one as unavailable. To find one:\n\n" +
+    `(\`search_tools\`, \`describe_tool\`, \`call_tool\`), this guide${resident}; every ` +
+    "OTHER domain capability is found through them or the `GET /v1/admin/mcp/manifest` " +
+    "capability index. A capability missing from `tools/list` is not a capability this " +
+    "deployment lacks — search before you report one as unavailable. To find one:\n\n" +
     "1. `search_tools { query }` returns matching tool names and one-line descriptions; " +
     "`describe_tool { name }` returns a tool's full input schema. The manifest carries " +
     "each capability's `requiredScopes` and risk, so you can see what a key can do " +

--- a/packages/mcp/src/rate-limit.ts
+++ b/packages/mcp/src/rate-limit.ts
@@ -14,6 +14,11 @@
  *   a non-`read` {@link ToolManifestEntry.tier}, a `destructive` risk policy, or
  *   an action-ledgered capability (`actionPolicy`). Tight limit.
  *
+ * The bucket is chosen from the tool the request will actually DISPATCH, not
+ * from the name on the envelope — see {@link dispatchedToolName}. Classifying the
+ * envelope let `call_tool`, the ordinary way to reach the long tail, carry any
+ * write at the read limit.
+ *
  * The classification reads only manifest metadata already carried by the
  * registry (`tier` / `riskPolicy` / `actionPolicy`) — it invents no new
  * taxonomy. Limits and the window are deployment-configurable with safe
@@ -24,6 +29,8 @@
 import type { ToolManifestEntry, ToolRegistry } from "@voyant-travel/tools"
 import type { Context, MiddlewareHandler } from "hono"
 import { MemoryStore, rateLimiter, type Store } from "hono-rate-limiter"
+
+import { CALL_TOOL_NAME } from "./meta-tools.js"
 
 /** The two throttle buckets, keyed apart so a read burst never starves writes. */
 export type McpRateLimitBucket = "read" | "write"
@@ -94,17 +101,48 @@ function restrictedNames(registry: ToolRegistry): ReadonlySet<string> {
   return names
 }
 
+/**
+ * The tool name a `tools/call` will actually dispatch.
+ *
+ * Two unwrappings, because both are things dispatch already accepts and a
+ * throttle that does not accept them is a throttle with a documented way around
+ * it:
+ *
+ * - **`call_tool`.** Progressive disclosure made the meta-tools the ordinary way
+ *   to reach the long tail, so `call_tool({name: "issue_invoice_refund"})` is not
+ *   an exotic call — it is the normal one. Classified on the outer name it is
+ *   `call_tool`, which is in no registry and falls to the loose read bucket, so
+ *   every non-eager write ran at the read limit (voyant#4661 review).
+ * - **A namespace prefix.** `resolveInvocationName` accepts
+ *   `functions.record_payment` because models emit it; if this did not, the
+ *   prefix would be a one-character bucket downgrade.
+ */
+function dispatchedToolName(body: {
+  method?: unknown
+  params?: { name?: unknown; arguments?: unknown }
+}): string | undefined {
+  if (body?.method !== "tools/call") return undefined
+  const outer = unprefixed(body.params?.name)
+  if (outer !== CALL_TOOL_NAME) return outer
+  const args = body.params?.arguments
+  const inner =
+    typeof args === "object" && args !== null ? (args as { name?: unknown }).name : undefined
+  return unprefixed(inner) ?? outer
+}
+
+/** A tool name with any client namespace prefix (`functions.x`) removed. */
+function unprefixed(name: unknown): string | undefined {
+  if (typeof name !== "string" || name.length === 0) return undefined
+  if (!name.includes(".")) return name
+  const tail = name.split(".").pop()
+  return tail && tail.length > 0 ? tail : name
+}
+
 /** Classify the JSON-RPC request into a bucket, reading only the cached body. */
 async function bucketFor(c: Context, restricted: ReadonlySet<string>): Promise<McpRateLimitBucket> {
   try {
-    const body = (await c.req.json()) as {
-      method?: unknown
-      params?: { name?: unknown }
-    }
-    if (body?.method === "tools/call") {
-      const name = body.params?.name
-      if (typeof name === "string" && restricted.has(name)) return "write"
-    }
+    const name = dispatchedToolName(await c.req.json())
+    if (name !== undefined && restricted.has(name)) return "write"
   } catch {
     // A malformed body is rejected downstream by the route validator; treat it
     // as a read for throttling so a parse slip cannot bypass the tighter bucket.

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -177,6 +177,12 @@ export function createMcpApiRoutes(options: McpApiRoutesOptions): OpenAPIHono {
     // prunes an unauthorized read out of its group.
     const projection = buildReadProjection(surface)
 
+    // Which domain tools are eager is resolved BEFORE the server is built,
+    // because the guide describes the eager surface and must describe the one
+    // this caller will actually receive — an authorized-and-selected set, not the
+    // configured list (voyant#4661 review).
+    const eagerNames = selectEagerToolNames(surface, options.eagerToolNames)
+
     // The guide layer's `instructions` are scope-aware — a read-only key is told
     // the write journeys are unreachable rather than shown workflows it cannot
     // perform — so whether any write Tool is reachable must be known before the
@@ -186,6 +192,7 @@ export function createMcpApiRoutes(options: McpApiRoutesOptions): OpenAPIHono {
         ({ entry }) => entry.annotations.readOnlyHint !== true,
       ),
       anyToolReachable: surface.size > 0,
+      eagerToolNames: [...eagerNames],
     }
     const server = new McpServer(serverInfo, {
       instructions: buildServerInstructions(guideScope),
@@ -193,7 +200,6 @@ export function createMcpApiRoutes(options: McpApiRoutesOptions): OpenAPIHono {
     const guideToolNames = new Set(registerGuideTools(server, guideScope))
 
     // Register only the tier-0 domain tools eagerly; the long tail stays lazy.
-    const eagerNames = selectEagerToolNames(surface, options.eagerToolNames)
     for (const name of eagerNames)
       registerSurfaceTool(server, registry, surface, name, ctx, requireActionPolicy, budgetBytes)
 

--- a/packages/mcp/tests/rate-limit.test.ts
+++ b/packages/mcp/tests/rate-limit.test.ts
@@ -181,6 +181,51 @@ describe("createMcpRateLimiter middleware", () => {
     expect((await second.request("/", echoCall)).status).toBe(200)
   })
 
+  it("charges a write dispatched through call_tool to the write bucket", async () => {
+    // The bucket has to follow the tool that will RUN, not the name on the
+    // envelope. Progressive disclosure made `call_tool` the ordinary way to reach
+    // a non-eager tool, so classifying the envelope let every such write run at
+    // the loose read limit (voyant#4661 review).
+    const server = app({ readLimit: 100, writeLimit: 1 })
+    const nested = rpc("tools/call", {
+      name: "call_tool",
+      arguments: { name: "delete_record", arguments: { id: "r1" } },
+    })
+
+    expect((await server.request("/", nested)).status).toBe(200)
+    expect((await server.request("/", nested)).status).toBe(429)
+    // Still its own counter: the read bucket was never touched.
+    expect((await server.request("/", echoCall)).status).toBe(200)
+  })
+
+  it("charges a namespaced write name to the write bucket", async () => {
+    // Dispatch accepts `functions.delete_record`, so a throttle that does not
+    // would make the prefix a one-token way down to the read limit.
+    const server = app({ readLimit: 100, writeLimit: 1 })
+    const prefixed = rpc("tools/call", {
+      name: "functions.delete_record",
+      arguments: { id: "r1" },
+    })
+
+    await server.request("/", prefixed)
+    expect((await server.request("/", prefixed)).status).toBe(429)
+  })
+
+  it("keeps a read dispatched through call_tool on the read bucket", async () => {
+    // The unwrapping must not push everything into the tight bucket — a read is
+    // still a read wherever it is called from.
+    const server = app({ readLimit: 100, writeLimit: 1 })
+    const nested = rpc("tools/call", {
+      name: "call_tool",
+      arguments: { name: "echo", arguments: { text: "hi" } },
+    })
+
+    expect((await server.request("/", nested)).status).toBe(200)
+    expect((await server.request("/", nested)).status).toBe(200)
+    // The write budget of 1 is untouched.
+    expect((await server.request("/", deleteCall)).status).toBe(200)
+  })
+
   it("does not throttle when rate limiting is disabled", async () => {
     const server = app({ rateLimit: false })
     for (let i = 0; i < 10; i++) {

--- a/packages/mcp/tests/reachability.test.ts
+++ b/packages/mcp/tests/reachability.test.ts
@@ -249,6 +249,58 @@ describe("the core operator writes are reachable without configuration", () => {
   })
 })
 
+describe("the guide describes the eager surface this caller actually got", () => {
+  /** `initialize` instructions plus the `discovery` guide topic — both claim it. */
+  async function orientation(app: Hono): Promise<string> {
+    const initialized = await readRpc(
+      await app.request(
+        "/",
+        rpc("initialize", {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: { name: "test", version: "1" },
+        }),
+      ),
+    )
+    const instructions = (initialized.result as { instructions?: string } | undefined)?.instructions
+    const guide = await callText(app, "voyant_guide", { topic: "discovery" })
+    return `${instructions ?? ""}\n${guide}`
+  }
+
+  it("names the eager writes when they are resident", async () => {
+    const text = await orientation(harness().app)
+
+    expect(text).toContain("book_product")
+    expect(text).toContain("record_payment")
+  })
+
+  it("does not promise them to a caller that has neither", async () => {
+    // A read-only key is authorized for no write, so `selectEagerToolNames`
+    // promotes nothing. Telling it two writes are resident is the exact failure
+    // this guide exists to prevent — it would report a tool it cannot see.
+    const text = await orientation(harness({ scopes: ["bookings:read"] }).app)
+
+    expect(text).not.toContain("book_product")
+    expect(text).not.toContain("record_payment")
+    // And it still says the absent long tail is reachable, which is the point.
+    expect(text).toContain("search")
+  })
+
+  it("does not promise them to a deployment that opted out", async () => {
+    const text = await orientation(harness({ eagerToolNames: [] }).app)
+
+    expect(text).not.toContain("book_product")
+    expect(text).not.toContain("record_payment")
+  })
+
+  it("names exactly the one write a partially authorized caller got", async () => {
+    const text = await orientation(harness({ scopes: ["bookings:read", "bookings:write"] }).app)
+
+    expect(text).toContain("book_product")
+    expect(text).not.toContain("record_payment")
+  })
+})
+
 describe("a folded read says where it went", () => {
   const EXPECTED = ["bookings_query", 'resource "booking"']
 


### PR DESCRIPTION
Follow-up to #4661, addressing all three findings from the automated review on
that PR. Each was checked against the code before being acted on; all three hold.

## P1 — a write through `call_tool` was charged to the read bucket

`bucketFor` read `params.name` only. A `tools/call` with `name: "call_tool"` and
`arguments.name: "issue_invoice_refund"` classified as `call_tool`, which is in
no registry, so it fell to the loose `read` bucket — 120/min instead of 20/min.

**This is not specific to the new eager writes, and that is what makes it worth
fixing.** Progressive disclosure made `call_tool` the ordinary way to reach
anything non-eager, so the tight write bucket has been bypassable for the entire
long tail since #3927 — including `void_invoice` and `issue_invoice_refund`.

The bucket now follows the tool the request will **dispatch**. A namespace prefix
(`functions.delete_record`) is unwrapped too, because `resolveInvocationName`
already accepts it at dispatch, and a throttle that does not accept exactly what
dispatch accepts is a throttle with a documented way around it. Three tests: a
nested write is throttled, a prefixed write is throttled, and a nested READ still
uses the read bucket — the last one matters, because "classify everything nested
as a write" would pass the first two and quietly throttle discovery.

## P2 — `record_payment` accepted states it cannot record

`paymentStatusSchema` has four states. `failed` is not money received, and
`refunded` is reached by refunding a payment (`issue_invoice_refund` →
`record_refund_settlement`), never by recording one. Both were accepted,
inserted, and then ignored by the balance recomputation, which counts only
`completed` — so the agent reported success against an invoice that never moved.

Narrowed to `pending | completed` via `paymentStatusSchema.extract([...])` rather
than a re-listed enum, so a new lifecycle state has to be considered here instead
of being silently admitted.

## P2 — the guide promised eager writes that some callers never get

The instructions and the `discovery` guide topic named `book_product` and
`record_payment` unconditionally. Three real cases get something else: a
read-only key (authorized for neither), a deployment passing `eagerToolNames: []`
or its own list, and a graph shipping neither tool.

Telling an agent a tool is resident when it is not is precisely the failure this
guide exists to prevent — it is #4656 in a new costume. `GuideScope` now carries
the eager names **as selected for this caller** (`server.ts` resolves
`selectEagerToolNames` before constructing the server), and both texts name what
is actually there, or say nothing when nothing is. Four tests cover resident,
read-only, opted-out, and partially-authorized.

## Verification

- `pnpm -F @voyant-travel/mcp test` — 17 files, 122 tests (+7)
- `pnpm -F @voyant-travel/finance test` — 78 files, 588 tests
- `pnpm -F operator test` — 15 files, 72 tests
- `pnpm verify:architecture` — clean
- Both packages `build` / `typecheck` clean
