### PR TITLE
Render the booking contract's payment clause from settlement

### DIFF
--- a/.changeset/booking-contract-settlement-variables.md
+++ b/.changeset/booking-contract-settlement-variables.md
@@ -19,3 +19,12 @@ expired rows excluded). Legal reads it through that service and emits
 `isPaidInFull`, the deposit/balance installments, and `payment.method` /
 `latestCompleted` / `schedule`, so the auto-generated contract and the agent
 path now render the same clause.
+
+A credit note is a negative receivable, so `getBookingSettlement` nets it out
+of the balance rather than summing it as debt, and never presents a
+credit-note refund as the customer's latest payment.
+
+The acceptance-evidence digest is matched against a third candidate rendered
+with preview-time settlement — nothing paid, the whole price outstanding —
+because the shopper accepted the terms before paying, and a card booking is
+settled by the time `booking.confirmed` lands.

--- a/.changeset/booking-contract-settlement-variables.md
+++ b/.changeset/booking-contract-settlement-variables.md
@@ -1,0 +1,21 @@
+---
+"@voyant-travel/finance": minor
+"@voyant-travel/legal": minor
+---
+
+Render the auto-generated booking contract's payment clause from settlement.
+
+The post-confirm variable bag carried the booking's list price and nothing
+about what had been paid, so a template branching on `booking.isPaidInFull`
+took the `else` arm on every contract and printed the missing-value
+placeholder for each amount — telling a customer who had paid in full that
+they owed "-" by "-".
+
+Finance gains `getBookingSettlement`, the one answer for what a booking has
+paid and still owes: completed payments against non-void invoices, the
+invoice balance, and the installments that still stand (cancelled, waived and
+expired rows excluded). Legal reads it through that service and emits
+`booking.paidAmountCents`, `amountDueCents`, `balanceDueCents`,
+`isPaidInFull`, the deposit/balance installments, and `payment.method` /
+`latestCompleted` / `schedule`, so the auto-generated contract and the agent
+path now render the same clause.

--- a/packages/accommodations/tsconfig.build.json
+++ b/packages/accommodations/tsconfig.build.json
@@ -1044,6 +1044,9 @@
       "@voyant-travel/finance/booking-schedule-subscriber": [
         "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
       ],
