### PR TITLE
Restore the content catalog detail pages were dropping

### DIFF
--- a/.changeset/catalog-detail-missing-info.md
+++ b/.changeset/catalog-detail-missing-info.md
@@ -1,0 +1,49 @@
+---
+"@voyant-travel/catalog-react": patch
+"@voyant-travel/cruises": patch
+"@voyant-travel/inventory": patch
+---
+
+Restore the content catalog detail pages were dropping.
+
+Resolve a sourced cruise's adapter by its own `source_kind` scoped to the
+connection before falling back to the bare connection id. A channel registers
+several adapters per connection and keys them apart by suffixing the registry
+key (`<connectionId>:cruises`), so resolving by connection alone returned the
+connection's *generic* adapter. That adapter carries no `cruiseAdapter`, so
+`getCruiseSailingPricing` reached through it for nothing and every
+connection-scoped cruise reported no cabin pricing at all.
+
+Read the projection's own camelCase keys in the cruise content synthesizer. It
+read the snake_case names of the content shape it produces, which overlapped the
+shim's projection on `id`/`name`/`status` and nothing else, so the fallback
+rendered blank even when discovery had captured the data.
+
+Stamp the provider key rather than the connection id as a sourced cruise's
+`source_provider`, and project the cruise line, ship and port display names
+alongside their faceted ids. The shim read `sourceRef.provider` while Voyant
+Connect writes `providerKey`, so the fallback fired every time and a raw
+`conn_…` string surfaced as the cruise line on the detail page.
+
+Read the indexed document by id on the URL-addressable vertical detail pages.
+Entered by id there is no result row to carry the index projection, so price,
+offers, status, categories, destinations and the whole Attributes tab were
+dropped — the same record showed far more when opened as a sheet from the list.
+The supplier formatter is now held by ref so the supplier directory settling no
+longer rebuilds the fetchers and re-requests the record (one page load issued the
+content route three times).
+
+Fall back to an itinerary-day image for an owned product's hero when it has no
+product-level image, instead of reporting no hero while the same image sits in
+`content.media`.
+
+Degrade to the synthesizer when a cruise adapter's `getContent` fails, rather
+than letting the throw escape and 500 the detail route. We hold a durable
+sourced-entry projection and §3.6 defines the synthesizer as exactly that
+degraded read, so an upstream miss should not blank the page. On sandbox,
+`resolveCruiseRow` in `@voyant-travel/connect-adapter` throws
+`Connect cruise content not found` for cruises discovery has already indexed,
+which turned every concurrent cruise detail open into a 500. The failure is
+reported through the new `onContentFetchError` option (defaulting to
+`console.warn`) so an upstream outage stays visible instead of silently
+degrading every cruise to a stub.

--- a/packages/catalog-react/src/catalog-enrichment-supplier.test.ts
+++ b/packages/catalog-react/src/catalog-enrichment-supplier.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest"
+
+import { mapContentToEnrichment } from "./catalog-enrichment-mappers.js"
+
+/**
+ * The supplier label on a vertical detail page is resolved twice, and both
+ * times matter.
+ *
+ * `mapContentToEnrichment` resolves it once when the content lands. The page
+ * then resolves it again at render, because the detail page's fetchers
+ * deliberately do NOT depend on the supplier directory — depending on it made
+ * one page load issue the content route three times. That means a directory
+ * arriving after the content never triggers a refetch, so the snapshot taken
+ * here can be a raw id forever unless the render re-resolves it.
+ *
+ * These pin the property the render step relies on: the resolver is a lookup
+ * that returns its input on a miss, so applying it to an already-resolved name
+ * is a no-op.
+ */
+const payload = (supplier: string | null) => ({
+  data: {
+    content: {
+      product: { id: "prod_1", name: "Sunset Sail", supplier },
+      days: [],
+      media: [],
+      options: [],
+      policies: [],
+      departures: [],
+    },
+    served_locale: "en-GB",
+  },
+})
+
+const mapWith = (supplier: string | null, formatSupplier?: (id: string) => string) =>
+  mapContentToEnrichment(payload(supplier) as never, new Map(), formatSupplier)
+
+describe("supplier label on a mapped enrichment", () => {
+  it("resolves the id through the directory when it is already loaded", () => {
+    const directory = (id: string) => (id === "sup_1" ? "TUI" : id)
+    expect(mapWith("sup_1", directory).supplier).toBe("TUI")
+  })
+
+  it("snapshots the raw id when the directory has not loaded yet", () => {
+    // The race this whole arrangement exists for: content first, directory
+    // second. Nothing refetches, so the page must re-resolve at render.
+    const emptyDirectory = (id: string) => id
+    expect(mapWith("sup_1", emptyDirectory).supplier).toBe("sup_1")
+  })
+
+  it("is idempotent over an already-resolved name, so re-resolving is safe", () => {
+    const directory = (id: string) => (id === "sup_1" ? "TUI" : id)
+    // What the render step does to the snapshot above, twice over.
+    expect(directory(directory("sup_1"))).toBe("TUI")
+    expect(directory("TUI")).toBe("TUI")
+  })
+
+  it("leaves a missing supplier missing rather than inventing a label", () => {
+    expect(mapWith(null, (id) => id).supplier).toBeNull()
+  })
+})

