### PR TITLE
Show flight availability where the date is chosen

### DIFF
--- a/.changeset/flights-fare-calendar-and-airport-scoping.md
+++ b/.changeset/flights-fare-calendar-and-airport-scoping.md
@@ -1,0 +1,32 @@
+---
+"@voyant-travel/flights-contracts": minor
+"@voyant-travel/flights": minor
+"@voyant-travel/flights-react": minor
+"@voyant-travel/ui": minor
+---
+
+Show flight availability where the traveller chooses it.
+
+Adds two capability-gated connector methods and the UI that consumes them:
+
+- `flight/fare-calendar` (`searchFareCalendar`) quotes a window of departure
+  dates, so the date picker shows the cheapest indicative price per day, bands
+  it cheap / mid / expensive against the visible window, and strikes out days
+  the provider doesn't fly. Served as `POST /v1/admin/flights/fare-calendar`,
+  capped at a 92-day window.
+- `flight/served-markets` (`listServedMarkets`) declares the airports a
+  connection sells, so the airport picker leads with the operator's own
+  network. It ranks, it never filters — every airport stays reachable.
+
+The airport picker also groups by routes this operator has actually searched,
+remembered per browser, and the airport reference list is now deterministically
+ordered instead of returning an arbitrary slice.
+
+Flight offer rows now name the airline and its flight numbers instead of
+relying on the carrier logo alone.
+
+`Calendar` and `DatePicker` gain a `dayAnnotation` prop for rendering a
+secondary line under a day's number.
+
+Connectors that declare neither capability answer 501 and every surface
+degrades to its previous behaviour.

--- a/apps/flights-demo-api/src/routes.ts
+++ b/apps/flights-demo-api/src/routes.ts
@@ -4,6 +4,8 @@
  * integration source. Each endpoint maps 1:1 to an adapter call.
  *
  *   POST   /search                       searchFlights
+ *   POST   /fare-calendar                searchFareCalendar
+ *   GET    /served-markets                listServedMarkets
  *   POST   /price                        priceOffer
  *   POST   /book                         bookFlight
  *   GET    /orders                       listOrders
@@ -17,6 +19,7 @@
 
 import type {
   AncillaryRequest,
+  FareCalendarRequest,
   FlightBookRequest,
   FlightOrder,
   FlightOrderStatus,
@@ -33,11 +36,13 @@ import {
   findSegmentInOffer,
   parsePageCursor,
   synthesizeAncillaryCatalog,
+  synthesizeFareCalendar,
   synthesizeOffers,
   synthesizeOrder,
   synthesizeSeatMap,
   ticketHeldOrder,
 } from "./synthesis.js"
+import { demoServedMarkets } from "./synthesis-common.js"
 
 interface PriceRequest {
   offerId: string
@@ -69,6 +74,21 @@ export function createRoutes(db: DemoFlightsDb): Hono {
         ...(hasMore ? { cursor: String(page + 1) } : {}),
       },
     })
+  })
+
+  // ── Served markets ────────────────────────────────────────────────────
+  app.get("/served-markets", (c) => c.json(demoServedMarkets()))
+
+  // ── Fare calendar ─────────────────────────────────────────────────────
+  app.post("/fare-calendar", async (c) => {
+    const body = await c.req.json<FareCalendarRequest>()
+    if (!body.origin || !body.destination) {
+      return c.json({ error: "origin and destination are required" }, 400)
+    }
+    if (!body.from || !body.to) {
+      return c.json({ error: "from and to are required" }, 400)
+    }
+    return c.json(synthesizeFareCalendar(body))
   })
 
   // ── Price ─────────────────────────────────────────────────────────────

--- a/apps/flights-demo-api/src/synthesis-common.ts
+++ b/apps/flights-demo-api/src/synthesis-common.ts
@@ -32,6 +32,61 @@ export const CARRIERS: DemoCarrier[] = [
   { code: "FR", hubs: ["STN"], basePriceMultiplier: 0.55 },
 ]
 
+/**
+ * Airports the demo network sells — every carrier hub plus the leisure and
+ * long-haul points the demo routes terminate at.
+ *
+ * Narrower than what `synthesizeOffers` will actually price, and deliberately
+ * so: this models a real connector, which knows its contracted network rather
+ * than the whole world. Consumers rank by it and never filter on it, so the
+ * narrowness costs nothing.
+ */
+export function demoServedMarkets(): { origins: string[] } {
+  const hubs = CARRIERS.flatMap((carrier) => carrier.hubs)
+  const destinations = [
+    "JFK",
+    "FCO",
+    "BCN",
+    "MAD",
+    "GRU",
+    "JNB",
+    "NRT",
+    "HND",
+    "BKK",
+    "SIN",
+    "SFO",
+    "OTP",
+    "FNC",
+  ]
+  return { origins: [...new Set([...hubs, ...destinations])].sort() }
+}
+
+/**
+ * Thin long-haul markets in the demo network. Routes touching one of these
+ * fly a weekly pattern rather than daily, which is what gives a date picker
+ * over demo supply real gaps instead of a uniform wall of availability.
+ *
+ * Every other demo route operates daily, so short-haul behavior — and the
+ * offer-id fixtures pinned on it — is unchanged.
+ */
+const LOW_FREQUENCY_ENDPOINTS = new Set(["GRU", "JNB", "NRT", "HND", "BKK", "SIN", "SFO"])
+
+/** Mon / Wed / Fri / Sat, as `Date#getUTCDay` values. */
+const LOW_FREQUENCY_WEEKDAYS = new Set([1, 3, 5, 6])
+
+/**
+ * Whether demo supply operates this route on this date. Search and the fare
+ * calendar both consult it, so a day the calendar greys out is a day search
+ * genuinely returns nothing for — the two can never disagree.
+ */
+export function routeOperatesOn(origin: string, destination: string, departureDate: string) {
+  if (!LOW_FREQUENCY_ENDPOINTS.has(origin) && !LOW_FREQUENCY_ENDPOINTS.has(destination)) {
+    return true
+  }
+  const day = new Date(`${departureDate}T00:00:00Z`).getUTCDay()
+  return Number.isNaN(day) ? true : LOW_FREQUENCY_WEEKDAYS.has(day)
+}
+
 export const CABIN_PRICE_MULT: Record<CabinClass, number> = {
   economy: 1,
   premium_economy: 1.6,

--- a/apps/flights-demo-api/src/synthesis-fare-calendar.test.ts
+++ b/apps/flights-demo-api/src/synthesis-fare-calendar.test.ts
@@ -1,0 +1,101 @@
+import type { FareCalendarRequest } from "@voyant-travel/flights/contract/types"
+import { describe, expect, it } from "vitest"
+
+import { synthesizeFareCalendar } from "./synthesis-fare-calendar.js"
+import { applySearchFilters, synthesizeOffers } from "./synthesis-offers.js"
+
+const PASSENGERS = { adults: 1, children: 0, infants: 0 }
+
+function calendarRequest(overrides: Partial<FareCalendarRequest> = {}): FareCalendarRequest {
+  return {
+    origin: "BCN",
+    destination: "FCO",
+    from: "2026-07-06",
+    to: "2026-07-12",
+    passengers: PASSENGERS,
+    cabin: "economy",
+    ...overrides,
+  }
+}
+
+/** Cheapest total a real search returns for one leg, or undefined when none. */
+function cheapestFromSearch(origin: string, destination: string, departureDate: string) {
+  const request = {
+    slices: [{ origin, destination, departureDate }],
+    passengers: PASSENGERS,
+    cabin: "economy" as const,
+  }
+  const offers = applySearchFilters(synthesizeOffers(request), request)
+  return offers.reduce<string | undefined>(
+    (best, offer) =>
+      best != null && Number(best) <= Number(offer.totalPrice.amount)
+        ? best
+        : offer.totalPrice.amount,
+    undefined,
+  )
+}
+
+describe("synthesizeFareCalendar", () => {
+  it("quotes every day in the inclusive window, ascending", () => {
+    const { days } = synthesizeFareCalendar(calendarRequest())
+
+    expect(days.map((day) => day.date)).toEqual([
+      "2026-07-06",
+      "2026-07-07",
+      "2026-07-08",
+      "2026-07-09",
+      "2026-07-10",
+      "2026-07-11",
+      "2026-07-12",
+    ])
+  })
+
+  // The whole point of pricing through the real offer path: a picker that
+  // shows one number and a search that returns another is worse than no
+  // number at all.
+  it("quotes each day at the price a search on that day returns", () => {
+    const { days } = synthesizeFareCalendar(calendarRequest())
+
+    for (const day of days) {
+      expect(day.cheapestPrice?.amount).toBe(cheapestFromSearch("BCN", "FCO", day.date))
+    }
+  })
+
+  it("marks a day unavailable exactly when search finds nothing", () => {
+    // SFO is a thin long-haul endpoint in the demo network, so its route
+    // operates Mon/Wed/Fri/Sat only. 2026-07-07 is a Tuesday.
+    const { days } = synthesizeFareCalendar(
+      calendarRequest({ origin: "LHR", destination: "SFO", from: "2026-07-06", to: "2026-07-08" }),
+    )
+
+    expect(days.map((day) => day.available)).toEqual([true, false, true])
+    expect(days[1]?.cheapestPrice).toBeUndefined()
+    expect(cheapestFromSearch("LHR", "SFO", "2026-07-07")).toBeUndefined()
+  })
+
+  it("prices a round-trip day as the whole trip, not just the outbound", () => {
+    const oneWay = synthesizeFareCalendar(calendarRequest())
+    const roundTrip = synthesizeFareCalendar(calendarRequest({ returnAfterDays: 7 }))
+
+    const oneWayFirst = Number(oneWay.days[0]?.cheapestPrice?.amount)
+    const roundTripFirst = Number(roundTrip.days[0]?.cheapestPrice?.amount)
+
+    expect(roundTripFirst).toBeGreaterThan(oneWayFirst)
+  })
+
+  it("returns no days when the window is inverted", () => {
+    const { days } = synthesizeFareCalendar(
+      calendarRequest({ from: "2026-07-12", to: "2026-07-06" }),
+    )
+
+    expect(days).toEqual([])
+  })
+
+  it("caps a window wider than the quotable range", () => {
+    const { days } = synthesizeFareCalendar(
+      calendarRequest({ from: "2026-01-01", to: "2026-12-31" }),
+    )
+
+    expect(days).toHaveLength(92)
+  })
+})

--- a/apps/flights-demo-api/src/synthesis-fare-calendar.ts
+++ b/apps/flights-demo-api/src/synthesis-fare-calendar.ts
@@ -1,0 +1,100 @@
+/**
+ * Fare-calendar synthesis for the demo flight service.
+ *
+ * Every quoted day is priced by running the *real* offer synthesis for that
+ * date and taking the cheapest survivor. That is deliberately more work than
+ * a standalone price model would be: it guarantees the number the picker
+ * shows for a day is the number a search on that day actually returns, and
+ * that a greyed-out day is one search genuinely finds nothing for.
+ *
+ * Real connectors serve this from cached lowest-fare data instead, which is
+ * why the contract calls the prices indicative and callers re-quote before
+ * booking.
+ */
+
+import type {
+  FareCalendarDay,
+  FareCalendarRequest,
+  FareCalendarResponse,
+  FlightSearchRequest,
+  FlightSlice,
+} from "@voyant-travel/flights/contract/types"
+
+import { applySearchFilters, synthesizeOffers } from "./synthesis-offers.js"
+
+/** Demo quotes are cheap to recompute; keep the freshness window short. */
+const QUOTE_TTL_MS = 15 * 60_000
+
+/** Hard stop on how many days one call will price, mirroring the route's cap. */
+const MAX_DAYS = 92
+
+export function synthesizeFareCalendar(request: FareCalendarRequest): FareCalendarResponse {
+  const days: FareCalendarDay[] = []
+
+  for (const date of eachDate(request.from, request.to, MAX_DAYS)) {
+    const searchRequest = searchForDate(request, date)
+    const offers = applySearchFilters(synthesizeOffers(searchRequest), searchRequest)
+    const cheapest = offers.reduce<(typeof offers)[number] | undefined>(
+      (best, offer) =>
+        best && Number(best.totalPrice.amount) <= Number(offer.totalPrice.amount) ? best : offer,
+      undefined,
+    )
+
+    if (!cheapest) {
+      days.push({ date, available: false })
+      continue
+    }
+
+    days.push({
+      date,
+      available: true,
+      cheapestPrice: cheapest.totalPrice,
+      offerCount: offers.length,
+    })
+  }
+
+  return {
+    days,
+    expiresAt: new Date(Date.now() + QUOTE_TTL_MS).toISOString(),
+  }
+}
+
+/**
+ * The search a given calendar day stands for. With `returnAfterDays` the day
+ * is priced as the whole round trip, because that is what the traveller
+ * actually buys when they pick a departure date in a round-trip picker.
+ */
+function searchForDate(request: FareCalendarRequest, departureDate: string): FlightSearchRequest {
+  const slices: FlightSlice[] = [
+    { origin: request.origin, destination: request.destination, departureDate },
+  ]
+  if (request.returnAfterDays != null) {
+    slices.push({
+      origin: request.destination,
+      destination: request.origin,
+      departureDate: shiftDate(departureDate, request.returnAfterDays),
+    })
+  }
+  return {
+    slices,
+    passengers: request.passengers,
+    cabin: request.cabin,
+    searchOptions: request.searchOptions,
+  }
+}
+
+/** Inclusive `yyyy-MM-dd` walk, capped so a bad window can't spin. */
+function* eachDate(from: string, to: string, maxDays: number): Generator<string> {
+  const start = Date.parse(`${from}T00:00:00Z`)
+  const end = Date.parse(`${to}T00:00:00Z`)
+  if (Number.isNaN(start) || Number.isNaN(end) || end < start) return
+
+  const total = Math.min(Math.floor((end - start) / 86_400_000) + 1, maxDays)
+  for (let i = 0; i < total; i++) {
+    yield new Date(start + i * 86_400_000).toISOString().slice(0, 10)
+  }
+}
+
+function shiftDate(date: string, days: number): string {
+  return new Date(Date.parse(`${date}T00:00:00Z`) + days * 86_400_000).toISOString().slice(0, 10)
+}

--- a/apps/flights-demo-api/src/synthesis-offers.ts
+++ b/apps/flights-demo-api/src/synthesis-offers.ts
@@ -18,6 +18,7 @@ import {
   hashRequest,
   minutesToIso8601,
   mulberry32,
+  routeOperatesOn,
   setHourMinute,
 } from "./synthesis-common.js"
 import { synthesizeFareBundles } from "./synthesis-fare-bundles.js"
@@ -42,6 +43,13 @@ function routeSignature(slices: FlightSlice[]): string {
 }
 
 export function synthesizeOffers(request: FlightSearchRequest): FlightOffer[] {
+  // A trip is only sellable when every leg operates on its date. Returning
+  // nothing here is what the fare calendar reports as an unavailable day.
+  const operates = request.slices.every((slice) =>
+    routeOperatesOn(slice.origin, slice.destination, slice.departureDate),
+  )
+  if (!operates) return []
+
   // Hash without pagination so the same route produces the same pool across
   // page navigations — pagination is applied as a slice on top of the pool.
   const { pagination: _ignored, ...rest } = request

--- a/apps/flights-demo-api/src/synthesis.ts
+++ b/apps/flights-demo-api/src/synthesis.ts
@@ -5,6 +5,7 @@
  */
 
 export { synthesizeAncillaryCatalog } from "./synthesis-ancillaries.js"
+export { synthesizeFareCalendar } from "./synthesis-fare-calendar.js"
 export { applySearchFilters, parsePageCursor, synthesizeOffers } from "./synthesis-offers.js"
 export { synthesizeOrder, ticketHeldOrder } from "./synthesis-orders.js"
 export { findSegmentInOffer, synthesizeSeatMap } from "./synthesis-seat-maps.js"

--- a/packages/flights-contracts/src/contract/adapter.ts
+++ b/packages/flights-contracts/src/contract/adapter.ts
@@ -18,6 +18,8 @@ import type {
   AncillaryResponse,
   CheckInRequest,
   CheckInResponse,
+  FareCalendarRequest,
+  FareCalendarResponse,
   FlightBookRequest,
   FlightCapability,
   FlightModifyRequest,
@@ -34,6 +36,7 @@ import type {
   SeatMapResponse,
   SeatSelectionRequest,
   SeatSelectionResponse,
+  ServedMarketsResponse,
   SsrRequest,
   SsrResponse,
 } from "./types.js"
@@ -217,6 +220,24 @@ export interface FlightConnectorAdapter {
     ctx: FlightAdapterContext,
     query: FlightOrdersListQuery,
   ): Promise<FlightOrdersListResponse>
+
+  /**
+   * `flight/fare-calendar` — quote a window of departure dates so a picker can
+   * show where availability is before a day is chosen. Indicative pricing from
+   * the provider's cached lowest-fare data; callers re-quote with
+   * `searchFlights` before booking.
+   */
+  searchFareCalendar?(
+    ctx: FlightAdapterContext,
+    request: FareCalendarRequest,
+  ): Promise<FareCalendarResponse>
+
+  /**
+   * `flight/served-markets` — declare the airports this connection sells, so a
+   * picker can lead with the operator's own network instead of every airport
+   * on earth. Consumers rank by it; they must not filter on it.
+   */
+  listServedMarkets?(ctx: FlightAdapterContext): Promise<ServedMarketsResponse>
 
   /** `flight/holds` — promote a held order to ticketed. */
   ticketOrder?(ctx: FlightAdapterContext, orderId: string): Promise<FlightGetOrderResponse>

--- a/packages/flights-contracts/src/contract/schemas.ts
+++ b/packages/flights-contracts/src/contract/schemas.ts
@@ -14,9 +14,15 @@ const iataCodeSchema = z.string().length(3)
  * caller never asked for and quote the wrong month back. Round-tripping the
  * parsed parts is what rejects a day that does not exist.
  */
-const isoDateSchema = z.string().refine(isCalendarDate, {
-  message: "Expected a calendar date in yyyy-MM-dd form",
-})
+const isoDateSchema = z
+  .string()
+  .refine(isCalendarDate, { message: "Expected a calendar date in yyyy-MM-dd form" })
+  // `z.toJSONSchema` drops refinements, so a caller reading only the generated
+  // schema — an agent, say — would learn the day-must-exist rule from a 400.
+  // The description is the part it can actually see.
+  .describe(
+    "A calendar date as yyyy-MM-dd. The day must exist: 2026-02-31 and 2026-13-01 are rejected rather than rolled forward.",
+  )
 
 function isCalendarDate(value: string): boolean {
   const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value)

--- a/packages/flights-contracts/src/contract/schemas.ts
+++ b/packages/flights-contracts/src/contract/schemas.ts
@@ -6,8 +6,30 @@ import { FLIGHT_CAPABILITIES, type FlightCapability } from "./types.js"
 const decimalStringSchema = z.string().regex(/^\d+(\.\d+)?$/)
 const signedDecimalStringSchema = z.string().regex(/^-?\d+(\.\d+)?$/)
 const iataCodeSchema = z.string().length(3)
-/** Calendar-day precision. The fare calendar iterates these, so shape matters. */
-const isoDateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/)
+/**
+ * A real calendar day, not merely a `yyyy-MM-dd`-shaped string.
+ *
+ * Shape alone is not enough: `Date` silently rolls `2026-02-31` forward to
+ * 2026-03-03, so a format-only check would hand the connector a window the
+ * caller never asked for and quote the wrong month back. Round-tripping the
+ * parsed parts is what rejects a day that does not exist.
+ */
+const isoDateSchema = z.string().refine(isCalendarDate, {
+  message: "Expected a calendar date in yyyy-MM-dd form",
+})
+
+function isCalendarDate(value: string): boolean {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value)
+  if (!match) return false
+  const [, year, month, day] = match
+  const parsed = new Date(`${value}T00:00:00Z`)
+  if (Number.isNaN(parsed.getTime())) return false
+  return (
+    parsed.getUTCFullYear() === Number(year) &&
+    parsed.getUTCMonth() + 1 === Number(month) &&
+    parsed.getUTCDate() === Number(day)
+  )
+}
 const carrierCodeSchema = z.string().min(2).max(3)
 const currencyCodeSchema = z.string().length(3)
 const providerDataSchema = z.record(z.string(), z.unknown())

--- a/packages/flights-contracts/src/contract/schemas.ts
+++ b/packages/flights-contracts/src/contract/schemas.ts
@@ -6,6 +6,8 @@ import { FLIGHT_CAPABILITIES, type FlightCapability } from "./types.js"
 const decimalStringSchema = z.string().regex(/^\d+(\.\d+)?$/)
 const signedDecimalStringSchema = z.string().regex(/^-?\d+(\.\d+)?$/)
 const iataCodeSchema = z.string().length(3)
+/** Calendar-day precision. The fare calendar iterates these, so shape matters. */
+const isoDateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/)
 const carrierCodeSchema = z.string().min(2).max(3)
 const currencyCodeSchema = z.string().length(3)
 const providerDataSchema = z.record(z.string(), z.unknown())
