### PR TITLE
Refuse an over-long billing value at the Session write path, and stop a settled payment being stranded by the Session clock

### DIFF
--- a/.changeset/booking-session-settlement-widths.md
+++ b/.changeset/booking-session-settlement-widths.md
@@ -3,10 +3,11 @@
 "@voyant-travel/catalog": minor
 "@voyant-travel/catalog-react": patch
 "@voyant-travel/commerce": minor
+"@voyant-travel/core": minor
 ---
 
 Refuse an over-long billing value at the Booking Session write path instead of after the card is captured, and stop a settled payment from being stranded by the Session's own expiry.
 
 The Session's selection normalizer projected the billing block field by field rather than parsing it, so the widths `bookingSelectionPublicV1` declared never ran while the Booking create enforced its own. A 25-character postal code was accepted at every step and refused once, at settlement. `requirements.bookingFields` now publishes `maxLength`, advertises the whole billing address, and the write path rejects with `invalid_selection` / `value_too_long` naming the field as the caller sent it (`billing.address.postal`, not `contactPostalCode`).
 
-A Session whose money is with a processor is no longer expired by the commit preflight or the expiry sweep, and can no longer be abandoned; `BookingSessionRecordV1` carries `requirementsFingerprint`, so a Commit is reachable from a read rather than only from a Quote. A settlement that produces no Booking emits `booking_session.settlement.failed`.
+A Session whose money is with a processor is no longer expired by the commit preflight or the expiry sweep, and can no longer be abandoned; `BookingSessionRecordV1` carries `requirementsFingerprint`, so a Commit is reachable from a read rather than only from a Quote. A settlement that produces no Booking emits `booking_session.settlement.failed`, and `ANALYTICS_FAILURE_REASONS` gains `value_too_long` so the new rejection reaches the breakdown rather than the `unknown` bucket.

--- a/.changeset/booking-session-settlement-widths.md
+++ b/.changeset/booking-session-settlement-widths.md
@@ -1,0 +1,12 @@
+---
+"@voyant-travel/catalog-contracts": minor
+"@voyant-travel/catalog": minor
+"@voyant-travel/catalog-react": patch
+"@voyant-travel/commerce": minor
+---
+
+Refuse an over-long billing value at the Booking Session write path instead of after the card is captured, and stop a settled payment from being stranded by the Session's own expiry.
+
+The Session's selection normalizer projected the billing block field by field rather than parsing it, so the widths `bookingSelectionPublicV1` declared never ran while the Booking create enforced its own. A 25-character postal code was accepted at every step and refused once, at settlement. `requirements.bookingFields` now publishes `maxLength`, advertises the whole billing address, and the write path rejects with `invalid_selection` / `value_too_long` naming the field as the caller sent it (`billing.address.postal`, not `contactPostalCode`).
+
+A Session whose money is with a processor is no longer expired by the commit preflight or the expiry sweep, and can no longer be abandoned; `BookingSessionRecordV1` carries `requirementsFingerprint`, so a Commit is reachable from a read rather than only from a Quote. A settlement that produces no Booking emits `booking_session.settlement.failed`.

--- a/packages/catalog-contracts/src/booking-engine/requirements-contracts.ts
+++ b/packages/catalog-contracts/src/booking-engine/requirements-contracts.ts
@@ -298,6 +298,8 @@ export const travelerFieldRequirementV1 = z.object({
   required: z.boolean(),
   options: z.array(z.object({ value: z.string(), label: z.string() })).optional(),
   appliesToBands: z.array(z.string()).optional(),
+  /** See {@link bookingFieldRequirementV1}'s `maxLength`. */
+  maxLength: z.number().int().positive().optional(),
 })
 export type TravelerFieldRequirementV1 = z.infer<typeof travelerFieldRequirementV1>
 
@@ -308,6 +310,21 @@ export const bookingFieldRequirementV1 = z.object({
   type: z.string(),
   required: z.boolean(),
   group: z.enum(["billing", "company", "preferences"]),
+  /**
+   * The longest value this field accepts, when it is bounded at all.
+   *
+   * A descriptor that says a field exists but not how wide it is leaves a
+   * client unable to pre-validate even when it wants to: `address.postal` was
+   * published with no length information, accepted at 25 characters by the
+   * Session `PATCH`, and refused at 20 by the commit — after the card was
+   * captured (voyant#4734). Publishing the bound is what lets the refusal
+   * happen at the step instead.
+   *
+   * Optional because most fields are genuinely unbounded. Absent means "no
+   * declared limit", never "unknown": the server bounds a field here whenever
+   * it will bound it later.
+   */
+  maxLength: z.number().int().positive().optional(),
 })
 export type BookingFieldRequirementV1 = z.infer<typeof bookingFieldRequirementV1>
 

--- a/packages/catalog-contracts/src/booking-engine/requirements-defaults.ts
+++ b/packages/catalog-contracts/src/booking-engine/requirements-defaults.ts
@@ -11,6 +11,10 @@ import type {
   PaxBandSpecV1,
   TravelerFieldRequirementV1,
 } from "./requirements-contracts.js"
