### PR TITLE
Bind the observability sinks a served deployment ships with

### DIFF
--- a/.changeset/bind-observability-sinks.md
+++ b/.changeset/bind-observability-sinks.md
@@ -1,0 +1,17 @@
+---
+"@voyant-travel/core": minor
+"@voyant-travel/runtime": minor
+---
+
+Bind the observability sinks a served deployment ships with.
+
+`analytics.runtime` had no provider anywhere in the repository, so every
+deployment ran with the booking engine's `engine.*` events — including
+`engine.hold.failed` and its `failure_reason` — reaching `noopAnalytics`. The
+runtime now binds `consoleAnalytics`, a new built-in sink writing one JSON line
+per event to stdout, unless the project supplies its own `analytics.runtime`; a
+deployment that wants silence binds `noopAnalytics` explicitly.
+
+The reporter was hard-coded to `consoleReporter`, which left the first-party
+Sentry adapter unreachable from a generated project. `host.reporter` now accepts
+the deployment's own `Reporter`, with the console one as the default.

--- a/docs/architecture/analytics-events.md
+++ b/docs/architecture/analytics-events.md
@@ -28,9 +28,19 @@ Four properties are guaranteed by `@voyant-travel/core/analytics` rather than
 left to each implementation:
 
 1. **Unbound is a supported, silent state.** The default is `noopAnalytics`. A
-   deployment that binds nothing behaves exactly as it did before the port
+   library consumer that binds nothing behaves exactly as it did before the port
    existed and pays nothing for it — no network call, no error, no measurable
    overhead.