+      "@voyant-travel/finance/booking-settlement": [
+        "../finance/dist/service-booking-settlement.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/accommodations/tsconfig.typecheck.json
+++ b/packages/accommodations/tsconfig.typecheck.json
@@ -1045,6 +1045,9 @@
       "@voyant-travel/finance/booking-schedule-subscriber": [
         "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
       ],
+      "@voyant-travel/finance/booking-settlement": [
+        "../finance/dist/service-booking-settlement.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/catalog/tsconfig.build.json
+++ b/packages/catalog/tsconfig.build.json
@@ -993,6 +993,9 @@
       "@voyant-travel/finance/booking-schedule-subscriber": [
         "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
       ],
+      "@voyant-travel/finance/booking-settlement": [
+        "../finance/dist/service-booking-settlement.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/catalog/tsconfig.typecheck.json
+++ b/packages/catalog/tsconfig.typecheck.json
@@ -994,6 +994,9 @@
       "@voyant-travel/finance/booking-schedule-subscriber": [
         "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
       ],
+      "@voyant-travel/finance/booking-settlement": [
+        "../finance/dist/service-booking-settlement.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -1004,6 +1004,9 @@
       "@voyant-travel/finance/booking-schedule-subscriber": [
         "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
       ],
+      "@voyant-travel/finance/booking-settlement": [
+        "../finance/dist/service-booking-settlement.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -998,6 +998,9 @@
       "@voyant-travel/finance/booking-schedule-subscriber": [
         "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
       ],
+      "@voyant-travel/finance/booking-settlement": [
+        "../finance/dist/service-booking-settlement.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -1049,6 +1049,9 @@
       "@voyant-travel/finance/booking-schedule-subscriber": [
         "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
       ],
+      "@voyant-travel/finance/booking-settlement": [
+        "../finance/dist/service-booking-settlement.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -1050,6 +1050,9 @@
       "@voyant-travel/finance/booking-schedule-subscriber": [
         "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
       ],
+      "@voyant-travel/finance/booking-settlement": [
+        "../finance/dist/service-booking-settlement.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -1053,6 +1053,9 @@
       "@voyant-travel/finance/booking-schedule-subscriber": [
         "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
       ],
+      "@voyant-travel/finance/booking-settlement": [
+        "../finance/dist/service-booking-settlement.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -1054,6 +1054,9 @@
       "@voyant-travel/finance/booking-schedule-subscriber": [
         "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
       ],
+      "@voyant-travel/finance/booking-settlement": [
+        "../finance/dist/service-booking-settlement.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -1085,6 +1085,9 @@
       "@voyant-travel/finance/booking-schedule-subscriber": [
         "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
       ],
+      "@voyant-travel/finance/booking-settlement": [
+        "../finance/dist/service-booking-settlement.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -1080,6 +1080,9 @@
       "@voyant-travel/finance/booking-schedule-subscriber": [
         "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
       ],
+      "@voyant-travel/finance/booking-settlement": [
+        "../finance/dist/service-booking-settlement.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/finance/package.json
+++ b/packages/finance/package.json
@@ -12,6 +12,7 @@
     "./checkout-routes": "./src/checkout-routes.ts",
     "./checkout-validation": "./src/checkout-validation.ts",
     "./invoice-fx": "./src/invoice-fx.ts",
+    "./booking-settlement": "./src/service-booking-settlement.ts",
     "./service-invoice-core": "./src/service-invoice-core.ts",
     "./reporting": "./src/reporting.ts",
     "./order-payment-sessions": "./src/order-payment-sessions.ts",
@@ -130,6 +131,11 @@
         "types": "./dist/invoice-fx.d.ts",
         "import": "./dist/invoice-fx.js",
         "default": "./dist/invoice-fx.js"
+      },
+      "./booking-settlement": {
+        "types": "./dist/service-booking-settlement.d.ts",
+        "import": "./dist/service-booking-settlement.js",
+        "default": "./dist/service-booking-settlement.js"
       },
       "./service-invoice-core": {
         "types": "./dist/service-invoice-core.d.ts",

--- a/packages/finance/src/service-booking-settlement.ts
+++ b/packages/finance/src/service-booking-settlement.ts
@@ -1,0 +1,210 @@
+import { and, asc, desc, eq, ne } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import { bookingPaymentSchedules, invoices, payments } from "./schema.js"
+
+type PaymentRow = typeof payments.$inferSelect
+type InvoiceRow = typeof invoices.$inferSelect
+type ScheduleRow = typeof bookingPaymentSchedules.$inferSelect
+
+/** The most recent completed customer payment recorded against a booking. */
+export interface BookingSettlementPayment {
+  method: PaymentRow["paymentMethod"]
+  /** Calendar date the payment was recorded on (`YYYY-MM-DD`). */
+  date: string
+  amountCents: number
+  currency: string
+}
+
+/**
+ * A scheduled installment that still stands. `cancelled`, `waived` and
+ * `expired` rows are excluded — an obligation the operator withdrew is not
+ * something a document may present as owed.
+ */
+export interface BookingSettlementInstallment {
+  type: ScheduleRow["scheduleType"]
+  status: ScheduleRow["status"]
+  amountCents: number
+  currency: string
+  dueDate: string
+}
+
+/**
+ * What a booking currently owes and has paid.
+ *
+ * Two different amounts sit close together here and mean opposite things:
+ * `balanceDueCents` is payment-aware and drops to 0 once the booking is
+ * settled, while `balanceAmountCents` is the GROSS scheduled balance
+ * installment and never moves. Renderers that confuse the two tell the
+ * customer they owe money they already paid.
+ */
+export interface BookingSettlement {
+  /** Currency every amount below is expressed in. */
+  currency: string
+  /** Sum of completed payments against the booking's non-void invoices. */
+  paidAmountCents: number
+  /**
+   * Remaining balance across the booking's non-void invoices, or `null` when
+   * the booking has no invoice at all. An absent invoice is not a zero
+   * balance, and callers that flatten it to one report settled bookings that
+   * were never billed.
+   */
+  balanceDueCents: number | null
+  /** Amount still owed: the invoice balance, or the total less payments. */
+  amountDueCents: number
+  isPaidInFull: boolean
+  latestCompletedPayment: BookingSettlementPayment | null
+  /** Installments that still stand, oldest due date first. */
+  installments: BookingSettlementInstallment[]
+  /** Gross scheduled deposit installment. Not reduced by payments. */
+  depositAmountCents: number
+  depositDueDate: string | null
+  /** Gross scheduled balance installment. Not the remaining amount owed. */
+  balanceAmountCents: number
+  balanceDueDate: string | null
+}
+
+export interface GetBookingSettlementOptions {
+  /**
+   * Currency to express amounts in. Defaults to the first non-void invoice's
+   * currency. Rows in another currency contribute their base-currency amount
+   * when that matches, and nothing otherwise.
+   */
+  currency?: string
+  /**
+   * Booking sell total. Used only to derive `amountDueCents` when the booking
+   * has no invoice yet, where there is no balance to read.
+   */
+  bookingTotalCents?: number
+}
+
+/** Schedule rows a document may still present as an obligation. */
+const STANDING_SCHEDULE_STATUSES = new Set<ScheduleRow["status"]>(["pending", "due", "paid"])
+
+export const financeBookingSettlementService = {
+  /**
+   * Resolve a booking's settlement state — what has been paid, what is still
+   * owed, and the installments behind it.
+   *
+   * This is the single answer for every surface that states settlement to a
+   * customer (contracts, notifications, the portal). Recomputing it per caller
+   * is how one document came to say "you owe -" on a booking paid in full
+   * (voyant#4690).
+   */
+  async getBookingSettlement(
+    db: PostgresJsDatabase,
+    bookingId: string,
+    options: GetBookingSettlementOptions = {},
+  ): Promise<BookingSettlement> {
+    const [invoiceRows, scheduleRows] = await Promise.all([
+      db
+        .select({
+          currency: invoices.currency,
+          baseCurrency: invoices.baseCurrency,
+          balanceDueCents: invoices.balanceDueCents,
+          baseBalanceDueCents: invoices.baseBalanceDueCents,
+        })
+        .from(invoices)
+        .where(and(eq(invoices.bookingId, bookingId), ne(invoices.status, "void"))),
+      db
+        .select()
+        .from(bookingPaymentSchedules)
+        .where(eq(bookingPaymentSchedules.bookingId, bookingId))
+        .orderBy(asc(bookingPaymentSchedules.dueDate), asc(bookingPaymentSchedules.createdAt)),
+    ])
+
+    const currency = options.currency || invoiceRows[0]?.currency || ""
+
+    const completedPayments = await db
+      .select({
+        amountCents: payments.amountCents,
+        currency: payments.currency,
+        baseCurrency: payments.baseCurrency,
+        baseAmountCents: payments.baseAmountCents,
+        paymentMethod: payments.paymentMethod,
+        paymentDate: payments.paymentDate,
+      })
+      .from(payments)
+      .innerJoin(invoices, eq(payments.invoiceId, invoices.id))
+      .where(
+        and(
+          eq(invoices.bookingId, bookingId),
+          ne(invoices.status, "void"),
+          eq(payments.status, "completed"),
+        ),
+      )
+      .orderBy(desc(payments.paymentDate), desc(payments.createdAt))
+
+    const paidAmountCents = completedPayments.reduce(
+      (sum, payment) => sum + paymentAmountInCurrency(payment, currency),
+      0,
+    )
+    const balanceDueCents =
+      invoiceRows.length > 0
+        ? invoiceRows.reduce((sum, invoice) => sum + invoiceBalanceInCurrency(invoice, currency), 0)
+        : null
+    const bookingTotalCents = options.bookingTotalCents ?? 0
+    // An invoice is the authority on what is owed. Without one, fall back to
+    // the booking's own total less what has been paid — an overpayment or a
+    // credit note must not surface as a negative amount owed.
+    const amountDueCents =
+      balanceDueCents != null
+        ? Math.max(0, balanceDueCents)
+        : Math.max(0, bookingTotalCents - paidAmountCents)
+    const isPaidInFull = amountDueCents <= 0
+
+    const standing = scheduleRows.filter((row) => STANDING_SCHEDULE_STATUSES.has(row.status))
+    const deposit = standing.find((row) => row.scheduleType === "deposit")
+    const balance = standing.find((row) => row.scheduleType === "balance")
+    const latest = completedPayments[0]
+
+    return {
+      currency,
+      paidAmountCents,
+      balanceDueCents,
+      amountDueCents,
+      isPaidInFull,
+      latestCompletedPayment: latest
+        ? {
+            method: latest.paymentMethod,
+            date: latest.paymentDate,
+            amountCents: latest.amountCents,
+            currency: latest.currency,
+          }
+        : null,
+      installments: standing.map((row) => ({
+        type: row.scheduleType,
+        status: row.status,
+        amountCents: row.amountCents,
+        currency: row.currency,
+        dueDate: row.dueDate,
+      })),
+      depositAmountCents: deposit?.amountCents ?? 0,
+      depositDueDate: deposit?.dueDate ?? null,
+      balanceAmountCents: balance?.amountCents ?? 0,
+      balanceDueDate: balance?.dueDate ?? null,
+    }
+  },
+}
+
+type SettlementPaymentRow = Pick<
+  PaymentRow,
+  "amountCents" | "currency" | "baseCurrency" | "baseAmountCents"
+>
+
+type SettlementInvoiceRow = Pick<
+  InvoiceRow,
+  "currency" | "baseCurrency" | "balanceDueCents" | "baseBalanceDueCents"
+>
+
+function paymentAmountInCurrency(payment: SettlementPaymentRow, currency: string): number {
+  if (!currency || payment.currency === currency) return payment.amountCents
+  if (payment.baseCurrency === currency) return payment.baseAmountCents ?? 0
+  return 0
+}
+
+function invoiceBalanceInCurrency(invoice: SettlementInvoiceRow, currency: string): number {
+  if (!currency || invoice.currency === currency) return invoice.balanceDueCents
+  if (invoice.baseCurrency === currency) return invoice.baseBalanceDueCents ?? 0
+  return 0
+}

--- a/packages/finance/src/service-booking-settlement.ts
+++ b/packages/finance/src/service-booking-settlement.ts
@@ -41,18 +41,22 @@ export interface BookingSettlementInstallment {
 export interface BookingSettlement {
   /** Currency every amount below is expressed in. */
   currency: string
-  /** Sum of completed payments against the booking's non-void invoices. */
+  /**
+   * Completed payments against the booking's non-void invoices, net of money
+   * moved back out against a credit note.
+   */
   paidAmountCents: number
   /**
-   * Remaining balance across the booking's non-void invoices, or `null` when
-   * the booking has no invoice at all. An absent invoice is not a zero
-   * balance, and callers that flatten it to one report settled bookings that
-   * were never billed.
+   * Net receivable across the booking's non-void invoices — credit notes
+   * subtract — or `null` when the booking has no invoice at all. An absent
+   * invoice is not a zero balance, and callers that flatten it to one report
+   * settled bookings that were never billed.
    */
   balanceDueCents: number | null
   /** Amount still owed: the invoice balance, or the total less payments. */
   amountDueCents: number
   isPaidInFull: boolean
+  /** Most recent customer payment. Never a credit-note refund. */
   latestCompletedPayment: BookingSettlementPayment | null
   /** Installments that still stand, oldest due date first. */
   installments: BookingSettlementInstallment[]
@@ -99,6 +103,7 @@ export const financeBookingSettlementService = {
     const [invoiceRows, scheduleRows] = await Promise.all([
       db
         .select({
+          invoiceType: invoices.invoiceType,
           currency: invoices.currency,
           baseCurrency: invoices.baseCurrency,
           balanceDueCents: invoices.balanceDueCents,
@@ -117,6 +122,7 @@ export const financeBookingSettlementService = {
 
     const completedPayments = await db
       .select({
+        invoiceType: invoices.invoiceType,
         amountCents: payments.amountCents,
         currency: payments.currency,
         baseCurrency: payments.baseCurrency,
@@ -135,13 +141,22 @@ export const financeBookingSettlementService = {
       )
       .orderBy(desc(payments.paymentDate), desc(payments.createdAt))
 
-    const paidAmountCents = completedPayments.reduce(
-      (sum, payment) => sum + paymentAmountInCurrency(payment, currency),
+    const paidAmountCents = Math.max(
       0,
+      completedPayments.reduce(
+        (sum, payment) =>
+          sum + receivableSign(payment.invoiceType) * paymentAmountInCurrency(payment, currency),
+        0,
+      ),
     )
     const balanceDueCents =
       invoiceRows.length > 0
-        ? invoiceRows.reduce((sum, invoice) => sum + invoiceBalanceInCurrency(invoice, currency), 0)
+        ? invoiceRows.reduce(
+            (sum, invoice) =>
+              sum +
+              receivableSign(invoice.invoiceType) * invoiceBalanceInCurrency(invoice, currency),
+            0,
+          )
         : null
     const bookingTotalCents = options.bookingTotalCents ?? 0
     // An invoice is the authority on what is owed. Without one, fall back to
@@ -156,7 +171,7 @@ export const financeBookingSettlementService = {
     const standing = scheduleRows.filter((row) => STANDING_SCHEDULE_STATUSES.has(row.status))
     const deposit = standing.find((row) => row.scheduleType === "deposit")
     const balance = standing.find((row) => row.scheduleType === "balance")
-    const latest = completedPayments[0]
+    const latest = completedPayments.find((payment) => receivableSign(payment.invoiceType) === 1)
 
     return {
       currency,
@@ -196,6 +211,16 @@ type SettlementInvoiceRow = Pick<
   InvoiceRow,
   "currency" | "baseCurrency" | "balanceDueCents" | "baseBalanceDueCents"
 >
+
+/**
+ * Which way a document moves the receivable. A credit note is a negative
+ * receivable — `service-profitability` applies the same sign to its totals —
+ * so summing its balance as debt would tell a customer whose invoice was
+ * credited that they still owe the credited amount.
+ */
+function receivableSign(invoiceType: InvoiceRow["invoiceType"]): 1 | -1 {
+  return invoiceType === "credit_note" ? -1 : 1
+}
 
 function paymentAmountInCurrency(payment: SettlementPaymentRow, currency: string): number {
   if (!currency || payment.currency === currency) return payment.amountCents

--- a/packages/finance/src/service.ts
+++ b/packages/finance/src/service.ts
@@ -1,5 +1,6 @@
 import { getFinanceAggregates } from "./service-aggregates.js"
 import { financeBookingBillingService } from "./service-booking-billing.js"
+import { financeBookingSettlementService } from "./service-booking-settlement.js"
 import { costCategoriesService } from "./service-cost-categories.js"
 import { financeInvoiceArtifactService } from "./service-invoice-artifacts.js"
 import { financeInvoiceNumberingService } from "./service-invoice-numbering.js"
@@ -30,6 +31,7 @@ export const financeService = {
   refundSettlements: financeRefundSettlementService,
   ...financePaymentProcessingService,
   ...financeBookingBillingService,
+  ...financeBookingSettlementService,
   ...financeReportService,
   ...financeSupplierPaymentService,
   ...financeInvoiceService,

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -1097,6 +1097,9 @@
       "@voyant-travel/finance/booking-schedule-subscriber": [
         "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
       ],
+      "@voyant-travel/finance/booking-settlement": [
+        "../finance/dist/service-booking-settlement.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -1098,6 +1098,9 @@
       "@voyant-travel/finance/booking-schedule-subscriber": [
         "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
       ],
+      "@voyant-travel/finance/booking-settlement": [
+        "../finance/dist/service-booking-settlement.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -1103,6 +1103,9 @@
       "@voyant-travel/finance/booking-schedule-subscriber": [
         "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
       ],
+      "@voyant-travel/finance/booking-settlement": [
+        "../finance/dist/service-booking-settlement.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -1098,6 +1098,9 @@
       "@voyant-travel/finance/booking-schedule-subscriber": [
         "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
       ],
+      "@voyant-travel/finance/booking-settlement": [
+        "../finance/dist/service-booking-settlement.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/inventory/tsconfig.build.json
+++ b/packages/inventory/tsconfig.build.json
@@ -1097,6 +1097,9 @@
       "@voyant-travel/finance/booking-schedule-subscriber": [
         "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
       ],
+      "@voyant-travel/finance/booking-settlement": [
+        "../finance/dist/service-booking-settlement.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/inventory/tsconfig.typecheck.json
+++ b/packages/inventory/tsconfig.typecheck.json
@@ -1098,6 +1098,9 @@
       "@voyant-travel/finance/booking-schedule-subscriber": [
         "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
       ],
+      "@voyant-travel/finance/booking-settlement": [
+        "../finance/dist/service-booking-settlement.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/legal/src/booking-contract-confirmed.ts
+++ b/packages/legal/src/booking-contract-confirmed.ts
@@ -22,6 +22,10 @@ import {
   resolveBookingContractLanguage,
 } from "./booking-contract-review.js"
 import {
+  type BookingContractSettlement,
+  resolveBookingContractSettlement,
+} from "./booking-contract-settlement.js"
+import {
   bookingContractAcceptanceContentDigest,
   isBookingContractAcceptanceContentDigest,
 } from "./contract-acceptance.js"
@@ -440,7 +444,15 @@ async function prepareBookingContractTarget(
   // had deliberately fallen back to, which on a single-language deployment is
   // the only template there is (voyant#4650).
   const language = selected.template.language
-  const variables = bookingContractVariables(booking, items, travelers)
+  // Settlement is read after the template is chosen because the payment
+  // method label is written in the contract's language, and the contract's
+  // language is the template's — not the shopper's preference.
+  const settlement = await resolveBookingContractSettlement(db, bookingId, {
+    currency: booking.sellCurrency,
+    totalAmountCents: booking.sellAmountCents,
+    language,
+  })
+  const variables = bookingContractVariables(booking, items, travelers, settlement)
   const missingPrerequisites = bookingContractPrerequisites({
     templateApplicable:
       reusable?.templateVersionId === selected.version.id ||
@@ -751,6 +763,7 @@ export function bookingContractVariables(
   booking: BookingContractReviewInput["booking"],
   items: BookingContractReviewInput["items"],
   travelers: Awaited<ReturnType<typeof bookingsService.listTravelers>>,
+  settlement: BookingContractSettlement,
   now = new Date(),
 ): Record<string, unknown> {
   const primaryProduct = items[0]
@@ -807,6 +820,18 @@ export function bookingContractVariables(
       currency: booking.sellCurrency,
       sellAmountCents: booking.sellAmountCents,
       totalAmountCents: booking.sellAmountCents,
+      // Settlement. `balanceDueCents` / `amountDueCents` are payment-aware and
+      // reach 0 once the booking is settled; `balanceAmountCents` is the gross
+      // scheduled balance installment and never moves. A payment clause that
+      // binds the wrong one bills a customer who has already paid.
+      paidAmountCents: settlement.paidAmountCents,
+      amountDueCents: settlement.amountDueCents,
+      balanceDueCents: settlement.amountDueCents,
+      isPaidInFull: settlement.isPaidInFull,
+      depositAmountCents: settlement.depositAmountCents,
+      depositDueDate: settlement.depositDueDate,
+      balanceAmountCents: settlement.balanceAmountCents,
+      balanceDueDate: settlement.balanceDueDate,
       items: normalizedItems,
     },
     customer: {
@@ -835,6 +860,14 @@ export function bookingContractVariables(
     payment: {
       amountCents: booking.sellAmountCents,
       currency: booking.sellCurrency,
+      isPaidInFull: settlement.isPaidInFull,
+      paidAmountCents: settlement.paidAmountCents,
+      balanceDueCents: settlement.amountDueCents,
+      method: settlement.latestCompleted?.methodLabel ?? "",
+      capturedAt: settlement.latestCompleted?.date ?? "",
+      createdAt: settlement.latestCompleted?.date ?? "",
+      latestCompleted: settlement.latestCompleted,
+      schedule: settlement.schedule,
     },
     product: {
       title: primaryProduct?.productNameSnapshot ?? primaryProduct?.title ?? null,

--- a/packages/legal/src/booking-contract-confirmed.ts
+++ b/packages/legal/src/booking-contract-confirmed.ts
@@ -23,6 +23,7 @@ import {
 } from "./booking-contract-review.js"
 import {
   type BookingContractSettlement,
+  bookingContractPreviewSettlement,
   resolveBookingContractSettlement,
 } from "./booking-contract-settlement.js"
 import {
@@ -503,6 +504,23 @@ async function prepareBookingContractTarget(
     body: selected.version.body,
     variables: bookingContractAcceptanceVariables(variables),
   })
+  // Settlement moves between the two too, and stripping identity does not
+  // undo it: a card booking is paid by the time `booking.confirmed` lands, so
+  // a template that binds the payment clause renders "paid in full" here and
+  // rendered "nothing paid yet" for the shopper. Offer that reading as a
+  // third candidate so the acceptance stays recoverable on exactly the
+  // bookings the storefront settles up front.
+  const acceptancePreviewRenderedBody = contractsService.renderPreview({
+    body: selected.version.body,
+    variables: bookingContractAcceptanceVariables(
+      bookingContractVariables(
+        booking,
+        items,
+        travelers,
+        bookingContractPreviewSettlement(settlement, booking.sellAmountCents),
+      ),
+    ),
+  })
   const priorMetadata = record(reusable?.metadata)
   const pendingAcceptance = await bookingContractAcceptanceMetadata({
     internalNotes: booking.internalNotes,
@@ -510,7 +528,7 @@ async function prepareBookingContractTarget(
     templateVersionId: selected.version.id,
     templateSlug: selected.template.slug,
     renderedBody,
-    additionalRenderedBodies: [acceptanceRenderedBody],
+    additionalRenderedBodies: [acceptanceRenderedBody, acceptancePreviewRenderedBody],
   })
   const acceptance = priorMetadata.acceptance ?? pendingAcceptance ?? undefined
   const paymentConfirmation =

--- a/packages/legal/src/booking-contract-settlement.ts
+++ b/packages/legal/src/booking-contract-settlement.ts
@@ -1,0 +1,143 @@
+import {
+  type BookingSettlement,
+  financeBookingSettlementService,
+} from "@voyant-travel/finance/booking-settlement"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+/**
+ * The settlement half of a booking contract's variable bag.
+ *
+ * Kept as an explicit input to `bookingContractVariables` rather than read
+ * inside it: the bag is a pure projection, and a payment clause that renders
+ * from whatever the function happened to have in scope is exactly how the
+ * auto-generated contract came to tell settled customers they owed an
+ * unspecified balance (voyant#4690).
+ */
+export interface BookingContractSettlement {
+  paidAmountCents: number
+  /** Payment-aware remaining amount. 0 once the booking is settled. */
+  amountDueCents: number
+  isPaidInFull: boolean
+  /** Gross scheduled deposit installment. Not reduced by payments. */
+  depositAmountCents: number
+  depositDueDate: string
+  /** Gross scheduled balance installment. Not the remaining amount owed. */
+  balanceAmountCents: number
+  balanceDueDate: string
+  schedule: Array<{
+    index: number
+    type: string
+    status: string
+    amountCents: number
+    currency: string
+    dueDate: string
+  }>
+  latestCompleted: {
+    method: string
+    methodLabel: string
+    date: string
+  } | null
+}
+
+/**
+ * A booking with nothing settled and nothing scheduled. Used when the
+ * contract is prepared without a settlement lookup — every field is present
+ * and numeric, so the payment clause renders "0 paid" rather than the
+ * missing-value placeholder.
+ */
+export const EMPTY_BOOKING_CONTRACT_SETTLEMENT: BookingContractSettlement = {
+  paidAmountCents: 0,
+  amountDueCents: 0,
+  isPaidInFull: false,
+  depositAmountCents: 0,
+  depositDueDate: "",
+  balanceAmountCents: 0,
+  balanceDueDate: "",
+  schedule: [],
+  latestCompleted: null,
+}
+
+/**
+ * Read the booking's settlement state through Finance and shape it for the
+ * contract renderer. Finance owns what is paid and what is owed; this only
+ * localizes the method label and flattens nulls to the empty string the
+ * renderer already treats as "missing".
+ */
+export async function resolveBookingContractSettlement(
+  db: PostgresJsDatabase,
+  bookingId: string,
+  options: { currency?: string | null; totalAmountCents?: number | null; language: string },
+): Promise<BookingContractSettlement> {
+  const settlement = await financeBookingSettlementService.getBookingSettlement(db, bookingId, {
+    currency: options.currency ?? undefined,
+    bookingTotalCents: options.totalAmountCents ?? 0,
+  })
+  return toBookingContractSettlement(settlement, options.language)
+}
+
+export function toBookingContractSettlement(
+  settlement: BookingSettlement,
+  language: string,
+): BookingContractSettlement {
+  return {
+    paidAmountCents: settlement.paidAmountCents,
+    amountDueCents: settlement.amountDueCents,
+    isPaidInFull: settlement.isPaidInFull,
+    depositAmountCents: settlement.depositAmountCents,
+    depositDueDate: settlement.depositDueDate ?? "",
+    balanceAmountCents: settlement.balanceAmountCents,
+    balanceDueDate: settlement.balanceDueDate ?? "",
+    schedule: settlement.installments.map((installment, index) => ({
+      index: index + 1,
+      type: installment.type,
+      status: installment.status,
+      amountCents: installment.amountCents,
+      currency: installment.currency,
+      dueDate: installment.dueDate,
+    })),
+    latestCompleted: settlement.latestCompletedPayment
+      ? {
+          method: settlement.latestCompletedPayment.method,
+          methodLabel: formatPaymentMethodLabel(settlement.latestCompletedPayment.method, language),
+          date: settlement.latestCompletedPayment.date,
+        }
+      : null,
+  }
+}
+
+const paymentMethodLabelsByLanguage: Record<string, Record<string, string>> = {
+  en: {
+    bank_transfer: "Bank Transfer",
+    credit_card: "Credit Card",
+    debit_card: "Debit Card",
+    cash: "Cash",
+    cheque: "Cheque",
+    wallet: "Wallet",
+    direct_bill: "Direct Bill",
+    voucher: "Voucher",
+    other: "Other",
+  },
+  ro: {
+    bank_transfer: "Transfer bancar",
+    credit_card: "Card de credit",
+    debit_card: "Card de debit",
+    cash: "Numerar",
+    cheque: "Cec",
+    wallet: "Portofel",
+    direct_bill: "Facturare directa",
+    voucher: "Voucher",
+    other: "Alta",
+  },
+}
+
+export function formatPaymentMethodLabel(method: string, language: string): string {
+  const locale = language.trim().toLowerCase().split(/[-_]/)[0] || "en"
+  const localizedLabel = paymentMethodLabelsByLanguage[locale]?.[method]
+  if (localizedLabel) return localizedLabel
+
+  return method
+    .split("_")
+    .filter(Boolean)
+    .map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`)
+    .join(" ")
+}

--- a/packages/legal/src/booking-contract-settlement.ts
+++ b/packages/legal/src/booking-contract-settlement.ts
@@ -58,6 +58,36 @@ export const EMPTY_BOOKING_CONTRACT_SETTLEMENT: BookingContractSettlement = {
 }
 
 /**
+ * Settlement as the shopper saw it when they accepted the terms at checkout:
+ * nothing paid, the whole price outstanding, and every installment still
+ * pending. That is what `resolveContractVariables` emits in the storefront
+ * preview, and the acceptance evidence is a digest over the body rendered
+ * from it.
+ *
+ * The canonical contract must state the truth at confirmation — a booking
+ * paid by card is paid by the time `booking.confirmed` lands. So the two
+ * bodies legitimately differ, and matching the stored digest needs a
+ * candidate rendered the shopper's way, not the settled bag with a few
+ * fields deleted (voyant#4700 review).
+ */
+export function bookingContractPreviewSettlement(
+  settlement: BookingContractSettlement,
+  totalAmountCents: number | null | undefined,
+): BookingContractSettlement {
+  return {
+    ...settlement,
+    paidAmountCents: 0,
+    amountDueCents: totalAmountCents ?? 0,
+    isPaidInFull: false,
+    latestCompleted: null,
+    schedule: settlement.schedule.map((installment) => ({
+      ...installment,
+      status: "pending",
+    })),
+  }
+}
+
+/**
  * Read the booking's settlement state through Finance and shape it for the
  * contract renderer. Finance owns what is paid and what is owed; this only
  * localizes the method label and flattens nulls to the empty string the

--- a/packages/legal/src/contracts/template-authoring.ts
+++ b/packages/legal/src/contracts/template-authoring.ts
@@ -615,6 +615,36 @@ export const contractTemplateVariableCatalog: ContractTemplateVariableCategory[]
         description: "Alias for `payment.capturedAt`.",
       },
       {
+        key: "payment.paidAmountCents",
+        label: "Paid so far (alias)",
+        example: "50000",
+        type: "cents",
+        description: "Alias for `booking.paidAmountCents`.",
+      },
+      {
+        key: "payment.balanceDueCents",
+        label: "Balance due (alias)",
+        example: "199900",
+        type: "cents",
+        description: "Alias for `booking.balanceDueCents`. Payment-aware; 0 once settled.",
+      },
+      {
+        key: "payment.isPaidInFull",
+        label: "Paid in full (alias)",
+        example: "false",
+        type: "boolean",
+        description: "Alias for `booking.isPaidInFull`.",
+      },
+      {
+        key: "payment.schedule",
+        label: "Installments",
+        example: "[]",
+        type: "loop",
+        description:
+          "Installments that still stand, oldest due date first. Loop with " +
+          "`{% for line in payment.schedule %}`; cancelled, waived and expired rows are excluded.",
+      },
+      {
         key: "payment.latestCompleted.method",
         label: "Latest payment method",
         example: "bank_transfer",

--- a/packages/legal/tests/integration/booking-contract-confirmed.test.ts
+++ b/packages/legal/tests/integration/booking-contract-confirmed.test.ts
@@ -3,6 +3,7 @@ import { bookingItems, bookings, bookingTravelers } from "@voyant-travel/booking
 import { createEventBus } from "@voyant-travel/core"
 import { createDbClient } from "@voyant-travel/db"
 import { cleanupTestDb } from "@voyant-travel/db/test-utils"
+import { bookingPaymentSchedules, invoices, payments } from "@voyant-travel/finance/schema"
 import { eq } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
@@ -564,5 +565,190 @@ describe.skipIf(!DB_AVAILABLE)("booking-confirmed contract generation", () => {
     expect(detail!.summary).toContain('preferred language "en"')
     expect(detail!.summary).toContain('selected template "Contract de comercializare" in "ro"')
     expect(detail!.summary).toContain("booking channel none")
+  })
+
+  // voyant#4690: the auto-generated bag carried the booking's list price and
+  // nothing about settlement, so a payment clause branching on
+  // `booking.isPaidInFull` took the `else` arm on every contract and printed
+  // the missing-value placeholder for each amount — telling a customer who had
+  // paid in full that they owed "-". Drive the real subscriber so the
+  // assertion is on the persisted rendered body, not on a hand-built bag.
+  it("renders the payment clause from settlement on a booking paid in full", async () => {
+    const [booking] = await db
+      .insert(bookings)
+      .values({
+        bookingNumber: "BK-AUTO-CONTRACT-PAID",
+        status: "confirmed",
+        contactFirstName: "Ana",
+        contactLastName: "Pop",
+        contactEmail: "ana@example.test",
+        contactPreferredLanguage: "en",
+        sellCurrency: "EUR",
+        sellAmountCents: 500_00,
+        startDate: "2026-09-01",
+        endDate: "2026-09-07",
+        pax: 1,
+      })
+      .returning()
+    await db.insert(bookingItems).values({
+      bookingId: booking!.id,
+      title: "Autumn tour",
+      status: "confirmed",
+      productNameSnapshot: "Autumn tour",
+      quantity: 1,
+      sellCurrency: "EUR",
+      totalSellAmountCents: 500_00,
+    })
+    const [invoice] = await db
+      .insert(invoices)
+      .values({
+        invoiceNumber: "INV-4690-1",
+        bookingId: booking!.id,
+        status: "paid",
+        currency: "EUR",
+        subtotalCents: 500_00,
+        totalCents: 500_00,
+        paidCents: 500_00,
+        balanceDueCents: 0,
+        issueDate: "2026-08-01",
+        dueDate: "2026-08-10",
+      })
+      .returning()
+    // A voided invoice must not resurrect a balance the customer has settled.
+    await db.insert(invoices).values({
+      invoiceNumber: "PRO-4690-1",
+      bookingId: booking!.id,
+      invoiceType: "proforma",
+      status: "void",
+      currency: "EUR",
+      subtotalCents: 500_00,
+      totalCents: 500_00,
+      balanceDueCents: 500_00,
+      issueDate: "2026-07-20",
+      dueDate: "2026-08-10",
+    })
+    await db.insert(payments).values([
+      {
+        invoiceId: invoice!.id,
+        amountCents: 200_00,
+        currency: "EUR",
+        paymentMethod: "bank_transfer",
+        status: "completed",
+        paymentDate: "2026-08-02",
+      },
+      {
+        invoiceId: invoice!.id,
+        amountCents: 300_00,
+        currency: "EUR",
+        paymentMethod: "credit_card",
+        status: "completed",
+        paymentDate: "2026-08-05",
+      },
+      // Not completed, so it must not count toward what has been paid.
+      {
+        invoiceId: invoice!.id,
+        amountCents: 999_00,
+        currency: "EUR",
+        paymentMethod: "cash",
+        status: "pending",
+        paymentDate: "2026-08-06",
+      },
+    ])
+    await db.insert(bookingPaymentSchedules).values([
+      {
+        bookingId: booking!.id,
+        scheduleType: "deposit",
+        status: "paid",
+        dueDate: "2026-08-01",
+        currency: "EUR",
+        amountCents: 200_00,
+      },
+      {
+        bookingId: booking!.id,
+        scheduleType: "balance",
+        status: "paid",
+        dueDate: "2026-08-05",
+        currency: "EUR",
+        amountCents: 300_00,
+      },
+      // Withdrawn obligations are not something a contract may present.
+      {
+        bookingId: booking!.id,
+        scheduleType: "installment",
+        status: "cancelled",
+        dueDate: "2026-08-09",
+        currency: "EUR",
+        amountCents: 100_00,
+      },
+    ])
+
+    const body =
+      "{% if booking.isPaidInFull %}Paid in full: {{ booking.paidAmountCents | cents: booking.currency }}" +
+      "{% else %}Deposit {{ booking.paidAmountCents | cents: booking.currency }}, " +
+      "balance {{ booking.balanceDueCents | cents: booking.currency }} by {{ booking.balanceDueDate }}" +
+      "{% endif %} via {{ payment.method }} on {{ payment.latestCompleted.date }}" +
+      " over {{ payment.schedule.size }} installments"
+    const [template] = await db
+      .insert(contractTemplates)
+      .values({
+        name: "Customer agreement",
+        slug: "customer-agreement-settlement",
+        scope: "customer",
+        language: "en",
+        body,
+        active: true,
+        isDefault: true,
+      })
+      .returning()
+    const [version] = await db
+      .insert(contractTemplateVersions)
+      .values({ templateId: template!.id, version: 1, body, variableSchema: {} })
+      .returning()
+    await db
+      .update(contractTemplates)
+      .set({ currentVersionId: version!.id })
+      .where(eq(contractTemplates.id, template!.id))
+    await db.insert(contractNumberSeries).values({
+      name: "Customer contracts",
+      prefix: "CTR",
+      scope: "customer",
+      isDefault: true,
+      active: true,
+      currentSequence: 0,
+      padLength: 5,
+      separator: "-",
+      resetStrategy: "never",
+    })
+
+    const eventBus = createEventBus({ handlerTimeoutMs: false })
+    await createLegalBookingContractConfirmedSubscriber({
+      resolveDb: async () => db,
+      provider: provider(),
+    }).register({ bindings: {}, container: {} as never, eventBus })
+    await eventBus.emit(
+      "booking.confirmed",
+      {
+        bookingId: booking!.id,
+        bookingNumber: booking!.bookingNumber,
+        actorId: null,
+      } satisfies LegalBookingConfirmedPayload,
+      {
+        eventId: `evt_finance_booking_confirmed_${booking!.id}`,
+        category: "domain",
+        source: "service",
+      },
+    )
+
+    const contractRows = await db
+      .select()
+      .from(contracts)
+      .where(eq(contracts.bookingId, booking!.id))
+    expect(contractRows).toHaveLength(1)
+    // Two completed payments, the pending one excluded; the cancelled
+    // installment excluded from the schedule; the void proforma excluded from
+    // the balance.
+    expect(contractRows[0]!.renderedBody).toBe(
+      "Paid in full: €500.00 via Credit Card on 2026-08-05 over 2 installments",
+    )
   })
 })

--- a/packages/legal/tests/integration/booking-contract-confirmed.test.ts
+++ b/packages/legal/tests/integration/booking-contract-confirmed.test.ts
@@ -13,6 +13,7 @@ import {
   type LegalBookingConfirmedPayload,
 } from "../../src/booking-contract-confirmed-subscriber.js"
 import { createCommerceLegalRuntime } from "../../src/commerce-runtime.js"
+import { bookingContractAcceptanceContentDigest } from "../../src/contract-acceptance.js"
 import {
   checksumLegalDocumentBytes,
   LEGAL_DOCUMENT_ARTIFACT_PROVIDER_PROTOCOL,
@@ -750,5 +751,258 @@ describe.skipIf(!DB_AVAILABLE)("booking-confirmed contract generation", () => {
     expect(contractRows[0]!.renderedBody).toBe(
       "Paid in full: €500.00 via Credit Card on 2026-08-05 over 2 installments",
     )
+  })
+
+  // Review of #4700: a credit note is a NEGATIVE receivable — the
+  // profitability rollup signs it the same way. Summing its balance as debt
+  // would tell a customer whose invoice was credited that they owe the
+  // credited amount back.
+  it("nets a credit note out of the balance the contract states", async () => {
+    const [booking] = await db
+      .insert(bookings)
+      .values({
+        bookingNumber: "BK-AUTO-CONTRACT-CREDIT",
+        status: "confirmed",
+        contactFirstName: "Ana",
+        contactLastName: "Pop",
+        contactEmail: "ana@example.test",
+        contactPreferredLanguage: "en",
+        sellCurrency: "EUR",
+        sellAmountCents: 500_00,
+        startDate: "2026-09-01",
+        endDate: "2026-09-07",
+        pax: 1,
+      })
+      .returning()
+    await db.insert(bookingItems).values({
+      bookingId: booking!.id,
+      title: "Autumn tour",
+      status: "confirmed",
+      productNameSnapshot: "Autumn tour",
+      quantity: 1,
+      sellCurrency: "EUR",
+      totalSellAmountCents: 500_00,
+    })
+    await db.insert(invoices).values({
+      invoiceNumber: "INV-4700-1",
+      bookingId: booking!.id,
+      status: "issued",
+      currency: "EUR",
+      subtotalCents: 500_00,
+      totalCents: 500_00,
+      paidCents: 0,
+      balanceDueCents: 500_00,
+      issueDate: "2026-08-01",
+      dueDate: "2026-08-10",
+    })
+    await db.insert(invoices).values({
+      invoiceNumber: "CN-4700-1",
+      bookingId: booking!.id,
+      invoiceType: "credit_note",
+      status: "issued",
+      currency: "EUR",
+      subtotalCents: 200_00,
+      totalCents: 200_00,
+      paidCents: 0,
+      balanceDueCents: 200_00,
+      issueDate: "2026-08-02",
+      dueDate: "2026-08-10",
+    })
+
+    const body = "Outstanding {{ booking.balanceDueCents | cents: booking.currency }}"
+    const [template] = await db
+      .insert(contractTemplates)
+      .values({
+        name: "Customer agreement",
+        slug: "customer-agreement-credit-note",
+        scope: "customer",
+        language: "en",
+        body,
+        active: true,
+        isDefault: true,
+      })
+      .returning()
+    const [version] = await db
+      .insert(contractTemplateVersions)
+      .values({ templateId: template!.id, version: 1, body, variableSchema: {} })
+      .returning()
+    await db
+      .update(contractTemplates)
+      .set({ currentVersionId: version!.id })
+      .where(eq(contractTemplates.id, template!.id))
+    await db.insert(contractNumberSeries).values({
+      name: "Customer contracts",
+      prefix: "CTR",
+      scope: "customer",
+      isDefault: true,
+      active: true,
+      currentSequence: 0,
+      padLength: 5,
+      separator: "-",
+      resetStrategy: "never",
+    })
+
+    const eventBus = createEventBus({ handlerTimeoutMs: false })
+    await createLegalBookingContractConfirmedSubscriber({
+      resolveDb: async () => db,
+      provider: provider(),
+    }).register({ bindings: {}, container: {} as never, eventBus })
+    await eventBus.emit(
+      "booking.confirmed",
+      {
+        bookingId: booking!.id,
+        bookingNumber: booking!.bookingNumber,
+        actorId: null,
+      } satisfies LegalBookingConfirmedPayload,
+      {
+        eventId: `evt_finance_booking_confirmed_${booking!.id}`,
+        category: "domain",
+        source: "service",
+      },
+    )
+
+    const contractRows = await db
+      .select()
+      .from(contracts)
+      .where(eq(contracts.bookingId, booking!.id))
+    // 500 owed less a 200 credit note, not 700.
+    expect(contractRows[0]!.renderedBody).toBe("Outstanding €300.00")
+  })
+
+  // Review of #4700: the acceptance evidence is a digest over the body the
+  // shopper reviewed at checkout, and the shopper reviewed it before paying.
+  // A card booking is settled by the time `booking.confirmed` lands, so
+  // without a preview-shaped candidate the digest stops matching for exactly
+  // the bookings the storefront settles up front — and the accepted contract
+  // never passes the promotion gate.
+  it("recovers a checkout acceptance whose preview predates the payment", async () => {
+    const body =
+      "{% if booking.isPaidInFull %}Paid in full{% else %}" +
+      "Balance {{ booking.balanceDueCents | cents: booking.currency }}{% endif %}"
+    const [template] = await db
+      .insert(contractTemplates)
+      .values({
+        name: "Customer agreement",
+        slug: "customer-agreement-acceptance",
+        scope: "customer",
+        language: "en",
+        body,
+        active: true,
+        isDefault: true,
+      })
+      .returning()
+    const [version] = await db
+      .insert(contractTemplateVersions)
+      .values({ templateId: template!.id, version: 1, body, variableSchema: {} })
+      .returning()
+    await db
+      .update(contractTemplates)
+      .set({ currentVersionId: version!.id })
+      .where(eq(contractTemplates.id, template!.id))
+    await db.insert(contractNumberSeries).values({
+      name: "Customer contracts",
+      prefix: "CTR",
+      scope: "customer",
+      isDefault: true,
+      active: true,
+      currentSequence: 0,
+      padLength: 5,
+      separator: "-",
+      resetStrategy: "never",
+    })
+
+    // What the storefront rendered and the shopper accepted: nothing paid yet.
+    const acceptedBody = "Balance €500.00"
+    const contentDigest = await bookingContractAcceptanceContentDigest({
+      templateId: template!.id,
+      templateVersionId: version!.id,
+      renderedBody: acceptedBody,
+    })
+    const [booking] = await db
+      .insert(bookings)
+      .values({
+        bookingNumber: "BK-AUTO-CONTRACT-ACCEPT",
+        status: "confirmed",
+        contactFirstName: "Ana",
+        contactLastName: "Pop",
+        contactEmail: "ana@example.test",
+        contactPreferredLanguage: "en",
+        sellCurrency: "EUR",
+        sellAmountCents: 500_00,
+        startDate: "2026-09-01",
+        endDate: "2026-09-07",
+        pax: 1,
+        internalNotes: `__contract_acceptance__:${JSON.stringify({
+          acceptedAt: "2026-08-01T09:00:00.000Z",
+          acceptedMarketing: false,
+          templateId: template!.id,
+          templateVersionId: version!.id,
+          contentDigest,
+        })}`,
+      })
+      .returning()
+    await db.insert(bookingItems).values({
+      bookingId: booking!.id,
+      title: "Autumn tour",
+      status: "confirmed",
+      productNameSnapshot: "Autumn tour",
+      quantity: 1,
+      sellCurrency: "EUR",
+      totalSellAmountCents: 500_00,
+    })
+    // …and then the card settled, before the confirmation was delivered.
+    const [invoice] = await db
+      .insert(invoices)
+      .values({
+        invoiceNumber: "INV-4700-2",
+        bookingId: booking!.id,
+        status: "paid",
+        currency: "EUR",
+        subtotalCents: 500_00,
+        totalCents: 500_00,
+        paidCents: 500_00,
+        balanceDueCents: 0,
+        issueDate: "2026-08-01",
+        dueDate: "2026-08-10",
+      })
+      .returning()
+    await db.insert(payments).values({
+      invoiceId: invoice!.id,
+      amountCents: 500_00,
+      currency: "EUR",
+      paymentMethod: "credit_card",
+      status: "completed",
+      paymentDate: "2026-08-01",
+    })
+
+    const eventBus = createEventBus({ handlerTimeoutMs: false })
+    await createLegalBookingContractConfirmedSubscriber({
+      resolveDb: async () => db,
+      provider: provider(),
+    }).register({ bindings: {}, container: {} as never, eventBus })
+    await eventBus.emit(
+      "booking.confirmed",
+      {
+        bookingId: booking!.id,
+        bookingNumber: booking!.bookingNumber,
+        actorId: null,
+      } satisfies LegalBookingConfirmedPayload,
+      {
+        eventId: `evt_finance_booking_confirmed_${booking!.id}`,
+        category: "domain",
+        source: "service",
+      },
+    )
+
+    const [contract] = await db.select().from(contracts).where(eq(contracts.bookingId, booking!.id))
+    // The canonical document states the truth at confirmation…
+    expect(contract!.renderedBody).toBe("Paid in full")
+    // …and the acceptance the shopper gave before paying is still recovered.
+    expect((contract!.metadata as Record<string, unknown>).acceptance).toMatchObject({
+      acceptedAt: "2026-08-01T09:00:00.000Z",
+      templateId: template!.id,
+      templateVersionId: version!.id,
+      contentDigest,
+    })
   })
 })

--- a/packages/legal/tests/unit/booking-contract-confirmed.test.ts
+++ b/packages/legal/tests/unit/booking-contract-confirmed.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest"
 import { bookingContractVariables } from "../../src/booking-contract-confirmed.js"
+import {
+  type BookingContractSettlement,
+  EMPTY_BOOKING_CONTRACT_SETTLEMENT,
+  toBookingContractSettlement,
+} from "../../src/booking-contract-settlement.js"
 import { contractsService } from "../../src/contracts/service.js"
 
 describe("automatic booking contract variables", () => {
@@ -55,6 +60,7 @@ describe("automatic booking contract variables", () => {
           isPrimary: false,
         },
       ] as never,
+      EMPTY_BOOKING_CONTRACT_SETTLEMENT,
       new Date("2026-08-08T06:45:12.000Z"),
     )
 
@@ -80,5 +86,187 @@ describe("automatic booking contract variables", () => {
         variables,
       }),
     ).toBe("Booking BK-AUTO-1 for Ana Pop and 2 travellers: €120.00 on 2026-08-08")
+  })
+})
+
+/**
+ * The payment clause every seeded customer agreement carries. It branches on
+ * `booking.isPaidInFull` and prints the two settlement amounts, so a bag that
+ * omits them takes the `else` branch and renders "you owe -" (voyant#4690).
+ */
+const PAYMENT_CLAUSE =
+  "{% if booking.isPaidInFull %}Paid in full: {{ booking.paidAmountCents | cents: booking.currency }}" +
+  "{% else %}Deposit paid: {{ booking.paidAmountCents | cents: booking.currency }}. " +
+  "Balance {{ booking.balanceDueCents | cents: booking.currency }} due by {{ booking.balanceDueDate }}." +
+  "{% endif %}"
+
+function variablesWithSettlement(settlement: BookingContractSettlement): Record<string, unknown> {
+  return bookingContractVariables(
+    {
+      id: "book_1",
+      bookingNumber: "BK-AUTO-1",
+      status: "confirmed",
+      contactFirstName: "Ana",
+      contactLastName: "Pop",
+      contactPartyType: "individual",
+      sellCurrency: "EUR",
+      sellAmountCents: 120_00,
+      pax: 1,
+      startDate: "2026-09-01",
+      endDate: "2026-09-07",
+    } as never,
+    [] as never,
+    [] as never,
+    settlement,
+    new Date("2026-08-08T06:45:12.000Z"),
+  )
+}
+
+describe("automatic booking contract settlement variables", () => {
+  it("renders the paid branch on a settled booking", () => {
+    const variables = variablesWithSettlement({
+      ...EMPTY_BOOKING_CONTRACT_SETTLEMENT,
+      paidAmountCents: 120_00,
+      amountDueCents: 0,
+      isPaidInFull: true,
+      latestCompleted: {
+        method: "bank_transfer",
+        methodLabel: "Transfer bancar",
+        date: "2026-08-01",
+      },
+    })
+
+    expect(variables).toMatchObject({
+      booking: {
+        paidAmountCents: 120_00,
+        amountDueCents: 0,
+        balanceDueCents: 0,
+        isPaidInFull: true,
+      },
+      payment: { method: "Transfer bancar", capturedAt: "2026-08-01" },
+    })
+    expect(contractsService.renderPreview({ body: PAYMENT_CLAUSE, variables })).toBe(
+      "Paid in full: €120.00",
+    )
+  })
+
+  it("renders the outstanding branch with real amounts, never the missing-value placeholder", () => {
+    const variables = variablesWithSettlement({
+      ...EMPTY_BOOKING_CONTRACT_SETTLEMENT,
+      paidAmountCents: 30_00,
+      amountDueCents: 90_00,
+      isPaidInFull: false,
+      depositAmountCents: 30_00,
+      depositDueDate: "2026-08-01",
+      balanceAmountCents: 90_00,
+      balanceDueDate: "2026-08-20",
+    })
+
+    // Every amount is a value, not the `-` the renderer substitutes for a
+    // missing one — which is what the customer saw before voyant#4690.
+    expect(contractsService.renderPreview({ body: PAYMENT_CLAUSE, variables })).toBe(
+      "Deposit paid: €30.00. Balance €90.00 due by 2026-08-20.",
+    )
+  })
+
+  it("keeps the gross scheduled balance distinct from the amount still owed", () => {
+    const variables = variablesWithSettlement({
+      ...EMPTY_BOOKING_CONTRACT_SETTLEMENT,
+      paidAmountCents: 120_00,
+      amountDueCents: 0,
+      isPaidInFull: true,
+      balanceAmountCents: 90_00,
+      balanceDueDate: "2026-08-20",
+    })
+
+    // `balanceAmountCents` is the installment the operator scheduled and does
+    // not move when it is paid; `balanceDueCents` is what is still owed.
+    expect(variables).toMatchObject({
+      booking: { balanceAmountCents: 90_00, balanceDueCents: 0 },
+    })
+  })
+
+  it("renders zero settlement as amounts rather than blanks when nothing is paid", () => {
+    const variables = variablesWithSettlement(EMPTY_BOOKING_CONTRACT_SETTLEMENT)
+
+    expect(
+      contractsService.renderPreview({
+        body: "{{ booking.paidAmountCents | cents: booking.currency }}",
+        variables,
+      }),
+    ).toBe("€0.00")
+  })
+})
+
+describe("toBookingContractSettlement", () => {
+  it("localizes the payment method label into the contract's language", () => {
+    const settlement = {
+      currency: "EUR",
+      paidAmountCents: 120_00,
+      balanceDueCents: 0,
+      amountDueCents: 0,
+      isPaidInFull: true,
+      latestCompletedPayment: {
+        method: "bank_transfer" as const,
+        date: "2026-08-01",
+        amountCents: 120_00,
+        currency: "EUR",
+      },
+      installments: [],
+      depositAmountCents: 0,
+      depositDueDate: null,
+      balanceAmountCents: 0,
+      balanceDueDate: null,
+    }
+
+    expect(toBookingContractSettlement(settlement, "ro").latestCompleted).toEqual({
+      method: "bank_transfer",
+      methodLabel: "Transfer bancar",
+      date: "2026-08-01",
+    })
+    expect(toBookingContractSettlement(settlement, "en").latestCompleted?.methodLabel).toBe(
+      "Bank Transfer",
+    )
+    // An unmapped language falls back to a title-cased method, not a blank.
+    expect(toBookingContractSettlement(settlement, "de").latestCompleted?.methodLabel).toBe(
+      "Bank Transfer",
+    )
+  })
+
+  it("numbers the installments it was given and flattens absent due dates", () => {
+    const mapped = toBookingContractSettlement(
+      {
+        currency: "EUR",
+        paidAmountCents: 0,
+        balanceDueCents: null,
+        amountDueCents: 120_00,
+        isPaidInFull: false,
+        latestCompletedPayment: null,
+        installments: [
+          {
+            type: "deposit",
+            status: "paid",
+            amountCents: 30_00,
+            currency: "EUR",
+            dueDate: "2026-08-01",
+          },
+          {
+            type: "balance",
+            status: "due",
+            amountCents: 90_00,
+            currency: "EUR",
+            dueDate: "2026-08-20",
+          },
+        ],
+        depositAmountCents: 30_00,
+        depositDueDate: "2026-08-01",
+        balanceAmountCents: 90_00,
+        balanceDueDate: null,
+      },
+      "en",
+    )
+
+    expect(mapped.schedule.map((row) => row.index)).toEqual([1, 2])
+    expect(mapped.balanceDueDate).toBe("")
   })
 })

--- a/packages/legal/tests/unit/booking-contract-confirmed.test.ts
+++ b/packages/legal/tests/unit/booking-contract-confirmed.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 import { bookingContractVariables } from "../../src/booking-contract-confirmed.js"
 import {
   type BookingContractSettlement,
+  bookingContractPreviewSettlement,
   EMPTY_BOOKING_CONTRACT_SETTLEMENT,
   toBookingContractSettlement,
 } from "../../src/booking-contract-settlement.js"
@@ -195,6 +196,57 @@ describe("automatic booking contract settlement variables", () => {
         variables,
       }),
     ).toBe("€0.00")
+  })
+
+  // The acceptance evidence is a digest over the body the shopper reviewed,
+  // and the shopper reviewed it before paying. Rendering the settled bag with
+  // identity stripped is not that body, so a card booking's acceptance would
+  // stop being recoverable the moment a template bound the payment clause.
+  it("re-renders the shopper's reading of the payment clause for acceptance matching", () => {
+    const settled: BookingContractSettlement = {
+      ...EMPTY_BOOKING_CONTRACT_SETTLEMENT,
+      paidAmountCents: 120_00,
+      amountDueCents: 0,
+      isPaidInFull: true,
+      latestCompleted: { method: "credit_card", methodLabel: "Credit Card", date: "2026-08-05" },
+      schedule: [
+        {
+          index: 1,
+          type: "balance",
+          status: "paid",
+          amountCents: 120_00,
+          currency: "EUR",
+          dueDate: "2026-08-20",
+        },
+      ],
+    }
+
+    expect(
+      contractsService.renderPreview({
+        body: PAYMENT_CLAUSE,
+        variables: variablesWithSettlement(settled),
+      }),
+    ).toBe("Paid in full: €120.00")
+
+    const preview = bookingContractPreviewSettlement(settled, 120_00)
+    expect(
+      contractsService.renderPreview({
+        body: PAYMENT_CLAUSE,
+        variables: variablesWithSettlement(preview),
+      }),
+    ).toBe("Deposit paid: €0.00. Balance €120.00 due by -.")
+    // The storefront preview shows every installment as still pending.
+    expect(preview.schedule).toEqual([
+      {
+        index: 1,
+        type: "balance",
+        status: "pending",
+        amountCents: 120_00,
+        currency: "EUR",
+        dueDate: "2026-08-20",
+      },
+    ])
+    expect(preview.latestCompleted).toBeNull()
   })
 })
 

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -1103,6 +1103,9 @@
       "@voyant-travel/finance/booking-schedule-subscriber": [
         "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
       ],
+      "@voyant-travel/finance/booking-settlement": [
+        "../finance/dist/service-booking-settlement.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -1098,6 +1098,9 @@
       "@voyant-travel/finance/booking-schedule-subscriber": [
         "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
       ],
+      "@voyant-travel/finance/booking-settlement": [
+        "../finance/dist/service-booking-settlement.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -1096,6 +1096,9 @@
       "@voyant-travel/finance/booking-schedule-subscriber": [
         "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
       ],
+      "@voyant-travel/finance/booking-settlement": [
+        "../finance/dist/service-booking-settlement.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],


### PR DESCRIPTION
Closes #4690.

## The defect

`bookingContractVariables()` — the variable bag for the post-confirm
auto-generated contract — emitted the booking's list price and nothing about
settlement. It had no invoice, payment or schedule input, so no lookup could
have filled those fields.

A template binding the standard payment clause therefore took the `else` arm
on **every** auto-generated contract, and every missing value rendered as the
`-` placeholder the contract renderer substitutes:

> **Avansul achitat este:** -. Diferență plată - până la data de -.

on a booking that was paid in full.

## The fix

**Finance owns the answer.** New `financeService.getBookingSettlement(db,
bookingId, { currency, bookingTotalCents })` returns what a booking has paid
and still owes: completed payments against its non-void invoices, the invoice
balance (`null` when there is no invoice — an absent invoice is not a zero
balance), the derived `amountDueCents` / `isPaidInFull`, the latest completed
payment, and the installments that still stand with `cancelled`, `waived` and
`expired` rows excluded.

It is one function rather than a derivation per caller, because two callers
deriving it separately is precisely how the two generation paths came to
disagree about what a contract's payment clause says.

**Legal reads it through that service, not through Finance's tables.** A
direct `@voyant-travel/finance/schema` import would have opened a new
`legal->finance` pair in the `verify:table-privacy` ratchet; the service call
is the sanctioned route and the ratchet is unchanged at 183 reach-ins / 34
pairs.

`bookingContractVariables` now takes settlement as an explicit parameter and
emits:

- `booking.paidAmountCents`, `amountDueCents`, `balanceDueCents`,
  `isPaidInFull`
- `booking.depositAmountCents` / `depositDueDate` /
  `balanceAmountCents` / `balanceDueDate`
- `payment.method`, `capturedAt`, `createdAt`, `latestCompleted`, `schedule`,
  plus the `paidAmountCents` / `balanceDueCents` / `isPaidInFull` aliases

matching the keys `contractTemplateVariableCatalog` already documents and the
keys the storefront preview bag already emits, so a template authored once
renders the same clause in both.

**The gross/net naming trap is kept explicit.** `balanceAmountCents` is the
scheduled balance installment and never moves; `balanceDueCents` is
payment-aware and reaches 0 once settled. Binding the wrong one bills a
customer who has already paid, so both the type and the emitted bag carry that
distinction in a comment, and a unit test pins it.

Settlement is resolved **after** template selection because the payment method
label is written in the contract's language, and the contract's language is
the template's (#4650).

## Verification

The integration test drives the real subscriber — `booking.confirmed` →
persisted `renderedBody` — rather than asserting against a hand-built bag, and
it lives in `tests/integration/booking-contract-confirmed.test.ts`, which the
`db-integration` CI lane already runs by name.

Red/green control, with the settlement lookup stubbed out:

```
- Expected: "Paid in full: €500.00 via Credit Card on 2026-08-05 over 2 installments"
+ Received: "Deposit €0.00, balance €0.00 by - via - on - over - installments"
```

— the reported defect, reproduced. With the fix, green.

The fixture also pins the exclusions: a pending payment does not count as
paid, a void proforma does not resurrect a settled balance, and a cancelled
installment does not appear in `payment.schedule`.

Also run: `pnpm --filter @voyant-travel/{legal,finance} typecheck` (0 errors),
`turbo run build --filter=@voyant-travel/legal...` (34/34, 0 `error TS`),
`biome check .` (0 errors), and `verify:table-privacy`, `verify:dep-paths`,
`verify:dist-configs`, `verify:public-surface`, `verify:symbol-policy`,
`verify:graph-conformance`, `verify:chain-reachability`,
`verify:typecheck-coverage`, `verify:vitest-include`,
`verify:ci-typecheck-selection` — all green.

Three legal integration files (`document-operation`,
`booking-contract-workflow`, `public-routes`) fail identically on
`origin/main` and on this branch; none of them run in CI. Not touched here.
