### PR TITLE
Measure the checkout payment policy from the selected departure

### DIFF
--- a/.changeset/checkout-departure-payment-policy.md
+++ b/.changeset/checkout-departure-payment-policy.md
@@ -1,0 +1,12 @@
+---
+"@voyant-travel/catalog": patch
+"@voyant-travel/inventory": patch
+---
+
+Measure the customer payment policy at checkout from the departure the shopper selected, not from `products.startDate`.
+
+The policy gates on the distance to departure, and Commit measured that distance from the product row's own `startDate` — which, for any slot-based product, is the listing's window and not the departure being bought. A product seeded with today's date collapsed a 50% deposit policy to full payment on a departure five weeks out; a product dated months ahead did the reverse, offering a deposit on a trip leaving tomorrow and dating the balance in the past. Checkout and `generatePaymentScheduleForBooking`, which has always read the Booking's selected `startDate`, could therefore compute two different plans for one booking from one policy.
+
+Resolution now mirrors what the Booking itself records: the selected slot's local date, then a date stated inline on the selection, then the product row as the last resort for a product with no departures. The checkout line item a hosted payment provider renders names the same departure.
+
+Operators running a deposit policy will see checkout start collecting the deposit on departures where it previously collected the full amount.

--- a/.changeset/checkout-departure-payment-policy.md
+++ b/.changeset/checkout-departure-payment-policy.md
@@ -7,6 +7,6 @@ Measure the customer payment policy at checkout from the departure the shopper s
 
 The policy gates on the distance to departure, and Commit measured that distance from the product row's own `startDate` — which, for any slot-based product, is the listing's window and not the departure being bought. A product seeded with today's date collapsed a 50% deposit policy to full payment on a departure five weeks out; a product dated months ahead did the reverse, offering a deposit on a trip leaving tomorrow and dating the balance in the past. Checkout and `generatePaymentScheduleForBooking`, which has always read the Booking's selected `startDate`, could therefore compute two different plans for one booking from one policy.
 
-Resolution now mirrors what the Booking itself records: the selected slot's local date, then a date stated inline on the selection, then the product row as the last resort for a product with no departures. The checkout line item a hosted payment provider renders names the same departure.
+Resolution now mirrors exactly what the Booking itself records — the selected slot's local date, then the product row — so the two schedules agree by construction. The checkout line item a hosted payment provider renders names the same departure.
 
 Operators running a deposit policy will see checkout start collecting the deposit on departures where it previously collected the full amount.

--- a/packages/catalog/src/booking-engine/sessions-payment-production.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-payment-production.test.ts
@@ -4,11 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { createProductionBookingSessionPaymentPorts } from "./sessions-payment-production.js"
 
 /** Every departure resolution the port asked for, in order. Reset per `prepare`. */
-const resolveCalls: Array<{
-  productId: string
-  departureSlotId?: string | null
-  departureDate?: string | null
-}> = []
+const resolveCalls: Array<{ productId: string; departureSlotId?: string | null }> = []
 
 const startPaymentAdapterCardPayment = vi.hoisted(() => vi.fn(async (..._args: unknown[]) => null))
 
@@ -435,16 +431,6 @@ describe("production Booking Session payment policy departure", () => {
     expect(scheduleInput().departureDate).toBe("2026-09-20")
   })
 
