### PR TITLE
Publish the payment plan on the Quote

### DIFF
--- a/.changeset/quote-payment-plan.md
+++ b/.changeset/quote-payment-plan.md
@@ -1,0 +1,15 @@
+---
+"@voyant-travel/catalog-contracts": patch
+"@voyant-travel/catalog": patch
+"@voyant-travel/bookings-react": patch
+---
+
+Publish the payment plan on the Quote, so checkout can say what is due now and when the balance falls due.
+
+A shopper under a deposit policy was never told they were paying a deposit. They reviewed a total, accepted a contract stating that total, pressed pay, and were charged something else — €378 reviewed and agreed, €189 charged. Nothing in the Session lifecycle carried the plan until Commit answered `payment_required`, which happens after the review step and after contract acceptance, so no storefront could state the terms at the moment the shopper agreed to them.
+
+`quote.paymentPlan` now carries `policySource`, `currency`, `totalCents`, `dueNowCents` and every scheduled entry. It is a projection over the Quote's total and the selected departure — `resolveEffectivePaymentPolicy` then `computePaymentSchedule`, the same derivation Commit charges from, shared rather than duplicated so the two cannot come apart. Nothing is stored and no table changes; the field sits beside `pricing` rather than inside it, keeping it out of the price fingerprint that supersession compares.
+
+`resolveContractVariables` accepts the quoted plan and prefers it over a host-computed schedule, so the accepted document states the real deposit, the real balance and its due date. A new `payment.dueNowCents` names what the card will actually be charged; `payment.amountCents` still means the booking total, so existing templates render unchanged.
+
+Additive throughout — a deployment that wires no payment ports publishes no plan, and a storefront that does not read the field is unaffected.

--- a/packages/bookings-react/src/public-api/resolve-contract-variables.test.ts
+++ b/packages/bookings-react/src/public-api/resolve-contract-variables.test.ts
@@ -66,3 +66,137 @@ describe("resolveContractVariables — booking.source provenance", () => {
     })
   })
 })
+
+/**
+ * The contract states what the shopper is agreeing to pay, so it has to state
+ * what will actually be charged. Under a deposit policy the document used to
+ * name a single total while the card was charged the deposit, because nothing
+ * carried the plan to the acceptance step (voyant#4741).
+ *
+ * The Quote now publishes the server's plan, and that is the one the document
+ * must render — a schedule the storefront computed for itself agrees only for
+ * as long as both sides stay in step.
+ */
+describe("resolveContractVariables — payment plan", () => {
+  const PLAN = {
+    policySource: "supplier" as const,
+    currency: "EUR",
+    totalCents: 37_800,
+    dueNowCents: 18_900,
+    entries: [
+      {
+        scheduleType: "deposit" as const,
+        amountCents: 18_900,
+        currency: "EUR",
+        dueDate: "2026-08-16",
+      },
+      {
+        scheduleType: "balance" as const,
+        amountCents: 18_900,
+        currency: "EUR",
+        dueDate: "2026-09-06",
+      },
+    ],
+  }
+
+  const BASE = { entityModule: "products", entityId: "prod_owned_1" }
+
+  /** The deposit / balance / policy-source block lives under `booking`. */
+  function bookingVars(vars: Record<string, unknown>) {
+    return vars.booking as Record<string, unknown>
+  }
+
+  it("renders the deposit and balance the server quoted", () => {
+    const vars = resolveContractVariables(makeDraft(), { ...BASE, paymentPlan: PLAN })
+
+    expect(bookingVars(vars)).toMatchObject({
+      depositAmountCents: 18_900,
+      depositDueDate: "2026-08-16",
+      balanceAmountCents: 18_900,
+      balanceDueDate: "2026-09-06",
+      paymentPolicy: { source: "supplier" },
+    })
+  })
+
+  it("states what is due now, which is not the booking total", () => {
+    const vars = resolveContractVariables(makeDraft(), { ...BASE, paymentPlan: PLAN })
+
+    expect((vars.payment as Record<string, unknown>).dueNowCents).toBe(18_900)
+  })
+
+  it("carries every instalment through to the template", () => {
+    const vars = resolveContractVariables(makeDraft(), { ...BASE, paymentPlan: PLAN })
+
+    expect((vars.payment as { schedule: unknown[] }).schedule).toEqual([
+      {
+        index: 1,
+        type: "deposit",
+        amountCents: 18_900,
+        currency: "EUR",
+        dueDate: "2026-08-16",
+        status: "pending",
+      },
+      {
+        index: 2,
+        type: "balance",
+        amountCents: 18_900,
+        currency: "EUR",
+        dueDate: "2026-09-06",
+        status: "pending",
+      },
+    ])
+  })
+
+  // The server's answer is the one that will be charged, so it outranks a
+  // locally computed one rather than merging with it.
+  it("prefers the quoted plan over a schedule the host computed itself", () => {
+    const vars = resolveContractVariables(makeDraft(), {
+      ...BASE,
+      paymentPlan: PLAN,
+      paymentSchedule: [
+        { scheduleType: "full", amountCents: 37_800, currency: "EUR", dueDate: "2026-08-16" },
+      ],
+      paymentPolicySource: "operator_default",
+    })
+
+    expect(bookingVars(vars)).toMatchObject({
+      depositAmountCents: 18_900,
+      paymentPolicy: { source: "supplier" },
+    })
+  })
+
+  // Additive: a host quoting against a deployment that publishes no plan keeps
+  // the behaviour it had.
+  it("falls back to a host-computed schedule when the quote carried no plan", () => {
+    const vars = resolveContractVariables(makeDraft(), {
+      ...BASE,
+      paymentSchedule: [
+        { scheduleType: "deposit", amountCents: 5_000, currency: "EUR", dueDate: "2026-08-16" },
+      ],
+      paymentPolicySource: "listing",
+    })
+
+    expect(bookingVars(vars)).toMatchObject({
+      depositAmountCents: 5_000,
+      paymentPolicy: { source: "listing" },
+    })
+  })
+
+  // A contract with no schedule at all still owes the total, so `dueNowCents`
+  // must not render as a blank or a zero next to a real price.
+  it("owes the total when nothing states a plan", () => {
+    const vars = resolveContractVariables(makeDraft(), {
+      ...BASE,
+      pricing: {
+        currency: "EUR",
+        lines: [],
+        taxes: [],
+        subtotal: 37_800,
+        taxTotal: 0,
+        total: 37_800,
+      },
+    })
+
+    expect((vars.payment as Record<string, unknown>).dueNowCents).toBe(37_800)
+  })
+})

