### PR TITLE
Let an operator issue and send a booking contract without an agent

### DIFF
--- a/.changeset/operator-booking-contract-issue.md
+++ b/.changeset/operator-booking-contract-issue.md
@@ -1,0 +1,18 @@
+---
+"@voyant-travel/legal-contracts": minor
+"@voyant-travel/legal": minor
+"@voyant-travel/legal-react": minor
+---
+
+Let an operator issue and send a booking contract without an agent.
+
+A booking-linked contract could only complete its reviewed lifecycle through `executeLegalContractLifecycleCommand`, which has no admin route and is invoked only from the MCP runtime. `POST /v1/admin/legal/contracts/{id}/issue` refused with a 400 while the admin UI rendered its `Issue` button anyway, so on a deployment where the agent is not wired for contracts every generated contract accumulated in `draft` with no operator path out of it.
+
+What the reviewed lifecycle actually enforces is three facts about the contract row — the revision has not been superseded, its content is still the reviewed content, and the caller approved the revision that is current. Those are checkable without the agent-approval machinery wrapped around them, so the admin routes now check them directly:
+
+- `GET /v1/admin/legal/contracts/{id}/booking-review` serves the un-redacted revision, including the `revision` and `contentFingerprint` a caller approves against. Managed booking revisions only; requires `bookings-pii:read` and records the access on the booking's PII log.
+- `POST /{id}/issue` and `POST /{id}/send` accept `{ revision, contentFingerprint }`. A managed booking revision without them is refused and told where to read them; a mismatched fingerprint, a stale revision, or an existing successor revision is refused for the same reason an agent would be.
+- Issuing a managed booking revision now promotes the reviewed content verbatim — no template re-render, no contract-number allocation — matching the reviewed lifecycle command's own issue leg instead of rewriting the document the approval covered.
+- The contract detail page opens a review dialog for booking contracts instead of firing an `Issue` that was guaranteed to fail, and disables the action with a reason when the review cannot be read.
+
+Document regeneration for a draft whose content is wrong is not part of this change: it needs the durable document-operation engine and an artifact provider on the admin route surface, neither of which the contracts admin routes carry today.

--- a/.changeset/operator-booking-contract-issue.md
+++ b/.changeset/operator-booking-contract-issue.md
@@ -2,6 +2,8 @@
 "@voyant-travel/legal-contracts": minor
 "@voyant-travel/legal": minor
 "@voyant-travel/legal-react": minor
+"@voyant-travel/admin-contracts": minor
+"@voyant-travel/admin-react": minor
 ---
 
 Let an operator issue and send a booking contract without an agent.
@@ -14,5 +16,8 @@ What the reviewed lifecycle actually enforces is three facts about the contract 
 - `POST /{id}/issue` and `POST /{id}/send` accept `{ revision, contentFingerprint }`. A managed booking revision without them is refused and told where to read them; a mismatched fingerprint, a stale revision, or an existing successor revision is refused for the same reason an agent would be.
 - Issuing a managed booking revision now promotes the reviewed content verbatim — no template re-render, no contract-number allocation — matching the reviewed lifecycle command's own issue leg instead of rewriting the document the approval covered.
 - The contract detail page opens a review dialog for booking contracts instead of firing an `Issue` that was guaranteed to fail, and disables the action with a reason when the review cannot be read.
+
+- `legal.contracts.issue` on the standard admin client took `z.object({})`, so it stripped the approval and would have hit `approval_required` on every booking contract. It now derives its input from the route schema, and `legal.contracts.send` and `legal.contracts.bookingReview` join it.
+- `packages/legal/openapi/admin/legal.json` says "Do not edit by hand" but nothing regenerated it. `pnpm --filter @voyant-travel/legal generate:openapi` now produces the contracts slice from the live routes through the operator app's own composition, and `verify:openapi-drift` holds it. Regenerating also corrected a `DELETE /{id}` conflict description that had already drifted from the route.
 
 Document regeneration for a draft whose content is wrong is not part of this change: it needs the durable document-operation engine and an artifact provider on the admin route surface, neither of which the contracts admin routes carry today.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,6 +425,8 @@ jobs:
                 tests/integration/contract-lifecycle-command.test.ts
               pnpm --filter @voyant-travel/legal exec vitest run \
                 tests/integration/booking-contract-confirmed.test.ts
+              pnpm --filter @voyant-travel/legal exec vitest run \
+                tests/integration/admin-booking-contract-lifecycle.test.ts
               pnpm --filter @voyant-travel/db exec vitest run \
                 tests/integration/outbox.test.ts
               pnpm --filter @voyant-travel/notifications exec vitest run \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,7 +304,12 @@ jobs:
             runner: ubuntu-24.04
             postgres_image: postgres:16
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 15
+    # The integration lane runs each listed file as its own vitest process and
+    # takes 11-13 minutes on main, so a 15-minute cap left it with no headroom:
+    # a runner ~30% slower than usual cancels it mid-suite, and every file added
+    # to the lane brings that closer. Raised to 20 so the cap stays a backstop
+    # against a hang rather than a budget the lane is already spending.
+    timeout-minutes: 20
     env:
       HUSKY: 0
       NODE_OPTIONS: --conditions=development --max-old-space-size=12288

