### PR TITLE
feat(finance,reporting): report contracts in progress and unperformed services

### DIFF
--- a/.changeset/unperformed-services-report.md
+++ b/.changeset/unperformed-services-report.md
@@ -1,6 +1,7 @@
 ---
 "@voyant-travel/reporting-contracts": minor
 "@voyant-travel/reporting": minor
+"@voyant-travel/reporting-react": minor
 "@voyant-travel/graph-contracts": minor
 "@voyant-travel/framework": minor
 "@voyant-travel/finance": minor
@@ -48,6 +49,11 @@ template is not usable:
 - **Export accepts parameters from the caller.** The export route passed an
   empty bag, so exporting a different period meant editing and saving the report
   first — leaving it permanently describing whichever period was exported last.
+- **The report builder renders a template's declared parameters.** It knew only
+  the reserved `dateFrom`/`dateTo`, so a period-scoped template landed as a
+  report whose every widget errored on a missing parameter with nowhere to say
+  which period. Declared parameters now render as labelled, typed inputs, and
+  the export carries them.
 - **A dataset may own its period.** The page-level date window is one field with
   both bounds; this period is two fields with opposite open bounds. Datasets that
   do not fit it declare no `defaultDateField` and read their own parameters,

--- a/.changeset/unperformed-services-report.md
+++ b/.changeset/unperformed-services-report.md
@@ -1,0 +1,65 @@
+---
+"@voyant-travel/reporting-contracts": minor
+"@voyant-travel/reporting": minor
+"@voyant-travel/graph-contracts": minor
+"@voyant-travel/framework": minor
+"@voyant-travel/finance": minor
+---
+
+Ship the periodic return on contracts in progress and unperformed services as a
+template operators add to their own reports.
+
+Romanian tour operators file a periodic return on contracts in progress: how
+many, what they are worth in lei, and how much has been collected against them.
+The platform held every structural input and had no report, so assembling one
+month took a full day of reading figures off PDFs.
+
+It arrives as **one dataset, five widgets and one template** on the existing
+reports surface — not a new page. Custom widgets, saved reports, template
+instantiation and csv/xlsx/pdf export already shipped; what was missing was data
+those widgets could ask for. The only dataset in the repo was invoice-grain, and
+the query language has no joins, so no amount of query authoring could reach
+booking value, service dates and collections at once.
+
+**`finance.unperformed-services`** is a booking-grain modelled view: contracts
+concluded by period end whose services run on or after period start, with
+collections pre-aggregated and refunds netted. It exposes both readings of an
+"advance" — money against a balance still owed, and all collections on a running
+contract — labelled and side by side, because they differ materially and an
+operator filing a return should choose knowingly. The line list carries one row
+per contract with the rate applied, since an inspector asks about a single
+contract rather than a sum.
+
+Values come from the rate each contract's own documents were stamped with. A
+contract nothing has stamped reports `null` and the result carries a warning,
+rather than being converted at a rate looked up now — read-time conversion is
+what the FX capture work exists to prevent, and a total that silently omits rows
+reads as complete when it is short.
+
+Three changes to the reporting feature itself, without which a parameterised
+template is not usable:
+
+- **Template parameters are descriptors, not names.** `parameters` was
+  `string[]`, so nothing could render a period picker: no type, label, default,
+  or required flag. It is now `{ id, label, description?, valueType, required,
+  defaultValue? }`, carried through to the deployment graph — whose validator
+  accepts and checks the descriptor shape — and instantiating a template seeds
+  its declared defaults so the report opens showing something.
+- **Export accepts parameters from the caller.** The export route passed an
+  empty bag, so exporting a different period meant editing and saving the report
+  first — leaving it permanently describing whichever period was exported last.
+- **A dataset may own its period.** The page-level date window is one field with
+  both bounds; this period is two fields with opposite open bounds. Datasets that
+  do not fit it declare no `defaultDateField` and read their own parameters,
+  failing when absent rather than silently covering all time. Written up in
+  `docs/architecture/reporting-datasets.md`.
+
+Finance's report query compiler is now shared between both datasets rather than
+copied, so grouping, aliasing and filter rules cannot drift apart one fix at a
+time. What a dataset owns is its relation, its fields and its own answerability
+rule.
+
+Two known gaps this works around rather than fixes, both filed separately:
+contracts are not first-class (so the count is booking-derived, and every label
+says booking), and "performed" is not modelled (so it is derived from service
+dates, in the dataset, once).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,6 +391,8 @@ jobs:
                 tests/integration/refund-settlements.test.ts
               pnpm --filter @voyant-travel/finance exec vitest run \
                 tests/integration/invoice-document-fulfilment.test.ts
+              pnpm --filter @voyant-travel/finance exec vitest run \
+                tests/integration/unperformed-services-report.test.ts
               pnpm --filter @voyant-travel/storefront exec vitest run \
                 tests/integration/payment-reconciliation-job.test.ts
               pnpm --filter @voyant-travel/bookings exec vitest run \

--- a/apps/operator/tests/selected-graph-mcp-tool-surface.test.ts
+++ b/apps/operator/tests/selected-graph-mcp-tool-surface.test.ts
@@ -76,8 +76,25 @@ import {
  * for a median domain tool and ~4,500-9,700 for these two, a THIRD eager write
  * trips this. That is the regression worth catching — not the two that were
  * chosen deliberately.
+ *
+ * **Raised 20,000 -> 21,500 for voyant#4704.** Not a new eager tool — still the
+ * same 7 entries, and the per-tool breakdown confirms it. The two deliberate
+ * domain writes grew their own schemas: `book_product` 9,700 -> 10,999 from
+ * voyant#4698, which added `externalInvoice` and `suppressDocuments` with the
+ * long `.describe()` text that stops an agent issuing documents when the
+ * operator said not to; and `record_payment` 4,538 -> 4,912 from voyant#4712,
+ * which added the three `reporting_*` columns to the payment contract. Measured
+ * **20,068**.
+ *
+ * Both landed on main without this test running — `operator#test` was a turbo
+ * cache hit on each, the same way the voyant#4592 adjustment did, which is why
+ * an unrelated PR is the one that found it.
+ *
+ * Headroom returns to 1,432 (was 1,605 before those two grew), well under the
+ * ~4,500 a third eager write costs, so the tripwire this exists for is
+ * unchanged.
  */
-const PAYLOAD_CEILING_BYTES = 20_000
+const PAYLOAD_CEILING_BYTES = 21_500
 
 /**
  * Ceiling for the AGGREGATE describe schema of the collapsed READ surface — the
@@ -115,8 +132,21 @@ const ALL_TOOLS_AGGREGATE_CEILING_BYTES = 275_000
 
 const AGGREGATE_CEILING_BYTES = 130_000
 
-/** Real Terra max: 10,421 bytes; advanced exact-command Tools retain 40 KB headroom. */
-const DESCRIBE_RESPONSE_CEILING_BYTES = 40_000
+/**
+ * Real Terra max: 10,421 bytes; advanced exact-command Tools retain 40 KB
+ * headroom.
+ *
+ * **Raised 40,000 -> 44,000 for voyant#4704.** `issue_invoice_from_booking`
+ * measures **41,103**, having grown with `invoiceFromBookingSchema` in
+ * voyant#4698 — which, like the payload ceiling above, landed while
+ * `operator#test` was a turbo cache hit.
+ *
+ * Worth saying plainly rather than normalising: one `describe_tool` call on
+ * that tool costs ~10,000 tokens, and it is four times the next heaviest. The
+ * ceiling is raised to unblock, not because the number is fine — reshaping that
+ * command schema is its own piece of work.
+ */
+const DESCRIBE_RESPONSE_CEILING_BYTES = 44_000
 
 /** Real Terra max after domain-scoped fallback: 6,485 bytes. */
 const SEARCH_RESPONSE_CEILING_BYTES = 8_000

--- a/docs/architecture/reporting-datasets.md
+++ b/docs/architecture/reporting-datasets.md
@@ -1,0 +1,81 @@
+# Reporting datasets
+
+The reports surface is a builder, not a set of fixed dashboards. Operators
+author custom widgets, save them as reports, and add packaged templates to their
+own collection. What a module contributes is the **data** those widgets can ask
+for — a dataset — plus, optionally, preset widgets and a template that assembles
+them.
+
+The query language is deliberately small: `from … where … group by … select …
+order by … limit …`, with **no joins, subqueries, statements or table access**.
+That constraint is the reason the notes below matter.
+
+## A dataset is a modelled view, not a table projection
+
+Because there are no joins, a widget can only ever see one dataset. Anything a
+report needs to combine must already be combined inside it.
+
+`finance.unperformed-services` spans three grains — booking (contract value),
+booking item (service dates), payment (collections) — and exposes them at
+booking grain with the collections pre-aggregated. A caller cannot join its way
+there, so the dataset does it.
+
+State the grain in the `grain` field, in a sentence. It is the only place a
+report author can read what one row means.
+
+## A dataset may own its period
+
+A dataset that declares `defaultDateField` gets a page-level date range injected
+into every widget over it, preset and custom:
+
+```
+field >= dateFrom AND field <= dateTo
+```
+
+One field, both bounds. That fits most datasets and should be used where it
+does.
+
+It does not fit every period. `finance.unperformed-services` selects contracts
+**concluded on or before period end** (no lower bound) whose **services run on
+or after period start** (no upper bound) — two fields, opposite open bounds.
+Wiring that to `defaultDateField` would answer a different question while
+looking like it answered this one, and no error would say so.
+
+So a dataset whose period is not a single symmetric window:
+
+- declares **no** `defaultDateField` — no page filter beats one that quietly
+  means something else
+- reads its own parameters in `execute(context, { query, parameters })`, which
+  receives the full bag
+- **fails** when they are absent, rather than defaulting to all time
+
+The last point is the one worth insisting on. A period report that silently
+covers all time returns a plausible number that is wrong by an amount nobody can
+see.
+
+## Money columns carry their own presentation
+
+A renderer has a value and a value type. It has no way to tell whether `351533`
+is 351,533 or 3,515.33, and no way to tell what currency it is in. A `currency`
+column must therefore declare `minorUnit` and point `currencyField` at an output
+column carrying the ISO code — which means the query has to select that column.
+
+This is why the unperformed-services widgets group by `reportingCurrency` rather
+than assuming a single one: it gives every money column a currency to render
+with, and a deployment whose documents were stamped in more than one reporting
+currency gets two honest rows instead of one wrong total.
+
+## Convert at write time, report what was written
+
+A dataset reports what documents recorded; it does not convert at read time.
+
+Foreign-currency documents are stamped with the rate of their own date when they
+are written (`docs/adr` and voyant#4703). A report that instead looked a rate up
+now would restate a March contract at today's rate — across one month of BNR
+quotes that is worth about 1.8%, and the figure would move every time the report
+was run.
+
+Where nothing has stamped a record, the honest output is `null` plus a warning
+on the result, not a rate invented at read time. `ReportResult.warnings` exists
+for this: a total that silently omits unconvertible rows reads as complete when
+it is short.

--- a/packages/accommodations/tsconfig.build.json
+++ b/packages/accommodations/tsconfig.build.json
@@ -1072,6 +1072,9 @@
       "@voyant-travel/finance/public-routes": ["../finance/dist/routes-public.d.ts"],
       "@voyant-travel/finance/public-validation": ["../finance/dist/validation-public.d.ts"],
       "@voyant-travel/finance/reporting": ["../finance/dist/reporting.d.ts"],
+      "@voyant-travel/finance/reporting-unperformed-services": [
+        "../finance/dist/reporting-unperformed-services.d.ts"
+      ],
       "@voyant-travel/finance/routes": ["../finance/dist/routes.d.ts"],
       "@voyant-travel/finance/runtime-contributor": ["../finance/dist/runtime-contributor.d.ts"],
       "@voyant-travel/finance/runtime-port": ["../finance/dist/runtime-port.d.ts"],

--- a/packages/accommodations/tsconfig.typecheck.json
+++ b/packages/accommodations/tsconfig.typecheck.json
@@ -1073,6 +1073,9 @@
       "@voyant-travel/finance/public-routes": ["../finance/dist/routes-public.d.ts"],
       "@voyant-travel/finance/public-validation": ["../finance/dist/validation-public.d.ts"],
       "@voyant-travel/finance/reporting": ["../finance/dist/reporting.d.ts"],
+      "@voyant-travel/finance/reporting-unperformed-services": [
+        "../finance/dist/reporting-unperformed-services.d.ts"
+      ],
       "@voyant-travel/finance/routes": ["../finance/dist/routes.d.ts"],
       "@voyant-travel/finance/runtime-contributor": ["../finance/dist/runtime-contributor.d.ts"],
       "@voyant-travel/finance/runtime-port": ["../finance/dist/runtime-port.d.ts"],

--- a/packages/catalog/tsconfig.build.json
+++ b/packages/catalog/tsconfig.build.json
@@ -1021,6 +1021,9 @@
       "@voyant-travel/finance/public-routes": ["../finance/dist/routes-public.d.ts"],
       "@voyant-travel/finance/public-validation": ["../finance/dist/validation-public.d.ts"],
       "@voyant-travel/finance/reporting": ["../finance/dist/reporting.d.ts"],
+      "@voyant-travel/finance/reporting-unperformed-services": [
+        "../finance/dist/reporting-unperformed-services.d.ts"
+      ],
       "@voyant-travel/finance/routes": ["../finance/dist/routes.d.ts"],
       "@voyant-travel/finance/runtime-contributor": ["../finance/dist/runtime-contributor.d.ts"],
       "@voyant-travel/finance/runtime-port": ["../finance/dist/runtime-port.d.ts"],

--- a/packages/catalog/tsconfig.typecheck.json
+++ b/packages/catalog/tsconfig.typecheck.json
@@ -1022,6 +1022,9 @@
       "@voyant-travel/finance/public-routes": ["../finance/dist/routes-public.d.ts"],
       "@voyant-travel/finance/public-validation": ["../finance/dist/validation-public.d.ts"],
       "@voyant-travel/finance/reporting": ["../finance/dist/reporting.d.ts"],
+      "@voyant-travel/finance/reporting-unperformed-services": [
+        "../finance/dist/reporting-unperformed-services.d.ts"
+      ],
       "@voyant-travel/finance/routes": ["../finance/dist/routes.d.ts"],
       "@voyant-travel/finance/runtime-contributor": ["../finance/dist/runtime-contributor.d.ts"],
       "@voyant-travel/finance/runtime-port": ["../finance/dist/runtime-port.d.ts"],

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -1032,6 +1032,9 @@
       "@voyant-travel/finance/public-routes": ["../finance/dist/routes-public.d.ts"],
       "@voyant-travel/finance/public-validation": ["../finance/dist/validation-public.d.ts"],
       "@voyant-travel/finance/reporting": ["../finance/dist/reporting.d.ts"],
+      "@voyant-travel/finance/reporting-unperformed-services": [
+        "../finance/dist/reporting-unperformed-services.d.ts"
+      ],
       "@voyant-travel/finance/routes": ["../finance/dist/routes.d.ts"],
       "@voyant-travel/finance/runtime-contributor": ["../finance/dist/runtime-contributor.d.ts"],
       "@voyant-travel/finance/runtime-port": ["../finance/dist/runtime-port.d.ts"],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -1026,6 +1026,9 @@
       "@voyant-travel/finance/public-routes": ["../finance/dist/routes-public.d.ts"],
       "@voyant-travel/finance/public-validation": ["../finance/dist/validation-public.d.ts"],
       "@voyant-travel/finance/reporting": ["../finance/dist/reporting.d.ts"],
+      "@voyant-travel/finance/reporting-unperformed-services": [
+        "../finance/dist/reporting-unperformed-services.d.ts"
+      ],
       "@voyant-travel/finance/routes": ["../finance/dist/routes.d.ts"],
       "@voyant-travel/finance/runtime-contributor": ["../finance/dist/runtime-contributor.d.ts"],
       "@voyant-travel/finance/runtime-port": ["../finance/dist/runtime-port.d.ts"],

--- a/packages/commerce/vitest.config.ts
+++ b/packages/commerce/vitest.config.ts
@@ -5,5 +5,18 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.test.ts", "tests/**/*.test.ts"],
     passWithNoTests: true,
+    // Database tests here share one test database, and `cleanupTestDb`
+    // truncates the whole operator schema — 464 tables. Run in parallel, two
+    // files TRUNCATE each other and block until a hook times out; run against
+    // vitest's 10s default, even an uncontended truncate on a cold database is
+    // marginal.
+    //
+    // Commerce was the last package in the `integration` CI lane still on both
+    // defaults, which is why its file was the one that failed. Finance and
+    // relationships already set exactly these three, so this matches them
+    // rather than inventing a per-file exception.
+    fileParallelism: false,
+    maxWorkers: 1,
+    hookTimeout: 60_000,
   },
 })

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -1077,6 +1077,9 @@
       "@voyant-travel/finance/public-routes": ["../finance/dist/routes-public.d.ts"],
       "@voyant-travel/finance/public-validation": ["../finance/dist/validation-public.d.ts"],
       "@voyant-travel/finance/reporting": ["../finance/dist/reporting.d.ts"],
+      "@voyant-travel/finance/reporting-unperformed-services": [
+        "../finance/dist/reporting-unperformed-services.d.ts"
+      ],
       "@voyant-travel/finance/routes": ["../finance/dist/routes.d.ts"],
       "@voyant-travel/finance/runtime-contributor": ["../finance/dist/runtime-contributor.d.ts"],
       "@voyant-travel/finance/runtime-port": ["../finance/dist/runtime-port.d.ts"],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -1078,6 +1078,9 @@
       "@voyant-travel/finance/public-routes": ["../finance/dist/routes-public.d.ts"],
       "@voyant-travel/finance/public-validation": ["../finance/dist/validation-public.d.ts"],
       "@voyant-travel/finance/reporting": ["../finance/dist/reporting.d.ts"],
+      "@voyant-travel/finance/reporting-unperformed-services": [
+        "../finance/dist/reporting-unperformed-services.d.ts"
+      ],
       "@voyant-travel/finance/routes": ["../finance/dist/routes.d.ts"],
       "@voyant-travel/finance/runtime-contributor": ["../finance/dist/runtime-contributor.d.ts"],
       "@voyant-travel/finance/runtime-port": ["../finance/dist/runtime-port.d.ts"],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -1081,6 +1081,9 @@
       "@voyant-travel/finance/public-routes": ["../finance/dist/routes-public.d.ts"],
       "@voyant-travel/finance/public-validation": ["../finance/dist/validation-public.d.ts"],
       "@voyant-travel/finance/reporting": ["../finance/dist/reporting.d.ts"],
+      "@voyant-travel/finance/reporting-unperformed-services": [
+        "../finance/dist/reporting-unperformed-services.d.ts"
+      ],
       "@voyant-travel/finance/routes": ["../finance/dist/routes.d.ts"],
       "@voyant-travel/finance/runtime-contributor": ["../finance/dist/runtime-contributor.d.ts"],
       "@voyant-travel/finance/runtime-port": ["../finance/dist/runtime-port.d.ts"],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -1082,6 +1082,9 @@
       "@voyant-travel/finance/public-routes": ["../finance/dist/routes-public.d.ts"],
       "@voyant-travel/finance/public-validation": ["../finance/dist/validation-public.d.ts"],
       "@voyant-travel/finance/reporting": ["../finance/dist/reporting.d.ts"],
+      "@voyant-travel/finance/reporting-unperformed-services": [
+        "../finance/dist/reporting-unperformed-services.d.ts"
+      ],
       "@voyant-travel/finance/routes": ["../finance/dist/routes.d.ts"],
       "@voyant-travel/finance/runtime-contributor": ["../finance/dist/runtime-contributor.d.ts"],
       "@voyant-travel/finance/runtime-port": ["../finance/dist/runtime-port.d.ts"],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -1113,6 +1113,9 @@
       "@voyant-travel/finance/public-routes": ["../finance/dist/routes-public.d.ts"],
       "@voyant-travel/finance/public-validation": ["../finance/dist/validation-public.d.ts"],
       "@voyant-travel/finance/reporting": ["../finance/dist/reporting.d.ts"],
