### PR TITLE
Retire the Boat Tours catalog surface

### DIFF
--- a/.changeset/retire-boat-tours-surface.md
+++ b/.changeset/retire-boat-tours-surface.md
@@ -1,0 +1,13 @@
+---
+"@voyant-travel/catalog-react": minor
+"@voyant-travel/catalog": minor
+"@voyant-travel/i18n": minor
+---
+
+Retire the Boat Tours catalog surface — a subtype is not a browse scope.
+
+Every other Catalog entry is a Product family (`tour`, `activity`, `attraction`, `event`, `transportation`) or a vertical with its own index. Boat Tours was neither: it locked `familyCode = tour` plus `subtypeCode = boat-tour`, making it a strict subset of Tours that showed the same products a second time.
+
+Subtypes are free-form per deployment (`products.productSubtypeCode` accepts any kebab-case code), so promoting one of them to a nav surface hardcoded one operator's vocabulary and left every other subtype — `day-tour`, `wine-tour` — without an equivalent. Families are a closed, seeded set, so a family view means the same thing on every deployment.
+
+`subtypeCode` remains a facet on the product filter rail, so a Boat Tour is found by filtering Tours the same way any other subtype is. `ScheduledScope` no longer accepts `"boat-tours"`, and `/catalog/boat-tours` (index and detail) is no longer routed.

--- a/docs/architecture/catalog-supply-models.md
+++ b/docs/architecture/catalog-supply-models.md
@@ -68,11 +68,20 @@ review warning), never the family.
 
 Catalog views facet on the stable family/subtype codes, not on free-text
 labels. The standard Tour, Activity, Attraction, Event, and Transportation
-views each lock their corresponding `familyCode`; the Boat Tour view locks
-`familyCode = tour` plus `subtypeCode = boat-tour`. This is independent of
-which surface (§3) the product renders in — a `scheduled` Tour and a `dynamic`
-Tour both facet the same way. Excursions remains a contextual compatibility
-view for scheduled products and is not primary family navigation.
+views each lock exactly one `familyCode` and nothing else. This is independent
+of which surface (§3) the product renders in — a `scheduled` Tour and a
+`dynamic` Tour both facet the same way. Excursions remains a contextual
+compatibility view for scheduled products and is not primary family navigation.
+
+**A subtype never gets a catalog view of its own.** Families are a closed,
+seeded set, so a family view is the same concept on every deployment; subtypes
+are free-form per deployment, so promoting one to a browse surface hardcodes one
+operator's vocabulary and silently leaves every other subtype without a home.
+Subtypes browse as the ordinary `subtypeCode` facet inside their family's view —
+a Boat Tour is found by filtering Tours, the same way a Wine Tour or a Day Tour
+is. A dedicated Boat Tours surface existed until it was retired for exactly this
+reason: it was a strict subset of Tours, and no rule explained why `boat-tour`
+had a page and `day-tour` did not.
 
 ## 3. Two catalog surfaces (split on the mechanic)
 

