### PR TITLE
Separate recording a booking's payment from issuing a fiscal document for it

### DIFF
--- a/.changeset/booking-document-suppression.md
+++ b/.changeset/booking-document-suppression.md
@@ -1,0 +1,16 @@
+---
+"@voyant-travel/bookings-contracts": minor
+"@voyant-travel/finance-contracts": minor
+"@voyant-travel/bookings": minor
+"@voyant-travel/finance": minor
+"@voyant-travel/legal": minor
+---
+
+Make recording a booking's payment separable from issuing a fiscal document for it.
+
+Creating a booking with a recorded payment issued an invoice and mirrored it to the operator's accounting provider, and confirming one generated a contract. Both were consequences of the create rather than calls anyone made, so an operator's explicit "do not issue a proforma, invoice or contract" had nowhere to land, and back-filling a booking for an already-invoiced sale filed a second real fiscal document for it.
+
+- `suppressDocuments` on booking create records the booking without producing documents for it. The invoice is still written, as an unissued draft carrying the payments, so the booking records what was paid. Persisted as `bookings.documents_suppressed` and re-read by contract generation, which runs off an event after the create commits.
+- `documentGeneration.externalInvoice` (and `externalDocument` on `POST /invoices/from-booking`) records the sale against a fiscal document the operator already issued in their provider: the platform's invoice is issued so balances and contracts stay right, the mirror is suppressed, and the invoice's external reference names the operator's document.
+- Issuing from a booking that already carries a live external fiscal document now refuses with `duplicate_external_document` (HTTP 409) instead of sending a duplicate; `acknowledgeExistingExternalDocument: true` overrides it.
+- `POST /invoices/{id}/external-refs/{refId}/supersede` records that a provider document was cancelled outside the platform, keeping the superseded identity, and optionally repoints the reference at its replacement.

--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -2090,6 +2090,7 @@ Constraints:
 | `pax` | integer • nullable |
 | `internal_notes` (`internalNotes`) | text • nullable |
 | `notifications_suppressed` (`notificationsSuppressed`) | boolean • not null • default false |
+| `documents_suppressed` (`documentsSuppressed`) | boolean • not null • default false |
 | `customer_payment_policy` (`customerPaymentPolicy`) | jsonb • nullable |
 | `price_override` (`priceOverride`) | jsonb • nullable |
 | `custom_fields` (`customFields`) | jsonb • not null • default |

--- a/packages/bookings-contracts/src/validation-bookings.ts
+++ b/packages/bookings-contracts/src/validation-bookings.ts
@@ -77,6 +77,11 @@ const bookingCoreSchema = z.object({
   pax: z.number().int().positive().optional().nullable(),
   internalNotes: z.string().optional().nullable(),
   notificationsSuppressed: z.boolean().optional(),
+  /**
+   * "Record this booking, do not produce documents for it" — no automatic
+   * invoice issuance, no automatic contract generation (voyant#4688).
+   */
+  documentsSuppressed: z.boolean().optional(),
   customerPaymentPolicy: bookingCustomerPaymentPolicySchema.optional().nullable(),
   priceOverride: bookingPriceOverrideSchema.optional().nullable(),
   // Values are always `customFields[namespace][key]`; definitions and scalar
@@ -95,6 +100,10 @@ export const updateBookingSchema = bookingCoreSchema
   .extend({
     sourceType: bookingSourceTypeSchema.optional(),
     notificationsSuppressed: z.literal(true).optional(),
+    // Same one-way latch as notification suppression, for the same reason:
+    // clearing it cannot un-issue anything, and turning generation back on is
+    // an operator issuing the document deliberately, not a flag flip.
+    documentsSuppressed: z.literal(true).optional(),
   })
   .strict()
   .superRefine(validateExclusiveBillingParty)
@@ -228,6 +237,12 @@ export const convertProductSchema = z
       .boolean()
       .optional()
       .describe("Persistently suppress customer-facing messages for this booking lifecycle."),
+    suppressDocuments: z
+      .boolean()
+      .optional()
+      .describe(
+        "Record the booking without producing documents for it: no invoice or proforma is issued to the accounting provider, and no contract is generated. Persists on the booking, so the paths that run after the create honour it too. Use it when the operator says not to issue, or when the sale is already invoiced outside the platform.",
+      ),
     /**
      * Billing-contact snapshot. Captures who the operator was billing
      * at create time so the booking detail page renders the right

--- a/packages/bookings/migrations/20260815160000_persist_document_suppression.sql
+++ b/packages/bookings/migrations/20260815160000_persist_document_suppression.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "bookings"
+ADD COLUMN "documents_suppressed" boolean DEFAULT false NOT NULL;

--- a/packages/bookings/migrations/meta/_journal.json
+++ b/packages/bookings/migrations/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1786968060000,
       "tag": "20260815120100_booking_document_issued_identity",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1786982400000,
+      "tag": "20260815160000_persist_document_suppression",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/bookings/src/mcp-runtime.test.ts
+++ b/packages/bookings/src/mcp-runtime.test.ts
@@ -291,6 +291,7 @@ function bookingDetailWithDates(id: string) {
     pax: 1,
     internalNotes: null,
     notificationsSuppressed: false,
+    documentsSuppressed: false,
     customerPaymentPolicy: null,
     priceOverride: null,
     customFields: {},

--- a/packages/bookings/src/routes-admin.ts
+++ b/packages/bookings/src/routes-admin.ts
@@ -1291,6 +1291,7 @@ const bookingSchema = z.object({
   pax: z.number().int().nullable(),
   internalNotes: z.string().nullable(),
   notificationsSuppressed: z.boolean(),
+  documentsSuppressed: z.boolean(),
   customerPaymentPolicy: z.unknown().nullable(),
   priceOverride: jsonObject.nullable(),
   customFields: namespacedCustomFields,

--- a/packages/bookings/src/schema-core.ts
+++ b/packages/bookings/src/schema-core.ts
@@ -77,6 +77,25 @@ export const bookings = pgTable(
      */
     notificationsSuppressed: boolean("notifications_suppressed").notNull().default(false),
     /**
+     * Durable "record this booking, do not produce documents for it" decision.
+     *
+     * voyant#4688: an operator told the agent, in words, not to issue a
+     * proforma, invoice or contract. The agent invoked no issuance call and
+     * truthfully reported that none were issued — and creating the booking
+     * issued a fiscal invoice to the accounting provider anyway, plus a
+     * contract, because both are consequences of booking creation rather than
+     * actions anyone chose. There was no flag at any layer that could say no.
+     *
+     * It lives on the row rather than only on the create input for the reason
+     * `notifications_suppressed` does: the paths that must honour it run after
+     * the creating transaction has committed, off events, and re-read the
+     * booking. A decision that exists only in the command cannot reach them.
+     *
+     * This governs automatic generation. An operator issuing a document by
+     * hand afterwards is a deliberate act and is not blocked by it.
+     */
+    documentsSuppressed: boolean("documents_suppressed").notNull().default(false),
+    /**
      * Booking-level customer payment policy override. When set, this
      * booking's payment schedule uses these terms instead of the
      * cascade default. Wins over listing / category / supplier /

--- a/packages/bookings/src/service-core.ts
+++ b/packages/bookings/src/service-core.ts
@@ -2714,6 +2714,7 @@ const bookingsServiceInternal = {
         pax: bookingPax,
         internalNotes: data.internalNotes ?? null,
         notificationsSuppressed: data.suppressNotifications === true,
+        documentsSuppressed: data.suppressDocuments === true,
       })
       .returning()
 

--- a/packages/bookings/src/tool-output-schemas.ts
+++ b/packages/bookings/src/tool-output-schemas.ts
@@ -43,6 +43,7 @@ export const bookingToolSchema = z.object({
   pax: z.number().int().nullable(),
   internalNotes: z.string().nullable(),
   notificationsSuppressed: z.boolean(),
+  documentsSuppressed: z.boolean(),
   customerPaymentPolicy: bookingCustomerPaymentPolicySchema.nullable(),
   priceOverride: jsonObject.nullable(),
   customFields: namespacedCustomFields,

--- a/packages/bookings/tests/admin/unit/routes-contract.test.ts
+++ b/packages/bookings/tests/admin/unit/routes-contract.test.ts
@@ -88,6 +88,7 @@ const booking: Booking = {
   pax: 2,
   internalNotes: null,
   notificationsSuppressed: false,
+  documentsSuppressed: false,
   customerPaymentPolicy: null,
   priceOverride: null,
   customFields: { custom: { source: "intake" } },

--- a/packages/bookings/tests/tools.test.ts
+++ b/packages/bookings/tests/tools.test.ts
@@ -66,6 +66,7 @@ function bookingDetail(id: string, status: "confirmed" | "cancelled") {
     pax: null,
     internalNotes: null,
     notificationsSuppressed: false,
+    documentsSuppressed: false,
     customerPaymentPolicy: null,
     priceOverride: null,
     customFields: {},

--- a/packages/finance-contracts/src/validation-billing.ts
+++ b/packages/finance-contracts/src/validation-billing.ts
@@ -281,21 +281,38 @@ export function formatExternalDocumentLabel(document: {
  * cancelled document, and blindly overwriting it would lose the identity of the
  * document the operator's accounting system still has on file.
  */
-export const supersedeInvoiceExternalRefSchema = z.object({
-  reason: z.string().trim().min(3).max(1000),
-  replacement: z
-    .object({
-      externalId: z.string().trim().min(1).max(255).optional().nullable(),
-      externalNumber: z.string().trim().min(1).max(255).optional().nullable(),
-      externalUrl: z.string().trim().min(1).max(1000).optional().nullable(),
-      status: z.string().trim().min(1).max(100).optional().nullable(),
-      series: z.string().trim().min(1).max(100).optional().nullable(),
-    })
-    .optional()
-    .describe(
-      "The document that replaces the cancelled one. Omit it when the cancellation stands on its own — the reference is then marked cancelled and the booking may be invoiced again.",
-    ),
-})
+export const supersedeInvoiceExternalRefSchema = z
+  .object({
+    reason: z.string().trim().min(3).max(1000),
+    replacement: z
+      .object({
+        externalId: z.string().trim().min(1).max(255).optional().nullable(),
+        externalNumber: z.string().trim().min(1).max(255).optional().nullable(),
+        externalUrl: z.string().trim().min(1).max(1000).optional().nullable(),
+        status: z.string().trim().min(1).max(100).optional().nullable(),
+        series: z.string().trim().min(1).max(100).optional().nullable(),
+      })
+      .optional()
+      .describe(
+        "The document that replaces the cancelled one. Omit it when the cancellation stands on its own — the reference is then marked cancelled and the booking may be invoiced again.",
+      ),
+  })
+  .superRefine((value, ctx) => {
+    if (!value.replacement) return
+    // A replacement with no identity is the worst of both: the reference stops
+    // being marked cancelled, so it reads as live, while carrying no document
+    // number the guard can recognise — which silently releases the guard
+    // without anyone having said the old document was retracted. Omitting
+    // `replacement` is how you say "cancelled, nothing replaces it".
+    if (!value.replacement.externalId && !value.replacement.externalNumber) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "A replacement document needs an externalId or an externalNumber. Omit `replacement` to record the cancellation on its own.",
+        path: ["replacement"],
+      })
+    }
+  })
 
 export const invoiceFromBookingSchema = z
   .object({

--- a/packages/finance-contracts/src/validation-billing.ts
+++ b/packages/finance-contracts/src/validation-billing.ts
@@ -208,6 +208,95 @@ const invoiceExternalRefCoreSchema = z.object({
   syncError: z.string().optional().nullable(),
 })
 
+/**
+ * `invoice_external_refs.status` values that mean the provider document the row
+ * points at is no longer a live fiscal document.
+ *
+ * The column carries whatever word the provider uses, so this is a vocabulary
+ * rather than an enum. It is what tells the duplicate-issuance guard that a
+ * booking's external document was retracted and a replacement may be issued:
+ * a ref whose status is not in here still counts as a fiscal document that
+ * exists in the operator's accounting system.
+ */
+export const CANCELLED_EXTERNAL_DOCUMENT_STATUSES = [
+  "cancelled",
+  "canceled",
+  "void",
+  "voided",
+  "storno",
+  "reversed",
+  "annulled",
+] as const
+
+export function isCancelledExternalDocumentStatus(status: string | null | undefined): boolean {
+  if (!status) return false
+  const normalized = status.trim().toLowerCase()
+  return CANCELLED_EXTERNAL_DOCUMENT_STATUSES.some((value) => value === normalized)
+}
+
+/**
+ * A fiscal document the operator already issued in their accounting provider,
+ * outside this platform.
+ *
+ * Declaring one records the sale against that document instead of issuing a
+ * second one: the platform writes its own invoice so balances, payments and
+ * contracts are right, but the mirror is suppressed and the external reference
+ * points at the operator's document. This is what back-filling a booking for an
+ * already-invoiced sale needs, and it is equally the answer for an operator who
+ * invoices outside the platform as a matter of course (voyant#4688).
+ *
+ * `series` and `number` are kept apart because that is how the providers this
+ * targets identify a document; the series lands in the reference's metadata,
+ * `number` in `external_number`.
+ */
+export const externalInvoiceDocumentSchema = z.object({
+  provider: z.string().trim().min(1).max(100),
+  series: z.string().trim().min(1).max(100).optional().nullable(),
+  number: z.string().trim().min(1).max(255),
+  externalId: z.string().trim().min(1).max(255).optional().nullable(),
+  externalUrl: z.string().trim().min(1).max(1000).optional().nullable(),
+  issuedAt: z.string().min(1).optional().nullable(),
+  note: z.string().max(1000).optional().nullable(),
+})
+
+export type ExternalInvoiceDocumentInput = z.infer<typeof externalInvoiceDocumentSchema>
+
+/** How an already-issued external document reads in an operator-facing message. */
+export function formatExternalDocumentLabel(document: {
+  series?: string | null
+  number?: string | null
+  externalNumber?: string | null
+}): string {
+  const number = document.number ?? document.externalNumber ?? null
+  if (!number) return "an unnumbered document"
+  return document.series ? `${document.series} ${number}` : number
+}
+
+/**
+ * Record that the provider document an external reference points at was
+ * cancelled in the provider's own UI, and optionally repoint the reference at
+ * its replacement.
+ *
+ * Without this there is no supported way back: the reference keeps naming a
+ * cancelled document, and blindly overwriting it would lose the identity of the
+ * document the operator's accounting system still has on file.
+ */
+export const supersedeInvoiceExternalRefSchema = z.object({
+  reason: z.string().trim().min(3).max(1000),
+  replacement: z
+    .object({
+      externalId: z.string().trim().min(1).max(255).optional().nullable(),
+      externalNumber: z.string().trim().min(1).max(255).optional().nullable(),
+      externalUrl: z.string().trim().min(1).max(1000).optional().nullable(),
+      status: z.string().trim().min(1).max(100).optional().nullable(),
+      series: z.string().trim().min(1).max(100).optional().nullable(),
+    })
+    .optional()
+    .describe(
+      "The document that replaces the cancelled one. Omit it when the cancellation stands on its own — the reference is then marked cancelled and the booking may be invoiced again.",
+    ),
+})
+
 export const invoiceFromBookingSchema = z
   .object({
     bookingId: z.string().min(1),
@@ -242,6 +331,21 @@ export const invoiceFromBookingSchema = z
      * see it; only the external-provider subscribers honour this flag.
      */
     skipExternalSync: z.boolean().optional(),
+    /**
+     * This sale is already invoiced in the operator's accounting provider —
+     * record it against that document rather than issuing a second one.
+     * Implies `skipExternalSync`.
+     */
+    externalDocument: externalInvoiceDocumentSchema.optional(),
+    /**
+     * Issue anyway, knowing the booking already carries a live external fiscal
+     * document. Without it the issuance refuses rather than sending a duplicate
+     * to the provider (voyant#4688).
+     *
+     * `z.literal(true)` on purpose: this is an operator saying yes, so there is
+     * no `false` to send and no default to inherit.
+     */
+    acknowledgeExistingExternalDocument: z.literal(true).optional(),
     wait: invoiceDocumentWaitModeSchema.optional(),
     waitTimeoutMs: z.coerce.number().int().min(0).max(60_000).optional(),
   })
@@ -256,6 +360,28 @@ export const invoiceFromBookingSchema = z
         })
       }
       providers.add(ref.provider)
