### PR TITLE
Group the departure roster by reservation and gate rooming on a declared plan

### DIFF
--- a/.changeset/departure-roster-by-reservation.md
+++ b/.changeset/departure-roster-by-reservation.md
@@ -1,0 +1,11 @@
+---
+"@voyant-travel/operations": minor
+"@voyant-travel/operations-react": minor
+"@voyant-travel/i18n": minor
+---
+
+Group the departure traveler roster by reservation, and stop asking departures that allocate nothing about rooms and seats.
+
+The roster was a flat table that repeated the booking number on every row, so who travelled together had to be reconstructed by matching strings by eye. Each reservation is now its own group carrying what belongs to the party — who booked it, its status, whether it is paid, and how many of its sold seats have names yet — with the traveler rows underneath.
+
+The departure summary now reports whether a departure allocates positions at all (`allocation.planned`, derived from the resources laid out on it and the resource templates its option declares, alongside a new `allocation.templated` count). A day excursion has neither, so its Seated / Not seated counters, its Seat / room column and its allocation manager no longer render, and `allocation_resources_missing` and `travelers_unassigned` are no longer raised against a rooming plan that was never going to exist. Departures whose catalog does declare resources are unaffected.

--- a/packages/i18n/src/admin/availability/en-part-2.ts
+++ b/packages/i18n/src/admin/availability/en-part-2.ts
@@ -193,7 +193,9 @@ export const adminAvailabilityMessagesEnPart2 = {
       overview: {
         capacityTitle: "Capacity",
         authoredPaxLabel: "Authored pax",
-        effectivePaxLabel: "Seatable pax",
+        // Not "seatable": on a departure with no rooms or seats this is simply
+        // the authored capacity, and rooming language there is noise.
+        effectivePaxLabel: "Effective capacity",
         storedRemainingLabel: "Stored remaining",
         derivedRemainingLabel: "Derived remaining",
         consumedPaxLabel: "Consumed pax",
@@ -220,19 +222,32 @@ export const adminAvailabilityMessagesEnPart2 = {
       },
       travelers: {
         title: "Traveler roster",
+        reservationsLabel: "Reservations",
         enteredLabel: "Names entered",
-        leadLabel: "Lead travelers",
+        leadHint: "Lead travelers: {count}",
         seatedLabel: "Seated",
         unseatedLabel: "Not seated",
         missingLabel: "Names still missing",
         excessLabel: "Names beyond sold pax",
-        columnTraveler: "Traveler",
-        columnBooking: "Booking",
-        columnStatus: "Status",
-        columnSeat: "Seat / room",
-        seatedBadge: "Seated",
+        bookedByLabel: "Booked by {name}",
+        namesOfPaxLabel: "{entered} / {pax} names",
+        namesEnteredLabel: "{entered} names",
+        groupNoNames: "No names entered on this reservation yet",
         unseatedBadge: "Not seated",
         leadBadge: "Lead",
+        accessibilityBadge: "Accessibility",
+        dietaryBadge: "Dietary",
+        bookingStatusLabels: {
+          confirmed: "Confirmed",
+          in_progress: "In progress",
+          completed: "Completed",
+          cancelled: "Cancelled",
+        },
+        paymentStatusLabels: {
+          paid: "Paid",
+          partial: "Part paid",
+          unpaid: "Unpaid",
+        },
         emptyTitle: "Nobody is booked on this departure yet",
         emptyDescription:
           "Travelers appear here the moment a booking is allocated to this departure.",
@@ -292,6 +307,13 @@ export const adminAvailabilityMessagesEnPart2 = {
         emptyDescription:
           "Resource changes and traveler assignments are recorded here as they are made.",
         emptyAction: "Go to Allocation",
+      },
+      allocation: {
+        notPlannedTitle: "This departure does not allocate rooms or seats",
+        notPlannedDescription:
+          "Nothing on this product declares rooms, cabins or a seat map, so there is no rooming list to keep. Set up the resource templates on the product if this departure should have one.",
+        notPlannedProductAction: "Configure resources on the product",
+        notPlannedAnywayAction: "Lay out rooms or seats anyway",
       },
       resources: {
         title: "Resources",

--- a/packages/i18n/src/admin/availability/ro-part-2.ts
+++ b/packages/i18n/src/admin/availability/ro-part-2.ts
@@ -190,7 +190,7 @@ export const adminAvailabilityMessagesRoPart2 = {
       overview: {
         capacityTitle: "Capacitate",
         authoredPaxLabel: "Pax configurati",
-        effectivePaxLabel: "Pax care pot fi cazati",
+        effectivePaxLabel: "Capacitate efectiva",
         storedRemainingLabel: "Ramasi (stocat)",
         derivedRemainingLabel: "Ramasi (calculat)",
         consumedPaxLabel: "Pax consumati",
@@ -217,19 +217,32 @@ export const adminAvailabilityMessagesRoPart2 = {
       },
       travelers: {
         title: "Lista calatorilor",
+        reservationsLabel: "Rezervari",
         enteredLabel: "Nume introduse",
-        leadLabel: "Calatori principali",
+        leadHint: "Calatori principali: {count}",
         seatedLabel: "Cazati",
         unseatedLabel: "Necazati",
         missingLabel: "Nume lipsa",
         excessLabel: "Nume peste pax vanduti",
-        columnTraveler: "Calator",
-        columnBooking: "Rezervare",
-        columnStatus: "Status",
-        columnSeat: "Loc / camera",
-        seatedBadge: "Cazat",
+        bookedByLabel: "Rezervat de {name}",
+        namesOfPaxLabel: "{entered} / {pax} nume",
+        namesEnteredLabel: "{entered} nume",
+        groupNoNames: "Niciun nume introdus pe aceasta rezervare",
         unseatedBadge: "Necazat",
         leadBadge: "Principal",
+        accessibilityBadge: "Accesibilitate",
+        dietaryBadge: "Regim alimentar",
+        bookingStatusLabels: {
+          confirmed: "Confirmata",
+          in_progress: "In lucru",
+          completed: "Finalizata",
+          cancelled: "Anulata",
+        },
+        paymentStatusLabels: {
+          paid: "Achitat",
+          partial: "Achitat partial",
+          unpaid: "Neachitat",
+        },
         emptyTitle: "Nimeni nu este rezervat pe aceasta plecare",
         emptyDescription:
           "Calatorii apar aici imediat ce o rezervare este alocata acestei plecari.",
@@ -289,6 +302,13 @@ export const adminAvailabilityMessagesRoPart2 = {
         emptyDescription:
           "Modificarile de resurse si alocarile de calatori se inregistreaza aici pe masura ce sunt facute.",
         emptyAction: "Mergi la Alocare",
+      },
+      allocation: {
+        notPlannedTitle: "Aceasta plecare nu aloca camere sau locuri",
+        notPlannedDescription:
+          "Nimic pe acest produs nu declara camere, cabine sau o harta de locuri, deci nu exista o lista de cazare de tinut. Configureaza sabloanele de resurse pe produs daca aceasta plecare ar trebui sa aiba una.",
+        notPlannedProductAction: "Configureaza resursele pe produs",
+        notPlannedAnywayAction: "Pregateste totusi camere sau locuri",
       },
       resources: {
         title: "Resurse",

--- a/packages/operations-react/src/availability/components/availability-slot-detail-page.test.tsx
+++ b/packages/operations-react/src/availability/components/availability-slot-detail-page.test.tsx
@@ -5,7 +5,12 @@ import { act } from "react"
 import { createRoot, type Root } from "react-dom/client"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import type { DepartureIssue, DepartureSummary } from "../index.js"
+import type {
+  AllocationManifestBooking,
+  AllocationManifestTraveler,
+  DepartureIssue,
+  DepartureSummary,
+} from "../index.js"
 import { AvailabilitySlotDetailPage } from "./availability-slot-detail-page.js"
 
 /**
@@ -57,7 +62,19 @@ const EMPTY_SUMMARY: DepartureSummary = {
     },
     bookings: { active: 0, cancelledWithLiveAllocation: 0, expectedPax: 0, byStatus: {} },
     travelers: { entered: 0, lead: 0, assigned: 0, unassigned: 0, missing: 0 },
-    resources: { total: 0, seating: 0, capacity: 0, assigned: 0, available: 0, overCapacity: 0 },
+    resources: {
+      total: 0,
+      // The base fixture is a TOUR: its option declares rooms, none of which have
+      // been laid out on this departure yet. An excursion — a departure that
+      // allocates nothing at all — is its own fixture below.
+      templated: 4,
+      seating: 0,
+      capacity: 0,
+      assigned: 0,
+      available: 0,
+      overCapacity: 0,
+      planned: true,
+    },
     resourceBreakdown: [],
   },
   bookings: {
@@ -70,12 +87,78 @@ const EMPTY_SUMMARY: DepartureSummary = {
     outstandingAmountCents: null,
   },
   travelers: { entered: 0, lead: 0, assigned: 0, unassigned: 0, missing: 0 },
-  allocation: { total: 0, seating: 0, capacity: 0, assigned: 0, available: 0, overCapacity: 0 },
+  allocation: {
+    total: 0,
+    // The base fixture is a TOUR: its option declares rooms, none of which have
+    // been laid out on this departure yet. An excursion — a departure that
+    // allocates nothing at all — is its own fixture below.
+    templated: 4,
+    seating: 0,
+    capacity: 0,
+    assigned: 0,
+    available: 0,
+    overCapacity: 0,
+    planned: true,
+  },
   operations: { issues: [], criticalCount: 0, warningCount: 0, clear: true },
   extras: null,
   // No Finance provider is bound in this deployment — an explicit
   // "unavailable", not a grid of zeros.
   finance: null,
+}
+
+/** A manifest booking with only the fields the roster reads spelled out. */
+function booking(
+  overrides: Partial<AllocationManifestBooking> & Pick<AllocationManifestBooking, "id">,
+): AllocationManifestBooking {
+  return {
+    bookingNumber: "BK-0000-0000",
+    status: "confirmed",
+    bookingSequence: 1,
+    paymentStatus: "unpaid",
+    contactFirstName: null,
+    contactLastName: null,
+    contactEmail: null,
+    contactPhone: null,
+    sellCurrency: "RON",
+    pax: null,
+    sellAmountCents: null,
+    paidAmountCents: null,
+    travelers: [],
+    ...overrides,
+  }
+}
+
+function travelerRow(
+  id: string,
+  fullName: string,
+  overrides: Partial<AllocationManifestTraveler> = {},
+): AllocationManifestTraveler {
+  const [firstName = fullName, ...rest] = fullName.split(" ")
+  return {
+    id,
+    bookingId: "bkg_1",
+    bookingNumber: "BK-0000-0000",
+    bookingStatus: "confirmed",
+    bookingSequence: 1,
+    paymentStatus: "unpaid",
+    firstName,
+    lastName: rest.join(" "),
+    fullName,
+    email: null,
+    phone: null,
+    isLeadTraveler: false,
+    isPrimary: false,
+    sharingGroupId: null,
+    roomTypeId: null,
+    bedPreference: null,
+    allocations: {},
+    travelerCategory: null,
+    participantType: "traveler",
+    hasAccessibilityNeeds: false,
+    hasDietaryRequirements: false,
+    ...overrides,
+  }
 }
 
 const OVERSOLD_ISSUE: DepartureIssue = {
@@ -98,6 +181,8 @@ const UNSEATED_ISSUE: DepartureIssue = {
 
 const testState = vi.hoisted(() => ({
   summary: null as unknown,
+  /** Allocation manifest bookings backing the traveler roster. */
+  bookings: [] as unknown[],
   /** Captured from the mocked `Tabs`, so a trigger click can drive it. */
   onValueChange: undefined as ((value: string) => void) | undefined,
   activeTab: undefined as string | undefined,
@@ -154,7 +239,7 @@ vi.mock("@tanstack/react-query", () => ({
       case "allocation":
         return {
           isPending: false,
-          data: { data: { bookings: [], resources: [], sharingGroupLabels: {} } },
+          data: { data: { bookings: testState.bookings, resources: [], sharingGroupLabels: {} } },
         }
       default:
         return { isPending: false, data: { data: [] } }
@@ -162,7 +247,15 @@ vi.mock("@tanstack/react-query", () => ({
   },
 }))
 
-vi.mock("../index.js", () => ({
+// The barrel is stubbed so the page's query options and hooks can be driven,
+// but `departureAllocatesPositions` is the REAL rule — a reimplementation here
+// would let the page and the rule drift apart while both tests stayed green.
+vi.mock("../index.js", async () => ({
+  departureAllocatesPositions: (
+    await vi.importActual<typeof import("../departure-summary-schemas.js")>(
+      "../departure-summary-schemas.js",
+    )
+  ).departureAllocatesPositions,
   getDepartureSummaryQueryOptions: () => ({ queryKey: ["summary"] }),
   getPickupPointsQueryOptions: () => ({ queryKey: ["pickup-points"] }),
   getProductQueryOptions: () => ({ queryKey: ["product"] }),
@@ -277,6 +370,7 @@ describe("AvailabilitySlotDetailPage — the departure workspace", () => {
     root = null
     container = null
     testState.summary = null
+    testState.bookings = []
     testState.onValueChange = undefined
     testState.activeTab = undefined
   })
@@ -334,6 +428,107 @@ describe("AvailabilitySlotDetailPage — the departure workspace", () => {
     // Activity.
     expect(text).toContain("Nothing has happened on this departure yet")
     expect(text).toContain("Go to Allocation")
+  })
+
+  it("groups the roster by reservation instead of repeating a booking number per row", () => {
+    testState.summary = {
+      ...EMPTY_SUMMARY,
+      travelers: { entered: 3, lead: 1, assigned: 0, unassigned: 3, missing: 0 },
+      bookings: { ...EMPTY_SUMMARY.bookings, count: 2 },
+    } satisfies DepartureSummary
+    testState.bookings = [
+      booking({
+        id: "bkg_2",
+        bookingNumber: "BK-2605-6381",
+        bookingSequence: 2,
+        pax: 1,
+        travelers: [travelerRow("trv_3", "Violeta Luca")],
+      }),
+      booking({
+        id: "bkg_1",
+        bookingNumber: "BK-2605-1014",
+        bookingSequence: 1,
+        paymentStatus: "paid",
+        contactFirstName: "Mariana",
+        contactLastName: "Marin",
+        pax: 3,
+        travelers: [
+          travelerRow("trv_1", "Mariana Marin", { isLeadTraveler: true }),
+          travelerRow("trv_2", "Ileana Plangă"),
+        ],
+      }),
+    ]
+
+    const view = render(<AvailabilitySlotDetailPage id="slot_1" tab="travelers" />)
+
+    const groups = [...view.querySelectorAll("[data-slot='departure-traveler-group']")]
+    // Two reservations, in departure-local sequence — not the manifest's order.
+    expect(groups.map((group) => group.getAttribute("data-booking-id"))).toEqual(["bkg_1", "bkg_2"])
+    // Every traveler sits inside its own reservation, so who came together is
+    // structural rather than a booking number the reader has to match by eye.
+    expect(groups[0]?.querySelectorAll("[data-slot='departure-traveler']")).toHaveLength(2)
+    expect(groups[1]?.querySelectorAll("[data-slot='departure-traveler']")).toHaveLength(1)
+    expect(groups[0]?.textContent).toContain("BK-2605-1014")
+    expect(groups[0]?.textContent).toContain("Mariana Marin")
+    expect(groups[0]?.textContent).toContain("Ileana Plangă")
+    expect(groups[1]?.textContent).toContain("Violeta Luca")
+
+    const text = view.textContent ?? ""
+    // The group carries what belongs to the party: who booked it, whether it is
+    // paid, and which reservation is short of names.
+    expect(text).toContain("Booked by Mariana Marin")
+    expect(text).toContain("Paid")
+    expect(text).toContain("2 / 3 names")
+    expect(text).toContain("1 / 1 names")
+  })
+
+  it("drops every seat-shaped affordance on a departure that allocates nothing", () => {
+    const excursion = {
+      total: 0,
+      templated: 0,
+      seating: 0,
+      capacity: 0,
+      assigned: 0,
+      available: 0,
+      overCapacity: 0,
+      planned: false,
+    }
+    testState.summary = {
+      ...EMPTY_SUMMARY,
+      capacity: { ...EMPTY_SUMMARY.capacity, resources: excursion },
+      allocation: excursion,
+      travelers: { entered: 2, lead: 1, assigned: 0, unassigned: 2, missing: 0 },
+    } satisfies DepartureSummary
+    testState.bookings = [
+      booking({
+        id: "bkg_1",
+        bookingNumber: "BK-2608-907921",
+        bookingSequence: 1,
+        pax: 2,
+        travelers: [travelerRow("trv_1", "Jeni Irimia"), travelerRow("trv_2", "Andrei Irimia")],
+      }),
+    ]
+
+    const view = render(
+      <AvailabilitySlotDetailPage
+        id="slot_1"
+        renderAllocation={() => <p>allocation-manager</p>}
+        onOpenProduct={() => undefined}
+      />,
+    )
+    const text = view.textContent ?? ""
+
+    // No "0 seated / 2 not seated" against a rooming plan that does not exist…
+    expect(text).not.toContain("Seated")
+    expect(text).not.toContain("Not seated")
+    // …and the roster itself is still there.
+    expect(text).toContain("Jeni Irimia")
+    // The Allocation section says so plainly rather than opening an empty
+    // rooming plan, and still leaves a way in.
+    expect(view.querySelector("[data-slot='departure-allocation-not-planned']")).not.toBeNull()
+    expect(text).toContain("This departure does not allocate rooms or seats")
+    expect(text).not.toContain("allocation-manager")
+    expect(text).toContain("Lay out rooms or seats anyway")
   })
 
   it("renders typed issues with their severity and clears them after the repair", () => {

--- a/packages/operations-react/src/availability/components/availability-slot-detail-page.tsx
+++ b/packages/operations-react/src/availability/components/availability-slot-detail-page.tsx
@@ -3,22 +3,30 @@
 import { useQuery } from "@tanstack/react-query"
 import {
   Badge,
+  Button,
   Card,
   CardContent,
   CardHeader,
   CardTitle,
   cn,
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
   Tabs,
   TabsContent,
   TabsList,
   TabsTrigger,
 } from "@voyant-travel/ui/components"
+import { BedDouble } from "lucide-react"
 import { type ReactNode, useState } from "react"
 import { useAvailabilityUiI18nOrDefault } from "../i18n/index.js"
 import {
   type DepartureIssue,
   type DepartureWorkspaceTab,
   defaultDepartureWorkspaceTab,
+  departureAllocatesPositions,
   useAvailabilitySlotMutation,
   useSlotAllocationAuditLog,
   useVoyantAvailabilityContext,
@@ -189,6 +197,14 @@ export function AvailabilitySlotDetailPage({
   const [uncontrolledTab, setUncontrolledTab] = useState<DepartureWorkspaceTab>(
     defaultDepartureWorkspaceTab,
   )
+  /**
+   * Reveals the allocation manager on a departure that allocates nothing. The
+   * manager is never the DEFAULT there — a day excursion presented with an
+   * empty rooming plan reads as a plan someone forgot to fill in — but the
+   * operator can still open it, because "this product has no templates yet" and
+   * "this product will never have rooms" are indistinguishable from here.
+   */
+  const [allocationOverridden, setAllocationOverridden] = useState(false)
   const activeTab = tab ?? uncontrolledTab
   const selectTab = (next: DepartureWorkspaceTab) => {
     setUncontrolledTab(next)
@@ -360,6 +376,10 @@ export function AvailabilitySlotDetailPage({
   const attentionCount =
     (summary?.operations.criticalCount ?? 0) + (summary?.operations.warningCount ?? 0)
   const logisticsCount = pickupRows.length + closeoutRows.length
+  // Whether this departure has a rooming / seating plan at all. Drives every
+  // seat-shaped affordance in the workspace, so an excursion stops being asked
+  // about rooms it will never have.
+  const allocatesPositions = departureAllocatesPositions(summary?.allocation)
 
   return (
     <div className={cn("flex flex-col gap-6", className)}>
@@ -454,6 +474,7 @@ export function AvailabilitySlotDetailPage({
             summary={summary}
             bookings={allocationBookings}
             resourceLabelById={resourceLabelById}
+            allocatesPositions={allocatesPositions}
             messages={messages}
             onCreateBooking={onCreateBooking}
             onOpenBooking={onOpenBooking}
@@ -461,19 +482,45 @@ export function AvailabilitySlotDetailPage({
         </TabsContent>
 
         <TabsContent value="allocation" className="mt-4 flex flex-col gap-8">
-          {renderAllocation ? (
-            renderAllocation({ slotId: id, productId: slot.productId })
+          {allocatesPositions || allocationOverridden ? (
+            <>
+              {renderAllocation ? (
+                renderAllocation({ slotId: id, productId: slot.productId })
+              ) : (
+                <p className="rounded-md border border-dashed p-6 text-sm text-muted-foreground">
+                  {detailMessages.tabs.allocationUnwired}
+                </p>
+              )}
+              <DepartureResourcesSection
+                summary={summary}
+                messages={messages}
+                productId={slot.productId}
+                onOpenLink={openLink}
+              />
+            </>
           ) : (
-            <p className="rounded-md border border-dashed p-6 text-sm text-muted-foreground">
-              {detailMessages.tabs.allocationUnwired}
-            </p>
+            <Empty data-slot="departure-allocation-not-planned" className="border">
+              <EmptyHeader>
+                <EmptyMedia variant="icon">
+                  <BedDouble aria-hidden="true" />
+                </EmptyMedia>
+                <EmptyTitle>{departureMessages.allocation.notPlannedTitle}</EmptyTitle>
+                <EmptyDescription>
+                  {departureMessages.allocation.notPlannedDescription}
+                </EmptyDescription>
+              </EmptyHeader>
+              <div className="flex flex-wrap items-center justify-center gap-2">
+                {onOpenProduct ? (
+                  <Button variant="outline" onClick={() => onOpenProduct(slot.productId)}>
+                    {departureMessages.allocation.notPlannedProductAction}
+                  </Button>
+                ) : null}
+                <Button variant="ghost" onClick={() => setAllocationOverridden(true)}>
+                  {departureMessages.allocation.notPlannedAnywayAction}
+                </Button>
+              </div>
+            </Empty>
           )}
-          <DepartureResourcesSection
-            summary={summary}
-            messages={messages}
-            productId={slot.productId}
-            onOpenLink={openLink}
-          />
         </TabsContent>
 
         <TabsContent value="operations" className="mt-4">

--- a/packages/operations-react/src/availability/components/departure-workspace-travelers.tsx
+++ b/packages/operations-react/src/availability/components/departure-workspace-travelers.tsx
@@ -3,36 +3,56 @@
 import {
   Badge,
   Button,
+  cn,
   Empty,
   EmptyDescription,
   EmptyHeader,
   EmptyMedia,
   EmptyTitle,
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
 } from "@voyant-travel/ui/components"
 import { UserPlus, Users } from "lucide-react"
 import type { AvailabilityUiMessages } from "../i18n/index.js"
-import type { AllocationManifestBooking, DepartureSummary } from "../index.js"
+import type {
+  AllocationManifestBooking,
+  AllocationManifestTraveler,
+  DepartureSummary,
+} from "../index.js"
 import { DepartureSection, StatCard, StatGrid } from "./departure-stat.js"
+
+type TravelersCopy = AvailabilityUiMessages["details"]["departure"]["travelers"]
 
 /**
  * Travelers: who is actually coming, and whether the names match what was
  * sold.
  *
- * The counters are the summary's whole-departure aggregates; the rows are the
+ * **The roster is grouped by reservation, not flat.** A departure is bought in
+ * parties — a family of four, a couple, a solo traveler — and the operator's
+ * first question about any name is who it arrived with. The flat table
+ * answered that by repeating the booking number on every row and asking the
+ * reader to match strings by eye, which failed exactly where it mattered:
+ * consecutive bookings whose numbers differ in one digit.
+ *
+ * Each reservation is its own bordered group carrying the facts that belong to
+ * the party rather than to a person — who booked it, its status, whether it is
+ * paid, and how many of its sold seats have names yet. The per-traveler row is
+ * then only what is true of that traveler.
+ *
+ * The counters are the summary's whole-departure aggregates; the groups are the
  * allocation manifest's page. That split is deliberate — a paged manifest can
  * never move a headline number (`service-departure-summary.ts`), so "3 names
  * missing" stays true no matter how much of the roster is on screen.
+ *
+ * Everything seat-shaped — the Seated / Not seated counters and the Seat /
+ * room column — renders only when the departure actually allocates positions
+ * (`allocatesPositions`). A day excursion has no rooms and no seat map, and
+ * reporting its whole roster as "not seated" against a plan that does not
+ * exist is noise nobody can act on.
  */
 export function DepartureTravelersSection({
   summary,
   bookings,
   resourceLabelById,
+  allocatesPositions,
   messages,
   onCreateBooking,
   onOpenBooking,
@@ -41,6 +61,8 @@ export function DepartureTravelersSection({
   bookings: ReadonlyArray<AllocationManifestBooking>
   /** Allocation resource id → its operator-facing label, for the seat column. */
   resourceLabelById: ReadonlyMap<string, string>
+  /** Whether this departure has a rooming / seating plan at all. */
+  allocatesPositions: boolean
   messages: AvailabilityUiMessages
   /** Next action when nobody is booked yet (AC7). */
   onCreateBooking?: () => void
@@ -48,23 +70,32 @@ export function DepartureTravelersSection({
 }) {
   const copy = messages.details.departure.travelers
   const travelers = summary?.travelers ?? null
-  const rows = bookings.flatMap((booking) =>
-    booking.travelers.map((traveler) => ({ booking, traveler })),
-  )
+  const groups = orderReservations(bookings)
 
   return (
     <div className="flex flex-col gap-6">
       <DepartureSection slot="departure-traveler-counters" title={copy.title}>
-        <StatGrid className="sm:grid-cols-5">
-          <StatCard label={copy.enteredLabel}>{String(travelers?.entered ?? 0)}</StatCard>
-          <StatCard label={copy.leadLabel}>{String(travelers?.lead ?? 0)}</StatCard>
-          <StatCard label={copy.seatedLabel}>{String(travelers?.assigned ?? 0)}</StatCard>
-          <StatCard
-            label={copy.unseatedLabel}
-            tone={travelers && travelers.unassigned > 0 ? "attention" : "default"}
-          >
-            {String(travelers?.unassigned ?? 0)}
+        <StatGrid className={allocatesPositions ? "sm:grid-cols-5" : "sm:grid-cols-3"}>
+          <StatCard label={copy.reservationsLabel}>
+            {String(summary?.bookings.count ?? groups.length)}
           </StatCard>
+          <StatCard
+            label={copy.enteredLabel}
+            hint={copy.leadHint.replace("{count}", String(travelers?.lead ?? 0))}
+          >
+            {String(travelers?.entered ?? 0)}
+          </StatCard>
+          {allocatesPositions ? (
+            <>
+              <StatCard label={copy.seatedLabel}>{String(travelers?.assigned ?? 0)}</StatCard>
+              <StatCard
+                label={copy.unseatedLabel}
+                tone={travelers && travelers.unassigned > 0 ? "attention" : "default"}
+              >
+                {String(travelers?.unassigned ?? 0)}
+              </StatCard>
+            </>
+          ) : null}
           {/* `missing` is signed: positive means names are outstanding, negative
               means more travelers were entered than pax were sold. */}
           <StatCard
@@ -76,7 +107,7 @@ export function DepartureTravelersSection({
         </StatGrid>
       </DepartureSection>
 
-      {rows.length === 0 ? (
+      {groups.length === 0 ? (
         <Empty data-slot="departure-travelers-empty" className="border">
           <EmptyHeader>
             <EmptyMedia variant="icon">
@@ -93,71 +124,190 @@ export function DepartureTravelersSection({
           ) : null}
         </Empty>
       ) : (
-        <div className="overflow-x-auto rounded-md border">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>{copy.columnTraveler}</TableHead>
-                <TableHead>{copy.columnBooking}</TableHead>
-                <TableHead>{copy.columnStatus}</TableHead>
-                <TableHead>{copy.columnSeat}</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {rows.map(({ booking, traveler }) => {
-                const seats = Object.values(traveler.allocations)
-                  .map((resourceId) => resourceLabelById.get(resourceId) ?? null)
-                  .filter((label): label is string => Boolean(label))
-
-                return (
-                  <TableRow key={traveler.id}>
-                    <TableCell>
-                      <span className="flex flex-wrap items-center gap-2">
-                        <span className="font-medium">{traveler.fullName}</span>
-                        {traveler.isLeadTraveler ? (
-                          <Badge variant="secondary">{copy.leadBadge}</Badge>
-                        ) : null}
-                      </span>
-                    </TableCell>
-                    <TableCell>
-                      {onOpenBooking ? (
-                        <Button
-                          variant="link"
-                          className="h-auto p-0"
-                          onClick={() => onOpenBooking(booking.id)}
-                          aria-label={copy.openBookingAction}
-                        >
-                          {booking.bookingNumber}
-                        </Button>
-                      ) : (
-                        booking.bookingNumber
-                      )}
-                    </TableCell>
-                    <TableCell className="capitalize">
-                      {booking.status.replace(/[._-]/g, " ")}
-                    </TableCell>
-                    <TableCell>
-                      {seats.length > 0 ? (
-                        <span className="flex flex-wrap gap-1">
-                          {seats.map((label) => (
-                            <Badge key={label} variant="outline">
-                              {label}
-                            </Badge>
-                          ))}
-                        </span>
-                      ) : (
-                        <Badge variant="outline" className="text-muted-foreground">
-                          {copy.unseatedBadge}
-                        </Badge>
-                      )}
-                    </TableCell>
-                  </TableRow>
-                )
-              })}
-            </TableBody>
-          </Table>
+        <div data-slot="departure-traveler-roster" className="flex flex-col gap-3">
+          {groups.map((booking) => (
+            <ReservationGroup
+              key={booking.id}
+              booking={booking}
+              copy={copy}
+              resourceLabelById={resourceLabelById}
+              allocatesPositions={allocatesPositions}
+              onOpenBooking={onOpenBooking}
+            />
+          ))}
         </div>
       )}
     </div>
   )
+}
+
+/**
+ * Live reservations first, in the departure-local order the manifest numbers
+ * them by, then the cancelled ones. A cancelled party still holding an
+ * allocation is worth seeing — that is its own attention issue — but it is not
+ * who is travelling, so it does not sit between two parties who are.
+ */
+function orderReservations(
+  bookings: ReadonlyArray<AllocationManifestBooking>,
+): AllocationManifestBooking[] {
+  return [...bookings].sort((left, right) => {
+    const cancelled = Number(left.status === "cancelled") - Number(right.status === "cancelled")
+    if (cancelled !== 0) return cancelled
+    return left.bookingSequence - right.bookingSequence
+  })
+}
+
+function ReservationGroup({
+  booking,
+  copy,
+  resourceLabelById,
+  allocatesPositions,
+  onOpenBooking,
+}: {
+  booking: AllocationManifestBooking
+  copy: TravelersCopy
+  resourceLabelById: ReadonlyMap<string, string>
+  allocatesPositions: boolean
+  onOpenBooking?: (bookingId: string) => void
+}) {
+  const cancelled = booking.status === "cancelled"
+  const contactName = [booking.contactFirstName, booking.contactLastName]
+    .filter((part): part is string => Boolean(part?.trim()))
+    .join(" ")
+  const entered = booking.travelers.length
+  // The departure-level "names missing" counter says how many are outstanding;
+  // only the group can say WHICH reservation is short of them.
+  const short = booking.pax !== null && booking.pax !== entered
+
+  return (
+    <section
+      data-slot="departure-traveler-group"
+      data-booking-id={booking.id}
+      data-booking-status={booking.status}
+      className={cn("overflow-hidden rounded-md border", cancelled && "opacity-70")}
+    >
+      <header className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2 border-b bg-muted/40 px-4 py-2.5">
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
+          {booking.bookingSequence > 0 ? (
+            <span className="text-xs font-semibold tabular-nums text-muted-foreground">
+              #{booking.bookingSequence}
+            </span>
+          ) : null}
+          {onOpenBooking ? (
+            <Button
+              variant="link"
+              className="h-auto p-0 font-medium"
+              onClick={() => onOpenBooking(booking.id)}
+              aria-label={copy.openBookingAction}
+            >
+              {booking.bookingNumber}
+            </Button>
+          ) : (
+            <span className="font-medium">{booking.bookingNumber}</span>
+          )}
+          <Badge variant="outline">{bookingStatusLabel(booking.status, copy)}</Badge>
+          <Badge variant="outline" className={paymentTones[booking.paymentStatus]}>
+            {copy.paymentStatusLabels[booking.paymentStatus]}
+          </Badge>
+        </div>
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
+          {contactName ? <span>{copy.bookedByLabel.replace("{name}", contactName)}</span> : null}
+          <span
+            className={cn("tabular-nums", short && "font-medium text-red-600 dark:text-red-400")}
+          >
+            {booking.pax === null
+              ? copy.namesEnteredLabel.replace("{entered}", String(entered))
+              : copy.namesOfPaxLabel
+                  .replace("{entered}", String(entered))
+                  .replace("{pax}", String(booking.pax))}
+          </span>
+        </div>
+      </header>
+
+      {entered === 0 ? (
+        <p className="px-4 py-3 text-sm text-muted-foreground">{copy.groupNoNames}</p>
+      ) : (
+        <ul className="divide-y">
+          {booking.travelers.map((traveler, index) => (
+            <TravelerRow
+              key={traveler.id}
+              traveler={traveler}
+              ordinal={index + 1}
+              copy={copy}
+              resourceLabelById={resourceLabelById}
+              allocatesPositions={allocatesPositions}
+            />
+          ))}
+        </ul>
+      )}
+    </section>
+  )
+}
+
+function TravelerRow({
+  traveler,
+  ordinal,
+  copy,
+  resourceLabelById,
+  allocatesPositions,
+}: {
+  traveler: AllocationManifestTraveler
+  ordinal: number
+  copy: TravelersCopy
+  resourceLabelById: ReadonlyMap<string, string>
+  allocatesPositions: boolean
+}) {
+  const seats = Object.values(traveler.allocations)
+    .map((resourceId) => resourceLabelById.get(resourceId) ?? null)
+    .filter((label): label is string => Boolean(label))
+
+  return (
+    <li
+      data-slot="departure-traveler"
+      className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 px-4 py-2 text-sm"
+    >
+      <span className="flex min-w-0 flex-wrap items-center gap-2">
+        <span className="w-5 shrink-0 tabular-nums text-xs text-muted-foreground">{ordinal}</span>
+        <span className="font-medium">{traveler.fullName}</span>
+        {traveler.isLeadTraveler ? <Badge variant="secondary">{copy.leadBadge}</Badge> : null}
+        {traveler.hasAccessibilityNeeds ? (
+          <Badge variant="outline">{copy.accessibilityBadge}</Badge>
+        ) : null}
+        {traveler.hasDietaryRequirements ? (
+          <Badge variant="outline">{copy.dietaryBadge}</Badge>
+        ) : null}
+      </span>
+      {allocatesPositions ? (
+        <span className="flex flex-wrap gap-1">
+          {seats.length > 0 ? (
+            seats.map((label) => (
+              <Badge key={label} variant="outline">
+                {label}
+              </Badge>
+            ))
+          ) : (
+            <Badge variant="outline" className="text-muted-foreground">
+              {copy.unseatedBadge}
+            </Badge>
+          )}
+        </span>
+      ) : null}
+    </li>
+  )
+}
+
+/**
+ * A booking status the operator can read. Unknown values — a status a newer
+ * Bookings release invented — degrade to the de-underscored wire value rather
+ * than to a blank badge.
+ */
+function bookingStatusLabel(status: string, copy: TravelersCopy): string {
+  const labels: Record<string, string> = copy.bookingStatusLabels
+  return labels[status] ?? status.replace(/[._-]/g, " ")
+}
+
+const paymentTones: Record<string, string> = {
+  paid: "border-transparent bg-emerald-500/10 text-emerald-700 dark:text-emerald-400",
+  partial: "border-transparent bg-yellow-500/10 text-yellow-700 dark:text-yellow-400",
+  unpaid: "border-transparent bg-red-500/10 text-red-600 dark:text-red-400",
 }

--- a/packages/operations-react/src/availability/departure-summary-schemas.test.ts
+++ b/packages/operations-react/src/availability/departure-summary-schemas.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest"
+
+import { departureAllocatesPositions } from "./departure-summary-schemas.js"
+
+/**
+ * The one rule behind every seat-shaped affordance in the departure workspace.
+ * Its third case is the one that is easy to get wrong: a server that has not
+ * shipped `planned` yet is not the same as a server that answered `false`.
+ */
+describe("departureAllocatesPositions", () => {
+  it("takes the server's answer when it has one", () => {
+    expect(departureAllocatesPositions({ total: 0, planned: true })).toBe(true)
+    expect(departureAllocatesPositions({ total: 3, planned: false })).toBe(false)
+  })
+
+  it("falls back to whether resources exist against a server that does not answer", () => {
+    expect(departureAllocatesPositions({ total: 3 })).toBe(true)
+    expect(departureAllocatesPositions({ total: 0 })).toBe(false)
+  })
+
+  it("treats a departure with no summary as allocating nothing", () => {
+    expect(departureAllocatesPositions(null)).toBe(false)
+    expect(departureAllocatesPositions(undefined)).toBe(false)
+  })
+})

--- a/packages/operations-react/src/availability/departure-summary-schemas.ts
+++ b/packages/operations-react/src/availability/departure-summary-schemas.ts
@@ -84,13 +84,46 @@ export type DepartureTravelerCounters = z.infer<typeof departureTravelerCounters
 
 export const departureResourceCountersSchema = z.object({
   total: z.number().int(),
+  /**
+   * Resource templates the departure's option declares. Defaulted so a client
+   * one release ahead of its server still parses.
+   */
+  templated: z.number().int().default(0),
   seating: z.number().int(),
   capacity: z.number().int(),
   assigned: z.number().int(),
   available: z.number().int(),
   overCapacity: z.number().int(),
+  /**
+   * Whether this departure allocates rooms or seats at all. Optional rather
+   * than defaulted: absent means "this server does not answer the question",
+   * which `departureAllocatesPositions` resolves differently from a server that
+   * answered `false`.
+   */
+  planned: z.boolean().optional(),
 })
 export type DepartureResourceCounters = z.infer<typeof departureResourceCountersSchema>
+
+/**
+ * Does this departure have a rooming or seating plan?
+ *
+ * The server derives it (`resources.planned`) so there is one authority for the
+ * rule. Against an older server the field is absent and the only fact available
+ * is whether resources exist — which is the same answer for every departure
+ * that has any, and a safe "no seat column" for those that do not.
+ *
+ * Everything seat-shaped in the workspace hangs off this: the Seated / Not
+ * seated counters, the Seat / room column, and the Allocation section's
+ * default. A day excursion allocates nothing, and showing it a rooming list
+ * with its whole roster marked "not seated" is noise the operator cannot act
+ * on.
+ */
+export function departureAllocatesPositions(
+  counters: Pick<DepartureResourceCounters, "total" | "planned"> | null | undefined,
+): boolean {
+  if (!counters) return false
+  return counters.planned ?? counters.total > 0
+}
 
 export const departureResourceRowSchema = z.object({
   id: z.string(),

--- a/packages/operations/openapi/admin/operations.json
+++ b/packages/operations/openapi/admin/operations.json
@@ -4830,6 +4830,9 @@
                                 "total": {
                                   "type": "integer"
                                 },
+                                "templated": {
+                                  "type": "integer"
+                                },
                                 "seating": {
                                   "type": "integer"
                                 },
@@ -4844,15 +4847,20 @@
                                 },
                                 "overCapacity": {
                                   "type": "integer"
+                                },
+                                "planned": {
+                                  "type": "boolean"
                                 }
                               },
                               "required": [
                                 "total",
+                                "templated",
                                 "seating",
                                 "capacity",
                                 "assigned",
                                 "available",
-                                "overCapacity"
+                                "overCapacity",
+                                "planned"
                               ]
                             },
                             "resourceBreakdown": {
@@ -5026,6 +5034,9 @@
                             "total": {
                               "type": "integer"
                             },
+                            "templated": {
+                              "type": "integer"
+                            },
                             "seating": {
                               "type": "integer"
                             },
@@ -5040,15 +5051,20 @@
                             },
                             "overCapacity": {
                               "type": "integer"
+                            },
+                            "planned": {
+                              "type": "boolean"
                             }
                           },
                           "required": [
                             "total",
+                            "templated",
                             "seating",
                             "capacity",
                             "assigned",
                             "available",
-                            "overCapacity"
+                            "overCapacity",
+                            "planned"
                           ]
                         },
                         "operations": {

--- a/packages/operations/src/availability/routes-core.ts
+++ b/packages/operations/src/availability/routes-core.ts
@@ -271,11 +271,18 @@ const departureTravelerCountersSchema = z.object({
 
 const departureResourceCountersSchema = z.object({
   total: z.number().int(),
+  /** Resource templates the departure's option declares. */
+  templated: z.number().int(),
   seating: z.number().int(),
   capacity: z.number().int(),
   assigned: z.number().int(),
   available: z.number().int(),
   overCapacity: z.number().int(),
+  /**
+   * Whether this departure allocates rooms or seats at all. False on a day
+   * excursion, where every counter above is structurally zero.
+   */
+  planned: z.boolean(),
 })
 
 const departureResourceRowSchema = z.object({

--- a/packages/operations/src/availability/service-departure-capacity.ts
+++ b/packages/operations/src/availability/service-departure-capacity.ts
@@ -105,6 +105,19 @@ export interface DepartureResourceCounters {
   /** Every `allocation_resources` row on the slot, parents included. */
   total: number
   /**
+   * `product_option_resource_templates` declared for the departure's option —
+   * the catalog's statement that this product is *supposed* to have rooms or
+   * seats. Zero on a departure whose option declares none, and on a departure
+   * with no option at all.
+   *
+   * This is what separates "the rooming list has not been laid out yet" from
+   * "this product allocates nothing" (a day excursion). Without it, every
+   * excursion reported its whole roster as unseated and carried a permanent
+   * `allocation_resources_missing` warning for a plan that was never going to
+   * exist (#4033 follow-up).
+   */
+  templated: number
+  /**
    * Resources that actually seat a traveler — a `vehicle` whose
    * `vehicle_seat` children are also rows would otherwise be counted twice.
    */
@@ -117,6 +130,16 @@ export interface DepartureResourceCounters {
   available: number
   /** Seating resources whose assigned count exceeds their capacity. */
   overCapacity: number
+  /**
+   * Whether this departure allocates positions at all: it already has
+   * resources, or its option declares templates to materialize them from.
+   *
+   * Derived here rather than by each reader, so "does this departure have a
+   * rooming/seating plan" has exactly one answer. `false` means every
+   * seat/room counter below is structurally zero and reporting them as a
+   * shortfall would be inventing a requirement nobody declared.
+   */
+  planned: boolean
 }
 
 export interface DepartureCapacityCounters {
@@ -183,18 +206,20 @@ export async function getDepartureCapacityCounters(
 
   if (!slot) return null
 
-  const [allocationRows, bookingRows, travelerRows, holds, resourceBreakdown] = await Promise.all([
-    loadAllocationStatusRows(db, slotId, now),
-    loadBookingStatusRows(db, slotId),
-    loadTravelerCounts(db, slotId),
-    countSlotHolds(db, slotId, now),
-    getSlotResourceAvailability(db, slotId),
-  ])
+  const [allocationRows, bookingRows, travelerRows, holds, resourceBreakdown, templated] =
+    await Promise.all([
+      loadAllocationStatusRows(db, slotId, now),
+      loadBookingStatusRows(db, slotId),
+      loadTravelerCounts(db, slotId),
+      countSlotHolds(db, slotId, now),
+      getSlotResourceAvailability(db, slotId),
+      countOptionResourceTemplates(db, slot.optionId),
+    ])
 
   const allocations = rollUpAllocations(allocationRows)
   const bookings = rollUpBookings(bookingRows)
   const travelers = rollUpTravelers(travelerRows[0], bookings.expectedPax)
-  const resources = rollUpResources(resourceBreakdown)
+  const resources = rollUpResources(resourceBreakdown, templated)
 
   const derivedConsumedPax = bookings.expectedPax + holds.activePax
   const initialPax = slot.initialPax ?? null
@@ -373,8 +398,29 @@ function rollUpTravelers(
   }
 }
 
+/**
+ * How many resource templates the departure's option declares. A departure with
+ * no `option_id` cannot inherit any, and answers zero without a query.
+ */
+async function countOptionResourceTemplates(
+  db: PostgresJsDatabase,
+  optionId: string | null,
+): Promise<number> {
+  if (!optionId) return 0
+  const rows = await executeRows<{ template_count: number }>(
+    db,
+    sql`
+      SELECT COUNT(*)::int AS template_count
+      FROM product_option_resource_templates
+      WHERE product_option_id = ${optionId}
+    `,
+  )
+  return rows[0]?.template_count ?? 0
+}
+
 function rollUpResources(
   breakdown: readonly SlotResourceAvailability[],
+  templated: number,
 ): DepartureResourceCounters {
   const parentIds = new Set(
     breakdown.flatMap((resource) => (resource.parentId ? [resource.parentId] : [])),
@@ -383,10 +429,12 @@ function rollUpResources(
 
   return {
     total: breakdown.length,
+    templated,
     seating: seating.length,
     capacity: seating.reduce((sum, resource) => sum + resource.capacity, 0),
     assigned: seating.reduce((sum, resource) => sum + resource.assigned, 0),
     available: seating.reduce((sum, resource) => sum + resource.available, 0),
     overCapacity: seating.filter((resource) => resource.assigned > resource.capacity).length,
+    planned: breakdown.length > 0 || templated > 0,
   }
 }

--- a/packages/operations/src/availability/service-departure-capacity.ts
+++ b/packages/operations/src/availability/service-departure-capacity.ts
@@ -105,10 +105,10 @@ export interface DepartureResourceCounters {
   /** Every `allocation_resources` row on the slot, parents included. */
   total: number
   /**
-   * `product_option_resource_templates` declared for the departure's option —
+   * `product_option_resource_templates` this departure would materialize from —
    * the catalog's statement that this product is *supposed* to have rooms or
-   * seats. Zero on a departure whose option declares none, and on a departure
-   * with no option at all.
+   * seats. Resolved like the materializer does: its own option when it has one,
+   * every option of its product when it does not.
    *
    * This is what separates "the rooming list has not been laid out yet" from
    * "this product allocates nothing" (a day excursion). Without it, every
@@ -213,7 +213,7 @@ export async function getDepartureCapacityCounters(
       loadTravelerCounts(db, slotId),
       countSlotHolds(db, slotId, now),
       getSlotResourceAvailability(db, slotId),
-      countOptionResourceTemplates(db, slot.optionId),
+      countResourceTemplates(db, { optionId: slot.optionId, productId: slot.productId }),
     ])
 
   const allocations = rollUpAllocations(allocationRows)
@@ -399,21 +399,34 @@ function rollUpTravelers(
 }
 
 /**
- * How many resource templates the departure's option declares. A departure with
- * no `option_id` cannot inherit any, and answers zero without a query.
+ * How many resource templates this departure would materialize from.
+ *
+ * Resolved exactly the way `materializeSlotResourcesFromTemplateDefaultsLocked`
+ * resolves it, because the two have to agree on what "this departure has a
+ * declared plan" means: an option-scoped slot draws from its own option, and a
+ * **product-level slot** (`option_id IS NULL`) draws from every option of its
+ * product. Counting only the slot's own option reported zero for every
+ * product-level departure and hid a rooming plan that the materializer would
+ * happily have created.
  */
-async function countOptionResourceTemplates(
+async function countResourceTemplates(
   db: PostgresJsDatabase,
-  optionId: string | null,
+  slot: { optionId: string | null; productId: string },
 ): Promise<number> {
-  if (!optionId) return 0
   const rows = await executeRows<{ template_count: number }>(
     db,
-    sql`
-      SELECT COUNT(*)::int AS template_count
-      FROM product_option_resource_templates
-      WHERE product_option_id = ${optionId}
-    `,
+    slot.optionId
+      ? sql`
+          SELECT COUNT(*)::int AS template_count
+          FROM product_option_resource_templates
+          WHERE product_option_id = ${slot.optionId}
+        `
+      : sql`
+          SELECT COUNT(*)::int AS template_count
+          FROM product_option_resource_templates t
+          JOIN product_options o ON o.id = t.product_option_id
+          WHERE o.product_id = ${slot.productId}
+        `,
   )
   return rows[0]?.template_count ?? 0
 }

--- a/packages/operations/src/availability/service-departure-issues.ts
+++ b/packages/operations/src/availability/service-departure-issues.ts
@@ -60,7 +60,11 @@ export type DepartureIssueCode =
   | "resource_over_capacity"
   /** Travelers with no resource assignment on a departure that has resources. */
   | "travelers_unassigned"
-  /** Travelers to seat, but no `allocation_resources` laid out. */
+  /**
+   * Travelers to seat, and a declared rooming/seating plan, but no
+   * `allocation_resources` laid out. Never raised on a departure that
+   * allocates nothing (`resources.planned === false`).
+   */
   | "allocation_resources_missing"
   /** The slot was never bound to an immutable Product Version. */
   | "departure_not_version_bound"
@@ -225,14 +229,21 @@ export function evaluateDepartureIssues(input: DepartureIssueInput): DepartureIs
     })
   }
 
-  if (counters.resources.seating === 0 && counters.travelers.entered > 0) {
+  // Both of these are about a rooming/seating plan, so neither means anything
+  // on a departure that has no plan to fall short of. `planned` is the
+  // catalog's own statement — templates declared, or resources already laid
+  // out. Without the gate every day excursion carried a permanent
+  // `allocation_resources_missing` warning for rooms nobody ever intended to
+  // allocate, which is how operators learn to ignore the attention list.
+  const allocationPlanned = counters.resources.planned
+  if (allocationPlanned && counters.resources.seating === 0 && counters.travelers.entered > 0) {
     departureIssue(
       "allocation_resources_missing",
       "warning",
       counters.travelers.entered,
       "Travelers are booked on this departure but no rooms or seats have been laid out.",
     )
-  } else if (counters.travelers.unassigned > 0) {
+  } else if (allocationPlanned && counters.travelers.unassigned > 0) {
     departureIssue(
       "travelers_unassigned",
       "warning",

--- a/packages/operations/tests/availability/integration/departure-summary.test.ts
+++ b/packages/operations/tests/availability/integration/departure-summary.test.ts
@@ -255,6 +255,50 @@ describe.skipIf(!DB_AVAILABLE)("departure summary (integration)", () => {
     expect(page?.bookings[0]?.id).toBe(whole?.bookings[1]?.id)
   })
 
+  /**
+   * Whether a departure has a rooming plan at all, resolved the same way the
+   * materializer resolves which templates it would create from. The seeded slot
+   * carries no `option_id` — a PRODUCT-LEVEL departure, which
+   * `materializeSlotResourcesFromTemplateDefaultsLocked` serves by drawing from
+   * every option of the product. Counting only the slot's own option answered
+   * zero for all of them and hid a plan the materializer would have created.
+   */
+  it("counts the product's option templates on a product-level departure", async () => {
+    const optionId = newId("product_options")
+    await db.execute(sql`
+      INSERT INTO product_options (id, product_id, name)
+      VALUES (${optionId}, ${productId}, 'Standard')
+    `)
+    await db.execute(sql`
+      INSERT INTO product_option_resource_templates
+        (id, product_option_id, kind, capacity, name_pattern)
+      VALUES (
+        ${newId("product_option_resource_templates")}, ${optionId}, 'room', 2, 'DBL {sequence}'
+      )
+    `)
+    await seedBooking({ pax: 2, travelerCount: 2 })
+
+    const counters = await getDepartureCapacityCounters(db, slotId)
+    expect(counters?.resources.templated).toBe(1)
+    expect(counters?.resources.planned).toBe(true)
+
+    // Declared but never laid out — the one state this warning is for.
+    const issues = await getDepartureIssues(db, slotId, { counters: counters ?? undefined })
+    expect(codesFor(issues ?? [])).toContain("allocation_resources_missing")
+  })
+
+  it("says nothing about rooms on a departure whose catalog declares none", async () => {
+    await seedBooking({ pax: 2, travelerCount: 2 })
+
+    const counters = await getDepartureCapacityCounters(db, slotId)
+    expect(counters?.resources.templated).toBe(0)
+    expect(counters?.resources.planned).toBe(false)
+
+    const issues = await getDepartureIssues(db, slotId, { counters: counters ?? undefined })
+    expect(codesFor(issues ?? [])).not.toContain("allocation_resources_missing")
+    expect(codesFor(issues ?? [])).not.toContain("travelers_unassigned")
+  })
+
   it("reports a resource holding more travelers than it can seat", async () => {
     const resourceId = newId("allocation_resources")
     await db.execute(sql`

--- a/packages/operations/tests/availability/unit/departure-issues.test.ts
+++ b/packages/operations/tests/availability/unit/departure-issues.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest"
+
+import type { DepartureCapacityCounters } from "../../../src/availability/service-departure-capacity.js"
+import { evaluateDepartureIssues } from "../../../src/availability/service-departure-issues.js"
+
+/**
+ * The rooming/seating issues, and the departure that has no rooming plan to be
+ * short of.
+ *
+ * A day excursion has no rooms, no seat map and no resource templates, so every
+ * seat-shaped counter on it is structurally zero. Before `resources.planned`,
+ * the evaluator read that zero as a shortfall and every such departure carried
+ * a permanent `allocation_resources_missing` warning — a detector that fires on
+ * a state nobody can repair is how operators learn to ignore the whole list.
+ *
+ * Both halves matter here: the excursion stays quiet, and a departure whose
+ * catalog DOES declare resources still gets told when they are missing.
+ */
+
+function counters(overrides: {
+  travelersEntered?: number
+  travelersAssigned?: number
+  resourcesTotal?: number
+  resourcesSeating?: number
+  templated?: number
+}): DepartureCapacityCounters {
+  const entered = overrides.travelersEntered ?? 0
+  const assigned = overrides.travelersAssigned ?? 0
+  const total = overrides.resourcesTotal ?? 0
+  const seating = overrides.resourcesSeating ?? total
+  const templated = overrides.templated ?? 0
+
+  return {
+    slotId: "slot_1",
+    unlimited: false,
+    initialPax: null,
+    effectivePax: null,
+    remainingPax: null,
+    derivedRemainingPax: null,
+    derivedConsumedPax: 0,
+    holds: { active: 0, activePax: 0, expired: 0, expiredPax: 0, released: 0, converted: 0 },
+    allocations: {
+      held: 0,
+      confirmed: 0,
+      fulfilled: 0,
+      staleHeld: 0,
+      released: 0,
+      expired: 0,
+      cancelled: 0,
+      active: 0,
+      inactive: 0,
+    },
+    bookings: {
+      active: 1,
+      cancelledWithLiveAllocation: 0,
+      expectedPax: entered,
+      byStatus: { confirmed: 1 },
+    },
+    travelers: {
+      entered,
+      lead: entered > 0 ? 1 : 0,
+      assigned,
+      unassigned: Math.max(0, entered - assigned),
+      missing: 0,
+    },
+    resources: {
+      total,
+      templated,
+      seating,
+      capacity: seating * 2,
+      assigned,
+      available: Math.max(0, seating * 2 - assigned),
+      overCapacity: 0,
+      planned: total > 0 || templated > 0,
+    },
+    resourceBreakdown: [],
+  }
+}
+
+const evaluate = (input: Parameters<typeof counters>[0]) =>
+  evaluateDepartureIssues({
+    slotId: "slot_1",
+    productVersionId: "pver_1",
+    counters: counters(input),
+    staleHeldAllocationIds: [],
+    cancelledBookingIds: [],
+  }).map((issue) => issue.code)
+
+describe("evaluateDepartureIssues — the rooming plan a departure does not have", () => {
+  it("says nothing about rooms on a departure that allocates none", () => {
+    // A day excursion: 13 names, no resources, no templates declaring any.
+    const codes = evaluate({ travelersEntered: 13 })
+
+    expect(codes).not.toContain("allocation_resources_missing")
+    expect(codes).not.toContain("travelers_unassigned")
+    expect(codes).toEqual([])
+  })
+
+  it("still reports missing resources when the catalog declares templates", () => {
+    const codes = evaluate({ travelersEntered: 13, templated: 3 })
+
+    expect(codes).toContain("allocation_resources_missing")
+  })
+
+  it("still reports missing resources once some are laid out but nothing seats", () => {
+    // A parent-only layout (a vehicle with no seat children) seats nobody.
+    const codes = evaluate({ travelersEntered: 4, resourcesTotal: 1, resourcesSeating: 0 })
+
+    expect(codes).toContain("allocation_resources_missing")
+  })
+
+  it("reports unseated travelers once the departure has somewhere to seat them", () => {
+    const codes = evaluate({ travelersEntered: 4, travelersAssigned: 1, resourcesTotal: 2 })
+
+    expect(codes).toContain("travelers_unassigned")
+    expect(codes).not.toContain("allocation_resources_missing")
+  })
+
+  it("clears once every traveler holds an assignment", () => {
+    const codes = evaluate({ travelersEntered: 4, travelersAssigned: 4, resourcesTotal: 2 })
+
+    expect(codes).toEqual([])
+  })
+})


### PR DESCRIPTION
Users could not tell who is grouped with whom on a departure's traveler list, and every day excursion was being managed as though it had rooms.

## What was wrong

**The roster was flat.** One table row per traveler with the booking number repeated in a column, so "who travelled together" had to be reconstructed by matching strings by eye — worst exactly where it matters, between two reservations whose numbers differ by a digit. The manifest already carries `bookingSequence`, the contact, `pax`, `paymentStatus` and per-traveler flags; none of it was rendered. Booking statuses leaked the wire value (`Confirmed`) into a Romanian UI.

**Seat and room affordances were unconditional.** An excursion has no rooms, no seat map and no resource templates, so every seat-shaped counter on it is structurally zero — and the workspace read that zero as a shortfall:

- the Travelers tab showed `Cazați 0 / Necazați 13` in attention red, plus a `Loc / cameră` column that could only ever say "Necazat";
- `evaluateDepartureIssues` raised `allocation_resources_missing` whenever `resources.seating === 0 && travelers.entered > 0` — true for *every* excursion with bookings, permanently, with no repair available;
- the Allocation tab always offered Room / Vehicle / Seats, because `deriveAllocationKinds` injects those three kinds unconditionally.

A detector that fires on a state nobody can act on is how operators learn to ignore the attention list.

## The change

`allocation_resources` and `product_option_resource_templates` are the catalog's own statement about whether a departure has positions to allocate (`docs/architecture/allocation-resources-lifecycle.md`). The departure summary now derives that once, server-side:

- `allocation.templated` — resource templates declared for the departure's option;
- `allocation.planned` — `total > 0 || templated > 0`.

Both rooming issues are gated on `planned`, and the client hangs every seat-shaped affordance off one shared rule (`departureAllocatesPositions`), which falls back to "are there resources" against a server that does not answer yet.

The roster is now grouped per reservation: a bordered group per booking carrying who booked it, its status, whether it is paid, and `2 / 3 names` when that party is short — the departure-level counter says how many names are outstanding, only the group can say *which* reservation is missing them. Cancelled reservations sort last and render demoted.

On a departure that allocates nothing, the Allocation section says so and offers the product's resource templates, rather than opening an empty rooming plan. It is not a dead end: "lay out rooms or seats anyway" reveals the manager, because "no templates yet" and "never any rooms" are not distinguishable from the departure.

## Notes

- Behaviour change worth flagging: a multi-day tour whose option has **no** templates configured and no resources laid out now gets the same treatment as an excursion — no rooming warning, explain-and-opt-in on Allocation. The alternative was to keep warning by default, which is what makes the warning worthless today. `availability_slots.nights` exists but is operator-entered and null in practice, so it was not used as a second signal.
- Not a new checker: this is a rule about domain state, not about the tree's shape.

## Verification

- `packages/operations` — new `tests/availability/unit/departure-issues.test.ts` (5 tests): an excursion raises no rooming issues; a departure whose option declares templates still gets `allocation_resources_missing`; a parent-only layout still gets it; `travelers_unassigned` fires only once there is somewhere to seat people, and clears when everyone is assigned.
- `packages/operations-react` — 10 tests pass, including new coverage that the roster groups by reservation in departure-local sequence and that an excursion drops the Seated / Not seated counters, the Seat / room column and the allocation manager while keeping a way in.
- `pnpm -F @voyant-travel/operations verify:openapi` — up to date (the regenerated document is in this branch).
- `node --import tsx scripts/check-i18n-parity.ts` — passes, 24 definition sets.
- Biome clean over the touched trees.
