### PR TITLE
Stop paying the admin session round trip once per navigation

### DIFF
--- a/.changeset/admin-cold-load-request-budget.md
+++ b/.changeset/admin-cold-load-request-budget.md
@@ -1,0 +1,28 @@
+---
+"@voyant-travel/admin": patch
+"@voyant-travel/auth": patch
+"@voyant-travel/hono": patch
+---
+
+Cut the admin cold-load and per-navigation request budget.
+
+The workspace guard now resolves the authenticated shell bootstrap through the
+router's QueryClient. TanStack re-runs `beforeLoad` for every matched route on
+every navigation, so the guard's single round trip was being paid again on each
+client-side navigation; it is now paid once per session and revalidated in the
+background. Shell slices are re-seeded only from a freshly fetched response, so
+a navigation no longer overwrites what the shell has since done with them.
+
+`/auth/shell-bootstrap` now claims a capability for any slice the host answered
+for, including one it answered with nothing. Resolving "no navigation
+preferences stored" used to drop the capability and send the shell asking
+`/v1/admin/navigation-preferences` for the same nothing on every page load.
+
+Admin locale narrowing (`en-GB` → `en`) happens on the first render instead of
+the one after, so the authenticated tree no longer re-renders — and re-keys
+everything derived from the locale — a tick after it mounts.
+
+`/v1/admin/*` GETs returning JSON now carry `ETag` and
+`Cache-Control: private, no-cache`, and answer a matching `If-None-Match` with a
+bodyless 304, so a repeat navigation revalidates instead of re-downloading. A
+route that sets its own `Cache-Control` is left alone.

--- a/docs/architecture/caching-architecture.md
+++ b/docs/architecture/caching-architecture.md
@@ -290,6 +290,34 @@ is read as no tier in front of the origin, and a database-backed response cache
 with no declared edge tier is reported at startup rather than left for a route
 author to discover from a header that did not behave as written.
 
+### 13. The staff surface states a policy too — revalidation, not reuse
+
+Rules 11 and 12 are about what caches *in front of* the origin. The staff
+surface has none, by design: `/v1/admin/*` is cookie-bearing and personalized,
+so no shared cache may store it. That is not a reason to say nothing.
+
+An admin read with no `Cache-Control` at all is not merely uncached at the
+edge — it is unusable by the *browser*, so every repeat navigation and every
+reload re-downloads a body the client already holds. `adminResponseRevalidation`
+(`@voyant-travel/hono`) stamps safe JSON reads of that surface with an `ETag`
+and `Cache-Control: private, no-cache`, and answers a matching `If-None-Match`
+with a bodyless 304.
+
+`no-cache` is the operative word, and it is not `no-store`: the browser keeps
+the payload and *asks* before reusing it. A repeat read therefore costs one
+round trip and an empty 304 instead of a full transfer, with no window in which
+a staff member is shown a record they have already changed. Skipping the round
+trip as well means `private, max-age=N`, which is a per-route judgement about
+how stale that particular read may be — the dashboard aggregates declare
+`private, max-age=30` for exactly that reason. A route that sets its own
+`Cache-Control` is never restamped, so that opt-in stays with the route.
+
+Rule:
+
+Every admin GET states its cache policy. The default is revalidation; a
+freshness window is a route's decision to make explicitly, and never a shared
+cache's.
+
 ## Practical Checklist
 
 When adding caching in Voyant:

--- a/docs/architecture/caching-architecture.md
+++ b/docs/architecture/caching-architecture.md
@@ -312,11 +312,28 @@ how stale that particular read may be — the dashboard aggregates declare
 `private, max-age=30` for exactly that reason. A route that sets its own
 `Cache-Control` is never restamped, so that opt-in stays with the route.
 
+**This puts admin payloads on the device, and that is a decision rather than a
+side effect.** Revalidation requires storage — no directive yields a 304 without
+the browser having kept the body — so admin JSON moves from "most browsers store
+nothing" (no directives, no validators) to "stored in the operator's own profile
+cache". `private` keeps it out of every shared cache, but the browser cache is
+not session-scoped: booking and customer payloads persist on the device after
+sign-out, and signing out does not evict them.
+
+That is accepted for a staff workstation, whose profile already holds the admin
+bundle and the session cookie, and it is bounded — entries are `private`,
+revalidated before every reuse, and evicted under ordinary disk-cache pressure.
+A deployment that cannot accept device-resident admin payloads sets
+`adminRevalidation: false` and gets the previous behaviour back: no directives,
+no storage, a full re-transfer per navigation. Revisit this if the staff surface
+is ever served to shared or unmanaged devices, where the profile cache stops
+being the operator's own.
+
 Rule:
 
-Every admin GET states its cache policy. The default is revalidation; a
-freshness window is a route's decision to make explicitly, and never a shared
-cache's.
+Every admin GET states its cache policy. The default is revalidation, which
+means the payload is stored on the member's device; a freshness window on top of
+that is a route's decision to make explicitly, and never a shared cache's.
 
 ## Practical Checklist
 