+      "@voyant-travel/finance/reporting-unperformed-services": [
+        "../finance/dist/reporting-unperformed-services.d.ts"
+      ],
       "@voyant-travel/finance/routes": ["../finance/dist/routes.d.ts"],
       "@voyant-travel/finance/runtime-contributor": ["../finance/dist/runtime-contributor.d.ts"],
       "@voyant-travel/finance/runtime-port": ["../finance/dist/runtime-port.d.ts"],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -1108,6 +1108,9 @@
       "@voyant-travel/finance/public-routes": ["../finance/dist/routes-public.d.ts"],
       "@voyant-travel/finance/public-validation": ["../finance/dist/validation-public.d.ts"],
       "@voyant-travel/finance/reporting": ["../finance/dist/reporting.d.ts"],
+      "@voyant-travel/finance/reporting-unperformed-services": [
+        "../finance/dist/reporting-unperformed-services.d.ts"
+      ],
       "@voyant-travel/finance/routes": ["../finance/dist/routes.d.ts"],
       "@voyant-travel/finance/runtime-contributor": ["../finance/dist/runtime-contributor.d.ts"],
       "@voyant-travel/finance/runtime-port": ["../finance/dist/runtime-port.d.ts"],

--- a/packages/finance/package.json
+++ b/packages/finance/package.json
@@ -15,6 +15,7 @@
     "./booking-settlement": "./src/service-booking-settlement.ts",
     "./service-invoice-core": "./src/service-invoice-core.ts",
     "./reporting": "./src/reporting.ts",
+    "./reporting-unperformed-services": "./src/reporting-unperformed-services.ts",
     "./order-payment-sessions": "./src/order-payment-sessions.ts",
     "./payment-policy": "./src/payment-policy.ts",
     "./payment-policy-cascade": "./src/payment-policy-cascade.ts",
@@ -146,6 +147,11 @@
         "types": "./dist/reporting.d.ts",
         "import": "./dist/reporting.js",
         "default": "./dist/reporting.js"
+      },
+      "./reporting-unperformed-services": {
+        "types": "./dist/reporting-unperformed-services.d.ts",
+        "import": "./dist/reporting-unperformed-services.js",
+        "default": "./dist/reporting-unperformed-services.js"
       },
       "./order-payment-sessions": {
         "types": "./dist/order-payment-sessions.d.ts",

--- a/packages/finance/src/reporting-definitions.ts
+++ b/packages/finance/src/reporting-definitions.ts
@@ -133,6 +133,400 @@ export const financeReceivablesDatasetDefinition = {
   ],
 } satisfies ReportDatasetDefinition
 
+export const FINANCE_UNPERFORMED_SERVICES_DATASET_ID = "finance.unperformed-services"
+
+/**
+ * Contracted services not yet performed, and the cash already collected against
+ * them (voyant#4704).
+ *
+ * Romanian tour operators file a periodic return on exactly this: how many
+ * contracts are in progress, what they are worth in lei, and how much has been
+ * collected. The measure itself is general — the value of services sold but not
+ * delivered, and the operator's exposure on them — so the dataset is named for
+ * what it measures rather than for the filing it was built for.
+ *
+ * **The count is booking-derived, not contract-derived.** `contracts` is not
+ * populated on real deployments (14 issued rows out of 225 on the tenant this
+ * came from), and the signed contracts of a period exist as PDFs attached to
+ * bookings. A contract-record count would be silently wrong, so every label here
+ * says booking.
+ *
+ * **"Performed" is derived from service dates.** A departure that has passed
+ * does not set `completed_at`, so booking status cannot answer it. The rule
+ * lives here, once, instead of in each widget's query.
+ *
+ * This dataset deliberately declares no `defaultDateField`: its period is two
+ * bounds on two different fields, which the page-level date window — one field,
+ * both bounds — cannot express. It reads `periodStart`/`periodEnd` itself.
+ */
+export const financeUnperformedServicesDatasetDefinition = {
+  id: FINANCE_UNPERFORMED_SERVICES_DATASET_ID,
+  version: 1,
+  label: "Unperformed services",
+  description:
+    "Bookings concluded on or before period end whose services run on or after period start and are not fully performed by it, with the value and collections converted at each document's own stamped rate. Requires periodStart and periodEnd.",
+  grain:
+    "One booking concluded by period end whose services are not fully performed at period end.",
+  requiredScopes: ["finance:read"],
+  defaultLimit: 100,
+  maximumLimit: 1_000,
+  fields: [
+    {
+      id: "bookingId",
+      label: "Booking id",
+      description: "Stable identifier of the booking the contract was signed against.",
+      role: "dimension",
+      valueType: "string",
+      sensitivity: "internal",
+      requiredScopes: ["finance:read"],
+      aggregations: ["count", "countDistinct"],
+    },
+    {
+      id: "bookingNumber",
+      label: "Booking number",
+      description: "The reference an inspector quotes when asking about one contract.",
+      role: "dimension",
+      valueType: "string",
+      sensitivity: "internal",
+      requiredScopes: ["finance:read"],
+      aggregations: ["count", "countDistinct"],
+    },
+    {
+      id: "clientName",
+      label: "Client",
+      description:
+        "Organization name, else the person on the booking, else the booking's own contact name.",
+      role: "dimension",
+      valueType: "string",
+      sensitivity: "pii",
+      requiredScopes: ["finance:read"],
+      aggregations: ["count", "countDistinct"],
+    },
+    {
+      id: "confirmedAt",
+      label: "Concluded",
+      description: "The date the booking was confirmed — when the contract was concluded.",
+      role: "dimension",
+      valueType: "date",
+      sensitivity: "internal",
+      requiredScopes: ["finance:read"],
+      aggregations: [],
+    },
+    {
+      id: "firstServiceDate",
+      label: "First service",
+      description: "Earliest dated service on the booking — the departure, for a package.",
+      role: "dimension",
+      valueType: "date",
+      sensitivity: "internal",
+      requiredScopes: ["finance:read"],
+      aggregations: [],
+    },
+    {
+      id: "lastServiceDate",
+      label: "Last service",
+      description: "Latest dated service on the booking; performance is judged against it.",
+      role: "dimension",
+      valueType: "date",
+      sensitivity: "internal",
+      requiredScopes: ["finance:read"],
+      aggregations: [],
+    },
+    {
+      id: "status",
+      label: "Booking status",
+      description:
+        "Current booking status, so a departure cancelled inside the period is visible in the line list rather than only in the totals.",
+      role: "dimension",
+      valueType: "string",
+      sensitivity: "internal",
+      requiredScopes: ["finance:read"],
+      aggregations: ["count", "countDistinct"],
+    },
+    {
+      id: "sellCurrency",
+      label: "Contract currency",
+      description: "Currency the contract is priced in.",
+      role: "dimension",
+      valueType: "string",
+      sensitivity: "internal",
+      requiredScopes: ["finance:read"],
+      aggregations: ["count", "countDistinct"],
+    },
+    {
+      id: "reportingCurrency",
+      label: "Reporting currency",
+      description:
+        "Currency the converted columns are denominated in, taken from the stamps the booking's own documents carry.",
+      role: "dimension",
+      valueType: "string",
+      sensitivity: "internal",
+      requiredScopes: ["finance:read"],
+      aggregations: ["count", "countDistinct"],
+    },
+    {
+      id: "fxRateSetId",
+      label: "Rate set",
+      description: "The captured rate set the contract's conversion is bound to.",
+      role: "dimension",
+      valueType: "string",
+      sensitivity: "internal",
+      requiredScopes: ["finance:read"],
+      aggregations: ["count", "countDistinct"],
+    },
+    {
+      id: "fxRateApplied",
+      label: "Rate applied",
+      description:
+        "Reporting-currency units per one unit of contract currency, margin included — the rate printed on the operator's own paperwork.",
+      role: "dimension",
+      valueType: "number",
+      sensitivity: "internal",
+      requiredScopes: ["finance:read"],
+      aggregations: [],
+    },
+    {
+      id: "contractValueCents",
+      label: "Contract value",
+      description: "Booking sell total in contract-currency minor units.",
+      role: "measure",
+      valueType: "currency",
+      sensitivity: "sensitive",
+      requiredScopes: ["finance:read"],
+      aggregations: ["sum"],
+    },
+    {
+      id: "contractValueReportingCents",
+      label: "Contract value (reporting)",
+      description:
+        "Booking sell total in the reporting currency, at the rate its own documents were stamped with. Null when nothing has stamped this contract yet.",
+      role: "measure",
+      valueType: "currency",
+      sensitivity: "sensitive",
+      requiredScopes: ["finance:read"],
+      aggregations: ["sum"],
+    },
+    {
+      id: "advancesStrictReportingCents",
+      label: "Advances (balance still owed)",
+      description:
+        "Net collections in the reporting currency on contracts where a balance is still owed — the strict reading of an advance. Zero on contracts already collected in full.",
+      role: "measure",
+      valueType: "currency",
+      sensitivity: "sensitive",
+      requiredScopes: ["finance:read"],
+      aggregations: ["sum"],
+    },
+    {
+      id: "collectionsTotalReportingCents",
+      label: "Collections (all)",
+      description:
+        "All net collections in the reporting currency on contracts in progress, whether or not a balance remains. Refunds and reversals are already netted off.",
+      role: "measure",
+      valueType: "currency",
+      sensitivity: "sensitive",
+      requiredScopes: ["finance:read"],
+      aggregations: ["sum"],
+    },
+    {
+      id: "balanceReportingCents",
+      label: "Balance owed",
+      description:
+        "Contract value less all collections, floored at zero — the exposure on services not yet delivered.",
+      role: "measure",
+      valueType: "currency",
+      sensitivity: "sensitive",
+      requiredScopes: ["finance:read"],
+      aggregations: ["sum"],
+    },
+    {
+      id: "invoicedNotCollectedReportingCents",
+      label: "Invoiced, not recorded collected",
+      description:
+        "Fiscal invoices issued against the contract whose value exceeds the payments recorded for it. A fiscal invoice means the money was taken, so anything here is a missing payment record rather than an uncollected sale — surfaced instead of being silently counted as collected.",
+      role: "measure",
+      valueType: "currency",
+      sensitivity: "sensitive",
+      requiredScopes: ["finance:read"],
+      aggregations: ["sum"],
+    },
+  ],
+} satisfies ReportDatasetDefinition
+
+/**
+ * The periodic return, as ordinary widgets over one dataset (voyant#4704).
+ *
+ * Every one groups by `reportingCurrency` rather than assuming a single one:
+ * it is what gives each money column a currency to render with, and a
+ * deployment whose documents were stamped in more than one reporting currency
+ * gets two honest rows instead of one wrong total.
+ */
+const financeUnperformedServicesWidgets = [
+  {
+    id: "finance.unperformed-services-count",
+    version: 1,
+    label: "Contracts in progress",
+    description:
+      "Bookings concluded by period end whose services are not fully performed by it. Counted from bookings — contract records are not populated on real deployments.",
+    query: {
+      dataset: { id: FINANCE_UNPERFORMED_SERVICES_DATASET_ID, version: 1 },
+      select: [{ kind: "aggregate", operation: "count", as: "contractCount" }],
+      filters: [],
+      groupBy: [],
+      orderBy: [],
+      limit: 1,
+    },
+    visualization: { type: "kpi", options: { value: "contractCount" } },
+    defaultSize: { width: 3, height: 2 },
+    minimumSize: { width: 2, height: 2 },
+    maximumSize: { width: 6, height: 3 },
+  },
+  {
+    id: "finance.unperformed-services-value",
+    version: 1,
+    label: "Value in progress",
+    description:
+      "Total value of contracts in progress, in the reporting currency, at the rate each contract's own documents were stamped with.",
+    query: {
+      dataset: { id: FINANCE_UNPERFORMED_SERVICES_DATASET_ID, version: 1 },
+      select: [
+        { kind: "field", field: "reportingCurrency" },
+        {
+          kind: "aggregate",
+          operation: "sum",
+          field: "contractValueReportingCents",
+          as: "contractValueReportingCents",
+        },
+      ],
+      filters: [],
+      groupBy: [{ field: "reportingCurrency" }],
+      orderBy: [{ by: "contractValueReportingCents", direction: "descending" }],
+      limit: 5,
+    },
+    visualization: {
+      type: "kpi",
+      options: {
+        value: "contractValueReportingCents",
+        currencyField: "reportingCurrency",
+        minorUnit: true,
+      },
+    },
+    defaultSize: { width: 3, height: 2 },
+    minimumSize: { width: 2, height: 2 },
+    maximumSize: { width: 6, height: 3 },
+  },
+  {
+    id: "finance.unperformed-services-advances",
+    version: 1,
+    label: "Advances collected",
+    description:
+      "Collections against contracts that still owe a balance — the strict reading of an advance. Refunds are already netted off, so a cancelled, refunded departure contributes nothing here.",
+    query: {
+      dataset: { id: FINANCE_UNPERFORMED_SERVICES_DATASET_ID, version: 1 },
+      select: [
+        { kind: "field", field: "reportingCurrency" },
+        {
+          kind: "aggregate",
+          operation: "sum",
+          field: "advancesStrictReportingCents",
+          as: "advancesStrictReportingCents",
+        },
+        {
+          kind: "aggregate",
+          operation: "sum",
+          field: "collectionsTotalReportingCents",
+          as: "collectionsTotalReportingCents",
+        },
+      ],
+      filters: [],
+      groupBy: [{ field: "reportingCurrency" }],
+      orderBy: [{ by: "advancesStrictReportingCents", direction: "descending" }],
+      limit: 5,
+    },
+    // Both readings ship side by side, labelled. They differ materially and the
+    // operator filing the return should be choosing between them knowingly
+    // rather than discovering later which one the platform picked.
+    visualization: {
+      type: "table",
+      options: { currencyField: "reportingCurrency", minorUnit: true },
+    },
+    defaultSize: { width: 3, height: 2 },
+    minimumSize: { width: 3, height: 2 },
+    maximumSize: { width: 6, height: 4 },
+  },
+  {
+    id: "finance.unperformed-services-balance",
+    version: 1,
+    label: "Balance on undelivered services",
+    description:
+      "Contract value less collections — the exposure the return exists to measure, and what an operator's guarantee is sized against.",
+    query: {
+      dataset: { id: FINANCE_UNPERFORMED_SERVICES_DATASET_ID, version: 1 },
+      select: [
+        { kind: "field", field: "reportingCurrency" },
+        {
+          kind: "aggregate",
+          operation: "sum",
+          field: "balanceReportingCents",
+          as: "balanceReportingCents",
+        },
+      ],
+      filters: [],
+      groupBy: [{ field: "reportingCurrency" }],
+      orderBy: [{ by: "balanceReportingCents", direction: "descending" }],
+      limit: 5,
+    },
+    visualization: {
+      type: "kpi",
+      options: {
+        value: "balanceReportingCents",
+        currencyField: "reportingCurrency",
+        minorUnit: true,
+      },
+    },
+    defaultSize: { width: 3, height: 2 },
+    minimumSize: { width: 2, height: 2 },
+    maximumSize: { width: 6, height: 3 },
+  },
+  {
+    id: "finance.unperformed-services-lines",
+    version: 1,
+    label: "Contracts in progress — line list",
+    description:
+      "One row per contract behind the totals: reference, client, dates, value, converted value, the rate applied, collections and balance. An inspector asks about a single contract, not a sum.",
+    query: {
+      dataset: { id: FINANCE_UNPERFORMED_SERVICES_DATASET_ID, version: 1 },
+      select: [
+        { kind: "field", field: "bookingNumber" },
+        { kind: "field", field: "clientName" },
+        { kind: "field", field: "confirmedAt" },
+        { kind: "field", field: "firstServiceDate" },
+        { kind: "field", field: "lastServiceDate" },
+        { kind: "field", field: "status" },
+        { kind: "field", field: "sellCurrency" },
+        { kind: "field", field: "contractValueCents" },
+        { kind: "field", field: "reportingCurrency" },
+        { kind: "field", field: "fxRateApplied" },
+        { kind: "field", field: "contractValueReportingCents" },
+        { kind: "field", field: "collectionsTotalReportingCents" },
+        { kind: "field", field: "balanceReportingCents" },
+        { kind: "field", field: "invoicedNotCollectedReportingCents" },
+      ],
+      filters: [],
+      groupBy: [],
+      orderBy: [{ by: "confirmedAt", direction: "ascending" }],
+      limit: 1_000,
+    },
+    visualization: {
+      type: "table",
+      options: { currencyField: "reportingCurrency", minorUnit: true },
+    },
+    defaultSize: { width: 12, height: 6 },
+    minimumSize: { width: 6, height: 3 },
+    maximumSize: { width: 12, height: 12 },
+  },
+] satisfies readonly ReportWidgetDefinition[]
+
 export const financeReportingWidgets = [
   {
     id: "finance.outstanding-by-currency",
@@ -255,6 +649,7 @@ export const financeReportingWidgets = [
     minimumSize: { width: 4, height: 2 },
     maximumSize: { width: 12, height: 8 },
   },
+  ...financeUnperformedServicesWidgets,
 ] satisfies readonly ReportWidgetDefinition[]
 
 export const financeReportingTemplates = [
@@ -285,6 +680,59 @@ export const financeReportingTemplates = [
         id: "collections",
         source: { kind: "preset", widgetId: "finance.collections-by-currency", version: 1 },
         layout: { x: 4, y: 3, width: 8, height: 3 },
+      },
+    ],
+  },
+  {
+    // Distinct from the dataset id: the graph namespaces entity ids across
+    // datasets, widgets and templates alike, so reusing it collides.
+    id: "finance.contracts-in-progress",
+    version: 1,
+    label: "Contracts in progress and unperformed services",
+    description:
+      "Contracts concluded by period end whose services are not fully performed by it: how many, what they are worth in the reporting currency, what has been collected against them, and the balance outstanding — with the line list behind every figure. Built for the periodic return Romanian tour operators file, and exportable because it gets attached to a filing.",
+    parameters: [
+      {
+        id: "periodStart",
+        label: "Period start",
+        description: "First day of the reporting period.",
+        valueType: "date",
+        required: true,
+      },
+      {
+        id: "periodEnd",
+        label: "Period end",
+        description:
+          "Last day of the reporting period. Contracts are counted as concluded by this date and collections are counted up to it.",
+        valueType: "date",
+        required: true,
+      },
+    ],
+    widgets: [
+      {
+        id: "contracts",
+        source: { kind: "preset", widgetId: "finance.unperformed-services-count", version: 1 },
+        layout: { x: 0, y: 0, width: 3, height: 2 },
+      },
+      {
+        id: "value",
+        source: { kind: "preset", widgetId: "finance.unperformed-services-value", version: 1 },
+        layout: { x: 3, y: 0, width: 3, height: 2 },
+      },
+      {
+        id: "advances",
+        source: { kind: "preset", widgetId: "finance.unperformed-services-advances", version: 1 },
+        layout: { x: 6, y: 0, width: 3, height: 2 },
+      },
+      {
+        id: "balance",
+        source: { kind: "preset", widgetId: "finance.unperformed-services-balance", version: 1 },
+        layout: { x: 9, y: 0, width: 3, height: 2 },
+      },
+      {
+        id: "lines",
+        source: { kind: "preset", widgetId: "finance.unperformed-services-lines", version: 1 },
+        layout: { x: 0, y: 2, width: 12, height: 6 },
       },
     ],
   },

