### PR TITLE
Ask staff whether to notify the customer, not whether to suppress

### DIFF
--- a/.changeset/notify-customer-toggle-polarity.md
+++ b/.changeset/notify-customer-toggle-polarity.md
@@ -1,0 +1,11 @@
+---
+"@voyant-travel/bookings-react": patch
+---
+
+Ask staff whether to notify the customer, rather than whether to suppress the notification.
+
+The status-change dialog carried a switch labelled "Don't notify the customer", off by default — a box you tick to make less happen. The booking journey's equivalent already asks the question positively ("Notify traveler", on by default) and maps it to the wire flag itself, so the same decision had two opposite presentations depending on where an operator made it. The status dialog now matches: `notifyCustomer` is on by default and sends `suppressNotifications: true` only when switched off.
+
+The domain flag stays negative. `suppressNotifications` is the safe default at the boundary — a call site that forgets it sends a redundant email, where an opt-in flag that is forgotten leaves the customer never told, and every downstream consumer in `notifications` is a skip-guard that would have to read a missing field as "stay silent".
+
+Both toggles now also disclose what switching notifications off actually does. Turning it off latches `bookings.notifications_suppressed`, which `updateBookingSchema` types as `z.literal(true)` — nothing can clear it, so the booking is silent for good, future reminders included. The old helper text described it as confirming "silently", which reads as a one-time choice about this action.

--- a/packages/bookings-react/src/components/booking-detail-page.tsx
+++ b/packages/bookings-react/src/components/booking-detail-page.tsx
@@ -639,6 +639,7 @@ export function BookingDetailPage({
         onOpenChange={setStatusDialogOpen}
         bookingId={id}
         currentStatus={booking.status}
+        notificationsSuppressed={booking.notificationsSuppressed === true}
       />
 
       <BookingCancellationDialog

--- a/packages/bookings-react/src/components/status-change-dialog.tsx
+++ b/packages/bookings-react/src/components/status-change-dialog.tsx
@@ -50,6 +50,12 @@ export interface StatusChangeDialogProps {
   onOpenChange: (open: boolean) => void
   bookingId: string
   currentStatus: BookingRecord["status"]
+  /**
+   * The Booking's persisted suppression latch. Once set, the service ignores
+   * anything this dialog sends, so the control is shown off and disabled
+   * rather than promising a send that will not happen.
+   */
+  notificationsSuppressed?: boolean
   onSuccess?: () => void
 }
 
@@ -58,6 +64,7 @@ export function StatusChangeDialog({
   onOpenChange,
   bookingId,
   currentStatus,
+  notificationsSuppressed = false,
   onSuccess,
 }: StatusChangeDialogProps) {
   const mutation = useBookingStatusMutation(bookingId)
@@ -79,7 +86,7 @@ export function StatusChangeDialog({
     defaultValues: {
       status: "confirmed",
       note: "",
-      notifyCustomer: true,
+      notifyCustomer: !notificationsSuppressed,
     },
   })
 
@@ -88,10 +95,10 @@ export function StatusChangeDialog({
       form.reset({
         status: currentStatus,
         note: "",
-        notifyCustomer: true,
+        notifyCustomer: !notificationsSuppressed,
       })
     }
-  }, [currentStatus, form, open])
+  }, [currentStatus, form, notificationsSuppressed, open])
 
   // Customer lifecycle messages can be silenced for cancellation and for
   // an exceptional correction back to confirmed.
@@ -164,11 +171,14 @@ export function StatusChangeDialog({
                   <Switch
                     id="notify-customer"
                     checked={notifyCustomer}
+                    disabled={notificationsSuppressed}
                     onCheckedChange={(checked) => form.setValue("notifyCustomer", checked === true)}
                   />
                 </div>
                 <p className="text-muted-foreground text-xs">
-                  {messages.statusChangeDialog.helpers.notifyCustomer}
+                  {notificationsSuppressed
+                    ? messages.statusChangeDialog.helpers.notificationsAlreadySilenced
+                    : messages.statusChangeDialog.helpers.notifyCustomer}
                 </p>
               </div>
             ) : null}

--- a/packages/bookings-react/src/components/status-change-dialog.tsx
+++ b/packages/bookings-react/src/components/status-change-dialog.tsx
@@ -30,10 +30,16 @@ import {
   useBookingStatusMutation,
 } from "../index.js"
 