--- a/packages/catalog-react/src/catalog-offers-client.test.ts
+++ b/packages/catalog-react/src/catalog-offers-client.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test, vi } from "vitest"
+
+import { fetchCatalogIndexDocument } from "./catalog-offers-client.js"
+
+function ok(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  })
+}
+
+function searchResponse(hits: Array<{ id: string; fields: Record<string, unknown> }>) {
+  return {
+    vertical: "products",
+    mode: "keyword" as const,
+    total: hits.length,
+    hits: hits.map((hit) => ({
+      id: hit.id,
+      score: 1,
+      document: { id: hit.id, fields: hit.fields },
+    })),
+  }
+}
+
+/**
+ * The URL-addressable detail pages are entered by id, so they have no result
+ * row to carry the index projection — and everything the detail body renders
+ * off `hit.document.fields` (price, offers, status, the Attributes tab) lives
+ * only in the index.
+ */
+describe("fetchCatalogIndexDocument", () => {
+  test("reads the document by id through an eq filter on the search route", async () => {
+    const fetcher = vi.fn<typeof globalThis.fetch>(async () =>
+      ok(
+        searchResponse([{ id: "prod_1", fields: { name: "Food crawl", sellAmountCents: 11500 } }]),
+      ),
+    )
+
+    const doc = await fetchCatalogIndexDocument(
+      { baseUrl: "https://operator.example/api", fetcher },
+      { vertical: "products", id: "prod_1" },
+    )
+
+    expect(doc?.document.fields.sellAmountCents).toBe(11500)
+    const [url, init] = fetcher.mock.calls[0]!
+    expect(url).toBe("https://operator.example/api/v1/admin/catalog/search")
+    expect(JSON.parse(String((init as RequestInit).body))).toMatchObject({
+      vertical: "products",
+      filters: [{ kind: "eq", field: "id", value: "prod_1" }],
+      pagination: { limit: 1 },
+    })
+  })
+
+  test("switches to the public surface when asked", async () => {
+    const fetcher = vi.fn<typeof globalThis.fetch>(async () => ok(searchResponse([])))
+
+    await fetchCatalogIndexDocument(
+      { baseUrl: "/api", fetcher, surface: "public" },
+      { vertical: "cruises", id: "crus_1" },
+    )
+
+    expect(fetcher.mock.calls[0]![0]).toBe("/api/v1/public/catalog/search")
+  })
+
+  test("resolves null when the id is not indexed", async () => {
+    const fetcher = vi.fn<typeof globalThis.fetch>(async () => ok(searchResponse([])))
+
+    await expect(
+      fetchCatalogIndexDocument(
+        { baseUrl: "/api", fetcher },
+        { vertical: "products", id: "prod_1" },
+      ),
+    ).resolves.toBeNull()
+  })
+
+  test("ignores a hit the search route returned for some other id", async () => {
+    const fetcher = vi.fn<typeof globalThis.fetch>(async () =>
+      ok(searchResponse([{ id: "prod_other", fields: { name: "Wrong record" } }])),
+    )
+
+    await expect(
+      fetchCatalogIndexDocument(
+        { baseUrl: "/api", fetcher },
+        { vertical: "products", id: "prod_1" },
+      ),
+    ).resolves.toBeNull()
+  })
+})

--- a/packages/catalog-react/src/catalog-offers-client.ts
+++ b/packages/catalog-react/src/catalog-offers-client.ts
@@ -11,6 +11,7 @@
  */
 
 import { fetchWithValidation, type VoyantFetcher } from "./client.js"
