### PR TITLE
Bind a booking document's issue date through its column

### DIFF
--- a/.changeset/booking-document-issued-identity-bind.md
+++ b/.changeset/booking-document-issued-identity-bind.md
@@ -1,0 +1,27 @@
+---
+"@voyant-travel/bookings": patch
+"@voyant-travel/finance": patch
+"@voyant-travel/inventory": patch
+---
+
+Record a Booking Document that carries the issuer's identity.
+
+Every `POST /v1/admin/bookings/{id}/documents` request carrying the `issued*`
+group answered 500, so `contract` and `invoice` — the types whose validation
+*requires* that group — could not be created at all: without the fields the
+request was refused 400, with them it crashed.
+
+The insert was never the problem. The replay lookup that runs before it
+interpolated the issue date straight into a `sql` fragment, and an interpolated
+value goes to the driver unencoded — unlike `eq(column, value)`, which encodes
+it through the column first. postgres-js cannot bind a `Date`, so the query
+threw before it was ever sent, which is why writing the same values to the same
+columns by hand always worked. The lookup now binds through the column, so it
+and the insert agree by construction.
+
+The same interpolation sat in `buildCreatedAtCondition` in all three
+action-ledger drift checkers, where it crashed
+`check_booking_action_ledger_drift`, `check_finance_action_ledger_drift` and
+`check_product_action_ledger_drift` for any caller that narrowed by
+`createdAtFrom`. Each is bound as an encoded timestamp now, and each package's
+unit test pins the parameter's type rather than just the SQL it builds.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,6 +397,8 @@ jobs:
                 tests/integration/frozen-supplier-statuses.test.ts
               pnpm --filter @voyant-travel/bookings exec vitest run \
                 tests/integration/mcp-lookup.test.ts
+              pnpm --filter @voyant-travel/bookings exec vitest run \
+                tests/integration/booking-documents.test.ts
               pnpm --filter @voyant-travel/operations exec vitest run \
                 tests/availability/integration/auto-allocate-concurrency.test.ts
               pnpm --filter @voyant-travel/operations exec vitest run \

--- a/packages/bookings/src/action-ledger-drift.ts
+++ b/packages/bookings/src/action-ledger-drift.ts
@@ -238,8 +238,11 @@ function buildCreatedAtCondition(
   if (Number.isNaN(date.getTime())) {
     throw new Error("createdAtFrom must be a valid date")
   }
+  // A `sql` interpolation hands the value to the driver as-is, and postgres-js
+  // cannot bind a `Date` — the whole check threw as soon as a caller narrowed
+  // it by date (voyant#4696). Bind the encoded timestamp instead.
   // agent-quality: raw-sql reviewed -- owner: bookings; dynamic SQL interpolation uses Drizzle parameter binding or vetted SQL identifiers.
-  return sql`AND ${column} >= ${date}`
+  return sql`AND ${column} >= ${date.toISOString()}::timestamptz`
 }
 
 function extractRows(result: unknown): BookingActionLedgerDriftQueryRow[] {

--- a/packages/bookings/src/service-core.ts
+++ b/packages/bookings/src/service-core.ts
@@ -5417,11 +5417,30 @@ async function findBookingDocumentByIssuedIdentity(
         sql`coalesce(${bookingDocuments.issuedBy}, '') = ${identity.issuedBy ?? ""}`,
         sql`coalesce(${bookingDocuments.issuedSeries}, '') = ${identity.issuedSeries ?? ""}`,
         eq(bookingDocuments.issuedNumber, identity.issuedNumber),
-        sql`coalesce(${bookingDocuments.issuedAt}, '-infinity'::timestamptz) = coalesce(${identity.issuedAt}::timestamptz, '-infinity'::timestamptz)`,
+        sql`coalesce(${bookingDocuments.issuedAt}, '-infinity'::timestamptz) = coalesce(${issuedAtParam(identity.issuedAt)}, '-infinity'::timestamptz)`,
       ),
     )
     .limit(1)
   return row ?? null