-  it("measures from a date stated inline when the product sells without slots", async () => {
-    await prepare({
-      locale: "en-GB",
-      departureDate: "2026-08-16",
-      selection: { departureDate: "2026-09-20" },
-    })
-
-    expect(scheduleInput().departureDate).toBe("2026-09-20")
-  })
-
   it("falls back to the product row when the selection names no departure", async () => {
     await prepare({ locale: "en-GB", departureDate: "2026-08-16" })
 
@@ -455,14 +441,31 @@ describe("production Booking Session payment policy departure", () => {
     await prepare({
       locale: "en-GB",
       departureDate: null,
-      selection: { departureSlotId: "avsl_01k", departureDate: "2026-09-20" },
+      selection: { departureSlotId: "avsl_01k" },
     })
 
-    expect(resolveArgs()).toEqual({
-      productId: "prod_1",
-      departureSlotId: "avsl_01k",
-      departureDate: "2026-09-20",
+    expect(resolveArgs()).toEqual({ productId: "prod_1", departureSlotId: "avsl_01k" })
+  })
+
+  /**
+   * `configure.departureDate` sits next to the slot id on the same selection
+   * step and quoting does price against it, so consulting it here looks
+   * obviously right. It is not: `deriveSelfServiceCommand` carries only
+   * `slotId`, so an inline date never reaches `bookings.startDate`, and
+   * `generatePaymentScheduleForBooking` would go on reading the product row.
+   * Measuring checkout from a date the Booking will not record is the same
+   * two-plans-from-one-policy divergence this issue is about, arrived at from
+   * the other side. Honouring it means persisting it on the Booking first.
+   */
+  it("does not measure from a departure date the Booking will never record", async () => {
+    await prepare({
+      locale: "en-GB",
+      departureDate: "2026-08-16",
+      selection: { departureDate: "2026-09-20" },
     })
+
+    expect(resolveArgs()).toEqual({ productId: "prod_1", departureSlotId: null })
+    expect(scheduleInput().departureDate).toBe("2026-08-16")
   })
 
   // The line item is the only product-shaped thing a hosted provider renders,
@@ -532,7 +535,7 @@ async function prepare(input: {
   departureDate: string | null
   /** What the shopper selected, as it sits on the Session's `configure` step. */
   selection?: { departureSlotId?: string; departureDate?: string }
-  /** Resolver answers keyed by slot id; anything else falls to `departureDate`. */
+  /** Resolver answers keyed by slot id; anything else falls to the product row. */
   slotDates?: Record<string, string>
   name?: string
   personId?: string
@@ -570,14 +573,14 @@ async function prepare(input: {
         supplierId: null,
         name: input.name ?? "Danube Delta tour",
       }),
-      // Stands in for inventory's resolver with the same precedence: the
-      // selected slot's date, then an inline one, then the product row.
+      // Stands in for inventory's resolver with the same precedence it has:
+      // the selected slot's date, then the product row. Nothing else.
       resolveSelectedDepartureDate: async (_db, resolve) => {
         resolveCalls.push(resolve)
         const slotDate = resolve.departureSlotId
           ? input.slotDates?.[resolve.departureSlotId]
           : undefined
-        return slotDate ?? resolve.departureDate ?? input.departureDate
+        return slotDate ?? input.departureDate
       },
     },
     distribution: { loadSupplierPaymentPolicy: async () => null },

--- a/packages/catalog/src/booking-engine/sessions-payment-production.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-payment-production.test.ts
@@ -3,6 +3,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { createProductionBookingSessionPaymentPorts } from "./sessions-payment-production.js"
 
+/** Every departure resolution the port asked for, in order. Reset per `prepare`. */
+const resolveCalls: Array<{
+  productId: string
+  departureSlotId?: string | null
+  departureDate?: string | null
+}> = []
+
 const startPaymentAdapterCardPayment = vi.hoisted(() => vi.fn(async (..._args: unknown[]) => null))
 
 /**
@@ -14,10 +21,20 @@ const getPaymentSessionById = vi.hoisted(() =>
   vi.fn(async (..._args: unknown[]) => null as unknown),
 )
 
-vi.mock("@voyant-travel/finance", () => ({
-  computePaymentSchedule: () => [
+/**
+ * Spied rather than stubbed so the *input* the policy is measured from can be
+ * asserted. What comes back is fixed — the amount a real cascade would return
+ * is finance's own tested behaviour; what this file owns is which date reaches
+ * it (voyant#4740).
+ */
+const computePaymentSchedule = vi.hoisted(() =>
+  vi.fn((..._args: unknown[]) => [
     { amountCents: 10_000, currency: "EUR", scheduleType: "deposit", dueDate: "2026-08-05" },
-  ],
+  ]),
+)
+
+vi.mock("@voyant-travel/finance", () => ({
+  computePaymentSchedule,
   createOrReuseBookingSessionPayment: async () => ({
     id: "pmts_1",
     status: "pending",
@@ -39,9 +56,10 @@ vi.mock("@voyant-travel/finance", () => ({
 describe("production Booking Session staff payment policy", () => {
   it("does not create a customer checkout when staff supplied a collection schedule", async () => {
     const loadProductPaymentPolicyContext = vi.fn()
+    const resolveSelectedDepartureDate = vi.fn()
     const payments = createProductionBookingSessionPaymentPorts({
       db: {} as never,
-      inventory: { loadProductPaymentPolicyContext },
+      inventory: { loadProductPaymentPolicyContext, resolveSelectedDepartureDate },
       distribution: { loadSupplierPaymentPolicy: vi.fn() },
       settings: { resolveOperatorDefaultPaymentPolicy: vi.fn() },
     })
@@ -76,12 +94,14 @@ describe("production Booking Session staff payment policy", () => {
       } as never),
     ).resolves.toEqual({ kind: "not_required" })
     expect(loadProductPaymentPolicyContext).not.toHaveBeenCalled()
+    expect(resolveSelectedDepartureDate).not.toHaveBeenCalled()
   })
 })
 
 describe("production Booking Session bank-transfer intent", () => {
   it("does not start card collection and delegates durable offline establishment", async () => {
     const loadProductPaymentPolicyContext = vi.fn()
+    const resolveSelectedDepartureDate = vi.fn()
     const establishBankTransfer = vi.fn(async () => ({
       paymentSessionId: "pays_bank",
       document: { id: "invc_proforma", number: "PRO-42", type: "proforma" as const },
@@ -97,7 +117,7 @@ describe("production Booking Session bank-transfer intent", () => {
     }))
     const payments = createProductionBookingSessionPaymentPorts({
       db: {} as never,
-      inventory: { loadProductPaymentPolicyContext },
+      inventory: { loadProductPaymentPolicyContext, resolveSelectedDepartureDate },
       distribution: { loadSupplierPaymentPolicy: vi.fn() },
       settings: { resolveOperatorDefaultPaymentPolicy: vi.fn() },
       establishBankTransfer,
@@ -114,6 +134,7 @@ describe("production Booking Session bank-transfer intent", () => {
       payments.establishBankTransfer?.({ bookingId: "book_42" } as never),
     ).resolves.toMatchObject({ document: { id: "invc_proforma" } })
     expect(loadProductPaymentPolicyContext).not.toHaveBeenCalled()
+    expect(resolveSelectedDepartureDate).not.toHaveBeenCalled()
     expect(startPaymentAdapterCardPayment).not.toHaveBeenCalled()
     expect(establishBankTransfer).toHaveBeenCalledWith({ bookingId: "book_42" })
   })
@@ -384,6 +405,81 @@ describe("production Booking Session checkout handoff preference", () => {
   })
 })
 
+/**
+ * A customer payment policy gates on the distance to departure — "deposit now
+ * if the trip is far enough out, otherwise collect in full". The distance is
+ * only meaningful measured from the departure the shopper is buying, and
+ * voyant#4740 measured it from `products.startDate`: for a slot-based product
+ * that is the listing's own window, so a seeded "today" collapsed the gate to
+ * full payment on a departure five weeks away, and a listing dated months out
+ * offered a 50% deposit on a trip leaving tomorrow.
+ *
+ * `generatePaymentScheduleForBooking` has always read the Booking's own
+ * `startDate` — the selected departure — so this is also what stops checkout
+ * and the post-confirmation schedule computing two plans from one policy.
+ */
+describe("production Booking Session payment policy departure", () => {
+  beforeEach(() => {
+    computePaymentSchedule.mockClear()
+    startPaymentAdapterCardPayment.mockClear()
+  })
+
+  it("measures the policy from the selected slot, not the product row", async () => {
+    await prepare({
+      locale: "en-GB",
+      departureDate: "2026-08-16",
+      selection: { departureSlotId: "avsl_01k" },
+      slotDates: { avsl_01k: "2026-09-20" },
+    })
+
+    expect(scheduleInput().departureDate).toBe("2026-09-20")
+  })
+
+  it("measures from a date stated inline when the product sells without slots", async () => {
+    await prepare({
+      locale: "en-GB",
+      departureDate: "2026-08-16",
+      selection: { departureDate: "2026-09-20" },
+    })
+
+    expect(scheduleInput().departureDate).toBe("2026-09-20")
+  })
+
+  it("falls back to the product row when the selection names no departure", async () => {
+    await prepare({ locale: "en-GB", departureDate: "2026-08-16" })
+
+    expect(scheduleInput().departureDate).toBe("2026-08-16")
+  })
+
+  it("asks about the product the Session targets", async () => {
+    await prepare({
+      locale: "en-GB",
+      departureDate: null,
+      selection: { departureSlotId: "avsl_01k", departureDate: "2026-09-20" },
+    })
+
+    expect(resolveArgs()).toEqual({
+      productId: "prod_1",
+      departureSlotId: "avsl_01k",
+      departureDate: "2026-09-20",
+    })
+  })
+
+  // The line item is the only product-shaped thing a hosted provider renders,
+  // so a shopper reading it must see the departure they are paying for — the
+  // same one the amount was computed from, not a second answer.
+  it("names the selected departure on the checkout line item", async () => {
+    await prepare({
+      locale: "en-GB",
+      departureDate: "2026-08-16",
+      selection: { departureSlotId: "avsl_01k" },
+      slotDates: { avsl_01k: "2026-09-20" },
+    })
+
+    expect(startArgs().description).toBe("Danube Delta tour — 20 September 2026")
+  })
+})
+
 describe("production Booking Session settlement", () => {
   beforeEach(() => {
     startPaymentAdapterCardPayment.mockClear()
@@ -434,6 +530,10 @@ describe("production Booking Session settlement", () => {
 async function prepare(input: {
   locale: string
   departureDate: string | null
+  /** What the shopper selected, as it sits on the Session's `configure` step. */
+  selection?: { departureSlotId?: string; departureDate?: string }
+  /** Resolver answers keyed by slot id; anything else falls to `departureDate`. */
+  slotDates?: Record<string, string>
   name?: string
   personId?: string
   actorKind?: string
@@ -446,6 +546,7 @@ async function prepare(input: {
   mandate?: { enabled: boolean; revision: string } | null
   contractAcceptedAt?: string
 }) {
+  resolveCalls.length = 0
   if (input.refreshedCheckout !== undefined) {
     // What the adapter persisted, read back by the port exactly as production
     // reads it — through `financeService.getPaymentSessionById`, not by
@@ -467,9 +568,17 @@ async function prepare(input: {
         listingPolicy: null,
         categoryPolicy: null,
         supplierId: null,
-        departureDate: input.departureDate,
         name: input.name ?? "Danube Delta tour",
       }),
+      // Stands in for inventory's resolver with the same precedence: the
+      // selected slot's date, then an inline one, then the product row.
+      resolveSelectedDepartureDate: async (_db, resolve) => {
+        resolveCalls.push(resolve)
+        const slotDate = resolve.departureSlotId
+          ? input.slotDates?.[resolve.departureSlotId]
+          : undefined
+        return slotDate ?? resolve.departureDate ?? input.departureDate
+      },
     },
     distribution: { loadSupplierPaymentPolicy: async () => null },
     settings: { resolveOperatorDefaultPaymentPolicy: async () => null },
@@ -488,6 +597,7 @@ async function prepare(input: {
       target: { kind: "product", productId: "prod_1" },
       expiresAt: new Date("2026-08-06T00:00:00Z"),
       statePayload: {
+        ...(input.selection ? { configure: input.selection } : {}),
         ...(input.contractAcceptedAt
           ? { contractAcceptance: { acceptedAt: input.contractAcceptedAt } }
           : {}),
@@ -528,6 +638,20 @@ async function prepare(input: {
     },
     now: new Date("2026-08-05T00:00:00Z"),
   } as never)
+}
+
+/** What the payment policy was measured against. */
+function scheduleInput() {
+  const call = computePaymentSchedule.mock.calls.at(-1)
+  if (!call) throw new Error("the payment schedule was never computed")
+  return call[0] as { departureDate: string | null; totalCents: number; today: Date }
+}
+
+/** What the port asked inventory to resolve the departure from. */
+function resolveArgs() {
+  const call = resolveCalls.at(-1)
+  if (!call) throw new Error("the departure was never resolved")
+  return call
 }
 
 function startArgs() {

--- a/packages/catalog/src/booking-engine/sessions-payment-production.ts
+++ b/packages/catalog/src/booking-engine/sessions-payment-production.ts
@@ -25,7 +25,10 @@ import type { BookingSessionPaymentPorts } from "./sessions-service.js"
 
 export interface ProductionBookingSessionPaymentDeps {
   db: PostgresJsDatabase
-  inventory: Pick<CatalogInventoryRuntimeExtension, "loadProductPaymentPolicyContext">
+  inventory: Pick<
+    CatalogInventoryRuntimeExtension,
+    "loadProductPaymentPolicyContext" | "resolveSelectedDepartureDate"
+  >
   distribution: Pick<CatalogDistributionRuntimeExtension, "loadSupplierPaymentPolicy">
   settings: Pick<FinanceOperatorSettingsRuntime, "resolveOperatorDefaultPaymentPolicy">
   resolvePaymentAdapter?: () => PaymentAdapter | null | Promise<PaymentAdapter | null>
@@ -96,11 +99,19 @@ export function createProductionBookingSessionPaymentPorts(
       // same Commit transaction, by `establishBankTransfer` below.
       if (commit.checkoutIntent === "bank_transfer") return { kind: "not_required" }
 
-      const context = await deps.inventory.loadProductPaymentPolicyContext(
-        deps.db,
-        session.target.productId,
-        { locale: session.scope.locale },
-      )
+      // The policy cascade and the departure are two different questions about
+      // two different things — the listing, and what the shopper selected off
+      // it. They were one call until voyant#4740, which is how every deposit
+      // gate came to be measured from `products.startDate`.
+      const [context, departureDate] = await Promise.all([
+        deps.inventory.loadProductPaymentPolicyContext(deps.db, session.target.productId, {
+          locale: session.scope.locale,
+        }),
+        deps.inventory.resolveSelectedDepartureDate(deps.db, {
+          productId: session.target.productId,
+          ...selectedDeparture(session.statePayload),
+        }),
+      ])
       if (!context) throw new Error("booking_session_payment_product_not_found")
       const [supplierPolicy, operatorDefault] = await Promise.all([
         context.supplierId
@@ -118,7 +129,7 @@ export function createProductionBookingSessionPaymentPorts(
         {
           totalCents: quote.pricing.total,
           currency: quote.pricing.currency,
-          departureDate: context.departureDate,
+          departureDate,
           today: now,
         },
         resolved.policy,
@@ -209,7 +220,7 @@ export function createProductionBookingSessionPaymentPorts(
             },
             description: checkoutLineItem({
               productName: context.name,
-              departureDate: context.departureDate,
+              departureDate,
               locale: session.scope.locale,
             }),
             locale: session.scope.locale,
@@ -341,6 +352,26 @@ function customerReference(session: {
   if (personId) return personId
   if (session.actorKind !== "customer") return undefined
   return identifiedUserId(session.ownerPrincipalId) ?? undefined
+}
+
+/**
+ * Which departure the Session's selection names, as the shopper stated it.
+ *
+ * Both halves are carried because they are two different claims: a slot id
+ * names a row the operator publishes and is the authority on, while an inline
+ * `departureDate` is a bare date for a product that sells without slots. The
+ * resolver decides between them — this only reads the Session's own
+ * `configure` step, the same place quoting and the Commit read it from.
+ */
+function selectedDeparture(payload: Record<string, unknown>): {
+  departureSlotId: string | null
+  departureDate: string | null
+} {
+  const configure = record(payload.configure)
+  return {
+    departureSlotId: stringValue(configure?.departureSlotId),
+    departureDate: stringValue(configure?.departureDate),
+  }
 }
 
 function hasStaffPaymentSchedule(payload: Record<string, unknown>): boolean {

--- a/packages/catalog/src/booking-engine/sessions-payment-production.ts
+++ b/packages/catalog/src/booking-engine/sessions-payment-production.ts
@@ -109,7 +109,7 @@ export function createProductionBookingSessionPaymentPorts(
         }),
         deps.inventory.resolveSelectedDepartureDate(deps.db, {
           productId: session.target.productId,
-          ...selectedDeparture(session.statePayload),
+          departureSlotId: selectedDepartureSlotId(session.statePayload),
         }),
       ])
       if (!context) throw new Error("booking_session_payment_product_not_found")
@@ -355,23 +355,15 @@ function customerReference(session: {
 }
 
 /**
- * Which departure the Session's selection names, as the shopper stated it.
+ * Which departure the Session's selection names.
  *
- * Both halves are carried because they are two different claims: a slot id
- * names a row the operator publishes and is the authority on, while an inline
- * `departureDate` is a bare date for a product that sells without slots. The
- * resolver decides between them — this only reads the Session's own
- * `configure` step, the same place quoting and the Commit read it from.
+ * The slot id and nothing else, read off the Session's own `configure` step —
+ * the same place the Commit reads it from, and the only part of the selection
+ * that reaches `bookings.startDate`. `configure.departureDate` sits right next
+ * to it and is deliberately left behind: see `resolveSelectedDepartureDate`.
  */
-function selectedDeparture(payload: Record<string, unknown>): {
-  departureSlotId: string | null
-  departureDate: string | null
-} {
-  const configure = record(payload.configure)
-  return {
-    departureSlotId: stringValue(configure?.departureSlotId),
-    departureDate: stringValue(configure?.departureDate),
-  }
+function selectedDepartureSlotId(payload: Record<string, unknown>): string | null {
+  return stringValue(record(payload.configure)?.departureSlotId)
 }
 
 function hasStaffPaymentSchedule(payload: Record<string, unknown>): boolean {

--- a/packages/catalog/src/runtime-contracts.ts
+++ b/packages/catalog/src/runtime-contracts.ts
@@ -265,19 +265,22 @@ export interface CatalogInventoryRuntimeExtension {
    * slot-based product is the listing's own window and has nothing to do with
    * the departure being sold (voyant#4740).
    *
-   * Resolves the same way the Booking does: the selected slot's local date
-   * wins, then a date stated inline on the selection, then the product row as
-   * the last resort for a product that genuinely has no departures. A slot id
-   * that does not belong to this product is ignored — the Commit refuses that
-   * combination outright, so its date is not this product's departure.
+   * Resolves **exactly** as the Booking records it — `slot?.dateLocal ??
+   * product.startDate`, per `convertProductToBooking` — so checkout and
+   * `generatePaymentScheduleForBooking` cannot compute two plans from one
+   * policy. A slot id that does not belong to this product is ignored, because
+   * the Commit refuses that combination outright.
+   *
+   * A `configure.departureDate` stated inline is deliberately **not** consulted,
+   * even though quoting prices against it. The self-service command carries only
+   * `slotId` (`deriveSelfServiceCommand`), so an inline date never reaches
+   * `bookings.startDate` — measuring checkout from something the Booking will
+   * not record is how the two schedules diverge, which is the whole bug.
+   * Honouring it here means persisting it there first.
    */
   resolveSelectedDepartureDate(
     db: AnyDrizzleDb,
-    input: {
-      productId: string
-      departureSlotId?: string | null
-      departureDate?: string | null
-    },
+    input: { productId: string; departureSlotId?: string | null },
   ): Promise<string | null>
   buildSnapshotInput(
     db: AnyDrizzleDb,

--- a/packages/catalog/src/runtime-contracts.ts
+++ b/packages/catalog/src/runtime-contracts.ts
@@ -235,6 +235,12 @@ export interface CatalogInventoryRuntimeExtension {
    * shopper is being asked to pay for. `locale` selects the language `name` is
    * returned in — the checkout line item a hosted provider renders is built
    * from it, so it has to be the shopper's language, not the operator's.
+   *
+   * This is a policy cascade over the *listing*. It deliberately says nothing
+   * about when the shopper travels: the departure is a property of the
+   * selection, and reading it off the product row measured every payment
+   * policy from the wrong date (voyant#4740). Ask
+   * {@link resolveSelectedDepartureDate} instead.
    */
   loadProductPaymentPolicyContext(
     db: AnyDrizzleDb,
@@ -244,13 +250,35 @@ export interface CatalogInventoryRuntimeExtension {
     listingPolicy: PaymentPolicy | null
     categoryPolicy: PaymentPolicy | null
     supplierId: string | null
-    departureDate: string | null
     /**
      * The product's name in the requested locale, falling back to its base
      * `name` when that language has no translation.
      */
     name: string | null
   } | null>
+  /**
+   * The departure a Session's selection actually buys.
+   *
+   * A customer payment policy gates on the distance to departure, and so does
+   * the checkout line item the shopper reads, so both have to measure from the
+   * date the shopper picked — not from `products.startDate`, which for a
+   * slot-based product is the listing's own window and has nothing to do with
+   * the departure being sold (voyant#4740).
+   *
+   * Resolves the same way the Booking does: the selected slot's local date
+   * wins, then a date stated inline on the selection, then the product row as
+   * the last resort for a product that genuinely has no departures. A slot id
+   * that does not belong to this product is ignored — the Commit refuses that
+   * combination outright, so its date is not this product's departure.
+   */
+  resolveSelectedDepartureDate(
+    db: AnyDrizzleDb,
+    input: {
+      productId: string
+      departureSlotId?: string | null
+      departureDate?: string | null
+    },
+  ): Promise<string | null>
   buildSnapshotInput(
     db: AnyDrizzleDb,
     productId: Parameters<CatalogBookingSnapshotExecutionContext["buildSnapshotInput"]>[0],

--- a/packages/inventory/src/catalog-runtime-extension.ts
+++ b/packages/inventory/src/catalog-runtime-extension.ts
@@ -125,7 +125,7 @@ export const catalogInventoryRuntimeExtension = {
       name: pickTranslatedName(translations, options?.locale) ?? product.name,
     }
   },
-  async resolveSelectedDepartureDate(db, { productId, departureSlotId, departureDate }) {
+  async resolveSelectedDepartureDate(db, { productId, departureSlotId }) {
     if (departureSlotId) {
       // Through availability's own service, not its table: the slot belongs to
       // `operations`, and a departure date is exactly what that module is the
@@ -133,7 +133,6 @@ export const catalogInventoryRuntimeExtension = {
       const slot = await availabilityService.getSlotById(db as PostgresJsDatabase, departureSlotId)
       if (slot?.productId === productId && slot.dateLocal) return slot.dateLocal
     }
-    if (isCalendarDate(departureDate)) return departureDate
     const [product] = await db
       .select({ startDate: products.startDate })
       .from(products)
@@ -143,18 +142,6 @@ export const catalogInventoryRuntimeExtension = {
   },
   buildSnapshotInput: (db, productId, options) => buildProductSnapshotInput(db, productId, options),
 } satisfies CatalogInventoryRuntimeExtension
-
-/**
- * A date-only selection value the payment policy can measure from.
- *
- * The selection is normalized but not date-validated at the Session edge, and
- * a policy gate that parses garbage answers "0 days to departure" — which is
- * the collapse-to-full-payment failure voyant#4740 was about. Anything that is
- * not a plain `YYYY-MM-DD` falls through to the product row instead.
- */
-function isCalendarDate(value: string | null | undefined): value is string {
-  return typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value)
-}
 
 /**
  * Resolve a product's name in `locale` from its translation rows.

--- a/packages/inventory/src/catalog-runtime-extension.ts
+++ b/packages/inventory/src/catalog-runtime-extension.ts
@@ -1,5 +1,6 @@
 import type { CatalogInventoryRuntimeExtension } from "@voyant-travel/catalog/runtime-contracts"
 import type { PaymentPolicy } from "@voyant-travel/finance"
+import { availabilityService } from "@voyant-travel/operations"
 import { and, asc, eq, gt, isNotNull } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
@@ -90,7 +91,6 @@ export const catalogInventoryRuntimeExtension = {
           name: products.name,
           listingPolicy: products.customerPaymentPolicy,
           supplierId: products.supplierId,
-          departureDate: products.startDate,
         })
         .from(products)
         .where(eq(products.id, productId))
@@ -122,12 +122,39 @@ export const catalogInventoryRuntimeExtension = {
       listingPolicy: (product.listingPolicy as PaymentPolicy | null | undefined) ?? null,
       categoryPolicy: (category?.categoryPolicy as PaymentPolicy | null | undefined) ?? null,
       supplierId: product.supplierId,
-      departureDate: product.departureDate,
       name: pickTranslatedName(translations, options?.locale) ?? product.name,
     }
   },
+  async resolveSelectedDepartureDate(db, { productId, departureSlotId, departureDate }) {
+    if (departureSlotId) {
+      // Through availability's own service, not its table: the slot belongs to
+      // `operations`, and a departure date is exactly what that module is the
+      // authority on.
+      const slot = await availabilityService.getSlotById(db as PostgresJsDatabase, departureSlotId)
+      if (slot?.productId === productId && slot.dateLocal) return slot.dateLocal
+    }
+    if (isCalendarDate(departureDate)) return departureDate
+    const [product] = await db
+      .select({ startDate: products.startDate })
+      .from(products)
+      .where(eq(products.id, productId))
+      .limit(1)
+    return product?.startDate ?? null
+  },
   buildSnapshotInput: (db, productId, options) => buildProductSnapshotInput(db, productId, options),
 } satisfies CatalogInventoryRuntimeExtension
+
+/**
+ * A date-only selection value the payment policy can measure from.
+ *
+ * The selection is normalized but not date-validated at the Session edge, and
+ * a policy gate that parses garbage answers "0 days to departure" — which is
+ * the collapse-to-full-payment failure voyant#4740 was about. Anything that is
+ * not a plain `YYYY-MM-DD` falls through to the product row instead.
+ */
+function isCalendarDate(value: string | null | undefined): value is string {
+  return typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value)
+}
 
 /**
  * Resolve a product's name in `locale` from its translation rows.

--- a/packages/inventory/tests/unit/catalog-runtime-payment-context.test.ts
+++ b/packages/inventory/tests/unit/catalog-runtime-payment-context.test.ts
@@ -1,3 +1,4 @@
+import { availabilitySlots } from "@voyant-travel/operations"
 import { describe, expect, it } from "vitest"
 
 import { catalogInventoryRuntimeExtension } from "../../src/catalog-runtime-extension.js"
@@ -8,7 +9,7 @@ const BASE_PRODUCT = {
   name: "Base tour",
   listingPolicy: null,
   supplierId: null,
-  departureDate: null,
+  startDate: null,
 }
 
 const TRANSLATIONS = [
@@ -24,7 +25,7 @@ const TRANSLATIONS = [
 describe("loadProductPaymentPolicyContext product name", () => {
   it("returns the translation for the requested locale", async () => {
     const db = fakeDb([
-      [products, [{ ...BASE_PRODUCT, departureDate: "2026-09-12" }]],
+      [products, [BASE_PRODUCT]],
       [productTranslations, TRANSLATIONS],
     ])
 
@@ -35,7 +36,23 @@ describe("loadProductPaymentPolicyContext product name", () => {
     )
 
     expect(context?.name).toBe("Tur în Delta Dunării")
-    expect(context?.departureDate).toBe("2026-09-12")
+  })
+
+  // voyant#4740: the cascade is over the listing, and the departure is a
+  // property of the selection. Returning one from the other is what let every
+  // payment policy be measured from `products.startDate`.
+  it("says nothing about when the shopper travels", async () => {
+    const db = fakeDb([
+      [products, [{ ...BASE_PRODUCT, startDate: "2026-08-16" }]],
+      [productTranslations, TRANSLATIONS],
+    ])
+
+    const context = await catalogInventoryRuntimeExtension.loadProductPaymentPolicyContext(
+      db,
+      "prod_1",
+    )
+
+    expect(context).not.toHaveProperty("departureDate")
   })
 
   it("matches on the language subtag when the exact tag has no translation", async () => {
@@ -87,6 +104,111 @@ describe("loadProductPaymentPolicyContext product name", () => {
 
     expect(context?.name).toBe("Base tour")
     expect(readTranslations).toBe(false)
+  })
+})
+
+/**
+ * The date a customer payment policy is measured from, and the departure the
+ * checkout line item names.
+ *
+ * `products.startDate` is the listing's own window. For a slot-based product it
+ * has nothing to do with the departure being bought, and reading it as one
+ * collapsed a 50% deposit policy to full payment on a departure five weeks out
+ * (voyant#4740). Resolution mirrors what the Booking itself records —
+ * `slot?.dateLocal ?? product.startDate` in `convertProductToBooking` — with an
+ * inline selection date in between for products that sell without slots.
+ */
+describe("resolveSelectedDepartureDate", () => {
+  const SLOT = {
+    id: "avsl_01k",
+    productId: "prod_1",
+    dateLocal: "2026-09-20",
+    startsAt: new Date("2026-09-20T06:00:00Z"),
+    endsAt: null,
+    timezone: "Europe/Bucharest",
+  }
+
+  it("returns the selected slot's local date", async () => {
+    const db = fakeDb([
+      [availabilitySlots, [SLOT]],
+      [products, [{ startDate: "2026-08-16" }]],
+    ])
+
+    await expect(
+      catalogInventoryRuntimeExtension.resolveSelectedDepartureDate(db, {
+        productId: "prod_1",
+        departureSlotId: "avsl_01k",
+        departureDate: "2026-10-01",
+      }),
+    ).resolves.toBe("2026-09-20")
+  })
+
+  it("falls back to a date stated inline when no slot was selected", async () => {
+    const db = fakeDb([
+      [availabilitySlots, []],
+      [products, [{ startDate: "2026-08-16" }]],
+    ])
+
+    await expect(
+      catalogInventoryRuntimeExtension.resolveSelectedDepartureDate(db, {
+        productId: "prod_1",
+        departureDate: "2026-10-01",
+      }),
+    ).resolves.toBe("2026-10-01")
+  })
+
+  it("falls back to the product row when the selection names no departure", async () => {
+    const db = fakeDb([
+      [availabilitySlots, []],
+      [products, [{ startDate: "2026-08-16" }]],
+    ])
+
+    await expect(
+      catalogInventoryRuntimeExtension.resolveSelectedDepartureDate(db, { productId: "prod_1" }),
+    ).resolves.toBe("2026-08-16")
+  })
+
+  // A policy gate that parses garbage answers "0 days to departure", which is
+  // the collapse-to-full-payment this issue was about, arrived at differently.
+  it("ignores a selection date that is not a calendar date", async () => {
+    const db = fakeDb([
+      [availabilitySlots, []],
+      [products, [{ startDate: "2026-08-16" }]],
+    ])
+
+    await expect(
+      catalogInventoryRuntimeExtension.resolveSelectedDepartureDate(db, {
+        productId: "prod_1",
+        departureDate: "next Tuesday",
+      }),
+    ).resolves.toBe("2026-08-16")
+  })
+
+  // The Commit refuses a slot that belongs to another product outright, so its
+  // date is not this product's departure and must not price this checkout.
+  it("ignores a slot that belongs to another product", async () => {
+    const db = fakeDb([
+      [availabilitySlots, [{ ...SLOT, productId: "prod_other" }]],
+      [products, [{ startDate: "2026-08-16" }]],
+    ])
+
+    await expect(
+      catalogInventoryRuntimeExtension.resolveSelectedDepartureDate(db, {
+        productId: "prod_1",
+        departureSlotId: "avsl_01k",
+      }),
+    ).resolves.toBe("2026-08-16")
+  })
+
+  it("reports no departure for a product with neither a slot nor a start date", async () => {
+    const db = fakeDb([
+      [availabilitySlots, []],
+      [products, [{ startDate: null }]],
+    ])
+
+    await expect(
+      catalogInventoryRuntimeExtension.resolveSelectedDepartureDate(db, { productId: "prod_1" }),
+    ).resolves.toBeNull()
   })
 })
 

--- a/packages/inventory/tests/unit/catalog-runtime-payment-context.test.ts
+++ b/packages/inventory/tests/unit/catalog-runtime-payment-context.test.ts
@@ -115,8 +115,8 @@ describe("loadProductPaymentPolicyContext product name", () => {
  * has nothing to do with the departure being bought, and reading it as one
  * collapsed a 50% deposit policy to full payment on a departure five weeks out
  * (voyant#4740). Resolution mirrors what the Booking itself records —
- * `slot?.dateLocal ?? product.startDate` in `convertProductToBooking` — with an
- * inline selection date in between for products that sell without slots.
+ * `slot?.dateLocal ?? product.startDate` in `convertProductToBooking` — because
+ * agreeing with that by construction is the point.
  */
 describe("resolveSelectedDepartureDate", () => {
   const SLOT = {
@@ -138,26 +138,11 @@ describe("resolveSelectedDepartureDate", () => {
       catalogInventoryRuntimeExtension.resolveSelectedDepartureDate(db, {
         productId: "prod_1",
         departureSlotId: "avsl_01k",
-        departureDate: "2026-10-01",
       }),
     ).resolves.toBe("2026-09-20")
   })
 
-  it("falls back to a date stated inline when no slot was selected", async () => {
-    const db = fakeDb([
-      [availabilitySlots, []],
-      [products, [{ startDate: "2026-08-16" }]],
-    ])
-
-    await expect(
-      catalogInventoryRuntimeExtension.resolveSelectedDepartureDate(db, {
-        productId: "prod_1",
-        departureDate: "2026-10-01",
-      }),
-    ).resolves.toBe("2026-10-01")
-  })
-
-  it("falls back to the product row when the selection names no departure", async () => {
+  it("falls back to the product row when the selection names no slot", async () => {
     const db = fakeDb([
       [availabilitySlots, []],
       [products, [{ startDate: "2026-08-16" }]],
@@ -165,22 +150,6 @@ describe("resolveSelectedDepartureDate", () => {
 
     await expect(
       catalogInventoryRuntimeExtension.resolveSelectedDepartureDate(db, { productId: "prod_1" }),
-    ).resolves.toBe("2026-08-16")
-  })
-
-  // A policy gate that parses garbage answers "0 days to departure", which is
-  // the collapse-to-full-payment this issue was about, arrived at differently.
-  it("ignores a selection date that is not a calendar date", async () => {
-    const db = fakeDb([
-      [availabilitySlots, []],
-      [products, [{ startDate: "2026-08-16" }]],
-    ])
-
-    await expect(
-      catalogInventoryRuntimeExtension.resolveSelectedDepartureDate(db, {
-        productId: "prod_1",
-        departureDate: "next Tuesday",
-      }),
     ).resolves.toBe("2026-08-16")
   })
 


### PR DESCRIPTION
Closes #4740.

## The bug

The customer payment policy decides between "deposit now, balance later" and "full payment now" by measuring the distance to departure. At Commit it measured that distance from `products.startDate`.

`loadProductPaymentPolicyContext` returned `departureDate: products.startDate`, and `prepare()` fed it straight into `computePaymentSchedule`. For any slot-based product that column is the listing's own window and has nothing to do with the departure being bought — the reproduction in the issue shows a €378 product on a slot 35 days out charging the full €378 instead of the €189 deposit, purely because the product row was seeded with today's date.

It fails the expensive way too: a product whose `startDate` sits months out hands a shopper a 50% deposit on a departure leaving tomorrow, with the balance row dated in the past.

`generatePaymentScheduleForBooking` reads `booking.startDate` — the *selected* departure — so checkout and the post-confirmation schedule could produce two different plans for the same booking from the same policy.

## The fix

`loadProductPaymentPolicyContext` stops being the source of the departure date. It is a policy cascade over the **listing**; the departure is a property of the **selection**.

A new `resolveSelectedDepartureDate` port on `CatalogInventoryRuntimeExtension` answers that question, resolving the same way the Booking itself records it (`convertProductToBooking`: `slot?.dateLocal ?? product.startDate`), with an inline selection date in between for products that sell without slots:

1. the selected slot's `dateLocal` — read through `availabilityService.getSlotById`, availability's own service, not its table, so no new cross-module reach-in
2. `configure.departureDate`, when it is a plain `YYYY-MM-DD` — a policy gate that parses garbage answers "0 days to departure", which is the same collapse arrived at differently
3. `products.startDate`, the last resort for a product that genuinely has no departures

A slot id belonging to another product is ignored: the Commit refuses that combination outright, so its date is not this product's departure.

`prepare()` reads the Session's own `configure` step — the same place quoting and the Commit read it from — and uses the resolved date for both the schedule **and** the hosted-checkout line item, so the shopper reads the departure the amount was computed from.

## Rollout

`@voyant-travel/catalog` + `@voyant-travel/inventory`, patch. No schema change, no migration. The changeset carries the operator-facing note: **operators running a deposit policy will see checkout start collecting the deposit where it previously collected the full amount.**

## Verification

- `packages/catalog` — 848 passing; 5 new tests pin which date reaches `computePaymentSchedule` (spied, not stubbed) and that the line item names the selected departure
- `packages/inventory` — 608 passing; 6 new tests cover each arm of the resolver plus the two rejections (non-calendar date, foreign slot), and one asserts the policy loader no longer carries `departureDate` at all
- `verify:table-privacy`, `verify:graph-conformance`, `verify:symbol-policy` pass; `biome check` clean
- `tsc -p tsconfig.build.json` clean for `catalog`; the `inventory` typecheck ran on a disposable Sprite (locally it resolves sibling sources and exhausts an 8 GB heap in a fresh worktree)