+import {
+  BOOKING_SELECTION_BILLING_MAX_LENGTHS,
+  BOOKING_SELECTION_TRAVELER_MAX_LENGTHS,
+} from "./selection-contracts.js"
 
 /**
  * Default pax bands used when a vertical doesn't supply its own.
@@ -146,8 +150,20 @@ export function defaultRequirementsFlags(): Pick<
  */
 export function defaultTravelerFields(): TravelerFieldRequirementV1[] {
   return [
-    { key: "firstName", label: "First name", type: "text", required: true },
-    { key: "lastName", label: "Last name", type: "text", required: true },
+    {
+      key: "firstName",
+      label: "First name",
+      type: "text",
+      required: true,
+      maxLength: BOOKING_SELECTION_TRAVELER_MAX_LENGTHS.firstName,
+    },
+    {
+      key: "lastName",
+      label: "Last name",
+      type: "text",
+      required: true,
+      maxLength: BOOKING_SELECTION_TRAVELER_MAX_LENGTHS.lastName,
+    },
     { key: "email", label: "Email", type: "email", required: false },
     {
       key: "phone",
@@ -155,6 +171,7 @@ export function defaultTravelerFields(): TravelerFieldRequirementV1[] {
       type: "phone",
       required: false,
       appliesToBands: ["adult", "senior", "student", "other"],
+      maxLength: BOOKING_SELECTION_TRAVELER_MAX_LENGTHS.phone,
     },
     {
       key: "dateOfBirth",
@@ -180,6 +197,12 @@ export function defaultTravelerFields(): TravelerFieldRequirementV1[] {
 /**
  * Standard booking-fields set: contact + address. Verticals append
  * VAT / company fields for B2B flows.
+ *
+ * Every address line the selection carries is listed, with the width the
+ * commit will hold it to. Publishing three of the six was what left
+ * `address.postal` unadvertised and unbounded on the wire while the commit
+ * capped it at 20 (voyant#4734): a client that wanted to pre-validate had
+ * nothing to pre-validate against, and the refusal arrived after capture.
  */
 export function defaultBookingFields(): BookingFieldRequirementV1[] {
   return [
@@ -190,14 +213,47 @@ export function defaultBookingFields(): BookingFieldRequirementV1[] {
       type: "text",
       required: false,
       group: "billing",
+      maxLength: BOOKING_SELECTION_BILLING_MAX_LENGTHS["address.line1"],
     },
-    { key: "address.city", label: "City", type: "text", required: false, group: "billing" },
+    {
+      key: "address.line2",
+      label: "Address line 2",
+      type: "text",
+      required: false,
+      group: "billing",
+      maxLength: BOOKING_SELECTION_BILLING_MAX_LENGTHS["address.line2"],
+    },
+    {
+      key: "address.city",
+      label: "City",
+      type: "text",
+      required: false,
+      group: "billing",
+      maxLength: BOOKING_SELECTION_BILLING_MAX_LENGTHS["address.city"],
+    },
+    {
+      key: "address.region",
+      label: "Region",
+      type: "text",
+      required: false,
+      group: "billing",
+      maxLength: BOOKING_SELECTION_BILLING_MAX_LENGTHS["address.region"],
+    },
+    {
+      key: "address.postal",
+      label: "Postal code",
+      type: "text",
+      required: false,
+      group: "billing",
+      maxLength: BOOKING_SELECTION_BILLING_MAX_LENGTHS["address.postal"],
+    },
     {
       key: "address.country",
       label: "Country",
       type: "country",
       required: false,
       group: "billing",
+      maxLength: BOOKING_SELECTION_BILLING_MAX_LENGTHS["address.country"],
     },
   ]
 }

--- a/packages/catalog-contracts/src/booking-engine/selection-contracts.ts
+++ b/packages/catalog-contracts/src/booking-engine/selection-contracts.ts
@@ -40,15 +40,74 @@ export const travelerBandCodeSchema = z.string().min(1).max(128)
 
 const optionalEmailStringV1 = z.union([z.literal(""), z.email()])
 
+/**
+ * How long each free-text billing value may be, keyed by its path inside the
+ * selection's `billing` block.
+ *
+ * **One table, because three paths need the same number and only one of them
+ * used to have it.** The `max()` calls below are a parse the Session never
+ * runs — `normalizeBookingSelection` projects the billing block value by value
+ * rather than parsing it, so every bound declared here was decorative and the
+ * write path accepted anything. The commit's own `contact_*` write did not,
+ * and a 25-character postal code was therefore accepted a dozen times at the
+ * step where it could still be edited and refused once, after the card was
+ * captured, under a field name (`contactPostalCode`) the client never sent
+ * (voyant#4734).
+ *
+ * So the same table now drives all three:
+ *
+ * 1. the schema below, so a caller that does parse sees the bound;
+ * 2. the Session's selection normalizer, which refuses at `PATCH` naming the
+ *    path the caller wrote;
+ * 3. `requirements.bookingFields[].maxLength`, so a client can refuse before
+ *    the shopper leaves the step.
+ *
+ * Every width is the one the Booking's own create accepts
+ * (`convertProductSchema` in `@voyant-travel/bookings-contracts`). A value
+ * this table admits cannot be rejected by the commit, which is the property
+ * the widths were introduced to have.
+ */
+export const BOOKING_SELECTION_BILLING_MAX_LENGTHS = {
+  "contact.firstName": 255,
+  "contact.lastName": 255,
+  "contact.phone": 50,
+  "address.line1": 500,
+  "address.line2": 500,
+  "address.city": 100,
+  "address.region": 100,
+  "address.postal": 20,
+  "address.country": 2,
+} as const satisfies Record<string, number>
+
+export type BookingSelectionBillingFieldKey = keyof typeof BOOKING_SELECTION_BILLING_MAX_LENGTHS
+
+/**
+ * The same table for a traveler row, keyed by the field key
+ * `requirements.travelerFields` publishes.
+ *
+ * Widths come from `insertTravelerSchema` in
+ * `@voyant-travel/bookings-contracts`, which is what the commit writes each
+ * row through. `email` is absent because it is bounded by shape rather than
+ * length, and `band` is a code the requirements enumerate rather than free
+ * text.
+ */
+export const BOOKING_SELECTION_TRAVELER_MAX_LENGTHS = {
+  firstName: 255,
+  lastName: 255,
+  phone: 50,
+} as const satisfies Record<string, number>
+
+export type BookingSelectionTravelerFieldKey = keyof typeof BOOKING_SELECTION_TRAVELER_MAX_LENGTHS
+
 export const travelerEntryV1 = z.object({
   /** Stable client-side row id — the wizard uses it to keep
    *  travelers stable across re-renders and to attach passengers
    *  to room units. Defaults to a fresh uuid when omitted. */
   rowId: z.string().min(1).optional(),
-  firstName: z.string().min(1).max(255),
-  lastName: z.string().min(1).max(255),
+  firstName: z.string().min(1).max(BOOKING_SELECTION_TRAVELER_MAX_LENGTHS.firstName),
+  lastName: z.string().min(1).max(BOOKING_SELECTION_TRAVELER_MAX_LENGTHS.lastName),
   email: optionalEmailStringV1.optional(),
-  phone: z.string().max(50).optional(),
+  phone: z.string().max(BOOKING_SELECTION_TRAVELER_MAX_LENGTHS.phone).optional(),
   /** Linked CRM person, when the traveler was picked from (or copied as)
    *  an existing contact. Lets the picker reflect the selection and the
    *  commit path attach the traveler to a known person. */
@@ -190,26 +249,33 @@ export const bookingSelectionPublicV1 = z.object({
       /** CRM organization id when a company (B2B) lead was picked. */
       organizationId: z.string().optional(),
       contact: z.object({
-        firstName: z.string().default(""),
-        lastName: z.string().default(""),
+        firstName: z
+          .string()
+          .max(BOOKING_SELECTION_BILLING_MAX_LENGTHS["contact.firstName"])
+          .default(""),
+        lastName: z
+          .string()
+          .max(BOOKING_SELECTION_BILLING_MAX_LENGTHS["contact.lastName"])
+          .default(""),
         email: optionalEmailStringV1.default(""),
-        phone: z.string().optional(),
+        phone: z.string().max(BOOKING_SELECTION_BILLING_MAX_LENGTHS["contact.phone"]).optional(),
         /** CRM person id when the lead was picked from CRM (vs typed). */
         personId: z.string().optional(),
       }),
       /**
        * Billing address.
        *
-       * Field widths match the `contact_*` columns these land in via
-       * booking-create, so an address this schema admits cannot be rejected
-       * later by the commit — the failure belongs at the Session edge, where
-       * the caller can still see which field was too long.
+       * Field widths come from {@link BOOKING_SELECTION_BILLING_MAX_LENGTHS}
+       * and match the `contact_*` columns these land in via booking-create, so
+       * an address this schema admits cannot be rejected later by the commit —
+       * the failure belongs at the Session edge, where the caller can still
+       * see which field was too long.
        */
       address: z
         .object({
-          line1: z.string().max(500).optional(),
-          line2: z.string().max(500).optional(),
-          city: z.string().max(100).optional(),
+          line1: z.string().max(BOOKING_SELECTION_BILLING_MAX_LENGTHS["address.line1"]).optional(),
+          line2: z.string().max(BOOKING_SELECTION_BILLING_MAX_LENGTHS["address.line2"]).optional(),
+          city: z.string().max(BOOKING_SELECTION_BILLING_MAX_LENGTHS["address.city"]).optional(),
           /**
            * Administrative subdivision below the country — state, province,
            * county, `judet`. Free-form because the Booking column it lands in
@@ -223,10 +289,19 @@ export const bookingSelectionPublicV1 = z.object({
            * in `city` and `RO-B` in `region`, not by overloading an address
            * line (voyant#4290).
            */
-          region: z.string().max(100).optional(),
-          postal: z.string().max(20).optional(),
+          region: z
+            .string()
+            .max(BOOKING_SELECTION_BILLING_MAX_LENGTHS["address.region"])
+            .optional(),
+          postal: z
+            .string()
+            .max(BOOKING_SELECTION_BILLING_MAX_LENGTHS["address.postal"])
+            .optional(),
           /** ISO 3166-1 alpha-2 country code. */
-          country: z.string().max(2).optional(),
+          country: z
+            .string()
+            .max(BOOKING_SELECTION_BILLING_MAX_LENGTHS["address.country"])
+            .optional(),
         })
         .default({}),
       company: z

--- a/packages/catalog-contracts/src/booking-engine/session-contracts.ts
+++ b/packages/catalog-contracts/src/booking-engine/session-contracts.ts
@@ -166,6 +166,24 @@ export const bookingSessionRecordV1 = z.object({
    * Sessions, whose target is no longer re-derived.
    */
   requirements: bookingRequirementsV1.optional(),
+  /**
+   * Fingerprint of `requirements`, computed exactly as the Quote's is.
+   * Present whenever `requirements` is, absent whenever it is not.
+   *
+   * It rides the Session so that **a Commit is always reachable from a read.**
+   * Commit requires this value and only a Quote used to produce it, which is a
+   * dead end precisely when it matters most: while a payment is settled the
+   * Session refuses to quote (`payment_in_flight`, correctly — a re-quote
+   * would release the Hold the money was collected for), so a host that lost
+   * its Quote response to a reload or a crash had no call left that could
+   * finish the booking it had already been paid for (voyant#4733).
+   *
+   * Publishing it here costs nothing: it is a hash of a descriptor the read
+   * already returns, so it carries no authority a caller did not have, and a
+   * Commit that echoes a stale one is refused by the same `requirements_changed`
+   * comparison as before.
+   */
+  requirementsFingerprint: z.string().min(1).optional(),
   expiresAt: z.string().datetime(),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
@@ -227,6 +245,22 @@ export type CreateAcceptedProposalBookingSessionV1 = z.input<
  * three different prices. Re-scoping is a new Session.
  */
 export const updateBookingSessionV1 = z.object({
+  /**
+   * One user action, one key, for every retry of that action.
+   *
+   * **Derive it from the payload, not from the revision alone.** A revision
+   * only advances on a *successful* mutation, so two different edits attempted
+   * at the same revision collide on one key — and the second is answered
+   * `idempotency_conflict` and dropped. That turns a rejected write into a
+   * write that can never be corrected: the shopper edits the field that caused
+   * the rejection, the corrected `PATCH` reuses the failed one's key, and the
+   * stored value never changes however many times they try (voyant#4733).
+   *
+   * `bookingSessionIdempotencyKey(root, "update", revision,
+   * bookingSelectionDigest(selection))` in `@voyant-travel/catalog-react` is
+   * the derivation this contract expects: the revision fences the write, the
+   * digest distinguishes the edits.
+   */
   idempotencyKey: z.string().min(8).max(128),
   expectedRevision: z.number().int().positive(),
   selection: z.record(z.string(), z.unknown()),
@@ -483,9 +517,23 @@ export const bookingSessionLifecycleErrorV1 = z.discriminatedUnion("kind", [
     nextAction: z.literal("select_supported_checkout_intent"),
   }),
   z.object({
+    /**
+     * The selection cannot be written as sent.
+     *
+     * `value_too_long` is the one arm the shopper can fix, and it exists so
+     * they are told at the step rather than after the card is captured: the
+     * Session write path used to accept any width while the commit held the
+     * value to the Booking's own column, so a 25-character postal code was
+     * taken a dozen times and refused once, too late to edit (voyant#4734).
+     * `path` names the field as the caller sent it (`billing.address.postal`),
+     * not as the commit would have reported it (`contactPostalCode`), and
+     * `maxLength` repeats the bound the Session's
+     * `requirements.bookingFields` already publishes.
+     */
     kind: z.literal("invalid_selection"),
-    reason: z.enum(["unsupported_target", "forbidden_field"]),
+    reason: z.enum(["unsupported_target", "forbidden_field", "value_too_long"]),
     path: z.string().min(1).optional(),
+    maxLength: z.number().int().positive().optional(),
   }),
   z.object({
     kind: z.literal("renewal_not_allowed"),

--- a/packages/catalog-react/src/booking-engine/session-outcomes.ts
+++ b/packages/catalog-react/src/booking-engine/session-outcomes.ts
@@ -240,6 +240,17 @@ export function bookingSessionRecoveryV1(
       return "quoteUnavailable"
     case "selection_incomplete":
       return "selectionIncomplete"
+    /**
+     * One arm of `invalid_selection` is the shopper's to fix and the others
+     * are not. `value_too_long` names a field they typed and a width they can
+     * meet, which is the same remedy `selection_incomplete` carries — and
+     * classifying it as `unknown` would put "the Booking Session rejected this
+     * request" in front of somebody whose postal code is five characters too
+     * long (voyant#4734). The other arms are a caller sending a key it may not
+     * send, which no shopper can act on.
+     */
+    case "invalid_selection":
+      return outcome.error.reason === "value_too_long" ? "selectionIncomplete" : "unknown"
     case "requirements_changed":
       return "requirementsChanged"
     case "commit_rejected":
@@ -274,7 +285,6 @@ export function bookingSessionRecoveryV1(
     case "session_consumed":
     case "renewal_not_allowed":
     case "idempotency_conflict":
-    case "invalid_selection":
     case "checkout_intent_not_offered":
     case "hold_quantity_mismatch":
       return "unknown"

--- a/packages/catalog/openapi/admin/catalog-booking.json
+++ b/packages/catalog/openapi/admin/catalog-booking.json
@@ -554,6 +554,10 @@
                               "items": {
                                 "type": "string"
                               }
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required"]
@@ -579,6 +583,10 @@
                             "group": {
                               "type": "string",
                               "enum": ["billing", "company", "preferences"]
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required", "group"]
@@ -944,6 +952,10 @@
                       "bookingFields",
                       "paymentIntents"
                     ]
+                  },
+                  "requirementsFingerprint": {
+                    "type": "string",
+                    "minLength": 1
                   },
                   "expiresAt": {
                     "type": "string",
@@ -1512,6 +1524,10 @@
                               "items": {
                                 "type": "string"
                               }
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required"]
@@ -1537,6 +1553,10 @@
                             "group": {
                               "type": "string",
                               "enum": ["billing", "company", "preferences"]
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required", "group"]
@@ -1902,6 +1922,10 @@
                       "bookingFields",
                       "paymentIntents"
                     ]
+                  },
+                  "requirementsFingerprint": {
+                    "type": "string",
+                    "minLength": 1
                   },
                   "expiresAt": {
                     "type": "string",
@@ -2470,6 +2494,10 @@
                               "items": {
                                 "type": "string"
                               }
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required"]
@@ -2495,6 +2523,10 @@
                             "group": {
                               "type": "string",
                               "enum": ["billing", "company", "preferences"]
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required", "group"]
@@ -2860,6 +2892,10 @@
                       "bookingFields",
                       "paymentIntents"
                     ]
+                  },
+                  "requirementsFingerprint": {
+                    "type": "string",
+                    "minLength": 1
                   },
                   "expiresAt": {
                     "type": "string",
@@ -3437,6 +3473,10 @@
                               "items": {
                                 "type": "string"
                               }
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required"]
@@ -3462,6 +3502,10 @@
                             "group": {
                               "type": "string",
                               "enum": ["billing", "company", "preferences"]
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required", "group"]
@@ -3827,6 +3871,10 @@
                       "bookingFields",
                       "paymentIntents"
                     ]
+                  },
+                  "requirementsFingerprint": {
+                    "type": "string",
+                    "minLength": 1
                   },
                   "expiresAt": {
                     "type": "string",
@@ -4404,6 +4452,10 @@
                               "items": {
                                 "type": "string"
                               }
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required"]
@@ -4429,6 +4481,10 @@
                             "group": {
                               "type": "string",
                               "enum": ["billing", "company", "preferences"]
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required", "group"]
@@ -4794,6 +4850,10 @@
                       "bookingFields",
                       "paymentIntents"
                     ]
+                  },
+                  "requirementsFingerprint": {
+                    "type": "string",
+                    "minLength": 1
                   },
                   "expiresAt": {
                     "type": "string",
@@ -5362,6 +5422,10 @@
                               "items": {
                                 "type": "string"
                               }
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required"]
@@ -5387,6 +5451,10 @@
                             "group": {
                               "type": "string",
                               "enum": ["billing", "company", "preferences"]
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required", "group"]
@@ -5752,6 +5820,10 @@
                       "bookingFields",
                       "paymentIntents"
                     ]
+                  },
+                  "requirementsFingerprint": {
+                    "type": "string",
+                    "minLength": 1
                   },
                   "expiresAt": {
                     "type": "string",
@@ -6320,6 +6392,10 @@
                               "items": {
                                 "type": "string"
                               }
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required"]
@@ -6345,6 +6421,10 @@
                             "group": {
                               "type": "string",
                               "enum": ["billing", "company", "preferences"]
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required", "group"]
@@ -6710,6 +6790,10 @@
                       "bookingFields",
                       "paymentIntents"
                     ]
+                  },
+                  "requirementsFingerprint": {
+                    "type": "string",
+                    "minLength": 1
                   },
                   "expiresAt": {
                     "type": "string",
@@ -7133,6 +7217,10 @@
                               "items": {
                                 "type": "string"
                               }
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required"]
@@ -7158,6 +7246,10 @@
                             "group": {
                               "type": "string",
                               "enum": ["billing", "company", "preferences"]
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required", "group"]
@@ -8327,6 +8419,10 @@
                               "items": {
                                 "type": "string"
                               }
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required"]
@@ -8352,6 +8448,10 @@
                             "group": {
                               "type": "string",
                               "enum": ["billing", "company", "preferences"]
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required", "group"]
@@ -8717,6 +8817,10 @@
                       "bookingFields",
                       "paymentIntents"
                     ]
+                  },
+                  "requirementsFingerprint": {
+                    "type": "string",
+                    "minLength": 1
                   },
                   "expiresAt": {
                     "type": "string",
@@ -10688,6 +10792,10 @@
                                   "items": {
                                     "type": "string"
                                   }
+                                },
+                                "maxLength": {
+                                  "type": "integer",
+                                  "exclusiveMinimum": 0
                                 }
                               },
                               "required": ["key", "label", "type", "required"]
@@ -10713,6 +10821,10 @@
                                 "group": {
                                   "type": "string",
                                   "enum": ["billing", "company", "preferences"]
+                                },
+                                "maxLength": {
+                                  "type": "integer",
+                                  "exclusiveMinimum": 0
                                 }
                               },
                               "required": ["key", "label", "type", "required", "group"]
@@ -11237,11 +11349,15 @@
                       },
                       "reason": {
                         "type": "string",
-                        "enum": ["unsupported_target", "forbidden_field"]
+                        "enum": ["unsupported_target", "forbidden_field", "value_too_long"]
                       },
                       "path": {
                         "type": "string",
                         "minLength": 1
+                      },
+                      "maxLength": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0
                       }
                     },
                     "required": ["kind", "reason"]
@@ -11746,6 +11862,10 @@
                               "items": {
                                 "type": "string"
                               }
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required"]
@@ -11771,6 +11891,10 @@
                             "group": {
                               "type": "string",
                               "enum": ["billing", "company", "preferences"]
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required", "group"]
@@ -12918,6 +13042,10 @@
                                   "items": {
                                     "type": "string"
                                   }
+                                },
+                                "maxLength": {
+                                  "type": "integer",
+                                  "exclusiveMinimum": 0
                                 }
                               },
                               "required": ["key", "label", "type", "required"]
@@ -12943,6 +13071,10 @@
                                 "group": {
                                   "type": "string",
                                   "enum": ["billing", "company", "preferences"]
+                                },
+                                "maxLength": {
+                                  "type": "integer",
+                                  "exclusiveMinimum": 0
                                 }
                               },
                               "required": ["key", "label", "type", "required", "group"]
@@ -13467,11 +13599,15 @@
                       },
                       "reason": {
                         "type": "string",
-                        "enum": ["unsupported_target", "forbidden_field"]
+                        "enum": ["unsupported_target", "forbidden_field", "value_too_long"]
                       },
                       "path": {
                         "type": "string",
                         "minLength": 1
+                      },
+                      "maxLength": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0
                       }
                     },
                     "required": ["kind", "reason"]
@@ -14875,10 +15011,12 @@
                             "properties": {
                               "firstName": {
                                 "type": "string",
+                                "maxLength": 255,
                                 "default": ""
                               },
                               "lastName": {
                                 "type": "string",
+                                "maxLength": 255,
                                 "default": ""
                               },
                               "email": {
@@ -14895,7 +15033,8 @@
                                 "default": ""
                               },
                               "phone": {
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 50
                               },
                               "personId": {
                                 "type": "string"

--- a/packages/catalog/openapi/storefront/catalog-booking.json
+++ b/packages/catalog/openapi/storefront/catalog-booking.json
@@ -554,6 +554,10 @@
                               "items": {
                                 "type": "string"
                               }
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required"]
@@ -579,6 +583,10 @@
                             "group": {
                               "type": "string",
                               "enum": ["billing", "company", "preferences"]
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required", "group"]
@@ -944,6 +952,10 @@
                       "bookingFields",
                       "paymentIntents"
                     ]
+                  },
+                  "requirementsFingerprint": {
+                    "type": "string",
+                    "minLength": 1
                   },
                   "expiresAt": {
                     "type": "string",
@@ -1512,6 +1524,10 @@
                               "items": {
                                 "type": "string"
                               }
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required"]
@@ -1537,6 +1553,10 @@
                             "group": {
                               "type": "string",
                               "enum": ["billing", "company", "preferences"]
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required", "group"]
@@ -1902,6 +1922,10 @@
                       "bookingFields",
                       "paymentIntents"
                     ]
+                  },
+                  "requirementsFingerprint": {
+                    "type": "string",
+                    "minLength": 1
                   },
                   "expiresAt": {
                     "type": "string",
@@ -2470,6 +2494,10 @@
                               "items": {
                                 "type": "string"
                               }
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required"]
@@ -2495,6 +2523,10 @@
                             "group": {
                               "type": "string",
                               "enum": ["billing", "company", "preferences"]
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required", "group"]
@@ -2860,6 +2892,10 @@
                       "bookingFields",
                       "paymentIntents"
                     ]
+                  },
+                  "requirementsFingerprint": {
+                    "type": "string",
+                    "minLength": 1
                   },
                   "expiresAt": {
                     "type": "string",
@@ -3437,6 +3473,10 @@
                               "items": {
                                 "type": "string"
                               }
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required"]
@@ -3462,6 +3502,10 @@
                             "group": {
                               "type": "string",
                               "enum": ["billing", "company", "preferences"]
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required", "group"]
@@ -3827,6 +3871,10 @@
                       "bookingFields",
                       "paymentIntents"
                     ]
+                  },
+                  "requirementsFingerprint": {
+                    "type": "string",
+                    "minLength": 1
                   },
                   "expiresAt": {
                     "type": "string",
@@ -4404,6 +4452,10 @@
                               "items": {
                                 "type": "string"
                               }
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required"]
@@ -4429,6 +4481,10 @@
                             "group": {
                               "type": "string",
                               "enum": ["billing", "company", "preferences"]
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required", "group"]
@@ -4794,6 +4850,10 @@
                       "bookingFields",
                       "paymentIntents"
                     ]
+                  },
+                  "requirementsFingerprint": {
+                    "type": "string",
+                    "minLength": 1
                   },
                   "expiresAt": {
                     "type": "string",
@@ -5362,6 +5422,10 @@
                               "items": {
                                 "type": "string"
                               }
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required"]
@@ -5387,6 +5451,10 @@
                             "group": {
                               "type": "string",
                               "enum": ["billing", "company", "preferences"]
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required", "group"]
@@ -5752,6 +5820,10 @@
                       "bookingFields",
                       "paymentIntents"
                     ]
+                  },
+                  "requirementsFingerprint": {
+                    "type": "string",
+                    "minLength": 1
                   },
                   "expiresAt": {
                     "type": "string",
@@ -6320,6 +6392,10 @@
                               "items": {
                                 "type": "string"
                               }
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required"]
@@ -6345,6 +6421,10 @@
                             "group": {
                               "type": "string",
                               "enum": ["billing", "company", "preferences"]
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required", "group"]
@@ -6710,6 +6790,10 @@
                       "bookingFields",
                       "paymentIntents"
                     ]
+                  },
+                  "requirementsFingerprint": {
+                    "type": "string",
+                    "minLength": 1
                   },
                   "expiresAt": {
                     "type": "string",
@@ -7133,6 +7217,10 @@
                               "items": {
                                 "type": "string"
                               }
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required"]
@@ -7158,6 +7246,10 @@
                             "group": {
                               "type": "string",
                               "enum": ["billing", "company", "preferences"]
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required", "group"]
@@ -8327,6 +8419,10 @@
                               "items": {
                                 "type": "string"
                               }
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required"]
@@ -8352,6 +8448,10 @@
                             "group": {
                               "type": "string",
                               "enum": ["billing", "company", "preferences"]
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required", "group"]
@@ -8717,6 +8817,10 @@
                       "bookingFields",
                       "paymentIntents"
                     ]
+                  },
+                  "requirementsFingerprint": {
+                    "type": "string",
+                    "minLength": 1
                   },
                   "expiresAt": {
                     "type": "string",
@@ -10688,6 +10792,10 @@
                                   "items": {
                                     "type": "string"
                                   }
+                                },
+                                "maxLength": {
+                                  "type": "integer",
+                                  "exclusiveMinimum": 0
                                 }
                               },
                               "required": ["key", "label", "type", "required"]
@@ -10713,6 +10821,10 @@
                                 "group": {
                                   "type": "string",
                                   "enum": ["billing", "company", "preferences"]
+                                },
+                                "maxLength": {
+                                  "type": "integer",
+                                  "exclusiveMinimum": 0
                                 }
                               },
                               "required": ["key", "label", "type", "required", "group"]
@@ -11237,11 +11349,15 @@
                       },
                       "reason": {
                         "type": "string",
-                        "enum": ["unsupported_target", "forbidden_field"]
+                        "enum": ["unsupported_target", "forbidden_field", "value_too_long"]
                       },
                       "path": {
                         "type": "string",
                         "minLength": 1
+                      },
+                      "maxLength": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0
                       }
                     },
                     "required": ["kind", "reason"]
@@ -11746,6 +11862,10 @@
                               "items": {
                                 "type": "string"
                               }
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required"]
@@ -11771,6 +11891,10 @@
                             "group": {
                               "type": "string",
                               "enum": ["billing", "company", "preferences"]
+                            },
+                            "maxLength": {
+                              "type": "integer",
+                              "exclusiveMinimum": 0
                             }
                           },
                           "required": ["key", "label", "type", "required", "group"]
@@ -12918,6 +13042,10 @@
                                   "items": {
                                     "type": "string"
                                   }
+                                },
+                                "maxLength": {
+                                  "type": "integer",
+                                  "exclusiveMinimum": 0
                                 }
                               },
                               "required": ["key", "label", "type", "required"]
@@ -12943,6 +13071,10 @@
                                 "group": {
                                   "type": "string",
                                   "enum": ["billing", "company", "preferences"]
+                                },
+                                "maxLength": {
+                                  "type": "integer",
+                                  "exclusiveMinimum": 0
                                 }
                               },
                               "required": ["key", "label", "type", "required", "group"]