@@ -213,6 +215,42 @@ export const flightSearchRequestSchema = z.object({
 export const flightSearchResponseSchema = z.object({
   offers: z.array(flightOfferSchema),
   pagination: flightSearchPaginationMetaSchema.optional(),
+  providerData: providerDataSchema.optional(),
+})
+
+export const fareCalendarRequestSchema = z.object({
+  origin: iataCodeSchema,
+  destination: iataCodeSchema,
+  from: isoDateSchema,
+  to: isoDateSchema,
+  passengers: passengerCountsSchema,
+  cabin: cabinClassSchema.optional(),
+  returnAfterDays: z.number().int().min(0).optional(),
+  searchOptions: z
+    .object({
+      directOnly: z.boolean().optional(),
+      maxStops: z.number().int().min(0).optional(),
+    })
+    .optional(),
+})
+
+export const fareCalendarDaySchema = z.object({
+  date: isoDateSchema,
+  available: z.boolean(),
+  cheapestPrice: moneySchema.optional(),
+  offerCount: z.number().int().min(0).optional(),
+})
+
+export const fareCalendarResponseSchema = z.object({
+  days: z.array(fareCalendarDaySchema),
+  expiresAt: z.string().optional(),
+  providerData: providerDataSchema.optional(),
+})
+
+export const servedMarketsResponseSchema = z.object({
+  origins: z.array(iataCodeSchema),
+  destinations: z.array(iataCodeSchema).optional(),
+  expiresAt: z.string().optional(),
   providerData: providerDataSchema.optional(),
 })
 

--- a/packages/flights-contracts/src/contract/types.ts
+++ b/packages/flights-contracts/src/contract/types.ts
@@ -522,6 +522,103 @@ export interface SeatMapResponse {
   validUntil?: string
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Fare calendar
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Ask a provider which departure dates it sells a route on, and for how much.
+ *
+ * This is a *shopping* call, not a search: it answers "when is this route
+ * flyable and roughly what does it cost" across a window of dates, so a date
+ * picker can show availability before the traveller commits to a day. It is
+ * deliberately cheaper and coarser than `searchFlights` — providers serve it
+ * from cached lowest-fare data (Amadeus Flight Cheapest Date Search, Sabre
+ * BFM Calendar), so prices are indicative and MUST be re-quoted by a real
+ * search before anything is booked.
+ */
+export interface FareCalendarRequest {
+  origin: string // 3-char IATA
+  destination: string
+  /** Inclusive ISO date (yyyy-MM-dd) lower bound of the quoted window. */
+  from: string
+  /** Inclusive ISO date (yyyy-MM-dd) upper bound of the quoted window. */
+  to: string
+  passengers: PassengerCounts
+  cabin?: CabinClass
+  /**
+   * Round-trip stay length in nights. When set, each quoted day is priced as
+   * a return trip departing that day and coming back `returnAfterDays` later,
+   * which is what a round-trip picker needs. Omit for one-way pricing.
+   */
+  returnAfterDays?: number
+  searchOptions?: {
+    directOnly?: boolean
+    maxStops?: number
+  }
+}
+
+/** One day in the quoted window. */
+export interface FareCalendarDay {
+  /** ISO date, yyyy-MM-dd. */
+  date: string
+  /**
+   * Whether the provider sells this route on this date at all. `false` is a
+   * positive statement of no availability — distinct from a day the provider
+   * simply didn't quote, which is omitted from `days` entirely.
+   */
+  available: boolean
+  /**
+   * Cheapest indicative total for the requested party — same basis as
+   * `FlightOffer.totalPrice`, not a per-passenger fare. Omitted when
+   * `available` is false, or when the provider reports availability without
+   * a price.
+   */
+  cheapestPrice?: Money
+  /** Offers behind the quote, when the provider reports it. */
+  offerCount?: number
+}
+
+export interface FareCalendarResponse {
+  /**
+   * Quoted days, ascending. A provider may return fewer days than requested
+   * (window caps, no data) — a missing day means "not quoted", never
+   * "unavailable".
+   */
+  days: FareCalendarDay[]
+  /** ISO 8601 — when this quote goes stale. Cached calendars are not live. */
+  expiresAt?: string
+  /** Provider-specific data, opaque to the consumer. */
+  providerData?: Record<string, unknown>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Served markets
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The airports a connection actually sells, so a picker can put an operator's
+ * own network in front of the global airport reference.
+ *
+ * This is a **ranking hint, never a filter**. A connection that declares a
+ * narrow network is describing where its supply is concentrated, not where the
+ * operator is permitted to search — consumers must keep every other airport
+ * reachable, or a stale declaration silently amputates the product.
+ */
+export interface ServedMarketsResponse {
+  /** IATA codes the connection sells departures from. */
+  origins: string[]
+  /**
+   * IATA codes the connection sells arrivals to. Omit when the network is
+   * symmetric, which is the common case.
+   */
+  destinations?: string[]
+  /** ISO 8601 — when this declaration goes stale. */
+  expiresAt?: string
+  /** Provider-specific data, opaque to the consumer. */
+  providerData?: Record<string, unknown>
+}
+
 export type {
   CheckInRequest,
   CheckInResponse,
@@ -563,6 +660,17 @@ export const FLIGHT_CAPABILITIES = {
   BRANDED_FARES: "flight/branded-fares",
   /** `listOrders(ctx, query)` is queryable — the adapter persists orders. */
   LIST_ORDERS: "flight/list-orders",
+  /**
+   * `searchFareCalendar(ctx, request)` quotes a window of departure dates, so
+   * a date picker can show where availability actually is.
+   */
+  FARE_CALENDAR: "flight/fare-calendar",
+  /**
+   * `listServedMarkets(ctx)` declares the airports this connection sells, so a
+   * picker can lead with the operator's own network. A hint for ordering, not
+   * a restriction on what may be searched.
+   */
+  SERVED_MARKETS: "flight/served-markets",
 } as const
 
 export type FlightCapability = (typeof FLIGHT_CAPABILITIES)[keyof typeof FLIGHT_CAPABILITIES]

--- a/packages/flights-react/package.json
+++ b/packages/flights-react/package.json
@@ -68,6 +68,7 @@
   "devDependencies": {
     "@tanstack/react-query": "^5.101.2",
     "@tanstack/react-table": "^8.21.3",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@voyant-travel/admin": "workspace:^",
@@ -79,6 +80,7 @@
     "@voyant-travel/relationships-react": "workspace:^",
     "@voyant-travel/ui": "workspace:^",
     "@voyant-travel/voyant-typescript-config": "workspace:^",
+    "jsdom": "^29.1.1",
     "lucide-react": "^1.23.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/packages/flights-react/src/components/airport-combobox.test.tsx
+++ b/packages/flights-react/src/components/airport-combobox.test.tsx
@@ -1,0 +1,216 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { VoyantFlightsProvider } from "../provider.js"
+import {
+  clearRecentAirports,
+  noteAirportSelected,
+  rememberSearchedAirports,
+} from "../recent-routes.js"
+import type { AirportDto } from "../schemas.js"
+import { AirportCombobox } from "./airport-combobox.js"
+
+function airport(iataCode: string, city: string, name: string): AirportDto {
+  return { iataCode, city, name, country: "XX" }
+}
+
+const LHR = airport("LHR", "London", "Heathrow")
+const OTP = airport("OTP", "Bucharest", "Otopeni")
+const FNC = airport("FNC", "Funchal", "Madeira")
+const NRT = airport("NRT", "Tokyo", "Narita")
+
+const REFERENCE = [LHR, OTP, FNC, NRT]
+
+function fetcherFor({
+  airports = REFERENCE,
+  servedMarkets,
+}: {
+  airports?: AirportDto[]
+  servedMarkets?: { origins: string[]; destinations?: string[] } | number
+} = {}) {
+  return vi.fn(async (url: string, _init?: RequestInit) => {
+    if (url.includes("/served-markets")) {
+      if (typeof servedMarkets === "number") {
+        return Response.json({ error: "nope" }, { status: servedMarkets })
+      }
+      if (!servedMarkets) return Response.json({ error: "nope" }, { status: 501 })
+      return Response.json(servedMarkets)
+    }
+    if (url.includes("/reference/airports")) {
+      const query = new URL(url, "http://localhost").searchParams.get("q")?.toLowerCase()
+      const data = query
+        ? airports.filter((a) =>
+            [a.iataCode, a.city, a.name].some((field) => field.toLowerCase().includes(query)),
+          )
+        : airports
+      return Response.json({ data })
+    }
+    return Response.json({ data: [] })
+  })
+}
+
+function renderCombobox(fetcher: (url: string, init?: RequestInit) => Promise<Response>) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <VoyantFlightsProvider baseUrl="/api" fetcher={fetcher}>
+        <AirportCombobox value={null} onChange={vi.fn()} placeholder="From" side="origin" />
+      </VoyantFlightsProvider>
+    </QueryClientProvider>,
+  )
+}
+
+function openCombobox() {
+  fireEvent.click(screen.getByRole("button", { name: /From/ }))
+}
+
+/**
+ * The option labels under a named group heading, in render order. cmdk renders
+ * the heading as a sibling of the `role=group` items container, so the shared
+ * ancestor is the command-group wrapper rather than the group itself.
+ */
+function optionsUnder(heading: string): string[] {
+  const group = screen.getByText(heading).closest("[data-slot=command-group]")
+  if (!group) throw new Error(`No group for heading ${heading}`)
+  return within(group as HTMLElement)
+    .getAllByRole("option")
+    .map((option) => option.textContent ?? "")
+}
+
+/** Record airports as genuinely searched, which is what promotes them. */
+function haveSearched(...airports: AirportDto[]) {
+  for (const a of airports) noteAirportSelected(a)
+  rememberSearchedAirports(airports.map((a) => a.iataCode))
+}
+
+// The command list virtualizes, which needs ResizeObserver; jsdom lacks it.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeEach(() => {
+  vi.stubGlobal("ResizeObserver", ResizeObserverStub)
+  // Active-item tracking scrolls the highlighted option into view.
+  Element.prototype.scrollIntoView = vi.fn()
+  clearRecentAirports()
+})
+
+afterEach(() => {
+  clearRecentAirports()
+  cleanup()
+})
+
+describe("AirportCombobox grouping", () => {
+  it("leads with the airports this operator has actually searched", async () => {
+    haveSearched(OTP)
+    renderCombobox(fetcherFor())
+    openCombobox()
+
+    // Remembered airports render immediately from local memory; wait for the
+    // reference page to land before comparing the two groups.
+    await screen.findByText("All airports")
+    expect(optionsUnder("Your routes").join()).toContain("OTP")
+    // ...and it is not repeated further down.
+    expect(optionsUnder("All airports").join()).not.toContain("OTP")
+  })
+
+  it("ranks a route flown more often above one flown once", async () => {
+    haveSearched(OTP)
+    haveSearched(LHR)
+    haveSearched(LHR)
+    renderCombobox(fetcherFor())
+    openCombobox()
+
+    await screen.findByText("Your routes")
+    const [first, second] = optionsUnder("Your routes")
+    expect(first).toContain("LHR")
+    expect(second).toContain("OTP")
+  })
+
+  it("groups the connector's declared network above the global reference", async () => {
+    renderCombobox(fetcherFor({ servedMarkets: { origins: ["FNC"] } }))
+    openCombobox()
+
+    await screen.findByText("Served by your providers")
+    expect(optionsUnder("Served by your providers").join()).toContain("FNC")
+    expect(optionsUnder("All airports").join()).toContain("NRT")
+  })
+
+  // The rule that keeps a stale declaration from amputating the product.
+  it("still offers airports the connector does not declare", async () => {
+    renderCombobox(fetcherFor({ servedMarkets: { origins: ["FNC"] } }))
+    openCombobox()
+
+    await screen.findByText("Served by your providers")
+    const everything = screen.getAllByRole("option").map((option) => option.textContent ?? "")
+    for (const code of ["LHR", "OTP", "FNC", "NRT"]) {
+      expect(everything.join()).toContain(code)
+    }
+  })
+
+  it("reads the destination side of an asymmetric network", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    render(
+      <QueryClientProvider client={queryClient}>
+        <VoyantFlightsProvider
+          baseUrl="/api"
+          fetcher={fetcherFor({ servedMarkets: { origins: ["OTP"], destinations: ["FNC"] } })}
+        >
+          <AirportCombobox value={null} onChange={vi.fn()} placeholder="To" side="destination" />
+        </VoyantFlightsProvider>
+      </QueryClientProvider>,
+    )
+    fireEvent.click(screen.getByRole("button", { name: /To/ }))
+
+    await screen.findByText("Served by your providers")
+    expect(optionsUnder("Served by your providers").join()).toContain("FNC")
+    expect(optionsUnder("Served by your providers").join()).not.toContain("OTP")
+  })
+
+  it("shows one unheaded list when there is no signal to group by", async () => {
+    renderCombobox(fetcherFor({ servedMarkets: 501 }))
+    openCombobox()
+
+    await waitFor(() => expect(screen.getAllByRole("option").length).toBe(REFERENCE.length))
+    expect(screen.queryByText("Your routes")).toBeNull()
+    expect(screen.queryByText("Served by your providers")).toBeNull()
+    expect(screen.queryByText("All airports")).toBeNull()
+  })
+
+  // "Your routes" that ignores the query is just a list in the way.
+  it("narrows remembered airports to the typeahead", async () => {
+    haveSearched(OTP)
+    renderCombobox(fetcherFor())
+    openCombobox()
+    await screen.findByText("Your routes")
+
+    fireEvent.change(screen.getByPlaceholderText(/Type city or IATA/), {
+      target: { value: "tokyo" },
+    })
+
+    await waitFor(() => expect(screen.queryByText("Your routes")).toBeNull())
+    expect(
+      screen
+        .getAllByRole("option")
+        .map((o) => o.textContent ?? "")
+        .join(),
+    ).toContain("NRT")
+  })
+
+  it("keeps a remembered airport visible even when the reference page drops it", async () => {
+    haveSearched(OTP)
+    // The reference no longer returns OTP at all — local memory carries it.
+    renderCombobox(fetcherFor({ airports: [LHR, FNC, NRT] }))
+    openCombobox()
+
+    await screen.findByText("Your routes")
+    expect(optionsUnder("Your routes").join()).toContain("Bucharest")
+  })
+})

--- a/packages/flights-react/src/components/airport-combobox.tsx
+++ b/packages/flights-react/src/components/airport-combobox.tsx
@@ -12,9 +12,17 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from "@voyant-travel/ui/components/popover"
 import { cn } from "@voyant-travel/ui/lib/utils"
 import { ChevronDown, MapPin } from "lucide-react"
-import { useState } from "react"
+import { useMemo, useState } from "react"
+import { useServedMarkets } from "../hooks/use-served-markets.js"
 import { useFlightsUiMessagesOrDefault } from "../i18n/index.js"
 import { type AirportDto, useAirportSearch } from "../index.js"
+import {
+  matchRecentAirports,
+  noteAirportSelected,
+  type RecentAirport,
+  readRecentAirports,
+} from "../recent-routes.js"
+import type { ServedMarketsResponseDto } from "../schemas.js"
 
 export interface AirportComboboxProps {
   /** Selected IATA code, or null when nothing is selected. */
@@ -22,6 +30,11 @@ export interface AirportComboboxProps {
   onChange: (next: string | null, airport: AirportDto | null) => void
   /** Trigger placeholder when nothing is selected (e.g. "From", "To"). */
   placeholder?: string
+  /**
+   * Which side of the route this picker fills. Only affects ordering: a
+   * connector may declare different origins and destinations.
+   */
+  side?: "origin" | "destination"
   className?: string
   disabled?: boolean
 }
@@ -38,15 +51,41 @@ export function AirportCombobox({
   value,
   onChange,
   placeholder,
+  side = "origin",
   className,
   disabled,
 }: AirportComboboxProps) {
   const messages = useFlightsUiMessagesOrDefault().airportCombobox
   const [open, setOpen] = useState(false)
   const [input, setInput] = useState("")
-  const search = useAirportSearch(input, { enabled: open, limit: 30 })
+  // Ask for more than fits so the reference list still has depth after the
+  // operator's own airports are lifted out of it into their own groups.
+  const search = useAirportSearch(input, { enabled: open, limit: 40 })
+  const servedMarkets = useServedMarkets({ enabled: open })
   const airports = search.data?.data ?? []
   const selected = value ? airports.find((a) => a.iataCode === value) : null
+
+  // Read once per open, not per keystroke: the ranking should hold still
+  // while the user types into it.
+  const remembered = useMemo(() => (open ? readRecentAirports() : []), [open])
+
+  const groups = useMemo(
+    () =>
+      groupAirports({
+        airports,
+        recent: matchRecentAirports(remembered, input),
+        servedCodes: servedMarketCodes(servedMarkets.data, side),
+        messages,
+      }),
+    [airports, remembered, input, servedMarkets.data, side, messages],
+  )
+
+  const select = (airport: AirportDto) => {
+    noteAirportSelected(airport)
+    onChange(airport.iataCode, airport)
+    setOpen(false)
+    setInput("")
+  }
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -86,33 +125,113 @@ export function AirportCombobox({
           />
           <CommandList>
             <CommandEmpty>{search.isLoading ? messages.searching : messages.empty}</CommandEmpty>
-            <CommandGroup>
-              {airports.map((a) => (
-                <CommandItem
-                  key={a.iataCode}
-                  value={`${a.iataCode} ${a.city} ${a.name}`}
-                  onSelect={() => {
-                    onChange(a.iataCode, a)
-                    setOpen(false)
-                    setInput("")
-                  }}
-                >
-                  <span className="mr-2 inline-flex w-10 justify-center rounded bg-muted px-1.5 py-0.5 font-mono text-[10px] font-medium">
-                    {a.iataCode}
-                  </span>
-                  <div className="flex min-w-0 flex-1 flex-col">
-                    <span className="truncate text-sm">{a.city}</span>
-                    <span className="truncate text-xs text-muted-foreground">{a.name}</span>
-                  </div>
-                  <span className="ml-2 text-[10px] uppercase text-muted-foreground">
-                    {a.country}
-                  </span>
-                </CommandItem>
-              ))}
-            </CommandGroup>
+            {groups.map((group) => (
+              <CommandGroup key={group.key} heading={group.heading}>
+                {group.airports.map((a) => (
+                  <CommandItem
+                    key={a.iataCode}
+                    value={`${group.key} ${a.iataCode} ${a.city} ${a.name}`}
+                    onSelect={() => {
+                      select(a)
+                    }}
+                  >
+                    <span className="mr-2 inline-flex w-10 justify-center rounded bg-muted px-1.5 py-0.5 font-mono text-[10px] font-medium">
+                      {a.iataCode}
+                    </span>
+                    <div className="flex min-w-0 flex-1 flex-col">
+                      <span className="truncate text-sm">{a.city}</span>
+                      <span className="truncate text-xs text-muted-foreground">{a.name}</span>
+                    </div>
+                    <span className="ml-2 text-[10px] uppercase text-muted-foreground">
+                      {a.country}
+                    </span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            ))}
           </CommandList>
         </Command>
       </PopoverContent>
     </Popover>
   )
+}
+
+interface AirportGroup {
+  key: "recent" | "served" | "all"
+  heading: string
+  airports: AirportDto[]
+}
+
+/**
+ * Split the reference results into three bands, most relevant first:
+ *
+ *   1. airports this operator has actually searched (local memory)
+ *   2. airports the connector declares it sells (`flight/served-markets`)
+ *   3. everything else the reference returned
+ *
+ * Each airport appears exactly once, in the highest band that claims it.
+ * Nothing is ever removed — a stale served-markets declaration must not be
+ * able to hide an airport the operator needs, so the third group always
+ * carries the remainder.
+ */
+function groupAirports({
+  airports,
+  recent,
+  servedCodes,
+  messages,
+}: {
+  airports: AirportDto[]
+  recent: RecentAirport[]
+  servedCodes: Set<string>
+  messages: ReturnType<typeof useFlightsUiMessagesOrDefault>["airportCombobox"]
+}): AirportGroup[] {
+  const byCode = new Map(airports.map((airport) => [airport.iataCode, airport]))
+
+  // Recent airports keep their own order (most-used first), not the
+  // reference's — that ranking is the entire point of remembering them. They
+  // render from local memory, so one that fell off the current result page
+  // still appears.
+  const recentAirports: AirportDto[] = recent.map(
+    (entry) =>
+      byCode.get(entry.iataCode) ?? {
+        iataCode: entry.iataCode,
+        city: entry.city,
+        name: entry.name,
+        country: entry.country,
+      },
+  )
+  const claimed = new Set(recentAirports.map((airport) => airport.iataCode))
+
+  const served: AirportDto[] = []
+  const rest: AirportDto[] = []
+  for (const airport of airports) {
+    if (claimed.has(airport.iataCode)) continue
+    if (servedCodes.has(airport.iataCode)) served.push(airport)
+    else rest.push(airport)
+  }
+
+  const groups: AirportGroup[] = []
+  if (recentAirports.length > 0) {
+    groups.push({ key: "recent", heading: messages.recentHeading, airports: recentAirports })
+  }
+  if (served.length > 0) {
+    groups.push({ key: "served", heading: messages.servedHeading, airports: served })
+  }
+  if (rest.length > 0) {
+    // Only name the last group when something sits above it; on its own it is
+    // simply "the list" and a heading would be noise.
+    const heading = groups.length > 0 ? messages.allHeading : ""
+    groups.push({ key: "all", heading, airports: rest })
+  }
+  return groups
+}
+
+/** The side of the network this picker cares about. */
+function servedMarketCodes(
+  markets: ServedMarketsResponseDto | undefined,
+  side: "origin" | "destination",
+): Set<string> {
+  if (!markets) return new Set()
+  const codes = side === "destination" ? (markets.destinations ?? markets.origins) : markets.origins
+  return new Set(codes)
 }

--- a/packages/flights-react/src/components/flight-date-picker.test.tsx
+++ b/packages/flights-react/src/components/flight-date-picker.test.tsx
@@ -50,12 +50,14 @@ function renderPicker({
   destination = "JFK",
   onChange = vi.fn(),
   minDate,
+  disabled,
 }: {
   fetcher: (url: string, init?: RequestInit) => Promise<Response>
   origin?: string | null
   destination?: string | null
   onChange?: (next: string | null) => void
   minDate?: string | null
+  disabled?: boolean
 }) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
@@ -71,6 +73,7 @@ function renderPicker({
           passengers={{ adults: 1 }}
           cabin="economy"
           minDate={minDate}
+          disabled={disabled}
           placeholder="Depart"
         />
       </VoyantFlightsProvider>
@@ -175,9 +178,34 @@ describe("FlightDatePicker", () => {
     expect(onChange).toHaveBeenCalledWith("2026-08-25")
   })
 
+  // A long-haul business quote is five digits and will not fit in a day cell.
+  it("compacts a fare too long to fit in a cell", async () => {
+    renderPicker({
+      fetcher: fetcherFor([
+        priced("2026-08-17", "89.00"),
+        priced("2026-08-18", "12450.00"),
+        priced("2026-08-19", "260.00"),
+      ]),
+    })
+    openPicker()
+
+    expect(await screen.findByText("€12.5K")).toBeInstanceOf(HTMLElement)
+    // ...while an ordinary fare stays exact.
+    expect(screen.getByText("€89")).toBeInstanceOf(HTMLElement)
+  })
+
   it("stays dormant until the route is known", () => {
     const fetcher = fetcherFor(AUGUST_DAYS)
     renderPicker({ fetcher, destination: null })
+
+    expect(fetcher).not.toHaveBeenCalled()
+  })
+
+  // The return leg of a one-way trip: no date there is selectable, so quoting
+  // one spends a supplier call on nothing.
+  it("stays dormant while disabled", () => {
+    const fetcher = fetcherFor(AUGUST_DAYS)
+    renderPicker({ fetcher, disabled: true })
 
     expect(fetcher).not.toHaveBeenCalled()
   })

--- a/packages/flights-react/src/components/flight-date-picker.test.tsx
+++ b/packages/flights-react/src/components/flight-date-picker.test.tsx
@@ -1,0 +1,213 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import type { FareCalendarDay } from "@voyant-travel/flights/contract/types"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { VoyantFlightsProvider } from "../provider.js"
+import { FlightDatePicker } from "./flight-date-picker.js"
+
+/**
+ * Pinned "today". The picker's whole job is relative to now — what's in the
+ * past, which month opens, which window it quotes — so the clock is an input,
+ * not ambient state.
+ */
+const TODAY = new Date(2026, 7, 16) // 2026-08-16, local
+
+function priced(date: string, amount: string): FareCalendarDay {
+  return { date, available: true, cheapestPrice: { amount, currency: "EUR" } }
+}
+
+function soldOut(date: string): FareCalendarDay {
+  return { date, available: false }
+}
+
+/** A spread wide enough to band: cheapest, middle, dearest, and one sold out. */
+const AUGUST_DAYS: FareCalendarDay[] = [
+  priced("2026-08-17", "89.00"),
+  priced("2026-08-18", "140.00"),
+  priced("2026-08-19", "260.00"),
+  soldOut("2026-08-20"),
+  priced("2026-08-21", "95.00"),
+  priced("2026-08-22", "180.00"),
+  priced("2026-08-23", "410.00"),
+]
+
+function fetcherFor(days: FareCalendarDay[], status = 200) {
+  return vi.fn(async (url: string, _init?: RequestInit) => {
+    if (!url.includes("/flights/fare-calendar")) return Response.json({})
+    if (status !== 200) {
+      return Response.json({ error: "nope" }, { status })
+    }
+    return Response.json({ days })
+  })
+}
+
+function renderPicker({
+  fetcher,
+  origin = "LHR",
+  destination = "JFK",
+  onChange = vi.fn(),
+  minDate,
+}: {
+  fetcher: (url: string, init?: RequestInit) => Promise<Response>
+  origin?: string | null
+  destination?: string | null
+  onChange?: (next: string | null) => void
+  minDate?: string | null
+}) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <VoyantFlightsProvider baseUrl="/api" fetcher={fetcher}>
+        <FlightDatePicker
+          value={null}
+          onChange={onChange}
+          origin={origin}
+          destination={destination}
+          passengers={{ adults: 1 }}
+          cabin="economy"
+          minDate={minDate}
+          placeholder="Depart"
+        />
+      </VoyantFlightsProvider>
+    </QueryClientProvider>,
+  )
+}
+
+function openPicker() {
+  fireEvent.click(screen.getByRole("button", { name: "Depart" }))
+}
+
+/**
+ * The day button for a given day-of-month in the open grid. react-day-picker
+ * labels days in ordinal form ("Monday, August 17th, 2026"), so the match has
+ * to allow the suffix or it silently finds nothing and every assertion on the
+ * result passes vacuously.
+ */
+function dayButton(dayOfMonth: number, month = "August") {
+  const label = new RegExp(`${month} ${dayOfMonth}(st|nd|rd|th), `)
+  const found = screen
+    .getAllByRole("button")
+    .find((button) => label.test(button.getAttribute("aria-label") ?? ""))
+  if (!found) throw new Error(`No day button for ${month} ${dayOfMonth}`)
+  return found
+}
+
+/** Band classes are applied to the day cell, which styles the price inside it. */
+function bandingOf(priceText: string) {
+  return screen.getByText(priceText).closest("td")?.className ?? ""
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  vi.setSystemTime(TODAY)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  cleanup()
+})
+
+describe("FlightDatePicker", () => {
+  it("quotes the visible month plus the next, starting no earlier than today", async () => {
+    const fetcher = fetcherFor(AUGUST_DAYS)
+    renderPicker({ fetcher })
+
+    await waitFor(() => expect(fetcher).toHaveBeenCalled())
+
+    const body = JSON.parse(String(fetcher.mock.calls[0]?.[1]?.body))
+    expect(body).toMatchObject({
+      origin: "LHR",
+      destination: "JFK",
+      from: "2026-08-16",
+      to: "2026-09-30",
+    })
+  })
+
+  it("shows the cheapest price on each quoted day", async () => {
+    renderPicker({ fetcher: fetcherFor(AUGUST_DAYS) })
+    openPicker()
+
+    expect(await screen.findByText("€89")).toBeInstanceOf(HTMLElement)
+    expect(screen.getByText("€260")).toBeInstanceOf(HTMLElement)
+  })
+
+  // The complaint that started this: a calendar that looks identical on every
+  // day tells you nothing about where the flights are.
+  it("bands prices so cheap and expensive days do not look alike", async () => {
+    renderPicker({ fetcher: fetcherFor(AUGUST_DAYS) })
+    openPicker()
+    await screen.findByText("€89")
+
+    expect(bandingOf("€89")).toContain("emerald")
+    expect(bandingOf("€410")).toContain("rose")
+    expect(bandingOf("€89")).not.toEqual(bandingOf("€410"))
+  })
+
+  it("makes a sold-out day unselectable", async () => {
+    const onChange = vi.fn()
+    renderPicker({ fetcher: fetcherFor(AUGUST_DAYS), onChange })
+    openPicker()
+    await screen.findByText("€89")
+
+    const soldOut = dayButton(20)
+    expect(soldOut.hasAttribute("disabled")).toBe(true)
+
+    fireEvent.click(soldOut)
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it("keeps a day the provider never quoted selectable", async () => {
+    const onChange = vi.fn()
+    // 2026-08-25 is absent from the response entirely — unknown, not sold out.
+    renderPicker({ fetcher: fetcherFor(AUGUST_DAYS), onChange })
+    openPicker()
+    await screen.findByText("€89")
+
+    const unquoted = dayButton(25)
+    expect(unquoted.hasAttribute("disabled")).toBe(false)
+
+    fireEvent.click(unquoted)
+    expect(onChange).toHaveBeenCalledWith("2026-08-25")
+  })
+
+  it("stays dormant until the route is known", () => {
+    const fetcher = fetcherFor(AUGUST_DAYS)
+    renderPicker({ fetcher, destination: null })
+
+    expect(fetcher).not.toHaveBeenCalled()
+  })
+
+  // A connector without the capability is the common case, not a failure.
+  it("still offers a working calendar when the connector cannot quote", async () => {
+    const onChange = vi.fn()
+    const fetcher = fetcherFor([], 501)
+    renderPicker({ fetcher, onChange })
+
+    await waitFor(() => expect(fetcher).toHaveBeenCalled())
+    openPicker()
+
+    const anyDay = dayButton(25)
+    expect(anyDay.hasAttribute("disabled")).toBe(false)
+
+    fireEvent.click(anyDay)
+    expect(onChange).toHaveBeenCalledWith("2026-08-25")
+  })
+
+  it("never offers a date before the outbound it returns from", async () => {
+    const fetcher = fetcherFor(AUGUST_DAYS)
+    renderPicker({ fetcher, minDate: "2026-08-22" })
+
+    await waitFor(() => expect(fetcher).toHaveBeenCalled())
+    const body = JSON.parse(String(fetcher.mock.calls[0]?.[1]?.body))
+    expect(body.from).toBe("2026-08-22")
+
+    openPicker()
+    await screen.findByText("€180")
+    expect(dayButton(18).hasAttribute("disabled")).toBe(true)
+  })
+})

--- a/packages/flights-react/src/components/flight-date-picker.tsx
+++ b/packages/flights-react/src/components/flight-date-picker.tsx
@@ -1,0 +1,232 @@
+"use client"
+
+import type {
+  CabinClass,
+  FareCalendarDay,
+  PassengerCounts,
+} from "@voyant-travel/flights/contract/types"
+import { DatePicker } from "@voyant-travel/ui/components/date-picker"
+import type { ReactNode } from "react"
+import { useMemo, useState } from "react"
+import { useFareCalendar } from "../hooks/use-fare-calendar.js"
+import { useFlightsUiI18nOrDefault } from "../i18n/index.js"
+
+export interface FlightDatePickerProps {
+  /** Selected ISO date, or null. */
+  value: string | null
+  onChange: (next: string | null) => void
+  /** Route being priced. The calendar stays dormant until both are set. */
+  origin: string | null
+  destination: string | null
+  passengers: PassengerCounts
+  cabin?: CabinClass
+  /**
+   * Earliest selectable date, ISO. Defaults to today; a return picker passes
+   * the outbound date so a return can't precede its own outbound.
+   */
+  minDate?: string | null
+  placeholder?: ReactNode
+  disabled?: boolean
+  className?: string
+}
+
+/**
+ * Departure-date picker that shows where availability actually is.
+ *
+ * Each day carries the cheapest indicative price for the leg being picked,
+ * banded cheap / mid / expensive against the rest of the visible window, and
+ * days the provider doesn't fly are struck out and unselectable.
+ *
+ * The decoration is strictly an enhancement. A connector that doesn't declare
+ * `flight/fare-calendar` — or a calendar still in flight — leaves a plain
+ * working calendar behind, never an error or a blocked form.
+ */
+export function FlightDatePicker({
+  value,
+  onChange,
+  origin,
+  destination,
+  passengers,
+  cabin,
+  minDate,
+  placeholder,
+  disabled,
+  className,
+}: FlightDatePickerProps) {
+  const i18n = useFlightsUiI18nOrDefault()
+  const [month, setMonth] = useState(() => startOfMonth(parseIsoDate(value) ?? new Date()))
+
+  // Quote the visible month plus the next, so paging forward one month is
+  // already answered and the common "look a few weeks out" move never waits.
+  const earliest = latestOf(startOfDay(new Date()), parseIsoDate(minDate))
+  const windowFrom = latestOf(month, earliest) ?? month
+  const windowTo = endOfMonth(addMonths(month, 1))
+  // Paging back past `earliest` inverts the window. There is nothing to quote
+  // behind today, so stay quiet rather than ask for a range that can't exist.
+  const quotable = Boolean(origin && destination) && windowFrom <= windowTo
+
+  const calendar = useFareCalendar(
+    {
+      origin: origin ?? "",
+      destination: destination ?? "",
+      from: toIsoDate(windowFrom),
+      to: toIsoDate(windowTo),
+      passengers,
+      cabin,
+    },
+    { enabled: quotable },
+  )
+
+  const days = calendar.data?.days
+  const quotes = useMemo(() => indexByDate(days), [days])
+  const bands = useMemo(() => priceBands(days), [days])
+
+  const dayModifiers = useMemo(() => bandModifiers(days, bands), [days, bands])
+
+  return (
+    <DatePicker
+      value={value}
+      onChange={onChange}
+      placeholder={placeholder}
+      disabled={disabled}
+      className={className}
+      // Annotated cells need more room than the 2rem default. Sized on intent
+      // rather than on arrival of the data, so the grid doesn't jump under the
+      // cursor when the quote lands.
+      contentClassName={
+        quotable && !calendar.isCapabilityMissing ? "[--cell-size:--spacing(12)]" : undefined
+      }
+      dateDisabled={(date) => {
+        if (earliest && startOfDay(date) < earliest) return true
+        // Only a quoted day may be ruled out. An unquoted day is unknown, and
+        // unknown must stay selectable or a missing calendar becomes a
+        // calendar that says "nothing is available".
+        return quotes.get(toIsoDate(date))?.available === false
+      }}
+      dayAnnotation={(date) => {
+        const quote = quotes.get(toIsoDate(date))
+        if (!quote?.cheapestPrice) return null
+        return formatFare(quote.cheapestPrice, i18n)
+      }}
+      modifiers={dayModifiers}
+      modifiersClassNames={BAND_CLASS_NAMES}
+      month={month}
+      onMonthChange={setMonth}
+    />
+  )
+}
+
+/**
+ * Band colours are applied to the annotation line only — the day number keeps
+ * its normal contrast, so the price is what carries the signal and selection
+ * state stays legible on top of it.
+ */
+const BAND_CLASS_NAMES = {
+  fareCheap:
+    "[&_[data-slot=day-annotation]]:text-emerald-600 [&_[data-slot=day-annotation]]:opacity-100 dark:[&_[data-slot=day-annotation]]:text-emerald-400",
+  fareMid:
+    "[&_[data-slot=day-annotation]]:text-amber-600 [&_[data-slot=day-annotation]]:opacity-100 dark:[&_[data-slot=day-annotation]]:text-amber-400",
+  fareHigh:
+    "[&_[data-slot=day-annotation]]:text-rose-600 [&_[data-slot=day-annotation]]:opacity-100 dark:[&_[data-slot=day-annotation]]:text-rose-400",
+  fareUnavailable: "[&_button]:line-through",
+}
+
+type PriceBands = { cheapUpTo: number; midUpTo: number } | null
+
+/**
+ * Terciles over the quoted window. Bands are relative to what is on screen —
+ * "cheap for this route in this window", which is the only comparison a
+ * traveller can act on. Fewer than three distinct prices means there is no
+ * meaningful spread to band, so nothing is coloured.
+ */
+function priceBands(days: FareCalendarDay[] | undefined): PriceBands {
+  const amounts = (days ?? [])
+    .map((day) => Number(day.cheapestPrice?.amount))
+    .filter((amount) => Number.isFinite(amount))
+    .sort((a, b) => a - b)
+
+  if (new Set(amounts).size < 3) return null
+
+  const cheapUpTo = amounts[Math.floor(amounts.length / 3)]
+  const midUpTo = amounts[Math.floor((amounts.length * 2) / 3)]
+  if (cheapUpTo == null || midUpTo == null) return null
+  return { cheapUpTo, midUpTo }
+}
+
+function bandModifiers(days: FareCalendarDay[] | undefined, bands: PriceBands) {
+  const fareCheap: Date[] = []
+  const fareMid: Date[] = []
+  const fareHigh: Date[] = []
+  const fareUnavailable: Date[] = []
+
+  for (const day of days ?? []) {
+    const date = parseIsoDate(day.date)
+    if (!date) continue
+    if (!day.available) {
+      fareUnavailable.push(date)
+      continue
+    }
+    const amount = Number(day.cheapestPrice?.amount)
+    if (!bands || !Number.isFinite(amount)) continue
+    if (amount <= bands.cheapUpTo) fareCheap.push(date)
+    else if (amount <= bands.midUpTo) fareMid.push(date)
+    else fareHigh.push(date)
+  }
+
+  return { fareCheap, fareMid, fareHigh, fareUnavailable }
+}
+
+function indexByDate(days: FareCalendarDay[] | undefined): Map<string, FareCalendarDay> {
+  return new Map((days ?? []).map((day) => [day.date, day]))
+}
+
+function formatFare(
+  price: { amount: string; currency: string },
+  i18n: ReturnType<typeof useFlightsUiI18nOrDefault>,
+): string {
+  const amount = Number(price.amount)
+  if (!Number.isFinite(amount)) return `${price.amount} ${price.currency}`
+  return i18n.formatCurrency(amount, price.currency, { maximumFractionDigits: 0 })
+}
+
+// ── Local-time date helpers ──────────────────────────────────────────────────
+// react-day-picker works in local time. Parsing `2026-08-16` with `new Date()`
+// would land on UTC midnight, which is the previous day west of Greenwich — so
+// every price would sit one cell off for half the world. These stay local.
+
+function parseIsoDate(value: string | null | undefined): Date | null {
+  if (!value) return null
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value)
+  if (!match) return null
+  const [, year, month, day] = match
+  return new Date(Number(year), Number(month) - 1, Number(day))
+}
+
+function toIsoDate(date: Date): string {
+  const month = String(date.getMonth() + 1).padStart(2, "0")
+  const day = String(date.getDate()).padStart(2, "0")
+  return `${date.getFullYear()}-${month}-${day}`
+}
+
+function startOfDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate())
+}
+
+function startOfMonth(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), 1)
+}
+
+function endOfMonth(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth() + 1, 0)
+}
+
+function addMonths(date: Date, months: number): Date {
+  return new Date(date.getFullYear(), date.getMonth() + months, 1)
+}
+
+function latestOf(...dates: Array<Date | null>): Date | null {
+  return dates.reduce<Date | null>(
+    (latest, date) => (date && (!latest || date > latest) ? date : latest),
+    null,
+  )
+}

--- a/packages/flights-react/src/components/flight-date-picker.tsx
+++ b/packages/flights-react/src/components/flight-date-picker.tsx
@@ -63,7 +63,9 @@ export function FlightDatePicker({
   const windowTo = endOfMonth(addMonths(month, 1))
   // Paging back past `earliest` inverts the window. There is nothing to quote
   // behind today, so stay quiet rather than ask for a range that can't exist.
-  const quotable = Boolean(origin && destination) && windowFrom <= windowTo
+  // A disabled picker never quotes either — the return leg of a one-way trip
+  // would otherwise spend a supplier call on a date nobody can pick.
+  const quotable = Boolean(origin && destination) && !disabled && windowFrom <= windowTo
 
   const calendar = useFareCalendar(
     {
@@ -180,12 +182,25 @@ function indexByDate(days: FareCalendarDay[] | undefined): Map<string, FareCalen
   return new Map((days ?? []).map((day) => [day.date, day]))
 }
 
+/**
+ * Above this, an exact fare stops fitting in a calendar cell — a long-haul
+ * business quote is five or six digits — so it switches to compact notation.
+ * Below it the exact figure is both readable and more useful.
+ */
+const COMPACT_FARE_THRESHOLD = 1000
+
 function formatFare(
   price: { amount: string; currency: string },
   i18n: ReturnType<typeof useFlightsUiI18nOrDefault>,
 ): string {
   const amount = Number(price.amount)
   if (!Number.isFinite(amount)) return `${price.amount} ${price.currency}`
+  if (amount >= COMPACT_FARE_THRESHOLD) {
+    return i18n.formatCurrency(amount, price.currency, {
+      notation: "compact",
+      maximumFractionDigits: 1,
+    })
+  }
   return i18n.formatCurrency(amount, price.currency, { maximumFractionDigits: 0 })
 }
 

--- a/packages/flights-react/src/components/flight-offer-row.tsx
+++ b/packages/flights-react/src/components/flight-offer-row.tsx
@@ -167,10 +167,22 @@ function ItineraryRow({
 
   return (
     <div className="flex items-center gap-3">
-      <div className="flex shrink-0 items-center -space-x-1.5">
-        {carriers.map((code) => (
-          <AirlineLogo key={code} iataCode={code} name={carrierName?.(code)} size={28} />
-        ))}
+      {/* Who is flying this, in words. The logo alone identifies a carrier
+          only to someone who already knows the livery. */}
+      <div className="flex w-40 shrink-0 items-center gap-2">
+        <div className="flex shrink-0 items-center -space-x-1.5">
+          {carriers.map((code) => (
+            <AirlineLogo key={code} iataCode={code} name={carrierName?.(code)} size={28} />
+          ))}
+        </div>
+        <div className="flex min-w-0 flex-col leading-tight">
+          <span className="truncate font-medium text-xs">
+            {carrierLabel(carriers, carrierName, messages)}
+          </span>
+          <span className="truncate font-mono text-[10px] text-muted-foreground">
+            {flightNumbers(segs)}
+          </span>
+        </div>
       </div>
       <div className="flex min-w-0 flex-1 items-center gap-3">
         <Endpoint at={first.departure.at} iata={first.departure.iataCode} />
@@ -219,6 +231,34 @@ function ItineraryRow({
       </Badge>
     </div>
   )
+}
+
+/**
+ * The airline as a traveller would name it. Falls back to the IATA code when
+ * reference data doesn't know the carrier, which is never wrong — just terser.
+ * Interline itineraries name the first carrier and count the rest, because the
+ * full list doesn't fit and the operating carriers are on the detail sheet.
+ */
+function carrierLabel(
+  carriers: string[],
+  carrierName: ((iataCode: string) => string | undefined) | undefined,
+  messages: ReturnType<typeof useFlightsUiI18nOrDefault>["messages"],
+): string {
+  const [first, ...rest] = carriers
+  if (!first) return ""
+  const name = carrierName?.(first) ?? first
+  if (rest.length === 0) return name
+  return formatMessage(messages.flightOfferRow.plusCarriers, {
+    carrier: name,
+    count: String(rest.length),
+  })
+}
+
+/** Marketing flight numbers in order, capped so a 3-leg trip stays on one line. */
+function flightNumbers(segs: Itinerary["segments"]): string {
+  const numbers = segs.map((segment) => `${segment.carrierCode} ${segment.flightNumber}`)
+  if (numbers.length <= 2) return numbers.join(" · ")
+  return `${numbers.slice(0, 2).join(" · ")} +${numbers.length - 2}`
 }
 
 function Endpoint({

--- a/packages/flights-react/src/components/flight-search-form.tsx
+++ b/packages/flights-react/src/components/flight-search-form.tsx
@@ -7,12 +7,13 @@ import type {
   PassengerCounts,
 } from "@voyant-travel/flights/contract/types"
 import { Button } from "@voyant-travel/ui/components/button"
-import { DatePicker } from "@voyant-travel/ui/components/date-picker"
 import { ToggleGroup, ToggleGroupItem } from "@voyant-travel/ui/components/toggle-group"
 import { ArrowLeftRight, Search } from "lucide-react"
 import { useState } from "react"
 import { useFlightsUiMessagesOrDefault } from "../i18n/index.js"
+import { rememberSearchedAirports } from "../recent-routes.js"
 import { AirportCombobox } from "./airport-combobox.js"
+import { FlightDatePicker } from "./flight-date-picker.js"
 import { PaxCabinPopover } from "./pax-cabin-popover.js"
 
 export type TripType = "one_way" | "round_trip"
@@ -67,6 +68,9 @@ export function FlightSearchForm({ onSearch, loading, initial }: FlightSearchFor
   const submit = (e: React.FormEvent) => {
     e.preventDefault()
     if (!ready || origin == null || destination == null || departureDate == null) return
+    // Only a submitted search counts — this is what puts an operator's own
+    // airports at the top of the picker next time.
+    rememberSearchedAirports([origin, destination])
     const slices: FlightSlice[] = [{ origin, destination, departureDate }]
     if (tripType === "round_trip" && returnDate) {
       slices.push({
@@ -105,6 +109,7 @@ export function FlightSearchForm({ onSearch, loading, initial }: FlightSearchFor
           <AirportCombobox
             value={origin}
             onChange={setOrigin}
+            side="origin"
             placeholder={messages.fromPlaceholder}
             className="flex-1"
           />
@@ -121,22 +126,34 @@ export function FlightSearchForm({ onSearch, loading, initial }: FlightSearchFor
           <AirportCombobox
             value={destination}
             onChange={setDestination}
+            side="destination"
             placeholder={messages.toPlaceholder}
             className="flex-1"
           />
         </div>
 
-        {/* Date pair — flush together so the trip dates read as a unit. */}
+        {/* Date pair — flush together so the trip dates read as a unit. Each
+            picker prices the leg it selects, so the return shows the fare for
+            coming back rather than repeating the outbound. */}
         <div className="flex items-center gap-1">
-          <DatePicker
+          <FlightDatePicker
             value={departureDate}
             onChange={setDepartureDate}
+            origin={origin}
+            destination={destination}
+            passengers={passengers}
+            cabin={cabin}
             placeholder={messages.departPlaceholder}
             className="h-10 flex-1 min-w-32"
           />
-          <DatePicker
+          <FlightDatePicker
             value={returnDate}
             onChange={setReturnDate}
+            origin={destination}
+            destination={origin}
+            passengers={passengers}
+            cabin={cabin}
+            minDate={departureDate}
             placeholder={messages.returnPlaceholder}
             disabled={tripType === "one_way"}
             className="h-10 flex-1 min-w-32"

--- a/packages/flights-react/src/hooks/index.ts
+++ b/packages/flights-react/src/hooks/index.ts
@@ -2,6 +2,7 @@ export { useAircraft } from "./use-aircraft.js"
 export { useAirlines } from "./use-airlines.js"
 export { type UseAirportSearchOptions, useAirportSearch } from "./use-airport-search.js"
 export { type UseAirportsOptions, useAirports } from "./use-airports.js"
+export { type UseFareCalendarOptions, useFareCalendar } from "./use-fare-calendar.js"
 export {
   type UseFlightAncillariesOptions,
   useFlightAncillaries,
@@ -25,3 +26,4 @@ export {
   type UseSavedPaymentMethodsOptions,
   useSavedPaymentMethods,
 } from "./use-saved-payment-methods.js"
+export { type UseServedMarketsOptions, useServedMarkets } from "./use-served-markets.js"

--- a/packages/flights-react/src/hooks/use-fare-calendar.ts
+++ b/packages/flights-react/src/hooks/use-fare-calendar.ts
@@ -1,0 +1,47 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+import type { FareCalendarRequest } from "@voyant-travel/flights/contract/types"
+
+import { useVoyantFlightsContext } from "../provider.js"
+import { getFareCalendarQueryOptions } from "../query-options.js"
+
+export interface UseFareCalendarOptions {
+  /** Disable the query — e.g. while the route is incomplete or the picker is shut. */
+  enabled?: boolean
+  /**
+   * TanStack Query stale time, milliseconds. Default 5 minutes: calendars are
+   * served from the provider's cached lowest-fare data, so re-asking on every
+   * picker open buys nothing.
+   */
+  staleTime?: number
+}
+
+/**
+ * POST `/v1/admin/flights/fare-calendar` — indicative prices and availability
+ * across a window of departure dates.
+ *
+ * Availability decoration is an enhancement, never a gate: a connector that
+ * doesn't declare `flight/fare-calendar` answers 501, and callers are expected
+ * to render a plain calendar rather than surface an error. Read
+ * `isCapabilityMissing` for that case instead of treating it as a failure.
+ */
+export function useFareCalendar(
+  request: FareCalendarRequest,
+  options: UseFareCalendarOptions = {},
+) {
+  const client = useVoyantFlightsContext()
+  const { enabled = false, staleTime = 5 * 60_000 } = options
+  const query = useQuery({
+    ...getFareCalendarQueryOptions(client, request),
+    enabled: enabled && Boolean(request.origin && request.destination),
+    staleTime,
+  })
+
+  const status = (query.error as { status?: number } | null | undefined)?.status
+  return {
+    ...query,
+    /** The connector has no fare-calendar support. Degrade, don't report. */
+    isCapabilityMissing: status === 501,
+  }
+}

--- a/packages/flights-react/src/hooks/use-served-markets.ts
+++ b/packages/flights-react/src/hooks/use-served-markets.ts
@@ -1,0 +1,33 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+
+import { useVoyantFlightsContext } from "../provider.js"
+import { getServedMarketsQueryOptions } from "../query-options.js"
+
+export interface UseServedMarketsOptions {
+  enabled?: boolean
+  /** TanStack Query stale time. Default 1 hour — a network doesn't move often. */
+  staleTime?: number
+}
+
+/**
+ * GET `/v1/admin/flights/served-markets` — the airports the connector sells.
+ *
+ * Use it to *order* an airport list, never to restrict one. A connector that
+ * doesn't declare `flight/served-markets` answers 501, which is the normal
+ * case, not a failure: read `isCapabilityMissing` and fall back to the plain
+ * reference list.
+ */
+export function useServedMarkets(options: UseServedMarketsOptions = {}) {
+  const client = useVoyantFlightsContext()
+  const { enabled = true, staleTime = 60 * 60_000 } = options
+  const query = useQuery({
+    ...getServedMarketsQueryOptions(client),
+    enabled,
+    staleTime,
+  })
+
+  const status = (query.error as { status?: number } | null | undefined)?.status
+  return { ...query, isCapabilityMissing: status === 501 }
+}

--- a/packages/flights-react/src/i18n/en.ts
+++ b/packages/flights-react/src/i18n/en.ts
@@ -131,6 +131,9 @@ export const flightsUiEn = {
     searchPlaceholder: "Type city or IATA code...",
     searching: "Searching...",
     empty: "No airports.",
+    recentHeading: "Your routes",
+    servedHeading: "Served by your providers",
+    allHeading: "All airports",
   },
   flightBaggageStep: {
     unavailable: "Bags couldn't be loaded for this offer.",
@@ -334,6 +337,7 @@ export const flightsUiEn = {
     viewDetails: "View flight details",
     codeshare: "Codeshare",
     interline: "Interline",
+    plusCarriers: "{carrier} +{count}",
   },
   flightOrderConfirmation: {
     bookingConfirmed: "Booking confirmed",

--- a/packages/flights-react/src/i18n/messages.ts
+++ b/packages/flights-react/src/i18n/messages.ts
@@ -96,6 +96,9 @@ export type FlightsUiMessages = {
     searchPlaceholder: string
     searching: string
     empty: string
+    recentHeading: string
+    servedHeading: string
+    allHeading: string
   }
   flightBaggageStep: {
     unavailable: string
@@ -291,6 +294,7 @@ export type FlightsUiMessages = {
     viewDetails: string
     codeshare: string
     interline: string
+    plusCarriers: string
   }
   flightOrderConfirmation: {
     bookingConfirmed: string

--- a/packages/flights-react/src/i18n/ro.ts
+++ b/packages/flights-react/src/i18n/ro.ts
@@ -131,6 +131,9 @@ export const flightsUiRo = {
     searchPlaceholder: "Tasteaza oras sau cod IATA...",
     searching: "Se cauta...",
     empty: "Niciun aeroport.",
+    recentHeading: "Rutele tale",
+    servedHeading: "Deservite de furnizorii tai",
+    allHeading: "Toate aeroporturile",
   },
   flightBaggageStep: {
     unavailable: "Bagajele nu au putut fi incarcate pentru aceasta oferta.",
@@ -335,6 +338,7 @@ export const flightsUiRo = {
     viewDetails: "Vezi detaliile zborului",
     codeshare: "Codeshare",
     interline: "Interline",
+    plusCarriers: "{carrier} +{count}",
   },
   flightOrderConfirmation: {
     bookingConfirmed: "Rezervare confirmata",

--- a/packages/flights-react/src/index.ts
+++ b/packages/flights-react/src/index.ts
@@ -26,4 +26,12 @@ export {
   getFlightSearchQueryOptions,
   getFlightSeatMapQueryOptions,
 } from "./query-options.js"
+export {
+  clearRecentAirports,
+  matchRecentAirports,
+  noteAirportSelected,
+  type RecentAirport,
+  readRecentAirports,
+  rememberSearchedAirports,
+} from "./recent-routes.js"
 export * from "./schemas.js"

--- a/packages/flights-react/src/query-keys.ts
+++ b/packages/flights-react/src/query-keys.ts
@@ -1,4 +1,8 @@
-import type { FlightOrderStatus, FlightSearchRequest } from "@voyant-travel/flights/contract/types"
+import type {
+  FareCalendarRequest,
+  FlightOrderStatus,
+  FlightSearchRequest,
+} from "@voyant-travel/flights/contract/types"
 
 export interface AirportSearchFilters {
   q?: string | undefined
@@ -35,6 +39,12 @@ export const flightsQueryKeys = {
 
   search: () => [...flightsQueryKeys.all, "search"] as const,
   searchRequest: (request: FlightSearchRequest) => [...flightsQueryKeys.search(), request] as const,
+
+  fareCalendar: () => [...flightsQueryKeys.all, "fare-calendar"] as const,
+  fareCalendarWindow: (request: FareCalendarRequest) =>
+    [...flightsQueryKeys.fareCalendar(), request] as const,
+
+  servedMarkets: () => [...flightsQueryKeys.all, "served-markets"] as const,
 
   offer: () => [...flightsQueryKeys.all, "offer"] as const,
   offerDetail: (offerId: string) => [...flightsQueryKeys.offer(), "detail", offerId] as const,

--- a/packages/flights-react/src/query-options.ts
+++ b/packages/flights-react/src/query-options.ts
@@ -1,7 +1,11 @@
 "use client"
 
 import { queryOptions } from "@tanstack/react-query"
-import type { FlightOffer, FlightSearchRequest } from "@voyant-travel/flights/contract/types"
+import type {
+  FareCalendarRequest,
+  FlightOffer,
+  FlightSearchRequest,
+} from "@voyant-travel/flights/contract/types"
 
 import { type FetchWithValidationOptions, fetchWithValidation } from "./client.js"
 import { type AirportSearchFilters, flightsQueryKeys } from "./query-keys.js"
@@ -10,8 +14,10 @@ import {
   airlineListResponseSchema,
   airportListResponseSchema,
   ancillaryResponseSchema,
+  fareCalendarResponseSchema,
   flightSearchResponseSchema,
   seatMapResponseSchema,
+  servedMarketsResponseSchema,
 } from "./schemas.js"
 
 export function getFlightSearchQueryOptions(
@@ -25,6 +31,41 @@ export function getFlightSearchQueryOptions(
         method: "POST",
         body: JSON.stringify(request),
       }),
+  })
+}
+
+/**
+ * Quote a window of departure dates for one route.
+ *
+ * `retry: false` is deliberate: a connector without the capability answers
+ * 501, and that is a settled answer about this deployment's supply, not a
+ * transient failure worth three round-trips.
+ */
+export function getFareCalendarQueryOptions(
+  client: FetchWithValidationOptions,
+  request: FareCalendarRequest,
+) {
+  return queryOptions({
+    queryKey: flightsQueryKeys.fareCalendarWindow(request),
+    retry: false,
+    queryFn: () =>
+      fetchWithValidation("/v1/admin/flights/fare-calendar", fareCalendarResponseSchema, client, {
+        method: "POST",
+        body: JSON.stringify(request),
+      }),
+  })
+}
+
+/**
+ * The connector's declared network. `retry: false` for the same reason the
+ * fare calendar sets it: 501 is an answer about this deployment, not a blip.
+ */
+export function getServedMarketsQueryOptions(client: FetchWithValidationOptions) {
+  return queryOptions({
+    queryKey: flightsQueryKeys.servedMarkets(),
+    retry: false,
+    queryFn: () =>
+      fetchWithValidation("/v1/admin/flights/served-markets", servedMarketsResponseSchema, client),
   })
 }
 

--- a/packages/flights-react/src/recent-routes.ts
+++ b/packages/flights-react/src/recent-routes.ts
@@ -1,0 +1,153 @@
+"use client"
+
+/**
+ * The airports this operator actually works with, remembered locally.
+ *
+ * An agency flies a handful of routes over and over, and the global airport
+ * reference has no idea which. Recording what was searched is the cheapest
+ * honest signal available: it needs no contract, no capability, and no server
+ * round-trip, and it is right from the second search onward.
+ *
+ * Deliberately per-browser. This is a convenience ordering, not operator
+ * configuration — nothing downstream may depend on it being present, and
+ * losing it costs a user one extra keystroke.
+ */
+
+const STORAGE_KEY = "voyant.flights.recent-airports"
+const MAX_REMEMBERED = 12
+
+/**
+ * One remembered airport. The display fields are stored alongside the code so
+ * the group can render without a second reference lookup — a recent airport
+ * that fell off the current result page must still appear.
+ */
+export interface RecentAirport {
+  iataCode: string
+  city: string
+  name: string
+  country: string
+  /** Epoch millis of the last search, so ties break on recency. */
+  lastUsedAt: number
+  /**
+   * Searches this airport has appeared in. Selection alone records the airport
+   * at zero; only a submitted search counts as a use, so a code that was
+   * picked and then thought better of never becomes "a route you fly".
+   */
+  uses: number
+}
+
+function readStore(): RecentAirport[] {
+  if (typeof localStorage === "undefined") return []
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return []
+    const parsed: unknown = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter(isRecentAirport)
+  } catch {
+    // A corrupt or unreadable store is not worth a broken picker.
+    return []
+  }
+}
+
+function isRecentAirport(value: unknown): value is RecentAirport {
+  if (typeof value !== "object" || value === null) return false
+  const candidate = value as Partial<RecentAirport>
+  return (
+    typeof candidate.iataCode === "string" &&
+    typeof candidate.city === "string" &&
+    typeof candidate.name === "string" &&
+    typeof candidate.country === "string" &&
+    typeof candidate.lastUsedAt === "number" &&
+    typeof candidate.uses === "number"
+  )
+}
+
+function writeStore(entries: RecentAirport[]): void {
+  const next = entries
+    .sort((a, b) => b.uses - a.uses || b.lastUsedAt - a.lastUsedAt)
+    .slice(0, MAX_REMEMBERED)
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(next))
+  } catch {
+    // Storage full or blocked (private mode, strict cookie policy). The
+    // picker still works; it just won't learn.
+  }
+}
+
+/**
+ * Airports actually searched, most useful first: frequency, then recency.
+ * Airports only ever selected — never searched — are held but not returned.
+ */
+export function readRecentAirports(): RecentAirport[] {
+  return readStore()
+    .filter((entry) => entry.uses > 0)
+    .sort((a, b) => b.uses - a.uses || b.lastUsedAt - a.lastUsedAt)
+}
+
+/** Cache an airport's display fields when it is picked. Does not count a use. */
+export function noteAirportSelected(airport: {
+  iataCode: string
+  city: string
+  name: string
+  country: string
+}): void {
+  if (typeof localStorage === "undefined") return
+  const entries = readStore()
+  const existing = entries.find((entry) => entry.iataCode === airport.iataCode)
+  if (existing) {
+    existing.city = airport.city
+    existing.name = airport.name
+    existing.country = airport.country
+    writeStore(entries)
+    return
+  }
+  entries.push({ ...airport, lastUsedAt: Date.now(), uses: 0 })
+  writeStore(entries)
+}
+
+/**
+ * Count a submitted search against its airports. Codes with no cached display
+ * fields are skipped rather than stored half-formed — they'll be picked up the
+ * next time the airport is chosen from the picker.
+ */
+export function rememberSearchedAirports(codes: Array<string | null | undefined>): void {
+  if (typeof localStorage === "undefined") return
+  const entries = readStore()
+  const now = Date.now()
+  let touched = false
+
+  for (const code of codes) {
+    if (!code) continue
+    const entry = entries.find((candidate) => candidate.iataCode === code)
+    if (!entry) continue
+    entry.uses += 1
+    entry.lastUsedAt = now
+    touched = true
+  }
+
+  if (touched) writeStore(entries)
+}
+
+/** Forget everything. Exposed for settings/reset surfaces and tests. */
+export function clearRecentAirports(): void {
+  if (typeof localStorage === "undefined") return
+  try {
+    localStorage.removeItem(STORAGE_KEY)
+  } catch {
+    // Nothing to do — see above.
+  }
+}
+
+/**
+ * Narrow remembered airports to those matching the typeahead, using the same
+ * fields the server matches on. Without this the group would keep offering
+ * "your routes" while the user is plainly searching for something else.
+ */
+export function matchRecentAirports(entries: RecentAirport[], query: string): RecentAirport[] {
+  const needle = query.trim().toLowerCase()
+  if (!needle) return entries
+  return entries.filter((entry) =>
+    [entry.iataCode, entry.city, entry.name].some((field) => field.toLowerCase().includes(needle)),
+  )
+}

--- a/packages/flights-react/src/schemas.ts
+++ b/packages/flights-react/src/schemas.ts
@@ -116,6 +116,28 @@ export const flightSearchResponseSchema = z.object({
 
 export type FlightSearchResponseDto = z.infer<typeof flightSearchResponseSchema>
 
+export const fareCalendarDaySchema = z.object({
+  date: z.string(),
+  available: z.boolean(),
+  cheapestPrice: moneySchema.optional(),
+  offerCount: z.number().optional(),
+})
+
+export const fareCalendarResponseSchema = z.object({
+  days: z.array(fareCalendarDaySchema),
+  expiresAt: z.string().optional(),
+  providerData: z.record(z.string(), z.unknown()).optional(),
+})
+
+export const servedMarketsResponseSchema = z.object({
+  origins: z.array(z.string()),
+  destinations: z.array(z.string()).optional(),
+  expiresAt: z.string().optional(),
+  providerData: z.record(z.string(), z.unknown()).optional(),
+})
+
+export type ServedMarketsResponseDto = z.infer<typeof servedMarketsResponseSchema>
+
 export const flightPriceResponseSchema = z.object({
   offer: flightOfferSchema,
   valid: z.boolean(),

--- a/packages/flights-react/src/ui.ts
+++ b/packages/flights-react/src/ui.ts
@@ -48,6 +48,10 @@ export {
   validateContact,
 } from "./components/flight-contact-form.js"
 export {
+  FlightDatePicker,
+  type FlightDatePickerProps,
+} from "./components/flight-date-picker.js"
+export {
   FlightFareUpsellStep,
   type FlightFareUpsellStepProps,
 } from "./components/flight-fare-upsell-step.js"

--- a/packages/flights/openapi/admin/flights.json
+++ b/packages/flights/openapi/admin/flights.json
@@ -144,6 +144,40 @@
         "x-voyant-package-name": "@voyant-travel/flights"
       }
     },
+    "/v1/admin/flights/fare-calendar": {
+      "post": {
+        "summary": "Quote departure dates across a window",
+        "x-voyant-api-id": "@voyant-travel/flights#api",
+        "responses": {
+          "200": {
+            "description": "Successful response."
+          }
+        },
+        "operationId": "postAdminFlightsFareCalendar",
+        "tags": ["flights"],
+        "x-voyant-module": "flights",
+        "x-voyant-surface": "admin",
+        "x-voyant-unit-id": "@voyant-travel/flights",
+        "x-voyant-package-name": "@voyant-travel/flights"
+      }
+    },
+    "/v1/admin/flights/served-markets": {
+      "get": {
+        "summary": "List airports the connector sells",
+        "x-voyant-api-id": "@voyant-travel/flights#api",
+        "responses": {
+          "200": {
+            "description": "Successful response."
+          }
+        },
+        "operationId": "getAdminFlightsServedMarkets",
+        "tags": ["flights"],
+        "x-voyant-module": "flights",
+        "x-voyant-surface": "admin",
+        "x-voyant-unit-id": "@voyant-travel/flights",
+        "x-voyant-package-name": "@voyant-travel/flights"
+      }
+    },
     "/v1/admin/flights/ancillaries": {
       "post": {
         "summary": "Get flight ancillaries",

--- a/packages/flights/package.json
+++ b/packages/flights/package.json
@@ -51,13 +51,14 @@
     ]
   },
   "scripts": {
-    "typecheck": "tsc -p tsconfig.typecheck.json",
-    "lint": "biome check src/",
-    "test": "vitest run",
     "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "db:generate": "drizzle-kit generate --config=drizzle.migrations.config.ts --name=flights_baseline && node ../../scripts/migrations/guard-create-type.mjs ./migrations && node ../../scripts/migrations/ensure-extensions.mjs ./migrations",
+    "generate:openapi": "node --import tsx scripts/generate-openapi.ts && biome format --write openapi/admin/flights.json",
+    "lint": "biome check src/",
     "prepack": "pnpm run build",
-    "db:generate": "drizzle-kit generate --config=drizzle.migrations.config.ts --name=flights_baseline && node ../../scripts/migrations/guard-create-type.mjs ./migrations && node ../../scripts/migrations/ensure-extensions.mjs ./migrations"
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.typecheck.json"
   },
   "files": [
     "dist",

--- a/packages/flights/scripts/generate-openapi.ts
+++ b/packages/flights/scripts/generate-openapi.ts
@@ -1,0 +1,87 @@
+/**
+ * Regenerates this package's published admin OpenAPI document from the live
+ * route module.
+ *
+ * `openapi/admin/flights.json` says "Do not edit by hand", but nothing
+ * regenerated it — so adding `/fare-calendar` and `/served-markets` left the
+ * published contract describing a surface the deployment no longer has, and
+ * `verify:openapi-drift` could not see it because the artifact was not
+ * registered (voyant#4748 review). Same failure legal hit in #4706.
+ *
+ * Registered in `scripts/checks/openapi/generated-specs.json`, so
+ * `verify:openapi-drift` now fails when the artifact and the routes disagree.
+ */
+import { readFileSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { stampModuleMetadata } from "@voyant-travel/hono/openapi"
+
+import { createFlightAdminRoutes } from "../src/api-runtime.js"
+
+const PREFIX = "/v1/admin/flights"
+const UNIT_ID = "@voyant-travel/flights"
+
+const artifactPath = resolve(import.meta.dirname, "..", "openapi/admin/flights.json")
+const artifact = JSON.parse(readFileSync(artifactPath, "utf8"))
+
+// Generating the document never dispatches a request, so the adapter is never
+// resolved. Failing loudly beats handing the generator a fake connector that
+// could quietly shape the output.
+const routes = createFlightAdminRoutes({
+  resolveAdapter: () => {
+    throw new Error("The OpenAPI generator must not resolve a flight connector.")
+  },
+})
+
+const live = routes.getOpenAPI31Document({
+  openapi: artifact.openapi,
+  info: artifact.info,
+})
+
+// The route module mounts at `/`, so its own document is prefix-relative. The
+// published document is absolute, and `stampModuleMetadata` derives operation
+// ids, summaries and the owning module from the absolute path — so re-prefix
+// before stamping, not after.
+const prefixed = {
+  ...live,
+  paths: Object.fromEntries(
+    Object.entries(live.paths ?? {}).map(([path, item]) => [
+      path === "/" ? PREFIX : `${PREFIX}${path}`,
+      item,
+    ]),
+  ),
+}
+const stamped = stampModuleMetadata(prefixed, new Map([[PREFIX, "flights"]]))
+
+/**
+ * The composed operator app stamps the owning unit onto every operation;
+ * `stampModuleMetadata` does not. Re-applying them here is what keeps
+ * regeneration from silently stripping the fields off all twelve existing
+ * operations. Every path in this document is owned by flights, so the values
+ * are constant.
+ */
+function withUnitMetadata(item: Record<string, unknown>): Record<string, unknown> {
+  const next: Record<string, unknown> = { ...item }
+  for (const [method, operation] of Object.entries(item)) {
+    if (!operation || typeof operation !== "object" || Array.isArray(operation)) continue
+    next[method] = {
+      ...(operation as Record<string, unknown>),
+      "x-voyant-unit-id": UNIT_ID,
+      "x-voyant-package-name": UNIT_ID,
+    }
+  }
+  return next
+}
+
+// Everything under the prefix comes from the live routes, so a retired route
+// actually disappears instead of outliving itself in the artifact. Anything
+// outside the prefix is another module's and is left alone.
+const paths: Record<string, unknown> = {}
+for (const [path, item] of Object.entries(artifact.paths as Record<string, unknown>)) {
+  if (!path.startsWith(PREFIX)) paths[path] = item
+}
+for (const [path, item] of Object.entries(stamped.paths ?? {})) {
+  paths[path] = withUnitMetadata(item as Record<string, unknown>)
+}
+
+writeFileSync(artifactPath, `${JSON.stringify({ ...artifact, paths }, null, 2)}\n`)

--- a/packages/flights/src/api-runtime.test.ts
+++ b/packages/flights/src/api-runtime.test.ts
@@ -1,3 +1,4 @@
+import { handleApiError } from "@voyant-travel/hono"
 import { Hono } from "hono"
 import { describe, expect, it, vi } from "vitest"
 import {
@@ -20,9 +21,16 @@ function stubAdapter(over: Partial<FlightConnectorAdapter> = {}): FlightConnecto
 }
 
 function mount(adapter: FlightConnectorAdapter, payment?: FlightPaymentIntegration) {
-  return new Hono().route(
-    "/v1/admin/flights",
-    createFlightAdminRoutes({ resolveAdapter: () => adapter, payment }),
+  return (
+    new Hono()
+      .route(
+        "/v1/admin/flights",
+        createFlightAdminRoutes({ resolveAdapter: () => adapter, payment }),
+      )
+      // Routes that validate through `parseJsonBody` signal by throwing, and the
+      // host app is what turns that into a status. Without this the harness
+      // would report 500 for what production answers 400.
+      .onError((err, c) => handleApiError(err, c, { appName: "flights-test" }))
   )
 }
 
@@ -72,6 +80,81 @@ describe("flights hono module", () => {
       body: JSON.stringify({ passengers: { adults: 1 } }),
     })
     expect(res.status).toBe(400)
+  })
+
+  describe("POST /fare-calendar", () => {
+    const window = {
+      origin: "LHR",
+      destination: "JFK",
+      from: "2026-08-01",
+      to: "2026-08-31",
+      passengers: { adults: 1 },
+    }
+
+    function callCalendar(app: Hono, body: unknown) {
+      return app.request("/v1/admin/flights/fare-calendar", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      })
+    }
+
+    it("delegates the quoted window to the resolved adapter", async () => {
+      const searchFareCalendar = vi.fn(async () => ({ days: [] }))
+      const app = mount(stubAdapter({ searchFareCalendar }))
+
+      const res = await callCalendar(app, window)
+
+      expect(res.status).toBe(200)
+      expect(searchFareCalendar).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ origin: "LHR", from: "2026-08-01", to: "2026-08-31" }),
+      )
+    })
+
+    // A connector without cached lowest-fare data is the common case; the
+    // picker reads 501 as "no decoration" rather than as an error.
+    it("answers 501 when the connector does not declare the capability", async () => {
+      const app = mount(stubAdapter())
+
+      const res = await callCalendar(app, window)
+
+      expect(res.status).toBe(501)
+      expect(await res.json()).toEqual({
+        error: "Connector does not declare flight/fare-calendar capability",
+      })
+    })
+
+    it("rejects an inverted window", async () => {
+      const searchFareCalendar = vi.fn(async () => ({ days: [] }))
+      const app = mount(stubAdapter({ searchFareCalendar }))
+
+      const res = await callCalendar(app, { ...window, from: "2026-08-31", to: "2026-08-01" })
+
+      expect(res.status).toBe(400)
+      expect(searchFareCalendar).not.toHaveBeenCalled()
+    })
+
+    // The cap is what stops one request becoming a year of supplier lookups.
+    it("rejects a window wider than the cap before reaching the connector", async () => {
+      const searchFareCalendar = vi.fn(async () => ({ days: [] }))
+      const app = mount(stubAdapter({ searchFareCalendar }))
+
+      const res = await callCalendar(app, { ...window, from: "2026-01-01", to: "2026-12-31" })
+
+      expect(res.status).toBe(400)
+      expect(searchFareCalendar).not.toHaveBeenCalled()
+    })
+
+    it("rejects a malformed date rather than passing it through", async () => {
+      const searchFareCalendar = vi.fn(async () => ({ days: [] }))
+      const app = mount(stubAdapter({ searchFareCalendar }))
+
+      const res = await callCalendar(app, { ...window, from: "August 2026" })
+
+      expect(res.status).toBe(400)
+      expect(searchFareCalendar).not.toHaveBeenCalled()
+    })
   })
 
   it("returns 501 when the connector lacks an optional capability", async () => {

--- a/packages/flights/src/api-runtime.test.ts
+++ b/packages/flights/src/api-runtime.test.ts
@@ -155,6 +155,30 @@ describe("flights hono module", () => {
       expect(res.status).toBe(400)
       expect(searchFareCalendar).not.toHaveBeenCalled()
     })
+
+    // `new Date("2026-02-31")` rolls forward to March 3rd, so a shape-only
+    // check would quote a month the caller never asked for.
+    it("rejects a date-shaped string that is not a real day", async () => {
+      const searchFareCalendar = vi.fn(async () => ({ days: [] }))
+      const app = mount(stubAdapter({ searchFareCalendar }))
+
+      for (const from of ["2026-02-31", "2026-13-01", "2026-04-31", "2026-00-10"]) {
+        const res = await callCalendar(app, { ...window, from })
+        expect(res.status, `expected 400 for ${from}`).toBe(400)
+      }
+      expect(searchFareCalendar).not.toHaveBeenCalled()
+    })
+
+    it("accepts a leap day in a leap year and refuses it otherwise", async () => {
+      const searchFareCalendar = vi.fn(async () => ({ days: [] }))
+      const app = mount(stubAdapter({ searchFareCalendar }))
+
+      const leap = await callCalendar(app, { ...window, from: "2028-02-29", to: "2028-03-05" })
+      expect(leap.status).toBe(200)
+
+      const notLeap = await callCalendar(app, { ...window, from: "2027-02-29", to: "2027-03-05" })
+      expect(notLeap.status).toBe(400)
+    })
   })
 
   it("returns 501 when the connector lacks an optional capability", async () => {

--- a/packages/flights/src/api-runtime.ts
+++ b/packages/flights/src/api-runtime.ts
@@ -14,6 +14,8 @@
  *   GET    /orders/:orderId          — adapter.getOrder (+ optional payment status)
  *   POST   /orders/:orderId/ticket   — adapter.ticketOrder (capability-gated)
  *   POST   /orders/:orderId/cancel   — adapter.cancelOrder
+ *   POST   /fare-calendar
+ *   GET    /served-markets
  *   GET    /reference/airports?q=&limit=
  *   GET    /reference/airlines
  *   GET    /reference/aircraft
@@ -27,7 +29,7 @@ import { OpenAPIHono } from "@hono/zod-openapi"
 import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
 import type { AnyDrizzleDb } from "@voyant-travel/db"
 import { createOrderPaymentSessions } from "@voyant-travel/finance/order-payment-sessions"
-import type { ApiModule } from "@voyant-travel/hono"
+import { type ApiModule, parseJsonBody } from "@voyant-travel/hono"
 import { ilike, or } from "drizzle-orm"
 import type { Context } from "hono"
 
@@ -36,6 +38,7 @@ import type {
   FlightConnectorAdapter,
   FlightPriceRequest,
 } from "./contract/adapter.js"
+import { fareCalendarRequestSchema } from "./contract/schemas.js"
 import type {
   AncillaryRequest,
   FlightBookRequest,
@@ -95,6 +98,8 @@ export const FLIGHTS_OPENAPI_API_ID = "@voyant-travel/flights#api"
 
 const FLIGHT_OPENAPI_OPERATIONS = [
   ["post", "/search", "Search flights"],
+  ["post", "/fare-calendar", "Quote departure dates across a window"],
+  ["get", "/served-markets", "List airports the connector sells"],
   ["post", "/ancillaries", "Get flight ancillaries"],
   ["post", "/seatmap", "Get a flight seat map"],
   ["post", "/price", "Price a flight offer"],
@@ -153,6 +158,21 @@ function statusForAdapterErrorMessage(message: string): 404 | 500 | 503 {
   return 500
 }
 
+/**
+ * Widest window `/fare-calendar` will ask a connector for. A picker shows two
+ * months at most, and the cap is what stops a caller from turning one request
+ * into a year of supplier lookups.
+ */
+const MAX_FARE_CALENDAR_WINDOW_DAYS = 92
+
+/** Inclusive day count between two `yyyy-MM-dd` dates. */
+function calendarWindowDays(from: string, to: string): number {
+  const start = Date.parse(`${from}T00:00:00Z`)
+  const end = Date.parse(`${to}T00:00:00Z`)
+  if (Number.isNaN(start) || Number.isNaN(end)) return 0
+  return Math.floor((end - start) / 86_400_000) + 1
+}
+
 function paymentSessionOptionsForIntent(
   intent: PaymentIntent | undefined,
 ): { paymentMethod?: "bank_transfer" | "credit_card"; startCardPayment?: boolean } | null {
@@ -190,6 +210,55 @@ export function createFlightAdminRoutes(options: FlightsRouteOptions): OpenAPIHo
     }
     try {
       const response = await resolveAdapter(c).searchFlights(buildContext(c), body)
+      return c.json(response)
+    } catch (err) {
+      const { message, status } = adapterErrorDetails(err)
+      return c.json({ error: message }, status)
+    }
+  })
+
+  // ── Fare calendar ───────────────────────────────────────────────────────
+  // Quotes a window of departure dates so the date picker can show where
+  // availability is. Capability-gated: connectors without cached lowest-fare
+  // data answer 501 and the picker degrades to a plain calendar.
+  hono.post("/fare-calendar", async (c) => {
+    const body = await parseJsonBody(c, fareCalendarRequestSchema)
+    if (body.to < body.from) {
+      return c.json({ error: "to must not precede from" }, 400)
+    }
+    const windowDays = calendarWindowDays(body.from, body.to)
+    if (windowDays > MAX_FARE_CALENDAR_WINDOW_DAYS) {
+      return c.json(
+        {
+          error: `Fare calendar window must not exceed ${MAX_FARE_CALENDAR_WINDOW_DAYS} days`,
+        },
+        400,
+      )
+    }
+    const adapter = resolveAdapter(c)
+    if (!adapter.searchFareCalendar) {
+      return c.json({ error: "Connector does not declare flight/fare-calendar capability" }, 501)
+    }
+    try {
+      const response = await adapter.searchFareCalendar(buildContext(c), body)
+      return c.json(response)
+    } catch (err) {
+      const { message, status } = adapterErrorDetails(err)
+      return c.json({ error: message }, status)
+    }
+  })
+
+  // ── Served markets ──────────────────────────────────────────────────────
+  // The airports this connection actually sells. A picker leads with these;
+  // it must not restrict itself to them, so a connector that declares nothing
+  // (501) simply falls back to the full airport reference.
+  hono.get("/served-markets", async (c) => {
+    const adapter = resolveAdapter(c)
+    if (!adapter.listServedMarkets) {
+      return c.json({ error: "Connector does not declare flight/served-markets capability" }, 501)
+    }
+    try {
+      const response = await adapter.listServedMarkets(buildContext(c))
       return c.json(response)
     } catch (err) {
       const { message, status } = adapterErrorDetails(err)
@@ -402,6 +471,9 @@ export function createFlightAdminRoutes(options: FlightsRouteOptions): OpenAPIHo
     const db = getDb(c)
     const q = c.req.query("q")?.trim()
     const limit = Math.min(Number(c.req.query("limit") ?? 50), 200)
+    // Ordered, not merely limited. Without this the "first 200" a picker shows
+    // on open is whatever Postgres hands back — a different arbitrary slice of
+    // every airport on earth run to run.
     let rows: Array<typeof referenceAirports.$inferSelect>
     if (q) {
       const pattern = `%${q}%`
@@ -415,9 +487,14 @@ export function createFlightAdminRoutes(options: FlightsRouteOptions): OpenAPIHo
             ilike(referenceAirports.name, pattern),
           ),
         )
+        .orderBy(referenceAirports.city, referenceAirports.iataCode)
         .limit(limit)
     } else {
-      rows = await db.select().from(referenceAirports).limit(limit)
+      rows = await db
+        .select()
+        .from(referenceAirports)
+        .orderBy(referenceAirports.city, referenceAirports.iataCode)
+        .limit(limit)
     }
     return c.json({ data: rows })
   })

--- a/packages/flights/src/mcp-runtime.ts
+++ b/packages/flights/src/mcp-runtime.ts
@@ -40,6 +40,13 @@ export const voyantToolContextContribution = defineToolContextContribution({
         searchFlights: (
           input: Parameters<ReturnType<typeof runtime.resolveAdapter>["searchFlights"]>[1],
         ) => runtime.resolveAdapter(c).searchFlights(adapterContext, input),
+        searchFareCalendar: (input: Parameters<FlightsToolServices["searchFareCalendar"]>[0]) => {
+          const adapter = runtime.resolveAdapter(c)
+          return requireFlightCapabilityMethod(
+            adapter.searchFareCalendar?.bind(adapter),
+            "searchFareCalendar",
+          )(adapterContext, input)
+        },
         priceOffer: (
           input: Parameters<ReturnType<typeof runtime.resolveAdapter>["priceOffer"]>[1],
         ) => runtime.resolveAdapter(c).priceOffer(adapterContext, input),

--- a/packages/flights/src/tools.test.ts
+++ b/packages/flights/src/tools.test.ts
@@ -35,6 +35,7 @@ describe("flight tools", () => {
       "get_flight_order",
       "list_flight_orders",
       "price_flight_offer",
+      "search_fare_calendar",
       "search_flights",
       "ticket_flight_order",
     ])
@@ -85,6 +86,57 @@ describe("flight tools", () => {
         }),
       ),
     ).resolves.toEqual({ offers: [], pagination: { total: 0, hasMore: false } })
+  })
+
+  it("quotes a fare calendar window through the connector", async () => {
+    await expect(
+      registry().dispatch(
+        "search_fare_calendar",
+        {
+          origin: "OTP",
+          destination: "FNC",
+          from: "2026-09-01",
+          to: "2026-09-30",
+          passengers: { adults: 1 },
+        },
+        ctx({
+          async searchFareCalendar() {
+            return {
+              days: [
+                {
+                  date: "2026-09-01",
+                  available: true,
+                  cheapestPrice: { amount: "199.00", currency: "EUR" },
+                },
+                { date: "2026-09-02", available: false },
+              ],
+            }
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({ days: [{ date: "2026-09-01" }, { date: "2026-09-02" }] })
+  })
+
+  // A day that does not exist would be rolled forward by `Date`, so the agent
+  // has to be told rather than handed quotes for another month.
+  it("refuses a window bound that is not a real calendar day", async () => {
+    await expect(
+      registry().dispatch(
+        "search_fare_calendar",
+        {
+          origin: "OTP",
+          destination: "FNC",
+          from: "2026-02-31",
+          to: "2026-03-15",
+          passengers: { adults: 1 },
+        },
+        ctx({
+          async searchFareCalendar() {
+            throw new Error("the connector must never be reached with an impossible date")
+          },
+        }),
+      ),
+    ).rejects.toThrow()
   })
 
   it("fails closed without connector wiring", async () => {

--- a/packages/flights/src/tools.ts
+++ b/packages/flights/src/tools.ts
@@ -1,6 +1,8 @@
 /** Provider-neutral flight search, pricing, order, ticketing, and cancellation Tools. */
 
 import {
+  fareCalendarRequestSchema,
+  fareCalendarResponseSchema,
   flightCancelReasonSchema,
   flightCancelResponseSchema,
   flightGetOrderResponseSchema,
@@ -29,6 +31,7 @@ const orderIdSchema = z.object({ orderId: z.string().min(1) })
 const cancelOrderSchema = orderIdSchema.extend({ reason: flightCancelReasonSchema.optional() })
 const DURABLE_FLIGHT_ACTION_VERSION = "v2"
 
+type FareCalendarInput = z.infer<typeof fareCalendarRequestSchema>
 type FlightSearchInput = z.infer<typeof flightSearchRequestSchema>
 type FlightPriceInput = z.infer<typeof flightPriceRequestSchema>
 type FlightOrdersListInput = z.infer<typeof flightOrdersListQuerySchema>
@@ -36,6 +39,7 @@ type FlightCancelInput = z.infer<typeof cancelOrderSchema>
 
 export interface FlightsToolServices {
   searchFlights(input: FlightSearchInput): Promise<unknown>
+  searchFareCalendar(input: FareCalendarInput): Promise<unknown>
   priceOffer(input: FlightPriceInput): Promise<unknown>
   listOrders(input: FlightOrdersListInput): Promise<unknown>
   getOrder(orderId: string): Promise<unknown>
@@ -121,6 +125,30 @@ export const searchFlightsTool = defineTool({
   },
 })
 
+/**
+ * The date question, answerable without running a search per day. "When is
+ * Bucharest to Madeira cheapest in September" is a question an agent should be
+ * able to answer, and doing it through `search_flights` would mean thirty
+ * supplier calls to learn what one returns.
+ *
+ * Capability-gated: connectors without cached lowest-fare data raise
+ * MISSING_SERVICE rather than silently returning an empty window, so the agent
+ * can say the supply cannot answer instead of reporting no availability.
+ */
+export const searchFareCalendarTool = defineTool({
+  ...offerReadMetadata,
+  capabilityId: `${OWNER}#tool.fare-calendar`,
+  name: "search_fare_calendar",
+  description:
+    "Quote indicative cheapest fares and availability for one route across a window of departure dates. Prices are cached and must be re-quoted with search_flights before booking.",
+  requiredScopes: ["flights:write"],
+  inputSchema: fareCalendarRequestSchema,
+  outputSchema: fareCalendarResponseSchema,
+  async handler(input, ctx: FlightsToolContext) {
+    return fareCalendarResponseSchema.parse(await flights(ctx).searchFareCalendar(input))
+  },
+})
+
 export const priceFlightOfferTool = defineTool({
   ...offerReadMetadata,
   capabilityId: `${OWNER}#tool.price-offer`,
@@ -202,6 +230,7 @@ export const cancelFlightOrderTool = defineTool({
 
 export const flightsTools = [
   searchFlightsTool,
+  searchFareCalendarTool,
   priceFlightOfferTool,
   listFlightOrdersTool,
   getFlightOrderTool,

--- a/packages/flights/src/voyant.test.ts
+++ b/packages/flights/src/voyant.test.ts
@@ -133,7 +133,7 @@ describe("flights deployment manifest", () => {
     const operations = Object.values(document.paths ?? {}).flatMap((path) =>
       Object.values(path).filter((operation) => typeof operation === "object"),
     ) as Array<Record<string, unknown>>
-    expect(operations).toHaveLength(12)
+    expect(operations).toHaveLength(14)
     expect(
       operations.every((operation) => operation["x-voyant-api-id"] === FLIGHTS_OPENAPI_API_ID),
     ).toBe(true)

--- a/packages/flights/src/voyant.ts
+++ b/packages/flights/src/voyant.ts
@@ -69,6 +69,18 @@ export const flightsVoyantModule = defineModule({
       risk: "low",
     },
     {
+      id: "@voyant-travel/flights#tool.fare-calendar",
+      name: "search_fare_calendar",
+      runtime: { entry: "@voyant-travel/flights/tools", export: "searchFareCalendarTool" },
+      requiredScopes: ["flights:write"],
+      context: ["flights"],
+      risk: "low",
+      // Name matching reads a resource's trailing noun, which for this Tool is
+      // "calendar" and would never meet `flight/fare-calendar`. Declaring the
+      // path it fronts is the explicit form and does not drift with the name.
+      adminWrites: ["/v1/admin/flights/fare-calendar"],
+    },
+    {
       id: "@voyant-travel/flights#tool.price-offer",
       name: "price_flight_offer",
       runtime: { entry: "@voyant-travel/flights/tools", export: "priceFlightOfferTool" },
@@ -119,6 +131,16 @@ export const flightsVoyantModule = defineModule({
       risk: "low",
       ledger: "optional",
       from: { tools: ["@voyant-travel/flights#tool.search"] },
+    },
+    {
+      id: "@voyant-travel/flights#action.fare-calendar",
+      version: "v1",
+      kind: "read",
+      targetType: "flight-offer",
+      requiredScopes: ["flights:write"],
+      risk: "low",
+      ledger: "optional",
+      from: { tools: ["@voyant-travel/flights#tool.fare-calendar"] },
     },
     {
       id: "@voyant-travel/flights#action.price-offer",

--- a/packages/ui/src/components/calendar.tsx
+++ b/packages/ui/src/components/calendar.tsx
@@ -6,6 +6,16 @@ import { type DayButton, DayPicker, getDefaultClassNames, type Locale } from "re
 import { cn } from "../lib/utils.js"
 import { Button, buttonVariants } from "./button.js"
 
+/**
+ * Renders a secondary line under a day's number — a price, a count, a status.
+ * Return `null`/`undefined` for days with nothing to say; the cell then looks
+ * exactly as it would without annotations at all.
+ *
+ * Annotated cells need more room than the 2rem default, so callers should
+ * widen `--cell-size` on the calendar when they use this.
+ */
+type CalendarDayAnnotation = (date: Date) => React.ReactNode
+
 function Calendar({
   className,
   classNames,
@@ -15,9 +25,11 @@ function Calendar({
   locale,
   formatters,
   components,
+  dayAnnotation,
   ...props
 }: React.ComponentProps<typeof DayPicker> & {
   buttonVariant?: React.ComponentProps<typeof Button>["variant"]
+  dayAnnotation?: CalendarDayAnnotation
 }) {
   const defaultClassNames = getDefaultClassNames()
 
@@ -126,7 +138,9 @@ function Calendar({
 
           return <ChevronDownIcon className={cn("size-4", className)} {...props} />
         },
-        DayButton: ({ ...props }) => <CalendarDayButton locale={locale} {...props} />,
+        DayButton: ({ ...props }) => (
+          <CalendarDayButton locale={locale} dayAnnotation={dayAnnotation} {...props} />
+        ),
         WeekNumber: ({ children, ...props }) => {
           return (
             <td {...props}>
@@ -148,14 +162,21 @@ function CalendarDayButton({
   day,
   modifiers,
   locale,
+  dayAnnotation,
+  children,
   ...props
-}: React.ComponentProps<typeof DayButton> & { locale?: Partial<Locale> }) {
+}: React.ComponentProps<typeof DayButton> & {
+  locale?: Partial<Locale>
+  dayAnnotation?: CalendarDayAnnotation
+}) {
   const defaultClassNames = getDefaultClassNames()
 
   const ref = React.useRef<HTMLButtonElement>(null)
   React.useEffect(() => {
     if (modifiers.focused) ref.current?.focus()
   }, [modifiers.focused])
+
+  const annotation = dayAnnotation?.(day.date)
 
   return (
     <Button
@@ -187,8 +208,12 @@ function CalendarDayButton({
         defaultClassNames.day,
         className,
       )}
-    />
+    >
+      {children}
+      {annotation == null ? null : <span data-slot="day-annotation">{annotation}</span>}
+    </Button>
   )
 }
 
+export type { CalendarDayAnnotation }
 export { Calendar, CalendarDayButton }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,7 +249,7 @@ importers:
         version: 1.6.0(@date-fns/tz@1.4.1)(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@better-auth/api-key':
         specifier: 1.6.23
-        version: 1.6.23(1ac6a98f3eafa8cc5361cfcd8d9e497a)
+        version: 1.6.23(4cc07405e1e664eaf96048bc4329d318)
       '@fontsource-variable/inter-tight':
         specifier: ^5.2.7
         version: 5.2.7
@@ -2894,6 +2894,9 @@ importers:
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -2921,6 +2924,9 @@ importers:
       '@voyant-travel/voyant-typescript-config':
         specifier: workspace:^
         version: link:../typescript-config
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1(@noble/hashes@2.2.0)
       lucide-react:
         specifier: ^1.23.0
         version: 1.23.0(react@19.2.7)
@@ -12455,15 +12461,8 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
-  tldts-core@7.4.3:
-    resolution: {integrity: sha512-27ep5H9PzdBrNd5OFM/j3WCU8F3kPwM9D0BOaOf7uYfxMJfyr0K5Tjj69Gri+sZlh2WXd5buIm47NuPF29CDiw==}
-
   tldts-core@7.4.8:
     resolution: {integrity: sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw==}
-
-  tldts@7.4.3:
-    resolution: {integrity: sha512-A3BDQBeeukYPzB4QdQ1DtdlUmp4x2OCH8n5UVhEWbyANxNep8GavottKzd1xYKFJKjUgMyPT7EzOfnBO55s8Sg==}
-    hasBin: true
 
   tldts@7.4.8:
     resolution: {integrity: sha512-htwgN/8KRB3z3vnC0BOETVh2m499g5GmyTK9Wq5JBLX3FNz6tSBveAd+fQhzy9hkjif8vy2jwDMR1sGhLtZl2A==}
@@ -12480,10 +12479,6 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
-
-  tough-cookie@6.0.1:
-    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
-    engines: {node: '>=16'}
 
   tough-cookie@6.0.2:
     resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
@@ -13417,6 +13412,14 @@ snapshots:
   '@better-auth/api-key@1.6.23(1ac6a98f3eafa8cc5361cfcd8d9e497a)':
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0)
+      '@better-auth/utils': 0.4.2
+      better-auth: 1.6.23(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.3)(rollup@4.60.2)(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9))(mongodb@7.1.0(socks@2.8.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.11)(vitest@4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)))(vue@3.5.39(typescript@6.0.3))
+      better-call: 1.3.7(zod@4.4.3)
+      zod: 4.4.3
+
+  '@better-auth/api-key@1.6.23(4cc07405e1e664eaf96048bc4329d318)':
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
       better-auth: 1.6.23(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.3)(rollup@4.60.2)(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9))(mongodb@7.1.0(socks@2.8.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.11)(vitest@4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)))(vue@3.5.39(typescript@6.0.3))
       better-call: 1.3.7(zod@4.4.3)
@@ -18004,7 +18007,7 @@ snapshots:
       parse5: 8.0.1
       saxes: 6.0.0
       symbol-tree: 3.2.4
-      tough-cookie: 6.0.1
+      tough-cookie: 6.0.2
       undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
@@ -19902,19 +19905,11 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
-  tldts-core@7.4.3: {}
-
-  tldts-core@7.4.8:
-    optional: true
-
-  tldts@7.4.3:
-    dependencies:
-      tldts-core: 7.4.3
+  tldts-core@7.4.8: {}
 
   tldts@7.4.8:
     dependencies:
       tldts-core: 7.4.8
-    optional: true
 
   tmp@0.2.7: {}
 
@@ -19924,14 +19919,9 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
-  tough-cookie@6.0.1:
-    dependencies:
-      tldts: 7.4.3
-
   tough-cookie@6.0.2:
     dependencies:
       tldts: 7.4.8
-    optional: true
 
   tr46@5.1.1:
     dependencies:

--- a/scripts/checks/openapi/generated-specs.json
+++ b/scripts/checks/openapi/generated-specs.json
@@ -25,6 +25,10 @@
     {
       "command": "pnpm --filter @voyant-travel/legal generate:openapi",
       "files": ["packages/legal/openapi/admin/legal.json"]
+    },
+    {
+      "command": "pnpm --filter @voyant-travel/flights generate:openapi",
+      "files": ["packages/flights/openapi/admin/flights.json"]
     }
   ]
 }

--- a/scripts/tool-refinement-inventory.json
+++ b/scripts/tool-refinement-inventory.json
@@ -68,6 +68,11 @@
       "note": "Documented. The Tool description states all three cross-field rules in full: creditNoteId is required and paymentId bounds the refundable amount, processor_reversal requires paymentSessionId, and instrumentAmountCents requires instrumentCurrency (voyant#4303)."
     },
     {
+      "id": "@voyant-travel/flights:search_fare_calendar:from",
+      "documented": true,
+      "note": "Documented. Both window bounds share one date schema whose description states the yyyy-MM-dd shape and that the day must exist, naming 2026-02-31 and 2026-13-01 as rejected."
+    },
+    {
       "id": "@voyant-travel/inventory:create_option_unit:<root>",
       "documented": false,
       "note": "Not stated. update_option_unit documents its occupancy rule but create_option_unit does not, though the same class of rule applies (voyant#3822 fixed only the update side)."


### PR DESCRIPTION
The flights date picker rendered an undecorated calendar — every day looked identical, so nothing on screen said which dates the operator's providers actually fly or what they cost. Nothing behind it could have said so either: there was no fare-calendar concept anywhere in the flights stack.

## What changed

**`flight/fare-calendar`** — new capability + `searchFareCalendar` on `FlightConnectorAdapter`, served as `POST /v1/admin/flights/fare-calendar` (92-day window cap). The picker shows the cheapest indicative price per day, bands it cheap/mid/expensive against the visible window, and strikes out days with no service. Each picker prices the leg it selects, so the return shows the fare for coming back rather than repeating the outbound.

The demo adapter prices every day by running the *real* offer synthesis rather than a parallel price model, so a number the picker shows and a search on that day can never disagree — a test pins exactly that. Demo supply also gained a weekly operating pattern on thin long-haul routes, which is what gives the calendar real gaps instead of a uniform wall of availability.

**`flight/served-markets`** — new capability + `listServedMarkets`, served as `GET /v1/admin/flights/served-markets`. The airport picker leads with the operator's own network. **It ranks, it never filters**: a stale declaration must not be able to hide an airport, so the remainder group always carries everything else.

**Operator signal** — the airport picker also groups by routes actually searched, remembered per browser (selection caches display fields; only a submitted search counts as a use). And `GET /reference/airports` is now deterministically ordered — previously the "first 200" a picker showed was whatever Postgres happened to hand back.

**Airline visibility** — offer rows name the airline and its flight numbers. `carrierName` was already resolved and passed down; it was only being spent on the logo's `alt` text.

**`packages/ui`** — `Calendar`/`DatePicker` gain `dayAnnotation` for a secondary line under a day's number. The shadcn `CalendarDayButton` was already a flex-column with `[&>span]` styling, so this fills a seam that was already there.

## Degradation

A connector declaring neither capability answers 501 and every surface falls back to exactly what it did before — a plain working calendar, an ungrouped airport list. That is the common case, not a failure, and it's covered by tests.

## New checks

Both new checks are declarative additions to existing capability/route machinery rather than new `scripts/check-*.mjs` — no new links in the `verify:architecture` chain.

## Verification

- `flights-contracts`, `flights`, `flights-react`, `ui`, `flights-demo-api`: build, typecheck, lint, test all green
- 18 new component tests in `flights-react` (first jsdom tests in that package; `@testing-library/react` + `jsdom` added as devDeps, matching `media-react`)
- `i18n:check` green, en+ro parity for every new string
- `verify:openapi-drift`, `route-conformance`, `route-authoring`, `graph-conformance`, `symbol-policy`, `public-surface`, `boundary`, `client-package-boundaries`, `typecheck-coverage`, `vitest-include`, `agent-tool-coverage`, `agent-write-coverage`, `dep-paths`, `dist-configs`, `flights-runtime-authority` — all green

Not verified in a running browser: the operator's flights adapter is deployment-wired outside this repo, so there is no local path that serves a fare calendar. Behaviour is pinned in a real DOM instead — prices rendered, band classes on the right cells, sold-out days unselectable, unquoted days still selectable, 501 degradation.