+    }
+
+    if (!value.externalDocument) return
+
+    // The two halves of "already invoiced externally" used to be independent
+    // flags a caller had to remember to set together. Setting only one is what
+    // the duplicate is made of, so the incoherent combinations are rejected
+    // rather than silently honoured.
+    if (value.skipExternalSync === false) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "An invoice recorded against an existing external document cannot also be synced to the provider",
+        path: ["skipExternalSync"],
+      })
+    }
+    if (providers.has(value.externalDocument.provider)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "externalDocument duplicates an externalRefs entry for the same provider",
+        path: ["externalDocument", "provider"],
+      })
     }
   })
 

--- a/packages/finance/src/book-product.ts
+++ b/packages/finance/src/book-product.ts
@@ -18,6 +18,7 @@
  * work (reference allocation, the durable command) lives in `mcp-runtime.ts`,
  * which holds the request-scoped services.
  */
+import { externalInvoiceDocumentSchema } from "@voyant-travel/finance-contracts"
 import { emailAddress } from "@voyant-travel/schema-kit/email"
 import { z } from "zod"
 
@@ -93,6 +94,11 @@ const documentGenerationSchema = z.object({
   contractDocument: z.boolean().default(false),
   invoiceDocument: z.boolean().default(false),
   invoiceType: z.enum(["invoice", "proforma"]).default("invoice"),
+  externalInvoice: externalInvoiceDocumentSchema
+    .optional()
+    .describe(
+      "The sale is already invoiced in the operator's accounting provider — give the document's series and number and no second one is issued. Use this for a back-fill after a failed settlement, or for an operator who invoices outside the platform.",
+    ),
 })
 
 export const bookProductToolInputSchema = z.object({
@@ -165,6 +171,12 @@ export const bookProductToolInputSchema = z.object({
     .boolean()
     .optional()
     .describe("Confirm silently — skip customer-facing email and document bundles."),
+  suppressDocuments: z
+    .boolean()
+    .optional()
+    .describe(
+      "Record the booking without producing documents for it: no invoice or proforma is issued to the accounting provider, and no contract is generated. Set this whenever the operator says not to issue — issuance is otherwise a consequence of creating the booking, so declining to call an issuance tool does not prevent it. Payments are still recorded, on an unissued draft invoice.",
+    ),
   allowDuplicate: z
     .boolean()
     .optional()
@@ -257,6 +269,9 @@ export function mapBookProductIntentToCommand(
     documentGeneration: input.documentGeneration,
     ...(input.suppressNotifications !== undefined
       ? { suppressNotifications: input.suppressNotifications }
+      : {}),
+    ...(input.suppressDocuments !== undefined
+      ? { suppressDocuments: input.suppressDocuments }
       : {}),
     ...(input.allowDuplicate !== undefined ? { allowDuplicate: input.allowDuplicate } : {}),
   }

--- a/packages/finance/src/booking-create-command.ts
+++ b/packages/finance/src/booking-create-command.ts
@@ -202,10 +202,15 @@ async function insertBookingCreatedOutbox(
           ? result.travelCreditRedemption.redemption.amountCents
           : null,
         groupId: result.groupMembership?.groupId ?? null,
-        documentGeneration: command.documentGeneration ?? {
-          contractDocument: false,
-          invoiceDocument: false,
-          invoiceType: "invoice",
+        // Named field by field rather than spread: `documentGeneration` also
+        // carries `externalInvoice`, the identity of a document in the
+        // operator's accounting provider, and `booking.created` is externally
+        // deliverable. The payload schema is `additionalProperties: false`, so
+        // spreading it would also fail validation.
+        documentGeneration: {
+          contractDocument: command.documentGeneration?.contractDocument ?? false,
+          invoiceDocument: command.documentGeneration?.invoiceDocument ?? false,
+          invoiceType: command.documentGeneration?.invoiceType ?? "invoice",
         },
         createdByUserId: context.userId ?? null,
         occurredAt: new Date(),

--- a/packages/finance/src/index.ts
+++ b/packages/finance/src/index.ts
@@ -355,6 +355,14 @@ export {
   resolveFxMoneyBaseAmount,
 } from "./fx-money.js"
 export {
+  describeDuplicateExternalDocument,
+  EXTERNAL_DOCUMENT_METADATA_KEY,
+  externalDocumentToRefInput,
+  findLiveBookingExternalDocument,
+  type LiveBookingExternalDocument,
+  SUPERSEDED_DOCUMENTS_METADATA_KEY,
+} from "./invoice-external-document.js"
+export {
   createInvoiceFxApiExtension,
   createInvoiceFxRoutes,
   createVoyantDataFxExchangeRateResolver,
@@ -630,11 +638,13 @@ export {
   financeDocumentsService,
 } from "./service-documents.js"
 export type {
+  InvoiceFromBookingCommandOutcome,
   InvoiceIssuedEvent,
   InvoiceIssueRuntime,
   InvoiceProformaConvertedEvent,
 } from "./service-issue.js"
 export {
+  applyExternalDocumentDeclaration,
   buildInvoiceIssuedEvent,
   convertProformaToInvoice,
   issueInvoiceFromBooking,

--- a/packages/finance/src/invoice-external-document.ts
+++ b/packages/finance/src/invoice-external-document.ts
@@ -1,0 +1,224 @@
+import {
+  type ExternalInvoiceDocumentInput,
+  formatExternalDocumentLabel,
+  isCancelledExternalDocumentStatus,
+} from "@voyant-travel/finance-contracts"
+import { and, eq, inArray, ne } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import { invoiceExternalRefs, invoiceLineItems, invoices } from "./schema.js"
+import type { CreateInvoiceExternalRefInput } from "./service-shared.js"
+
+/**
+ * Recording a sale against a fiscal document the operator already issued
+ * elsewhere, and refusing to issue a second one over the top of it.
+ *
+ * voyant#4688: back-filling a booking for an already-invoiced sale mirrored a
+ * second real fiscal document to the accounting provider — same customer, same
+ * amount, same date, different series — and for a Romanian operator both landed
+ * in e-Factura. There was no flag that said "this sale is already invoiced",
+ * and `voidInvoice` refuses once a payment is recorded, so there was no way
+ * forward and no way back.
+ *
+ * The external reference row is what carries the fact. Writing one alongside a
+ * suppressed mirror is the declaration; reading them back is the guard.
+ */
+
+/** The metadata key the platform's own bookkeeping lives under on a ref row. */
+export const EXTERNAL_DOCUMENT_METADATA_KEY = "voyantExternalDocument"
+
+/** Where the identities of documents this reference used to point at are kept. */
+export const SUPERSEDED_DOCUMENTS_METADATA_KEY = "voyantSupersededDocuments"
+
+export interface LiveBookingExternalDocument {
+  invoiceId: string
+  invoiceNumber: string
+  invoiceStatus: string
+  provider: string
+  externalId: string | null
+  externalNumber: string | null
+  externalUrl: string | null
+  status: string | null
+  /** `"SERIES 1234"`, for an operator-facing refusal message. */
+  label: string
+}
+
+/**
+ * Translate an operator's "already invoiced externally" declaration into the
+ * external reference row that records it.
+ *
+ * `series` has no column of its own — the providers this targets number within
+ * a series, but `external_number` is the document's number, so the series rides
+ * in metadata next to the rest of the operator's declaration.
+ */
+export function externalDocumentToRefInput(
+  document: ExternalInvoiceDocumentInput,
+  options: { recordedAt?: Date } = {},
+): CreateInvoiceExternalRefInput {
+  const recordedAt = (options.recordedAt ?? new Date()).toISOString()
+  return {
+    provider: document.provider,
+    externalId: document.externalId ?? null,
+    externalNumber: document.number,
+    externalUrl: document.externalUrl ?? null,
+    // Not a provider status: the platform never called the provider. It says
+    // the document exists there and this row did not put it there.
+    status: "recorded_externally",
+    metadata: {
+      [EXTERNAL_DOCUMENT_METADATA_KEY]: {
+        series: document.series ?? null,
+        number: document.number,
+        issuedAt: document.issuedAt ?? null,
+        note: document.note ?? null,
+        recordedAt,
+      },
+    },
+    // The operator issued it; the platform did not sync it. `syncedAt` would
+    // claim a successful mirror that never ran.
+    syncedAt: null,
+    syncError: null,
+  }
+}
+
+function readSeries(metadata: unknown): string | null {
+  if (typeof metadata !== "object" || metadata === null) return null
+  const scoped = (metadata as Record<string, unknown>)[EXTERNAL_DOCUMENT_METADATA_KEY]
+  if (typeof scoped !== "object" || scoped === null) return null
+  const series = (scoped as Record<string, unknown>).series
+  return typeof series === "string" ? series : null
+}
+
+/**
+ * A live fiscal document already covering what a new invoice for this booking
+ * would cover, if there is one.
+ *
+ * **"Live"** is two conditions, and both matter. The invoice must not be void —
+ * a voided invoice's document is not the operator's current record of the sale.
+ * And the reference's own status must not be one of the cancelled words: a
+ * document retracted in the provider's UI (see `supersedeInvoiceExternalRef`)
+ * has to stop blocking, otherwise the only remedy for the first duplicate would
+ * permanently prevent the correction.
+ *
+ * **"Covering the same thing"** is what keeps this from breaking ordinary
+ * travel invoicing. A booking legitimately has more than one fiscal document —
+ * a deposit and a balance are two real sales of two different amounts — so
+ * "this booking already has a document" is not on its own a duplicate. The
+ * question is overlap:
+ *
+ * - a request naming a payment schedule overlaps a document whose invoice bills
+ *   that same schedule, and one that bills the booking as a whole
+ * - a request naming none is for the whole booking, so it overlaps any document
+ *   the booking has
+ *
+ * When it cannot tell, it does not refuse. A guard that blocks a legitimate
+ * balance invoice costs more than the duplicate it would have caught, and the
+ * declaration (`externalDocument`) is the primary remedy here — this is the
+ * backstop.
+ */
+export async function findLiveBookingExternalDocument(
+  db: PostgresJsDatabase,
+  bookingId: string,
+  options: { excludeInvoiceId?: string; bookingPaymentScheduleId?: string | null } = {},
+): Promise<LiveBookingExternalDocument | null> {
+  const rows = await db
+    .select({
+      invoiceId: invoices.id,
+      invoiceNumber: invoices.invoiceNumber,
+      invoiceStatus: invoices.status,
+      provider: invoiceExternalRefs.provider,
+      externalId: invoiceExternalRefs.externalId,
+      externalNumber: invoiceExternalRefs.externalNumber,
+      externalUrl: invoiceExternalRefs.externalUrl,
+      status: invoiceExternalRefs.status,
+      metadata: invoiceExternalRefs.metadata,
+    })
+    .from(invoiceExternalRefs)
+    .innerJoin(invoices, eq(invoices.id, invoiceExternalRefs.invoiceId))
+    .where(and(eq(invoices.bookingId, bookingId), ne(invoices.status, "void")))
+
+  const candidates = rows.filter((row) => {
+    if (options.excludeInvoiceId && row.invoiceId === options.excludeInvoiceId) return false
+    if (isCancelledExternalDocumentStatus(row.status)) return false
+    // A reference with no identity at all is a placeholder the provider has not
+    // answered yet, not a document that exists. Blocking on one would refuse
+    // every issuance a pending external allocation is waiting on.
+    return Boolean(row.externalId || row.externalNumber)
+  })
+  if (candidates.length === 0) return null
+
+  const overlapping = options.bookingPaymentScheduleId
+    ? await filterToOverlappingSchedule(db, candidates, options.bookingPaymentScheduleId)
+    : candidates
+  const row = overlapping[0]
+  if (!row) return null
+
+  return {
+    invoiceId: row.invoiceId,
+    invoiceNumber: row.invoiceNumber,
+    invoiceStatus: row.invoiceStatus,
+    provider: row.provider,
+    externalId: row.externalId,
+    externalNumber: row.externalNumber,
+    externalUrl: row.externalUrl,
+    status: row.status,
+    label: formatExternalDocumentLabel({
+      series: readSeries(row.metadata),
+      externalNumber: row.externalNumber,
+    }),
+  }
+}
+
+type ExternalDocumentCandidate = {
+  invoiceId: string
+  invoiceNumber: string
+  invoiceStatus: string
+  provider: string
+  externalId: string | null
+  externalNumber: string | null
+  externalUrl: string | null
+  status: string | null
+  metadata: unknown
+}
+
+/**
+ * Keep the candidates whose invoice bills the given schedule, plus those that
+ * bill no schedule at all — a whole-booking document already covers every
+ * schedule in it, so a per-schedule invoice on top of one is still a second
+ * document for money already invoiced.
+ */
+async function filterToOverlappingSchedule(
+  db: PostgresJsDatabase,
+  candidates: ExternalDocumentCandidate[],
+  bookingPaymentScheduleId: string,
+): Promise<ExternalDocumentCandidate[]> {
+  const lines = await db
+    .select({
+      invoiceId: invoiceLineItems.invoiceId,
+      bookingPaymentScheduleId: invoiceLineItems.bookingPaymentScheduleId,
+    })
+    .from(invoiceLineItems)
+    .where(
+      inArray(
+        invoiceLineItems.invoiceId,
+        candidates.map((candidate) => candidate.invoiceId),
+      ),
+    )
+
+  const scheduleIdsByInvoice = new Map<string, Set<string>>()
+  for (const line of lines) {
+    const scoped = scheduleIdsByInvoice.get(line.invoiceId) ?? new Set<string>()
+    if (line.bookingPaymentScheduleId) scoped.add(line.bookingPaymentScheduleId)
+    scheduleIdsByInvoice.set(line.invoiceId, scoped)
+  }
+
+  return candidates.filter((candidate) => {
+    const scoped = scheduleIdsByInvoice.get(candidate.invoiceId)
+    if (!scoped || scoped.size === 0) return true
+    return scoped.has(bookingPaymentScheduleId)
+  })
+}
+
+/** The operator-facing sentence a refusal carries. */
+export function describeDuplicateExternalDocument(existing: LiveBookingExternalDocument): string {
+  return `This booking is already invoiced in ${existing.provider} as ${existing.label} (invoice ${existing.invoiceNumber}). Issuing again would send a second fiscal document for the same sale.`
+}

--- a/packages/finance/src/mcp-runtime.test.ts
+++ b/packages/finance/src/mcp-runtime.test.ts
@@ -272,6 +272,7 @@ function bookingDetailWithDates(id: string) {
     pax: 1,
     internalNotes: null,
     notificationsSuppressed: false,
+    documentsSuppressed: false,
     customerPaymentPolicy: null,
     priceOverride: null,
     customFields: {},

--- a/packages/finance/src/routes-invoice-documents.ts
+++ b/packages/finance/src/routes-invoice-documents.ts
@@ -412,10 +412,12 @@ const externalRefRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidationH
     return row ? c.json({ data: row }, 201) : c.json({ error: "Invoice not found" }, 404)
   })
   .openapi(supersedeExternalRefRoute, async (c) => {
+    const { id, refId } = c.req.valid("param")
     const row = await financeService.supersedeInvoiceExternalRef(
       c.get("db"),
-      c.req.valid("param").refId,
+      refId,
       c.req.valid("json"),
+      { invoiceId: id },
     )
     return row ? c.json({ data: row }, 200) : c.json({ error: "External ref not found" }, 404)
   })

--- a/packages/finance/src/routes-invoice-documents.ts
+++ b/packages/finance/src/routes-invoice-documents.ts
@@ -2,7 +2,7 @@
  * Admin invoice-document routes — mounted by the operator starter under
  * `/v1/admin/finance/...`. Covers invoice renditions (list + render), invoice
  * attachments (list/create/update/delete + signed download redirect), and
- * invoice external refs (list/register/delete).
+ * invoice external refs (list/register/supersede/delete).
  *
  * Migrated to `@hono/zod-openapi` for the OpenAPI admin backfill (voyant#2114 /
  * voyant#2208 — finance sub-batch 9B). Request schemas reuse the existing
@@ -33,6 +33,7 @@ import {
   insertInvoiceExternalRefSchema,
   invoiceDocumentWaitQuerySchema,
   renderInvoiceInputSchema,
+  supersedeInvoiceExternalRefSchema,
   updateInvoiceAttachmentSchema,
 } from "./validation.js"
 
@@ -347,6 +348,38 @@ const registerExternalRefRoute = createRoute({
   },
 })
 
+const supersedeExternalRefRoute = createRoute({
+  method: "post",
+  path: "/invoices/{id}/external-refs/{refId}/supersede",
+  description:
+    "Record that the provider document this reference points at was cancelled " +
+    "in the provider's own UI, and optionally repoint the reference at its " +
+    "replacement. The superseded identity is kept in the reference's metadata; " +
+    "with no replacement the reference is marked `cancelled`, which is what " +
+    "lets the booking be invoiced again (voyant#4688).",
+  request: {
+    params: refParamSchema,
+    body: {
+      required: true,
+      content: { "application/json": { schema: supersedeInvoiceExternalRefSchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "The superseded external ref",
+      content: { "application/json": { schema: z.object({ data: invoiceExternalRefSchema }) } },
+    },
+    400: {
+      description: "invalid_request: request body failed validation",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    404: {
+      description: "External ref not found",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
 const deleteExternalRefRoute = createRoute({
   method: "delete",
   path: "/invoices/{id}/external-refs/{refId}",
@@ -377,6 +410,14 @@ const externalRefRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidationH
       c.req.valid("json"),
     )
     return row ? c.json({ data: row }, 201) : c.json({ error: "Invoice not found" }, 404)
+  })
+  .openapi(supersedeExternalRefRoute, async (c) => {
+    const row = await financeService.supersedeInvoiceExternalRef(
+      c.get("db"),
+      c.req.valid("param").refId,
+      c.req.valid("json"),
+    )
+    return row ? c.json({ data: row }, 200) : c.json({ error: "External ref not found" }, 404)
   })
   .openapi(deleteExternalRefRoute, async (c) => {
     const row = await financeService.deleteInvoiceExternalRef(

--- a/packages/finance/src/routes-invoice-issue.ts
+++ b/packages/finance/src/routes-invoice-issue.ts
@@ -18,6 +18,7 @@ import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import { openApiValidationHook, parseJsonBody } from "@voyant-travel/hono"
 import { listResponseSchema } from "@voyant-travel/types"
 import type { MiddlewareHandler } from "hono"
+import { describeDuplicateExternalDocument } from "./invoice-external-document.js"
 import {
   errorResponseSchema,
   invoiceListItemSchema,
@@ -92,7 +93,9 @@ const issueInvoiceFromBookingRoute = createRoute({
     body: {
       required: true,
       description:
-        "Create + issue an invoice or proforma from a booking (and optionally a payment schedule). `invoiceType` selects invoice vs proforma; `bookingPaymentScheduleId`, when present, must belong to the booking.",
+        "Create + issue an invoice or proforma from a booking (and optionally a payment schedule). `invoiceType` selects invoice vs proforma; `bookingPaymentScheduleId`, when present, must belong to the booking. " +
+        "Pass `externalDocument` when the operator already issued a fiscal document for this sale in their accounting provider — the invoice is recorded against that document and no second one is requested. " +
+        "If the booking already carries a live external document the request is refused with `duplicate_external_document`; `acknowledgeExistingExternalDocument: true` overrides it.",
       content: { "application/json": { schema: invoiceFromBookingSchema } },
     },
   },
@@ -111,7 +114,7 @@ const issueInvoiceFromBookingRoute = createRoute({
     },
     409: {
       description:
-        "Invoice number allocation failed, the invoice number already exists, or the booking failed issuance validation",
+        "Invoice number allocation failed, the invoice number already exists, the booking failed issuance validation, or the booking already has a live fiscal document in an accounting provider (`duplicate_external_document`)",
       content: { "application/json": { schema: errorResponseSchema } },
     },
   },
@@ -252,6 +255,23 @@ financeInvoiceIssueRoutes
     }
     if (outcome.status === "booking_changed" || outcome.status === "approval_snapshot_changed") {
       return c.json({ error: "Booking changed after review" }, 409)
+    }
+    if (outcome.status === "duplicate_external_document") {
+      return c.json(
+        {
+          error: describeDuplicateExternalDocument(outcome.existing),
+          code: "duplicate_external_document",
+          details: {
+            invoiceId: outcome.existing.invoiceId,
+            invoiceNumber: outcome.existing.invoiceNumber,
+            provider: outcome.existing.provider,
+            externalNumber: outcome.existing.externalNumber,
+            externalId: outcome.existing.externalId,
+            externalUrl: outcome.existing.externalUrl,
+          },
+        },
+        409,
+      )
     }
     return c.json({ data: outcome.invoice }, 201)
   })

--- a/packages/finance/src/service-booking-create.ts
+++ b/packages/finance/src/service-booking-create.ts
@@ -2972,7 +2972,16 @@ export async function createBookingMutation(
   }
 
   const paidSchedules = (input.paymentSchedules ?? []).filter(isAlreadyPaidSchedule)
-  const shouldCreateInvoice = documentGeneration.invoiceDocument || paidSchedules.length > 0
+  // Declaring an external document is itself a reason to write the invoice.
+  // Without this, `externalInvoice` on a create that asked for no invoice
+  // document and has no already-paid schedule is silently dropped: no invoice,
+  // no external reference, and therefore nothing for the duplicate guard to
+  // find — so the next issuance mirrors exactly the document this field exists
+  // to prevent.
+  const shouldCreateInvoice =
+    documentGeneration.invoiceDocument ||
+    paidSchedules.length > 0 ||
+    documentGeneration.externalInvoice !== undefined
 
   if (shouldCreateInvoice) {
     const items = await tx

--- a/packages/finance/src/service-booking-create.ts
+++ b/packages/finance/src/service-booking-create.ts
@@ -25,13 +25,17 @@ import {
   missingFiscalBillingFields,
 } from "@voyant-travel/bookings-contracts"
 import { withBookingFinanceInsertionFence } from "@voyant-travel/db/booking-finance-fence"
+import {
+  externalInvoiceDocumentSchema,
+  formatExternalDocumentLabel,
+} from "@voyant-travel/finance-contracts"
 import { classifyOccupancyPrice } from "@voyant-travel/products-contracts/occupancy-pricing"
 import { emailAddress } from "@voyant-travel/schema-kit/email"
 import { and, asc, eq, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import * as rrulePackage from "rrule"
 import { z } from "zod"
-
+import { externalDocumentToRefInput } from "./invoice-external-document.js"
 import type {
   BookingPaymentSchedule,
   Invoice,
@@ -101,6 +105,22 @@ const documentGenerationInputSchema = z
      * shortcut on the new-booking dialog).
      */
     invoiceType: z.enum(["invoice", "proforma"]).default("invoice"),
+    /**
+     * The sale is already invoiced in the operator's accounting provider.
+     *
+     * This is what back-filling a booking for an already-invoiced sale needs
+     * (voyant#4688): the standard recovery after a checkout takes the money and
+     * the settlement commit fails, where the operator has already issued a
+     * fiscal document by hand so the customer has one. Without it the back-fill
+     * mirrored a second real document to the provider — for a Romanian operator
+     * both land in e-Factura and the sale is declared twice.
+     *
+     * The booking's invoice is still written and still issued, so payments,
+     * balances and the contract are right. What changes is that no document is
+     * requested from the provider and the invoice's external reference names
+     * the one the operator already has.
+     */
+    externalInvoice: externalInvoiceDocumentSchema.optional(),
   })
   .default({ contractDocument: false, invoiceDocument: false, invoiceType: "invoice" })
 
@@ -528,6 +548,24 @@ const bookingCreateBaseSchema = z.object({
    */
   suppressNotifications: z.boolean().optional(),
   /**
+   * Record this booking without producing documents for it: no invoice or
+   * proforma reaches the accounting provider, and no contract is generated.
+   *
+   * voyant#4688: an operator instructed the agent not to issue a proforma,
+   * invoice or contract. The agent invoked no issuance call and said none were
+   * issued — and creating the booking issued a real fiscal invoice to the
+   * provider anyway, because issuance is a consequence of booking creation
+   * rather than a call anyone makes. An agent cannot decline an action it never
+   * invokes, so the instruction had nowhere to land. This is where it lands.
+   *
+   * The invoice is still written when there is money to record, as an unissued
+   * draft carrying the payments — recording that a booking was paid is
+   * deliberately separable from issuing a fiscal document for it. Persisted on
+   * the booking as `documents_suppressed`, because contract generation runs off
+   * an event after this transaction commits and cannot see a command flag.
+   */
+  suppressDocuments: z.boolean().optional(),
+  /**
    * Explicit operator override for same billing party + departure creates.
    * Defaults to guarded behavior so retries and concurrent double-submit
    * attempts return a structured duplicate signal instead of minting another
@@ -666,9 +704,23 @@ export interface BookingCreateResult {
    * fine, and the operator completes the buyer's billing details and issues it.
    * It is here so the caller can say that rather than leaving an unissued
    * invoice looking like an issued one (voyant#4654).
+   *
+   * `recorded_externally` is issued too — the invoice is a real, issued record
+   * with the right balance. What it says is that no fiscal document was
+   * requested from the accounting provider, because the operator already has
+   * one for this sale (voyant#4688).
+   *
+   * `withheld` is the operator's instruction honoured: the invoice exists as an
+   * unissued draft and carries the payments, so the booking records what was
+   * paid, and no fiscal document was produced for it. It is the answer to "an
+   * operator said do not issue" — which previously had nowhere to land, because
+   * issuance was a consequence of creating the booking rather than a call
+   * anyone made (voyant#4688).
    */
   invoiceIssuance:
     | { status: "issued" }
+    | { status: "recorded_externally"; externalDocument: { provider: string; label: string } }
+    | { status: "withheld" }
     | { status: "blocked"; missingBillingFields: readonly FiscalBillingField[] }
     | { status: "not_applicable" }
   payments: Payment[]
@@ -2613,6 +2665,7 @@ export async function createBookingMutation(
           priceOverrideReason: input.priceOverrideReason ?? null,
           manualPriceOverride: input.manualPriceOverride,
           suppressNotifications: input.suppressNotifications,
+          suppressDocuments: input.suppressDocuments,
           contactFirstName: input.contactFirstName ?? null,
           contactLastName: input.contactLastName ?? null,
           contactPartyType: input.contactPartyType ?? null,
@@ -2939,6 +2992,16 @@ export async function createBookingMutation(
       documentGeneration.invoiceType,
     )
 
+    const externalInvoice = documentGeneration.externalInvoice ?? null
+    // An operator saying "do not issue" and an operator saying "it is already
+    // issued, over there" are different instructions with the same consequence
+    // for the provider: this create must not put a fiscal document into the
+    // world. They differ in what the platform's own invoice ends up being — an
+    // unissued draft that records the money, or an issued record pointed at the
+    // operator's document — so `externalInvoice` is the more specific of the
+    // two and decides when both are given.
+    const withholdIssuance = input.suppressDocuments === true && externalInvoice === null
+
     const invoice = await financeService.createInvoiceFromBooking(
       tx,
       {
@@ -2949,7 +3012,13 @@ export async function createBookingMutation(
         issueDate,
         dueDate,
         invoiceType: documentGeneration.invoiceType,
-        notes: "Generated from booking create.",
+        notes: externalInvoice
+          ? "Generated from booking create. Already invoiced externally."
+          : "Generated from booking create.",
+        // The reference is written with the invoice, in the same fenced insert,
+        // so there is no window where an issued invoice exists without the
+        // record of which external document already covers it.
+        ...(externalInvoice ? { externalRefs: [externalDocumentToRefInput(externalInvoice)] } : {}),
       },
       { booking: result.booking, dueDatePaymentSchedule, items },
       invoiceRuntime,
@@ -2977,8 +3046,10 @@ export async function createBookingMutation(
       // and the operator gets told what is missing.
       const missingBillingFields = missingFiscalBillingFields(result.booking)
       const issuance =
-        missingBillingFields.length === 0
-          ? await issueBookingInvoiceInTransaction(tx, invoice, invoiceRuntime)
+        missingBillingFields.length === 0 && !withholdIssuance
+          ? await issueBookingInvoiceInTransaction(tx, invoice, invoiceRuntime, {
+              skipExternalSync: externalInvoice !== null,
+            })
           : null
       if (issuance) domainEvents.push(issuance.event)
 
@@ -3014,7 +3085,13 @@ export async function createBookingMutation(
       // it. `not_available` says the document was wanted and withheld, which
       // `not_requested` (nobody asked) does not.
       if (documentGeneration.invoiceDocument) {
-        if (!issuance) {
+        if (!issuance || externalInvoice) {
+          // Withheld for the same reason above, and for one more when the sale
+          // is already invoiced externally: our rendition carries our invoice
+          // number and reads as an invoice, so a `ready` one would join the
+          // booking's notification bundle and mail the customer a second
+          // document for a purchase they already hold one for (voyant#4688).
+          // The operator's own document is the one to send.
           invoiceDocument = { status: "not_available" }
         } else {
           const requested = await financeService.renderInvoice(tx, invoice.id, { format: "pdf" })
@@ -3029,9 +3106,19 @@ export async function createBookingMutation(
         ...result,
         invoice: await financeService.getInvoiceById(tx, invoice.id),
         invoiceDocument,
-        invoiceIssuance: issuance
-          ? { status: "issued" }
-          : { status: "blocked", missingBillingFields },
+        invoiceIssuance: withholdIssuance
+          ? { status: "withheld" }
+          : !issuance
+            ? { status: "blocked", missingBillingFields }
+            : externalInvoice
+              ? {
+                  status: "recorded_externally",
+                  externalDocument: {
+                    provider: externalInvoice.provider,
+                    label: formatExternalDocumentLabel(externalInvoice),
+                  },
+                }
+              : { status: "issued" },
         payments,
       }
     }

--- a/packages/finance/src/service-issue.ts
+++ b/packages/finance/src/service-issue.ts
@@ -12,6 +12,11 @@ import { and, asc, eq, inArray, ne } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import { resolveBookingSellTaxRate } from "./booking-tax.js"
+import {
+  externalDocumentToRefInput,
+  findLiveBookingExternalDocument,
+  type LiveBookingExternalDocument,
+} from "./invoice-external-document.js"
 import { resolveInvoiceFxContext } from "./invoice-fx.js"
 import { isInvoiceNumberUniqueConstraintError } from "./invoice-number-errors.js"
 import {
@@ -59,6 +64,39 @@ export type InvoiceFromBookingCommandOutcome =
       currentUpdatedAt: string
     }
   | { status: "approval_snapshot_changed"; bookingNumber: string }
+  /**
+   * The booking already has a fiscal document in an accounting provider, so
+   * issuing would mirror a second one for the same sale (voyant#4688). The
+   * caller decides: record the sale against the existing document with
+   * `externalDocument`, retract that document with
+   * `supersedeInvoiceExternalRef`, or say yes with
+   * `acknowledgeExistingExternalDocument`.
+   */
+  | { status: "duplicate_external_document"; existing: LiveBookingExternalDocument }
+
+/**
+ * Fold an "already invoiced externally" declaration into the plain
+ * create-from-booking input.
+ *
+ * The declaration is two facts that only work together: write the reference row
+ * naming the operator's document, and keep the mirror from issuing one of our
+ * own. Callers used to have to remember both (`externalRefs` + `skipExternalSync`)
+ * and nothing checked that they had; folding them here is what makes the
+ * primitive a single thing to get right.
+ */
+export function applyExternalDocumentDeclaration(
+  input: CreateInvoiceFromBookingInput,
+): CreateInvoiceFromBookingInput {
+  if (!input.externalDocument) return input
+  return {
+    ...input,
+    skipExternalSync: true,
+    externalRefs: [
+      ...(input.externalRefs ?? []),
+      externalDocumentToRefInput(input.externalDocument),
+    ],
+  }
+}
 
 export interface UnsyncedProformaApprovalSnapshot {
   id: string
@@ -405,6 +443,18 @@ export async function issueInvoiceFromBookingCommand(
   const bookingQuery = db.select().from(bookings).where(eq(bookings.id, input.bookingId)).limit(1)
   const [booking] = options.atomicScope ? await bookingQuery.for("update") : await bookingQuery
   if (!booking) return { status: "booking_not_found" }
+
+  // Before anything is written: a booking that already has a fiscal document in
+  // an accounting provider must not quietly get a second one (voyant#4688).
+  // This refuses whether or not the caller is declaring an external document —
+  // recording the sale against a second provider document is the same duplicate
+  // as issuing one.
+  if (!input.acknowledgeExistingExternalDocument) {
+    const existing = await findLiveBookingExternalDocument(db, booking.id, {
+      bookingPaymentScheduleId: input.bookingPaymentScheduleId ?? null,
+    })
+    if (existing) return { status: "duplicate_external_document", existing }
+  }
   if (
     options.expectedBookingUpdatedAt &&
     new Date(options.expectedBookingUpdatedAt).getTime() !== booking.updatedAt.getTime()
@@ -515,7 +565,7 @@ export async function issueInvoiceFromBookingCommand(
   }
   const issuer =
     input.invoiceType === "proforma" ? issueProformaFromBooking : issueInvoiceFromBooking
-  const invoice = await issuer(db, input, bookingData, runtime)
+  const invoice = await issuer(db, applyExternalDocumentDeclaration(input), bookingData, runtime)
   if (!invoice) return { status: "booking_not_found" }
   return { status: "issued", invoice }
 }
@@ -597,6 +647,7 @@ export async function issueBookingInvoiceInTransaction(
   tx: PostgresJsDatabase,
   invoice: typeof invoices.$inferSelect,
   runtime: InvoiceIssueRuntime = {},
+  options: { skipExternalSync?: boolean } = {},
 ): Promise<BookingInvoiceIssuance | null> {
   // An external series never gets a real number here — allocation is the
   // accounting provider's, and `pending_external_allocation` is what tells the
@@ -611,6 +662,10 @@ export async function issueBookingInvoiceInTransaction(
   await touchLinkedBookingUpdatedAt(tx, issued.bookingId)
 
   const payload = await buildInvoiceIssuedEvent(tx, issued, runtime)
+  // The event still fires — ledgers and audit want it — but the external
+  // subscribers stand down, because the fiscal document for this sale already
+  // exists in the operator's provider (voyant#4688).
+  if (options.skipExternalSync) payload.skipExternalSync = true
   return {
     invoice: issued,
     event: {

--- a/packages/finance/src/service-reference-data.ts
+++ b/packages/finance/src/service-reference-data.ts
@@ -1,3 +1,7 @@
+import {
+  EXTERNAL_DOCUMENT_METADATA_KEY,
+  SUPERSEDED_DOCUMENTS_METADATA_KEY,
+} from "./invoice-external-document.js"
 import type {
   CreateInvoiceExternalRefInput,
   CreateTaxClassInput,
@@ -5,6 +9,7 @@ import type {
   CreateTaxPolicyRuleInput,
   CreateTaxRegimeInput,
   PostgresJsDatabase,
+  SupersedeInvoiceExternalRefInput,
   TaxClassListQuery,
   TaxPolicyProfileListQuery,
   TaxPolicyRuleListQuery,
@@ -435,6 +440,97 @@ export const financeReferenceDataService = {
         provider: data.provider,
         ...values,
       })
+      .returning()
+    return row ?? null
+  },
+
+  /**
+   * Record that the provider document a reference points at was cancelled in
+   * the provider's own UI, and optionally repoint the reference at the document
+   * that replaces it.
+   *
+   * voyant#4688: once a duplicate fiscal document had been issued, the only
+   * remedy was cancelling it by hand in the provider, which left the reference
+   * naming a cancelled document with nothing supported to do about it —
+   * `voidInvoice` refuses on a recorded payment, and overwriting the reference
+   * would lose the identity of the document the operator's accounting system
+   * still has on file. So the previous identity is kept, appended to the row's
+   * own metadata, and the cancelled status is what releases the
+   * duplicate-issuance guard.
+   *
+   * Deleting the row instead is not the same thing: it erases the fact that a
+   * document was ever issued there, which is what an audit needs to see.
+   */
+  async supersedeInvoiceExternalRef(
+    db: PostgresJsDatabase,
+    id: string,
+    input: SupersedeInvoiceExternalRefInput,
+  ) {
+    const [existing] = await db
+      .select()
+      .from(invoiceExternalRefs)
+      .where(eq(invoiceExternalRefs.id, id))
+      .limit(1)
+    if (!existing) return null
+
+    const previousMetadata =
+      existing.metadata &&
+      typeof existing.metadata === "object" &&
+      !Array.isArray(existing.metadata)
+        ? (existing.metadata as Record<string, unknown>)
+        : {}
+    const history = Array.isArray(previousMetadata[SUPERSEDED_DOCUMENTS_METADATA_KEY])
+      ? (previousMetadata[SUPERSEDED_DOCUMENTS_METADATA_KEY] as unknown[])
+      : []
+
+    const replacement = input.replacement ?? null
+    const now = new Date()
+
+    const [row] = await db
+      .update(invoiceExternalRefs)
+      .set({
+        externalId: replacement ? (replacement.externalId ?? null) : existing.externalId,
+        externalNumber: replacement
+          ? (replacement.externalNumber ?? null)
+          : existing.externalNumber,
+        externalUrl: replacement ? (replacement.externalUrl ?? null) : existing.externalUrl,
+        // With a replacement the row now names a live document again, so it
+        // carries the replacement's status (or none). Without one it is the
+        // cancellation itself, and `cancelled` is what tells the guard this
+        // booking may be invoiced again.
+        status: replacement ? (replacement.status ?? null) : "cancelled",
+        metadata: {
+          ...previousMetadata,
+          ...(replacement?.series
+            ? {
+                [EXTERNAL_DOCUMENT_METADATA_KEY]: {
+                  ...(typeof previousMetadata[EXTERNAL_DOCUMENT_METADATA_KEY] === "object" &&
+                  previousMetadata[EXTERNAL_DOCUMENT_METADATA_KEY] !== null
+                    ? (previousMetadata[EXTERNAL_DOCUMENT_METADATA_KEY] as Record<string, unknown>)
+                    : {}),
+                  series: replacement.series,
+                  number: replacement.externalNumber ?? null,
+                },
+              }
+            : {}),
+          [SUPERSEDED_DOCUMENTS_METADATA_KEY]: [
+            ...history,
+            {
+              externalId: existing.externalId,
+              externalNumber: existing.externalNumber,
+              externalUrl: existing.externalUrl,
+              status: existing.status,
+              reason: input.reason,
+              supersededAt: now.toISOString(),
+            },
+          ],
+        },
+        // The platform did not talk to the provider here either way: an
+        // operator told it what happened there.
+        syncedAt: null,
+        updatedAt: now,
+      })
+      .where(eq(invoiceExternalRefs.id, id))
       .returning()
     return row ?? null
   },

--- a/packages/finance/src/service-reference-data.ts
+++ b/packages/finance/src/service-reference-data.ts
@@ -465,11 +465,21 @@ export const financeReferenceDataService = {
     db: PostgresJsDatabase,
     id: string,
     input: SupersedeInvoiceExternalRefInput,
+    // Reference ids are globally addressable, so a route that resolves one from
+    // its own path must also prove it belongs to the invoice in that path.
+    // Without this, superseding under invoice A can mutate a reference on
+    // invoice B — releasing B's duplicate-document guard from a request that
+    // never named it.
+    scope: { invoiceId?: string } = {},
   ) {
     const [existing] = await db
       .select()
       .from(invoiceExternalRefs)
-      .where(eq(invoiceExternalRefs.id, id))
+      .where(
+        scope.invoiceId
+          ? and(eq(invoiceExternalRefs.id, id), eq(invoiceExternalRefs.invoiceId, scope.invoiceId))
+          : eq(invoiceExternalRefs.id, id),
+      )
       .limit(1)
     if (!existing) return null
 

--- a/packages/finance/src/service-shared.ts
+++ b/packages/finance/src/service-shared.ts
@@ -179,6 +179,7 @@ import type {
   profitabilityQuerySchema,
   renderInvoiceInputSchema,
   revenueReportQuerySchema,
+  supersedeInvoiceExternalRefSchema,
   supplierPaymentListQuerySchema,
   taxClassListQuerySchema,
   taxPolicyProfileListQuerySchema,
@@ -336,6 +337,7 @@ export type TaxPolicyRuleListQuery = z.infer<typeof taxPolicyRuleListQuerySchema
 export type CreateTaxPolicyRuleInput = z.infer<typeof insertTaxPolicyRuleSchema>
 export type UpdateTaxPolicyRuleInput = z.infer<typeof updateTaxPolicyRuleSchema>
 export type CreateInvoiceExternalRefInput = z.infer<typeof insertInvoiceExternalRefSchema>
+export type SupersedeInvoiceExternalRefInput = z.infer<typeof supersedeInvoiceExternalRefSchema>
 export type RenderInvoiceInput = z.infer<typeof renderInvoiceInputSchema>
 export type MarkPaymentSessionRequiresRedirectInput = z.infer<
   typeof markPaymentSessionRequiresRedirectSchema

--- a/packages/finance/tests/integration/booking-create.test.ts
+++ b/packages/finance/tests/integration/booking-create.test.ts
@@ -6004,6 +6004,74 @@ describe.skipIf(!DB_AVAILABLE)("createBooking", () => {
       expect(outcome.status).toBe("issued")
     })
 
+    it("records the declaration even when no invoice document was asked for", async () => {
+      // The declaration is itself a reason to write the invoice. Dropping it
+      // because `invoiceDocument` defaulted to false would leave no external
+      // reference, so the guard would find nothing and the next issuance would
+      // mirror exactly the document this field exists to prevent.
+      const { productId } = await seedProduct()
+      const command = await durableCommand("finance-booking-create-external-only", {
+        productId,
+        bookingNumber: nextBookingNumber(),
+        ...fiscalBillingParty(),
+        documentGeneration: { externalInvoice: alreadyIssuedBySmartBill },
+      })
+
+      const result = await executeFinanceStaffBookingCreateCommand(command)
+
+      const [invoice] = await db
+        .select()
+        .from(invoices)
+        .where(eq(invoices.bookingId, result.value.bookingId))
+      expect(invoice).toBeDefined()
+      expect(
+        await db
+          .select()
+          .from(invoiceExternalRefs)
+          .where(eq(invoiceExternalRefs.invoiceId, invoice!.id)),
+      ).toMatchObject([{ provider: "mapp_smartbill", externalNumber: "1042" }])
+
+      // And the guard can now see it.
+      const outcome = await issueInvoiceFromBookingCommand(db, {
+        bookingId: result.value.bookingId,
+        invoiceNumber: "INV-EXTERNAL-ONLY",
+        issueDate: "2026-08-15",
+        dueDate: "2026-08-15",
+        invoiceType: "invoice",
+      })
+      expect(outcome.status).toBe("duplicate_external_document")
+    })
+
+    it("refuses to supersede a reference belonging to another invoice", async () => {
+      // Reference ids are globally addressable, so the route must prove the
+      // reference belongs to the invoice in its own path — otherwise a request
+      // naming invoice A can release invoice B's guard.
+      const { invoice } = await backFillAlreadyInvoicedBooking(
+        "finance-booking-create-external-scope",
+        "BT-EXTERNAL-6",
+      )
+      const [ref] = await db
+        .select()
+        .from(invoiceExternalRefs)
+        .where(eq(invoiceExternalRefs.invoiceId, invoice.id))
+
+      await expect(
+        financeService.supersedeInvoiceExternalRef(
+          db,
+          ref!.id,
+          { reason: "Cancelled in SmartBill." },
+          { invoiceId: "inv_someone_elses" },
+        ),
+      ).resolves.toBeNull()
+
+      // Untouched: still live, still guarding.
+      const [unchanged] = await db
+        .select()
+        .from(invoiceExternalRefs)
+        .where(eq(invoiceExternalRefs.id, ref!.id))
+      expect(unchanged).toMatchObject({ status: "recorded_externally", externalNumber: "1042" })
+    })
+
     it("repoints a reference at the document that replaced the cancelled one", async () => {
       const { invoice } = await backFillAlreadyInvoicedBooking(
         "finance-booking-create-external-repoint",

--- a/packages/finance/tests/integration/booking-create.test.ts
+++ b/packages/finance/tests/integration/booking-create.test.ts
@@ -45,6 +45,7 @@ import { financeBookingLifecycle } from "../../src/booking-lifecycle.js"
 import {
   bookingItemTaxLines,
   bookingPaymentSchedules,
+  invoiceExternalRefs,
   invoiceNumberSeries,
   invoiceRenditions,
   invoices,
@@ -53,10 +54,11 @@ import {
   travelCreditRedemptions,
   travelCredits,
 } from "../../src/schema.js"
-import type { FinanceServiceRuntime } from "../../src/service.js"
+import { type FinanceServiceRuntime, financeService } from "../../src/service.js"
 import { bookingCreateSchema, createBookingMutation } from "../../src/service-booking-create.js"
 import { financeBookingPaymentScheduleService } from "../../src/service-booking-payment-schedules.js"
 import { financeInvoiceCoreService } from "../../src/service-invoice-core.js"
+import { issueInvoiceFromBookingCommand } from "../../src/service-issue.js"
 
 const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
 let directCreateSequence = 0
@@ -5651,6 +5653,380 @@ describe.skipIf(!DB_AVAILABLE)("createBooking", () => {
           status: "completed",
         }),
       })
+    })
+
+    // voyant#4688. The recovery flow this covers: a checkout took the money,
+    // the settlement commit failed, and the operator issued a fiscal document
+    // by hand so the customer has one. Support then back-fills the booking so
+    // the operational record matches — and that back-fill used to mirror a
+    // second real fiscal document for the same sale.
+    const alreadyIssuedBySmartBill = {
+      provider: "mapp_smartbill",
+      series: "VOY",
+      number: "1042",
+      externalId: "sb_doc_1042",
+      externalUrl: "https://smartbill.example/doc/1042",
+      issuedAt: "2026-06-10",
+      note: "Issued by hand after the settlement commit failed.",
+    }
+
+    const paidByBankTransfer = (reference: string) => [
+      {
+        scheduleType: "balance" as const,
+        status: "paid" as const,
+        dueDate: "2026-06-15",
+        currency: "EUR",
+        amountCents: 50_000,
+        notes: JSON.stringify({
+          alreadyPaid: true,
+          paymentDate: "2026-06-10",
+          paymentMethod: "bank_transfer",
+          paymentReference: reference,
+        }),
+      },
+    ]
+
+    async function backFillAlreadyInvoicedBooking(idempotencyKey: string, reference: string) {
+      const { productId } = await seedProduct()
+      const command = await durableCommand(idempotencyKey, {
+        productId,
+        bookingNumber: nextBookingNumber(),
+        ...fiscalBillingParty(),
+        documentGeneration: {
+          contractDocument: false,
+          invoiceDocument: true,
+          externalInvoice: alreadyIssuedBySmartBill,
+        },
+        paymentSchedules: paidByBankTransfer(reference),
+      })
+      const result = await executeFinanceStaffBookingCreateCommand(command)
+      const [invoice] = await db
+        .select()
+        .from(invoices)
+        .where(eq(invoices.bookingId, result.value.bookingId))
+      return { bookingId: result.value.bookingId, invoice: invoice! }
+    }
+
+    it("records what was paid without issuing anything when the operator said not to", async () => {
+      // The incident this is for: an operator instructed the agent not to issue
+      // a proforma, invoice or contract. The agent made no issuance call and
+      // reported that none were issued — and a real fiscal invoice reached the
+      // accounting provider ~38s later, because issuance followed from creating
+      // the booking rather than from any call. Recording the money and issuing
+      // a document for it had to become separable.
+      const { productId } = await seedProduct()
+      const command = await durableCommand("finance-booking-create-suppressed", {
+        productId,
+        bookingNumber: nextBookingNumber(),
+        ...fiscalBillingParty(),
+        suppressDocuments: true,
+        documentGeneration: { contractDocument: false, invoiceDocument: true },
+        paymentSchedules: paidByBankTransfer("BT-SUPPRESSED-1"),
+      })
+
+      const result = await executeFinanceStaffBookingCreateCommand(command)
+
+      // The money is recorded.
+      const [invoice] = await db
+        .select()
+        .from(invoices)
+        .where(eq(invoices.bookingId, result.value.bookingId))
+      expect(invoice?.paidCents).toBe(50_000)
+      expect(
+        await db.select().from(payments).where(eq(payments.referenceNumber, "BT-SUPPRESSED-1")),
+      ).toHaveLength(1)
+
+      // The fiscal document is not. Nothing announced an issuance, so no
+      // subscribed accounting app can act on one — that event is the whole
+      // mechanism by which a document reaches the provider.
+      //
+      // The row's status is not the assertion to make here: `createPayment`
+      // moves any invoice to `paid` once it is settled, issued or not, so a
+      // withheld invoice that was paid in full reads `paid` exactly as the
+      // existing missing-billing-fields path does. What distinguishes it is
+      // that it was never issued.
+      const events = await outboxByName()
+      expect(events.has("invoice.issued")).toBe(false)
+      expect(events.has("invoice.proforma.issued")).toBe(false)
+      expect(
+        await db
+          .select()
+          .from(invoiceExternalRefs)
+          .where(eq(invoiceExternalRefs.invoiceId, invoice!.id)),
+      ).toHaveLength(0)
+
+      // And no rendition, which would otherwise reach the customer.
+      expect(
+        await db
+          .select()
+          .from(invoiceRenditions)
+          .where(eq(invoiceRenditions.invoiceId, invoice!.id)),
+      ).toHaveLength(0)
+    })
+
+    it("persists the suppression so the paths that run after the create can honour it", async () => {
+      // Contract generation runs off `booking.confirmed` once this transaction
+      // has committed. A decision that existed only on the command could not
+      // reach it, which is why the contract was generated anyway.
+      const { productId } = await seedProduct()
+      const command = await durableCommand("finance-booking-create-suppressed-persist", {
+        productId,
+        bookingNumber: nextBookingNumber(),
+        ...fiscalBillingParty(),
+        suppressDocuments: true,
+      })
+
+      const result = await executeFinanceStaffBookingCreateCommand(command)
+
+      await expect(
+        bookingsService.getBookingById(db, result.value.bookingId),
+      ).resolves.toMatchObject({ documentsSuppressed: true })
+    })
+
+    it("issues as before when nothing suppressed it", async () => {
+      // The control for the two above: without the flag this is still the
+      // behaviour every deployment has today.
+      const { productId } = await seedProduct()
+      const command = await durableCommand("finance-booking-create-unsuppressed", {
+        productId,
+        bookingNumber: nextBookingNumber(),
+        ...fiscalBillingParty(),
+        documentGeneration: { contractDocument: false, invoiceDocument: true },
+        paymentSchedules: paidByBankTransfer("BT-UNSUPPRESSED-1"),
+      })
+
+      const result = await executeFinanceStaffBookingCreateCommand(command)
+
+      const [invoice] = await db
+        .select()
+        .from(invoices)
+        .where(eq(invoices.bookingId, result.value.bookingId))
+      expect(invoice?.status).toBe("paid")
+      expect((await outboxByName()).has("invoice.issued")).toBe(true)
+      await expect(
+        bookingsService.getBookingById(db, result.value.bookingId),
+      ).resolves.toMatchObject({ documentsSuppressed: false })
+    })
+
+    it("records a back-filled sale against the operator's own document instead of issuing a second one", async () => {
+      const { invoice } = await backFillAlreadyInvoicedBooking(
+        "finance-booking-create-external-invoice",
+        "BT-EXTERNAL-1",
+      )
+
+      // The internal record is a real, issued, fully-paid invoice — the point
+      // is that the balance and the contract stay right.
+      expect(invoice.status).toBe("paid")
+      expect(invoice.paidCents).toBe(50_000)
+
+      // The external reference names the operator's document, and says the
+      // platform did not put it there.
+      const [ref] = await db
+        .select()
+        .from(invoiceExternalRefs)
+        .where(eq(invoiceExternalRefs.invoiceId, invoice.id))
+      expect(ref).toMatchObject({
+        provider: "mapp_smartbill",
+        externalNumber: "1042",
+        externalId: "sb_doc_1042",
+        status: "recorded_externally",
+        syncedAt: null,
+      })
+
+      // The event still fires for ledgers and audit; the external subscribers
+      // are told to stand down, which is what stops the duplicate.
+      const issued = (await outboxByName()).get("invoice.issued")
+      expect(issued).toMatchObject({
+        payload: expect.objectContaining({ invoiceId: invoice.id, skipExternalSync: true }),
+      })
+
+      // And no rendition: ours reads as an invoice and would join the booking's
+      // notification bundle, mailing the customer a second document.
+      expect(
+        await db
+          .select()
+          .from(invoiceRenditions)
+          .where(eq(invoiceRenditions.invoiceId, invoice.id)),
+      ).toHaveLength(0)
+    })
+
+    it("refuses to issue over a booking that already has a live external document", async () => {
+      const { bookingId } = await backFillAlreadyInvoicedBooking(
+        "finance-booking-create-external-guard",
+        "BT-EXTERNAL-2",
+      )
+
+      const outcome = await issueInvoiceFromBookingCommand(db, {
+        bookingId,
+        issueDate: "2026-08-15",
+        dueDate: "2026-08-15",
+        invoiceType: "invoice",
+      })
+
+      expect(outcome).toMatchObject({
+        status: "duplicate_external_document",
+        existing: { provider: "mapp_smartbill", externalNumber: "1042", label: "VOY 1042" },
+      })
+      expect(
+        await db.select().from(invoices).where(eq(invoices.bookingId, bookingId)),
+      ).toHaveLength(1)
+    })
+
+    it("still issues a balance invoice for a booking whose deposit is already invoiced", async () => {
+      // The guard must not mistake staged invoicing for a duplicate: a deposit
+      // and a balance are two real sales of two different amounts, and a
+      // booking legitimately carries a fiscal document for each. Overlap is the
+      // question, not "does this booking have a document".
+      const { productId } = await seedProduct()
+      const command = await durableCommand("finance-booking-create-external-staged", {
+        productId,
+        bookingNumber: nextBookingNumber(),
+        ...fiscalBillingParty(),
+        paymentSchedules: [
+          {
+            scheduleType: "deposit" as const,
+            status: "paid" as const,
+            dueDate: "2026-06-15",
+            currency: "EUR",
+            amountCents: 20_000,
+            notes: JSON.stringify({
+              alreadyPaid: true,
+              paymentDate: "2026-06-10",
+              paymentReference: "BT-DEPOSIT-1",
+            }),
+          },
+          {
+            scheduleType: "balance" as const,
+            status: "pending" as const,
+            dueDate: "2026-07-15",
+            currency: "EUR",
+            amountCents: 30_000,
+          },
+        ],
+      })
+      const created = await executeFinanceStaffBookingCreateCommand(command)
+      const schedules = await db
+        .select()
+        .from(bookingPaymentSchedules)
+        .where(eq(bookingPaymentSchedules.bookingId, created.value.bookingId))
+      const deposit = schedules.find((schedule) => schedule.scheduleType === "deposit")
+      const balance = schedules.find((schedule) => schedule.scheduleType === "balance")
+
+      // The deposit is invoiced against a document the operator already holds.
+      const depositOutcome = await issueInvoiceFromBookingCommand(db, {
+        bookingId: created.value.bookingId,
+        bookingPaymentScheduleId: deposit!.id,
+        invoiceNumber: "INV-STAGED-DEPOSIT",
+        issueDate: "2026-06-15",
+        dueDate: "2026-06-15",
+        invoiceType: "invoice",
+        externalDocument: { ...alreadyIssuedBySmartBill, number: "2001" },
+      })
+      expect(depositOutcome.status).toBe("issued")
+
+      // The balance is a different sale and must still go through.
+      const balanceOutcome = await issueInvoiceFromBookingCommand(db, {
+        bookingId: created.value.bookingId,
+        bookingPaymentScheduleId: balance!.id,
+        invoiceNumber: "INV-STAGED-BALANCE",
+        issueDate: "2026-07-15",
+        dueDate: "2026-07-15",
+        invoiceType: "invoice",
+      })
+      expect(balanceOutcome.status).toBe("issued")
+
+      // But re-invoicing the deposit is the duplicate the guard is for.
+      const repeatOutcome = await issueInvoiceFromBookingCommand(db, {
+        bookingId: created.value.bookingId,
+        bookingPaymentScheduleId: deposit!.id,
+        invoiceNumber: "INV-STAGED-DEPOSIT-AGAIN",
+        issueDate: "2026-08-15",
+        dueDate: "2026-08-15",
+        invoiceType: "invoice",
+      })
+      expect(repeatOutcome).toMatchObject({
+        status: "duplicate_external_document",
+        existing: { externalNumber: "2001" },
+      })
+    })
+
+    it("issues anyway when the operator acknowledges the existing document", async () => {
+      const { bookingId } = await backFillAlreadyInvoicedBooking(
+        "finance-booking-create-external-ack",
+        "BT-EXTERNAL-3",
+      )
+
+      const outcome = await issueInvoiceFromBookingCommand(db, {
+        bookingId,
+        invoiceNumber: "INV-ACKNOWLEDGED",
+        issueDate: "2026-08-15",
+        dueDate: "2026-08-15",
+        invoiceType: "invoice",
+        acknowledgeExistingExternalDocument: true,
+      })
+
+      expect(outcome.status).toBe("issued")
+    })
+
+    it("lets the booking be invoiced again once the provider document is retracted", async () => {
+      // The way out the issue asked for: cancelling in the provider's UI left
+      // the reference pointing at a cancelled document with nothing supported
+      // to do about it, and `voidInvoice` refuses on a recorded payment.
+      const { bookingId, invoice } = await backFillAlreadyInvoicedBooking(
+        "finance-booking-create-external-supersede",
+        "BT-EXTERNAL-4",
+      )
+      const [ref] = await db
+        .select()
+        .from(invoiceExternalRefs)
+        .where(eq(invoiceExternalRefs.invoiceId, invoice.id))
+
+      const superseded = await financeService.supersedeInvoiceExternalRef(db, ref!.id, {
+        reason: "Cancelled in SmartBill after the duplicate was spotted.",
+      })
+
+      expect(superseded).toMatchObject({ status: "cancelled" })
+      // The identity is kept, not erased — an audit has to be able to see that
+      // a document was issued there at all.
+      expect(
+        (superseded?.metadata as Record<string, unknown>)?.voyantSupersededDocuments,
+      ).toMatchObject([
+        expect.objectContaining({ externalNumber: "1042", externalId: "sb_doc_1042" }),
+      ])
+
+      const outcome = await issueInvoiceFromBookingCommand(db, {
+        bookingId,
+        invoiceNumber: "INV-AFTER-SUPERSEDE",
+        issueDate: "2026-08-15",
+        dueDate: "2026-08-15",
+        invoiceType: "invoice",
+      })
+      expect(outcome.status).toBe("issued")
+    })
+
+    it("repoints a reference at the document that replaced the cancelled one", async () => {
+      const { invoice } = await backFillAlreadyInvoicedBooking(
+        "finance-booking-create-external-repoint",
+        "BT-EXTERNAL-5",
+      )
+      const [ref] = await db
+        .select()
+        .from(invoiceExternalRefs)
+        .where(eq(invoiceExternalRefs.invoiceId, invoice.id))
+
+      const superseded = await financeService.supersedeInvoiceExternalRef(db, ref!.id, {
+        reason: "Reissued under the correct series.",
+        replacement: { series: "VOY", externalNumber: "1043", externalId: "sb_doc_1043" },
+      })
+
+      expect(superseded).toMatchObject({ externalNumber: "1043", externalId: "sb_doc_1043" })
+      // Still one row: the reference moved, it did not multiply.
+      expect(
+        await db
+          .select()
+          .from(invoiceExternalRefs)
+          .where(eq(invoiceExternalRefs.invoiceId, invoice.id)),
+      ).toHaveLength(1)
     })
 
     it("keeps the issuance events atomic with the booking that caused them", async () => {

--- a/packages/finance/tests/tools.test.ts
+++ b/packages/finance/tests/tools.test.ts
@@ -79,6 +79,7 @@ function bookingDetail(id = "booking_1") {
     pax: 1,
     internalNotes: null,
     notificationsSuppressed: false,
+    documentsSuppressed: false,
     customerPaymentPolicy: null,
     priceOverride: null,
     customFields: {},

--- a/packages/finance/tests/unit/invoice-external-document.test.ts
+++ b/packages/finance/tests/unit/invoice-external-document.test.ts
@@ -1,0 +1,185 @@
+import {
+  formatExternalDocumentLabel,
+  invoiceFromBookingSchema,
+  isCancelledExternalDocumentStatus,
+} from "@voyant-travel/finance-contracts"
+import { describe, expect, it } from "vitest"
+
+import {
+  describeDuplicateExternalDocument,
+  EXTERNAL_DOCUMENT_METADATA_KEY,
+  externalDocumentToRefInput,
+} from "../../src/invoice-external-document.js"
+import { applyExternalDocumentDeclaration } from "../../src/service-issue.js"
+
+const document = {
+  provider: "smartbill",
+  series: "VOY",
+  number: "1042",
+  externalId: "sb_9",
+  externalUrl: "https://provider.example/doc/9",
+  issuedAt: "2026-08-14",
+  note: "Issued by hand after the settlement commit failed.",
+}
+
+describe("externalDocumentToRefInput", () => {
+  it("puts the document number in external_number and the series in metadata", () => {
+    const ref = externalDocumentToRefInput(document, {
+      recordedAt: new Date("2026-08-15T09:00:00Z"),
+    })
+
+    expect(ref.provider).toBe("smartbill")
+    expect(ref.externalNumber).toBe("1042")
+    expect(ref.externalId).toBe("sb_9")
+    expect(ref.externalUrl).toBe("https://provider.example/doc/9")
+    expect(ref.metadata?.[EXTERNAL_DOCUMENT_METADATA_KEY]).toEqual({
+      series: "VOY",
+      number: "1042",
+      issuedAt: "2026-08-14",
+      note: "Issued by hand after the settlement commit failed.",
+      recordedAt: "2026-08-15T09:00:00.000Z",
+    })
+  })
+
+  it("does not claim a successful sync, because none ran", () => {
+    const ref = externalDocumentToRefInput(document)
+
+    expect(ref.syncedAt).toBeNull()
+    expect(ref.syncError).toBeNull()
+    expect(ref.status).toBe("recorded_externally")
+  })
+})
+
+describe("isCancelledExternalDocumentStatus", () => {
+  it.each([
+    "cancelled",
+    "Canceled",
+    " VOID ",
+    "storno",
+    "reversed",
+  ])("treats %s as a retracted provider document", (status) => {
+    expect(isCancelledExternalDocumentStatus(status)).toBe(true)
+  })
+
+  it.each([
+    "issued",
+    "paid",
+    "recorded_externally",
+    "",
+    null,
+    undefined,
+  ])("treats %s as a document that still exists", (status) => {
+    expect(isCancelledExternalDocumentStatus(status)).toBe(false)
+  })
+})
+
+describe("formatExternalDocumentLabel", () => {
+  it("joins series and number", () => {
+    expect(formatExternalDocumentLabel({ series: "VOY", number: "1042" })).toBe("VOY 1042")
+  })
+
+  it("falls back to the stored external number when there is no series", () => {
+    expect(formatExternalDocumentLabel({ externalNumber: "1042" })).toBe("1042")
+  })
+
+  it("says so rather than rendering an empty label", () => {
+    expect(formatExternalDocumentLabel({ series: "VOY" })).toBe("an unnumbered document")
+  })
+})
+
+describe("applyExternalDocumentDeclaration", () => {
+  const base = {
+    bookingId: "bkg_1",
+    issueDate: "2026-08-15",
+    dueDate: "2026-08-15",
+    invoiceType: "invoice" as const,
+  }
+
+  it("suppresses the mirror and writes the reference together", () => {
+    const applied = applyExternalDocumentDeclaration({ ...base, externalDocument: document })
+
+    expect(applied.skipExternalSync).toBe(true)
+    expect(applied.externalRefs).toHaveLength(1)
+    expect(applied.externalRefs?.[0]?.externalNumber).toBe("1042")
+  })
+
+  it("keeps references the caller supplied for other providers", () => {
+    const applied = applyExternalDocumentDeclaration({
+      ...base,
+      externalDocument: document,
+      externalRefs: [{ provider: "stripe", externalId: "in_1" }],
+    })
+
+    expect(applied.externalRefs?.map((ref) => ref.provider)).toEqual(["stripe", "smartbill"])
+  })
+
+  it("leaves an input without a declaration untouched", () => {
+    const input = { ...base, skipExternalSync: false }
+    expect(applyExternalDocumentDeclaration(input)).toBe(input)
+  })
+})
+
+describe("invoiceFromBookingSchema external-document refinements", () => {
+  const base = { bookingId: "bkg_1", issueDate: "2026-08-15", dueDate: "2026-08-15" }
+
+  it("accepts a declaration on its own", () => {
+    expect(
+      invoiceFromBookingSchema.safeParse({ ...base, externalDocument: document }).success,
+    ).toBe(true)
+  })
+
+  it("rejects declaring an external document while asking for the mirror", () => {
+    const result = invoiceFromBookingSchema.safeParse({
+      ...base,
+      externalDocument: document,
+      skipExternalSync: false,
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error?.issues.map((issue) => issue.path.join("."))).toContain("skipExternalSync")
+  })
+
+  it("rejects declaring the same provider twice", () => {
+    const result = invoiceFromBookingSchema.safeParse({
+      ...base,
+      externalDocument: document,
+      externalRefs: [{ provider: "smartbill", externalNumber: "1042" }],
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error?.issues.map((issue) => issue.path.join("."))).toContain(
+      "externalDocument.provider",
+    )
+  })
+
+  it("only accepts `true` for the duplicate acknowledgement", () => {
+    expect(
+      invoiceFromBookingSchema.safeParse({ ...base, acknowledgeExistingExternalDocument: true })
+        .success,
+    ).toBe(true)
+    expect(
+      invoiceFromBookingSchema.safeParse({ ...base, acknowledgeExistingExternalDocument: false })
+        .success,
+    ).toBe(false)
+  })
+})
+
+describe("describeDuplicateExternalDocument", () => {
+  it("names the provider, the document and the invoice that already has it", () => {
+    const message = describeDuplicateExternalDocument({
+      invoiceId: "inv_1",
+      invoiceNumber: "INV-7",
+      invoiceStatus: "paid",
+      provider: "smartbill",
+      externalId: "sb_9",
+      externalNumber: "1042",
+      externalUrl: null,
+      status: "issued",
+      label: "VOY 1042",
+    })
+
+    expect(message).toContain("smartbill")
+    expect(message).toContain("VOY 1042")
+    expect(message).toContain("INV-7")
+  })
+})

--- a/packages/finance/tests/unit/invoice-external-document.test.ts
+++ b/packages/finance/tests/unit/invoice-external-document.test.ts
@@ -2,6 +2,7 @@ import {
   formatExternalDocumentLabel,
   invoiceFromBookingSchema,
   isCancelledExternalDocumentStatus,
+  supersedeInvoiceExternalRefSchema,
 } from "@voyant-travel/finance-contracts"
 import { describe, expect, it } from "vitest"
 
@@ -160,6 +161,45 @@ describe("invoiceFromBookingSchema external-document refinements", () => {
     expect(
       invoiceFromBookingSchema.safeParse({ ...base, acknowledgeExistingExternalDocument: false })
         .success,
+    ).toBe(false)
+  })
+})
+
+describe("supersedeInvoiceExternalRefSchema", () => {
+  it("accepts a cancellation on its own", () => {
+    expect(
+      supersedeInvoiceExternalRefSchema.safeParse({ reason: "Cancelled in the provider." }).success,
+    ).toBe(true)
+  })
+
+  it("accepts a replacement that names a document", () => {
+    expect(
+      supersedeInvoiceExternalRefSchema.safeParse({
+        reason: "Reissued under the correct series.",
+        replacement: { externalNumber: "1043" },
+      }).success,
+    ).toBe(true)
+  })
+
+  it("rejects a replacement with no identity", () => {
+    // An empty replacement leaves the reference reading as live while carrying
+    // no number the guard can match, which releases the guard without anyone
+    // recording that the old document was retracted.
+    const result = supersedeInvoiceExternalRefSchema.safeParse({
+      reason: "Cancelled in the provider.",
+      replacement: {},
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error?.issues.map((issue) => issue.path.join("."))).toContain("replacement")
+  })
+
+  it("rejects a replacement carrying only a status", () => {
+    expect(
+      supersedeInvoiceExternalRefSchema.safeParse({
+        reason: "Cancelled in the provider.",
+        replacement: { status: "issued" },
+      }).success,
     ).toBe(false)
   })
 })

--- a/packages/legal/src/booking-contract-confirmed.ts
+++ b/packages/legal/src/booking-contract-confirmed.ts
@@ -59,6 +59,14 @@ export type BookingContractConfirmationResult =
       status: "skipped"
       reason:
         | "booking_not_found"
+        /**
+         * The operator said not to produce documents for this booking
+         * (voyant#4688). Generation used to be a consequence of confirmation
+         * with nothing able to decline it, so an operator's explicit
+         * instruction had no effect — the decision is now persisted on the
+         * booking and read here, where the generation actually happens.
+         */
+        | "documents_suppressed"
         | "template_not_found"
         | "template_version_missing"
         | "series_not_found"
@@ -200,7 +208,18 @@ export async function generateBookingContractOnConfirmation(
     if (prepared.status === "already_generated") {
       await promotePaidAcceptedBookingContract(input.db, prepared.contractId, input.eventBus)
     }
-    if (prepared.status === "skipped" && prepared.reason !== "booking_not_found") {
+    // `documents_suppressed` joins `booking_not_found` in not being recorded as
+    // unfulfilled. The entry these write is a `failed` one, and nothing failed
+    // — an operator said not to produce documents for this booking. The
+    // voyant#4634 reason for recording the others is that silence there is
+    // indistinguishable from a deployment where generation never works; here it
+    // is not, because `bookings.documents_suppressed` is set on the booking and
+    // says exactly why nothing was generated.
+    if (
+      prepared.status === "skipped" &&
+      prepared.reason !== "booking_not_found" &&
+      prepared.reason !== "documents_suppressed"
+    ) {
       await recordUnfulfilledBookingContract(input.db, {
         event: input.event,
         reason: prepared.reason,
@@ -243,7 +262,7 @@ export async function generateBookingContractOnConfirmation(
 export type UnfulfilledBookingContractReason =
   | Exclude<
       Extract<BookingContractConfirmationResult, { status: "skipped" }>["reason"],
-      "booking_not_found"
+      "booking_not_found" | "documents_suppressed"
     >
   | "document_renderer_unavailable"
 
@@ -372,6 +391,12 @@ async function prepareBookingContractTarget(
 > {
   const booking = await bookingsService.getBookingById(db, bookingId)
   if (!booking) return { status: "skipped", reason: "booking_not_found" }
+  // Checked before anything is looked up or written, so a suppressed booking
+  // leaves no half-prepared contract behind. Read from the row rather than the
+  // event for the reason voyant#4634 gave for notification suppression: the
+  // decision lives on the booking, and every path that must honour it re-reads
+  // it there.
+  if (booking.documentsSuppressed) return { status: "skipped", reason: "documents_suppressed" }
 
   const existingContracts = await db
     .select()

--- a/packages/legal/tests/integration/booking-contract-confirmed.test.ts
+++ b/packages/legal/tests/integration/booking-contract-confirmed.test.ts
@@ -6,7 +6,10 @@ import { cleanupTestDb } from "@voyant-travel/db/test-utils"
 import { eq } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
-import { LEGAL_BOOKING_CONTRACT_CONFIRMED_ACTION_ID } from "../../src/booking-contract-confirmed.js"
+import {
+  generateBookingContractOnConfirmation,
+  LEGAL_BOOKING_CONTRACT_CONFIRMED_ACTION_ID,
+} from "../../src/booking-contract-confirmed.js"
 import {
   createLegalBookingContractConfirmedSubscriber,
   type LegalBookingConfirmedPayload,
@@ -302,6 +305,63 @@ describe.skipIf(!DB_AVAILABLE)("booking-confirmed contract generation", () => {
         .from(contractSignatures)
         .where(eq(contractSignatures.contractId, contractRows[0]!.id)),
     ).toHaveLength(1)
+  })
+
+  // voyant#4688: an operator told the agent not to issue a proforma, invoice or
+  // contract. The contract was generated ~5s after booking creation anyway,
+  // because generation follows from confirmation rather than from a call anyone
+  // makes — there was nothing at any layer the instruction could reach.
+  it("generates nothing for a booking the operator suppressed documents on", async () => {
+    const [booking] = await db
+      .insert(bookings)
+      .values({
+        bookingNumber: "BK-AUTO-CONTRACT-SUPPRESSED",
+        status: "confirmed",
+        contactFirstName: "Ana",
+        contactLastName: "Pop",
+        contactEmail: "ana@example.test",
+        contactPreferredLanguage: "en",
+        sellCurrency: "EUR",
+        sellAmountCents: 120_00,
+        startDate: "2026-09-01",
+        endDate: "2026-09-07",
+        pax: 2,
+        documentsSuppressed: true,
+      })
+      .returning()
+
+    const result = await generateBookingContractOnConfirmation({
+      db,
+      provider: provider(),
+      event: {
+        data: {
+          bookingId: booking!.id,
+          bookingNumber: booking!.bookingNumber,
+          actorId: null,
+        },
+        metadata: {
+          eventId: `evt_finance_booking_confirmed_${booking!.id}`,
+          category: "domain",
+          source: "service",
+        },
+      } as never,
+    })
+
+    // Specifically suppression, not "no template" — the refusal happens before
+    // any template or series is looked at, so the same booking without a
+    // template would have skipped for a different reason.
+    expect(result).toEqual({ status: "skipped", reason: "documents_suppressed" })
+    expect(
+      await db.select().from(contracts).where(eq(contracts.bookingId, booking!.id)),
+    ).toHaveLength(0)
+    // And no `failed` ledger entry: nothing failed. The booking row carries the
+    // reason, so the absence is explained without misreporting a decision.
+    expect(
+      await db
+        .select()
+        .from(actionLedgerEntries)
+        .where(eq(actionLedgerEntries.targetId, booking!.id)),
+    ).toHaveLength(0)
   })
 
   // voyant#4634: with no template to render, generation used to return a

--- a/packages/mcp/tests/response-budget.test.ts
+++ b/packages/mcp/tests/response-budget.test.ts
@@ -71,6 +71,7 @@ function bookingRow(index: number): Record<string, unknown> {
     pax: 2,
     internalNotes: null,
     notificationsSuppressed: false,
+    documentsSuppressed: false,
     priceOverride: null,
     customFields: { "voyant.loyalty": { tier: "gold", points: 4200 } },
     holdExpiresAt: null,


### PR DESCRIPTION
Closes #4688.

## The problem

Creating a booking with a recorded payment created an invoice, issued it, and emitted `invoice.issued`; a subscribed accounting app then filed a real fiscal document. Confirming a booking generated a contract. Both were **consequences of the create**, not calls anyone made.

That has two effects, and the second is worse than the first:

1. **Back-filling an already-invoiced sale files a duplicate.** The standard recovery after a checkout takes the money and settlement fails: the operator issues an invoice by hand so the customer has a fiscal document, then support back-fills the booking. The back-fill re-invoices the same sale — same customer, same amount, same date, different series. For a Romanian operator both land in e-Factura.

2. **An operator's explicit instruction not to invoice is unenforceable.** An operator told the agent *"nu emite proforma, factura si contract"*. The agent made no issuance call and truthfully reported that none were issued. A fiscal invoice reached the provider ~38s later and a contract ~5s later. **An agent cannot decline an action it never invokes**, and the instruction had no layer to land on.

And the undo is closed: `voidInvoice` refuses on `paid` and refuses again on a recorded payment, so the platform cannot retract what it just issued.

## What this does

**Recording that a booking was paid is now separable from issuing a fiscal document for it, and the choice is expressible at booking-create time.**

### 1. `suppressDocuments` — record it, do not issue it

New on booking create (`book_product`, the staff create command, `bookings.create`). No invoice or proforma is issued, no `invoice.issued` fires, no contract is generated. Payments are still recorded on the invoice, so the booking's balance is right.

Persisted as `bookings.documents_suppressed`, not carried only on the command — contract generation runs off `booking.confirmed` *after* the creating transaction commits, so a decision living only in the command cannot reach it. This is the same shape `notifications_suppressed` already uses, and the same reasoning #4634 gave for it: the decision lives on the booking and every path that must honour it re-reads it there. Legal now refuses in `prepareBookingContractTarget`, before any template, series or contract row is touched.

### 2. `externalInvoice` / `externalDocument` — already invoiced elsewhere

Give the provider, series and number of a document the operator already issued. The platform's own invoice is still written and issued, so balances, payments and the contract stay right — but the mirror is suppressed and the invoice's external reference names the operator's document. No rendition is produced: ours reads as an invoice and a `ready` one joins the booking's notification bundle, which is how the customer ends up holding two.

The two halves used to be independent flags (`externalRefs` + `skipExternalSync`) that a caller had to remember to set together, with nothing checking that they had. They are now one declaration, and the incoherent combinations are rejected by the schema.

Available on `POST /invoices/from-booking` and on booking create.

### 3. The duplicate guard

Issuing from a booking that already carries a live external fiscal document now returns `duplicate_external_document` (HTTP 409) instead of sending a second one. `acknowledgeExistingExternalDocument: true` overrides it — the explicit-acknowledgement shape `void_legal_contract` already uses.

**The guard is scoped by overlap, not by "this booking has a document."** A deposit and a balance are two real sales and a booking legitimately carries a document for each. A request naming a payment schedule only refuses against a document covering that same schedule (or the whole booking); a request naming none is for the whole booking, so any document overlaps. Where it cannot tell, it does not refuse — a guard that blocks a legitimate balance invoice costs more than the duplicate it catches, and the declaration above is the primary remedy.

### 4. A supported way back

`POST /invoices/{id}/external-refs/{refId}/supersede` records that a provider document was cancelled outside the platform, **keeping the superseded identity** in the reference's metadata, and optionally repoints the reference at its replacement. Marking one cancelled is what releases the guard, so the remedy for the first duplicate does not permanently prevent the correction. Deleting the row is not the same thing — it erases the fact that a document was ever issued there.

## Notes for review

- **The issue's claim that `voidInvoice` sets `paidCents: 0` is not quite right.** `voidInvoice` (`service-invoice-core.ts:412`) does not zero paid amounts; the *conversion* path does, on the source proforma (`service-issue.ts:1108`). The conclusion still holds — voiding is the wrong remedy — but by a different route.
- **A withheld invoice can still read `paid`.** `createPayment` moves any settled invoice to `paid`, issued or not, so a fully-paid withheld invoice looks the same as the existing missing-billing-fields path. There is no column that says "was this ever issued"; the absence of `invoice.issued` is what distinguishes it. Pre-existing, not introduced here, but worth a follow-up.
- **`generate:schema-docs` is broken on `main`** — it requires `packages/availability/src/schema.ts`, which was absorbed into `operations`. The `bookings` row in `SCHEMA.md` was added by hand.
- **No UI.** The operator create dialog does not yet expose "record, do not issue". The reported incident was agent-driven, and the dialog change needs en+ro parity; deliberately left as follow-up.

## Verification

All run locally; the `legal` build needed `--max-old-space-size=8192` after a first attempt aborted with SIGABRT under parallel-worktree load (exit 134, zero `error TS` — pressure, not a type error).

- `build` clean (0 `error TS`): `bookings-contracts`, `finance-contracts`, `bookings`, `finance`, `legal`
- `packages/finance/tests/unit/invoice-external-document.test.ts` — 24 passed
- `packages/finance/tests/integration/booking-create.test.ts` — 112 passed, 1 skipped
- `packages/legal/tests/integration/booking-contract-confirmed.test.ts` — 5 passed
- `biome check .` from the repo root — exit 0; none of the 22 warnings / 8 infos are in changed files
- `verify:booking-create-authority`, `verify:legal-subscriber-authority`, `verify:first-party-tool-output-schemas`, `verify:migration-boundaries`, `verify:migration-identity` — pass

Both integration suites were run against a dedicated database cloned from the shared test DB, because another session's suite was truncating tables mid-run and producing deadlocks in a shared one.

Both files are listed by name in the `db-integration` CI lane (`ci.yml:382` and `ci.yml:422`), so every new case here runs in CI rather than being green-by-skipping.