+/**
+ * `notifyCustomer` is the positive form of the wire flag: the service takes
+ * `suppressNotifications`, so the form default is "on" and only an explicit
+ * opt-out sends anything. Sending is the safe default — a forgotten flag
+ * produces a redundant email rather than a customer who is never told.
+ */
 const statusChangeFormSchema = z.object({
   status: bookingStatusSchema,
   note: z.string().optional().nullable(),
-  suppressNotifications: z.boolean(),
+  notifyCustomer: z.boolean(),
 })
 
 type StatusChangeFormValues = z.input<typeof statusChangeFormSchema>
@@ -73,7 +79,7 @@ export function StatusChangeDialog({
     defaultValues: {
       status: "confirmed",
       note: "",
-      suppressNotifications: false,
+      notifyCustomer: true,
     },
   })
 
@@ -82,23 +88,23 @@ export function StatusChangeDialog({
       form.reset({
         status: currentStatus,
         note: "",
-        suppressNotifications: false,
+        notifyCustomer: true,
       })
     }
   }, [currentStatus, form, open])
 
-  // Customer lifecycle messages can be suppressed for cancellation and for
+  // Customer lifecycle messages can be silenced for cancellation and for
   // an exceptional correction back to confirmed.
   const targetStatus = form.watch("status")