--- a/packages/admin-host/package.json
+++ b/packages/admin-host/package.json
@@ -38,14 +38,17 @@
     "@voyant-travel/runtime-core": "workspace:^"
   },
   "devDependencies": {
+    "@tanstack/react-query": "^5.101.2",
     "@tanstack/react-router": "^1.170.17",
     "@tanstack/react-start": "^1.168.27",
+    "@testing-library/react": "^16.0.0",
     "@types/node": "catalog:",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@voyant-travel/admin": "workspace:^",
     "@voyant-travel/admin-app": "workspace:^",
     "@voyant-travel/admin-react": "workspace:^",
+    "@voyant-travel/react": "workspace:^",
     "@voyant-travel/types": "workspace:^",
     "@voyant-travel/voyant-typescript-config": "workspace:^",
     "hono": "catalog:",

--- a/packages/admin-host/tests/admin-request-budget.test.tsx
+++ b/packages/admin-host/tests/admin-request-budget.test.tsx
@@ -1,0 +1,371 @@
+// @vitest-environment jsdom
+/**
+ * The admin cold-load request budget (voyant#4754).
+ *
+ * The regression this guards is not a slow endpoint — every response here is
+ * instant. It is the *shape* of the traffic: a serial chain of session/shell
+ * probes before any page data is asked for, and page queries that fire twice
+ * because the authenticated tree settles a beat after it mounts. Neither is
+ * visible to a per-endpoint assertion and both are obvious in a request
+ * ledger, so this mounts the real router + workspace over a recording fetch
+ * and asserts against the ledger.
+ *
+ * It composes through `createAdminHostWorkspace` rather than assembling the
+ * shell by hand, because the pieces it adds — the current-user provider, the
+ * realtime boundary — are themselves places a duplicate read has come from.
+ */
+import { type QueryClient, useQuery } from "@tanstack/react-query"
+import {
+  createMemoryHistory,
+  createRootRouteWithContext,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from "@tanstack/react-router"
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react"
+import type { AdminExtension, AdminNavigationPreferencesSnapshot } from "@voyant-travel/admin"
+import { ADMIN_ACTIVE_MODULES_QUERY_KEY } from "@voyant-travel/admin/app"
+import { createAdminQueryClient } from "@voyant-travel/admin/app/router"
+import { useLocale } from "@voyant-travel/admin/providers/locale"
+import { OperatorAdminShellProvider } from "@voyant-travel/admin/providers/operator-admin-shell"
+import { UI_EXTENSIONS_QUERY_KEY } from "@voyant-travel/admin/ui-extensions"
+import { useVoyantReactContext } from "@voyant-travel/react"
+import { type ReactNode, useEffect, useMemo, useState } from "react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { createAdminHostWorkspace } from "../src/workspace.js"
+
+/** Mirrors `navigationPreferencesQueryKey` in `@voyant-travel/navigation-preferences-react`. */
+const navigationPreferencesQueryKey = (memberKey: string) =>
+  ["navigation-preferences", memberKey] as const
+
+const ENTITLEMENTS_QUERY_KEY = ["voyant", "admin", "entitlements"] as const
+
+interface ShellUser {
+  id: string
+  email: string
+  firstName: string | null
+  lastName: string | null
+  /**
+   * A regional tag, not a supported admin locale. The shell narrows it to
+   * `en`; narrowing a render late is what re-keys every locale-derived query
+   * and makes a page fetch itself twice.
+   */
+  locale: string
+  timezone: string | null
+}
+
+const USER: ShellUser = {
+  id: "usr_1",
+  email: "staff@example.test",
+  firstName: "Staff",
+  lastName: "User",
+  locale: "en-GB",
+  timezone: "Europe/Bucharest",
+}
+
+const SHELL_BOOTSTRAP = {
+  version: 1,
+  compatibility: {
+    minimumShellVersion: 1,
+    capabilities: [
+      "admin.shell-bootstrap.v1",
+      "admin.shell-bootstrap.focus-invalidation",
+      "admin.shell-bootstrap.entitlements",
+      "admin.shell-bootstrap.navigation-preferences",
+      "admin.shell-bootstrap.extensions",
+    ],
+  },
+  user: USER,
+  activeModules: ["catalog"],
+  entitlements: { "catalog.read": true },
+  // The host resolved this member's preferences and found none stored. That is
+  // an answer, and the shell must not go asking for it again.
+  navigationPreferences: null,
+  extensions: [],
+} as const
+
+let requests: string[] = []
+
+function recordFetch(): void {
+  requests = []
+  vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url
+    const path = url.replace("http://localhost", "")
+    requests.push(path)
+    const body = path.startsWith("/api/auth/shell-bootstrap") ? SHELL_BOOTSTRAP : { path }
+    return new Response(JSON.stringify(body), {
+      headers: { "content-type": "application/json" },
+    })
+  })
+}
+
+const fetchJson = async <T,>(path: string): Promise<T> => {
+  const response = await fetch(`/api${path}`, { credentials: "include" })
+  return (await response.json()) as T
+}
+
+const auth = {
+  getCurrentUser: () => fetchJson<ShellUser>("/auth/me"),
+  getShellBootstrap: () => fetchJson<typeof SHELL_BOOTSTRAP>("/auth/shell-bootstrap"),
+  getBootstrapStatus: () => fetchJson<{ hasUsers: boolean }>("/auth/bootstrap-status"),
+  cloudAuthStartHref: () => "/api/auth/admin/cloud/start",
+  signOut: async () => {},
+}
+
+/** Mirrors `hydrateShellBootstrap` in `@voyant-travel/operator-standard`. */
+function hydrateShellBootstrap(bootstrap: typeof SHELL_BOOTSTRAP, queryClient: QueryClient): void {
+  const capabilities = new Set<string>(bootstrap.compatibility.capabilities)
+  if (capabilities.has("admin.shell-bootstrap.navigation-preferences")) {
+    queryClient.setQueryData(
+      navigationPreferencesQueryKey(bootstrap.user.id),
+      bootstrap.navigationPreferences,
+    )
+  }
+  if (capabilities.has("admin.shell-bootstrap.extensions")) {
+    queryClient.setQueryData(UI_EXTENSIONS_QUERY_KEY, bootstrap.extensions)
+  }
+  if (capabilities.has("admin.shell-bootstrap.entitlements")) {
+    queryClient.setQueryData(ENTITLEMENTS_QUERY_KEY, bootstrap.entitlements)
+  }
+  queryClient.setQueryData(ADMIN_ACTIVE_MODULES_QUERY_KEY, bootstrap.activeModules)
+}
+
+/** Stands in for the shell chrome that reads the installed extension list. */
+function UiExtensionsProbe() {
+  useQuery({
+    queryKey: UI_EXTENSIONS_QUERY_KEY,
+    queryFn: () => fetchJson("/v1/admin/ui-extensions"),
+  })
+  return null
+}
+
+/** Stands in for the entitlement-gated chrome. */
+function EntitlementsProbe() {
+  useQuery({
+    queryKey: ENTITLEMENTS_QUERY_KEY,
+    queryFn: () => fetchJson("/v1/admin/entitlements"),
+  })
+  return null
+}
+
+/**
+ * Stands in for a catalog detail page: one React Query read and one
+ * effect-driven read, both keyed on the resolved admin locale. The second
+ * shape is the one that bit hardest — an effect has no request cache, so a
+ * locale that settles after mount re-runs it outright.
+ */
+function CatalogDetailPage() {
+  const { resolvedLocale } = useLocale()
+  const { baseUrl } = useVoyantReactContext()
+
+  useQuery({
+    queryKey: ["catalog", "detail", "prd_1", resolvedLocale],
+    queryFn: () => fetchJson(`/v1/admin/catalog/prd_1/content?locale=${resolvedLocale}`),
+  })
+
+  const [enrichment, setEnrichment] = useState<unknown>(null)
+  const fetchers = useMemo(
+    () => ({ load: () => fetchJson(`${baseUrl}/v1/admin/catalog/prd_1/slots`) }),
+    [baseUrl],
+  )
+  useEffect(() => {
+    let cancelled = false
+    void fetchers.load().then((result) => {
+      if (!cancelled) setEnrichment(result)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [fetchers])
+
+  return (
+    <div>
+      <span data-testid="catalog-detail">catalog detail</span>
+      <span data-testid="enriched">{enrichment ? "enriched" : "pending"}</span>
+    </div>
+  )
+}
+
+function DashboardPage() {
+  return <span data-testid="dashboard">dashboard</span>
+}
+
+const extensions: AdminExtension[] = [
+  {
+    id: "catalog",
+    navigationPreferences: {
+      queryKey: navigationPreferencesQueryKey,
+      load: () => fetchJson<AdminNavigationPreferencesSnapshot>("/v1/admin/navigation-preferences"),
+    },
+  },
+]
+
+function PassthroughRealtimeProvider({ children }: { children: ReactNode }) {
+  return <>{children}</>
+}
+
+function buildRouter() {
+  const queryClient = createAdminQueryClient()
+  const workspace = createAdminHostWorkspace({
+    auth,
+    presentation: { extensions, createExtensions: () => extensions },
+    api: { getBaseUrl: () => "/api", fetcher: fetch },
+    realtime: { Provider: PassthroughRealtimeProvider, channel: {}, useSession: () => null },
+    hydrateShellBootstrap,
+  })
+
+  const rootRoute = createRootRouteWithContext<{ queryClient: QueryClient }>()({
+    component: () => (
+      <OperatorAdminShellProvider
+        baseUrl="/api"
+        queryClient={queryClient}
+        localeStorageKey={null}
+        themeStorageKey={null}
+        timeZoneStorageKey={null}
+      >
+        <Outlet />
+      </OperatorAdminShellProvider>
+    ),
+  })
+
+  const workspaceRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    id: "_workspace",
+    beforeLoad: ({ location, context }) => workspace.beforeLoad({ location, context }),
+    loader: ({ context }) => ({ user: context.user }),
+    pendingComponent: workspace.PendingComponent,
+    component: WorkspaceLayout,
+  })
+
+  function WorkspaceLayout(): ReactNode {
+    const { user } = workspaceRoute.useLoaderData()
+    return (
+      <workspace.Workspace initialUser={user}>
+        <UiExtensionsProbe />
+        <EntitlementsProbe />
+        <Outlet />
+      </workspace.Workspace>
+    )
+  }
+
+  const dashboardRoute = createRoute({
+    getParentRoute: () => workspaceRoute,
+    path: "/",
+    component: DashboardPage,
+  })
+  const catalogRoute = createRoute({
+    getParentRoute: () => workspaceRoute,
+    path: "/catalog/prd_1",
+    component: CatalogDetailPage,
+  })
+
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([workspaceRoute.addChildren([dashboardRoute, catalogRoute])]),
+    context: { queryClient },
+    history: createMemoryHistory({ initialEntries: ["/catalog/prd_1"] }),
+  })
+
+  return { queryClient, router }
+}
+
+function duplicates(paths: readonly string[]): string[] {
+  const seen = new Map<string, number>()
+  for (const path of paths) seen.set(path, (seen.get(path) ?? 0) + 1)
+  return [...seen.entries()].filter(([, count]) => count > 1).map(([path]) => path)
+}
+
+describe("admin cold-load request budget", () => {
+  beforeEach(() => {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+    recordFetch()
+  })
+
+  afterEach(() => {
+    // Vitest runs without `globals`, so testing-library never registers its own
+    // auto-cleanup and each render would otherwise stack in the same document.
+    cleanup()
+    vi.unstubAllGlobals()
+  })
+
+  it("opens the authenticated shell with one round trip and no duplicate reads", async () => {
+    const { router } = buildRouter()
+
+    render(<RouterProvider router={router} />)
+    await waitFor(() => expect(screen.getByTestId("enriched").textContent).toBe("enriched"))
+
+    // One authenticated bootstrap — and none of the probes it answers for.
+    expect(requests.filter((path) => path === "/api/auth/shell-bootstrap")).toHaveLength(1)
+    expect(requests).not.toContain("/api/auth/me")
+    expect(requests).not.toContain("/api/auth/bootstrap-status")
+    expect(requests.filter((path) => path.includes("/ui-extensions"))).toEqual([])
+    expect(requests.filter((path) => path.includes("/entitlements"))).toEqual([])
+    expect(requests.filter((path) => path.includes("/navigation-preferences"))).toEqual([])
+
+    // Page data is asked for, once each.
+    expect(requests.some((path) => path.includes("/catalog/prd_1/content"))).toBe(true)
+    expect(requests.some((path) => path.includes("/catalog/prd_1/slots"))).toBe(true)
+    expect(duplicates(requests)).toEqual([])
+  })
+
+  it("asks for page data without waiting on a session probe first", async () => {
+    const { router } = buildRouter()
+
+    render(<RouterProvider router={router} />)
+    await waitFor(() => expect(screen.getByTestId("catalog-detail")).toBeTruthy())
+
+    // Exactly one request may precede the first page read. Any more means a
+    // hop was re-introduced ahead of the shell bootstrap.
+    const firstPageRead = requests.findIndex((path) => path.includes("/v1/admin/catalog/"))
+    expect(firstPageRead).toBe(1)
+    expect(requests[0]).toBe("/api/auth/shell-bootstrap")
+  })
+
+  it("keeps the budget across a soft navigation away and back", async () => {
+    const { router } = buildRouter()
+
+    render(<RouterProvider router={router} />)
+    await waitFor(() => expect(screen.getByTestId("enriched").textContent).toBe("enriched"))
+    const afterColdLoad = requests.length
+
+    await act(async () => {
+      await router.navigate({ to: "/" })
+    })
+    await waitFor(() => expect(screen.getByTestId("dashboard")).toBeTruthy())
+
+    await act(async () => {
+      await router.navigate({ to: "/catalog/prd_1" })
+    })
+    await waitFor(() => expect(screen.getByTestId("enriched").textContent).toBe("enriched"))
+
+    // Re-entering the route re-runs its effect-driven read; the cached query
+    // and every session/shell probe stay put.
+    const added = requests.slice(afterColdLoad)
+    expect(added.filter((path) => path.includes("/auth/"))).toEqual([])
+    expect(duplicates(added)).toEqual([])
+  })
+
+  it("seeds every shell slice the bootstrap answered for", async () => {
+    const { queryClient, router } = buildRouter()
+
+    render(<RouterProvider router={router} />)
+    await waitFor(() => expect(screen.getByTestId("catalog-detail")).toBeTruthy())
+
+    expect(queryClient.getQueryData(UI_EXTENSIONS_QUERY_KEY)).toEqual([])
+    expect(queryClient.getQueryData(ENTITLEMENTS_QUERY_KEY)).toEqual({ "catalog.read": true })
+    expect(queryClient.getQueryData(ADMIN_ACTIVE_MODULES_QUERY_KEY)).toEqual(["catalog"])
+    // Answered-with-nothing still counts as answered: the query must exist and
+    // hold `null`, not be missing and send the shell asking.
+    expect(queryClient.getQueryState(navigationPreferencesQueryKey(USER.id))?.data).toBeNull()
+  })
+})

--- a/packages/admin/src/app/auth-runtime.ts
+++ b/packages/admin/src/app/auth-runtime.ts
@@ -21,6 +21,25 @@ export type AdminAuthMode = "local" | "voyant-cloud"
 
 export const ADMIN_ACTIVE_MODULES_QUERY_KEY = ["voyant", "admin", "active-modules"] as const
 