--- a/packages/finance/src/reporting-query-compiler.ts
+++ b/packages/finance/src/reporting-query-compiler.ts
@@ -1,0 +1,363 @@
+import type {
+  ReportDatasetExecutionInput,
+  ReportDatasetField,
+  ReportDatasetQueryError,
+  ReportParameters,
+  ReportQuery,
+  ReportResult,
+  ReportScalar,
+} from "@voyant-travel/reporting-contracts"
+import { type SQL, sql } from "drizzle-orm"
+
+/**
+ * Compile the public single-dataset AST to parameter-bound SQL over a
+ * Finance-owned semantic relation.
+ *
+ * The compiler is shared because the alternative is not one dataset with a
+ * bespoke compiler — it is every dataset with its own copy of the same
+ * grouping, aliasing and filter rules, diverging one fix at a time. What a
+ * dataset actually owns is its relation, its fields and its own answerability
+ * rule; those are the spec below, and nothing else varies.
+ *
+ * Query text can never address tables or columns directly: a selection resolves
+ * through the dataset's declared fields to a SQL fragment the dataset wrote.
+ */
+export interface FinanceReportRelationSpec {
+  datasetId: string
+  /** Accepted dataset version; a query pinning any other is refused. */
+  version: number
+  fields: readonly ReportDatasetField[]
+  /** Alias the relation is exposed under, and referenced by `fieldSql`. */
+  alias: string
+  /** The semantic relation. Takes parameters so a dataset can own its period. */
+  relation(parameters: ReportParameters): SQL
+  fieldSql: Readonly<Record<string, SQL>>
+  /** Fields whose values are currency minor units. */
+  moneyFields: ReadonlySet<string>
+  /** Dimension carrying each row's ISO currency code, when the query selects it. */
+  currencyDimension: string
+  /**
+   * A dataset's own rule for whether a well-formed query is answerable — e.g.
+   * receivables refusing to sum across currencies without grouping by one.
+   */
+  assertAnswerable?(input: {
+    query: ReportQuery
+    parameters: ReportParameters
+    groups: ReadonlySet<string>
+    aggregateQuery: boolean
+    moneySelected: boolean
+  }): void
+  error(message: string): ReportDatasetQueryError
+}
+
+interface CompiledSelection {
+  id: string
+  field?: ReportDatasetField
+  expression: SQL
+  column: ReportResult["columns"][number]
+}
+
+export function compileFinanceReportQuery(
+  spec: FinanceReportRelationSpec,
+  input: ReportDatasetExecutionInput,
+): { statement: SQL; columns: ReportResult["columns"]; rowLimit: number } {
+  const { query, parameters } = input
+  if (!Number.isInteger(input.maximumRows) || input.maximumRows < 1) {
+    throw spec.error("maximumRows must be a positive integer.")
+  }
+  if (query.dataset.id !== spec.datasetId) {
+    throw spec.error(`Unsupported dataset ${JSON.stringify(query.dataset.id)}.`)
+  }
+  if (query.dataset.version !== undefined && query.dataset.version !== spec.version) {
+    throw spec.error(
+      `Unsupported ${spec.datasetId} dataset version ${String(query.dataset.version)}.`,
+    )
+  }
+
+  const definitions = new Map(spec.fields.map((field) => [field.id, field]))
+  const requireField = (id: string): ReportDatasetField => {
+    const field = definitions.get(id)
+    if (!field || !spec.fieldSql[id]) {
+      throw spec.error(`Unknown Finance field ${JSON.stringify(id)}.`)
+    }
+    return field
+  }
+  const fieldExpression = (id: string): SQL => {
+    const expression = spec.fieldSql[id]
+    if (!expression) throw spec.error(`Unknown Finance field ${JSON.stringify(id)}.`)
+    return expression
+  }
+  const groupExpression = (
+    id: string,
+    grain?: ReportQuery["groupBy"][number]["timeGrain"],
+  ): SQL => {
+    const expression = fieldExpression(id)
+    if (!grain) return expression
+    switch (grain) {
+      case "day":
+        return sql`date_trunc('day', ${expression}::timestamp)::date`
+      case "week":
+        return sql`date_trunc('week', ${expression}::timestamp)::date`
+      case "month":
+        return sql`date_trunc('month', ${expression}::timestamp)::date`
+      case "quarter":
+        return sql`date_trunc('quarter', ${expression}::timestamp)::date`
+      case "year":
+        return sql`date_trunc('year', ${expression}::timestamp)::date`
+    }
+  }
+
+  const groups = new Map<string, ReportQuery["groupBy"][number]>()
+  for (const group of query.groupBy) {
+    const field = requireField(group.field)
+    if (field.role !== "dimension") {
+      throw spec.error(`Cannot group by measure ${JSON.stringify(group.field)}.`)
+    }
+    if (groups.has(group.field)) {
+      throw spec.error(`Duplicate group ${JSON.stringify(group.field)}.`)
+    }
+    if (group.timeGrain && field.valueType !== "date" && field.valueType !== "datetime") {
+      throw spec.error(`Time grain is not valid for ${JSON.stringify(group.field)}.`)
+    }
+    groups.set(group.field, group)
+  }
+
+  // The output column that carries each row's ISO currency code, when the query
+  // selects one. Money measures are denominated by it; without it in the result
+  // there is no currency to render with.
+  const currencySelection = query.select.find(
+    (selection) => selection.kind === "field" && selection.field === spec.currencyDimension,
+  )
+  const currencyField =
+    currencySelection?.kind === "field"
+      ? (currencySelection.as ?? spec.currencyDimension)
+      : undefined
+
+  const aggregateQuery = query.select.some((selection) => selection.kind === "aggregate")
+  const selections = query.select.map((selection): CompiledSelection => {
+    if (selection.kind === "field") {
+      const field = requireField(selection.field)
+      if (aggregateQuery && !groups.has(field.id)) {
+        throw spec.error(`Selected field ${JSON.stringify(field.id)} must appear in groupBy.`)
+      }
+      const id = selection.as ?? field.id
+      return {
+        id,
+        field,
+        expression: groupExpression(field.id, groups.get(field.id)?.timeGrain),
+        column: {
+          id,
+          label: outputLabel(selection.as, field),
+          valueType: field.valueType,
+          ...moneyPresentation(field.valueType, currencyField),
+        },
+      }
+    }
+
+    if (
+      selection.operation !== "count" &&
+      selection.operation !== "countDistinct" &&
+      selection.operation !== "sum"
+    ) {
+      throw spec.error(`${spec.datasetId} does not support ${selection.operation}.`)
+    }
+    const field = selection.field ? requireField(selection.field) : undefined
+    if (selection.operation === "sum" && field?.role !== "measure") {
+      throw spec.error("sum() requires a Finance measure.")
+    }
+    if (selection.operation === "countDistinct" && !field) {
+      throw spec.error("countDistinct() requires a field.")
+    }
+    if (field && !field.aggregations.includes(selection.operation)) {
+      throw spec.error(`${selection.operation} is not declared for ${JSON.stringify(field.id)}.`)
+    }
+    const expression =
+      selection.operation === "count"
+        ? field
+          ? sql`count(${fieldExpression(field.id)})::bigint`
+          : sql`count(*)::bigint`
+        : selection.operation === "countDistinct"
+          ? sql`count(DISTINCT ${fieldExpression(field?.id ?? "")})::bigint`
+          : sql`coalesce(sum(${fieldExpression(field?.id ?? "")}), 0)::bigint`
+    const valueType =
+      selection.operation === "count" || selection.operation === "countDistinct"
+        ? "integer"
+        : (field?.valueType ?? "number")
+    return {
+      id: selection.as,
+      field,
+      expression,
+      column: {
+        id: selection.as,
+        label: field ? outputLabel(selection.as, field) : "Count",
+        valueType,
+        ...moneyPresentation(valueType, currencyField),
+      },
+    }
+  })
+
+  const aliases = new Set<string>()
+  for (const selection of selections) {
+    if (aliases.has(selection.id)) {
+      throw spec.error(`Duplicate selection alias ${JSON.stringify(selection.id)}.`)
+    }
+    aliases.add(selection.id)
+  }
+
+  spec.assertAnswerable?.({
+    query,
+    parameters,
+    groups: new Set(groups.keys()),
+    aggregateQuery,
+    moneySelected: query.select.some(
+      (selection) => selection.field !== undefined && spec.moneyFields.has(selection.field),
+    ),
+  })
+
+  const filters = query.filters.map((filter) =>
+    compileFilter(spec, filter, requireField, fieldExpression, parameters),
+  )
+  const selectSql = sql.join(
+    selections.map(({ expression, id }) => sql`${expression} AS ${sql.identifier(id)}`),
+    sql`, `,
+  )
+  const groupSql = [...groups.values()].map((group) =>
+    groupExpression(group.field, group.timeGrain),
+  )
+  const orderSql = query.orderBy.map((order) => {
+    if (!aliases.has(order.by)) {
+      throw spec.error(
+        `Ordering must reference a selected output; ${JSON.stringify(order.by)} is unavailable.`,
+      )
+    }
+    return sql`${sql.identifier(order.by)} ${
+      order.direction === "descending" ? sql`DESC` : sql`ASC`
+    }`
+  })
+  const rowLimit = Math.min(query.limit ?? input.maximumRows, input.maximumRows)
+
+  return {
+    statement: sql`
+      WITH ${sql.identifier(spec.alias)} AS (${spec.relation(parameters)})
+      SELECT ${selectSql}
+      FROM ${sql.identifier(spec.alias)}
+      ${filters.length ? sql`WHERE ${sql.join(filters, sql` AND `)}` : sql``}
+      ${groupSql.length ? sql`GROUP BY ${sql.join(groupSql, sql`, `)}` : sql``}
+      ${orderSql.length ? sql`ORDER BY ${sql.join(orderSql, sql`, `)}` : sql``}
+      LIMIT ${rowLimit + 1}
+    `,
+    columns: selections.map(({ column }) => column),
+    rowLimit,
+  }
+}
+
+/**
+ * The header a selection should carry. The query language requires an alias on
+ * every aggregate, so an alias that merely restates the field id is the DSL's
+ * mandatory output name and the dataset's own label still reads better; an alias
+ * that says something else is the author naming the column, and replacing it
+ * with a canned field label loses what they asked for.
+ */
+function outputLabel(alias: string | undefined, field: ReportDatasetField): string {
+  return alias && alias !== field.id ? alias : field.label
+}
+
+/**
+ * Every money field in these datasets is a `*Cents` measure — there is no
+ * major-unit alternative to select — so a currency column is always minor-unit,
+ * and is denominated by the currency dimension whenever the query selects it.
+ */
+function moneyPresentation(
+  valueType: ReportDatasetField["valueType"],
+  currencyField: string | undefined,
+): { minorUnit?: true; currencyField?: string } {
+  if (valueType !== "currency") return {}
+  return { minorUnit: true, ...(currencyField ? { currencyField } : {}) }
+}
+
+function compileFilter(
+  spec: FinanceReportRelationSpec,
+  filter: ReportQuery["filters"][number],
+  requireField: (id: string) => ReportDatasetField,
+  fieldExpression: (id: string) => SQL,
+  parameters: ReportParameters,
+): SQL {
+  const field = requireField(filter.field)
+  if (field.role !== "dimension") {
+    throw spec.error("Filtering measures is not supported.")
+  }
+  const expression = fieldExpression(field.id)
+  if (filter.operator === "isNull") return sql`${expression} IS NULL`
+  if (filter.operator === "isNotNull") return sql`${expression} IS NOT NULL`
+  const value = requireFilterValue(spec, filter, parameters)
+  switch (filter.operator) {
+    case "equal":
+      return value === null
+        ? sql`${expression} IS NULL`
+        : sql`${expression} = ${scalar(spec, value)}`
+    case "notEqual":
+      return value === null
+        ? sql`${expression} IS NOT NULL`
+        : sql`${expression} <> ${scalar(spec, value)}`
+    case "greaterThan":
+      return sql`${expression} > ${scalar(spec, value)}`
+    case "greaterThanOrEqual":
+      return sql`${expression} >= ${scalar(spec, value)}`
+    case "lessThan":
+      return sql`${expression} < ${scalar(spec, value)}`
+    case "lessThanOrEqual":
+      return sql`${expression} <= ${scalar(spec, value)}`
+    case "contains": {
+      if (typeof value !== "string" || field.valueType !== "string") {
+        throw spec.error("contains requires a string dimension and value.")
+      }
+      return sql`${expression} ILIKE ${`%${value}%`}`
+    }
+    case "in":
+    case "notIn": {
+      if (!Array.isArray(value) || value.length === 0) {
+        throw spec.error(`${filter.operator} requires a non-empty array.`)
+      }
+      const values = sql.join(
+        value.map((entry) => sql`${scalar(spec, entry)}`),
+        sql`, `,
+      )
+      return filter.operator === "in"
+        ? sql`${expression} IN (${values})`
+        : sql`${expression} NOT IN (${values})`
+    }
+    case "between": {
+      if (!Array.isArray(value) || value.length !== 2) {
+        throw spec.error("between requires exactly two values.")
+      }
+      return sql`${expression} BETWEEN ${scalar(spec, value[0])} AND ${scalar(spec, value[1])}`
+    }
+    default:
+      throw spec.error(`Unsupported filter operator ${filter.operator}.`)
+  }
+}
+
+function requireFilterValue(
+  spec: FinanceReportRelationSpec,
+  filter: ReportQuery["filters"][number],
+  parameters: ReportParameters,
+): ReportScalar | readonly ReportScalar[] {
+  if (!filter.value) throw spec.error(`${filter.operator} requires a value.`)
+  if (filter.value.kind === "literal") return filter.value.value
+  if (!(filter.value.name in parameters)) {
+    throw spec.error(`Missing query parameter ${JSON.stringify(filter.value.name)}.`)
+  }
+  const value = parameters[filter.value.name]
+  if (value === undefined) {
+    throw spec.error(`Missing query parameter ${JSON.stringify(filter.value.name)}.`)
+  }
+  return value
+}
+
+function scalar(
+  spec: FinanceReportRelationSpec,
+  value: ReportScalar | readonly ReportScalar[],
+): ReportScalar {
+  if (Array.isArray(value)) throw spec.error("Expected a scalar value.")
+  return value as ReportScalar
+}

--- a/packages/finance/src/reporting-unperformed-services.ts
+++ b/packages/finance/src/reporting-unperformed-services.ts
@@ -2,6 +2,7 @@ import type {
   ReportDatasetContribution,
   ReportDatasetExecutionInput,
   ReportParameters,
+  ReportQuery,
   ReportResult,
 } from "@voyant-travel/reporting-contracts"
 import { ReportDatasetQueryError } from "@voyant-travel/reporting-contracts"
@@ -115,8 +116,18 @@ function unperformedServicesRelation(periodStart: string, periodEnd: string): SQ
         WHEN stamp.contract_value_reporting_cents IS NULL THEN NULL
         ELSE greatest(stamp.contract_value_reporting_cents - collected.collections_cents, 0)
       END::bigint AS "balanceReportingCents",
-      greatest(collected.fiscal_invoiced_cents - collected.collections_cents, 0)::bigint
-        AS "invoicedNotCollectedReportingCents"
+      -- Converting an invoice whole and converting its installments separately
+      -- do not have to agree to the minor unit: each conversion rounds once. An
+      -- allowance of one unit per payment is the actual bound on that, and
+      -- without it every installment-paid contract carries a one-cent "missing
+      -- payment record" flag — noise that teaches an operator to ignore the
+      -- flag that exists to be read.
+      CASE
+        WHEN invoiced.fiscal_invoiced_cents - collected.collections_cents
+             > coalesce(collected.payment_count, 0)
+          THEN invoiced.fiscal_invoiced_cents - collected.collections_cents
+        ELSE 0
+      END::bigint AS "invoicedNotCollectedReportingCents"
     FROM bookings booking
     LEFT JOIN people person ON person.id = booking.person_id
     LEFT JOIN organizations organization ON organization.id = booking.organization_id
@@ -129,6 +140,10 @@ function unperformedServicesRelation(periodStart: string, periodEnd: string): SQ
         AND item.service_date IS NOT NULL
     ) service ON true
     LEFT JOIN LATERAL (
+      -- Collections and invoiced value are aggregated at their OWN grains. A
+      -- single query joining invoices to payments fans an installment-paid
+      -- invoice out once per payment and counts its total that many times,
+      -- inventing a collection gap that does not exist.
       SELECT
         -- Collections net of reversals, at each payment's own stamped rate.
         -- A departure cancelled and refunded inside the period therefore
@@ -139,26 +154,48 @@ function unperformedServicesRelation(periodStart: string, periodEnd: string): SQ
             WHEN 'refunded' THEN -payment.reporting_amount_cents
             ELSE 0
           END
+          -- Money actually paid back. The refund workflow records a settlement
+          -- and leaves the payment completed, so netting only refunded
+          -- payments would report a fully refunded contract as fully collected
+          -- — the exact case the return exists to get right. Converted at the
+          -- rate the payment it reverses was stamped at, so a full refund
+          -- cancels exactly, and skipped when that payment is already marked
+          -- refunded so the reversal is not counted twice.
+          - coalesce(refunded.settled_cents, 0)
         ), 0)::bigint AS collections_cents,
-        -- A fiscal invoice means the money was taken. Counted separately so a
-        -- gap against recorded payments is visible rather than assumed away.
-        coalesce(sum(
-          CASE
-            WHEN invoice.invoice_type = 'invoice'
-              AND invoice.status <> 'void'
-              AND invoice.base_total_cents IS NOT NULL
-              THEN invoice.base_total_cents
-            ELSE 0
-          END
-        ), 0)::bigint AS fiscal_invoiced_cents
-      FROM invoices invoice
-      LEFT JOIN payments payment
-        ON payment.invoice_id = invoice.id
-        AND payment.payment_date <= ${periodEnd}::date
-        AND payment.reporting_amount_cents IS NOT NULL
+        count(*)::bigint AS payment_count
+      FROM payments payment
+      JOIN invoices invoice ON invoice.id = payment.invoice_id
+      LEFT JOIN LATERAL (
+        SELECT coalesce(sum(
+          round(
+            settlement.amount_cents::numeric
+              * payment.reporting_amount_cents::numeric
+              / nullif(payment.amount_cents, 0)
+          )
+        ), 0)::bigint AS settled_cents
+        FROM refund_settlements settlement
+        WHERE settlement.payment_id = payment.id
+          AND settlement.status = 'settled'
+          AND settlement.settled_at::date <= ${periodEnd}::date
+          AND payment.status <> 'refunded'
+      ) refunded ON true
       WHERE invoice.booking_id = booking.id
         AND invoice.status <> 'void'
+        AND payment.payment_date <= ${periodEnd}::date
+        AND payment.reporting_amount_cents IS NOT NULL
     ) collected ON true
+    LEFT JOIN LATERAL (
+      -- A fiscal invoice means the money was taken. Counted at invoice grain,
+      -- separately from collections, so a gap against recorded payments is
+      -- visible rather than assumed away or inflated by a join fan-out.
+      SELECT coalesce(sum(invoice.base_total_cents), 0)::bigint AS fiscal_invoiced_cents
+      FROM invoices invoice
+      WHERE invoice.booking_id = booking.id
+        AND invoice.invoice_type = 'invoice'
+        AND invoice.status <> 'void'
+        AND invoice.base_total_cents IS NOT NULL
+    ) invoiced ON true
     LEFT JOIN LATERAL (
       -- The rate this contract's own paperwork was stamped at. Preferring a
       -- payment over an invoice is deliberate: a deposit is usually the first
@@ -258,7 +295,11 @@ export const financeUnperformedServicesDataset: ReportDatasetContribution = {
       columns: compiled.columns,
       rows: visible.map((row) => normalizeRow(row, compiled.columns)),
       truncated,
-      warnings: unconvertedWarnings(visible, compiled.columns),
+      warnings: await unconvertedWarnings(
+        context.db as PostgresJsDatabase,
+        input.query,
+        input.parameters,
+      ),
     }
   },
 }