+import { type CatalogSearchHit, catalogSearchResponseSchema } from "./schemas.js"
 import {
   type CatalogSlotsResponse,
   type CruiseContentResponse,
@@ -163,6 +164,42 @@ export function fetchCruiseContent(
     { baseUrl: ctx.baseUrl, fetcher: ctx.fetcher },
     { method: "GET", signal },
   )
+}
+
+/**
+ * Fetch a single indexed catalog document by its catalog id.
+ *
+ * The URL-addressable detail pages are entered by id, not from a result row, so
+ * they have no search hit to carry the index projection. Everything the detail
+ * body renders off `hit.document.fields` — price, offers, status, and the whole
+ * Attributes tab — is in the index and nowhere else; without this the page
+ * dropped all of it and rendered a fraction of what the same record shows in
+ * the detail sheet. An `eq` filter on `id` is the by-id read the search route
+ * already supports.
+ *
+ * Resolves to `null` when nothing matches (an id that is real but unindexed —
+ * the caller still has the content route).
+ */
+export function fetchCatalogIndexDocument(
+  ctx: CatalogOffersClientContext,
+  args: { vertical: string; id: string },
+  signal?: AbortSignal,
+): Promise<CatalogSearchHit | null> {
+  return fetchWithValidation(
+    catalogPath(ctx.surface, "search"),
+    catalogSearchResponseSchema,
+    { baseUrl: ctx.baseUrl, fetcher: ctx.fetcher },
+    post(
+      {
+        vertical: args.vertical,
+        query: "",
+        mode: "keyword",
+        filters: [{ kind: "eq", field: "id", value: args.id }],
+        pagination: { limit: 1 },
+      },
+      signal,
+    ),
+  ).then((res) => res.hits.find((hit) => hit.id === args.id) ?? null)
 }
 
 export function fetchCatalogSlots(

--- a/packages/catalog-react/src/components/catalog-vertical-detail-page.tsx
+++ b/packages/catalog-react/src/components/catalog-vertical-detail-page.tsx
@@ -215,7 +215,15 @@ export function CatalogVerticalDetailPage({
   }
 
   const heroUrl = enrichment.heroImageUrl
+  // `enrichment.supplier` was resolved once, when the content was mapped. If
+  // the content request won the race against the supplier directory, that
+  // snapshot is the raw id — and nothing refetches to correct it, because the
+  // fetchers deliberately do not depend on the directory. So resolve again
+  // here, where the directory is whatever it is now. The lookup returns its
+  // input on a miss, which makes it idempotent over an already-resolved name.
   const subtitle = enrichment.supplier
+    ? (formatSupplier?.(enrichment.supplier) ?? enrichment.supplier)
+    : null
 
   return (
     <div className="mx-auto w-full max-w-screen-2xl px-6 py-6 lg:px-8">

--- a/packages/catalog-react/src/components/catalog-vertical-detail-page.tsx
+++ b/packages/catalog-react/src/components/catalog-vertical-detail-page.tsx
@@ -1,10 +1,10 @@
 "use client"
 
 import { Image as ImageIcon } from "lucide-react"
-import { useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useCatalogUiI18nOrDefault, useCatalogUiMessagesOrDefault } from "../i18n/index.js"
 import type { CatalogSearchHit } from "../index.js"
-import { fetchCatalogSlots, useVoyantCatalogContext } from "../index.js"
+import { fetchCatalogIndexDocument, fetchCatalogSlots, useVoyantCatalogContext } from "../index.js"
 import { type CatalogDetailEnrichment, CatalogDetailView } from "./catalog-detail-sheet.js"
 import {
   type CatalogSlotAvailability,
@@ -89,6 +89,18 @@ export function CatalogVerticalDetailPage({
   const { locale: resolvedLocale } = useCatalogUiI18nOrDefault()
   const contentLocale = locale ?? resolvedLocale
 
+  // `formatSupplier` is backed by the host's supplier directory, so its identity
+  // changes when that query settles or refetches. Depending on it directly
+  // rebuilt `fetchers` and re-ran the content + slots effect each time — one
+  // page load issued the content route three times. Read it through a ref so
+  // the directory can land without re-fetching the record.
+  const formatSupplierRef = useRef(formatSupplier)
+  formatSupplierRef.current = formatSupplier
+  const stableFormatSupplier = useCallback(
+    (supplierId: string) => formatSupplierRef.current?.(supplierId) ?? supplierId,
+    [],
+  )
+
   const fetchers = useMemo(
     () =>
       createCatalogEnrichmentFetchers({
@@ -96,7 +108,7 @@ export function CatalogVerticalDetailPage({
         contentBasePathByVertical,
         credentials: "include",
         locale: contentLocale,
-        formatSupplier,
+        formatSupplier: stableFormatSupplier,
         loadSlotAvailability: (productId) =>
           fetchCatalogSlots({ baseUrl, fetcher }, { entityModule: "products", entityId: productId })
             .then(
@@ -104,15 +116,20 @@ export function CatalogVerticalDetailPage({
             )
             .catch(() => new Map<string, CatalogSlotAvailability>()),
       }),
-    [baseUrl, fetcher, contentBasePathByVertical, contentLocale, formatSupplier],
+    [baseUrl, fetcher, contentBasePathByVertical, contentLocale, stableFormatSupplier],
   )
 
-  // Minimal hit — the detail body keys off `hit.id` for content + the slots
-  // call; the index projection isn't available by id, so fields stay empty and
-  // the rich content comes from the enrichment.
+  // The index projection carries everything the detail body renders off
+  // `hit.document.fields` — price, offers, status, categories, destinations and
+  // the whole Attributes tab. Entered by id there is no result row to carry it,
+  // so read the document by id; the rich prose/itinerary/departures still come
+  // from the content route via the enrichment. `indexFields` stays empty when
+  // the id isn't indexed, which degrades to the previous behaviour rather than
+  // failing the page.
+  const [indexFields, setIndexFields] = useState<Record<string, unknown>>({})
   const hit = useMemo<CatalogSearchHit>(
-    () => ({ id, score: 0, document: { id, fields: {} } }),
-    [id],
+    () => ({ id, score: 0, document: { id, fields: indexFields } }),
+    [id, indexFields],
   )
 
   const [enrichment, setEnrichment] = useState<CatalogDetailEnrichment | null>(null)
@@ -122,9 +139,18 @@ export function CatalogVerticalDetailPage({
     let cancelled = false
     setStatus("loading")
     setEnrichment(null)
+    setIndexFields({})
     void (async () => {
+      // The index read is best-effort and must not gate the page: a failure
+      // costs the attributes, not the record.
+      const indexed = fetchCatalogIndexDocument({ baseUrl, fetcher }, { vertical, id }).catch(
+        () => null,
+      )
       try {
-        const enr = await fetchers.loadProductDetail(hit, vertical)
+        const enr = await fetchers.loadProductDetail(
+          { id, score: 0, document: { id, fields: {} } },
+          vertical,
+        )
         if (cancelled) return
         if (!enr) {
           setStatus("notfound")
@@ -134,12 +160,15 @@ export function CatalogVerticalDetailPage({
         setStatus("ready")
       } catch {
         if (!cancelled) setStatus("error")
+        return
       }
+      const doc = await indexed
+      if (!cancelled && doc) setIndexFields(doc.document.fields)
     })()
     return () => {
       cancelled = true
     }
-  }, [hit, vertical, fetchers])
+  }, [id, vertical, fetchers, baseUrl, fetcher])
 
   const name = enrichment?.name ?? null
   useEffect(() => {

--- a/packages/catalog-react/src/index.ts
+++ b/packages/catalog-react/src/index.ts
@@ -15,6 +15,7 @@ export {
 export {
   type CatalogOffersClientContext,
   type CatalogSurface,
+  fetchCatalogIndexDocument,
   fetchCatalogSlots,
   fetchCruiseContent,
   fetchCruisePrice,

--- a/packages/cruises/src/adapters/source-adapter-shim.ts
+++ b/packages/cruises/src/adapters/source-adapter-shim.ts
@@ -709,10 +709,17 @@ function toCatalogProjection(
 ): CatalogProjection {
   const provenance: Provenance = {
     source_kind: sourceKind,
+    // `SourceRef` is open-ended, so the provider lives under whichever key the
+    // channel writes: Voyant Connect uses `providerKey`. Reading only `provider`
+    // meant the fallback fired every time and stamped the *connection id* as the
+    // provider, which then surfaced as the cruise line on the detail page.
+    // Prefer the source kind's own provider suffix (`cruise:<provider>`) over
+    // restating the connection id.
     source_provider:
-      typeof entry.sourceRef.provider === "string"
-        ? entry.sourceRef.provider
-        : entry.sourceRef.connectionId,
+      stringField(entry.sourceRef, "providerKey") ??
+      stringField(entry.sourceRef, "provider") ??
+      providerFromSourceKind(sourceKind) ??
+      entry.sourceRef.connectionId,
     source_connection_id: entry.sourceRef.connectionId,
     source_ref: encodeSourceRef(entry.sourceRef),
     source_freshness: "sync",
@@ -739,6 +746,15 @@ function toCatalogProjection(
       cruiseType: entry.cruiseType,
       status: entry.salesStatus ?? null,
       nights: entry.nights,
+      // Display names alongside the faceted ids below. The index drops any key
+      // that isn't a policy path, but `catalog_sourced_entries.projection`
+      // stores `fields` verbatim — and that projection is the only thing the
+      // content synthesizer can read when no adapter serves `getContent`.
+      // Without these it had ids to show and no names, so it showed neither.
+      lineName: entry.lineName ?? null,
+      shipName: entry.shipName ?? null,
+      embarkPortName: entry.embarkPortName ?? null,
+      disembarkPortName: entry.disembarkPortName ?? null,
       // Supplier / Ship columns facet on ids. connect-cruises ≥0.3.0 surfaces
       // the upstream external ids; map them onto the policy's id fields (#1466
       // fix 2). Falls back to null on older adapters that only carry names.
@@ -780,6 +796,20 @@ function toCatalogProjection(
 // ─────────────────────────────────────────────────────────────────────────────
 // Cursor encoding / entity-id translation
 // ─────────────────────────────────────────────────────────────────────────────
+
+/** Read a string field off the open-ended `SourceRef` bag. */
+function stringField(sourceRef: SourceRef, key: string): string | undefined {
+  const value = sourceRef[key]
+  return typeof value === "string" && value.length > 0 ? value : undefined
+}
+
+/** `cruise:uniworld` → `uniworld`. Returns undefined for an unsuffixed kind. */
+function providerFromSourceKind(sourceKind: string): string | undefined {
+  const idx = sourceKind.indexOf(":")
+  if (idx < 0) return undefined
+  const provider = sourceKind.slice(idx + 1)
+  return provider.length > 0 ? provider : undefined
+}
 
 function parseCursor(cursor: DiscoveryCursor): number {
   if (!cursor) return 0

--- a/packages/cruises/src/lib/adapter-resolution.ts
+++ b/packages/cruises/src/lib/adapter-resolution.ts
@@ -1,0 +1,42 @@
+/**
+ * Registry lookup for the adapter that owns a sourced cruise.
+ *
+ * Internal to the package — `src/lib/*` is deliberately outside the exports map,
+ * so this stays testable without becoming supported API.
+ */
+
+import type { SourceAdapter } from "@voyant-travel/catalog"
+import type { SourceAdapterRegistry } from "@voyant-travel/catalog/booking-engine"
+
+/**
+ * Resolve the catalog `SourceAdapter` that owns a sourced cruise.
+ *
+ * Connection id alone is not enough. A channel registers several adapters for
+ * one connection and can only key them apart by suffixing the registry key —
+ * Voyant Connect registers its generic adapter under `<connectionId>` and its
+ * cruise shim under `<connectionId>:cruises`. A bare
+ * `resolveByConnection(connectionId)` therefore returns the *generic* adapter
+ * for a cruise, which cannot reach through to `cruiseAdapter` for sailing
+ * pricing and silently sent every connection-scoped cruise down the synthesizer
+ * fallback instead of fetching real content.
+ *
+ * The sourced entry's own `source_kind` (`cruise:<provider>`) is what the cruise
+ * shim registers under, so match on that first and keep only adapters bound to
+ * this connection. Fall back to the bare connection lookup — deployment-owned
+ * connectors register under it, and a generic adapter that implements
+ * `getContent` can still serve cruise content — then to any adapter of the kind.
+ */
+export function resolveCruiseSourceAdapter(
+  registry: SourceAdapterRegistry,
+  sourceKind: string,
+  connectionId: string | null | undefined,
+): SourceAdapter | undefined {
+  const ofKind = registry.byKind(sourceKind)
+  if (!connectionId) return ofKind[0]?.adapter
+  const scoped = ofKind.find(
+    (entry) =>
+      entry.connectionId === connectionId || entry.connectionId.startsWith(`${connectionId}:`),
+  )
+  if (scoped) return scoped.adapter
+  return registry.resolveByConnection(connectionId) ?? ofKind[0]?.adapter
+}

--- a/packages/cruises/src/service-content-synthesizer.ts
+++ b/packages/cruises/src/service-content-synthesizer.ts
@@ -103,6 +103,34 @@ function entityIdFromProvenance(
   return provenance.entry_id
 }
 
+/**
+ * Read the first non-empty string among `keys`.
+ *
+ * The catalog projection a cruise sourced-entry carries is written by
+ * `toCatalogProjection` in the source-adapter shim, whose keys are **camelCase**
+ * — they have to match the cruise field policy so the indexer doesn't drop them
+ * (#1466). This synthesizer originally read the snake_case names of the content
+ * shape it produces, which overlapped the projection on `id`/`name`/`status`
+ * and nothing else, so every synthesized cruise rendered blank. Read the
+ * projection's own spelling first and keep the snake_case names as a fallback
+ * for adapters that project the content shape directly.
+ */
+function firstString(projection: Record<string, unknown>, ...keys: string[]): string | null {
+  for (const key of keys) {
+    const value = stringOr(projection[key], null)
+    if (value !== null) return value
+  }
+  return null
+}
+
+function firstNumber(projection: Record<string, unknown>, ...keys: string[]): number | null {
+  for (const key of keys) {
+    const value = numberOr(projection[key], null)
+    if (value !== null) return value
+  }
+  return null
+}
+
 function pickCruiseSummary(
   projection: Record<string, unknown>,
   provenance: Extract<ProvenanceReadResult, { kind: "sourced" }>,
@@ -111,31 +139,45 @@ function pickCruiseSummary(
     id: stringOr(projection.id, "") || provenance.entry_id,
     name: stringOr(projection.name, "") || stringOr(projection.title, "") || "Unnamed cruise",
     status: stringOr(projection.status, undefined),
-    description: stringOr(projection.description, null),
-    cruise_type: stringOr(projection.cruise_type, null),
-    hero_image_url: stringOr(projection.hero_image_url, null),
+    description: firstString(projection, "description"),
+    cruise_type: firstString(projection, "cruiseType", "cruise_type"),
+    hero_image_url: firstString(projection, "heroImageUrl", "hero_image_url", "thumbnailUrl"),
     highlights: stringArrayOr(projection.highlights, []),
     cruise_line:
-      stringOr(projection.cruise_line, null) ??
-      stringOr(projection.line_name, null) ??
-      provenance.provenance.source_provider ??
-      null,
-    duration_nights: numberOr(projection.duration_nights, null),
-    embarkation_port: stringOr(projection.embarkation_port, null),
-    disembarkation_port: stringOr(projection.disembarkation_port, null),
+      firstString(projection, "lineName", "cruise_line", "line_name") ??
+      displayableSourceProvider(provenance),
+    duration_nights: firstNumber(projection, "nights", "duration_nights"),
+    embarkation_port: firstString(projection, "embarkPortName", "embarkation_port"),
+    disembarkation_port: firstString(projection, "disembarkPortName", "disembarkation_port"),
   }
 }
 
+/**
+ * The provider key is a reasonable last-resort cruise line label, but only when
+ * it is actually a provider key. `toCatalogProjection` used to fall back to the
+ * connection id when it couldn't read one, which surfaced a raw
+ * `conn_…` string as the cruise line on the detail page. Rows written before
+ * that fix still carry it, so drop the fallback when it is just the connection
+ * id restated.
+ */
+function displayableSourceProvider(
+  provenance: Extract<ProvenanceReadResult, { kind: "sourced" }>,
+): string | null {
+  const provider = provenance.provenance.source_provider
+  if (!provider) return null
+  return provider === provenance.provenance.source_connection_id ? null : provider
+}
+
 function pickShip(projection: Record<string, unknown>): CruiseContent["ship"] {
-  const shipName = stringOr(projection.ship_name, null) ?? stringOr(projection.ship, null)
+  const shipName = firstString(projection, "shipName", "ship_name", "ship")
   if (!shipName) return null
   return {
     name: shipName,
-    description: stringOr(projection.ship_description, null),
-    deck_plan_url: stringOr(projection.ship_deck_plan_url, null),
+    description: firstString(projection, "shipDescription", "ship_description"),
+    deck_plan_url: firstString(projection, "shipDeckPlanUrl", "ship_deck_plan_url"),
     deck_plans: [],
-    capacity: numberOr(projection.ship_capacity, null),
-    decks: numberOr(projection.ship_decks, null),
+    capacity: firstNumber(projection, "shipCapacity", "ship_capacity"),
+    decks: firstNumber(projection, "shipDecks", "ship_decks"),
     gallery: [],
   }
 }

--- a/packages/cruises/src/service-content.ts
+++ b/packages/cruises/src/service-content.ts
@@ -34,7 +34,6 @@ import type { AnyDrizzleDb } from "@voyant-travel/db"
 import { and, eq } from "drizzle-orm"
 
 import type { CruiseAdapter, ExternalPriceRow, SourceRef } from "./adapters/index.js"
-
 import {
   CRUISES_CONTENT_SCHEMA_VERSION,
   type CruiseContent,
@@ -42,6 +41,7 @@ import {
   mergeOverlaysIntoCruiseContent,
   validateCruiseContent,
 } from "./content-shape.js"
+import { resolveCruiseSourceAdapter } from "./lib/adapter-resolution.js"
 import {
   CRUISES_CONTENT_MARKET_ANY,
   cruisesSourcedContentTable,
@@ -66,6 +66,11 @@ export interface GetCruiseContentOptions {
   registry: SourceAdapterRegistry
   buildAdapterContext?: (adapter: SourceAdapter) => SourceAdapterContext
   onOverlayError?: (event: { field_path: string; reason: string }) => void
+  /**
+   * Called when the adapter's `getContent` fails and the read degrades to the
+   * synthesizer. Defaults to `console.warn`; the read still succeeds.
+   */
+  onContentFetchError?: (event: { entity_id: string; reason: string }) => void
 }
 
 export interface ResolvedCruiseContent {
@@ -146,10 +151,11 @@ export async function getCruiseContent(
   }
   const resultProvenance = sourcedEntryToContentProvenance(sourcedEntry)
 
-  const adapter = sourcedEntry.source_connection_id
-    ? (options.registry.resolveByConnection(sourcedEntry.source_connection_id) ??
-      options.registry.byKind(sourcedEntry.source_kind)[0]?.adapter)
-    : options.registry.byKind(sourcedEntry.source_kind)[0]?.adapter
+  const adapter = resolveCruiseSourceAdapter(
+    options.registry,
+    sourcedEntry.source_kind,
+    sourcedEntry.source_connection_id,
+  )
   const adapterCtx: SourceAdapterContext = options.buildAdapterContext?.(adapter!) ?? {
     connection_id: sourcedEntry.source_connection_id ?? sourcedEntry.source_kind,
   }
@@ -210,13 +216,19 @@ export async function getCruiseContent(
     return wrapSynthesized(synthesized, scope, false, resultProvenance)
   }
 
-  const fresh = await fetchFreshContent(db, adapter, adapterCtx, {
-    entity_module: "cruises",
-    entity_id: entityId,
-    locale: scope.preferredLocales[0] ?? "en-GB",
-    market,
-    currency: scope.currency,
-  })
+  const fresh = await fetchFreshContent(
+    db,
+    adapter,
+    adapterCtx,
+    {
+      entity_module: "cruises",
+      entity_id: entityId,
+      locale: scope.preferredLocales[0] ?? "en-GB",
+      market,
+      currency: scope.currency,
+    },
+    options.onContentFetchError,
+  )
   if (!fresh) {
     const overlays = await fetchOverlaysForEntity(db, "cruises", entityId)
     const synthesized = synthesizeCruiseContent(
@@ -262,10 +274,11 @@ export async function getCruiseSailingPricing(
   const sourcedEntry = await readSourcedEntry(db, "cruises", entityId)
   if (!sourcedEntry) return null
 
-  const adapter = sourcedEntry.source_connection_id
-    ? (options.registry.resolveByConnection(sourcedEntry.source_connection_id) ??
-      options.registry.byKind(sourcedEntry.source_kind)[0]?.adapter)
-    : options.registry.byKind(sourcedEntry.source_kind)[0]?.adapter
+  const adapter = resolveCruiseSourceAdapter(
+    options.registry,
+    sourcedEntry.source_kind,
+    sourcedEntry.source_connection_id,
+  )
 
   // The catalog SourceAdapter for cruises is the `cruiseAdapterToSourceAdapter`
   // shim, which exposes the underlying multi-method `CruiseAdapter`. Pricing
@@ -306,33 +319,60 @@ async function fetchCacheCandidates(
     )
 }
 
+/**
+ * Fetch content from the adapter, or resolve `null` so the caller can fall back
+ * to the synthesizer.
+ *
+ * A throw here used to escape `getCruiseContent` and 500 the detail route, which
+ * is the wrong answer twice over: we hold a durable sourced-entry projection for
+ * this cruise, and §3.6 defines the synthesizer as exactly the degraded read for
+ * when the adapter can't serve content. Blanking the page with a 500 because an
+ * upstream lookup missed loses data we already have.
+ *
+ * It is not hypothetical — `resolveCruiseRow` in `@voyant-travel/connect-adapter`
+ * throws `Connect cruise content not found` for cruises discovery has indexed,
+ * and on sandbox that turned into a 500 on every concurrent detail open. The
+ * failure is still reported through `onContentFetchError` so an upstream outage
+ * stays visible instead of silently degrading every cruise to a stub.
+ */
 async function fetchFreshContent(
   db: AnyDrizzleDb,
   adapter: SourceAdapter,
   ctx: SourceAdapterContext,
   request: GetContentRequest,
+  onContentFetchError?: (event: { entity_id: string; reason: string }) => void,
 ): Promise<GetContentResult | null> {
-  const result = await withContentRefreshLock(
-    db,
-    {
-      entityModule: request.entity_module,
-      entityId: request.entity_id,
-      locale: request.locale,
-      market: request.market,
-    },
-    async () => {
-      const got = await adapter.getContent!(ctx, request)
-      const validation = validateCruiseContent(got.content)
-      if (!validation.valid) {
-        throw new Error(
-          `cruises getContent for ${request.entity_id} failed validation: ${validation.reason}`,
-        )
-      }
-      await writeCacheRow(db, request, got)
-      return got
-    },
-  )
-  return result ?? null
+  try {
+    const result = await withContentRefreshLock(
+      db,
+      {
+        entityModule: request.entity_module,
+        entityId: request.entity_id,
+        locale: request.locale,
+        market: request.market,
+      },
+      async () => {
+        const got = await adapter.getContent!(ctx, request)
+        const validation = validateCruiseContent(got.content)
+        if (!validation.valid) {
+          throw new Error(
+            `cruises getContent for ${request.entity_id} failed validation: ${validation.reason}`,
+          )
+        }
+        await writeCacheRow(db, request, got)
+        return got
+      },
+    )
+    return result ?? null
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error)
+    if (onContentFetchError) {
+      onContentFetchError({ entity_id: request.entity_id, reason })
+    } else {
+      console.warn(`[cruises] getContent failed for ${request.entity_id}: ${reason}`)
+    }
+    return null
+  }
 }
 
 async function fetchPassThroughContent(

--- a/packages/cruises/tests/unit/adapter-resolution.test.ts
+++ b/packages/cruises/tests/unit/adapter-resolution.test.ts
@@ -1,0 +1,78 @@
+import type { SourceAdapter } from "@voyant-travel/catalog"
+import { createSourceAdapterRegistry } from "@voyant-travel/catalog/booking-engine"
+import { describe, expect, it } from "vitest"
+
+import { resolveCruiseSourceAdapter } from "../../src/lib/adapter-resolution.js"
+
+const CONNECTION = "conn_db9b7a69e2d474bd143d045c"
+
+function stubAdapter(kind: string, extra: Record<string, unknown> = {}): SourceAdapter {
+  return {
+    kind,
+    capabilities: { verticals: ["cruises"] },
+    ...extra,
+  } as unknown as SourceAdapter
+}
+
+/**
+ * A channel registers several adapters for one connection and can only key them
+ * apart by suffixing the registry key — Voyant Connect puts its generic adapter
+ * under `<connectionId>` and its cruise shim under `<connectionId>:cruises`.
+ * Resolving a cruise by bare connection id therefore returned the *generic*
+ * adapter, which cannot reach through to `cruiseAdapter` and sent every
+ * connection-scoped cruise down the synthesizer fallback with a blank page.
+ */
+describe("resolveCruiseSourceAdapter", () => {
+  it("prefers the connection's cruise shim over its generic adapter", () => {
+    const registry = createSourceAdapterRegistry()
+    const generic = stubAdapter("voyant-connect")
+    const cruises = stubAdapter("cruise:uniworld", { cruiseAdapter: {} })
+    registry.register(CONNECTION, generic)
+    registry.register(`${CONNECTION}:cruises`, cruises)
+
+    expect(resolveCruiseSourceAdapter(registry, "cruise:uniworld", CONNECTION)).toBe(cruises)
+  })
+
+  it("resolves a cruise adapter registered under the bare connection id", () => {
+    const registry = createSourceAdapterRegistry()
+    const cruises = stubAdapter("cruise:uniworld")
+    registry.register(CONNECTION, cruises)
+
+    expect(resolveCruiseSourceAdapter(registry, "cruise:uniworld", CONNECTION)).toBe(cruises)
+  })
+
+  it("does not cross connections when the kind matches another connection's shim", () => {
+    const registry = createSourceAdapterRegistry()
+    const otherConnection = stubAdapter("cruise:uniworld", { cruiseAdapter: {} })
+    registry.register("conn_someone_else:cruises", otherConnection)
+    const generic = stubAdapter("voyant-connect")
+    registry.register(CONNECTION, generic)
+
+    // This connection has no cruise shim, so the generic adapter it *does* have
+    // is the right answer — it can still serve content via `getContent`.
+    expect(resolveCruiseSourceAdapter(registry, "cruise:uniworld", CONNECTION)).toBe(generic)
+  })
+
+  it("falls back to any adapter of the kind when the connection has none", () => {
+    const registry = createSourceAdapterRegistry()
+    const cruises = stubAdapter("cruise:uniworld")
+    registry.register("conn_someone_else:cruises", cruises)
+
+    expect(resolveCruiseSourceAdapter(registry, "cruise:uniworld", CONNECTION)).toBe(cruises)
+  })
+
+  it("resolves by kind alone when the sourced entry carries no connection", () => {
+    const registry = createSourceAdapterRegistry()
+    const cruises = stubAdapter("cruise:uniworld")
+    registry.register(`${CONNECTION}:cruises`, cruises)
+
+    expect(resolveCruiseSourceAdapter(registry, "cruise:uniworld", null)).toBe(cruises)
+  })
+
+  it("returns undefined when nothing matches", () => {
+    const registry = createSourceAdapterRegistry()
+    registry.register(CONNECTION, stubAdapter("voyant-connect"))
+
+    expect(resolveCruiseSourceAdapter(registry, "cruise:viking", "conn_unknown")).toBeUndefined()
+  })
+})

--- a/packages/cruises/tests/unit/service-content-adapter-failure.test.ts
+++ b/packages/cruises/tests/unit/service-content-adapter-failure.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const catalogMocks = vi.hoisted(() => ({
+  fetchOverlaysForEntity: vi.fn(async () => [] as Array<{ field_path: string; value: unknown }>),
+  readSourcedEntry: vi.fn(async () => null as unknown),
+  pickBestCachedLocale: vi.fn(() => undefined as unknown),
+  // Run the callback inline; the real implementation takes a DB advisory lock.
+  withContentRefreshLock: vi.fn(async (_db: unknown, _key: unknown, fn: () => Promise<unknown>) =>
+    fn(),
+  ),
+}))
+
+vi.mock("@voyant-travel/catalog", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@voyant-travel/catalog")>()),
+  ...catalogMocks,
+}))
+
+import { getCruiseContent } from "../../src/service-content.js"
+
+const ENTITY_ID = "crus_sr_test"
+const CONNECTION = "conn_01kztv84ncexvvgxy6s6gb33df"
+
+function sourcedEntry() {
+  const now = new Date()
+  return {
+    id: "cse_1",
+    entity_module: "cruises",
+    entity_id: ENTITY_ID,
+    source_kind: "cruise:viking",
+    source_provider: "viking",
+    source_connection_id: CONNECTION,
+    source_ref: "sr_test",
+    source_freshness: "sync",
+    last_sourced_at: now,
+    status: "active",
+    projection: {
+      id: ENTITY_ID,
+      name: "Elegant Elbe",
+      status: "active",
+      cruiseType: "river",
+      nights: 7,
+      lineName: "Viking Cruises (US)",
+    },
+    projection_etag: null,
+    projection_seen_at: now,
+    first_seen_at: now,
+    last_seen_at: now,
+  }
+}
+
+/** No cached content rows — forces the adapter path. Accepts the cache write. */
+function emptyCacheDb() {
+  return {
+    select: () => ({ from: () => ({ where: async () => [] }) }),
+    insert: () => ({
+      values: () => ({ onConflictDoUpdate: async () => undefined }),
+    }),
+  } as never
+}
+
+function registryWith(getContent: () => Promise<never>) {
+  const adapter = {
+    kind: "cruise:viking",
+    capabilities: { verticals: ["cruises"] },
+    getContent,
+  }
+  return {
+    byKind: (kind: string) =>
+      kind === "cruise:viking" ? [{ connectionId: `${CONNECTION}:cruises`, adapter }] : [],
+    resolveByConnection: () => undefined,
+  } as never
+}
+
+/**
+ * The adapter throwing used to escape `getCruiseContent` and 500 the detail
+ * route. We hold a durable projection for the cruise and §3.6 defines the
+ * synthesizer as the degraded read, so an upstream miss must not blank the page.
+ * On sandbox this turned into a 500 on every concurrent cruise detail open.
+ */
+describe("getCruiseContent — adapter getContent failure", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    catalogMocks.fetchOverlaysForEntity.mockResolvedValue([])
+    catalogMocks.readSourcedEntry.mockResolvedValue(sourcedEntry())
+    catalogMocks.pickBestCachedLocale.mockReturnValue(undefined)
+    catalogMocks.withContentRefreshLock.mockImplementation(
+      async (_db: unknown, _key: unknown, fn: () => Promise<unknown>) => fn(),
+    )
+  })
+
+  it("degrades to synthesized content instead of throwing", async () => {
+    const onContentFetchError = vi.fn()
+    const result = await getCruiseContent(
+      emptyCacheDb(),
+      ENTITY_ID,
+      { preferredLocales: ["en-GB"] },
+      {
+        registry: registryWith(async () => {
+          throw new Error(`Connect cruise content not found for ${ENTITY_ID} on ${CONNECTION}`)
+        }),
+        onContentFetchError,
+      },
+    )
+
+    expect(result?.source).toBe("synthesized")
+    expect(result?.synthesized).toBe(true)
+    // The projection we already hold still renders.
+    expect(result?.content.cruise.name).toBe("Elegant Elbe")
+    expect(result?.content.cruise.cruise_type).toBe("river")
+    expect(result?.content.cruise.cruise_line).toBe("Viking Cruises (US)")
+  })
+
+  it("reports the failure so an upstream outage stays visible", async () => {
+    const onContentFetchError = vi.fn()
+    await getCruiseContent(
+      emptyCacheDb(),
+      ENTITY_ID,
+      { preferredLocales: ["en-GB"] },
+      {
+        registry: registryWith(async () => {
+          throw new Error("Connect cruise content not found")
+        }),
+        onContentFetchError,
+      },
+    )
+
+    expect(onContentFetchError).toHaveBeenCalledTimes(1)
+    expect(onContentFetchError.mock.calls[0]?.[0]).toMatchObject({
+      entity_id: ENTITY_ID,
+      reason: expect.stringContaining("Connect cruise content not found"),
+    })
+  })
+
+  it("still serves fresh content when the adapter succeeds", async () => {
+    const result = await getCruiseContent(
+      emptyCacheDb(),
+      ENTITY_ID,
+      { preferredLocales: ["en-GB"] },
+      {
+        registry: registryWith(
+          async () =>
+            ({
+              entity_module: "cruises",
+              entity_id: ENTITY_ID,
+              returned_locale: "en-GB",
+              content: {
+                cruise: { id: ENTITY_ID, name: "Elegant Elbe", cruise_line: "Viking Cruises (US)" },
+                ship: null,
+                sailings: [],
+                cabin_categories: [],
+                itinerary_stops: [],
+                policies: [],
+              },
+              content_schema_version: "cruises/v1",
+            }) as never,
+        ),
+        onContentFetchError: () => {},
+      },
+    )
+
+    expect(result?.synthesized).toBe(false)
+  })
+})

--- a/packages/cruises/tests/unit/service-content-synthesizer.test.ts
+++ b/packages/cruises/tests/unit/service-content-synthesizer.test.ts
@@ -1,6 +1,8 @@
 import type { ProvenanceReadResult } from "@voyant-travel/catalog"
 import { describe, expect, it } from "vitest"
 
+import type { CruiseAdapter, CruiseSearchProjectionEntry } from "../../src/adapters/index.js"
+import { cruiseAdapterToSourceAdapter } from "../../src/adapters/source-adapter-shim.js"
 import { CRUISES_CONTENT_SCHEMA_VERSION } from "../../src/content-shape.js"
 import { synthesizeCruiseContent } from "../../src/service-content-synthesizer.js"
 
@@ -148,5 +150,102 @@ describe("synthesizeCruiseContent — typed empty states", () => {
       },
     )
     expect(result.content.cruise.description).toBe("Descriere în română")
+  })
+
+  it("drops a source_provider cruise_line fallback that just restates the connection id", () => {
+    const result = synthesizeCruiseContent(
+      { locale: "en-GB" },
+      {
+        provenance: makeProvenance(
+          { id: "crus_abc", name: "Greek Isles" },
+          {
+            provenance: {
+              source_kind: "cruise:uniworld",
+              source_provider: "conn_db9b7a69e2d474bd143d045c",
+              source_connection_id: "conn_db9b7a69e2d474bd143d045c",
+              source_ref: "sr_x",
+              source_freshness: "sync",
+              last_sourced_at: new Date(),
+            },
+          },
+        ),
+      },
+    )
+    // Rows written before the shim learned to read `providerKey` carry the
+    // connection id as the provider; rendering it as the cruise line put a raw
+    // `conn_…` string under the title on the detail page.
+    expect(result.content.cruise.cruise_line).toBeNull()
+  })
+})
+
+/**
+ * The synthesizer's only input is `catalog_sourced_entries.projection`, which is
+ * written verbatim from the source-adapter shim's `discover()`. Asserting
+ * against a hand-written projection proves nothing about that hand-off — and it
+ * is exactly what let the two sides drift apart on key casing until every
+ * synthesized cruise rendered blank. Drive the real path instead.
+ */
+describe("synthesizeCruiseContent — over a real shim projection", () => {
+  const entry: CruiseSearchProjectionEntry = {
+    sourceRef: {
+      externalId: "178_88-from-2027",
+      connectionId: "conn_db9b7a69e2d474bd143d045c",
+      providerKey: "uniworld",
+    },
+    slug: "classic-christmas-markets",
+    name: "Classic Christmas Markets",
+    cruiseType: "river",
+    lineName: "Uniworld (US)",
+    shipName: "S.S. Audrey",
+    nights: 7,
+    embarkPortName: "Frankfurt",
+    disembarkPortName: "Nuremberg",
+    heroImageUrl: "https://cdn/uniworld-hero.jpg",
+    salesStatus: "active",
+  }
+
+  function synthesizeFromDiscovery() {
+    const shim = cruiseAdapterToSourceAdapter(
+      {
+        name: "uniworld",
+        async *searchProjection() {
+          yield entry
+        },
+      } as unknown as CruiseAdapter,
+      { pageSize: 10 },
+    )
+    return shim.discover({ connection_id: "conn_db9b7a69e2d474bd143d045c" }).then((page) => {
+      const projection = page.projections[0]
+      if (!projection) throw new Error("discover() produced no projection")
+      return synthesizeCruiseContent(
+        { locale: "en-GB" },
+        {
+          provenance: makeProvenance(projection.fields, {
+            provenance: {
+              ...projection.provenance,
+              source_freshness: "sync",
+            },
+          }),
+        },
+      )
+    })
+  }
+
+  it("carries the discovered cruise summary through to synthesized content", async () => {
+    const { content } = await synthesizeFromDiscovery()
+
+    expect(content.cruise.name).toBe("Classic Christmas Markets")
+    expect(content.cruise.cruise_type).toBe("river")
+    expect(content.cruise.duration_nights).toBe(7)
+    expect(content.cruise.hero_image_url).toBe("https://cdn/uniworld-hero.jpg")
+    expect(content.cruise.cruise_line).toBe("Uniworld (US)")
+    expect(content.cruise.embarkation_port).toBe("Frankfurt")
+    expect(content.cruise.disembarkation_port).toBe("Nuremberg")
+    expect(content.ship?.name).toBe("S.S. Audrey")
+  })
+
+  it("stamps the provider key, not the connection id, as source_provider", async () => {
+    const { source_provider } = await synthesizeFromDiscovery()
+    expect(source_provider).toBe("uniworld")
   })
 })

--- a/packages/inventory/src/service-content-owned.ts
+++ b/packages/inventory/src/service-content-owned.ts
@@ -183,6 +183,17 @@ export async function buildOwnedProductContent(
     undefined
   const openGraphImage =
     productImages.find((m: typeof productMedia.$inferSelect) => m.isOpenGraph) ?? cover
+  // `productImages` is deliberately product-level only (`dayId === null`), but a
+  // product whose only imagery hangs off its itinerary days then reported no
+  // hero at all — the detail page rendered a placeholder while the very same
+  // image sat in `content.media`. Fall back to the first day image so the hero
+  // reflects what the record actually has. Open Graph keeps the stricter rule:
+  // a day photo is not a deliberate share image.
+  const heroImage =
+    cover ??
+    mediaRows.find(
+      (m: typeof productMedia.$inferSelect) => m.mediaType === "image" && !m.isBrochure,
+    )
 
   const localizedName = bestProductTrn?.candidate.name ?? productRow.name
   const localizedDescription =
@@ -220,7 +231,7 @@ export async function buildOwnedProductContent(
       terms_html: localizedTerms,
       contract_template_id: productRow.contractTemplateId ?? null,
       contractTemplateId: productRow.contractTemplateId ?? null,
-      hero_image_url: cover?.url ?? null,
+      hero_image_url: heroImage?.url ?? null,
       duration_days: resolveProductDuration({
         durationMinutes: productRow.durationMinutes,
         itineraryDurationDays: itineraryDurationDays(days),

--- a/packages/inventory/tests/unit/service-content-owned.test.ts
+++ b/packages/inventory/tests/unit/service-content-owned.test.ts
@@ -325,6 +325,68 @@ describe("buildOwnedProductContent", () => {
     expect(result?.content.product.open_graph_image_height).toBe(630)
     expect(result?.content.product.open_graph_image_type).toBe("image/jpeg")
     expect(result?.content.product.open_graph_image_alt).toBe("Tur montan")
+    // A product-level cover is still the hero when one exists.
+    expect(result?.content.product.hero_image_url).toBe("https://example.com/cover.jpg")
+  })
+
+  it("falls back to a day image for the hero when the product has no product-level image", async () => {
+    const db = fakeDb(
+      new Map<unknown, unknown[]>([
+        [
+          products,
+          [
+            {
+              id: "prod_1",
+              name: "Food crawl",
+              status: "active",
+              description: null,
+              inclusionsHtml: null,
+              exclusionsHtml: null,
+              termsHtml: null,
+              contractTemplateId: null,
+              startDate: null,
+              endDate: null,
+              sellCurrency: "EUR",
+              supplierId: null,
+              tags: [],
+            },
+          ],
+        ],
+        [productOptions, []],
+        [productOptionTranslations, []],
+        [
+          productMedia,
+          [
+            {
+              id: "pmed_day",
+              productId: "prod_1",
+              // Attached to an itinerary day, so it is excluded from the
+              // product-level image list the cover is picked from.
+              dayId: "day_1",
+              mediaType: "image",
+              url: "https://example.com/day.jpg",
+              isCover: false,
+              isOpenGraph: false,
+              isBrochure: false,
+              sortOrder: 0,
+              createdAt: new Date(0),
+              altText: null,
+            },
+          ],
+        ],
+        [productTranslations, []],
+        [productItineraries, []],
+      ]),
+    )
+
+    const result = await buildOwnedProductContent(db, "prod_1", { preferredLocales: ["en"] })
+
+    // The image is already in `content.media`; reporting no hero made the
+    // detail page render a placeholder next to it.
+    expect(result?.content.product.hero_image_url).toBe("https://example.com/day.jpg")
+    expect(result?.content.media.map((m) => m.url)).toContain("https://example.com/day.jpg")
+    // Open Graph keeps the stricter rule — a day photo is not a share image.
+    expect(result?.content.product.open_graph_image_url).toBeNull()
   })
 })
 


### PR DESCRIPTION
Fixes the report that individual catalog detail pages look broken or are missing information — e.g. `/catalog/activities/prod_01kz996xesegnv4vd6aescjnhf` on sandbox.

### The page was rendering a record it never fetched

`CatalogVerticalDetailPage` built its hit with an empty field map:

```ts
const hit = { id, score: 0, document: { id, fields: {} } }
```

Entered by id there is no result row to carry the index projection, so price, offers, status, categories and destinations were all absent and the **entire Attributes tab disappeared** (`hasAttributes` is computed from those fields). The same record showed far more when opened as a sheet from the list than on its own page. It now reads the indexed document by id.

The supplier formatter is also held by ref, so the supplier directory settling no longer rebuilds the enrichment fetchers and re-requests the record — one page load was issuing the content route three times.

### Sourced cruises were degrading to blank in four separate ways

- **Adapter resolved by connection alone.** A channel registers several adapters per connection and keys them apart by suffixing the registry key (`<connectionId>:cruises`), so resolving by connection returned the connection's *generic* adapter, which carries no `cruiseAdapter`. Every connection-scoped cruise reported no cabin pricing at all. Now resolved by its own `source_kind` scoped to the connection, falling back to the bare connection id.
- **The synthesizer read the wrong casing.** It read the snake_case names of the content shape it *produces* rather than the projection's camelCase keys. Those overlapped on `id`/`name`/`status` and nothing else, so the fallback rendered blank even when discovery had captured the data.
- **`source_provider` held a connection id.** The shim read `sourceRef.provider` while Voyant Connect writes `providerKey`, so a raw `conn_…` string surfaced as the cruise line. Now stamps the provider key, and projects cruise line, ship and port display names alongside their faceted ids.
- **A failing adapter 500'd the route.** `resolveCruiseRow` in `@voyant-travel/connect-adapter` throws `Connect cruise content not found` for cruises discovery has already indexed, so every concurrent cruise detail open on sandbox became a 500. We hold a durable sourced-entry projection and §3.6 defines the synthesizer as exactly that degraded read, so it now degrades instead of throwing. The failure is reported through a new `onContentFetchError` option (default `console.warn`) so an upstream outage stays visible rather than silently degrading every cruise to a stub.

### Owned products

Fall back to an itinerary-day image for the hero when there is no product-level image, instead of reporting no hero while the same image sits in `content.media`.

### Verification

- `catalog-react` 89, `inventory` 601 (+71 skipped), `cruises` 284 (+7 skipped) — all pass
- `tsc -p tsconfig.typecheck.json` on `catalog-react` → exit 0, 0 `error TS`
- `pnpm verify:architecture` → exit 0
- `biome check .` from repo root → 0 errors

### Provenance

This work was written in an earlier session, never pushed, and left on a local branch based on stale main. It has been rebased onto current main and re-verified end to end rather than rewritten.
