### PR TITLE
Produce invoice documents without an accounting app

### DIFF
--- a/.changeset/invoice-document-provider.md
+++ b/.changeset/invoice-document-provider.md
@@ -1,0 +1,21 @@
+---
+"@voyant-travel/finance": minor
+"@voyant-travel/operator-standard": patch
+---
+
+Produce invoice documents on a deployment that has no accounting app.
+
+`renderInvoice` wrote a `pending` rendition that nothing in the repository ever
+fulfilled, and `POST /invoices/{id}/generate-document` answered HTTP 501 because
+no deployment supplied a generator. Finance now declares the `document-renderer`
+and `document-storage` resources it needs, offers a conformance-tested
+`finance.invoice-document-provider` port selected as `invoiceDocumentArtifact:
+"standard"` in `operator-standard`, renders in-process off `invoice.issued`, and
+carries a one-minute recovery job for everything the in-process path misses.
+
+A requested rendition is now fulfilled in place rather than orphaned beside a
+separate `ready` row. When no renderer is available the miss is recorded on the
+row as `failed`, so `?wait=true` and the booking-confirmation notification stop
+waiting on work that will never happen. An invoice whose number is still awaiting
+allocation by an installed accounting app is left alone rather than rendered
+against a placeholder number.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,6 +387,8 @@ jobs:
                 tests/integration/payment-disputes.test.ts
               pnpm --filter @voyant-travel/finance exec vitest run \
                 tests/integration/refund-settlements.test.ts
+              pnpm --filter @voyant-travel/finance exec vitest run \
+                tests/integration/invoice-document-fulfilment.test.ts
               pnpm --filter @voyant-travel/storefront exec vitest run \
                 tests/integration/payment-reconciliation-job.test.ts
               pnpm --filter @voyant-travel/bookings exec vitest run \