--- a/packages/catalog-react/src/admin/admin-extension.test.ts
+++ b/packages/catalog-react/src/admin/admin-extension.test.ts
@@ -35,7 +35,6 @@ describe("createCatalogAdminExtension", () => {
         catalogProducts: "Pachete",
         catalogExcursions: "Excursii",
         catalogTours: "Tururi",
-        catalogBoatTours: "Tururi cu barca",
         catalogActivities: "Activitati",
         catalogAttractions: "Atractii",
         catalogEvents: "Evenimente",
@@ -57,11 +56,6 @@ describe("createCatalogAdminExtension", () => {
           items: [
             { id: "catalog-products", title: "Pachete", url: "/catalog/products" },
             { id: "catalog-tours", title: "Tururi", url: "/catalog/tours" },
-            {
-              id: "catalog-boat-tours",
-              title: "Tururi cu barca",
-              url: "/catalog/boat-tours",
-            },
             { id: "catalog-activities", title: "Activitati", url: "/catalog/activities" },
             { id: "catalog-attractions", title: "Atractii", url: "/catalog/attractions" },
             { id: "catalog-events", title: "Evenimente", url: "/catalog/events" },
@@ -86,7 +80,6 @@ describe("createCatalogAdminExtension", () => {
       items: [
         { title: "Products" },
         { title: "Tours" },
-        { title: "Boat Tours" },
         { title: "Activities" },
         { title: "Attractions" },
         { title: "Events" },
@@ -106,14 +99,13 @@ describe("createCatalogAdminExtension", () => {
   it("describes the index redirect plus one route per catalog surface page", () => {
     const extension = createCatalogAdminExtension()
     const routes = extension.routes ?? []
-    expect(routes).toHaveLength(21)
-    expect(new Set(routes.map((route) => route.id)).size).toBe(21)
-    expect(new Set(routes.map((route) => route.path)).size).toBe(21)
+    expect(routes).toHaveLength(19)
+    expect(new Set(routes.map((route) => route.id)).size).toBe(19)
+    expect(new Set(routes.map((route) => route.path)).size).toBe(19)
     for (const surface of [
       "products",
       "excursions",
       "tours",
-      "boat-tours",
       "activities",
       "attractions",
       "events",

--- a/packages/catalog-react/src/admin/index.tsx
+++ b/packages/catalog-react/src/admin/index.tsx
@@ -130,7 +130,6 @@ export interface CreateCatalogAdminExtensionOptions {
     products?: string
     excursions?: string
     tours?: string
-    boatTours?: string
     activities?: string
     attractions?: string
     events?: string
@@ -244,7 +243,6 @@ export function createCatalogAdminExtension(
     products = "Packages",
     excursions = "Excursions",
     tours = "Tours",
-    boatTours = "Boat Tours",
     activities = "Activities",
     attractions = "Attractions",
     events = "Events",
@@ -322,7 +320,6 @@ export function createCatalogAdminExtension(
       },
       ...(
         [
-          ["boat-tours", boatTours],
           ["activities", activities],
           ["attractions", attractions],
           ["events", events],
@@ -397,7 +394,6 @@ export function createSelectedCatalogAdminExtension({
     products: navMessages.catalogProducts ?? "Products",
     excursions: navMessages.catalogExcursions ?? "Excursions",
     tours: navMessages.catalogTours ?? "Tours",
-    boatTours: navMessages.catalogBoatTours ?? "Boat Tours",
     activities: navMessages.catalogActivities ?? "Activities",
     attractions: navMessages.catalogAttractions ?? "Attractions",
     events: navMessages.catalogEvents ?? "Events",
@@ -432,11 +428,6 @@ export function createSelectedCatalogAdminExtension({
                 url: "/catalog/products",
               },
               { id: "catalog-tours", title: labels.tours, url: "/catalog/tours" },
-              {
-                id: "catalog-boat-tours",
-                title: labels.boatTours,
-                url: "/catalog/boat-tours",
-              },
               {
                 id: "catalog-activities",
                 title: labels.activities,

--- a/packages/catalog-react/src/admin/scheduled-catalog-host.tsx
+++ b/packages/catalog-react/src/admin/scheduled-catalog-host.tsx
@@ -67,8 +67,6 @@ function scheduledScopeCopy(
       return [nav.catalogExcursions, nav.catalogExcursionsTagline]
     case "tours":
       return [nav.catalogTours, nav.catalogToursTagline]
-    case "boat-tours":
-      return [nav.catalogBoatTours, nav.catalogBoatToursTagline]
     case "activities":
       return [nav.catalogActivities, nav.catalogActivitiesTagline]
     case "attractions":

--- a/packages/catalog-react/src/admin/vertical-detail-host.tsx
+++ b/packages/catalog-react/src/admin/vertical-detail-host.tsx
@@ -68,8 +68,6 @@ function surfaceTitle(
       return nav.catalogExcursions
     case "tours":
       return nav.catalogTours
-    case "boat-tours":
-      return nav.catalogBoatTours
     case "activities":
       return nav.catalogActivities
     case "attractions":

--- a/packages/catalog-react/src/catalog-surfaces.ts
+++ b/packages/catalog-react/src/catalog-surfaces.ts
@@ -9,7 +9,6 @@ export const catalogDetailSurfaces = [
   "accommodations",
   "excursions",
   "tours",
-  "boat-tours",
   "activities",
   "attractions",
   "events",

--- a/packages/catalog-react/src/components/catalog-page-config.tsx
+++ b/packages/catalog-react/src/components/catalog-page-config.tsx
@@ -135,8 +135,9 @@ export function makeProductFilters(
     },
     { field: "supplierId", label: messages.filters.supplier, formatValue: formatSupplier },
     { field: "bookingMode", label: messages.filters.bookingMode },
-    // Merchandising family + subtype facets, keyed on the stable codes. The
-    // Tour view locks `familyCode`; the Boat Tour facet locks `subtypeCode`.
+    // Merchandising family + subtype facets, keyed on the stable codes. A
+    // family view locks `familyCode`; `subtypeCode` always stays a free facet,
+    // since subtypes are per-deployment vocabulary with no surface of their own.
     { field: "familyCode", label: messages.filters.family },
     { field: "subtypeCode", label: messages.filters.subtype },
     { field: "capacityMode", label: messages.filters.capacity },

--- a/packages/catalog-react/src/components/product-family-catalog.test.ts
+++ b/packages/catalog-react/src/components/product-family-catalog.test.ts
@@ -2,21 +2,33 @@ import { describe, expect, it } from "vitest"
 
 import { catalogUiEn } from "../i18n/en.js"
 import { durationMeta } from "./catalog-page-cards.js"
-import { resolveScheduledScopeLocks } from "./scheduled-catalog-page.js"
+import { resolveScheduledScopeLocks, type ScheduledScope } from "./scheduled-catalog-page.js"
+
+const FAMILY_SCOPES = [
+  "tours",
+  "activities",
+  "attractions",
+  "events",
+  "transportation",
+] as const satisfies readonly ScheduledScope[]
 
 describe("product family catalog views", () => {
-  it("locks family and subtype independently from duration and supply mechanics", () => {
+  it("locks family independently from duration and supply mechanics", () => {
     expect(resolveScheduledScopeLocks("tours")).toEqual({
       lockedFacets: { familyCode: ["tour"] },
-      lockedRanges: {},
-    })
-    expect(resolveScheduledScopeLocks("boat-tours")).toEqual({
-      lockedFacets: { familyCode: ["tour"], subtypeCode: ["boat-tour"] },
       lockedRanges: {},
     })
     expect(resolveScheduledScopeLocks("activities").lockedFacets).toEqual({
       familyCode: ["activity"],
     })
+  })
+
+  it("never locks a subtype, so no subtype gets a surface of its own", () => {
+    for (const scope of FAMILY_SCOPES) {
+      const { lockedFacets } = resolveScheduledScopeLocks(scope)
+      expect(Object.keys(lockedFacets)).toEqual(["familyCode"])
+      expect(lockedFacets.familyCode).toHaveLength(1)
+    }
   })
 
   it("shows a sixty-minute Boat Tour as 60 min rather than one day", () => {

--- a/packages/catalog-react/src/components/scheduled-catalog-page.tsx
+++ b/packages/catalog-react/src/components/scheduled-catalog-page.tsx
@@ -3,21 +3,25 @@
 import type { ReactNode } from "react"
 
 /**
- * Product-family catalog surface. Family and subtype views intentionally do
- * not lock booking/supply mechanics: those concepts are orthogonal to how a
- * product is merchandised. The legacy Excursions context remains the only
- * scheduled-only scope.
+ * Product-family catalog surface. Family views intentionally do not lock
+ * booking/supply mechanics: those concepts are orthogonal to how a product is
+ * merchandised. The legacy Excursions context remains the only scheduled-only
+ * scope.
  *
- * The scope is defined by the **Product family / subtype stable codes**, NOT by
- * duration. The old `durationDays ≤ 1` / `≥ 2` split is retired: a product's
- * duration is display/range information, never its identity, so a 60-minute Boat
- * Tour appears under the Tour view (family `tour`) and the Boat Tour view
- * (subtype `boat-tour`) exactly like a multi-day tour, and it is never shunted
- * into a short/`excursions` bucket because it is brief. "Excursion" is
- * contextual vocabulary, not a `≤ 1-day` family.
+ * A scope is exactly one **Product family stable code** — never a duration and
+ * never a subtype. The old `durationDays ≤ 1` / `≥ 2` split is retired: a
+ * product's duration is display/range information, never its identity, so a
+ * 60-minute Boat Tour appears under the Tour view (family `tour`) exactly like a
+ * multi-day tour, and it is never shunted into a short/`excursions` bucket
+ * because it is brief. "Excursion" is contextual vocabulary, not a `≤ 1-day`
+ * family.
  *   - family views — lock exactly one standard family code
- *   - `boat-tours` — locks family `tour` + subtype `boat-tour`
  *   - `excursions` — contextual scheduled browse (no duration lock)
+ *
+ * Subtypes (`subtypeCode`, e.g. `boat-tour`) are deliberately NOT scopes. They
+ * are free-form per deployment, so no single subtype can earn a hardcoded
+ * surface here without arbitrarily privileging one operator's vocabulary; they
+ * browse as the ordinary subtype facet inside their family's view.
  *
  * Presentational: the localized `title`/`subtitle` and the browse grid itself
  * (`renderBrowseGrid`, the host's `CatalogBrowsePage` wired to its data) are
@@ -27,7 +31,6 @@ import type { ReactNode } from "react"
 export type ScheduledScope =
   | "excursions"
   | "tours"
-  | "boat-tours"
   | "activities"
   | "attractions"
   | "events"
@@ -38,20 +41,12 @@ export interface ScheduledCatalogLocks {
   lockedRanges: Record<string, { gte?: number; lte?: number }>
 }
 
-/** Resolve the family/subtype facet locks for a scope. Duration never locks. */
+/** Resolve the family facet lock for a scope. Duration and subtype never lock. */
 export function resolveScheduledScopeLocks(scope: ScheduledScope): ScheduledCatalogLocks {
   switch (scope) {
     case "tours":
       return {
         lockedFacets: { familyCode: ["tour"] },
-        lockedRanges: {},
-      }
-    case "boat-tours":
-      return {
-        lockedFacets: {
-          familyCode: ["tour"],
-          subtypeCode: ["boat-tour"],
-        },
         lockedRanges: {},
       }
     case "excursions":

--- a/packages/catalog/src/voyant.ts
+++ b/packages/catalog/src/voyant.ts
@@ -415,8 +415,6 @@ export const catalogVoyantModule = defineModule({
         ["excursions-detail", "/catalog/excursions/$id"],
         ["tours-index", "/catalog/tours"],
         ["tours-detail", "/catalog/tours/$id"],
-        ["boat-tours-index", "/catalog/boat-tours"],
-        ["boat-tours-detail", "/catalog/boat-tours/$id"],
         ["activities-index", "/catalog/activities"],
         ["activities-detail", "/catalog/activities/$id"],
         ["attractions-index", "/catalog/attractions"],

--- a/packages/catalog/tests/unit/voyant-manifest.test.ts
+++ b/packages/catalog/tests/unit/voyant-manifest.test.ts
@@ -254,8 +254,6 @@ describe("catalog deployment manifest", () => {
       ["@voyant-travel/catalog#admin.route.excursions-detail", "/catalog/excursions/$id"],
       ["@voyant-travel/catalog#admin.route.tours-index", "/catalog/tours"],
       ["@voyant-travel/catalog#admin.route.tours-detail", "/catalog/tours/$id"],
-      ["@voyant-travel/catalog#admin.route.boat-tours-index", "/catalog/boat-tours"],
-      ["@voyant-travel/catalog#admin.route.boat-tours-detail", "/catalog/boat-tours/$id"],
       ["@voyant-travel/catalog#admin.route.activities-index", "/catalog/activities"],
       ["@voyant-travel/catalog#admin.route.activities-detail", "/catalog/activities/$id"],
       ["@voyant-travel/catalog#admin.route.attractions-index", "/catalog/attractions"],

--- a/packages/i18n/src/admin/operator-nav.ts
+++ b/packages/i18n/src/admin/operator-nav.ts
@@ -9,8 +9,6 @@ export type OperatorAdminNavMessages = {
   catalogExcursionsTagline: string
   catalogTours: string
   catalogToursTagline: string
-  catalogBoatTours: string
-  catalogBoatToursTagline: string
   catalogActivities: string
   catalogActivitiesTagline: string
   catalogAttractions: string
@@ -82,8 +80,6 @@ export const operatorAdminNavMessages = {
       catalogExcursionsTagline: "Scheduled products shown in an excursion context.",
       catalogTours: "Tours",
       catalogToursTagline: "Products in the Tour family.",
-      catalogBoatTours: "Boat Tours",
-      catalogBoatToursTagline: "Tour products with the Boat Tour subtype.",
       catalogActivities: "Activities",
       catalogActivitiesTagline: "Products in the Activity family.",
       catalogAttractions: "Attractions",
@@ -154,8 +150,6 @@ export const operatorAdminNavMessages = {
       catalogExcursionsTagline: "Produse programate prezentate in context de excursie.",
       catalogTours: "Tururi",
       catalogToursTagline: "Produse din familia Tur.",
-      catalogBoatTours: "Tururi cu barca",
-      catalogBoatToursTagline: "Produse din familia Tur cu subtipul Tur cu barca.",
       catalogActivities: "Activitati",
       catalogActivitiesTagline: "Produse din familia Activitate.",
       catalogAttractions: "Atractii",


### PR DESCRIPTION
Every other Catalog nav entry is a **Product family** (`tour`, `activity`, `attraction`, `event`, `transportation`) or a vertical with its own search index (cruises, accommodations). Boat Tours was neither:

```ts
case "boat-tours":
  return { lockedFacets: { familyCode: ["tour"], subtypeCode: ["boat-tour"] }, lockedRanges: {} }
```

Family `tour` **plus** subtype `boat-tour` — a strict subset of Tours. Every boat tour already appeared under Tours; the Boat Tours page was Tours with one extra facet pre-checked, listing the same products a second time.

### Why a subtype cannot be a browse scope

`products.productSubtypeCode` is a free-form kebab-case string — `day-tour`, `boat-tour`, `wine-tour`, whatever a deployment types. Nothing makes `boat-tour` structurally special, so hardcoding it into a shared package's nav array privileges one operator's vocabulary and leaves every other subtype without an equivalent. An operator whose business is mostly wine tours got a Boat Tours link and no wine link.

Families are the opposite: a closed, seeded set, so a family view means the same thing on every deployment.

`subtypeCode` was already a facet on the product filter rail (`inventory/src/catalog-policy.ts`), so nothing is lost — a Boat Tour is found by filtering Tours, the same way any other subtype is.

### Changes

- `ScheduledScope` no longer accepts `"boat-tours"`; `resolveScheduledScopeLocks` now locks exactly one `familyCode` and never a subtype
- removed from `catalogDetailSurfaces`, the nav array, both host label switches, and the graph route manifest (`/catalog/boat-tours` index + detail are no longer routed)
- `catalogBoatTours` / `catalogBoatToursTagline` dropped from `OperatorNavMessages` (en + ro)
- `docs/architecture/catalog-supply-models.md` states the rule, so the next subtype does not get a surface either

### Not done deliberately

No redirect for `/catalog/boat-tours`. The surface shipped ~2 weeks ago (#4051) and is an internal admin route, so leaving a retired scope name in code to serve bookmarks costs more than it saves. Old links 404.

### Verification

- `catalog` 818 passed / 52 skipped, `catalog-react` 85 passed, `i18n` 13 passed
- new test asserts **no** scope locks a subtype; negative control confirms it goes red when the lock is reintroduced (not a vacuous pass)
- `packages/catalog-react` `tsc -p tsconfig.build.json` → exit 0, 0 `error TS`
- `biome check .` from repo root → 0 errors