--- a/packages/admin-contracts/src/contracts.test.ts
+++ b/packages/admin-contracts/src/contracts.test.ts
@@ -105,6 +105,9 @@ describe("@voyant-travel/admin-contracts registry", () => {
       "crm.people.documents.reveal",
       "crm.organizations.delete",
       "legal.contracts.create",
+      "legal.contracts.issue",
+      "legal.contracts.send",
+      "legal.contracts.bookingReview",
       "legal.contracts.void",
       "legal.policies.evaluate",
       "products.list",
@@ -124,6 +127,28 @@ describe("@voyant-travel/admin-contracts registry", () => {
     expect(getOperation("products.create")?.scopes).toEqual(["products:write"])
     expect(getOperation("products.delete")?.scopes).toEqual(["products:delete"])
     expect(getOperation("nope.missing")).toBeUndefined()
+  })
+
+  it("carries the booking-contract review approval through issue and send", () => {
+    // A client whose issue input is `z.object({})` strips the approval and every
+    // managed booking revision reaches `approval_required` (voyant#4706), so the
+    // descriptor must round-trip both fields the route checks.
+    const approval = {
+      revision: 2,
+      contentFingerprint: "booking-contract-content:v1:sha256:abc",
+    }
+    expect(legalOperations.contracts.issue.input.parse(approval)).toEqual(approval)
+    expect(
+      legalOperations.contracts.send.input.parse({ ...approval, subject: "Hi" }),
+    ).toMatchObject(approval)
+    // Both stay optional — an ordinary contract issues with no body at all.
+    expect(legalOperations.contracts.issue.input.parse({})).toEqual({})
+
+    // And the review that produces them is reachable, gated on booking PII.
+    expect(legalOperations.contracts.bookingReview.scopes).toEqual([
+      "legal:read",
+      "bookings-pii:read",
+    ])
   })
 
   it("list inputs match the real route filters (no advertised-but-stripped fields)", () => {

--- a/packages/admin-contracts/src/legal.ts
+++ b/packages/admin-contracts/src/legal.ts
@@ -8,8 +8,10 @@
  */
 
 import {
+  bookingContractReviewApprovalSchema,
   contractListQuerySchema,
   insertContractSchema,
+  sendContractInputSchema,
   updateContractSchema,
 } from "@voyant-travel/legal-contracts/contracts/validation"
 import {
@@ -34,6 +36,28 @@ export const contractSummarySchema = z.object({
   updatedAt: z.string().optional(),
 })
 export type ContractSummary = z.infer<typeof contractSummarySchema>
+
+/**
+ * Client-facing projection of the booking-contract review (ADR-0003: loose, so
+ * unknown server fields are stripped rather than rejected). The two fields a
+ * caller must round-trip into `issue`/`send` are the reason it exists.
+ */
+export const bookingContractReviewSummarySchema = z.object({
+  revision: z.number().int(),
+  contentFingerprint: z.string(),
+  effectiveStatus: z.string().nullable().optional(),
+  previousRevisionId: z.string().nullable().optional(),
+  contract: z
+    .object({
+      id: z.string(),
+      contractNumber: z.string().nullable().optional(),
+      status: z.string().nullable().optional(),
+      renderedBody: z.string().nullable().optional(),
+      renderedBodyFormat: z.string().nullable().optional(),
+    })
+    .optional(),
+})
+export type BookingContractReviewSummary = z.infer<typeof bookingContractReviewSummarySchema>
 
 export const policySummarySchema = z.object({
   id: z.string(),
@@ -102,17 +126,53 @@ const contractsUpdate = defineOperation({
   summary: "Update a contract.",
 })
 
+// A managed booking-contract revision only issues against the revision and
+// content fingerprint the caller reviewed, so the input derives from the route
+// schema rather than staying `z.object({})` — a client that cannot carry the
+// approval reaches `approval_required` on every booking contract (voyant#4706).
+// Both fields are optional: an ordinary contract still issues with no body.
 const contractsIssue = defineOperation({
   id: "legal.contracts.issue",
   method: "POST",
   path: (p: { id: string }) => `/v1/admin/legal/contracts/${p.id}/issue`,
   pathTemplate: "/v1/admin/legal/contracts/:id/issue",
-  input: z.object({}),
+  input: bookingContractReviewApprovalSchema,
   output: contractSummarySchema,
   classification: "routine_write",
   scopes: ["legal:write"],
   idempotent: true,
   summary: "Issue a draft contract (assigns its number, locks the body).",
+})
+
+const contractsSend = defineOperation({
+  id: "legal.contracts.send",
+  method: "POST",
+  path: (p: { id: string }) => `/v1/admin/legal/contracts/${p.id}/send`,
+  pathTemplate: "/v1/admin/legal/contracts/:id/send",
+  input: sendContractInputSchema,
+  output: contractSummarySchema,
+  classification: "routine_write",
+  scopes: ["legal:write"],
+  idempotent: true,
+  summary: "Send an issued contract to its recipient.",
+})
+
+/**
+ * The un-redacted booking-contract revision, and the `revision` +
+ * `contentFingerprint` that `issue` and `send` are approved against. Managed
+ * booking revisions only; anything else 404s. Needs `bookings-pii:read` on top
+ * of `legal:read`, because the payload carries the customer's own contract.
+ */
+const contractsBookingReview = defineOperation({
+  id: "legal.contracts.bookingReview",
+  method: "GET",
+  path: (p: { id: string }) => `/v1/admin/legal/contracts/${p.id}/booking-review`,
+  pathTemplate: "/v1/admin/legal/contracts/:id/booking-review",
+  input: z.object({}),
+  output: bookingContractReviewSummarySchema,
+  classification: "read",
+  scopes: ["legal:read", "bookings-pii:read"],
+  summary: "Read the reviewed booking-contract revision an issue/send approves.",
 })
 
 const contractsVoid = defineOperation({
@@ -200,6 +260,8 @@ export const legalOperations = {
     create: contractsCreate,
     update: contractsUpdate,
     issue: contractsIssue,
+    send: contractsSend,
+    bookingReview: contractsBookingReview,
     void: contractsVoid,
   },
   policies: {

--- a/packages/admin-react/src/client/client.ts
+++ b/packages/admin-react/src/client/client.ts
@@ -100,7 +100,17 @@ export function createAdminClient(config: AdminClientConfig) {
           params: { id: string },
           input: InferInput<typeof legalOperations.contracts.update>,
         ) => execute(legalOperations.contracts.update, params, input),
-        issue: (params: { id: string }) => execute(legalOperations.contracts.issue, params),
+        // A managed booking-contract revision needs the reviewed revision and
+        // content fingerprint from `bookingReview`; an ordinary contract omits
+        // the input entirely (voyant#4706).
+        issue: (
+          params: { id: string },
+          input?: InferInput<typeof legalOperations.contracts.issue>,
+        ) => execute(legalOperations.contracts.issue, params, input),
+        send: (params: { id: string }, input?: InferInput<typeof legalOperations.contracts.send>) =>
+          execute(legalOperations.contracts.send, params, input),
+        bookingReview: (params: { id: string }) =>
+          execute(legalOperations.contracts.bookingReview, params),
         void: (params: { id: string }) => execute(legalOperations.contracts.void, params),
       },
       policies: {

--- a/packages/legal-contracts/src/contracts/validation.ts
+++ b/packages/legal-contracts/src/contracts/validation.ts
@@ -192,6 +192,22 @@ export const publicRenderTemplatePreviewInputSchema = z.object({
 })
 
 /**
+ * The confirmation a managed booking-contract revision requires before it
+ * moves: the revision the caller was looking at, and a fingerprint of the exact
+ * content they reviewed. Both are read from
+ * `GET /v1/admin/legal/contracts/{id}/booking-review`.
+ *
+ * Optional because the same lifecycle routes serve ordinary contracts, which
+ * carry no reviewed revision at all; the route rejects an omitted approval only
+ * when the contract is a managed booking-contract revision (voyant#4706).
+ */
+export const bookingContractReviewApprovalSchema = z.object({
+  revision: z.number().int().positive().optional(),
+  contentFingerprint: z.string().startsWith("booking-contract-content:v1:sha256:").optional(),
+})
+export type BookingContractReviewApprovalInput = z.infer<typeof bookingContractReviewApprovalSchema>
+
+/**
  * Optional customization the operator typed in the Send-contract dialog.
  * All fields nullable — the route falls through to defaults (recipient
  * from the linked person record, subject + message resolved by the
@@ -201,6 +217,7 @@ export const sendContractInputSchema = z.object({
   recipientEmail: z.string().email().optional().nullable(),
   subject: z.string().max(500).optional().nullable(),
   message: z.string().max(10_000).optional().nullable(),
+  ...bookingContractReviewApprovalSchema.shape,
 })
 export type SendContractInput = z.infer<typeof sendContractInputSchema>
 

--- a/packages/legal-react/src/components/booking-contract-review-dialog.tsx
+++ b/packages/legal-react/src/components/booking-contract-review-dialog.tsx
@@ -1,0 +1,189 @@
+"use client"
+
+import {
+  Badge,
+  Button,
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@voyant-travel/ui/components"
+import { Loader2 } from "lucide-react"
+import { useLegalUiI18nOrDefault } from "../i18n/index.js"
+import {
+  type LegalBookingContractReview,
+  type LegalBookingContractReviewApproval,
+  useLegalBookingContractReview,
+} from "../index.js"
+
+export interface BookingContractReviewDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  contractId: string
+  /** Fired with the approval the route needs; the caller runs the mutation. */
+  onIssue: (approval: LegalBookingContractReviewApproval) => void
+  issuing?: boolean
+}
+
+/**
+ * The operator's half of the booking-contract reviewed lifecycle (voyant#4706).
+ *
+ * A managed booking-contract revision cannot be issued blind: the route checks
+ * the revision and content fingerprint the caller confirms against the row it
+ * is about to move. This dialog is where that confirmation comes from — it
+ * shows the un-redacted revision, and Issue carries the fingerprint of exactly
+ * what is on screen. If the review cannot be read (the deployment's staff role
+ * lacks booking PII read), Issue stays disabled with the reason, rather than
+ * offering an action that would be refused.
+ */
+export function BookingContractReviewDialog({
+  open,
+  onOpenChange,
+  contractId,
+  onIssue,
+  issuing = false,
+}: BookingContractReviewDialogProps) {
+  const i18n = useLegalUiI18nOrDefault()
+  const messages = i18n.messages.bookingContractReviewDialog
+  const reviewQuery = useLegalBookingContractReview({ contractId, enabled: open })
+  const review = reviewQuery.data ?? null
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent size="lg">
+        <DialogHeader>
+          <DialogTitle>{messages.title}</DialogTitle>
+        </DialogHeader>
+        <DialogBody className="grid gap-4">
+          <p className="text-muted-foreground text-sm">{messages.description}</p>
+
+          {reviewQuery.isPending ? (
+            <div className="flex items-center gap-2 text-muted-foreground text-xs">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+              {i18n.messages.common.loading}
+            </div>
+          ) : null}
+
+          {reviewQuery.isError ? (
+            <div
+              role="alert"
+              className="rounded-md border border-amber-500/50 bg-amber-500/10 px-3 py-2 text-amber-700 text-xs dark:text-amber-300"
+            >
+              {messages.unavailable}
+            </div>
+          ) : null}
+
+          {review ? <BookingContractReviewBody review={review} /> : null}
+        </DialogBody>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => onOpenChange(false)}
+            disabled={issuing}
+          >
+            {messages.actions.cancel}
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            disabled={!review || issuing}
+            onClick={() => {
+              if (!review) return
+              onIssue({
+                revision: review.revision,
+                contentFingerprint: review.contentFingerprint,
+              })
+            }}
+          >
+            {issuing ? <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" /> : null}
+            {messages.actions.issue}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function BookingContractReviewBody({ review }: { review: LegalBookingContractReview }) {
+  const i18n = useLegalUiI18nOrDefault()
+  const messages = i18n.messages.bookingContractReviewDialog
+  const total =
+    review.booking.totalAmountCents === null
+      ? i18n.messages.common.noResultsDash
+      : i18n.formatCurrency(review.booking.totalAmountCents / 100, review.booking.currency)
+
+  return (
+    <div className="grid gap-4">
+      <dl className="grid gap-2 text-sm sm:grid-cols-2">
+        <ReviewField label={messages.fields.booking}>{review.booking.reference}</ReviewField>
+        <ReviewField label={messages.fields.customer}>
+          {review.booking.customerName ?? i18n.messages.common.noResultsDash}
+        </ReviewField>
+        <ReviewField label={messages.fields.template}>
+          {review.template.name} (v{review.template.version}, {review.template.language})
+        </ReviewField>
+        <ReviewField label={messages.fields.revision}>
+          <Badge variant="outline">{review.revision}</Badge>
+        </ReviewField>
+        <ReviewField label={messages.fields.total}>{total}</ReviewField>
+      </dl>
+
+      {review.products.length > 0 ? (
+        <div className="grid gap-1">
+          <span className="font-medium text-sm">{messages.fields.products}</span>
+          <ul className="grid gap-1 rounded-md border bg-muted/40 px-3 py-2 text-xs">
+            {review.products.map((product, index) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: positional review snapshot -- owner: legal-react; the frozen product list has no identifier of its own and is never reordered or filtered.
+              <li key={`${product.title}-${index}`} className="flex justify-between gap-2">
+                <span className="truncate">
+                  {product.quantity} x {product.title}
+                </span>
+                <span className="shrink-0 text-muted-foreground">
+                  {product.amountCents === null
+                    ? i18n.messages.common.noResultsDash
+                    : i18n.formatCurrency(product.amountCents / 100, product.currency)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      <div className="grid gap-1">
+        <span className="font-medium text-sm">{messages.bodyHeading}</span>
+        {review.contract.renderedBody ? (
+          review.contract.renderedBodyFormat === "html" ? (
+            // Only the admin-authored template contributes markup here: an
+            // `html` body is rendered with `outputEscape: "escape"`, so every
+            // interpolated booking value arrives HTML-escaped. Same trust
+            // level as the template preview on the template detail page.
+            <div
+              className="prose prose-sm max-h-72 max-w-none overflow-y-auto rounded-md border bg-background px-3 py-2 text-xs"
+              // biome-ignore lint/security/noDangerouslySetInnerHtml: admin-authored template markup with escaped interpolations -- owner: legal-react; the reviewed document must render as the customer sees it.
+              dangerouslySetInnerHTML={{ __html: review.contract.renderedBody }}
+            />
+          ) : (
+            <pre className="max-h-72 overflow-y-auto whitespace-pre-wrap rounded-md border bg-background px-3 py-2 font-sans text-xs">
+              {review.contract.renderedBody}
+            </pre>
+          )
+        ) : (
+          <p className="text-muted-foreground text-xs">{messages.bodyUnavailable}</p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function ReviewField({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <dt className="text-muted-foreground text-xs">{label}</dt>
+      <dd className="text-sm">{children}</dd>
+    </div>
+  )
+}

--- a/packages/legal-react/src/components/booking-contract-review-dialog.tsx
+++ b/packages/legal-react/src/components/booking-contract-review-dialog.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { formatMessage } from "@voyant-travel/i18n"
 import {
   Badge,
   Button,
@@ -124,7 +125,11 @@ function BookingContractReviewBody({ review }: { review: LegalBookingContractRev
           {review.booking.customerName ?? i18n.messages.common.noResultsDash}
         </ReviewField>
         <ReviewField label={messages.fields.template}>
-          {review.template.name} (v{review.template.version}, {review.template.language})
+          {formatMessage(messages.templateSummary, {
+            name: review.template.name,
+            version: review.template.version,
+            language: review.template.language,
+          })}
         </ReviewField>
         <ReviewField label={messages.fields.revision}>
           <Badge variant="outline">{review.revision}</Badge>
@@ -140,7 +145,10 @@ function BookingContractReviewBody({ review }: { review: LegalBookingContractRev
               // biome-ignore lint/suspicious/noArrayIndexKey: positional review snapshot -- owner: legal-react; the frozen product list has no identifier of its own and is never reordered or filtered.
               <li key={`${product.title}-${index}`} className="flex justify-between gap-2">
                 <span className="truncate">
-                  {product.quantity} x {product.title}
+                  {formatMessage(messages.productLine, {
+                    quantity: product.quantity,
+                    title: product.title,
+                  })}
                 </span>
                 <span className="shrink-0 text-muted-foreground">
                   {product.amountCents === null

--- a/packages/legal-react/src/components/contract-detail-page.tsx
+++ b/packages/legal-react/src/components/contract-detail-page.tsx
@@ -25,6 +25,7 @@ import { useState } from "react"
 import { useLegalUiI18nOrDefault, useLegalUiMessagesOrDefault } from "../i18n/index.js"
 import type { LegalContractStatusValue } from "../i18n/messages.js"
 import {
+  type LegalBookingContractReviewApproval,
   type LegalContractAttachmentRecord,
   type LegalContractRecord,
   useLegalContract,
@@ -34,7 +35,9 @@ import {
   useLegalContractSignatures,
   useVoyantLegalContext,
 } from "../index.js"
+import { isManagedBookingContractRevision } from "../managed-booking-contract.js"
 import { AttachmentDialog } from "./attachment-dialog.js"
+import { BookingContractReviewDialog } from "./booking-contract-review-dialog.js"
 import { ContractSendDialog } from "./contract-send-dialog.js"
 import { SignatureDialog } from "./signature-dialog.js"
 
@@ -158,6 +161,7 @@ export function ContractDetailPage({
 
   const [editOpen, setEditOpen] = useState(false)
   const [sendOpen, setSendOpen] = useState(false)
+  const [reviewOpen, setReviewOpen] = useState(false)
   const [signOpen, setSignOpen] = useState(false)
   const [attachOpen, setAttachOpen] = useState(false)
   const [editingAttachment, setEditingAttachment] = useState<
@@ -196,6 +200,7 @@ export function ContractDetailPage({
   }
 
   const status = contract.status
+  const managedBookingRevision = isManagedBookingContractRevision(contract)
   const generationFailure = resolveContractGenerationFailure(contract)
   const generationFailureMessages = messages.contractDetailPage.generationFailure
   const failureLabelKey = generationFailure
@@ -248,7 +253,11 @@ export function ContractDetailPage({
         </div>
         <div className="flex flex-wrap items-center gap-2">
           {status === "draft" ? (
-            <Button size="sm" onClick={() => issue.mutate(id)} disabled={issue.isPending}>
+            <Button
+              size="sm"
+              onClick={() => (managedBookingRevision ? setReviewOpen(true) : issue.mutate({ id }))}
+              disabled={issue.isPending}
+            >
               {f.actions.issue}
             </Button>
           ) : null}
@@ -557,6 +566,16 @@ export function ContractDetailPage({
           setEditingAttachment(undefined)
           void refetchAttachments()
         }}
+      />
+
+      <BookingContractReviewDialog
+        open={reviewOpen}
+        onOpenChange={setReviewOpen}
+        contractId={id}
+        issuing={issue.isPending}
+        onIssue={(approval: LegalBookingContractReviewApproval) =>
+          issue.mutate({ id, approval }, { onSuccess: () => setReviewOpen(false) })
+        }
       />
 
       <ContractSendDialog

--- a/packages/legal-react/src/components/contract-send-dialog.tsx
+++ b/packages/legal-react/src/components/contract-send-dialog.tsx
@@ -16,7 +16,12 @@ import {
 import { Loader2, Mail, Paperclip } from "lucide-react"
 import { useEffect, useState } from "react"
 import { useLegalUiMessagesOrDefault } from "../i18n/index.js"
-import { type LegalContractRecord, useLegalContractMutation } from "../index.js"
+import {
+  type LegalContractRecord,
+  useLegalBookingContractReview,
+  useLegalContractMutation,
+} from "../index.js"
+import { isManagedBookingContractRevision } from "../managed-booking-contract.js"
 
 export interface ContractSendDialogProps {
   open: boolean
@@ -61,7 +66,24 @@ export function ContractSendDialog({
   onSent,
 }: ContractSendDialogProps) {
   const { send } = useLegalContractMutation()
-  const messages = useLegalUiMessagesOrDefault().contractSendDialog
+  const allMessages = useLegalUiMessagesOrDefault()
+  const messages = allMessages.contractSendDialog
+  const reviewUnavailableMessage = allMessages.bookingContractReviewDialog.unavailable
+  // A managed booking-contract revision carries the same review gate on send as
+  // on issue (voyant#4706): the route needs the revision and content
+  // fingerprint the operator is looking at. Ordinary contracts 404 here, which
+  // leaves the approval undefined and the generic send path unchanged.
+  const isManagedBookingRevision = isManagedBookingContractRevision(contract)
+  const reviewQuery = useLegalBookingContractReview({
+    contractId: contract.id,
+    enabled: open && isManagedBookingRevision,
+  })
+  const reviewApproval = reviewQuery.data
+    ? {
+        revision: reviewQuery.data.revision,
+        contentFingerprint: reviewQuery.data.contentFingerprint,
+      }
+    : null
 
   const fallbackSubject =
     defaultSubject ??
@@ -93,7 +115,10 @@ export function ContractSendDialog({
     }
   }, [open, fallbackSubject, fallbackMessage])
 
-  const canSend = Boolean(defaultRecipientEmail) && !send.isPending
+  const canSend =
+    Boolean(defaultRecipientEmail) &&
+    !send.isPending &&
+    (!isManagedBookingRevision || reviewApproval !== null)
   const isAlreadySent = contract.status === "sent" || contract.status === "signed"
 
   const handleSend = async () => {
@@ -103,6 +128,7 @@ export function ContractSendDialog({
         recipientEmail: defaultRecipientEmail ?? null,
         subject: subject.trim() || null,
         message: message.trim() || null,
+        ...(reviewApproval ?? {}),
       },
     })
     onOpenChange(false)
@@ -116,6 +142,15 @@ export function ContractSendDialog({
           <DialogTitle>{messages.title}</DialogTitle>
         </DialogHeader>
         <DialogBody className="grid gap-4">
+          {isManagedBookingRevision && reviewQuery.isError ? (
+            <div
+              role="alert"
+              className="rounded-md border border-amber-500/50 bg-amber-500/10 px-3 py-2 text-amber-700 text-xs dark:text-amber-300"
+            >
+              {reviewUnavailableMessage}
+            </div>
+          ) : null}
+
           {isAlreadySent ? (
             <div
               role="status"

--- a/packages/legal-react/src/hooks/index.ts
+++ b/packages/legal-react/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export * from "./use-booking-contract-review.js"
 export * from "./use-contract.js"
 export * from "./use-contract-attachment-mutation.js"
 export * from "./use-contract-attachments.js"

--- a/packages/legal-react/src/hooks/use-booking-contract-review.ts
+++ b/packages/legal-react/src/hooks/use-booking-contract-review.ts
@@ -1,0 +1,26 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+
+import { useVoyantLegalContext } from "../provider.js"
+import { getLegalBookingContractReviewQueryOptions } from "../query-options.js"
+
+export interface UseLegalBookingContractReviewOptions {
+  contractId: string
+  enabled?: boolean
+}
+
+/**
+ * The un-redacted review of one managed booking-contract revision. Only
+ * managed booking contracts have one — everything else 404s, which is the
+ * signal the generic lifecycle applies.
+ */
+export function useLegalBookingContractReview(options: UseLegalBookingContractReviewOptions) {
+  const { baseUrl, fetcher } = useVoyantLegalContext()
+  const { enabled = true, ...filters } = options
+
+  return useQuery({
+    ...getLegalBookingContractReviewQueryOptions({ baseUrl, fetcher }, filters),
+    enabled,
+  })
+}

--- a/packages/legal-react/src/hooks/use-contract-mutation.ts
+++ b/packages/legal-react/src/hooks/use-contract-mutation.ts
@@ -15,7 +15,17 @@ import { legalContractSingleResponse, successEnvelope } from "../schemas.js"
 export type CreateLegalContractInput = z.input<typeof insertContractSchema>
 export type UpdateLegalContractInput = z.input<typeof updateContractSchema>
 
-export interface SendLegalContractInputBody {
+/**
+ * What a managed booking-contract revision needs before it moves: the revision
+ * the operator reviewed and a fingerprint of its exact content, both read from
+ * `useLegalBookingContractReview`. Ordinary contracts omit it (voyant#4706).
+ */
+export interface LegalBookingContractReviewApproval {
+  revision: number
+  contentFingerprint: string
+}
+
+export interface SendLegalContractInputBody extends Partial<LegalBookingContractReviewApproval> {
   /** Customer email to deliver the contract to. */
   recipientEmail?: string | null
   /** Subject line for the outgoing email. */
@@ -27,6 +37,11 @@ export interface SendLegalContractInputBody {
 export interface SendLegalContractInput {
   id: string
   input?: SendLegalContractInputBody
+}
+
+export interface IssueLegalContractInput {
+  id: string
+  approval?: LegalBookingContractReviewApproval
 }
 
 export function useLegalContractMutation() {
@@ -84,12 +99,19 @@ export function useLegalContractMutation() {
   })
 
   const issue = useMutation({
-    mutationFn: async (id: string) => {
+    mutationFn: async (input: IssueLegalContractInput | string) => {
+      // Back-compat: ordinary contracts still pass the id string. A managed
+      // booking-contract revision passes `{ id, approval }` so the route can
+      // check the approval against the revision it is about to issue.
+      const normalized: IssueLegalContractInput = typeof input === "string" ? { id: input } : input
       const { data } = await fetchWithValidation(
-        `/v1/admin/legal/contracts/${id}/issue`,
+        `/v1/admin/legal/contracts/${normalized.id}/issue`,
         legalContractSingleResponse,
         { baseUrl, fetcher },
-        { method: "POST" },
+        {
+          method: "POST",
+          ...(normalized.approval ? { body: JSON.stringify(normalized.approval) } : {}),
+        },
       )
       return data
     },

--- a/packages/legal-react/src/i18n/en.ts
+++ b/packages/legal-react/src/i18n/en.ts
@@ -123,6 +123,8 @@ export const legalUiEn = {
       total: "Total",
       products: "Products",
     },
+    templateSummary: "{name} (version {version}, {language})",
+    productLine: "{quantity} x {title}",
     bodyHeading: "Contract content",
     bodyUnavailable: "This revision has no rendered content yet.",
     actions: {

--- a/packages/legal-react/src/i18n/en.ts
+++ b/packages/legal-react/src/i18n/en.ts
@@ -108,6 +108,28 @@ export const legalUiEn = {
       send: "Send",
     },
   },
+  bookingContractReviewDialog: {
+    title: "Review and issue booking contract",
+    description:
+      "Check the contract below against the booking. Issuing locks this exact content as the customer-facing document.",
+    unavailable:
+      "This booking contract cannot be reviewed with your current permissions. Reviewing a booking contract needs the bookings PII read permission.",
+    loadFailed: "The booking contract review could not be loaded.",
+    fields: {
+      booking: "Booking",
+      customer: "Customer",
+      template: "Template",
+      revision: "Revision",
+      total: "Total",
+      products: "Products",
+    },
+    bodyHeading: "Contract content",
+    bodyUnavailable: "This revision has no rendered content yet.",
+    actions: {
+      cancel: "Cancel",
+      issue: "Issue contract",
+    },
+  },
   contractDialog: {
     titleNew: "New Contract",
     titleEdit: "Edit Contract",

--- a/packages/legal-react/src/i18n/messages.ts
+++ b/packages/legal-react/src/i18n/messages.ts
@@ -130,6 +130,8 @@ export type LegalUiMessages = {
       total: string
       products: string
     }
+    templateSummary: string
+    productLine: string
     bodyHeading: string
     bodyUnavailable: string
     actions: {

--- a/packages/legal-react/src/i18n/messages.ts
+++ b/packages/legal-react/src/i18n/messages.ts
@@ -117,6 +117,26 @@ export type LegalUiMessages = {
       send: string
     }
   }
+  bookingContractReviewDialog: {
+    title: string
+    description: string
+    unavailable: string
+    loadFailed: string
+    fields: {
+      booking: string
+      customer: string
+      template: string
+      revision: string
+      total: string
+      products: string
+    }
+    bodyHeading: string
+    bodyUnavailable: string
+    actions: {
+      cancel: string
+      issue: string
+    }
+  }
   contractDialog: {
     titleNew: string
     titleEdit: string

--- a/packages/legal-react/src/i18n/ro.ts
+++ b/packages/legal-react/src/i18n/ro.ts
@@ -123,6 +123,8 @@ export const legalUiRo = {
       total: "Total",
       products: "Produse",
     },
+    templateSummary: "{name} (versiunea {version}, {language})",
+    productLine: "{quantity} x {title}",
     bodyHeading: "Continutul contractului",
     bodyUnavailable: "Aceasta revizie nu are inca un continut generat.",
     actions: {

--- a/packages/legal-react/src/i18n/ro.ts
+++ b/packages/legal-react/src/i18n/ro.ts
@@ -108,6 +108,28 @@ export const legalUiRo = {
       send: "Trimite",
     },
   },
+  bookingContractReviewDialog: {
+    title: "Verifica si emite contractul de rezervare",
+    description:
+      "Verifica contractul de mai jos fata de rezervare. Emiterea blocheaza exact acest continut ca document pentru client.",
+    unavailable:
+      "Acest contract de rezervare nu poate fi verificat cu permisiunile tale actuale. Verificarea unui contract de rezervare necesita permisiunea de citire a datelor personale din rezervari.",
+    loadFailed: "Verificarea contractului de rezervare nu a putut fi incarcata.",
+    fields: {
+      booking: "Rezervare",
+      customer: "Client",
+      template: "Sablon",
+      revision: "Revizie",
+      total: "Total",
+      products: "Produse",
+    },
+    bodyHeading: "Continutul contractului",
+    bodyUnavailable: "Aceasta revizie nu are inca un continut generat.",
+    actions: {
+      cancel: "Anuleaza",
+      issue: "Emite contractul",
+    },
+  },
   contractDialog: {
     titleNew: "Contract nou",
     titleEdit: "Editeaza contractul",

--- a/packages/legal-react/src/index.ts
+++ b/packages/legal-react/src/index.ts
@@ -6,6 +6,7 @@ export {
   type VoyantFetcher,
 } from "./client.js"
 export * from "./hooks/index.js"
+export { isManagedBookingContractRevision } from "./managed-booking-contract.js"
 export {
   useVoyantLegalContext,
   type VoyantLegalContextValue,
@@ -26,6 +27,7 @@ export {
 } from "./query-keys.js"
 export {
   getDefaultLegalContractTemplateQueryOptions,
+  getLegalBookingContractReviewQueryOptions,
   getLegalContractAttachmentsQueryOptions,
   getLegalContractNumberSeriesDetailQueryOptions,
   getLegalContractNumberSeriesQueryOptions,

--- a/packages/legal-react/src/managed-booking-contract.ts
+++ b/packages/legal-react/src/managed-booking-contract.ts
@@ -1,0 +1,17 @@
+import type { LegalContractRecord } from "./schemas.js"
+
+/**
+ * Whether this contract is a managed booking-contract revision — the shape
+ * whose lifecycle is gated on the reviewed revision and content fingerprint
+ * (voyant#4706).
+ *
+ * The generic contract detail redacts such a revision's body and variables but
+ * keeps the workflow marker, which is what this reads. It is the UI's signal to
+ * route Issue and Send through the review rather than firing them directly.
+ */
+export function isManagedBookingContractRevision(contract: LegalContractRecord): boolean {
+  const metadata = contract.metadata
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return false
+  const workflow = (metadata as Record<string, unknown>).bookingContractWorkflow
+  return !!workflow && typeof workflow === "object" && !Array.isArray(workflow)
+}

--- a/packages/legal-react/src/query-keys.ts
+++ b/packages/legal-react/src/query-keys.ts
@@ -108,6 +108,8 @@ export const legalQueryKeys = {
   contract: (id: string) => [...legalQueryKeys.contracts(), id] as const,
   contractSignatures: (id: string) => [...legalQueryKeys.contract(id), "signatures"] as const,
   contractAttachments: (id: string) => [...legalQueryKeys.contract(id), "attachments"] as const,
+  contractBookingReview: (id: string) =>
+    [...legalQueryKeys.contract(id), "booking-review"] as const,
   templates: () => [...legalQueryKeys.all, "templates"] as const,
   templatesList: (filters: LegalContractTemplatesListFilters) =>
     [...legalQueryKeys.templates(), filters] as const,

--- a/packages/legal-react/src/query-options.ts
+++ b/packages/legal-react/src/query-options.ts
@@ -3,6 +3,7 @@
 import { queryOptions } from "@tanstack/react-query"
 
 import { type FetchWithValidationOptions, fetchWithValidation } from "./client.js"
+import type { UseLegalBookingContractReviewOptions } from "./hooks/use-booking-contract-review.js"
 import type { UseLegalContractOptions } from "./hooks/use-contract.js"
 import type { UseLegalContractAttachmentsOptions } from "./hooks/use-contract-attachments.js"
 import type { UseLegalContractSignaturesOptions } from "./hooks/use-contract-signatures.js"
@@ -24,6 +25,7 @@ import {
   type ResolvePolicyFilters,
 } from "./query-keys.js"
 import {
+  legalBookingContractReviewResponse,
   legalContractAttachmentListResponse,
   legalContractListResponse,
   legalContractNumberSeriesListResponse,
@@ -122,6 +124,28 @@ export function getLegalContractAttachmentsQueryOptions(
       )
       return data
     },
+  })
+}
+
+export function getLegalBookingContractReviewQueryOptions(
+  client: FetchWithValidationOptions,
+  options: UseLegalBookingContractReviewOptions,
+) {
+  const { enabled: _enabled = true, contractId } = options
+  return queryOptions({
+    queryKey: legalQueryKeys.contractBookingReview(contractId),
+    queryFn: async () => {
+      const { data } = await fetchWithValidation(
+        `/v1/admin/legal/contracts/${contractId}/booking-review`,
+        legalBookingContractReviewResponse,
+        client,
+      )
+      return data
+    },
+    // The revision + content fingerprint here are what the operator approves
+    // against, so a stale cached copy would approve content that has moved on.
+    staleTime: 0,
+    retry: false,
   })
 }
 

--- a/packages/legal-react/src/schemas.ts
+++ b/packages/legal-react/src/schemas.ts
@@ -264,6 +264,70 @@ export const legalTermRecordSchema = z.object({
 
 export type LegalTermRecord = z.infer<typeof legalTermRecordSchema>
 
+/**
+ * The un-redacted view of one managed booking-contract revision, served by
+ * `GET /v1/admin/legal/contracts/{id}/booking-review`. It carries the
+ * `revision` + `contentFingerprint` an operator confirms before issuing or
+ * sending the revision (voyant#4706) — the generic contract detail redacts the
+ * body and variables, so this is the only operator read that can support that
+ * confirmation. Mirrored here rather than imported: the server schema lives
+ * next to the Tool registry, which a browser package may not reach.
+ */
+export const legalBookingContractReviewSchema = z.object({
+  contentFingerprint: z.string(),
+  effectiveStatus: z.enum(["draft", "sent", "viewed", "declined", "signed", "void"]),
+  revision: z.number().int(),
+  previousRevisionId: z.string().nullable(),
+  contract: z.object({
+    id: z.string(),
+    contractNumber: z.string().nullable(),
+    status: z.string(),
+    title: z.string(),
+    language: z.string(),
+    renderedBody: z.string().nullable(),
+    renderedBodyFormat: z.string(),
+  }),
+  booking: z.object({
+    id: z.string(),
+    reference: z.string(),
+    customerName: z.string().nullable(),
+    customerEmail: z.string().nullable(),
+    language: z.string(),
+    currency: z.string(),
+    totalAmountCents: z.number().int().nullable(),
+    startDate: z.string().nullable(),
+    endDate: z.string().nullable(),
+  }),
+  products: z.array(
+    z.object({
+      title: z.string(),
+      quantity: z.number().int(),
+      amountCents: z.number().int().nullable(),
+      currency: z.string(),
+    }),
+  ),
+  template: z.object({
+    id: z.string(),
+    name: z.string(),
+    versionId: z.string(),
+    version: z.number().int(),
+    language: z.string(),
+  }),
+  delivery: z.object({
+    recipient: z.string().nullable(),
+    channel: z.enum(["email", "sms", "whatsapp"]).nullable(),
+    sentRevision: z.number().int().nullable(),
+    sentAt: z.string().nullable(),
+    viewedAt: z.string().nullable(),
+    declinedAt: z.string().nullable(),
+    notificationsSuppressed: z.boolean(),
+  }),
+  voidConsequences: z.array(z.string()),
+})
+
+export type LegalBookingContractReview = z.infer<typeof legalBookingContractReviewSchema>
+export const legalBookingContractReviewResponse = singleEnvelope(legalBookingContractReviewSchema)
+
 export const legalContractListResponse = paginatedEnvelope(legalContractRecordSchema)
 export const legalContractSingleResponse = singleEnvelope(legalContractRecordSchema)
 export const legalContractSignatureListResponse = singleEnvelope(

--- a/packages/legal-react/src/ui.ts
+++ b/packages/legal-react/src/ui.ts
@@ -5,6 +5,10 @@ export {
   type BookingContractCardProps,
 } from "./components/booking-contract-card.js"
 export {
+  BookingContractReviewDialog,
+  type BookingContractReviewDialogProps,
+} from "./components/booking-contract-review-dialog.js"
+export {
   type ContractDetailDialogRenderProps,
   ContractDetailPage,
   type ContractDetailPageProps,

--- a/packages/legal/openapi/admin/legal.json
+++ b/packages/legal/openapi/admin/legal.json
@@ -3708,7 +3708,7 @@
             }
           },
           "409": {
-            "description": "Only draft or void contracts can be deleted",
+            "description": "Contract cannot be deleted",
             "content": {
               "application/json": {
                 "schema": {
@@ -3743,6 +3743,25 @@
             "in": "path"
           }
         ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "revision": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0
+                  },
+                  "contentFingerprint": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "The issued contract",
@@ -3951,6 +3970,22 @@
               }
             }
           },
+          "400": {
+            "description": "invalid_request: request body failed validation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
           "404": {
             "description": "Contract not found",
             "content": {
@@ -4003,6 +4038,37 @@
             "in": "path"
           }
         ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "recipientEmail": {
+                    "type": ["string", "null"],
+                    "format": "email"
+                  },
+                  "subject": {
+                    "type": ["string", "null"],
+                    "maxLength": 500
+                  },
+                  "message": {
+                    "type": ["string", "null"],
+                    "maxLength": 10000
+                  },
+                  "revision": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0
+                  },
+                  "contentFingerprint": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "The sent contract",
@@ -11240,6 +11306,318 @@
         },
         "operationId": "deleteAdminLegalTermsById",
         "summary": "DELETE /v1/admin/legal/terms/{id}",
+        "tags": ["legal"],
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
+      }
+    },
+    "/v1/admin/legal/contracts/{id}/booking-review": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The booking-contract revision under review",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "contract": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string"
+                            },
+                            "contractNumber": {
+                              "type": ["string", "null"]
+                            },
+                            "scope": {
+                              "type": "string",
+                              "enum": ["customer", "supplier", "partner", "channel", "other"]
+                            },
+                            "status": {
+                              "type": "string",
+                              "enum": [
+                                "draft",
+                                "issued",
+                                "sent",
+                                "signed",
+                                "executed",
+                                "expired",
+                                "void"
+                              ]
+                            },
+                            "title": {
+                              "type": "string"
+                            },
+                            "bookingId": {
+                              "type": ["string", "null"]
+                            },
+                            "language": {
+                              "type": "string"
+                            },
+                            "templateVersionId": {
+                              "type": ["string", "null"]
+                            },
+                            "renderedBodyFormat": {
+                              "type": "string",
+                              "enum": ["markdown", "html", "lexical_json"]
+                            },
+                            "renderedBody": {
+                              "type": ["string", "null"]
+                            },
+                            "variables": {
+                              "type": ["object", "null"],
+                              "additionalProperties": {}
+                            },
+                            "metadata": {
+                              "type": ["object", "null"],
+                              "additionalProperties": {}
+                            },
+                            "issuedAt": {
+                              "type": ["string", "null"]
+                            },
+                            "sentAt": {
+                              "type": ["string", "null"]
+                            },
+                            "executedAt": {
+                              "type": ["string", "null"]
+                            },
+                            "expiresAt": {
+                              "type": ["string", "null"]
+                            },
+                            "voidedAt": {
+                              "type": ["string", "null"]
+                            },
+                            "createdAt": {
+                              "type": "string"
+                            },
+                            "updatedAt": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "contractNumber",
+                            "scope",
+                            "status",
+                            "title",
+                            "bookingId",
+                            "language",
+                            "templateVersionId",
+                            "renderedBodyFormat",
+                            "renderedBody",
+                            "variables",
+                            "metadata",
+                            "issuedAt",
+                            "sentAt",
+                            "executedAt",
+                            "expiresAt",
+                            "voidedAt",
+                            "createdAt",
+                            "updatedAt"
+                          ]
+                        },
+                        "contentFingerprint": {
+                          "type": "string"
+                        },
+                        "effectiveStatus": {
+                          "type": "string",
+                          "enum": ["draft", "sent", "viewed", "declined", "signed", "void"]
+                        },
+                        "revision": {
+                          "type": "integer",
+                          "exclusiveMinimum": 0
+                        },
+                        "previousRevisionId": {
+                          "type": ["string", "null"]
+                        },
+                        "booking": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string"
+                            },
+                            "reference": {
+                              "type": "string"
+                            },
+                            "customerName": {
+                              "type": ["string", "null"]
+                            },
+                            "customerEmail": {
+                              "type": ["string", "null"]
+                            },
+                            "language": {
+                              "type": "string"
+                            },
+                            "currency": {
+                              "type": "string"
+                            },
+                            "totalAmountCents": {
+                              "type": ["integer", "null"]
+                            },
+                            "startDate": {
+                              "type": ["string", "null"]
+                            },
+                            "endDate": {
+                              "type": ["string", "null"]
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "reference",
+                            "customerName",
+                            "customerEmail",
+                            "language",
+                            "currency",
+                            "totalAmountCents",
+                            "startDate",
+                            "endDate"
+                          ]
+                        },
+                        "products": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "title": {
+                                "type": "string"
+                              },
+                              "quantity": {
+                                "type": "integer",
+                                "exclusiveMinimum": 0
+                              },
+                              "amountCents": {
+                                "type": ["integer", "null"]
+                              },
+                              "currency": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["title", "quantity", "amountCents", "currency"]
+                          }
+                        },
+                        "template": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "versionId": {
+                              "type": "string"
+                            },
+                            "version": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
+                            },
+                            "language": {
+                              "type": "string"
+                            }
+                          },
+                          "required": ["id", "name", "versionId", "version", "language"]
+                        },
+                        "commercialTerms": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "delivery": {
+                          "type": "object",
+                          "properties": {
+                            "recipient": {
+                              "type": ["string", "null"]
+                            },
+                            "channel": {
+                              "type": ["string", "null"],
+                              "enum": ["email", "sms", "whatsapp", null]
+                            },
+                            "sentRevision": {
+                              "type": ["integer", "null"],
+                              "exclusiveMinimum": 0
+                            },
+                            "sentAt": {
+                              "type": ["string", "null"]
+                            },
+                            "viewedAt": {
+                              "type": ["string", "null"]
+                            },
+                            "declinedAt": {
+                              "type": ["string", "null"]
+                            },
+                            "notificationsSuppressed": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "recipient",
+                            "channel",
+                            "sentRevision",
+                            "sentAt",
+                            "viewedAt",
+                            "declinedAt",
+                            "notificationsSuppressed"
+                          ]
+                        },
+                        "voidConsequences": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "contract",
+                        "contentFingerprint",
+                        "effectiveStatus",
+                        "revision",
+                        "previousRevisionId",
+                        "booking",
+                        "products",
+                        "template",
+                        "commercialTerms",
+                        "delivery",
+                        "voidConsequences"
+                      ]
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Contract not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "getAdminLegalContractsByIdBookingReview",
+        "summary": "GET /v1/admin/legal/contracts/{id}/booking-review",
         "tags": ["legal"],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"

--- a/packages/legal/package.json
+++ b/packages/legal/package.json
@@ -43,7 +43,8 @@
     "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build",
-    "db:generate": "drizzle-kit generate --config=drizzle.migrations.config.ts --name=legal_baseline && node ../../scripts/migrations/guard-create-type.mjs ./migrations && node ../../scripts/migrations/ensure-extensions.mjs ./migrations"
+    "db:generate": "drizzle-kit generate --config=drizzle.migrations.config.ts --name=legal_baseline && node ../../scripts/migrations/guard-create-type.mjs ./migrations && node ../../scripts/migrations/ensure-extensions.mjs ./migrations",
+    "generate:openapi": "node --import tsx scripts/generate-openapi.ts && biome format --write openapi/admin/legal.json"
   },
   "dependencies": {
     "@hono/zod-openapi": "catalog:",

--- a/packages/legal/scripts/generate-openapi.ts
+++ b/packages/legal/scripts/generate-openapi.ts
@@ -1,0 +1,58 @@
+/**
+ * Regenerates the contracts slice of this package's published admin OpenAPI
+ * document from the live route module.
+ *
+ * `openapi/admin/legal.json` says "Do not edit by hand", but nothing in the
+ * repository regenerated it — so adding a route left the published contract
+ * describing a surface the deployment no longer has (voyant#4706 review). This
+ * drives the real routes through the same composition the operator app applies
+ * (`stampModuleMetadata`), so the artifact is generated rather than transcribed.
+ *
+ * Only the `/v1/admin/legal/contracts` paths are owned here; the policies and
+ * terms paths in the same document come from their own route modules and are
+ * left untouched.
+ *
+ * Registered in `scripts/checks/openapi/generated-specs.json`, so
+ * `verify:openapi-drift` fails when the artifact and the routes disagree.
+ */
+import { readFileSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { stampModuleMetadata } from "@voyant-travel/hono/openapi"
+
+import { createContractsAdminRoutes } from "../src/contracts/routes.js"
+
+const PREFIX = "/v1/admin/legal/contracts"
+const artifactPath = resolve(import.meta.dirname, "..", "openapi/admin/legal.json")
+const artifact = JSON.parse(readFileSync(artifactPath, "utf8"))
+
+const live = createContractsAdminRoutes().getOpenAPI31Document({
+  openapi: artifact.openapi,
+  info: artifact.info,
+})
+
+// The route module mounts at `/`, so its own document is prefix-relative. The
+// published document is absolute, and `stampModuleMetadata` derives operation
+// ids, summaries and the owning module from the absolute path — so re-prefix
+// before stamping, not after.
+const prefixed = {
+  ...live,
+  paths: Object.fromEntries(
+    Object.entries(live.paths ?? {}).map(([path, item]) => [
+      path === "/" ? PREFIX : `${PREFIX}${path}`,
+      item,
+    ]),
+  ),
+}
+const stamped = stampModuleMetadata(prefixed, new Map([[PREFIX, "legal"]]))
+
+const generated = stamped.paths ?? {}
+const paths: Record<string, unknown> = {}
+for (const [path, item] of Object.entries(artifact.paths)) {
+  paths[path] = path in generated ? generated[path] : item
+}
+for (const [path, item] of Object.entries(generated)) {
+  if (!(path in paths)) paths[path] = item
+}
+
+writeFileSync(artifactPath, `${JSON.stringify({ ...artifact, paths }, null, 2)}\n`)

--- a/packages/legal/src/booking-contract-review.ts
+++ b/packages/legal/src/booking-contract-review.ts
@@ -1,6 +1,6 @@
 import { sha256 } from "@voyant-travel/action-ledger"
 import { bookingItems, bookings } from "@voyant-travel/bookings/schema"
-import { and, eq } from "drizzle-orm"
+import { and, eq, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { z } from "zod"
 import { legalContractDetail } from "./contract-dto.js"
@@ -267,6 +267,74 @@ export async function listApplicableBookingContractTemplates(
       }),
   )
   return { bookingFound: true, data }
+}
+
+/**
+ * What an operator confirms before a booking-contract revision moves: the
+ * revision they were looking at, and a fingerprint of its exact content.
+ */
+export interface BookingContractReviewApproval {
+  revision: number
+  contentFingerprint: string
+}
+
+export type BookingContractReviewApprovalCheck =
+  /** Not a managed booking-contract revision — the generic lifecycle applies. */
+  | { status: "not_managed" }
+  | { status: "approved" }
+  | { status: "approval_required" }
+  | { status: "content_changed" }
+  | { status: "revision_mismatch"; expectedRevision: number }
+  | { status: "superseded"; successorRevisionId: string }
+
+/**
+ * The review contract a managed booking-contract revision carries, checked
+ * independently of who is asking.
+ *
+ * `executeLegalContractLifecycleCommand` enforces exactly these three facts
+ * inside its action-ledger claim (voyant#4706): the revision has not been
+ * superseded, its content is still the reviewed content, and the caller
+ * approved the revision that is actually current. Those are properties of the
+ * contract row, not of the agent-approval machinery wrapped around it — so an
+ * admin route can satisfy them too, and issuing a booking contract stops
+ * requiring an agent to be present, configured and authorized.
+ */
+export async function checkBookingContractReviewApproval(
+  db: PostgresJsDatabase,
+  contract: {
+    id: string
+    bookingId: string | null
+    title: string
+    language: string
+    templateVersionId: string | null
+    variables: unknown
+    renderedBody: string | null
+    metadata: unknown
+  },
+  approval: BookingContractReviewApproval | null | undefined,
+): Promise<BookingContractReviewApprovalCheck> {
+  const workflow = parseManagedBookingContractReviewWorkflow(contract.metadata)
+  if (!workflow) return { status: "not_managed" }
+  if (!approval) return { status: "approval_required" }
+
+  const [successor] = await db
+    .select({ id: contracts.id })
+    .from(contracts)
+    .where(
+      // agent-quality: raw-sql reviewed -- owner: legal; JSONB lineage lookup is parameterized and mirrors the successor guard the reviewed lifecycle command runs.
+      sql`${contracts.metadata}->'bookingContractWorkflow'->>'previousRevisionId' = ${contract.id}`,
+    )
+    .limit(1)
+  if (successor) return { status: "superseded", successorRevisionId: successor.id }
+
+  const currentFingerprint = await bookingContractContentFingerprint(contract)
+  if (approval.contentFingerprint !== currentFingerprint) return { status: "content_changed" }
+
+  const expectedRevision = workflow.revision ?? 1
+  if (approval.revision !== expectedRevision) {
+    return { status: "revision_mismatch", expectedRevision }
+  }
+  return { status: "approved" }
 }
 
 export async function getBookingContractReview(

--- a/packages/legal/src/contracts/routes.ts
+++ b/packages/legal/src/contracts/routes.ts
@@ -37,6 +37,12 @@ import { listResponseSchema } from "@voyant-travel/types"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
 import {
+  type BookingContractReviewApproval,
+  type BookingContractReviewApprovalCheck,
+  checkBookingContractReviewApproval,
+  getBookingContractReview,
+} from "../booking-contract-review.js"
+import {
   hasManagedBookingWorkflow,
   redactManagedBookingContractForGenericDetail,
 } from "../contract-dto.js"
@@ -50,6 +56,7 @@ import { renderAcceptancePreviewResponse, renderPreviewResponse } from "./route-
 import type { Contract, ContractSignature } from "./schema.js"
 import { contractsService, DurableContractDocumentAttachmentMutationError } from "./service.js"
 import {
+  bookingContractReviewApprovalSchema,
   contractBodyFormatSchema,
   contractListQuerySchema,
   contractNumberResetStrategySchema,
@@ -483,6 +490,88 @@ const jsonValue = z.unknown()
 
 const dataEnvelope = <T extends z.ZodTypeAny>(schema: T) => z.object({ data: schema })
 
+/**
+ * The booking-contract review response, authored here rather than reusing the
+ * Tool's `bookingContractReviewSchema`.
+ *
+ * That schema types its free-form members with `z.json()`, which in Zod 4 is a
+ * self-referential schema: registering it on a route makes
+ * `getOpenAPIDocument()` recurse until the stack overflows, so the deployment
+ * publishes no document at all. This states the same payload with the
+ * OpenAPI-expressible types the published contract needs. The handler returns
+ * what `getBookingContractReview` already parsed, so nothing is validated less.
+ *
+ * Annotated rather than inferred: this module composes its route chains
+ * structurally, and inferring a payload this size on top of that is what tips
+ * it into TS2589 (see the quadratic cost in the module header). The annotation
+ * only widens the static type — the OpenAPI document is generated from the
+ * runtime schema, which is the full shape below.
+ */
+const bookingContractReviewResponseSchema: z.ZodType = z.object({
+  contract: z.object({
+    id: z.string(),
+    contractNumber: z.string().nullable(),
+    scope: contractScopeSchema,
+    status: contractStatusSchema,
+    title: z.string(),
+    bookingId: z.string().nullable(),
+    language: z.string(),
+    templateVersionId: z.string().nullable(),
+    renderedBodyFormat: contractBodyFormatSchema,
+    renderedBody: z.string().nullable(),
+    variables: jsonRecord.nullable(),
+    metadata: jsonRecord.nullable(),
+    issuedAt: isoTimestamp.nullable(),
+    sentAt: isoTimestamp.nullable(),
+    executedAt: isoTimestamp.nullable(),
+    expiresAt: isoTimestamp.nullable(),
+    voidedAt: isoTimestamp.nullable(),
+    createdAt: isoTimestamp,
+    updatedAt: isoTimestamp,
+  }),
+  contentFingerprint: z.string(),
+  effectiveStatus: z.enum(["draft", "sent", "viewed", "declined", "signed", "void"]),
+  revision: z.number().int().positive(),
+  previousRevisionId: z.string().nullable(),
+  booking: z.object({
+    id: z.string(),
+    reference: z.string(),
+    customerName: z.string().nullable(),
+    customerEmail: z.string().nullable(),
+    language: z.string(),
+    currency: z.string(),
+    totalAmountCents: z.number().int().nullable(),
+    startDate: z.string().nullable(),
+    endDate: z.string().nullable(),
+  }),
+  products: z.array(
+    z.object({
+      title: z.string(),
+      quantity: z.number().int().positive(),
+      amountCents: z.number().int().nullable(),
+      currency: z.string(),
+    }),
+  ),
+  template: z.object({
+    id: z.string(),
+    name: z.string(),
+    versionId: z.string(),
+    version: z.number().int().positive(),
+    language: z.string(),
+  }),
+  commercialTerms: jsonRecord,
+  delivery: z.object({
+    recipient: z.string().nullable(),
+    channel: z.enum(["email", "sms", "whatsapp"]).nullable(),
+    sentRevision: z.number().int().positive().nullable(),
+    sentAt: isoTimestamp.nullable(),
+    viewedAt: isoTimestamp.nullable(),
+    declinedAt: isoTimestamp.nullable(),
+    notificationsSuppressed: z.boolean(),
+  }),
+  voidConsequences: z.array(z.string()),
+})
+
 const invalidRequestResponse = {
   description: "invalid_request: request body failed validation",
   content: { "application/json": { schema: errorResponseSchema } },
@@ -704,6 +793,53 @@ function toGenericAdminContract<T extends { variables: unknown; metadata: unknow
 
 function isGenericContractRenderAllowed(contract: Pick<Contract, "metadata">): boolean {
   return !hasManagedBookingWorkflow(contract.metadata)
+}
+
+function toBookingContractReviewApproval(
+  input: { revision?: number; contentFingerprint?: string } | null | undefined,
+): BookingContractReviewApproval | null {
+  return input?.revision !== undefined && input.contentFingerprint !== undefined
+    ? { revision: input.revision, contentFingerprint: input.contentFingerprint }
+    : null
+}
+
+const BOOKING_CONTRACT_REVIEW_RACED =
+  "The contract revision changed while this transition was running. Re-open the review and try again."
+
+/**
+ * The review contract, stated in the operator's language. Same failures
+ * `executeLegalContractLifecycleCommand` raises, so an agent and an operator
+ * are refused for the same reasons and told the same thing.
+ */
+function bookingContractReviewRejection(
+  check: BookingContractReviewApprovalCheck,
+): { status: 400 | 409; error: string } | null {
+  switch (check.status) {
+    case "approval_required":
+      return {
+        status: 400,
+        error:
+          "Booking contract revisions require the reviewed revision and content fingerprint. " +
+          "Read them from GET /v1/admin/legal/contracts/{id}/booking-review.",
+      }
+    case "content_changed":
+      return {
+        status: 400,
+        error: "The approved contract content is no longer the reviewed content.",
+      }
+    case "revision_mismatch":
+      return {
+        status: 400,
+        error: "The approved contract revision is no longer the selected revision.",
+      }
+    case "superseded":
+      return {
+        status: 409,
+        error: "A successor revision already exists for this contract revision.",
+      }
+    default:
+      return null
+  }
 }
 
 function toPublicSignature(
@@ -1245,6 +1381,7 @@ export function createContractsAdminRoutes(options: ContractsRouteOptions = {}) 
         description: "The issued contract",
         content: { "application/json": { schema: dataEnvelope(contractSchema) } },
       },
+      400: invalidRequestResponse,
       404: notFoundResponse("Contract not found"),
       409: conflictResponse("Only draft contracts can be issued"),
     },
@@ -1262,6 +1399,21 @@ export function createContractsAdminRoutes(options: ContractsRouteOptions = {}) 
       400: invalidRequestResponse,
       404: notFoundResponse("Contract not found"),
       409: conflictResponse("Only issued/sent contracts can be sent"),
+    },
+  })
+
+  const getBookingContractReviewRoute = createRoute({
+    method: "get",
+    path: "/{id}/booking-review",
+    request: { params: idParamSchema },
+    responses: {
+      200: {
+        description: "The booking-contract revision under review",
+        content: {
+          "application/json": { schema: dataEnvelope(bookingContractReviewResponseSchema) },
+        },
+      },
+      404: notFoundResponse("Contract not found"),
     },
   })
 
@@ -1341,14 +1493,33 @@ export function createContractsAdminRoutes(options: ContractsRouteOptions = {}) 
   })
 
   const lifecycleRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidationHook })
+    // A managed booking-contract revision is issued here too, not only through
+    // the Tool-owned reviewed lifecycle command (voyant#4706). The caller
+    // confirms the revision and content fingerprint it reviewed; the same three
+    // checks the command runs decide whether the transition is admissible, and
+    // the reviewed content is promoted verbatim.
     .openapi(issueContractRoute, async (c) => {
       const runtime = getRuntime(options, c.env, (key) => c.var.container?.resolve(key))
-      const result = await contractsService.issueContract(
-        c.get("db"),
-        c.req.valid("param").id,
-        runtime,
+      const db = c.get("db")
+      const id = c.req.valid("param").id
+      const approval = toBookingContractReviewApproval(
+        await parseOptionalJsonBody(c, bookingContractReviewApprovalSchema),
       )
+      const contract = await contractsService.getContractById(db, id)
+      if (!contract) return c.json({ error: "Contract not found" }, 404)
+      const review = await checkBookingContractReviewApproval(db, contract, approval)
+      const rejection = bookingContractReviewRejection(review)
+      if (rejection) return c.json({ error: rejection.error }, rejection.status)
+      const result = await contractsService.issueContract(db, id, runtime, {
+        allowManagedBookingContractWorkflow: review.status === "approved",
+        ...(review.status === "approved" && approval
+          ? { bookingContractReviewApproval: approval }
+          : {}),
+      })
       if (result.status === "not_found") return c.json({ error: "Contract not found" }, 404)
+      if (result.status === "review_changed") {
+        return c.json({ error: BOOKING_CONTRACT_REVIEW_RACED }, 409)
+      }
       if (result.status === "not_draft") {
         return c.json({ error: "Only draft contracts can be issued" }, 409)
       }
@@ -1356,18 +1527,42 @@ export function createContractsAdminRoutes(options: ContractsRouteOptions = {}) 
     })
     .openapi(sendContractRoute, async (c) => {
       const runtime = getRuntime(options, c.env, (key) => c.var.container?.resolve(key))
+      const db = c.get("db")
+      const id = c.req.valid("param").id
       // Body is optional — older callers POST without one and the
       // service falls back to defaults. The Send-contract dialog POSTs
       // `{ recipientEmail, subject, message }` so the notification
-      // subscriber can deliver the operator's customised copy.
+      // subscriber can deliver the operator's customised copy, plus the
+      // reviewed `{ revision, contentFingerprint }` for booking contracts.
       const input = await parseOptionalJsonBody(c, sendContractInputSchema)
+      const contract = await contractsService.getContractById(db, id)
+      if (!contract) return c.json({ error: "Contract not found" }, 404)
+      const sendApproval = toBookingContractReviewApproval(input)
+      const review = await checkBookingContractReviewApproval(db, contract, sendApproval)
+      const rejection = bookingContractReviewRejection(review)
+      if (rejection) return c.json({ error: rejection.error }, rejection.status)
       const result = await contractsService.sendContract(
-        c.get("db"),
-        c.req.valid("param").id,
+        db,
+        id,
         runtime,
-        input ?? undefined,
+        input
+          ? {
+              recipientEmail: input.recipientEmail,
+              subject: input.subject,
+              message: input.message,
+            }
+          : undefined,
+        {
+          allowManagedBookingContractWorkflow: review.status === "approved",
+          ...(review.status === "approved" && sendApproval
+            ? { bookingContractReviewApproval: sendApproval }
+            : {}),
+        },
       )
       if (result.status === "not_found") return c.json({ error: "Contract not found" }, 404)
+      if (result.status === "review_changed") {
+        return c.json({ error: BOOKING_CONTRACT_REVIEW_RACED }, 409)
+      }
       if (result.status === "not_issued") {
         return c.json({ error: "Only issued/sent contracts can be sent" }, 409)
       }
@@ -1437,6 +1632,46 @@ export function createContractsAdminRoutes(options: ContractsRouteOptions = {}) 
         })(),
       ),
     )
+
+  // Its own sub-chain rather than another link on `lifecycleRoutes`: the
+  // per-chain `.openapi()` inference cost is quadratic, and appending one more
+  // there is what tips this module into TS2589 (see the module header).
+  const bookingReviewRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidationHook })
+    // The un-redacted read the issue and send routes are approved against. The
+    // generic contract detail redacts a managed booking revision's body and
+    // variables, so without this an operator could not see what they are
+    // issuing, let alone fingerprint it.
+    .openapi(getBookingContractReviewRoute, async (c) => {
+      const db = c.get("db")
+      const id = c.req.valid("param").id
+      const contract = await contractsService.getContractById(db, id)
+      if (!contract || !hasManagedBookingWorkflow(contract.metadata)) {
+        return c.json({ error: "Contract not found" }, 404)
+      }
+      const revealed = shouldRevealBookingPiiForRoute(c)
+      if (contract.bookingId) {
+        await bookingsService.recordPiiAccess(db, {
+          bookingId: contract.bookingId,
+          travelerId: null,
+          actorId: routeActorId(c),
+          actorType: c.get("actor") ?? null,
+          callerType: c.get("callerType") ?? null,
+          action: "read",
+          outcome: revealed ? "allowed" : "denied",
+          reason: revealed ? "booking_contract_review_reveal" : "insufficient_scope",
+          metadata: revealed
+            ? { contractId: contract.id, reveal: true }
+            : {
+                contractId: contract.id,
+                reveal: false,
+                requiredScopes: ["legal:read", "bookings-pii:read"],
+              },
+        })
+      }
+      if (!revealed) return c.json({ error: "Contract not found" }, 404)
+      const review = await getBookingContractReview(db, id)
+      return review ? c.json({ data: review }, 200) : c.json({ error: "Contract not found" }, 404)
+    })
 
   // --- signatures + attachments ---------------------------------------------
 
@@ -1681,6 +1916,7 @@ export function createContractsAdminRoutes(options: ContractsRouteOptions = {}) 
     .route("/", numberSeriesRoutes)
     .route("/", contractRoutes)
     .route("/", lifecycleRoutes)
+    .route("/", bookingReviewRoutes)
     .route("/", signatureAttachmentRoutes)
 }
 

--- a/packages/legal/src/contracts/routes.ts
+++ b/packages/legal/src/contracts/routes.ts
@@ -1375,7 +1375,17 @@ export function createContractsAdminRoutes(options: ContractsRouteOptions = {}) 
   const issueContractRoute = createRoute({
     method: "post",
     path: "/{id}/issue",
-    request: { params: idParamSchema },
+    // Declared but not required: the handler parses with
+    // `parseOptionalJsonBody`, so an ordinary contract still issues with no
+    // body at all. Declaring it is what lets a generated client discover the
+    // approval a managed booking revision has to carry (voyant#4706).
+    request: {
+      params: idParamSchema,
+      body: {
+        required: false,
+        content: { "application/json": { schema: bookingContractReviewApprovalSchema } },
+      },
+    },
     responses: {
       200: {
         description: "The issued contract",
@@ -1390,7 +1400,13 @@ export function createContractsAdminRoutes(options: ContractsRouteOptions = {}) 
   const sendContractRoute = createRoute({
     method: "post",
     path: "/{id}/send",
-    request: { params: idParamSchema },
+    request: {
+      params: idParamSchema,
+      body: {
+        required: false,
+        content: { "application/json": { schema: sendContractInputSchema } },
+      },
+    },
     responses: {
       200: {
         description: "The sent contract",

--- a/packages/legal/src/contracts/service-contracts.ts
+++ b/packages/legal/src/contracts/service-contracts.ts
@@ -6,6 +6,10 @@ import { RequestValidationError } from "@voyant-travel/hono"
 import { organizations, people, personDirectoryView } from "@voyant-travel/relationships/schema"
 import { and, desc, eq, getTableColumns, ilike, notInArray, or, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import {
+  type BookingContractReviewApproval,
+  checkBookingContractReviewApproval,
+} from "../booking-contract-review.js"
 import { parseManagedBookingContractReviewWorkflow } from "../managed-booking-contract-workflow.js"
 import { normalizeLegalTargetFields, normalizeLegalTargetUpdateFields } from "../targets/service.js"
 import {
@@ -105,6 +109,26 @@ function assertGenericLifecycleMutationAllowed(
   throw new RequestValidationError(
     `Managed booking contract revisions must be ${label} through the reviewed lifecycle command.`,
   )
+}
+
+/**
+ * Re-checks the caller's review approval against the row the transition is
+ * about to move, while it is locked.
+ *
+ * A route checks the approval before it calls, so it can say precisely what is
+ * wrong. That check reads an unlocked row, so a concurrent successor revision
+ * or a regenerated draft could land between it and the transition — and the
+ * point of the fingerprint is that nothing may move under an approval. Returns
+ * false when the locked row no longer matches.
+ */
+async function reviewApprovalStillHolds(
+  db: PostgresJsDatabase,
+  contract: typeof contracts.$inferSelect,
+  approval: BookingContractReviewApproval | undefined,
+): Promise<boolean> {
+  if (!approval) return true
+  const check = await checkBookingContractReviewApproval(db, contract, approval)
+  return check.status === "approved" || check.status === "not_managed"
 }
 
 /**
@@ -317,7 +341,10 @@ export const contractRecordsService = {
     db: PostgresJsDatabase,
     contractId: string,
     runtime?: ContractLifecycleRuntimeOptions,
-    options?: { allowManagedBookingContractWorkflow?: boolean },
+    options?: {
+      allowManagedBookingContractWorkflow?: boolean
+      bookingContractReviewApproval?: BookingContractReviewApproval
+    },
   ) {
     const result = await db.transaction(async (tx) => {
       const [contract] = await tx
@@ -332,9 +359,25 @@ export const contractRecordsService = {
       if (!options?.allowManagedBookingContractWorkflow) {
         assertGenericLifecycleMutationAllowed(contract.metadata, "issue")
       }
+      if (
+        !(await reviewApprovalStillHolds(
+          tx as PostgresJsDatabase,
+          contract,
+          options?.bookingContractReviewApproval,
+        ))
+      ) {
+        return { status: "review_changed" as const }
+      }
+      // A managed booking-contract revision was reviewed as a whole — body,
+      // variables and number together — and its content fingerprint is what a
+      // caller approves before it moves. Re-rendering it from the template or
+      // allocating a number here would change the document out from under that
+      // approval, so an allowed managed issue promotes the reviewed content
+      // verbatim, matching `contract-lifecycle-command.ts`'s own issue leg.
+      const immutableReviewedRevision = isManagedBookingContract(contract.metadata)
 
       let contractNumber = contract.contractNumber
-      if (!contractNumber && contract.seriesId) {
+      if (!immutableReviewedRevision && !contractNumber && contract.seriesId) {
         const allocated = await allocateContractNumber(tx as PostgresJsDatabase, contract.seriesId)
         if (allocated) contractNumber = allocated.number
       }
@@ -346,7 +389,7 @@ export const contractRecordsService = {
 
       let renderedBody = contract.renderedBody
       let renderedBodyFormat = contract.renderedBodyFormat
-      if (contract.templateVersionId) {
+      if (!immutableReviewedRevision && contract.templateVersionId) {
         const [version] = await tx
           .select()
           .from(contractTemplateVersions)
@@ -397,7 +440,10 @@ export const contractRecordsService = {
     contractId: string,
     runtime?: ContractLifecycleRuntimeOptions,
     delivery?: { recipientEmail?: string | null; subject?: string | null; message?: string | null },
-    options?: { allowManagedBookingContractWorkflow?: boolean },
+    options?: {
+      allowManagedBookingContractWorkflow?: boolean
+      bookingContractReviewApproval?: BookingContractReviewApproval
+    },
   ) {
     const result = await db.transaction(async (tx) => {
       const [contract] = await tx
@@ -409,6 +455,15 @@ export const contractRecordsService = {
       if (!contract) return { status: "not_found" as const }
       if (!options?.allowManagedBookingContractWorkflow) {
         assertGenericLifecycleMutationAllowed(contract.metadata, "send")
+      }
+      if (
+        !(await reviewApprovalStillHolds(
+          tx as PostgresJsDatabase,
+          contract,
+          options?.bookingContractReviewApproval,
+        ))
+      ) {
+        return { status: "review_changed" as const }
       }
       const transition = checkContractLifecycleTransition(contract.status, "sent")
       if (!transition.ok) return { status: transition.reason }
@@ -424,9 +479,40 @@ export const contractRecordsService = {
           enteredAt: now,
         }),
       )
+      // An operator send that satisfied the review gate records what it
+      // delivered on the workflow, the same way the reviewed lifecycle command
+      // does — otherwise the booking-contract review reports a revision with a
+      // `sentAt` and no recipient, and nothing says it stopped being a draft
+      // under review. Paths that send without a stated recipient (the
+      // storefront's paid-and-accepted promotion) leave the workflow untouched.
+      const reviewedWorkflow = options?.bookingContractReviewApproval
+        ? parseManagedBookingContractReviewWorkflow(contract.metadata)
+        : null
       const [updated] = await tx
         .update(contracts)
-        .set({ status: "sent", stageHistory, sentAt: now, updatedAt: now })
+        .set({
+          status: "sent",
+          stageHistory,
+          sentAt: now,
+          updatedAt: now,
+          ...(reviewedWorkflow
+            ? {
+                metadata: {
+                  ...(contract.metadata as Record<string, unknown>),
+                  bookingContractWorkflow: {
+                    ...reviewedWorkflow,
+                    reviewOnly: false,
+                    delivery: {
+                      recipient: delivery?.recipientEmail ?? null,
+                      channel: delivery?.recipientEmail ? "email" : null,
+                      revision: reviewedWorkflow.revision,
+                      notificationsSuppressed: false,
+                    },
+                  },
+                },
+              }
+            : {}),
+        })
         .where(eq(contracts.id, contractId))
         .returning()
       // Forward the operator's send-dialog customization onto the

--- a/packages/legal/tests/integration/admin-booking-contract-lifecycle.test.ts
+++ b/packages/legal/tests/integration/admin-booking-contract-lifecycle.test.ts
@@ -1,0 +1,284 @@
+import { bookingPiiAccessLog } from "@voyant-travel/bookings/schema"
+import { createEventBus } from "@voyant-travel/core"
+import { createDbClient } from "@voyant-travel/db"
+import { cleanupTestDb } from "@voyant-travel/db/test-utils"
+import { handleApiError } from "@voyant-travel/hono"
+import { eq } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { Hono } from "hono"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+import { getBookingContractReview } from "../../src/booking-contract-review.js"
+import { createContractsAdminRoutes } from "../../src/contracts/routes.js"
+import { contracts } from "../../src/schema.js"
+import { createManagedDraft, seedBookingTemplate } from "./helpers/booking-contract-fixtures.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+type ClosableTestDb = PostgresJsDatabase & {
+  $client: { end(options?: { timeout?: number | null }): Promise<unknown> }
+}
+
+/**
+ * The operator's half of the booking-contract reviewed lifecycle (voyant#4706).
+ *
+ * Before this, a managed booking-contract revision could only complete its
+ * lifecycle through the Tool-owned command, which has no admin route — so a
+ * deployment whose agent is not wired for contracts had drafts it could never
+ * issue. These cover the admin surface honouring the same review contract the
+ * command does, and refusing for the same reasons.
+ */
+describe.skipIf(!DB_AVAILABLE)("admin booking contract lifecycle", () => {
+  let db: ClosableTestDb
+
+  beforeAll(() => {
+    db = createDbClient(process.env.TEST_DATABASE_URL as string, {
+      adapter: "node",
+      nodeMaxConnections: 4,
+      timeouts: { statementMs: false, queryMs: false, connectMs: false },
+    }) as ClosableTestDb
+  })
+  beforeEach(() => cleanupTestDb(db))
+  afterAll(async () => {
+    await db.$client.end({ timeout: 0 })
+  })
+
+  it("refuses a managed revision issued without the reviewed revision and fingerprint", async () => {
+    const { booking, version } = await seedBookingTemplate(db, "BK-ADMIN-ISSUE-GUARD")
+    const managed = await managedDraft(booking.id, version.id, "admin-issue-guard")
+    const [ordinary] = await db
+      .insert(contracts)
+      .values({ title: "Ordinary draft", scope: "customer" })
+      .returning()
+    const [before] = await db
+      .select()
+      .from(contracts)
+      .where(eq(contracts.id, managed.value.id))
+      .limit(1)
+    const issuedEvents: unknown[] = []
+    const eventBus = createEventBus()
+    eventBus.subscribe("contract.issued", (event) => issuedEvents.push(event))
+    const app = adminApp(eventBus)
+
+    const rejected = await app.request(`/${managed.value.id}/issue`, { method: "POST" })
+    expect(rejected.status).toBe(400)
+    await expect(rejected.json()).resolves.toMatchObject({
+      error: expect.stringContaining(
+        "Booking contract revisions require the reviewed revision and content fingerprint",
+      ),
+    })
+    await expect(
+      db.select().from(contracts).where(eq(contracts.id, managed.value.id)).limit(1),
+    ).resolves.toEqual([before])
+    expect(issuedEvents).toHaveLength(0)
+
+    // An ordinary contract has no reviewed revision, so it still issues with
+    // no body at all — the gate is on the managed shape, not on every caller.
+    const issued = await app.request(`/${ordinary!.id}/issue`, { method: "POST" })
+    expect(issued.status).toBe(200)
+    await expect(issued.json()).resolves.toMatchObject({
+      data: { id: ordinary!.id, status: "issued" },
+    })
+    expect(issuedEvents).toHaveLength(1)
+  })
+
+  it("issues a managed revision against the content the operator reviewed", async () => {
+    const { booking, version } = await seedBookingTemplate(db, "BK-ADMIN-ISSUE-REVIEWED")
+    const managed = await managedDraft(booking.id, version.id, "admin-issue-reviewed")
+    const review = (await getBookingContractReview(db, managed.value.id))!
+    const issuedEvents: unknown[] = []
+    const eventBus = createEventBus()
+    eventBus.subscribe("contract.issued", (event) => issuedEvents.push(event))
+    const app = adminApp(eventBus)
+
+    // A stale fingerprint is refused even though the revision matches, so an
+    // operator cannot approve content that moved after they read it.
+    const stale = await postJson(app, `/${managed.value.id}/issue`, {
+      revision: review.revision,
+      contentFingerprint: "booking-contract-content:v1:sha256:stale",
+    })
+    expect(stale.status).toBe(400)
+    await expect(stale.json()).resolves.toEqual({
+      error: "The approved contract content is no longer the reviewed content.",
+    })
+
+    const wrongRevision = await postJson(app, `/${managed.value.id}/issue`, {
+      revision: review.revision + 1,
+      contentFingerprint: review.contentFingerprint,
+    })
+    expect(wrongRevision.status).toBe(400)
+    await expect(wrongRevision.json()).resolves.toEqual({
+      error: "The approved contract revision is no longer the selected revision.",
+    })
+    await expect(draftStatus(managed.value.id)).resolves.toEqual([{ status: "draft" }])
+    expect(issuedEvents).toHaveLength(0)
+
+    const accepted = await postJson(app, `/${managed.value.id}/issue`, {
+      revision: review.revision,
+      contentFingerprint: review.contentFingerprint,
+    })
+    expect(accepted.status).toBe(200)
+    await expect(accepted.json()).resolves.toMatchObject({
+      data: { id: managed.value.id, status: "issued" },
+    })
+    expect(issuedEvents).toHaveLength(1)
+
+    // The reviewed content is promoted verbatim: issuing must not re-render the
+    // body from the template or move the number the approval covered.
+    const [issued] = await db
+      .select()
+      .from(contracts)
+      .where(eq(contracts.id, managed.value.id))
+      .limit(1)
+    expect(issued?.renderedBody).toBe(review.contract.renderedBody)
+    expect(issued?.contractNumber).toBe(review.contract.contractNumber)
+    expect(issued?.issuedAt).toBeInstanceOf(Date)
+  })
+
+  it("refuses to issue a managed revision a successor already supersedes", async () => {
+    const { booking, version } = await seedBookingTemplate(db, "BK-ADMIN-ISSUE-SUPERSEDED")
+    const managed = await managedDraft(booking.id, version.id, "admin-issue-superseded")
+    const review = (await getBookingContractReview(db, managed.value.id))!
+    const successor = await createManagedDraft(db, "admin-issue-superseded-revision", {
+      title: "Customer agreement",
+      revisionOfContractId: managed.value.id,
+      variables: { customer: { name: "Ana Pop" }, commercial: { depositDueCents: 20_00 } },
+    })
+    expect(successor.value.id).not.toBe(managed.value.id)
+
+    const response = await postJson(adminApp(), `/${managed.value.id}/issue`, {
+      revision: review.revision,
+      contentFingerprint: review.contentFingerprint,
+    })
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toEqual({
+      error: "A successor revision already exists for this contract revision.",
+    })
+    await expect(draftStatus(managed.value.id)).resolves.toEqual([{ status: "draft" }])
+  })
+
+  it("sends an issued managed revision only against its reviewed content", async () => {
+    const { booking, version } = await seedBookingTemplate(db, "BK-ADMIN-SEND-REVIEWED")
+    const managed = await managedDraft(booking.id, version.id, "admin-send-reviewed")
+    const review = (await getBookingContractReview(db, managed.value.id))!
+    const app = adminApp()
+
+    const issued = await postJson(app, `/${managed.value.id}/issue`, {
+      revision: review.revision,
+      contentFingerprint: review.contentFingerprint,
+    })
+    expect(issued.status).toBe(200)
+
+    const withoutApproval = await postJson(app, `/${managed.value.id}/send`, {
+      recipientEmail: "ana@example.test",
+    })
+    expect(withoutApproval.status).toBe(400)
+    await expect(draftStatus(managed.value.id)).resolves.toEqual([{ status: "issued" }])
+
+    // Issuing rewrote the row's timestamps, so the fingerprint the operator
+    // sends against is the one the review reports now, not the pre-issue one.
+    const afterIssue = (await getBookingContractReview(db, managed.value.id))!
+    const sent = await postJson(app, `/${managed.value.id}/send`, {
+      recipientEmail: "ana@example.test",
+      subject: "Your contract",
+      revision: afterIssue.revision,
+      contentFingerprint: afterIssue.contentFingerprint,
+    })
+    expect(sent.status).toBe(200)
+    await expect(draftStatus(managed.value.id)).resolves.toEqual([{ status: "sent" }])
+
+    // The review surface reports what was actually delivered, so a revision
+    // never carries a `sentAt` with no record of where it went.
+    await expect(getBookingContractReview(db, managed.value.id)).resolves.toMatchObject({
+      effectiveStatus: "sent",
+      delivery: {
+        recipient: "ana@example.test",
+        channel: "email",
+        sentRevision: afterIssue.revision,
+        notificationsSuppressed: false,
+      },
+    })
+  })
+
+  it("serves the managed revision review only to a caller with booking PII scope", async () => {
+    const { booking, version } = await seedBookingTemplate(db, "BK-ADMIN-REVIEW-READ")
+    const managed = await managedDraft(booking.id, version.id, "admin-review-read")
+    const [ordinary] = await db
+      .insert(contracts)
+      .values({ title: "Ordinary draft", scope: "customer" })
+      .returning()
+
+    const denied = await adminApp(undefined, ["legal:read"]).request(
+      `/${managed.value.id}/booking-review`,
+    )
+    expect(denied.status).toBe(404)
+    await expect(
+      db.select().from(bookingPiiAccessLog).where(eq(bookingPiiAccessLog.bookingId, booking.id)),
+    ).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: "read",
+          outcome: "denied",
+          reason: "insufficient_scope",
+          metadata: expect.objectContaining({ contractId: managed.value.id, reveal: false }),
+        }),
+      ]),
+    )
+
+    const allowed = await adminApp().request(`/${managed.value.id}/booking-review`)
+    expect(allowed.status).toBe(200)
+    await expect(allowed.json()).resolves.toMatchObject({
+      data: {
+        revision: 1,
+        contentFingerprint: expect.stringContaining("booking-contract-content:v1:sha256:"),
+        booking: { id: booking.id, reference: "BK-ADMIN-REVIEW-READ" },
+        contract: { id: managed.value.id },
+      },
+    })
+
+    // Only managed booking revisions have a review; everything else is not
+    // there to read, which is how the UI knows the generic lifecycle applies.
+    const ordinaryReview = await adminApp().request(`/${ordinary!.id}/booking-review`)
+    expect(ordinaryReview.status).toBe(404)
+  })
+
+  function managedDraft(bookingId: string, templateVersionId: string, key: string) {
+    return createManagedDraft(db, `${key}-create`, {
+      title: "Customer agreement",
+      bookingId,
+      templateVersionId,
+      variables: { customer: { name: "Ana Pop" }, commercial: { depositDueCents: 10_00 } },
+    })
+  }
+
+  function draftStatus(contractId: string) {
+    return db
+      .select({ status: contracts.status })
+      .from(contracts)
+      .where(eq(contracts.id, contractId))
+  }
+
+  function adminApp(
+    eventBus?: ReturnType<typeof createEventBus>,
+    scopes: string[] = ["legal:read", "bookings-pii:read"],
+  ) {
+    const app = new Hono()
+    app.onError(handleApiError)
+    app.use("*", async (c, next) => {
+      c.set("db" as never, db)
+      c.set("actor" as never, "staff")
+      c.set("callerType" as never, "session")
+      c.set("userId" as never, "usr_legal_admin_review")
+      c.set("scopes" as never, scopes)
+      await next()
+    })
+    app.route("/", createContractsAdminRoutes(eventBus ? { eventBus } : {}))
+    return app
+  }
+
+  function postJson(app: Hono, path: string, body: unknown) {
+    return app.request(path, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    })
+  }
+})

--- a/packages/legal/tests/integration/booking-contract-workflow.test.ts
+++ b/packages/legal/tests/integration/booking-contract-workflow.test.ts
@@ -631,9 +631,9 @@ describe.skipIf(!DB_AVAILABLE)("managed booking contract workflow", () => {
     const rejected = await app.request(`/${managed.value.id}/issue`, { method: "POST" })
     expect(rejected.status).toBe(400)
     await expect(rejected.json()).resolves.toMatchObject({
-      error:
-        "Managed booking contract revisions must be issued through the reviewed lifecycle command.",
-      code: "invalid_request",
+      error: expect.stringContaining(
+        "Booking contract revisions require the reviewed revision and content fingerprint",
+      ),
     })
     await expect(
       db.select().from(contracts).where(eq(contracts.id, managed.value.id)).limit(1),

--- a/packages/legal/tests/integration/helpers/booking-contract-fixtures.ts
+++ b/packages/legal/tests/integration/helpers/booking-contract-fixtures.ts
@@ -1,0 +1,128 @@
+import { bookingItems, bookings } from "@voyant-travel/bookings/schema"
+import { eq } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { contractsService } from "../../../src/contracts/service.js"
+import { LEGAL_CONTRACT_DRAFT_HANDLER_EXPECTATION } from "../../../src/created-target-policy.js"
+import { executeLegalContractDraftCreate } from "../../../src/mcp-runtime.js"
+import { contractTemplates, contractTemplateVersions } from "../../../src/schema.js"
+
+/**
+ * One confirmed booking with a single item and an active customer template
+ * whose current version renders `customer.name` — the minimum a managed
+ * booking-contract draft needs to exist.
+ */
+export async function seedBookingTemplate(db: PostgresJsDatabase, bookingNumber: string) {
+  const [booking] = await db
+    .insert(bookings)
+    .values({
+      bookingNumber,
+      status: "confirmed",
+      contactFirstName: "Ana",
+      contactLastName: "Pop",
+      contactEmail: "ana@example.test",
+      contactPhone: "+40700000000",
+      contactPreferredLanguage: "en",
+      sellCurrency: "EUR",
+      sellAmountCents: 100_00,
+      startDate: "2026-09-01",
+      endDate: "2026-09-07",
+    })
+    .returning()
+  const [item] = await db
+    .insert(bookingItems)
+    .values({
+      bookingId: booking!.id,
+      title: "Fallback title",
+      status: "confirmed",
+      productNameSnapshot: "Original tour",
+      quantity: 2,
+      sellCurrency: "EUR",
+      totalSellAmountCents: 100_00,
+    })
+    .returning()
+  const [template] = await db
+    .insert(contractTemplates)
+    .values({
+      name: `Customer ${bookingNumber}`,
+      slug: `customer-${bookingNumber.toLowerCase()}`,
+      scope: "customer",
+      language: "en",
+      body: "Hello {{ customer.name }}",
+      active: true,
+    })
+    .returning()
+  const [version] = await db
+    .insert(contractTemplateVersions)
+    .values({
+      templateId: template!.id,
+      version: 1,
+      body: "Hello {{ customer.name }}",
+      variableSchema: { required: ["customer.name"] },
+    })
+    .returning()
+  await db
+    .update(contractTemplates)
+    .set({ currentVersionId: version!.id })
+    .where(eq(contractTemplates.id, template!.id))
+  return { booking: booking!, item: item!, template: template!, version: version! }
+}
+
+/**
+ * Creates a managed booking-contract draft the way the Tool does — through the
+ * created-target command with a handler admission — so the revision metadata
+ * and review snapshot are the real ones rather than a hand-written fixture.
+ */
+export function createManagedDraft(
+  db: PostgresJsDatabase,
+  idempotencyKey: string,
+  input: Parameters<typeof executeLegalContractDraftCreate>[2],
+) {
+  return executeLegalContractDraftCreate(
+    db,
+    {
+      userId: "usr_legal_booking_contract",
+      callerType: "session",
+      actor: "staff",
+      organizationId: "org_legal_booking_contract",
+      scopes: ["legal:write", "bookings-pii:read"],
+    },
+    { ...input, idempotencyKey },
+    legalDraftAdmission(idempotencyKey),
+    async (command, handlers) => {
+      const mutation = await command.db.transaction((tx) => handlers.create(tx as never))
+      return {
+        replayed: false as const,
+        value: mutation.value,
+        result: {
+          entry: {} as never,
+          reference: {
+            type: "legal-contract",
+            id: mutation.targetId,
+            value: `legal-contract:${mutation.targetId}` as const,
+          },
+        },
+      }
+    },
+    contractsService.createContract,
+  )
+}
+
+export function legalDraftAdmission(idempotencyKey: string) {
+  const expected = LEGAL_CONTRACT_DRAFT_HANDLER_EXPECTATION
+  return {
+    capabilityId: expected.capabilityId,
+    capabilityVersion: expected.capabilityVersion,
+    canonicalName: expected.canonicalName,
+    actionPolicy: {
+      ...expected.actionPolicy,
+      enforcement: "handler" as const,
+      invocation: {
+        controlField: "_voyant" as const,
+        requiredFields: ["confirmed"] as const,
+        optionalFields: [] as const,
+        fingerprintAlgorithm: "action-ledger-command-v1" as const,
+      },
+    },
+    invocation: { confirmed: true, idempotencyKey },
+  }
+}

--- a/packages/legal/tests/integration/public-routes.test.ts
+++ b/packages/legal/tests/integration/public-routes.test.ts
@@ -709,11 +709,15 @@ describe.skipIf(!DB_AVAILABLE)("Legal public routes", () => {
         metadata: managedBookingWorkflowMetadata(2, false),
       })
       .returning()
+    // Sending a managed revision now goes through the operator's own review
+    // gate (voyant#4706) rather than being refused outright — but without the
+    // reviewed revision + fingerprint it is still refused, and says why.
     const managedSend = await adminApp.request(`/${managedIssued!.id}/send`, { method: "POST" })
     expect(managedSend.status).toBe(400)
     await expect(managedSend.json()).resolves.toEqual({
-      error:
-        "Managed booking contract revisions must be sent through the reviewed lifecycle command.",
+      error: expect.stringContaining(
+        "Booking contract revisions require the reviewed revision and content fingerprint",
+      ),
     })
 
     const [managedSent] = await db

--- a/scripts/checks/openapi/generated-specs.json
+++ b/scripts/checks/openapi/generated-specs.json
@@ -21,6 +21,10 @@
         "packages/trips/openapi/admin/trips.json",
         "packages/trips/openapi/storefront/trips.json"
       ]
+    },
+    {
+      "command": "pnpm --filter @voyant-travel/legal generate:openapi",
+      "files": ["packages/legal/openapi/admin/legal.json"]
     }
   ]
 }


### PR DESCRIPTION
Refs #4706.

A booking-linked contract could only complete its lifecycle through
`executeLegalContractLifecycleCommand`, which is invoked from
`packages/legal/src/mcp-runtime.ts` and nowhere else.
`POST /v1/admin/legal/contracts/{id}/issue` refused with a 400 while the admin UI
rendered its `Issue` button unconditionally, so on a deployment where the agent is
not wired for contracts every generated contract sat in `draft` with no operator
path out of it.

## What the gate is actually protecting

Reading the command, the reviewed lifecycle enforces three facts about the
contract row before it moves:

1. no successor revision exists,
2. the content is still the content that was reviewed (`contentFingerprint`),
3. the caller approved the revision that is current.

None of those are properties of the action-ledger admission wrapped around them —
they are properties of the row, and an admin route can check them too. So the
admin routes now check them directly rather than refusing outright.

Worth noting for reviewers: the command has no standalone managed `issue` either.
Its `issue` leg refuses a managed revision, and `send` issues implicitly after the
fingerprint matches. That is why "expose the command over REST" would not have
been a one-liner, and why this takes the second option in the issue — `/issue`
routes through the review for managed booking contracts.

## Changes

- `GET /v1/admin/legal/contracts/{id}/booking-review` serves the un-redacted
  revision, including the `revision` and `contentFingerprint` a caller approves
  against. Managed booking revisions only (everything else 404s, which is how the
  UI knows the generic lifecycle applies), requires `bookings-pii:read`, and
  records allowed/denied on the booking's PII access log — the same shape the
  `get_booking_contract_review` Tool and the attachment download already use.
- `POST /{id}/issue` and `POST /{id}/send` accept `{ revision, contentFingerprint }`.
  A managed revision without them is refused and told where to read them; a stale
  fingerprint, a superseded revision, or a mismatched revision is refused with the
  same wording an agent would get. Ordinary contracts are untouched — no body, no
  gate.
- The approval is **re-checked on the locked row** inside the service transaction.
  The route's pre-check reads an unlocked row so it can report precisely what is
  wrong; the re-check is what makes it safe, and a lost race is a 409 rather than a
  document moving under an approval.
- Issuing a managed revision now promotes the reviewed content **verbatim** — no
  template re-render, no contract-number allocation — matching
  `contract-lifecycle-command.ts`'s own issue leg. Previously the service re-rendered
  even when the caller passed `allowManagedBookingContractWorkflow`, which would
  have rewritten the document an approval covered.
- An operator send that satisfied the gate records its delivery on the workflow, so
  the review surface no longer reports a revision with a `sentAt` and no recipient.
  Paths that send without a stated recipient (the storefront paid-and-accepted
  promotion) are unchanged.
- UI: the contract detail page opens a review dialog for booking contracts instead
  of firing an `Issue` that was guaranteed to 400; the send dialog carries the
  approval; both disable the action with a stated reason when the review cannot be
  read. en + ro.

## Tests

`packages/legal/tests/integration/admin-booking-contract-lifecycle.test.ts` — five
integration tests over the real routes and a real managed draft created through the
Tool's own created-target command, not a hand-written metadata fixture. They cover
the refusal without an approval, each individual mismatch, the successor case, the
verbatim content promotion, send, and the PII gate on the review read in both
directions.

**Added to the `db-integration` lane in `ci.yml`.** That lane lists files by name,
so a new integration test otherwise runs nowhere and is green by skipping.

Two failures in this area reproduce identically on `origin/main` and are left
alone — neither file runs in CI today, which is why they rotted:

- `public-routes.test.ts > refuses PATCH mutation of managed drafts and every
  non-draft revision` — 500 instead of 400 (its test app mounts no error handler).
- `booking-contract-workflow.test.ts > serializes same-parent successor creation and
  rejects the second successor` — the second successor resolves instead of being
  rejected.

## Review round 2

Both P2 comments were correct and are addressed:

- **Publish the reviewed lifecycle in OpenAPI.** `issueContractRoute` and
  `sendContractRoute` now declare their bodies as `required: false` — the handlers
  still parse with `parseOptionalJsonBody`, so an ordinary contract issues with no
  body at all (covered by an existing test). More importantly,
  `packages/legal/openapi/admin/legal.json` said "Do not edit by hand" while
  nothing in the repo regenerated it. `packages/legal/scripts/generate-openapi.ts`
  now drives the live routes through the operator app's own composition
  (`stampModuleMetadata`), and the artifact is registered in
  `scripts/checks/openapi/generated-specs.json` so `verify:openapi-drift` holds it.
  I verified the method rather than trusting it: it reproduces **35 of the 38**
  committed paths byte-identically, and the 3 that changed are the two I touched
  plus a `DELETE /{id}` conflict description that had **already** drifted from the
  route ("Only draft or void contracts can be deleted" vs. the route's "Contract
  cannot be deleted").
- **Let the standard admin client send the approval.** `legal.contracts.issue`
  took `z.object({})`, so it stripped the approval and every managed booking
  revision would have hit `approval_required`. Its input now derives from the
  route schema, and `legal.contracts.send` and `legal.contracts.bookingReview`
  join it; `@voyant-travel/admin-react` passes them through. A test asserts the
  approval round-trips and that the review read is gated on `bookings-pii:read`.

CI's `architecture` job was red on the **i18n** step, not `verify:architecture` —
the review dialog rendered a literal `(v` before the template version. That and
the product quantity line now go through `formatMessage`, en + ro.

## Not in this change

Ask 2 of the issue — regenerating a draft whose content is wrong — is not here.
Re-rendering the document needs the durable document-operation engine and a
`LegalDocumentArtifactProvider` bound to the contracts admin route surface, and
`ContractsRouteOptions` carries neither. That is its own slice, so #4706 stays open
for it.
