### PR TITLE
fix(connect): adopt connect-adapter 0.6.1 for encoded SourceRef cruise keys

### DIFF
--- a/.changeset/connect-adapter-source-ref-decode.md
+++ b/.changeset/connect-adapter-source-ref-decode.md
@@ -1,0 +1,12 @@
+---
+"@voyant-travel/voyant-connect-adapter": patch
+---
+
+Adopt `@voyant-travel/connect-adapter` 0.6.1, which resolves cruises keyed by an encoded SourceRef.
+
+The catalog keys sourced cruises as `crus_sr_<base64url(JSON)>`, but the Connect
+adapter only understood the legacy `cruise:<externalId>:<locale>` form, so no
+candidate ever reduced to the upstream external id. The per-id lookup 404'd, the
+fallback list scan matched nothing, and `getContent` threw
+`Connect cruise content not found` — a 500 on every sourced cruise content read,
+admin and storefront alike.

--- a/packages/voyant-connect-adapter/package.json
+++ b/packages/voyant-connect-adapter/package.json
@@ -35,7 +35,7 @@
     "prepack": "pnpm --workspace-concurrency=1 --filter @voyant-travel/voyant-connect-adapter... run build"
   },
   "dependencies": {
-    "@voyant-travel/connect-adapter": "^0.5.0",
+    "@voyant-travel/connect-adapter": "^0.6.1",
     "@voyant-travel/connect-cruises": "^0.6.2",
     "@voyant-travel/connect-sdk": "^0.10.0",
     "@voyant-travel/core": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6181,8 +6181,8 @@ importers:
   packages/voyant-connect-adapter:
     dependencies:
       '@voyant-travel/connect-adapter':
-        specifier: ^0.5.0
-        version: 0.5.0(@voyant-travel/catalog@packages+catalog)
+        specifier: ^0.6.1
+        version: 0.6.1(@voyant-travel/catalog-contracts@packages+catalog-contracts)
       '@voyant-travel/connect-cruises':
         specifier: ^0.6.2
         version: 0.6.2(@voyant-travel/cruises@packages+cruises)
@@ -9021,10 +9021,10 @@ packages:
     bundledDependencies:
       - '@voyant-travel/sdk-core'
 
-  '@voyant-travel/connect-adapter@0.5.0':
-    resolution: {integrity: sha512-O1vOJeTYPeHmDo0/6CqJ87vKv20Q9lfhiU6E3FKT3FAVVrDx8/Q69qobwSMGy7ig+Ke2Tc82UJcY75yCALDM5A==}
+  '@voyant-travel/connect-adapter@0.6.1':
+    resolution: {integrity: sha512-DMdRcJBVOvaEeXkfKVTTclDSbtS/du0gGwfD5tk0aurL6V64ugYDWDGX09alpL5XK6GmxIYWoOamgI/Y4kIh1Q==}
     peerDependencies:
-      '@voyant-travel/catalog': '>=0.130.0 <1'
+      '@voyant-travel/catalog-contracts': '>=0.112.2 <0.114.0'
 
   '@voyant-travel/connect-cruises@0.6.2':
     resolution: {integrity: sha512-qqaC61HPHaqRJIfStElVcDZoJALtkc+kHHrTANkcKCf6quX9+tkNIA+xxc6stiTraZaTe9GoyWlUNshib572WA==}
@@ -16205,9 +16205,9 @@ snapshots:
     optionalDependencies:
       typesense: 3.0.6(@babel/runtime@7.29.7)
 
-  '@voyant-travel/connect-adapter@0.5.0(@voyant-travel/catalog@packages+catalog)':
+  '@voyant-travel/connect-adapter@0.6.1(@voyant-travel/catalog-contracts@packages+catalog-contracts)':
     dependencies:
-      '@voyant-travel/catalog': link:packages/catalog
+      '@voyant-travel/catalog-contracts': link:packages/catalog-contracts
       '@voyant-travel/connect-sdk': 0.10.0
 
   '@voyant-travel/connect-cruises@0.6.2(@voyant-travel/cruises@packages+cruises)':


### PR DESCRIPTION
## Problem

Every sourced cruise detail read returns **500** — admin and storefront. On `sandbox.onvoyant.com` this surfaces as *"Could not load this item. Try again."* on every cruise in the catalog.

Runtime logs (Cloud Run `voyant-sandbox-acme-admin-production`):

```
GET /v1/admin/cruises/crus_sr_eyJ…/content → 500
err: 'Connect cruise content not found for crus_sr_eyJ… on conn_db9b7a69e2d474bd143d045c'
  at resolveCruiseRow (@voyant-travel/connect-adapter@0.5.0/dist/index.js:824)
  at getCruiseContentFromConnect
```

Over 14 days: `GET /v1/public/cruises/:key/content → 500` ×81, `GET /v1/admin/cruises/:key/content → 500` ×6, across two unrelated connections (Viking and Uniworld) — not provider- or tenant-specific.

## Cause

The catalog keys sourced cruises as `crus_sr_<base64url(JSON)>` with payload `{connectionId, externalId, kind, providerKey}`. The Connect adapter's `sourceRefCandidatesForEntityId` only understood the legacy colon form `cruise:<externalId>:<locale>` plus a bare `crus_` prefix strip, so for `crus_sr_eyJ…` it produced `["sr_eyJ…", "crus_sr_eyJ…"]`.

Connect keys the same row the other way — `external_id = "178_88-from-2027"`, `source_ref = "cruise:178_88-from-2027:en"`. The sets never intersect, so the per-id lookup 404s, the fallback 500-row list scan matches nothing, and `resolveCruiseRow` throws.

Fixed upstream in voyant-travel/connect#113, released as `@voyant-travel/connect-adapter@0.6.1`.

## This change

Bumps `packages/voyant-connect-adapter` from `^0.5.0` to `^0.6.1`. `^0.5.0` on a 0.x means `>=0.5.0 <0.6.0`, so the fix could not arrive without this bump.

The bump crosses **0.6.0**, which moved the adapter's peer from `@voyant-travel/catalog` to `@voyant-travel/catalog-contracts` (`>=0.112.2 <0.114.0`) per ADR-0002. Worth a look during review: this repo is on `catalog-contracts` 0.132.1, outside that declared window. In practice it resolves and compiles — the wrapper consumes the adapter's built `.d.ts`, which declares `Promise<GetReservationResult | null>` and picks up this repo's contracts, rather than re-checking the adapter's own source. Verified locally:

- `pnpm install` resolves 0.6.1 with no peer failure; installed dist contains the decode.
- `@voyant-travel/voyant-connect-adapter`: `typecheck` ✅, `build` ✅, `test` ✅ (17/17).

Leaving the broader typecheck to CI — `operator-standard` OOM'd locally (SIGABRT in V8), which is a laptop limit, not a diagnostic.

No source changes here; the fix is entirely in the upstream dependency.

## Shipping

Merging this is not shipping. The runtime image has to be rebuilt on the new workspace version before any tenant recovers — cruise pages keep 500ing until that rolls.

## Unrelated issues found in the same logs

Not addressed here, flagged for triage:

- `Postgres catalog indexer vector strategy requires a positive vectorDimensions deployment setting.` ×29
- `write CONNECTION_ENDED …neon.tech:5432` ×20, cascading into `Failed to get session` ×22
- `Unsupported storefront shopping locale: en` ×12; `POST /v1/public/shopping/search → 500` ×31
- `[outbox-drain] 21 dead-lettered event(s) need attention`
- `[CORS] Origin not in allowlist` for `https://sandbox.onvoyant.com` with `allowlist: []`