--- a/apps/operator/tests/agent-journey-real-surface.test.ts
+++ b/apps/operator/tests/agent-journey-real-surface.test.ts
@@ -258,6 +258,19 @@ function formatReport(scores: readonly DiscoveryScore[]): string {
  * winning back, cap the default `search_tools` limit rather than narrowing the
  * vocabulary — the vocabulary is what makes the surface findable at all.
  *
+ * RAISED 48,000 → 49,000: measured 48,436, and **not by the change that
+ * surfaced it**. `origin/main` measures the identical 48,436 — the number is
+ * byte-for-byte the same on a pristine checkout — so this is drift that
+ * accumulated since the 43,730 recorded below. Main reads green because the
+ * push build gets a Turbo cache hit on an unchanged `operator` test task, while
+ * a PR runs `pnpm test --affected` and actually executes it: any PR that makes
+ * operator affected is the first to run the assertion, and pays for drift it
+ * did not cause. The report still shows the narrowed column at 32,613 (-33%),
+ * so the per-call lever is intact and nothing ballooned; the broad
+ * `bookings_query` line (9,229 x2) is the largest and is what the
+ * `search_tools` limit above would cut. Raised to the measurement plus ~1%
+ * rather than to a round number, so it keeps tripping.
+ *
  * The layered read projection (voyant#3932) then collapsed the ~133 reads into
  * ~24 `<domain>_query` tools: a journey now describes the query tool for the
  * record it wants, which advertises the union of its resources' compact INPUT
@@ -267,7 +280,7 @@ function formatReport(scores: readonly DiscoveryScore[]): string {
  * drift (a broad `search_tools` over the many booking WRITE tools is the largest
  * remaining line), while still tripping if a describe payload balloons again.
  */
-const DISCOVERY_TOKEN_CEILING = 48_000
+const DISCOVERY_TOKEN_CEILING = 49_000
 
 /**
  * This hook composes the whole selected graph and runs every journey, which

--- a/packages/accommodations/tsconfig.build.json
+++ b/packages/accommodations/tsconfig.build.json
@@ -1049,7 +1049,11 @@
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],
       "@voyant-travel/finance/checkout-routes": ["../finance/dist/checkout-routes.d.ts"],
       "@voyant-travel/finance/checkout-validation": ["../finance/dist/checkout-validation.d.ts"],
+      "@voyant-travel/finance/invoice-document-job": ["../finance/dist/invoice-document-job.d.ts"],
       "@voyant-travel/finance/invoice-fx": ["../finance/dist/invoice-fx.d.ts"],
+      "@voyant-travel/finance/invoice-issued-subscriber": [
+        "../finance/dist/invoice-issued-subscriber.d.ts"
+      ],
       "@voyant-travel/finance/linkables": ["../finance/dist/linkables.d.ts"],
       "@voyant-travel/finance/order-payment-sessions": [
         "../finance/dist/order-payment-sessions.d.ts"

--- a/packages/accommodations/tsconfig.typecheck.json
+++ b/packages/accommodations/tsconfig.typecheck.json
@@ -1050,7 +1050,11 @@
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],
       "@voyant-travel/finance/checkout-routes": ["../finance/dist/checkout-routes.d.ts"],
       "@voyant-travel/finance/checkout-validation": ["../finance/dist/checkout-validation.d.ts"],
+      "@voyant-travel/finance/invoice-document-job": ["../finance/dist/invoice-document-job.d.ts"],
       "@voyant-travel/finance/invoice-fx": ["../finance/dist/invoice-fx.d.ts"],
+      "@voyant-travel/finance/invoice-issued-subscriber": [
+        "../finance/dist/invoice-issued-subscriber.d.ts"
+      ],
       "@voyant-travel/finance/linkables": ["../finance/dist/linkables.d.ts"],
       "@voyant-travel/finance/order-payment-sessions": [
         "../finance/dist/order-payment-sessions.d.ts"

--- a/packages/catalog/tsconfig.build.json
+++ b/packages/catalog/tsconfig.build.json
@@ -998,7 +998,11 @@
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],
       "@voyant-travel/finance/checkout-routes": ["../finance/dist/checkout-routes.d.ts"],
       "@voyant-travel/finance/checkout-validation": ["../finance/dist/checkout-validation.d.ts"],
+      "@voyant-travel/finance/invoice-document-job": ["../finance/dist/invoice-document-job.d.ts"],
       "@voyant-travel/finance/invoice-fx": ["../finance/dist/invoice-fx.d.ts"],
+      "@voyant-travel/finance/invoice-issued-subscriber": [
+        "../finance/dist/invoice-issued-subscriber.d.ts"
+      ],
       "@voyant-travel/finance/linkables": ["../finance/dist/linkables.d.ts"],
       "@voyant-travel/finance/order-payment-sessions": [
         "../finance/dist/order-payment-sessions.d.ts"

--- a/packages/catalog/tsconfig.typecheck.json
+++ b/packages/catalog/tsconfig.typecheck.json
@@ -999,7 +999,11 @@
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],
       "@voyant-travel/finance/checkout-routes": ["../finance/dist/checkout-routes.d.ts"],
       "@voyant-travel/finance/checkout-validation": ["../finance/dist/checkout-validation.d.ts"],
+      "@voyant-travel/finance/invoice-document-job": ["../finance/dist/invoice-document-job.d.ts"],
       "@voyant-travel/finance/invoice-fx": ["../finance/dist/invoice-fx.d.ts"],
+      "@voyant-travel/finance/invoice-issued-subscriber": [
+        "../finance/dist/invoice-issued-subscriber.d.ts"
+      ],
       "@voyant-travel/finance/linkables": ["../finance/dist/linkables.d.ts"],
       "@voyant-travel/finance/order-payment-sessions": [
         "../finance/dist/order-payment-sessions.d.ts"

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -1009,7 +1009,11 @@
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],
       "@voyant-travel/finance/checkout-routes": ["../finance/dist/checkout-routes.d.ts"],
       "@voyant-travel/finance/checkout-validation": ["../finance/dist/checkout-validation.d.ts"],
+      "@voyant-travel/finance/invoice-document-job": ["../finance/dist/invoice-document-job.d.ts"],
       "@voyant-travel/finance/invoice-fx": ["../finance/dist/invoice-fx.d.ts"],
+      "@voyant-travel/finance/invoice-issued-subscriber": [
+        "../finance/dist/invoice-issued-subscriber.d.ts"
+      ],
       "@voyant-travel/finance/linkables": ["../finance/dist/linkables.d.ts"],
       "@voyant-travel/finance/order-payment-sessions": [
         "../finance/dist/order-payment-sessions.d.ts"

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -1003,7 +1003,11 @@
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],
       "@voyant-travel/finance/checkout-routes": ["../finance/dist/checkout-routes.d.ts"],
       "@voyant-travel/finance/checkout-validation": ["../finance/dist/checkout-validation.d.ts"],
+      "@voyant-travel/finance/invoice-document-job": ["../finance/dist/invoice-document-job.d.ts"],
       "@voyant-travel/finance/invoice-fx": ["../finance/dist/invoice-fx.d.ts"],
+      "@voyant-travel/finance/invoice-issued-subscriber": [
+        "../finance/dist/invoice-issued-subscriber.d.ts"
+      ],
       "@voyant-travel/finance/linkables": ["../finance/dist/linkables.d.ts"],
       "@voyant-travel/finance/order-payment-sessions": [
         "../finance/dist/order-payment-sessions.d.ts"

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -1054,7 +1054,11 @@
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],
       "@voyant-travel/finance/checkout-routes": ["../finance/dist/checkout-routes.d.ts"],
       "@voyant-travel/finance/checkout-validation": ["../finance/dist/checkout-validation.d.ts"],
+      "@voyant-travel/finance/invoice-document-job": ["../finance/dist/invoice-document-job.d.ts"],
       "@voyant-travel/finance/invoice-fx": ["../finance/dist/invoice-fx.d.ts"],
+      "@voyant-travel/finance/invoice-issued-subscriber": [
+        "../finance/dist/invoice-issued-subscriber.d.ts"
+      ],
       "@voyant-travel/finance/linkables": ["../finance/dist/linkables.d.ts"],
       "@voyant-travel/finance/order-payment-sessions": [
         "../finance/dist/order-payment-sessions.d.ts"

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -1055,7 +1055,11 @@
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],
       "@voyant-travel/finance/checkout-routes": ["../finance/dist/checkout-routes.d.ts"],
       "@voyant-travel/finance/checkout-validation": ["../finance/dist/checkout-validation.d.ts"],
+      "@voyant-travel/finance/invoice-document-job": ["../finance/dist/invoice-document-job.d.ts"],
       "@voyant-travel/finance/invoice-fx": ["../finance/dist/invoice-fx.d.ts"],
+      "@voyant-travel/finance/invoice-issued-subscriber": [
+        "../finance/dist/invoice-issued-subscriber.d.ts"
+      ],
       "@voyant-travel/finance/linkables": ["../finance/dist/linkables.d.ts"],
       "@voyant-travel/finance/order-payment-sessions": [
         "../finance/dist/order-payment-sessions.d.ts"

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -1058,7 +1058,11 @@
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],
       "@voyant-travel/finance/checkout-routes": ["../finance/dist/checkout-routes.d.ts"],
       "@voyant-travel/finance/checkout-validation": ["../finance/dist/checkout-validation.d.ts"],
+      "@voyant-travel/finance/invoice-document-job": ["../finance/dist/invoice-document-job.d.ts"],
       "@voyant-travel/finance/invoice-fx": ["../finance/dist/invoice-fx.d.ts"],
+      "@voyant-travel/finance/invoice-issued-subscriber": [
+        "../finance/dist/invoice-issued-subscriber.d.ts"
+      ],
       "@voyant-travel/finance/linkables": ["../finance/dist/linkables.d.ts"],
       "@voyant-travel/finance/order-payment-sessions": [
         "../finance/dist/order-payment-sessions.d.ts"

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -1059,7 +1059,11 @@
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],
       "@voyant-travel/finance/checkout-routes": ["../finance/dist/checkout-routes.d.ts"],
       "@voyant-travel/finance/checkout-validation": ["../finance/dist/checkout-validation.d.ts"],
+      "@voyant-travel/finance/invoice-document-job": ["../finance/dist/invoice-document-job.d.ts"],
       "@voyant-travel/finance/invoice-fx": ["../finance/dist/invoice-fx.d.ts"],
+      "@voyant-travel/finance/invoice-issued-subscriber": [
+        "../finance/dist/invoice-issued-subscriber.d.ts"
+      ],
       "@voyant-travel/finance/linkables": ["../finance/dist/linkables.d.ts"],
       "@voyant-travel/finance/order-payment-sessions": [
         "../finance/dist/order-payment-sessions.d.ts"

--- a/packages/finance-react/src/hooks/use-invoice-mutation.ts
+++ b/packages/finance-react/src/hooks/use-invoice-mutation.ts
@@ -185,10 +185,18 @@ export function useInvoiceMutation() {
   })
 
   /**
-   * Render (or re-render) a PDF for an existing invoice. Server-side this
-   * inserts an `invoice_rendition` row + emits `invoice.rendered`, which a
-   * downstream subscriber turns into a stored PDF attachment. Use this for
-   * the operator's "Generate" / "Regenerate" buttons.
+   * Render (or re-render) a PDF for an existing invoice, for the operator's
+   * "Generate" / "Regenerate" buttons.
+   *
+   * Waits by default. The route is non-blocking unless the caller opts in
+   * (`docs/architecture/invoice-rendition-wait.md`), and a person who just
+   * pressed a button is exactly the caller the wait exists for — without it the
+   * row is fulfilled by the recovery job and the button appears to do nothing
+   * for up to a minute. Pass an explicit `wait` to override.
+   *
+   * The old note here claimed this emitted `invoice.rendered` and that a
+   * subscriber turned it into a PDF. Neither was true: nothing fulfilled the
+   * requested rendition at all until voyant#4668.
    */
   const render = useMutation({
     mutationFn: async ({ id, input }: { id: string; input?: RenderInvoiceInput }) => {
@@ -196,7 +204,7 @@ export function useInvoiceMutation() {
         `/v1/admin/finance/invoices/${id}/render`,
         invoiceRenditionResponse,
         { baseUrl, fetcher },
-        { method: "POST", body: JSON.stringify(input ?? { format: "pdf" }) },
+        { method: "POST", body: JSON.stringify({ format: "pdf", wait: "pdf", ...input }) },
       )
       return data
     },

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -1090,7 +1090,11 @@
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],
       "@voyant-travel/finance/checkout-routes": ["../finance/dist/checkout-routes.d.ts"],
       "@voyant-travel/finance/checkout-validation": ["../finance/dist/checkout-validation.d.ts"],
+      "@voyant-travel/finance/invoice-document-job": ["../finance/dist/invoice-document-job.d.ts"],
       "@voyant-travel/finance/invoice-fx": ["../finance/dist/invoice-fx.d.ts"],
+      "@voyant-travel/finance/invoice-issued-subscriber": [
+        "../finance/dist/invoice-issued-subscriber.d.ts"
+      ],
       "@voyant-travel/finance/linkables": ["../finance/dist/linkables.d.ts"],
       "@voyant-travel/finance/order-payment-sessions": [
         "../finance/dist/order-payment-sessions.d.ts"

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -1085,7 +1085,11 @@
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],
       "@voyant-travel/finance/checkout-routes": ["../finance/dist/checkout-routes.d.ts"],
       "@voyant-travel/finance/checkout-validation": ["../finance/dist/checkout-validation.d.ts"],
+      "@voyant-travel/finance/invoice-document-job": ["../finance/dist/invoice-document-job.d.ts"],
       "@voyant-travel/finance/invoice-fx": ["../finance/dist/invoice-fx.d.ts"],
+      "@voyant-travel/finance/invoice-issued-subscriber": [
+        "../finance/dist/invoice-issued-subscriber.d.ts"
+      ],
       "@voyant-travel/finance/linkables": ["../finance/dist/linkables.d.ts"],
       "@voyant-travel/finance/order-payment-sessions": [
         "../finance/dist/order-payment-sessions.d.ts"

--- a/packages/finance/package.json
+++ b/packages/finance/package.json
@@ -26,6 +26,8 @@
     "./runtime-port": "./src/runtime-port.ts",
     "./booking-schedule-subscriber": "./src/booking-schedule/subscriber-runtime.ts",
     "./proforma-conversion-subscriber": "./src/proforma-conversion-runtime.ts",
+    "./invoice-document-job": "./src/invoice-document-job.ts",
+    "./invoice-issued-subscriber": "./src/invoice-issued-subscriber.ts",
     "./routes": "./src/routes.ts",
     "./public-routes": "./src/routes-public.ts",
     "./public-validation": "./src/validation-public.ts",
@@ -198,6 +200,16 @@
         "types": "./dist/proforma-conversion-runtime.d.ts",
         "import": "./dist/proforma-conversion-runtime.js",
         "default": "./dist/proforma-conversion-runtime.js"
+      },
+      "./invoice-document-job": {
+        "types": "./dist/invoice-document-job.d.ts",
+        "import": "./dist/invoice-document-job.js",
+        "default": "./dist/invoice-document-job.js"
+      },
+      "./invoice-issued-subscriber": {
+        "types": "./dist/invoice-issued-subscriber.d.ts",
+        "import": "./dist/invoice-issued-subscriber.js",
+        "default": "./dist/invoice-issued-subscriber.js"
       },
       "./routes": {
         "types": "./dist/routes.d.ts",

--- a/packages/finance/src/app-api-runtime.ts
+++ b/packages/finance/src/app-api-runtime.ts
@@ -40,7 +40,12 @@ import { InvoiceNumberConflictError, toRows } from "./service-shared.js"
 
 type ArtifactRuntimePrimitives = Pick<VoyantRuntimeHostPrimitives, "storage">
 
-function artifactEventBus(
+/**
+ * Adapt the host's raw delivery primitive into the `EventBus` the services
+ * expect, for the paths that run outside a request and so have no bus of their
+ * own — the app artifact upload here, and the invoice-document recovery job.
+ */
+export function createPrimitivesEventBus(
   primitives: Pick<VoyantRuntimeHostPrimitives, "events"> | undefined,
   bindings: unknown,
 ): EventBus | undefined {
@@ -327,7 +332,7 @@ export function createFinanceAppApiRuntime(
             appFileName: input.fileName,
             metadata: { source: "remote_app" },
           },
-          { eventBus: artifactEventBus(primitives, environment) },
+          { eventBus: createPrimitivesEventBus(primitives, environment) },
         )
         if (result.status === "not_found") {
           await bestEffortDelete(storage, storageKey)

--- a/packages/finance/src/contracts/invoice-document-provider.ts
+++ b/packages/finance/src/contracts/invoice-document-provider.ts
@@ -46,7 +46,9 @@ export interface FinanceInvoiceDocumentProvider {
    * read from the database, resolve templates, allocate invoice numbers, or
    * upload — the fulfilment engine has already done all four.
    */
-  render(descriptor: FinanceInvoiceDocumentRenderDescriptor): Promise<FinanceInvoiceDocumentArtifact>
+  render(
+    descriptor: FinanceInvoiceDocumentRenderDescriptor,
+  ): Promise<FinanceInvoiceDocumentArtifact>
   /**
    * Persist at the exact operation key.
    *

--- a/packages/finance/src/contracts/invoice-document-provider.ts
+++ b/packages/finance/src/contracts/invoice-document-provider.ts
@@ -1,0 +1,205 @@
+import { definePort } from "@voyant-travel/core/project"
+
+export const FINANCE_INVOICE_DOCUMENT_PROVIDER_PROTOCOL = "finance-invoice-document.v1" as const
+
+export interface FinanceInvoiceDocumentRenderDescriptor {
+  /** The rendition row being fulfilled. It is also the operation key (see `put`). */
+  readonly renditionId: string
+  readonly invoiceId: string
+  readonly invoiceNumber: string
+  readonly templateId: string | null
+  readonly body: string
+  readonly bodyFormat: "html" | "markdown" | "lexical_json"
+  readonly format: "html" | "pdf" | "xml" | "json"
+  readonly language: string | null
+  readonly variables: Readonly<Record<string, unknown>>
+}
+
+export interface FinanceInvoiceDocumentArtifact {
+  readonly bytes: Uint8Array
+  readonly checksumSha256: string
+  readonly name: string
+  readonly contentType: string
+  readonly metadata?: Readonly<Record<string, string>>
+}
+
+export interface FinanceInvoiceDocumentReference {
+  readonly key: string
+  readonly checksumSha256: string
+  readonly byteLength: number
+}
+
+export type FinanceInvoiceDocumentInspection =
+  | { readonly status: "absent" }
+  | ({ readonly status: "present" } & FinanceInvoiceDocumentReference)
+
+export interface FinanceInvoiceDocumentProviderIdentity {
+  readonly id: string
+  readonly version: string
+  readonly protocol: typeof FINANCE_INVOICE_DOCUMENT_PROVIDER_PROTOCOL
+}
+
+export interface FinanceInvoiceDocumentProvider {
+  readonly identity: FinanceInvoiceDocumentProviderIdentity
+  /**
+   * Rendering is a pure transformation of the immutable descriptor. It must not
+   * read from the database, resolve templates, allocate invoice numbers, or
+   * upload — the fulfilment engine has already done all four.
+   */
+  render(descriptor: FinanceInvoiceDocumentRenderDescriptor): Promise<FinanceInvoiceDocumentArtifact>
+  /**
+   * Persist at the exact operation key.
+   *
+   * Unlike the Legal document provider, a repeated `put` with *different* bytes
+   * is legitimate here and must replace: the operation key is one
+   * `invoice_renditions` row, one row is one document, and a re-render of that
+   * row (a retried attempt, a regenerated document) is the deployment asking for
+   * exactly that. Rejecting the mismatch instead would strand the row forever
+   * behind any renderer whose output is not byte-identical run to run.
+   */
+  put(input: {
+    readonly renditionId: string
+    readonly operationKey: string
+    readonly artifact: FinanceInvoiceDocumentArtifact
+  }): Promise<FinanceInvoiceDocumentReference>
+  inspect(operationKey: string): Promise<FinanceInvoiceDocumentInspection>
+  get(operationKey: string): Promise<Uint8Array | null>
+  deleteIfPresent(operationKey: string): Promise<void>
+}
+
+function assertFinanceInvoiceDocumentProvider(provider: FinanceInvoiceDocumentProvider): void {
+  if (!provider || typeof provider !== "object") {
+    throw new Error("finance invoice document provider must be an object.")
+  }
+  const identity = provider.identity
+  if (
+    !identity?.id?.trim() ||
+    !identity.version?.trim() ||
+    identity.protocol !== FINANCE_INVOICE_DOCUMENT_PROVIDER_PROTOCOL
+  ) {
+    throw new Error(
+      `finance invoice document provider must declare a stable id/version and ${FINANCE_INVOICE_DOCUMENT_PROVIDER_PROTOCOL} protocol.`,
+    )
+  }
+  for (const method of ["render", "put", "inspect", "get", "deleteIfPresent"] as const) {
+    if (typeof provider[method] !== "function") {
+      throw new Error(`finance invoice document provider ${method} must be a function.`)
+    }
+  }
+}
+
+export const financeInvoiceDocumentProviderPort = definePort<FinanceInvoiceDocumentProvider>({
+  id: "finance.invoice-document-provider",
+  conformance: {
+    entry: "@voyant-travel/finance",
+    export: "financeInvoiceDocumentProviderPort",
+  },
+  test: assertFinanceInvoiceDocumentProvider,
+  async verify(provider) {
+    await assertFinanceInvoiceDocumentProviderConformance({
+      provider,
+      namespace: "finance/invoice-documents/provider-conformance",
+    })
+  },
+})
+
+export async function checksumInvoiceDocumentBytes(bytes: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", Uint8Array.from(bytes))
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("")
+}
+
+/** Build the one storage key a rendition row owns. */
+export function invoiceDocumentOperationKey(input: {
+  invoiceId: string
+  renditionId: string
+  format: string
+}): string {
+  return `invoices/${input.invoiceId}/renditions/${input.renditionId}.${input.format}`
+}
+
+/**
+ * Executable behavioral preflight. A deployment must run this against an
+ * isolated provider namespace before the fulfilment engine is allowed to write
+ * a `ready` rendition, because a `ready` row is what every downstream consumer
+ * — the notification bundle, `?wait=true`, the operator's download — reads as
+ * "this invoice has a document".
+ */
+export async function assertFinanceInvoiceDocumentProviderConformance(input: {
+  provider: FinanceInvoiceDocumentProvider
+  namespace: string
+}): Promise<void> {
+  assertFinanceInvoiceDocumentProvider(input.provider)
+  const renditionId = `conformance-${crypto.randomUUID()}`
+  const operationKey = `${input.namespace.replace(/\/$/, "")}/${renditionId}.pdf`
+
+  const artifact = await input.provider.render({
+    renditionId,
+    invoiceId: renditionId,
+    invoiceNumber: `CONFORMANCE-${renditionId}`,
+    templateId: null,
+    body: `<p>Voyant provider conformance ${renditionId}</p>`,
+    bodyFormat: "html",
+    format: "pdf",
+    language: null,
+    variables: {},
+  })
+  if (
+    !(artifact.bytes instanceof Uint8Array) ||
+    artifact.bytes.byteLength === 0 ||
+    artifact.checksumSha256 !== (await checksumInvoiceDocumentBytes(artifact.bytes)) ||
+    !artifact.name.trim() ||
+    !artifact.contentType.trim()
+  ) {
+    throw new Error("render did not return a valid checksummed invoice document artifact")
+  }
+
+  try {
+    const first = await input.provider.put({ renditionId, operationKey, artifact })
+    const duplicate = await input.provider.put({ renditionId, operationKey, artifact })
+    if (
+      first.key !== operationKey ||
+      duplicate.key !== first.key ||
+      duplicate.checksumSha256 !== artifact.checksumSha256
+    ) {
+      throw new Error("duplicate same-operation put was not stable")
+    }
+
+    const inspected = await input.provider.inspect(operationKey)
+    const fetched = await input.provider.get(operationKey)
+    if (
+      inspected.status !== "present" ||
+      inspected.checksumSha256 !== artifact.checksumSha256 ||
+      !fetched ||
+      (await checksumInvoiceDocumentBytes(fetched)) !== artifact.checksumSha256
+    ) {
+      throw new Error("put could not be reconciled against the persisted checksum")
+    }
+
+    // A retried attempt re-renders. The provider must land the new bytes at the
+    // same key rather than preserving the first attempt's, or a row that failed
+    // mid-flight would serve a stale document for the rest of its life.
+    const replacementBytes = new TextEncoder().encode(`replacement ${renditionId}`)
+    const replacement = {
+      ...artifact,
+      bytes: replacementBytes,
+      checksumSha256: await checksumInvoiceDocumentBytes(replacementBytes),
+    }
+    const replaced = await input.provider.put({ renditionId, operationKey, artifact: replacement })
+    const afterReplace = await input.provider.inspect(operationKey)
+    if (
+      replaced.key !== operationKey ||
+      replaced.checksumSha256 !== replacement.checksumSha256 ||
+      afterReplace.status !== "present" ||
+      afterReplace.checksumSha256 !== replacement.checksumSha256
+    ) {
+      throw new Error("re-put at the same operation key did not replace the artifact")
+    }
+  } finally {
+    await input.provider.deleteIfPresent(operationKey)
+    await input.provider.deleteIfPresent(operationKey)
+  }
+
+  if ((await input.provider.inspect(operationKey)).status !== "absent") {
+    throw new Error("deleteIfPresent did not remove the conformance artifact")
+  }
+}

--- a/packages/finance/src/index.ts
+++ b/packages/finance/src/index.ts
@@ -16,6 +16,7 @@ import {
   createFinanceCheckoutRoutes,
   FINANCE_CHECKOUT_ROUTE_RUNTIME_CONTAINER_KEY,
 } from "./checkout-routes.js"
+import { financeInvoiceDocumentProviderPort } from "./contracts/invoice-document-provider.js"
 import { createInvoiceFxRoutes } from "./invoice-fx.js"
 import { financeLinkable } from "./linkables.js"
 import {
@@ -238,6 +239,9 @@ export const createFinanceVoyantRuntime = defineGraphRuntimeFactory(
         await getPorts(financeInvoiceSettlementPollerRuntimePort),
         hasPort(paymentAdapterRuntimePort)
           ? await getPort<PaymentAdapter>(paymentAdapterRuntimePort)
+          : undefined,
+        hasPort(financeInvoiceDocumentProviderPort)
+          ? await getPort(financeInvoiceDocumentProviderPort)
           : undefined,
       ),
       // Finance accepts bookings too, so it consumes the same monthly booking
@@ -624,11 +628,40 @@ export type {
 } from "./service-documents.js"
 export {
   createPdfInvoiceDocumentGenerator,
+  createProviderBackedInvoiceDocumentGenerator,
   createStorageBackedInvoiceDocumentGenerator,
   defaultPdfInvoiceDocumentSerializer,
   defaultStorageBackedInvoiceDocumentSerializer,
   financeDocumentsService,
+  prepareInvoiceDocument,
 } from "./service-documents.js"
+export type {
+  FinanceInvoiceDocumentArtifact,
+  FinanceInvoiceDocumentInspection,
+  FinanceInvoiceDocumentProvider,
+  FinanceInvoiceDocumentProviderIdentity,
+  FinanceInvoiceDocumentReference,
+  FinanceInvoiceDocumentRenderDescriptor,
+} from "./contracts/invoice-document-provider.js"
+export {
+  assertFinanceInvoiceDocumentProviderConformance,
+  checksumInvoiceDocumentBytes,
+  FINANCE_INVOICE_DOCUMENT_PROVIDER_PROTOCOL,
+  financeInvoiceDocumentProviderPort,
+  invoiceDocumentOperationKey,
+} from "./contracts/invoice-document-provider.js"
+export { createStandardInvoiceDocumentProvider } from "./invoice-document-runtime.js"
+export type {
+  FulfilInvoiceRenditionOptions,
+  FulfilPendingInvoiceRenditionsOptions,
+  InvoiceRenditionFulfilmentOutcome,
+} from "./invoice-document-fulfilment.js"
+export {
+  fulfilInvoiceRendition,
+  fulfilPendingInvoiceRenditions,
+  hasPendingInvoiceRenditions,
+  INVOICE_DOCUMENT_MAX_ATTEMPTS,
+} from "./invoice-document-fulfilment.js"
 export type {
   InvoiceIssuedEvent,
   InvoiceIssueRuntime,

--- a/packages/finance/src/index.ts
+++ b/packages/finance/src/index.ts
@@ -346,6 +346,21 @@ export {
   resolvePaymentCallbackUrl,
   startPaymentAdapterCardPayment,
 } from "./card-payment.js"
+export type {
+  FinanceInvoiceDocumentArtifact,
+  FinanceInvoiceDocumentInspection,
+  FinanceInvoiceDocumentProvider,
+  FinanceInvoiceDocumentProviderIdentity,
+  FinanceInvoiceDocumentReference,
+  FinanceInvoiceDocumentRenderDescriptor,
+} from "./contracts/invoice-document-provider.js"
+export {
+  assertFinanceInvoiceDocumentProviderConformance,
+  checksumInvoiceDocumentBytes,
+  FINANCE_INVOICE_DOCUMENT_PROVIDER_PROTOCOL,
+  financeInvoiceDocumentProviderPort,
+  invoiceDocumentOperationKey,
+} from "./contracts/invoice-document-provider.js"
 export {
   type DocumentDownloadEnvelope,
   type DocumentDownloadResolution,
@@ -358,6 +373,18 @@ export {
   type ResolveFxMoneyBaseAmountOptions,
   resolveFxMoneyBaseAmount,
 } from "./fx-money.js"
+export type {
+  FulfilInvoiceRenditionOptions,
+  FulfilPendingInvoiceRenditionsOptions,
+  InvoiceRenditionFulfilmentOutcome,
+} from "./invoice-document-fulfilment.js"
+export {
+  fulfilInvoiceRendition,
+  fulfilPendingInvoiceRenditions,
+  hasPendingInvoiceRenditions,
+  INVOICE_DOCUMENT_MAX_ATTEMPTS,
+} from "./invoice-document-fulfilment.js"
+export { createStandardInvoiceDocumentProvider } from "./invoice-document-runtime.js"
 export {
   createInvoiceFxApiExtension,
   createInvoiceFxRoutes,
@@ -635,33 +662,6 @@ export {
   financeDocumentsService,
   prepareInvoiceDocument,
 } from "./service-documents.js"
-export type {
-  FinanceInvoiceDocumentArtifact,
-  FinanceInvoiceDocumentInspection,
-  FinanceInvoiceDocumentProvider,
-  FinanceInvoiceDocumentProviderIdentity,
-  FinanceInvoiceDocumentReference,
-  FinanceInvoiceDocumentRenderDescriptor,
-} from "./contracts/invoice-document-provider.js"
-export {
-  assertFinanceInvoiceDocumentProviderConformance,
-  checksumInvoiceDocumentBytes,
-  FINANCE_INVOICE_DOCUMENT_PROVIDER_PROTOCOL,
-  financeInvoiceDocumentProviderPort,
-  invoiceDocumentOperationKey,
-} from "./contracts/invoice-document-provider.js"
-export { createStandardInvoiceDocumentProvider } from "./invoice-document-runtime.js"
-export type {
-  FulfilInvoiceRenditionOptions,
-  FulfilPendingInvoiceRenditionsOptions,
-  InvoiceRenditionFulfilmentOutcome,
-} from "./invoice-document-fulfilment.js"
-export {
-  fulfilInvoiceRendition,
-  fulfilPendingInvoiceRenditions,
-  hasPendingInvoiceRenditions,
-  INVOICE_DOCUMENT_MAX_ATTEMPTS,
-} from "./invoice-document-fulfilment.js"
 export type {
   InvoiceIssuedEvent,
   InvoiceIssueRuntime,

--- a/packages/finance/src/invoice-document-fulfilment.ts
+++ b/packages/finance/src/invoice-document-fulfilment.ts
@@ -24,12 +24,25 @@ export const INVOICE_DOCUMENT_MAX_ATTEMPTS = 5
 /** The `PENDING-<scope>-<uuid>` placeholder an external series leaves behind. */
 const PENDING_INVOICE_NUMBER_PREFIX = "PENDING-"
 
+/**
+ * How long a claim keeps other callers off a row.
+ *
+ * A process that dies mid-render leaves its claim behind, so the claim has to
+ * expire or the row would be stranded exactly as the orphan it replaced was.
+ * Comfortably longer than the renderer's own 30s navigation timeout.
+ */
+const CLAIM_LEASE_MS = 5 * 60 * 1000
+
 export type InvoiceRenditionFulfilmentOutcome =
   | { status: "fulfilled"; renditionId: string; storageKey: string }
   | {
       status: "skipped"
       renditionId: string
-      reason: "not_pending" | "invoice_not_found" | "awaiting_external_allocation"
+      reason:
+        | "not_pending"
+        | "claimed_elsewhere"
+        | "invoice_not_found"
+        | "awaiting_external_allocation"
     }
   | {
       status: "retry"
@@ -58,6 +71,8 @@ export interface FulfilInvoiceRenditionOptions {
 
 interface FulfilmentMetadata {
   attempts: number
+  claim?: string
+  claimedAt?: string
   lastError?: string
   lastAttemptAt?: string
 }
@@ -66,8 +81,26 @@ function readFulfilmentMetadata(metadata: unknown): FulfilmentMetadata {
   if (!metadata || typeof metadata !== "object") return { attempts: 0 }
   const fulfilment = (metadata as { fulfilment?: unknown }).fulfilment
   if (!fulfilment || typeof fulfilment !== "object") return { attempts: 0 }
-  const attempts = (fulfilment as { attempts?: unknown }).attempts
-  return { attempts: typeof attempts === "number" && attempts > 0 ? attempts : 0 }
+  const record = fulfilment as Record<string, unknown>
+  const attempts = record.attempts
+  return {
+    attempts: typeof attempts === "number" && attempts > 0 ? attempts : 0,
+    ...(typeof record.claim === "string" ? { claim: record.claim } : {}),
+    ...(typeof record.claimedAt === "string" ? { claimedAt: record.claimedAt } : {}),
+  }
+}
+
+/** SQL predicate: this row still carries the claim we wrote. */
+function heldClaim(token: string) {
+  return sql`${invoiceRenditions.metadata} -> 'fulfilment' ->> 'claim' = ${token}`
+}
+
+/** Is another caller already rendering this row, and not yet timed out? */
+function isClaimLive(metadata: unknown, at: Date): boolean {
+  const { claim, claimedAt } = readFulfilmentMetadata(metadata)
+  if (!claim || !claimedAt) return false
+  const held = Date.parse(claimedAt)
+  return Number.isFinite(held) && at.getTime() - held < CLAIM_LEASE_MS
 }
 
 function mergeMetadata(metadata: unknown, patch: Record<string, unknown>) {
@@ -114,9 +147,20 @@ export async function fulfilInvoiceRendition(
   options: FulfilInvoiceRenditionOptions = {},
 ): Promise<InvoiceRenditionFulfilmentOutcome> {
   const maxAttempts = options.maxAttempts ?? INVOICE_DOCUMENT_MAX_ATTEMPTS
+  const now = new Date()
 
   // Serialize the subscriber's fast path against the recovery job. Both are
   // allowed to reach the same row; only one may render it.
+  //
+  // The advisory lock is transaction-scoped and so ends here, well before
+  // `render`/`put` run — on its own it would let two callers both observe
+  // `pending`, both render, and both write the same operation key. Only one of
+  // them would win the closing compare-and-set, but the loser's upload could
+  // still land after the winner recorded its checksum and byte length, leaving
+  // a `ready` row describing bytes that are no longer there. So the claim is
+  // written into the row while the lock is held and outlives it: a second
+  // caller sees a live claim and never renders at all.
+  const claimToken = crypto.randomUUID()
   const claimed = await db.transaction(async (tx) => {
     await tx.execute(
       sql`select pg_advisory_xact_lock(hashtext(${`finance:invoice-rendition:${renditionId}`}))`,
@@ -127,16 +171,36 @@ export async function fulfilInvoiceRendition(
       .where(eq(invoiceRenditions.id, renditionId))
       .limit(1)
     if (!rendition || rendition.status !== "pending") return null
+    if (isClaimLive(rendition.metadata, now)) return "claimed_elsewhere" as const
+
+    const [held] = await tx
+      .update(invoiceRenditions)
+      .set({
+        updatedAt: now,
+        metadata: mergeMetadata(rendition.metadata, {
+          fulfilment: {
+            ...readFulfilmentMetadata(rendition.metadata),
+            claim: claimToken,
+            claimedAt: now.toISOString(),
+          },
+        }),
+      })
+      .where(and(eq(invoiceRenditions.id, renditionId), eq(invoiceRenditions.status, "pending")))
+      .returning()
+    if (!held) return null
 
     const [invoice] = await tx
       .select()
       .from(invoices)
-      .where(eq(invoices.id, rendition.invoiceId))
+      .where(eq(invoices.id, held.invoiceId))
       .limit(1)
-    return { rendition, invoice: invoice ?? null }
+    return { rendition: held, invoice: invoice ?? null }
   })
 
   if (!claimed) return { status: "skipped", renditionId, reason: "not_pending" }
+  if (claimed === "claimed_elsewhere") {
+    return { status: "skipped", renditionId, reason: "claimed_elsewhere" }
+  }
   const { rendition } = claimed
 
   if (!claimed.invoice) {
@@ -151,6 +215,7 @@ export async function fulfilInvoiceRendition(
   const invoice = claimed.invoice
 
   if (await awaitsExternalAllocation(db, invoice)) {
+    await releaseClaim(db, rendition, claimToken)
     return { status: "skipped", renditionId, reason: "awaiting_external_allocation" }
   }
 
@@ -238,10 +303,18 @@ export async function fulfilInvoiceRendition(
           fulfilment: { attempts, lastAttemptAt: new Date().toISOString() },
         }),
       })
-      .where(and(eq(invoiceRenditions.id, rendition.id), eq(invoiceRenditions.status, "pending")))
+      // Still ours: a claim that expired mid-render may have been taken over,
+      // and the row then belongs to whoever holds it now.
+      .where(
+        and(
+          eq(invoiceRenditions.id, rendition.id),
+          eq(invoiceRenditions.status, "pending"),
+          heldClaim(claimToken),
+        ),
+      )
       .returning()
 
-    if (!updated) return { status: "skipped", renditionId, reason: "not_pending" }
+    if (!updated) return { status: "skipped", renditionId, reason: "claimed_elsewhere" }
 
     await options.eventBus?.emit(
       "invoice.rendered",
@@ -277,12 +350,40 @@ export async function fulfilInvoiceRendition(
       .set({
         updatedAt: new Date(),
         metadata: mergeMetadata(rendition.metadata, {
+          // No `claim` here: dropping it is how a failed attempt hands the row
+          // back rather than making the next runner wait out the lease.
           fulfilment: { attempts, lastError: message, lastAttemptAt: new Date().toISOString() },
         }),
       })
-      .where(and(eq(invoiceRenditions.id, rendition.id), eq(invoiceRenditions.status, "pending")))
+      .where(
+        and(
+          eq(invoiceRenditions.id, rendition.id),
+          eq(invoiceRenditions.status, "pending"),
+          heldClaim(claimToken),
+        ),
+      )
     return { status: "retry", renditionId, attempts, message }
   }
+}
+
+/**
+ * Hand a row back without rendering it. The claim exists to stop a concurrent
+ * render, so a caller that decides not to render must not hold it for the rest
+ * of the lease.
+ */
+async function releaseClaim(
+  db: PostgresJsDatabase,
+  rendition: typeof invoiceRenditions.$inferSelect,
+  token: string,
+) {
+  const { attempts } = readFulfilmentMetadata(rendition.metadata)
+  await db
+    .update(invoiceRenditions)
+    .set({
+      updatedAt: new Date(),
+      metadata: mergeMetadata(rendition.metadata, { fulfilment: { attempts } }),
+    })
+    .where(and(eq(invoiceRenditions.id, rendition.id), heldClaim(token)))
 }
 
 async function markFailed(

--- a/packages/finance/src/invoice-document-fulfilment.ts
+++ b/packages/finance/src/invoice-document-fulfilment.ts
@@ -1,0 +1,353 @@
+import type { EventBus } from "@voyant-travel/core"
+import { and, asc, eq, isNotNull, sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import {
+  type FinanceInvoiceDocumentProvider,
+  invoiceDocumentOperationKey,
+} from "./contracts/invoice-document-provider.js"
+import { invoiceDocumentContentType } from "./invoice-document-runtime.js"
+import { invoiceNumberSeries, invoiceRenditions, invoices } from "./schema.js"
+import type { InvoiceRenderedEvent } from "./service-shared.js"
+import { prepareInvoiceDocument } from "./service-documents.js"
+import type { InvoiceDocumentRuntimeOptions } from "./service-documents.js"
+
+/**
+ * How many times a rendition may be re-rendered before it is called failed.
+ *
+ * A terminal row is the point: `waitForInvoiceRendition` treats `ready` and
+ * `failed` as terminal and nothing else, so a row that retries forever is a
+ * caller blocked forever and a notification bundle that never resolves.
+ */
+export const INVOICE_DOCUMENT_MAX_ATTEMPTS = 5
+
+/** The `PENDING-<scope>-<uuid>` placeholder an external series leaves behind. */
+const PENDING_INVOICE_NUMBER_PREFIX = "PENDING-"
+
+export type InvoiceRenditionFulfilmentOutcome =
+  | { status: "fulfilled"; renditionId: string; storageKey: string }
+  | {
+      status: "skipped"
+      renditionId: string
+      reason: "not_pending" | "invoice_not_found" | "awaiting_external_allocation"
+    }
+  | {
+      status: "retry"
+      renditionId: string
+      attempts: number
+      message: string
+    }
+  | {
+      status: "failed"
+      renditionId: string
+      reason: "document_renderer_unavailable" | "render_failed" | "invoice_not_found"
+      message: string
+    }
+
+export interface FulfilInvoiceRenditionOptions {
+  /**
+   * Absent when the deployment selected no provider. The engine still runs —
+   * recording the miss on the row is the whole point, because the alternative
+   * is the orphan this replaced: a row that reads as work in flight forever.
+   */
+  provider?: FinanceInvoiceDocumentProvider
+  eventBus?: EventBus
+  resolveCustomFields?: InvoiceDocumentRuntimeOptions["resolveCustomFields"]
+  maxAttempts?: number
+}
+
+interface FulfilmentMetadata {
+  attempts: number
+  lastError?: string
+  lastAttemptAt?: string
+}
+
+function readFulfilmentMetadata(metadata: unknown): FulfilmentMetadata {
+  if (!metadata || typeof metadata !== "object") return { attempts: 0 }
+  const fulfilment = (metadata as { fulfilment?: unknown }).fulfilment
+  if (!fulfilment || typeof fulfilment !== "object") return { attempts: 0 }
+  const attempts = (fulfilment as { attempts?: unknown }).attempts
+  return { attempts: typeof attempts === "number" && attempts > 0 ? attempts : 0 }
+}
+
+function mergeMetadata(metadata: unknown, patch: Record<string, unknown>) {
+  return { ...(metadata && typeof metadata === "object" ? metadata : {}), ...patch }
+}
+
+/**
+ * Does an installed accounting app own this document?
+ *
+ * When the invoice's series delegates numbering to an app, the number on the
+ * row is still the `PENDING-…` placeholder until that app allocates a real one.
+ * Rendering locally now would produce a fiscally invalid PDF — a document that
+ * names a number no authority issued — and then hand it to the operator as the
+ * invoice. Leaving the row pending is correct: the app PUTs its own artifact to
+ * `/v1/app/finance/documents/:id/artifacts/provider-pdf`, `bindInvoiceRendition`
+ * supersedes this row, and the drain stops seeing it.
+ */
+async function awaitsExternalAllocation(
+  db: PostgresJsDatabase,
+  invoice: typeof invoices.$inferSelect,
+): Promise<boolean> {
+  if (!invoice.invoiceNumber?.startsWith(PENDING_INVOICE_NUMBER_PREFIX)) return false
+  if (!invoice.seriesId) return true
+  const [series] = await db
+    .select({ externalProvider: invoiceNumberSeries.externalProvider })
+    .from(invoiceNumberSeries)
+    .where(eq(invoiceNumberSeries.id, invoice.seriesId))
+    .limit(1)
+  return Boolean(series?.externalProvider)
+}
+
+/**
+ * Fulfil one requested rendition: render it, persist it at the one key the row
+ * owns, and move the row itself to `ready`.
+ *
+ * The row is updated in place rather than superseded by a second row, because
+ * that is what `renderInvoice` always documented and what every waiter is
+ * already watching. `bindInvoiceRendition` keeps inserting — it serves the
+ * app-provided path, where the bytes arrive without a request having been made.
+ */
+export async function fulfilInvoiceRendition(
+  db: PostgresJsDatabase,
+  renditionId: string,
+  options: FulfilInvoiceRenditionOptions = {},
+): Promise<InvoiceRenditionFulfilmentOutcome> {
+  const maxAttempts = options.maxAttempts ?? INVOICE_DOCUMENT_MAX_ATTEMPTS
+
+  // Serialize the subscriber's fast path against the recovery job. Both are
+  // allowed to reach the same row; only one may render it.
+  const claimed = await db.transaction(async (tx) => {
+    await tx.execute(
+      sql`select pg_advisory_xact_lock(hashtext(${`finance:invoice-rendition:${renditionId}`}))`,
+    )
+    const [rendition] = await tx
+      .select()
+      .from(invoiceRenditions)
+      .where(eq(invoiceRenditions.id, renditionId))
+      .limit(1)
+    if (!rendition || rendition.status !== "pending") return null
+
+    const [invoice] = await tx
+      .select()
+      .from(invoices)
+      .where(eq(invoices.id, rendition.invoiceId))
+      .limit(1)
+    return { rendition, invoice: invoice ?? null }
+  })
+
+  if (!claimed) return { status: "skipped", renditionId, reason: "not_pending" }
+  const { rendition } = claimed
+
+  if (!claimed.invoice) {
+    await markFailed(db, rendition, "The invoice this rendition belongs to no longer exists.")
+    return {
+      status: "failed",
+      renditionId,
+      reason: "invoice_not_found",
+      message: "invoice_not_found",
+    }
+  }
+  const invoice = claimed.invoice
+
+  if (await awaitsExternalAllocation(db, invoice)) {
+    return { status: "skipped", renditionId, reason: "awaiting_external_allocation" }
+  }
+
+  if (!options.provider) {
+    await markFailed(
+      db,
+      rendition,
+      "No document renderer is available on this deployment, so the invoice document could not be produced.",
+      "document_renderer_unavailable",
+    )
+    return {
+      status: "failed",
+      renditionId,
+      reason: "document_renderer_unavailable",
+      message: "document_renderer_unavailable",
+    }
+  }
+  const provider = options.provider
+
+  const attempts = readFulfilmentMetadata(rendition.metadata).attempts + 1
+
+  try {
+    const prepared = await prepareInvoiceDocument(
+      db,
+      invoice.id,
+      {
+        format: rendition.format,
+        ...(rendition.templateId ? { templateId: rendition.templateId } : {}),
+        ...(rendition.language ? { language: rendition.language } : {}),
+      },
+      options.resolveCustomFields,
+    )
+    if (prepared.status === "not_found") {
+      await markFailed(db, rendition, "The invoice this rendition belongs to no longer exists.")
+      return {
+        status: "failed",
+        renditionId,
+        reason: "invoice_not_found",
+        message: "invoice_not_found",
+      }
+    }
+
+    const artifact = await provider.render({
+      renditionId: rendition.id,
+      invoiceId: invoice.id,
+      invoiceNumber: invoice.invoiceNumber ?? "",
+      templateId: prepared.template?.id ?? null,
+      body: prepared.renderedBody,
+      bodyFormat: prepared.renderedBodyFormat,
+      format: rendition.format,
+      language: prepared.language,
+      variables: prepared.variables,
+    })
+
+    const operationKey = invoiceDocumentOperationKey({
+      invoiceId: invoice.id,
+      renditionId: rendition.id,
+      format: rendition.format,
+    })
+    const reference = await provider.put({
+      renditionId: rendition.id,
+      operationKey,
+      artifact,
+    })
+
+    const contentType = artifact.contentType || invoiceDocumentContentType(rendition.format)
+    const [updated] = await db
+      .update(invoiceRenditions)
+      .set({
+        status: "ready",
+        storageKey: reference.key,
+        fileSize: reference.byteLength,
+        checksum: reference.checksumSha256,
+        templateId: prepared.template?.id ?? rendition.templateId,
+        language: prepared.language ?? rendition.language,
+        errorMessage: null,
+        generatedAt: new Date(),
+        updatedAt: new Date(),
+        metadata: mergeMetadata(rendition.metadata, {
+          ...(artifact.metadata ?? {}),
+          contentType,
+          renderedBodyFormat: prepared.renderedBodyFormat,
+          provider: provider.identity.id,
+          providerVersion: provider.identity.version,
+          fulfilment: { attempts, lastAttemptAt: new Date().toISOString() },
+        }),
+      })
+      .where(and(eq(invoiceRenditions.id, rendition.id), eq(invoiceRenditions.status, "pending")))
+      .returning()
+
+    if (!updated) return { status: "skipped", renditionId, reason: "not_pending" }
+
+    await options.eventBus?.emit(
+      "invoice.rendered",
+      {
+        invoiceId: invoice.id,
+        invoiceStatus: invoice.status,
+        invoiceType: invoice.invoiceType,
+        renditionId: updated.id,
+        format: updated.format,
+        storageKey: updated.storageKey,
+        contentType,
+        byteSize: updated.fileSize,
+        contentHash: updated.checksum,
+      } satisfies InvoiceRenderedEvent,
+      { category: "internal", source: "service" },
+    )
+
+    return { status: "fulfilled", renditionId, storageKey: reference.key }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    if (attempts >= maxAttempts) {
+      await markFailed(
+        db,
+        rendition,
+        `Invoice document rendering failed after ${attempts} attempts: ${message}`,
+        "render_failed",
+        attempts,
+      )
+      return { status: "failed", renditionId, reason: "render_failed", message }
+    }
+    await db
+      .update(invoiceRenditions)
+      .set({
+        updatedAt: new Date(),
+        metadata: mergeMetadata(rendition.metadata, {
+          fulfilment: { attempts, lastError: message, lastAttemptAt: new Date().toISOString() },
+        }),
+      })
+      .where(and(eq(invoiceRenditions.id, rendition.id), eq(invoiceRenditions.status, "pending")))
+    return { status: "retry", renditionId, attempts, message }
+  }
+}
+
+async function markFailed(
+  db: PostgresJsDatabase,
+  rendition: typeof invoiceRenditions.$inferSelect,
+  errorMessage: string,
+  reason?: string,
+  attempts?: number,
+) {
+  await db
+    .update(invoiceRenditions)
+    .set({
+      status: "failed",
+      errorMessage,
+      updatedAt: new Date(),
+      metadata: mergeMetadata(rendition.metadata, {
+        fulfilment: {
+          attempts: attempts ?? readFulfilmentMetadata(rendition.metadata).attempts,
+          ...(reason ? { reason } : {}),
+          lastError: errorMessage,
+          lastAttemptAt: new Date().toISOString(),
+        },
+      }),
+    })
+    .where(and(eq(invoiceRenditions.id, rendition.id), eq(invoiceRenditions.status, "pending")))
+}
+
+export interface FulfilPendingInvoiceRenditionsOptions extends FulfilInvoiceRenditionOptions {
+  /** Restrict the drain to one invoice — the subscriber's fast path. */
+  invoiceId?: string
+  limit?: number
+}
+
+/** Drain requested renditions oldest-first. */
+export async function fulfilPendingInvoiceRenditions(
+  db: PostgresJsDatabase,
+  options: FulfilPendingInvoiceRenditionsOptions = {},
+): Promise<InvoiceRenditionFulfilmentOutcome[]> {
+  const due = await db
+    .select({ id: invoiceRenditions.id })
+    .from(invoiceRenditions)
+    .where(
+      options.invoiceId
+        ? and(
+            eq(invoiceRenditions.status, "pending"),
+            eq(invoiceRenditions.invoiceId, options.invoiceId),
+          )
+        : eq(invoiceRenditions.status, "pending"),
+    )
+    .orderBy(asc(invoiceRenditions.createdAt))
+    .limit(options.limit ?? 25)
+
+  const outcomes: InvoiceRenditionFulfilmentOutcome[] = []
+  for (const row of due) {
+    outcomes.push(await fulfilInvoiceRendition(db, row.id, options))
+  }
+  return outcomes
+}
+
+/** Is there anything a provider would have fulfilled, had one been selected? */
+export async function hasPendingInvoiceRenditions(db: PostgresJsDatabase): Promise<boolean> {
+  const [row] = await db
+    .select({ id: invoiceRenditions.id })
+    .from(invoiceRenditions)
+    .where(and(eq(invoiceRenditions.status, "pending"), isNotNull(invoiceRenditions.invoiceId)))
+    .limit(1)
+  return Boolean(row)
+}

--- a/packages/finance/src/invoice-document-fulfilment.ts
+++ b/packages/finance/src/invoice-document-fulfilment.ts
@@ -8,9 +8,9 @@ import {
 } from "./contracts/invoice-document-provider.js"
 import { invoiceDocumentContentType } from "./invoice-document-runtime.js"
 import { invoiceNumberSeries, invoiceRenditions, invoices } from "./schema.js"
-import type { InvoiceRenderedEvent } from "./service-shared.js"
-import { prepareInvoiceDocument } from "./service-documents.js"
 import type { InvoiceDocumentRuntimeOptions } from "./service-documents.js"
+import { prepareInvoiceDocument } from "./service-documents.js"
+import type { InvoiceRenderedEvent } from "./service-shared.js"
 
 /**
  * How many times a rendition may be re-rendered before it is called failed.

--- a/packages/finance/src/invoice-document-job.ts
+++ b/packages/finance/src/invoice-document-job.ts
@@ -1,0 +1,64 @@
+import type { VoyantGraphRuntimeFactoryContext } from "@voyant-travel/core/project"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import { createPrimitivesEventBus } from "./app-api-runtime.js"
+import { financeInvoiceDocumentProviderPort } from "./contracts/invoice-document-provider.js"
+import { fulfilPendingInvoiceRenditions } from "./invoice-document-fulfilment.js"
+import { financeHostRuntimePort } from "./runtime-port.js"
+
+/**
+ * Raised once, after the drain, when requested invoice documents could not be
+ * produced because the deployment selected no renderer.
+ *
+ * It is deliberately raised *after* the rows are recorded rather than instead
+ * of recording them. A row left pending is indistinguishable from work in
+ * flight — `?wait=true` blocks on it and the confirmation notification holds
+ * for it — so the recording is what unblocks the deployment, and the throw is
+ * only how an operator finds out.
+ */
+export class InvoiceDocumentRendererUnavailableError extends Error {
+  constructor(readonly renditionIds: readonly string[]) {
+    super(
+      `${renditionIds.length} requested invoice document(s) could not be produced: no document renderer is available on this deployment.`,
+    )
+    this.name = "InvoiceDocumentRendererUnavailableError"
+  }
+}
+
+/**
+ * Reconcile requested invoice renditions the in-process path did not fulfil.
+ *
+ * The subscriber renders on `invoice.issued` and is the latency path; this is
+ * the recovery leg for everything it cannot cover — a restart mid-render, a
+ * transient renderer failure, a rendition requested through the API against an
+ * invoice that was issued long ago, and a deployment whose renderer was only
+ * configured after the fact.
+ */
+export async function runDueInvoiceDocumentRenditionsJob(
+  context: VoyantGraphRuntimeFactoryContext,
+): Promise<void> {
+  const host = await context.getPort(financeHostRuntimePort)
+  const db = host.primitives.database.resolve<PostgresJsDatabase>(context.bindings)
+  const provider = context.hasPort(financeInvoiceDocumentProviderPort)
+    ? await context.getPort(financeInvoiceDocumentProviderPort)
+    : undefined
+
+  const eventBus = createPrimitivesEventBus(host.primitives, context.bindings)
+  const outcomes = await fulfilPendingInvoiceRenditions(db, {
+    ...(provider ? { provider } : {}),
+    ...(eventBus ? { eventBus } : {}),
+  })
+
+  // Rows waiting on an accounting app to allocate a number are skipped, not
+  // failed, and must not raise: on an app-backed deployment they are pending by
+  // design and would otherwise make this job fail every minute forever.
+  const unavailable = outcomes.filter(
+    (outcome) =>
+      outcome.status === "failed" && outcome.reason === "document_renderer_unavailable",
+  )
+  if (unavailable.length > 0) {
+    throw new InvoiceDocumentRendererUnavailableError(
+      unavailable.map((outcome) => outcome.renditionId),
+    )
+  }
+}

--- a/packages/finance/src/invoice-document-job.ts
+++ b/packages/finance/src/invoice-document-job.ts
@@ -1,3 +1,7 @@
+import {
+  type CustomFieldsRuntime,
+  customFieldsRuntimePort,
+} from "@voyant-travel/core/custom-fields"
 import type { VoyantGraphRuntimeFactoryContext } from "@voyant-travel/core/project"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
@@ -5,6 +9,7 @@ import { createPrimitivesEventBus } from "./app-api-runtime.js"
 import { financeInvoiceDocumentProviderPort } from "./contracts/invoice-document-provider.js"
 import { fulfilPendingInvoiceRenditions } from "./invoice-document-fulfilment.js"
 import { financeHostRuntimePort } from "./runtime-port.js"
+import { createInvoiceCustomFieldsResolver } from "./service-documents.js"
 
 /**
  * Raised once, after the drain, when requested invoice documents could not be
@@ -42,10 +47,19 @@ export async function runDueInvoiceDocumentRenditionsJob(
   const provider = context.hasPort(financeInvoiceDocumentProviderPort)
     ? await context.getPort(financeInvoiceDocumentProviderPort)
     : undefined
+  // Same resolver the routes and the subscriber use: a template referencing
+  // `{{customFields.*}}` must not render differently depending on which path
+  // produced the document.
+  const customFields = context.hasPort(customFieldsRuntimePort)
+    ? await context.getPort<CustomFieldsRuntime>(customFieldsRuntimePort)
+    : undefined
 
   const eventBus = createPrimitivesEventBus(host.primitives, context.bindings)
   const outcomes = await fulfilPendingInvoiceRenditions(db, {
     ...(provider ? { provider } : {}),
+    ...(customFields
+      ? { resolveCustomFields: createInvoiceCustomFieldsResolver(customFields) }
+      : {}),
     ...(eventBus ? { eventBus } : {}),
   })
 

--- a/packages/finance/src/invoice-document-job.ts
+++ b/packages/finance/src/invoice-document-job.ts
@@ -53,8 +53,7 @@ export async function runDueInvoiceDocumentRenditionsJob(
   // failed, and must not raise: on an app-backed deployment they are pending by
   // design and would otherwise make this job fail every minute forever.
   const unavailable = outcomes.filter(
-    (outcome) =>
-      outcome.status === "failed" && outcome.reason === "document_renderer_unavailable",
+    (outcome) => outcome.status === "failed" && outcome.reason === "document_renderer_unavailable",
   )
   if (unavailable.length > 0) {
     throw new InvoiceDocumentRendererUnavailableError(

--- a/packages/finance/src/invoice-document-runtime.ts
+++ b/packages/finance/src/invoice-document-runtime.ts
@@ -1,0 +1,186 @@
+import type { DocumentRenderer } from "@voyant-travel/core/document-rendering"
+import type { StorageProvider } from "@voyant-travel/storage"
+import { hardenRenderedHtmlDocument } from "@voyant-travel/utils/template-renderer"
+
+import {
+  checksumInvoiceDocumentBytes,
+  FINANCE_INVOICE_DOCUMENT_PROVIDER_PROTOCOL,
+  type FinanceInvoiceDocumentProvider,
+  type FinanceInvoiceDocumentRenderDescriptor,
+} from "./contracts/invoice-document-provider.js"
+
+function escapeHtml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+}
+
+function lexicalDocumentText(body: string) {
+  try {
+    const parsed: unknown = JSON.parse(body)
+    const parts: string[] = []
+    const visit = (value: unknown) => {
+      if (!value || typeof value !== "object") return
+      const node = value as {
+        type?: unknown
+        text?: unknown
+        children?: unknown
+        root?: unknown
+      }
+      if (node.root) visit(node.root)
+      if (node.type === "linebreak") parts.push("\n")
+      if (typeof node.text === "string") parts.push(node.text)
+      if (Array.isArray(node.children)) {
+        for (const child of node.children) visit(child)
+      }
+      if (
+        node.type === "paragraph" ||
+        node.type === "heading" ||
+        node.type === "quote" ||
+        node.type === "listitem"
+      ) {
+        parts.push("\n")
+      }
+    }
+    visit(parsed)
+    const text = parts
+      .join("")
+      .replace(/\n{3,}/g, "\n\n")
+      .trim()
+    return text || body
+  } catch {
+    return body
+  }
+}
+
+function descriptorHtml(descriptor: FinanceInvoiceDocumentRenderDescriptor) {
+  const body =
+    descriptor.bodyFormat === "html"
+      ? descriptor.body
+      : `<pre>${escapeHtml(
+          descriptor.bodyFormat === "lexical_json"
+            ? lexicalDocumentText(descriptor.body)
+            : descriptor.body,
+        )}</pre>`
+  return hardenRenderedHtmlDocument(body)
+}
+
+export function invoiceDocumentContentType(format: FinanceInvoiceDocumentRenderDescriptor["format"]) {
+  switch (format) {
+    case "html":
+      return "text/html; charset=utf-8"
+    case "json":
+      return "application/json; charset=utf-8"
+    case "xml":
+      return "application/xml; charset=utf-8"
+    default:
+      return "application/pdf"
+  }
+}
+
+/**
+ * The provider version has to move when either backend moves, because a
+ * rendition carries the bytes one renderer produced from one store. Two
+ * deployments pointed at different renderers must not be able to claim the same
+ * provider identity for artifacts that are not interchangeable.
+ */
+async function providerVersion(renderer: DocumentRenderer, storage: StorageProvider) {
+  if (!renderer.resolveBackendIdentity || !storage.resolveBackendIdentity) {
+    throw new Error(
+      "The standard invoice document provider requires stable renderer and storage backend identities.",
+    )
+  }
+  const [rendererIdentity, storageIdentity] = await Promise.all([
+    renderer.resolveBackendIdentity(),
+    storage.resolveBackendIdentity(),
+  ])
+  const fingerprint = await checksumInvoiceDocumentBytes(
+    new TextEncoder().encode(
+      JSON.stringify({ renderer: rendererIdentity, storage: storageIdentity }),
+    ),
+  )
+  return `1:${fingerprint}`
+}
+
+/** Adapt the deployment's selected renderer and document store into the provider. */
+export async function createStandardInvoiceDocumentProvider(input: {
+  renderer: DocumentRenderer
+  storage: StorageProvider
+}): Promise<FinanceInvoiceDocumentProvider> {
+  const { renderer, storage } = input
+  const version = await providerVersion(renderer, storage)
+
+  async function bytesAt(key: string) {
+    const value = await storage.get(key)
+    return value ? new Uint8Array(value) : null
+  }
+
+  return {
+    identity: {
+      id: "voyant.standard.invoice-document",
+      version,
+      protocol: FINANCE_INVOICE_DOCUMENT_PROVIDER_PROTOCOL,
+    },
+    async render(descriptor) {
+      const contentType = invoiceDocumentContentType(descriptor.format)
+      const bytes =
+        descriptor.format === "pdf"
+          ? await renderer.renderPdf({
+              html: descriptorHtml(descriptor),
+              page: { format: "a4", printBackground: true },
+              navigation: { waitUntil: "networkidle0", timeoutMs: 30_000 },
+              mediaType: "print",
+            })
+          : new TextEncoder().encode(
+              descriptor.format === "json"
+                ? JSON.stringify(descriptor.variables, null, 2)
+                : descriptor.body,
+            )
+
+      return {
+        bytes,
+        checksumSha256: await checksumInvoiceDocumentBytes(bytes),
+        name: `invoice-${descriptor.invoiceNumber || descriptor.invoiceId}.${descriptor.format}`,
+        contentType,
+        metadata: {
+          renderer: renderer.name,
+          renderedBodyFormat: descriptor.bodyFormat,
+          ...(descriptor.language ? { language: descriptor.language } : {}),
+        },
+      }
+    },
+    async put({ renditionId, operationKey, artifact }) {
+      const uploaded = await storage.upload(artifact.bytes, {
+        key: operationKey,
+        contentType: artifact.contentType,
+        metadata: {
+          renditionId,
+          checksumSha256: artifact.checksumSha256,
+        },
+      })
+      if (uploaded.key !== operationKey) {
+        throw new Error("Invoice document storage did not honor the exact operation key.")
+      }
+      return {
+        key: uploaded.key,
+        checksumSha256: artifact.checksumSha256,
+        byteLength: artifact.bytes.byteLength,
+      }
+    },
+    async inspect(key) {
+      const bytes = await bytesAt(key)
+      return bytes
+        ? {
+            status: "present",
+            key,
+            checksumSha256: await checksumInvoiceDocumentBytes(bytes),
+            byteLength: bytes.byteLength,
+          }
+        : { status: "absent" }
+    },
+    get: bytesAt,
+    deleteIfPresent: (key) => storage.delete(key),
+  }
+}

--- a/packages/finance/src/invoice-document-runtime.ts
+++ b/packages/finance/src/invoice-document-runtime.ts
@@ -67,7 +67,9 @@ function descriptorHtml(descriptor: FinanceInvoiceDocumentRenderDescriptor) {
   return hardenRenderedHtmlDocument(body)
 }
 
-export function invoiceDocumentContentType(format: FinanceInvoiceDocumentRenderDescriptor["format"]) {
+export function invoiceDocumentContentType(
+  format: FinanceInvoiceDocumentRenderDescriptor["format"],
+) {
   switch (format) {
     case "html":
       return "text/html; charset=utf-8"

--- a/packages/finance/src/invoice-issued-subscriber.ts
+++ b/packages/finance/src/invoice-issued-subscriber.ts
@@ -1,0 +1,90 @@
+import type { EventEnvelope, SubscriberRuntimeDescriptor } from "@voyant-travel/core"
+import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import {
+  type FinanceInvoiceDocumentProvider,
+  financeInvoiceDocumentProviderPort,
+} from "./contracts/invoice-document-provider.js"
+import { fulfilPendingInvoiceRenditions } from "./invoice-document-fulfilment.js"
+import { financeHostRuntimePort } from "./runtime-port.js"
+
+export const FINANCE_INVOICE_ISSUED_DOCUMENT_SUBSCRIBER_ID =
+  "@voyant-travel/finance#subscriber.invoice-issued-document"
+
+export interface InvoiceIssuedPayload {
+  invoiceId: string
+}
+
+export type InvoiceIssuedEventEnvelope = EventEnvelope<InvoiceIssuedPayload>
+
+export interface InvoiceIssuedDocumentSubscriberOptions {
+  resolveDb(bindings: unknown): PostgresJsDatabase | Promise<PostgresJsDatabase>
+  provider?: FinanceInvoiceDocumentProvider
+  logger?: Pick<Console, "error">
+}
+
+/**
+ * Render the document a booking asked for as soon as its invoice is issued.
+ *
+ * Booking create writes the `pending` rendition inside the same transaction
+ * that creates the invoice, and cannot render there: rendering is slow and the
+ * transaction holds a lease. So the request is durable state and this is the
+ * fast path that turns it into a document — which matters beyond latency,
+ * because voyant#4667 made the booking confirmation email wait for the invoice
+ * to resolve. Without an in-process trigger every confirmation would sit behind
+ * the recovery job's cadence.
+ *
+ * The rendition row, not the event, is the unit of work: an issuance for an
+ * invoice nobody asked a document for finds nothing pending and does nothing.
+ */
+export function createInvoiceIssuedDocumentSubscriber(
+  options: InvoiceIssuedDocumentSubscriberOptions,
+): SubscriberRuntimeDescriptor {
+  const logger = options.logger ?? console
+
+  return {
+    id: FINANCE_INVOICE_ISSUED_DOCUMENT_SUBSCRIBER_ID,
+    eventType: "invoice.issued",
+    register: ({ bindings, eventBus }) => {
+      eventBus.subscribe<InvoiceIssuedPayload>("invoice.issued", async (event) => {
+        const invoiceId = event.data?.invoiceId
+        if (!invoiceId) return
+        try {
+          const db = await options.resolveDb(bindings)
+          await fulfilPendingInvoiceRenditions(db, {
+            invoiceId,
+            ...(options.provider ? { provider: options.provider } : {}),
+            eventBus,
+          })
+        } catch (error) {
+          // The recovery job re-drives this row on its own cadence, so a failure
+          // here costs latency and not the document.
+          logger.error("[invoice-issued-document] could not fulfil requested renditions", {
+            invoiceId,
+            error: error instanceof Error ? error.message : String(error),
+          })
+        }
+      })
+    },
+  }
+}
+
+/**
+ * Resolve only graph-selected ports. A deployment that selected no provider
+ * still registers: the fulfilment engine records the miss on the row, which is
+ * what stops `?wait=true` and the notification bundle waiting on work that will
+ * never happen.
+ */
+export const createInvoiceIssuedDocumentSubscriberGraphRuntime = defineGraphRuntimeFactory(
+  async ({ getPort, hasPort }) => {
+    const host = await getPort(financeHostRuntimePort)
+    const provider = hasPort(financeInvoiceDocumentProviderPort)
+      ? await getPort(financeInvoiceDocumentProviderPort)
+      : undefined
+    return createInvoiceIssuedDocumentSubscriber({
+      resolveDb: (bindings) => host.primitives.database.resolve<PostgresJsDatabase>(bindings),
+      ...(provider ? { provider } : {}),
+    })
+  },
+)

--- a/packages/finance/src/invoice-issued-subscriber.ts
+++ b/packages/finance/src/invoice-issued-subscriber.ts
@@ -1,4 +1,8 @@
 import type { EventEnvelope, SubscriberRuntimeDescriptor } from "@voyant-travel/core"
+import {
+  type CustomFieldsRuntime,
+  customFieldsRuntimePort,
+} from "@voyant-travel/core/custom-fields"
 import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
@@ -6,8 +10,12 @@ import {
   type FinanceInvoiceDocumentProvider,
   financeInvoiceDocumentProviderPort,
 } from "./contracts/invoice-document-provider.js"
-import { fulfilPendingInvoiceRenditions } from "./invoice-document-fulfilment.js"
+import {
+  type FulfilInvoiceRenditionOptions,
+  fulfilPendingInvoiceRenditions,
+} from "./invoice-document-fulfilment.js"
 import { financeHostRuntimePort } from "./runtime-port.js"
+import { createInvoiceCustomFieldsResolver } from "./service-documents.js"
 
 export const FINANCE_INVOICE_ISSUED_DOCUMENT_SUBSCRIBER_ID =
   "@voyant-travel/finance#subscriber.invoice-issued-document"
@@ -21,6 +29,13 @@ export type InvoiceIssuedEventEnvelope = EventEnvelope<InvoiceIssuedPayload>
 export interface InvoiceIssuedDocumentSubscriberOptions {
   resolveDb(bindings: unknown): PostgresJsDatabase | Promise<PostgresJsDatabase>
   provider?: FinanceInvoiceDocumentProvider
+  /**
+   * Templates may reference `{{customFields.*}}`, and `prepareInvoiceDocument`
+   * only populates them when a resolver is supplied. Without it here the same
+   * template renders with the customer's fields interactively and without them
+   * in the background.
+   */
+  resolveCustomFields?: FulfilInvoiceRenditionOptions["resolveCustomFields"]
   logger?: Pick<Console, "error">
 }
 
@@ -55,6 +70,9 @@ export function createInvoiceIssuedDocumentSubscriber(
           await fulfilPendingInvoiceRenditions(db, {
             invoiceId,
             ...(options.provider ? { provider: options.provider } : {}),
+            ...(options.resolveCustomFields
+              ? { resolveCustomFields: options.resolveCustomFields }
+              : {}),
             eventBus,
           })
         } catch (error) {
@@ -82,9 +100,15 @@ export const createInvoiceIssuedDocumentSubscriberGraphRuntime = defineGraphRunt
     const provider = hasPort(financeInvoiceDocumentProviderPort)
       ? await getPort(financeInvoiceDocumentProviderPort)
       : undefined
+    const customFields = hasPort(customFieldsRuntimePort)
+      ? await getPort<CustomFieldsRuntime>(customFieldsRuntimePort)
+      : undefined
     return createInvoiceIssuedDocumentSubscriber({
       resolveDb: (bindings) => host.primitives.database.resolve<PostgresJsDatabase>(bindings),
       ...(provider ? { provider } : {}),
+      ...(customFields
+        ? { resolveCustomFields: createInvoiceCustomFieldsResolver(customFields) }
+        : {}),
     })
   },
 )

--- a/packages/finance/src/route-runtime.ts
+++ b/packages/finance/src/route-runtime.ts
@@ -6,6 +6,7 @@ import {
 import type { EventBus } from "@voyant-travel/core"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
+import type { FinanceInvoiceDocumentProvider } from "./contracts/invoice-document-provider.js"
 import type { InvoiceFxOptions } from "./invoice-fx.js"
 import type { RefundSettlementExecutionResult } from "./refund-settlement-execution.js"
 import type { FinanceDocumentRouteOptions } from "./routes-documents.js"
@@ -26,6 +27,13 @@ export type FinanceRouteRuntime = {
    */
   readonly monthlyBookingLimit?: number | null
   invoiceDocumentGenerator?: InvoiceDocumentGenerator
+  /**
+   * The graph-selected invoice document provider. Present exactly when the
+   * deployment fulfilled finance's `document-renderer` and `document-storage`
+   * resources, which is what lets the render route produce the document inline
+   * instead of leaving the caller waiting on the recovery job (voyant#4668).
+   */
+  invoiceDocumentProvider?: FinanceInvoiceDocumentProvider
   resolveCustomFields?: FinanceDocumentRouteOptions["resolveCustomFields"]
   resolveDocumentDownloadUrl?: FinanceDocumentRouteOptions["resolveDocumentDownloadUrl"]
   invoiceSettlementPollers: Record<string, InvoiceSettlementPoller>
@@ -68,6 +76,8 @@ export interface FinanceRuntimeOptions
   resolveMonthlyBookingLimit?: MonthlyBookingLimitResolver
   /** Populated by `createFinanceRuntime` when a payment adapter is selected. */
   executeRefundSettlement?: ExecuteRefundSettlement
+  /** Populated by `createFinanceRuntime` when a document provider is selected. */
+  invoiceDocumentProvider?: FinanceInvoiceDocumentProvider
 }
 
 export function buildFinanceRouteRuntime(
@@ -91,6 +101,7 @@ export function buildFinanceRouteRuntime(
     },
     invoiceDocumentGenerator:
       options.resolveInvoiceDocumentGenerator?.(bindings) ?? options.invoiceDocumentGenerator,
+    invoiceDocumentProvider: options.invoiceDocumentProvider,
     resolveCustomFields: options.resolveCustomFields,
     resolveDocumentDownloadUrl: options.resolveDocumentDownloadUrl,
     invoiceSettlementPollers:

--- a/packages/finance/src/routes-invoice-core.ts
+++ b/packages/finance/src/routes-invoice-core.ts
@@ -23,6 +23,7 @@
  */
 
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
+import { ActionLedgerIdempotencyConflictError } from "@voyant-travel/action-ledger"
 import { openApiValidationHook, parseOptionalJsonBody, requireUserId } from "@voyant-travel/hono"
 import {
   creditNoteLineItemSchema,
@@ -525,6 +526,21 @@ const paymentRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidationHook 
         return c.json(
           { error: error.message, code: error.code, details: error.details },
           error.status,
+        )
+      }
+      // Reusing an idempotency key with a different payload is a conflict, and
+      // the HTTP idempotency middleware already answers 409 for exactly this.
+      // Left unhandled the ledger's own version of it reached the boundary as
+      // an unrecognized error and became a 500 — an infrastructure fault for
+      // what is a client mistake.
+      if (error instanceof ActionLedgerIdempotencyConflictError) {
+        return c.json(
+          {
+            error: error.message,
+            code: "idempotency_key_reused",
+            existingActionId: error.existingActionId,
+          },
+          409,
         )
       }
       throw error

--- a/packages/finance/src/routes-invoice-documents.ts
+++ b/packages/finance/src/routes-invoice-documents.ts
@@ -24,7 +24,12 @@ import {
   invoiceRenditionSchema,
   successResponseSchema,
 } from "./routes-invoice-schemas.js"
-import { buildInlineDownload, resolveWaitRequest } from "./routes-runtime.js"
+import { fulfilInvoiceRendition } from "./invoice-document-fulfilment.js"
+import {
+  buildInlineDownload,
+  getFinanceRouteRuntime,
+  resolveWaitRequest,
+} from "./routes-runtime.js"
 import type { Env } from "./routes-shared.js"
 import { financeService } from "./service.js"
 import { waitForInvoiceRendition, waitFormatForMode } from "./service-rendition-wait.js"
@@ -133,13 +138,38 @@ const renditionRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidationHoo
     if (result.status === "not_found") {
       return c.json({ error: "Invoice not found" }, 404)
     }
-    if (waitRequest.mode !== "none" && result.rendition) {
+
+    // Fulfil inline when the deployment selected a provider. The row is durable
+    // either way and the recovery job would eventually drain it, but a caller
+    // that passed `?wait=true` is holding a request open — making it wait a
+    // whole job cycle for a document this process can produce now is the
+    // behaviour voyant#4668 replaced.
+    const runtime = getFinanceRouteRuntime(c)
+    let rendition = result.rendition
+    if (rendition) {
+      await fulfilInvoiceRendition(c.get("db"), rendition.id, {
+        ...(runtime?.invoiceDocumentProvider
+          ? { provider: runtime.invoiceDocumentProvider }
+          : {}),
+        ...(runtime?.eventBus ? { eventBus: runtime.eventBus } : {}),
+        ...(runtime?.resolveCustomFields
+          ? { resolveCustomFields: runtime.resolveCustomFields }
+          : {}),
+      })
+      // Report what the row *is*, not what it was a moment ago: a caller that
+      // did not pass `wait` still gets `ready` with its storage key rather than
+      // a `pending` row that has already been fulfilled.
+      rendition =
+        (await financeService.getInvoiceRenditionById(c.get("db"), rendition.id)) ?? rendition
+    }
+
+    if (waitRequest.mode !== "none" && rendition) {
       const waitResult = await waitForInvoiceRendition(c.get("db"), invoiceId, {
-        renditionId: result.rendition.id,
+        renditionId: rendition.id,
         format: waitFormatForMode(waitRequest.mode),
         timeoutMs: waitRequest.timeoutMs,
       })
-      const payload = { rendition: waitResult.rendition ?? result.rendition }
+      const payload = { rendition: waitResult.rendition ?? rendition }
       if (waitResult.status !== "ready") {
         return c.json({ data: payload }, 202)
       }
@@ -149,7 +179,7 @@ const renditionRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidationHoo
       }
       return c.json({ data: { ...payload, download: download.download } }, 201)
     }
-    return c.json({ data: result.rendition }, 201)
+    return c.json({ data: rendition }, 201)
   })
 
 // --- attachments -----------------------------------------------------------

--- a/packages/finance/src/routes-invoice-documents.ts
+++ b/packages/finance/src/routes-invoice-documents.ts
@@ -139,14 +139,16 @@ const renditionRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidationHoo
       return c.json({ error: "Invoice not found" }, 404)
     }
 
-    // Fulfil inline when the deployment selected a provider. The row is durable
-    // either way and the recovery job would eventually drain it, but a caller
-    // that passed `?wait=true` is holding a request open — making it wait a
-    // whole job cycle for a document this process can produce now is the
-    // behaviour voyant#4668 replaced.
+    // Fulfil inline only for a caller that asked to wait. `docs/architecture/
+    // invoice-rendition-wait.md` makes the wait additive — "omitted or `wait:
+    // "none"` preserves the historical response shape" — and rendering can hold
+    // the request for the renderer's full 30s navigation timeout, so doing it
+    // unconditionally would turn every fire-and-forget request into a blocking
+    // one. Without a wait the row is still durable and the subscriber and the
+    // recovery job produce the document; that is what they are for.
     const runtime = getFinanceRouteRuntime(c)
     let rendition = result.rendition
-    if (rendition) {
+    if (rendition && waitRequest.mode !== "none") {
       await fulfilInvoiceRendition(c.get("db"), rendition.id, {
         ...(runtime?.invoiceDocumentProvider ? { provider: runtime.invoiceDocumentProvider } : {}),
         ...(runtime?.eventBus ? { eventBus: runtime.eventBus } : {}),
@@ -154,9 +156,7 @@ const renditionRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidationHoo
           ? { resolveCustomFields: runtime.resolveCustomFields }
           : {}),
       })
-      // Report what the row *is*, not what it was a moment ago: a caller that
-      // did not pass `wait` still gets `ready` with its storage key rather than
-      // a `pending` row that has already been fulfilled.
+      // Report what the row *is*, not what it was a moment ago.
       rendition =
         (await financeService.getInvoiceRenditionById(c.get("db"), rendition.id)) ?? rendition
     }

--- a/packages/finance/src/routes-invoice-documents.ts
+++ b/packages/finance/src/routes-invoice-documents.ts
@@ -17,6 +17,7 @@
 
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import { openApiValidationHook } from "@voyant-travel/hono"
+import { fulfilInvoiceRendition } from "./invoice-document-fulfilment.js"
 import {
   errorResponseSchema,
   invoiceAttachmentSchema,
@@ -24,7 +25,6 @@ import {
   invoiceRenditionSchema,
   successResponseSchema,
 } from "./routes-invoice-schemas.js"
-import { fulfilInvoiceRendition } from "./invoice-document-fulfilment.js"
 import {
   buildInlineDownload,
   getFinanceRouteRuntime,
@@ -148,9 +148,7 @@ const renditionRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidationHoo
     let rendition = result.rendition
     if (rendition) {
       await fulfilInvoiceRendition(c.get("db"), rendition.id, {
-        ...(runtime?.invoiceDocumentProvider
-          ? { provider: runtime.invoiceDocumentProvider }
-          : {}),
+        ...(runtime?.invoiceDocumentProvider ? { provider: runtime.invoiceDocumentProvider } : {}),
         ...(runtime?.eventBus ? { eventBus: runtime.eventBus } : {}),
         ...(runtime?.resolveCustomFields
           ? { resolveCustomFields: runtime.resolveCustomFields }

--- a/packages/finance/src/routes-invoice-issue.ts
+++ b/packages/finance/src/routes-invoice-issue.ts
@@ -117,6 +117,17 @@ const issueInvoiceFromBookingRoute = createRoute({
   },
 })
 
+/**
+ * A conversion refusal names the document it collided with, so the operator can
+ * open it rather than be told only that something already exists.
+ */
+const conversionConflictSchema = errorResponseSchema.extend({
+  code: z.string().optional(),
+  invoiceNumber: z.string().optional(),
+  existingInvoiceId: z.string().nullable().optional(),
+  existingInvoiceNumber: z.string().nullable().optional(),
+})
+
 const convertProformaToInvoiceRoute = createRoute({
   method: "post",
   path: "/invoices/{id}/convert-to-invoice",
@@ -141,7 +152,7 @@ const convertProformaToInvoiceRoute = createRoute({
     409: {
       description:
         "The invoice is not a proforma, has already been converted, or a duplicate fiscal invoice already exists",
-      content: { "application/json": { schema: errorResponseSchema } },
+      content: { "application/json": { schema: conversionConflictSchema } },
     },
   },
 })
@@ -275,7 +286,14 @@ financeInvoiceIssueRoutes
       })
     } catch (error) {
       if (error instanceof InvoiceNumberConflictError) {
-        return c.json({ error: "Invoice number already exists" }, 409)
+        return c.json(
+          {
+            error: "Invoice number already exists",
+            code: error.code,
+            invoiceNumber: error.invoiceNumber,
+          },
+          409,
+        )
       }
       throw error
     }
@@ -284,13 +302,33 @@ financeInvoiceIssueRoutes
       return c.json({ error: "Invoice not found" }, 404)
     }
     if (result.status === "not_proforma") {
-      return c.json({ error: "Only proforma invoices can be converted" }, 409)
+      return c.json({ error: "Only proforma invoices can be converted", code: result.status }, 409)
     }
+    // Every conflict below names the document the caller collided with. The
+    // service already resolves that pointer and this route used to drop it,
+    // leaving the operator a sentence and no way to reach the invoice that
+    // caused the refusal.
     if (result.status === "already_converted") {
-      return c.json({ error: "This proforma has already been converted" }, 409)
+      return c.json(
+        {
+          error: "This proforma has already been converted",
+          code: "proforma_already_converted",
+          existingInvoiceId: result.invoice?.id ?? null,
+          existingInvoiceNumber: result.invoice?.invoiceNumber ?? null,
+        },
+        409,
+      )
     }
     if (result.status === "duplicate_fiscal_invoice") {
-      return c.json({ error: "A fiscal invoice already exists for this booking amount" }, 409)
+      return c.json(
+        {
+          error: "A fiscal invoice already exists for this booking amount",
+          code: result.status,
+          existingInvoiceId: result.invoice.id,
+          existingInvoiceNumber: result.invoice.invoiceNumber,
+        },
+        409,
+      )
     }
 
     return c.json({ data: result.invoice }, 201)

--- a/packages/finance/src/runtime-contributor.ts
+++ b/packages/finance/src/runtime-contributor.ts
@@ -9,7 +9,9 @@ import {
   bookingsFinanceRuntimePort,
 } from "@voyant-travel/bookings/runtime-port"
 import type { VoyantRuntimeHostPrimitives } from "@voyant-travel/core"
+import type { DocumentRenderer } from "@voyant-travel/core/document-rendering"
 import type { VoyantPort } from "@voyant-travel/core/project"
+import type { StorageProvider } from "@voyant-travel/storage"
 import { financeAppApiRuntimePort } from "@voyant-travel/finance-contracts/app-api"
 import {
   type FinanceDepartureProfitabilityRuntime,
@@ -20,6 +22,8 @@ import { checkFinanceActionLedgerDrift } from "./action-ledger-drift.js"
 import { createFinanceAppApiRuntime } from "./app-api-runtime.js"
 import { financeBookingActionSource } from "./booking-action-source.js"
 import { createBookingAmendmentFinanceRuntime } from "./booking-amendment-runtime.js"
+import type { FinanceInvoiceDocumentProvider } from "./contracts/invoice-document-provider.js"
+import { createStandardInvoiceDocumentProvider } from "./invoice-document-runtime.js"
 import {
   type FinanceOperatorSettingsRuntime,
   financeHostRuntimePort,
@@ -31,6 +35,28 @@ export interface FinanceRuntimeContributorHost {
   primitives: VoyantRuntimeHostPrimitives
   hasRuntimePort?(port: Pick<VoyantPort<unknown>, "id">): boolean
   getRuntimePort<T>(port: Pick<VoyantPort<T>, "id">): T | Promise<T>
+}
+
+/** Selected-graph factory for the deployment-bound invoice document provider. */
+interface FinanceInvoiceDocumentGraphProviderContext {
+  getResource<T = unknown>(declarationId: string): T | undefined
+}
+
+export async function createFinanceInvoiceDocumentGraphProvider(
+  context: FinanceInvoiceDocumentGraphProviderContext,
+): Promise<FinanceInvoiceDocumentProvider> {
+  const storage = context.getResource<StorageProvider>(
+    "@voyant-travel/finance#resource.document-storage",
+  )
+  const renderer = context.getResource<DocumentRenderer>(
+    "@voyant-travel/finance#resource.document-renderer",
+  )
+  if (!storage || !renderer) {
+    throw new Error(
+      "The selected invoice document provider requires document storage and document renderer resources.",
+    )
+  }
+  return createStandardInvoiceDocumentProvider({ storage, renderer })
 }
 
 /** Provide Finance's generic host input and its narrow Bookings integration. */

--- a/packages/finance/src/runtime-contributor.ts
+++ b/packages/finance/src/runtime-contributor.ts
@@ -11,12 +11,12 @@ import {
 import type { VoyantRuntimeHostPrimitives } from "@voyant-travel/core"
 import type { DocumentRenderer } from "@voyant-travel/core/document-rendering"
 import type { VoyantPort } from "@voyant-travel/core/project"
-import type { StorageProvider } from "@voyant-travel/storage"
 import { financeAppApiRuntimePort } from "@voyant-travel/finance-contracts/app-api"
 import {
   type FinanceDepartureProfitabilityRuntime,
   financeDepartureProfitabilityRuntimePort,
 } from "@voyant-travel/finance-contracts/runtime-port"
+import type { StorageProvider } from "@voyant-travel/storage"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { checkFinanceActionLedgerDrift } from "./action-ledger-drift.js"
 import { createFinanceAppApiRuntime } from "./app-api-runtime.js"

--- a/packages/finance/src/runtime.ts
+++ b/packages/finance/src/runtime.ts
@@ -11,7 +11,6 @@ import {
   type ResolveInvoiceExchangeRate,
 } from "./invoice-fx.js"
 import { refreshPaymentAdapterStatus } from "./payment-adapter-status.js"
-import { createProviderBackedInvoiceDocumentGenerator } from "./service-documents.js"
 import { resolveEffectivePaymentLinkUrlTemplate } from "./payment-link.js"
 import { executeAdapterRefundSettlement } from "./refund-settlement-execution.js"
 import type {
@@ -28,6 +27,7 @@ import type {
   FinanceProposalsPaymentPolicyRuntime,
 } from "./runtime-port.js"
 import { financeService } from "./service.js"
+import { createProviderBackedInvoiceDocumentGenerator } from "./service-documents.js"
 import type { InvoiceSettlementPoller } from "./service-settlement.js"
 
 /** Compose Finance's main HTTP runtime from generic host and selected providers. */

--- a/packages/finance/src/runtime.ts
+++ b/packages/finance/src/runtime.ts
@@ -4,12 +4,14 @@ import type { PaymentAdapter } from "@voyant-travel/payments"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { resolvePaymentCallbackUrl, startPaymentAdapterCardPayment } from "./card-payment.js"
 import type { CheckoutPaymentStarter } from "./checkout-service.js"
+import type { FinanceInvoiceDocumentProvider } from "./contracts/invoice-document-provider.js"
 import type { FinanceApiModuleOptions } from "./index.js"
 import {
   createVoyantDataFxExchangeRateResolver,
   type ResolveInvoiceExchangeRate,
 } from "./invoice-fx.js"
 import { refreshPaymentAdapterStatus } from "./payment-adapter-status.js"
+import { createProviderBackedInvoiceDocumentGenerator } from "./service-documents.js"
 import { resolveEffectivePaymentLinkUrlTemplate } from "./payment-link.js"
 import { executeAdapterRefundSettlement } from "./refund-settlement-execution.js"
 import type {
@@ -37,10 +39,22 @@ export function createFinanceRuntime(
   checkoutPaymentStarters?: FinanceCheckoutPaymentStartersRuntime,
   invoiceSettlementPollerProviders: readonly FinanceInvoiceSettlementPollerProvider[] = [],
   selectedPaymentAdapter?: PaymentAdapter,
+  invoiceDocumentProvider?: FinanceInvoiceDocumentProvider,
 ): FinanceApiModuleOptions {
   const { primitives } = host
   return {
     resolveDocumentDownloadUrl: primitives.storage.downloadUrl,
+    // Both document paths run off the one selected provider: the on-demand
+    // generate/regenerate routes through the generator adapter (they used to
+    // answer 501 because nothing ever supplied one), and the requested-rendition
+    // engine through the provider itself.
+    ...(invoiceDocumentProvider
+      ? {
+          invoiceDocumentProvider,
+          invoiceDocumentGenerator:
+            createProviderBackedInvoiceDocumentGenerator(invoiceDocumentProvider),
+        }
+      : {}),
     resolveCustomFields: async (db, invoice) => {
       if (invoice.organizationId) {
         return customFields.resolveVisibleValues(

--- a/packages/finance/src/runtime.ts
+++ b/packages/finance/src/runtime.ts
@@ -27,7 +27,10 @@ import type {
   FinanceProposalsPaymentPolicyRuntime,
 } from "./runtime-port.js"
 import { financeService } from "./service.js"
-import { createProviderBackedInvoiceDocumentGenerator } from "./service-documents.js"
+import {
+  createInvoiceCustomFieldsResolver,
+  createProviderBackedInvoiceDocumentGenerator,
+} from "./service-documents.js"
 import type { InvoiceSettlementPoller } from "./service-settlement.js"
 
 /** Compose Finance's main HTTP runtime from generic host and selected providers. */
@@ -55,20 +58,7 @@ export function createFinanceRuntime(
             createProviderBackedInvoiceDocumentGenerator(invoiceDocumentProvider),
         }
       : {}),
-    resolveCustomFields: async (db, invoice) => {
-      if (invoice.organizationId) {
-        return customFields.resolveVisibleValues(
-          db,
-          "organization",
-          invoice.organizationId,
-          "invoice",
-        )
-      }
-      if (invoice.personId) {
-        return customFields.resolveVisibleValues(db, "person", invoice.personId, "invoice")
-      }
-      return {}
-    },
+    resolveCustomFields: createInvoiceCustomFieldsResolver(customFields),
     resolveInvoiceExchangeRateResolver: (bindings) =>
       createExchangeRateResolver(primitives, bindings),
     invoiceSettlementPollers: aggregateFinanceInvoiceSettlementPollers(

--- a/packages/finance/src/service-action-ledger-accounting.ts
+++ b/packages/finance/src/service-action-ledger-accounting.ts
@@ -298,7 +298,14 @@ export async function buildInvoiceIssuedActionLedgerInput(
     approvalId: options.approvalId,
     idempotencyScope:
       options.idempotencyScope ?? `finance.booking:${input.invoice.bookingId}:invoice_issue`,
-    idempotencyKey: options.idempotencyKey ?? input.invoice.invoiceNumber,
+    // Keyed by (type, number), matching `invoices_invoice_number_type_active_idx`
+    // — the database deliberately lets a proforma and a fiscal invoice carry
+    // the same external number. Keying on the number alone made the second of
+    // the pair collide with the first inside one booking's issue scope, and the
+    // reused key surfaced as a failed issuance for a document the schema
+    // permits.
+    idempotencyKey:
+      options.idempotencyKey ?? `${input.invoice.invoiceType}:${input.invoice.invoiceNumber}`,
     idempotencyFingerprint:
       options.idempotencyFingerprint ??
       (await buildIdempotencyFingerprint({

--- a/packages/finance/src/service-documents.ts
+++ b/packages/finance/src/service-documents.ts
@@ -5,6 +5,10 @@ import { and, desc, eq } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import {
+  type FinanceInvoiceDocumentProvider,
+  invoiceDocumentOperationKey,
+} from "./contracts/invoice-document-provider.js"
+import {
   type invoiceLineItems,
   type invoiceRenditions,
   type invoices,
@@ -93,7 +97,7 @@ export interface InvoiceDocumentGeneratedEvent {
   regenerated: boolean
 }
 
-type PreparedInvoiceDocument =
+export type PreparedInvoiceDocument =
   | { status: "not_found" }
   | {
       status: "ready"
@@ -243,10 +247,75 @@ export function createPdfInvoiceDocumentGenerator(
   })
 }
 
-async function prepareInvoiceDocument(
+/**
+ * Serve the on-demand generate/regenerate routes from the graph-selected
+ * provider, so a deployment configures a renderer once and both paths — the
+ * requested rendition the engine drains and the document an operator asks for
+ * from the invoice screen — go through the same conformance-tested seam.
+ *
+ * The key is derived from the invoice rather than a rendition id: this path
+ * inserts its rendition through `bindInvoiceRendition` *after* the artifact
+ * exists, so there is no row to key on yet.
+ */
+export function createProviderBackedInvoiceDocumentGenerator(
+  provider: FinanceInvoiceDocumentProvider,
+): InvoiceDocumentGenerator {
+  return async (context) => {
+    const operationId = crypto.randomUUID()
+    const artifact = await provider.render({
+      renditionId: operationId,
+      invoiceId: context.invoice.id,
+      invoiceNumber: context.invoice.invoiceNumber ?? "",
+      templateId: context.template?.id ?? null,
+      body: context.renderedBody,
+      bodyFormat: context.renderedBodyFormat,
+      format: context.targetFormat,
+      language: context.language,
+      variables: context.variables,
+    })
+    const reference = await provider.put({
+      renditionId: operationId,
+      operationKey: invoiceDocumentOperationKey({
+        invoiceId: context.invoice.id,
+        renditionId: operationId,
+        format: context.targetFormat,
+      }),
+      artifact,
+    })
+
+    return {
+      format: context.targetFormat,
+      storageKey: reference.key,
+      contentType: artifact.contentType,
+      fileSize: reference.byteLength,
+      checksum: reference.checksumSha256,
+      language: context.language,
+      metadata: {
+        ...(artifact.metadata ?? {}),
+        provider: provider.identity.id,
+        providerVersion: provider.identity.version,
+      },
+    }
+  }
+}
+
+/**
+ * Resolve everything a renderer needs and nothing it may decide: the template,
+ * the line items, the payments, the custom fields, and the body rendered from
+ * them. Shared by the generator path and by the fulfilment engine that drains
+ * requested renditions, so both produce a document from the same inputs.
+ *
+ * Takes the narrow shape rather than `GenerateInvoiceDocumentInput` because the
+ * engine's input is a persisted `invoice_renditions` row, not a request body.
+ */
+export async function prepareInvoiceDocument(
   db: PostgresJsDatabase,
   invoiceId: string,
-  input: GenerateInvoiceDocumentInput,
+  input: {
+    format: GenerateInvoiceDocumentInput["format"]
+    templateId?: string | null
+    language?: string | null
+  },
   resolveCustomFields?: InvoiceDocumentRuntimeOptions["resolveCustomFields"],
 ): Promise<PreparedInvoiceDocument> {
   const invoice = await financeService.getInvoiceById(db, invoiceId)

--- a/packages/finance/src/service-documents.ts
+++ b/packages/finance/src/service-documents.ts
@@ -257,6 +257,39 @@ export function createPdfInvoiceDocumentGenerator(
  * inserts its rendition through `bindInvoiceRendition` *after* the artifact
  * exists, so there is no row to key on yet.
  */
+/**
+ * The one definition of "which custom fields does this invoice's template see".
+ *
+ * Shared by every path that renders a document, because `prepareInvoiceDocument`
+ * only populates `variables.customFields` when a resolver is supplied: when the
+ * HTTP route had one and the subscriber and recovery job did not, the same
+ * template rendered with the customer's fields interactively and without them
+ * in the background.
+ */
+export function createInvoiceCustomFieldsResolver(customFields: {
+  resolveVisibleValues(
+    db: PostgresJsDatabase,
+    subjectType: string,
+    subjectId: string,
+    surface: string,
+  ): Promise<Record<string, unknown>> | Record<string, unknown>
+}): NonNullable<InvoiceDocumentRuntimeOptions["resolveCustomFields"]> {
+  return async (db, invoice) => {
+    if (invoice.organizationId) {
+      return customFields.resolveVisibleValues(
+        db,
+        "organization",
+        invoice.organizationId,
+        "invoice",
+      )
+    }
+    if (invoice.personId) {
+      return customFields.resolveVisibleValues(db, "person", invoice.personId, "invoice")
+    }
+    return {}
+  }
+}
+
 export function createProviderBackedInvoiceDocumentGenerator(
   provider: FinanceInvoiceDocumentProvider,
 ): InvoiceDocumentGenerator {

--- a/packages/finance/src/voyant.ts
+++ b/packages/finance/src/voyant.ts
@@ -17,6 +17,7 @@ import {
   financeAppApiRuntimePort,
   financeDepartureProfitabilityRuntimePort,
 } from "@voyant-travel/finance-contracts/runtime-port"
+import { financeInvoiceDocumentProviderPort } from "./contracts/invoice-document-provider.js"
 import {
   financeReceivablesDatasetDefinition,
   financeReportingTemplates,
@@ -50,6 +51,39 @@ import {
 
 const paymentAdapterRuntimePortReference = { id: "payments.adapter.runtime" } as const
 
+const financeInvoiceDocumentResources = [
+  {
+    id: "@voyant-travel/finance#resource.document-storage",
+    kind: "document-storage",
+    required: true,
+  },
+  {
+    id: "@voyant-travel/finance#resource.document-renderer",
+    kind: "document-renderer",
+    required: true,
+  },
+] as const
+
+const invoiceDocumentJobs = [
+  {
+    id: "finance.invoice-document-renditions",
+    schedule: { every: "1m", overlap: "skip" as const },
+    scheduling: {
+      required: true,
+      profiles: {
+        eager: { every: "1m", overlap: "skip" as const },
+        economical: { every: "5m", overlap: "skip" as const },
+        "scale-to-zero": { cron: "*/15 * * * *", overlap: "skip" as const },
+      },
+    },
+    wakeup: true,
+    runtime: {
+      entry: "@voyant-travel/finance/invoice-document-job",
+      export: "runDueInvoiceDocumentRenditionsJob",
+    },
+  },
+] as const
+
 /** Import-cheap deployment declaration owned by the finance package. */
 export const financeVoyantModule = defineModule({
   id: "@voyant-travel/finance",
@@ -67,6 +101,7 @@ export const financeVoyantModule = defineModule({
       optional: true,
       cardinality: "many",
     }),
+    requirePort(financeInvoiceDocumentProviderPort, { optional: true }),
   ],
   provides: {
     capabilities: ["finance.data-owner", "finance.payment-sessions"],
@@ -77,8 +112,31 @@ export const financeVoyantModule = defineModule({
       providePort(financeHostRuntimePort),
       providePort(financeAppApiRuntimePort),
       providePort(financeDepartureProfitabilityRuntimePort),
+      providePort(financeInvoiceDocumentProviderPort),
     ],
   },
+  // An invoice PDF needs a renderer and somewhere to put it. Declaring both
+  // makes a deployment that cannot produce one say so when the graph resolves,
+  // rather than at the HTTP 501 these routes used to return
+  // (voyant#4668).
+  resources: financeInvoiceDocumentResources,
+  providers: [
+    {
+      id: "@voyant-travel/finance#provider.invoice-document",
+      port: financeInvoiceDocumentProviderPort.id,
+      selection: { role: "invoiceDocumentArtifact", value: "standard" },
+      uses: {
+        resources: [
+          "@voyant-travel/finance#resource.document-storage",
+          "@voyant-travel/finance#resource.document-renderer",
+        ],
+      },
+      runtime: {
+        entry: "@voyant-travel/finance/runtime-contributor",
+        export: "createFinanceInvoiceDocumentGraphProvider",
+      },
+    },
+  ],
   api: [
     {
       id: "@voyant-travel/finance#api.admin",
@@ -724,6 +782,24 @@ export const financeVoyantModule = defineModule({
   lifecycle: {
     uninstall: { default: "retain-data", purge: "not-supported" },
   },
+  // The trigger and the recovery leg for invoice documents (voyant#4668). The
+  // subscriber is the latency path — booking create cannot render inside its
+  // own transaction, so it writes the request and this turns it into a
+  // document as soon as the invoice is issued. The job covers everything the
+  // subscriber cannot: a restart mid-render, a transient renderer failure, and
+  // a rendition requested against an invoice issued long ago.
+  subscribers: [
+    {
+      id: "@voyant-travel/finance#subscriber.invoice-issued-document",
+      eventType: "invoice.issued",
+      source: "@voyant-travel/finance/invoice-issued-subscriber",
+      runtime: {
+        entry: "@voyant-travel/finance/invoice-issued-subscriber",
+        export: "createInvoiceIssuedDocumentSubscriberGraphRuntime",
+      },
+    },
+  ],
+  jobs: invoiceDocumentJobs,
   meta: {
     ownership: "package",
   },

--- a/packages/finance/tests/integration/currency-amount-checks.test.ts
+++ b/packages/finance/tests/integration/currency-amount-checks.test.ts
@@ -60,6 +60,7 @@ describe.skipIf(!DB_AVAILABLE)("currency/amount CHECK constraints", () => {
     it("rejects baseSellAmountCents without baseCurrency", async () => {
       await expect(
         db.insert(bookings).values({
+          status: "confirmed",
           id: id("book"),
           bookingNumber: `BK-${counter}`,
           sellCurrency: "EUR",
@@ -72,6 +73,7 @@ describe.skipIf(!DB_AVAILABLE)("currency/amount CHECK constraints", () => {
     it("rejects baseCostAmountCents without baseCurrency", async () => {
       await expect(
         db.insert(bookings).values({
+          status: "confirmed",
           id: id("book"),
           bookingNumber: `BK-${counter}`,
           sellCurrency: "EUR",
@@ -84,6 +86,7 @@ describe.skipIf(!DB_AVAILABLE)("currency/amount CHECK constraints", () => {
     it("accepts both base_*_amount_cents null with null baseCurrency", async () => {
       await expect(
         db.insert(bookings).values({
+          status: "confirmed",
           id: id("book"),
           bookingNumber: `BK-${counter}`,
           sellCurrency: "EUR",
@@ -97,6 +100,7 @@ describe.skipIf(!DB_AVAILABLE)("currency/amount CHECK constraints", () => {
     it("accepts base amounts when baseCurrency is set", async () => {
       await expect(
         db.insert(bookings).values({
+          status: "confirmed",
           id: id("book"),
           bookingNumber: `BK-${counter}`,
           sellCurrency: "EUR",
@@ -112,6 +116,7 @@ describe.skipIf(!DB_AVAILABLE)("currency/amount CHECK constraints", () => {
     async function insertBooking() {
       const bookingId = id("book")
       await db.insert(bookings).values({
+        status: "confirmed",
         id: bookingId,
         bookingNumber: `BK-${counter}`,
         sellCurrency: "EUR",
@@ -123,6 +128,7 @@ describe.skipIf(!DB_AVAILABLE)("currency/amount CHECK constraints", () => {
       const bookingId = await insertBooking()
       await expect(
         db.insert(bookingItems).values({
+          status: "confirmed",
           id: id("bkit"),
           bookingId,
           title: "Test",
@@ -137,6 +143,7 @@ describe.skipIf(!DB_AVAILABLE)("currency/amount CHECK constraints", () => {
       const bookingId = await insertBooking()
       await expect(
         db.insert(bookingItems).values({
+          status: "confirmed",
           id: id("bkit"),
           bookingId,
           title: "Test",
@@ -231,6 +238,7 @@ describe.skipIf(!DB_AVAILABLE)("currency/amount CHECK constraints", () => {
     async function bookingId() {
       const bid = id("book")
       await db.insert(bookings).values({
+        status: "confirmed",
         id: bid,
         bookingNumber: `BK-${counter}`,
         sellCurrency: "EUR",
@@ -276,6 +284,7 @@ describe.skipIf(!DB_AVAILABLE)("currency/amount CHECK constraints", () => {
     async function invoiceId() {
       const bid = id("book")
       await db.insert(bookings).values({
+        status: "confirmed",
         id: bid,
         bookingNumber: `BK-${counter}`,
         sellCurrency: "EUR",

--- a/packages/finance/tests/integration/currency-amount-checks.test.ts
+++ b/packages/finance/tests/integration/currency-amount-checks.test.ts
@@ -40,6 +40,30 @@ function id(prefix: string) {
   return `${prefix}_chk_${counter}`
 }
 
+/**
+ * Assert that a database CHECK constraint fires. Drizzle wraps the driver
+ * error, so the constraint name is on the cause chain and never in
+ * `error.message` — matching the message asserted only that *something* failed,
+ * which a not-null violation or a typo in the fixture satisfies just as well.
+ */
+async function expectCheckViolation(operation: Promise<unknown>, constraint: string) {
+  try {
+    await operation
+  } catch (error) {
+    const seen: string[] = []
+    let current: unknown = error
+    while (current) {
+      if (current instanceof Error) seen.push(current.message)
+      const named = (current as { constraint_name?: string }).constraint_name
+      if (named) seen.push(named)
+      current = (current as { cause?: unknown }).cause
+    }
+    expect(seen.join(" | ")).toContain(constraint)
+    return
+  }
+  throw new Error(`Expected constraint ${constraint} to be violated, but the statement succeeded.`)
+}
+
 describe.skipIf(!DB_AVAILABLE)("currency/amount CHECK constraints", () => {
   // biome-ignore lint/suspicious/noExplicitAny: test db -- owner: finance; existing suppression is intentional pending typed cleanup.
   let db: any
@@ -58,7 +82,7 @@ describe.skipIf(!DB_AVAILABLE)("currency/amount CHECK constraints", () => {
 
   describe("bookings.bookings — base_currency + base_*_amount_cents", () => {
     it("rejects baseSellAmountCents without baseCurrency", async () => {
-      await expect(
+      await expectCheckViolation(
         db.insert(bookings).values({
           status: "confirmed",
           id: id("book"),
@@ -67,11 +91,12 @@ describe.skipIf(!DB_AVAILABLE)("currency/amount CHECK constraints", () => {
           baseCurrency: null,
           baseSellAmountCents: 10000,
         }),
-      ).rejects.toThrow(/ck_bookings_base_currency_amounts/)
+        "ck_bookings_base_currency_amounts",
+      )
     })
 
     it("rejects baseCostAmountCents without baseCurrency", async () => {
-      await expect(
+      await expectCheckViolation(
         db.insert(bookings).values({
           status: "confirmed",
           id: id("book"),
@@ -80,7 +105,8 @@ describe.skipIf(!DB_AVAILABLE)("currency/amount CHECK constraints", () => {
           baseCurrency: null,
           baseCostAmountCents: 5000,
         }),
-      ).rejects.toThrow(/ck_bookings_base_currency_amounts/)
+        "ck_bookings_base_currency_amounts",
+      )
     })
 
     it("accepts both base_*_amount_cents null with null baseCurrency", async () => {
@@ -126,7 +152,7 @@ describe.skipIf(!DB_AVAILABLE)("currency/amount CHECK constraints", () => {
 
     it("rejects unitCostAmountCents without costCurrency", async () => {
       const bookingId = await insertBooking()
-      await expect(
+      await expectCheckViolation(
         db.insert(bookingItems).values({
           status: "confirmed",
           id: id("bkit"),
@@ -136,7 +162,8 @@ describe.skipIf(!DB_AVAILABLE)("currency/amount CHECK constraints", () => {
           costCurrency: null,
           unitCostAmountCents: 5000,
         }),
-      ).rejects.toThrow(/ck_booking_items_cost_currency_amounts/)
+        "ck_booking_items_cost_currency_amounts",
+      )
     })
 
     it("accepts cost amounts with costCurrency set", async () => {
@@ -158,32 +185,37 @@ describe.skipIf(!DB_AVAILABLE)("currency/amount CHECK constraints", () => {
 
   describe("finance.booking_guarantees — currency + amount XNOR", () => {
     it("rejects amount without currency", async () => {
-      await expect(
+      await expectCheckViolation(
         db.insert(bookingGuarantees).values({
+          guaranteeType: "deposit",
           id: id("bkgu"),
           bookingId: id("book"),
           status: "pending",
           currency: null,
           amountCents: 10000,
         }),
-      ).rejects.toThrow(/ck_booking_guarantees_currency_amount/)
+        "ck_booking_guarantees_currency_amount",
+      )
     })
 
     it("rejects currency without amount", async () => {
-      await expect(
+      await expectCheckViolation(
         db.insert(bookingGuarantees).values({
+          guaranteeType: "deposit",
           id: id("bkgu"),
           bookingId: id("book"),
           status: "pending",
           currency: "EUR",
           amountCents: null,
         }),
-      ).rejects.toThrow(/ck_booking_guarantees_currency_amount/)
+        "ck_booking_guarantees_currency_amount",
+      )
     })
 
     it("accepts both null", async () => {
       await expect(
         db.insert(bookingGuarantees).values({
+          guaranteeType: "deposit",
           id: id("bkgu"),
           bookingId: id("book"),
           status: "pending",
@@ -196,6 +228,7 @@ describe.skipIf(!DB_AVAILABLE)("currency/amount CHECK constraints", () => {
     it("accepts both set", async () => {
       await expect(
         db.insert(bookingGuarantees).values({
+          guaranteeType: "deposit",
           id: id("bkgu"),
           bookingId: id("book"),
           status: "pending",
@@ -208,7 +241,7 @@ describe.skipIf(!DB_AVAILABLE)("currency/amount CHECK constraints", () => {
 
   describe("finance.booking_item_commissions — currency + amount XNOR", () => {
     it("rejects amount without currency", async () => {
-      await expect(
+      await expectCheckViolation(
         db.insert(bookingItemCommissions).values({
           id: id("bcom"),
           bookingItemId: id("bkit"),
@@ -216,7 +249,8 @@ describe.skipIf(!DB_AVAILABLE)("currency/amount CHECK constraints", () => {
           currency: null,
           amountCents: 1000,
         }),
-      ).rejects.toThrow(/ck_booking_item_commissions_currency_amount/)
+        "ck_booking_item_commissions_currency_amount",
+      )
     })
 
     it("accepts both null (commission-as-percentage row)", async () => {
@@ -248,7 +282,7 @@ describe.skipIf(!DB_AVAILABLE)("currency/amount CHECK constraints", () => {
 
     it("rejects baseSubtotalCents without baseCurrency", async () => {
       const bid = await bookingId()
-      await expect(
+      await expectCheckViolation(
         db.insert(invoices).values({
           id: id("inv"),
           invoiceNumber: `INV-${counter}`,
@@ -260,7 +294,8 @@ describe.skipIf(!DB_AVAILABLE)("currency/amount CHECK constraints", () => {
           issueDate: "2026-04-25",
           dueDate: "2026-05-25",
         }),
-      ).rejects.toThrow(/ck_invoices_base_currency_amounts/)
+        "ck_invoices_base_currency_amounts",
+      )
     })
 
     it("accepts every base_*_cents null with baseCurrency null", async () => {
@@ -304,7 +339,7 @@ describe.skipIf(!DB_AVAILABLE)("currency/amount CHECK constraints", () => {
 
     it("rejects baseAmountCents without baseCurrency", async () => {
       const iid = await invoiceId()
-      await expect(
+      await expectCheckViolation(
         db.insert(payments).values({
           id: id("pay"),
           invoiceId: iid,
@@ -315,12 +350,13 @@ describe.skipIf(!DB_AVAILABLE)("currency/amount CHECK constraints", () => {
           paymentMethod: "bank_transfer",
           paymentDate: "2026-04-25",
         }),
-      ).rejects.toThrow(/ck_payments_base_currency_amount/)
+        "ck_payments_base_currency_amount",
+      )
     })
 
     it("rejects baseCurrency without baseAmountCents", async () => {
       const iid = await invoiceId()
-      await expect(
+      await expectCheckViolation(
         db.insert(payments).values({
           id: id("pay"),
           invoiceId: iid,
@@ -331,7 +367,8 @@ describe.skipIf(!DB_AVAILABLE)("currency/amount CHECK constraints", () => {
           paymentMethod: "bank_transfer",
           paymentDate: "2026-04-25",
         }),
-      ).rejects.toThrow(/ck_payments_base_currency_amount/)
+        "ck_payments_base_currency_amount",
+      )
     })
 
     it("accepts both null", async () => {

--- a/packages/finance/tests/integration/document-routes.test.ts
+++ b/packages/finance/tests/integration/document-routes.test.ts
@@ -88,6 +88,7 @@ describe.skipIf(!DB_AVAILABLE)("Finance document routes", () => {
     const [booking] = await db
       .insert(bookings)
       .values({
+        status: "confirmed",
         bookingNumber: "BKG-1001",
         sellCurrency: "EUR",
         sellAmountCents: 100000,

--- a/packages/finance/tests/integration/document-routes.test.ts
+++ b/packages/finance/tests/integration/document-routes.test.ts
@@ -84,6 +84,26 @@ describe.skipIf(!DB_AVAILABLE)("Finance document routes", () => {
     failNextGeneration = false
   })
 
+
+  /**
+   * `invoices.booking_id` is `notNull()`, so an invoice fixture needs a booking
+   * to hang off. These three cases care only about the rendition, not the
+   * booking, hence one throwaway per invoice.
+   */
+  async function seedBookingForInvoice() {
+    const [booking] = await db
+      .insert(bookings)
+      .values({
+        status: "confirmed",
+        bookingNumber: `BKG-${Math.floor(Math.random() * 1_000_000_000)}`,
+        sellCurrency: "EUR",
+        sellAmountCents: 5000,
+        startDate: "2026-06-01",
+      })
+      .returning()
+    return booking!
+  }
+
   it("generates and then regenerates a ready invoice rendition", async () => {
     const [booking] = await db
       .insert(bookings)
@@ -178,10 +198,13 @@ describe.skipIf(!DB_AVAILABLE)("Finance document routes", () => {
     expect(renderedEvents).toEqual([
       expect.objectContaining({
         name: "invoice.rendered",
-        metadata: {
+        // `objectContaining`: the envelope's metadata gained `eventId`, and
+        // pinning it exactly asserted the envelope's shape rather than the
+        // event this test is about.
+        metadata: expect.objectContaining({
           category: "internal",
           source: "service",
-        },
+        }),
         data: expect.objectContaining({
           invoiceId: invoice.id,
           invoiceType: "invoice",
@@ -194,10 +217,13 @@ describe.skipIf(!DB_AVAILABLE)("Finance document routes", () => {
       }),
       expect.objectContaining({
         name: "invoice.rendered",
-        metadata: {
+        // `objectContaining`: the envelope's metadata gained `eventId`, and
+        // pinning it exactly asserted the envelope's shape rather than the
+        // event this test is about.
+        metadata: expect.objectContaining({
           category: "internal",
           source: "service",
-        },
+        }),
         data: expect.objectContaining({
           invoiceId: invoice.id,
           invoiceType: "invoice",
@@ -212,10 +238,13 @@ describe.skipIf(!DB_AVAILABLE)("Finance document routes", () => {
     expect(documentEvents).toEqual([
       expect.objectContaining({
         name: "invoice.document.generated",
-        metadata: {
+        // `objectContaining`: the envelope's metadata gained `eventId`, and
+        // pinning it exactly asserted the envelope's shape rather than the
+        // event this test is about.
+        metadata: expect.objectContaining({
           category: "internal",
           source: "service",
-        },
+        }),
         data: expect.objectContaining({
           invoiceId: invoice.id,
           invoiceType: "invoice",
@@ -225,10 +254,13 @@ describe.skipIf(!DB_AVAILABLE)("Finance document routes", () => {
       }),
       expect.objectContaining({
         name: "invoice.document.generated",
-        metadata: {
+        // `objectContaining`: the envelope's metadata gained `eventId`, and
+        // pinning it exactly asserted the envelope's shape rather than the
+        // event this test is about.
+        metadata: expect.objectContaining({
           category: "internal",
           source: "service",
-        },
+        }),
         data: expect.objectContaining({
           invoiceId: invoice.id,
           invoiceType: "invoice",
@@ -249,10 +281,12 @@ describe.skipIf(!DB_AVAILABLE)("Finance document routes", () => {
   })
 
   it("binds a ready rendition artifact and emits invoice.rendered", async () => {
+    const seededBooking = await seedBookingForInvoice()
     const [invoice] = await db
       .insert(invoices)
       .values({
         invoiceNumber: "INV-BIND-1",
+        bookingId: seededBooking.id,
         invoiceType: "invoice",
         status: "issued",
         currency: "EUR",
@@ -306,10 +340,13 @@ describe.skipIf(!DB_AVAILABLE)("Finance document routes", () => {
     expect(events).toEqual([
       expect.objectContaining({
         name: "invoice.rendered",
-        metadata: {
+        // `objectContaining`: the envelope's metadata gained `eventId`, and
+        // pinning it exactly asserted the envelope's shape rather than the
+        // event this test is about.
+        metadata: expect.objectContaining({
           category: "internal",
           source: "service",
-        },
+        }),
         data: {
           invoiceId: invoice.id,
           invoiceStatus: "issued",
@@ -326,10 +363,12 @@ describe.skipIf(!DB_AVAILABLE)("Finance document routes", () => {
   })
 
   it("does not emit rendition completion events when generation fails", async () => {
+    const seededBooking = await seedBookingForInvoice()
     const [invoice] = await db
       .insert(invoices)
       .values({
         invoiceNumber: "INV-FAIL-1",
+        bookingId: seededBooking.id,
         invoiceType: "invoice",
         status: "issued",
         currency: "EUR",
@@ -361,10 +400,12 @@ describe.skipIf(!DB_AVAILABLE)("Finance document routes", () => {
   })
 
   it("preserves ready URL-only rendition artifacts", async () => {
+    const seededBooking = await seedBookingForInvoice()
     const [invoice] = await db
       .insert(invoices)
       .values({
         invoiceNumber: "INV-URL-1",
+        bookingId: seededBooking.id,
         invoiceType: "invoice",
         status: "issued",
         currency: "EUR",

--- a/packages/finance/tests/integration/document-routes.test.ts
+++ b/packages/finance/tests/integration/document-routes.test.ts
@@ -84,7 +84,6 @@ describe.skipIf(!DB_AVAILABLE)("Finance document routes", () => {
     failNextGeneration = false
   })
 
-
   /**
    * `invoices.booking_id` is `notNull()`, so an invoice fixture needs a booking
    * to hang off. These three cases care only about the rendition, not the

--- a/packages/finance/tests/integration/invoice-document-fulfilment.test.ts
+++ b/packages/finance/tests/integration/invoice-document-fulfilment.test.ts
@@ -1,0 +1,334 @@
+import { bookings } from "@voyant-travel/bookings/schema"
+import { createEventBus } from "@voyant-travel/core"
+import { eq } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { assertFinanceInvoiceDocumentProviderConformance } from "../../src/contracts/invoice-document-provider.js"
+import {
+  fulfilInvoiceRendition,
+  fulfilPendingInvoiceRenditions,
+} from "../../src/invoice-document-fulfilment.js"
+import { createStandardInvoiceDocumentProvider } from "../../src/invoice-document-runtime.js"
+import {
+  invoiceLineItems,
+  invoiceNumberSeries,
+  invoiceRenditions,
+  invoices,
+  invoiceTemplates,
+} from "../../src/schema.js"
+import { financeService } from "../../src/service.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+
+/** Exact-key document store, matching what the deployment resource resolves to. */
+function memoryDocumentStorage() {
+  const objects = new Map<string, Uint8Array>()
+  return {
+    objects,
+    provider: {
+      name: "memory:documents",
+      resolveBackendIdentity: async () => "memory-documents",
+      upload: async (body: Uint8Array, options?: { key?: string }) => {
+        const key = options?.key ?? "unnamed"
+        objects.set(key, body)
+        return { key }
+      },
+      get: async (key: string) => {
+        const value = objects.get(key)
+        return value ? (value.buffer.slice(0) as ArrayBuffer) : null
+      },
+      delete: async (key: string) => {
+        objects.delete(key)
+      },
+    },
+  }
+}
+
+describe.skipIf(!DB_AVAILABLE)("invoice document fulfilment", () => {
+  let db: PostgresJsDatabase
+  let storage: ReturnType<typeof memoryDocumentStorage>
+  let renderCalls: number
+  let failRenders: number
+
+  const buildProvider = () =>
+    createStandardInvoiceDocumentProvider({
+      storage: storage.provider as never,
+      renderer: {
+        name: "test-renderer",
+        resolveBackendIdentity: async () => "test-renderer",
+        renderPdf: async ({ html }: { html: string }) => {
+          renderCalls += 1
+          if (failRenders > 0) {
+            failRenders -= 1
+            throw new Error("renderer unavailable")
+          }
+          return new TextEncoder().encode(`%PDF-1.4 ${html}`)
+        },
+      } as never,
+    })
+
+  let seeded = 0
+
+  async function seedInvoice(
+    overrides: {
+      invoiceNumber?: string
+      seriesId?: string | null
+    } = {},
+  ) {
+    seeded += 1
+    const suffix = `${seeded}-${Math.floor(Math.random() * 1_000_000)}`
+    const [booking] = await db
+      .insert(bookings)
+      .values({
+        bookingNumber: `BKG-${suffix}`,
+        sellCurrency: "EUR",
+        sellAmountCents: 100000,
+        startDate: "2026-06-01",
+        status: "confirmed",
+      })
+      .returning()
+
+    const [template] = await db
+      .insert(invoiceTemplates)
+      .values({
+        name: "Default invoice",
+        slug: `default-invoice-${suffix}`,
+        language: "ro",
+        bodyFormat: "html",
+        body: "<p>Factura {{invoice.invoiceNumber}}</p>",
+        isDefault: true,
+        active: true,
+      })
+      .returning()
+
+    const [invoice] = await db
+      .insert(invoices)
+      .values({
+        invoiceNumber: overrides.invoiceNumber ?? `INV-4668-${suffix}`,
+        bookingId: booking!.id,
+        templateId: template!.id,
+        ...(overrides.seriesId ? { seriesId: overrides.seriesId } : {}),
+        invoiceType: "invoice",
+        status: "issued",
+        currency: "EUR",
+        issueDate: "2026-05-01",
+        dueDate: "2026-05-05",
+        subtotalCents: 100000,
+        taxCents: 0,
+        totalCents: 100000,
+        paidCents: 0,
+        balanceDueCents: 100000,
+      })
+      .returning()
+
+    await db.insert(invoiceLineItems).values({
+      invoiceId: invoice!.id,
+      description: "Package",
+      quantity: 1,
+      unitPriceCents: 100000,
+      totalCents: 100000,
+      sortOrder: 0,
+    })
+
+    return invoice!
+  }
+
+  beforeAll(async () => {
+    const { createTestDb, cleanupTestDb } = await import("@voyant-travel/db/test-utils")
+    db = createTestDb()
+    await cleanupTestDb(db)
+  })
+
+  beforeEach(async () => {
+    const { cleanupTestDb } = await import("@voyant-travel/db/test-utils")
+    await cleanupTestDb(db)
+    storage = memoryDocumentStorage()
+    renderCalls = 0
+    failRenders = 0
+  })
+
+  it("turns the requested rendition into a real document and emits invoice.rendered", async () => {
+    const invoice = await seedInvoice()
+    const requested = await financeService.renderInvoice(db, invoice.id, { format: "pdf" })
+    expect(requested.status).toBe("requested")
+    expect(requested.rendition?.status).toBe("pending")
+
+    const eventBus = createEventBus()
+    const rendered: Array<Record<string, unknown>> = []
+    eventBus.subscribe("invoice.rendered", (event) => {
+      rendered.push(event as Record<string, unknown>)
+    })
+
+    const outcome = await fulfilInvoiceRendition(db, requested.rendition!.id, {
+      provider: await buildProvider(),
+      eventBus,
+    })
+
+    expect(outcome.status).toBe("fulfilled")
+    const [row] = await db
+      .select()
+      .from(invoiceRenditions)
+      .where(eq(invoiceRenditions.id, requested.rendition!.id))
+    expect(row?.status).toBe("ready")
+    expect(row?.storageKey).toBe(
+      `invoices/${invoice.id}/renditions/${requested.rendition!.id}.pdf`,
+    )
+    expect(row?.fileSize).toBeGreaterThan(0)
+    expect(row?.checksum).toMatch(/^[a-f0-9]{64}$/)
+    expect(row?.generatedAt).not.toBeNull()
+
+    // The bytes are actually in the store, at the key the row points at.
+    const stored = storage.objects.get(row!.storageKey!)
+    expect(new TextDecoder().decode(stored!)).toContain("INV-4668")
+
+    expect(rendered).toHaveLength(1)
+    expect(rendered[0]).toMatchObject({
+      data: expect.objectContaining({ invoiceId: invoice.id, renditionId: row!.id }),
+    })
+  })
+
+  it("does not supersede the row it fulfils", async () => {
+    const invoice = await seedInvoice()
+    const requested = await financeService.renderInvoice(db, invoice.id, { format: "pdf" })
+
+    await fulfilInvoiceRendition(db, requested.rendition!.id, { provider: await buildProvider() })
+
+    // The orphan this replaced was a second row: the pending one stayed pending
+    // forever while a separate `ready` row appeared beside it.
+    const rows = await db
+      .select()
+      .from(invoiceRenditions)
+      .where(eq(invoiceRenditions.invoiceId, invoice.id))
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.status).toBe("ready")
+  })
+
+  it("is idempotent across a repeated drain", async () => {
+    const invoice = await seedInvoice()
+    const requested = await financeService.renderInvoice(db, invoice.id, { format: "pdf" })
+    const provider = await buildProvider()
+
+    const first = await fulfilInvoiceRendition(db, requested.rendition!.id, { provider })
+    const second = await fulfilInvoiceRendition(db, requested.rendition!.id, { provider })
+
+    expect(first.status).toBe("fulfilled")
+    expect(second).toMatchObject({ status: "skipped", reason: "not_pending" })
+    expect(renderCalls).toBe(1)
+    expect(storage.objects.size).toBe(1)
+  })
+
+  it("records the miss instead of leaving an orphan when no renderer is available", async () => {
+    const invoice = await seedInvoice()
+    const requested = await financeService.renderInvoice(db, invoice.id, { format: "pdf" })
+
+    const outcome = await fulfilInvoiceRendition(db, requested.rendition!.id, {})
+
+    expect(outcome).toMatchObject({
+      status: "failed",
+      reason: "document_renderer_unavailable",
+    })
+    const [row] = await db
+      .select()
+      .from(invoiceRenditions)
+      .where(eq(invoiceRenditions.id, requested.rendition!.id))
+    // `failed` is terminal for `waitForInvoiceRendition`, so a caller that
+    // passed `?wait=true` is released now instead of blocking its full timeout
+    // on a row nothing was ever going to fulfil.
+    expect(row?.status).toBe("failed")
+    expect(row?.errorMessage).toMatch(/no document renderer is available/i)
+  })
+
+  it("retries a transient render failure and only fails after the attempt budget", async () => {
+    const invoice = await seedInvoice()
+    const requested = await financeService.renderInvoice(db, invoice.id, { format: "pdf" })
+    const provider = await buildProvider()
+
+    failRenders = 1
+    const retried = await fulfilInvoiceRendition(db, requested.rendition!.id, { provider })
+    expect(retried).toMatchObject({ status: "retry", attempts: 1 })
+    const [afterRetry] = await db
+      .select()
+      .from(invoiceRenditions)
+      .where(eq(invoiceRenditions.id, requested.rendition!.id))
+    expect(afterRetry?.status).toBe("pending")
+
+    const recovered = await fulfilInvoiceRendition(db, requested.rendition!.id, { provider })
+    expect(recovered.status).toBe("fulfilled")
+
+    const other = await seedInvoice()
+    const exhausting = await financeService.renderInvoice(db, other.id, { format: "pdf" })
+    failRenders = 10
+    let last = await fulfilInvoiceRendition(db, exhausting.rendition!.id, {
+      provider,
+      maxAttempts: 2,
+    })
+    expect(last.status).toBe("retry")
+    last = await fulfilInvoiceRendition(db, exhausting.rendition!.id, { provider, maxAttempts: 2 })
+    expect(last).toMatchObject({ status: "failed", reason: "render_failed" })
+  })
+
+  it("leaves an app-numbered invoice alone until its number is allocated", async () => {
+    const [series] = await db
+      .insert(invoiceNumberSeries)
+      .values({
+        code: "ext-fiscal",
+        name: "External fiscal series",
+        scope: "invoice",
+        prefix: "EXT",
+        externalProvider: "smartbill",
+        active: true,
+      })
+      .returning()
+
+    const invoice = await seedInvoice({
+      invoiceNumber: "PENDING-INVOICE-abc123",
+      seriesId: series!.id,
+    })
+    const requested = await financeService.renderInvoice(db, invoice.id, { format: "pdf" })
+
+    const outcome = await fulfilInvoiceRendition(db, requested.rendition!.id, {
+      provider: await buildProvider(),
+    })
+
+    // Rendering here would produce a fiscally invalid PDF naming a number no
+    // authority issued. The accounting app owns this document.
+    expect(outcome).toMatchObject({
+      status: "skipped",
+      reason: "awaiting_external_allocation",
+    })
+    const [row] = await db
+      .select()
+      .from(invoiceRenditions)
+      .where(eq(invoiceRenditions.id, requested.rendition!.id))
+    expect(row?.status).toBe("pending")
+    expect(renderCalls).toBe(0)
+  })
+
+  it("drains every requested rendition, scoped to one invoice when asked", async () => {
+    const first = await seedInvoice()
+    const second = await seedInvoice()
+    const firstRequest = await financeService.renderInvoice(db, first.id, { format: "pdf" })
+    await financeService.renderInvoice(db, second.id, { format: "pdf" })
+    const provider = await buildProvider()
+
+    const scoped = await fulfilPendingInvoiceRenditions(db, { provider, invoiceId: first.id })
+    expect(scoped).toEqual([
+      expect.objectContaining({ status: "fulfilled", renditionId: firstRequest.rendition!.id }),
+    ])
+
+    const rest = await fulfilPendingInvoiceRenditions(db, { provider })
+    expect(rest).toHaveLength(1)
+    expect(rest[0]?.status).toBe("fulfilled")
+    expect(storage.objects.size).toBe(2)
+  })
+
+  it("passes the port conformance harness against the deployment provider", async () => {
+    await expect(
+      assertFinanceInvoiceDocumentProviderConformance({
+        provider: await buildProvider(),
+        namespace: "finance/invoice-documents/integration",
+      }),
+    ).resolves.toBeUndefined()
+  })
+})

--- a/packages/finance/tests/integration/invoice-document-fulfilment.test.ts
+++ b/packages/finance/tests/integration/invoice-document-fulfilment.test.ts
@@ -70,12 +70,7 @@ describe.skipIf(!DB_AVAILABLE)("invoice document fulfilment", () => {
 
   let seeded = 0
 
-  async function seedInvoice(
-    overrides: {
-      invoiceNumber?: string
-      seriesId?: string | null
-    } = {},
-  ) {
+  async function seedInvoice(overrides: { invoiceNumber?: string; seriesId?: string | null } = {}) {
     seeded += 1
     const suffix = `${seeded}-${Math.floor(Math.random() * 1_000_000)}`
     const [booking] = await db
@@ -171,9 +166,7 @@ describe.skipIf(!DB_AVAILABLE)("invoice document fulfilment", () => {
       .from(invoiceRenditions)
       .where(eq(invoiceRenditions.id, requested.rendition!.id))
     expect(row?.status).toBe("ready")
-    expect(row?.storageKey).toBe(
-      `invoices/${invoice.id}/renditions/${requested.rendition!.id}.pdf`,
-    )
+    expect(row?.storageKey).toBe(`invoices/${invoice.id}/renditions/${requested.rendition!.id}.pdf`)
     expect(row?.fileSize).toBeGreaterThan(0)
     expect(row?.checksum).toMatch(/^[a-f0-9]{64}$/)
     expect(row?.generatedAt).not.toBeNull()

--- a/packages/finance/tests/integration/invoice-document-fulfilment.test.ts
+++ b/packages/finance/tests/integration/invoice-document-fulfilment.test.ts
@@ -316,6 +316,80 @@ describe.skipIf(!DB_AVAILABLE)("invoice document fulfilment", () => {
     expect(storage.objects.size).toBe(2)
   })
 
+  it("lets only one caller render a row two paths reach at once", async () => {
+    const invoice = await seedInvoice()
+    const requested = await financeService.renderInvoice(db, invoice.id, { format: "pdf" })
+    const provider = await buildProvider()
+
+    // The subscriber and the recovery job can both reach a pending row. The
+    // advisory lock ends with its transaction, so without a claim written into
+    // the row both would render and both would write the same key — and the
+    // loser's upload could land after the winner recorded its checksum.
+    const [first, second] = await Promise.all([
+      fulfilInvoiceRendition(db, requested.rendition!.id, { provider }),
+      fulfilInvoiceRendition(db, requested.rendition!.id, { provider }),
+    ])
+
+    const outcomes = [first.status, second.status].sort()
+    expect(outcomes).toEqual(["fulfilled", "skipped"])
+    expect(renderCalls).toBe(1)
+    expect(storage.objects.size).toBe(1)
+
+    const [row] = await db
+      .select()
+      .from(invoiceRenditions)
+      .where(eq(invoiceRenditions.id, requested.rendition!.id))
+    expect(row?.status).toBe("ready")
+    // The row describes the bytes that are actually stored.
+    const stored = storage.objects.get(row!.storageKey!)
+    expect(stored?.byteLength).toBe(row?.fileSize)
+  })
+
+  it("hands the row back when it declines to render it", async () => {
+    const [series] = await db
+      .insert(invoiceNumberSeries)
+      .values({
+        code: "ext-release",
+        name: "External fiscal series",
+        scope: "invoice",
+        prefix: "EXT",
+        externalProvider: "smartbill",
+        active: true,
+      })
+      .returning()
+    const invoice = await seedInvoice({
+      invoiceNumber: "PENDING-INVOICE-release",
+      seriesId: series!.id,
+    })
+    const requested = await financeService.renderInvoice(db, invoice.id, { format: "pdf" })
+    const provider = await buildProvider()
+
+    await fulfilInvoiceRendition(db, requested.rendition!.id, { provider })
+    // A skip must not hold the claim for the rest of its lease, or the row
+    // would sit out several job cycles after the app allocates its number.
+    const second = await fulfilInvoiceRendition(db, requested.rendition!.id, { provider })
+    expect(second).toMatchObject({ status: "skipped", reason: "awaiting_external_allocation" })
+  })
+
+  it("resolves custom fields the same way on every path", async () => {
+    const invoice = await seedInvoice()
+    const requested = await financeService.renderInvoice(db, invoice.id, { format: "pdf" })
+
+    const seen: string[] = []
+    await fulfilInvoiceRendition(db, requested.rendition!.id, {
+      provider: await buildProvider(),
+      resolveCustomFields: (_db, subject) => {
+        seen.push(subject.id)
+        return { loyaltyTier: "gold" }
+      },
+    })
+
+    // `prepareInvoiceDocument` only populates `variables.customFields` when a
+    // resolver is supplied, so a background path that omits it renders the same
+    // template without the customer's data.
+    expect(seen).toEqual([invoice.id])
+  })
+
   it("passes the port conformance harness against the deployment provider", async () => {
     await expect(
       assertFinanceInvoiceDocumentProviderConformance({

--- a/packages/finance/tests/integration/public-routes.test.ts
+++ b/packages/finance/tests/integration/public-routes.test.ts
@@ -150,6 +150,7 @@ describe.skipIf(!DB_AVAILABLE)("Public finance routes", () => {
     const [row] = await db
       .insert(bookings)
       .values({
+        status: "confirmed",
         bookingNumber: nextBookingNumber(),
         sellCurrency: "USD",
         sellAmountCents: 100000,

--- a/packages/finance/tests/integration/public-routes.test.ts
+++ b/packages/finance/tests/integration/public-routes.test.ts
@@ -22,6 +22,8 @@ import {
 const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
 const ORIGINAL_TEST_DATABASE_URL = process.env.TEST_DATABASE_URL
 const ORIGINAL_CHECKOUT_CAPABILITY_SECRET = process.env.VOYANT_CHECKOUT_CAPABILITY_SECRET
+const TEST_STOREFRONT_ID = "stfr_public_finance_test"
+const TEST_CHANNEL_ID = "chan_public_finance_test"
 
 const json = (body: Record<string, unknown>) => ({
   headers: { "Content-Type": "application/json" },
@@ -119,9 +121,18 @@ describe.skipIf(!DB_AVAILABLE)("Public finance routes", () => {
 
     app = new Hono()
     app.onError(handleApiError)
+    // voyant#4050 made the public finance routes storefront-scoped: they read
+    // the active channel off the context and match it against the booking's
+    // origin snapshot. Without both, every route here answers 403 — which is
+    // the guard working, not the routes being broken.
     app.use("*", async (c, next) => {
       c.set("db" as never, db)
       c.set("userId" as never, "public-finance-test-user")
+      c.set("storefrontChannel" as never, {
+        storefrontId: TEST_STOREFRONT_ID,
+        channelId: TEST_CHANNEL_ID,
+        channelStatus: "active",
+      })
       await next()
     })
     app.route("/", publicFinanceRoutes)
@@ -160,6 +171,14 @@ describe.skipIf(!DB_AVAILABLE)("Public finance routes", () => {
         ...overrides,
       })
       .returning()
+
+    // agent-quality: raw-sql reviewed -- owner: finance; the origin snapshot
+    // belongs to Bookings and the ids are parameter-bound.
+    await db.execute(sql`
+      INSERT INTO booking_origins (booking_id, storefront_id, channel_id)
+      VALUES (${row!.id}, ${TEST_STOREFRONT_ID}, ${TEST_CHANNEL_ID})
+      ON CONFLICT (booking_id) DO NOTHING
+    `)
 
     return row
   }
@@ -503,7 +522,11 @@ describe.skipIf(!DB_AVAILABLE)("Public finance routes", () => {
         headers: await capabilityHeaders(otherBooking.id),
       },
     )
-    expect(mismatchedCapabilityRes.status).toBe(401)
+    // A capability minted for another booking is rejected as 403, not 401:
+    // `verifyPublicCapabilityToken` distinguishes an absent or unverifiable
+    // token (unauthenticated, 401) from a valid one scoped to a different
+    // subject (authenticated, not permitted).
+    expect(mismatchedCapabilityRes.status).toBe(403)
 
     const mismatchedReferenceRes = await app.request(
       `/bookings/${booking.id}/documents/by-reference?reference=PF-SCOPED-2002`,
@@ -804,6 +827,10 @@ describe.skipIf(!DB_AVAILABLE)("Public finance routes", () => {
       code: "SPRING-2026",
       initialAmountCents: 30000,
       remainingAmountCents: 18000,
+      // The request below validates in EUR, and currency is checked before
+      // balance — a USD credit answers `currency_mismatch` and never reaches
+      // the assertion this test is named for.
+      currency: "EUR",
       sourceBookingId: booking.id,
       expiresAt: new Date("2026-12-31T23:59:59.000Z"),
     })
@@ -832,6 +859,7 @@ describe.skipIf(!DB_AVAILABLE)("Public finance routes", () => {
       code: "LOW-10",
       initialAmountCents: 1000,
       remainingAmountCents: 1000,
+      currency: "EUR",
     })
 
     const res = await app.request("/travel-credits/validate", {

--- a/packages/finance/tests/integration/routes.test.ts
+++ b/packages/finance/tests/integration/routes.test.ts
@@ -1,6 +1,7 @@
 // agent-quality: file-size exception -- owner: finance; existing coverage file stays co-located until a dedicated split preserves behavior and tests.
 import { bookingItems, bookings } from "@voyant-travel/bookings/schema"
 import { createEventBus } from "@voyant-travel/core"
+import { handleApiError } from "@voyant-travel/hono"
 import { prepareExternalWebhookEvent } from "@voyant-travel/webhook-delivery"
 import { eq, sql } from "drizzle-orm"
 import { Hono } from "hono"
@@ -95,6 +96,17 @@ async function cleanupFinanceTestData(
   db: any,
 ) {
   const tableNames = [
+    // The action ledger carries the idempotency records these routes replay
+    // against. Leaving them behind meant a rerun against the same database
+    // matched a stored key with a different payload fingerprint and answered
+    // 409 to the *first* request of a test, not the second.
+    "idempotency_keys",
+    "action_approvals",
+    "action_mutation_details",
+    "action_sensitive_read_details",
+    "action_ledger_payloads",
+    "action_delegations",
+    "action_ledger_entries",
     "payment_sessions",
     "supplier_payments",
     "payments",
@@ -353,6 +365,12 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
       c.set("container" as never, containerStub)
       await next()
     })
+    // The routes signal validation and conflict failures by throwing; turning
+    // those into status codes is `createApp`'s job, not each route's. Mounting
+    // them on a bare Hono without it made every such case a default 500, so
+    // these tests asserted 400/409 against a harness that could not produce
+    // one.
+    app.onError((err, c) => handleApiError(err, c))
     app.route("/", financeRoutes)
   })
 
@@ -380,6 +398,7 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
     const [row] = await db
       .insert(bookings)
       .values({
+        status: "confirmed",
         bookingNumber: nextBookingNumber(),
         sellCurrency: "USD",
         sellAmountCents: 100000,
@@ -399,6 +418,7 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
     const [row] = await db
       .insert(bookingItems)
       .values({
+        status: "confirmed",
         bookingId,
         title: "Test Service",
         quantity: 2,
@@ -721,7 +741,7 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
       // `invoice.settled` so plugin callbacks (Netopia and friends) don't
       // need a separate poller — see issue #357.
       expect(settlementEvents).toHaveLength(1)
-      expect(settlementEvents[0]).toMatchObject({
+      expect(settlementEvents[0]?.data).toMatchObject({
         invoiceId: invoice.id,
         paymentId: data.paymentId,
         provider: "netopia",
@@ -730,7 +750,7 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
         balanceDueCents: 0,
       })
       expect(invoicePaymentRecordedEvents).toHaveLength(1)
-      expect(invoicePaymentRecordedEvents[0]).toMatchObject({
+      expect(invoicePaymentRecordedEvents[0]?.data).toMatchObject({
         invoiceId: invoice.id,
         invoiceNumber: invoice.invoiceNumber,
         invoiceType: "invoice",
@@ -808,7 +828,7 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
       expect(storedInvoice?.balanceDueCents).toBe(0)
       expect(storedInvoice?.status).toBe("paid")
       expect(schedulePaidEvents).toHaveLength(1)
-      expect(schedulePaidEvents[0]).toMatchObject({
+      expect(schedulePaidEvents[0]?.data).toMatchObject({
         bookingId: booking.id,
         bookingPaymentScheduleId: schedule.id,
         paymentSessionId: session.id,
@@ -819,7 +839,7 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
         provider: "netopia",
       })
       expect(paymentCompletedEvents).toHaveLength(1)
-      expect(paymentCompletedEvents[0]).toMatchObject({
+      expect(paymentCompletedEvents[0]?.data).toMatchObject({
         paymentSessionId: session.id,
         targetType: "booking_payment_schedule",
         targetId: schedule.id,
@@ -2152,7 +2172,7 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
       expect(res.status).toBe(201)
       const { data } = await res.json()
       expect(data.invoiceNumber).toBe("INV-0042")
-      expect(data.seriesId).toMatch(/^ins_/)
+      expect(data.seriesId).toMatch(/^invs_/)
       expect(data.sequence).toBe(42)
       expect(data.totalCents).toBe(16500)
     })
@@ -2299,7 +2319,7 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
   })
 
   describe("Invoice rendition wait", () => {
-    it("returns 202 with the pending rendition when render wait times out", async () => {
+    it("records the miss when no document provider is configured", async () => {
       const booking = await seedBooking()
       const invoice = await seedInvoice(booking.id)
 
@@ -2308,13 +2328,19 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
         ...json({ format: "pdf" }),
       })
 
+      // This route used to answer 202 with a `pending` row and leave it there
+      // forever — the orphan voyant#4668 was filed for. These routes are built
+      // without a provider, so the request cannot be served; saying so on the
+      // row is what releases every waiter, because `failed` is terminal for
+      // `waitForInvoiceRendition` and `pending` is not.
       expect(res.status).toBe(202)
       const { data } = await res.json()
       expect(data.rendition).toMatchObject({
         invoiceId: invoice.id,
         format: "pdf",
-        status: "pending",
+        status: "failed",
       })
+      expect(data.rendition.errorMessage).toMatch(/no document renderer is available/i)
 
       const rows = await db
         .select()

--- a/packages/finance/tests/integration/routes.test.ts
+++ b/packages/finance/tests/integration/routes.test.ts
@@ -447,7 +447,23 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
     const res = await app.request("/invoices", { method: "POST", ...json(body) })
     expect(res.status).toBe(201)
     const { data } = await res.json()
-    return data as { id: string; [k: string]: unknown }
+    const created = data as { id: string; [k: string]: unknown }
+
+    // `POST /invoices` has no `invoiceType` in its contract — proformas are
+    // only ever minted by the from-booking issuance path — so passing one here
+    // was silently dropped and the caller got a plain invoice it believed was
+    // a proforma. Apply it directly for the tests that need a proforma to
+    // convert; the conversion itself still runs through the route.
+    if (typeof overrides.invoiceType === "string" && overrides.invoiceType !== "invoice") {
+      const [updated] = await db
+        .update(invoices)
+        .set({ invoiceType: overrides.invoiceType as "proforma" })
+        .where(eq(invoices.id, created.id))
+        .returning()
+      return { ...created, invoiceType: updated?.invoiceType } as typeof created
+    }
+
+    return created
   }
 
   async function seedPaymentInstrument(overrides: Record<string, unknown> = {}) {
@@ -1356,9 +1372,21 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
       const replayBody = await replay.json()
       expect(replayBody.data.id).toBe(firstBody.data.id)
 
+      // Reusing the number just issued must conflict. The body has to be a
+      // valid from-booking request to get that far — the invoice-create shape
+      // this used to send is rejected by the route's schema now, so the 409 it
+      // asserted could never be reached.
       const conflict = await app.request("/invoices/from-booking?wait=pdf", {
         method: "POST",
-        ...jsonWithIdempotency(input, "finance-invoice-from-booking-1"),
+        ...jsonWithIdempotency(
+          {
+            bookingId: booking.id,
+            invoiceNumber: input.invoiceNumber,
+            issueDate: input.issueDate,
+            dueDate: input.dueDate,
+          },
+          "finance-invoice-from-booking-1",
+        ),
       })
       expect(conflict.status).toBe(409)
     })
@@ -1725,7 +1753,11 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
 
     it("returns a conflict when conversion would reuse an active invoice number", async () => {
       const booking = await seedBooking()
-      await seedInvoice(booking.id, {
+      // The colliding invoice belongs to a *different* booking on purpose: on
+      // the same one the duplicate-fiscal-invoice guard fires first and this
+      // test never reaches the number-uniqueness check it is named for.
+      const otherBooking = await seedBooking()
+      await seedInvoice(otherBooking.id, {
         invoiceNumber: "INV-CONVERT-DUP",
         invoiceType: "invoice",
         status: "issued",
@@ -1975,7 +2007,10 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
       expect(data.id).toMatch(/^inv_/)
       expect(data.bookingId).toBe(booking.id)
       expect(data.currency).toBe("USD")
-      expect(data.status).toBe("draft")
+      // `/invoices/from-booking` is an *issuing* command — `issued` is its only
+      // success shape. The `draft` assertion predates that and has been wrong
+      // since the route stopped merely composing a draft.
+      expect(data.status).toBe("issued")
       // Should have subtotal based on items
       expect(data.subtotalCents).toBeGreaterThan(0)
       expect(data.balanceDueCents).toBeGreaterThan(0)
@@ -2268,14 +2303,26 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
         }),
       })
 
-      expect(res.status).toBe(201)
-      const { data } = await res.json()
-      expect(data.currency).toBe("EUR")
-      expect(data.baseCurrency).toBe("RON")
-      expect(data.subtotalCents).toBe(16500)
-      expect(data.baseSubtotalCents).toBeNull()
-      expect(data.baseTotalCents).toBeNull()
-      expect(data.baseBalanceDueCents).toBeNull()
+      // The rule this test is named for is now enforced by refusing the
+      // invoice outright rather than by issuing one with null base amounts: a
+      // schedule in another currency cannot be converted without a rate set,
+      // and guessing from the booking's sell currency is exactly what must not
+      // happen. The refusal names what was missing.
+      expect(res.status).toBe(400)
+      await expect(res.json()).resolves.toMatchObject({
+        code: "invalid_invoice_from_booking",
+        details: {
+          scheduleCurrency: "EUR",
+          bookingSellCurrency: "USD",
+          fxRateSetId: null,
+        },
+      })
+
+      const created = await db
+        .select({ id: invoices.id })
+        .from(invoices)
+        .where(eq(invoices.bookingId, booking.id))
+      expect(created).toHaveLength(0)
     })
 
     it("returns 404 for non-existent booking", async () => {
@@ -3258,6 +3305,7 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
     it("requires userId to create notes", async () => {
       // Create a separate app without userId
       const noUserApp = new Hono()
+      noUserApp.onError((err, c) => handleApiError(err, c))
       noUserApp.use("*", async (c, next) => {
         c.set("db" as never, db)
         // userId NOT set
@@ -3272,9 +3320,11 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
         method: "POST",
         ...json({ content: "No user" }),
       })
-      expect(res.status).toBe(400)
-      const body = await res.json()
-      expect(body.error).toContain("User ID")
+      // A request with no actor is unauthenticated, not malformed: the route
+      // raises `UnauthorizedApiError` and the boundary renders 401. The old
+      // 400 / "User ID" message belonged to a hand-rolled guard that no longer
+      // exists.
+      expect(res.status).toBe(401)
     })
 
     it("lists notes for an invoice", async () => {

--- a/packages/finance/tests/integration/routes.test.ts
+++ b/packages/finance/tests/integration/routes.test.ts
@@ -2366,6 +2366,25 @@ describe.skipIf(!DB_AVAILABLE)("Finance routes", () => {
   })
 
   describe("Invoice rendition wait", () => {
+    it("leaves the row pending when the caller did not ask to wait", async () => {
+      const booking = await seedBooking()
+      const invoice = await seedInvoice(booking.id)
+
+      const res = await app.request(`/invoices/${invoice.id}/render`, {
+        method: "POST",
+        ...json({ format: "pdf" }),
+      })
+
+      // `docs/architecture/invoice-rendition-wait.md`: the wait is additive, and
+      // omitting it preserves the historical response shape. Rendering inline
+      // regardless would hold a fire-and-forget request for the renderer's full
+      // navigation timeout.
+      expect(res.status).toBe(201)
+      const { data } = await res.json()
+      expect(data).toMatchObject({ invoiceId: invoice.id, format: "pdf", status: "pending" })
+      expect(data.errorMessage).toBeNull()
+    })
+
     it("records the miss when no document provider is configured", async () => {
       const booking = await seedBooking()
       const invoice = await seedInvoice(booking.id)

--- a/packages/finance/tests/integration/settlement-routes.test.ts
+++ b/packages/finance/tests/integration/settlement-routes.test.ts
@@ -152,10 +152,13 @@ describe.skipIf(!DB_AVAILABLE)("Finance settlement routes", () => {
     expect(settlementEvents).toEqual([
       expect.objectContaining({
         name: "invoice.settled",
-        metadata: {
+        // `objectContaining`: the envelope's metadata gained `eventId`, and
+        // pinning it exactly asserted the envelope's shape rather than the
+        // event this test is about.
+        metadata: expect.objectContaining({
           category: "domain",
           source: "service",
-        },
+        }),
         data: expect.objectContaining({
           invoiceId: invoice.id,
           provider: "smartbill",

--- a/packages/finance/tests/integration/settlement-routes.test.ts
+++ b/packages/finance/tests/integration/settlement-routes.test.ts
@@ -62,6 +62,7 @@ describe.skipIf(!DB_AVAILABLE)("Finance settlement routes", () => {
     const [booking] = await db
       .insert(bookings)
       .values({
+        status: "confirmed",
         bookingNumber: "BKG-2001",
         sellCurrency: "EUR",
         sellAmountCents: 100000,

--- a/packages/finance/tests/integration/unsynced-proforma-command.test.ts
+++ b/packages/finance/tests/integration/unsynced-proforma-command.test.ts
@@ -56,6 +56,7 @@ describe.skipIf(!DB_AVAILABLE)("unsynced proforma command", () => {
     const [booking] = await db
       .insert(bookings)
       .values({
+        status: "confirmed",
         bookingNumber: "BK-UNSYNCED-PROFORMA",
         sellCurrency: "EUR",
         sellAmountCents: 80_000,
@@ -67,6 +68,7 @@ describe.skipIf(!DB_AVAILABLE)("unsynced proforma command", () => {
     const [item] = await db
       .insert(bookingItems)
       .values({
+        status: "confirmed",
         bookingId: booking!.id,
         title: "Coastal day cruise",
         quantity: 2,

--- a/packages/finance/tests/integration/unsynced-proforma-command.test.ts
+++ b/packages/finance/tests/integration/unsynced-proforma-command.test.ts
@@ -61,7 +61,9 @@ describe.skipIf(!DB_AVAILABLE)("unsynced proforma command", () => {
         sellCurrency: "EUR",
         sellAmountCents: 80_000,
         costAmountCents: 50_000,
-        marginPercent: 37.5,
+        // `bookings.margin_percent` is an integer column, so a fractional
+        // margin is rejected by Postgres before the command under test runs.
+        marginPercent: 38,
         startDate: "2026-08-10",
       })
       .returning()

--- a/packages/finance/tests/unit/invoice-document-graph-provider.test.ts
+++ b/packages/finance/tests/unit/invoice-document-graph-provider.test.ts
@@ -1,0 +1,140 @@
+import { createHttpDocumentRendererFromEnv } from "@voyant-travel/core/document-rendering"
+import { createGatewayStorageProvider } from "@voyant-travel/storage"
+import { describe, expect, it, vi } from "vitest"
+
+import { assertFinanceInvoiceDocumentProviderConformance } from "../../src/contracts/invoice-document-provider.js"
+import { createStandardInvoiceDocumentProvider } from "../../src/invoice-document-runtime.js"
+import { createFinanceInvoiceDocumentGraphProvider } from "../../src/runtime-contributor.js"
+
+describe("Finance invoice document graph provider", () => {
+  it("constructs the standard provider from selected deployment resources", async () => {
+    const resources = {
+      "@voyant-travel/finance#resource.document-storage": {
+        name: "documents",
+        resolveBackendIdentity: async () => "storage-primary",
+      },
+      "@voyant-travel/finance#resource.document-renderer": {
+        name: "renderer",
+        resolveBackendIdentity: async () => "renderer-primary",
+      },
+    }
+    const getResource = vi.fn((id: keyof typeof resources) => resources[id])
+
+    const provider = await createFinanceInvoiceDocumentGraphProvider({ getResource } as never)
+
+    expect(provider.identity).toMatchObject({
+      id: "voyant.standard.invoice-document",
+      protocol: "finance-invoice-document.v1",
+    })
+    expect(provider.identity.version).toMatch(/^1:[a-f0-9]{64}$/)
+    expect(getResource).toHaveBeenCalledTimes(2)
+  })
+
+  it("changes provider identity for the same endpoints with different credentials", async () => {
+    const build = (credential: string) =>
+      createFinanceInvoiceDocumentGraphProvider({
+        getResource: (id: string) => {
+          if (id.endsWith("document-storage")) {
+            return createGatewayStorageProvider({
+              endpoint: "https://storage.example",
+              tier: "documents",
+              token: credential,
+            })
+          }
+          return createHttpDocumentRendererFromEnv({
+            VOYANT_DOCUMENT_RENDERER_URL: "https://renderer.example/pdf",
+            VOYANT_DOCUMENT_RENDERER_TOKEN: credential,
+          })
+        },
+      } as never)
+
+    const primary = await build("account-a-token")
+    const swapped = await build("account-b-token")
+
+    expect(swapped.identity.version).not.toBe(primary.identity.version)
+  })
+
+  it("fails startup instead of substituting a provider", async () => {
+    await expect(
+      createFinanceInvoiceDocumentGraphProvider({ getResource: () => undefined } as never),
+    ).rejects.toThrow(/document storage and document renderer resources/)
+  })
+})
+
+/** An in-memory document store that honours exact keys, like the real ones do. */
+function memoryDocumentStorage() {
+  const objects = new Map<string, Uint8Array>()
+  return {
+    objects,
+    provider: {
+      name: "memory:documents",
+      resolveBackendIdentity: async () => "memory",
+      upload: async (body: Uint8Array, options?: { key?: string }) => {
+        const key = options?.key ?? "unnamed"
+        objects.set(key, body)
+        return { key }
+      },
+      get: async (key: string) => {
+        const value = objects.get(key)
+        return value ? (value.buffer.slice(0) as ArrayBuffer) : null
+      },
+      delete: async (key: string) => {
+        objects.delete(key)
+      },
+    },
+  }
+}
+
+describe("standard invoice document provider", () => {
+  it("passes the port's own conformance harness", async () => {
+    const storage = memoryDocumentStorage()
+    const provider = await createStandardInvoiceDocumentProvider({
+      storage: storage.provider as never,
+      renderer: {
+        name: "renderer",
+        resolveBackendIdentity: async () => "renderer",
+        renderPdf: async ({ html }: { html: string }) => new TextEncoder().encode(`pdf:${html}`),
+      } as never,
+    })
+
+    await expect(
+      assertFinanceInvoiceDocumentProviderConformance({
+        provider,
+        namespace: "finance/invoice-documents/test",
+      }),
+    ).resolves.toBeUndefined()
+    // The harness cleans up after itself; a leftover object would mean a later
+    // rendition could read another operation's bytes.
+    expect(storage.objects.size).toBe(0)
+  })
+
+  it("refuses a store that does not honour the exact key", async () => {
+    const provider = await createStandardInvoiceDocumentProvider({
+      storage: {
+        name: "renaming",
+        resolveBackendIdentity: async () => "renaming",
+        upload: async () => ({ key: "somewhere/else.pdf" }),
+        get: async () => null,
+        delete: async () => {},
+      } as never,
+      renderer: {
+        name: "renderer",
+        resolveBackendIdentity: async () => "renderer",
+        renderPdf: async () => new TextEncoder().encode("pdf"),
+      } as never,
+    })
+
+    await expect(
+      provider.put({
+        renditionId: "rendition-1",
+        operationKey: "invoices/inv-1/renditions/rendition-1.pdf",
+        artifact: {
+          bytes: new TextEncoder().encode("pdf"),
+          checksumSha256: "checksum",
+          name: "invoice.pdf",
+          contentType: "application/pdf",
+        },
+      }),
+    ).rejects.toThrow(/did not honor the exact operation key/)
+  })
+})

--- a/packages/finance/tests/unit/service-action-ledger-accounting.test.ts
+++ b/packages/finance/tests/unit/service-action-ledger-accounting.test.ts
@@ -398,7 +398,11 @@ describe("finance accounting action ledger builders", () => {
       routeOrToolName: "finance.invoice.issue_from_booking",
       authorizationSource: "finance.invoice.from_booking.route",
       idempotencyScope: "finance.booking:book_123:invoice_issue",
-      idempotencyKey: "INV-2026-001",
+      // Keyed by (type, number) to match
+      // `invoices_invoice_number_type_active_idx`: a proforma and a fiscal
+      // invoice may share an external number, and keying on the number
+      // alone made the second of the pair collide with the first.
+      idempotencyKey: "invoice:INV-2026-001",
       mutationDetail: {
         commandInputRef: "booking:book_123:invoice_issue",
         commandResultRef: "invoice:inv_123",

--- a/packages/finance/tests/unit/voyant-manifest.test.ts
+++ b/packages/finance/tests/unit/voyant-manifest.test.ts
@@ -34,6 +34,7 @@ describe("finance deployment manifest", () => {
           { id: "finance.host.runtime" },
           { id: "finance.app-api.runtime" },
           { id: "finance.departure-profitability.runtime" },
+          { id: "finance.invoice-document-provider" },
         ],
       },
       runtime: { entry: "@voyant-travel/finance", export: "createFinanceVoyantRuntime" },
@@ -45,6 +46,7 @@ describe("finance deployment manifest", () => {
         { id: "finance.checkout-payment-starters.runtime", optional: true },
         { id: "payments.adapter.runtime", optional: true },
         { id: "finance.invoice-settlement-poller", optional: true, cardinality: "many" },
+        { id: "finance.invoice-document-provider", optional: true },
       ],
       api: [
         {
@@ -780,6 +782,84 @@ describe("finance deployment manifest", () => {
         label: { namespace: "finance.admin", key: "invoicesPage.title" },
       }),
     ])
+  })
+})
+
+/**
+ * voyant#4668: finance could request an invoice document and nothing anywhere
+ * would produce one. The four declarations below are what makes that
+ * impossible to reintroduce silently — an unfulfillable deployment now fails
+ * when the graph resolves rather than returning HTTP 501 at the route.
+ */
+describe("invoice document production", () => {
+  it("declares the resources an invoice PDF actually needs", () => {
+    expect(financeVoyantModule.resources).toEqual([
+      {
+        id: "@voyant-travel/finance#resource.document-storage",
+        kind: "document-storage",
+        required: true,
+      },
+      {
+        id: "@voyant-travel/finance#resource.document-renderer",
+        kind: "document-renderer",
+        required: true,
+      },
+    ])
+  })
+
+  it("offers the document provider as a selectable, resource-backed provider", () => {
+    expect(financeVoyantModule.providers).toEqual([
+      expect.objectContaining({
+        id: "@voyant-travel/finance#provider.invoice-document",
+        port: "finance.invoice-document-provider",
+        selection: { role: "invoiceDocumentArtifact", value: "standard" },
+        uses: {
+          resources: [
+            "@voyant-travel/finance#resource.document-storage",
+            "@voyant-travel/finance#resource.document-renderer",
+          ],
+        },
+        runtime: {
+          entry: "@voyant-travel/finance/runtime-contributor",
+          export: "createFinanceInvoiceDocumentGraphProvider",
+        },
+      }),
+    ])
+  })
+
+  it("carries both a trigger and a recovery leg", () => {
+    expect(financeVoyantModule.subscribers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "@voyant-travel/finance#subscriber.invoice-issued-document",
+          eventType: "invoice.issued",
+          runtime: {
+            entry: "@voyant-travel/finance/invoice-issued-subscriber",
+            export: "createInvoiceIssuedDocumentSubscriberGraphRuntime",
+          },
+        }),
+      ]),
+    )
+    expect(financeVoyantModule.jobs).toEqual([
+      expect.objectContaining({
+        id: "finance.invoice-document-renditions",
+        wakeup: true,
+        schedule: { every: "1m", overlap: "skip" },
+        runtime: {
+          entry: "@voyant-travel/finance/invoice-document-job",
+          export: "runDueInvoiceDocumentRenditionsJob",
+        },
+      }),
+    ])
+  })
+
+  it("keeps the provider port optional so a deployment without one still boots", () => {
+    expect(declaredRuntimePorts.has("finance.invoice-document-provider")).toBe(true)
+    expect(
+      financeVoyantModule.runtimePorts.find(
+        ({ id }) => id === "finance.invoice-document-provider",
+      ),
+    ).toMatchObject({ optional: true })
   })
 })
 

--- a/packages/finance/tests/unit/voyant-manifest.test.ts
+++ b/packages/finance/tests/unit/voyant-manifest.test.ts
@@ -856,9 +856,7 @@ describe("invoice document production", () => {
   it("keeps the provider port optional so a deployment without one still boots", () => {
     expect(declaredRuntimePorts.has("finance.invoice-document-provider")).toBe(true)
     expect(
-      financeVoyantModule.runtimePorts.find(
-        ({ id }) => id === "finance.invoice-document-provider",
-      ),
+      financeVoyantModule.runtimePorts.find(({ id }) => id === "finance.invoice-document-provider"),
     ).toMatchObject({ optional: true })
   })
 })

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -1102,7 +1102,11 @@
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],
       "@voyant-travel/finance/checkout-routes": ["../finance/dist/checkout-routes.d.ts"],
       "@voyant-travel/finance/checkout-validation": ["../finance/dist/checkout-validation.d.ts"],
+      "@voyant-travel/finance/invoice-document-job": ["../finance/dist/invoice-document-job.d.ts"],
       "@voyant-travel/finance/invoice-fx": ["../finance/dist/invoice-fx.d.ts"],
+      "@voyant-travel/finance/invoice-issued-subscriber": [
+        "../finance/dist/invoice-issued-subscriber.d.ts"
+      ],
       "@voyant-travel/finance/linkables": ["../finance/dist/linkables.d.ts"],
       "@voyant-travel/finance/order-payment-sessions": [
         "../finance/dist/order-payment-sessions.d.ts"

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -1103,7 +1103,11 @@
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],
       "@voyant-travel/finance/checkout-routes": ["../finance/dist/checkout-routes.d.ts"],
       "@voyant-travel/finance/checkout-validation": ["../finance/dist/checkout-validation.d.ts"],
+      "@voyant-travel/finance/invoice-document-job": ["../finance/dist/invoice-document-job.d.ts"],
       "@voyant-travel/finance/invoice-fx": ["../finance/dist/invoice-fx.d.ts"],
+      "@voyant-travel/finance/invoice-issued-subscriber": [
+        "../finance/dist/invoice-issued-subscriber.d.ts"
+      ],
       "@voyant-travel/finance/linkables": ["../finance/dist/linkables.d.ts"],
       "@voyant-travel/finance/order-payment-sessions": [
         "../finance/dist/order-payment-sessions.d.ts"

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -1108,7 +1108,11 @@
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],
       "@voyant-travel/finance/checkout-routes": ["../finance/dist/checkout-routes.d.ts"],
       "@voyant-travel/finance/checkout-validation": ["../finance/dist/checkout-validation.d.ts"],
+      "@voyant-travel/finance/invoice-document-job": ["../finance/dist/invoice-document-job.d.ts"],
       "@voyant-travel/finance/invoice-fx": ["../finance/dist/invoice-fx.d.ts"],
+      "@voyant-travel/finance/invoice-issued-subscriber": [
+        "../finance/dist/invoice-issued-subscriber.d.ts"
+      ],
       "@voyant-travel/finance/linkables": ["../finance/dist/linkables.d.ts"],
       "@voyant-travel/finance/order-payment-sessions": [
         "../finance/dist/order-payment-sessions.d.ts"

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -1103,7 +1103,11 @@
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],
       "@voyant-travel/finance/checkout-routes": ["../finance/dist/checkout-routes.d.ts"],
       "@voyant-travel/finance/checkout-validation": ["../finance/dist/checkout-validation.d.ts"],
+      "@voyant-travel/finance/invoice-document-job": ["../finance/dist/invoice-document-job.d.ts"],
       "@voyant-travel/finance/invoice-fx": ["../finance/dist/invoice-fx.d.ts"],
+      "@voyant-travel/finance/invoice-issued-subscriber": [
+        "../finance/dist/invoice-issued-subscriber.d.ts"
+      ],
       "@voyant-travel/finance/linkables": ["../finance/dist/linkables.d.ts"],
       "@voyant-travel/finance/order-payment-sessions": [
         "../finance/dist/order-payment-sessions.d.ts"

--- a/packages/inventory/tsconfig.build.json
+++ b/packages/inventory/tsconfig.build.json
@@ -1102,7 +1102,11 @@
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],
       "@voyant-travel/finance/checkout-routes": ["../finance/dist/checkout-routes.d.ts"],
       "@voyant-travel/finance/checkout-validation": ["../finance/dist/checkout-validation.d.ts"],
+      "@voyant-travel/finance/invoice-document-job": ["../finance/dist/invoice-document-job.d.ts"],
       "@voyant-travel/finance/invoice-fx": ["../finance/dist/invoice-fx.d.ts"],
+      "@voyant-travel/finance/invoice-issued-subscriber": [
+        "../finance/dist/invoice-issued-subscriber.d.ts"
+      ],
       "@voyant-travel/finance/linkables": ["../finance/dist/linkables.d.ts"],
       "@voyant-travel/finance/order-payment-sessions": [
         "../finance/dist/order-payment-sessions.d.ts"

--- a/packages/inventory/tsconfig.typecheck.json
+++ b/packages/inventory/tsconfig.typecheck.json
@@ -1103,7 +1103,11 @@
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],
       "@voyant-travel/finance/checkout-routes": ["../finance/dist/checkout-routes.d.ts"],
       "@voyant-travel/finance/checkout-validation": ["../finance/dist/checkout-validation.d.ts"],
+      "@voyant-travel/finance/invoice-document-job": ["../finance/dist/invoice-document-job.d.ts"],
       "@voyant-travel/finance/invoice-fx": ["../finance/dist/invoice-fx.d.ts"],
+      "@voyant-travel/finance/invoice-issued-subscriber": [
+        "../finance/dist/invoice-issued-subscriber.d.ts"
+      ],
       "@voyant-travel/finance/linkables": ["../finance/dist/linkables.d.ts"],
       "@voyant-travel/finance/order-payment-sessions": [
         "../finance/dist/order-payment-sessions.d.ts"

--- a/packages/legal/src/voyant.ts
+++ b/packages/legal/src/voyant.ts
@@ -284,7 +284,14 @@ export const legalVoyantModule = defineModule({
       openapi: { document: "contract-document" },
       runtime: {
         entry: "@voyant-travel/legal/contract-document-routes",
-        export: "createContractDocumentApiModule",
+        // The graph-runtime wrapper, not the raw factory beneath it:
+        // `createContractDocumentApiModule` takes its options as its first
+        // argument, so pointing the bundle at it handed the graph's own
+        // context in as `options` and every request to
+        // `/v1/admin/documents/files/*` died destructuring `undefined`. That
+        // is the download target for every private document — contracts, and
+        // now invoice renditions.
+        export: "createContractDocumentVoyantRuntime",
       },
     },
     {

--- a/packages/legal/tests/unit/voyant-manifest.test.ts
+++ b/packages/legal/tests/unit/voyant-manifest.test.ts
@@ -49,7 +49,10 @@ describe("legal deployment manifest", () => {
           openapi: { document: "contract-document" },
           runtime: {
             entry: "@voyant-travel/legal/contract-document-routes",
-            export: "createContractDocumentApiModule",
+            // The graph-runtime wrapper, not the raw factory: the raw one
+            // takes its options as its first argument and the graph has none
+            // to give, which is why this bundle answered 500 on every request.
+            export: "createContractDocumentVoyantRuntime",
           },
         },
         {

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -1108,7 +1108,11 @@
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],
       "@voyant-travel/finance/checkout-routes": ["../finance/dist/checkout-routes.d.ts"],
       "@voyant-travel/finance/checkout-validation": ["../finance/dist/checkout-validation.d.ts"],
+      "@voyant-travel/finance/invoice-document-job": ["../finance/dist/invoice-document-job.d.ts"],
       "@voyant-travel/finance/invoice-fx": ["../finance/dist/invoice-fx.d.ts"],
+      "@voyant-travel/finance/invoice-issued-subscriber": [
+        "../finance/dist/invoice-issued-subscriber.d.ts"
+      ],
       "@voyant-travel/finance/linkables": ["../finance/dist/linkables.d.ts"],
       "@voyant-travel/finance/order-payment-sessions": [
         "../finance/dist/order-payment-sessions.d.ts"

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -1103,7 +1103,11 @@
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],
       "@voyant-travel/finance/checkout-routes": ["../finance/dist/checkout-routes.d.ts"],
       "@voyant-travel/finance/checkout-validation": ["../finance/dist/checkout-validation.d.ts"],
+      "@voyant-travel/finance/invoice-document-job": ["../finance/dist/invoice-document-job.d.ts"],
       "@voyant-travel/finance/invoice-fx": ["../finance/dist/invoice-fx.d.ts"],
+      "@voyant-travel/finance/invoice-issued-subscriber": [
+        "../finance/dist/invoice-issued-subscriber.d.ts"
+      ],
       "@voyant-travel/finance/linkables": ["../finance/dist/linkables.d.ts"],
       "@voyant-travel/finance/order-payment-sessions": [
         "../finance/dist/order-payment-sessions.d.ts"

--- a/packages/operator-standard/src/index.ts
+++ b/packages/operator-standard/src/index.ts
@@ -126,6 +126,7 @@ export const STANDARD_OPERATOR_DEPLOYMENT: VoyantGraphProjectDeployment = {
     scheduledJobs: "node-cron",
     outboundWebhooks: "postgres",
     legalDocumentArtifact: "standard",
+    invoiceDocumentArtifact: "standard",
     payments: "custom",
   },
 }

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -1101,7 +1101,11 @@
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],
       "@voyant-travel/finance/checkout-routes": ["../finance/dist/checkout-routes.d.ts"],
       "@voyant-travel/finance/checkout-validation": ["../finance/dist/checkout-validation.d.ts"],
+      "@voyant-travel/finance/invoice-document-job": ["../finance/dist/invoice-document-job.d.ts"],
       "@voyant-travel/finance/invoice-fx": ["../finance/dist/invoice-fx.d.ts"],
+      "@voyant-travel/finance/invoice-issued-subscriber": [
+        "../finance/dist/invoice-issued-subscriber.d.ts"
+      ],
       "@voyant-travel/finance/linkables": ["../finance/dist/linkables.d.ts"],
       "@voyant-travel/finance/order-payment-sessions": [
         "../finance/dist/order-payment-sessions.d.ts"


### PR DESCRIPTION
Closes #4668.

## The gap

`renderInvoice` inserted a `pending` rendition and its own docblock said a background job would fulfil it. No such job existed — nothing in the repository read `invoice_renditions` where `status = 'pending'`. The row was an orphan: `?wait=true` polled it for its full 30s and returned 202, and the booking-confirmation notification held for a document that was never coming. `POST /invoices/{id}/generate-document` answered 501, because `createFinanceRuntime` never set `invoiceDocumentGenerator` and no deployment supplied one — `createPdfInvoiceDocumentGenerator` had been written, exported and tested, and its only callers were a unit test and the export checker.

So a deployment without an accounting app could not produce an invoice PDF at all.

## What decided the shape

The issue reads as "wire the existing generator into `createFinanceRuntime`". That is not possible: a graph runtime factory receives `getPort`/`hasPort` and no `getResource`. Resources reach only **selected provider factories** (`packages/runtime/src/index.ts`). Until finance declared a provider there was no seam through which a renderer could arrive, so the port is the mechanism, not ceremony.

## The four pieces

| | before | after |
|---|---|---|
| resources | none declared | `#resource.document-storage` + `#resource.document-renderer`, both required — an unfulfillable deployment now fails at graph resolution, not at a 501 |
| provider | an optional options field nobody set | `finance.invoice-document-provider`, conformance-tested, selected as `invoiceDocumentArtifact: "standard"` in `operator-standard` |
| trigger | none | an `invoice.issued` subscriber renders in-process |
| recovery | none — finance declared no jobs | `finance.invoice-document-renditions`, `every: "1m"`, `wakeup: true` |
| the miss | silent orphan | recorded on the row as `failed` with a reason |

The subscriber matters beyond latency: #4667 made the confirmation email wait for the invoice to resolve, so without an in-process trigger every confirmation would sit behind the job's cadence. Booking create cannot render inside its own transaction, so it writes the request and this turns it into a document.

**One deliberate divergence from the legal provider.** A repeated `put` with different bytes *replaces* rather than being rejected, because the operation key is one `invoice_renditions` row and re-rendering that row is exactly what a retry is. Rejecting the mismatch would strand the row behind any renderer whose output is not byte-identical run to run.

**The requested row is fulfilled in place** rather than superseded by a second `ready` row beside it — that orphan is what this replaced. `bindInvoiceRendition` keeps inserting; it serves the app-provided path, where bytes arrive without a request having been made.

**An invoice awaiting external allocation is skipped, not rendered.** When the series delegates numbering to an accounting app, the number is still `PENDING-…`; rendering locally would produce a fiscally invalid PDF naming a number no authority issued.

## Verified end to end, not just in tests

Booted `apps/operator` against Postgres in Docker and drove the real HTTP surface:

- `POST /invoices/{id}/render?wait=pdf` → **201**, `status: ready`, in 1.1s. Previously: a `pending` orphan and a 202 after the full wait.
- The artifact is a real **PDF 1.7, 96,164 bytes**, at the key the row points to, and its SHA-256 equals the `checksum` column exactly.
- `POST /invoices/{id}/generate-document` → **201**. Previously: 501.
- `GET /v1/admin/documents/files/…` → **200**, `application/pdf`, checksum matching the row.

That last one only works because of the second commit.

## Three further defects this turned up

Found while getting the finance integration suite honest; each is a case where the code discarded or refused something it should not.

1. **Private document downloads were 500 on every Node deployment.** The contract-document bundle pointed at `createContractDocumentApiModule` — the raw factory that takes its options as its first argument — instead of `createContractDocumentVoyantRuntime`, the wrapper that resolves them from the port. The graph handed its own context in as `options` and every request died destructuring `undefined`. That is the download target for contract PDFs and now invoice renditions.
2. **A reused idempotency key was a 500.** `ActionLedgerIdempotencyConflictError` reached the boundary unrecognized, so a client mistake the HTTP idempotency middleware already answers 409 for read as an infrastructure fault.
3. **A proforma could not share a number with its invoice.** Issuance keyed the action ledger on the invoice number alone, while `invoices_invoice_number_type_active_idx` is unique on (number, *type*) — the database deliberately permits the pair. The second document failed. Now keyed on (type, number).

Plus: conversion conflicts returned a sentence and threw away the pointer to the colliding invoice that the service had already resolved, so an operator could not open it. The 409 now carries `code`, `existingInvoiceId` and `existingInvoiceNumber`, and the route declares that shape.

## The finance integration suite

It had been failing on every run long enough to be read as "known red". `routes.test.ts` alone was **108 failing**; all six affected files are now green. Four mechanical causes and a tail of stale assertions, each checked against the change that moved the behaviour before being touched:

- #4100 removed `.default("draft")` from `bookings.status` — 106 of the 108 were fixtures omitting a now-required column.
- The harness mounted routes on a bare `Hono` with no error boundary, so every thrown validation/conflict became a default 500 and tests asserting 400/409 could never pass.
- `idempotency_keys` and the action-ledger tables were not truncated between tests, so a rerun matched a stored key with a different fingerprint and answered 409 to the *first* request.
- Assertions pinned shapes that moved: the series TypeID prefix is `invs`, and captured events are `EventEnvelope`s that gained `eventId`/`emittedAt`.
- CHECK-constraint tests matched the constraint name against `error.message`, which Drizzle's wrapper no longer carries — they passed on *any* failure, including a bad fixture. They now walk the cause chain.
- `POST /invoices` has no `invoiceType`; tests passing one were silently getting a plain invoice and asserting against it.
- #4050 made the public finance routes storefront-scoped, so all twelve 403s were the guard working, not the routes broken.
- A capability scoped to another booking is 403, not 401 — `ForbiddenApiError` deliberately separates "valid token, wrong subject" from "no token".

## Verification

- `pnpm verify:architecture` — passes, 99 chain links, including `verify:openapi-drift` and `verify:graph-conformance`.
- `biome check .` — 6,932 files, **0 errors** (23 warnings, 8 infos).
- `tsc -p tsconfig.build.json` and `tsconfig.typecheck.json` for finance — 0 errors; `turbo build` 34/34.
- `finance` — 79 files / 597 tests. `legal` — 26 files / 196 tests. `operator-standard` — 21 tests.
- Integration against Postgres: `routes` 147, `booking-create` 103, `currency-amount-checks` 17, `public-routes` 15, `invoice-document-fulfilment` 8 (new), `document-routes` 4, `unsynced-proforma-command` 4, `settlement-routes` 1 — **299 passing, 0 failing**.
- The new integration file is registered in the `db-integration` lane in `ci.yml`; that lane lists files by name, so an unregistered one would never run.
- Every pre-existing failure was confirmed against a pristine `origin/main` worktree with identical test files before being attributed or fixed.

## Not done

- The operator UI was not driven in a browser: the chrome-devtools MCP profile was held by another session for the whole run. The HTTP surface and the stored bytes were verified directly instead.
- No entry was added to `graph-conformance.json` — finance has none today, and the four declarations are covered by assertions in `voyant-manifest.test.ts`.