@@ -267,17 +308,39 @@ export const financeUnperformedServicesDataset: ReportDatasetContribution = {
  * A total that silently omits the contracts nothing has stamped reads as
  * complete when it is short. Say so instead — and the remedy is the FX stamp
  * routes from voyant#4703, not a rate invented here.
+ *
+ * This asks the relation rather than reading the result rows, because on the
+ * KPI widgets the rows are already aggregated: `sum` skips nulls and the
+ * compiler coalesces an all-null sum to zero, so an unstamped contract is
+ * invisible in exactly the output where the shortfall matters most.
  */
-function unconvertedWarnings(
-  rows: readonly Record<string, unknown>[],
-  columns: ReportResult["columns"],
-): string[] {
-  const converted = columns.find((column) => column.id.includes("Reporting"))
-  if (!converted) return []
-  const unconverted = rows.filter((row) => row[converted.id] === null).length
-  if (unconverted === 0) return []
+async function unconvertedWarnings(
+  db: PostgresJsDatabase,
+  query: ReportQuery,
+  parameters: ReportParameters,
+): Promise<string[]> {
+  // Only the converted figures can be short; a plain contract count cannot.
+  const touchesConverted = query.select.some((selection) =>
+    selection.kind === "field"
+      ? selection.field.includes("Reporting")
+      : (selection.field?.includes("Reporting") ?? false),
+  )
+  if (!touchesConverted) return []
+
+  const [row] = await executeBoundaryRows<{ unstamped: number | string; total: number | string }>(
+    db,
+    sql`
+      SELECT
+        count(*) FILTER (WHERE contract."contractValueReportingCents" IS NULL) AS unstamped,
+        count(*) AS total
+      FROM (${unperformedServicesSpec.relation(parameters)}) contract
+    `,
+  )
+  const unstamped = Number(row?.unstamped ?? 0)
+  const total = Number(row?.total ?? 0)
+  if (unstamped === 0) return []
   return [
-    `${unconverted} of ${rows.length} contracts have no stamped reporting-currency value and are excluded from the converted totals. Stamp them to include them.`,
+    `${unstamped} of ${total} contracts have no stamped reporting-currency value and are excluded from the converted totals. Stamp them to include them.`,
   ]
 }
 

--- a/packages/finance/src/reporting-unperformed-services.ts
+++ b/packages/finance/src/reporting-unperformed-services.ts
@@ -1,0 +1,324 @@
+import type {
+  ReportDatasetContribution,
+  ReportDatasetExecutionInput,
+  ReportParameters,
+  ReportResult,
+} from "@voyant-travel/reporting-contracts"
+import { ReportDatasetQueryError } from "@voyant-travel/reporting-contracts"
+import { hasApiKeyPermission, permissionStringsToPermissions } from "@voyant-travel/types/api-keys"
+import { type SQL, sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import {
+  FINANCE_UNPERFORMED_SERVICES_DATASET_ID,
+  financeUnperformedServicesDatasetDefinition,
+} from "./reporting-definitions.js"
+import {
+  compileFinanceReportQuery,
+  type FinanceReportRelationSpec,
+} from "./reporting-query-compiler.js"
+import { executeBoundaryRows } from "./service-boundary-sql.js"
+
+/** A query shape or period outside this dataset's surface. */
+export class FinanceUnperformedServicesQueryError extends ReportDatasetQueryError {
+  constructor(message: string) {
+    super(message)
+    this.name = "FinanceUnperformedServicesQueryError"
+  }
+}
+
+export const PERIOD_START_PARAM = "periodStart"
+export const PERIOD_END_PARAM = "periodEnd"
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/
+
+const MONEY_FIELDS = new Set([
+  "contractValueCents",
+  "contractValueReportingCents",
+  "advancesStrictReportingCents",
+  "collectionsTotalReportingCents",
+  "balanceReportingCents",
+  "invoicedNotCollectedReportingCents",
+])
+
+const fieldSql: Readonly<Record<string, SQL>> = {
+  bookingId: sql`contract."bookingId"`,
+  bookingNumber: sql`contract."bookingNumber"`,
+  clientName: sql`contract."clientName"`,
+  confirmedAt: sql`contract."confirmedAt"`,
+  firstServiceDate: sql`contract."firstServiceDate"`,
+  lastServiceDate: sql`contract."lastServiceDate"`,
+  status: sql`contract.status`,
+  sellCurrency: sql`contract."sellCurrency"`,
+  reportingCurrency: sql`contract."reportingCurrency"`,
+  fxRateSetId: sql`contract."fxRateSetId"`,
+  fxRateApplied: sql`contract."fxRateApplied"`,
+  contractValueCents: sql`contract."contractValueCents"`,
+  contractValueReportingCents: sql`contract."contractValueReportingCents"`,
+  advancesStrictReportingCents: sql`contract."advancesStrictReportingCents"`,
+  collectionsTotalReportingCents: sql`contract."collectionsTotalReportingCents"`,
+  balanceReportingCents: sql`contract."balanceReportingCents"`,
+  invoicedNotCollectedReportingCents: sql`contract."invoicedNotCollectedReportingCents"`,
+}
+
+/**
+ * Bookings whose contracted services are not fully performed at period end,
+ * with value and collections expressed at the rate their own documents were
+ * stamped with (voyant#4704).
+ *
+ * Three things about the shape:
+ *
+ * **Period membership is two bounds on two different fields.** Concluded on or
+ * before period end, services running on or after period start. That is why this
+ * dataset takes the period as parameters instead of declaring a
+ * `defaultDateField` — the page-level window is one field with both bounds and
+ * would answer a different question while looking like it answered this one.
+ *
+ * **The reporting currency comes from the documents, not from a setting.** A
+ * setting can change; what the operator filed cannot. `payments.reporting_currency`
+ * and `invoices.base_currency` are stamped at the moment each document is
+ * written, so they are what the converted columns are denominated in.
+ *
+ * **Nothing is converted at read time.** A contract with no stamped document
+ * reports a null converted value rather than a rate looked up now, because a
+ * figure derived at read time is exactly what voyant#4703 exists to stop. The
+ * executor counts those rows and warns, so a total is never quietly short.
+ */
+function unperformedServicesRelation(periodStart: string, periodEnd: string): SQL {
+  return sql`
+    SELECT
+      booking.id AS "bookingId",
+      booking.booking_number AS "bookingNumber",
+      coalesce(
+        organization.name,
+        nullif(trim(concat_ws(' ', person.first_name, person.last_name)), ''),
+        nullif(trim(concat_ws(' ', booking.contact_first_name, booking.contact_last_name)), '')
+      ) AS "clientName",
+      booking.confirmed_at::date AS "confirmedAt",
+      service.first_service_date AS "firstServiceDate",
+      service.last_service_date AS "lastServiceDate",
+      booking.status::text AS status,
+      booking.sell_currency AS "sellCurrency",
+      stamp.reporting_currency AS "reportingCurrency",
+      stamp.fx_rate_set_id AS "fxRateSetId",
+      stamp.rate_applied AS "fxRateApplied",
+      coalesce(booking.sell_amount_cents, 0)::bigint AS "contractValueCents",
+      stamp.contract_value_reporting_cents AS "contractValueReportingCents",
+      CASE
+        WHEN stamp.contract_value_reporting_cents IS NULL THEN NULL
+        WHEN collected.collections_cents < stamp.contract_value_reporting_cents
+          THEN collected.collections_cents
+        ELSE 0
+      END::bigint AS "advancesStrictReportingCents",
+      collected.collections_cents::bigint AS "collectionsTotalReportingCents",
+      CASE
+        WHEN stamp.contract_value_reporting_cents IS NULL THEN NULL
+        ELSE greatest(stamp.contract_value_reporting_cents - collected.collections_cents, 0)
+      END::bigint AS "balanceReportingCents",
+      greatest(collected.fiscal_invoiced_cents - collected.collections_cents, 0)::bigint
+        AS "invoicedNotCollectedReportingCents"
+    FROM bookings booking
+    LEFT JOIN people person ON person.id = booking.person_id
+    LEFT JOIN organizations organization ON organization.id = booking.organization_id
+    JOIN LATERAL (
+      SELECT
+        min(item.service_date) AS first_service_date,
+        max(item.service_date) AS last_service_date
+      FROM booking_items item
+      WHERE item.booking_id = booking.id
+        AND item.service_date IS NOT NULL
+    ) service ON true
+    LEFT JOIN LATERAL (
+      SELECT
+        -- Collections net of reversals, at each payment's own stamped rate.
+        -- A departure cancelled and refunded inside the period therefore
+        -- contributes its contract and value but nothing to advances.
+        coalesce(sum(
+          CASE payment.status
+            WHEN 'completed' THEN payment.reporting_amount_cents
+            WHEN 'refunded' THEN -payment.reporting_amount_cents
+            ELSE 0
+          END
+        ), 0)::bigint AS collections_cents,
+        -- A fiscal invoice means the money was taken. Counted separately so a
+        -- gap against recorded payments is visible rather than assumed away.
+        coalesce(sum(
+          CASE
+            WHEN invoice.invoice_type = 'invoice'
+              AND invoice.status <> 'void'
+              AND invoice.base_total_cents IS NOT NULL
+              THEN invoice.base_total_cents
+            ELSE 0
+          END
+        ), 0)::bigint AS fiscal_invoiced_cents
+      FROM invoices invoice
+      LEFT JOIN payments payment
+        ON payment.invoice_id = invoice.id
+        AND payment.payment_date <= ${periodEnd}::date
+        AND payment.reporting_amount_cents IS NOT NULL
+      WHERE invoice.booking_id = booking.id
+        AND invoice.status <> 'void'
+    ) collected ON true
+    LEFT JOIN LATERAL (
+      -- The rate this contract's own paperwork was stamped at. Preferring a
+      -- payment over an invoice is deliberate: a deposit is usually the first
+      -- document a contract gets, and it is the rate the customer was quoted.
+      SELECT
+        stamped.reporting_currency,
+        stamped.fx_rate_set_id,
+        CASE
+          WHEN booking.sell_currency = stamped.reporting_currency THEN 1
+          ELSE coalesce(rate.effective_rate_decimal, rate.rate_decimal)
+        END AS rate_applied,
+        CASE
+          WHEN booking.sell_amount_cents IS NULL THEN NULL
+          WHEN booking.sell_currency = stamped.reporting_currency
+            THEN booking.sell_amount_cents::bigint
+          WHEN coalesce(rate.effective_rate_decimal, rate.rate_decimal) IS NULL THEN NULL
+          ELSE round(
+            booking.sell_amount_cents * coalesce(rate.effective_rate_decimal, rate.rate_decimal)
+          )::bigint
+        END AS contract_value_reporting_cents
+      FROM (
+        SELECT payment.reporting_currency, payment.reporting_fx_rate_set_id AS fx_rate_set_id,
+               payment.payment_date AS stamped_on, 0 AS precedence
+        FROM payments payment
+        JOIN invoices invoice ON invoice.id = payment.invoice_id
+        WHERE invoice.booking_id = booking.id
+          AND payment.reporting_currency IS NOT NULL
+        UNION ALL
+        SELECT invoice.base_currency, invoice.fx_rate_set_id, invoice.issue_date, 1
+        FROM invoices invoice
+        WHERE invoice.booking_id = booking.id
+          AND invoice.status <> 'void'
+          AND invoice.base_currency IS NOT NULL
+      ) stamped
+      LEFT JOIN exchange_rates rate
+        ON rate.fx_rate_set_id = stamped.fx_rate_set_id
+        AND rate.base_currency = booking.sell_currency
+        AND rate.quote_currency = stamped.reporting_currency
+      ORDER BY stamped.precedence, stamped.stamped_on
+      LIMIT 1
+    ) stamp ON true
+    WHERE booking.confirmed_at IS NOT NULL
+      AND booking.confirmed_at::date <= ${periodEnd}::date
+      AND service.last_service_date >= ${periodStart}::date
+  `
+}
+
+const unperformedServicesSpec: FinanceReportRelationSpec = {
+  datasetId: FINANCE_UNPERFORMED_SERVICES_DATASET_ID,
+  version: 1,
+  fields: financeUnperformedServicesDatasetDefinition.fields,
+  alias: "contract",
+  relation: (parameters) => {
+    const periodStart = requirePeriodBound(parameters, PERIOD_START_PARAM)
+    const periodEnd = requirePeriodBound(parameters, PERIOD_END_PARAM)
+    if (periodEnd < periodStart) {
+      throw new FinanceUnperformedServicesQueryError(
+        `${PERIOD_END_PARAM} must not precede ${PERIOD_START_PARAM}.`,
+      )
+    }
+    return unperformedServicesRelation(periodStart, periodEnd)
+  },
+  fieldSql,
+  moneyFields: MONEY_FIELDS,
+  currencyDimension: "reportingCurrency",
+  error: (message) => new FinanceUnperformedServicesQueryError(message),
+}
+
+export function compileFinanceUnperformedServicesQuery(input: ReportDatasetExecutionInput): {
+  statement: SQL
+  columns: ReportResult["columns"]
+  rowLimit: number
+} {
+  return compileFinanceReportQuery(unperformedServicesSpec, input)
+}
+
+export const financeUnperformedServicesDataset: ReportDatasetContribution = {
+  definition: financeUnperformedServicesDatasetDefinition,
+  async execute(context, input) {
+    if (
+      !hasApiKeyPermission(permissionStringsToPermissions(context.grantedScopes), "finance", "read")
+    ) {
+      throw new FinanceUnperformedServicesQueryError(
+        "finance:read is required to query unperformed services.",
+      )
+    }
+    if (context.signal?.aborted) throw abortReason(context.signal)
+    const compiled = compileFinanceUnperformedServicesQuery(input)
+    const rows = await executeBoundaryRows<Record<string, unknown>>(
+      context.db as PostgresJsDatabase,
+      compiled.statement,
+    )
+    if (context.signal?.aborted) throw abortReason(context.signal)
+    const truncated = rows.length > compiled.rowLimit
+    const visible = rows.slice(0, compiled.rowLimit)
+    return {
+      columns: compiled.columns,
+      rows: visible.map((row) => normalizeRow(row, compiled.columns)),
+      truncated,
+      warnings: unconvertedWarnings(visible, compiled.columns),
+    }
+  },
+}
+
+/**
+ * A total that silently omits the contracts nothing has stamped reads as
+ * complete when it is short. Say so instead — and the remedy is the FX stamp
+ * routes from voyant#4703, not a rate invented here.
+ */
+function unconvertedWarnings(
+  rows: readonly Record<string, unknown>[],
+  columns: ReportResult["columns"],
+): string[] {
+  const converted = columns.find((column) => column.id.includes("Reporting"))
+  if (!converted) return []
+  const unconverted = rows.filter((row) => row[converted.id] === null).length
+  if (unconverted === 0) return []
+  return [
+    `${unconverted} of ${rows.length} contracts have no stamped reporting-currency value and are excluded from the converted totals. Stamp them to include them.`,
+  ]
+}
+
+function requirePeriodBound(parameters: ReportParameters, name: string): string {
+  const value = parameters[name]
+  if (typeof value !== "string" || !ISO_DATE.test(value)) {
+    throw new FinanceUnperformedServicesQueryError(
+      `${name} is required and must be a YYYY-MM-DD date.`,
+    )
+  }
+  return value
+}
+
+function normalizeRow(
+  row: Record<string, unknown>,
+  columns: ReportResult["columns"],
+): Record<string, unknown> {
+  const normalized: Record<string, unknown> = {}
+  for (const column of columns) {
+    const value = row[column.id]
+    if (value === undefined || value === null) {
+      normalized[column.id] = null
+      continue
+    }
+    if (column.valueType === "date" || column.valueType === "datetime") {
+      normalized[column.id] = value instanceof Date ? value.toISOString().slice(0, 10) : value
+      continue
+    }
+    if (
+      column.valueType === "integer" ||
+      column.valueType === "number" ||
+      column.valueType === "currency"
+    ) {
+      normalized[column.id] = typeof value === "string" ? Number(value) : value
+      continue
+    }
+    normalized[column.id] = value
+  }
+  return normalized
+}
+
+function abortReason(signal: AbortSignal): unknown {
+  return signal.reason ?? new Error("Report query aborted.")
+}

--- a/packages/finance/src/reporting.ts
+++ b/packages/finance/src/reporting.ts
@@ -1,11 +1,9 @@
 import type {
   ReportDatasetContribution,
   ReportDatasetExecutionInput,
-  ReportDatasetField,
   ReportParameters,
   ReportQuery,
   ReportResult,
-  ReportScalar,
 } from "@voyant-travel/reporting-contracts"
 import { ReportDatasetQueryError } from "@voyant-travel/reporting-contracts"
 import { hasApiKeyPermission, permissionStringsToPermissions } from "@voyant-travel/types/api-keys"
@@ -15,6 +13,10 @@ import {
   FINANCE_RECEIVABLES_DATASET_ID,
   financeReceivablesDatasetDefinition,
 } from "./reporting-definitions.js"
+import {
+  compileFinanceReportQuery,
+  type FinanceReportRelationSpec,
+} from "./reporting-query-compiler.js"
 import { executeBoundaryRows } from "./service-boundary-sql.js"
 
 const MONEY_FIELDS = new Set([
@@ -161,199 +163,47 @@ export class FinanceReportingQueryError extends ReportDatasetQueryError {
   }
 }
 
-interface CompiledSelection {
-  id: string
-  field?: ReportDatasetField
-  expression: SQL
-  column: ReportResult["columns"][number]
+/** The receivables relation, as a spec the shared compiler can execute. */
+const receivablesSpec: FinanceReportRelationSpec = {
+  datasetId: FINANCE_RECEIVABLES_DATASET_ID,
+  version: 1,
+  fields: financeReceivablesDatasetDefinition.fields,
+  alias: "receivable",
+  // Page-level "show in base currency": read money from recording-time base
+  // snapshots so every amount is already in one currency (the operator base).
+  relation: (parameters) =>
+    parameters[REPORT_CURRENCY_PARAM] === BASE_CURRENCY_MODE
+      ? baseReceivables
+      : semanticReceivables,
+  fieldSql,
+  moneyFields: MONEY_FIELDS,
+  currencyDimension: "currency",
+  assertAnswerable: ({ query, parameters, groups, aggregateQuery, moneySelected }) => {
+    if (parameters[REPORT_CURRENCY_PARAM] === BASE_CURRENCY_MODE) return
+    const currencyIsExplicit = aggregateQuery
+      ? groups.has("currency")
+      : query.select.some(
+          (selection) => selection.kind === "field" && selection.field === "currency",
+        )
+    if (moneySelected && !currencyIsExplicit && !hasSingleCurrencyFilter(query, parameters)) {
+      throw new FinanceReportingQueryError(
+        "Currency measures must include or group by currency, or be filtered to exactly one currency.",
+      )
+    }
+  },
+  error: (message) => new FinanceReportingQueryError(message),
 }
 
 /**
  * Compile the public single-dataset AST to parameter-bound SQL over the
- * Finance-owned semantic receivables relation. Only the small set implemented
- * here is accepted; query text can never address tables or columns directly.
+ * Finance-owned semantic receivables relation.
  */
 export function compileFinanceReceivablesQuery(input: ReportDatasetExecutionInput): {
   statement: SQL
   columns: ReportResult["columns"]
   rowLimit: number
 } {
-  const { query, parameters } = input
-  // Page-level "show in base currency": read money from recording-time base
-  // snapshots so every amount is already in one currency (the operator base).
-  const baseMode = parameters[REPORT_CURRENCY_PARAM] === BASE_CURRENCY_MODE
-  if (!Number.isInteger(input.maximumRows) || input.maximumRows < 1) {
-    throw new FinanceReportingQueryError("maximumRows must be a positive integer.")
-  }
-  if (query.dataset.id !== FINANCE_RECEIVABLES_DATASET_ID) {
-    throw new FinanceReportingQueryError(`Unsupported dataset ${JSON.stringify(query.dataset.id)}.`)
-  }
-  if (query.dataset.version !== undefined && query.dataset.version !== 1) {
-    throw new FinanceReportingQueryError(
-      `Unsupported receivables dataset version ${query.dataset.version}.`,
-    )
-  }
-
-  const definitions = new Map(
-    financeReceivablesDatasetDefinition.fields.map((field) => [field.id, field]),
-  )
-  const groups = new Map<string, ReportQuery["groupBy"][number]>()
-  for (const group of query.groupBy) {
-    const field = requireField(definitions, group.field)
-    if (field.role !== "dimension") {
-      throw new FinanceReportingQueryError(
-        `Cannot group by measure ${JSON.stringify(group.field)}.`,
-      )
-    }
-    if (groups.has(group.field)) {
-      throw new FinanceReportingQueryError(`Duplicate group ${JSON.stringify(group.field)}.`)
-    }
-    if (group.timeGrain && field.valueType !== "date" && field.valueType !== "datetime") {
-      throw new FinanceReportingQueryError(
-        `Time grain is not valid for ${JSON.stringify(group.field)}.`,
-      )
-    }
-    groups.set(group.field, group)
-  }
-
-  // The output column that carries each row's ISO currency code, when the query
-  // selects one. Money measures are denominated by it; without it in the result
-  // there is no currency to render with.
-  const currencySelection = query.select.find(
-    (selection) => selection.kind === "field" && selection.field === "currency",
-  )
-  const currencyField =
-    currencySelection?.kind === "field" ? (currencySelection.as ?? "currency") : undefined
-
-  const aggregateQuery = query.select.some((selection) => selection.kind === "aggregate")
-  const selections = query.select.map((selection): CompiledSelection => {
-    if (selection.kind === "field") {
-      const field = requireField(definitions, selection.field)
-      if (aggregateQuery && !groups.has(field.id)) {
-        throw new FinanceReportingQueryError(
-          `Selected field ${JSON.stringify(field.id)} must appear in groupBy.`,
-        )
-      }
-      const id = selection.as ?? field.id
-      return {
-        id,
-        field,
-        expression: groupExpression(field.id, groups.get(field.id)?.timeGrain),
-        column: {
-          id,
-          label: outputLabel(selection.as, field),
-          valueType: field.valueType,
-          ...moneyPresentation(field.valueType, currencyField),
-        },
-      }
-    }
-
-    if (
-      selection.operation !== "count" &&
-      selection.operation !== "countDistinct" &&
-      selection.operation !== "sum"
-    ) {
-      throw new FinanceReportingQueryError(
-        `Finance receivables does not support ${selection.operation}.`,
-      )
-    }
-    const field = selection.field ? requireField(definitions, selection.field) : undefined
-    if (selection.operation === "sum" && field?.role !== "measure") {
-      throw new FinanceReportingQueryError("sum() requires a Finance measure.")
-    }
-    if (selection.operation === "countDistinct" && !field) {
-      throw new FinanceReportingQueryError("countDistinct() requires a field.")
-    }
-    if (field && !field.aggregations.includes(selection.operation)) {
-      throw new FinanceReportingQueryError(
-        `${selection.operation} is not declared for ${JSON.stringify(field.id)}.`,
-      )
-    }
-    const expression =
-      selection.operation === "count"
-        ? field
-          ? sql`count(${fieldExpression(field.id)})::bigint`
-          : sql`count(*)::bigint`
-        : selection.operation === "countDistinct"
-          ? sql`count(DISTINCT ${fieldExpression(field?.id ?? "")})::bigint`
-          : sql`coalesce(sum(${fieldExpression(field?.id ?? "")}), 0)::bigint`
-    const valueType =
-      selection.operation === "count" || selection.operation === "countDistinct"
-        ? "integer"
-        : (field?.valueType ?? "number")
-    return {
-      id: selection.as,
-      field,
-      expression,
-      column: {
-        id: selection.as,
-        label: field ? outputLabel(selection.as, field) : "Count",
-        valueType,
-        ...moneyPresentation(valueType, currencyField),
-      },
-    }
-  })
-
-  const aliases = new Set<string>()
-  for (const selection of selections) {
-    if (aliases.has(selection.id)) {
-      throw new FinanceReportingQueryError(
-        `Duplicate selection alias ${JSON.stringify(selection.id)}.`,
-      )
-    }
-    aliases.add(selection.id)
-  }
-
-  const moneySelections = query.select.filter(
-    (selection) => selection.field !== undefined && MONEY_FIELDS.has(selection.field),
-  )
-  const currencyIsExplicit = aggregateQuery
-    ? groups.has("currency")
-    : query.select.some((selection) => selection.kind === "field" && selection.field === "currency")
-  if (
-    !baseMode &&
-    moneySelections.length > 0 &&
-    !currencyIsExplicit &&
-    !hasSingleCurrencyFilter(query, parameters)
-  ) {
-    throw new FinanceReportingQueryError(
-      "Currency measures must include or group by currency, or be filtered to exactly one currency.",
-    )
-  }
-
-  const filters = query.filters.map((filter) => compileFilter(filter, definitions, parameters))
-  const selectSql = sql.join(
-    selections.map(({ expression, id }) => sql`${expression} AS ${sql.identifier(id)}`),
-    sql`, `,
-  )
-  const groupSql = [...groups.values()].map((group) =>
-    groupExpression(group.field, group.timeGrain),
-  )
-  const orderSql = query.orderBy.map((order) => {
-    if (!aliases.has(order.by)) {
-      throw new FinanceReportingQueryError(
-        `Ordering must reference a selected output; ${JSON.stringify(order.by)} is unavailable.`,
-      )
-    }
-    return sql`${sql.identifier(order.by)} ${
-      order.direction === "descending" ? sql`DESC` : sql`ASC`
-    }`
-  })
-  const rowLimit = Math.min(query.limit ?? input.maximumRows, input.maximumRows)
-
-  return {
-    statement: sql`
-      WITH receivable AS (${baseMode ? baseReceivables : semanticReceivables})
-      SELECT ${selectSql}
-      FROM receivable
-      ${filters.length ? sql`WHERE ${sql.join(filters, sql` AND `)}` : sql``}
-      ${groupSql.length ? sql`GROUP BY ${sql.join(groupSql, sql`, `)}` : sql``}
-      ${orderSql.length ? sql`ORDER BY ${sql.join(orderSql, sql`, `)}` : sql``}
-      LIMIT ${rowLimit + 1}
-    `,
-    columns: selections.map(({ column }) => column),
-    rowLimit,
-  }
+  return compileFinanceReportQuery(receivablesSpec, input)
 }
 
 export const financeReceivablesDataset: ReportDatasetContribution = {
@@ -379,149 +229,6 @@ export const financeReceivablesDataset: ReportDatasetContribution = {
       warnings: [],
     }
   },
-}
-
-/**
- * The header a selection should carry. The query language requires an alias on
- * every aggregate, so an alias that merely restates the field id is the DSL's
- * mandatory output name and the dataset's own label still reads better; an alias
- * that says something else is the author naming the column, and replacing it
- * with a canned field label loses what they asked for.
- */
-function outputLabel(alias: string | undefined, field: ReportDatasetField): string {
-  return alias && alias !== field.id ? alias : field.label
-}
-
-/**
- * Every money field in this dataset is a `*Cents` measure in the document
- * currency — there is no major-unit alternative to select — so a currency column
- * is always minor-unit, and is denominated by the currency dimension whenever
- * the query selects it.
- */
-function moneyPresentation(
-  valueType: ReportDatasetField["valueType"],
-  currencyField: string | undefined,
-): { minorUnit?: true; currencyField?: string } {
-  if (valueType !== "currency") return {}
-  return { minorUnit: true, ...(currencyField ? { currencyField } : {}) }
-}
-
-function requireField(
-  fields: ReadonlyMap<string, ReportDatasetField>,
-  id: string,
-): ReportDatasetField {
-  const field = fields.get(id)
-  if (!field || !fieldSql[id]) {
-    throw new FinanceReportingQueryError(`Unknown Finance field ${JSON.stringify(id)}.`)
-  }
-  return field
-}
-
-function fieldExpression(id: string): SQL {
-  const expression = fieldSql[id]
-  if (!expression)
-    throw new FinanceReportingQueryError(`Unknown Finance field ${JSON.stringify(id)}.`)
-  return expression
-}
-
-function groupExpression(id: string, grain?: ReportQuery["groupBy"][number]["timeGrain"]): SQL {
-  const expression = fieldExpression(id)
-  if (!grain) return expression
-  switch (grain) {
-    case "day":
-      return sql`date_trunc('day', ${expression}::timestamp)::date`
-    case "week":
-      return sql`date_trunc('week', ${expression}::timestamp)::date`
-    case "month":
-      return sql`date_trunc('month', ${expression}::timestamp)::date`
-    case "quarter":
-      return sql`date_trunc('quarter', ${expression}::timestamp)::date`
-    case "year":
-      return sql`date_trunc('year', ${expression}::timestamp)::date`
-  }
-}
-
-function compileFilter(
-  filter: ReportQuery["filters"][number],
-  fields: ReadonlyMap<string, ReportDatasetField>,
-  parameters: ReportParameters,
-): SQL {
-  const field = requireField(fields, filter.field)
-  if (field.role !== "dimension") {
-    throw new FinanceReportingQueryError(`Filtering measures is not supported.`)
-  }
-  const expression = fieldExpression(field.id)
-  if (filter.operator === "isNull") return sql`${expression} IS NULL`
-  if (filter.operator === "isNotNull") return sql`${expression} IS NOT NULL`
-  const value = requireFilterValue(filter, parameters)
-  switch (filter.operator) {
-    case "equal":
-      return value === null ? sql`${expression} IS NULL` : sql`${expression} = ${scalar(value)}`
-    case "notEqual":
-      return value === null
-        ? sql`${expression} IS NOT NULL`
-        : sql`${expression} <> ${scalar(value)}`
-    case "greaterThan":
-      return sql`${expression} > ${scalar(value)}`
-    case "greaterThanOrEqual":
-      return sql`${expression} >= ${scalar(value)}`
-    case "lessThan":
-      return sql`${expression} < ${scalar(value)}`
-    case "lessThanOrEqual":
-      return sql`${expression} <= ${scalar(value)}`
-    case "contains": {
-      if (typeof value !== "string" || field.valueType !== "string") {
-        throw new FinanceReportingQueryError("contains requires a string dimension and value.")
-      }
-      return sql`${expression} ILIKE ${`%${value}%`}`
-    }
-    case "in":
-    case "notIn": {
-      if (!Array.isArray(value) || value.length === 0) {
-        throw new FinanceReportingQueryError(`${filter.operator} requires a non-empty array.`)
-      }
-      const values = sql.join(
-        value.map((entry) => sql`${scalar(entry)}`),
-        sql`, `,
-      )
-      return filter.operator === "in"
-        ? sql`${expression} IN (${values})`
-        : sql`${expression} NOT IN (${values})`
-    }
-    case "between": {
-      if (!Array.isArray(value) || value.length !== 2) {
-        throw new FinanceReportingQueryError("between requires exactly two values.")
-      }
-      return sql`${expression} BETWEEN ${scalar(value[0])} AND ${scalar(value[1])}`
-    }
-    default:
-      throw new FinanceReportingQueryError(`Unsupported filter operator ${filter.operator}.`)
-  }
-}
-
-function requireFilterValue(
-  filter: ReportQuery["filters"][number],
-  parameters: ReportParameters,
-): ReportScalar | readonly ReportScalar[] {
-  if (!filter.value) throw new FinanceReportingQueryError(`${filter.operator} requires a value.`)
-  if (filter.value.kind === "literal") return filter.value.value
-  if (!(filter.value.name in parameters)) {
-    throw new FinanceReportingQueryError(
-      `Missing query parameter ${JSON.stringify(filter.value.name)}.`,
-    )
-  }
-  const value = parameters[filter.value.name]
-  if (value === undefined) {
-    throw new FinanceReportingQueryError(
-      `Missing query parameter ${JSON.stringify(filter.value.name)}.`,
-    )
-  }
-  return value
-}
-
-function scalar(value: ReportScalar | readonly ReportScalar[]): ReportScalar {
-  if (Array.isArray(value)) throw new FinanceReportingQueryError("Expected a scalar value.")
-  return value as ReportScalar
 }
 
 function hasSingleCurrencyFilter(query: ReportQuery, parameters: ReportParameters): boolean {

--- a/packages/finance/src/voyant.ts
+++ b/packages/finance/src/voyant.ts
@@ -22,6 +22,7 @@ import {
   financeReceivablesDatasetDefinition,
   financeReportingTemplates,
   financeReportingWidgets,
+  financeUnperformedServicesDatasetDefinition,
 } from "./reporting-definitions.js"
 import {
   financeAccommodationsPaymentPolicyRuntimePort,
@@ -210,6 +211,18 @@ export const financeVoyantModule = defineModule({
           export: "financeReceivablesDataset",
         },
       },
+      {
+        id: financeUnperformedServicesDatasetDefinition.id,
+        version: financeUnperformedServicesDatasetDefinition.version,
+        label: financeUnperformedServicesDatasetDefinition.label,
+        description: financeUnperformedServicesDatasetDefinition.description,
+        descriptor: financeUnperformedServicesDatasetDefinition,
+        requiredScopes: financeUnperformedServicesDatasetDefinition.requiredScopes,
+        runtime: {
+          entry: "@voyant-travel/finance/reporting-unperformed-services",
+          export: "financeUnperformedServicesDataset",
+        },
+      },
     ],
     widgets: financeReportingWidgets.map((widget) => ({
       id: widget.id,
@@ -238,6 +251,10 @@ export const financeVoyantModule = defineModule({
       version: template.version,
       label: template.label,
       description: template.description,
+      // The parameters reach the graph so a host can render the template's own
+      // inputs before instantiating it. Dropping them here is what would leave
+      // an operator with a period-scoped report and nowhere to say which period.
+      ...(template.parameters.length > 0 ? { parameters: template.parameters } : {}),
       requirements: template.widgets.map((widget) => ({
         kind: "widget" as const,
         id: widget.source.kind === "preset" ? widget.source.widgetId : widget.id,

--- a/packages/finance/tests/integration/unperformed-services-report.test.ts
+++ b/packages/finance/tests/integration/unperformed-services-report.test.ts
@@ -77,6 +77,8 @@ describe.skipIf(!DB_AVAILABLE)("unperformed services report", () => {
     /** Omit to leave the contract unstamped — no document has converted it. */
     stamped?: boolean
     payments?: Array<{ date: string; cents: number; status: "completed" | "refunded" }>
+    /** Money paid back the way the product actually records it. */
+    refundSettlements?: Array<{ date: string; cents: number; status: "settled" | "pending" }>
   }) {
     const bookingId = newId("bookings")
     await db.insert(bookings).values({
@@ -124,9 +126,12 @@ describe.skipIf(!DB_AVAILABLE)("unperformed services report", () => {
         : {}),
     })
 
+    const paymentIds: string[] = []
     for (const payment of input.payments ?? []) {
+      const paymentId = newId("payments")
+      paymentIds.push(paymentId)
       await db.insert(payments).values({
-        id: newId("payments"),
+        id: paymentId,
         invoiceId,
         amountCents: payment.cents,
         currency: "EUR",
@@ -137,6 +142,19 @@ describe.skipIf(!DB_AVAILABLE)("unperformed services report", () => {
         reportingAmountCents: lei(payment.cents),
         reportingFxRateSetId: rateSetId,
       })
+    }
+    for (const settlement of input.refundSettlements ?? []) {
+      await db.execute(sql`
+        INSERT INTO refund_settlements (
+          id, payment_id, invoice_id, booking_id, method, status,
+          amount_cents, currency, settled_at
+        ) VALUES (
+          ${newId("refund_settlements")}, ${paymentIds[0] ?? null}, ${invoiceId}, ${bookingId},
+          'bank_transfer', ${settlement.status},
+          ${settlement.cents}, 'EUR',
+          ${settlement.status === "settled" ? `${settlement.date}T12:00:00Z` : null}
+        )
+      `)
     }
     return bookingId
   }
@@ -318,6 +336,132 @@ describe.skipIf(!DB_AVAILABLE)("unperformed services report", () => {
     // A contract whose payments match its invoice is not flagged.
     const settled = result.rows.find((row) => row.bookingNumber === "C2")
     expect(settled?.invoicedNotCollectedReportingCents).toBe(0)
+  })
+
+  it("nets a refund recorded the way the product records it", async () => {
+    // The refund workflow writes a settled `refund_settlements` row and leaves
+    // the payment `completed`. Netting only payments marked `refunded` would
+    // report this contract as fully collected — the exact case the return
+    // exists to get right, and the one the original fixture papered over by
+    // hand-inserting a synthetic refunded payment.
+    await seedContract({
+      number: "C6-SETTLED-REFUND",
+      confirmedAt: "2026-07-01",
+      serviceDate: "2026-09-10",
+      sellCents: 80_000,
+      payments: [{ date: "2026-07-02", cents: 80_000, status: "completed" }],
+      refundSettlements: [{ date: "2026-08-12", cents: 80_000, status: "settled" }],
+    })
+
+    const result = await run(["bookingNumber", "collectionsTotalReportingCents"])
+    const refunded = result.rows.find((row) => row.bookingNumber === "C6-SETTLED-REFUND")
+    expect(refunded?.collectionsTotalReportingCents).toBe(0)
+  })
+
+  it("ignores a refund that has not settled, and one settled after period end", async () => {
+    await seedContract({
+      number: "C7-PENDING-REFUND",
+      confirmedAt: "2026-07-01",
+      serviceDate: "2026-09-10",
+      sellCents: 40_000,
+      payments: [{ date: "2026-07-02", cents: 40_000, status: "completed" }],
+      refundSettlements: [{ date: "2026-08-12", cents: 40_000, status: "pending" }],
+    })
+    await seedContract({
+      number: "C8-LATE-REFUND",
+      confirmedAt: "2026-07-01",
+      serviceDate: "2026-09-10",
+      sellCents: 40_000,
+      payments: [{ date: "2026-07-02", cents: 40_000, status: "completed" }],
+      refundSettlements: [{ date: "2026-09-20", cents: 40_000, status: "settled" }],
+    })
+
+    const result = await run(["bookingNumber", "collectionsTotalReportingCents"])
+    const byNumber = new Map(result.rows.map((row) => [row.bookingNumber, row]))
+    // Money that has not moved is still collected.
+    expect(byNumber.get("C7-PENDING-REFUND")?.collectionsTotalReportingCents).toBe(lei(40_000))
+    // And a refund after period end had not happened yet at period end.
+    expect(byNumber.get("C8-LATE-REFUND")?.collectionsTotalReportingCents).toBe(lei(40_000))
+  })
+
+  it("does not inflate the invoiced figure for an installment-paid contract", async () => {
+    // Joining invoices to payments fans the invoice out once per payment. Summed
+    // naively, a three-installment contract counts its invoice three times and
+    // invents a collection gap twice its value.
+    await seedContract({
+      number: "C9-INSTALMENTS",
+      confirmedAt: "2026-07-05",
+      serviceDate: "2026-10-10",
+      sellCents: 90_000,
+      payments: [
+        { date: "2026-07-06", cents: 30_000, status: "completed" },
+        { date: "2026-07-20", cents: 30_000, status: "completed" },
+        { date: "2026-08-04", cents: 30_000, status: "completed" },
+      ],
+    })
+
+    const result = await run([
+      "bookingNumber",
+      "collectionsTotalReportingCents",
+      "invoicedNotCollectedReportingCents",
+    ])
+    const instalments = result.rows.find((row) => row.bookingNumber === "C9-INSTALMENTS")
+
+    expect(instalments?.collectionsTotalReportingCents).toBe(lei(30_000) * 3)
+    // Fully collected across three payments: no gap.
+    expect(instalments?.invoicedNotCollectedReportingCents).toBe(0)
+  })
+
+  it("warns on an aggregate total, where a null row is invisible", async () => {
+    // This is the shape the KPI widgets use. `sum` skips nulls and the compiler
+    // coalesces an all-null sum to zero, so inspecting the returned rows for a
+    // null can never detect the shortfall here — the relation has to be asked.
+    const result = await financeUnperformedServicesDataset.execute(
+      { db, grantedScopes: ["finance:read"] },
+      {
+        query: {
+          dataset: { id: "finance.unperformed-services", version: 1 },
+          select: [
+            { kind: "field" as const, field: "reportingCurrency" },
+            {
+              kind: "aggregate" as const,
+              operation: "sum" as const,
+              field: "contractValueReportingCents",
+              as: "contractValueReportingCents",
+            },
+          ],
+          filters: [],
+          groupBy: [{ field: "reportingCurrency" }],
+          orderBy: [],
+        },
+        parameters: PERIOD,
+        maximumRows: 100,
+      },
+    )
+
+    // The unstamped contract seeded earlier contributes nothing to the sum and
+    // no null row to inspect, so the total is short and only the warning says so.
+    expect(result.rows.every((row) => row.contractValueReportingCents !== null)).toBe(true)
+    expect(result.warnings.join(" ")).toMatch(/contracts have no stamped reporting-currency value/)
+  })
+
+  it("does not warn on a figure stamping cannot shorten", async () => {
+    const result = await financeUnperformedServicesDataset.execute(
+      { db, grantedScopes: ["finance:read"] },
+      {
+        query: {
+          dataset: { id: "finance.unperformed-services", version: 1 },
+          select: [{ kind: "aggregate" as const, operation: "count" as const, as: "contracts" }],
+          filters: [],
+          groupBy: [],
+          orderBy: [],
+        },
+        parameters: PERIOD,
+        maximumRows: 100,
+      },
+    )
+    // A contract count is complete whether or not the contract is stamped.
+    expect(result.warnings).toEqual([])
   })
 
   it("refuses a period it was not given", async () => {

--- a/packages/finance/tests/integration/unperformed-services-report.test.ts
+++ b/packages/finance/tests/integration/unperformed-services-report.test.ts
@@ -1,0 +1,331 @@
+/**
+ * The periodic return on contracts in progress and unperformed services, end to
+ * end over real Postgres (voyant#4704).
+ *
+ * The dataset is a modelled view across three grains — booking, booking item and
+ * payment — so a fixture-driven unit test would only prove the compiler works.
+ * What has to be true is that the SQL selects the right contracts and nets the
+ * right money, and only a database can say so.
+ *
+ * The scenario is the worked month from the issue, including each edge case it
+ * asked to have encoded rather than rediscovered.
+ */
+
+import { bookingItems, bookings } from "@voyant-travel/bookings/schema"
+import { newId } from "@voyant-travel/db/lib/typeid"
+import { sql } from "drizzle-orm"
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest"
+
+import { financeUnperformedServicesDataset } from "../../src/reporting-unperformed-services.js"
+import { invoices, payments } from "../../src/schema.js"
+
+const DB_AVAILABLE = Boolean(process.env.TEST_DATABASE_URL)
+
+vi.setConfig({ testTimeout: 60_000, hookTimeout: 60_000 })
+
+/** The operator reports in lei and applies a 2% currency-risk commission. */
+const REPORTING_CURRENCY = "RON"
+/** BNR's EUR/RON quote for the period, with the margin already folded in. */
+const APPLIED_RATE = 5.352144
+
+const PERIOD = { periodStart: "2026-08-01", periodEnd: "2026-08-31" }
+
+const lei = (eurCents: number) => Math.round(eurCents * APPLIED_RATE)
+
+describe.skipIf(!DB_AVAILABLE)("unperformed services report", () => {
+  let db: ReturnType<typeof import("@voyant-travel/db/test-utils").createTestDb>
+  let rateSetId: string
+
+  beforeAll(async () => {
+    const { createTestDb, cleanupTestDb } = await import("@voyant-travel/db/test-utils")
+    db = createTestDb()
+    await cleanupTestDb(db)
+    rateSetId = await seedRateSet()
+    await seedScenario()
+  })
+
+  afterAll(async () => {
+    const { closeTestDb } = await import("@voyant-travel/db/test-utils")
+    await closeTestDb()
+  })
+
+  async function seedRateSet() {
+    const id = newId("fx_rate_sets")
+    await db.execute(sql`
+      INSERT INTO fx_rate_sets (id, source, base_currency, effective_at, observed_at)
+      VALUES (${id}, 'bnr', ${REPORTING_CURRENCY}, '2026-08-01T00:00:00Z', '2026-08-01T00:00:00Z')
+    `)
+    await db.execute(sql`
+      INSERT INTO exchange_rates (
+        id, fx_rate_set_id, base_currency, quote_currency,
+        rate_decimal, inverse_rate_decimal, effective_rate_decimal, commission_bps, observed_at
+      ) VALUES (
+        ${newId("exchange_rates")}, ${id}, 'EUR', ${REPORTING_CURRENCY},
+        '5.24720000', '0.19057800', '5.35214400', 200, '2026-08-01T00:00:00Z'
+      )
+    `)
+    return id
+  }
+
+  /** One contract, its invoice, and optionally a collection against it. */
+  async function seedContract(input: {
+    number: string
+    confirmedAt: string
+    serviceDate: string
+    sellCents: number
+    status?: "confirmed" | "cancelled"
+    /** Omit to leave the contract unstamped — no document has converted it. */
+    stamped?: boolean
+    payments?: Array<{ date: string; cents: number; status: "completed" | "refunded" }>
+  }) {
+    const bookingId = newId("bookings")
+    await db.insert(bookings).values({
+      id: bookingId,
+      bookingNumber: input.number,
+      status: input.status ?? "confirmed",
+      sellCurrency: "EUR",
+      sellAmountCents: input.sellCents,
+      confirmedAt: new Date(`${input.confirmedAt}T10:00:00Z`),
+      contactFirstName: "Ada",
+      contactLastName: input.number,
+    })
+    await db.insert(bookingItems).values({
+      id: newId("booking_items"),
+      bookingId,
+      title: "Package",
+      itemType: "unit",
+      status: input.status === "cancelled" ? "cancelled" : "confirmed",
+      quantity: 1,
+      sellCurrency: "EUR",
+      totalSellAmountCents: input.sellCents,
+      serviceDate: input.serviceDate,
+    })
+
+    const invoiceId = newId("invoices")
+    const stamped = input.stamped ?? true
+    await db.insert(invoices).values({
+      id: invoiceId,
+      invoiceNumber: `INV-${input.number}`,
+      bookingId,
+      status: "issued",
+      currency: "EUR",
+      subtotalCents: input.sellCents,
+      totalCents: input.sellCents,
+      balanceDueCents: input.sellCents,
+      issueDate: input.confirmedAt,
+      dueDate: input.confirmedAt,
+      ...(stamped
+        ? {
+            baseCurrency: REPORTING_CURRENCY,
+            fxRateSetId: rateSetId,
+            baseSubtotalCents: lei(input.sellCents),
+            baseTotalCents: lei(input.sellCents),
+          }
+        : {}),
+    })
+
+    for (const payment of input.payments ?? []) {
+      await db.insert(payments).values({
+        id: newId("payments"),
+        invoiceId,
+        amountCents: payment.cents,
+        currency: "EUR",
+        paymentMethod: "bank_transfer",
+        paymentDate: payment.date,
+        status: payment.status,
+        reportingCurrency: REPORTING_CURRENCY,
+        reportingAmountCents: lei(payment.cents),
+        reportingFxRateSetId: rateSetId,
+      })
+    }
+    return bookingId
+  }
+
+  async function seedScenario() {
+    // Runs after the period — squarely in progress.
+    await seedContract({
+      number: "C1",
+      confirmedAt: "2026-07-10",
+      serviceDate: "2026-10-05",
+      sellCents: 200_000,
+      payments: [{ date: "2026-07-20", cents: 60_000, status: "completed" }],
+    })
+    // Collected in full before the period ends: still in progress, but its money
+    // is no longer an advance against a balance.
+    await seedContract({
+      number: "C2",
+      confirmedAt: "2026-08-02",
+      serviceDate: "2026-09-15",
+      sellCents: 100_000,
+      payments: [{ date: "2026-08-03", cents: 100_000, status: "completed" }],
+    })
+    // Ran inside the period, then cancelled and fully refunded. Contributes a
+    // contract and its value, and zero advances.
+    await seedContract({
+      number: "C3",
+      confirmedAt: "2026-06-01",
+      serviceDate: "2026-08-20",
+      sellCents: 50_000,
+      status: "cancelled",
+      payments: [
+        { date: "2026-06-05", cents: 50_000, status: "completed" },
+        { date: "2026-08-25", cents: 50_000, status: "refunded" },
+      ],
+    })
+    // Finished before the period began — out of scope.
+    await seedContract({
+      number: "OUT-PERFORMED",
+      confirmedAt: "2026-05-01",
+      serviceDate: "2026-06-30",
+      sellCents: 999_000,
+      payments: [{ date: "2026-05-02", cents: 999_000, status: "completed" }],
+    })
+    // Concluded after the period ended — out of scope even though it runs later.
+    await seedContract({
+      number: "OUT-LATE",
+      confirmedAt: "2026-09-15",
+      serviceDate: "2026-11-01",
+      sellCents: 888_000,
+    })
+  }
+
+  async function run(select: string[], parameters: Record<string, string> = PERIOD) {
+    return financeUnperformedServicesDataset.execute(
+      { db, grantedScopes: ["finance:read"] },
+      {
+        query: {
+          dataset: { id: "finance.unperformed-services", version: 1 },
+          select: select.map((field) => ({ kind: "field" as const, field })),
+          filters: [],
+          groupBy: [],
+          orderBy: [{ by: "bookingNumber", direction: "ascending" as const }],
+        },
+        parameters,
+        maximumRows: 100,
+      },
+    )
+  }
+
+  it("counts contracts concluded by period end whose services are not finished by it", async () => {
+    const result = await run(["bookingNumber"])
+    expect(result.rows.map((row) => row.bookingNumber)).toEqual(["C1", "C2", "C3"])
+  })
+
+  it("values contracts at the rate their own documents were stamped with", async () => {
+    const result = await run(["bookingNumber", "fxRateApplied", "contractValueReportingCents"])
+    const byNumber = new Map(result.rows.map((row) => [row.bookingNumber, row]))
+
+    // 2000.00 EUR × 5.352144 = 10704.29 RON, at the applied rate — not the
+    // published 5.2472, which would be 10494.40 and is not what was invoiced.
+    expect(byNumber.get("C1")?.fxRateApplied).toBeCloseTo(APPLIED_RATE, 6)
+    expect(byNumber.get("C1")?.contractValueReportingCents).toBe(lei(200_000))
+    expect(byNumber.get("C2")?.contractValueReportingCents).toBe(lei(100_000))
+  })
+
+  it("reports both readings of an advance, and they differ", async () => {
+    const result = await run([
+      "bookingNumber",
+      "advancesStrictReportingCents",
+      "collectionsTotalReportingCents",
+    ])
+    const byNumber = new Map(result.rows.map((row) => [row.bookingNumber, row]))
+
+    // C1 owes a balance, so its deposit is an advance under both readings.
+    expect(byNumber.get("C1")?.advancesStrictReportingCents).toBe(lei(60_000))
+    expect(byNumber.get("C1")?.collectionsTotalReportingCents).toBe(lei(60_000))
+
+    // C2 is collected in full: money on a running contract, but not money
+    // against a balance still owed. This is the difference the issue warns is
+    // material, and why both ship labelled instead of the platform choosing.
+    expect(byNumber.get("C2")?.advancesStrictReportingCents).toBe(0)
+    expect(byNumber.get("C2")?.collectionsTotalReportingCents).toBe(lei(100_000))
+  })
+
+  it("nets a cancelled, refunded departure to zero advances while keeping its value", async () => {
+    const result = await run([
+      "bookingNumber",
+      "status",
+      "contractValueReportingCents",
+      "collectionsTotalReportingCents",
+    ])
+    const cancelled = result.rows.find((row) => row.bookingNumber === "C3")
+
+    expect(cancelled?.status).toBe("cancelled")
+    expect(cancelled?.contractValueReportingCents).toBe(lei(50_000))
+    expect(cancelled?.collectionsTotalReportingCents).toBe(0)
+  })
+
+  it("counts collections up to period end, not after it", async () => {
+    // C3's refund lands on 2026-08-25. Cut the period short and the refund has
+    // not happened yet, so its collection still stands.
+    const result = await run(["bookingNumber", "collectionsTotalReportingCents"], {
+      periodStart: "2026-08-01",
+      periodEnd: "2026-08-10",
+    })
+    const cancelled = result.rows.find((row) => row.bookingNumber === "C3")
+    expect(cancelled?.collectionsTotalReportingCents).toBe(lei(50_000))
+  })
+
+  it("derives the balance the return exists to measure", async () => {
+    const result = await run(["bookingNumber", "balanceReportingCents"])
+    const byNumber = new Map(result.rows.map((row) => [row.bookingNumber, row]))
+
+    expect(byNumber.get("C1")?.balanceReportingCents).toBe(lei(200_000) - lei(60_000))
+    expect(byNumber.get("C2")?.balanceReportingCents).toBe(0)
+  })
+
+  it("reports an unstamped contract as unconverted rather than converting it now", async () => {
+    await seedContract({
+      number: "C4-UNSTAMPED",
+      confirmedAt: "2026-08-05",
+      serviceDate: "2026-12-01",
+      sellCents: 70_000,
+      stamped: false,
+    })
+
+    const result = await run(["bookingNumber", "contractValueReportingCents"])
+    const unstamped = result.rows.find((row) => row.bookingNumber === "C4-UNSTAMPED")
+
+    // No document has converted this contract, so there is no authoritative
+    // figure. Looking a rate up now is precisely what voyant#4703 exists to
+    // stop, so the row is null and the total says it is short.
+    expect(unstamped?.contractValueReportingCents).toBeNull()
+    expect(result.warnings.join(" ")).toContain("no stamped reporting-currency value")
+  })
+
+  it("flags a fiscal invoice with no collection recorded against it", async () => {
+    // A fiscal invoice, unlike a proforma, means the money was taken. A gap
+    // against recorded payments is a missing payment record — surfaced so the
+    // operator can fix it, rather than counted as collected on its say-so or
+    // silently ignored.
+    await seedContract({
+      number: "C5-INVOICED",
+      confirmedAt: "2026-08-06",
+      serviceDate: "2026-11-20",
+      sellCents: 30_000,
+    })
+
+    const result = await run([
+      "bookingNumber",
+      "collectionsTotalReportingCents",
+      "invoicedNotCollectedReportingCents",
+    ])
+    const flagged = result.rows.find((row) => row.bookingNumber === "C5-INVOICED")
+
+    expect(flagged?.collectionsTotalReportingCents).toBe(0)
+    expect(flagged?.invoicedNotCollectedReportingCents).toBe(lei(30_000))
+
+    // A contract whose payments match its invoice is not flagged.
+    const settled = result.rows.find((row) => row.bookingNumber === "C2")
+    expect(settled?.invoicedNotCollectedReportingCents).toBe(0)
+  })
+
+  it("refuses a period it was not given", async () => {
+    await expect(run(["bookingNumber"], { periodStart: "2026-08-01" })).rejects.toThrow(
+      /periodEnd is required/,
+    )
+    await expect(
+      run(["bookingNumber"], { periodStart: "2026-08-31", periodEnd: "2026-08-01" }),
+    ).rejects.toThrow(/must not precede/)
+  })
+})

--- a/packages/finance/tests/unit/reporting-unperformed-services.test.ts
+++ b/packages/finance/tests/unit/reporting-unperformed-services.test.ts
@@ -142,11 +142,18 @@ describe("unperformed services executor", () => {
     ).rejects.toThrow("finance:read")
   })
 
-  it("warns rather than quietly shortening a total when a contract is unstamped", async () => {
-    const execute = vi.fn().mockResolvedValue([
-      { bookingNumber: "C1", reportingCurrency: "RON", contractValueReportingCents: "1000" },
-      { bookingNumber: "C2", reportingCurrency: null, contractValueReportingCents: null },
-    ])
+  it("asks the relation how many contracts are unstamped, not the returned rows", async () => {
+    // The executor issues the data query, then a companion count over the same
+    // relation. Inspecting the returned rows cannot work: on the KPI widgets
+    // they are already aggregated, so an unstamped contract leaves no null
+    // behind to find.
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce([
+        { bookingNumber: "C1", reportingCurrency: "RON", contractValueReportingCents: "1000" },
+        { bookingNumber: "C2", reportingCurrency: null, contractValueReportingCents: null },
+      ])
+      .mockResolvedValueOnce([{ unstamped: "1", total: "2" }])
 
     const result = await financeUnperformedServicesDataset.execute(
       { db: { execute }, grantedScopes: ["finance:read"] },
@@ -158,5 +165,26 @@ describe("unperformed services executor", () => {
       { bookingNumber: "C2", reportingCurrency: null, contractValueReportingCents: null },
     ])
     expect(result.warnings.join(" ")).toContain("1 of 2 contracts")
+  })
+
+  it("does not pay for a count on a figure stamping cannot shorten", async () => {
+    const execute = vi.fn().mockResolvedValue([{ contracts: "3" }])
+
+    const result = await financeUnperformedServicesDataset.execute(
+      { db: { execute }, grantedScopes: ["finance:read"] },
+      {
+        query: {
+          ...lineListQuery,
+          select: [{ kind: "aggregate" as const, operation: "count" as const, as: "contracts" }],
+        },
+        parameters: PERIOD as never,
+        maximumRows: 10,
+      },
+    )
+
+    expect(result.warnings).toEqual([])
+    // A contract count is complete whether or not the contract is stamped, so
+    // the companion query is not issued at all.
+    expect(execute).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/finance/tests/unit/reporting-unperformed-services.test.ts
+++ b/packages/finance/tests/unit/reporting-unperformed-services.test.ts
@@ -1,0 +1,162 @@
+import {
+  reportDatasetDefinitionSchema,
+  reportTemplateDefinitionSchema,
+  reportWidgetDefinitionSchema,
+} from "@voyant-travel/reporting-contracts"
+import { PgDialect } from "drizzle-orm/pg-core"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  financeReportingTemplates,
+  financeReportingWidgets,
+  financeUnperformedServicesDatasetDefinition,
+} from "../../src/reporting-definitions.js"
+import {
+  compileFinanceUnperformedServicesQuery,
+  financeUnperformedServicesDataset,
+} from "../../src/reporting-unperformed-services.js"
+
+const PERIOD = { periodStart: "2026-08-01", periodEnd: "2026-08-31" }
+
+const lineListQuery = {
+  dataset: { id: "finance.unperformed-services", version: 1 },
+  select: [
+    { kind: "field" as const, field: "bookingNumber" },
+    { kind: "field" as const, field: "reportingCurrency" },
+    { kind: "field" as const, field: "contractValueReportingCents" },
+  ],
+  filters: [],
+  groupBy: [],
+  orderBy: [],
+}
+
+function compile(parameters: Record<string, unknown>, query = lineListQuery) {
+  return new PgDialect().sqlToQuery(
+    compileFinanceUnperformedServicesQuery({
+      query,
+      parameters: parameters as never,
+      maximumRows: 100,
+    }).statement,
+  )
+}
+
+describe("unperformed services definitions", () => {
+  it("declares a valid dataset, widgets, and an operator-addable template", () => {
+    expect(
+      reportDatasetDefinitionSchema.safeParse(financeUnperformedServicesDatasetDefinition),
+    ).toMatchObject({ success: true })
+
+    const template = financeReportingTemplates.find(
+      (candidate) => candidate.id === "finance.contracts-in-progress",
+    )
+    expect(reportTemplateDefinitionSchema.safeParse(template)).toMatchObject({ success: true })
+
+    // Every widget the template names has to exist, or instantiating it lands
+    // the operator on a report full of missing-widget errors.
+    const widgetIds = new Set(financeReportingWidgets.map((widget) => widget.id))
+    for (const instance of template?.widgets ?? []) {
+      expect(
+        reportWidgetDefinitionSchema.safeParse(
+          financeReportingWidgets.find(
+            (widget) => instance.source.kind === "preset" && widget.id === instance.source.widgetId,
+          ),
+        ),
+      ).toMatchObject({ success: true })
+      if (instance.source.kind === "preset") {
+        expect(widgetIds.has(instance.source.widgetId)).toBe(true)
+      }
+    }
+  })
+
+  it("owns its period instead of declaring a page date field", () => {
+    // The page-level window is one field with both bounds; this period is two
+    // fields with opposite open bounds. Declaring `defaultDateField` would let
+    // the header control silently answer a different question.
+    expect(financeUnperformedServicesDatasetDefinition).not.toHaveProperty("defaultDateField")
+
+    const template = financeReportingTemplates.find(
+      (candidate) => candidate.id === "finance.contracts-in-progress",
+    )
+    expect(template?.parameters.map((parameter) => parameter.id)).toEqual([
+      "periodStart",
+      "periodEnd",
+    ])
+    expect(template?.parameters.every((parameter) => parameter.required)).toBe(true)
+  })
+
+  it("marks the client name as PII", () => {
+    const clientName = financeUnperformedServicesDatasetDefinition.fields.find(
+      (field) => field.id === "clientName",
+    )
+    expect(clientName?.sensitivity).toBe("pii")
+  })
+})
+
+describe("unperformed services compiler", () => {
+  it("binds the period rather than inlining it", () => {
+    const { sql, params } = compile(PERIOD)
+    expect(sql).not.toContain("2026-08-01")
+    expect(params).toContain("2026-08-01")
+    expect(params).toContain("2026-08-31")
+  })
+
+  it("refuses a query with no period, or a backwards one", () => {
+    expect(() => compile({})).toThrow(/periodStart is required/)
+    expect(() => compile({ periodStart: "2026-08-01" })).toThrow(/periodEnd is required/)
+    // A period report that quietly covers all time returns a plausible number
+    // that is wrong by an amount nobody can see.
+    expect(() => compile({ periodStart: "August", periodEnd: "2026-08-31" })).toThrow(/YYYY-MM-DD/)
+    expect(() => compile({ periodStart: "2026-08-31", periodEnd: "2026-08-01" })).toThrow(
+      /must not precede/,
+    )
+  })
+
+  it("denominates money columns by the reporting currency the query selects", () => {
+    const compiled = compileFinanceUnperformedServicesQuery({
+      query: lineListQuery,
+      parameters: PERIOD as never,
+      maximumRows: 100,
+    })
+    const value = compiled.columns.find((column) => column.id === "contractValueReportingCents")
+    expect(value).toMatchObject({ minorUnit: true, currencyField: "reportingCurrency" })
+  })
+
+  it("rejects a field the dataset does not declare", () => {
+    expect(() =>
+      compile(PERIOD, {
+        ...lineListQuery,
+        select: [{ kind: "field" as const, field: "bookings.sell_amount_cents" }],
+      }),
+    ).toThrow(/Unknown Finance field/)
+  })
+})
+
+describe("unperformed services executor", () => {
+  it("requires finance read scope", async () => {
+    const execute = vi.fn().mockResolvedValue([])
+    await expect(
+      financeUnperformedServicesDataset.execute(
+        { db: { execute }, grantedScopes: [] },
+        { query: lineListQuery, parameters: PERIOD as never, maximumRows: 10 },
+      ),
+    ).rejects.toThrow("finance:read")
+  })
+
+  it("warns rather than quietly shortening a total when a contract is unstamped", async () => {
+    const execute = vi.fn().mockResolvedValue([
+      { bookingNumber: "C1", reportingCurrency: "RON", contractValueReportingCents: "1000" },
+      { bookingNumber: "C2", reportingCurrency: null, contractValueReportingCents: null },
+    ])
+
+    const result = await financeUnperformedServicesDataset.execute(
+      { db: { execute }, grantedScopes: ["finance:read"] },
+      { query: lineListQuery, parameters: PERIOD as never, maximumRows: 10 },
+    )
+
+    expect(result.rows).toEqual([
+      { bookingNumber: "C1", reportingCurrency: "RON", contractValueReportingCents: 1000 },
+      { bookingNumber: "C2", reportingCurrency: null, contractValueReportingCents: null },
+    ])
+    expect(result.warnings.join(" ")).toContain("1 of 2 contracts")
+  })
+})

--- a/packages/finance/tests/unit/reporting.test.ts
+++ b/packages/finance/tests/unit/reporting.test.ts
@@ -34,20 +34,33 @@ const groupedOutstandingQuery = {
   limit: 20,
 }
 
+/**
+ * Each dataset names the dimension its money columns are denominated by. The
+ * rule below is per dataset, not per package — a second dataset does not get to
+ * skip it, and does not have to borrow the first one's dimension name.
+ */
+const CURRENCY_DIMENSION_BY_DATASET: Readonly<Record<string, string>> = {
+  "finance.receivables": "currency",
+  "finance.unperformed-services": "reportingCurrency",
+}
+
 describe("Finance reporting definitions", () => {
   it("publishes contract-valid dataset, widget, and template definitions", () => {
     expect(reportDatasetDefinitionSchema.parse(financeReceivablesDatasetDefinition).id).toBe(
       "finance.receivables",
     )
-    expect(
-      financeReportingWidgets.map((widget) => reportWidgetDefinitionSchema.parse(widget)),
-    ).toHaveLength(4)
-    expect(
-      financeReportingTemplates.map((template) => reportTemplateDefinitionSchema.parse(template)),
-    ).toHaveLength(1)
+    for (const widget of financeReportingWidgets) {
+      expect(reportWidgetDefinitionSchema.safeParse(widget)).toMatchObject({ success: true })
+      // A widget over a dataset nobody contributes is a preset that can only
+      // ever render an error.
+      expect(Object.keys(CURRENCY_DIMENSION_BY_DATASET)).toContain(widget.query.dataset.id)
+    }
+    for (const template of financeReportingTemplates) {
+      expect(reportTemplateDefinitionSchema.safeParse(template)).toMatchObject({ success: true })
+    }
   })
 
-  it("keeps all contributed monetary presets partitioned by currency", () => {
+  it("keeps every contributed monetary preset partitioned by its dataset's currency", () => {
     const monetaryWidgets = financeReportingWidgets.filter((widget) =>
       widget.query.select.some(
         (selection) => selection.kind === "aggregate" && selection.operation === "sum",
@@ -55,18 +68,14 @@ describe("Finance reporting definitions", () => {
     )
 
     expect(monetaryWidgets).not.toHaveLength(0)
-    expect(
-      monetaryWidgets.every((widget) =>
-        widget.query.groupBy.some((group) => group.field === "currency"),
-      ),
-    ).toBe(true)
-    expect(
-      monetaryWidgets.every(
-        (widget) =>
-          widget.visualization.options.minorUnit === true &&
-          widget.visualization.options.currencyField === "currency",
-      ),
-    ).toBe(true)
+    for (const widget of monetaryWidgets) {
+      const currency = CURRENCY_DIMENSION_BY_DATASET[widget.query.dataset.id]
+      expect(widget.query.groupBy.some((group) => group.field === currency)).toBe(true)
+      // Without both, a renderer has no way to tell whether 351533 is 351,533
+      // or 3,515.33, nor which currency it is in.
+      expect(widget.visualization.options.minorUnit).toBe(true)
+      expect(widget.visualization.options.currencyField).toBe(currency)
+    }
   })
 })
 

--- a/packages/finance/tests/unit/voyant-manifest.test.ts
+++ b/packages/finance/tests/unit/voyant-manifest.test.ts
@@ -76,22 +76,42 @@ describe("finance deployment manifest", () => {
       schema: [{ id: "@voyant-travel/finance#schema" }],
       migrations: [{ id: "@voyant-travel/finance#migrations" }],
       reporting: {
-        datasets: [
-          {
+        datasets: expect.arrayContaining([
+          expect.objectContaining({
             id: "finance.receivables",
             version: 1,
             runtime: {
               entry: "@voyant-travel/finance/reporting",
               export: "financeReceivablesDataset",
             },
-          },
-        ],
+          }),
+          expect.objectContaining({
+            id: "finance.unperformed-services",
+            version: 1,
+            runtime: {
+              entry: "@voyant-travel/finance/reporting-unperformed-services",
+              export: "financeUnperformedServicesDataset",
+            },
+          }),
+        ]),
         widgets: expect.arrayContaining([
           expect.objectContaining({ id: "finance.outstanding-by-currency" }),
           expect.objectContaining({ id: "finance.net-issued-trend" }),
           expect.objectContaining({ id: "finance.invoice-status-breakdown" }),
+          expect.objectContaining({ id: "finance.unperformed-services-lines" }),
         ]),
-        templates: [expect.objectContaining({ id: "finance.overview" })],
+        templates: expect.arrayContaining([
+          expect.objectContaining({ id: "finance.overview" }),
+          // The period reaches the graph as descriptors, so a host can render
+          // the inputs before instantiating the template.
+          expect.objectContaining({
+            id: "finance.contracts-in-progress",
+            parameters: [
+              expect.objectContaining({ id: "periodStart", valueType: "date", required: true }),
+              expect.objectContaining({ id: "periodEnd", valueType: "date", required: true }),
+            ],
+          }),
+        ]),
       },
       setupMigrations: [
         {

--- a/packages/framework/src/deployment-graph.ts
+++ b/packages/framework/src/deployment-graph.ts
@@ -2753,7 +2753,12 @@ function validateReportingFacet(
           )
         } else {
           entry.parameters.forEach((parameter, index) => {
-            requireReportingString(parameter, `${facet}.parameters[${index}]`, source, diagnostics)
+            validateReportingTemplateParameter(
+              parameter,
+              `${facet}.parameters[${index}]`,
+              source,
+              diagnostics,
+            )
           })
         }
       }
@@ -2880,6 +2885,45 @@ function requireReportingString(
 ): void {
   if (typeof value === "string" && value.trim().length > 0) return
   invalidReportingFacet(facet, source, diagnostics, "Expected a non-empty string.")
+}
+
+/**
+ * A template parameter is a descriptor, not a name (voyant#4704). A bare string
+ * cannot be rendered as an input: nothing downstream could tell that
+ * `periodStart` wants a date, what to label it, or that the report means
+ * nothing without it.
+ */
+const REPORTING_PARAMETER_VALUE_TYPES = new Set(["date", "string", "number"])
+
+function validateReportingTemplateParameter(
+  value: unknown,
+  facet: string,
+  source: string | undefined,
+  diagnostics: VoyantGraphDiagnostic[],
+): void {
+  if (!isRecord(value)) {
+    invalidReportingFacet(facet, source, diagnostics, "Expected a template parameter object.")
+    return
+  }
+  requireReportingString(value.id, `${facet}.id`, source, diagnostics)
+  requireReportingString(value.label, `${facet}.label`, source, diagnostics)
+  if (
+    typeof value.valueType !== "string" ||
+    !REPORTING_PARAMETER_VALUE_TYPES.has(value.valueType)
+  ) {
+    invalidReportingFacet(
+      `${facet}.valueType`,
+      source,
+      diagnostics,
+      "Expected one of date, string, number.",
+    )
+  }
+  if (value.required !== undefined && typeof value.required !== "boolean") {
+    invalidReportingFacet(`${facet}.required`, source, diagnostics, "Expected a boolean.")
+  }
+  if (value.description !== undefined && typeof value.description !== "string") {
+    invalidReportingFacet(`${facet}.description`, source, diagnostics, "Expected a string.")
+  }
 }
 
 function validateReportingGridSize(

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -1125,6 +1125,9 @@
       "@voyant-travel/finance/public-routes": ["../finance/dist/routes-public.d.ts"],
       "@voyant-travel/finance/public-validation": ["../finance/dist/validation-public.d.ts"],
       "@voyant-travel/finance/reporting": ["../finance/dist/reporting.d.ts"],
+      "@voyant-travel/finance/reporting-unperformed-services": [
+        "../finance/dist/reporting-unperformed-services.d.ts"
+      ],
       "@voyant-travel/finance/routes": ["../finance/dist/routes.d.ts"],
       "@voyant-travel/finance/runtime-contributor": ["../finance/dist/runtime-contributor.d.ts"],
       "@voyant-travel/finance/runtime-port": ["../finance/dist/runtime-port.d.ts"],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -1126,6 +1126,9 @@
       "@voyant-travel/finance/public-routes": ["../finance/dist/routes-public.d.ts"],
       "@voyant-travel/finance/public-validation": ["../finance/dist/validation-public.d.ts"],
       "@voyant-travel/finance/reporting": ["../finance/dist/reporting.d.ts"],
+      "@voyant-travel/finance/reporting-unperformed-services": [
+        "../finance/dist/reporting-unperformed-services.d.ts"
+      ],
       "@voyant-travel/finance/routes": ["../finance/dist/routes.d.ts"],
       "@voyant-travel/finance/runtime-contributor": ["../finance/dist/runtime-contributor.d.ts"],
       "@voyant-travel/finance/runtime-port": ["../finance/dist/runtime-port.d.ts"],

--- a/packages/graph-contracts/src/facets.ts
+++ b/packages/graph-contracts/src/facets.ts
@@ -318,12 +318,22 @@ export interface VoyantGraphReportTemplateWidget {
   title?: string
 }
 
+/** A value a template's widgets read but cannot supply themselves. */
+export interface VoyantGraphReportTemplateParameter {
+  id: string
+  label: string
+  description?: string
+  valueType: "date" | "string" | "number"
+  required?: boolean
+  defaultValue?: string | number | boolean | null
+}
+
 /** A complete grid page which may compose widgets contributed by several selected units. */
 export interface VoyantGraphReportTemplate extends VoyantGraphFacetEntity {
   version: number
   label: string
   description?: string
-  parameters?: readonly string[]
+  parameters?: readonly VoyantGraphReportTemplateParameter[]
   requirements?: readonly VoyantGraphReportingRequirement[]
   widgets: readonly VoyantGraphReportTemplateWidget[]
 }

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -1131,6 +1131,9 @@
       "@voyant-travel/finance/public-routes": ["../finance/dist/routes-public.d.ts"],
       "@voyant-travel/finance/public-validation": ["../finance/dist/validation-public.d.ts"],
       "@voyant-travel/finance/reporting": ["../finance/dist/reporting.d.ts"],
+      "@voyant-travel/finance/reporting-unperformed-services": [
+        "../finance/dist/reporting-unperformed-services.d.ts"
+      ],
       "@voyant-travel/finance/routes": ["../finance/dist/routes.d.ts"],
       "@voyant-travel/finance/runtime-contributor": ["../finance/dist/runtime-contributor.d.ts"],
       "@voyant-travel/finance/runtime-port": ["../finance/dist/runtime-port.d.ts"],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -1126,6 +1126,9 @@
       "@voyant-travel/finance/public-routes": ["../finance/dist/routes-public.d.ts"],
       "@voyant-travel/finance/public-validation": ["../finance/dist/validation-public.d.ts"],
       "@voyant-travel/finance/reporting": ["../finance/dist/reporting.d.ts"],
+      "@voyant-travel/finance/reporting-unperformed-services": [
+        "../finance/dist/reporting-unperformed-services.d.ts"
+      ],
       "@voyant-travel/finance/routes": ["../finance/dist/routes.d.ts"],
       "@voyant-travel/finance/runtime-contributor": ["../finance/dist/runtime-contributor.d.ts"],
       "@voyant-travel/finance/runtime-port": ["../finance/dist/runtime-port.d.ts"],

--- a/packages/inventory/tsconfig.build.json
+++ b/packages/inventory/tsconfig.build.json
@@ -1125,6 +1125,9 @@
       "@voyant-travel/finance/public-routes": ["../finance/dist/routes-public.d.ts"],
       "@voyant-travel/finance/public-validation": ["../finance/dist/validation-public.d.ts"],
       "@voyant-travel/finance/reporting": ["../finance/dist/reporting.d.ts"],
+      "@voyant-travel/finance/reporting-unperformed-services": [
+        "../finance/dist/reporting-unperformed-services.d.ts"
+      ],
       "@voyant-travel/finance/routes": ["../finance/dist/routes.d.ts"],
       "@voyant-travel/finance/runtime-contributor": ["../finance/dist/runtime-contributor.d.ts"],
       "@voyant-travel/finance/runtime-port": ["../finance/dist/runtime-port.d.ts"],

--- a/packages/inventory/tsconfig.typecheck.json
+++ b/packages/inventory/tsconfig.typecheck.json
@@ -1126,6 +1126,9 @@
       "@voyant-travel/finance/public-routes": ["../finance/dist/routes-public.d.ts"],
       "@voyant-travel/finance/public-validation": ["../finance/dist/validation-public.d.ts"],
       "@voyant-travel/finance/reporting": ["../finance/dist/reporting.d.ts"],
+      "@voyant-travel/finance/reporting-unperformed-services": [
+        "../finance/dist/reporting-unperformed-services.d.ts"
+      ],
       "@voyant-travel/finance/routes": ["../finance/dist/routes.d.ts"],
       "@voyant-travel/finance/runtime-contributor": ["../finance/dist/runtime-contributor.d.ts"],
       "@voyant-travel/finance/runtime-port": ["../finance/dist/runtime-port.d.ts"],

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -1131,6 +1131,9 @@
       "@voyant-travel/finance/public-routes": ["../finance/dist/routes-public.d.ts"],
       "@voyant-travel/finance/public-validation": ["../finance/dist/validation-public.d.ts"],
       "@voyant-travel/finance/reporting": ["../finance/dist/reporting.d.ts"],
+      "@voyant-travel/finance/reporting-unperformed-services": [
+        "../finance/dist/reporting-unperformed-services.d.ts"
+      ],
       "@voyant-travel/finance/routes": ["../finance/dist/routes.d.ts"],
       "@voyant-travel/finance/runtime-contributor": ["../finance/dist/runtime-contributor.d.ts"],
       "@voyant-travel/finance/runtime-port": ["../finance/dist/runtime-port.d.ts"],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -1126,6 +1126,9 @@
       "@voyant-travel/finance/public-routes": ["../finance/dist/routes-public.d.ts"],
       "@voyant-travel/finance/public-validation": ["../finance/dist/validation-public.d.ts"],
       "@voyant-travel/finance/reporting": ["../finance/dist/reporting.d.ts"],
+      "@voyant-travel/finance/reporting-unperformed-services": [
+        "../finance/dist/reporting-unperformed-services.d.ts"
+      ],
       "@voyant-travel/finance/routes": ["../finance/dist/routes.d.ts"],
       "@voyant-travel/finance/runtime-contributor": ["../finance/dist/runtime-contributor.d.ts"],
       "@voyant-travel/finance/runtime-port": ["../finance/dist/runtime-port.d.ts"],

--- a/packages/reporting-contracts/src/contracts.ts
+++ b/packages/reporting-contracts/src/contracts.ts
@@ -249,16 +249,51 @@ export const reportWidgetInstanceSchema = z
   .strict()
 export type ReportWidgetInstance = z.infer<typeof reportWidgetInstanceSchema>
 
+/**
+ * A value a template's widgets read but cannot supply themselves — a reporting
+ * period, a currency, a threshold.
+ *
+ * A bare name is not enough to ask an operator for one: nothing downstream can
+ * tell whether `periodStart` wants a date or a string, what to label the input,
+ * or whether the report means anything without it. So a template describes its
+ * parameters rather than naming them.
+ */
+export const reportTemplateParameterSchema = z
+  .object({
+    id: reportingIdentifierSchema,
+    label: z.string().trim().min(1).max(160),
+    description: z.string().trim().max(500).optional(),
+    valueType: z.enum(["date", "string", "number"]),
+    /** A report that cannot be read without it; instantiation seeds a default. */
+    required: z.boolean().default(false),
+    defaultValue: reportParameterValueSchema.optional(),
+  })
+  .strict()
+export type ReportTemplateParameter = z.infer<typeof reportTemplateParameterSchema>
+
 export const reportTemplateDefinitionSchema = z
   .object({
     id: reportingIdentifierSchema,
     version: reportingVersionSchema,
     label: z.string().trim().min(1).max(160),
     description: z.string().trim().max(2_000).optional(),
-    parameters: z.array(reportingIdentifierSchema).max(50).default([]),
+    parameters: z.array(reportTemplateParameterSchema).max(50).default([]),
     widgets: z.array(reportWidgetInstanceSchema).max(50),
   })
   .strict()
+  .superRefine((template, context) => {
+    const ids = new Set<string>()
+    for (const [index, parameter] of template.parameters.entries()) {
+      if (ids.has(parameter.id)) {
+        context.addIssue({
+          code: "custom",
+          message: `Duplicate template parameter ${JSON.stringify(parameter.id)}.`,
+          path: ["parameters", index, "id"],
+        })
+      }
+      ids.add(parameter.id)
+    }
+  })
 export type ReportTemplateDefinition = z.infer<typeof reportTemplateDefinitionSchema>
 
 export const reportDraftSchema = z

--- a/packages/reporting-react/src/admin/api.ts
+++ b/packages/reporting-react/src/admin/api.ts
@@ -198,10 +198,20 @@ export async function exportReport(
   client: ReportingClient,
   id: string,
   format: ReportExportFormat,
+  /**
+   * The report's current parameters. Sent explicitly rather than relying on
+   * whatever was last saved, so exporting one period does not depend on a
+   * flush having landed first.
+   */
+  parameters: Readonly<Record<string, unknown>> = {},
 ): Promise<void> {
+  const query = new URLSearchParams({ format })
+  for (const [key, value] of Object.entries(parameters)) {
+    if (typeof value === "string" && value.length > 0) query.set(key, value)
+  }
   const url = `${client.baseUrl.replace(/\/$/, "")}${REPORTING_API_BASE}/reports/${encodeURIComponent(
     id,
-  )}/export?format=${format}`
+  )}/export?${query.toString()}`
   const response = await client.fetcher(url, { credentials: "include" })
   if (!response.ok) {
     throw new VoyantApiError(`Report export failed: ${response.status}`, response.status, undefined)

--- a/packages/reporting-react/src/admin/report-builder-admin.tsx
+++ b/packages/reporting-react/src/admin/report-builder-admin.tsx
@@ -163,6 +163,33 @@ export function ReportBuilderAdmin({
     [doc],
   )
 
+  // A template can declare inputs its widgets read but cannot supply — a
+  // reporting period, most of all. Without rendering them, adding a
+  // period-scoped template gives the operator a report whose every widget
+  // errors on a missing parameter, with nowhere to say which period.
+  const templateParameters = useMemo(() => {
+    if (!report.sourceTemplateId) return []
+    const template = catalog.templates.find(
+      (candidate) =>
+        candidate.id === report.sourceTemplateId &&
+        (report.sourceTemplateVersion == null ||
+          candidate.version === report.sourceTemplateVersion),
+    )
+    return template?.parameters ?? []
+  }, [catalog.templates, report.sourceTemplateId, report.sourceTemplateVersion])
+
+  const handleTemplateParameter = useCallback(
+    (id: string, value: string) => {
+      doc.updateDraft((draft) => {
+        const next = { ...draft.parameters }
+        if (value) next[id] = value
+        else delete next[id]
+        return { ...draft, parameters: next }
+      })
+    },
+    [doc],
+  )
+
   // "Show in base currency": converts every money widget to the operator's base
   // currency using each record's recording-time FX snapshot (handled server-side).
   const baseCurrency = parameters.reportCurrency === "base"
@@ -202,13 +229,13 @@ export function ReportBuilderAdmin({
           anchor.remove()
           URL.revokeObjectURL(objectUrl)
         } else {
-          await exportReport(client, report.id, format)
+          await exportReport(client, report.id, format, parameters)
         }
       } finally {
         setExporting(null)
       }
     },
-    [client, report.id, doc],
+    [client, report.id, doc, parameters],
   )
 
   // One grid `WidgetDefinition` per AVAILABLE instance, keyed by the *instance*
@@ -385,6 +412,48 @@ export function ReportBuilderAdmin({
           <span className="text-muted-foreground text-xs font-medium">Show in base currency</span>
         </label>
       </div>
+
+      {templateParameters.length === 0 ? null : (
+        <div className="flex flex-wrap items-end gap-3">
+          {templateParameters.map((parameter) => {
+            const value = parameters[parameter.id]
+            const current = typeof value === "string" ? value : ""
+            const inputId = `vrb-parameter-${parameter.id}`
+            return (
+              <div key={parameter.id} className="flex flex-col gap-1">
+                <Label htmlFor={inputId} className="text-muted-foreground text-xs font-medium">
+                  {parameter.label}
+                  {parameter.required && !current ? (
+                    <span className="text-destructive ml-1" aria-hidden="true">
+                      *
+                    </span>
+                  ) : null}
+                </Label>
+                <Input
+                  id={inputId}
+                  type={
+                    parameter.valueType === "date"
+                      ? "date"
+                      : parameter.valueType === "number"
+                        ? "number"
+                        : "text"
+                  }
+                  value={current}
+                  aria-describedby={parameter.description ? `${inputId}-hint` : undefined}
+                  aria-required={parameter.required || undefined}
+                  onChange={(event) => handleTemplateParameter(parameter.id, event.target.value)}
+                  className="w-[11rem]"
+                />
+                {parameter.description ? (
+                  <span id={`${inputId}-hint`} className="text-muted-foreground text-xs">
+                    {parameter.description}
+                  </span>
+                ) : null}
+              </div>
+            )
+          })}
+        </div>
+      )}
 
       {doc.status === "conflict" ? (
         <div

--- a/packages/reporting/src/routes.ts
+++ b/packages/reporting/src/routes.ts
@@ -13,6 +13,7 @@ import {
   parseReportQuerySourceSchema,
   previewReportQuerySchema,
   ReportDatasetQueryError,
+  type ReportParameters,
   ReportQuerySyntaxError,
   updateReportDefinitionSchema,
 } from "@voyant-travel/reporting-contracts"
@@ -153,10 +154,15 @@ export function createReportingRoutes(registry: ReportingRegistry) {
       return c.json({ error: "invalid_format", message: "format must be csv, xlsx, or pdf." }, 400)
     }
     try {
+      // A period-parameterised report is exported once per period, and the
+      // export is the artifact that gets filed. Reading parameters off the
+      // query string is what lets an operator export August without first
+      // editing and saving the report — which would leave the saved report
+      // permanently describing whichever period was exported last.
       const report = await service.exportReport(
         c.get("db"),
         c.req.param("id"),
-        {},
+        exportParametersFromQuery(c.req.query()),
         {
           actorId: c.get("userId"),
           grantedScopes: c.get("scopes") ?? [],
@@ -186,6 +192,23 @@ export function createReportingRoutes(registry: ReportingRegistry) {
   })
 
   return routes
+}
+
+/** Query keys the export route owns; everything else is a report parameter. */
+const EXPORT_RESERVED_QUERY_KEYS = new Set(["format"])
+
+/**
+ * Read report parameters off the export query string. Values stay strings —
+ * dataset executors already parse what they need, and coercing here would
+ * guess at a type the parameter's own descriptor knows and this route does not.
+ */
+function exportParametersFromQuery(query: Record<string, string>): ReportParameters {
+  const parameters: ReportParameters = {}
+  for (const [key, value] of Object.entries(query)) {
+    if (EXPORT_RESERVED_QUERY_KEYS.has(key)) continue
+    if (typeof value === "string" && value.length > 0) parameters[key] = value
+  }
+  return parameters
 }
 
 function requireReportsPermission(

--- a/packages/reporting/src/service.ts
+++ b/packages/reporting/src/service.ts
@@ -74,6 +74,14 @@ export function createReportingService(registry: ReportingRegistry) {
     ) {
       const template = registry.getTemplate(input.templateId, input.version)
       if (!template) throw new ReportingRecordNotFoundError("Report template")
+      // Seed the template's declared defaults so an instantiated report opens
+      // showing something. A parameterised template that lands with an empty
+      // bag renders every widget as a missing-parameter error, which reads as
+      // "this template is broken" rather than "choose a period".
+      const parameters: ReportParameters = {}
+      for (const parameter of template.parameters) {
+        if (parameter.defaultValue !== undefined) parameters[parameter.id] = parameter.defaultValue
+      }
       return this.create(
         db,
         {
@@ -81,7 +89,7 @@ export function createReportingService(registry: ReportingRegistry) {
           description: input.description,
           sourceTemplateId: template.id,
           sourceTemplateVersion: template.version,
-          draft: { parameters: {}, widgets: template.widgets },
+          draft: { parameters, widgets: template.widgets },
         },
         actorId,
       )

--- a/packages/reporting/tests/unit/export-parameters.test.ts
+++ b/packages/reporting/tests/unit/export-parameters.test.ts
@@ -1,0 +1,132 @@
+import { OpenAPIHono } from "@hono/zod-openapi"
+import { handleApiError } from "@voyant-travel/hono"
+import { describe, expect, it } from "vitest"
+
+import { ReportingRegistry } from "../../src/registry.js"
+import { createReportingRoutes } from "../../src/routes.js"
+
+/**
+ * A period-parameterised report is exported once per period, and the export is
+ * the artifact that gets filed (voyant#4704). The export route used to pass an
+ * empty parameter bag, so the only way to export August was to edit and save
+ * the report first — leaving it permanently describing whichever period was
+ * exported last.
+ */
+
+const reportDefinition = {
+  id: "rpdf_export_params",
+  name: "Contracts in progress",
+  description: null,
+  draft: {
+    // The saved report carries a period; the caller's should win over it.
+    parameters: { periodStart: "2026-01-01", periodEnd: "2026-01-31" },
+    widgets: [
+      {
+        id: "w1",
+        source: {
+          kind: "custom" as const,
+          definition: {
+            id: "custom-1",
+            version: 1,
+            label: "Contracts",
+            query: {
+              dataset: { id: "test.periodic", version: 1 },
+              select: [{ kind: "aggregate", operation: "count", as: "n" }],
+              filters: [],
+              groupBy: [],
+              orderBy: [],
+            },
+            visualization: { type: "kpi", options: {} },
+            defaultSize: { width: 4, height: 2 },
+          },
+        },
+        layout: { x: 0, y: 0, width: 4, height: 2 },
+      },
+    ],
+  },
+}
+
+/** Echoes the parameters it was executed with, so the route's plumbing is visible. */
+function echoingRegistry(seen: Record<string, unknown>[]) {
+  return new ReportingRegistry([
+    {
+      namespace: "test",
+      datasets: [
+        {
+          definition: {
+            id: "test.periodic",
+            version: 1,
+            label: "Periodic",
+            grain: "One row per period",
+            requiredScopes: [],
+            fields: [
+              {
+                id: "n",
+                label: "Count",
+                role: "measure",
+                valueType: "integer",
+                sensitivity: "internal",
+                requiredScopes: [],
+                aggregations: ["sum"],
+              },
+            ],
+            defaultLimit: 100,
+            maximumLimit: 1_000,
+          },
+          execute: async (_context, input) => {
+            seen.push(input.parameters)
+            return {
+              columns: [{ id: "n", label: "Count", valueType: "integer" as const }],
+              rows: [{ n: 1 }],
+              truncated: false,
+              warnings: [],
+            }
+          },
+        },
+      ],
+    },
+  ])
+}
+
+function requestWith(seen: Record<string, unknown>[], query: string) {
+  const app = new OpenAPIHono()
+  app.use("*", async (c, next) => {
+    c.set("db", {
+      select: () => ({
+        from: () => ({ where: () => ({ limit: async () => [reportDefinition] }) }),
+      }),
+    } as never)
+    c.set("scopes", ["reports:export"])
+    await next()
+  })
+  app.route("/v1/admin/reporting", createReportingRoutes(echoingRegistry(seen)))
+  app.onError((error, c) => handleApiError(error, c))
+  return app.request(`/v1/admin/reporting/reports/${reportDefinition.id}/export${query}`)
+}
+
+describe("report export parameters", () => {
+  it("passes query-string parameters through to the dataset", async () => {
+    const seen: Record<string, unknown>[] = []
+    const response = await requestWith(
+      seen,
+      "?format=csv&periodStart=2026-08-01&periodEnd=2026-08-31",
+    )
+
+    expect(response.status).toBe(200)
+    expect(seen[0]).toMatchObject({ periodStart: "2026-08-01", periodEnd: "2026-08-31" })
+  })
+
+  it("keeps the saved report's parameters when the caller supplies none", async () => {
+    const seen: Record<string, unknown>[] = []
+    await requestWith(seen, "?format=csv")
+
+    expect(seen[0]).toMatchObject({ periodStart: "2026-01-01", periodEnd: "2026-01-31" })
+  })
+
+  it("does not mistake the format for a report parameter", async () => {
+    const seen: Record<string, unknown>[] = []
+    await requestWith(seen, "?format=csv&periodStart=2026-08-01")
+
+    expect(seen[0]).not.toHaveProperty("format")
+  })
+})

--- a/packages/reporting/tests/unit/template-parameters.test.ts
+++ b/packages/reporting/tests/unit/template-parameters.test.ts
@@ -1,0 +1,110 @@
+import { reportTemplateDefinitionSchema } from "@voyant-travel/reporting-contracts"
+import { describe, expect, it, vi } from "vitest"
+
+import { ReportingRegistry } from "../../src/registry.js"
+import { createReportingService } from "../../src/service.js"
+
+/**
+ * A template that needs a reporting period has to be able to say so, and an
+ * operator adding it has to land on something that renders (voyant#4704).
+ */
+
+const periodTemplate = {
+  id: "finance.unperformed-services",
+  version: 1,
+  label: "Contracts in progress",
+  parameters: [
+    { id: "periodStart", label: "Period start", valueType: "date" as const, required: true },
+    {
+      id: "periodEnd",
+      label: "Period end",
+      valueType: "date" as const,
+      required: true,
+      defaultValue: "2026-08-31",
+    },
+  ],
+  widgets: [
+    {
+      id: "lines",
+      source: { kind: "preset" as const, widgetId: "finance.lines", version: 1 },
+      layout: { x: 0, y: 0, width: 12, height: 6 },
+    },
+  ],
+}
+
+function registryWithTemplate() {
+  return new ReportingRegistry([
+    {
+      namespace: "finance",
+      widgets: [
+        {
+          id: "finance.lines",
+          version: 1,
+          label: "Lines",
+          query: {
+            dataset: { id: "finance.unperformed-services", version: 1 },
+            select: [{ kind: "aggregate", operation: "count", as: "n" }],
+            filters: [],
+            groupBy: [],
+            orderBy: [],
+          },
+          visualization: { type: "table", options: {} },
+          defaultSize: { width: 12, height: 6 },
+        },
+      ],
+      templates: [periodTemplate],
+    },
+  ])
+}
+
+describe("template parameters", () => {
+  it("describes a parameter rather than only naming it", () => {
+    const parsed = reportTemplateDefinitionSchema.parse(periodTemplate)
+    // A bare name cannot be rendered as an input: nothing downstream could tell
+    // that `periodStart` wants a date, what to label it, or that the report
+    // means nothing without it.
+    expect(parsed.parameters[0]).toMatchObject({
+      id: "periodStart",
+      label: "Period start",
+      valueType: "date",
+      required: true,
+    })
+  })
+
+  it("rejects a template that declares the same parameter twice", () => {
+    const duplicated = {
+      ...periodTemplate,
+      parameters: [
+        { id: "periodStart", label: "One", valueType: "date" as const },
+        { id: "periodStart", label: "Two", valueType: "date" as const },
+      ],
+    }
+    expect(reportTemplateDefinitionSchema.safeParse(duplicated).success).toBe(false)
+  })
+
+  it("seeds declared defaults when an operator adds the template to their reports", async () => {
+    const service = createReportingService(registryWithTemplate())
+    const created = vi.fn(async (input: unknown) => input)
+    const db = {} as never
+    const spy = vi.spyOn(service, "create").mockImplementation(created as never)
+
+    await service.instantiateTemplate(
+      db,
+      { templateId: "finance.unperformed-services", name: "August return" },
+      "user_1",
+    )
+
+    // Without this an instantiated period report opens with every widget in a
+    // missing-parameter error, which reads as a broken template rather than as
+    // "choose a period".
+    expect(created).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({
+        sourceTemplateId: "finance.unperformed-services",
+        draft: expect.objectContaining({ parameters: { periodEnd: "2026-08-31" } }),
+      }),
+      "user_1",
+    )
+    spy.mockRestore()
+  })
+})

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -1124,6 +1124,9 @@
       "@voyant-travel/finance/public-routes": ["../finance/dist/routes-public.d.ts"],
       "@voyant-travel/finance/public-validation": ["../finance/dist/validation-public.d.ts"],
       "@voyant-travel/finance/reporting": ["../finance/dist/reporting.d.ts"],
+      "@voyant-travel/finance/reporting-unperformed-services": [
+        "../finance/dist/reporting-unperformed-services.d.ts"
+      ],
       "@voyant-travel/finance/routes": ["../finance/dist/routes.d.ts"],
       "@voyant-travel/finance/runtime-contributor": ["../finance/dist/runtime-contributor.d.ts"],
       "@voyant-travel/finance/runtime-port": ["../finance/dist/runtime-port.d.ts"],


### PR DESCRIPTION
Romanian tour operators file a periodic return on contracts in progress: how many, what they are worth in lei, and how much has been collected against them. Every structural input was present and there was no report, so assembling one month meant reading figures off PDFs for a day.

**No new page.** It arrives as **one dataset, five widgets and one template** on the existing reports surface, which an operator adds to their own collection through the template route that already ships.

## Why a dataset was the missing piece

More of this was already built than the issue assumed. Custom widgets (`reportWidgetInstance` has a `kind: "custom"` variant), saved reports, `POST /templates/:id/instantiate`, and csv/xlsx/pdf export all shipped.

What was missing was **data those widgets could ask for**. There was exactly one dataset in the repo — `finance.receivables`, invoice grain, dated on `issueDate`. Nothing exposed `booking_items.service_date`, `bookings.confirmed_at`, booking value, or collections at *payment* date. And the query language is deliberately *"SQL-like … but has no joins, subqueries, statements, or table access"*, so an operator could not assemble them however good the builder got — and the totals and the line list have to come from the **same** dataset.

## The dataset

`finance.unperformed-services` — booking grain, spanning three (booking value, booking-item service dates, payment collections) with collections pre-aggregated and refunds netted inside it. Finance owns it because it needs both sides and `finance→bookings` is an established read pair with 29 baselined reach-ins, while `bookings→finance` is not a pair at all and `verify:table-privacy` forbids opening one.

Three decisions worth review:

**Both readings of "advance" ship, labelled.** The issue is explicit that reading it strictly (money against a balance still owed) versus as all collections on a running contract changes the total materially. Rather than pick, the dataset exposes `advancesStrictReportingCents` and `collectionsTotalReportingCents` side by side so an operator filing a return chooses knowingly instead of discovering later which one the platform picked.

**Nothing is converted at read time.** Values come from the rate each contract's own documents were stamped with (#4712). A contract nothing has stamped reports `null` and the result carries a warning naming how many rows are excluded — because looking a rate up now is exactly what the FX work exists to prevent, and a total that silently omits rows reads as complete when it is short.

**The count is booking-derived, and says so.** `contracts` holds 225 rows of which 14 are `issued`, so a contract-record count would be quietly wrong. Every label says booking.

## Three changes to the reporting feature

Without these a parameterised template exists but an operator cannot drive it.

**Template parameters are descriptors, not names.** `parameters` was `string[]` — no type, label, default or required flag, so nothing could render a period picker. Now `{ id, label, description?, valueType, required, defaultValue? }`, carried through the deployment graph (whose validator checks the shape), and instantiating a template seeds its declared defaults so the report opens showing something rather than a wall of missing-parameter errors.

**Export accepts parameters from the caller.** The route passed `{}`, so exporting a different period meant editing and saving the report first — leaving it permanently describing whichever period was exported last. The export is the artifact that gets filed, so this mattered.

**A dataset may own its period.** `applyPageDateWindow` injects one field with both bounds:

```
field >= dateFrom AND field <= dateTo
```

This period is two fields with *opposite open bounds* — concluded on or before period end (no lower bound), services running on or after period start (no upper bound). Not expressible, and wiring it up would answer a different question while looking like it answered this one. Datasets that do not fit declare no `defaultDateField`, read their own parameters, and **fail when absent** rather than silently covering all time. Written up in `docs/architecture/reporting-datasets.md`.

## One refactor

Finance's report query compiler is now shared between both datasets rather than copied. The alternative was not one dataset with a bespoke compiler; it was every dataset with its own copy of the same grouping, aliasing and filter rules, diverging one fix at a time. A dataset owns its relation, its fields and its own answerability rule — receivables keeps its "group by currency or filter to one" invariant as a hook it passes in. Its nine existing unit tests are the regression net and pass unchanged.

## The open question I did not guess at

"In progress" has two readings — still running **at** period end, versus running at any point **during** it — and they give different numbers. The issue's own cancelled-departure case only makes sense under the second, so that is what is implemented and what the tests pin. **The offered worked month should settle it**; whichever wins gets written into the dataset's `grain` string, where a report reader can see it.

## Verification

- **The integration test drives the real path over real Postgres** and is registered by name in the `integration` CI lane — an unlisted integration test here is green by never running, which for a regulatory report would be the worst place for that to happen. It covers each edge case the issue asked to have encoded: a cancelled, refunded departure inside the period contributing contracts and value but zero advances; collections counted only up to period end; a contract collected in full distinguishing the two advance readings; an unstamped contract reporting null with a warning; and a fiscal invoice with no payment recorded against it being flagged rather than assumed collected.
- Unit coverage for the compiler (period binding, refusal without a period, money columns denominated by the dataset's own currency dimension) and for both reporting-feature changes.
- The two existing finance reporting tests that assumed a single dataset were generalised rather than renumbered — the rule they encode is still right, they just needed to know each dataset's own currency dimension.
- Full builds and suites for framework (426), finance (646), reporting (22), reporting-contracts (14); `biome check .` clean; **all 94 `verify:architecture` checks pass**.

A first run surfaced a real graph error worth noting: the template originally reused the dataset's id, and graph entity ids are namespaced across datasets, widgets and templates alike. The template is `finance.contracts-in-progress`.

Refs #4704