@@ -13467,11 +13599,15 @@
                       },
                       "reason": {
                         "type": "string",
-                        "enum": ["unsupported_target", "forbidden_field"]
+                        "enum": ["unsupported_target", "forbidden_field", "value_too_long"]
                       },
                       "path": {
                         "type": "string",
                         "minLength": 1
+                      },
+                      "maxLength": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0
                       }
                     },
                     "required": ["kind", "reason"]
@@ -14875,10 +15011,12 @@
                             "properties": {
                               "firstName": {
                                 "type": "string",
+                                "maxLength": 255,
                                 "default": ""
                               },
                               "lastName": {
                                 "type": "string",
+                                "maxLength": 255,
                                 "default": ""
                               },
                               "email": {
@@ -14895,7 +15033,8 @@
                                 "default": ""
                               },
                               "phone": {
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 50
                               },
                               "personId": {
                                 "type": "string"

--- a/packages/catalog/src/booking-engine/billing-field-widths.test.ts
+++ b/packages/catalog/src/booking-engine/billing-field-widths.test.ts
@@ -1,0 +1,70 @@
+/**
+ * The Session's published billing widths and the Booking create's enforced
+ * ones are the same widths.
+ *
+ * This is the whole of voyant#4734 as one assertion. The two numbers live in
+ * two packages and nothing used to compare them, so `address.postal` was
+ * published unbounded, accepted at 25 characters by the Session `PATCH`, and
+ * refused at 20 by the Booking create — after the card had been captured, and
+ * under a field name (`contactPostalCode`) the client had never sent.
+ *
+ * Both sides are driven, not restated: the widths come out of
+ * `defaultBookingFields()` exactly as a storefront reads them off
+ * `requirements.bookingFields`, and the refusal comes out of
+ * `bookingCreateSchema`, which is the schema the commit actually parses
+ * through. Asserting `20 === 20` against a hand-copied constant would pass on
+ * the day someone changes one of them, which is the failure this exists to
+ * catch.
+ */
+import { defaultBookingFields } from "@voyant-travel/catalog-contracts/booking-engine/requirements-defaults"
+import { BOOKING_SELECTION_BILLING_MAX_LENGTHS } from "@voyant-travel/catalog-contracts/booking-engine/selection-contracts"
+import { bookingCreateSchema } from "@voyant-travel/finance"
+import { describe, expect, it } from "vitest"
+
+import { BOOKING_SESSION_BILLING_FIELD_TARGETS } from "./sessions-production.js"
+
+function publishedMaxLength(key: string): number | undefined {
+  return defaultBookingFields().find((field) => field.key === key)?.maxLength
+}
+
+/**
+ * Whether the create schema objects to *this* field, ignoring whatever else
+ * the surrounding payload is missing. Asked this way rather than by building a
+ * fully valid create: the question is what the schema does to one value, and a
+ * payload that has to stay valid as the rest of the create evolves is a
+ * payload that will eventually be fixed by weakening the assertion.
+ */
+function rejectsField(target: string, value: string): boolean {
+  const result = bookingCreateSchema.safeParse({ [target]: value })
+  return (
+    !result.success &&
+    result.error.issues.some((issue) => issue.path.length === 1 && issue.path[0] === target)
+  )
+}
+
+describe("billing field widths", () => {
+  const entries = Object.entries(BOOKING_SESSION_BILLING_FIELD_TARGETS) as Array<
+    [keyof typeof BOOKING_SELECTION_BILLING_MAX_LENGTHS, string]
+  >
+
+  it.each(
+    entries.filter(([key]) => key.startsWith("address.")),
+  )("publishes %s under the width the Booking create enforces on %s", (key, target) => {
+    const published = publishedMaxLength(key)
+    // Every billing address field the selection carries is advertised. Three
+    // of the six were not, which is why a client could not pre-validate the
+    // one that bit.
+    expect(published).toBe(BOOKING_SELECTION_BILLING_MAX_LENGTHS[key])
+
+    expect(rejectsField(target, "x".repeat(published!))).toBe(false)
+    expect(rejectsField(target, "x".repeat(published! + 1))).toBe(true)
+  })
+
+  it("names every billing key the selection bounds", () => {
+    // The mapping and the widths must cover the same keys, or a field gets a
+    // published bound the commit never applies — or worse, the reverse.
+    expect(Object.keys(BOOKING_SESSION_BILLING_FIELD_TARGETS).sort()).toEqual(
+      Object.keys(BOOKING_SELECTION_BILLING_MAX_LENGTHS).sort(),
+    )
+  })
+})

--- a/packages/catalog/src/booking-engine/errors.ts
+++ b/packages/catalog/src/booking-engine/errors.ts
@@ -39,8 +39,14 @@ export type BookingEngineErrorCode =
 
 /**
  * A selection payload the Booking Session plane refuses to derive from —
- * either the target does not take a selection at all, or the payload carried a
- * key only the engine or an operator may write.
+ * the target does not take a selection at all, the payload carried a key only
+ * the engine or an operator may write, or a value is longer than the width the
+ * requirements publish for it.
+ *
+ * `value_too_long` carries `maxLength` because the caller has to be able to
+ * act on it without a lookup table: the refusal is the whole point of moving
+ * this check to the write path, and a refusal that only says "too long"
+ * reproduces in miniature the problem it exists to fix (voyant#4734).
  *
  * Lives here rather than beside the Session service because both the Session
  * lifecycle and the stateless Offer Preview raise and recognise it, and a
@@ -48,8 +54,9 @@ export type BookingEngineErrorCode =
  */
 export class InvalidBookingSessionSelectionError extends Error {
   constructor(
-    readonly reason: "unsupported_target" | "forbidden_field",
+    readonly reason: "unsupported_target" | "forbidden_field" | "value_too_long",
     readonly path?: string,
+    readonly maxLength?: number,
   ) {
     super(`booking_session_selection_${reason}${path ? `:${path}` : ""}`)
   }

--- a/packages/catalog/src/booking-engine/sessions-production.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-production.test.ts
@@ -45,6 +45,7 @@ import { defaultRequirementsFlags } from "@voyant-travel/catalog-contracts/booki
 import type { SQL } from "drizzle-orm"
 import { PgDialect } from "drizzle-orm/pg-core"
 import type { SourceAdapter } from "../adapter/contract.js"
+import { InvalidBookingSessionSelectionError } from "./errors.js"
 import type { OwnedBookingHandler } from "./owned-handler.js"
 import { createOwnedBookingHandlerRegistry } from "./owned-handler.js"
 import { createSourceAdapterRegistry } from "./registry.js"
@@ -246,6 +247,60 @@ describe("normalizeProductSelection", () => {
     expect(normalized.billing).toEqual({
       address: { region: "Ile-de-France", country: "FR" },
     })
+  })
+
+  it("refuses a billing value the commit would refuse, at the step that can still edit it", () => {
+    // voyant#4734. `bookingSelectionPublicV1` has carried `postal: max(20)`
+    // since #4298 with a comment promising that "an address this schema admits
+    // cannot be rejected later by the commit" — but this function projects the
+    // billing block value by value instead of parsing it, so the bound never
+    // ran. A 25-character postal code was accepted here a dozen times and
+    // refused once, by the Booking's own write, after the card was captured.
+    let thrown: unknown
+    try {
+      normalizeProductSelection(PRODUCT_TARGET, {
+        billing: { address: { postal: "0".repeat(25), country: "RO" } },
+      })
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeInstanceOf(InvalidBookingSessionSelectionError)
+    expect(thrown).toMatchObject({
+      reason: "value_too_long",
+      // The name the caller wrote, not `contactPostalCode` — the commit
+      // reported the field under a name no client had ever sent.
+      path: "billing.address.postal",
+      maxLength: 20,
+    })
+  })
+
+  it("still accepts a billing value of exactly the published width", () => {
+    const normalized = normalizeProductSelection(PRODUCT_TARGET, {
+      billing: { address: { postal: `  ${"0".repeat(20)}  `, country: "RO" } },
+    })
+
+    // Measured after trimming, because that is the value the commit writes.
+    expect(normalized.billing).toEqual({
+      address: { postal: "0".repeat(20), country: "RO" },
+    })
+  })
+
+  it.each([
+    ["a contact name", { billing: { contact: { firstName: "A".repeat(256) } } }, 255],
+    ["a country that is not an ISO alpha-2 code", { billing: { address: { country: "USA" } } }, 2],
+    ["a traveler name", { travelers: [{ firstName: "A".repeat(256), lastName: "Lovelace" }] }, 255],
+  ])("refuses %s the same way", (_label, selection, maxLength) => {
+    // The same projection dropped the bounds off every free-text field, not
+    // only the postal code the incident happened to hit.
+    expect(() => normalizeProductSelection(PRODUCT_TARGET, selection)).toThrow(
+      /booking_session_selection_value_too_long/,
+    )
+    try {
+      normalizeProductSelection(PRODUCT_TARGET, selection)
+    } catch (error) {
+      expect(error).toMatchObject({ maxLength })
+    }
   })
 
   it.each([

--- a/packages/catalog/src/booking-engine/sessions-production.ts
+++ b/packages/catalog/src/booking-engine/sessions-production.ts
@@ -15,8 +15,12 @@ import {
   paxBandsAllowedTotalFrom,
 } from "@voyant-travel/catalog-contracts/booking-engine/requirements-defaults"
 import {
+  BOOKING_SELECTION_BILLING_MAX_LENGTHS,
   BOOKING_SELECTION_PRIVILEGED_KEYS,
   BOOKING_SELECTION_PUBLIC_KEYS,
+  BOOKING_SELECTION_TRAVELER_MAX_LENGTHS,
+  type BookingSelectionBillingFieldKey,
+  type BookingSelectionTravelerFieldKey,
 } from "@voyant-travel/catalog-contracts/booking-engine/selection-contracts"
 import { bookingSessionAudienceForActorV1 } from "@voyant-travel/catalog-contracts/booking-engine/session-contracts"
 import type { AnalyticsPort } from "@voyant-travel/core/analytics"
@@ -825,25 +829,55 @@ async function resolveBilling(
   return personId ? { ...contact, personId: personId.id, organizationId: null } : null
 }
 
+/**
+ * Which Booking `contact_*` field each billing selection path lands in.
+ *
+ * Exported and load-bearing rather than inlined, because the rename it
+ * performs is invisible from outside and was reported as part of the bug: the
+ * commit refused `contactPostalCode`, a name no client had ever sent, for a
+ * value the client wrote as `address.postal` (voyant#4734). A caller that has
+ * to map the two by hand writes a table like this one and gets it wrong; the
+ * one the engine actually uses is the one worth publishing.
+ *
+ * It is also what makes the widths checkable end to end: the width the Session
+ * publishes for a key and the width the Booking create enforces on its target
+ * are two numbers in two packages, and this is the only thing that says which
+ * two are supposed to agree.
+ */
+export const BOOKING_SESSION_BILLING_FIELD_TARGETS = {
+  "contact.firstName": "contactFirstName",
+  "contact.lastName": "contactLastName",
+  "contact.phone": "contactPhone",
+  "address.line1": "contactAddressLine1",
+  "address.line2": "contactAddressLine2",
+  "address.city": "contactCity",
+  "address.region": "contactRegion",
+  "address.postal": "contactPostalCode",
+  "address.country": "contactCountry",
+} as const satisfies Record<BookingSelectionBillingFieldKey, string>
+
 function billingContact(payload: Record<string, unknown>) {
   const billing = asRecord(payload.billing)
   const contact = asRecord(billing?.contact)
   const address = asRecord(billing?.address)
   const staffBooking = asRecord(payload.staffBooking)
   const trim = (value: unknown) => (typeof value === "string" && value.trim() ? value.trim() : null)
+  const group = { contact, address }
+  const mapped: Record<string, string | null> = {}
+  for (const [path, target] of Object.entries(BOOKING_SESSION_BILLING_FIELD_TARGETS)) {
+    const [bucket, key] = path.split(".") as ["contact" | "address", string]
+    mapped[target] = trim(group[bucket]?.[key])
+  }
   return {
     personId: trim(staffBooking?.personId),
     organizationId: trim(staffBooking?.organizationId),
-    contactFirstName: trim(contact?.firstName),
-    contactLastName: trim(contact?.lastName),
+    // Not in the table: `email` is bounded by shape rather than by width, and
+    // its selection key and target name already agree.
     contactEmail: trim(contact?.email),
-    contactPhone: trim(contact?.phone),
-    contactCountry: trim(address?.country),
-    contactRegion: trim(address?.region),
-    contactCity: trim(address?.city),
-    contactAddressLine1: trim(address?.line1),
-    contactAddressLine2: trim(address?.line2),
-    contactPostalCode: trim(address?.postal),
+    ...(mapped as Record<
+      (typeof BOOKING_SESSION_BILLING_FIELD_TARGETS)[BookingSelectionBillingFieldKey],
+      string | null
+    >),
   }
 }
 
@@ -1260,10 +1294,10 @@ export function normalizeBookingSelection(
           ? billing.buyerType
           : undefined,
       contact: pruneEmpty({
-        firstName: stringValue(billingContact?.firstName),
-        lastName: stringValue(billingContact?.lastName),
+        firstName: boundedBillingValue(billingContact?.firstName, "contact.firstName"),
+        lastName: boundedBillingValue(billingContact?.lastName, "contact.lastName"),
         email: stringValue(billingContact?.email),
-        phone: stringValue(billingContact?.phone),
+        phone: boundedBillingValue(billingContact?.phone, "contact.phone"),
       }),
       // The whole declared address, not just the country. The tracer
       // (voyant#4039) projected the rest away, so a caller that filled the
@@ -1272,12 +1306,12 @@ export function normalizeBookingSelection(
       // (voyant#4290); the other four were declared all along and simply
       // never survived to the commit.
       address: pruneEmpty({
-        line1: stringValue(billingAddress?.line1),
-        line2: stringValue(billingAddress?.line2),
-        city: stringValue(billingAddress?.city),
-        region: stringValue(billingAddress?.region),
-        postal: stringValue(billingAddress?.postal),
-        country: stringValue(billingAddress?.country),
+        line1: boundedBillingValue(billingAddress?.line1, "address.line1"),
+        line2: boundedBillingValue(billingAddress?.line2, "address.line2"),
+        city: boundedBillingValue(billingAddress?.city, "address.city"),
+        region: boundedBillingValue(billingAddress?.region, "address.region"),
+        postal: boundedBillingValue(billingAddress?.postal, "address.postal"),
+        country: boundedBillingValue(billingAddress?.country, "address.country"),
       }),
     }),
     travelers: arrayValue(source.travelers)
@@ -1457,15 +1491,15 @@ function normalizeOptionSelection(value: unknown): Record<string, unknown> | nul
   return normalized.optionId && quantity ? normalized : null
 }
 
-function normalizeTraveler(value: unknown): Record<string, unknown> | null {
+function normalizeTraveler(value: unknown, index: number): Record<string, unknown> | null {
   const record = asRecord(value)
   if (!record) return null
   const normalized = pruneEmpty({
     rowId: stringValue(record.rowId),
-    firstName: stringValue(record.firstName),
-    lastName: stringValue(record.lastName),
+    firstName: boundedTravelerValue(record.firstName, "firstName", index),
+    lastName: boundedTravelerValue(record.lastName, "lastName", index),
     email: stringValue(record.email),
-    phone: stringValue(record.phone),
+    phone: boundedTravelerValue(record.phone, "phone", index),
     band: stringValue(record.band),
     travelerCategory: stringValue(record.travelerCategory),
     isPrimary: record.isPrimary === true ? true : undefined,
@@ -1539,6 +1573,50 @@ function arrayValue(value: unknown): unknown[] | undefined {
 
 function stringValue(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined
+}
+
+/**
+ * A billing value, refused rather than stored when it is wider than the
+ * commit will accept.
+ *
+ * This projection is why the widths on `bookingSelectionPublicV1` never bound
+ * anything: the Session does not parse the selection, it reads it field by
+ * field, so a `max()` on the schema was documentation. The commit's own
+ * `contact_*` write did parse, which put the only enforcement on the far side
+ * of the card capture — a 25-character postal code accepted at every step and
+ * refused once, when nothing could still be edited (voyant#4734).
+ *
+ * The bound is read from the same table the schema and
+ * `requirements.bookingFields` read, so the three cannot drift apart again,
+ * and the path is the one the caller wrote.
+ */
+function boundedBillingValue(
+  value: unknown,
+  key: BookingSelectionBillingFieldKey,
+): string | undefined {
+  return boundedValue(value, `billing.${key}`, BOOKING_SELECTION_BILLING_MAX_LENGTHS[key])
+}
+
+/** {@link boundedBillingValue} for a traveler row; the path carries its index. */
+function boundedTravelerValue(
+  value: unknown,
+  key: BookingSelectionTravelerFieldKey,
+  index: number,
+): string | undefined {
+  return boundedValue(
+    value,
+    `travelers.${index}.${key}`,
+    BOOKING_SELECTION_TRAVELER_MAX_LENGTHS[key],
+  )
+}
+
+function boundedValue(value: unknown, path: string, maxLength: number): string | undefined {
+  const trimmed = stringValue(value)
+  // Measured after trimming, because that is the value the commit will write.
+  if (trimmed !== undefined && trimmed.length > maxLength) {
+    throw new InvalidBookingSessionSelectionError("value_too_long", path, maxLength)
+  }
+  return trimmed
 }
 
 function positiveInteger(value: unknown): number | undefined {

--- a/packages/catalog/src/booking-engine/sessions-service.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-service.test.ts
@@ -412,6 +412,134 @@ describe("Booking Session v1 owned tracer", () => {
     expect(harness.repository.sessions.get(session.id)?.state).toBe("active")
   })
 
+  it("settles a paid Session whose own shopping clock has already lapsed", async () => {
+    // voyant#4733. The third half of the same story: the refusal path stopped
+    // tearing the Quote and Hold down, but the Session's own TTL still ran, and
+    // the commit preflight expired a lapsed Session before looking at who was
+    // asking. That expiry releases the Hold, expires the Quote and moves the
+    // Session out of `active` — every input the settlement needs — so the
+    // retry that arrived next answered `session_expired`, and so did every one
+    // after it.
+    //
+    // The window was minutes: the payment session's expiry is the earliest of
+    // the Session, Quote and Hold, so a settlement that failed once for any
+    // reason usually had less than the Session's remaining TTL to recover.
+    const payment = createPaymentHarness()
+    // The Session is the earliest of the three clocks, which is the reported
+    // shape: the payment session's own expiry is `earliest(session, quote,
+    // hold)`, and in the live case it was under four minutes from capture.
+    const harness = createHarness(
+      { sessionTtlMs: 60_000, quoteTtlMs: 600_000, holdTtlMs: 600_000 },
+      payment.ports,
+    )
+    const { session, quote, hold } = await createQuoteAndHold(harness)
+    payment.established = { quoteId: quote.id, holdId: hold.id }
+    payment.inFlight = true
+    harness.advance(120_000)
+
+    const settled = await harness.module.commitPaidSession({
+      bookingSessionId: session.id,
+      paymentSessionId: "payment_session_1",
+    })
+
+    expect(harness.inventory.bookingIds).toEqual([settled.bookingId])
+    expect(harness.repository.quotes.get(quote.id)?.state).toBe("consumed")
+  })
+
+  it("does not sweep away a lapsed Session whose money is with a processor", async () => {
+    // The same door, opened by the expiry sweep rather than the commit. Both
+    // reach `expireSession`, which is where the guard lives.
+    const payment = createPaymentHarness()
+    const harness = createHarness({ sessionTtlMs: 60_000 }, payment.ports)
+    const { session, quote, hold } = await createQuoteAndHold(harness)
+    payment.inFlight = true
+    harness.advance(120_000)
+
+    const swept = await harness.module.expireDueSessions(
+      { limit: 10 },
+      { actorKind: "staff", staffAuthority: { admitted: true, reason: "sweep" } },
+    )
+
+    // Counted as skipped, not as expired: a sweep that reported work it did not
+    // do would go on reporting it every pass.
+    expect(swept).toEqual({ expired: 0 })
+    expect(harness.repository.sessions.get(session.id)?.state).toBe("active")
+    expect(harness.repository.quotes.get(quote.id)?.state).toBe("active")
+    expect(harness.repository.holds.get(hold.id)?.state).toBe("active")
+  })
+
+  it("sweeps a lapsed Session once its handoff has lapsed with it", async () => {
+    // The other direction, which the guard must not break: a shopper who opened
+    // a checkout page and walked away leaves no settled money, so the Session
+    // is still ordinary rubbish and the sweep must still collect it.
+    const payment = createPaymentHarness()
+    const harness = createHarness({ sessionTtlMs: 60_000 }, payment.ports)
+    const { session } = await createQuoteAndHold(harness)
+    harness.advance(120_000)
+
+    const swept = await harness.module.expireDueSessions(
+      { limit: 10 },
+      { actorKind: "staff", staffAuthority: { admitted: true, reason: "sweep" } },
+    )
+
+    expect(swept).toEqual({ expired: 1 })
+    expect(harness.repository.sessions.get(session.id)?.state).toBe("expired")
+  })
+
+  it("refuses to abandon a Session whose money is with a processor", async () => {
+    // Abandon tears down exactly what a settlement needs, and it was the one
+    // lifecycle door with no in-flight guard on it — which is unfortunate,
+    // because it is what a "start over" button calls.
+    const payment = createPaymentHarness()
+    const harness = createHarness({}, payment.ports)
+    const { session, quote, hold } = await createQuoteAndHold(harness)
+    payment.inFlight = true
+
+    const outcome = await harness.module.abandonSession(
+      session.id,
+      { expectedRevision: session.revision, idempotencyKey: "abandon_while_paying" },
+      ANONYMOUS_ACCESS,
+    )
+
+    expect(outcome).toEqual({
+      kind: "rejected",
+      error: { kind: "payment_in_flight", nextAction: "await_payment_outcome" },
+    })
+    expect(harness.repository.sessions.get(session.id)?.state).toBe("active")
+    expect(harness.repository.quotes.get(quote.id)?.state).toBe("active")
+    expect(harness.repository.holds.get(hold.id)?.state).toBe("active")
+  })
+
+  it("publishes a requirementsFingerprint a Commit accepts, without a fresh Quote", async () => {
+    // voyant#4733's first trap: Commit requires a fingerprint and only a Quote
+    // used to produce one, so a host that lost its Quote response had no call
+    // left that could finish a booking it had already been paid for — quoting
+    // is refused while the payment is settled, and correctly so.
+    const payment = createPaymentHarness()
+    const harness = createHarness({}, payment.ports)
+    const { session, quote, hold } = await createQuoteAndHold(harness)
+
+    const resumed = await harness.module.resumeSession(session.id, ANONYMOUS_ACCESS)
+    if (resumed.kind !== "session_resumed") throw new Error("session not resumed")
+    expect(resumed.session.requirementsFingerprint).toBe(quote.requirementsFingerprint)
+
+    payment.established = true
+    const committed = await harness.module.commitSession(
+      session.id,
+      {
+        expectedRevision: resumed.session.revision,
+        quoteId: quote.id,
+        // The value read off the Session, not off the Quote response.
+        requirementsFingerprint: resumed.session.requirementsFingerprint!,
+        holdId: hold.id,
+        idempotencyKey: "commit_from_session_fingerprint",
+      },
+      ANONYMOUS_ACCESS,
+    )
+
+    expect(committed).toMatchObject({ kind: "commit_result", outcome: { kind: "committed" } })
+  })
+
   it("commits a paid Session without the shopper capability and converges retries", async () => {
     const payment = createPaymentHarness()
     payment.established = true

--- a/packages/catalog/src/booking-engine/sessions-service.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-service.test.ts
@@ -446,6 +446,30 @@ describe("Booking Session v1 owned tracer", () => {
     expect(harness.repository.quotes.get(quote.id)?.state).toBe("consumed")
   })
 
+  it("settles a lapsed Session on a payments port that cannot say what is in flight", async () => {
+    // `hasInFlight` is optional on the port, so a runtime that omits it answers
+    // `undefined` — and a guard that asks it reads that as "no money here" and
+    // expires the Session the settlement came to settle. The authority the
+    // caller holds is the fact that does not depend on anyone implementing
+    // anything, so the preflight keys on that too.
+    const payment = createPaymentHarness()
+    const harness = createHarness(
+      { sessionTtlMs: 60_000, quoteTtlMs: 600_000, holdTtlMs: 600_000 },
+      { ...payment.ports, hasInFlight: undefined },
+    )
+    const { session, quote, hold } = await createQuoteAndHold(harness)
+    payment.established = { quoteId: quote.id, holdId: hold.id }
+    harness.advance(120_000)
+
+    const settled = await harness.module.commitPaidSession({
+      bookingSessionId: session.id,
+      paymentSessionId: "payment_session_1",
+    })
+
+    expect(harness.inventory.bookingIds).toEqual([settled.bookingId])
+    expect(harness.repository.quotes.get(quote.id)?.state).toBe("consumed")
+  })
+
   it("does not sweep away a lapsed Session whose money is with a processor", async () => {
     // The same door, opened by the expiry sweep rather than the commit. Both
     // reach `expireSession`, which is where the guard lives.

--- a/packages/catalog/src/booking-engine/sessions-service.ts
+++ b/packages/catalog/src/booking-engine/sessions-service.ts
@@ -1413,7 +1413,22 @@ export function createBookingSessionModule(
           (session.target.kind === "catalog_item" && session.state === "supplier_pending") ||
           (session.target.kind === "trip_snapshot" &&
             (session.state === "supplier_pending" || session.state === "component_pending"))
-        if (!durableContinuation && session.state === "active" && session.expiresAt <= at) {
+        // `!settling` as well as the guard inside `expireSession`, and not
+        // instead of it. That guard asks the payments port whether money is
+        // outstanding, and `hasInFlight` is optional on the port — a runtime
+        // that omits it answers `undefined`, the guard reads false, and a
+        // settlement whose TTL had elapsed would expire the very Session it
+        // came to settle. The authority the caller is holding is the fact that
+        // does not depend on anyone else implementing anything: this is a
+        // settlement, so the shopping clock is not evidence about it. The port
+        // probe still earns its place — it is what protects the sweep and the
+        // shopper-facing paths, which carry no settlement authority at all.
+        if (
+          !durableContinuation &&
+          !settling &&
+          session.state === "active" &&
+          session.expiresAt <= at
+        ) {
           await expireSession(repository, options.ports, session, access, at, tx)
         }
         if (session.state !== "active" && !durableContinuation) {

--- a/packages/catalog/src/booking-engine/sessions-service.ts
+++ b/packages/catalog/src/booking-engine/sessions-service.ts
@@ -838,7 +838,7 @@ export function createBookingSessionModule(
       }
       return {
         kind: "session_created",
-        session: serializeSession(existing, await sessionRequirements(existing, at), access),
+        session: await serializeSession(existing, await sessionRequirements(existing, at), access),
       }
     }
     let statePayload: Record<string, unknown>
@@ -885,12 +885,12 @@ export function createBookingSessionModule(
       }
       return {
         kind: "session_created",
-        session: serializeSession(created, await sessionRequirements(created, at), access),
+        session: await serializeSession(created, await sessionRequirements(created, at), access),
       }
     }
     return {
       kind: "session_created",
-      session: serializeSession(session, await sessionRequirements(session, at), access),
+      session: await serializeSession(session, await sessionRequirements(session, at), access),
     }
   }
 
@@ -952,7 +952,7 @@ export function createBookingSessionModule(
         })
         return {
           kind: "session_resumed",
-          session: serializeSessionView(
+          session: await serializeSessionView(
             session,
             access,
             await sessionRequirements(session, at, tx),
@@ -1010,7 +1010,7 @@ export function createBookingSessionModule(
         await appendSessionAudit(repository, session, "adopt", access, at)
         const outcome: BookingSessionOutcomeV1 = {
           kind: "session_adopted",
-          session: serializeSessionView(
+          session: await serializeSessionView(
             session,
             access,
             await sessionRequirements(session, at, tx),
@@ -1070,7 +1070,7 @@ export function createBookingSessionModule(
         })
         const outcome: BookingSessionOutcomeV1 = {
           kind: "session_renewed",
-          session: serializeSession(session, undefined, access),
+          session: await serializeSession(session, undefined, access),
         }
         await repository.completeOperation({ id: claim.id, outcome })
         return outcome
@@ -1124,7 +1124,11 @@ export function createBookingSessionModule(
         await appendSessionAudit(repository, session, "update", access, at)
         const outcome: BookingSessionOutcomeV1 = {
           kind: "session_updated",
-          session: serializeSession(session, await sessionRequirements(session, at, tx), access),
+          session: await serializeSession(
+            session,
+            await sessionRequirements(session, at, tx),
+            access,
+          ),
         }
         await repository.completeOperation({ id: claim.id, outcome })
         return outcome
@@ -1190,7 +1194,7 @@ export function createBookingSessionModule(
           kind: "quote_created",
           // The compose call already derived requirements for this target;
           // publish those rather than re-deriving them for the record.
-          session: serializeSession(session, requirements, access),
+          session: await serializeSession(session, requirements, access),
           quote: serializeQuote(quote),
         }
         await repository.completeOperation({ id: claim.id, outcome })
@@ -1298,7 +1302,7 @@ export function createBookingSessionModule(
         })
         const outcome: BookingSessionOutcomeV1 = {
           kind: "hold_created",
-          session: serializeSession(session, undefined, access),
+          session: await serializeSession(session, undefined, access),
           hold: serializeHold(hold, access),
         }
         await repository.completeOperation({ id: claim.id, outcome })
@@ -1341,6 +1345,15 @@ export function createBookingSessionModule(
         const revisionRejected = rejectRevision(input.expectedRevision, session)
         if (revisionRejected) return completeAndReturn(repository, claim.id, revisionRejected)
 
+        // Abandon tears down exactly what a settlement needs — the Hold, the
+        // Quote, the `active` state — so it is refused for the same reason
+        // quoting and re-selecting are. The one path that used to be missing
+        // this guard was also the one a "give up and start over" button calls.
+        const abandoningWhilePaying = await rejectWhilePaymentInFlight(session)
+        if (abandoningWhilePaying) {
+          return completeAndReturn(repository, claim.id, abandoningWhilePaying)
+        }
+
         session.state = "abandoned"
         session.revision += 1
         session.updatedAt = at
@@ -1358,7 +1371,7 @@ export function createBookingSessionModule(
         await appendSessionAudit(repository, session, "abandon", access, at)
         const outcome: BookingSessionOutcomeV1 = {
           kind: "session_abandoned",
-          session: serializeSession(session, undefined, access),
+          session: await serializeSession(session, undefined, access),
         }
         await repository.completeOperation({ id: claim.id, outcome })
         return outcome
@@ -1946,8 +1959,12 @@ export function createBookingSessionModule(
         await repository.withSessionTransaction(candidate.id, async (tx) => {
           const session = await repository.getSession(candidate.id)
           if (session?.state !== "active" || session.expiresAt > at) return
-          await expireSession(repository, options.ports, session, access, at, tx)
-          expired += 1
+          // Not `expired += 1` unconditionally: a Session holding settled money
+          // is skipped, and a sweep that counted it would report work it did
+          // not do — and would keep reporting it on every pass.
+          if (await expireSession(repository, options.ports, session, access, at, tx)) {
+            expired += 1
+          }
         })
       }
       return { expired }
@@ -2039,7 +2056,13 @@ async function consumeCommittedSources(input: {
         currentSession?.state === "consumed" ? "consumed" : "expired",
       )
     }
-    if (!persistedSourcedCommit && currentSession.expiresAt <= currentAt) {
+    // Not for a settlement, for the same reason the revision is not: the
+    // Session's expiry is a shopping clock, and a payment that is already
+    // captured is not shopping. Refusing here answered `session_expired` to
+    // every retry of a Commit whose money had landed, which is the state
+    // voyant#4733 was reported from — money captured, no Booking, and no call
+    // that could produce one.
+    if (!persistedSourcedCommit && !settling && currentSession.expiresAt <= currentAt) {
       throw new CommitSessionStateError("expired")
     }
     const currentQuote = settling
@@ -2230,7 +2253,9 @@ async function consumeCompositeCommittedSources(input: {
         currentSession?.state === "consumed" ? "consumed" : "expired",
       )
     }
-    if (!continuing && currentSession.expiresAt <= currentAt) {
+    // Exempt for a settlement, as on the single-Booking path above: the
+    // shopping clock says nothing about money a processor already has.
+    if (!continuing && !settling && currentSession.expiresAt <= currentAt) {
       throw new CommitSessionStateError("expired")
     }
     const currentQuote = settling
@@ -2441,6 +2466,35 @@ async function expireSessionInSessionTransaction(
   })
 }
 
+/**
+ * Retire a lapsed Session — **unless its money is with a processor.**
+ *
+ * A Booking Session's expiry is a shopping clock: it exists to give a seat
+ * back when nobody is coming for it. Once a payment is settled nobody is
+ * shopping, and the clock is measuring the wrong thing. Expiring anyway
+ * releases the Hold, expires the Quote and moves the Session out of `active`,
+ * which is every input the settlement Commit needs — so the settlement that
+ * arrives next answers `session_expired`, and so does every retry after it.
+ * The money stays captured and there is no sequence of calls that produces a
+ * booking (voyant#4733).
+ *
+ * The window this closes was minutes wide, not hours: the payment session's
+ * own `expiresAt` is the earliest of the Session, Quote and Hold, so a
+ * settlement that failed once for any reason — a validation refusal, a
+ * transient error, a slow processor callback — usually had less than the
+ * Session's remaining TTL to succeed on retry.
+ *
+ * One guard rather than one per call site, because every path that expires a
+ * Session has the same reason not to: the commit preflight, the sweep, and the
+ * lapsed-Session preamble on quote/update/hold all reach here. `hasInFlight`
+ * is the same predicate that already freezes those operations, and its
+ * handoff arm lapses on the Session's own clock, so only **settled** money
+ * ever holds a Session open past its expiry — a checkout page the shopper
+ * abandoned does not.
+ *
+ * Returns whether the Session was actually retired, so a sweep counts what it
+ * did rather than what it looked at.
+ */
 async function expireSession(
   repository: BookingSessionRepository,
   ports: BookingSessionModulePorts,
@@ -2448,7 +2502,8 @@ async function expireSession(
   access: BookingSessionAccessContext,
   now: Date,
   tx: unknown,
-): Promise<void> {
+): Promise<boolean> {
+  if (await ports.payments?.hasInFlight?.({ bookingSessionId: session.id })) return false
   await releaseLiveHolds(repository, ports, session, access, now, tx)
   await ports.payments?.expirePending({ tx, bookingSessionId: session.id, at: now })
   for (const quote of await repository.listActiveQuotes(session.id)) {
@@ -2460,6 +2515,7 @@ async function expireSession(
   session.updatedAt = now
   await repository.saveSession(session)
   await appendSessionAudit(repository, session, "expire", access, now)
+  return true
 }
 
 async function persistCommitFailureState(
@@ -2607,6 +2663,7 @@ function invalidSelectionOutcome(error: unknown): BookingSessionOutcomeV1 | null
       kind: "invalid_selection",
       reason: error.reason,
       ...(error.path ? { path: error.path } : {}),
+      ...(error.maxLength ? { maxLength: error.maxLength } : {}),
     },
   }
 }
@@ -2763,11 +2820,11 @@ function resolveSessionScope(scope: BookingSessionScopeV1 | undefined): BookingS
   }
 }
 
-function serializeSession(
+async function serializeSession(
   session: BookingSessionInternalRecord,
   requirements?: BookingRequirementsV1,
   access?: BookingSessionAccessContext,
-): BookingSessionRecordV1 {
+): Promise<BookingSessionRecordV1> {
   const redactComposite = session.target.kind === "trip_snapshot" && access?.actorKind !== "staff"
   return {
     id: session.id,
@@ -2777,19 +2834,21 @@ function serializeSession(
     state: session.state,
     revision: session.revision,
     scope: session.scope,
-    ...(requirements ? { requirements } : {}),
+    ...(requirements
+      ? { requirements, requirementsFingerprint: await stableFingerprint(requirements) }
+      : {}),
     expiresAt: session.expiresAt.toISOString(),
     createdAt: session.createdAt.toISOString(),
     updatedAt: session.updatedAt.toISOString(),
   }
 }
 
-function serializeSessionView(
+async function serializeSessionView(
   session: BookingSessionInternalRecord,
   access: BookingSessionAccessContext,
   requirements?: BookingRequirementsV1,
-): BookingSessionViewV1 {
-  const record = serializeSession(session, requirements, access)
+): Promise<BookingSessionViewV1> {
+  const record = await serializeSession(session, requirements, access)
   if (access.actorKind === "staff") {
     return { ...record, redaction: "selection_omitted" }
   }

--- a/packages/commerce/src/checkout/subscriber-runtime.ts
+++ b/packages/commerce/src/checkout/subscriber-runtime.ts
@@ -186,12 +186,38 @@ export function createCheckoutFinalizeSubscriberRuntime<TBindings = unknown>(
               if (!options.settleBookingSession) {
                 throw new Error("Booking Session settlement runtime is not configured")
               }
-              bookingId = (
-                await options.settleBookingSession({
-                  bookingSessionId: data.targetId,
-                  paymentSessionId: data.paymentSessionId,
-                })
-              ).bookingId
+              const bookingSessionId = data.targetId
+              try {
+                bookingId = (
+                  await options.settleBookingSession({
+                    bookingSessionId,
+                    paymentSessionId: data.paymentSessionId,
+                  })
+                ).bookingId
+              } catch (error) {
+                // Money captured, nothing booked. Announce it here because
+                // this is the only place that holds both halves of that fact:
+                // the settlement knows it failed and the payment event knows
+                // the money landed. Without the event the state is reachable
+                // only by querying `payment_sessions` for
+                // `status = 'paid' AND booking_id IS NULL`, which is how the
+                // three wedged sessions in voyant#4733 were eventually found.
+                //
+                // Emitted before the rethrow so the signal survives even
+                // though the handler still fails and is retried — a delivery
+                // that eventually succeeds should leave the failed attempts on
+                // the record, not erase them.
+                await ((context?.eventBus ?? eventBus) as EventBus).emit(
+                  "booking_session.settlement.failed",
+                  {
+                    bookingSessionId,
+                    paymentSessionId: data.paymentSessionId,
+                    reason: error instanceof Error ? error.message : String(error),
+                  },
+                  { category: "internal", source: "service" },
+                )
+                throw error
+              }
             }
             if (!bookingId) return
             const finalizedBookingId = bookingId

--- a/packages/commerce/src/voyant-event-schemas.ts
+++ b/packages/commerce/src/voyant-event-schemas.ts
@@ -61,3 +61,27 @@ export const checkoutFinalizedPayloadSchema = {
   },
   additionalProperties: false,
 } as const
+
+/**
+ * The shopper's money is captured and no Booking came out of it.
+ *
+ * Emitted when settling a paid Booking Session raises, which is the only
+ * moment anything in the system knows the two facts together. Until this
+ * existed the state was discoverable solely by querying `payment_sessions`
+ * for `status = 'paid' AND booking_id IS NULL` — three live sessions on one
+ * tenant were found that way, one of them a real customer with a paid trip
+ * and no booking (voyant#4733).
+ *
+ * `reason` is the settlement error's message, which is a stable machine
+ * string (`booking_session_settlement_commit_rejected:<outcome>`), not prose.
+ */
+export const bookingSessionSettlementFailedPayloadSchema = {
+  type: "object",
+  required: ["bookingSessionId", "paymentSessionId", "reason"],
+  properties: {
+    bookingSessionId: { type: "string" },
+    paymentSessionId: { type: "string" },
+    reason: { type: "string" },
+  },
+  additionalProperties: false,
+} as const

--- a/packages/commerce/src/voyant.ts
+++ b/packages/commerce/src/voyant.ts
@@ -37,6 +37,7 @@ import {
 } from "./runtime-port.js"
 import { commerceAccess } from "./voyant-access.js"
 import {
+  bookingSessionSettlementFailedPayloadSchema,
   checkoutFinalizedPayloadSchema,
   inquiryCreatedPayloadSchema,
   pricingRuleChangedPayloadSchema,
@@ -344,6 +345,14 @@ export const commerceVoyantModule = defineModule({
       eventType: "checkout.finalized",
       version: "1.0.0",
       payloadSchema: checkoutFinalizedPayloadSchema,
+      visibility: "internal",
+      audit: { sourceModule: "commerce", category: "domain" },
+    },
+    {
+      id: "@voyant-travel/commerce#event.booking-session.settlement-failed",
+      eventType: "booking_session.settlement.failed",
+      version: "1.0.0",
+      payloadSchema: bookingSessionSettlementFailedPayloadSchema,
       visibility: "internal",
       audit: { sourceModule: "commerce", category: "domain" },
     },

--- a/packages/commerce/tests/unit/catalog-checkout-subscriber-runtime.test.ts
+++ b/packages/commerce/tests/unit/catalog-checkout-subscriber-runtime.test.ts
@@ -329,6 +329,54 @@ describe("catalog-checkout subscriber runtimes", () => {
     expect(calls).toEqual(["settle", "finalize"])
   })
 
+  it("announces a payment that settled with no booking", async () => {
+    // voyant#4733. Money captured, nothing booked, and the only way anybody
+    // learned of it was querying `payment_sessions` for
+    // `status = 'paid' AND booking_id IS NULL`. Three live sessions on one
+    // tenant were found that way; one was a real customer with a paid trip and
+    // no booking.
+    const db = {} as PostgresJsDatabase
+    const settleBookingSession = vi.fn(async () => {
+      throw new Error("booking_session_settlement_commit_rejected:invalid_request")
+    })
+    const withDb = vi.fn(async (_bindings, operation) => operation(db))
+    const { eventBus, subscriptions } = recordingEventBus()
+    const emitted: Array<{ type: string; payload: unknown }> = []
+    vi.spyOn(eventBus, "emit").mockImplementation(async (type, payload) => {
+      emitted.push({ type, payload: payload as unknown })
+    })
+    const descriptor = createCheckoutFinalizeSubscriberRuntime({
+      withDb,
+      settleBookingSession,
+      logger: { error: vi.fn() },
+    })
+    await descriptor.register({ bindings: {}, container: createContainer(), eventBus })
+
+    // Still rethrown: the handler genuinely failed and the outbox must retry
+    // it. The signal is in addition to the failure, not instead of it.
+    await expect(
+      subscriptions[0]?.handler(
+        event("payment.completed", {
+          bookingId: null,
+          paymentSessionId: "payment_session_1",
+          targetType: "booking_session",
+          targetId: "booking_session_1",
+        }),
+      ),
+    ).rejects.toThrow(/booking_session_settlement_commit_rejected/)
+
+    expect(emitted).toEqual([
+      {
+        type: "booking_session.settlement.failed",
+        payload: {
+          bookingSessionId: "booking_session_1",
+          paymentSessionId: "payment_session_1",
+          reason: "booking_session_settlement_commit_rejected:invalid_request",
+        },
+      },
+    ])
+  })
+
   it("resolves the monthly booking limit per event, not once at registration", async () => {
     let live: number | null | undefined = 10
     const finalize = vi.fn(async () => undefined)

--- a/packages/commerce/tests/unit/voyant-manifest.test.ts
+++ b/packages/commerce/tests/unit/voyant-manifest.test.ts
@@ -141,6 +141,10 @@ describe("commerce deployment manifest", () => {
           eventType: "checkout.finalized",
         },
         {
+          id: "@voyant-travel/commerce#event.booking-session.settlement-failed",
+          eventType: "booking_session.settlement.failed",
+        },
+        {
           id: "@voyant-travel/commerce#event.promotion.changed",
           eventType: "promotion.changed",
         },

--- a/packages/core/src/analytics-events.ts
+++ b/packages/core/src/analytics-events.ts
@@ -151,6 +151,11 @@ export const ANALYTICS_FAILURE_REASONS = [
   // `invalid_selection`:
   "unsupported_target",
   "forbidden_field",
+  // Worth watching rather than fixing, like `payment_in_flight` above: it is
+  // the shopper being told at the billing step that a value is too long, which
+  // is the correct place to tell them. A storefront producing many of them is
+  // ignoring the `maxLength` its own requirements publish (voyant#4734).
+  "value_too_long",
   // `renewal_not_allowed`:
   "session_not_active",
   "extension_too_large",


### PR DESCRIPTION
Closes #4734, closes #4733.

## What was wrong

**#4734 — the write path never applied its own widths.** `bookingSelectionPublicV1` has carried `postal: max(20)` since #4298, under a comment promising "an address this schema admits cannot be rejected later by the commit". But `normalizeBookingSelection` **projects** the billing block value by value (`stringValue(...)`) instead of parsing it, so none of those bounds ever ran. The Booking create does parse, which put the only enforcement on the far side of the card capture: a 25-character postal code accepted a dozen times at the step where it could still be edited, and refused once, at settlement, under a field name (`contactPostalCode`) the client had never sent.

**#4733 — the Session's shopping clock kept running under a captured payment.** #4636 stopped the refusal path tearing down the Quote and Hold, but the Session's own TTL was untouched. Two places expire a lapsed Session before asking who is calling — the commit preflight and `consumeCommittedSources` — and expiry releases the Hold, expires the Quote and moves the Session out of `active`: every input a settlement needs. The retry that arrived next answered `session_expired`, and so did every one after it. The window was minutes, not hours, because the payment session's own `expiresAt` is `earliest(session, quote, hold)`.

The two compose into the reported incident: the validation asymmetry supplies a commit refusal, and the expiry makes it permanent.

## What changed

### #4734

- `BOOKING_SELECTION_BILLING_MAX_LENGTHS` / `..._TRAVELER_...` are one table driving three things that used to hold the number separately: the Zod schema, the Session normalizer, and `requirements.bookingFields[].maxLength`.
- The write path rejects with `invalid_selection` / `value_too_long`, carrying `path` as the caller wrote it (`billing.address.postal`) and `maxLength`. Measured after trimming, because that is the value the commit writes.
- `bookingFieldRequirementV1` and `travelerFieldRequirementV1` publish `maxLength`, and `defaultBookingFields()` now advertises the whole billing address rather than three of six — `address.postal`, `address.line2` and `address.region` were carried by the selection but never published, so a client could not pre-validate the field that bit.
- The selection-to-`contact_*` rename is exported as `BOOKING_SESSION_BILLING_FIELD_TARGETS` and is load-bearing in `billingContact()`, which answers ask 3: the mapping is published rather than reconstructed by hand.
- `bookingSessionRecoveryV1` classifies `value_too_long` as `selectionIncomplete`, not `unknown` — the shopper can fix it, and the generic "the Booking Session rejected this request" is the failure that file exists to prevent.

### #4733

- Money with a processor freezes a Session against expiry, guarded at `expireSession` — the one choke point the commit preflight, the sweep and the lapsed-Session preambles all reach. Only *settled* money holds a Session open: `hasInFlight`'s handoff arm lapses on the Session's own clock, so an abandoned checkout page still gets swept.
- `consumeCommittedSources` and its composite twin no longer consult `expiresAt` for a settlement, for the same reason they already skip the revision check.
- `abandonSession` gets the in-flight guard it was missing. It tears down exactly what a settlement needs, and it is what a "start over" button calls.
- `BookingSessionRecordV1` carries `requirementsFingerprint` (ask 1). Commit requires the fingerprint and only a Quote produced one, which is a dead end precisely while a payment is settled — quoting is refused, correctly. It is a hash of a descriptor the read already returns, so it grants no new authority, and a stale one is still refused by the existing `requirements_changed` comparison.
- A settlement that produces no Booking emits `booking_session.settlement.failed` (ask 4). Emitted before the rethrow, so the handler still fails and still retries; the state was previously discoverable only by querying `payment_sessions` for `status = 'paid' AND booking_id IS NULL`.

### Ask 2 (idempotency) is documented, not changed

The corrective-`PATCH` trap is a client key-derivation defect, and this repo's own client already avoids it: `useBookingSession.updateSelection` keys on `bookingSessionIdempotencyKey(root, "update", revision, bookingSelectionDigest(selection))`. The revision-only key the report describes is not derived here. `updateBookingSessionV1.idempotencyKey` now states the rule and names the derivation, so a client reading the contract does not reinvent the broken one. Server-side, `idempotency_conflict` is already a distinct outcome kind; the `200` is the outcome-envelope convention every rejection uses and is not worth breaking for one arm.

Note that a corrective `PATCH` is still refused while a payment is settled (`payment_in_flight`) — that is #4636's guard and it stays. With the width enforced at the step, the value that triggered it cannot get in.

## Verification

- `packages/catalog` — 835 passed, 7 files skipped
- `packages/commerce` — 188 passed
- `core` 198, `catalog-contracts` 104, `catalog-react` 121, `storefront-sdk` 10, `trips` 220
- `bookings-react` — 248 passed; `admin-extension.test.ts` hit a 5s timeout under parallel-worktree load and passes in isolation (15/15). Unrelated to this diff.
- `biome check .` from root — 6967 files, **0 errors**, 23 warnings, 8 infos
- `packages/catalog` OpenAPI regenerated (`maxLength` on both field descriptors, `requirementsFingerprint` on the Session record). `trips` and `legal` regenerate clean.

The width test is the one worth reading: it drives `defaultBookingFields()` on one side and `bookingCreateSchema` on the other, at the limit and one past it, rather than asserting `20 === 20` against a hand-copied constant — which would pass on the day somebody changes one of them.

## Deploy note

`requirements` gained a field, so every `requirementsFingerprint` changes. In-flight Quotes taken before the deploy are refused with `requirements_changed` / `request_fresh_quote`, which is the designed recovery for exactly this.