+}
+
+/**
+ * Bind an issue date as a `timestamptz` parameter.
+ *
+ * Interpolating a value into a `sql` fragment hands it to the driver as-is —
+ * unlike `eq(column, value)`, which encodes it through the column first. A
+ * `Date` reaches postgres-js unencoded and its bind step throws, which is why
+ * every recording that carried an issue date 500ed while the insert beside it,
+ * writing the same `Date` through the same column, worked (voyant#4696).
+ *
+ * The column is the encoder, so the lookup and the insert agree by
+ * construction. `null` cannot go through it — the timestamp encoder calls
+ * `toISOString()` — so it is bound as a plain typed null instead.
+ */
+function issuedAtParam(issuedAt: Date | null): SQL {
+  return issuedAt
+    ? sql`${sql.param(issuedAt, bookingDocuments.issuedAt)}::timestamptz`
+    : sql`null::timestamptz`
 }
 
 /**

--- a/packages/bookings/tests/integration/booking-documents.test.ts
+++ b/packages/bookings/tests/integration/booking-documents.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Recording a Booking Document over the live admin route.
+ *
+ * voyant#4696: every request carrying the `issued*` group 500ed, so `contract`
+ * and `invoice` — the types the validation *requires* to carry it — could not
+ * be created at all. The defect was in the identity lookup that precedes the
+ * insert, which no unit test reaches: it only exists against a real database.
+ *
+ * The one case in `routes.integration-suite.ts` that would have caught this is
+ * in a file the CI integration lane does not list, so it has never run. This
+ * file is listed, and seeds its bookings by insert rather than through the
+ * retired `POST /` route, so it does not rot the same way.
+ */
+
+import { handleApiError } from "@voyant-travel/hono"
+import { eq } from "drizzle-orm"
+import { Hono } from "hono"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+import { bookingRoutes } from "../../src/routes.js"
+import { bookingDocuments, bookings } from "../../src/schema.js"
+
+const DB_AVAILABLE = Boolean(process.env.TEST_DATABASE_URL)
+
+const json = (body: Record<string, unknown>) => ({
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify(body),
+})
+
+/** The types whose validation *requires* the issuer's number and date. */
+const ISSUED_TYPES = ["contract", "invoice", "proforma", "credit_note"] as const
+
+describe.skipIf(!DB_AVAILABLE)("Booking document recording", () => {
+  let app: Hono
+  let db: ReturnType<typeof import("@voyant-travel/db/test-utils").createTestDb>
+  let sequence = 0
+
+  beforeAll(async () => {
+    const { createTestDb, cleanupTestDb } = await import("@voyant-travel/db/test-utils")
+    const { createEventBus } = await import("@voyant-travel/core")
+    db = createTestDb()
+    await cleanupTestDb(db)
+
+    const eventBus = createEventBus()
+    app = new Hono()
+    // The same error handler the deployment installs. Without it Hono's
+    // default one answers, a refused body reads as a bare 500, and the
+    // difference between "refused" and "crashed" — the whole subject of
+    // voyant#4696 — is invisible to this file.
+    app.onError((err, c) => handleApiError(err, c))
+    app.use("*", async (c, next) => {
+      c.set("db" as never, db)
+      c.set("eventBus" as never, eventBus)
+      c.set("userId" as never, "test-user-id")
+      c.set("actor" as never, "staff")
+      await next()
+    })
+    app.route("/", bookingRoutes)
+  })
+
+  beforeEach(async () => {
+    const { cleanupTestDb } = await import("@voyant-travel/db/test-utils")
+    await cleanupTestDb(db)
+  })
+
+  afterAll(async () => {
+    const { closeTestDb } = await import("@voyant-travel/db/test-utils")
+    await closeTestDb()
+  })
+
+  async function seedBooking() {
+    sequence += 1
+    const [booking] = await db
+      .insert(bookings)
+      .values({
+        bookingNumber: `BK-DOC-${String(sequence).padStart(6, "0")}`,
+        sellCurrency: "EUR",
+        status: "confirmed",
+      })
+      .returning()
+    return booking!
+  }
+
+  function issuedBody(type: string, overrides: Record<string, unknown> = {}) {
+    return {
+      type,
+      fileName: `${type}.pdf`,
+      fileUrl: `https://example.com/${type}.pdf`,
+      issuedBy: "Contabilitate SRL",
+      issuedSeries: "VYT",
+      issuedNumber: "1042",
+      issuedAt: "2026-03-04T00:00:00.000Z",
+      ...overrides,
+    }
+  }
+
+  for (const type of ISSUED_TYPES) {
+    it(`records a ${type} document carrying the issuer's identity`, async () => {
+      const booking = await seedBooking()
+      const res = await app.request(`/${booking.id}/documents`, {
+        method: "POST",
+        ...json(issuedBody(type)),
+      })
+
+      expect(res.status).toBe(201)
+      const { data } = await res.json()
+      expect(data).toMatchObject({
+        type,
+        issuedBy: "Contabilitate SRL",
+        issuedSeries: "VYT",
+        issuedNumber: "1042",
+        issuedAt: "2026-03-04T00:00:00.000Z",
+      })
+
+      const [row] = await db.select().from(bookingDocuments).where(eq(bookingDocuments.id, data.id))
+      expect(row?.issuedAt?.toISOString()).toBe("2026-03-04T00:00:00.000Z")
+    })
+  }
+
+  // The 500 tracked the presence of the group, not any particular member, so a
+  // type that does not require the identity still has to survive carrying it.
+  it("records issued identity on a type that does not require it", async () => {
+    const booking = await seedBooking()
+    const res = await app.request(`/${booking.id}/documents`, {
+      method: "POST",
+      ...json(issuedBody("other")),
+    })
+
+    expect(res.status).toBe(201)
+    expect((await res.json()).data.issuedNumber).toBe("1042")
+  })
+
+  it("records a document whose issuer left off the series and the issuer name", async () => {
+    const booking = await seedBooking()
+    const res = await app.request(`/${booking.id}/documents`, {
+      method: "POST",
+      ...json({
+        type: "invoice",
+        fileName: "scan.pdf",
+        fileUrl: "https://example.com/scan.pdf",
+        issuedNumber: "77",
+        issuedAt: "2026-03-04T00:00:00.000Z",
+      }),
+    })
+
+    expect(res.status).toBe(201)
+    const { data } = await res.json()
+    expect(data.issuedBy).toBeNull()
+    expect(data.issuedSeries).toBeNull()
+  })
+
+  // The reporter sent both shapes; a date-only value takes a different branch
+  // through the contract's `issuedAt` union.
+  it("accepts a date-only issue date", async () => {
+    const booking = await seedBooking()
+    const res = await app.request(`/${booking.id}/documents`, {
+      method: "POST",
+      ...json(issuedBody("invoice", { issuedAt: "2026-07-23" })),
+    })
+
+    expect(res.status).toBe(201)
+    expect((await res.json()).data.issuedAt).toBe("2026-07-23T00:00:00.000Z")
+  })
+
+  it("replays the same issued document instead of doubling it", async () => {
+    const booking = await seedBooking()
+    const first = await app.request(`/${booking.id}/documents`, {
+      method: "POST",
+      ...json(issuedBody("invoice")),
+    })
+    const second = await app.request(`/${booking.id}/documents`, {
+      method: "POST",
+      ...json(issuedBody("invoice")),
+    })
+
+    expect(first.status).toBe(201)
+    expect(second.status).toBe(201)
+    expect((await second.json()).data.id).toBe((await first.json()).data.id)
+
+    const rows = await db
+      .select()
+      .from(bookingDocuments)
+      .where(eq(bookingDocuments.bookingId, booking.id))
+    expect(rows).toHaveLength(1)
+  })
+
+  // The identity lookup has to agree with the unique index on every member of
+  // the key, including the one that used to crash it.
+  it("keeps documents apart when only the issue date differs", async () => {
+    const booking = await seedBooking()
+    await app.request(`/${booking.id}/documents`, {
+      method: "POST",
+      ...json(issuedBody("invoice")),
+    })
+    const other = await app.request(`/${booking.id}/documents`, {
+      method: "POST",
+      ...json(issuedBody("invoice", { issuedAt: "2026-03-05T00:00:00.000Z" })),
+    })
+
+    expect(other.status).toBe(201)
+    const rows = await db
+      .select()
+      .from(bookingDocuments)
+      .where(eq(bookingDocuments.bookingId, booking.id))
+    expect(rows).toHaveLength(2)
+  })
+
+  it("keeps documents apart when only the issuer differs", async () => {
+    const booking = await seedBooking()
+    await app.request(`/${booking.id}/documents`, {
+      method: "POST",
+      ...json(issuedBody("invoice")),
+    })
+    const other = await app.request(`/${booking.id}/documents`, {
+      method: "POST",
+      ...json(issuedBody("invoice", { issuedBy: "Alt Accounting SRL" })),
+    })
+
+    expect(other.status).toBe(201)
+    const rows = await db
+      .select()
+      .from(bookingDocuments)
+      .where(eq(bookingDocuments.bookingId, booking.id))
+    expect(rows).toHaveLength(2)
+  })
+
+  it("audits the recording once across a replay", async () => {
+    const { actionLedgerEntries } = await import("@voyant-travel/action-ledger")
+    const booking = await seedBooking()
+    await app.request(`/${booking.id}/documents`, {
+      method: "POST",
+      ...json(issuedBody("contract")),
+    })
+    await app.request(`/${booking.id}/documents`, {
+      method: "POST",
+      ...json(issuedBody("contract")),
+    })
+
+    const entries = await db
+      .select()
+      .from(actionLedgerEntries)
+      .where(eq(actionLedgerEntries.targetId, booking.id))
+    expect(entries.filter((entry) => entry.actionName === "booking.document.record")).toHaveLength(
+      1,
+    )
+  })
+
+  it("still rejects an issued type that carries no identity", async () => {
+    const booking = await seedBooking()
+    const res = await app.request(`/${booking.id}/documents`, {
+      method: "POST",
+      ...json({
+        type: "invoice",
+        fileName: "scan.pdf",
+        fileUrl: "https://example.com/scan.pdf",
+      }),
+    })
+
+    expect(res.status).toBe(400)
+  })
+})

