### PR TITLE
Say team members instead of roster in team settings

### DIFF
--- a/.changeset/quiet-teams-listen.md
+++ b/.changeset/quiet-teams-listen.md
@@ -1,0 +1,16 @@
+---
+"@voyant-travel/auth-react": patch
+"@voyant-travel/auth": patch
+---
+
+Say "team members" instead of "roster" in team settings
+
+Settings > Team called its member list a "Roster", a word from a domain Voyant
+does not have — an agency has a team and team members, and the Romanian copy
+already said so. The card is now "Team members", its description drops
+"provider-supplied activity" for what the columns actually show, and the invite
+card no longer mentions the identity provider a travel agent never configured.
+
+The `viewRoster` team-management capability is renamed `viewMembers` across the
+runtime port, both adapters, and the guarded provider, so the vocabulary the UI
+reads matches the one it renders.

--- a/packages/auth-react/src/components/team-management-page.tsx
+++ b/packages/auth-react/src/components/team-management-page.tsx
@@ -82,7 +82,7 @@ function TeamManagementView() {
     queryKey: queryKeys.capabilities,
     queryFn: () => api.get<{ data: TeamManagementCapabilitiesDto }>("/v1/admin/team/capabilities"),
   })
-  const canView = capabilitiesQuery.data?.data.viewRoster === true
+  const canView = capabilitiesQuery.data?.data.viewMembers === true
   const membersQuery = useQuery({
     queryKey: queryKeys.members,
     queryFn: () => api.get<{ data: TeamMemberDto[] }>("/v1/admin/team/members"),

--- a/packages/auth-react/src/i18n/en.ts
+++ b/packages/auth-react/src/i18n/en.ts
@@ -151,7 +151,7 @@ export const authUiEn: AuthUiMessages = {
     loadFailed: "Could not load team management.",
     invite: {
       title: "Invite member",
-      description: "Invite a staff member through the configured identity provider.",
+      description: "Send a colleague an invitation to join your team.",
       emailLabel: "Email",
       emailPlaceholder: "teammate@example.com",
       roleLabel: "Role",
@@ -164,8 +164,8 @@ export const authUiEn: AuthUiMessages = {
       copyFailed: "Could not copy the invitation link.",
     },
     members: {
-      title: "Roster",
-      description: "Current staff access and provider-supplied activity.",
+      title: "Team members",
+      description: "Everyone who can sign in, with their role and last activity.",
       memberColumn: "Member",
       roleColumn: "Role",
       statusColumn: "Status",

--- a/packages/auth-react/src/i18n/ro.ts
+++ b/packages/auth-react/src/i18n/ro.ts
@@ -152,7 +152,7 @@ export const authUiRo: AuthUiMessages = {
     loadFailed: "Administrarea echipei nu a putut fi incarcata.",
     invite: {
       title: "Invita membru",
-      description: "Invita un coleg prin furnizorul de identitate configurat.",
+      description: "Trimite unui coleg o invitatie de a se alatura echipei.",
       emailLabel: "Email",
       emailPlaceholder: "coleg@example.com",
       roleLabel: "Rol",
@@ -166,8 +166,8 @@ export const authUiRo: AuthUiMessages = {
       copyFailed: "Linkul de invitatie nu a putut fi copiat.",
     },
     members: {
-      title: "Echipa",
-      description: "Accesul curent si activitatea furnizata de serviciul de identitate.",
+      title: "Membrii echipei",
+      description: "Toti cei care se pot autentifica, cu rolul si ultima activitate.",
       memberColumn: "Membru",
       roleColumn: "Rol",
       statusColumn: "Stare",

--- a/packages/auth-react/src/team-management-page.test.tsx
+++ b/packages/auth-react/src/team-management-page.test.tsx
@@ -29,7 +29,7 @@ function seedTeamQueries(
 ) {
   queryClient.setQueryData(["team-management", "capabilities"], {
     data: {
-      viewRoster: true,
+      viewMembers: true,
       inviteMembers: overrides.inviteMembers ?? false,
       manageRoles: false,
       activateMembers: overrides.activateMembers ?? false,
@@ -71,7 +71,7 @@ describe("Auth team-management admin surface", () => {
     })
   })
 
-  it("renders neutral roster data and nullable provider activity without auth-mode discovery", () => {
+  it("renders neutral member data and nullable provider activity without auth-mode discovery", () => {
     const queryClient = new QueryClient()
     seedTeamQueries(queryClient)
     const api = pageApi()

--- a/packages/auth/openapi/admin/team.json
+++ b/packages/auth/openapi/admin/team.json
@@ -18,7 +18,7 @@
         "operationId": "listTeamMembers",
         "tags": ["Team"],
         "x-voyant-api-id": "@voyant-travel/auth#team.api.admin",
-        "responses": { "200": { "description": "Team roster." } }
+        "responses": { "200": { "description": "Team members." } }
       }
     },
     "/v1/admin/team/roles": {

--- a/packages/auth/src/cloud-broker/members.ts
+++ b/packages/auth/src/cloud-broker/members.ts
@@ -1,8 +1,8 @@
 /**
  * Deployment-side client for Voyant Cloud member management.
  *
- * The team roster of a `voyant-cloud`-auth deployment lives on the platform, not
- * in the deployment DB. This client lets the deployment manage that roster
+ * The team of a `voyant-cloud`-auth deployment lives on the platform, not
+ * in the deployment DB. This client lets the deployment manage those members
  * (list members, list/send/revoke invitations, grant/revoke this deployment's
  * access) by calling the platform's `/cloud/v1/admin-auth/*` member endpoints —
  * the management counterpart to {@link revalidateCloudAdminAuthAccess}.

--- a/packages/auth/src/team-management-cloud-adapter.ts
+++ b/packages/auth/src/team-management-cloud-adapter.ts
@@ -149,7 +149,7 @@ export function createCloudTeamManagementAdapter(
     async getCapabilities(_context, actor): Promise<TeamManagementCapabilitiesDto> {
       const canManage = actor.roleId === "owner" || actor.roleId === "admin"
       return {
-        viewRoster: true,
+        viewMembers: true,
         inviteMembers: canManage,
         manageRoles: canManage,
         activateMembers: canManage,

--- a/packages/auth/src/team-management-local-adapter.ts
+++ b/packages/auth/src/team-management-local-adapter.ts
@@ -187,7 +187,7 @@ export function createLocalTeamManagementAdapter(
     async getCapabilities(_context, actor): Promise<TeamManagementCapabilitiesDto> {
       const canManage = actor.roleId === "owner" || actor.roleId === "admin"
       return {
-        viewRoster: true,
+        viewMembers: true,
         inviteMembers: canManage,
         manageRoles: canManage,
         activateMembers: canManage,

--- a/packages/auth/src/team-management-policy.ts
+++ b/packages/auth/src/team-management-policy.ts
@@ -154,17 +154,17 @@ export function createGuardedTeamManagementProvider(
     },
     async listMembers(context) {
       const adapter = resolveAdapter(context)
-      await authorize(adapter, context, "viewRoster")
+      await authorize(adapter, context, "viewMembers")
       return adapter.listMembers(context)
     },
     async listRoles(context) {
       const adapter = resolveAdapter(context)
-      await authorize(adapter, context, "viewRoster")
+      await authorize(adapter, context, "viewMembers")
       return adapter.listRoles(context)
     },
     async listInvitations(context) {
       const adapter = resolveAdapter(context)
-      await authorize(adapter, context, "viewRoster")
+      await authorize(adapter, context, "viewMembers")
       return adapter.listInvitations(context)
     },
     async inviteMember(context, input) {

--- a/packages/auth/src/team-management-runtime-port.ts
+++ b/packages/auth/src/team-management-runtime-port.ts
@@ -36,7 +36,7 @@ export interface CreatedTeamInvitationDto extends TeamInvitationDto {
 }
 
 export interface TeamManagementCapabilitiesDto {
-  viewRoster: boolean
+  viewMembers: boolean
   inviteMembers: boolean
   manageRoles: boolean
   activateMembers: boolean

--- a/packages/auth/tests/unit/team-management-policy.test.ts
+++ b/packages/auth/tests/unit/team-management-policy.test.ts
@@ -11,7 +11,7 @@ import type {
 
 const context = { bindings: {}, db: {} as never, userId: "user_actor" }
 const allCapabilities: TeamManagementCapabilitiesDto = {
-  viewRoster: true,
+  viewMembers: true,
   inviteMembers: true,
   manageRoles: true,
   activateMembers: true,

--- a/packages/auth/tests/unit/team-routes.test.ts
+++ b/packages/auth/tests/unit/team-routes.test.ts
@@ -8,7 +8,7 @@ import { createTeamAdminRoutes } from "../../src/team-routes.js"
 function runtime(): TeamManagementRuntimeProvider {
   return {
     getCapabilities: vi.fn(async () => ({
-      viewRoster: true,
+      viewMembers: true,
       inviteMembers: true,
       manageRoles: true,
       activateMembers: true,
@@ -84,7 +84,7 @@ function app(provider: TeamManagementRuntimeProvider, authenticated = true) {
 }
 
 describe("team admin routes", () => {
-  it("returns provider-neutral roster and nullable last activity", async () => {
+  it("returns provider-neutral members and nullable last activity", async () => {
     const response = await app(runtime()).request("/v1/admin/team/members")
 
     expect(response.status).toBe(200)


### PR DESCRIPTION
Settings > Team titled its member list **"Roster"**. Voyant has no roster — an agency has a team and team members, and the Romanian copy already said `Echipa`, so only the English string carried the sports vocabulary.

## Copy

| | before | after |
|---|---|---|
| members card title | Roster | Team members |
| members card description | Current staff access and provider-supplied activity. | Everyone who can sign in, with their role and last activity. |
| invite card description | Invite a staff member through the configured identity provider. | Send a colleague an invitation to join your team. |

The two descriptions named the plumbing rather than the thing on screen. The identity provider is something the deployment configures once and a travel agent never sees; "provider-supplied activity" describes where the value came from instead of what the column shows.

Romanian moves in step: `Membrii echipei`, and both descriptions rewritten to match.

## Capability rename

`viewRoster` becomes `viewMembers` on `TeamManagementCapabilitiesDto`, in both the cloud and local adapters, in the guarded provider's three `authorize` calls, and at the one read site in the React page. It is an internal `/v1/admin/team/capabilities` field with no response schema in the published bundle and no consumer outside this repo, so nothing external moves with it. The hand-maintained `team.json` description "Team roster." becomes "Team members."

Left alone: `previewRosterChange` and the traveler rosters in bookings, trips, operations and mice. A passenger roster is real travel vocabulary; a staff roster is not.

## Verification

- `pnpm -F @voyant-travel/auth -F @voyant-travel/auth-react build` — exit 0, 0 `error TS`
- `pnpm -F @voyant-travel/auth -F @voyant-travel/auth-react test` — 300 + 69 passed
- `biome check` on both packages — clean
- `pnpm i18n:check` — passed across 23 roots