--- a/packages/bookings-react/src/public-api/resolve-contract-variables.ts
+++ b/packages/bookings-react/src/public-api/resolve-contract-variables.ts
@@ -40,6 +40,7 @@
  */
 
 import type {
+  BookingPaymentPlanV1,
   BookingSelectionV1,
   PricingBreakdownV1,
 } from "@voyant-travel/catalog-contracts/booking-engine/contracts"
@@ -125,13 +126,29 @@ export interface ResolveContractVariablesContext {
    *  storefront leaves this undefined and the variables render
    *  empty. */
   acceptance?: AcceptanceContextVariables
+  /**
+   * The plan the server published on the Quote (`quote.paymentPlan`).
+   *
+   * Prefer this over {@link paymentSchedule}. The contract states what the
+   * shopper is agreeing to pay, so it has to state what will actually be
+   * charged — and that is Commit's derivation, which this block is a
+   * projection of. A schedule the storefront computed itself agrees only as
+   * long as both sides stay in step (voyant#4741).
+   *
+   * Wins over `paymentSchedule` and `paymentPolicySource` when present.
+   */
+  paymentPlan?: BookingPaymentPlanV1 | null
   /** Pre-computed schedule from `computePaymentSchedule()`. The
    *  storefront wrapper computes this in real time as the customer
    *  picks their date so the contract preview shows live deposit
-   *  / balance numbers. */
+   *  / balance numbers.
+   *
+   *  Retained for hosts that quote against a deployment which publishes no
+   *  `paymentPlan`; pass the server's plan instead wherever there is one. */
   paymentSchedule?: ComputedScheduleEntry[] | null
   /** Which layer of the cascade the active policy came from. Used
-   *  for traceability in contract templates. */
+   *  for traceability in contract templates. Ignored when `paymentPlan`
+   *  is present, which carries its own `policySource`. */
   paymentPolicySource?: PaymentPolicySource
   /** Resolved source provenance for the booked entity. Populated by
    *  the storefront wrapper from the public content endpoint's
@@ -260,14 +277,23 @@ export function resolveContractVariables(
   const todayIsoDateTime = today.toISOString()
   const todayTime = today.toISOString().slice(11, 19)
 
-  // Map the precomputed schedule into the deposit / balance / full
-  // shapes contract templates read. `"full"` collapses to the
-  // balance-row slot (it's the single payment due in that scenario).
-  const schedule = ctx.paymentSchedule ?? []
+  // Map the schedule into the deposit / balance / full shapes contract
+  // templates read. `"full"` collapses to the balance-row slot (it's the
+  // single payment due in that scenario).
+  //
+  // The server's plan wins: the contract states what the shopper agrees to
+  // pay, and Commit charges the plan, so a locally computed schedule is at
+  // best a second opinion about the same policy (voyant#4741).
+  const schedule = ctx.paymentPlan?.entries ?? ctx.paymentSchedule ?? []
+  const policySource =
+    ctx.paymentPlan?.policySource ?? ctx.paymentPolicySource ?? "operator_default"
   const depositRow = schedule.find((r) => r.scheduleType === "deposit")
   const balanceRow =
     schedule.find((r) => r.scheduleType === "balance") ??
     schedule.find((r) => r.scheduleType === "full")
+  // The plan states this outright; without one, the first row is the same
+  // answer, and a contract with no schedule at all still owes the total.
+  const dueNowCents = ctx.paymentPlan?.dueNowCents ?? schedule[0]?.amountCents ?? totalCents
 
   return {
     // ───────── Top-level clocks ─────────
@@ -374,7 +400,7 @@ export function resolveContractVariables(
       balanceAmountCents: balanceRow?.amountCents ?? 0,
       balanceDueDate: balanceRow?.dueDate ?? "",
       paymentPolicy: {
-        source: ctx.paymentPolicySource ?? "operator_default",
+        source: policySource,
       },
 
       // Best-effort accommodation summary. Server-side resolver
@@ -458,6 +484,14 @@ export function resolveContractVariables(
       intent: draft.payment.intent,
       method: paymentMethodLabel(draft.payment.intent),
       amountCents: totalCents,
+      /**
+       * What the card will actually be charged on this commit — the plan's
+       * first row, not the booking total. Added rather than folded into
+       * `amountCents`, which templates have always read as the total and
+       * which redefining would silently change every rendered contract.
+       * Falls back to the total when no plan says otherwise.
+       */
+      dueNowCents: dueNowCents,
       currency: sellCurrency,
       schedule: schedule.map((row, idx) => ({
         index: idx + 1,

--- a/packages/catalog-contracts/src/booking-engine/pricing-contracts.ts
+++ b/packages/catalog-contracts/src/booking-engine/pricing-contracts.ts
@@ -176,3 +176,61 @@ export const bookingPaymentScheduleV1 = z.object({
   amountCents: z.number().int().nonnegative(),
   notes: z.string().nullable().optional(),
 })
+
+/**
+ * One row of the collection plan a shopper is shown before they commit.
+ *
+ * `scheduleType` mirrors finance's `PaymentScheduleEntryType`, which is a
+ * narrower set than {@link bookingPaymentScheduleV1}'s: this describes what
+ * `computePaymentSchedule` emits, not what a persisted schedule row may later
+ * become. `"full"` is the collapse case — a policy with no deposit, a departure
+ * too close for one, or a split that would leave a zero-cent partner.
+ *
+ * Nothing pins the mirror declaratively; the assignment in
+ * `sessions-payment-production.ts` does it structurally, and a fourth entry
+ * type in finance fails to compile there.
+ */
+export const bookingPaymentPlanEntryV1 = z.object({
+  scheduleType: z.enum(["deposit", "balance", "full"]),
+  amountCents: z.number().int().nonnegative(),
+  currency: z.string().length(3),
+  /** ISO `YYYY-MM-DD`. */
+  dueDate: z.string(),
+})
+
+/**
+ * What the shopper will actually be charged, and when — published on the Quote
+ * so a storefront can state the terms at the moment the shopper agrees to them.
+ *
+ * A shopper under a deposit policy used to review a total, accept a contract
+ * naming that total, and then be charged something else, because nothing
+ * carried the plan until Commit answered `payment_required` — after the review
+ * step and after contract acceptance (voyant#4741).
+ *
+ * This is a pure projection over the Quote's total and the selected departure:
+ * `resolveEffectivePaymentPolicy` then `computePaymentSchedule`, the same two
+ * calls Commit makes. It is computed, never stored, so it cannot drift from the
+ * Quote it is published on — and it is outside `pricing`, so it stays out of
+ * the price fingerprint that supersession compares.
+ *
+ * `dueNowCents` is `entries[0].amountCents`, named separately because it is the
+ * one number the pay button has to agree with.
+ */
+export const bookingPaymentPlanV1 = z.object({
+  /** Which cascade layer the active policy came from. Mirrors finance's `PaymentPolicySource`. */
+  policySource: z.enum([
+    "booking",
+    "proposal",
+    "listing",
+    "category",
+    "supplier",
+    "operator_default",
+  ]),
+  currency: z.string().length(3),
+  totalCents: z.number().int().nonnegative(),
+  dueNowCents: z.number().int().nonnegative(),
+  entries: z.array(bookingPaymentPlanEntryV1).min(1),
+})
+
+export type BookingPaymentPlanEntryV1 = z.infer<typeof bookingPaymentPlanEntryV1>
+export type BookingPaymentPlanV1 = z.infer<typeof bookingPaymentPlanV1>

--- a/packages/catalog-contracts/src/booking-engine/session-contracts.ts
+++ b/packages/catalog-contracts/src/booking-engine/session-contracts.ts
@@ -1,6 +1,6 @@
 import { z } from "zod"
 import { bookingLifecycleCommitOutcomeV1 } from "./lifecycle-conformance.js"
-import { pricingBreakdownV1 } from "./pricing-contracts.js"
+import { bookingPaymentPlanV1, pricingBreakdownV1 } from "./pricing-contracts.js"
 import { bookingCheckoutIntentV1, bookingRequirementsV1 } from "./requirements-contracts.js"
 import { unsatisfiedRequirementV1 } from "./requirements-validation.js"
 
@@ -302,6 +302,17 @@ export const bookingQuoteRecordV1 = z.object({
    */
   requirementsFingerprint: z.string().min(1),
   pricing: pricingBreakdownV1,
+  /**
+   * What the shopper will be charged and when, if a Commit happened now.
+   *
+   * Optional because it is a projection and a host that wires no payment
+   * ports has no plan to state — absent means "this deployment does not
+   * publish one", not "pay the total". Deliberately a sibling of `pricing`
+   * rather than a member of it: the price fingerprint is computed over
+   * `pricing` alone, and a due date derived from *today* inside it would
+   * supersede every Quote on the next compose.
+   */
+  paymentPlan: bookingPaymentPlanV1.optional(),
   quotedAt: z.string().datetime(),
   expiresAt: z.string().datetime(),
 })

--- a/packages/catalog/openapi/admin/catalog-booking.json
+++ b/packages/catalog/openapi/admin/catalog-booking.json
@@ -7856,6 +7856,62 @@
                     },
                     "required": ["currency", "lines", "taxes", "subtotal", "taxTotal", "total"]
                   },
+                  "paymentPlan": {
+                    "type": "object",
+                    "properties": {
+                      "policySource": {
+                        "type": "string",
+                        "enum": [
+                          "booking",
+                          "proposal",
+                          "listing",
+                          "category",
+                          "supplier",
+                          "operator_default"
+                        ]
+                      },
+                      "currency": {
+                        "type": "string",
+                        "minLength": 3,
+                        "maxLength": 3
+                      },
+                      "totalCents": {
+                        "type": "integer",
+                        "minimum": 0
+                      },
+                      "dueNowCents": {
+                        "type": "integer",
+                        "minimum": 0
+                      },
+                      "entries": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "scheduleType": {
+                              "type": "string",
+                              "enum": ["deposit", "balance", "full"]
+                            },
+                            "amountCents": {
+                              "type": "integer",
+                              "minimum": 0
+                            },
+                            "currency": {
+                              "type": "string",
+                              "minLength": 3,
+                              "maxLength": 3
+                            },
+                            "dueDate": {
+                              "type": "string"
+                            }
+                          },
+                          "required": ["scheduleType", "amountCents", "currency", "dueDate"]
+                        },
+                        "minItems": 1
+                      }
+                    },
+                    "required": ["policySource", "currency", "totalCents", "dueNowCents", "entries"]
+                  },
                   "quotedAt": {
                     "type": "string",
                     "format": "date-time"

--- a/packages/catalog/openapi/public-api/catalog-booking.json
+++ b/packages/catalog/openapi/public-api/catalog-booking.json
@@ -7856,6 +7856,62 @@
                     },
                     "required": ["currency", "lines", "taxes", "subtotal", "taxTotal", "total"]
                   },
