### PR TITLE
Tell a host to stop when a recovery class keeps repeating

### DIFF
--- a/packages/catalog-react/src/booking-engine/session-outcomes.ts
+++ b/packages/catalog-react/src/booking-engine/session-outcomes.ts
@@ -158,6 +158,18 @@ export function bookingSessionOf(
  * never a replacement for it: the error itself stays on
  * `BookingSessionJourneyError.error` so a host that wants
  * `unsatisfied[]` — or `revision_conflict.actualRevision` — can still reach it.
+ *
+ * **A host that sees the same class repeatedly must stop and tell the shopper.**
+ * These name a remedy, not a promise that retrying applies it: several classes
+ * are deterministic for a given Session state, so re-running the same remedy is
+ * rejected identically every time. One shopper retried a checkout for eleven
+ * minutes — 30 holds, no commit — and saw a spinner throughout, because nothing
+ * between the rejection and the screen ever concluded that it would not work
+ * (voyant#4655, voyant#4683). Where to give up is a host decision and these
+ * hooks deliberately do not make it: a library that silently declined a call
+ * the host asked for would be a worse failure than the loop. But something must
+ * make it, and a terminal "we could not complete this — please contact us" is
+ * the only part of that eleven minutes the shopper would have valued.
  */
 export type BookingSessionRecoveryV1 =
   | "revisionConflict"

--- a/packages/catalog-react/src/booking-engine/session-outcomes.ts
+++ b/packages/catalog-react/src/booking-engine/session-outcomes.ts
@@ -159,17 +159,24 @@ export function bookingSessionOf(
  * `BookingSessionJourneyError.error` so a host that wants
  * `unsatisfied[]` — or `revision_conflict.actualRevision` — can still reach it.
  *
- * **A host that sees the same class repeatedly must stop and tell the shopper.**
- * These name a remedy, not a promise that retrying applies it: several classes
- * are deterministic for a given Session state, so re-running the same remedy is
- * rejected identically every time. One shopper retried a checkout for eleven
- * minutes — 30 holds, no commit — and saw a spinner throughout, because nothing
- * between the rejection and the screen ever concluded that it would not work
- * (voyant#4655, voyant#4683). Where to give up is a host decision and these
- * hooks deliberately do not make it: a library that silently declined a call
- * the host asked for would be a worse failure than the loop. But something must
- * make it, and a terminal "we could not complete this — please contact us" is
- * the only part of that eleven minutes the shopper would have valued.
+ * **A repeating class is not always a loop, and the difference decides what a
+ * host may say.** `commitInFlight` — `payment_in_flight`,
+ * `supplier_operation_active`, `supplier_in_doubt`, `component_commit_pending`
+ * — repeats precisely because external work is still running, and its next
+ * actions are to await, reconcile or continue. Observing it many times is what
+ * waiting looks like, and a host that answered it with a terminal failure would
+ * abandon a payment that was about to succeed.
+ *
+ * **Every other class names a remedy, not a promise that retrying applies it.**
+ * Most are deterministic for a given Session state, so re-running the same
+ * remedy is rejected identically every time. One shopper retried a checkout for
+ * eleven minutes — 30 holds, no commit — and saw a spinner throughout, because
+ * nothing between the rejection and the screen ever concluded that it would not
+ * work (voyant#4655, voyant#4683). Where to give up is a host decision and
+ * these hooks deliberately do not make it: a library that silently declined a
+ * call the host asked for would be a worse failure than the loop. But something
+ * must make it, and a terminal "we could not complete this — please contact us"
+ * is the only part of that eleven minutes the shopper would have valued.
  */
 export type BookingSessionRecoveryV1 =
   | "revisionConflict"


### PR DESCRIPTION
Refs #4683 (closed as not planned), #4655.

`bookingSessionRecoveryV1` maps every rejection kind to a coarse remedy class, which reads as an invitation to apply the remedy and try again. Several of those classes are **deterministic for a given Session state**, so re-running the remedy is rejected identically every time. That is what eleven silent minutes looked like in #4655: 55 `update`, 55 `quote` and 30 `hold` operations, no commit, and a spinner throughout, because nothing between the rejection and the screen ever concluded that it would not work.

#4683 asked for a retry cap in `useBookingHold`. It was closed rather than built, and this is what replaces it:

- **A cap does not belong in the hook.** Silently declining a call the host explicitly made is a worse failure than the loop — invisible from the host's side — and the reset semantics (new revision? new Quote? new Session?) are host policy the hook cannot decide.
- **The half that helps the shopper is not here.** A terminal "we could not complete this — please contact us" can only be rendered by the storefront, and no host in this repository consumes these hooks.
- **The capability already shipped.** #4666 added `bookingSessionNextActionV1`, `bookingSessionRecoveryV1` and `bookingSessionContinuationIsStale`; a host that wants to stop needs about five lines and no new export.

So the guidance goes where a storefront author is already reading when they handle a rejection, rather than into a README section or an issue nobody reopens.

## Scope

Comment only. No runtime behaviour, no type surface, no export changes — `git diff` is twelve added lines inside one docblock.

**No changeset**, and `verify:agent-quality:changed` asks that this be documented: `@voyant-travel/catalog-react` is `private: true`, and a docblock cannot change what a consumer resolves, so cutting a version for it would be noise. Biome clean on the file.