+
+   A *served deployment* is different, and voyant#4682 is what taught us the
+   difference: because unbound was silent and nothing in the repository ever
+   bound the port, every deployment ran with the whole catalogue going nowhere.
+   A storefront checkout rejected 30 holds in eleven minutes, emitted
+   `engine.hold.failed` 30 times into the no-op, and the operator found out when
+   the customer wrote in (voyant#4655). So `@voyant-travel/runtime` binds
+   `consoleAnalytics` — one JSON line per event on stdout — unless the project
+   supplies its own `analytics.runtime`. A deployment that wants silence back
+   binds `noopAnalytics` explicitly, which is a decision rather than a default.
 2. **Fire-and-forget.** `track` returns `void`. There is nothing to await, so
    no caller can put an analytics round-trip on a booking's critical path.
 3. **It cannot fail a booking.** `createSafeAnalytics` swallows a provider that
@@ -45,7 +55,14 @@ Where the binding is made:
 | Surface | Bind through |
 |---|---|
 | Server | `requirePort(analyticsPort, { optional: true })`, resolved by the package's runtime contributor |
+| Deployment | `createVoyantProjectServerEntry({ host: { runtimePorts: { "analytics.runtime": … } } })` — overrides the built-in stdout sink |
 | Browser | `<VoyantReactProvider analytics={…}>`, or `<VoyantAnalyticsProvider>` for a surface with its own provider |
+
+Exceptions travel the other seam. `Reporter` is `captureException` only, and a
+rejected Hold is a typed outcome on a *successful* response — so a rejection is
+invisible to it by construction, no matter which vendor is bound. That seam is
+`host.reporter` (default `consoleReporter`, RFC voyant#1553); this one is where
+a failing checkout shows up.
 
 `useVoyantAnalytics()` never throws and never returns null: outside a provider
 it returns the no-op, because a component that emits an event still renders

--- a/packages/core/src/analytics.ts
+++ b/packages/core/src/analytics.ts
@@ -86,6 +86,37 @@ export const noopAnalytics: AnalyticsEmitter = Object.freeze({
   group: () => undefined,
 })
 
+/**
+ * Built-in sink that writes one JSON line per event to `console.log`.
+ *
+ * The vendor-neutral port is the right seam, but "unbound is supported" made
+ * *unbound* the state every deployment shipped in: a storefront checkout could
+ * reject 30 holds in eleven minutes and emit `engine.hold.failed` 30 times into
+ * {@link noopAnalytics}, so the break was invisible until a customer wrote in
+ * (voyant#4655, voyant#4682). A deployment whose log drain is its telemetry
+ * backend should not have to write an adapter to see that.
+ *
+ * One object per line, no timestamp — the drain stamps ingestion time, and
+ * omitting it keeps the line diffable in a test. Grep `"voyant":"analytics"`.
+ *
+ * Never throws: a sink that cannot serialize an event must not be able to break
+ * the booking that emitted it.
+ */
+export function consoleAnalytics(sink: Pick<Console, "log"> = console): AnalyticsPort {
+  const emit = (line: Record<string, unknown>): void => {
+    try {
+      sink.log(JSON.stringify({ voyant: "analytics", ...line }))
+    } catch {
+      // measuring the funnel must never break the funnel
+    }
+  }
+  return {
+    track: (event, properties) => emit({ kind: "track", event, properties }),
+    identify: (id, properties) => emit({ kind: "identify", id, properties }),
+    group: (type, key, properties) => emit({ kind: "group", type, key, properties }),
+  }
+}
+
 function swallow(run: () => unknown): void {
   try {
     const result = run()

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@ export {
   analyticsFailureReason,
   analyticsPort,
   analyticsProperties,
+  consoleAnalytics,
   createSafeAnalytics,
   noopAnalytics,
 } from "./analytics.js"

--- a/packages/core/src/runtime-port.ts
+++ b/packages/core/src/runtime-port.ts
@@ -12,7 +12,12 @@ export type {
   AnalyticsProperties,
   AnalyticsPropertyValue,
 } from "./analytics.js"
-export { analyticsPort, createSafeAnalytics, noopAnalytics } from "./analytics.js"
+export {
+  analyticsPort,
+  consoleAnalytics,
+  createSafeAnalytics,
+  noopAnalytics,
+} from "./analytics.js"
 export type {
   DocumentRenderer,
   PdfPageFormat,

--- a/packages/core/tests/unit/analytics.test.ts
+++ b/packages/core/tests/unit/analytics.test.ts
@@ -8,6 +8,7 @@ import {
   analyticsFailureReason,
   analyticsPort,
   analyticsProperties,
+  consoleAnalytics,
   createSafeAnalytics,
   noopAnalytics,
 } from "../../src/analytics.js"
@@ -165,6 +166,64 @@ describe("the catalogue", () => {
       if (!name.startsWith("engine.") || exempt.has(name)) continue
       expect(properties as readonly string[], name).toContain("booking_session_id")
     }
+  })
+})
+
+describe("consoleAnalytics", () => {
+  function lines(): { sink: Pick<Console, "log">; written: unknown[] } {
+    const written: unknown[] = []
+    return { sink: { log: (line: unknown) => written.push(line) }, written }
+  }
+
+  it("writes one parseable line per event", () => {
+    const { sink, written } = lines()
+
+    consoleAnalytics(sink).track("engine.hold.failed", {
+      booking_session_id: "bses_1",
+      failure_reason: "hold_quantity_mismatch",
+    })
+
+    expect(written).toHaveLength(1)
+    expect(JSON.parse(String(written[0]))).toEqual({
+      voyant: "analytics",
+      kind: "track",
+      event: "engine.hold.failed",
+      properties: { booking_session_id: "bses_1", failure_reason: "hold_quantity_mismatch" },
+    })
+  })
+
+  it("distinguishes the three calls a host can receive", () => {
+    const { sink, written } = lines()
+    const analytics = consoleAnalytics(sink)
+
+    analytics.identify("usr_1", { role: "agent" })
+    analytics.group("organization", "org_1")
+
+    expect(written.map((line) => JSON.parse(String(line)))).toEqual([
+      { voyant: "analytics", kind: "identify", id: "usr_1", properties: { role: "agent" } },
+      { voyant: "analytics", kind: "group", type: "organization", key: "org_1" },
+    ])
+  })
+
+  it("swallows an event it cannot serialize rather than failing the booking", () => {
+    const { sink, written } = lines()
+    const circular: Record<string, unknown> = {}
+    circular.self = circular
+
+    expect(() =>
+      consoleAnalytics(sink).track("engine.hold.failed", circular as never),
+    ).not.toThrow()
+    expect(written).toEqual([])
+  })
+
+  it("swallows a sink that throws", () => {
+    const analytics = consoleAnalytics({
+      log: () => {
+        throw new Error("stdout closed")
+      },
+    })
+
+    expect(() => analytics.track("engine.hold.failed")).not.toThrow()
   })
 })
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -508,6 +508,13 @@ export async function loadVoyantProject(
     env: authEnv,
     app: {
       linkDefinitions: projectLinks,
+      // Without this the app config carries no reporter at all, so `createApp`
+      // falls back to `noopReporter` and every catch point it owns — the 5xx
+      // boundary, `c.set("reporter")`, module bootstrap, event-bus subscribers
+      // — discards its exception. That was true of the hard-coded console
+      // reporter too: the only paths ever reporting anything were the auth
+      // runtime and the two webhook loops below.
+      reporter,
       auth: {
         handler: () => ({
           fetch: (request, requestEnv, ctx) =>

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -34,6 +34,8 @@ import {
   storefrontRuntimePort,
 } from "@voyant-travel/auth/storefront-runtime-port"
 import {
+  analyticsPort,
+  consoleAnalytics,
   createHttpDocumentRendererFromEnv,
   type EventEnvelope,
   type LinkDefinition,
@@ -53,7 +55,7 @@ import {
   type VoyantProductJobWakeProducer,
   validateVoyantNodeProviderPlanEnv,
 } from "@voyant-travel/framework/node-runtime"
-import { consoleReporter } from "@voyant-travel/hono/observability/reporter"
+import { consoleReporter, type Reporter } from "@voyant-travel/hono/observability/reporter"
 import { createNodeServer, type NodeServerHandle } from "@voyant-travel/runtime-core"
 import type { StorageProviderResolver } from "@voyant-travel/storage/types"
 import { renderPdfDocument } from "@voyant-travel/utils/pdf-renderer"
@@ -129,6 +131,16 @@ export interface LoadVoyantProjectOptions {
     jobWakeProducers?: readonly VoyantProductJobWakeProducer[]
     /** Project-owned provider overrides keyed by their published runtime-port id. */
     runtimePorts?: VoyantGraphRuntimePorts
+    /**
+     * Where framework catch points send exceptions. Defaults to
+     * {@link consoleReporter}.
+     *
+     * The vendor SDK stays a deployment choice (RFC voyant#1553), so a project
+     * binding Sentry passes `sentryReporter(Sentry)` from
+     * `@voyant-travel/observability-sentry` here — before voyant#4682 the
+     * console reporter was hard-coded and the adapter was unreachable.
+     */
+    reporter?: Reporter
     storage?: StorageProviderResolver
     /** Resolve a canonical storefront auth origin and server-side provider credentials. */
     resolveCustomerAuthContext?: (
@@ -167,6 +179,26 @@ export interface VoyantProjectHost {
 export interface VoyantProjectAuth {
   getBootstrapStatusForRequest(request: Request, env: VoyantNodeRuntimeEnv): Promise<unknown>
   getCurrentUserForRequest(request: Request, env: VoyantNodeRuntimeEnv): Promise<unknown>
+}
+
+/**
+ * Bind the built-in analytics sink unless the project brought its own.
+ *
+ * The port is optional and unbound resolves to `noopAnalytics`, so every
+ * deployment shipped with the booking engine's `engine.*` events — the ones
+ * carrying `failure_reason` and `booking_session_id` — going nowhere at all
+ * (voyant#4682). A rejected Hold is a typed outcome on a successful response,
+ * not an exception, so the reporter never saw them either: silence was the
+ * default on both seams.
+ *
+ * Defaulting here rather than in the port keeps "unbound is supported" true for
+ * a library consumer while making a *served deployment* observable. A project
+ * that wants a vendor passes its own `analytics.runtime`; one that wants
+ * silence passes `noopAnalytics`.
+ */
+function withDefaultAnalyticsSink(ports: VoyantGraphRuntimePorts): VoyantGraphRuntimePorts {
+  if (Object.hasOwn(ports, analyticsPort.id)) return ports
+  return { ...ports, [analyticsPort.id]: consoleAnalytics() }
 }
 
 /**
@@ -227,7 +259,7 @@ export async function loadVoyantProject(
   const adminAuthProvider = deployment.providers.adminAuth
   const customerAuthProvider = selectedCustomerAuthProvider(deployment.providers.customerAuth)
   const authMode = selectedOperatorAuthMode(adminAuthProvider)
-  const reporter = consoleReporter()
+  const reporter = options.host?.reporter ?? consoleReporter()
   const providerPlan = resolveVoyantNodeProviderPlan(deployment.providers)
   const providerIssues = validateVoyantNodeProviderPlanEnv(providerPlan, rawEnv)
   if (providerIssues.length > 0) {
@@ -237,10 +269,12 @@ export async function loadVoyantProject(
   }
   const env = createVoyantNodeEnv(rawEnv, providerPlan)
   const authEnv = requireVoyantAuthEnv(env, authMode, customerAuthProvider)
-  const explicitRuntimePorts = admitHostPorts(options.host?.runtimePorts ?? {}, {
-    deployment,
-    graphRuntime,
-  })
+  const explicitRuntimePorts = withDefaultAnalyticsSink(
+    admitHostPorts(options.host?.runtimePorts ?? {}, {
+      deployment,
+      graphRuntime,
+    }),
+  )
   const selectedStoragePorts = await resolveSelectedGraphProviderPorts(graphRuntime, rawEnv, {
     includedPorts: ["storage.object"],
     excludedPorts: [

--- a/packages/runtime/src/runtime-composition-observability.test.ts
+++ b/packages/runtime/src/runtime-composition-observability.test.ts
@@ -95,4 +95,27 @@ describe("Voyant observability composition", () => {
 
     expect(mocks.consoleReporter).not.toHaveBeenCalled()
   })
+
+  /**
+   * Selecting a reporter and not handing it to the application is the failure
+   * this whole PR is about, one layer up: `createApp` falls back to
+   * `noopReporter` when its config carries none, so the 5xx boundary and every
+   * other catch point it owns would discard exceptions while the composition
+   * looked correctly wired. Nothing had ever passed one.
+   */
+  it("hands the reporter to the application, not only to auth and the webhook loops", async () => {
+    const projectReporter = { captureException: vi.fn() }
+
+    await composeProject({ reporter: projectReporter })
+
+    const [runtimeOptions] = mocks.loadVoyantNodeRuntime.mock.calls.at(0) ?? []
+    expect(runtimeOptions?.app?.reporter).toBe(projectReporter)
+  })
+
+  it("hands the console reporter to the application when the project supplies none", async () => {
+    await composeProject()
+
+    const [runtimeOptions] = mocks.loadVoyantNodeRuntime.mock.calls.at(0) ?? []
+    expect(runtimeOptions?.app?.reporter).toBe(mocks.consoleReporter.mock.results.at(0)?.value)
+  })
 })

--- a/packages/runtime/src/runtime-composition-observability.test.ts
+++ b/packages/runtime/src/runtime-composition-observability.test.ts
@@ -1,0 +1,98 @@
+import path from "node:path"
+import { noopAnalytics } from "@voyant-travel/core/analytics"
+import { describe, expect, it, vi } from "vitest"
+import {
+  createGeneratedProject,
+  getRuntimeCompositionMocks,
+  loadVoyantProject,
+} from "./runtime-composition.test-support.js"
+
+const mocks = getRuntimeCompositionMocks()
+
+/**
+ * Both observability seams shipped unbound: `analytics.runtime` had no provider
+ * anywhere in the repository, so the booking engine's `engine.*` events reached
+ * `noopAnalytics` on every deployment, and the reporter was hard-coded past the
+ * Sentry adapter nobody could reach (voyant#4682). These pin the composition,
+ * not the emission — `booking-engine/analytics.test.ts` owns which events a
+ * rejection produces.
+ */
+
+type BoundAnalytics = {
+  track(event: string, properties?: Record<string, unknown>): void
+}
+
+async function composeProject(host?: Record<string, unknown>): Promise<void> {
+  const projectRoot = await createGeneratedProject()
+  await loadVoyantProject({
+    projectRoot,
+    adminAssetsDir: path.join(projectRoot, "admin"),
+    ...(host ? { host } : {}),
+  })
+}
+
+function boundAnalytics(): BoundAnalytics {
+  const composed = mocks.runtimePortHosts.at(0)
+  if (!composed) throw new Error("the project composed no runtime-port host")
+  return composed.runtimePorts?.["analytics.runtime"] as BoundAnalytics
+}
+
+describe("Voyant observability composition", () => {
+  it("binds a sink that writes the event a silent checkout would have emitted", async () => {
+    await composeProject()
+
+    const lines = vi.spyOn(console, "log").mockImplementation(() => undefined)
+    try {
+      boundAnalytics().track("engine.hold.failed", {
+        booking_session_id: "bses_1",
+        failure_reason: "hold_quantity_mismatch",
+      })
+      expect(lines).toHaveBeenCalledTimes(1)
+      expect(JSON.parse(String(lines.mock.calls[0]?.[0]))).toEqual({
+        voyant: "analytics",
+        kind: "track",
+        event: "engine.hold.failed",
+        properties: {
+          booking_session_id: "bses_1",
+          failure_reason: "hold_quantity_mismatch",
+        },
+      })
+    } finally {
+      lines.mockRestore()
+    }
+  })
+
+  it("keeps a project's own analytics binding", async () => {
+    const projectAnalytics = { track: vi.fn(), identify: vi.fn(), group: vi.fn() }
+
+    await composeProject({ runtimePorts: { "analytics.runtime": projectAnalytics } })
+
+    expect(boundAnalytics()).toBe(projectAnalytics)
+  })
+
+  it("lets a project opt back into silence", async () => {
+    await composeProject({ runtimePorts: { "analytics.runtime": noopAnalytics } })
+
+    const lines = vi.spyOn(console, "log").mockImplementation(() => undefined)
+    try {
+      boundAnalytics().track("engine.hold.failed", { booking_session_id: "bses_1" })
+      expect(lines).not.toHaveBeenCalled()
+    } finally {
+      lines.mockRestore()
+    }
+  })
+
+  it("falls back to the console reporter when the project supplies none", async () => {
+    await composeProject()
+
+    expect(mocks.consoleReporter).toHaveBeenCalledTimes(1)
+  })
+
+  it("uses the project's reporter instead of constructing the console one", async () => {
+    const projectReporter = { captureException: vi.fn() }
+
+    await composeProject({ reporter: projectReporter })
+
+    expect(mocks.consoleReporter).not.toHaveBeenCalled()
+  })
+})

--- a/packages/runtime/src/runtime-composition.test-support.ts
+++ b/packages/runtime/src/runtime-composition.test-support.ts
@@ -12,6 +12,8 @@ interface RuntimeCompositionMocks {
   adminSsrHandler: Mock
   createAdminSsrHandler: Mock
   authRuntimeOptions: Array<Record<string, unknown>>
+  /** Constructed only when the project supplies no reporter of its own. */
+  consoleReporter: Mock
   createNodeServer: Mock
   postgresEnqueue: Mock
   appEnqueue: Mock
@@ -88,6 +90,7 @@ const mocks: RuntimeCompositionMocks = vi.hoisted(() => {
         }
       },
     ),
+    consoleReporter: vi.fn(() => ({ captureException: vi.fn() })),
     postgresEnqueue: vi.fn(async () => ["queued"]),
     appEnqueue: vi.fn(async () => ["app-queued"]),
     createAppWebhookDeliveryEnqueuer: vi.fn(),
@@ -250,7 +253,7 @@ vi.mock("./deployment-resources.js", async (importOriginal) => {
 })
 
 vi.mock("@voyant-travel/hono/observability/reporter", () => ({
-  consoleReporter: () => ({}),
+  consoleReporter: mocks.consoleReporter,
 }))
 
 vi.mock("@voyant-travel/runtime-core", () => ({


### PR DESCRIPTION
Fixes #4682.

A storefront checkout rejected 30 holds over eleven minutes and the operator found out when the customer emailed (#4655). The events describing it existed the whole time — `engine.hold.failed` carries a typed `failure_reason` and the `booking_session_id`, and the engine emits one on every rejection. They reached nothing, because **no deployment has ever bound `analytics.runtime`**: `catalog` requires it optionally, unbound resolves to `noopAnalytics`, and the only references to the port in the tree were its definition and catalog's own `hasRuntimePort` check.

## Unbound was the default *and* the only state

"Unbound is a supported, silent state" is the right rule for a library consumer and the wrong one for a served deployment. The port shipped with nothing on the other end, so the silence was not a deployment's choice — it was the only thing on offer.

`@voyant-travel/runtime` now binds `consoleAnalytics` unless the project supplies its own `analytics.runtime`. One JSON line per event on stdout:

```json
{"voyant":"analytics","kind":"track","event":"engine.hold.failed","properties":{"booking_session_id":"bses_1","failure_reason":"hold_quantity_mismatch"}}
```

No timestamp — the drain stamps ingestion time, and omitting it keeps the line diffable in a test. A deployment that wants a vendor passes its own port; one that wants silence back binds `noopAnalytics`, which is now a decision rather than a default.

## The reporter was hard-coded past its own adapter

`packages/runtime/src/index.ts` built `consoleReporter()` unconditionally, so `sentryReporter` from `@voyant-travel/observability-sentry` — first-party, tested, shipped in #2100 — was unreachable from a generated project. `host.reporter` now accepts the deployment's own `Reporter`, console still the default.

**That seam would not have caught this anyway, and the docs now say so.** `Reporter` is `captureException` only; a rejected Hold is a typed outcome on a *successful* response. Wiring Sentry perfectly would have produced zero events for all 30 rejections. Analytics is where a failing checkout shows up; exceptions are the other seam.

## No vendor

Neither half takes a dependency. RFC #1553 put the vendor SDK on the deployment side deliberately and that is unchanged — this makes the deployment side reachable, and gives a deployment whose log drain *is* its telemetry backend something to read without writing an adapter first.

## Coverage

`runtime-composition-observability.test.ts` drives the real composition path rather than asserting against a hand-built port:

- the bound sink writes the exact line a silent checkout would have emitted, parsed back and compared
- a project's own `analytics.runtime` survives composition unchanged
- a project binding `noopAnalytics` writes nothing — the opt-out works
- the console reporter is constructed only when the project supplies none

`core/tests/unit/analytics.test.ts` covers the sink itself: one parseable line per call, the three call kinds distinguished, and both failure modes swallowed — a circular property bag and a sink that throws. Measuring the funnel must not break the funnel.

**Limit worth naming in review:** the runtime-composition harness mocks the node runtime's `fetch`, so no test here drives an exception through `app.onError` into a live reporter. The assertions pin selection and hand-off, not delivery.

## Review follow-up: the app never had a reporter at all

Review caught that the selected reporter reached only the auth runtime and the webhook loops. That was right, and the gap predates this branch: **`packages/framework/src/*.ts` contains no reference to `reporter`**, so `config.reporter ?? noopReporter` (`packages/hono/src/app.ts:192`) has always resolved to the no-op. The 5xx boundary, `c.set("reporter")`, module bootstrap and event-bus subscribers have been discarding exceptions on every deployment since the seam was built — the hard-coded console reporter never reached them either.

`CreateVoyantAppConfig` already accepts and forwards `reporter` through `node-runtime.ts`'s `...options.app` spread, so the fix is one line in the app config. Two tests pin it, and I checked they go red without it: removing the line fails exactly those two and leaves the other five green.

## Not in scope

Which product a deployment points the sink at, and the rate alert built on top of it. Both live in whatever the technical team already watches; the repository's job was to emit somewhere readable, and it now does.