-  const suppressNotifications = form.watch("suppressNotifications")
-  const showSuppressToggle = targetStatus === "confirmed" || targetStatus === "cancelled"
+  const notifyCustomer = form.watch("notifyCustomer")
+  const showNotifyToggle = targetStatus === "confirmed" || targetStatus === "cancelled"
 
   const onSubmit = async (values: StatusChangeFormOutput) => {
     await mutation.mutateAsync({
       currentStatus,
       status: values.status,
       note: values.note || null,
-      suppressNotifications: values.suppressNotifications || undefined,
+      suppressNotifications: values.notifyCustomer ? undefined : true,
     })
     onOpenChange(false)
     onSuccess?.()
@@ -149,22 +155,20 @@ export function StatusChangeDialog({
               />
             </div>
 
-            {showSuppressToggle ? (
+            {showNotifyToggle ? (
               <div className="flex flex-col gap-2 rounded-md border bg-muted/30 p-3">
                 <div className="flex items-center justify-between gap-3">
-                  <Label htmlFor="suppress-notifications">
-                    {messages.statusChangeDialog.fields.suppressNotifications}
+                  <Label htmlFor="notify-customer">
+                    {messages.statusChangeDialog.fields.notifyCustomer}
                   </Label>
                   <Switch
-                    id="suppress-notifications"
-                    checked={suppressNotifications}
-                    onCheckedChange={(checked) =>
-                      form.setValue("suppressNotifications", checked === true)
-                    }
+                    id="notify-customer"
+                    checked={notifyCustomer}
+                    onCheckedChange={(checked) => form.setValue("notifyCustomer", checked === true)}
                   />
                 </div>
                 <p className="text-muted-foreground text-xs">
-                  {messages.statusChangeDialog.helpers.suppressNotifications}
+                  {messages.statusChangeDialog.helpers.notifyCustomer}
                 </p>
               </div>
             ) : null}

--- a/packages/bookings-react/src/i18n/en-create-list.ts
+++ b/packages/bookings-react/src/i18n/en-create-list.ts
@@ -166,7 +166,7 @@ export const bookingsUiEnCreateList = {
       internalNotes: "Internal notes",
       notifyTraveler: "Notify traveler",
       notifyTravelerHint:
-        "Sends the customer their booking confirmation and documents. Turn off for a silent operator commit.",
+        "Sends the customer their booking confirmation and documents. Turning it off silences the booking permanently, including future reminders — it cannot be switched back on.",
     },
     placeholders: {
       departure: "Select a departure...",

--- a/packages/bookings-react/src/i18n/en-operations.ts
+++ b/packages/bookings-react/src/i18n/en-operations.ts
@@ -14,6 +14,8 @@ export const bookingsUiEnOperations = {
     helpers: {
       notifyCustomer:
         "Sends the confirmation or cancellation email and any document bundle that would normally go out. Turning it off silences this booking permanently, including future reminders — it cannot be switched back on.",
+      notificationsAlreadySilenced:
+        "This booking was silenced earlier, so nothing will be sent to the customer. That cannot be undone.",
     },
     actions: {
       updateStatus: "Update status",

--- a/packages/bookings-react/src/i18n/en-operations.ts
+++ b/packages/bookings-react/src/i18n/en-operations.ts
@@ -6,14 +6,14 @@ export const bookingsUiEnOperations = {
     fields: {
       status: "New status",
       note: "Note (optional)",
-      suppressNotifications: "Don't notify the customer",
+      notifyCustomer: "Notify the customer",
     },
     placeholders: {
       note: "Reason for status change...",
     },
     helpers: {
-      suppressNotifications:
-        "Confirm silently — skip the confirmation email and any document bundle that would normally go out.",
+      notifyCustomer:
+        "Sends the confirmation or cancellation email and any document bundle that would normally go out. Turning it off silences this booking permanently, including future reminders — it cannot be switched back on.",
     },
     actions: {
       updateStatus: "Update status",

--- a/packages/bookings-react/src/i18n/messages-operations.ts
+++ b/packages/bookings-react/src/i18n/messages-operations.ts
@@ -11,6 +11,7 @@ export type BookingsUiOperationsMessages = {
     }
     helpers: {
       notifyCustomer: string
+      notificationsAlreadySilenced: string
     }
     actions: {
       updateStatus: string

--- a/packages/bookings-react/src/i18n/messages-operations.ts
+++ b/packages/bookings-react/src/i18n/messages-operations.ts
@@ -4,13 +4,13 @@ export type BookingsUiOperationsMessages = {
     fields: {
       status: string
       note: string
-      suppressNotifications: string
+      notifyCustomer: string
     }
     placeholders: {
       note: string
     }
     helpers: {
-      suppressNotifications: string
+      notifyCustomer: string
     }
     actions: {
       updateStatus: string

--- a/packages/bookings-react/src/i18n/ro-create-list.ts
+++ b/packages/bookings-react/src/i18n/ro-create-list.ts
@@ -168,7 +168,7 @@ export const bookingsUiRoCreateList = {
       internalNotes: "Note interne",
       notifyTraveler: "Anunta calatorul",
       notifyTravelerHint:
-        "Trimite clientului confirmarea rezervarii si documentele. Dezactiveaza pentru o finalizare silentioasa de catre operator.",
+        "Trimite clientului confirmarea rezervarii si documentele. Dezactivarea face rezervarea silentioasa definitiv, inclusiv reamintirile viitoare — nu mai poate fi reactivata.",
     },
     placeholders: {
       departure: "Selecteaza o plecare...",

--- a/packages/bookings-react/src/i18n/ro-operations.ts
+++ b/packages/bookings-react/src/i18n/ro-operations.ts
@@ -6,14 +6,14 @@ export const bookingsUiRoOperations = {
     fields: {
       status: "Status nou",
       note: "Nota (optional)",
-      suppressNotifications: "Nu notifica clientul",
+      notifyCustomer: "Notifica clientul",
     },
     placeholders: {
       note: "Motivul schimbarii statusului...",
     },
     helpers: {
-      suppressNotifications:
-        "Confirma silentios — sari peste emailul de confirmare si pachetul de documente care ar fi trimise in mod normal.",
+      notifyCustomer:
+        "Trimite emailul de confirmare sau de anulare si pachetul de documente care ar pleca in mod normal. Dezactivarea face rezervarea silentioasa definitiv, inclusiv reamintirile viitoare — nu mai poate fi reactivata.",
     },
     actions: {
       updateStatus: "Actualizeaza statusul",

--- a/packages/bookings-react/src/i18n/ro-operations.ts
+++ b/packages/bookings-react/src/i18n/ro-operations.ts
@@ -14,6 +14,8 @@ export const bookingsUiRoOperations = {
     helpers: {
       notifyCustomer:
         "Trimite emailul de confirmare sau de anulare si pachetul de documente care ar pleca in mod normal. Dezactivarea face rezervarea silentioasa definitiv, inclusiv reamintirile viitoare — nu mai poate fi reactivata.",
+      notificationsAlreadySilenced:
+        "Aceasta rezervare a fost facuta silentioasa anterior, deci clientul nu va primi nimic. Actiunea nu poate fi anulata.",
     },
     actions: {
       updateStatus: "Actualizeaza statusul",

--- a/packages/bookings-react/src/schemas.ts
+++ b/packages/bookings-react/src/schemas.ts
@@ -81,6 +81,12 @@ export const bookingRecordSchema = z.object({
   pax: z.number().int().nullable(),
   items: z.array(bookingRecordItemSummarySchema).optional(),
   internalNotes: z.string().nullable(),
+  /**
+   * One-way suppression latch. The admin route returns it; `updateBookingSchema`
+   * types it as `z.literal(true)`, so once set nothing clears it. Optional here
+   * because responses built before it was surfaced omit the field.
+   */
+  notificationsSuppressed: z.boolean().optional(),
   communicationLanguage: z.string().nullable().optional(),
   contactFirstName: z.string().nullable().optional(),
   contactLastName: z.string().nullable().optional(),

--- a/packages/bookings-react/tests/unit/status-change-dialog-notify.test.tsx
+++ b/packages/bookings-react/tests/unit/status-change-dialog-notify.test.tsx
@@ -1,0 +1,86 @@
+import type { ReactNode } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { z } from "zod/v4"
+
+const bookingHooks = vi.hoisted(() => ({
+  useBookingStatusMutation: vi.fn(),
+}))
+
+vi.mock("@voyant-travel/ui/components", () => ({
+  Button: ({ children }: { children?: ReactNode }) => <button type="button">{children}</button>,
+  Dialog: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DialogBody: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DialogContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DialogFooter: ({ children }: { children?: ReactNode }) => <footer>{children}</footer>,
+  DialogHeader: ({ children }: { children?: ReactNode }) => <header>{children}</header>,
+  DialogTitle: ({ children }: { children?: ReactNode }) => <h1>{children}</h1>,
+  Label: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
+  Select: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  SelectContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  SelectItem: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  SelectTrigger: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  SelectValue: () => <span />,
+  // Surfaces the resolved `checked` prop so the default polarity is assertable
+  // from static markup.
+  Switch: ({ id, checked }: { id?: string; checked?: boolean }) => (
+    <span data-switch={id} data-checked={String(checked === true)} />
+  ),
+  Textarea: () => <textarea />,
+}))
+
+vi.mock("../../src/index.js", () => ({
+  useBookingStatusMutation: bookingHooks.useBookingStatusMutation,
+  bookingStatusOptions: [{ value: "confirmed" }, { value: "cancelled" }],
+  bookingStatusSchema: z.enum(["confirmed", "cancelled", "in_progress", "completed"]),
+}))
+
+import { StatusChangeDialog } from "../../src/components/status-change-dialog.js"
+
+beforeEach(() => {
+  bookingHooks.useBookingStatusMutation.mockReturnValue({
+    mutateAsync: vi.fn(),
+    isPending: false,
+    error: null,
+  })
+})
+
+function render(currentStatus: "confirmed" | "cancelled") {
+  return renderToStaticMarkup(
+    <StatusChangeDialog
+      open
+      onOpenChange={() => {}}
+      bookingId="book_1"
+      currentStatus={currentStatus}
+    />,
+  )
+}
+
+describe("StatusChangeDialog notification toggle", () => {
+  // The service takes `suppressNotifications`, so the dialog is the one place
+  // the polarity is flipped. Notifying has to stay the default: a staff member
+  // who never touches the toggle must not silently strand the customer.
+  it("defaults to notifying the customer", () => {
+    const html = render("confirmed")
+
+    expect(html).toContain('data-switch="notify-customer"')
+    expect(html).toContain('data-checked="true"')
+  })
+
+  it("labels the toggle positively rather than as a suppression", () => {
+    const html = render("cancelled")
+
+    expect(html).toContain("Notify the customer")
+    expect(html).not.toContain("Don't notify the customer")
+  })
+
+  // Turning the toggle off latches `notifications_suppressed` on the Booking
+  // row, which `updateBookingSchema` types as `z.literal(true)` — nothing can
+  // clear it. The helper text is the only place a staff member learns that.
+  it("discloses that switching notifications off is permanent", () => {
+    const html = render("cancelled")
+
+    expect(html).toContain("permanently")
+    expect(html).toContain("cannot be switched back on")
+  })
+})

--- a/packages/bookings-react/tests/unit/status-change-dialog-notify.test.tsx
+++ b/packages/bookings-react/tests/unit/status-change-dialog-notify.test.tsx
@@ -23,8 +23,12 @@ vi.mock("@voyant-travel/ui/components", () => ({
   SelectValue: () => <span />,
   // Surfaces the resolved `checked` prop so the default polarity is assertable
   // from static markup.
-  Switch: ({ id, checked }: { id?: string; checked?: boolean }) => (
-    <span data-switch={id} data-checked={String(checked === true)} />
+  Switch: ({ id, checked, disabled }: { id?: string; checked?: boolean; disabled?: boolean }) => (
+    <span
+      data-switch={id}
+      data-checked={String(checked === true)}
+      data-disabled={String(disabled === true)}
+    />
   ),
   Textarea: () => <textarea />,
 }))
@@ -45,13 +49,14 @@ beforeEach(() => {
   })
 })
 
-function render(currentStatus: "confirmed" | "cancelled") {
+function render(currentStatus: "confirmed" | "cancelled", notificationsSuppressed = false) {
   return renderToStaticMarkup(
     <StatusChangeDialog
       open
       onOpenChange={() => {}}
       bookingId="book_1"
       currentStatus={currentStatus}
+      notificationsSuppressed={notificationsSuppressed}
     />,
   )
 }
@@ -82,5 +87,15 @@ describe("StatusChangeDialog notification toggle", () => {
 
     expect(html).toContain("permanently")
     expect(html).toContain("cannot be switched back on")
+  })
+
+  // A Booking latched silent by an earlier action ignores whatever this dialog
+  // sends, so showing the toggle on would promise a send that never happens.
+  it("shows the toggle off and disabled when the booking is already silenced", () => {
+    const html = render("cancelled", true)
+
+    expect(html).toContain('data-checked="false"')
+    expect(html).toContain('data-disabled="true"')
+    expect(html).toContain("This booking was silenced earlier")
   })
 })


### PR DESCRIPTION
The status-change dialog carried a switch labelled **"Don't notify the customer"**, off by default — a box you tick to make less happen. The booking journey's equivalent already asks the question positively (**"Notify traveler"**, on by default) and maps it to the wire flag itself, so the same decision had two opposite presentations depending on where an operator made it.

| | before | after |
|---|---|---|
| status dialog label | "Don't notify the customer" | "Notify the customer" |
| default | off | on |
| wire | `suppressNotifications: values.suppressNotifications \|\| undefined` | `suppressNotifications: values.notifyCustomer ? undefined : true` |

## The domain flag deliberately stays negative

Only the dialog flips. `suppressNotifications` and `bookings.notifications_suppressed` are unchanged, because the negative default is the fail-safe one:

- A call site that forgets the flag sends a redundant email — noisy, visible, recoverable. A forgotten opt-in leaves the customer never told, and silence fails silently.
- Every downstream consumer in `notifications` is a skip-guard (`service-reminders.ts`, `service-reminder-events.ts`, `service-reminder-stage-runs.ts`, `subscriber-runtime.ts`). Inverted, each would have to read a missing or unhydrated field as "stay silent".
- `updateBookingSchema` types the column as `z.literal(true)` — a deliberate monotonic latch. Inverted it reads "`notificationsEnabled` may only ever be set to `false`", which is the same latch spelled backwards and looks like a bug.

## Both toggles now disclose the latch

Switching notifications off doesn't just skip this action's email. It latches `bookings.notifications_suppressed`, which nothing can clear — the booking is silent for good, future reminders included. This holds on all three paths: cancel (`service-core.ts:3267`), override-status (`:3661`), and create (`:2716`).

The old copy described it as confirming "silently", which reads as a one-time choice about the action in front of you. Both surfaces now say it is permanent, in en and ro.

## Verification

- `turbo run typecheck --filter=@voyant-travel/bookings-react` — 68/68 tasks, exit 0, zero `error TS`
- `vitest run tests/unit` — 30 files / 208 tests pass, including 3 new
- `biome check .` from the repo root — 0 errors; no diagnostics on changed files
- `pnpm i18n:check` — passes, en+ro parity kept

The new test pins the polarity rather than just asserting current behaviour: flipping the default back to off makes `defaults to notifying the customer` fail, and restoring it makes it pass. Verified both directions rather than trusting the green.

## Not addressed here

`status-dispatch.ts:41` honours `suppressNotifications` only for `cancelled`/`confirmed`, and `suppressLifecycleEvents` only for `confirmed`. The dialog hides the toggle elsewhere so the UI agrees today, but the admin API and MCP tool accept the flag on other transitions and silently ignore it. Separate change.