--- a/packages/bookings/tests/unit/action-ledger-drift.test.ts
+++ b/packages/bookings/tests/unit/action-ledger-drift.test.ts
@@ -75,6 +75,21 @@ describe("booking action ledger drift checks", () => {
     })
   })
 
+  // voyant#4696: a `Date` interpolated into a `sql` fragment reaches the driver
+  // unencoded and postgres-js throws while binding it, so the check crashed for
+  // every caller that narrowed by date. Building the query proves nothing on
+  // its own — what the parameter *is* decides whether the query can be sent.
+  it("binds createdAtFrom as an encoded timestamp rather than a Date", () => {
+    const dialect = new PgDialect()
+    for (const value of [new Date("2026-05-17T00:00:00.000Z"), "2026-05-17T00:00:00.000Z"]) {
+      const query = dialect.sqlToQuery(
+        buildBookingActionLedgerDriftQueries({ createdAtFrom: value }).booking_cancelled,
+      )
+      expect(query.params).toContain("2026-05-17T00:00:00.000Z")
+      expect(query.params.some((param) => param instanceof Date)).toBe(false)
+    }
+  })
+
   it("rejects invalid createdAtFrom values while building queries", () => {
     expect(() => buildBookingActionLedgerDriftQueries({ createdAtFrom: "not-a-date" })).toThrow(
       "createdAtFrom must be a valid date",

--- a/packages/finance/src/action-ledger-drift.ts
+++ b/packages/finance/src/action-ledger-drift.ts
@@ -187,8 +187,11 @@ function buildCreatedAtCondition(
   if (Number.isNaN(date.getTime())) {
     throw new Error("createdAtFrom must be a valid date")
   }
+  // A `sql` interpolation hands the value to the driver as-is, and postgres-js
+  // cannot bind a `Date` — the whole check threw as soon as a caller narrowed
+  // it by date (voyant#4696). Bind the encoded timestamp instead.
   // agent-quality: raw-sql reviewed -- owner: finance; dynamic SQL interpolation uses Drizzle parameter binding or vetted SQL identifiers.
-  return sql`AND ${column} >= ${date}`
+  return sql`AND ${column} >= ${date.toISOString()}::timestamptz`
 }
 
 function extractRows(result: unknown): FinanceActionLedgerDriftQueryRow[] {

--- a/packages/finance/tests/unit/action-ledger-drift.test.ts
+++ b/packages/finance/tests/unit/action-ledger-drift.test.ts
@@ -62,6 +62,21 @@ describe("finance action ledger drift checks", () => {
     })
   })
 
+  // voyant#4696: a `Date` interpolated into a `sql` fragment reaches the driver
+  // unencoded and postgres-js throws while binding it, so the check crashed for
+  // every caller that narrowed by date. Building the query proves nothing on
+  // its own — what the parameter *is* decides whether the query can be sent.
+  it("binds createdAtFrom as an encoded timestamp rather than a Date", () => {
+    const dialect = new PgDialect()
+    for (const value of [new Date("2026-05-17T00:00:00.000Z"), "2026-05-17T00:00:00.000Z"]) {
+      const query = dialect.sqlToQuery(
+        buildFinanceActionLedgerDriftQueries({ createdAtFrom: value }).invoice,
+      )
+      expect(query.params).toContain("2026-05-17T00:00:00.000Z")
+      expect(query.params.some((param) => param instanceof Date)).toBe(false)
+    }
+  })
+
   it("rejects invalid createdAtFrom values while building queries", () => {
     expect(() => buildFinanceActionLedgerDriftQueries({ createdAtFrom: "not-a-date" })).toThrow(
       "createdAtFrom must be a valid date",

--- a/packages/inventory/src/action-ledger-drift.ts
+++ b/packages/inventory/src/action-ledger-drift.ts
@@ -373,8 +373,11 @@ function buildCreatedAtCondition(
   if (Number.isNaN(date.getTime())) {
     throw new Error("createdAtFrom must be a valid date")
   }
+  // A `sql` interpolation hands the value to the driver as-is, and postgres-js
+  // cannot bind a `Date` — the whole check threw as soon as a caller narrowed
+  // it by date (voyant#4696). Bind the encoded timestamp instead.
   // agent-quality: raw-sql reviewed -- owner: inventory; dynamic SQL interpolation uses Drizzle parameter binding or vetted SQL identifiers.
-  return sql`AND ${column} >= ${date}`
+  return sql`AND ${column} >= ${date.toISOString()}::timestamptz`
 }
 
 function extractRows(result: unknown): ProductActionLedgerDriftQueryRow[] {

--- a/packages/inventory/tests/unit/action-ledger-drift.test.ts
+++ b/packages/inventory/tests/unit/action-ledger-drift.test.ts
@@ -93,6 +93,21 @@ describe("product action ledger drift checks", () => {
     })
   })
 
+  // voyant#4696: a `Date` interpolated into a `sql` fragment reaches the driver
+  // unencoded and postgres-js throws while binding it, so the check crashed for
+  // every caller that narrowed by date. Building the query proves nothing on
+  // its own — what the parameter *is* decides whether the query can be sent.
+  it("binds createdAtFrom as an encoded timestamp rather than a Date", () => {
+    const dialect = new PgDialect()
+    for (const value of [new Date("2026-05-17T00:00:00.000Z"), "2026-05-17T00:00:00.000Z"]) {
+      const query = dialect.sqlToQuery(
+        buildProductActionLedgerDriftQueries({ createdAtFrom: value }).product,
+      )
+      expect(query.params).toContain("2026-05-17T00:00:00.000Z")
+      expect(query.params.some((param) => param instanceof Date)).toBe(false)
+    }
+  })
+
   it("rejects invalid createdAtFrom values while building queries", () => {
     expect(() => buildProductActionLedgerDriftQueries({ createdAtFrom: "not-a-date" })).toThrow(
       "createdAtFrom must be a valid date",


### PR DESCRIPTION
Fixes #4696.

## What was wrong

Not the insert, and not the schema — both were fine, which is why writing the
identical values straight to `booking_documents` succeeded.

`createDocument` runs a replay lookup *before* the insert, keyed on the
document's whole issued identity, and that lookup built its date comparison by
interpolating a `Date` into a `sql` fragment:

```ts
sql`coalesce(${bookingDocuments.issuedAt}, '-infinity'::timestamptz) = coalesce(${identity.issuedAt}::timestamptz, …)`
```

An interpolated value goes to the driver **as-is**. `eq(column, value)` encodes
through the column first; a `sql` interpolation does not. postgres-js then
throws in its bind step —

```
TypeError: The "string" argument must be of type string or an instance of
Buffer or ArrayBuffer. Received an instance of Date
```

— so the query never reached PostgreSQL. The lookup only runs when
`issuedNumber` is present, which is exactly why the 500 tracked the presence of
the `issued*` group rather than any particular member or any particular type.

The fix binds through the column, so the lookup and the insert encode the same
value the same way by construction.

## The same bug, twice more

`buildCreatedAtCondition` in the bookings, finance and inventory action-ledger
drift checkers had the identical interpolation, crashing
`check_booking_action_ledger_drift`, `check_finance_action_ledger_drift` and
`check_product_action_ledger_drift` for any caller that passed `createdAtFrom`.
Reproduced against a live database, fixed, and pinned.

Their existing unit tests already passed a `createdAtFrom` and asserted on the
generated SQL — green the whole time, because the SQL was never the problem.
The added assertion checks what the bound *parameter is*, which is the thing
that decides whether the query can be sent at all.

## Why no test caught it

There *is* a case for this — `routes.integration-suite.ts` records an external
invoice with series, number and date. The CI `integration` lane lists its files
by name and does not list `tests/integration/routes.test.ts`, so it has never
run. It has since rotted for an unrelated reason: 57 of its 64 tests fail
because `seedBooking` posts to `POST /`, a route that no longer exists (booking
creation moved to the Finance created-target command).

Rather than resurrect that suite here, this adds
`tests/integration/booking-documents.test.ts`, **wired into the CI lane**, which
seeds by insert so it cannot rot the same way. It covers all four types that
require the issuer's identity, a type that merely carries it, a partial identity
(no issuer, no series), a date-only `issuedAt`, replay, and two
keep-them-apart cases. 11 of its 12 cases fail on `main` and pass here.

The rotted suite needs its own fix; filed separately as #4702.

## On the third ask

The bare `Internal Server Error` + `requestId` body is deliberate: `handleApiError`
logs the full error, stack and cause server-side and forwards 5xx to the
observability sink, while keeping internals off the wire. Widening that
response is a different decision from this bug, and this change removes the 500
rather than dressing it up. The new test does install the deployment's error
handler, so a refusal and a crash are distinguishable in the suite — without it
a rejected body reads as a bare 500 there too.

## Verification

- `booking-documents.test.ts` — 12/12 pass; 11 fail with the fix reverted
- drift unit tests — bookings 5/5, finance 4/4, inventory 5/5; the new case
  fails with the fix reverted
- `pnpm --filter @voyant-travel/bookings test` — 481 passed
- finance unit 569 passed, inventory unit 472 passed
- `turbo typecheck` over the three packages — clean, 0 `error TS`
- `biome check .` — 0 errors
- `pnpm verify:architecture` — exit 0