+                  "paymentPlan": {
+                    "type": "object",
+                    "properties": {
+                      "policySource": {
+                        "type": "string",
+                        "enum": [
+                          "booking",
+                          "proposal",
+                          "listing",
+                          "category",
+                          "supplier",
+                          "operator_default"
+                        ]
+                      },
+                      "currency": {
+                        "type": "string",
+                        "minLength": 3,
+                        "maxLength": 3
+                      },
+                      "totalCents": {
+                        "type": "integer",
+                        "minimum": 0
+                      },
+                      "dueNowCents": {
+                        "type": "integer",
+                        "minimum": 0
+                      },
+                      "entries": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "scheduleType": {
+                              "type": "string",
+                              "enum": ["deposit", "balance", "full"]
+                            },
+                            "amountCents": {
+                              "type": "integer",
+                              "minimum": 0
+                            },
+                            "currency": {
+                              "type": "string",
+                              "minLength": 3,
+                              "maxLength": 3
+                            },
+                            "dueDate": {
+                              "type": "string"
+                            }
+                          },
+                          "required": ["scheduleType", "amountCents", "currency", "dueDate"]
+                        },
+                        "minItems": 1
+                      }
+                    },
+                    "required": ["policySource", "currency", "totalCents", "dueNowCents", "entries"]
+                  },
                   "quotedAt": {
                     "type": "string",
                     "format": "date-time"

--- a/packages/catalog/src/booking-engine/sessions-payment-production.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-payment-production.test.ts
@@ -566,6 +566,28 @@ describe("production Booking Session quoted payment plan", () => {
     })
   })
 
