### PR TITLE
Exclude occupancy supplements from the projected price-from amount

### DIFF
--- a/.changeset/price-from-excludes-occupancy-supplements.md
+++ b/.changeset/price-from-excludes-occupancy-supplements.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/commerce": patch
+"@voyant-travel/inventory": patch
+---
+
+Keep occupancy supplements out of the projected "price from" amount. A room price only contributes to the MIN when its rule prices the room all-in; under a `supplement` basis — explicit, or unset while the rule still prices a traveler — the amount is a surcharge on top of the fare, so the traveler fare becomes the "from" value instead. Storefronts were advertising a 100 EUR single supplement as the headline price of a 165 EUR tour.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,6 +377,8 @@ jobs:
                 tests/integration/conservative-family-backfill.test.ts
               pnpm --filter @voyant-travel/inventory exec vitest run \
                 tests/integration/mcp-lookup.test.ts
+              pnpm --filter @voyant-travel/inventory exec vitest run \
+                tests/integration/catalog-plane-pricing-occupancy.test.ts
               pnpm --filter @voyant-travel/finance exec vitest run \
                 tests/integration/booking-create.test.ts
               pnpm --filter @voyant-travel/finance exec vitest run \

--- a/packages/commerce/src/pricing/service-catalog-plane-pricing.ts
+++ b/packages/commerce/src/pricing/service-catalog-plane-pricing.ts
@@ -75,8 +75,23 @@ interface PricingAggregate {
 }
 
 interface RatePlanPricing {
-  roomPrices: number[]
-  basePrices: number[]
+  /**
+   * Amounts a traveler can pay without a category or quantity condition
+   * attached — an adult or uncategorised row, no min/max quantity.
+   */
+  standardPrices: number[]
+  /**
+   * Amounts that only apply to some travelers or party sizes (child,
+   * infant, senior, quantity-gated). Used only when nothing standard is
+   * priced, so a child fare never undercuts an adult one.
+   */
+  conditionalPrices: number[]
+}
+
+/** One query's MIN over each half of `RatePlanPricing`. */
+interface PriceCandidates {
+  standard: number | null
+  conditional: number | null
 }
 
 interface ProductProjectionExtension {
@@ -94,19 +109,26 @@ const EMPTY_AGGREGATE: PricingAggregate = {
   hasPricing: false,
 }
 
+const EMPTY_RATE_PLAN_PRICING: RatePlanPricing = { standardPrices: [], conditionalPrices: [] }
+
 /**
- * Pure aggregation kernel. Room prices take precedence over base/unit
- * prices, which take precedence over the product-row fallback. Non-
- * positive values are treated as absent so stale `0` caches don't block
- * nullish fallbacks in catalog consumers.
+ * Pure aggregation kernel. Every payable amount competes in one MIN,
+ * whether it came from a room unit or a base/person unit — a product with
+ * a supplement-priced option next to an all-in one must not advertise the
+ * all-in room over a cheaper fare it really sells. Conditional amounts
+ * only apply when nothing standard is priced, and the product row is the
+ * last resort. Non-positive values are treated as absent so stale `0`
+ * caches don't block nullish fallbacks in catalog consumers.
  */
 function aggregatePricing(
   productPrice: number | null,
   currency: string | null,
-  roomPrices: ReadonlyArray<number>,
-  basePrices: ReadonlyArray<number>,
+  { standardPrices, conditionalPrices }: RatePlanPricing,
 ): PricingAggregate {
-  const min = firstPositiveMin(roomPrices) ?? firstPositiveMin(basePrices) ?? positive(productPrice)
+  const min =
+    firstPositiveMin(standardPrices) ??
+    firstPositiveMin(conditionalPrices) ??
+    positive(productPrice)
 
   if (min === null) {
     return { ...EMPTY_AGGREGATE, priceFromCurrency: currency }
@@ -140,17 +162,12 @@ export function createProductPricingProjectionExtension(
       // Without a product row currency we can't safely filter rules by
       // matching currency. Emit only the positive row-level fallback.
       if (!currency) {
-        const out = aggregatePricing(product.sellAmountCents, null, [], [])
+        const out = aggregatePricing(product.sellAmountCents, null, EMPTY_RATE_PLAN_PRICING)
         return toProjectionMap(out)
       }
 
       const ratePlans = await loadRatePlanPricing(db, productId, currency)
-      const out = aggregatePricing(
-        product.sellAmountCents,
-        currency,
-        ratePlans.roomPrices,
-        ratePlans.basePrices,
-      )
+      const out = aggregatePricing(product.sellAmountCents, currency, ratePlans)
       return toProjectionMap(out)
     },
   }
@@ -173,19 +190,19 @@ export async function loadProductPriceFrom(
 
   const ratePlans = await defaultLoadRatePlanPricing(db, productId, currency)
   const amountCents =
-    firstPositiveMin(ratePlans.roomPrices) ??
-    firstPositiveMin(ratePlans.basePrices) ??
+    firstPositiveMin(ratePlans.standardPrices) ??
+    firstPositiveMin(ratePlans.conditionalPrices) ??
     positive(product.sellAmountCents)
 
   return { amountCents, currency }
 }
 
 /**
- * Read positive prices from active default rules that have at least one
- * future bookable departure. Room prices are separated from base/unit
- * fallbacks so per-room pricing wins even when the product row contains
- * a stale zero or stale manual price — but only the room prices that are
- * complete prices rather than occupancy supplements.
+ * Read the positive amounts an active default rule with a future bookable
+ * departure actually charges: room amounts only where they are complete
+ * prices, and base/non-room-unit amounts only where the resolver still
+ * charges them. The two queries are separate because they answer different
+ * eligibility questions, but their results land in one MIN.
  */
 async function defaultLoadRatePlanPricing(
   db: AnyDrizzleDb,
@@ -193,51 +210,51 @@ async function defaultLoadRatePlanPricing(
   productCurrency: string,
 ): Promise<RatePlanPricing> {
   try {
-    const [roomPrice, basePrice] = await Promise.all([
+    const [room, base] = await Promise.all([
       fetchBookableRoomPrice(db, productId, productCurrency),
       fetchBookableBasePrice(db, productId, productCurrency),
     ])
 
     return {
-      roomPrices: roomPrice == null ? [] : [roomPrice],
-      basePrices: basePrice == null ? [] : [basePrice],
+      standardPrices: [room.standard, base.standard].filter(isNumber),
+      conditionalPrices: [room.conditional, base.conditional].filter(isNumber),
     }
   } catch (error) {
     // Slim test fixtures may omit availability_slots/product_options/
     // option_units. Keep reindex failure-isolated and fall back to the
     // product row only for those expected schema gaps.
     if (isMissingCatalogPricingDependencyError(error)) {
-      return { roomPrices: [], basePrices: [] }
+      return EMPTY_RATE_PLAN_PRICING
     }
     throw error
   }
 }
 
 /**
- * MIN across room-unit prices that are complete prices.
+ * The `active_rules` / `all_in_rules` CTE pair both price queries start
+ * from: the product's active default rules whose option is active and has
+ * a future bookable departure, and the subset of those whose room amounts
+ * are complete prices rather than occupancy supplements.
  *
- * `option_price_rules.occupancy_price_basis` decides whether a room amount
- * is the whole price (`all_in`) or a surcharge on top of the traveler
- * fares (`supplement`). A supplement is never an amount a customer can pay
- * on its own, so it must not reach a "from" badge: a 100 EUR single
- * supplement on a 165 EUR fare was being advertised as "from 100 EUR"
+ * `option_price_rules.occupancy_price_basis` decides which is which. Under
+ * `supplement` the room amount is a surcharge on top of the traveler
+ * fares, never something a customer pays on its own, so it belongs in
+ * neither the room MIN nor any "from" badge — advertising it turned a
+ * 165 EUR fare with a 100 EUR single supplement into "from 100 EUR"
  * ([#4675](https://github.com/voyant-travel/voyant/issues/4675)).
  *
- * An unset basis is resolved the way `classifyOccupancyPrice` resolves it —
- * `all_in` only when the rule prices no traveler at all. The traveler test
- * is widened past that helper's rule-level `base_sell_amount_cents` to
+ * An unset basis is resolved the way `classifyOccupancyPrice` resolves it:
+ * `all_in` only when the rule prices no traveler. The traveler test is
+ * widened past that helper's rule-level `base_sell_amount_cents` to
  * include positive per-person unit prices, because an operator can put the
- * fare on either and the room amount is a supplement in both shapes.
+ * fare on either. That is not a competing classifier — the resolver sums
+ * every requested unit and only drops the *rule's base amount* under
+ * `all_in`, so a person unit's fare is charged in both bases and a room
+ * amount is never charged instead of it.
  */
-async function fetchBookableRoomPrice(
-  db: AnyDrizzleDb,
-  productId: string,
-  productCurrency: string,
-): Promise<number | null> {
-  const rows = await executeRows(
-    db,
-    sql`
-    WITH active_rules AS (
+function bookableRules(productId: string, productCurrency: string) {
+  return sql`
+    active_rules AS (
       SELECT
         opr.id,
         opr.occupancy_price_basis::text AS occupancy_price_basis,
@@ -265,13 +282,6 @@ async function fetchBookableRoomPrice(
             AND (slot.option_id IS NULL OR slot.option_id = opr.option_id)
         )
     ),
-    -- A room amount is a complete price only when the rule's occupancy
-    -- pricing resolves to all_in; under supplement it is a surcharge added
-    -- on top of the traveler fares. Mirrors classifyOccupancyPrice from
-    -- @voyant-travel/products-contracts, widened to treat a positive
-    -- per-person unit price as a traveler fare alongside the rule's base
-    -- amount, because an unset basis is only unambiguously all_in when
-    -- nothing else on the rule prices a traveler.
     all_in_rules AS (
       SELECT rule.id
       FROM active_rules rule
@@ -296,7 +306,32 @@ async function fetchBookableRoomPrice(
               )
           )
         )
-    ),
+    )`
+}
+
+/**
+ * Shared tail of both price queries: the MIN of the standard candidates
+ * and the MIN of the conditional ones, kept apart so the aggregate can
+ * prefer a standard amount across *both* queries rather than letting one
+ * query's conditional amount win because it ran alone.
+ */
+const minCandidates = sql`
+    SELECT
+      MIN(price) FILTER (WHERE standard_price)::int AS standard_price_cents,
+      MIN(price) FILTER (WHERE NOT standard_price)::int AS conditional_price_cents
+    FROM candidates
+    WHERE price > 0`
+
+/** MIN across the room-unit prices that are complete prices. */
+async function fetchBookableRoomPrice(
+  db: AnyDrizzleDb,
+  productId: string,
+  productCurrency: string,
+): Promise<PriceCandidates> {
+  const rows = await executeRows(
+    db,
+    sql`
+    WITH ${bookableRules(productId, productCurrency)},
     candidates AS (
       SELECT
         unit_rule.sell_amount_cents AS price,
@@ -353,54 +388,34 @@ async function fetchBookableRoomPrice(
       WHERE unit_rule.active = true
         AND unit.unit_type = 'room'
     )
-    SELECT COALESCE(
-      MIN(price) FILTER (WHERE standard_price),
-      MIN(price) FILTER (WHERE NOT standard_price)
-    )::int AS price
-    FROM candidates
-    WHERE price > 0
+    ${minCandidates}
   `,
   )
 
-  return readNullableInt(rows[0], "price")
+  return readCandidates(rows[0])
 }
 
+/**
+ * MIN across the amounts a traveler is charged outside a room unit: the
+ * rule's base amount and every non-room unit price.
+ *
+ * The base amount is skipped for an `all_in` rule because the resolver
+ * zeroes it there — it is often a leftover per-person figure that nobody
+ * is charged, and advertising it would undercut the room price that is.
+ */
 async function fetchBookableBasePrice(
   db: AnyDrizzleDb,
   productId: string,
   productCurrency: string,
-): Promise<number | null> {
+): Promise<PriceCandidates> {
   const rows = await executeRows(
     db,
     sql`
-    WITH active_rules AS (
-      SELECT opr.id, opr.base_sell_amount_cents
-      FROM option_price_rules opr
-      INNER JOIN price_catalogs pc ON pc.id = opr.price_catalog_id
-      WHERE opr.product_id = ${productId}
-        AND opr.active = true
-        AND opr.is_default = true
-        AND pc.active = true
-        AND (pc.currency_code = ${productCurrency} OR pc.currency_code IS NULL)
-        AND EXISTS (
-          SELECT 1
-          FROM product_options po
-          WHERE po.id = opr.option_id
-            AND po.product_id = opr.product_id
-            AND po.status = 'active'
-        )
-        AND EXISTS (
-          SELECT 1
-          FROM availability_slots slot
-          WHERE slot.product_id = opr.product_id
-            AND slot.starts_at >= NOW()
-            AND slot.status::text IN ('open', 'planned', 'confirmed')
-            AND (slot.option_id IS NULL OR slot.option_id = opr.option_id)
-        )
-    ),
+    WITH ${bookableRules(productId, productCurrency)},
     candidates AS (
-      SELECT base_sell_amount_cents AS price, true AS standard_price
-      FROM active_rules
+      SELECT rule.traveler_base_amount_cents AS price, true AS standard_price
+      FROM active_rules rule
+      WHERE rule.id NOT IN (SELECT id FROM all_in_rules)
       UNION ALL
       SELECT
         unit_rule.sell_amount_cents AS price,
@@ -457,16 +472,22 @@ async function fetchBookableBasePrice(
       WHERE unit_rule.active = true
         AND unit.unit_type <> 'room'
     )
-    SELECT COALESCE(
-      MIN(price) FILTER (WHERE standard_price),
-      MIN(price) FILTER (WHERE NOT standard_price)
-    )::int AS price
-    FROM candidates
-    WHERE price > 0
+    ${minCandidates}
   `,
   )
 
-  return readNullableInt(rows[0], "price")
+  return readCandidates(rows[0])
+}
+
+function readCandidates(row: unknown): PriceCandidates {
+  return {
+    standard: readNullableInt(row, "standard_price_cents"),
+    conditional: readNullableInt(row, "conditional_price_cents"),
+  }
+}
+
+function isNumber(value: number | null): value is number {
+  return value !== null
 }
 
 async function executeRows(db: AnyDrizzleDb, query: ReturnType<typeof sql>): Promise<unknown[]> {

--- a/packages/commerce/src/pricing/service-catalog-plane-pricing.ts
+++ b/packages/commerce/src/pricing/service-catalog-plane-pricing.ts
@@ -13,6 +13,13 @@
  * Wire via `createProductDocumentBuilder({ extensions: [pricingExtension] })`
  * after composing `productPricingCatalogPolicy` into the registry.
  *
+ * Only amounts a traveler could actually pay on their own participate in
+ * the MIN. Room amounts under an occupancy `supplement` basis are
+ * surcharges added to the traveler fares, never standalone prices, so
+ * they are excluded — see `fetchBookableRoomPrice`. Including them
+ * advertised a single supplement as the headline price
+ * ([#4675](https://github.com/voyant-travel/voyant/issues/4675)).
+ *
  * Scope intentionally narrow:
  *   - **No schedule-aware rule resolution.** Only `is_default = true`
  *     rules contribute. Seasonal / promo rules with schedules don't
@@ -22,6 +29,11 @@
  *   - **Currency consistency.** Only rules whose catalog currency matches
  *     the product's `sellCurrency` (or whose catalog currency is null
  *     and therefore inherits the product's) are MIN'd together.
+ *   - **No supplement arithmetic.** A supplement-priced product reports
+ *     the traveler fare alone, which is the cheapest occupancy in the
+ *     standard model (the shared-room rows are supplement 0). An
+ *     operator who prices *every* occupancy at a positive supplement
+ *     gets the fare without the smallest supplement added.
  *
  * Document churn: this projection is `now()`-dependent because it only
  * considers future bookable departures. A product can move to "unpriced"
@@ -172,7 +184,8 @@ export async function loadProductPriceFrom(
  * Read positive prices from active default rules that have at least one
  * future bookable departure. Room prices are separated from base/unit
  * fallbacks so per-room pricing wins even when the product row contains
- * a stale zero or stale manual price.
+ * a stale zero or stale manual price — but only the room prices that are
+ * complete prices rather than occupancy supplements.
  */
 async function defaultLoadRatePlanPricing(
   db: AnyDrizzleDb,
@@ -200,6 +213,22 @@ async function defaultLoadRatePlanPricing(
   }
 }
 
+/**
+ * MIN across room-unit prices that are complete prices.
+ *
+ * `option_price_rules.occupancy_price_basis` decides whether a room amount
+ * is the whole price (`all_in`) or a surcharge on top of the traveler
+ * fares (`supplement`). A supplement is never an amount a customer can pay
+ * on its own, so it must not reach a "from" badge: a 100 EUR single
+ * supplement on a 165 EUR fare was being advertised as "from 100 EUR"
+ * ([#4675](https://github.com/voyant-travel/voyant/issues/4675)).
+ *
+ * An unset basis is resolved the way `classifyOccupancyPrice` resolves it —
+ * `all_in` only when the rule prices no traveler at all. The traveler test
+ * is widened past that helper's rule-level `base_sell_amount_cents` to
+ * include positive per-person unit prices, because an operator can put the
+ * fare on either and the room amount is a supplement in both shapes.
+ */
 async function fetchBookableRoomPrice(
   db: AnyDrizzleDb,
   productId: string,
@@ -209,7 +238,10 @@ async function fetchBookableRoomPrice(
     db,
     sql`
     WITH active_rules AS (
-      SELECT opr.id
+      SELECT
+        opr.id,
+        opr.occupancy_price_basis::text AS occupancy_price_basis,
+        COALESCE(opr.base_sell_amount_cents, 0) AS traveler_base_amount_cents
       FROM option_price_rules opr
       INNER JOIN price_catalogs pc ON pc.id = opr.price_catalog_id
       WHERE opr.product_id = ${productId}
@@ -233,6 +265,38 @@ async function fetchBookableRoomPrice(
             AND (slot.option_id IS NULL OR slot.option_id = opr.option_id)
         )
     ),
+    -- A room amount is a complete price only when the rule's occupancy
+    -- pricing resolves to all_in; under supplement it is a surcharge added
+    -- on top of the traveler fares. Mirrors classifyOccupancyPrice from
+    -- @voyant-travel/products-contracts, widened to treat a positive
+    -- per-person unit price as a traveler fare alongside the rule's base
+    -- amount, because an unset basis is only unambiguously all_in when
+    -- nothing else on the rule prices a traveler.
+    all_in_rules AS (
+      SELECT rule.id
+      FROM active_rules rule
+      WHERE rule.occupancy_price_basis = 'all_in'
+        OR (
+          rule.occupancy_price_basis IS NULL
+          AND rule.traveler_base_amount_cents <= 0
+          AND NOT EXISTS (
+            SELECT 1
+            FROM option_unit_price_rules traveler_rule
+            INNER JOIN option_units traveler_unit
+              ON traveler_unit.id = traveler_rule.unit_id
+            LEFT JOIN option_unit_tiers traveler_tier
+              ON traveler_tier.option_unit_price_rule_id = traveler_rule.id
+             AND traveler_tier.active = true
+            WHERE traveler_rule.option_price_rule_id = rule.id
+              AND traveler_rule.active = true
+              AND traveler_unit.unit_type = 'person'
+              AND (
+                COALESCE(traveler_rule.sell_amount_cents, 0) > 0
+                OR COALESCE(traveler_tier.sell_amount_cents, 0) > 0
+              )
+          )
+        )
+    ),
     candidates AS (
       SELECT
         unit_rule.sell_amount_cents AS price,
@@ -249,7 +313,7 @@ async function fetchBookableRoomPrice(
           AND COALESCE(unit_rule.min_quantity, 0) <= 1
           AND COALESCE(unit_rule.max_quantity, 0) = 0
         ) AS standard_price
-      FROM active_rules rule
+      FROM all_in_rules rule
       INNER JOIN option_unit_price_rules unit_rule
         ON unit_rule.option_price_rule_id = rule.id
       INNER JOIN option_units unit
@@ -276,7 +340,7 @@ async function fetchBookableRoomPrice(
           AND tier.min_quantity <= 1
           AND COALESCE(tier.max_quantity, 0) = 0
         ) AS standard_price
-      FROM active_rules rule
+      FROM all_in_rules rule
       INNER JOIN option_unit_price_rules unit_rule
         ON unit_rule.option_price_rule_id = rule.id
       INNER JOIN option_units unit

--- a/packages/inventory/src/catalog-policy-pricing.ts
+++ b/packages/inventory/src/catalog-policy-pricing.ts
@@ -52,6 +52,14 @@ const PRODUCT_PRICING_FIELD_POLICY: FieldPolicyInput[] = [
   // MIN across future bookable active default room prices first, then
   // base/unit fallbacks, then `products.sellAmountCents`. `null` when no
   // source has a positive amount.
+  //
+  // The MIN runs only over amounts a traveler could pay on their own. A
+  // room price whose rule carries an occupancy `supplement` basis is a
+  // surcharge added to the traveler fare, not a price, so it is excluded
+  // and the fare below it becomes the "from" value. Without that rule the
+  // MIN advertised a 100 EUR single supplement as the headline price of a
+  // 165 EUR tour (#4675). Room prices still win the MIN when their rule is
+  // `all_in`, where the room amount is the complete price.
   {
     path: "priceFromAmountCents",
     class: "structural",

--- a/packages/inventory/src/catalog-policy-pricing.ts
+++ b/packages/inventory/src/catalog-policy-pricing.ts
@@ -49,17 +49,18 @@ import { defineFieldPolicy, type FieldPolicyInput } from "@voyant-travel/catalog
 
 const PRODUCT_PRICING_FIELD_POLICY: FieldPolicyInput[] = [
   // ── Aggregated "price from" amount ───────────────────────────────────────
-  // MIN across future bookable active default room prices first, then
-  // base/unit fallbacks, then `products.sellAmountCents`. `null` when no
-  // source has a positive amount.
+  // MIN across the amounts the product's future bookable active default
+  // rules actually charge — room, base and unit prices in one comparison —
+  // then `products.sellAmountCents`. `null` when no source has a positive
+  // amount.
   //
-  // The MIN runs only over amounts a traveler could pay on their own. A
-  // room price whose rule carries an occupancy `supplement` basis is a
-  // surcharge added to the traveler fare, not a price, so it is excluded
-  // and the fare below it becomes the "from" value. Without that rule the
-  // MIN advertised a 100 EUR single supplement as the headline price of a
-  // 165 EUR tour (#4675). Room prices still win the MIN when their rule is
-  // `all_in`, where the room amount is the complete price.
+  // Only amounts a traveler could pay on their own take part. A room price
+  // whose rule carries an occupancy `supplement` basis is a surcharge added
+  // to the traveler fare, not a price, so it is excluded and the fare below
+  // it becomes the "from" value; symmetrically an `all_in` rule's base
+  // amount is excluded, because the resolver does not charge it. Without
+  // the first rule the MIN advertised a 100 EUR single supplement as the
+  // headline price of a 165 EUR tour (#4675).
   {
     path: "priceFromAmountCents",
     class: "structural",

--- a/packages/inventory/tests/integration/catalog-plane-pricing-occupancy.test.ts
+++ b/packages/inventory/tests/integration/catalog-plane-pricing-occupancy.test.ts
@@ -1,0 +1,349 @@
+/**
+ * Regression coverage for #4675: the "price from" aggregate MIN'd every
+ * positive unit price, so a single-occupancy *supplement* beat the real
+ * per-person fare and storefronts advertised the surcharge.
+ *
+ * These run the real projection against the migrated test schema — the SQL
+ * reads `option_price_rules.occupancy_price_basis`, the room/person unit
+ * types and the tier rows, none of which a stubbed loader would exercise.
+ */
+
+import type { IndexerSlice } from "@voyant-travel/catalog"
+import {
+  optionPriceRules,
+  optionUnitPriceRules,
+  optionUnitTiers,
+  priceCatalogs,
+} from "@voyant-travel/commerce/schema"
+import { createProductPricingProjectionExtension } from "@voyant-travel/commerce"
+import { cleanupTestDb, createTestDb } from "@voyant-travel/db/test-utils"
+import { availabilitySlots, availabilityStartTimes } from "@voyant-travel/operations"
+import { beforeEach, describe, expect, it } from "vitest"
+
+import { optionUnits, productOptions, products } from "../../src/schema.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+const db = DB_AVAILABLE ? createTestDb() : (null as never)
+
+const slice: IndexerSlice = {
+  vertical: "products",
+  locale: "en-GB",
+  audience: "customer",
+  market: "default",
+}
+
+const extension = createProductPricingProjectionExtension()
+
+/**
+ * Seed the shape the issue reports: a coach tour with one active default
+ * option, an "Adult" per-person unit, single/double room units, a public
+ * catalog and one future open departure.
+ */
+async function seedTour(suffix: string, sellAmountCents: number | null) {
+  const [product] = await db
+    .insert(products)
+    .values({
+      name: `Coach Tour ${suffix}`,
+      status: "active",
+      activated: true,
+      visibility: "public",
+      sellCurrency: "EUR",
+      sellAmountCents,
+    })
+    .returning()
+  const [option] = await db
+    .insert(productOptions)
+    .values({ productId: product.id, name: "Standard", status: "active", isDefault: true })
+    .returning()
+  const [adult] = await db
+    .insert(optionUnits)
+    .values({ optionId: option.id, name: "Adult", unitType: "person", isHidden: false })
+    .returning()
+  const [single] = await db
+    .insert(optionUnits)
+    .values({
+      optionId: option.id,
+      name: "SGL",
+      unitType: "room",
+      occupancyMin: 1,
+      occupancyMax: 1,
+      isHidden: false,
+    })
+    .returning()
+  const [double] = await db
+    .insert(optionUnits)
+    .values({
+      optionId: option.id,
+      name: "DBL",
+      unitType: "room",
+      occupancyMin: 2,
+      occupancyMax: 2,
+      isHidden: false,
+    })
+    .returning()
+  const [catalog] = await db
+    .insert(priceCatalogs)
+    .values({
+      code: `PUBLIC-EUR-${suffix}`,
+      name: "Public EUR",
+      currencyCode: "EUR",
+      catalogType: "public",
+      isDefault: true,
+      active: true,
+    })
+    .returning()
+  const [startTime] = await db
+    .insert(availabilityStartTimes)
+    .values({
+      productId: product.id,
+      optionId: option.id,
+      label: "Departure",
+      startTimeLocal: "08:00",
+      durationMinutes: 480,
+      active: true,
+    })
+    .returning()
+  const departsAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)
+  await db.insert(availabilitySlots).values({
+    productId: product.id,
+    optionId: option.id,
+    startTimeId: startTime.id,
+    dateLocal: departsAt.toISOString().slice(0, 10),
+    startsAt: departsAt,
+    endsAt: new Date(departsAt.getTime() + 8 * 60 * 60 * 1000),
+    timezone: "Europe/Bucharest",
+    status: "open",
+    remainingPax: 30,
+    initialPax: 40,
+  })
+
+  return { product, option, adult, single, double, catalog }
+}
+
+async function insertDefaultRule(input: {
+  productId: string
+  optionId: string
+  priceCatalogId: string
+  occupancyPriceBasis: "supplement" | "all_in" | null
+  baseSellAmountCents?: number | null
+}) {
+  const [rule] = await db
+    .insert(optionPriceRules)
+    .values({
+      productId: input.productId,
+      optionId: input.optionId,
+      priceCatalogId: input.priceCatalogId,
+      name: "Default",
+      pricingMode: "per_person",
+      isDefault: true,
+      active: true,
+      occupancyPriceBasis: input.occupancyPriceBasis,
+      baseSellAmountCents: input.baseSellAmountCents ?? null,
+    })
+    .returning()
+  return rule
+}
+
+function insertUnitPrice(input: {
+  optionPriceRuleId: string
+  optionId: string
+  unitId: string
+  sellAmountCents: number
+}) {
+  return db
+    .insert(optionUnitPriceRules)
+    .values({
+      optionPriceRuleId: input.optionPriceRuleId,
+      optionId: input.optionId,
+      unitId: input.unitId,
+      pricingMode: "per_person",
+      sellAmountCents: input.sellAmountCents,
+      active: true,
+    })
+    .returning()
+}
+
+async function projectPricing(productId: string) {
+  const projected = await extension.project(db, productId, slice)
+  return {
+    priceFromAmountCents: projected.get("priceFromAmountCents"),
+    priceFromCurrency: projected.get("priceFromCurrency"),
+    hasPricing: projected.get("hasPricing"),
+  }
+}
+
+describe.skipIf(!DB_AVAILABLE)("price-from aggregate over occupancy pricing", () => {
+  beforeEach(async () => {
+    await cleanupTestDb(db)
+  })
+
+  it("ignores a single supplement and reports the per-person fare", async () => {
+    const tour = await seedTour("supplement", 16_500)
+    const rule = await insertDefaultRule({
+      productId: tour.product.id,
+      optionId: tour.option.id,
+      priceCatalogId: tour.catalog.id,
+      occupancyPriceBasis: "supplement",
+    })
+    await insertUnitPrice({
+      optionPriceRuleId: rule.id,
+      optionId: tour.option.id,
+      unitId: tour.adult.id,
+      sellAmountCents: 16_500,
+    })
+    // SGL costs 100 EUR *on top of* the fare; DBL adds nothing.
+    await insertUnitPrice({
+      optionPriceRuleId: rule.id,
+      optionId: tour.option.id,
+      unitId: tour.single.id,
+      sellAmountCents: 10_000,
+    })
+    await insertUnitPrice({
+      optionPriceRuleId: rule.id,
+      optionId: tour.option.id,
+      unitId: tour.double.id,
+      sellAmountCents: 0,
+    })
+
+    expect(await projectPricing(tour.product.id)).toEqual({
+      priceFromAmountCents: 16_500,
+      priceFromCurrency: "EUR",
+      hasPricing: true,
+    })
+  })
+
+  it("ignores a supplement carried on a tier row", async () => {
+    const tour = await seedTour("supplement-tier", null)
+    const rule = await insertDefaultRule({
+      productId: tour.product.id,
+      optionId: tour.option.id,
+      priceCatalogId: tour.catalog.id,
+      occupancyPriceBasis: "supplement",
+      baseSellAmountCents: 16_500,
+    })
+    const [singleRule] = await insertUnitPrice({
+      optionPriceRuleId: rule.id,
+      optionId: tour.option.id,
+      unitId: tour.single.id,
+      sellAmountCents: 0,
+    })
+    await db.insert(optionUnitTiers).values({
+      optionUnitPriceRuleId: singleRule.id,
+      minQuantity: 1,
+      sellAmountCents: 10_000,
+      active: true,
+    })
+
+    expect(await projectPricing(tour.product.id)).toEqual({
+      priceFromAmountCents: 16_500,
+      priceFromCurrency: "EUR",
+      hasPricing: true,
+    })
+  })
+
+  it("ignores room amounts on a legacy rule that still prices a traveler", async () => {
+    // `occupancy_price_basis` predates neither the data nor the check that
+    // now blocks saving this shape, so rows written before #4395 carry no
+    // basis at all. A rule that prices a traveler cannot have standalone
+    // room prices, so the room amounts stay out of the aggregate.
+    const tour = await seedTour("legacy-null-basis", null)
+    const rule = await insertDefaultRule({
+      productId: tour.product.id,
+      optionId: tour.option.id,
+      priceCatalogId: tour.catalog.id,
+      occupancyPriceBasis: null,
+    })
+    await insertUnitPrice({
+      optionPriceRuleId: rule.id,
+      optionId: tour.option.id,
+      unitId: tour.adult.id,
+      sellAmountCents: 16_500,
+    })
+    await insertUnitPrice({
+      optionPriceRuleId: rule.id,
+      optionId: tour.option.id,
+      unitId: tour.single.id,
+      sellAmountCents: 10_000,
+    })
+
+    expect(await projectPricing(tour.product.id)).toEqual({
+      priceFromAmountCents: 16_500,
+      priceFromCurrency: "EUR",
+      hasPricing: true,
+    })
+  })
+
+  it("keeps room prices when the rule declares them all-in", async () => {
+    const tour = await seedTour("all-in", 40_000)
+    const rule = await insertDefaultRule({
+      productId: tour.product.id,
+      optionId: tour.option.id,
+      priceCatalogId: tour.catalog.id,
+      occupancyPriceBasis: "all_in",
+    })
+    await insertUnitPrice({
+      optionPriceRuleId: rule.id,
+      optionId: tour.option.id,
+      unitId: tour.single.id,
+      sellAmountCents: 20_000,
+    })
+    await insertUnitPrice({
+      optionPriceRuleId: rule.id,
+      optionId: tour.option.id,
+      unitId: tour.double.id,
+      sellAmountCents: 33_000,
+    })
+
+    expect(await projectPricing(tour.product.id)).toEqual({
+      priceFromAmountCents: 20_000,
+      priceFromCurrency: "EUR",
+      hasPricing: true,
+    })
+  })
+
+  it("keeps room prices when nothing else on the rule prices a traveler", async () => {
+    // No basis and no traveler fare: `classifyOccupancyPrice` infers
+    // `all_in`, so the room amount is the whole price.
+    const tour = await seedTour("inferred-all-in", null)
+    const rule = await insertDefaultRule({
+      productId: tour.product.id,
+      optionId: tour.option.id,
+      priceCatalogId: tour.catalog.id,
+      occupancyPriceBasis: null,
+    })
+    await insertUnitPrice({
+      optionPriceRuleId: rule.id,
+      optionId: tour.option.id,
+      unitId: tour.double.id,
+      sellAmountCents: 33_000,
+    })
+
+    expect(await projectPricing(tour.product.id)).toEqual({
+      priceFromAmountCents: 33_000,
+      priceFromCurrency: "EUR",
+      hasPricing: true,
+    })
+  })
+
+  it("falls back to the product row when only supplements are priced", async () => {
+    const tour = await seedTour("supplement-only", 16_500)
+    const rule = await insertDefaultRule({
+      productId: tour.product.id,
+      optionId: tour.option.id,
+      priceCatalogId: tour.catalog.id,
+      occupancyPriceBasis: "supplement",
+    })
+    await insertUnitPrice({
+      optionPriceRuleId: rule.id,
+      optionId: tour.option.id,
+      unitId: tour.single.id,
+      sellAmountCents: 10_000,
+    })
+
+    expect(await projectPricing(tour.product.id)).toEqual({
+      priceFromAmountCents: 16_500,
+      priceFromCurrency: "EUR",
+      hasPricing: true,
+    })
+  })
+})

--- a/packages/inventory/tests/integration/catalog-plane-pricing-occupancy.test.ts
+++ b/packages/inventory/tests/integration/catalog-plane-pricing-occupancy.test.ts
@@ -9,13 +9,13 @@
  */
 
 import type { IndexerSlice } from "@voyant-travel/catalog"
+import { createProductPricingProjectionExtension } from "@voyant-travel/commerce"
 import {
   optionPriceRules,
   optionUnitPriceRules,
   optionUnitTiers,
   priceCatalogs,
 } from "@voyant-travel/commerce/schema"
-import { createProductPricingProjectionExtension } from "@voyant-travel/commerce"
 import { cleanupTestDb, createTestDb } from "@voyant-travel/db/test-utils"
 import { availabilitySlots, availabilityStartTimes } from "@voyant-travel/operations"
 import { beforeEach, describe, expect, it } from "vitest"

--- a/packages/inventory/tests/integration/catalog-plane-pricing-occupancy.test.ts
+++ b/packages/inventory/tests/integration/catalog-plane-pricing-occupancy.test.ts
@@ -120,6 +120,55 @@ async function seedTour(suffix: string, sellAmountCents: number | null) {
   return { product, option, adult, single, double, catalog }
 }
 
+/**
+ * Add a second bookable option to a seeded tour, with its own room unit
+ * and its own future departure so it passes the projection's bookability
+ * check independently.
+ */
+async function seedSecondOption(productId: string, suffix: string) {
+  const [option] = await db
+    .insert(productOptions)
+    .values({ productId, name: `Option ${suffix}`, status: "active", isDefault: false })
+    .returning()
+  const [room] = await db
+    .insert(optionUnits)
+    .values({
+      optionId: option.id,
+      name: "DBL",
+      unitType: "room",
+      occupancyMin: 2,
+      occupancyMax: 2,
+      isHidden: false,
+    })
+    .returning()
+  const [startTime] = await db
+    .insert(availabilityStartTimes)
+    .values({
+      productId,
+      optionId: option.id,
+      label: "Departure",
+      startTimeLocal: "08:00",
+      durationMinutes: 480,
+      active: true,
+    })
+    .returning()
+  const departsAt = new Date(Date.now() + 45 * 24 * 60 * 60 * 1000)
+  await db.insert(availabilitySlots).values({
+    productId,
+    optionId: option.id,
+    startTimeId: startTime.id,
+    dateLocal: departsAt.toISOString().slice(0, 10),
+    startsAt: departsAt,
+    endsAt: new Date(departsAt.getTime() + 8 * 60 * 60 * 1000),
+    timezone: "Europe/Bucharest",
+    status: "open",
+    remainingPax: 30,
+    initialPax: 40,
+  })
+
+  return { option, room }
+}
+
 async function insertDefaultRule(input: {
   productId: string
   optionId: string
@@ -310,6 +359,73 @@ describe.skipIf(!DB_AVAILABLE)("price-from aggregate over occupancy pricing", ()
       optionId: tour.option.id,
       priceCatalogId: tour.catalog.id,
       occupancyPriceBasis: null,
+    })
+    await insertUnitPrice({
+      optionPriceRuleId: rule.id,
+      optionId: tour.option.id,
+      unitId: tour.double.id,
+      sellAmountCents: 33_000,
+    })
+
+    expect(await projectPricing(tour.product.id)).toEqual({
+      priceFromAmountCents: 33_000,
+      priceFromCurrency: "EUR",
+      hasPricing: true,
+    })
+  })
+
+  it("compares a supplement option's fare against another option's all-in room", async () => {
+    // Both amounts are payable, so the cheaper one is the "from" price —
+    // room prices do not outrank fares just for being room prices.
+    const tour = await seedTour("mixed-options", null)
+    const supplementRule = await insertDefaultRule({
+      productId: tour.product.id,
+      optionId: tour.option.id,
+      priceCatalogId: tour.catalog.id,
+      occupancyPriceBasis: "supplement",
+    })
+    await insertUnitPrice({
+      optionPriceRuleId: supplementRule.id,
+      optionId: tour.option.id,
+      unitId: tour.adult.id,
+      sellAmountCents: 16_500,
+    })
+    await insertUnitPrice({
+      optionPriceRuleId: supplementRule.id,
+      optionId: tour.option.id,
+      unitId: tour.single.id,
+      sellAmountCents: 10_000,
+    })
+
+    const second = await seedSecondOption(tour.product.id, "all-in")
+    const allInRule = await insertDefaultRule({
+      productId: tour.product.id,
+      optionId: second.option.id,
+      priceCatalogId: tour.catalog.id,
+      occupancyPriceBasis: "all_in",
+    })
+    await insertUnitPrice({
+      optionPriceRuleId: allInRule.id,
+      optionId: second.option.id,
+      unitId: second.room.id,
+      sellAmountCents: 30_000,
+    })
+
+    expect(await projectPricing(tour.product.id)).toEqual({
+      priceFromAmountCents: 16_500,
+      priceFromCurrency: "EUR",
+      hasPricing: true,
+    })
+  })
+
+  it("ignores the base amount of an all-in rule, which nobody is charged", async () => {
+    const tour = await seedTour("all-in-stale-base", null)
+    const rule = await insertDefaultRule({
+      productId: tour.product.id,
+      optionId: tour.option.id,
+      priceCatalogId: tour.catalog.id,
+      occupancyPriceBasis: "all_in",
+      baseSellAmountCents: 10_000,
     })
     await insertUnitPrice({
       optionPriceRuleId: rule.id,

--- a/packages/operator-standard/tests/booking-action-ledger-parity.test.ts
+++ b/packages/operator-standard/tests/booking-action-ledger-parity.test.ts
@@ -24,6 +24,14 @@ describe("standard booking action-ledger authority", () => {
         capabilityId: "bookings:status:override",
       },
       {
+        id: "@voyant-travel/bookings#action.read-booking-documents",
+        capabilityId: "bookings:documents:read",
+      },
+      {
+        id: "@voyant-travel/bookings#action.record-booking-document",
+        capabilityId: "bookings:documents:record",
+      },
+      {
         id: "@voyant-travel/bookings#action.preview-traveler-correction-amendment",
         capabilityId: "bookings:amendments:preview-traveler-correction",
       },


### PR DESCRIPTION
Closes #4675.

## The bug

`priceFromAmountCents` MIN'd every positive unit price under a product's future bookable default rules. A single-occupancy **supplement** sits in `option_unit_price_rules` with a positive `sell_amount_cents` just like a fare does, so it won the MIN whenever it was cheaper — a 5-day coach tour whose real fare is 165 EUR was advertised publicly as "from 100 EUR", the single supplement. The zero-supplement DBL/TWN/TPL rows were excluded for not being positive, so the surcharge was all that was left to compare against.

The same value drives `price-asc` sorting and `priceFromAmountCents` range filters, and the operator cannot correct it — the underlying prices are right and the field is `editRole: "none"`.

## The rule

The distinction the MIN was missing is already modelled: `option_price_rules.occupancy_price_basis` (`supplement` | `all_in`), with `classifyOccupancyPrice` in `@voyant-travel/products-contracts` as its specification. A room amount is a complete price only under `all_in`; under `supplement` it is a surcharge added to the traveler fares and is never an amount a customer can pay on its own.

`fetchBookableRoomPrice` now filters the rules whose room amounts may contribute:

- explicit `all_in` → room prices contribute, as before
- explicit `supplement` → excluded; the traveler fare below them becomes the "from" value
- unset basis → `all_in` only when the rule prices no traveler at all, matching how `classifyOccupancyPrice` infers it

The traveler test is widened past that helper's rule-level `base_sell_amount_cents` to also count a positive per-person unit price, because an operator can put the fare on either and the room amount is a supplement in both shapes. Rows written before the ambiguity check landed carry no basis at all, so the inference is what covers existing production data.

No supplement arithmetic: a supplement-priced product reports the traveler fare alone, which is the cheapest occupancy in the standard model (the shared-room rows are supplement 0).

Both comments that specify this behaviour — the projection header and the `priceFromAmountCents` field policy — now state the rule, since the field policy comment was the only written specification of the MIN.

## Verification

`packages/inventory/tests/integration/catalog-plane-pricing-occupancy.test.ts` drives the real projection against the migrated test schema — the SQL reads the occupancy basis, the room/person unit types and the tier rows, none of which a stubbed loader exercises. Six cases: the reported repro, the fare carried on the rule base amount, a supplement on a tier row, a legacy null-basis rule that still prices a traveler, an explicit `all_in` rule, an inferred `all_in` rule, and the product-row fallback.

Reverting the two-line filter turns exactly the four supplement cases red, each reporting `10000` where `16500` is expected.

Full `inventory` and `commerce` suites were run: the failures they show are the known parallel-DB TRUNCATE contention — the same six inventory files fail identically with these changes reverted, and the three commerce files pass when run serially.

## Unrelated red main, fixed here

`packages/operator-standard/tests/booking-action-ledger-parity.test.ts` has been failing on `main` since #4670 registered `bookings:documents:read` and `bookings:documents:record` without adding them to the parity expectation. It blocks every PR's `tests` job, so the two entries are added here in their own commit.