### PR TITLE
Restore booking action-ledger parity for the document actions

### DIFF
--- a/packages/operator-standard/tests/booking-action-ledger-parity.test.ts
+++ b/packages/operator-standard/tests/booking-action-ledger-parity.test.ts
@@ -24,6 +24,14 @@ describe("standard booking action-ledger authority", () => {
         capabilityId: "bookings:status:override",
       },
       {
+        id: "@voyant-travel/bookings#action.read-booking-documents",
+        capabilityId: "bookings:documents:read",
+      },
+      {
+        id: "@voyant-travel/bookings#action.record-booking-document",
+        capabilityId: "bookings:documents:record",
+      },
+      {
         id: "@voyant-travel/bookings#action.preview-traveler-correction-amendment",
         capabilityId: "bookings:amendments:preview-traveler-correction",
       },


### PR DESCRIPTION
`main` is red: `tests` has been failing since #4670, and the `checks` aggregator fails with it.

## Cause

#4670 added two actions to `BOOKING_ACTION_DECLARATIONS.documents`:

- `@voyant-travel/bookings#action.read-booking-documents` (`bookings:documents:read`)
- `@voyant-travel/bookings#action.record-booking-document` (`bookings:documents:record`)

`BOOKING_VOYANT_ACTIONS` spreads that group between status and amendments:

```ts
export const BOOKING_VOYANT_ACTIONS = [
  toVoyantAction(BOOKING_ACTION_DECLARATIONS.piiRead),
  ...Object.values(BOOKING_ACTION_DECLARATIONS.status).map(toVoyantAction),
  ...Object.values(BOOKING_ACTION_DECLARATIONS.documents).map(toVoyantAction),
  ...Object.values(BOOKING_ACTION_DECLARATIONS.amendments).map(toVoyantAction),
] as const
```

`booking-action-ledger-parity.test.ts` asserts the module's actions against a hardcoded list, and that list was not extended.

## This is a stale expectation, not a graph gap

The CI diff shows both actions present in the **received** value, in the correct positions. The runtime graph is complete; only the test's expectation lagged. This adds the two entries where the declaration order puts them — after `override-booking-status`, before `preview-traveler-correction-amendment`.

## Verification

- `booking-action-ledger-parity.test.ts`: 1/1 pass
- full `packages/operator-standard` suite: **21/21 pass across 5 files**

The other two red checks on main are aggregators — `checks` gates on `tests`, and `db-checks` fails because a database lane reported `skipped` rather than `success`. This PR addresses the `tests` failure; the skipped db lane is separate.