+  /**
+   * The gate counts whole UTC days, so a Quote taken at 23:55 and committed at
+   * 00:02 measures one day less to departure. On a departure sitting exactly
+   * on `minDaysBeforeDepartureForDeposit` that flips the plan: the shopper is
+   * shown a deposit and charged the full total. Payment policy is outside the
+   * price fingerprint, so nothing rejects that Commit.
+   *
+   * Both sides therefore measure from the Quote's own instant, which is what
+   * the published plan was derived from.
+   */
+  it("charges against the instant the Quote was stamped with, not Commit's clock", async () => {
+    await prepare({
+      locale: "en-GB",
+      departureDate: "2026-09-20",
+      quotedAt: new Date("2026-08-15T23:55:00Z"),
+    })
+
+    expect(computePaymentSchedule.mock.calls.at(-1)?.[0]).toMatchObject({
+      today: new Date("2026-08-15T23:55:00Z"),
+    })
+  })
+
   // Same measurement as Commit, which voyant#4740 established has to be the
   // departure the shopper selected rather than the product row.
   it("measures from the departure the shopper selected", async () => {
@@ -694,6 +716,8 @@ async function prepare(input: {
   settlementPaymentSessionId?: string
   mandate?: { enabled: boolean; revision: string } | null
   contractAcceptedAt?: string
+  /** The instant the Quote was stamped with; what the plan must measure from. */
+  quotedAt?: Date
 }) {
   resolveCalls.length = 0
   if (input.refreshedCheckout !== undefined) {
@@ -765,6 +789,7 @@ async function prepare(input: {
     quote: {
       id: "bqot_01k",
       pricing: { total: 10_000, currency: "EUR" },
+      quotedAt: input.quotedAt ?? new Date("2026-08-05T00:00:00Z"),
       expiresAt: new Date("2026-08-06T00:00:00Z"),
     },
     commit: {

--- a/packages/catalog/src/booking-engine/sessions-payment-production.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-payment-production.test.ts
@@ -29,21 +29,38 @@ const computePaymentSchedule = vi.hoisted(() =>
   ]),
 )
 
-vi.mock("@voyant-travel/finance", () => ({
-  computePaymentSchedule,
-  createOrReuseBookingSessionPayment: async () => ({
+/** Which cascade layer answered. Spied so a plan can be asserted to report it. */
+const resolveEffectivePaymentPolicy = vi.hoisted(() =>
+  vi.fn((..._args: unknown[]) => ({
+    policy: { kind: "deposit" },
+    source: "operator_default" as string,
+  })),
+)
+
+/**
+ * Echoes the amount it was asked for rather than a constant, so what the port
+ * decided to collect is observable. A fixed stub would make every assertion
+ * about the charged amount an assertion about the stub.
+ */
+const createOrReuseBookingSessionPayment = vi.hoisted(() =>
+  vi.fn(async (_db: unknown, input: { amountCents: number; currency: string }) => ({
     id: "pmts_1",
     status: "pending",
-    amountCents: 10_000,
-    currency: "EUR",
+    amountCents: input.amountCents,
+    currency: input.currency,
     redirectUrl: null,
     expiresAt: null,
-  }),
+  })),
+)
+
+vi.mock("@voyant-travel/finance", () => ({
+  computePaymentSchedule,
+  createOrReuseBookingSessionPayment,
   expirePendingBookingSessionPayments: vi.fn(),
   financeService: { getPaymentSessionById },
   findEstablishedBookingSessionPayment: async () => null,
   noDepositPolicy: { kind: "no_deposit" },
-  resolveEffectivePaymentPolicy: () => ({ policy: { kind: "deposit" }, source: "operator" }),
+  resolveEffectivePaymentPolicy,
   resolvePaymentCallbackUrl: () => undefined,
   startPaymentAdapterCardPayment,
   transferBookingSessionPaymentToBooking: vi.fn(),
@@ -482,6 +499,135 @@ describe("production Booking Session payment policy departure", () => {
     expect(startArgs().description).toBe("Danube Delta tour — 20 September 2026")
   })
 })
+
+/**
+ * The plan published on the Quote, which is the last surface before the shopper
+ * accepts terms. Until voyant#4741 a deposit policy reached them only through
+ * Commit's `payment_required` — after the review step and after they had
+ * accepted a contract naming the full total — so they reviewed €378, agreed to
+ * €378, and were charged €189.
+ *
+ * The plan is a projection: it must be the same derivation `prepare` charges
+ * from, or quoting it just moves the disagreement earlier.
+ */
+describe("production Booking Session quoted payment plan", () => {
+  const DEPOSIT_AND_BALANCE = [
+    { amountCents: 18_900, currency: "EUR", scheduleType: "deposit", dueDate: "2026-08-16" },
+    { amountCents: 18_900, currency: "EUR", scheduleType: "balance", dueDate: "2026-09-06" },
+  ]
+
+  beforeEach(() => {
+    computePaymentSchedule.mockClear()
+    resolveEffectivePaymentPolicy.mockClear()
+  })
+
+  it("states every instalment, not just what is due now", async () => {
+    computePaymentSchedule.mockReturnValueOnce(DEPOSIT_AND_BALANCE)
+
+    await expect(describePlan({ totalCents: 37_800 })).resolves.toEqual({
+      policySource: "operator_default",
+      currency: "EUR",
+      totalCents: 37_800,
+      dueNowCents: 18_900,
+      entries: [
+        { scheduleType: "deposit", amountCents: 18_900, currency: "EUR", dueDate: "2026-08-16" },
+        { scheduleType: "balance", amountCents: 18_900, currency: "EUR", dueDate: "2026-09-06" },
+      ],
+    })
+  })
+
+  it("reports which layer of the cascade set the terms", async () => {
+    computePaymentSchedule.mockReturnValueOnce(DEPOSIT_AND_BALANCE)
+    resolveEffectivePaymentPolicy.mockReturnValueOnce({
+      policy: { kind: "deposit" },
+      source: "supplier",
+    })
+
+    await expect(describePlan({ totalCents: 37_800 })).resolves.toMatchObject({
+      policySource: "supplier",
+    })
+  })
+
+  // The whole point. `prepare` charges `entries[0]`; the Quote publishes the
+  // same array from the same derivation, so the number the shopper agreed to
+  // and the number the card is charged cannot come apart. €378 at 50%: the
+  // shopper is quoted a €189 deposit and the card is asked for €189.
+  it("promises exactly what Commit goes on to charge", async () => {
+    computePaymentSchedule.mockReturnValueOnce(DEPOSIT_AND_BALANCE)
+    const plan = await describePlan({ totalCents: 37_800 })
+
+    computePaymentSchedule.mockReturnValueOnce(DEPOSIT_AND_BALANCE)
+    const outcome = await prepare({ locale: "en-GB", departureDate: "2026-09-20" })
+
+    expect(plan?.dueNowCents).toBe(18_900)
+    expect(outcome).toMatchObject({
+      kind: "required",
+      paymentSession: { amountCents: plan?.dueNowCents },
+    })
+  })
+
+  // Same measurement as Commit, which voyant#4740 established has to be the
+  // departure the shopper selected rather than the product row.
+  it("measures from the departure the shopper selected", async () => {
+    computePaymentSchedule.mockReturnValueOnce(DEPOSIT_AND_BALANCE)
+
+    await describePlan({ totalCents: 37_800, slotDate: "2026-09-20" })
+
+    expect(computePaymentSchedule.mock.calls.at(-1)?.[0]).toMatchObject({
+      departureDate: "2026-09-20",
+      totalCents: 37_800,
+    })
+  })
+
+  // A Quote has nothing to protect: it states no plan and the storefront shows
+  // no terms. `prepare` throws on the same condition because it is about to
+  // take money against a product that is no longer there.
+  it("states no plan for a product that has gone", async () => {
+    await expect(describePlan({ totalCents: 37_800, context: null })).resolves.toBeNull()
+  })
+
+  it("states no plan for a target that is not a product", async () => {
+    await expect(
+      describePlan({ totalCents: 37_800, target: { kind: "trip_snapshot" } }),
+    ).resolves.toBeNull()
+  })
+})
+
+/** Build the production ports and ask them to describe a plan. */
+async function describePlan(input: {
+  totalCents: number
+  slotDate?: string
+  context?: unknown
+  target?: { kind: string; productId?: string }
+}) {
+  const payments = createProductionBookingSessionPaymentPorts({
+    db: {} as never,
+    inventory: {
+      loadProductPaymentPolicyContext: async () =>
+        input.context === undefined
+          ? {
+              listingPolicy: null,
+              categoryPolicy: null,
+              supplierId: null,
+              name: "Istanbul Bosphorus Heritage Day",
+            }
+          : (input.context as never),
+      resolveSelectedDepartureDate: async () => input.slotDate ?? null,
+    },
+    distribution: { loadSupplierPaymentPolicy: async () => null },
+    settings: { resolveOperatorDefaultPaymentPolicy: async () => null },
+  })
+  return payments.describePlan?.({
+    session: {
+      id: "bses_01k",
+      target: input.target ?? { kind: "product", productId: "prod_1" },
+      scope: { locale: "en-GB", market: "default" },
+      statePayload: { configure: { departureSlotId: "avsl_01k" } },
+    },
+    pricing: { total: input.totalCents, currency: "EUR" },
+    now: new Date("2026-08-16T00:00:00Z"),
+  } as never)
+}
 
 describe("production Booking Session settlement", () => {
   beforeEach(() => {

--- a/packages/catalog/src/booking-engine/sessions-payment-production.ts
+++ b/packages/catalog/src/booking-engine/sessions-payment-production.ts
@@ -99,7 +99,23 @@ export function createProductionBookingSessionPaymentPorts(
       // same Commit transaction, by `establishBankTransfer` below.
       if (commit.checkoutIntent === "bank_transfer") return { kind: "not_required" }
 
-      const plan = await resolvePlan(deps, session, quote.pricing, now)
+      // Anchored to the Quote's own instant, not Commit's.
+      //
+      // The deposit gate counts whole UTC days to departure, so a Quote taken
+      // at 23:55 and committed at 00:02 measures one day less — and a
+      // departure sitting exactly on `minDaysBeforeDepartureForDeposit`
+      // advertises a deposit and then charges the full total. Payment policy
+      // is outside the price fingerprint, so nothing rejects that Commit.
+      //
+      // `quotedAt` is what `describePlan` published from, and a Quote lives
+      // for minutes, so this is never a stale anchor — it is the instant the
+      // shopper was quoted at. It also stops the settlement re-check below
+      // from spuriously failing on an amount that moved under it.
+      //
+      // This does not close the whole gap: an operator editing the policy
+      // mid-session still changes the cascade, and only a fingerprinted or
+      // persisted plan can reject that. See the PR discussion.
+      const plan = await resolvePlan(deps, session, quote.pricing, quote.quotedAt)
       if (!plan) throw new Error("booking_session_payment_product_not_found")
       const { context, resolved, departureDate, entries } = plan
       const dueNow = entries[0]
@@ -369,7 +385,12 @@ async function resolvePlan(
     statePayload: Record<string, unknown>
   },
   pricing: { total: number; currency: string },
-  now: Date,
+  /**
+   * The instant the plan is measured from. Both callers pass the Quote's own
+   * `quotedAt`, so the plan published on a Quote and the plan charged against
+   * it are the same function of the same inputs.
+   */
+  asOf: Date,
 ) {
   const productId = session.target.productId
   if (session.target.kind !== "product" || !productId) return null
@@ -400,7 +421,7 @@ async function resolvePlan(
       totalCents: pricing.total,
       currency: pricing.currency,
       departureDate,
-      today: now,
+      today: asOf,
     },
     resolved.policy,
   )

--- a/packages/catalog/src/booking-engine/sessions-payment-production.ts
+++ b/packages/catalog/src/booking-engine/sessions-payment-production.ts
@@ -99,41 +99,10 @@ export function createProductionBookingSessionPaymentPorts(
       // same Commit transaction, by `establishBankTransfer` below.
       if (commit.checkoutIntent === "bank_transfer") return { kind: "not_required" }
 
-      // The policy cascade and the departure are two different questions about
-      // two different things — the listing, and what the shopper selected off
-      // it. They were one call until voyant#4740, which is how every deposit
-      // gate came to be measured from `products.startDate`.
-      const [context, departureDate] = await Promise.all([
-        deps.inventory.loadProductPaymentPolicyContext(deps.db, session.target.productId, {
-          locale: session.scope.locale,
-        }),
-        deps.inventory.resolveSelectedDepartureDate(deps.db, {
-          productId: session.target.productId,
-          departureSlotId: selectedDepartureSlotId(session.statePayload),
-        }),
-      ])
-      if (!context) throw new Error("booking_session_payment_product_not_found")
-      const [supplierPolicy, operatorDefault] = await Promise.all([
-        context.supplierId
-          ? deps.distribution.loadSupplierPaymentPolicy(deps.db, context.supplierId)
-          : Promise.resolve(null),
-        deps.settings.resolveOperatorDefaultPaymentPolicy(deps.db),
-      ])
-      const resolved = resolveEffectivePaymentPolicy({
-        listingPolicy: context.listingPolicy,
-        categoryPolicy: context.categoryPolicy,
-        supplierPolicy,
-        operatorDefault: operatorDefault ?? noDepositPolicy,
-      })
-      const dueNow = computePaymentSchedule(
-        {
-          totalCents: quote.pricing.total,
-          currency: quote.pricing.currency,
-          departureDate,
-          today: now,
-        },
-        resolved.policy,
-      )[0]
+      const plan = await resolvePlan(deps, session, quote.pricing, now)
+      if (!plan) throw new Error("booking_session_payment_product_not_found")
+      const { context, resolved, departureDate, entries } = plan
+      const dueNow = entries[0]
       if (!dueNow || dueNow.amountCents <= 0) return { kind: "not_required" }
 
       const settlementPaymentSessionId = access.settlementAuthority?.paymentSessionId
@@ -260,6 +229,27 @@ export function createProductionBookingSessionPaymentPorts(
         paymentSession: projectPaymentSession(paymentSession),
       }
     },
+    async describePlan({ session, pricing, now }) {
+      const plan = await resolvePlan(deps, session, pricing, now)
+      // A target with no product, or a product that has since gone: the Quote
+      // simply carries no plan. Commit throws on the same condition because it
+      // is about to take money; a projection has nothing to protect.
+      if (!plan) return null
+      const [dueNow] = plan.entries
+      if (!dueNow) return null
+      return {
+        policySource: plan.resolved.source,
+        currency: pricing.currency,
+        totalCents: pricing.total,
+        dueNowCents: dueNow.amountCents,
+        entries: plan.entries.map((entry) => ({
+          scheduleType: entry.scheduleType,
+          amountCents: entry.amountCents,
+          currency: entry.currency,
+          dueDate: entry.dueDate,
+        })),
+      }
+    },
     async hasInFlight({ bookingSessionId }) {
       return hasInFlightBookingSessionPayment(deps.db, bookingSessionId)
     },
@@ -352,6 +342,69 @@ function customerReference(session: {
   if (personId) return personId
   if (session.actorKind !== "customer") return undefined
   return identifiedUserId(session.ownerPrincipalId) ?? undefined
+}
+
+/**
+ * The collection plan for a product Session, and everything that went into it.
+ *
+ * One derivation, two readers: `prepare` charges `entries[0]` at Commit and
+ * `describePlan` publishes the whole thing on the Quote. Quoting a plan that a
+ * second, parallel derivation produced would put the shopper's stated terms and
+ * their actual charge back on separate code paths, which is the shape of
+ * voyant#4741 rather than a fix for it.
+ *
+ * The policy cascade and the departure are two different questions about two
+ * different things — the listing, and what the shopper selected off it. They
+ * were one call until voyant#4740, which is how every deposit gate came to be
+ * measured from `products.startDate`.
+ *
+ * Null when the product is gone. Callers differ on what that means: Commit
+ * throws, a Quote projection publishes nothing.
+ */
+async function resolvePlan(
+  deps: ProductionBookingSessionPaymentDeps,
+  session: {
+    target: { kind: string; productId?: string }
+    scope: { locale: string }
+    statePayload: Record<string, unknown>
+  },
+  pricing: { total: number; currency: string },
+  now: Date,
+) {
+  const productId = session.target.productId
+  if (session.target.kind !== "product" || !productId) return null
+  const [context, departureDate] = await Promise.all([
+    deps.inventory.loadProductPaymentPolicyContext(deps.db, productId, {
+      locale: session.scope.locale,
+    }),
+    deps.inventory.resolveSelectedDepartureDate(deps.db, {
+      productId,
+      departureSlotId: selectedDepartureSlotId(session.statePayload),
+    }),
+  ])
+  if (!context) return null
+  const [supplierPolicy, operatorDefault] = await Promise.all([
+    context.supplierId
+      ? deps.distribution.loadSupplierPaymentPolicy(deps.db, context.supplierId)
+      : Promise.resolve(null),
+    deps.settings.resolveOperatorDefaultPaymentPolicy(deps.db),
+  ])
+  const resolved = resolveEffectivePaymentPolicy({
+    listingPolicy: context.listingPolicy,
+    categoryPolicy: context.categoryPolicy,
+    supplierPolicy,
+    operatorDefault: operatorDefault ?? noDepositPolicy,
+  })
+  const entries = computePaymentSchedule(
+    {
+      totalCents: pricing.total,
+      currency: pricing.currency,
+      departureDate,
+      today: now,
+    },
+    resolved.policy,
+  )
+  return { context, resolved, departureDate, entries }
 }
 
 /**

--- a/packages/catalog/src/booking-engine/sessions-service.test.ts
+++ b/packages/catalog/src/booking-engine/sessions-service.test.ts
@@ -4,7 +4,7 @@ import {
 } from "@voyant-travel/catalog-contracts/booking-engine/lifecycle-conformance"
 import type { PricingBreakdownV1 } from "@voyant-travel/catalog-contracts/booking-engine/pricing-contracts"
 import { isPermanentSubscriberError } from "@voyant-travel/core"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
 import type { BookingRequirementsV1 } from "./contracts.js"
 import {
@@ -2911,6 +2911,84 @@ describe("Booking Session v1 authority under a publishable key", () => {
         storefront: { channelId: "chan_other" },
       }),
     ).resolves.toMatchObject({ kind: "rejected", error: { kind: "not_authorized" } })
+  })
+})
+
+/**
+ * A shopper under a deposit policy used to review a total, accept a contract
+ * naming that total, and then be charged something else — because nothing in
+ * the lifecycle carried the plan until Commit answered `payment_required`,
+ * which happens after the review step and after contract acceptance
+ * (voyant#4741). The Quote is the last surface before the shopper agrees to
+ * terms, so it is where the plan has to be readable.
+ */
+describe("Booking Session v1 quoted payment plan", () => {
+  const PLAN = {
+    policySource: "operator_default" as const,
+    currency: "EUR",
+    totalCents: 10_000,
+    dueNowCents: 5_000,
+    entries: [
+      {
+        scheduleType: "deposit" as const,
+        amountCents: 5_000,
+        currency: "EUR",
+        dueDate: "2026-08-01",
+      },
+      {
+        scheduleType: "balance" as const,
+        amountCents: 5_000,
+        currency: "EUR",
+        dueDate: "2026-09-06",
+      },
+    ],
+  }
+
+  it("publishes what the shopper will be charged, and when", async () => {
+    const describePlan = vi.fn(async () => PLAN)
+    const { quote } = await createQuoteAndHold(createHarness({}, { describePlan } as never))
+
+    expect(quote.paymentPlan).toEqual(PLAN)
+  })
+
+  it("measures the plan against the price it is published beside", async () => {
+    const describePlan = vi.fn(async () => PLAN)
+    await createQuoteAndHold(createHarness({}, { describePlan } as never))
+
+    // The same `pricing` object the Quote carries, and the same clock the
+    // Quote was stamped with. A plan computed against anything else would be
+    // a statement about a different quote than the one the shopper is reading.
+    expect(describePlan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pricing: expect.objectContaining({ total: 10_000, currency: "EUR" }),
+        now: new Date("2026-08-01T12:00:00.000Z"),
+      }),
+    )
+  })
+
+  // Additive: a deployment that wires no payment ports quotes exactly as it
+  // did before, and a storefront reading the field sees it absent rather than
+  // being told to collect the total.
+  it("omits the plan when no payments port is wired", async () => {
+    const { quote } = await createQuoteAndHold(createHarness())
+
+    expect(quote.paymentPlan).toBeUndefined()
+  })
+
+  it("omits the plan when the port has nothing to state for this target", async () => {
+    const { quote } = await createQuoteAndHold(
+      createHarness({}, { describePlan: async () => null } as never),
+    )
+
+    expect(quote.paymentPlan).toBeUndefined()
+  })
+
+  // A port predating this field is still a valid port.
+  it("quotes normally against a payments port that cannot describe a plan", async () => {
+    const { quote } = await createQuoteAndHold(createHarness({}, {} as never))
+
+    expect(quote.paymentPlan).toBeUndefined()
+    expect(quote.pricing.total).toBe(10_000)
   })
 })
 

--- a/packages/catalog/src/booking-engine/sessions-service.ts
+++ b/packages/catalog/src/booking-engine/sessions-service.ts
@@ -9,6 +9,7 @@ import type {
   AbandonBookingSessionV1,
   AdoptBookingSessionV1,
   BookingHoldRecordV1,
+  BookingPaymentPlanV1,
   BookingQuoteRecordV1,
   BookingSessionActorKindV1,
   BookingSessionCapabilityActionV1,
@@ -482,6 +483,23 @@ export interface BookingSessionPaymentPorts {
         allowedGuarantees: Array<"deposit" | "pre_auth" | "card_on_file" | "agency_letter">
       }
   >
+  /**
+   * What the shopper will be charged and when, if they committed now.
+   *
+   * Published on the Quote, which is the last surface before the shopper
+   * accepts terms — a deposit policy used to reach them only in Commit's
+   * `payment_required`, after the review step and after they had accepted a
+   * contract naming the full total (voyant#4741).
+   *
+   * A projection, not a decision: it computes what `prepare` will compute and
+   * stores nothing. Optional, so a host that wires no payment ports simply
+   * publishes no plan; null for a target that has none to state.
+   */
+  describePlan?(input: {
+    session: BookingSessionInternalRecord
+    pricing: PricingBreakdownV1
+    now: Date
+  }): Promise<BookingPaymentPlanV1 | null>
   /**
    * Establish the durable offline-payment record after the Booking id exists
    * but before the surrounding Commit transaction is consumed.
@@ -1191,12 +1209,22 @@ export function createBookingSessionModule(
         await appendSessionAudit(repository, session, "quote", access, at, {
           quoteId: quote.id,
         })
+        // What the shopper will actually be charged, stated here because this
+        // is the last surface before they accept terms (voyant#4741). Computed
+        // after the Quote is persisted and never with it: the plan is a
+        // projection of the same policy Commit will apply, and storing it would
+        // create a second copy that can disagree with the first.
+        const paymentPlan = await options.ports.payments?.describePlan?.({
+          session,
+          pricing,
+          now: at,
+        })
         const outcome: BookingSessionOutcomeV1 = {
           kind: "quote_created",
           // The compose call already derived requirements for this target;
           // publish those rather than re-deriving them for the record.
           session: await serializeSession(session, requirements, access),
-          quote: serializeQuote(quote),
+          quote: serializeQuote(quote, paymentPlan ?? undefined),
         }
         await repository.completeOperation({ id: claim.id, outcome })
         return outcome
@@ -3108,7 +3136,15 @@ async function serializeSessionView(
   return { ...record, selection: structuredClone(session.statePayload), redaction: "none" }
 }
 
-function serializeQuote(quote: BookingQuoteInternalRecord): BookingQuoteRecordV1 {
+/**
+ * `paymentPlan` is a parameter rather than a field on the record because it is
+ * derived, not stored — see `BookingSessionPaymentPorts.describePlan`. Absent
+ * on a deployment with no payment ports, and on a target with no plan to state.
+ */
+function serializeQuote(
+  quote: BookingQuoteInternalRecord,
+  paymentPlan?: BookingPaymentPlanV1,
+): BookingQuoteRecordV1 {
   return {
     id: quote.id,
     sessionId: quote.sessionId,
@@ -3117,6 +3153,7 @@ function serializeQuote(quote: BookingQuoteInternalRecord): BookingQuoteRecordV1
     requirements: quote.requirements,
     requirementsFingerprint: quote.requirementsFingerprint,
     pricing: quote.pricing,
+    ...(paymentPlan ? { paymentPlan } : {}),
     quotedAt: quote.quotedAt.toISOString(),
     expiresAt: quote.expiresAt.toISOString(),
   }

--- a/packages/catalog/src/booking-engine/sessions-service.ts
+++ b/packages/catalog/src/booking-engine/sessions-service.ts
@@ -9,7 +9,6 @@ import type {
   AbandonBookingSessionV1,
   AdoptBookingSessionV1,
   BookingHoldRecordV1,
-  BookingPaymentPlanV1,
   BookingQuoteRecordV1,
   BookingSessionActorKindV1,
   BookingSessionCapabilityActionV1,
@@ -37,6 +36,7 @@ import { withBookingSessionAnalytics } from "./analytics.js"
 import type {
   BookingCheckoutIntentV1,
   BookingLifecycleCommitOutcomeV1,
+  BookingPaymentPlanV1,
   BookingRequirementsV1,
   BookingSessionBankTransferV1,
   PricingBreakdownV1,


### PR DESCRIPTION
Closes #4741. Previously stacked on #4747 (issue #4740), now merged — this branch is rebased onto `main` and stands alone.

## The bug

A shopper under a deposit policy is never told they are paying a deposit. They review a total, accept a contract stating that total, press pay, and are charged something else — €378 reviewed and agreed, €189 charged.

Nothing in the Session lifecycle carried the plan until Commit answered `payment_required`, and Commit happens *after* the review step and *after* contract acceptance. There was no earlier surface a storefront could read, so no storefront could state the terms at the moment the shopper agreed to them.

## The fix

`quote.paymentPlan` now carries `policySource`, `currency`, `totalCents`, `dueNowCents` and every scheduled entry — exactly the shape the issue specified.

**One derivation, two readers.** `prepare()` (Commit) and `describePlan()` (Quote) now share a single `resolvePlan` helper: `resolveEffectivePaymentPolicy` then `computePaymentSchedule` over the Quote total and the selected departure. Commit charges `entries[0]`; the Quote publishes the whole array from the same call. Quoting a plan that a *second, parallel* derivation produced would put the shopper's stated terms and their actual charge back on separate code paths — the shape of this bug rather than a fix for it. The test `promises exactly what Commit goes on to charge` pins it: €378 at 50% → plan says `dueNowCents: 18_900`, card is asked for €189.

**Both sides measure from the same instant.** Review caught that `prepare` re-derived from Commit's clock, and the deposit gate counts whole *UTC days* — so a Quote at 23:55 committed at 00:02 measures a day less, and a departure sitting exactly on `minDaysBeforeDepartureForDeposit` advertises a deposit then charges the full total. Both sides now anchor to `quote.quotedAt`. This also removes a latent bug in the settlement re-check, which could previously fail spuriously on an amount that moved under it across midnight.

**Known residue:** an operator editing the policy *mid-session* still changes the cascade, and no clock anchor helps. Closing that needs the quoted plan persisted or echoed back on Commit, plus a rejection path — new state and a contract change, both outside what #4741 scoped, and it predates this PR. Worth a follow-up issue.

**Where it computes.** A new optional `describePlan` on `BookingSessionPaymentPorts`, called from `quoteSession`. This was the only shape needing no new wiring: the payment-port closure already captures `db`/`inventory`/`distribution`/`settings`, and `options.ports` is already in scope at the quote call site. Neither of the two runtime-contributor sites changes.

**Two deliberate calls:**

- **`paymentPlan` is a sibling of `pricing`, not a member.** The price fingerprint is computed over `pricing` alone; a due date derived from *today* inside it would supersede every Quote on the next compose (the voyant#4689 class of bug).
- **Nothing is persisted.** The plan is derived at projection time, so it cannot drift from the Quote it is published on — and it honours the issue's "no new state, no new table".

**Contract variables.** `resolveContractVariables` accepts the quoted plan and prefers it over a host-computed schedule, so the accepted document states the real deposit, balance and due date rather than a number the storefront computed for itself. `payment.dueNowCents` is new; `payment.amountCents` still means the booking total, because templates have always read it that way and redefining it would silently change every rendered contract.

## Additive

A deployment that wires no payment ports publishes no plan; a port predating the method is still a valid port; a storefront that does not read the field is unaffected. `paymentPlan` is optional in the schema and absent from `required` in both regenerated OpenAPI documents.

## Verification

- `packages/catalog` — 848 → **859** passing. 5 tests on the quoted outcome (published / measured against the same pricing and clock / omitted with no port / omitted for a null plan / omitted for a port that cannot describe one) and 6 on `describePlan` (every instalment, cascade layer, **agrees with what Commit charges**, measures from the selected departure, null for a vanished product, null for a non-product target).
- `packages/bookings-react` — 249 → **255**. Plan wins over a host-computed schedule; falls back when absent; `dueNowCents`; every instalment reaches the template.
- `packages/catalog-contracts` — 104 passing.
- `verify:openapi-drift` (5 documents match their routes, after regenerating), `verify:boundary` (50 packages, bookings-react stays browser-safe), `verify:symbol-policy`, `verify:graph-conformance`, `verify:table-privacy` — all pass. `biome check` clean.

## History

Opened stacked on #4747 and got only 3 CI checks (Socket ×2, gitleaks) — a non-`main` base runs a reduced set here. #4747 is now merged, so this is rebased onto `main` and retargeted for a full run.
