### PR TITLE
Stop the policy capture instant from superseding every Quote it rides on

### DIFF
--- a/.changeset/quote-price-fingerprint-capture-time.md
+++ b/.changeset/quote-price-fingerprint-capture-time.md
@@ -1,0 +1,26 @@
+---
+"@voyant-travel/catalog-contracts": patch
+"@voyant-travel/catalog": patch
+"@voyant-travel/trips": patch
+---
+
+Stop the policy capture instant from superseding every Quote it is attached to.
+
+Commit re-composes the Quote and compares price fingerprints to decide whether
+the price still stands. The composed pricing carries
+`policyEvidence.cancellation.capturedAt`, which
+`captureCancellationPolicySnapshot` stamps with `new Date()` on every read — so
+the two fingerprints could never agree. Every Commit against a product with a
+published cancellation policy was refused `quote_failure / superseded` and had
+its Hold released, deterministically and on the first attempt. Online checkout
+was down for those products, on any payment method, with no race involved.
+
+The capture instant now leaves the fingerprint input and nothing else does:
+`policyId`, `policyVersionId`, `version` and the rules themselves stay in, so a
+genuine price change or a policy version change still supersedes the Quote.
+Both comparison sites use one helper with the value written at quote time, so a
+normalization cannot be applied to some of them and not others.
+
+The same comparison in `materialPolicyChanged` had the same defect, reporting
+every catalog-backed Trip component as materially changed and demanding a
+proposal re-acceptance no traveller could clear.

--- a/packages/catalog-contracts/src/booking-engine/pricing-contracts.ts
+++ b/packages/catalog-contracts/src/booking-engine/pricing-contracts.ts
@@ -100,6 +100,74 @@ export const pricingBreakdownV1 = z.object({
 })
 export type PricingBreakdownV1 = z.infer<typeof pricingBreakdownV1>
 