+/**
+ * The cached authenticated shell bootstrap. TanStack re-runs `beforeLoad` for
+ * every matched route on every navigation, so without a cache the guard's one
+ * round trip becomes one round trip *per client-side navigation* — which is
+ * how the previous `getCurrentUser()` guard came to re-request `/auth/me`
+ * on soft navigations (voyant#4754).
+ */
+export const ADMIN_SHELL_BOOTSTRAP_QUERY_KEY = ["voyant", "admin", "shell-bootstrap"] as const
+
+/**
+ * The current-user query. Shared with `UserProvider` in
+ * `@voyant-travel/admin-react` so the guard's resolution seeds the provider
+ * instead of racing it.
+ */
+export const ADMIN_CURRENT_USER_QUERY_KEY = ["current-user"] as const
+
+/** How long the guard reuses a resolved session before revalidating it. */
+export const ADMIN_SESSION_STALE_TIME_MS = 5 * 60 * 1000
+
 /** Whether any user exists yet, plus the identity-broker mode. */
 export interface AdminBootstrapStatus {
   hasUsers: boolean

--- a/packages/admin/src/app/index.ts
+++ b/packages/admin/src/app/index.ts
@@ -3,7 +3,12 @@ export type {
   AdminAuthRuntime,
   AdminBootstrapStatus,
 } from "./auth-runtime.js"
-export { ADMIN_ACTIVE_MODULES_QUERY_KEY } from "./auth-runtime.js"
+export {
+  ADMIN_ACTIVE_MODULES_QUERY_KEY,
+  ADMIN_CURRENT_USER_QUERY_KEY,
+  ADMIN_SESSION_STALE_TIME_MS,
+  ADMIN_SHELL_BOOTSTRAP_QUERY_KEY,
+} from "./auth-runtime.js"
 export type {
   AdminExtensionChildRoutesOptions,
   AdminExtensionRouteLoaderArgs,

--- a/packages/admin/src/app/workspace.tsx
+++ b/packages/admin/src/app/workspace.tsx
@@ -27,7 +27,13 @@ import {
   useOperatorAdminMessages,
 } from "../providers/operator-admin-messages.js"
 import type { AdminUser } from "../types.js"
-import type { AdminAuthRuntime, AdminBootstrapStatus } from "./auth-runtime.js"
+import {
+  ADMIN_CURRENT_USER_QUERY_KEY,
+  ADMIN_SESSION_STALE_TIME_MS,
+  ADMIN_SHELL_BOOTSTRAP_QUERY_KEY,
+  type AdminAuthRuntime,
+  type AdminBootstrapStatus,
+} from "./auth-runtime.js"
 
 /**
  * Router-aware sidebar link. SidebarMenuButton with `asChild` wraps this in a
@@ -80,6 +86,11 @@ export interface CreateAdminWorkspaceBeforeLoadOptions<TUser> {
     >,
     queryClient: QueryClient,
   ) => void
+  /**
+   * How long a resolved session is reused before the guard revalidates it.
+   * Defaults to {@link ADMIN_SESSION_STALE_TIME_MS}.
+   */
+  sessionStaleTime?: number
 }
 
 /**
@@ -100,7 +111,38 @@ export function createAdminWorkspaceBeforeLoad<TUser>({
   auth,
   signInPath = "/sign-in",
   hydrateShellBootstrap,
+  sessionStaleTime = ADMIN_SESSION_STALE_TIME_MS,
 }: CreateAdminWorkspaceBeforeLoadOptions<TUser>) {
+  /**
+   * Resolve a session-scoped value through the QueryClient when the router
+   * supplied one. `beforeLoad` runs again for every matched route on every
+   * navigation, so calling the auth port directly turns one cold-load round
+   * trip into one per navigation. A `null` result is dropped rather than
+   * cached: signed-out is the state most likely to change underneath us, and
+   * caching it would keep redirecting a member who has just signed in.
+   */
+  async function resolveSession<TValue>(
+    queryClient: QueryClient | undefined,
+    queryKey: readonly unknown[],
+    load: () => Promise<TValue | null | undefined>,
+  ): Promise<{ value: TValue | null; fromCache: boolean }> {
+    if (!queryClient) return { value: (await load()) ?? null, fromCache: false }
+
+    const cached = queryClient.getQueryData<TValue | null>(queryKey)
+    const value = await queryClient.ensureQueryData<TValue | null>({
+      queryKey,
+      queryFn: async () => (await load()) ?? null,
+      staleTime: sessionStaleTime,
+      // Cached data is returned immediately and refreshed behind the
+      // navigation once it ages past `sessionStaleTime`. Without this the
+      // session would be resolved once and then never again for the life of
+      // the tab, because `ensureQueryData` does not revalidate on its own.
+      revalidateIfStale: true,
+    })
+    if (value === null) queryClient.removeQueries({ queryKey, exact: true })
+    return { value, fromCache: cached !== undefined && Object.is(cached, value) }
+  }
+
   return async ({
     location,
     context,
@@ -108,13 +150,25 @@ export function createAdminWorkspaceBeforeLoad<TUser>({
     location: { href: string }
     context?: { queryClient?: QueryClient }
   }): Promise<{ user: TUser }> => {
-    const usesShellBootstrap = auth.getShellBootstrap !== undefined
-    const shellBootstrap = await auth.getShellBootstrap?.()
-    const user = usesShellBootstrap ? shellBootstrap?.user : await auth.getCurrentUser()
+    const queryClient = context?.queryClient
+    const getShellBootstrap = auth.getShellBootstrap
+    const shellBootstrap = getShellBootstrap
+      ? await resolveSession(queryClient, ADMIN_SHELL_BOOTSTRAP_QUERY_KEY, () =>
+          getShellBootstrap(),
+        )
+      : null
+    const currentUser = shellBootstrap
+      ? null
+      : await resolveSession(queryClient, ADMIN_CURRENT_USER_QUERY_KEY, () => auth.getCurrentUser())
+    const user = shellBootstrap ? shellBootstrap.value?.user : currentUser?.value
 
     if (user) {
-      if (shellBootstrap && context?.queryClient) {
-        hydrateShellBootstrap?.(shellBootstrap, context.queryClient)
+      // Re-seeding on every navigation would overwrite whatever the shell has
+      // since done with these slices (a reordered navigation, a refetched
+      // entitlement) with the snapshot this session started from. Hydrate only
+      // the response that was actually fetched.
+      if (shellBootstrap?.value && !shellBootstrap.fromCache && queryClient) {
+        hydrateShellBootstrap?.(shellBootstrap.value, queryClient)
       }
       return { user }
     }

--- a/packages/admin/src/providers/locale.tsx
+++ b/packages/admin/src/providers/locale.tsx
@@ -127,6 +127,16 @@ export function LocaleProvider({
   const providerDepth = (parentContext?.providerDepth ?? -1) + 1
   const documentLocaleId = useRef(Symbol("locale-provider"))
   const [locale, setLocaleState] = useState<string>(() => {
+    // Account authority is derived from props alone, so narrow it here rather
+    // than in the effect below. Doing it a render late meant every member
+    // whose profile stores a regional tag (`en-GB`) mounted the whole
+    // authenticated tree at `en-GB` and re-rendered it at `en` one tick later
+    // — a wasted pass, and a re-key for anything derived from the locale
+    // (voyant#4754). The device branch cannot do this: its inputs are
+    // `localStorage` and `navigator`, which the server does not have.
+    if (preferenceAuthority === "account") {
+      return pickSupportedLocale(defaultLocale, supportedLocales, fallbackLocale)
+    }
     if (defaultLocale) {
       return defaultLocale
     }

--- a/packages/admin/tests/app/workspace-before-load.test.ts
+++ b/packages/admin/tests/app/workspace-before-load.test.ts
@@ -1,0 +1,126 @@
+import { QueryClient } from "@tanstack/react-query"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  ADMIN_CURRENT_USER_QUERY_KEY,
+  ADMIN_SHELL_BOOTSTRAP_QUERY_KEY,
+} from "../../src/app/auth-runtime.js"
+import { createAdminWorkspaceBeforeLoad } from "../../src/app/workspace.js"
+
+interface TestUser {
+  id: string
+  email: string
+}
+
+const user: TestUser = { id: "usr_1", email: "staff@example.test" }
+
+function bootstrap() {
+  return {
+    version: 1,
+    compatibility: { minimumShellVersion: 1, capabilities: ["admin.shell-bootstrap.v1"] },
+    user,
+    activeModules: ["catalog"],
+    entitlements: {},
+    navigationPreferences: null,
+    extensions: [],
+  }
+}
+
+const location = { href: "/catalog" }
+
+describe("createAdminWorkspaceBeforeLoad", () => {
+  it("resolves the shell bootstrap once per session, not once per navigation", async () => {
+    const getShellBootstrap = vi.fn(async () => bootstrap())
+    const queryClient = new QueryClient()
+    const beforeLoad = createAdminWorkspaceBeforeLoad<TestUser>({
+      auth: {
+        getCurrentUser: vi.fn(),
+        getShellBootstrap,
+        getBootstrapStatus: vi.fn(async () => ({ hasUsers: true })),
+        cloudAuthStartHref: () => "/cloud",
+      },
+    })
+
+    await beforeLoad({ location, context: { queryClient } })
+    await beforeLoad({ location, context: { queryClient } })
+    await beforeLoad({ location, context: { queryClient } })
+
+    expect(getShellBootstrap).toHaveBeenCalledOnce()
+    expect(queryClient.getQueryData(ADMIN_SHELL_BOOTSTRAP_QUERY_KEY)).toMatchObject({ user })
+  })
+
+  it("hydrates the shell slices from a fresh response only", async () => {
+    const hydrateShellBootstrap = vi.fn()
+    const queryClient = new QueryClient()
+    const beforeLoad = createAdminWorkspaceBeforeLoad<TestUser>({
+      auth: {
+        getCurrentUser: vi.fn(),
+        getShellBootstrap: vi.fn(async () => bootstrap()),
+        getBootstrapStatus: vi.fn(async () => ({ hasUsers: true })),
+        cloudAuthStartHref: () => "/cloud",
+      },
+      hydrateShellBootstrap,
+    })
+
+    await beforeLoad({ location, context: { queryClient } })
+    await beforeLoad({ location, context: { queryClient } })
+
+    // Re-seeding on every navigation would overwrite whatever the shell has
+    // since done with those slices with the snapshot the session started from.
+    expect(hydrateShellBootstrap).toHaveBeenCalledOnce()
+  })
+
+  it("seeds the current-user query the shell provider reads", async () => {
+    const getCurrentUser = vi.fn(async () => user)
+    const queryClient = new QueryClient()
+    const beforeLoad = createAdminWorkspaceBeforeLoad<TestUser>({
+      auth: {
+        getCurrentUser,
+        getBootstrapStatus: vi.fn(async () => ({ hasUsers: true })),
+        cloudAuthStartHref: () => "/cloud",
+      },
+    })
+
+    await beforeLoad({ location, context: { queryClient } })
+    await beforeLoad({ location, context: { queryClient } })
+
+    expect(getCurrentUser).toHaveBeenCalledOnce()
+    expect(queryClient.getQueryData(ADMIN_CURRENT_USER_QUERY_KEY)).toEqual(user)
+  })
+
+  it("never caches a signed-out probe", async () => {
+    const queryClient = new QueryClient()
+    const getShellBootstrap = vi.fn(async () => null)
+    const beforeLoad = createAdminWorkspaceBeforeLoad<TestUser>({
+      auth: {
+        getCurrentUser: vi.fn(),
+        getShellBootstrap,
+        getBootstrapStatus: vi.fn(async () => ({ hasUsers: true })),
+        cloudAuthStartHref: () => "/cloud",
+      },
+    })
+
+    await expect(beforeLoad({ location, context: { queryClient } })).rejects.toBeTruthy()
+    await expect(beforeLoad({ location, context: { queryClient } })).rejects.toBeTruthy()
+
+    // Caching "signed out" would keep redirecting a member who has since
+    // signed in, for as long as the entry lives.
+    expect(getShellBootstrap).toHaveBeenCalledTimes(2)
+    expect(queryClient.getQueryData(ADMIN_SHELL_BOOTSTRAP_QUERY_KEY)).toBeUndefined()
+  })
+
+  it("still works for a router that supplies no QueryClient", async () => {
+    const getShellBootstrap = vi.fn(async () => bootstrap())
+    const beforeLoad = createAdminWorkspaceBeforeLoad<TestUser>({
+      auth: {
+        getCurrentUser: vi.fn(),
+        getShellBootstrap,
+        getBootstrapStatus: vi.fn(async () => ({ hasUsers: true })),
+        cloudAuthStartHref: () => "/cloud",
+      },
+    })
+
+    await expect(beforeLoad({ location })).resolves.toEqual({ user })
+    expect(getShellBootstrap).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/admin/tests/unit/locale.test.tsx
+++ b/packages/admin/tests/unit/locale.test.tsx
@@ -152,6 +152,25 @@ describe("LocaleProvider", () => {
     expect(window.localStorage.getItem("admin-locale")).toBe("en")
   })
 
+  it("narrows an account locale on the first render, not the one after", () => {
+    // A profile storing `en-GB` used to mount the authenticated tree at
+    // `en-GB` and re-render it at `en` a tick later, re-keying everything
+    // derived from the locale (voyant#4754).
+    const seen: string[] = []
+    function Probe() {
+      seen.push(useLocale().locale)
+      return null
+    }
+
+    render(
+      <LocaleProvider defaultLocale="en-GB" preferenceAuthority="account">
+        <Probe />
+      </LocaleProvider>,
+    )
+
+    expect(new Set(seen)).toEqual(new Set(["en"]))
+  })
+
   it("uses the nearest locale provider for the document language", async () => {
     render(
       <LocaleProvider defaultLocale="en">

--- a/packages/auth/src/node-runtime.ts
+++ b/packages/auth/src/node-runtime.ts
@@ -89,6 +89,11 @@ import {
   handleApiTokenManagementRequest,
   handleOrganizationMembersRequest,
 } from "./server.js"
+import {
+  buildOperatorShellBootstrap,
+  type OperatorCurrentUser,
+  type OperatorShellBootstrapAdditions,
+} from "./shell-bootstrap.js"
 import { resolveStaffAccess } from "./staff-access.js"
 import { ensureCurrentUserProfile } from "./workspace.js"
 
@@ -160,40 +165,12 @@ export interface OperatorAuthNodeEnv extends NodeDatabaseEnv {
   VOYANT_OPERATOR_BROWSER_EVIDENCE?: string
 }
 
-export interface OperatorCurrentUser {
-  id: string
-  email: string
-  firstName: string | null
-  lastName: string | null
-  locale: string
-  timezone: string | null
-  uiPrefs: unknown
-  isSuperAdmin: boolean
-  isSupportUser: boolean
-  createdAt: string
-  profilePictureUrl: string | null
-}
-
-export const OPERATOR_SHELL_BOOTSTRAP_VERSION = 1 as const
-
-export interface OperatorShellBootstrapAdditions {
-  /** Host-owned feature entitlements. Keys are stable capability ids. */
-  entitlements?: Readonly<Record<string, boolean>>
-  /** Effective navigation snapshot, or null when the selected graph has no preference authority. */
-  navigationPreferences?: unknown
-  /** Lightweight, non-secret descriptors only. Full extension manifests remain deferred. */
-  extensions?: readonly Readonly<Record<string, unknown>>[]
-}
-
-export interface OperatorShellBootstrap extends Required<OperatorShellBootstrapAdditions> {
-  version: typeof OPERATOR_SHELL_BOOTSTRAP_VERSION
-  compatibility: {
-    minimumShellVersion: typeof OPERATOR_SHELL_BOOTSTRAP_VERSION
-    capabilities: readonly string[]
-  }
-  user: OperatorCurrentUser
-  activeModules: readonly string[]
-}
+export type {
+  OperatorCurrentUser,
+  OperatorShellBootstrap,
+  OperatorShellBootstrapAdditions,
+} from "./shell-bootstrap.js"
+export { OPERATOR_SHELL_BOOTSTRAP_VERSION } from "./shell-bootstrap.js"
 
 export type OperatorAuthBootstrapStatus = {
   hasUsers: boolean
@@ -1506,34 +1483,18 @@ export function createOperatorAuthNodeRuntime<Env extends OperatorAuthNodeEnv>(
       const user = await getCurrentUserForRequest(c.req.raw, c.env)
       if (!user) return c.json({ error: "Unauthorized" }, 401)
 
-      const additions =
-        (await runtimeOptions.resolveShellBootstrap?.({
-          env: c.env,
-          request: c.req.raw,
-          user,
-        })) ?? {}
-      const capabilities = [
-        "admin.shell-bootstrap.v1",
-        "admin.shell-bootstrap.focus-invalidation",
-        ...(additions.entitlements ? ["admin.shell-bootstrap.entitlements"] : []),
-        ...(additions.navigationPreferences
-          ? ["admin.shell-bootstrap.navigation-preferences"]
-          : []),
-        ...(additions.extensions ? ["admin.shell-bootstrap.extensions"] : []),
-      ]
-      const bootstrap: OperatorShellBootstrap = {
-        version: OPERATOR_SHELL_BOOTSTRAP_VERSION,
-        compatibility: {
-          minimumShellVersion: OPERATOR_SHELL_BOOTSTRAP_VERSION,
-          capabilities,
-        },
+      const additions = await runtimeOptions.resolveShellBootstrap?.({
+        env: c.env,
+        request: c.req.raw,
         user,
-        activeModules: [...(runtimeOptions.activeModules ?? [])],
-        entitlements: { ...(additions.entitlements ?? {}) },
-        navigationPreferences: additions.navigationPreferences ?? null,
-        extensions: [...(additions.extensions ?? [])],
-      }
-      return c.json(bootstrap)
+      })
+      return c.json(
+        buildOperatorShellBootstrap({
+          user,
+          activeModules: runtimeOptions.activeModules,
+          ...(additions ? { additions } : {}),
+        }),
+      )
     } catch (error) {
       if (error instanceof CurrentUserNotFoundError) {
         return c.json({ error: "User not found" }, 404)

--- a/packages/auth/src/shell-bootstrap.ts
+++ b/packages/auth/src/shell-bootstrap.ts
@@ -1,0 +1,109 @@
+/**
+ * The authenticated admin shell bootstrap contract.
+ *
+ * One versioned response carries everything the shell needs before it can
+ * render: who the member is, which modules the deployment runs, and the
+ * host-owned entitlement / navigation / extension snapshot. Without it the
+ * shell discovers each of those over its own round trip, and because each one
+ * gates the next, no page data is requested until they all land
+ * (voyant#4754).
+ *
+ * Kept out of the route body so the contract is a value: the capability list
+ * is the only thing telling the shell which slices it may stop asking for, and
+ * getting it wrong costs a round trip per page load rather than an error.
+ */
+
+export const OPERATOR_SHELL_BOOTSTRAP_VERSION = 1 as const
+
+export interface OperatorCurrentUser {
+  id: string
+  email: string
+  firstName: string | null
+  lastName: string | null
+  locale: string
+  timezone: string | null
+  uiPrefs: unknown
+  isSuperAdmin: boolean
+  isSupportUser: boolean
+  createdAt: string
+  profilePictureUrl: string | null
+}
+
+export interface OperatorShellBootstrapAdditions {
+  /** Host-owned feature entitlements. Keys are stable capability ids. */
+  entitlements?: Readonly<Record<string, boolean>>
+  /** Effective navigation snapshot, or null when the selected graph has no preference authority. */
+  navigationPreferences?: unknown
+  /** Lightweight, non-secret descriptors only. Full extension manifests remain deferred. */
+  extensions?: readonly Readonly<Record<string, unknown>>[]
+}
+
+export interface OperatorShellBootstrap extends Required<OperatorShellBootstrapAdditions> {
+  version: typeof OPERATOR_SHELL_BOOTSTRAP_VERSION
+  compatibility: {
+    minimumShellVersion: typeof OPERATOR_SHELL_BOOTSTRAP_VERSION
+    capabilities: readonly string[]
+  }
+  user: OperatorCurrentUser
+  activeModules: readonly string[]
+}
+
+/** Always present: the shell reads these to know it is talking to a v1 host. */
+export const OPERATOR_SHELL_BOOTSTRAP_BASE_CAPABILITIES = [
+  "admin.shell-bootstrap.v1",
+  "admin.shell-bootstrap.focus-invalidation",
+] as const
+
+/**
+ * Capability id per optional slice, keyed by the addition that answers for it.
+ */
+export const OPERATOR_SHELL_BOOTSTRAP_SLICE_CAPABILITIES = {
+  entitlements: "admin.shell-bootstrap.entitlements",
+  navigationPreferences: "admin.shell-bootstrap.navigation-preferences",
+  extensions: "admin.shell-bootstrap.extensions",
+} as const satisfies Record<keyof OperatorShellBootstrapAdditions, string>
+
+/**
+ * A capability states that this response ANSWERS for a slice — not that the
+ * answer is non-empty. Testing the value's truthiness instead dropped the
+ * navigation-preferences capability whenever the host resolved "nothing
+ * stored" (`null`), and the shell then asked
+ * `/v1/admin/navigation-preferences` for the same nothing on every page load.
+ * An absent key is the only thing that means "the host did not answer".
+ */
+export function resolveOperatorShellBootstrapCapabilities(
+  additions: OperatorShellBootstrapAdditions,
+): string[] {
+  return [
+    ...OPERATOR_SHELL_BOOTSTRAP_BASE_CAPABILITIES,
+    ...Object.entries(OPERATOR_SHELL_BOOTSTRAP_SLICE_CAPABILITIES)
+      .filter(([slice]) => additions[slice as keyof OperatorShellBootstrapAdditions] !== undefined)
+      .map(([, capability]) => capability),
+  ]
+}
+
+export interface BuildOperatorShellBootstrapInput {
+  user: OperatorCurrentUser
+  activeModules?: readonly string[]
+  additions?: OperatorShellBootstrapAdditions
+}
+
+/** Assemble the versioned bootstrap payload from the resolved host additions. */
+export function buildOperatorShellBootstrap({
+  user,
+  activeModules,
+  additions = {},
+}: BuildOperatorShellBootstrapInput): OperatorShellBootstrap {
+  return {
+    version: OPERATOR_SHELL_BOOTSTRAP_VERSION,
+    compatibility: {
+      minimumShellVersion: OPERATOR_SHELL_BOOTSTRAP_VERSION,
+      capabilities: resolveOperatorShellBootstrapCapabilities(additions),
+    },
+    user,
+    activeModules: [...(activeModules ?? [])],
+    entitlements: { ...(additions.entitlements ?? {}) },
+    navigationPreferences: additions.navigationPreferences ?? null,
+    extensions: [...(additions.extensions ?? [])],
+  }
+}

--- a/packages/auth/tests/unit/shell-bootstrap.test.ts
+++ b/packages/auth/tests/unit/shell-bootstrap.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildOperatorShellBootstrap,
+  type OperatorCurrentUser,
+  resolveOperatorShellBootstrapCapabilities,
+} from "../../src/shell-bootstrap.js"
+
+const user: OperatorCurrentUser = {
+  id: "usr_1",
+  email: "staff@example.test",
+  firstName: "Staff",
+  lastName: "User",
+  locale: "en",
+  timezone: null,
+  uiPrefs: null,
+  isSuperAdmin: false,
+  isSupportUser: false,
+  createdAt: "2026-08-16T00:00:00.000Z",
+  profilePictureUrl: null,
+}
+
+describe("operator shell bootstrap contract", () => {
+  it("declares only the base capabilities when the host answers for nothing", () => {
+    expect(resolveOperatorShellBootstrapCapabilities({})).toEqual([
+      "admin.shell-bootstrap.v1",
+      "admin.shell-bootstrap.focus-invalidation",
+    ])
+  })
+
+  it("claims a slice the host answered for even when the answer is empty", () => {
+    // The regression this pins: a host that resolved "no navigation
+    // preferences stored" used to drop the capability, and the shell then
+    // spent a round trip per page load re-asking for the same nothing.
+    const capabilities = resolveOperatorShellBootstrapCapabilities({
+      navigationPreferences: null,
+      entitlements: {},
+      extensions: [],
+    })
+
+    expect(capabilities).toContain("admin.shell-bootstrap.navigation-preferences")
+    expect(capabilities).toContain("admin.shell-bootstrap.entitlements")
+    expect(capabilities).toContain("admin.shell-bootstrap.extensions")
+  })
+
+  it("does not claim a slice the host left out", () => {
+    const capabilities = resolveOperatorShellBootstrapCapabilities({ entitlements: { beta: true } })
+
+    expect(capabilities).toContain("admin.shell-bootstrap.entitlements")
+    expect(capabilities).not.toContain("admin.shell-bootstrap.navigation-preferences")
+    expect(capabilities).not.toContain("admin.shell-bootstrap.extensions")
+  })
+
+  it("assembles the versioned payload with the deployment's active modules", () => {
+    const bootstrap = buildOperatorShellBootstrap({
+      user,
+      activeModules: ["catalog", "bookings"],
+      additions: {
+        entitlements: { "apps.install": true },
+        navigationPreferences: { pinned: ["bookings"] },
+        extensions: [{ id: "ext_1" }],
+      },
+    })
+
+    expect(bootstrap).toMatchObject({
+      version: 1,
+      compatibility: { minimumShellVersion: 1 },
+      user,
+      activeModules: ["catalog", "bookings"],
+      entitlements: { "apps.install": true },
+      navigationPreferences: { pinned: ["bookings"] },
+      extensions: [{ id: "ext_1" }],
+    })
+  })
+
+  it("gives a self-hosted deployment the same shape with empty additions", () => {
+    const bootstrap = buildOperatorShellBootstrap({ user })
+
+    expect(bootstrap.activeModules).toEqual([])
+    expect(bootstrap.entitlements).toEqual({})
+    expect(bootstrap.navigationPreferences).toBeNull()
+    expect(bootstrap.extensions).toEqual([])
+    expect(bootstrap.compatibility.capabilities).toEqual([
+      "admin.shell-bootstrap.v1",
+      "admin.shell-bootstrap.focus-invalidation",
+    ])
+  })
+})

--- a/packages/hono/src/app.ts
+++ b/packages/hono/src/app.ts
@@ -30,6 +30,7 @@ import { tryGetExecutionCtx } from "./lib/execution-ctx.js"
 import { matchesPublicPath, normalizePathname } from "./lib/public-paths.js"
 import { requestScopedEventBus } from "./lib/request-event-bus.js"
 import { createRequestOutboxStore } from "./lib/request-outbox-store.js"
+import { adminResponseRevalidation } from "./middleware/admin-revalidation.js"
 import { requireAuth } from "./middleware/auth.js"
 import {
   DEFAULT_REQUEST_BODY_LIMIT_BYTES,
@@ -536,6 +537,14 @@ export function mountApp<TBindings extends VoyantBindings>(
 
   if (config.securityHeaders !== false) {
     app.use("*", securityHeaders(config.securityHeaders))
+  }
+
+  // Conditional requests for the staff surface (voyant#4754). Cookie-bearing
+  // admin reads bypass the shared cache above, which left them with no cache
+  // policy at all — so every repeat navigation re-downloaded a body the
+  // browser already had. Stamping an ETag here turns that into a 304.
+  if (config.adminRevalidation !== false) {
+    app.use("/v1/admin/*", adminResponseRevalidation(config.adminRevalidation))
   }
 
   if (config.requestBodyLimit !== false) {

--- a/packages/hono/src/middleware/admin-revalidation.ts
+++ b/packages/hono/src/middleware/admin-revalidation.ts
@@ -7,19 +7,44 @@
  * repeat navigation and every reload re-downloaded a body the client already
  * had, byte for byte.
  *
- * The directive is `private, no-cache`, not `private, max-age=N`. `no-cache`
- * means "store it, but ask before reusing it": the browser keeps the payload
- * and revalidates with `If-None-Match`, so a repeat read costs one round trip
- * and a 304 with no body instead of a full re-transfer. `max-age` would skip
- * the round trip too, but at the price of a window in which a staff member
- * sees a record they have already changed — which is why the few admin routes
- * that opt into one (`private, max-age=30` on dashboard aggregates) do it
- * deliberately, per route. A route that sets its own `Cache-Control` is left
+ * ## Why `no-cache` and not `max-age`
+ *
+ * `no-cache` means "store it, but ask before reusing it": the browser keeps the
+ * payload and revalidates with `If-None-Match`, so a repeat read costs one
+ * round trip and a 304 with no body instead of a full re-transfer. `max-age`
+ * would skip the round trip too, but at the price of a window in which a staff
+ * member sees a record they have already changed — which is why the few admin
+ * routes that opt into one (`private, max-age=30` on dashboard aggregates) do
+ * it deliberately, per route. A route that sets its own `Cache-Control` is left
  * alone here, so that opt-in keeps working.
  *
- * Only JSON bodies are handled. Hashing requires buffering, and the staff
- * surface also streams documents and file downloads; those keep their
- * streaming behaviour and stay unstamped.
+ * ## What this stores, and where — a decision, not a side effect
+ *
+ * Revalidation requires storage: there is no `Cache-Control` that yields a 304
+ * without the browser having kept the body. So this changes admin JSON from
+ * "most browsers store nothing" (no directives, no validators) to "stored in
+ * the operator's own profile cache". `private` keeps it off every shared cache,
+ * but it does mean booking and customer payloads persist on the device after
+ * sign-out — the browser cache is not session-scoped, and signing out does not
+ * evict it.
+ *
+ * That is judged acceptable for a staff workstation, where the same profile
+ * already holds the admin bundle and the session cookie, and it is bounded: the
+ * entries are `private`, revalidated before every reuse, and evicted under
+ * ordinary disk-cache pressure. A deployment that cannot accept device-resident
+ * admin payloads turns it off with `adminRevalidation: false`, and gets the
+ * previous behaviour back — no directives, no storage, full re-transfer per
+ * navigation. See `docs/architecture/caching-architecture.md` §13.
+ *
+ * ## Bounding the buffer
+ *
+ * An `ETag` is a hash of the body, so the body has to be read. The read is
+ * incremental and stops at `maxBodyBytes`: past that the buffered chunks are
+ * stitched back in front of the unread remainder and the response continues
+ * unstamped, so a large or genuinely streamed body is neither held in memory
+ * whole nor collapsed into one. Only JSON is eligible at all — the staff
+ * surface also serves document and file downloads, which keep their streaming
+ * behaviour untouched.
  */
 import type { MiddlewareHandler } from "hono"
 
@@ -42,14 +67,17 @@ export interface AdminRevalidationOptions {
    */
   contentTypes?: readonly string[]
   /**
-   * Bodies larger than this are passed through unstamped rather than hashed.
-   * Default 4 MiB.
+   * Stop reading — and leave the response unstamped — once this many bytes have
+   * been buffered. This is the middleware's memory ceiling per in-flight
+   * request, and the point past which a streamed body is left streaming.
+   * Default 1 MiB, which is far above any admin page payload and far below
+   * anything worth delaying the first byte for.
    */
   maxBodyBytes?: number
 }
 
 const DEFAULT_CONTENT_TYPES = ["application/json"] as const
-const DEFAULT_MAX_BODY_BYTES = 4 * 1024 * 1024
+const DEFAULT_MAX_BODY_BYTES = 1024 * 1024
 
 function mediaType(contentType: string | null): string {
   return (contentType ?? "").split(";")[0]?.trim().toLowerCase() ?? ""
@@ -86,6 +114,74 @@ function appendVary(headers: Headers): void {
 }
 
 /**
+ * A view over its own `ArrayBuffer` — the narrower form `BodyInit` accepts. A
+ * chunk off a stream reader is only `ArrayBufferLike` and cannot be sent as-is.
+ */
+type BodyBytes = Uint8Array<ArrayBuffer>
+
+function concat(chunks: readonly Uint8Array[], size: number): BodyBytes {
+  const body = new Uint8Array(new ArrayBuffer(size))
+  let offset = 0
+  for (const chunk of chunks) {
+    body.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return body
+}
+
+/**
+ * Put the already-read chunks back in front of whatever the reader has left, so
+ * an over-cap body is passed on without ever having been held whole.
+ */
+function restitch(
+  chunks: readonly Uint8Array[],
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk)
+    },
+    async pull(controller) {
+      const { done, value } = await reader.read()
+      if (done) controller.close()
+      else controller.enqueue(value)
+    },
+    cancel(reason) {
+      return reader.cancel(reason)
+    },
+  })
+}
+
+interface BoundedBody {
+  /** The whole body, or `null` when it exceeded the cap. */
+  bytes: BodyBytes | null
+  /** The body to send on, equivalent to the one that was read. */
+  stream: BodyInit
+}
+
+async function readBounded(
+  body: ReadableStream<Uint8Array>,
+  maxBodyBytes: number,
+): Promise<BoundedBody> {
+  const reader = body.getReader()
+  const chunks: Uint8Array[] = []
+  let size = 0
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    chunks.push(value)
+    size += value.byteLength
+    if (size > maxBodyBytes) {
+      return { bytes: null, stream: restitch(chunks, reader) }
+    }
+  }
+
+  const bytes = concat(chunks, size)
+  return { bytes, stream: bytes }
+}
+
+/**
  * Stamp safe, successful JSON reads with `Cache-Control` + `ETag`, and answer
  * a matching `If-None-Match` with 304.
  *
@@ -112,28 +208,45 @@ export function adminResponseRevalidation<TBindings extends VoyantBindings = Voy
     // `private, max-age=30` aggregates and anything marked `no-store`.
     if (response.headers.has("Cache-Control")) return
     if (!contentTypes.has(mediaType(response.headers.get("Content-Type")))) return
-    if (!response.body) return
+    const body = response.body
+    if (!body) return
 
-    // Hash a clone: draining `c.res` itself would leave the runtime nothing to
-    // send, and reassigning `c.res` copies the previous headers back over the
-    // new response (Hono's `set res`), which would undo the stamp below.
-    const body = await response.clone().arrayBuffer()
-    if (body.byteLength > maxBodyBytes) return
+    // Read once rather than `clone()`ing: a clone tees the stream, so both
+    // branches hold the payload and the origin carries it twice.
+    const bounded = await readBounded(body, maxBodyBytes)
+    const contentType = response.headers.get("Content-Type")
 
-    const digest = await sha256Hex(new Uint8Array(body))
+    // `c.res =` copies the PREVIOUS response's headers onto the replacement
+    // (Hono's `set res`, skipping `Content-Type`), so stamp the old headers
+    // first and let the copy carry them across.
+    if (bounded.bytes === null) {
+      c.res = new Response(bounded.stream, {
+        status: response.status,
+        statusText: response.statusText,
+        ...(contentType ? { headers: { "content-type": contentType } } : {}),
+      })
+      return
+    }
+
+    const digest = await sha256Hex(bounded.bytes)
     const etag = `W/"${digest.slice(0, 32)}"`
     response.headers.set("ETag", etag)
     response.headers.set("Cache-Control", ADMIN_REVALIDATE_CACHE_CONTROL)
     appendVary(response.headers)
 
     const ifNoneMatch = c.req.header("if-none-match")
-    if (!ifNoneMatch || !matchesIfNoneMatch(ifNoneMatch, etag)) return
+    if (ifNoneMatch && matchesIfNoneMatch(ifNoneMatch, etag)) {
+      // RFC 9110 §15.4.5: a 304 carries no body, and keeps the validators and
+      // cache directives so the stored entry is refreshed.
+      response.headers.delete("Content-Length")
+      c.res = new Response(null, { status: 304 })
+      return
+    }
 
-    // RFC 9110 §15.4.5: a 304 carries no body, and keeps the validators and
-    // cache directives so the stored entry is refreshed. Hono's `set res`
-    // copies these headers onto the replacement (skipping `Content-Type`), so
-    // drop the now-wrong length before handing over.
-    response.headers.delete("Content-Length")
-    c.res = new Response(null, { status: 304 })
+    c.res = new Response(bounded.stream, {
+      status: response.status,
+      statusText: response.statusText,
+      ...(contentType ? { headers: { "content-type": contentType } } : {}),
+    })
   }
 }

--- a/packages/hono/src/middleware/admin-revalidation.ts
+++ b/packages/hono/src/middleware/admin-revalidation.ts
@@ -1,0 +1,139 @@
+/**
+ * Conditional-request support for the staff surface (voyant#4754).
+ *
+ * Admin reads were leaving cache policy unstated. Edge caching is already
+ * bypassed for cookie-bearing requests, so nothing shared was at risk — but a
+ * response with no directives is also not reusable by the *browser*, so every
+ * repeat navigation and every reload re-downloaded a body the client already
+ * had, byte for byte.
+ *
+ * The directive is `private, no-cache`, not `private, max-age=N`. `no-cache`
+ * means "store it, but ask before reusing it": the browser keeps the payload
+ * and revalidates with `If-None-Match`, so a repeat read costs one round trip
+ * and a 304 with no body instead of a full re-transfer. `max-age` would skip
+ * the round trip too, but at the price of a window in which a staff member
+ * sees a record they have already changed — which is why the few admin routes
+ * that opt into one (`private, max-age=30` on dashboard aggregates) do it
+ * deliberately, per route. A route that sets its own `Cache-Control` is left
+ * alone here, so that opt-in keeps working.
+ *
+ * Only JSON bodies are handled. Hashing requires buffering, and the staff
+ * surface also streams documents and file downloads; those keep their
+ * streaming behaviour and stay unstamped.
+ */
+import type { MiddlewareHandler } from "hono"
+
+import { sha256Hex } from "../auth/crypto.js"
+import type { VoyantBindings } from "../types.js"
+
+/** Store the body, but never reuse it without asking the origin first. */
+export const ADMIN_REVALIDATE_CACHE_CONTROL = "private, no-cache"
+
+/**
+ * A member's admin response is scoped by their session, so a stored entry may
+ * only be reused for the same credential.
+ */
+const ADMIN_VARY_HEADERS = ["Cookie", "Authorization"] as const
+
+export interface AdminRevalidationOptions {
+  /**
+   * Response media types eligible for an ETag. Matched against the media type
+   * of `Content-Type`, ignoring parameters. Defaults to JSON only.
+   */
+  contentTypes?: readonly string[]
+  /**
+   * Bodies larger than this are passed through unstamped rather than hashed.
+   * Default 4 MiB.
+   */
+  maxBodyBytes?: number
+}
+
+const DEFAULT_CONTENT_TYPES = ["application/json"] as const
+const DEFAULT_MAX_BODY_BYTES = 4 * 1024 * 1024
+
+function mediaType(contentType: string | null): string {
+  return (contentType ?? "").split(";")[0]?.trim().toLowerCase() ?? ""
+}
+
+/**
+ * `If-None-Match` is a list, and `W/"x"` and `"x"` are the same entity under
+ * the weak comparison a GET revalidation uses. Compare on the opaque tag.
+ */
+function opaqueTag(value: string): string {
+  const trimmed = value.trim()
+  const withoutWeak = trimmed.startsWith("W/") ? trimmed.slice(2) : trimmed
+  return withoutWeak.replace(/^"|"$/g, "")
+}
+
+function matchesIfNoneMatch(header: string, etag: string): boolean {
+  if (header.trim() === "*") return true
+  const wanted = opaqueTag(etag)
+  return header.split(",").some((candidate) => opaqueTag(candidate) === wanted)
+}
+
+function appendVary(headers: Headers): void {
+  const existing = headers.get("Vary")
+  if (existing?.trim() === "*") return
+  const present = new Set(
+    (existing ?? "")
+      .split(",")
+      .map((value) => value.trim().toLowerCase())
+      .filter(Boolean),
+  )
+  const missing = ADMIN_VARY_HEADERS.filter((value) => !present.has(value.toLowerCase()))
+  if (missing.length === 0) return
+  headers.set("Vary", existing ? `${existing}, ${missing.join(", ")}` : missing.join(", "))
+}
+
+/**
+ * Stamp safe, successful JSON reads with `Cache-Control` + `ETag`, and answer
+ * a matching `If-None-Match` with 304.
+ *
+ * Mount it on the staff surface (`/v1/admin/*`). It wraps the handler, so the
+ * origin still does the work on a revalidation — what a 304 saves is the
+ * payload, not the query. Skipping the round trip as well is a per-route
+ * `max-age` decision, deliberately not made here.
+ */
+export function adminResponseRevalidation<TBindings extends VoyantBindings = VoyantBindings>(
+  options: AdminRevalidationOptions = {},
+): MiddlewareHandler<{ Bindings: TBindings }> {
+  const contentTypes = new Set<string>(options.contentTypes ?? DEFAULT_CONTENT_TYPES)
+  const maxBodyBytes = options.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES
+
+  return async (c, next) => {
+    const method = c.req.method
+    if (method !== "GET" && method !== "HEAD") return next()
+
+    await next()
+
+    const response = c.res
+    if (response.status !== 200) return
+    // A route that stated its own policy owns it — including the deliberate
+    // `private, max-age=30` aggregates and anything marked `no-store`.
+    if (response.headers.has("Cache-Control")) return
+    if (!contentTypes.has(mediaType(response.headers.get("Content-Type")))) return
+    if (!response.body) return
+
+    // Hash a clone: draining `c.res` itself would leave the runtime nothing to
+    // send, and reassigning `c.res` copies the previous headers back over the
+    // new response (Hono's `set res`), which would undo the stamp below.
+    const body = await response.clone().arrayBuffer()
+    if (body.byteLength > maxBodyBytes) return
+
+    const digest = await sha256Hex(new Uint8Array(body))
+    const etag = `W/"${digest.slice(0, 32)}"`
+    response.headers.set("ETag", etag)
+    response.headers.set("Cache-Control", ADMIN_REVALIDATE_CACHE_CONTROL)
+    appendVary(response.headers)
+
+    const ifNoneMatch = c.req.header("if-none-match")
+    if (!ifNoneMatch || !matchesIfNoneMatch(ifNoneMatch, etag)) return
+
+    // RFC 9110 §15.4.5: a 304 carries no body, and keeps the validators and
+    // cache directives so the stored entry is refreshed. Hono's `set res`
+    // copies these headers onto the replacement (skipping `Content-Type`), so
+    // drop the now-wrong length before handing over.
+    response.headers.delete("Content-Length")
+    c.res = new Response(null, { status: 304 })
+  }
+}

--- a/packages/hono/src/middleware/index.ts
+++ b/packages/hono/src/middleware/index.ts
@@ -1,3 +1,8 @@
+export {
+  ADMIN_REVALIDATE_CACHE_CONTROL,
+  type AdminRevalidationOptions,
+  adminResponseRevalidation,
+} from "./admin-revalidation.js"
 export { requireAuth } from "./auth.js"
 export {
   DEFAULT_REQUEST_BODY_LIMIT_BYTES,

--- a/packages/hono/src/types.ts
+++ b/packages/hono/src/types.ts
@@ -396,6 +396,14 @@ export interface VoyantAppConfig<TBindings extends VoyantBindings = VoyantBindin
    */
   publicCache?: false | import("./middleware/public-cache.js").PublicCacheOptions
   /**
+   * `ETag` + `Cache-Control: private, no-cache` on safe JSON reads of the
+   * staff surface (`/v1/admin/*`), so a repeat navigation revalidates and gets
+   * a bodyless 304 instead of re-downloading the payload. Enabled by default;
+   * a route that sets its own `Cache-Control` is never restamped. Set `false`
+   * to disable, or pass options to widen the eligible media types.
+   */
+  adminRevalidation?: false | import("./middleware/admin-revalidation.js").AdminRevalidationOptions
+  /**
    * Transactional outbox (RFC #1687 Phase 2.1). When `true`, request
    * emits persist the envelope to the `event_outbox` table BEFORE any
    * subscriber runs (durable, at-least-once with retry/dead-letter via

--- a/packages/hono/tests/unit/admin-revalidation.test.ts
+++ b/packages/hono/tests/unit/admin-revalidation.test.ts
@@ -1,0 +1,120 @@
+import { Hono } from "hono"
+import { describe, expect, it } from "vitest"
+
+import {
+  ADMIN_REVALIDATE_CACHE_CONTROL,
+  adminResponseRevalidation,
+} from "../../src/middleware/admin-revalidation.js"
+
+function buildApp() {
+  const app = new Hono()
+  app.use("/v1/admin/*", adminResponseRevalidation())
+  app.get("/v1/admin/bookings", (c) => c.json({ rows: [{ id: "bkg_1" }] }))
+  app.get("/v1/admin/volatile", (c) => c.json({ at: c.req.query("at") ?? "0" }))
+  app.get("/v1/admin/aggregates", (c) => {
+    c.header("Cache-Control", "private, max-age=30")
+    return c.json({ total: 3 })
+  })
+  app.get("/v1/admin/export", (c) => {
+    c.header("Content-Type", "text/csv")
+    return c.body("id\nbkg_1\n")
+  })
+  app.get("/v1/admin/missing", (c) => c.json({ error: "Not found" }, 404))
+  app.post("/v1/admin/bookings", (c) => c.json({ id: "bkg_2" }, 200))
+  app.get("/v1/public/catalog", (c) => c.json({ rows: [] }))
+  return app
+}
+
+describe("adminResponseRevalidation middleware", () => {
+  it("stamps an ETag, a private cache directive, and the credential Vary", async () => {
+    const response = await buildApp().request("/v1/admin/bookings")
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("ETag")).toMatch(/^W\/"[0-9a-f]{32}"$/)
+    expect(response.headers.get("Cache-Control")).toBe(ADMIN_REVALIDATE_CACHE_CONTROL)
+    expect(response.headers.get("Vary")).toBe("Cookie, Authorization")
+    expect(await response.json()).toEqual({ rows: [{ id: "bkg_1" }] })
+  })
+
+  it("answers a matching If-None-Match with a bodyless 304 that keeps the validators", async () => {
+    const app = buildApp()
+    const first = await app.request("/v1/admin/bookings")
+    const etag = first.headers.get("ETag") ?? ""
+
+    const second = await app.request("/v1/admin/bookings", {
+      headers: { "if-none-match": etag },
+    })
+
+    expect(second.status).toBe(304)
+    expect(second.headers.get("ETag")).toBe(etag)
+    expect(second.headers.get("Cache-Control")).toBe(ADMIN_REVALIDATE_CACHE_CONTROL)
+    expect(second.headers.get("Content-Length")).toBeNull()
+    expect(await second.text()).toBe("")
+  })
+
+  it("matches an unquoted or listed candidate the same way a browser would", async () => {
+    const app = buildApp()
+    const etag = (await app.request("/v1/admin/bookings")).headers.get("ETag") ?? ""
+    const strong = etag.replace(/^W\//, "")
+
+    const listed = await app.request("/v1/admin/bookings", {
+      headers: { "if-none-match": `W/"stale", ${strong}` },
+    })
+
+    expect(listed.status).toBe(304)
+  })
+
+  it("returns the full body when the entity changed", async () => {
+    const app = buildApp()
+    const first = await app.request("/v1/admin/volatile?at=1")
+
+    const second = await app.request("/v1/admin/volatile?at=2", {
+      headers: { "if-none-match": first.headers.get("ETag") ?? "" },
+    })
+
+    expect(second.status).toBe(200)
+    expect(await second.json()).toEqual({ at: "2" })
+    expect(second.headers.get("ETag")).not.toBe(first.headers.get("ETag"))
+  })
+
+  it("leaves a route that stated its own cache policy alone", async () => {
+    const response = await buildApp().request("/v1/admin/aggregates")
+
+    expect(response.headers.get("Cache-Control")).toBe("private, max-age=30")
+    expect(response.headers.get("ETag")).toBeNull()
+  })
+
+  it("does not buffer non-JSON responses", async () => {
+    const response = await buildApp().request("/v1/admin/export")
+
+    expect(response.headers.get("ETag")).toBeNull()
+    expect(response.headers.get("Cache-Control")).toBeNull()
+    expect(await response.text()).toBe("id\nbkg_1\n")
+  })
+
+  it("ignores error responses, writes, and surfaces it is not mounted on", async () => {
+    const app = buildApp()
+
+    const notFound = await app.request("/v1/admin/missing")
+    expect(notFound.status).toBe(404)
+    expect(notFound.headers.get("ETag")).toBeNull()
+
+    const write = await app.request("/v1/admin/bookings", { method: "POST" })
+    expect(write.headers.get("ETag")).toBeNull()
+
+    const publicRead = await app.request("/v1/public/catalog")
+    expect(publicRead.headers.get("ETag")).toBeNull()
+  })
+
+  it("passes a body over the hashing cap through unstamped", async () => {
+    const app = new Hono()
+    app.use("*", adminResponseRevalidation({ maxBodyBytes: 8 }))
+    app.get("/v1/admin/big", (c) => c.json({ padding: "x".repeat(64) }))
+
+    const response = await app.request("/v1/admin/big")
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("ETag")).toBeNull()
+    expect(await response.json()).toEqual({ padding: "x".repeat(64) })
+  })
+})

--- a/packages/hono/tests/unit/admin-revalidation.test.ts
+++ b/packages/hono/tests/unit/admin-revalidation.test.ts
@@ -106,7 +106,7 @@ describe("adminResponseRevalidation middleware", () => {
     expect(publicRead.headers.get("ETag")).toBeNull()
   })
 
-  it("passes a body over the hashing cap through unstamped", async () => {
+  it("passes a body over the cap through unstamped, and intact", async () => {
     const app = new Hono()
     app.use("*", adminResponseRevalidation({ maxBodyBytes: 8 }))
     app.get("/v1/admin/big", (c) => c.json({ padding: "x".repeat(64) }))
@@ -115,6 +115,68 @@ describe("adminResponseRevalidation middleware", () => {
 
     expect(response.status).toBe(200)
     expect(response.headers.get("ETag")).toBeNull()
+    expect(response.headers.get("Cache-Control")).toBeNull()
     expect(await response.json()).toEqual({ padding: "x".repeat(64) })
+  })
+
+  it("stops reading at the cap instead of buffering the whole body first", async () => {
+    // The cap is the middleware's memory ceiling per in-flight request, so it
+    // has to be enforced *during* the read. Checking the size afterwards would
+    // buffer an oversized body in full and then discard it.
+    const chunk = new TextEncoder().encode("x".repeat(64))
+    let chunksRead = 0
+    const app = new Hono()
+    app.use("*", adminResponseRevalidation({ maxBodyBytes: 128 }))
+    app.get("/v1/admin/stream", (c) =>
+      c.body(
+        new ReadableStream<Uint8Array>({
+          pull(controller) {
+            if (chunksRead === 64) {
+              controller.close()
+              return
+            }
+            chunksRead += 1
+            controller.enqueue(chunk)
+          },
+        }),
+        { headers: { "content-type": "application/json" } },
+      ),
+    )
+
+    const response = await app.request("/v1/admin/stream")
+    const readWhenHandedBack = chunksRead
+
+    expect(response.headers.get("ETag")).toBeNull()
+    // Three 64-byte chunks is the first read past a 128-byte cap; the stream's
+    // own queue may have pulled one more. What matters is that it is a handful
+    // and not the whole 4 KiB body.
+    expect(readWhenHandedBack).toBeLessThan(8)
+    // The unread remainder is still delivered: the buffered chunks are put back
+    // in front of it rather than dropped.
+    expect((await response.text()).length).toBe(64 * 64)
+    expect(chunksRead).toBe(64)
+  })
+
+  it("does not tee the body it hashes", async () => {
+    // `clone()` would make the origin hold the payload twice for every
+    // in-flight admin read. Reading the single body proves it was not cloned:
+    // a teed stream would leave the original still unread.
+    let cloned = false
+    const app = new Hono()
+    app.use("/v1/admin/*", async (c, next) => {
+      await next()
+      const original = c.res.clone
+      c.res.clone = function trackedClone(this: Response) {
+        cloned = true
+        return original.call(this)
+      }
+    })
+    app.use("/v1/admin/*", adminResponseRevalidation())
+    app.get("/v1/admin/bookings", (c) => c.json({ rows: [] }))
+
+    const response = await app.request("/v1/admin/bookings")
+
+    expect(response.headers.get("ETag")).not.toBeNull()
+    expect(cloned).toBe(false)
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,7 +249,7 @@ importers:
         version: 1.6.0(@date-fns/tz@1.4.1)(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@better-auth/api-key':
         specifier: 1.6.23
-        version: 1.6.23(1ac6a98f3eafa8cc5361cfcd8d9e497a)
+        version: 1.6.23(4cc07405e1e664eaf96048bc4329d318)
       '@fontsource-variable/inter-tight':
         specifier: ^5.2.7
         version: 5.2.7
@@ -1123,12 +1123,18 @@ importers:
         specifier: workspace:^
         version: link:../runtime-core
     devDependencies:
+      '@tanstack/react-query':
+        specifier: ^5.101.2
+        version: 5.101.2(react@19.2.7)
       '@tanstack/react-router':
         specifier: ^1.170.17
         version: 1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/react-start':
         specifier: ^1.168.27
         version: 1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.3)(rollup@4.60.2)(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3))
+      '@testing-library/react':
+        specifier: ^16.0.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/node':
         specifier: 'catalog:'
         version: 25.5.2
@@ -1147,6 +1153,9 @@ importers:
       '@voyant-travel/admin-react':
         specifier: workspace:^
         version: link:../admin-react
+      '@voyant-travel/react':
+        specifier: workspace:^
+        version: link:../react
       '@voyant-travel/types':
         specifier: workspace:^
         version: link:../types
@@ -13417,6 +13426,14 @@ snapshots:
   '@better-auth/api-key@1.6.23(1ac6a98f3eafa8cc5361cfcd8d9e497a)':
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.4.0)
+      '@better-auth/utils': 0.4.2
+      better-auth: 1.6.23(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.3)(rollup@4.60.2)(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9))(mongodb@7.1.0(socks@2.8.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.11)(vitest@4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)))(vue@3.5.39(typescript@6.0.3))
+      better-call: 1.3.7(zod@4.4.3)
+      zod: 4.4.3
+
+  '@better-auth/api-key@1.6.23(4cc07405e1e664eaf96048bc4329d318)':
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
       better-auth: 1.6.23(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.0)(@tanstack/react-start@1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.3)(rollup@4.60.2)(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9))(mongodb@7.1.0(socks@2.8.7))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.11)(vitest@4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)))(vue@3.5.39(typescript@6.0.3))
       better-call: 1.3.7(zod@4.4.3)


### PR DESCRIPTION
Closes #4754.

The issue's trace is from a runtime that predates the shell bootstrap landing, so `me` → `bootstrap-status` → `entitlements` is already collapsed on main. What is **not** fixed on main is what a request ledger shows once you build one, and that is what this PR is.

## What the ledger found

`createAdminWorkspaceBeforeLoad` called `auth.getShellBootstrap()` directly. TanStack re-runs `beforeLoad` for **every matched route on every navigation**, so the guard's one cold-load round trip was paid again on each client-side navigation. That is the same mechanism behind the issue's "`/api/auth/me` is the one request that doubles on soft navigations too" — before the bootstrap landed it was `/auth/me`; after, it is `/auth/shell-bootstrap`.

It is resolved through the router's QueryClient now: once per session, revalidated *behind* the navigation once it ages past 5 minutes, and never cached when the probe says signed out (caching that would keep redirecting a member who has since signed in). Shell slices are re-seeded only from a freshly fetched response — re-seeding on every navigation would overwrite whatever the shell has since done with them.

## The other three

- **A capability meant "answered with something", not "answered".** `/auth/shell-bootstrap` tested the value's truthiness, so a host resolving *no navigation preferences stored* (`null`) dropped the capability and sent the shell asking `/v1/admin/navigation-preferences` for the same nothing on every page load. The contract moved out of the route body into `packages/auth/src/shell-bootstrap.ts` so the rule is a value with a test rather than a conditional inside a handler.
- **Locale narrowed a render late.** A profile storing `en-GB` mounted the whole authenticated tree at `en-GB` and re-rendered it at `en` on the next tick, re-keying everything derived from the locale. Account authority is derived from props alone, so it is narrowed in the state initializer. The device branch keeps its effect — its inputs are `localStorage` and `navigator`, which the server does not have.
- **`/v1/admin/*` stated no cache policy.** Edge caching already bypasses cookie-bearing admin requests, but saying nothing also makes a response unusable by the *browser*, so every reload re-downloaded a body the client already held. `adminResponseRevalidation` stamps safe JSON reads with an `ETag` and `Cache-Control: private, no-cache` and answers a matching `If-None-Match` with a bodyless 304. `no-cache`, not `max-age`: the payload is reused only after asking, so there is no window in which a staff member is shown a record they have already changed. A route that set its own policy (the deliberate `private, max-age=30` aggregates) is never restamped.

## Two things worth reviewing on their own

**This stores admin payloads on the device, and that is a decision.** Revalidation requires storage — no directive yields a 304 without the browser having kept the body — so admin JSON moves from "most browsers store nothing" (no directives, no validators) to "stored in the operator's profile cache". `private` keeps it out of every shared cache, but the browser cache is not session-scoped: booking and customer payloads persist after sign-out, and signing out does not evict them. Accepted for a staff workstation whose profile already holds the admin bundle and the session cookie; `adminRevalidation: false` restores the previous behaviour for a deployment that cannot accept it. Written down in `caching-architecture.md` §13 rather than left implicit, and flagged here for the open enterprise security review.

**The read is bounded during the read, not after it.** An `ETag` is a hash of the body, so the body has to be read. The read is incremental and stops at `maxBodyBytes` (default 1 MiB), stitching the buffered chunks back in front of the unread remainder and continuing unstamped — so a large or genuinely streamed body is neither held whole nor collapsed into one. `Content-Length` cannot be the gate: Hono does not set it on the `Response`, the runtime adds it at the wire, so gating on it would disable the middleware outright. The body is also read once rather than `clone()`d — a clone tees the stream, which would have the origin holding every admin payload twice.

## The regression check

`packages/admin-host/tests/admin-request-budget.test.tsx` mounts the real router and `createAdminHostWorkspace` over a recording fetch and asserts the **ledger** — what was asked for, in what order, how many times — on cold load and across a soft navigation away and back. A per-endpoint assertion cannot see either failure mode here; every response in the test is instant and the defect is the shape of the traffic.

Both new guards were confirmed to bite: reverting the QueryClient resolution fails the soft-navigation budget, reverting the locale initializer fails the locale test. The middleware's cap and its no-tee property have their own tests for the same reason.

## Acceptance criteria

| | |
|---|---|
| No admin request more than once per page load, cold and soft | ✅ asserted by the budget ledger |
| First page-data request not gated behind session probes | ✅ asserted structurally — exactly one request precedes it |
| Entitlements / UI extensions / active modules / nav preferences arrive with the bootstrap | ✅ and the `null` case now counts as answered |
| `/v1/admin/*` GETs carry cache directives and revalidate with ETags | ✅ |
| A regression check counting admin API requests per page load | ✅ |

`/api/admin/billing`, `/api/admin/whats-new` and `/api/admin/app-extensions` in the issue's trace are managed-platform endpoints served outside this repo; the `resolveShellBootstrap` port they would fold into is here and unchanged.

## Verification

- `@voyant-travel/hono` 39 files / 394 tests, `@voyant-travel/auth` 31 files / 305 tests, `@voyant-travel/admin` 31 files / 177 tests, `@voyant-travel/admin-host` 5 files / 18 tests, plus `operator-standard` and `admin-react` — all green
- `tsc -p tsconfig.build.json` clean for hono, auth, admin; admin-host's tests typecheck clean against a temporary tests-inclusive project (the package is in the `verify:typecheck-coverage` baseline, so CI does not typecheck its tests — unchanged by this PR)
- `biome check .` from the root: 0 errors
- CI on the first push: `architecture`, `tests`, `build-graph`, `quality-graph`, `operator-image-smoke`, `packaged-acceptance` all green. `db-integration` failed on `packages/inventory/tests/integration/conservative-family-backfill.test.ts` — a `cleanupTestDb` hook timeout in `beforeEach`, the known TRUNCATE contention flake, in a package this diff does not touch.

No new architecture checker: the cache policy is a runtime middleware, and its rule is recorded in `docs/architecture/caching-architecture.md` §13.