+/**
+ * The key a policy snapshot stamps with the instant it was READ.
+ *
+ * `captureCancellationPolicySnapshot` defaults it to `new Date()`, so it is
+ * different on every compose of the same unchanged selection. That is correct
+ * for evidence — it records when we looked — and wrong for identity: it says
+ * nothing about WHICH policy was captured or what it costs.
+ */
+const POLICY_CAPTURE_INSTANT = "capturedAt"
+
+/**
+ * Policy evidence reduced to what identifies the policy.
+ *
+ * Everything that decides whether a quote still stands survives:
+ * `policyId`, `policyVersionId`, `version` and the `rules` themselves. Only the
+ * capture instant is dropped, and only inside the evidence subtree.
+ *
+ * The recursion is deliberate. `cancellation` and `bookingTerms` are typed
+ * `unknown` because a supplier's terms are its own shape, so there is no field
+ * list to walk; the statable invariant — no capture instant anywhere inside
+ * policy evidence contributes to identity — is the one that survives the shape
+ * changing underneath it.
+ */
+export function policyEvidenceIdentity<T>(evidence: T): T {
+  return stripCaptureInstant(evidence) as T
+}
+
+function stripCaptureInstant(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stripCaptureInstant)
+  if (!value || typeof value !== "object") return value
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .filter(([key]) => key !== POLICY_CAPTURE_INSTANT)
+      .map(([key, item]) => [key, stripCaptureInstant(item)]),
+  )
+}
+
+/**
+ * The pricing, reduced to what a price fingerprint is allowed to depend on.
+ *
+ * A price fingerprint answers one question: has this quote's price moved since
+ * we issued it. Commit re-composes the quote and compares, so anything in the
+ * input that changes on every compose makes that comparison unconditionally
+ * false — the quote is declared superseded, the hold is released, and no
+ * booking can ever be made (voyant#4689).
+ *
+ * `policyEvidence.cancellation.capturedAt` was exactly that. Everything else
+ * here is left alone: money, taxes, applied offers and the policy's own
+ * identity all belong in the fingerprint, because a genuine change to any of
+ * them genuinely does supersede the quote.
+ */
+export function priceFingerprintInput<T>(pricing: T): T {
+  if (!pricing || typeof pricing !== "object") return pricing
+  const breakdown = pricing as Record<string, unknown>
+  if (breakdown.policyEvidence === undefined && breakdown.componentPolicies === undefined) {
+    return pricing
+  }
+  return {
+    ...breakdown,
+    ...(breakdown.policyEvidence !== undefined
+      ? { policyEvidence: policyEvidenceIdentity(breakdown.policyEvidence) }
+      : {}),
+    ...(breakdown.componentPolicies !== undefined
+      ? { componentPolicies: policyEvidenceIdentity(breakdown.componentPolicies) }
+      : {}),
+  } as T
+}
+
 export const bookingPaymentScheduleV1 = z.object({
   scheduleType: z.enum(["deposit", "installment", "balance", "hold", "other"]),
   status: z.enum(["pending", "due", "paid", "waived", "cancelled", "expired"]),

--- a/packages/catalog/src/booking-engine/sessions-service.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-service.test.ts
@@ -2,6 +2,7 @@ import {
   assertBookingLifecycleConformanceV1,
   bookingLifecycleConformanceScenariosV1,
 } from "@voyant-travel/catalog-contracts/booking-engine/lifecycle-conformance"
+import type { PricingBreakdownV1 } from "@voyant-travel/catalog-contracts/booking-engine/pricing-contracts"
 import { describe, expect, it } from "vitest"
 
 import type { BookingRequirementsV1 } from "./contracts.js"
@@ -55,6 +56,10 @@ function createHarness(
 ) {
   let currentNow = new Date("2026-08-01T12:00:00.000Z")
   let price = BASE_PRICING
+  // Some pricing is not a constant: a policy snapshot is stamped with the
+  // instant it was read, so the value differs on every compose of the very
+  // same selection. Set this to model that faithfully.
+  let pricePerCompose: (() => PricingBreakdownV1) | null = null
   let published = requirements ?? inMemoryBookingRequirements()
   const repository = createInMemoryBookingSessionRepository()
   const inventory = createInMemoryOwnedInventoryPorts()
@@ -76,7 +81,7 @@ function createHarness(
       composeQuote: async () => ({
         status: "quoted",
         requirements: published,
-        pricing: price,
+        pricing: pricePerCompose ? pricePerCompose() : price,
       }),
       placeCapacityHold: inventory.placeCapacityHold,
       releaseCapacityHold: inventory.releaseCapacityHold,
@@ -94,6 +99,9 @@ function createHarness(
     },
     setPrice(next: typeof BASE_PRICING) {
       price = next
+    },
+    setPricePerCompose(next: (() => PricingBreakdownV1) | null) {
+      pricePerCompose = next
     },
     setRequirements(next: BookingRequirementsV1) {
       published = next
@@ -978,6 +986,175 @@ describe("Booking Session v1 owned tracer", () => {
       outcome: { kind: "quote_failure", reason: "superseded" },
     })
     expect(harness.inventory.bookingIds).toEqual([])
+  })
+
+  /**
+   * A quote whose pricing carries a policy snapshot.
+   *
+   * `captureCancellationPolicySnapshot` stamps `capturedAt` with `new Date()`,
+   * so every compose of the same unchanged selection returns a different one.
+   * The counter here stands in for the clock.
+   */
+  function policyPricing(total = 10000) {
+    let captures = 0
+    return () => {
+      captures += 1
+      return {
+        ...BASE_PRICING,
+        lines: [{ ...BASE_PRICING.lines[0]!, unitAmount: total, totalAmount: total }],
+        subtotal: total,
+        total,
+        policyEvidence: {
+          cancellation: {
+            schemaVersion: 1,
+            policyId: "pol_1",
+            policyVersionId: "plvr_1",
+            version: 1,
+            capturedAt: new Date(1_760_000_000_000 + captures * 1000).toISOString(),
+            rules: [
+              {
+                id: "plrl_1",
+                daysBeforeDeparture: 30,
+                refundPercent: 10000,
+                refundType: "cash",
+                flatAmountCents: null,
+                currency: null,
+                label: "30 days or more",
+              },
+            ],
+          },
+        },
+      } as PricingBreakdownV1
+    }
+  }
+
+  it("commits against a Quote whose policy snapshot was re-captured at Commit", async () => {
+    // voyant#4689: the Commit preflight re-composes the Quote and compares price
+    // fingerprints. With the capture instant inside the fingerprint the two can
+    // never agree, so every Commit was refused `quote_failure / superseded` and
+    // the Hold released - checkout down for any product with a published
+    // cancellation policy, on the first attempt, with no race involved.
+    const payment = createPaymentHarness()
+    const harness = createHarness({}, payment.ports)
+    harness.setPricePerCompose(policyPricing())
+    const { session, quote, hold } = await createQuoteAndHold(harness)
+
+    const committed = await harness.module.commitSession(
+      session.id,
+      {
+        expectedRevision: session.revision,
+        quoteId: quote.id,
+        requirementsFingerprint: quote.requirementsFingerprint,
+        holdId: hold.id,
+        idempotencyKey: "commit_recaptured_policy",
+        checkoutIntent: "card" as const,
+      },
+      ANONYMOUS_ACCESS,
+    )
+
+    expect(committed).toMatchObject({
+      kind: "commit_result",
+      outcome: { kind: "payment_required" },
+    })
+    expect(harness.repository.quotes.get(quote.id)?.state).toBe("active")
+    expect(harness.repository.holds.get(hold.id)?.state).toBe("active")
+  })
+
+  it("fingerprints two composes of one unchanged selection identically", async () => {
+    const harness = createHarness()
+    harness.setPricePerCompose(policyPricing())
+    const created = await harness.module.createSession(
+      {
+        idempotencyKey: nextCreateKey("stable_fingerprint"),
+        target: { kind: "product", productId: "prod_owned_1" },
+      },
+      ANONYMOUS_ACCESS,
+    )
+    if (created.kind !== "session_created") throw new Error("session not created")
+
+    const first = await harness.module.quoteSession(
+      created.session.id,
+      { expectedRevision: created.session.revision, idempotencyKey: "quote_1" },
+      ANONYMOUS_ACCESS,
+    )
+    const second = await harness.module.quoteSession(
+      created.session.id,
+      { expectedRevision: created.session.revision, idempotencyKey: "quote_2" },
+      ANONYMOUS_ACCESS,
+    )
+    if (first.kind !== "quote_created" || second.kind !== "quote_created") {
+      throw new Error("quotes not created")
+    }
+
+    const left = harness.repository.quotes.get(first.quote.id)
+    const right = harness.repository.quotes.get(second.quote.id)
+    // Different capture instants, same price: one fingerprint.
+    expect(left?.pricing).not.toEqual(right?.pricing)
+    expect(left?.priceFingerprint).toBe(right?.priceFingerprint)
+  })
+
+  it("still supersedes a Quote whose price actually moved", async () => {
+    // The half of the invariant that must not be traded away for the fix above:
+    // a real price change still has to invalidate the Quote.
+    const harness = createHarness()
+    harness.setPricePerCompose(policyPricing(10000))
+    const { session, capability, quote, hold } = await createQuoteAndHold(harness)
+    harness.setPricePerCompose(policyPricing(12500))
+
+    const rejected = await harness.module.commitSession(
+      session.id,
+      {
+        expectedRevision: session.revision,
+        quoteId: quote.id,
+        requirementsFingerprint: quote.requirementsFingerprint,
+        holdId: hold.id,
+        idempotencyKey: "commit_real_price_change",
+        checkoutIntent: "card" as const,
+      },
+      { ...ANONYMOUS_ACCESS, capability },
+    )
+
+    expect(rejected).toMatchObject({
+      kind: "commit_result",
+      outcome: { kind: "quote_failure", reason: "superseded" },
+    })
+    expect(harness.repository.quotes.get(quote.id)?.state).toBe("superseded")
+    expect(harness.inventory.bookingIds).toEqual([])
+  })
+
+  it("still supersedes a Quote whose cancellation policy version changed", async () => {
+    // Policy identity stays inside the fingerprint: only the capture instant
+    // leaves. A traveller must not be booked onto refund terms they never saw.
+    const harness = createHarness()
+    harness.setPricePerCompose(policyPricing())
+    const { session, capability, quote, hold } = await createQuoteAndHold(harness)
+    harness.setPricePerCompose(() => {
+      const pricing = policyPricing()() as PricingBreakdownV1 & {
+        policyEvidence: { cancellation: Record<string, unknown> }
+      }
+      pricing.policyEvidence.cancellation.policyVersionId = "plvr_2"
+      pricing.policyEvidence.cancellation.version = 2
+      return pricing
+    })
+
+    const rejected = await harness.module.commitSession(
+      session.id,
+      {
+        expectedRevision: session.revision,
+        quoteId: quote.id,
+        requirementsFingerprint: quote.requirementsFingerprint,
+        holdId: hold.id,
+        idempotencyKey: "commit_policy_version_change",
+        checkoutIntent: "card" as const,
+      },
+      { ...ANONYMOUS_ACCESS, capability },
+    )
+
+    expect(rejected).toMatchObject({
+      kind: "commit_result",
+      outcome: { kind: "quote_failure", reason: "superseded" },
+    })
+    expect(harness.repository.quotes.get(quote.id)?.state).toBe("superseded")
   })
 
   it("reuses the transaction-locked Session and supersedes Quotes in one repository operation", async () => {

--- a/packages/catalog/src/booking-engine/sessions-service.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-service.test.ts
@@ -1562,6 +1562,7 @@ describe("Booking Session v1 owned tracer", () => {
       // quote record here; a narrower stub degrades it to `{ id }` and the
       // fingerprint read below stops typechecking.
       setPrice(_next: typeof BASE_PRICING) {},
+      setPricePerCompose(_next: (() => PricingBreakdownV1) | null) {},
       setRequirements(_next: BookingRequirementsV1) {},
     }
     const { session, capability, quote, hold } = await createQuoteAndHold(harness)

--- a/packages/catalog/src/booking-engine/sessions-service.ts
+++ b/packages/catalog/src/booking-engine/sessions-service.ts
@@ -4,6 +4,7 @@ import type {
   OfferPreviewOutcomeV1,
   OfferPreviewRequestV1,
 } from "@voyant-travel/catalog-contracts/booking-engine/preview-contracts"
+import { priceFingerprintInput } from "@voyant-travel/catalog-contracts/booking-engine/pricing-contracts"
 import type {
   AbandonBookingSessionV1,
   AdoptBookingSessionV1,
@@ -1176,7 +1177,7 @@ export function createBookingSessionModule(
           state: "active",
           requirements,
           pricing,
-          priceFingerprint: await stableFingerprint(pricing),
+          priceFingerprint: await priceFingerprint(pricing),
           requirementsFingerprint: await stableFingerprint(requirements),
           quotedAt: at,
           expiresAt: new Date(at.getTime() + quoteTtlMs),
@@ -1527,7 +1528,7 @@ export function createBookingSessionModule(
           await releaseLiveHolds(repository, options.ports, session, access, at, tx)
           return { status: "outcome" as const, outcome: quoteUnavailable(freshQuote) }
         }
-        if ((await stableFingerprint(freshQuote.pricing)) !== quote.priceFingerprint) {
+        if ((await priceFingerprint(freshQuote.pricing)) !== quote.priceFingerprint) {
           quote.state = "superseded"
           await repository.saveQuote(quote)
           await releaseLiveHolds(repository, options.ports, session, access, at, tx)
@@ -2112,7 +2113,7 @@ async function consumeCommittedSources(input: {
       // superseded as one whose price did.
       if (
         currentQuoteResult.status === "unavailable" ||
-        (await stableFingerprint(currentQuoteResult.pricing)) !== currentQuote.priceFingerprint ||
+        (await priceFingerprint(currentQuoteResult.pricing)) !== currentQuote.priceFingerprint ||
         (await stableFingerprint(currentQuoteResult.requirements)) !==
           currentQuote.requirementsFingerprint
       ) {
@@ -2950,6 +2951,20 @@ async function scopedCreateIdempotencyKey(
 
 async function stableFingerprint(value: unknown): Promise<string> {
   return sha256Hex(JSON.stringify(sortForStableJson(value)))
+}
+
+/**
+ * The fingerprint that decides whether a Quote's price still stands.
+ *
+ * One function rather than three call sites hashing `pricing` directly, because
+ * the value is written once at quote time and compared twice at commit — in the
+ * preflight and again inside the commit transaction — and a normalization
+ * applied to some of those but not all is the same outage in a subtler form.
+ *
+ * See `priceFingerprintInput` for what it deliberately does not depend on.
+ */
+async function priceFingerprint(pricing: unknown): Promise<string> {
+  return stableFingerprint(priceFingerprintInput(pricing))
 }
 
 async function sha256Hex(value: string): Promise<string> {

--- a/packages/trips/src/booking-session-composite-handler.ts
+++ b/packages/trips/src/booking-session-composite-handler.ts
@@ -10,6 +10,7 @@ import type {
   PricingBreakdownV1,
 } from "@voyant-travel/catalog/booking-engine"
 import { partySizeFromSelection } from "@voyant-travel/catalog/booking-engine"
+import { policyEvidenceIdentity } from "@voyant-travel/catalog-contracts/booking-engine/pricing-contracts"
 import {
   DEFAULT_PAX_BANDS,
   DEFAULT_PAYMENT_INTENTS,
@@ -648,11 +649,26 @@ function materialPolicyChanged(snapshot: TripSnapshot, pricing: PricingBreakdown
     if (!isCatalogBackedTripComponent(component)) continue
     const accepted = acceptedPolicyEvidence(component)
     const fresh = current.get(component.id)
+    // Compared on identity, not on the instant each side was read. The accepted
+    // snapshot was captured when the traveller accepted the proposal and the
+    // fresh one moments ago, so their `capturedAt` always differ - which used to
+    // report every catalog-backed component as materially changed and demand a
+    // re-acceptance no traveller could ever clear (voyant#4689).
     if (accepted?.cancellation !== undefined || fresh?.cancellation !== undefined) {
-      if (stableJson(accepted?.cancellation) !== stableJson(fresh?.cancellation)) return true
+      if (
+        stableJson(policyEvidenceIdentity(accepted?.cancellation)) !==
+        stableJson(policyEvidenceIdentity(fresh?.cancellation))
+      ) {
+        return true
+      }
     }
     if (accepted?.bookingTerms !== undefined || fresh?.bookingTerms !== undefined) {
-      if (stableJson(accepted?.bookingTerms) !== stableJson(fresh?.bookingTerms)) return true
+      if (
+        stableJson(policyEvidenceIdentity(accepted?.bookingTerms)) !==
+        stableJson(policyEvidenceIdentity(fresh?.bookingTerms))
+      ) {
+        return true
+      }
     }
   }
   return false


### PR DESCRIPTION
Fixes #4689. **This unblocks online checkout**, which is currently down on every tenant
running this release for any product with a published cancellation policy.

## The defect

`commitSession` re-composes the Quote in its preflight and compares price fingerprints to
decide whether the price the shopper is about to pay still stands:

```ts
if ((await stableFingerprint(freshQuote.pricing)) !== quote.priceFingerprint) { /* superseded */ }
```

`freshQuote.pricing` carries `policyEvidence.cancellation.capturedAt`, and
`captureCancellationPolicySnapshot` defaults it to `new Date()`. It is therefore a different
value on every compose of the same unchanged selection, so the two fingerprints can never
agree. Every Commit is refused `quote_failure / superseded` and releases its Hold on the way
out — deterministically, on the first attempt, on any payment method, with no race involved.

Introduced by #4417.

## Evidence

From a live tenant, two Quotes for an **unchanged** selection three minutes apart:

| quote | rev | `capturedAt` | `price_fingerprint` |
| --- | --- | --- | --- |
| `bsqu_01m036n1mseg2r1n1dh9fhxzkp` | 54 | `17:13:59.572Z` | `209c611386ca1f0b…` |
| `bsqu_01m036tn3tebgbybtb5h9pyrpr` | 55 | `17:17:03.362Z` | `c092a1f4a566775f…` |

Their `pricing` payloads are byte-identical except that one field. Reimplementing
`stableFingerprint` over the stored rows reproduced every stored fingerprint exactly, and:

- substituting q54's `capturedAt` into q55's pricing yields **exactly** q54's fingerprint;
- deleting the field makes both hash identically (`6a40c3167e051cc9…`).

So the capture instant is provably the only differing byte and the sole cause.

Corroborating, from the same tenant: the Hold was released **inside** the Commit request
window on all three attempts that day (created, released ~2s later, zero conversions), and
`booking_session_commits` has no row for any of them — the refusal lands in the preflight,
before `claimOperation`.

## The fix

`priceFingerprintInput` drops the capture instant from the fingerprint input, and nothing
else. `policyId`, `policyVersionId`, `version` and the rules themselves stay in.

That is the half of the invariant worth stating explicitly: **a genuine price change still
supersedes the Quote, and so does a policy version change.** Excluding `policyEvidence`
wholesale would have been simpler and wrong — it would let a traveller be booked onto refund
terms they were never shown, trading an outage for silent mispricing.

Both comparison sites now go through one `priceFingerprint` helper together with the value
written at quote time. The fingerprint is written once and checked twice — in the preflight
and again inside the commit transaction — so a normalization applied to some of those and not
others would be the same outage in a subtler form.

The recursion inside the evidence subtree is deliberate: `cancellation` and `bookingTerms` are
typed `unknown` because a supplier's terms are its own shape, so there is no field list to
walk. "No capture instant anywhere inside policy evidence contributes to identity" is the
invariant that survives that shape changing.

## Audit of the other fingerprint inputs

- `requirements` — stable. Confirmed against production: the requirements fingerprint was
  identical (`560ab571…`) across every Quote in the affected session.
- `lines`, `taxes`, `subtotal`, `taxTotal`, `total`, `currency`, `appliedOffers`,
  `promotionCodeStatus` — all deterministic for a given selection.
- `componentPolicies` — same opaque evidence as `policyEvidence`, so it gets the same
  treatment.
- `materialPolicyChanged` in `@voyant-travel/trips` compared the accepted snapshot against a
  freshly composed one the same way, so it reported **every** catalog-backed Trip component as
  materially changed and demanded a proposal re-acceptance no traveller could clear. Same
  cause, same helper, fixed here.

## Note on in-flight Quotes

A Quote issued before this deploy has a fingerprint computed over unnormalized pricing, so the
first Commit against it still supersedes. That is exactly today's behaviour, and one re-quote
clears it.

## Verification

- `@voyant-travel/catalog` — **270 passed / 17 files**.
- `@voyant-travel/catalog-contracts` — **104 passed / 10 files**.
- `@voyant-travel/trips` composite handler — **12 passed**.
- The two new failing-first tests fail on the unfixed tree with the exact production symptom:
  the Commit returns `quote_failure / superseded` instead of `payment_required`, and the two
  fingerprints differ. The two "still supersedes" tests pass either way — they guard the
  invariant rather than the fix.
- `catalog-contracts` typecheck clean; `biome check` clean on all touched files. Full
  `catalog` typecheck is heavy locally and is left to CI.
